### PR TITLE
Fix intro part1: gold price race example

### DIFF
--- a/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
+++ b/jane/doc/extensions/_01-tutorials/01-intro-to-parallelism-part-1.md
@@ -126,8 +126,8 @@ The other, domain B, accesses the variables:
 
 ```ocaml
 (* ... *)
-if !initialised then
-  if !price_of_gold < really_good_price_for_gold then
+if initialised then
+  if price_of_gold < really_good_price_for_gold then
     buy_lots_of_gold ()
 (* ... *)
 ```
@@ -141,7 +141,7 @@ B reads `initialised` and sees that it's `false`, and then domain A sets
 checks `initialised`, and then if gold is cheap, domain B heads to the market.
 
 The one thing we want _not_ to happen is for domain B to see that
-`!initialised` is `true` and yet find that `price_of_gold` is still stuck at
+`initialised` is `true` and yet find that `price_of_gold` is still stuck at
 its initial value of `0.0`, thus causing us to `buy_lots_of_gold ()` no matter
 the price. Our intuitive method reassures us that this cannot happen: domain A
 doesn't set `initialised` to `true` until it's already done setting


### PR DESCRIPTION
It seems like conditions are inverted in this example. What we'd like to avoid is "initialised" set to true, but the price still being 0, from the point of view of another domain.