### PR TITLE
Fix refined any records with float64 fields

### DIFF
--- a/testsuite/tests/typing-layouts/any_in_record.ml
+++ b/testsuite/tests/typing-layouts/any_in_record.ml
@@ -117,9 +117,7 @@ val make : int64# -> int64# -> int64# t = <fun>
 
 let make_float64 (fst : float#) snd = { fst; snd }
 [%%expect{|
->> Fatal error: Layout is not a value
-Uncaught exception: Misc.Fatal_error
-
+val make_float64 : float# -> float# -> float# t = <fun>
 |}]
 
 let make (type a : bits64) (fst : a) (snd : a) = { fst; snd }
@@ -190,9 +188,7 @@ let test_float64_direct =
   let t = { fst = #1.0; snd = #2.0 } |> Sys.opaque_identity in
   t.snd |> box_float
 [%%expect {|
->> Fatal error: Layout is not a value
-Uncaught exception: Misc.Fatal_error
-
+val test_float64_direct : float = 2.
 |}]
 
 let test_float64_via_index =
@@ -200,9 +196,7 @@ let test_float64_via_index =
   let idx = ((.snd) : (('a : float64) t, 'a) idx_mut) |> Sys.opaque_identity in
   Idx_mut.get t idx |> box_float
 [%%expect {|
->> Fatal error: Layout is not a value
-Uncaught exception: Misc.Fatal_error
-
+val test_float64_via_index : float = 2.
 |}]
 
 let test_float64_set_direct =
@@ -210,9 +204,7 @@ let test_float64_set_direct =
   t.snd <- #42.0;
   (t |> Sys.opaque_identity).snd |> box_float
 [%%expect {|
->> Fatal error: Layout is not a value
-Uncaught exception: Misc.Fatal_error
-
+val test_float64_set_direct : float = 42.
 |}]
 
 let test_float64_set_via_index =
@@ -221,9 +213,7 @@ let test_float64_set_via_index =
   Idx_mut.set t idx #42.0;
   Idx_mut.get t idx |> box_float
 [%%expect {|
->> Fatal error: Layout is not a value
-Uncaught exception: Misc.Fatal_error
-
+val test_float64_set_via_index : float = 42.
 |}]
 
 let test_unboxed_pair_block : #(int64# * int64#) t =

--- a/testsuite/tests/typing-layouts/any_in_record.ml
+++ b/testsuite/tests/typing-layouts/any_in_record.ml
@@ -115,6 +115,13 @@ let make (fst : int64#) (snd : int64#) = { fst; snd }
 val make : int64# -> int64# -> int64# t = <fun>
 |}]
 
+let make_float64 (fst : float#) snd = { fst; snd }
+[%%expect{|
+>> Fatal error: Layout is not a value
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
 let make (type a : bits64) (fst : a) (snd : a) = { fst; snd }
 [%%expect{|
 val make : ('a : bits64). 'a -> 'a -> 'a t = <fun>
@@ -123,6 +130,11 @@ val make : ('a : bits64). 'a -> 'a -> 'a t = <fun>
 external box_int64 : int64# -> int64 = "%box_int64"
 [%%expect {|
 external box_int64 : int64# -> int64 = "%box_int64"
+|}]
+
+external box_float : float# -> float = "%box_float"
+[%%expect {|
+external box_float : float# -> float = "%box_float"
 |}]
 
 (* Test that typing and genprintval work when the actual type has kind value *)
@@ -172,6 +184,46 @@ let test_set_via_index =
   Idx_mut.get t idx |> box_int64
 [%%expect {|
 val test_set_via_index : int64 = 42L
+|}]
+
+let test_float64_direct =
+  let t = { fst = #1.0; snd = #2.0 } |> Sys.opaque_identity in
+  t.snd |> box_float
+[%%expect {|
+>> Fatal error: Layout is not a value
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+let test_float64_via_index =
+  let t = { fst = #1.0; snd = #2.0 } |> Sys.opaque_identity in
+  let idx = ((.snd) : (('a : float64) t, 'a) idx_mut) |> Sys.opaque_identity in
+  Idx_mut.get t idx |> box_float
+[%%expect {|
+>> Fatal error: Layout is not a value
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+let test_float64_set_direct =
+  let t = { fst = #1.0; snd = #2.0 } |> Sys.opaque_identity in
+  t.snd <- #42.0;
+  (t |> Sys.opaque_identity).snd |> box_float
+[%%expect {|
+>> Fatal error: Layout is not a value
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+let test_float64_set_via_index =
+  let t = { fst = #1.0; snd = #2.0 } |> Sys.opaque_identity in
+  let idx = ((.snd) : (('a : float64) t, 'a) idx_mut) |> Sys.opaque_identity in
+  Idx_mut.set t idx #42.0;
+  Idx_mut.get t idx |> box_float
+[%%expect {|
+>> Fatal error: Layout is not a value
+Uncaught exception: Misc.Fatal_error
+
 |}]
 
 let test_unboxed_pair_block : #(int64# * int64#) t =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2085,6 +2085,7 @@ let compute_record_repr
     assert_mixed_product_support loc Record ~value_prefix_len:0;
     Ok (Record_mixed shape)
   (* Forbid atomic fields in mixed (or potentially mixed) blocks *)
+  | ~refining_block_with_any:true, ~float64s:true, ~atomic_fields:true, ..
   | ~values:true, ~voids:true, ~atomic_fields:true, ..
   | ~floats:true, ~voids:true, ~atomic_fields:true, ..
   | ~float64s:true, ~voids:true, ~atomic_fields:true, ..
@@ -2129,6 +2130,8 @@ let compute_record_repr
   | ~float64s:true, ~voids:true, ~atomic_fields:false, ..
   | ~values:true, ~float64s:true, ~atomic_fields:false, ..
   | ~non_float64_unboxed_fields:true, ~atomic_fields:false, .. ->
+    mixed_record ()
+  | ~refining_block_with_any:true, ~float64s:true, ~atomic_fields:false, .. ->
     mixed_record ()
   (* value-only records are stored as boxed records, as are records whose
       declared types have fields of kind [any] *)


### PR DESCRIPTION
This fixes a pre-existing compiler fatal when a record declared with an any field is later refined to float#.

The first commit adds and promotes an expect test showing the current failure: `Fatal error: Layout is not a value`

The second commit fixes representation selection so refined any records with unboxed fields use a mixed record representation, while preserving boxed representation for value-only and boxed-float cases. The promoted expect output now accepts the float# construction normally.