### PR TITLE
Remove useless constant moves (using CFG value propagation)

### DIFF
--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -212,7 +212,9 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
   in
   if !Oxcaml_flags.cfg_value_propagation_flow
   then infer_known_values_from_predecessor ();
-  Dll.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+  Dll.iter_cell block.body
+    ~f:(fun (cell : Cfg.basic Cfg.instruction Dll.cell) ->
+      let instr = Dll.value cell in
       let apply_int_op op right_opt =
         let result_opt =
           match find_opt instr.arg.(0) with
@@ -241,7 +243,15 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         remove_destroyed instr
       in
       match instr.desc with
-      | Op (Const_int c) -> replace instr.res.(0) (Const_int c)
+      | Op (Const_int c) ->
+        begin match find_opt instr.res.(0) with
+        | Some (Const_int c') ->
+          if Nativeint.equal c c'
+          then Dll.delete_curr cell
+          else replace instr.res.(0) (Const_int c)
+        | Some (Const_float32 _ | Const_float _) | None ->
+          replace instr.res.(0) (Const_int c)
+        end
       | Op (Const_float32 c) ->
         if !Oxcaml_flags.cfg_value_propagation_float
         then replace instr.res.(0) (Const_float32 c)
@@ -542,6 +552,13 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
       false)
   | Raise _ | Return | Tailcall_self _ | Tailcall_func _ | Call_no_return _
   | Call _ | Prim _ | Invalid _ ->
+    if is_after_regalloc
+    then begin
+      let _ : known_value Reg.UsingLocEquality.Tbl.t =
+        collect_known_values cfg block
+      in
+      ()
+    end;
     false
 
 let run cfg =

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -185,17 +185,31 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         Cfg.get_block_exn cfg (Label.Set.choose block.predecessors)
       in
       let predecessor_terminator = predecessor_block.terminator in
+      (* The predecessor's terminator may itself destroy registers (e.g. on
+         amd64, [Switch] destroys rax and rdx, and its argument may be allocated
+         to one of them), in which case the register no longer holds the tested
+         value at the start of the block. *)
+      let replace_unless_destroyed reg value =
+        let destroyed =
+          Proc.destroyed_at_terminator predecessor_terminator.desc
+        in
+        if not (Array.exists (fun r -> Reg.same_loc r reg) destroyed)
+        then replace reg value
+      in
       begin[@ocaml.warning "-4"] match predecessor_terminator.desc with
       | Truth_test { ifso; ifnot } ->
         if Label.equal ifnot block.start && not (Label.equal ifso ifnot)
-        then replace predecessor_block.terminator.arg.(0) (Const_int 0n)
+        then
+          replace_unless_destroyed
+            predecessor_block.terminator.arg.(0)
+            (Const_int 0n)
       | Int_test { lt; eq; gt; is_signed = Signed; imm = Some const } ->
         if
           Label.equal eq block.start
           && (not (Label.equal eq gt))
           && not (Label.equal eq lt)
         then
-          replace
+          replace_unless_destroyed
             predecessor_terminator.arg.(0)
             (Const_int (Nativeint.of_int const))
       | Switch labels ->
@@ -206,7 +220,7 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         begin match idx with
         | None -> ()
         | Some idx ->
-          replace
+          replace_unless_destroyed
             predecessor_terminator.arg.(0)
             (Const_int (Nativeint.of_int idx))
         end

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -266,12 +266,13 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         begin match find_opt instr.res.(0) with
         | Some (Const_int c') ->
           (* Deleting the move makes the (unchanged) `live` fields an
-             under-approximation of actual liveness: the destination register
+             under-approximation of actual liveness: the destination location
              now carries its value from the previous write of the constant,
              across instructions whose `live` sets do not mention it. This is
-             safe for the current consumers of `live`: the register is an
-             integer register holding a compile-time integer constant, so
-             omitting it from the frame descriptors of the GC points it now
+             safe for the current consumers of `live`: the destination - an
+             integer register, or a stack slot if register allocation rewrote
+             the result to a spill slot - holds a compile-time integer constant,
+             so omitting it from the frame descriptors of the GC points it now
              crosses is harmless (its value is never a heap pointer), and its
              liveness cannot change the decision to save SIMD registers at such
              points. Extending the deletion to other kinds of constants requires

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -150,7 +150,8 @@ let find_unique_index : 'a array -> f:('a -> bool) -> int option =
    contains a map from registers to known values after the instructions have
    been executed. Currently only tracks constant values, moves between
    registers, basic integer arithmetic, and basic float64 arithmetic over known
-   values. *)
+   values. Deletes moves deemed to be useless given the information in
+   `known_values`. *)
 let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
     known_value Reg.UsingLocEquality.Tbl.t =
   let known_values = Reg.UsingLocEquality.Tbl.create 17 in
