### PR TITLE
Fix: any-record refined to all-float64 gets `Record_boxed`

### DIFF
--- a/testsuite/tests/typing-layouts/any_in_record.ml
+++ b/testsuite/tests/typing-layouts/any_in_record.ml
@@ -406,3 +406,38 @@ Error: Signature mismatch:
        Hint: Is there a type that has a representable layout in the first
          but has layout any in the second?
 |}]
+
+(* [@@flatten_floats] *)
+
+type ('a : any) t = { a : 'a }
+[@@flatten_floats]
+[%%expect{|
+Lines 1-2, characters 0-18:
+1 | type ('a : any) t = { a : 'a }
+2 | [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}]
+
+type ('a : any) t = { a : 'a; f : float }
+[@@flatten_floats]
+[%%expect{|
+Lines 1-2, characters 0-18:
+1 | type ('a : any) t = { a : 'a; f : float }
+2 | [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}]
+
+type ('a : any) t = { a : 'a; f : float# }
+[@@flatten_floats]
+[%%expect{|
+Lines 1-2, characters 0-18:
+1 | type ('a : any) t = { a : 'a; f : float# }
+2 | [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}]

--- a/testsuite/tests/typing-layouts/any_in_types.ml
+++ b/testsuite/tests/typing-layouts/any_in_types.ml
@@ -131,11 +131,17 @@ end = struct
   type t = #{ i : int; r : Rec_unboxed_record_1.t }
 end
 
-(* Refining block with any to all-float64 record *)
 type ('a : any) t = { a : 'a }
 
+(* Refining block with any to all-float64 record *)
 let () =
   let t : float# t = { a = #1.0 } in
   let f = t.a in
   Printf.printf "Printing a float#: %f\n"
     (Stdlib_upstream_compatible.Float_u.to_float f)
+
+(* Refining block with any to float record *)
+let () =
+  let x : float t = { a = 1.0 } in
+  let y = x.a +. 1.0 in
+  Printf.printf "Printing a float: %f\n" y

--- a/testsuite/tests/typing-layouts/any_in_types.ml
+++ b/testsuite/tests/typing-layouts/any_in_types.ml
@@ -137,11 +137,22 @@ type ('a : any) t = { a : 'a }
 let () =
   let t : float# t = { a = #1.0 } in
   let f = t.a in
-  Printf.printf "Printing a float#: %f\n"
+  Printf.printf "Refining to float64 ==\n";
+  Printf.printf "%f\n"
     (Stdlib_upstream_compatible.Float_u.to_float f)
 
 (* Refining block with any to float record *)
 let () =
+  Printf.printf "Refining to float ==\n";
   let x : float t = { a = 1.0 } in
   let y = x.a +. 1.0 in
-  Printf.printf "Printing a float: %f\n" y
+  Printf.printf "%f\n" y
+
+(* Refining block with any to float-float64 record *)
+type ('a : any) mixed = { f : float; a : 'a }
+let () =
+  Printf.printf "Refining to mixed ==\n";
+  let x : float# mixed = { f = 1.; a = #10.0 } in
+  Printf.printf "%f\n" x.f;
+  Printf.printf "%f\n"
+    (Stdlib_upstream_compatible.Float_u.to_float x.a)

--- a/testsuite/tests/typing-layouts/any_in_types.ml
+++ b/testsuite/tests/typing-layouts/any_in_types.ml
@@ -130,3 +130,12 @@ and Rec_unboxed_record_2 : sig
 end = struct
   type t = #{ i : int; r : Rec_unboxed_record_1.t }
 end
+
+(* Refining block with any to all-float64 record *)
+type ('a : any) t = { a : 'a }
+
+let () =
+  let t : float# t = { a = #1.0 } in
+  let f = t.a in
+  Printf.printf "Printing a float#: %f\n"
+    (Stdlib_upstream_compatible.Float_u.to_float f)

--- a/testsuite/tests/typing-layouts/any_in_types.reference
+++ b/testsuite/tests/typing-layouts/any_in_types.reference
@@ -8,5 +8,10 @@ a
 b
 c
 d
-Printing a float#: 1.000000
-Printing a float: 2.000000
+Refining to float64 ==
+1.000000
+Refining to float ==
+2.000000
+Refining to mixed ==
+1.000000
+10.000000

--- a/testsuite/tests/typing-layouts/any_in_types.reference
+++ b/testsuite/tests/typing-layouts/any_in_types.reference
@@ -9,3 +9,4 @@ b
 c
 d
 Printing a float#: 1.000000
+Printing a float: 2.000000

--- a/testsuite/tests/typing-layouts/any_in_types.reference
+++ b/testsuite/tests/typing-layouts/any_in_types.reference
@@ -8,3 +8,4 @@ a
 b
 c
 d
+Printing a float#: 1.000000

--- a/testsuite/tests/typing-layouts/mixed_records.ml
+++ b/testsuite/tests/typing-layouts/mixed_records.ml
@@ -473,3 +473,31 @@ Error: The "[@@flatten_floats]" attribute is only allowed on records with one or
        non-atomic "float" fields, one or more "float#" fields, and all other fields
        void.
 |}];;
+
+(* void accepted *)
+type t =
+  { a : float#;
+    b : float;
+    u : unit#;
+  } [@@flatten_floats]
+[%%expect{|
+type t = { a : float#; b : float; u : unit#; }
+|}];;
+
+(* product of voids not counted as void *)
+type bad =
+  { a : float#;
+    b : float;
+    u : #(unit# * unit#);
+  } [@@flatten_floats]
+[%%expect{|
+Lines 1-5, characters 0-22:
+1 | type bad =
+2 |   { a : float#;
+3 |     b : float;
+4 |     u : #(unit# * unit#);
+5 |   } [@@flatten_floats]
+Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
+       non-atomic "float" fields, one or more "float#" fields, and all other fields
+       void.
+|}];;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2145,6 +2145,19 @@ let compute_record_repr
   (* Any record with a field of kind [any] can't be represented. *)
   | ~first_any:(Some id), .. ->
     Result.Error (Unrepresentable_field (Ident.name id))
+  | ~values:false, ~floats:false, ~atomic_floats:false,
+    ~float64s:true, ~non_float64_unboxed_fields:false,
+    ~voids:false, ~first_any:None, .. ->
+    if represent_as_float_array then begin
+      if refining_block_with_any then
+        (* CR-soon rtjoa: This fatal error is included for an abundance of
+           caution. We should make this function more defensive as a whole *)
+        Misc.fatal_error
+          "Typedecl.compute_record_repr: refining any with \
+           [@@represent_as_float_array]";
+      Ok Record_ufloat
+    end else
+      mixed_record ()
   (* For other mixed blocks, float fields are stored as flat
       only when they're unboxed.
   *)
@@ -2167,13 +2180,6 @@ let compute_record_repr
       ~float64s:false, ~non_float64_unboxed_fields:false,
       ~voids:false, ~first_any:None, .. ->
     Ok Record_float
-  | ~values:false, ~floats:false, ~atomic_floats:false,
-    ~float64s:true, ~non_float64_unboxed_fields:false,
-    ~voids:false, ~first_any:None, .. ->
-    if represent_as_float_array then
-      Ok Record_ufloat
-    else
-      mixed_record ()
   (* Records with atomic float fields cannot use flat representation *)
   | ~atomic_floats:true, ~first_any:None, .. ->
     if warn && floats && not values

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2163,15 +2163,17 @@ let compute_record_repr
   *)
   | ~values:true, ~voids:true, ~atomic_fields:false, ..
   | ~floats:true, ~voids:true, ~atomic_fields:false, ..
+  | ~floats:true, ~float64s:true, ~atomic_fields:false, ..
   | ~float64s:true, ~voids:true, ~atomic_fields:false, ..
   | ~values:true, ~float64s:true, ~atomic_fields:false, ..
   | ~non_float64_unboxed_fields:true, ~atomic_fields:false, .. ->
     mixed_record ()
-  (* value-only records are stored as boxed records, as are records whose
-      declared types have fields of kind [any] *)
-  | ~values:true, ~float64s:false, ~non_float64_unboxed_fields: false,
+  (* value-only records are stored as boxed records, including records whose
+     declared types have fields of kind [any] *)
+  | ~values:true, ~float64s:false, ~non_float64_unboxed_fields:false,
       ~voids:false, ..
-  | ~refining_block_with_any:true, .. ->
+  | ~refining_block_with_any:true, ~float64s:false,
+      ~non_float64_unboxed_fields:false, ~voids:false, .. ->
     Ok Record_boxed
   (* All-nonatomic-float and all-nonatomic-float64 records are stored as
       flat float records.


### PR DESCRIPTION
Currently, when refining a record containing `any`, to an all-`float64` record, we incorrectly compute representation `Record_boxed`.

This causes `ocamlopt` to fatal error for the following:  
```ocaml
type ('a : any) t = { a : 'a }

let () =
  let t : float# t = { a = #1.0 } in
  let f = t.a in
  Printf.printf "Printing a float#: %f\n"
    (Stdlib_upstream_compatible.Float_u.to_float f)
```
```
>> Fatal error: Unboxed constants are not allowed inside of Const_block: 
[0: #1.0]
Fatal error: exception Misc.Fatal_error
```

This PR fixes the above, and also adds some extra tests around record representation computation.