### PR TITLE
Avoid collecting profile info when not profiling

### DIFF
--- a/utils/profile.ml
+++ b/utils/profile.ml
@@ -103,6 +103,7 @@ let initial_measure = ref None
 let reset () = hierarchy := create (); initial_measure := None
 
 let record_call_internal ?(accumulate = false) ?counter_f name f =
+  if !Clflags.profile_columns = [] then f () else
   let E prev_hierarchy = !hierarchy in
   let start_measure = Measure.create () in
   if !initial_measure = None then initial_measure := Some start_measure;


### PR DESCRIPTION
The profiling system used by `-dprofile` / `-dcounters` / `-dtimings` is surprisingly slow, particularly because the backend makes very many calls to `Profile.record_call` (one per function per phase). Unfortunately, this overhead is always present, even if no profiling is in use. This patch avoids this overhead if profiling is not enabled.

In a microbenchmark with lots of small functions (1000 copies of `let f a b c = a, b, c`), this patch makes compilation 30-35% faster (!). I've seen 15% in some real programs (particularly large link jobs, that generate lots of small caml_curryN functions), but I expect a smaller improvement in general.

There's some future work to make this profiling not be slow even when enabled. The first part of that is #6139 but there's more to do.