@@ -216,7 +217,9 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
   in
   if !Oxcaml_flags.cfg_value_propagation_flow
   then infer_known_values_from_predecessor ();
-  Dll.iter block.body ~f:(fun (instr : Cfg.basic Cfg.instruction) ->
+  Dll.iter_cell block.body
+    ~f:(fun (cell : Cfg.basic Cfg.instruction Dll.cell) ->
+      let instr = Dll.value cell in
       let apply_int_op op right_opt =
         let result_opt =
           match find_opt instr.arg.(0) with
@@ -245,7 +248,26 @@ let collect_known_values (cfg : Cfg.t) (block : Cfg.basic_block) :
         remove_destroyed instr
       in
       match instr.desc with
-      | Op (Const_int c) -> replace instr.res.(0) (Const_int c)
+      | Op (Const_int c) ->
+        begin match find_opt instr.res.(0) with
+        | Some (Const_int c') ->
+          (* Deleting the move makes the (unchanged) `live` fields an
+             under-approximation of actual liveness: the destination register
+             now carries its value from the previous write of the constant,
+             across instructions whose `live` sets do not mention it. This is
+             safe for the current consumers of `live`: the register is an
+             integer register holding a compile-time integer constant, so
+             omitting it from the frame descriptors of the GC points it now
+             crosses is harmless (its value is never a heap pointer), and its
+             liveness cannot change the decision to save SIMD registers at such
+             points. Extending the deletion to other kinds of constants requires
+             revisiting this reasoning. *)
+          if Nativeint.equal c c'
+          then Dll.delete_curr cell
+          else replace instr.res.(0) (Const_int c)
+        | Some (Const_float32 _ | Const_float _) | None ->
+          replace instr.res.(0) (Const_int c)
+        end
       | Op (Const_float32 c) ->
         if !Oxcaml_flags.cfg_value_propagation_float
         then replace instr.res.(0) (Const_float32 c)
@@ -433,20 +455,18 @@ let evaluate_terminator (known_values : known_value Reg.UsingLocEquality.Tbl.t)
   | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
     None
 
-let block_known_values (cfg : Cfg.t) (block : C.basic_block)
-    ~(is_after_regalloc : bool) ~(allowed_to_be_irreducible : bool) : bool =
-  if
-    !Oxcaml_flags.cfg_value_propagation
-    && is_after_regalloc && allowed_to_be_irreducible
-  then (
-    let known_values = collect_known_values cfg block in
+let block_known_values (block : C.basic_block)
+    ~(known_values : known_value Reg.UsingLocEquality.Tbl.t option)
+    ~(allowed_to_be_irreducible : bool) : bool =
+  match known_values with
+  | Some known_values when allowed_to_be_irreducible -> (
     match evaluate_terminator known_values block.terminator with
     | None -> false
     | Some succ ->
       block.terminator
         <- { block.terminator with desc = Always succ; arg = [||]; res = [||] };
       true)
-  else false
+  | Some _ | None -> false
 
 (* CR-someday gyorsh: merge (Lbranch | Lcondbranch | Lcondbranch3)+ into a
    single terminator when the argments are the same. Enables reordering of
@@ -462,6 +482,15 @@ let block_known_values (cfg : Cfg.t) (block : C.basic_block)
    this terminator? *)
 let block (cfg : C.t) (block : C.basic_block) : bool =
   let is_after_regalloc = cfg.register_locations_are_set in
+  (* Note: in addition to collecting the known values, the call to
+     [collect_known_values] deletes the constant moves made redundant by the
+     collected values; it is hence performed whatever the shape of the
+     terminator is. *)
+  let known_values =
+    if !Oxcaml_flags.cfg_value_propagation && is_after_regalloc
+    then Some (collect_known_values cfg block)
+    else None
+  in
   match block.terminator.desc with
   | Always successor_label ->
     (* If we have a jump to an empty block whose terminator is a condition, we
@@ -471,21 +500,18 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
     if Dll.is_empty successor_block.body
     then
       (* CR-soon xclerc for xclerc: this logic is similar to the one of
-         `block_known_values`, except for the guard and whether one or two
-         blocks are involved. *)
+         `block_known_values`, except for whether one or two blocks are
+         involved. *)
       let new_successor =
         (* The graph may become irreducible if the successor block is the header
            block of a loop. Indeed, if we shortcircuit that block, it means we
            are jumping "inside" the loop directly, which in turn means the loop
            is no longer natural. This is acceptable if we are past the last use
            of the loop information. *)
-        if
-          !Oxcaml_flags.cfg_value_propagation
-          && is_after_regalloc && cfg.allowed_to_be_irreducible
-        then
-          let known_values = collect_known_values cfg block in
+        match known_values with
+        | Some known_values when cfg.allowed_to_be_irreducible ->
           evaluate_terminator known_values successor_block.terminator
-        else None
+        | Some _ | None -> None
       in
       match new_successor with
       | Some succ ->
@@ -534,11 +560,11 @@ let block (cfg : C.t) (block : C.basic_block) : bool =
         <- { block.terminator with desc = Always l; arg = [||]; res = [||] };
       false)
     else
-      block_known_values cfg block ~is_after_regalloc
+      block_known_values block ~known_values
         ~allowed_to_be_irreducible:cfg.allowed_to_be_irreducible
   | Switch labels ->
     let shortcircuit =
-      block_known_values cfg block ~is_after_regalloc
+      block_known_values block ~known_values
         ~allowed_to_be_irreducible:cfg.allowed_to_be_irreducible
     in
     if shortcircuit

--- a/testsuite/tests/codegen/constant_move_elimination.ml
+++ b/testsuite/tests/codegen/constant_move_elimination.ml
@@ -1,0 +1,132 @@
+(* TEST
+ flags += " -O3";
+ flags += " -cfg-prologue-shrink-wrap";
+ flags += " -x86-peephole-optimize";
+ flags += " -regalloc-param SPLIT_AROUND_LOOPS:on";
+ flags += " -regalloc-param AFFINITY:on -regalloc irc";
+ flags += " -cfg-merge-blocks";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Codegen tests for the deletion of redundant constant moves by
+   [Simplify_terminator]: a move of a constant to a register statically known
+   to already contain that constant is deleted. The constant below is too wide
+   for an immediate operand, so every use requires a move to a register. *)
+
+(* The constant is moved to a single register, used twice: the second move is
+   deleted. *)
+let[@inline never] same_constant x y =
+  (x + 0x11223344556677) lxor (y + 0x11223344556677)
+[%%expect_asm X86_64{|
+same_constant:
+  movabsq $9645356378410222, %rdi
+  addq  %rdi, %rbx
+  addq  %rdi, %rax
+  xorq  %rbx, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* Both moves are kept: when the second move is reached, the register contains
+   a different constant. *)
+let[@inline never] different_constants x y =
+  (x + 0x11223344556677) lxor (y + 0x77665544332211)
+[%%expect_asm X86_64{|
+different_constants:
+  movabsq $67216077262046242, %rdi
+  addq  %rdi, %rbx
+  movabsq $9645356378410222, %rdi
+  addq  %rdi, %rax
+  xorq  %rbx, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* Both moves are kept: the second move is in another block, and register
+   contents are not tracked across block boundaries (here, a call). *)
+let[@inline never] callee _ = ()
+[%%expect_asm X86_64{|
+callee:
+  movl  $1, %eax
+  ret
+|}]
+
+let[@inline never] call_between x y =
+  let a = x + 0x11223344556677 in
+  callee a;
+  a lxor (y + 0x11223344556677)
+[%%expect_asm X86_64{|
+call_between:
+  subq  $24, %rsp
+  movq  %rbx, (%rsp)
+  movabsq $9645356378410222, %rbx
+  addq  %rbx, %rax
+  movq  <hidden PC-relative offset>(%rip), %rbx
+  movq  24(%rbx), %rbx
+  movq  (%rbx), %rdi
+  movq  %rax, 8(%rsp)
+  call  *%rdi
+.L0:
+  movabsq $9645356378410222, %rax
+  movq  (%rsp), %rbx
+  addq  %rax, %rbx
+  movq  8(%rsp), %rax
+  xorq  %rbx, %rax
+  orq   $1, %rax
+  addq  $24, %rsp
+  ret
+|}]
+
+(* The second move is deleted: the instructions in between do not modify the
+   register containing the constant. *)
+let[@inline never] div_const_between x y =
+  let a = x + 0x11223344556677 in
+  let b = a / 3 in
+  b lxor (y + 0x11223344556677)
+[%%expect_asm X86_64{|
+div_const_between:
+  movabsq $9645356378410222, %rdi
+  addq  %rdi, %rax
+  sarq  $1, %rax
+  addq  %rbx, %rdi
+  movq  %rax, %rbx
+  shrq  $63, %rbx
+  movabsq $6148914691236517206, %rsi
+  imulq %rsi
+  leaq  (%rdx,%rbx), %rax
+  leaq  1(%rax,%rax), %rax
+  xorq  %rdi, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* The second move is deleted, in a block ending with an unconditional jump to
+   a non-empty block (the join point); the deletion used to be performed only
+   for some shapes of terminators. *)
+let[@inline never] branch_then_join p x y =
+  let r =
+    if p
+    then (x + 0x11223344556677) lxor (y + 0x11223344556677)
+    else x * y
+  in
+  r + 1
+[%%expect_asm X86_64{|
+branch_then_join:
+  cmpq  $1, %rax
+  jne   .L0
+  sarq  $1, %rdi
+  leaq  -1(%rbx), %rax
+  imulq %rdi, %rax
+  incq  %rax
+  jmp   .L1
+.L0:
+  movabsq $9645356378410222, %rax
+  addq  %rax, %rdi
+  addq  %rbx, %rax
+  xorq  %rdi, %rax
+  orq   $1, %rax
+.L1:
+  addq  $2, %rax
+  ret
+|}]

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -83,7 +83,6 @@ logand_branch:
   movq  (%rbx), %rdi
   jmp   *%rdi
 .L0:
-  movl  $1, %eax
   ret
 |}]
 

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -105,7 +105,6 @@ unsigned_div:
   jge   .L1
   movabsq $-9223372036854775808, %rax
   subq  %rax, %rcx
-  movabsq $-9223372036854775808, %rax
   subq  %rax, %rdi
   cmpq  %rcx, %rdi
   jge   .L0

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -538,7 +538,6 @@ unsigned_compare:
   movq  %rax, %rdi
   movabsq $-9223372036854775808, %rax
   subq  %rax, %rbx
-  movabsq $-9223372036854775808, %rax
   subq  %rax, %rdi
   movq  $-1, %rsi
   xorl  %eax, %eax

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -35,7 +35,6 @@ loop_code_layout:
   cmpq  $1, %rax
   jne   .L2
   movq  %rbx, (%rsp)
-  movl  $1, %eax
   call  camlTOP2__cold_1_4_code@PLT
 .L1:
   movq  (%rsp), %rax


### PR DESCRIPTION
(Very early draft, for illustration purposes only.)

When we know the value of a register (using
value propagation), and see a constant move
of the same value, we simply delete the move.
This draft is very partial, and should at the very
least be extended to handle more cases.

To be less abstract, given the following code:

```ocaml
let[@inline never] f1 _ = ()
let[@inline never] f2 _ = ()

let g x =
  match x with
  | Null -> f1 Null
  | This x -> f2 x
```

we used to get:

```asm
	testq	%rax, %rax
	jne	L112
	xorl	%eax, %eax
	jmp	_camlT00__f1_0_3_code
L112:
	jmp	_camlT00__f2_1_4_code
```

this pull request leads to the deletion of the
`xorl` instruction.