### PR TITLE
Fix layout bug for aliases in matching

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -261,9 +261,9 @@ end = struct
       | `Var (id, s, uid, sort, mode) ->
         continue p (`Alias (Patterns.omega, id, s, uid, sort, mode, p.pat_type))
       | `Fun_layout (_, _, _, _, _, lpoly, _) -> fatal_var_lpoly lpoly
-      | `Alias (p, id, _, duid, sort, _, _) ->
+      | `Alias (sub_p, id, _, duid, sort, _, _) ->
           aux
-            ( (General.view p, patl),
+            ( (General.view sub_p, patl),
               bind_alias p id duid ~arg
                 ~arg_sort:(Jkind.Sort.default_for_transl_and_get sort) ~action )
       | `Record ([], _, _, _) as view -> stop p view

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -427,13 +427,10 @@ let simplify_lets lam ~restrict_to_upstream_dwarf ~gdwarf_may_alter_codegen =
   in
   let optimize = !Clflags.native_code || not !Clflags.debug in
   let optimize_except_alias_bindings =
-    (* This doesn't yet include Alias bindings of variables to variables
-       because of what is described in this CR.  Other used-once Alias
-       bindings will not be substituted out when we want to preserve them
-       for DWARF.  (They will only be let-bound again by Flambda 2
-       anyway, even if substituted - it's just a matter of placement.) *)
-    (* CR mshinwell: Fix bug whereby Alias bindings of variables to variables
-      are being generated (probably by Matching) with the wrong layout. *)
+    (* The debug info degrades when we substitute let x = y in ... bindings. We
+       disable their simplification when [dwarf_wants_to_prevent_substitutions].
+       Flambda2 runs more simplification subsequently, which should take care of
+       these. *)
     optimize && not dwarf_wants_to_prevent_substitutions
   in
 
@@ -494,7 +491,7 @@ let simplify_lets lam ~restrict_to_upstream_dwarf ~gdwarf_may_alter_codegen =
       end
   | Lfunction fn ->
       count_lfunction fn
-  | Llet(_str, _k, v, _duid, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, _duid, Lvar w, l2) when optimize_except_alias_bindings ->
       (* v will be replaced by w in l2, so each occurrence of v in l2
          increases w's refcount *)
       count (bind_var bv v) l2;
@@ -638,7 +635,7 @@ let simplify_lets lam ~restrict_to_upstream_dwarf ~gdwarf_may_alter_codegen =
       | kind, ret_mode, body ->
           lfunction ~kind ~params ~return:outer_return ~body ~attr:attr1 ~loc ~mode ~ret_mode
       end
-  | Llet(_str, _k, v, _duid, Lvar w, l2) when optimize ->
+  | Llet(_str, _k, v, _duid, Lvar w, l2) when optimize_except_alias_bindings ->
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
   | Llet(Strict, kind, v, duid,

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -223,7 +223,7 @@ let _ = fun a b -> match a, b with
                                  (non_consts ([0: value<int>, value<int>]))>)
         x/5 p/4))
     (let
-      (x/6 =a[value<(consts ()) (non_consts ([0: ]))>] b/5
+      (x/6 =a[value<int>] b/5
        p/5 =a[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
          (makeblock 0 a/5 b/5))
       (makeblock 0 (value<int>,value<
@@ -266,7 +266,7 @@ let _ = fun a b -> match a, b with
            (makeblock 0 a/6 b/6))
         (exit 31 x/7 p/6))
       (let
-        (x/8 =a[value<(consts ()) (non_consts ([0: ]))>] b/6
+        (x/8 =a[value<int>] b/6
          p/7 =a[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
            (makeblock 0 a/6 b/6))
         (exit 31 x/8 p/7)))


### PR DESCRIPTION
This PR fixes a variable-shadowing bug in `Half_simple.of_clause` (`lambda/matching.ml`) that put wrong layouts on alias bindings. Investigating it surfaced what seems like a latent type-checker bug, which has been factored out into #6156 (currently squashed as the first commit on this PR).

**Matching bug.** A variable was accidentally shadowed in `Half_simple.of_clause` in `lambda/matching.ml`: the destructured inner pattern of an `` `Alias `` rebound `p`, so the surrounding call to `bind_alias p …` computed the alias binding's layout from the inner pattern's metadata rather than the outer alias's. As a result, alias bindings received an empty-tuple layout instead of their actual type's layout. 

The only reason this did not cause problems so far is that `simplif.ml` substituted those bindings away. It surfaces as soon as we disable the `let x = y in e ↦ e[y/x]` optimization (e.g., to preserve debug info under `-gdwarf-may-alter-codegen`, as done in this PR). The wrong layout is visible in the current test output of `testsuite/tests/basic/patmatch_for_multiple.ml`, where the binding for a `bool` variable goes from `value<(consts ()) (non_consts ([0: ]))>` (an empty-tuple layout) to `value<int>`.