### PR TITLE
Prevent creation of non-empty array types with bottom kind

### DIFF
--- a/middle_end/flambda2/tests/meet_test.expected
+++ b/middle_end/flambda2/tests/meet_test.expected
@@ -450,3 +450,21 @@ Res:
  (aliases
   ((canonical_elements {}) (aliases_of_canonical_names {})
    (aliases_of_consts {}))))
+
+MEET ARRAY ELEMENT KINDS
+
+The meet of:
+
+  (Val!
+   (Array (element_kind [0m[38;5;37;1m𝕍[0m?) (length (Val! (Variant (tagged_imms [0m[38;5;37;1m⊤[0m))))
+    (alloc_mode Heap)))
+
+and
+
+  (Val!
+   (Immutable_array (element_kind [0m[38;5;37;1mℕ𝕗[0m) (length (Val ([0m[38;5;160;1m=[0m [0m[38;5;70;1m1[0m))) (alloc_mode
+    Heap_or_local) (fields ((Naked_float [0m[38;5;37;1m⊤[0m)))))
+
+is:
+
+Bottom

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -433,6 +433,58 @@ let test_meet_bottom_after_alias () =
   Format.eprintf "@[<hov 2>after meet:@ %a@]@." T.print meet_ty;
   assert (T.is_bottom env meet_ty)
 
+let test_meet_array_element_kinds () =
+  let env = create_env () in
+  let define ?(kind = K.value) env v =
+    let v' = Bound_var.create v Flambda_debug_uid.none Name_mode.normal in
+    TE.add_definition env (Bound_name.create_var v') kind
+  in
+  let join ty1 ty2 =
+    let kind = T.kind ty1 in
+    let x = Variable.create "x" kind in
+    let env = define ~kind env x in
+    let scope = TE.current_scope env in
+    let scoped_env = TE.increment_scope env in
+    let env1 = TE.add_equation scoped_env (Name.var x) ty1 in
+    let env2 = TE.add_equation scoped_env (Name.var x) ty2 in
+    let env, _ =
+      T.cut_and_n_way_join scoped_env
+        [ env1, Apply_cont_rewrite_id.create (), Inlinable;
+          env2, Apply_cont_rewrite_id.create (), Inlinable ]
+        ~params:Bound_parameters.empty ~cut_after:scope
+        ~extra_allowed_names:Name_occurrences.empty
+        ~extra_lifted_consts_in_use_envs:Symbol.Set.empty
+    in
+    TE.find env (Name.var x) (Some kind)
+  in
+  let machine_width = TE.machine_width env in
+  let immutable_array ?(alloc_mode = Alloc_mode.For_types.heap) kind =
+    T.immutable_array ~element_kind:(Ok kind)
+      ~fields:[T.unknown_with_subkind ~machine_width kind]
+      alloc_mode ~machine_width
+  in
+  let mutable_array ?(alloc_mode = Alloc_mode.For_types.heap) kind =
+    T.mutable_array ~element_kind:(Ok kind) ~length:T.any_tagged_immediate
+      alloc_mode
+  in
+  let unknown_array ?alloc_mode kind =
+    join (mutable_array ?alloc_mode kind) (immutable_array ?alloc_mode kind)
+  in
+  let left_ty = unknown_array K.With_subkind.any_value in
+  let right_ty =
+    immutable_array
+      ~alloc_mode:(Alloc_mode.For_types.local ())
+      K.With_subkind.naked_float
+  in
+  Format.eprintf
+    "@[<v>The meet of:@ @;<1 2>@[%a@]@ @ and@ @;<1 2>@[%a@]@ @ is:@]@." T.print
+    left_ty T.print right_ty;
+  (* We expect this to be bottom, but it used to be a bogus array with an empty
+     element kind but non-empty fields. *)
+  match T.meet env left_ty right_ty with
+  | Bottom -> Format.eprintf "@.Bottom@."
+  | Ok (meet_ty, _env) -> Format.eprintf "@[<v>@;<1 2>%a@]@.@." T.print meet_ty
+
 let () =
   let comp_unit = "Meet_test" |> Compilation_unit.of_string in
   let unit_info = Unit_info.make_dummy ~input_name:"meet_test" comp_unit in
@@ -452,4 +504,6 @@ let () =
   Format.eprintf "@.JOIN WITH EXTENSIONS@\n@.";
   test_join_with_extensions ();
   Format.eprintf "@.JOIN WITH COMPLEX EXTENSIONS@\n@.";
-  test_join_with_complex_extensions ()
+  test_join_with_complex_extensions ();
+  Format.eprintf "@.MEET ARRAY ELEMENT KINDS@\n@.";
+  test_meet_array_element_kinds ()

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -768,49 +768,59 @@ and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)
     ~(meet_element_kind : _ Or_unknown_or_bottom.t) =
-  meet_unknown
-    (fun env (array_contents1 : TG.array_contents)
-         (array_contents2 : TG.array_contents) : TG.array_contents meet_result
-       ->
-      match array_contents1, array_contents2 with
-      | Mutable, Mutable -> Ok (Both_inputs, env)
-      | Mutable, Immutable _ | Immutable _, Mutable -> Bottom (New_result ())
-      | Immutable { fields = fields1 }, Immutable { fields = fields2 } -> (
-        if Array.length fields1 <> Array.length fields2
-        then Bottom (New_result ())
-        else
-          match meet_element_kind with
-          | Bottom ->
-            if Array.length fields1 = 0
-            then
-              (* Both empty arrays. Returning [Both_inputs] would be correct but
-                 may not propagate the Bottom element kind as far as we can.
-                 Using a New_result might lead us to extra work is one or both
-                 of the inputs already have Bottom kind. We choose the
-                 New_result solution because it's a case that is unlikely to
-                 happen, so the extra cost is likely very small (while losing
-                 precision might be noticeable). *)
-              Ok (New_result (Immutable { fields = [||] }), env)
-            else Bottom (New_result ())
-          | Unknown ->
-            (* vlaviron: If the meet of the kinds is Unknown, then both inputs
-               had Unknown kinds. I don't see how we could end up with an array
-               type where the contents are known but we don't know the kind, but
-               in that case we wouldn't be able to call meet because the two
-               sides may have different kinds. So we'll just return the first
-               input, which is guaranteed to be a correct approximation of the
-               meet. *)
-            Ok (Left_input, env)
-          | Ok _ ->
+  let contents_is_bottom (array_contents : TG.array_contents) =
+    match array_contents with
+    | Mutable -> false
+    | Immutable { fields } -> Array.exists TG.is_obviously_bottom fields
+  in
+  match meet_element_kind with
+  | Unknown ->
+    (* If the meet of the kinds is Unknown, then both inputs had Unknown kinds.
+       This is the case for arrays of unboxed products, which are not handled by
+       the types yet. In this case, we can't compute the meet of the array
+       contents because the two sides may have different kinds, so we'll just
+       arbitrarily return one of the inputs. *)
+    meet_unknown
+      (fun env (array_contents1 : TG.array_contents)
+           (array_contents2 : TG.array_contents) ->
+        match array_contents1, array_contents2 with
+        | Mutable, Mutable | Immutable _, Immutable _ -> Ok (Both_inputs, env)
+        | Mutable, Immutable _ | Immutable _, Mutable -> Bottom (New_result ()))
+      ~contents_is_bottom env array_contents1 array_contents2
+  | Bottom -> (
+    (* If the element kind is bottom, only empty (mutable or immutable) arrays
+       are allowed; in all other cases, the situation is impossible. We can't
+       call [meet_unknown] because it would return [Left_input] or [Right_input]
+       if one side is [Unknown] and the other is [Immutable], and we would end
+       up with non-empty arrays of bottom kind. *)
+    match array_contents1, array_contents2 with
+    | Unknown, Unknown
+    | Known Mutable, Known Mutable
+    | Known (Immutable { fields = [||] }), Known (Immutable { fields = [||] })
+      ->
+      Ok (Both_inputs, env)
+    | Unknown, Known (Mutable | Immutable { fields = [||] }) ->
+      Ok (Right_input, env)
+    | Known (Mutable | Immutable { fields = [||] }), Unknown ->
+      Ok (Left_input, env)
+    | _, Known (Immutable _) | Known (Immutable _), _ -> Bottom (New_result ()))
+  | Ok _ ->
+    meet_unknown
+      (fun env (array_contents1 : TG.array_contents)
+           (array_contents2 : TG.array_contents) : TG.array_contents meet_result
+         ->
+        match array_contents1, array_contents2 with
+        | Mutable, Mutable -> Ok (Both_inputs, env)
+        | Mutable, Immutable _ | Immutable _, Mutable -> Bottom (New_result ())
+        | Immutable { fields = fields1 }, Immutable { fields = fields2 } ->
+          if Array.length fields1 <> Array.length fields2
+          then Bottom (New_result ())
+          else
             map_result
               ~f:(fun fields : TG.array_contents -> Immutable { fields })
               (meet_array_of_types env fields1 fields2
-                 ~length:(Array.length fields1))))
-    ~contents_is_bottom:(fun (array_contents : TG.array_contents) ->
-      match array_contents with
-      | Mutable -> false
-      | Immutable { fields } -> Array.exists TG.is_obviously_bottom fields)
-    env array_contents1 array_contents2
+                 ~length:(Array.length fields1)))
+      ~contents_is_bottom env array_contents1 array_contents2
 
 and meet_relation env var1 var2 =
   match var1, var2 with

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -911,49 +911,59 @@ and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)
     ~(meet_element_kind : _ Or_unknown_or_bottom.t) =
-  meet_unknown
-    (fun env (array_contents1 : TG.array_contents)
-         (array_contents2 : TG.array_contents) : TG.array_contents meet_result
-       ->
-      match array_contents1, array_contents2 with
-      | Mutable, Mutable -> Ok (Both_inputs, env)
-      | Mutable, Immutable _ | Immutable _, Mutable -> Bottom (New_result ())
-      | Immutable { fields = fields1 }, Immutable { fields = fields2 } -> (
-        if Array.length fields1 <> Array.length fields2
-        then Bottom (New_result ())
-        else
-          match meet_element_kind with
-          | Bottom ->
-            if Array.length fields1 = 0
-            then
-              (* Both empty arrays. Returning [Both_inputs] would be correct but
-                 may not propagate the Bottom element kind as far as we can.
-                 Using a New_result might lead us to extra work is one or both
-                 of the inputs already have Bottom kind. We choose the
-                 New_result solution because it's a case that is unlikely to
-                 happen, so the extra cost is likely very small (while losing
-                 precision might be noticeable). *)
-              Ok (New_result (Immutable { fields = [||] }), env)
-            else Bottom (New_result ())
-          | Unknown ->
-            (* vlaviron: If the meet of the kinds is Unknown, then both inputs
-               had Unknown kinds. I don't see how we could end up with an array
-               type where the contents are known but we don't know the kind, but
-               in that case we wouldn't be able to call meet because the two
-               sides may have different kinds. So we'll just return the first
-               input, which is guaranteed to be a correct approximation of the
-               meet. *)
-            Ok (Left_input, env)
-          | Ok _ ->
+  let contents_is_bottom (array_contents : TG.array_contents) =
+    match array_contents with
+    | Mutable -> false
+    | Immutable { fields } -> Array.exists TG.is_obviously_bottom fields
+  in
+  match meet_element_kind with
+  | Unknown ->
+    (* If the meet of the kinds is Unknown, then both inputs had Unknown kinds.
+       This is the case for arrays of unboxed products, which are not handled by
+       the types yet. In this case, we can't compute the meet of the array
+       contents because the two sides may have different kinds, so we'll just
+       arbitrarily return one of the inputs. *)
+    meet_unknown
+      (fun env (array_contents1 : TG.array_contents)
+           (array_contents2 : TG.array_contents) ->
+        match array_contents1, array_contents2 with
+        | Mutable, Mutable | Immutable _, Immutable _ -> Ok (Both_inputs, env)
+        | Mutable, Immutable _ | Immutable _, Mutable -> Bottom (New_result ()))
+      ~contents_is_bottom env array_contents1 array_contents2
+  | Bottom -> (
+    (* If the element kind is bottom, only empty (mutable or immutable) arrays
+       are allowed; in all other cases, the situation is impossible. We can't
+       call [meet_unknown] because it would return [Left_input] or [Right_input]
+       if one side is [Unknown] and the other is [Immutable], and we would end
+       up with non-empty arrays of bottom kind. *)
+    match array_contents1, array_contents2 with
+    | Unknown, Unknown
+    | Known Mutable, Known Mutable
+    | Known (Immutable { fields = [||] }), Known (Immutable { fields = [||] })
+      ->
+      Ok (Both_inputs, env)
+    | Unknown, Known (Mutable | Immutable { fields = [||] }) ->
+      Ok (Right_input, env)
+    | Known (Mutable | Immutable { fields = [||] }), Unknown ->
+      Ok (Left_input, env)
+    | _, Known (Immutable _) | Known (Immutable _), _ -> Bottom (New_result ()))
+  | Ok _ ->
+    meet_unknown
+      (fun env (array_contents1 : TG.array_contents)
+           (array_contents2 : TG.array_contents) : TG.array_contents meet_result
+         ->
+        match array_contents1, array_contents2 with
+        | Mutable, Mutable -> Ok (Both_inputs, env)
+        | Mutable, Immutable _ | Immutable _, Mutable -> Bottom (New_result ())
+        | Immutable { fields = fields1 }, Immutable { fields = fields2 } ->
+          if Array.length fields1 <> Array.length fields2
+          then Bottom (New_result ())
+          else
             map_result
               ~f:(fun fields : TG.array_contents -> Immutable { fields })
               (meet_array_of_types env fields1 fields2
-                 ~length:(Array.length fields1))))
-    ~contents_is_bottom:(fun (array_contents : TG.array_contents) ->
-      match array_contents with
-      | Mutable -> false
-      | Immutable { fields } -> Array.exists TG.is_obviously_bottom fields)
-    env array_contents1 array_contents2
+                 ~length:(Array.length fields1)))
+      ~contents_is_bottom env array_contents1 array_contents2
 
 and meet_relation env var1 var2 =
   match var1, var2 with

--- a/testsuite/tests/flambda2/simplify/meet_array_element_kind.ml
+++ b/testsuite/tests/flambda2/simplify/meet_array_element_kind.ml
@@ -1,0 +1,43 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   ocamlopt_flags += " -flambda2-join-points";
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+ *)
+
+(* This test is ensuring that we don't build array types with a Bottom
+   element kind and non-empty contents, which was a regression introduced in
+   commit fa3e7c1db8660b36aa0a94f7b5a99d6a2368329e (PR #5771).
+   
+   Such array types would cause crashes when trying to compute the join with
+   another array that as a different kind in its fields. *)
+
+type _ w =
+  | Tagged_immediate : int iarray w
+  | Naked_float : float# iarray w
+
+let fail (type a) (w1 : a w) (w2 : a w) =
+  let[@local] tagged_immediate (arr : int iarray) = ignore arr in
+  let[@local] cast_naked_float (type a) (w : a w) (arr : a) =
+    match w with
+    | Tagged_immediate ->
+        (* Here, [arr] is an array with element kind [Naked_float] and
+           contents [[: #0.0 :]], but we are passing it to [tagged_immediate],
+           which expects an array with element kind [Value].
+           
+           This means that it is actually impossible to execute this code path!
+           It would be ideal to be able to remove it, but at the very least we
+           should certainly not think that [arr] is a non-empty array with
+           [Bottom] element kind.
+
+           bclement: We are able to prove that this is impossible, but only
+           when computing the typing envs for the join points, and we consider
+           this sufficiently unusual that we don't try to actually remove the
+           use. *)
+      tagged_immediate arr
+    | Naked_float -> assert false
+  in
+  match w1 with
+  | Tagged_immediate -> tagged_immediate [: 0 :]
+  | Naked_float -> cast_naked_float w2 [: #0.0 :]


### PR DESCRIPTION
This patch fixes a latent but currently unreachable bug in `meet_array_type`, where we could create an array type with a bottom `element_kind` but a known non-empty list of fields. If such a type is then joined with another type that has the right number of fields with types of an incompatible kind, this causes a crash in the join.

The conditions for this to mismatch are rather specific:

 - We are computing the meet of two array types, one of which has `Unknown` (not `Mutable`) contents, and the other has a known non-empty `Immutable` fields ;

 - Both arrays have incompatible, non-`Bottom` kinds ;

 - At least one of the other fields (`length` or `alloc_mode`) is more precise in the array type with `Unknown` contents.

The third condition is the one that prevents this from happening in practice: the `length` field cannot be more precise in the array type with `Unknown` contents because it is known exactly for an array type with known `Immutable` fields, so we'd need to meet *exactly* an array type with `Unknown` contents and `Heap` `alloc_mode` and an array type with known `Immutable` contents and `Heap_or_local` `alloc_mode`, which as far as I can tell cannot occur.

We started actually hitting this bug with #5771, which effectively removed this restrictive third condition.

This patch fixes the issue by taking into account the element kind outside of the call to `meet_unknown`, in order to ensure that `meet_unknown` returning `Left_input` or `Right_input` does not shortcut the propagation of a `Bottom` element kind and a non-empty array to a `Bottom` result.