### PR TITLE
[5.4] Add `--enable-keyword-edition` configure option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,19 +51,19 @@ jobs:
           # We use a custom install prefix for this workflow.
           # Consider renaming it to indicate as such when convenient.
           - name: runtime5 dev (x86_64-linux)
-            config: --enable-runtime5 --enable-dev
+            config: --enable-runtime5 --enable-dev --enable-keyword-edition=5.2
             os: warp-ubuntu-latest-x64-8x
             install_path: _custom_install
 
           - name: runtime5 debug stack-checks (x86_64-linux)
-            config: --enable-runtime5 --enable-stack-checks
+            config: --enable-runtime5 --enable-stack-checks --enable-keyword-edition=5.4
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: ''
             use_runtime: d
             ocamlrunparam: "v=0,V=1"
 
           - name: runtime5 debug (x86_64-linux)
-            config: --enable-runtime5
+            config: --enable-runtime5 --enable-keyword-edition=5.2+effect
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: ''
             use_runtime: d

--- a/configure.ac
+++ b/configure.ac
@@ -892,18 +892,25 @@ AC_ARG_ENABLE([assembler-suitable-for-dissector],
     [Use LLVM assembler with large code mode for dissector. If PATH is not
      specified, llvm-mc must be on PATH.  Overrides any setting of AS])])
 
