### PR TITLE
Create sort variables for record fields with kind `any`

### DIFF
--- a/testsuite/tests/typing-layouts-err-msg/concrete.ml
+++ b/testsuite/tests/typing-layouts-err-msg/concrete.ml
@@ -78,11 +78,11 @@ type t = { a : t_any; }
 Line 2, characters 15-18:
 2 | let f (t: t) = t.a
                    ^^^
-Error: Fields being projected must be representable.
+Error: Record element types must have a representable layout.
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable
-         because it's the type of a field being projected.
+         because it's the type of a field in a record being projected from.
 |}]
 
 (* Record_assignment *)

--- a/testsuite/tests/typing-layouts-or-null/basics.ml
+++ b/testsuite/tests/typing-layouts-or-null/basics.ml
@@ -45,11 +45,11 @@ let f t = t.x
 Line 1, characters 10-13:
 1 | let f t = t.x
               ^^^
-Error: Fields being projected must be representable.
+Error: Record element types must have a representable layout.
        The layout of t_any_mod_separable is any separable
          because of the definition of t_any_mod_separable at line 2, characters 0-44.
        But the layout of t_any_mod_separable must be representable
-         because it's the type of a field being projected.
+         because it's the type of a field in a record being projected from.
 |}]
 
 module type S1 = sig

--- a/testsuite/tests/typing-layouts/any_in_record.ml
+++ b/testsuite/tests/typing-layouts/any_in_record.ml
@@ -21,11 +21,11 @@ let fst (type a : any) (t : a t) = t.fst
 Line 1, characters 35-40:
 1 | let fst (type a : any) (t : a t) = t.fst
                                        ^^^^^
-Error: Fields being projected must be representable.
+Error: Record element types must have a representable layout.
        The layout of a is any
          because of the annotation on the abstract type declaration for a.
        But the layout of a must be representable
-         because it's the type of a field being projected.
+         because it's the type of a field in a record being projected from.
 |}]
 
 let fst (t : int t) = t.fst
@@ -267,19 +267,13 @@ type ('a : any) t = { t : 'a; } [@@unboxed]
 val f : 'a t -> 'a = <fun>
 |}]
 
-(* Sort variables are not initialized well *)
-
 (* Projecting a label other than the [any] *)
 
 type ('a : any) t = { i : int ; a : 'a }
 let foo t = (.a)
 [%%expect{|
 type ('a : any) t = { i : int; a : 'a; }
-Line 2, characters 14-15:
-2 | let foo t = (.a)
-                  ^
-Error: Cannot access record with unrepresentable field.
-       The record has type 'a t, whose field a is not representable.
+val foo : 'a -> ('b t, 'b) idx_imm = <fun>
 |}]
 
 (* Matching *)
@@ -288,42 +282,76 @@ type ('a : any) t = { a : 'a }
 let foo { a } = ()
 [%%expect{|
 type ('a : any) t = { a : 'a; }
-Line 2, characters 8-13:
-2 | let foo { a } = ()
-            ^^^^^
-Error: Cannot access record with unrepresentable field.
-       The record has type 'a t, whose field a is not representable.
+val foo : 'a t -> unit = <fun>
 |}]
 
 (* Block indices *)
 
-(* CR-soon rtjoa: This should typecheck and default to value *)
 type ('a : any) r = { t : 'a }
 let f = (.t)
 [%%expect{|
 type ('a : any) r = { t : 'a; }
-Line 2, characters 10-11:
-2 | let f = (.t)
-              ^
-Error: Cannot access record with unrepresentable field.
-       The record has type 'a r, whose field t is not representable.
+val f : ('a r, 'a) idx_imm = <abstr>
 |}]
 
-(* Abstract kinds *)
+(* Abstract kinds errors *)
 
 kind_ k
 type a : k
 type t = { a : a }
