### PR TITLE
CFG merge functions (share code of equivalent functions in compilation unit)

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -485,6 +485,8 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   match !Oxcaml_flags.cfg_merge_functions with
   | false -> cfg_with_layout
   | true ->
+    (* CR xclerc: we should maybe guard the feature with
+       `-gdwarf-may-alter-codegen`. *)
     Profile.record ~accumulate:true "cfg_merge_functions"
       (Cfg_merge_functions.run fd_cmm.fun_name)
       cfg_with_layout)

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -99,6 +99,7 @@ let (pass_to_cfg : Cfg_format.cfg_unit_info Compiler_pass_map.t) =
 
 let reset () =
   Zero_alloc_checker.reset_unit_info ();
+  Cfg_merge_functions.reset_unit_info ();
   start_from_emit := false;
   Compiler_pass_map.iter
     (fun pass (cfg_unit_info : Cfg_format.cfg_unit_info) ->
@@ -480,6 +481,13 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
           ~stack_slots:(fun x ->
             (Cfg_with_layout.cfg x).Cfg.fun_num_stack_slots)
           ~f:Cfg_available_regs.run)
+  ++ (fun cfg_with_layout ->
+  match !Oxcaml_flags.cfg_merge_functions with
+  | false -> cfg_with_layout
+  | true ->
+    Profile.record ~accumulate:true "cfg_merge_functions"
+      (Cfg_merge_functions.run fd_cmm)
+      cfg_with_layout)
   ++ Profile.record ~accumulate:true "cfg_to_linear" Cfg_to_linear.run
 
 let compile_via_llvm ~ppf_dump ~funcnames cfg_with_layout =

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -486,7 +486,7 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   | false -> cfg_with_layout
   | true ->
     Profile.record ~accumulate:true "cfg_merge_functions"
-      (Cfg_merge_functions.run fd_cmm)
+      (Cfg_merge_functions.run fd_cmm.fun_name)
       cfg_with_layout)
   ++ Profile.record ~accumulate:true "cfg_to_linear" Cfg_to_linear.run
 

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -95,8 +95,7 @@ let equal_codegen_option (l : codegen_option) (r : codegen_option) =
           loc = r_loc
         } ) ->
     Bool.equal l_strict r_strict
-    && Bool.equal l_nrn r_nrn
-    && Bool.equal l_nr r_nr
+    && Bool.equal l_nrn r_nrn && Bool.equal l_nr r_nr
     && equal_location l_loc r_loc
   | ( Check_zero_alloc
         { strict = l_strict; loc = l_loc; custom_error_msg = l_msg },

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -65,6 +65,52 @@ type codegen_option =
         custom_error_msg : string option
       }
 
+(* The destructuring style intentionally matches [Cfg_equiv_specific]: each
+   constructor is named explicitly so that a new variant of [codegen_option]
+   causes a compile error rather than being silently treated as equal. *)
+let equal_codegen_option (l : codegen_option) (r : codegen_option) =
+  let equal_location (l : Location.t) (r : Location.t) =
+    Int.equal (Location.compare l r) 0
+  in
+  match l, r with
+  | Reduce_code_size, Reduce_code_size
+  | No_CSE, No_CSE
+  | Use_linscan_regalloc, Use_linscan_regalloc
+  | Cold, Cold ->
+    true
+  | Use_regalloc l_ra, Use_regalloc r_ra ->
+    Clflags.Register_allocator.equal l_ra r_ra
+  | Use_regalloc_param l_params, Use_regalloc_param r_params ->
+    List.equal String.equal l_params r_params
+  | ( Assume_zero_alloc
+        { strict = l_strict;
+          never_returns_normally = l_nrn;
+          never_raises = l_nr;
+          loc = l_loc
+        },
+      Assume_zero_alloc
+        { strict = r_strict;
+          never_returns_normally = r_nrn;
+          never_raises = r_nr;
+          loc = r_loc
+        } ) ->
+    Bool.equal l_strict r_strict
+    && Bool.equal l_nrn r_nrn
+    && Bool.equal l_nr r_nr
+    && equal_location l_loc r_loc
+  | ( Check_zero_alloc
+        { strict = l_strict; loc = l_loc; custom_error_msg = l_msg },
+      Check_zero_alloc
+        { strict = r_strict; loc = r_loc; custom_error_msg = r_msg } ) ->
+    Bool.equal l_strict r_strict
+    && equal_location l_loc r_loc
+    && Option.equal String.equal l_msg r_msg
+  | ( ( Reduce_code_size | No_CSE | Use_linscan_regalloc | Use_regalloc _
+      | Use_regalloc_param _ | Cold | Assume_zero_alloc _ | Check_zero_alloc _
+        ),
+      _ ) ->
+    false
+
 let rec of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list =
  fun cmm_options ->
   match cmm_options with

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -87,6 +87,8 @@ type codegen_option =
         custom_error_msg : string option
       }
 
+val equal_codegen_option : codegen_option -> codegen_option -> bool
+
 val of_cmm_codegen_option : Cmm.codegen_option list -> codegen_option list
 
 (* CR-someday xclerc: we should probably make `t` abstract and make each and

--- a/backend/cfg/cfg_equiv.ml
+++ b/backend/cfg/cfg_equiv.ml
@@ -358,9 +358,19 @@ let equiv_terminator subst (left : Cfg.terminator) (right : Cfg.terminator) =
       _ ) ->
     false
 
+(* [same_loc] alone is not enough: it compares locations only up to register or
+   stack class, which conflates machtype components that share a class (e.g.
+   [Val], [Int], and [Addr] all map to the integer stack class). That
+   distinction matters here because [Val] denotes a GC root recorded in the
+   frame descriptor at call sites, whereas [Int] does not. Two bodies that are
+   instruction-identical at the location level but disagree on whether a live
+   value is a pointer have different frame tables; merging them and keeping only
+   one body would drop a GC root, so we additionally require the machtype
+   components to be equal. *)
 let same_loc r1 r2 =
   Reg.same_loc_fatal_on_unknown
     ~fatal_message:"Cfg_equiv: unknown register location." r1 r2
+  && Cmm.equal_machtype_component r1.Reg.typ r2.Reg.typ
 
 let equiv_instruction : type a.
     equiv_desc:(Cfg_equiv_subst.t -> a -> a -> bool) ->

--- a/backend/cfg/cfg_merge_blocks.ml
+++ b/backend/cfg/cfg_merge_blocks.ml
@@ -107,7 +107,9 @@ let run :
          lifted? *)
       if (not block.is_trap_handler) && not (Label.equal label cfg.entry_label)
       then begin
-        let block_hash = Cfg_quick_hash.basic_block block in
+        let block_hash =
+          Cfg_quick_hash.basic_block ~ignore_name_for_debugger:false block
+        in
         let curr =
           match Int.Tbl.find_opt buckets block_hash with
           | Some l -> l