-AC_ARG_ENABLE([keyword-version],
-  [AS_HELP_STRING([--enable-keyword-version=X.Y],
+AC_ARG_ENABLE([keyword-edition],
+  [AS_HELP_STRING([--enable-keyword-edition=X.Y@<:@+keyword@:>@@<:@+...@:>@],
     [Use the keyword set of OCaml X.Y by default; keywords from later versions
      are able to be used as identifiers.])],
-  [AS_CASE([$enable_keyword_version],
+  [dnl cf. Clflags.parse_keyword_edition
+   edition="${enable_keyword_edition%%+*}"
+   keywords="${enable_keyword_edition[#]*+}"
+   test x"$keywords" != x"$enable_keyword_edition" || keywords=''
+   dnl The strange dnl' on the next line is for syntax highlighting!
+   AS_IF([test x"$(echo "$keywords" | tr -d "[[:alnum:]]'+_")" != 'x'], dnl'
+    [AC_MSG_ERROR([invalid argument to --enable-keyword-edition])])
+   keywords="$(echo "$keywords" | sed -e 's/[[^+]][[^+]]*/"&"/g;s/+/; /g')"
+   AS_CASE([$edition],
     [[[1-9]].[[0-9]]|[[1-9]].[[0-9]][[0-9]]],
-      [v="$enable_keyword_version"
-       default_keyword_version="Some (${v%.*}, ${v[#]*.})"],
-    [no], [default_keyword_version='None'],
-    [AC_MSG_ERROR([invalid argument to --enable-keyword-version])])],
-  [default_keyword_version='None'])
-AC_SUBST([default_keyword_version])
+      [default_keyword_edition="Some (${edition%.*}, ${edition[#]*.}), [[$keywords]]"],
+    [no], [default_keyword_edition='None, [[]]'],
+    [AC_MSG_ERROR([invalid argument to --enable-keyword-edition])])],
+  [default_keyword_edition='None, [[]]'])
+AC_SUBST([default_keyword_edition])
 
 AC_ARG_WITH([flexdll],
   [AS_HELP_STRING([--with-flexdll],

--- a/configure.ac
+++ b/configure.ac
@@ -892,6 +892,19 @@ AC_ARG_ENABLE([assembler-suitable-for-dissector],
     [Use LLVM assembler with large code mode for dissector. If PATH is not
      specified, llvm-mc must be on PATH.  Overrides any setting of AS])])
 
+AC_ARG_ENABLE([keyword-version],
+  [AS_HELP_STRING([--enable-keyword-version=X.Y],
+    [Use the keyword set of OCaml X.Y by default; keywords from later versions
+     are able to be used as identifiers.])],
+  [AS_CASE([$enable_keyword_version],
+    [[[1-9]].[[0-9]]|[[1-9]].[[0-9]][[0-9]]],
+      [v="$enable_keyword_version"
+       default_keyword_version="Some (${v%.*}, ${v[#]*.})"],
+    [no], [default_keyword_version='None'],
+    [AC_MSG_ERROR([invalid argument to --enable-keyword-version])])],
+  [default_keyword_version='None'])
+AC_SUBST([default_keyword_version])
+
 AC_ARG_WITH([flexdll],
   [AS_HELP_STRING([--with-flexdll],
     [bootstrap FlexDLL from the given sources])],

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -1293,7 +1293,7 @@ and skip_hash_bang = parse
     in
       loop NoLine Initial lexbuf
 
-  let init ?(keyword_edition=None,[]) () =
+  let init ?(keyword_edition=Config.default_keyword_version,[]) () =
     populate_keywords keyword_edition;
     is_in_string := false;
     comment_start_loc := [];

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -1293,7 +1293,7 @@ and skip_hash_bang = parse
     in
       loop NoLine Initial lexbuf
 
-  let init ?(keyword_edition=Config.default_keyword_version,[]) () =
+  let init ?(keyword_edition=Config.default_keyword_edition) () =
     populate_keywords keyword_edition;
     is_in_string := false;
     comment_start_loc := [];

--- a/testsuite/tests/effect-syntax/coroutines.ml
+++ b/testsuite/tests/effect-syntax/coroutines.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Printf
 open Effect

--- a/testsuite/tests/effect-syntax/error_messages.ml
+++ b/testsuite/tests/effect-syntax/error_messages.ml
@@ -1,4 +1,5 @@
 (* TEST
+  flags += "-keywords 5.3";
   expect;
 *)
 

--- a/testsuite/tests/effect-syntax/iterators.ml
+++ b/testsuite/tests/effect-syntax/iterators.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Printf
 open Effect

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -1,4 +1,5 @@
 (* TEST
+  flags += "-keywords 5.3";
   expect;
 *)
 

--- a/testsuite/tests/effect-syntax/resume_exn.ml
+++ b/testsuite/tests/effect-syntax/resume_exn.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Printf
 open Effect

--- a/testsuite/tests/effect-syntax/shallow2deep.ml
+++ b/testsuite/tests/effect-syntax/shallow2deep.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Printf
 open Effect

--- a/testsuite/tests/effect-syntax/test1.ml
+++ b/testsuite/tests/effect-syntax/test1.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Effect
 open Effect.Deep

--- a/testsuite/tests/effect-syntax/test10.ml
+++ b/testsuite/tests/effect-syntax/test10.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Effect
 open Effect.Deep

--- a/testsuite/tests/effect-syntax/test11.ml
+++ b/testsuite/tests/effect-syntax/test11.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 (* Tests RESUMETERM with extra_args != 0 in bytecode,
    by calling a handler with a tail-continue that returns a function *)

--- a/testsuite/tests/effect-syntax/test2.ml
+++ b/testsuite/tests/effect-syntax/test2.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Printf
 open Effect

--- a/testsuite/tests/effect-syntax/test3.ml
+++ b/testsuite/tests/effect-syntax/test3.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Effect
 open Effect.Deep

--- a/testsuite/tests/effect-syntax/test4.ml
+++ b/testsuite/tests/effect-syntax/test4.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Effect
 open Effect.Deep

--- a/testsuite/tests/effect-syntax/test5.ml
+++ b/testsuite/tests/effect-syntax/test5.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Effect
 open Effect.Deep

--- a/testsuite/tests/effect-syntax/test6.ml
+++ b/testsuite/tests/effect-syntax/test6.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Effect
 open Effect.Deep

--- a/testsuite/tests/effect-syntax/tutorial.ml
+++ b/testsuite/tests/effect-syntax/tutorial.ml
@@ -1,4 +1,6 @@
-(* TEST *)
+(* TEST
+  flags += "-keywords 5.3";
+*)
 
 open Printf
 open Effect

--- a/testsuite/tests/effect-syntax/when_test.ml
+++ b/testsuite/tests/effect-syntax/when_test.ml
@@ -1,4 +1,5 @@
 (* TEST
+  flags += "-keywords 5.3";
   toplevel;
 *)
 

--- a/testsuite/tests/parsetree/test.ml
+++ b/testsuite/tests/parsetree/test.ml
@@ -119,6 +119,7 @@ let rec process ~(here : [%call_pos]) ?universe_for_parsing path =
       path
 
 let () =
+  Clflags.keyword_edition := Some "5.3";
   process "source.ml";
   process "source_jane_street.ml" ~universe_for_parsing:Language_extension.Universe.maximal;
   (* Check that parsing with no extensions enabled still succeeds.

--- a/testsuite/tests/typing-local/effects.ml
+++ b/testsuite/tests/typing-local/effects.ml
@@ -1,6 +1,7 @@
 (* TEST
    runtime5;
    stack-allocation;
+   flags += "-keywords 5.3";
    { native; }
 *)
 

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -151,4 +151,4 @@ let objcopy = {@QS@|@objcopy@|@QS@}
 
 let oxcaml_dwarf = "@enable_oxcaml_dwarf@" = "yes"
 
-let default_keyword_version = @default_keyword_version@
+let default_keyword_edition = @default_keyword_edition@

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -150,3 +150,5 @@ let objcopy_compress_debug_sections_flag = {@QS@|@objcopy_compress_debug_section
 let objcopy = {@QS@|@objcopy@|@QS@}
 
 let oxcaml_dwarf = "@enable_oxcaml_dwarf@" = "yes"
+
+let default_keyword_version = @default_keyword_version@

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -423,3 +423,6 @@ val has_fma : bool
 
 val oxcaml_dwarf : bool
 (* Whether OxCaml DWARF is used by default *)
+
+val default_keyword_version : (int * int) option
+(** The default set of keywords to assume when -keywords is not specified. *)

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -424,5 +424,5 @@ val has_fma : bool
 val oxcaml_dwarf : bool
 (* Whether OxCaml DWARF is used by default *)
 
-val default_keyword_version : (int * int) option
-(** The default set of keywords to assume when -keywords is not specified. *)
+val default_keyword_edition : (int * int) option * string list
+(** The default keyword edition to assume when -keywords is not specified. *)


### PR DESCRIPTION
Allows OxCaml to be configured with `--enable-keyword-version=5.2` which keeps `effect` as an identifier by default. OxCaml keywords are unaffected.