### PR TITLE
Cmm peephole: collapse [Cifthenelse (c, x, x)] when [x] is identical

### DIFF
--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -3203,8 +3203,15 @@ module SArgBlocks = struct
   let arg_as_test arg = arg
 
   let make_if () cond ifso ifnot =
-    Cifthenelse
-      (cond, Debuginfo.none, ifso, Debuginfo.none, ifnot, Debuginfo.none)
+    (* See [ite] below for the rationale for this peephole. [cond] is always a
+       comparison built by [make_isin]/[make_isout]/etc., so [Csequence]
+       directly is safe (the [sequence] helper that handles [Ctuple []]
+       specially is defined below this module). *)
+    if P.Cmm_comparator.equivalent ifso ifnot
+    then Csequence (cond, ifso)
+    else
+      Cifthenelse
+        (cond, Debuginfo.none, ifso, Debuginfo.none, ifnot, Debuginfo.none)
 
   let make_switch dbg () arg cases actions =
     let actions = Array.map (fun expr -> expr, dbg) actions in
@@ -4681,7 +4688,17 @@ let sequence x y =
   | _, _ -> Csequence (x, y)
 
 let ite ~dbg ~then_dbg ~then_ ~else_dbg ~else_ cond =
-  Cifthenelse (cond, then_dbg, then_, else_dbg, else_, dbg)
+  (* If the two branches are syntactically equivalent (modulo debug info), we
+     don't need to dispatch on [cond]: every execution evaluates the same
+     expression. We keep [cond] under [sequence] to preserve its effects and
+     coeffects; later passes (DCE/CSE) can drop it if it turns out to be pure.
+     This commonly fires when the match compiler produces per-arm field accesses
+     that disagree at the lambda level (e.g. [Pmixedfield]s on constructors with
+     different total field counts) but resolve to the same [Block_load] /
+     [Cload] in Cmm. *)
+  if P.Cmm_comparator.equivalent then_ else_
+  then sequence cond then_
+  else Cifthenelse (cond, then_dbg, then_, else_dbg, else_, dbg)
 
 let trywith ~dbg ~body ~exn_var ~extra_args ~handler_cont ~handler () =
   Ccatch

--- a/testsuite/tests/codegen/if_identical_branches.ml
+++ b/testsuite/tests/codegen/if_identical_branches.ml
@@ -1,0 +1,76 @@
+(* TEST
+ flags += " -O3";
+ flags += " -extension layouts_alpha";
+ flags += " -cfg-prologue-shrink-wrap";
+ flags += " -x86-peephole-optimize";
+ flags += " -regalloc-param SPLIT_AROUND_LOOPS:on";
+ flags += " -regalloc-param AFFINITY:on -regalloc irc";
+ flags += " -cfg-merge-blocks";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* The match compiler emits per-arm field accesses that disagree at the lambda
+   level (e.g. [Pmixedfield]s on constructors with different total field
+   counts), even when those accesses resolve to the same [Block_load] / [Cload]
+   in Cmm. Without help, the resulting [Cifthenelse (cond, x, x)] is preserved
+   all the way to the assembly. [Cmm_helpers.ite] collapses it. *)
+
+type unboxed = #{ foo : int; bar : int }
+
+module Length_of_mixed_variant = struct
+  type 'a t =
+    | Short of { length : int; tail : unboxed }
+    | Long of { length : int; tail : unboxed; shift : int }
+
+  (* Field 0 is at physical offset 0 in both constructors, so the two
+     [Pmixedfield]s collapse to identical [Cload]s in Cmm. *)
+  let length (Short { length; _ } | Long { length; _ }) = length
+end
+[%%expect_asm X86_64{|
+Length_of_mixed_variant.length:
+  movq  (%rax), %rax
+  ret
+|}]
+
+module Tail_of_mixed_variant = struct
+  type 'a t =
+    | Short of { length : int; tail : unboxed }
+    | Long of { length : int; tail : unboxed }
+
+  (* Both constructors have the same physical layout for the [tail] product, so
+     the two Cmm loads at offsets 1 and 2 are identical between arms. *)
+  let tail (Short { tail; _ } | Long { tail; _ }) = tail
+end
+[%%expect_asm X86_64{|
+Tail_of_mixed_variant.tail:
+  movq  16(%rax), %rbx
+  movq  8(%rax), %rax
+  ret
+|}]
+
+(* Sanity check: when the two branches really do differ (here the unscannable
+   [int64#] suffix lives at different offsets), the conditional must survive. *)
+
+type mixed_unboxed = #{ foo : int64#; bar : int }
+
+module Differing_branches = struct
+  type 'a t =
+    | Short of { length : int; tail : mixed_unboxed }
+    | Long of { length : int; tail : mixed_unboxed; shift : int }
+
+  let tail (Short { tail; _ } | Long { tail; _ }) = tail
+end
+[%%expect_asm X86_64{|
+Differing_branches.tail:
+  movzbq -8(%rax), %rbx
+  testq %rbx, %rbx
+  je    .L0
+  movq  8(%rax), %rbx
+  movq  24(%rax), %rax
+  ret
+.L0:
+  movq  8(%rax), %rbx
+  movq  16(%rax), %rax
+  ret
+|}]


### PR DESCRIPTION
When the match compiler produces or-patterns over constructors with different layouts (e.g. [Pmixedfield]s with different total field counts), the two arms may emit syntactically distinct Lambda primitives that resolve to byte-for-byte identical [Cload]s in Cmm. Flambda 2's switch-arm merger only merges arms that [Apply_cont] the same continuation with compatible arguments, so the dispatch survives all the way to assembly even when both branches are identical.

Example trigger (with [-extension layouts_alpha]):

  type unboxed = #{ foo : int; bar : int }
  type 'a t =
    | Short of { length : int; tail : unboxed }
    | Long  of { length : int; tail : unboxed; shift : int }

  let length (Short { length; _ } | Long { length; _ }) = length

Before this change the body compiles to:

  movzbq -8(%rax), %rbx
  testq  %rbx, %rbx
  je     .L0
  movq   (%rax), %rax
  ret
.L0:
  movq   (%rax), %rax
  ret

After:

  movq   (%rax), %rax
  ret

The peephole lives in [Cmm_helpers.ite] (used by [to_cmm_expr] when lowering 2-arm switches) and the analogous [SArgBlocks.make_if] (used by the switcher). It uses [Cmm_peephole_engine.Cmm_comparator.equivalent], which already implements structural Cmm equality modulo debug info, so no new comparison code is needed.

We keep [cond] under [Csequence] / [sequence] to preserve its effects and coeffects; later passes (CFG dead-code elimination via [Cfg.is_pure_basic]) drop pure conditions whose result is dead, so for the common case of dispatching on a tag-byte load the tag load is also removed and we emit a single [movq].