-let f { a } = ()
 [%%expect{|
 kind_ k
 type a : k
 type t = { a : a; }
-Line 4, characters 6-11:
-4 | let f { a } = ()
+|}]
+
+let f { a } = ()
+[%%expect{|
+Line 1, characters 6-11:
+1 | let f { a } = ()
           ^^^^^
-Error: Cannot access record with unrepresentable field.
-       The record has type t, whose field a is not representable.
+Error: Record element types must have a representable layout.
+       The kind of a is k
+         because of the definition of a at line 2, characters 0-10.
+       But the kind of a must be representable
+         because it's the type of a field in a record being projected from.
+|}]
+
+let i = (.a)
+[%%expect{|
+Line 1, characters 10-11:
+1 | let i = (.a)
+              ^
+Error: Record element types must have a representable layout.
+       The kind of a is k
+         because of the definition of a at line 2, characters 0-10.
+       But the kind of a must be representable
+         because it's the type of a field in a record type into which a
+         block index (idx_imm or idx_mut) is being created.
+|}]
+
+let f t = { t with a = assert false }
+[%%expect{|
+Line 1, characters 23-35:
+1 | let f t = { t with a = assert false }
+                           ^^^^^^^^^^^^
+Error: Values of fields must be representable.
+       The kind of a is k
+         because of the definition of a at line 2, characters 0-10.
+       But the kind of a must be representable
+         because it's the type of a field involved in a functional update.
+|}]
+
+let f = { a = assert false }
+[%%expect{|
+Line 1, characters 14-26:
+1 | let f = { a = assert false }
+                  ^^^^^^^^^^^^
+Error: Values of fields must be representable.
+       The kind of a is k
+         because of the definition of a at line 2, characters 0-10.
+       But the kind of a must be representable
+         because it's the type of a field being assigned a value.
 |}]
 
 (* CR-soon rtjoa: The below two programs should work *)
@@ -440,4 +468,36 @@ Lines 1-2, characters 0-18:
 Error: The "[@@flatten_floats]" attribute is only allowed on records with one or more
        non-atomic "float" fields, one or more "float#" fields, and all other fields
        void.
+|}]
+
+(* Projecting / setting / pattern-matching a representable field of a record
+   that has an [any] field. Each operation must create a sort variable for the
+   non-projected [any]-kinded field so the record's representation can be
+   computed. *)
+
+type ('a : any) t2 = { i : int; mutable j : int; a : 'a }
+[%%expect {|
+type ('a : any) t2 = { i : int; mutable j : int; a : 'a; }
+|}]
+
+let project_int (t : _ t2) = t.i
+[%%expect {|
+val project_int : 'a t2 -> int = <fun>
+|}]
+
+let set_int (t : _ t2) = t.j <- 0
+[%%expect {|
+val set_int : 'a t2 -> unit = <fun>
+|}]
+
+let pat_int (t : _ t2) = match t with { i; _ } -> i
+[%%expect {|
+val pat_int : 'a t2 -> int = <fun>
+|}]
+
+let project_int_via_index (t : _ t2) =
+  let idx = ((.i) : (('a : any) t2, int) idx_imm) in
+  Idx_imm.get t idx
+[%%expect {|
+val project_int_via_index : 'a t2 -> int = <fun>
 |}]

--- a/testsuite/tests/typing-layouts/any_in_record.ml
+++ b/testsuite/tests/typing-layouts/any_in_record.ml
@@ -294,6 +294,64 @@ type ('a : any) r = { t : 'a; }
 val f : ('a r, 'a) idx_imm = <abstr>
 |}]
 
+(* Any errors *)
+
+type a : any
+type t = { a : a }
+[%%expect{|
+type a : any
+type t = { a : a; }
+|}]
+
+let f { a } = ()
+[%%expect{|
+Line 1, characters 6-11:
+1 | let f { a } = ()
+          ^^^^^
+Error: Record element types must have a representable layout.
+       The layout of a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of a must be representable
+         because it's the type of a field in a record being projected from.
+|}]
+
+let i = (.a)
+[%%expect{|
+Line 1, characters 10-11:
+1 | let i = (.a)
+              ^
+Error: Record element types must have a representable layout.
+       The layout of a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of a must be representable
+         because it's the type of a field in a record type into which a
+         block index (idx_imm or idx_mut) is being created.
+|}]
+
+let f t = { t with a = assert false }
+[%%expect{|
+Line 1, characters 23-35:
+1 | let f t = { t with a = assert false }
+                           ^^^^^^^^^^^^
+Error: Values of fields must be representable.
+       The layout of a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of a must be representable
+         because it's the type of a field involved in a functional update.
+|}]
+
+let f = { a = assert false }
+[%%expect{|
+Line 1, characters 14-26:
+1 | let f = { a = assert false }
+                  ^^^^^^^^^^^^
+Error: Values of fields must be representable.
+       The layout of a is any
+         because of the definition of a at line 1, characters 0-12.
+       But the layout of a must be representable
+         because it's the type of a field being assigned a value.
+|}]
+
 (* Abstract kinds errors *)
 
 kind_ k

--- a/testsuite/tests/typing-layouts/any_in_record_variant.ml
+++ b/testsuite/tests/typing-layouts/any_in_record_variant.ml
@@ -8,19 +8,12 @@ type ('a : any, 'b : any) t = Nope | Yeah of { fst : 'a; snd : 'b }
 type ('a : any, 'b : any) t = Nope | Yeah of { fst : 'a; snd : 'b; }
 |}]
 
