### PR TITLE
Fix a crash while reporting mode solver errors

### DIFF
--- a/testsuite/tests/typing-modes/mode_error_reporting.ml
+++ b/testsuite/tests/typing-modes/mode_error_reporting.ml
@@ -1,0 +1,37 @@
+(* TEST
+   expect;
+*)
+
+type cont : value mod many
+
+[%%expect{|
+type cont : value mod many
+|}]
+
+type trigger_state = Awaiting of (unit -> unit) @@ portable
+
+[%%expect{|
+type trigger_state = Awaiting of (unit -> unit) @@ portable
+|}]
+
+let push (_ : _ @ once unique) = ()
+
+[%%expect{|
+val push : 'a @ unique once -> unit = <fun>
+|}]
+
+let continue : unit -> (trigger_state ref * cont) @ once unique =
+  fun () -> assert false
+
+[%%expect{|
+val continue : unit -> trigger_state ref * cont @ unique once = <fun>
+|}]
+
+let run () =
+  let trigger, k = continue () in
+  trigger := Awaiting (fun () -> push k)
+
+[%%expect{|
+Uncaught exception: Mode.Submode_error_simple_context(_, _)
+
+|}]

--- a/testsuite/tests/typing-modes/mode_error_reporting.ml
+++ b/testsuite/tests/typing-modes/mode_error_reporting.ml
@@ -32,6 +32,12 @@ let run () =
   trigger := Awaiting (fun () -> push k)
 
 [%%expect{|
-Uncaught exception: Mode.Submode_error_simple_context(_, _)
-
+Line 3, characters 33-37:
+3 |   trigger := Awaiting (fun () -> push k)
+                                     ^^^^
+Error: The value "push" is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at line 3, characters 22-40
+         which is expected to be "portable"
+         because it is contained (via constructor "Awaiting") (with some modality) in the value at line 3, characters 13-40.
 |}]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2222,7 +2222,7 @@ module Report = struct
         a ->
         other:a ->
         [`First | `Second] =
-     fun b a_obj x y ~other ->
+     fun b a_obj x _y ~other ->
       (* CR-someday zqian: in the case where each of [x] and [y] can be
          responsible independently, for not satisfying [~other], we currently
          arbitrarily prioritize `Second. In the future we might want to
@@ -2230,20 +2230,8 @@ module Report = struct
          element in a [join]. This requires inspecting the [solver.ml] to ensure
          the ordering in the [join] list is preserved. *)
       match b with
-      | Meet ->
-        if C.le a_obj other x
-        then begin
-          assert (not (C.le a_obj other y));
-          `Second
-        end
-        else `First
-      | Join ->
-        if C.le a_obj x other
-        then begin
-          assert (not (C.le a_obj y other));
-          `Second
-        end
-        else `First
+      | Meet -> if C.le a_obj other x then `Second else `First
+      | Join -> if C.le a_obj x other then `Second else `First
 
     type 'd side =
       | Left : left_only side


### PR DESCRIPTION
Reported by Aspen: the mode solver crashes when trying to report a mode error.

The minimized case stores a `@@ portable` callback that closes over a unique value. The mode solver correctly finds a mode error, but while producing the diagnostic, `Mode.Report.Of_solver.choose_branch_axis` assumes & asserts that only one branch can be responsible. This program violates that assumption and triggers that assert.

This change removes that assertion and just prints one of the choices. The result is a normal mode error instead of an assertion failure.