--- a/backend/cfg/cfg_merge_functions.ml
+++ b/backend/cfg/cfg_merge_functions.ml
@@ -56,9 +56,13 @@ let buckets : repr list Int.Tbl.t = Int.Tbl.create 64
 
 let reset_unit_info () = Int.Tbl.reset buckets
 
+(* See the note on [same_loc] in [Cfg_equiv]: comparing locations only up to
+   register/stack class conflates [Val] (a GC root) with [Int]/[Addr], so we
+   additionally require the machtype components to be equal. *)
 let same_loc r1 r2 =
   Reg.same_loc_fatal_on_unknown
     ~fatal_message:"Cfg_merge_functions: unknown register location." r1 r2
+  && Cmm.equal_machtype_component r1.Reg.typ r2.Reg.typ
 
 let equal_fun_args left right = Misc.Stdlib.Array.equal same_loc left right
 

--- a/backend/cfg/cfg_merge_functions.ml
+++ b/backend/cfg/cfg_merge_functions.ml
@@ -48,7 +48,7 @@ let max_bucket_size = 128
 (* Cap on the number of representatives per bucket; beyond this we stop
    comparing to keep the cost bounded. *)
 type repr =
-  { fd_cmm : Cmm.fundecl;
+  { fun_symbol : Cmm.symbol;
     cfg_with_layout : Cfg_with_layout.t
   }
 
@@ -88,62 +88,66 @@ let equal_fun_level_fields (left : Cfg.t) (right : Cfg.t) =
   && List.equal Cfg.equal_codegen_option left.fun_codegen_options
        right.fun_codegen_options
 
-let equivalent ~(incoming : Cmm.fundecl) ~(incoming_cfg : Cfg_with_layout.t)
-    ~(repr : repr) =
-  let incoming_cfg_t = Cfg_with_layout.cfg incoming_cfg in
+let equivalent ~(fun_symbol : Cmm.symbol)
+    ~(cfg_with_layout : Cfg_with_layout.t) ~(repr : repr) =
+  let incoming_cfg_t = Cfg_with_layout.cfg cfg_with_layout in
   let repr_cfg_t = Cfg_with_layout.cfg repr.cfg_with_layout in
   if not (equal_fun_level_fields incoming_cfg_t repr_cfg_t)
   then false
   else
     let subst = Cfg_equiv_subst.make () in
-    (* Seed self-recursion: a `Direct incoming_sym` in [incoming]'s body must be
-       considered equivalent to a `Direct repr_sym` in [repr]'s body. *)
-    Cfg_equiv_subst.add_symbol subst incoming.fun_name repr.fd_cmm.fun_name;
+    (* Seed self-recursion: a `Direct fun_symbol` in the incoming body must be
+       considered equivalent to a `Direct repr.fun_symbol` in [repr]'s body. *)
+    Cfg_equiv_subst.add_symbol subst fun_symbol repr.fun_symbol;
     (* CR xclerc: [ignore_dbg]/[ignore_name_for_debugger] default to [true]:
        debug information must not prevent merging. Worth revisiting once we care
        about debugger fidelity for merged functions. *)
     Cfg_equiv.equiv_cfg_with_layout ~ignore_name_for_debugger:true
-      ~ignore_dbg:true subst incoming_cfg repr.cfg_with_layout
+      ~ignore_dbg:true subst cfg_with_layout repr.cfg_with_layout
 
-let build_thunk ~(fd_cmm : Cmm.fundecl) ~(repr : repr) : Cfg_with_layout.t =
-  let repr_sym = repr.fd_cmm.fun_name in
-  let fun_args = (Cfg_with_layout.cfg repr.cfg_with_layout).fun_args in
-  let loc_arg = Array.copy fun_args in
-  let next_instruction_id = InstructionId.make_sequence () in
-  let cfg =
-    Cfg.create ~fun_name:fd_cmm.fun_name.sym_name ~fun_args:loc_arg
-      ~fun_codegen_options:
-        (Cfg.of_cmm_codegen_option fd_cmm.fun_codegen_options)
-      ~fun_dbg:fd_cmm.fun_dbg ~fun_contains_calls:true
-      ~fun_num_stack_slots:(Stack_class.Tbl.make 0) ~fun_poll:fd_cmm.fun_poll
-      ~next_instruction_id ~fun_ret_type:fd_cmm.fun_ret_type
-      ~allowed_to_be_irreducible:false
-  in
-  cfg.register_locations_are_set <- true;
+(* Rewrite [cfg_with_layout] in place to a single-block CFG whose only
+   instruction is a tail call to [repr]'s function symbol. The ABI-relevant
+   fields ([fun_args], [fun_ret_type], [fun_codegen_options], [fun_poll],
+   [fun_dbg], [entry_label], [next_instruction_id]) are kept as-is: they are
+   either immutable in [Cfg.t] or already match what we would have set them
+   to. [arg] is left empty on the terminator: [cfg_invariants] does not
+   constrain the arity of [Tailcall_func (Direct _)], and downstream emit for
+   [Ltailcall_imm] only reads the target symbol.
+
+   CR xclerc: [fun_contains_calls] is left untouched. It is correct when the
+   original body already contained a call (it still does, just a tail call),
+   but stale when the original was a leaf: the thunk now does call (jmp)
+   another function. The field is mainly informational at this stage, but if
+   downstream consumers grow to rely on it, [fun_contains_calls] should be
+   made mutable in [Cfg.t] and updated here. *)
+let rewrite_to_thunk ~(cfg_with_layout : Cfg_with_layout.t) ~(repr : repr) =
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  Stack_class.Tbl.iter cfg.fun_num_stack_slots
+    ~f:(fun stack_class _ ->
+      Stack_class.Tbl.replace cfg.fun_num_stack_slots stack_class 0);
+  Label.Tbl.reset cfg.blocks;
   let terminator : Cfg.terminator Cfg.instruction =
-    { desc = Cfg.Tailcall_func (Cfg.Direct repr_sym);
-      arg = loc_arg;
+    { desc = Cfg.Tailcall_func (Cfg.Direct repr.fun_symbol);
+      arg = [||];
       res = [||];
       dbg = Debuginfo.none;
       fdo = Fdo_info.none;
       live = Reg.Set.empty;
       stack_offset = 0;
-      id = InstructionId.get_and_incr next_instruction_id;
+      id = InstructionId.get_and_incr cfg.next_instruction_id;
       available_before = Unreachable;
       available_across = Unreachable
     }
   in
-  let entry_block =
-    Cfg.make_empty_block ~label:(Cfg.entry_label cfg) terminator
-  in
+  let entry_block = Cfg.make_empty_block ~label:cfg.entry_label terminator in
   entry_block.stack_offset <- 0;
   entry_block.can_raise <- false;
   Cfg.add_block_exn cfg entry_block;
-  let layout = DLL.make_empty () in
-  DLL.add_end layout entry_block.start;
-  Cfg_with_layout.create cfg ~layout
+  let layout = Cfg_with_layout.layout cfg_with_layout in
+  DLL.clear layout;
+  DLL.add_end layout entry_block.start
 
-let run fd_cmm cfg_with_layout =
+let run fun_symbol cfg_with_layout =
   let hash = Cfg_quick_hash.cfg_with_layout cfg_with_layout in
   let bucket =
     match Int.Tbl.find_opt buckets hash with None -> [] | Some l -> l
@@ -151,7 +155,7 @@ let run fd_cmm cfg_with_layout =
   let rec find_match = function
     | [] -> None
     | repr :: rest ->
-      if equivalent ~incoming:fd_cmm ~incoming_cfg:cfg_with_layout ~repr
+      if equivalent ~fun_symbol ~cfg_with_layout ~repr
       then Some repr
       else find_match rest
   in
@@ -162,7 +166,10 @@ let run fd_cmm cfg_with_layout =
     cfg_with_layout
   else
     match find_match bucket with
-    | Some repr -> build_thunk ~fd_cmm ~repr
+    | Some repr ->
+      rewrite_to_thunk ~cfg_with_layout ~repr;
+      cfg_with_layout
     | None ->
-      Int.Tbl.replace buckets hash ({ fd_cmm; cfg_with_layout } :: bucket);
+      Int.Tbl.replace buckets hash
+        ({ fun_symbol; cfg_with_layout } :: bucket);
       cfg_with_layout

--- a/backend/cfg/cfg_merge_functions.ml
+++ b/backend/cfg/cfg_merge_functions.ml
@@ -1,0 +1,214 @@
+(**********************************************************************************
+ *                             MIT License                                        *
+ *                                                                                *
+ *                                                                                *
+ * Copyright (c) 2026 Jane Street Group LLC                                       *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ *                                                                                *
+ **********************************************************************************)
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare
+module DLL = Oxcaml_utils.Doubly_linked_list
+module Int = Numbers.Int
+
+(* Once a duplicate function is identified, three rewrite strategies are
+   plausible: 1. Detect and report only: emit a diagnostic listing the
+   equivalence classes but leave the CFGs untouched. Useful for measurement
+   before committing to a rewriting strategy. 2. Symbol alias: collapse the
+   duplicate's symbol to the representative's via an assembler alias (e.g. `.set
+   foo, bar`). Zero instruction overhead, but the duplicate no longer has its
+   own entry point and its address coincides with the representative's, which
+   matters if anything compares function addresses for equality. 3. Tail-call
+   thunk: keep the duplicate's symbol and entry point but replace its body with
+   a single tail call to the representative. Costs one jump per call into the
+   duplicate, but preserves distinct addresses. This is the strategy implemented
+   here. *)
+
+(* CR xclerc: the per-bucket cap mirrors [Cfg_merge_blocks]. *)
+let max_bucket_size = 128
+
+(* Cap on the number of representatives per bucket; beyond this we stop
+   comparing to keep the cost bounded. *)
+type repr =
+  { fd_cmm : Cmm.fundecl;
+    cfg_with_layout : Cfg_with_layout.t
+  }
+
+let buckets : repr list Int.Tbl.t = Int.Tbl.create 64
+
+let reset_unit_info () = Int.Tbl.reset buckets
+
+let same_loc r1 r2 =
+  Reg.same_loc_fatal_on_unknown
+    ~fatal_message:"Cfg_merge_functions: unknown register location." r1 r2
+
+let equal_fun_args left right = Misc.Stdlib.Array.equal same_loc left right
+
+let equal_poll_attribute (l : Lambda.poll_attribute) (r : Lambda.poll_attribute)
+    =
+  match l, r with
+  | Error_poll, Error_poll | Default_poll, Default_poll -> true
+  | (Error_poll | Default_poll), _ -> false
+
+let equal_stack_slots left right =
+  Stack_class.Tbl.fold left ~init:true ~f:(fun stack_class n acc ->
+      acc && Int.equal n (Stack_class.Tbl.find right stack_class))
+
+let equal_location (l : Location.t) (r : Location.t) =
+  Int.equal (Location.compare l r) 0
+
+(* The destructuring style intentionally matches [Cfg_equiv_specific]: each
+   constructor is named explicitly so that a new variant of [Cfg.codegen_option]
+   causes a compile error rather than being silently treated as equal. *)
+let equal_codegen_option (l : Cfg.codegen_option) (r : Cfg.codegen_option) =
+  match l, r with
+  | Reduce_code_size, Reduce_code_size
+  | No_CSE, No_CSE
+  | Use_linscan_regalloc, Use_linscan_regalloc
+  | Cold, Cold ->
+    true
+  | Use_regalloc l_ra, Use_regalloc r_ra ->
+    Clflags.Register_allocator.equal l_ra r_ra
+  | Use_regalloc_param l_params, Use_regalloc_param r_params ->
+    List.equal String.equal l_params r_params
+  | ( Assume_zero_alloc
+        { strict = l_strict;
+          never_returns_normally = l_nrn;
+          never_raises = l_nr;
+          loc = l_loc
+        },
+      Assume_zero_alloc
+        { strict = r_strict;
+          never_returns_normally = r_nrn;
+          never_raises = r_nr;
+          loc = r_loc
+        } ) ->
+    Bool.equal l_strict r_strict
+    && Bool.equal l_nrn r_nrn
+    && Bool.equal l_nr r_nr
+    && equal_location l_loc r_loc
+  | ( Check_zero_alloc
+        { strict = l_strict; loc = l_loc; custom_error_msg = l_msg },
+      Check_zero_alloc
+        { strict = r_strict; loc = r_loc; custom_error_msg = r_msg } ) ->
+    Bool.equal l_strict r_strict
+    && equal_location l_loc r_loc
+    && Option.equal String.equal l_msg r_msg
+  | ( ( Reduce_code_size | No_CSE | Use_linscan_regalloc | Use_regalloc _
+      | Use_regalloc_param _ | Cold | Assume_zero_alloc _ | Check_zero_alloc _
+        ),
+      _ ) ->
+    false
+
+(* CR xclerc: the function-level guard below is intentionally conservative: it
+   requires equality of every [Cfg.t] field that could conceivably matter. In
+   particular, [fun_codegen_options] is compared per constructor, which means
+   two otherwise-equivalent functions that disagree on (say) a [Cold] attribute
+   or carry a [Check_zero_alloc] with distinct source locations will fail to
+   merge. The choice should be revisited once we have data on what gets
+   rejected. *)
+let equal_fun_level_fields (left : Cfg.t) (right : Cfg.t) =
+  equal_fun_args left.fun_args right.fun_args
+  && Cmm.equal_machtype left.fun_ret_type right.fun_ret_type
+  && Bool.equal left.fun_contains_calls right.fun_contains_calls
+  && equal_poll_attribute left.fun_poll right.fun_poll
+  && equal_stack_slots left.fun_num_stack_slots right.fun_num_stack_slots
+  && List.equal equal_codegen_option left.fun_codegen_options
+       right.fun_codegen_options
+
+let equivalent ~(incoming : Cmm.fundecl) ~(incoming_cfg : Cfg_with_layout.t)
+    ~(repr : repr) =
+  let incoming_cfg_t = Cfg_with_layout.cfg incoming_cfg in
+  let repr_cfg_t = Cfg_with_layout.cfg repr.cfg_with_layout in
+  if not (equal_fun_level_fields incoming_cfg_t repr_cfg_t)
+  then false
+  else
+    let subst = Cfg_equiv_subst.make () in
+    (* Seed self-recursion: a `Direct incoming_sym` in [incoming]'s body must be
+       considered equivalent to a `Direct repr_sym` in [repr]'s body. *)
+    Cfg_equiv_subst.add_symbol subst incoming.fun_name repr.fd_cmm.fun_name;
+    (* CR xclerc: [ignore_dbg]/[ignore_name_for_debugger] default to [true]:
+       debug information must not prevent merging. Worth revisiting once we care
+       about debugger fidelity for merged functions. *)
+    Cfg_equiv.equiv_cfg_with_layout ~ignore_name_for_debugger:true
+      ~ignore_dbg:true subst incoming_cfg repr.cfg_with_layout
+
+let build_thunk ~(fd_cmm : Cmm.fundecl) ~(repr : repr) : Cfg_with_layout.t =
+  let repr_sym = repr.fd_cmm.fun_name in
+  let fun_args = (Cfg_with_layout.cfg repr.cfg_with_layout).fun_args in
+  let loc_arg = Array.copy fun_args in
+  let next_instruction_id = InstructionId.make_sequence () in
+  let cfg =
+    Cfg.create ~fun_name:fd_cmm.fun_name.sym_name ~fun_args:loc_arg
+      ~fun_codegen_options:
+        (Cfg.of_cmm_codegen_option fd_cmm.fun_codegen_options)
+      ~fun_dbg:fd_cmm.fun_dbg ~fun_contains_calls:true
+      ~fun_num_stack_slots:(Stack_class.Tbl.make 0) ~fun_poll:fd_cmm.fun_poll
+      ~next_instruction_id ~fun_ret_type:fd_cmm.fun_ret_type
+      ~allowed_to_be_irreducible:false
+  in
+  cfg.register_locations_are_set <- true;
+  let terminator : Cfg.terminator Cfg.instruction =
+    { desc = Cfg.Tailcall_func (Cfg.Direct repr_sym);
+      arg = loc_arg;
+      res = [||];
+      dbg = Debuginfo.none;
+      fdo = Fdo_info.none;
+      live = Reg.Set.empty;
+      stack_offset = 0;
+      id = InstructionId.get_and_incr next_instruction_id;
+      available_before = Unreachable;
+      available_across = Unreachable
+    }
+  in
+  let entry_block =
+    Cfg.make_empty_block ~label:(Cfg.entry_label cfg) terminator
+  in
+  entry_block.stack_offset <- 0;
+  entry_block.can_raise <- false;
+  Cfg.add_block_exn cfg entry_block;
+  let layout = DLL.make_empty () in
+  DLL.add_end layout entry_block.start;
+  Cfg_with_layout.create cfg ~layout
+
+let run fd_cmm cfg_with_layout =
+  let hash = Cfg_quick_hash.cfg_with_layout cfg_with_layout in
+  let bucket =
+    match Int.Tbl.find_opt buckets hash with None -> [] | Some l -> l
+  in
+  let rec find_match = function
+    | [] -> None
+    | repr :: rest ->
+      if equivalent ~incoming:fd_cmm ~incoming_cfg:cfg_with_layout ~repr
+      then Some repr
+      else find_match rest
+  in
+  if List.length bucket >= max_bucket_size
+  then
+    (* Bucket saturated: do not even attempt the comparison, but do not register
+       this function either (we would never compare against it anyway). *)
+    cfg_with_layout
+  else
+    match find_match bucket with
+    | Some repr -> build_thunk ~fd_cmm ~repr
+    | None ->
+      Int.Tbl.replace buckets hash ({ fd_cmm; cfg_with_layout } :: bucket);
+      cfg_with_layout

--- a/backend/cfg/cfg_merge_functions.ml
+++ b/backend/cfg/cfg_merge_functions.ml
@@ -72,52 +72,6 @@ let equal_stack_slots left right =
   Stack_class.Tbl.fold left ~init:true ~f:(fun stack_class n acc ->
       acc && Int.equal n (Stack_class.Tbl.find right stack_class))
 
-let equal_location (l : Location.t) (r : Location.t) =
-  Int.equal (Location.compare l r) 0
-
-(* The destructuring style intentionally matches [Cfg_equiv_specific]: each
-   constructor is named explicitly so that a new variant of [Cfg.codegen_option]
-   causes a compile error rather than being silently treated as equal. *)
-let equal_codegen_option (l : Cfg.codegen_option) (r : Cfg.codegen_option) =
-  match l, r with
-  | Reduce_code_size, Reduce_code_size
-  | No_CSE, No_CSE
-  | Use_linscan_regalloc, Use_linscan_regalloc
-  | Cold, Cold ->
-    true
-  | Use_regalloc l_ra, Use_regalloc r_ra ->
-    Clflags.Register_allocator.equal l_ra r_ra
-  | Use_regalloc_param l_params, Use_regalloc_param r_params ->
-    List.equal String.equal l_params r_params
-  | ( Assume_zero_alloc
-        { strict = l_strict;
-          never_returns_normally = l_nrn;
-          never_raises = l_nr;
-          loc = l_loc
-        },
-      Assume_zero_alloc
-        { strict = r_strict;
-          never_returns_normally = r_nrn;
-          never_raises = r_nr;
-          loc = r_loc
-        } ) ->
-    Bool.equal l_strict r_strict
-    && Bool.equal l_nrn r_nrn
-    && Bool.equal l_nr r_nr
-    && equal_location l_loc r_loc
-  | ( Check_zero_alloc
-        { strict = l_strict; loc = l_loc; custom_error_msg = l_msg },
-      Check_zero_alloc
-        { strict = r_strict; loc = r_loc; custom_error_msg = r_msg } ) ->
-    Bool.equal l_strict r_strict
-    && equal_location l_loc r_loc
-    && Option.equal String.equal l_msg r_msg
-  | ( ( Reduce_code_size | No_CSE | Use_linscan_regalloc | Use_regalloc _
-      | Use_regalloc_param _ | Cold | Assume_zero_alloc _ | Check_zero_alloc _
-        ),
-      _ ) ->
-    false
-
 (* CR xclerc: the function-level guard below is intentionally conservative: it
    requires equality of every [Cfg.t] field that could conceivably matter. In
    particular, [fun_codegen_options] is compared per constructor, which means
@@ -131,7 +85,7 @@ let equal_fun_level_fields (left : Cfg.t) (right : Cfg.t) =
   && Bool.equal left.fun_contains_calls right.fun_contains_calls
   && equal_poll_attribute left.fun_poll right.fun_poll
   && equal_stack_slots left.fun_num_stack_slots right.fun_num_stack_slots
-  && List.equal equal_codegen_option left.fun_codegen_options
+  && List.equal Cfg.equal_codegen_option left.fun_codegen_options
        right.fun_codegen_options
 
 let equivalent ~(incoming : Cmm.fundecl) ~(incoming_cfg : Cfg_with_layout.t)

--- a/backend/cfg/cfg_merge_functions.ml
+++ b/backend/cfg/cfg_merge_functions.ml
@@ -148,7 +148,10 @@ let rewrite_to_thunk ~(cfg_with_layout : Cfg_with_layout.t) ~(repr : repr) =
   DLL.add_end layout entry_block.start
 
 let run fun_symbol cfg_with_layout =
-  let hash = Cfg_quick_hash.cfg_with_layout cfg_with_layout in
+  let hash =
+    Cfg_quick_hash.cfg_with_layout ~ignore_name_for_debugger:true
+      cfg_with_layout
+  in
   let bucket =
     match Int.Tbl.find_opt buckets hash with None -> [] | Some l -> l
   in

--- a/backend/cfg/cfg_merge_functions.ml
+++ b/backend/cfg/cfg_merge_functions.ml
@@ -88,8 +88,8 @@ let equal_fun_level_fields (left : Cfg.t) (right : Cfg.t) =
   && List.equal Cfg.equal_codegen_option left.fun_codegen_options
        right.fun_codegen_options
 
-let equivalent ~(fun_symbol : Cmm.symbol)
-    ~(cfg_with_layout : Cfg_with_layout.t) ~(repr : repr) =
+let equivalent ~(fun_symbol : Cmm.symbol) ~(cfg_with_layout : Cfg_with_layout.t)
+    ~(repr : repr) =
   let incoming_cfg_t = Cfg_with_layout.cfg cfg_with_layout in
   let repr_cfg_t = Cfg_with_layout.cfg repr.cfg_with_layout in
   if not (equal_fun_level_fields incoming_cfg_t repr_cfg_t)
@@ -109,21 +109,20 @@ let equivalent ~(fun_symbol : Cmm.symbol)
    instruction is a tail call to [repr]'s function symbol. The ABI-relevant
    fields ([fun_args], [fun_ret_type], [fun_codegen_options], [fun_poll],
    [fun_dbg], [entry_label], [next_instruction_id]) are kept as-is: they are
-   either immutable in [Cfg.t] or already match what we would have set them
-   to. [arg] is left empty on the terminator: [cfg_invariants] does not
-   constrain the arity of [Tailcall_func (Direct _)], and downstream emit for
+   either immutable in [Cfg.t] or already match what we would have set them to.
+   [arg] is left empty on the terminator: [cfg_invariants] does not constrain
+   the arity of [Tailcall_func (Direct _)], and downstream emit for
    [Ltailcall_imm] only reads the target symbol.
 
    CR xclerc: [fun_contains_calls] is left untouched. It is correct when the
-   original body already contained a call (it still does, just a tail call),
-   but stale when the original was a leaf: the thunk now does call (jmp)
-   another function. The field is mainly informational at this stage, but if
-   downstream consumers grow to rely on it, [fun_contains_calls] should be
-   made mutable in [Cfg.t] and updated here. *)
+   original body already contained a call (it still does, just a tail call), but
+   stale when the original was a leaf: the thunk now does call (jmp) another
+   function. The field is mainly informational at this stage, but if downstream
+   consumers grow to rely on it, [fun_contains_calls] should be made mutable in
+   [Cfg.t] and updated here. *)
 let rewrite_to_thunk ~(cfg_with_layout : Cfg_with_layout.t) ~(repr : repr) =
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
-  Stack_class.Tbl.iter cfg.fun_num_stack_slots
-    ~f:(fun stack_class _ ->
+  Stack_class.Tbl.iter cfg.fun_num_stack_slots ~f:(fun stack_class _ ->
       Stack_class.Tbl.replace cfg.fun_num_stack_slots stack_class 0);
   Label.Tbl.reset cfg.blocks;
   let terminator : Cfg.terminator Cfg.instruction =
@@ -173,6 +172,5 @@ let run fun_symbol cfg_with_layout =
       rewrite_to_thunk ~cfg_with_layout ~repr;
       cfg_with_layout
     | None ->
-      Int.Tbl.replace buckets hash
-        ({ fun_symbol; cfg_with_layout } :: bucket);
+      Int.Tbl.replace buckets hash ({ fun_symbol; cfg_with_layout } :: bucket);
       cfg_with_layout

--- a/backend/cfg/cfg_merge_functions.ml
+++ b/backend/cfg/cfg_merge_functions.ml
@@ -103,6 +103,41 @@ let equivalent ~(fun_symbol : Cmm.symbol) ~(cfg_with_layout : Cfg_with_layout.t)
     (* Seed self-recursion: a `Direct fun_symbol` in the incoming body must be
        considered equivalent to a `Direct repr.fun_symbol` in [repr]'s body. *)
     Cfg_equiv_subst.add_symbol subst fun_symbol repr.fun_symbol;
+    (* CR xclerc: we could also seed [subst] with the mappings of every function
+       already merged in this unit (each merged function's symbol -> its
+       representative's symbol). That would let us merge two functions that are
+       identical except that one calls [g2] where the other calls [g1], when
+       [g2] has itself already been merged into [g1]. The quick hash ignores
+       symbol identity (it hashes constructor tags only), so such pairs do land
+       in the same bucket and would get here.
+
+       It is *not* done today because it would be unsound as [subst] is
+       currently consumed. [Cfg_equiv] applies [subst_symbol] in two kinds of
+       position with the same map:
+       - call positions ([Direct]/[Indirect], [Tailcall_func], [Call]): mapping
+         a merged symbol to its representative is sound, because the merged
+         function is now a thunk that tail-jumps to the representative, so
+         calling either runs the same code;
+       - value/address positions ([Const_symbol], and [Ibased] addressing
+         modes -- e.g. a code pointer embedded in a closure): unsound. The whole
+         point of the tail-call-thunk strategy (over a symbol alias) is to keep
+         distinct addresses for the merged function and its representative, so
+         [&g2] and [&g1] must not be treated as equal. Anything comparing
+         closures/code pointers by physical equality would otherwise observe the
+         wrong identity.
+
+       To do it safely, [Cfg_equiv_subst] would need to split the symbol map
+       into a call-position map and a value-position map; [Cfg_equiv] would
+       consult the call map only from the call/tailcall cases and the
+       (identity-only) value map from [Const_symbol]/[Ibased]; and the merged
+       mappings -- and arguably the self-recursion seed above, which has the
+       same latent value-position issue if a function embeds its own code symbol
+       -- would go into the call-position map only. Two further caveats: the
+       mapping is one-directional (it only helps when the incoming function
+       references the merged symbol and the representative references the
+       representative symbol), and it assumes a representative never itself
+       later becomes a thunk (true today: representatives are never
+       reprocessed). *)
     (* CR xclerc: [ignore_dbg]/[ignore_name_for_debugger] default to [true]:
        debug information must not prevent merging. Worth revisiting once we care
        about debugger fidelity for merged functions. *)

--- a/backend/cfg/cfg_merge_functions.mli
+++ b/backend/cfg/cfg_merge_functions.mli
@@ -37,10 +37,13 @@
 
 val reset_unit_info : unit -> unit
 
-(** [run fd_cmm cfg_with_layout] inspects [cfg_with_layout]:
-    - if it is equivalent to a previously-registered representative, returns a
-      freshly-built thunk CFG whose body is a single tail call to the
+(** [run fun_symbol cfg_with_layout] inspects [cfg_with_layout]:
+    - if it is equivalent to a previously-registered representative, rewrites
+      [cfg_with_layout] in place to a single-block thunk that tail-calls the
       representative's symbol;
-    - otherwise registers [(fd_cmm, cfg_with_layout)] as a new representative
-      and returns [cfg_with_layout] unchanged. *)
-val run : Cmm.fundecl -> Cfg_with_layout.t -> Cfg_with_layout.t
+    - otherwise registers [cfg_with_layout] (with [fun_symbol]) as a new
+      representative and returns it unchanged.
+
+    The returned [Cfg_with_layout.t] is always the same instance as the one
+    passed in. *)
+val run : Cmm.symbol -> Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_merge_functions.mli
+++ b/backend/cfg/cfg_merge_functions.mli
@@ -1,0 +1,46 @@
+(**********************************************************************************
+ *                             MIT License                                        *
+ *                                                                                *
+ *                                                                                *
+ * Copyright (c) 2026 Jane Street Group LLC                                       *
+ *                                                                                *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy   *
+ * of this software and associated documentation files (the "Software"), to deal  *
+ * in the Software without restriction, including without limitation the rights   *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      *
+ * copies of the Software, and to permit persons to whom the Software is          *
+ * furnished to do so, subject to the following conditions:                       *
+ *                                                                                *
+ * The above copyright notice and this permission notice shall be included in all *
+ * copies or substantial portions of the Software.                                *
+ *                                                                                *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  *
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  *
+ * SOFTWARE.                                                                      *
+ *                                                                                *
+ **********************************************************************************)
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Identify functions in a compilation unit whose CFGs are equivalent (up to a
+    substitution, see [Cfg_equiv]) to one already seen and rewrite the
+    duplicates to a tail-call thunk that jumps to the representative.
+
+    The module maintains a unit-scoped, mutable set of representatives. It is
+    used as a streaming filter: each function passes through [process], and
+    either becomes a fresh representative or is rewritten in place.
+
+    [reset_unit_info] must be called at the start of every compilation unit. *)
+
+val reset_unit_info : unit -> unit
+
+(** [run fd_cmm cfg_with_layout] inspects [cfg_with_layout]:
+    - if it is equivalent to a previously-registered representative, returns a
+      freshly-built thunk CFG whose body is a single tail call to the
+      representative's symbol;
+    - otherwise registers [(fd_cmm, cfg_with_layout)] as a new representative
+      and returns [cfg_with_layout] unchanged. *)
+val run : Cmm.fundecl -> Cfg_with_layout.t -> Cfg_with_layout.t

--- a/backend/cfg/cfg_quick_hash.ml
+++ b/backend/cfg/cfg_quick_hash.ml
@@ -86,12 +86,13 @@ let rec basic_instruction_cell :
       let instr = DLL.value cell in
       if ignore_name_for_debugger && Cfg.is_name_for_debugger instr
       then
-        basic_instruction_cell ~ignore_name_for_debugger (DLL.next cell)
-          ~fuel ~acc
+        basic_instruction_cell ~ignore_name_for_debugger (DLL.next cell) ~fuel
+          ~acc
       else
         let instr_hash = basic instr.desc in
         basic_instruction_cell ~ignore_name_for_debugger (DLL.next cell)
-          ~fuel:(pred fuel) ~acc:(hash_combine acc instr_hash)
+          ~fuel:(pred fuel)
+          ~acc:(hash_combine acc instr_hash)
 
 let basic_instruction_list :
     ignore_name_for_debugger:bool -> Cfg.basic Cfg.instruction DLL.t -> int =
@@ -100,8 +101,7 @@ let basic_instruction_list :
   basic_instruction_cell ~ignore_name_for_debugger (DLL.hd_cell l) ~fuel:4
     ~acc:0
 
-let basic_block :
-    ignore_name_for_debugger:bool -> Cfg.basic_block -> int =
+let basic_block : ignore_name_for_debugger:bool -> Cfg.basic_block -> int =
  fun ~ignore_name_for_debugger block ->
   match block with
   | { start = _;
@@ -144,7 +144,6 @@ let cfg_with_layout ~ignore_name_for_debugger cfg_with_layout =
         let label = DLL.value cell in
         let block = Cfg.get_block_exn cfg label in
         hash (DLL.next cell) ~fuel:(pred fuel)
-          ~acc:
-            (hash_combine acc (basic_block ~ignore_name_for_debugger block))
+          ~acc:(hash_combine acc (basic_block ~ignore_name_for_debugger block))
   in
   hash (DLL.hd_cell layout) ~fuel:4 ~acc:0

--- a/backend/cfg/cfg_quick_hash.ml
+++ b/backend/cfg/cfg_quick_hash.ml
@@ -115,3 +115,22 @@ let basic_block : Cfg.basic_block -> int =
     let body_hash = basic_instruction_list body in
     let term_hash = terminator terminator_desc in
     hash_combine body_hash term_hash
+
+(* The hash walks at most [fuel] blocks of the layout: enough to discriminate
+   most functions while keeping the cost bounded for very large CFGs. *)
+let cfg_with_layout cfg_with_layout =
+  let cfg = Cfg_with_layout.cfg cfg_with_layout in
+  let layout = Cfg_with_layout.layout cfg_with_layout in
+  let rec hash label_cell ~fuel ~acc =
+    match label_cell with
+    | None -> acc
+    | Some cell ->
+      if fuel <= 0
+      then acc
+      else
+        let label = DLL.value cell in
+        let block = Cfg.get_block_exn cfg label in
+        hash (DLL.next cell) ~fuel:(pred fuel)
+          ~acc:(hash_combine acc (basic_block block))
+  in
+  hash (DLL.hd_cell layout) ~fuel:4 ~acc:0

--- a/backend/cfg/cfg_quick_hash.ml
+++ b/backend/cfg/cfg_quick_hash.ml
@@ -71,25 +71,38 @@ let terminator : Cfg.terminator -> int =
   | Prim _ -> 14
 
 let rec basic_instruction_cell :
-    Cfg.basic Cfg.instruction DLL.cell option -> fuel:int -> acc:int -> int =
- fun cell ~fuel ~acc ->
+    ignore_name_for_debugger:bool ->
+    Cfg.basic Cfg.instruction DLL.cell option ->
+    fuel:int ->
+    acc:int ->
+    int =
+ fun ~ignore_name_for_debugger cell ~fuel ~acc ->
   if fuel <= 0
   then acc
   else
     match cell with
     | None -> acc
     | Some cell ->
-      let instr_hash = basic (DLL.value cell).desc in
-      basic_instruction_cell (DLL.next cell) ~fuel:(pred fuel)
-        ~acc:(hash_combine acc instr_hash)
+      let instr = DLL.value cell in
+      if ignore_name_for_debugger && Cfg.is_name_for_debugger instr
+      then
+        basic_instruction_cell ~ignore_name_for_debugger (DLL.next cell)
+          ~fuel ~acc
+      else
+        let instr_hash = basic instr.desc in
+        basic_instruction_cell ~ignore_name_for_debugger (DLL.next cell)
+          ~fuel:(pred fuel) ~acc:(hash_combine acc instr_hash)
 
-let basic_instruction_list : Cfg.basic Cfg.instruction DLL.t -> int =
- fun l ->
+let basic_instruction_list :
+    ignore_name_for_debugger:bool -> Cfg.basic Cfg.instruction DLL.t -> int =
+ fun ~ignore_name_for_debugger l ->
   (* CR-someday xclerc for xclerc: also use the list length? *)
-  basic_instruction_cell (DLL.hd_cell l) ~fuel:4 ~acc:0
+  basic_instruction_cell ~ignore_name_for_debugger (DLL.hd_cell l) ~fuel:4
+    ~acc:0
 
-let basic_block : Cfg.basic_block -> int =
- fun block ->
+let basic_block :
+    ignore_name_for_debugger:bool -> Cfg.basic_block -> int =
+ fun ~ignore_name_for_debugger block ->
   match block with
   | { start = _;
       body;
@@ -112,13 +125,13 @@ let basic_block : Cfg.basic_block -> int =
       is_trap_handler = _;
       cold = _
     } ->
-    let body_hash = basic_instruction_list body in
+    let body_hash = basic_instruction_list ~ignore_name_for_debugger body in
     let term_hash = terminator terminator_desc in
     hash_combine body_hash term_hash
 
 (* The hash walks at most [fuel] blocks of the layout: enough to discriminate
    most functions while keeping the cost bounded for very large CFGs. *)
-let cfg_with_layout cfg_with_layout =
+let cfg_with_layout ~ignore_name_for_debugger cfg_with_layout =
   let cfg = Cfg_with_layout.cfg cfg_with_layout in
   let layout = Cfg_with_layout.layout cfg_with_layout in
   let rec hash label_cell ~fuel ~acc =
@@ -131,6 +144,7 @@ let cfg_with_layout cfg_with_layout =
         let label = DLL.value cell in
         let block = Cfg.get_block_exn cfg label in
         hash (DLL.next cell) ~fuel:(pred fuel)
-          ~acc:(hash_combine acc (basic_block block))
+          ~acc:
+            (hash_combine acc (basic_block ~ignore_name_for_debugger block))
   in
   hash (DLL.hd_cell layout) ~fuel:4 ~acc:0

--- a/backend/cfg/cfg_quick_hash.mli
+++ b/backend/cfg/cfg_quick_hash.mli
@@ -21,8 +21,16 @@ val basic : Cfg.basic -> int
 
 val terminator : Cfg.terminator -> int
 
-val basic_instruction_list : Cfg.basic Cfg.instruction DLL.t -> int
+(** When [ignore_name_for_debugger] is [true], [Op (Name_for_debugger _)]
+    cells are skipped: they do not contribute to the hash and do not shift
+    later cells out of the bounded walk window. Callers that compare with
+    [Cfg_equiv]'s [~ignore_name_for_debugger:true] should pass the same value
+    here, otherwise functions equivalent up to [Name_for_debugger] placement
+    can land in different buckets and be missed. *)
+val basic_instruction_list :
+  ignore_name_for_debugger:bool -> Cfg.basic Cfg.instruction DLL.t -> int
 
-val basic_block : Cfg.basic_block -> int
+val basic_block : ignore_name_for_debugger:bool -> Cfg.basic_block -> int
 
-val cfg_with_layout : Cfg_with_layout.t -> int
+val cfg_with_layout :
+  ignore_name_for_debugger:bool -> Cfg_with_layout.t -> int

--- a/backend/cfg/cfg_quick_hash.mli
+++ b/backend/cfg/cfg_quick_hash.mli
@@ -24,3 +24,5 @@ val terminator : Cfg.terminator -> int
 val basic_instruction_list : Cfg.basic Cfg.instruction DLL.t -> int
 
 val basic_block : Cfg.basic_block -> int
+
+val cfg_with_layout : Cfg_with_layout.t -> int

--- a/backend/cfg/cfg_quick_hash.mli
+++ b/backend/cfg/cfg_quick_hash.mli
@@ -21,16 +21,15 @@ val basic : Cfg.basic -> int
 
 val terminator : Cfg.terminator -> int
 
-(** When [ignore_name_for_debugger] is [true], [Op (Name_for_debugger _)]
-    cells are skipped: they do not contribute to the hash and do not shift
-    later cells out of the bounded walk window. Callers that compare with
-    [Cfg_equiv]'s [~ignore_name_for_debugger:true] should pass the same value
-    here, otherwise functions equivalent up to [Name_for_debugger] placement
-    can land in different buckets and be missed. *)
+(** When [ignore_name_for_debugger] is [true], [Op (Name_for_debugger _)] cells
+    are skipped: they do not contribute to the hash and do not shift later cells
+    out of the bounded walk window. Callers that compare with [Cfg_equiv]'s
+    [~ignore_name_for_debugger:true] should pass the same value here, otherwise
+    functions equivalent up to [Name_for_debugger] placement can land in
+    different buckets and be missed. *)
 val basic_instruction_list :
   ignore_name_for_debugger:bool -> Cfg.basic Cfg.instruction DLL.t -> int
 
 val basic_block : ignore_name_for_debugger:bool -> Cfg.basic_block -> int
 
-val cfg_with_layout :
-  ignore_name_for_debugger:bool -> Cfg_with_layout.t -> int
+val cfg_with_layout : ignore_name_for_debugger:bool -> Cfg_with_layout.t -> int

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -197,6 +197,14 @@ let mk_cfg_merge_blocks f =
 let mk_no_cfg_merge_blocks f =
   ("-no-cfg-merge-blocks", Arg.Unit f, " Do not merge equivalent CFG blocks")
 
+let mk_cfg_merge_functions f =
+  ("-cfg-merge-functions", Arg.Unit f, " Merge equivalent CFG functions")
+
+let mk_no_cfg_merge_functions f =
+  ( "-no-cfg-merge-functions",
+    Arg.Unit f,
+    " Do not merge equivalent CFG functions" )
+
 let mk_cfg_value_propagation f =
   ("-cfg-value-propagation", Arg.Unit f, " Propagate value to simplify CFG")
 
@@ -1294,6 +1302,8 @@ module type Oxcaml_options = sig
   val cfg_prologue_shrink_wrap_threshold : int -> unit
   val cfg_merge_blocks : unit -> unit
   val no_cfg_merge_blocks : unit -> unit
+  val cfg_merge_functions : unit -> unit
+  val no_cfg_merge_functions : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit
@@ -1480,6 +1490,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_prologue_shrink_wrap_threshold F.cfg_prologue_shrink_wrap_threshold;
       mk_cfg_merge_blocks F.cfg_merge_blocks;
       mk_no_cfg_merge_blocks F.no_cfg_merge_blocks;
+      mk_cfg_merge_functions F.cfg_merge_functions;
+      mk_no_cfg_merge_functions F.no_cfg_merge_functions;
       mk_cfg_value_propagation F.cfg_value_propagation;
       mk_no_cfg_value_propagation F.no_cfg_value_propagation;
       mk_cfg_value_propagation_float F.cfg_value_propagation_float;
@@ -1812,6 +1824,8 @@ module Oxcaml_options_impl = struct
   let no_cfg_prologue_shrink_wrap = clear' Oxcaml_flags.cfg_prologue_shrink_wrap
   let cfg_merge_blocks = set' Oxcaml_flags.cfg_merge_blocks
   let no_cfg_merge_blocks = clear' Oxcaml_flags.cfg_merge_blocks
+  let cfg_merge_functions = set' Oxcaml_flags.cfg_merge_functions
+  let no_cfg_merge_functions = clear' Oxcaml_flags.cfg_merge_functions
   let cfg_value_propagation = set' Oxcaml_flags.cfg_value_propagation
   let no_cfg_value_propagation = clear' Oxcaml_flags.cfg_value_propagation
 
@@ -2372,6 +2386,7 @@ module Extra_params = struct
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks
+    | "cfg-merge-functions" -> set' Oxcaml_flags.cfg_merge_functions
     | "cfg-value-propagation" -> set' Oxcaml_flags.cfg_value_propagation
     | "cfg-value-propagation-float" ->
         set' Oxcaml_flags.cfg_value_propagation_float

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -60,6 +60,8 @@ module type Oxcaml_options = sig
   val cfg_prologue_shrink_wrap_threshold : int -> unit
   val cfg_merge_blocks : unit -> unit
   val no_cfg_merge_blocks : unit -> unit
+  val cfg_merge_functions : unit -> unit
+  val no_cfg_merge_functions : unit -> unit
   val cfg_value_propagation : unit -> unit
   val no_cfg_value_propagation : unit -> unit
   val cfg_value_propagation_float : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -47,6 +47,8 @@ let cfg_prologue_shrink_wrap_threshold = ref 16384
 
 let cfg_merge_blocks = ref false        (* -[no]-cfg-merge-blocks *)
 
+let cfg_merge_functions = ref false     (* -[no]-cfg-merge-functions *)
+
 let cfg_value_propagation = ref true    (* -[no]-cfg-value-propagation *)
 let cfg_value_propagation_float = ref false
                                         (* -[no]-cfg-value-propagation-float *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -47,6 +47,8 @@ val cfg_prologue_shrink_wrap_threshold : int ref
 
 val cfg_merge_blocks : bool ref
 
+val cfg_merge_functions : bool ref
+
 val cfg_value_propagation : bool ref
 val cfg_value_propagation_float : bool ref
 val cfg_value_propagation_flow : bool ref

--- a/dune
+++ b/dune
@@ -659,6 +659,7 @@
   cfg_merge_blocks
   cfg_equiv_subst
   cfg_equiv
+  cfg_merge_functions
   extra_debug
   label
   printcfg

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -662,6 +662,8 @@ let ocaml_ignored_flags =
     "-no-cfg-prologue-shrink-wrap";
     "-cfg-merge-blocks";
     "-no-cfg-merge-blocks";
+    "-cfg-merge-functions";
+    "-no-cfg-merge-functions";
     "-cfg-value-propagation";
     "-no-cfg-value-propagation";
     "-cfg-value-propagation-float";


### PR DESCRIPTION
  ## Summary

  Adds `Cfg_merge_functions`, an Identical Code Folding pass that collapses
  functions with equivalent CFGs onto a single body. Gated by the new
  `-cfg-merge-functions` flag (off by default).

  The pass runs at the end of `compile_cfg`, just before `Cfg_to_linear`.
  For each function as it arrives, it is hashed via `Cfg_quick_hash` to
  bucket against previously-seen representatives in the same compilation
  unit; bucket members are then compared with `Cfg_equiv.equiv_cfg_with_layout`
  (seeded so self-recursive direct calls match). On a hit the duplicate's
  `Cfg_with_layout.t` is mutated in place into a single-block thunk whose
  terminator is `Tailcall_func (Direct repr_sym)`.

  ## Design notes

  - **Thunk vs. alternatives** — symbol aliases are smaller but collapse
    distinct entry points; detect-only is safer but useless. Tail-call
    thunks preserve distinct addresses at the cost of one `jmp`. See
    the header comment in `cfg_merge_functions.ml` for the full list.
  - **Conservative guard** — all function-level `Cfg.t` fields must match
    (CR comment notes this likely rejects too many cases; relax later
    once we have data).
  - **Hash/equivalence alignment** — `Cfg_quick_hash` now takes
    `~ignore_name_for_debugger`, threaded through so the bucketing matches
    the equivalence check; otherwise functions differing only in
    `Name_for_debugger` placement would never reach the comparison.
  - **Streaming, in-place** — state is unit-scoped (cleared from
    `Asmgen.reset`); `run` mutates the incoming `Cfg_with_layout.t`
    rather than allocating a new one.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)