### PR TITLE
Revert "Revert "Fix bug in meet for array element kinds (#5771)" (#61…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: ''
             ocamlparam: '_,Oclassic=1'
-            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l testsuite/tests/flambda2/gadt_simplified_switch.ml testsuite/tests/flambda2/simplify/* testsuite/tests/quotation/eval/current_unit/eval_before_init_ok.ml'
+            disable_testcases: 'testsuite/tests/typing-local/regression_cmm_unboxing.ml testsuite/tests/int64-unboxing/test.ml testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.ml testsuite/tests/flambda2/code_size_of_single_arg_switch.ml testsuite/tests/flambda2/code_size_of_boolean_not_switch.ml testsuite/tests/flambda2/removed_operations_of_switch.ml testsuite/tests/reaper/* testsuite/tests/flambda2/n_way_join_null.ml testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/array_element_kind_meet.ml testsuite/tests/flambda2/issue5721.ml testsuite/tests/flambda2/stdlib_functor_inlining.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l testsuite/tests/flambda2/gadt_simplified_switch.ml testsuite/tests/flambda2/simplify/* testsuite/tests/quotation/eval/current_unit/eval_before_init_ok.ml'
 
           - name: runtime4 (aarch64-darwin)
             config: --disable-runtime5 --disable-warn-error
@@ -253,7 +253,7 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             build_ocamlparam: 'flambda2-expert-cont-lifting-budget=1000,flambda2-expert-cont-spec-budget=100,_'
             ocamlparam: 'flambda2-expert-cont-lifting-budget=1000,flambda2-expert-cont-spec-budget=100,_'
-            disable_testcases: 'testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
+            disable_testcases: 'testsuite/tests/flambda2/n_way_join_preserves_null.ml testsuite/tests/flambda2/array_element_kind_meet.ml testsuite/tests/flambda2/examples/unknown/* testsuite/tests/flambda2/examples/wrong/* testsuite/tests/flambda2/examples/*.[mf]l'
             sysdeps: gdb
 
     env:

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -439,21 +439,23 @@ let[@inline always] join_unknown join_contents (env : Join_env.t)
 (* Note: Bottom is a valid element kind for empty arrays, so this function never
    leads to a general Bottom result *)
 let meet_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
-    (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
+    (element_kind2 : _ Or_unknown_or_bottom.t) :
+    _ Or_unknown_or_bottom.t meet_return_value =
   match element_kind1, element_kind2 with
-  | Unknown, Unknown -> Unknown
-  | Bottom, _ | _, Bottom -> Bottom
-  | Unknown, Ok kind | Ok kind, Unknown -> Ok kind
-  | Ok element_kind1, Ok element_kind2 ->
-    if
-      Flambda_kind.With_subkind.compatible element_kind1
-        ~when_used_at:element_kind2
-    then Ok element_kind1
-    else if
-      Flambda_kind.With_subkind.compatible element_kind2
-        ~when_used_at:element_kind1
-    then Ok element_kind2
-    else Bottom
+  | Unknown, Unknown | Bottom, Bottom -> Both_inputs
+  | Bottom, _ | Ok _, Unknown -> Left_input
+  | _, Bottom | Unknown, Ok _ -> Right_input
+  | Ok element_kind1, Ok element_kind2 -> (
+    match
+      ( Flambda_kind.With_subkind.compatible element_kind1
+          ~when_used_at:element_kind2,
+        Flambda_kind.With_subkind.compatible element_kind2
+          ~when_used_at:element_kind1 )
+    with
+    | true, true -> Both_inputs
+    | true, false -> Left_input
+    | false, true -> Right_input
+    | false, false -> New_result Bottom)
 
 let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
@@ -748,16 +750,20 @@ and meet_head_of_kind_value_non_null env
 and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
     (element_kind2, length2, contents2, alloc_mode2) =
   let element_kind = meet_array_element_kinds element_kind1 element_kind2 in
+  let meet_element_kind =
+    extract_value element_kind element_kind1 element_kind2
+  in
   combine_results env
-    ~rebuild:(fun (length, (contents, (alloc_mode, ()))) ->
+    ~rebuild:(fun (length, (contents, (alloc_mode, (element_kind, ())))) ->
       TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
         ~length contents alloc_mode)
     ~meet_ops:
       [ meet;
-        meet_array_contents ~meet_element_kind:element_kind;
-        meet_alloc_mode ]
-    ~left_inputs:[length1; contents1; alloc_mode1]
-    ~right_inputs:[length2; contents2; alloc_mode2]
+        meet_array_contents ~meet_element_kind;
+        meet_alloc_mode;
+        (fun env _element_kind1 _element_kind2 -> Ok (element_kind, env)) ]
+    ~left_inputs:[length1; contents1; alloc_mode1; element_kind1]
+    ~right_inputs:[length2; contents2; alloc_mode2; element_kind2]
 
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -582,21 +582,23 @@ let n_way_join_relation_simples env simples_opt =
 (* Note: Bottom is a valid element kind for empty arrays, so this function never
    leads to a general Bottom result *)
 let meet_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
-    (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
+    (element_kind2 : _ Or_unknown_or_bottom.t) :
+    _ Or_unknown_or_bottom.t meet_return_value =
   match element_kind1, element_kind2 with
-  | Unknown, Unknown -> Unknown
-  | Bottom, _ | _, Bottom -> Bottom
-  | Unknown, Ok kind | Ok kind, Unknown -> Ok kind
-  | Ok element_kind1, Ok element_kind2 ->
-    if
-      Flambda_kind.With_subkind.compatible element_kind1
-        ~when_used_at:element_kind2
-    then Ok element_kind1
-    else if
-      Flambda_kind.With_subkind.compatible element_kind2
-        ~when_used_at:element_kind1
-    then Ok element_kind2
-    else Bottom
+  | Unknown, Unknown | Bottom, Bottom -> Both_inputs
+  | Bottom, _ | Ok _, Unknown -> Left_input
+  | _, Bottom | Unknown, Ok _ -> Right_input
+  | Ok element_kind1, Ok element_kind2 -> (
+    match
+      ( Flambda_kind.With_subkind.compatible element_kind1
+          ~when_used_at:element_kind2,
+        Flambda_kind.With_subkind.compatible element_kind2
+          ~when_used_at:element_kind1 )
+    with
+    | true, true -> Both_inputs
+    | true, false -> Left_input
+    | false, true -> Right_input
+    | false, false -> New_result Bottom)
 
 let join_array_element_kinds (element_kind1 : _ Or_unknown_or_bottom.t)
     (element_kind2 : _ Or_unknown_or_bottom.t) : _ Or_unknown_or_bottom.t =
@@ -891,16 +893,20 @@ and meet_head_of_kind_value_non_null env
 and meet_array_type env (element_kind1, length1, contents1, alloc_mode1)
     (element_kind2, length2, contents2, alloc_mode2) =
   let element_kind = meet_array_element_kinds element_kind1 element_kind2 in
+  let meet_element_kind =
+    extract_value element_kind element_kind1 element_kind2
+  in
   combine_results env
-    ~rebuild:(fun (length, (contents, (alloc_mode, ()))) ->
+    ~rebuild:(fun (length, (contents, (alloc_mode, (element_kind, ())))) ->
       TG.Head_of_kind_value_non_null.create_array_with_contents ~element_kind
         ~length contents alloc_mode)
     ~meet_ops:
       [ meet;
-        meet_array_contents ~meet_element_kind:element_kind;
-        meet_alloc_mode ]
-    ~left_inputs:[length1; contents1; alloc_mode1]
-    ~right_inputs:[length2; contents2; alloc_mode2]
+        meet_array_contents ~meet_element_kind;
+        meet_alloc_mode;
+        (fun env _element_kind1 _element_kind2 -> Ok (element_kind, env)) ]
+    ~left_inputs:[length1; contents1; alloc_mode1; element_kind1]
+    ~right_inputs:[length2; contents2; alloc_mode2; element_kind2]
 
 and meet_array_contents env (array_contents1 : TG.array_contents Or_unknown.t)
     (array_contents2 : TG.array_contents Or_unknown.t)

--- a/testsuite/tests/flambda2/array_element_kind_meet.ml
+++ b/testsuite/tests/flambda2/array_element_kind_meet.ml
@@ -1,0 +1,19 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte with dump-simplify;
+ check-fexpr-dump;
+*)
+
+(* When a record field is known to be a value array, Is_flat_float_array
+   should be simplified to false and removed by the simplifier. *)
+
+type foo = A | B of string
+
+type t = { a : int; b : int; c : foo array }
+
+let sum (t : t) =
+  Array.fold_left (fun acc x ->
+    match x with A -> acc | B _ -> acc + 1) 0 t.c

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -1,0 +1,44 @@
+let code sum_0 deleted in
+let code loopify(never) size(52) newer_version_of(sum_0)
+      sum_0_1 (t : [ 0 of imm tagged * imm tagged * val array ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pfield = %block_load.[`2`] (t) in
+  let Parraylength = %array_length.generic (Pfield) in
+  let for_stop = %int_barith.sub (Parraylength, 1) in
+  let prim = %int_comp.le (0, for_stop) in
+  switch prim
+    | 0 -> k (0)
+    | 1 -> k2
+    where k2 =
+      let prim_1 = %untag_imm (for_stop) in
+      let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
+      (cont k2 (0L, 0)
+         where rec k2 (for_counter_naked : int64, r_420_unboxed0) =
+           let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
+           let i = %tag_imm (prim_2) in
+           let ifnot_result = %array_load.mut (Pfield, i) in
+           ((let prim_3 = %is_int (ifnot_result) in
+             switch prim_3
+               | 0 -> k4
+               | 1 -> k3 (r_420_unboxed0)
+               where k4 =
+                 let int_add = %int_barith.add (r_420_unboxed0, 1) in
+                 cont k3 (int_add))
+              where k3 (return_val0) =
+                let for_next_naked =
+                  %int_barith.`int64`.add (for_counter_naked, 1L)
+                in
+                let prim_3 =
+                  %int_comp.`int64`.le (for_next_naked, for_stop_naked)
+                in
+                switch prim_3
+                  | 0 -> k (return_val0)
+                  | 1 -> k2 (for_next_naked, return_val0)))
+in
+let $camlArray_element_kind_meet__sum_2 = closure sum_0_1 @sum in
+let $camlArray_element_kind_meet =
+  Block 0 ($camlArray_element_kind_meet__sum_2)
+in
+cont done ($camlArray_element_kind_meet)


### PR DESCRIPTION
…33)"

This reverts commit c6467270f3edff6f6442d52f62e596f12bb006a8.

#6134 fixes the latent bug that was reveled by #5771 ; #5771 should be safe to reapply now. The test `meet_array_element_kind.ml` added in #6134 was causing the compiler to crash with #5771 but not #6134.