-(* CR-someday lmaurer: Would be good to infer [value] as the kind here as we do
-   for the record and tuple-constructor cases. *)
 let to_option t =
   match t with
   | Yeah { fst; snd } -> Some (fst, snd)
   | Nope -> None
 [%%expect{|
-Line 3, characters 9-21:
-3 |   | Yeah { fst; snd } -> Some (fst, snd)
-             ^^^^^^^^^^^^
-Error: Cannot access record with unrepresentable field.
-       The record has type ('a, 'b) t.Yeah,
-       whose field fst is not representable.
+val to_option : ('a, 'b) t -> ('a * 'b) option = <fun>
 |}]
 
 let is_yeah (type a : any) (type b : any) (t : (a, b) t) =

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -586,6 +586,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                               (match
                                 Typedecl.update_record_representation env
                                   Location.none Legacy lds_and_types
+                                  ~why:Field_projection
                               with
                               | Ok (_sorts, rep) -> rep
                               | Error _ ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2829,7 +2829,8 @@ module Format_history = struct
       fprintf ppf "it's the record type used in an assignment"
     | Record_functional_update ->
       fprintf ppf "it's the record type used in a functional update"
-    | Field_projection -> fprintf ppf "it's the type of a field being projected"
+    | Field_projection ->
+      fprintf ppf "it's the type of a field in a record being projected from"
     | Field_assignment ->
       fprintf ppf "it's the type of a field being assigned a value"
     | Field_functional_update ->
@@ -2866,7 +2867,11 @@ module Format_history = struct
     | Idx_element ->
       fprintf ppf
         "it's the element type (the second type parameter) for a@ block index \
-         (idx or mut_idx)"
+         (idx_imm or idx_mut)"
+    | Field_in_indexed_record ->
+      fprintf ppf
+        "it's the type of a field in a record type into which a@ block index \
+         (idx_imm or idx_mut) is being created"
     | Structure_item ->
       fprintf ppf "it's the type of something stored in a module"
     | Signature_item -> fprintf ppf "it's the type of something in a signature"
@@ -3927,6 +3932,7 @@ module Debug_printers = struct
     | Peek_or_poke -> fprintf ppf "Peek_or_poke"
     | Array_element -> fprintf ppf "Array_element"
     | Idx_element -> fprintf ppf "Idx_element"
+    | Field_in_indexed_record -> fprintf ppf "Field_in_indexed_record"
     | Structure_item -> fprintf ppf "Structure_item"
     | Signature_item -> fprintf ppf "Signature_item"
     | Layout_poly -> fprintf ppf "Layout_poly"

--- a/typing/jkind_intf.ml
+++ b/typing/jkind_intf.ml
@@ -340,6 +340,7 @@ module History = struct
     | Peek_or_poke
     | Array_element
     | Idx_element
+    | Field_in_indexed_record
     | Structure_item
     | Signature_item
     | Layout_poly

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -292,7 +292,6 @@ type error =
   | Record_projection_not_rep of type_expr * Jkind.Violation.t
   | Record_not_rep of type_expr * Jkind.Violation.t
   | Mutable_var_not_rep of type_expr * Jkind.Violation.t
-  | Field_projection_not_rep of type_expr * Jkind.Violation.t
   | Field_value_not_rep of type_expr * Jkind.Violation.t
   | Constructor_arg_projection_not_rep of type_expr * Jkind.Violation.t
   | Constructor_arg_value_not_rep of type_expr * Jkind.Violation.t
@@ -1749,7 +1748,7 @@ let determined_lbl_repres (type rep) (form : rep record_form)
   if is_variable_repres form rep then None else Some rep
 
 let update_labels (type rep) env (form : rep record_form) ~representative_label
-      ~loc ~containing_type
+      ~why ~loc ~containing_type
     : record_sorts * rep =
   (* Might be good to short-circuit this. Possible we could do so by noticing
      that [containing_type] has no arguments (or only variables as
@@ -1771,7 +1770,7 @@ let update_labels (type rep) env (form : rep record_form) ~representative_label
           vars_and_ty_args
       in
       match
-        Typedecl.update_record_representation env loc form
+        Typedecl.update_record_representation ~why env loc form
           (lbls_and_ty_args |> Array.to_list)
       with
       | Ok (sorts, rep) ->
@@ -3249,6 +3248,7 @@ and type_pat_aux
       in
       let sorts, rep =
         update_labels !!penv record_form ~representative_label ~loc
+          ~why:Field_projection
           ~containing_type:(instance record_ty)
       in
       let lbl_a_list = List.map (type_label_pat sorts) lbl_a_list in
@@ -6561,11 +6561,16 @@ and type_expect_
                 label_descriptions label_definitions
               |> Array.to_list
             in
+            let why : Jkind.History.concrete_creation_reason =
+              if opt_sexp = None
+              then Field_assignment
+              else Field_functional_update
+            in
             begin match
               (* XXX This is redundantly going to get the sort and jkind for
                  each label all over again. Possibly we're doing things in the
                  wrong order. *)
-              Typedecl.update_record_representation env
+              Typedecl.update_record_representation ~why env
                 sexp.pexp_loc record_form labels_with_updated_types
             with
             | Ok (_, rep) -> rep
@@ -7263,6 +7268,7 @@ and type_expect_
       unify_exp env record ty_record;
       let record_sorts, record_repres =
         update_labels env Legacy ~representative_label:label ~loc
+          ~why:Field_assignment
           ~containing_type:ty_record
       in
       rue {
@@ -8335,6 +8341,7 @@ and type_block_access env expected_base_ty principal
     if mut then Env.mark_label_used Mutation label.lbl_uid;
     let _sorts, rep =
       update_labels env Legacy ~representative_label:label ~loc:lid.loc
+        ~why:Field_in_indexed_record
         ~containing_type:expected_base_ty
     in
     let ba = Baccess_field (lid, label, rep) in
@@ -8364,7 +8371,8 @@ and type_block_access env expected_base_ty principal
     let base_ty = newvar (Jkind.Builtin.value_or_null ~why:Idx_base) in
     let el_ty =
       newvar
-        (Jkind.of_new_sort ~why:Idx_element ~level:(Ctype.get_current_level ()))
+        (Jkind.of_new_sort ~why:Idx_element
+           ~level:(Ctype.get_current_level ()))
     in
     let idx_type_expected =
       match mut with
@@ -8408,6 +8416,7 @@ and type_unboxed_access env loc el_ty ua =
     end;
     let sorts, _rep =
       update_labels env Unboxed_product ~representative_label:label ~loc:lid.loc
+        ~why:Field_in_indexed_record
         ~containing_type:el_ty
     in
     (ty_arg, label.lbl_modalities), Uaccess_unboxed_field (lid, label, sorts)
@@ -9123,15 +9132,6 @@ and type_label_projection
       let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
       (* we now link the two record types *)
       unify_exp env record ty_res;
-      (* CR-soon rtjoa: merge this type of check with
-         [Typedecl.check_representable]. It should also be done within
-         [update_labels] - this will allow sort variables to be created for
-         other places that use [update_labels], such as for block indices *)
-      begin match type_sort ~why:Field_projection ~fixed:false env ty_arg with
-      | Ok _ -> ()
-      | Error err ->
-          raise (Error (loc, env, Field_projection_not_rep(ty_arg, err)))
-      end;
       let record_sorts, record_repres =
         (* This redundantly calculates the sort again. But calling
            [type_sort] above let us infer that the type is representable,
@@ -9141,7 +9141,7 @@ and type_label_projection
            necessary to do it in _this_ inner level so that the correct type
            hits a [generalize_structure] *)
         update_labels env record_form ~representative_label:label ~loc
-          ~containing_type:record.exp_type
+          ~why:Field_projection ~containing_type:record.exp_type
       in
       ty_arg, record_sorts, record_repres
     end ~post:(fun (ty_arg, _, _) -> generalize_structure ty_arg)
@@ -12832,12 +12832,6 @@ let report_error ~loc env =
   | Mutable_var_not_rep (ty, violation) ->
       Location.errorf ~loc
         "@[Mutable variables must be representable.@]@ %a"
-        (Jkind.Violation.report_with_offender
-           ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
-           env) violation
-  | Field_projection_not_rep (ty, violation) ->
-      Location.errorf ~loc
-        "@[Fields being projected must be representable.@]@ %a"
         (Jkind.Violation.report_with_offender
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
            env) violation

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -340,7 +340,6 @@ type error =
   | Record_projection_not_rep of type_expr * Jkind.Violation.t
   | Record_not_rep of type_expr * Jkind.Violation.t
   | Mutable_var_not_rep of type_expr * Jkind.Violation.t
-  | Field_projection_not_rep of type_expr * Jkind.Violation.t
   | Field_value_not_rep of type_expr * Jkind.Violation.t
   | Constructor_arg_projection_not_rep of type_expr * Jkind.Violation.t
   | Constructor_arg_value_not_rep of type_expr * Jkind.Violation.t

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -534,7 +534,7 @@ let set_private_row env loc p decl =
 (* Makes sure a type is representable. When called with a type variable, will
    lower [any] to a sort variable if [allow_unboxed = true], and to [value]
    if [allow_unboxed = false]. *)
-let check_representable ~why env loc kloc typ =
+let constrain_to_representable ~why env loc kloc typ =
   match Ctype.type_sort ~why ~fixed:false env typ with
   | Ok _ -> ()
   | Error err -> raise (Error (loc,Jkind_sort {env; kloc; typ; err}))
@@ -593,7 +593,8 @@ let transl_labels (type rep) ~(record_form : rep record_form) ~new_var_jkind
          let ty = ld.ld_type.ctyp_type in
          let ty = match get_desc ty with Tpoly(t,[]) -> t | _ -> ty in
          if extension then begin
-           check_representable ~why:(Extension_label_declaration ld.ld_id)
+           constrain_to_representable
+             ~why:(Extension_label_declaration ld.ld_id)
              env ld.ld_loc kloc ty
          end;
          {Types.ld_id = ld.ld_id;
@@ -624,7 +625,8 @@ let transl_types_gf ~new_var_jkind env loc univars closed cal kloc ~extension =
   let tyl_gfl = List.map mk cal in
   let tyl_gfl' = List.mapi (fun idx (ca : Typedtree.constructor_argument) ->
     if extension then begin
-      check_representable ~why:(Extension_constructor_declaration idx)
+      constrain_to_representable
+        ~why:(Extension_constructor_declaration idx)
         env loc kloc ca.ca_type.ctyp_type
     end;
     {
@@ -2395,7 +2397,8 @@ let update_record_representation
     | Unboxed_product -> Record_unboxed_product
   in
   List.iter
-    (fun (_lbl, ld_type) -> check_representable ~why env loc kloc ld_type)
+    (fun (_lbl, ld_type) ->
+       constrain_to_representable ~why env loc kloc ld_type)
     lbls_and_types;
   let sorts, rep =
     let warn =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2387,7 +2387,16 @@ let update_record_kind (type rep) env loc (form : rep record_form)
   in
   sorts, rep
 
-let update_record_representation env loc form lbls_and_types =
+let update_record_representation
+      (type rep) ~why env loc (form : rep Types.record_form) lbls_and_types =
+  let kloc : jkind_sort_loc =
+    match form with
+    | Legacy -> Record { unboxed = false }
+    | Unboxed_product -> Record_unboxed_product
+  in
+  List.iter
+    (fun (_lbl, ld_type) -> check_representable ~why env loc kloc ld_type)
+    lbls_and_types;
   let sorts, rep =
     let warn =
       (* Only warn during initial typechecking rather than when updating at

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -112,6 +112,7 @@ type unrepresentable_record =
 (* Update the representation of a record whose representation at declaration
    time was [None] because it has a field of kind [any]. *)
 val update_record_representation:
+    why:Jkind_intf.History.concrete_creation_reason ->
     Env.t -> Location.t -> 'rep Types.record_form ->
     (Types.label_declaration * Types.type_expr) list ->
     (Jkind.Sort.Const.t list * 'rep, unrepresentable_record) Result.t


### PR DESCRIPTION
This improves inference for records containing a type variable of kind `any` by creating sort variables for those types, when typechecking operations that require representability. Previously, we over-eagerly failed when we didn't already have a sort (except for field projection, which was special-cased).

This allows programs like the following to typecheck:

```ocaml
type ('a : any) t = { a : 'a }
let foo { a } = ()
[%%expect{|
type ('a : any) t = { a : 'a; }
val foo : 'a t -> unit = <fun>
|}]
```

Affected operations are pattern matching, record creation, functional update, and block index creation.

**Drive-by:** Fix the `Idx_element` variable creation reason to reference the correct types for indices (`idx_imm`/`idx_mut` instead of `idx`/`mut_idx`).