### PR TITLE
Add Lambda primitive for creating module blocks

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -527,7 +527,8 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         assert (kind = kind');
         comp_expr (Lambda.Lprim (Pmakearray (kind, mutability, m), args, loc))
       | _ -> unary (Ccall "caml_obj_dup"))
-    | Pmakeblock (tag, _mut, shape, _) -> (
+    | Pmakeblock (tag, _mut, shape, _)
+    | Pinit_module_block (tag, _mut, shape, _, _) -> (
       match Lambda.mixed_block_of_block_shape shape with
       | None -> pseudo_event (variadic (Makeblock { tag }))
       | Some shape ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -154,6 +154,8 @@ type primitive =
   | Pgetpredef of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * locality_mode
+  | Pinit_module_block of
+      int * mutable_flag * block_shape * locality_mode * Path.t
   | Pmakefloatblock of mutable_flag * locality_mode
   | Pmakeufloatblock of mutable_flag * locality_mode
   | Pmakelazyblock of lazy_block_tag
@@ -2435,6 +2437,7 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Pignore -> None
   | Pgetglobal _ | Pgetpredef _ -> None
   | Pmakeblock (_, _, _, m) -> Some m
+  | Pinit_module_block (_, _, _, m, _) -> Some m
   | Pmakefloatblock (_, m) -> Some m
   | Pmakeufloatblock (_, m) -> Some m
   | Pmakelazyblock _ -> Some alloc_heap
@@ -2657,7 +2660,7 @@ let primitive_can_raise prim =
   | Pbigarrayset (_, _, _, Pbigarray_unknown_layout) ->
     true
   | Pbytes_to_string | Pbytes_of_string | Parray_of_iarray | Parray_to_iarray
-  | Pignore | Pgetglobal _ | Pgetpredef _ | Pmakeblock _
+  | Pignore | Pgetglobal _ | Pgetpredef _ | Pmakeblock _ | Pinit_module_block _
   | Pmakefloatblock _ | Pfield _ | Pfield_computed _ | Psetfield _
   | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
   | Pmakeufloatblock _ | Pufloatfield _ | Psetufloatfield _ | Psequand | Psequor
@@ -3036,7 +3039,8 @@ let primitive_result_layout (p : primitive) =
   | Pgetglobal _ -> layout_module
     (* Note the assumption that predefs are always values *)
   | Pgetpredef _ -> layout_predef_value
-  | Pmakeblock _ | Pmakefloatblock _ | Pmakearray _ | Pmakearray_dynamic _
+  | Pmakeblock _ | Pinit_module_block _ | Pmakefloatblock _ | Pmakearray _
+  | Pmakearray_dynamic _
   | Pduprecord _ | Pmakeufloatblock _ | Pmakelazyblock _
   | Pduparray _ | Pbigarraydim _ | Pobj_dup -> layout_block
   | Pfield _ | Pfield_computed _ -> layout_value_field

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -131,6 +131,12 @@ type primitive =
   | Pgetpredef of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape * locality_mode
+  | Pinit_module_block of
+      int * mutable_flag * block_shape * locality_mode * Path.t
+    (** Like [Pmakeblock], but additionally records that the resulting block
+        is the value of the module identified by the given [Path.t].
+        Semantically identical to [Pmakeblock]; the path is metadata for
+        downstream consumers. Emitted only by [Translmod]. *)
   | Pmakefloatblock of mutable_flag * locality_mode
   | Pmakeufloatblock of mutable_flag * locality_mode
   | Pmakelazyblock of lazy_block_tag

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -416,6 +416,15 @@ let primitive ppf = function
   | Pmakeblock(tag, Mutable, shape, mode) ->
       fprintf ppf "make%smutable %i%a"
         (locality_mode_if_local mode) tag block_shape shape
+  | Pinit_module_block(tag, Immutable, shape, mode, path) ->
+      fprintf ppf "init_module_block[%s]%s %i%a"
+        (Path.name path) (locality_mode_if_local mode) tag block_shape shape
+  | Pinit_module_block(tag, Immutable_unique, shape, mode, path) ->
+      fprintf ppf "init_module_block_unique[%s]%s %i%a"
+        (Path.name path) (locality_mode_if_local mode) tag block_shape shape
+  | Pinit_module_block(tag, Mutable, shape, mode, path) ->
+      fprintf ppf "init_module_block_mutable[%s]%s %i%a"
+        (Path.name path) (locality_mode_if_local mode) tag block_shape shape
   | Pmakefloatblock (Immutable, mode) ->
       fprintf ppf "make%sfloatblock Immutable"
         (locality_mode_if_local mode)
@@ -937,6 +946,7 @@ let name_of_primitive = function
   | Pgetglobal _ -> "Pgetglobal"
   | Pgetpredef _ -> "Pgetpredef"
   | Pmakeblock _ -> "Pmakeblock"
+  | Pinit_module_block _ -> "Pinit_module_block"
   | Pmakefloatblock _ -> "Pmakefloatblock"
   | Pmakeufloatblock _ -> "Pmakeufloatblock"
   | Pmakelazyblock _ -> "Pmakelazyblock"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -357,7 +357,7 @@ and fracture_prim lambda prim args loc =
   | Pgetglobal (cu, Static) ->
     check_arity ~arity:0;
     SLhalves { sval_comptime = SLglobal cu; sval_runtime = lambda }
-  | Pmakeblock _ ->
+  | Pmakeblock _ | Pinit_module_block _ ->
     let rec fracture_make_block unchanged i args_c args_r = function
       | [] ->
         SLhalves

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -401,6 +401,11 @@ and eval_prim env prim =
   | Pmakeblock (n, mut, old_shape, mode) ->
     let new_shape = eval_block_shape env old_shape in
     if new_shape == old_shape then prim else Pmakeblock (n, mut, new_shape, mode)
+  | Pinit_module_block (n, mut, old_shape, mode, path) ->
+    let new_shape = eval_block_shape env old_shape in
+    if new_shape == old_shape
+    then prim
+    else Pinit_module_block (n, mut, new_shape, mode, path)
   | Pmixedfield (is, old_shape, sem) ->
     let new_shape = eval_mixed_block_shape env old_shape in
     if new_shape == old_shape then prim else Pmixedfield (is, new_shape, sem)
@@ -534,7 +539,8 @@ let assert_primitive_contains_no_splices (prim : Lambda.primitive) =
     assert_layout_contains_no_splices layout
   | Pmake_unboxed_product layouts | Punboxed_product_field (_, layouts) ->
     List.iter assert_layout_contains_no_splices layouts
-  | Pmakeblock (_, _, Shape shape, _) ->
+  | Pmakeblock (_, _, Shape shape, _)
+  | Pinit_module_block (_, _, Shape shape, _, _) ->
     assert_mixed_block_shape_contains_no_splices shape
   | Pmixedfield (_, shape, _) ->
     Array.iter assert_mixed_block_element_contains_no_splices shape

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -936,6 +936,7 @@ let rec choice ctx t =
     | Pmakefloatblock _
     | Pmakeufloatblock _
     | Pmakeblock _
+    | Pinit_module_block _
 
     (* nor unboxed products *)
     | Pmake_unboxed_product _ | Punboxed_product_field _

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -77,6 +77,12 @@ let field_path path field =
     None -> None
   | Some p -> Some(Longident.Ldot(p, Ident.name field))
 
+(* [Path.t] variant of [global_path], used to annotate the toplevel
+   [Pinit_module_block] with the module's path. *)
+let global_path_as_path cu =
+  Some (Path.Pident
+          (Ident.create_persistent (Compilation_unit.name_as_string cu)))
+
 (* Compile type extensions *)
 
 let transl_type_extension ~scopes env rootpath tyext body =
@@ -103,6 +109,28 @@ let block_of_module_representation ~loc = function
       Typedecl.assert_mixed_product_support loc Module
         ~value_prefix_len:(Mixed_product_bytes.value_prefix_len mpb);
     Pmakeblock(0, Immutable, Shape shape, alloc_heap)
+
+(* Variant of [block_of_module_representation] that builds the
+   [Pinit_module_block] primitive carrying the module's [Path.t].  Used for
+   the module block whose path is known statically. *)
+let init_module_block_of_module_representation ~loc ~module_path = function
+  | Module_value_only _ ->
+    Pinit_module_block (0, Immutable, All_value, alloc_heap, module_path)
+  | Module_mixed (shape, _) ->
+    let mpb = Mixed_product_bytes.count (Product shape) in
+    if not (Mixed_product_bytes.all_value mpb)
+    then
+      Typedecl.assert_mixed_product_support loc Module
+        ~value_prefix_len:(Mixed_product_bytes.value_prefix_len mpb);
+    Pinit_module_block (0, Immutable, Shape shape, alloc_heap, module_path)
+
+(* Pick [Pinit_module_block] when [module_path] is [Some], otherwise the plain
+   [Pmakeblock] variant. *)
+let module_block_primitive ~loc ~module_path repr =
+  match module_path with
+  | None -> block_of_module_representation ~loc repr
+  | Some module_path ->
+    init_module_block_of_module_representation ~loc ~module_path repr
 
 (* Compile a coercion *)
 
@@ -628,7 +656,9 @@ and transl_module ~scopes cc rootpath mexp =
       apply_coercion loc Strict cc
         (transl_module_path loc mexp.mod_env path)
   | Tmod_structure str ->
-      let lam, _repr = transl_struct ~scopes loc [] cc rootpath str in
+      (* Sub-modules called via [transl_module] do not propagate a static
+         module path; they keep [Pmakeblock]-based construction. *)
+      let lam, _repr = transl_struct ~scopes loc [] cc rootpath None str in
       lam
   | Tmod_functor _ ->
       oo_wrap mexp.mod_env true (fun () ->
@@ -662,15 +692,16 @@ and transl_apply ~scopes ~loc ~cc mod_env funct translated_arg =
        ap_specialised=Default_specialise;
        ap_probe=None;})
 
-and transl_struct ~scopes loc fields cc rootpath
+and transl_struct ~scopes loc fields cc rootpath module_path
       {str_final_env; str_items; _} =
-  transl_structure ~scopes loc fields cc rootpath str_final_env str_items
+  transl_structure ~scopes loc fields cc rootpath module_path
+    str_final_env str_items
 
 (* The function  transl_structure is called by  the bytecode compiler.
    Some effort is made to compile in top to bottom order, in order to display
    warning by increasing locations. *)
 and transl_structure ~scopes loc
-  (fields : (Ident.t * Jkind.Sort.t) list) cc rootpath final_env =
+  (fields : (Ident.t * Jkind.Sort.t) list) cc rootpath module_path final_env =
   function
     [] ->
       let body, repr =
@@ -678,7 +709,8 @@ and transl_structure ~scopes loc
           Tcoerce_none ->
             let ids, sorts = List.split (List.rev fields) in
             let repr = transl_module_representation (Array.of_list sorts) in
-            Lprim(block_of_module_representation ~loc:(to_location loc) repr,
+            Lprim(module_block_primitive ~loc:(to_location loc) ~module_path
+                    repr,
                   List.map (fun id -> Lvar id) ids, loc),
               repr
         | Tcoerce_structure
@@ -706,8 +738,8 @@ and transl_structure ~scopes loc
             in
             let output_repr = transl_module_representation output_repr in
             let lam =
-              Lprim(block_of_module_representation
-                      ~loc:(to_location loc) output_repr,
+              Lprim(module_block_primitive
+                      ~loc:(to_location loc) ~module_path output_repr,
                   List.map
                     (fun (pos, cc) ->
                       match cc with
@@ -745,7 +777,7 @@ and transl_structure ~scopes loc
       match item.str_desc with
       | Tstr_eval (expr, sort, _) ->
           let body, repr =
-            transl_structure ~scopes loc fields cc rootpath final_env rem
+            transl_structure ~scopes loc fields cc rootpath module_path final_env rem
           in
           let sort = Jkind.Sort.default_for_transl_and_get sort in
           Lsequence(transl_exp ~scopes sort expr, body), repr
@@ -762,14 +794,15 @@ and transl_structure ~scopes loc
           in
           (* Then, translate remainder of struct *)
           let body, repr =
-            transl_structure ~scopes loc ext_fields cc rootpath final_env rem
+            transl_structure ~scopes loc ext_fields cc rootpath module_path
+              final_env rem
           in
           mk_lam_let body, repr
       | Tstr_primitive descr ->
           record_primitive descr.val_val;
-          transl_structure ~scopes loc fields cc rootpath final_env rem
+          transl_structure ~scopes loc fields cc rootpath module_path final_env rem
       | Tstr_type _ ->
-          transl_structure ~scopes loc fields cc rootpath final_env rem
+          transl_structure ~scopes loc fields cc rootpath module_path final_env rem
       | Tstr_typext(tyext) ->
           let newfields =
             List.map
@@ -779,7 +812,7 @@ and transl_structure ~scopes loc
           in
           let body, repr =
             transl_structure ~scopes loc (List.rev_append newfields fields)
-              cc rootpath final_env rem
+              cc rootpath module_path final_env rem
           in
           transl_type_extension ~scopes item.str_env rootpath tyext body, repr
       | Tstr_exception ext ->
@@ -790,7 +823,7 @@ and transl_structure ~scopes loc
           let body, repr =
             transl_structure ~scopes loc
               ((id, Jkind.Sort.(of_const Const.for_exception)) :: fields)
-              cc rootpath final_env rem
+              cc rootpath module_path final_env rem
           in
           Llet(Strict, Lambda.layout_block, id, id_duid,
                transl_extension_constructor ~scopes
@@ -819,7 +852,7 @@ and transl_structure ~scopes loc
           (* Translate remainder second *)
           let body, repr =
             transl_structure ~scopes loc (cons_opt field fields)
-              cc rootpath final_env rem
+              cc rootpath module_path final_env rem
           in
           begin match id with
           | None ->
@@ -831,7 +864,7 @@ and transl_structure ~scopes loc
               id_duid, module_body, body), repr
           end
       | Tstr_module ({mb_presence=Mp_absent}) ->
-          transl_structure ~scopes loc fields cc rootpath final_env rem
+          transl_structure ~scopes loc fields cc rootpath module_path final_env rem
       | Tstr_recmodule bindings ->
           let newfields =
             List.filter_map
@@ -841,7 +874,7 @@ and transl_structure ~scopes loc
           in
           let body, repr =
             transl_structure ~scopes loc (List.rev_append newfields fields)
-              cc rootpath final_env rem
+              cc rootpath module_path final_env rem
           in
           let lam =
             compile_recmodule ~scopes (fun id modl ->
@@ -861,7 +894,7 @@ and transl_structure ~scopes loc
           in
           let body, repr =
             transl_structure ~scopes loc (List.rev_append newfields fields)
-              cc rootpath final_env rem
+              cc rootpath module_path final_env rem
           in
           Value_rec_compiler.compile_letrec class_bindings body, repr
       | Tstr_include incl ->
@@ -874,7 +907,8 @@ and transl_structure ~scopes loc
           let incl_repr = transl_module_representation incl.incl_repr in
           let rec rebind_idents pos newfields = function
               [] ->
-                transl_structure ~scopes loc newfields cc rootpath final_env rem
+                transl_structure ~scopes loc newfields cc rootpath module_path
+                  final_env rem
             | (id, sort) :: ids_with_sorts ->
                 let const_sort = Jkind.Sort.default_for_transl_and_get sort in
                 let lambda_layout =
@@ -918,7 +952,7 @@ and transl_structure ~scopes loc
              it. *)
           begin match od.open_bound_items with
           | [] when pure = Alias ->
-              transl_structure ~scopes loc fields cc rootpath final_env rem
+              transl_structure ~scopes loc fields cc rootpath module_path final_env rem
           | _ ->
               let ids_with_sorts =
                 bound_value_identifiers_and_sorts od.open_bound_items
@@ -928,7 +962,8 @@ and transl_structure ~scopes loc
               let open_repr = transl_module_representation od.open_items_repr in
               let rec rebind_idents pos newfields = function
                   [] -> transl_structure
-                          ~scopes loc newfields cc rootpath final_env rem
+                          ~scopes loc newfields cc rootpath module_path
+                          final_env rem
                 | (id, sort) :: ids_with_sorts ->
                   let const_sort = Jkind.Sort.default_for_transl_and_get sort in
                   let lambda_layout =
@@ -956,7 +991,7 @@ and transl_structure ~scopes loc
       | Tstr_class_type _
       | Tstr_attribute _
       | Tstr_jkind _->
-          transl_structure ~scopes loc fields cc rootpath final_env rem
+          transl_structure ~scopes loc fields cc rootpath module_path final_env rem
 
 (* construct functor application in "include functor" case *)
 and transl_include_functor ~generative ~input_repr modl params scopes loc =
@@ -1088,8 +1123,9 @@ let add_runtime_parameters lam params =
 
 let transl_implementation_module ~loc ~scopes module_id (str, cc, cc2) =
   let path = global_path module_id in
+  let module_path = global_path_as_path module_id in
   let lam, repr =
-    transl_struct ~scopes (of_location ~scopes loc) [] cc path str
+    transl_struct ~scopes (of_location ~scopes loc) [] cc path module_path str
   in
   match cc2 with
   | None -> lam, repr, None

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2536,7 +2536,8 @@ let lambda_primitive_needs_event_after = function
   | Pbytes_to_string | Pbytes_of_string
   | Parray_to_iarray | Parray_of_iarray
   | Pignore
-  | Pgetglobal _ | Pgetpredef _ | Pmakeblock _ | Pmakefloatblock _
+  | Pgetglobal _ | Pgetpredef _ | Pmakeblock _ | Pinit_module_block _
+  | Pmakefloatblock _
   | Pmakeufloatblock _ | Pmakelazyblock _
   | Pmake_unboxed_product _ | Punboxed_product_field _
   | Parray_element_size_in_bytes _

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -268,7 +268,8 @@ let compute_static_size lam =
             Misc.fatal_error
               "size_of_primitive: unexpected variable representation"
         end
-    | Pmakeblock (_, _, shape, _) ->
+    | Pmakeblock (_, _, shape, _)
+    | Pinit_module_block (_, _, shape, _, _) ->
         (* The block shape is unfortunately an option, so we rely on the
            number of arguments instead.
            Note that flat float arrays/records use Pmakearray, so we don't need

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1233,8 +1233,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Some exn_continuation -> exn_continuation
     in
     close_raise0 acc env ~raise_kind ~arg ~dbg exn_continuation
-  | ( (Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakearray _),
-      [] ) ->
+  | (Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakearray _), []
+    ->
     (* Special case for liftable empty block or array. [Pinit_module_block] is
        intentionally excluded so that even an empty module block is bound to its
        module symbol via [Lambda_to_flambda_primitives.convert_and_bind]. *)
@@ -1266,9 +1266,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Parrayblit _array_set_kind ->
         Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
       | Pmakearray_dynamic _ | Pinit_module_block _ | Pbytes_to_string
-      | Pbytes_of_string
-      | Parray_of_iarray | Parray_to_iarray | Pignore | Pgetglobal _
-      | Pgetpredef _ | Pfield _ | Pfield_computed _ | Psetfield _
+      | Pbytes_of_string | Parray_of_iarray | Parray_to_iarray | Pignore
+      | Pgetglobal _ | Pgetpredef _ | Pfield _ | Pfield_computed _ | Psetfield _
       | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
       | Pccall _ | Praise _ | Pufloatfield _ | Psetufloatfield _ | Psequand
       | Psequor | Pnot | Pmixedfield _ | Psetmixedfield _ | Poffsetref _
@@ -3890,9 +3889,9 @@ let bind_static_consts_and_code acc body =
     (acc, body) components
 
 let close_program (type mode) ~(mode : mode Flambda_features.mode)
-    ~machine_width ~big_endian ~cmx_loader ~compilation_unit
-    ~module_repr:_ ~program ~prog_return_cont ~exn_continuation
-    ~toplevel_my_region ~toplevel_my_ghost_region : mode close_program_result =
+    ~machine_width ~big_endian ~cmx_loader ~compilation_unit ~module_repr:_
+    ~program ~prog_return_cont ~exn_continuation ~toplevel_my_region
+    ~toplevel_my_ghost_region : mode close_program_result =
   let env = Env.create ~big_endian in
   let module_symbol =
     Symbol.create_wrapped
@@ -3907,11 +3906,11 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
       Flambda_kind.With_subkind.region
   in
   let acc = Acc.create ~cmx_loader ~machine_width in
-  (* [Pinit_module_block] now binds the module symbol via a static
-     [let_symbol] during primitive conversion, and the program ends by passing
-     that symbol to [prog_return_cont].  We can therefore use
-     [prog_return_cont] directly as the [Flambda_unit]'s return continuation,
-     without the previous [wrap_final_module_block] wrapping. *)
+  (* [Pinit_module_block] now binds the module symbol via a static [let_symbol]
+     during primitive conversion, and the program ends by passing that symbol to
+     [prog_return_cont]. We can therefore use [prog_return_cont] directly as the
+     [Flambda_unit]'s return continuation, without the previous
+     [wrap_final_module_block] wrapping. *)
   let return_cont = prog_return_cont in
   let acc, body =
     let acc, body = program acc env in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1233,9 +1233,11 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Some exn_continuation -> exn_continuation
     in
     close_raise0 acc env ~raise_kind ~arg ~dbg exn_continuation
-  | (Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakearray _), []
-    ->
-    (* Special case for liftable empty block or array *)
+  | ( (Pmakeblock _ | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakearray _),
+      [] ) ->
+    (* Special case for liftable empty block or array. [Pinit_module_block] is
+       intentionally excluded so that even an empty module block is bound to its
+       module symbol via [Lambda_to_flambda_primitives.convert_and_bind]. *)
     let acc, sym =
       match prim with
       | Pmakeblock (tag, _, shape, _mode) ->
@@ -1263,7 +1265,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
         register_const0 acc (Static_const.empty_array array_kind) "empty_array"
       | Parrayblit _array_set_kind ->
         Misc.fatal_error "Closure_conversion.close_primitive: unimplemented"
-      | Pmakearray_dynamic _ | Pbytes_to_string | Pbytes_of_string
+      | Pmakearray_dynamic _ | Pinit_module_block _ | Pbytes_to_string
+      | Pbytes_of_string
       | Parray_of_iarray | Parray_to_iarray | Pignore | Pgetglobal _
       | Pgetpredef _ | Pfield _ | Pfield_computed _ | Psetfield _
       | Psetfield_computed _ | Pfloatfield _ | Psetfloatfield _ | Pduprecord _
@@ -3886,159 +3889,15 @@ let bind_static_consts_and_code acc body =
         defining_expr ~body)
     (acc, body) components
 
-(* Returns a tuple [block_shape, field_count, block_access, kind_of_field].
-   [block_access] and [kind_of_field] are function that take an index [pos] and
-   return the block_access/kind of the [pos]th field of the module. "Fields" are
-   physical, so unboxed products count as more than one field when indexing and
-   determining [field_count]. *)
-let final_module_block_representation acc
-    ~(module_repr : Lambda.module_representation) =
-  let (block_shape : K.Scannable_block_shape.t), block_access, field_count =
-    match module_repr with
-    | Module_value_only { field_count } ->
-      let block_access _pos : P.Block_access_kind.t =
-        Values
-          { tag = Known Tag.Scannable.zero;
-            size =
-              Known
-                (Target_ocaml_int.of_int (Acc.machine_width acc) field_count);
-            field_kind = Any_value
-          }
-      in
-      Value_only, block_access, field_count
-    | Module_mixed (shape, _) ->
-      let shape =
-        K.Mixed_block_lambda_shape.of_mixed_block_elements shape
-          ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
-      in
-      let flattened_reordered_shape =
-        K.Mixed_block_lambda_shape.flattened_reordered_shape shape
-      in
-      let block_shape = K.Scannable_block_shape.from_mixed_block_shape shape in
-      let field_count = Array.length flattened_reordered_shape in
-      let block_access pos : P.Block_access_kind.t =
-        Lambda_to_flambda_primitives_helpers
-        .block_access_kind_of_mixed_field_element
-          ~tag:(Known Tag.Scannable.zero) ~size:Unknown ~kind_shape:block_shape
-          flattened_reordered_shape.(pos)
-      in
-      block_shape, block_access, field_count
-  in
-  let kind_of_field =
-    match block_shape with
-    | Value_only -> fun _ -> K.value
-    | Mixed_record shape ->
-      let field_kinds = K.Mixed_block_shape.field_kinds shape in
-      fun pos -> field_kinds.(pos)
-  in
-  block_shape, field_count, block_access, kind_of_field
-
-let wrap_final_module_block acc env ~program ~prog_return_cont
-    ~(module_repr : Lambda.module_representation) ~return_cont ~module_symbol =
-  let module_block_var = Variable.create "module_block" K.value in
-  let module_block_var_duid = Flambda_debug_uid.none in
-  let module_block_tag = Tag.Scannable.zero in
-  let block_shape, field_count, block_access, kind_of_field =
-    final_module_block_representation acc ~module_repr
-  in
-  let load_fields_body acc =
-    let env =
-      match Acc.continuation_known_arguments ~cont:prog_return_cont acc with
-      | Some [approx] -> Env.add_var_approximation env module_block_var approx
-      | None | Some ([] | _ :: _) -> env
-    in
-    let module_block_simple =
-      let simple_var = Simple.var module_block_var in
-      match find_value_approximation env simple_var with
-      | Value_approximation.Value_symbol s -> Simple.symbol s
-      | _ -> simple_var
-    in
-    let field_vars =
-      List.init field_count (fun pos ->
-          let pos_str = string_of_int pos in
-          ( pos,
-            Variable.create ("field_" ^ pos_str) (kind_of_field pos),
-            Flambda_debug_uid.none ))
-    in
-    let acc, body =
-      let static_const : Static_const.t =
-        let field_vars =
-          List.map
-            (fun (_, var, _) ->
-              Simple.With_debuginfo.create (Simple.var var) Debuginfo.none)
-            field_vars
-        in
-        Static_const.block module_block_tag Immutable block_shape field_vars
-      in
-      let acc, apply_cont =
-        (* Module initialisers return unit, but since that is taken care of
-           during Cmm generation, we can instead "return" [module_symbol] here
-           to ensure that its associated "let symbol" doesn't get deleted. *)
-        Apply_cont_with_acc.create acc return_cont
-          ~args:[Simple.symbol module_symbol]
-          ~dbg:Debuginfo.none
-      in
-      let acc, return = Expr_with_acc.create_apply_cont acc apply_cont in
-      let bound_static =
-        Bound_static.singleton (Bound_static.Pattern.block_like module_symbol)
-      in
-      let named =
-        Named.create_static_consts
-          (Static_const_group.create
-             [Static_const_or_code.create_static_const static_const])
-      in
-      Let_with_acc.create acc
-        (Bound_pattern.static bound_static)
-        named ~body:return
-    in
-    List.fold_left
-      (fun (acc, body) (pos, var, var_duid) ->
-        let var = VB.create var var_duid Name_mode.normal in
-        let pat = Bound_pattern.singleton var in
-        let field = Target_ocaml_int.of_int (Acc.machine_width acc) pos in
-        let block = module_block_simple in
-        match simplify_block_load acc env ~block ~field with
-        | Unknown | Not_a_block | Block_but_cannot_simplify _ ->
-          let named =
-            Named.create_prim
-              (Unary
-                 ( Block_load { kind = block_access pos; mut = Immutable; field },
-                   block ))
-              Debuginfo.none
-          in
-          Let_with_acc.create acc pat named ~body
-        | Field_contents sim ->
-          let named = Named.create_simple sim in
-          Let_with_acc.create acc pat named ~body)
-      (acc, body) (List.rev field_vars)
-  in
-  let load_fields_handler_param =
-    [BP.create module_block_var K.With_subkind.any_value module_block_var_duid]
-    |> Bound_parameters.create
-  in
-  (* This binds the return continuation that is free (or, at least, not bound)
-     in the incoming code. The handler for the continuation receives a tuple
-     with fields indexed from zero to [module_block_size_in_words]. The handler
-     extracts the fields; the variables bound to such fields are then used to
-     define the module block symbol. *)
-  let body acc =
-    let acc, body = program acc env in
-    bind_static_consts_and_code acc body
-  in
-  Let_cont_with_acc.build_non_recursive acc prog_return_cont
-    ~handler_params:load_fields_handler_param ~handler:load_fields_body ~body
-    ~is_exn_handler:false ~is_cold:false
-
 let close_program (type mode) ~(mode : mode Flambda_features.mode)
-    ~machine_width ~big_endian ~cmx_loader ~compilation_unit ~module_repr
-    ~program ~prog_return_cont ~exn_continuation ~toplevel_my_region
-    ~toplevel_my_ghost_region : mode close_program_result =
+    ~machine_width ~big_endian ~cmx_loader ~compilation_unit
+    ~module_repr:_ ~program ~prog_return_cont ~exn_continuation
+    ~toplevel_my_region ~toplevel_my_ghost_region : mode close_program_result =
   let env = Env.create ~big_endian in
   let module_symbol =
     Symbol.create_wrapped
       (Flambda2_import.Symbol.for_compilation_unit compilation_unit)
   in
-  let return_cont = Continuation.create ~sort:Toplevel_return () in
   let env, toplevel_my_region =
     Env.add_var_like env toplevel_my_region Not_user_visible
       Flambda_kind.With_subkind.region
@@ -4048,9 +3907,15 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
       Flambda_kind.With_subkind.region
   in
   let acc = Acc.create ~cmx_loader ~machine_width in
+  (* [Pinit_module_block] now binds the module symbol via a static
+     [let_symbol] during primitive conversion, and the program ends by passing
+     that symbol to [prog_return_cont].  We can therefore use
+     [prog_return_cont] directly as the [Flambda_unit]'s return continuation,
+     without the previous [wrap_final_module_block] wrapping. *)
+  let return_cont = prog_return_cont in
   let acc, body =
-    wrap_final_module_block acc env ~program ~prog_return_cont ~module_repr
-      ~return_cont ~module_symbol
+    let acc, body = program acc env in
+    bind_static_consts_and_code acc body
   in
   let module_block_approximation =
     match Acc.continuation_known_arguments ~cont:prog_return_cont acc with

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -21,6 +21,24 @@ module I_or_f = K.Standard_int_or_float
 module L = Lambda
 module P = Flambda_primitive
 
+(* Symbol identifying the module block at [path] within the current compilation
+   unit. For the toplevel module (a [Pident] whose name matches the current
+   compilation unit) we return the same symbol that [Closure_conversion] uses
+   for the actual module block. *)
+let module_block_symbol_for_path path =
+  let cu = Compilation_unit.get_current_exn () in
+  let current_unit_name =
+    Compilation_unit.Name.to_string (Compilation_unit.name cu)
+  in
+  match[@warning "-fragile-match"] path with
+  | Path.Pident id when String.equal (Ident.name id) current_unit_name ->
+    Symbol.create_wrapped (Flambda2_import.Symbol.for_compilation_unit cu)
+  | _ ->
+    let mangled =
+      String.map (function '.' -> '_' | c -> c) (Path.name path)
+    in
+    Symbol.create cu (Linkage_name.of_string ("caml_module_block_" ^ mangled))
+
 let needs_64_bit_target prim dbg =
   if not (Target_system.is_64_bit ())
   then
@@ -1786,7 +1804,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Pphys_equal eq, [[arg1]; [arg2]] ->
     let eq : P.equality_comparison = match eq with Eq -> Eq | Noteq -> Neq in
     [tag_int (Binary (Phys_equal eq, arg1, arg2))]
-  | Pmakeblock (tag, mutability, shape, mode), _ -> (
+  | ( ( Pmakeblock (tag, mutability, shape, mode)
+      | Pinit_module_block (tag, mutability, shape, mode, _) ),
+      _ ) -> (
     let args = List.flatten args in
     let mode = Alloc_mode.For_allocations.from_lambda mode ~current_region in
     let tag = Tag.Scannable.create_exn tag in
@@ -3346,16 +3366,69 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
 module Acc = Closure_conversion_aux.Acc
 module Expr_with_acc = Closure_conversion_aux.Expr_with_acc
 
+(* [Pinit_module_block (tag, _, _, _, path)] is translated directly into a
+   [Let_with_acc] binding the module's symbol to a [Static_const.block]. The
+   "result" handed to [cont] is [Simple.symbol module_symbol] so the calling
+   code sees the symbol as the value produced by the primitive. This replaces
+   the previous translation, which created a runtime block via [Make_block] and
+   required [wrap_final_module_block] to rebind it as a let-symbol. *)
+let emit_init_module_block_let_symbol acc (path : Path.t) (tag : int)
+    ~(args : Simple.t list list)
+    (cont : Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) : Expr_with_acc.t
+    =
+  let symbol = module_block_symbol_for_path path in
+  let field_simples =
+    List.flatten args
+    |> List.map (fun simple ->
+           Simple.With_debuginfo.create simple Debuginfo.none)
+  in
+  let static_const =
+    Static_const.block
+      (Tag.Scannable.create_exn tag)
+      Immutable Value_only field_simples
+  in
+  let approxs =
+    args |> List.flatten
+    |> List.map (fun _simple -> Value_approximation.Unknown Flambda_kind.value)
+    |> Array.of_list
+  in
+  let approx : _ Value_approximation.t =
+    Block_approximation
+      ( Tag.Scannable.create_exn tag,
+        Flambda_kind.Scannable_block_shape.Value_only,
+        approxs,
+        Alloc_mode.For_allocations.as_type Alloc_mode.For_allocations.heap )
+  in
+  let acc = Acc.add_symbol_approximation acc symbol approx in
+  let bound_static =
+    Bound_static.singleton (Bound_static.Pattern.block_like symbol)
+  in
+  let named =
+    Flambda.Named.create_static_consts
+      (Flambda.Static_const_group.create
+         [Flambda.Static_const_or_code.create_static_const static_const])
+  in
+  let acc, body_expr =
+    cont acc [Flambda.Named.create_simple (Simple.symbol symbol)]
+  in
+  Closure_conversion_aux.Let_with_acc.create acc
+    (Bound_pattern.static bound_static)
+    named ~body:body_expr
+
 let convert_and_bind acc ~big_endian exn_cont ~register_const0
     (prim : L.primitive) ~(args : Simple.t list list) (dbg : Debuginfo.t)
     ~current_region ~current_ghost_region
     (cont : Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) : Expr_with_acc.t
     =
-  let machine_width = Acc.machine_width acc in
-  let exprs =
-    convert_lprim ~machine_width ~big_endian prim args dbg ~current_region
-      ~current_ghost_region
-  in
-  H.bind_recs acc exn_cont ~register_const0
-    (H.maybe_create_unboxed_product exprs)
-    dbg cont
+  match[@warning "-fragile-match"] prim with
+  | Pinit_module_block (tag, _mut, _shape, _mode, path) ->
+    emit_init_module_block_let_symbol acc path tag ~args cont
+  | _ ->
+    let machine_width = Acc.machine_width acc in
+    let exprs =
+      convert_lprim ~machine_width ~big_endian prim args dbg ~current_region
+        ~current_ghost_region
+    in
+    H.bind_recs acc exn_cont ~register_const0
+      (H.maybe_create_unboxed_product exprs)
+      dbg cont

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -3380,7 +3380,7 @@ let emit_init_module_block_let_symbol acc (path : Path.t) (tag : int)
   let field_simples =
     List.flatten args
     |> List.map (fun simple ->
-           Simple.With_debuginfo.create simple Debuginfo.none)
+        Simple.With_debuginfo.create simple Debuginfo.none)
   in
   let static_const =
     Static_const.block


### PR DESCRIPTION
This adds `Pinit_module_block`, to be used instead of `Pmakeblock` for module block initializations corresponding to compilation units.  This produces better code in classic mode, which currently in at least some cases emits code to read all of the fields out of the symbol corresponding to the `Pmakeblock`, prior to writing them into the module block.  In addition it is a stepping stone to being able to reference the current compilation units in metaprogramming quotes, although we are not yet agreed on exactly how to represent this in Lambda and beyond.