### PR TITLE
Improve variable propagation in the compiler

### DIFF
--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -585,14 +585,17 @@ let simplify_lets lam ~restrict_to_upstream_dwarf ~gdwarf_may_alter_codegen =
    tail call later on. *)
 
   let mklet str kind v duid e1 e2 =
+    (* [let v = e in v]: collapsing this to [e] would drop the source name [v],
+       so we keep the binding when debug info would like to preserve
+       substitutions. *)
     match e2 with
-    | Lvar w when optimize && Ident.same v w -> e1
+    | Lvar w when optimize_except_alias_bindings && Ident.same v w -> e1
     | _ -> Llet (str, kind,v,duid,e1,e2)
   in
 
   let mkmutlet kind v duid e1 e2 =
     match e2 with
-    | Lmutvar w when optimize && Ident.same v w -> e1
+    | Lmutvar w when optimize_except_alias_bindings && Ident.same v w -> e1
     | _ -> Lmutlet (kind,v,duid,e1,e2)
   in
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1470,7 +1470,23 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
       match defining_expr with
       | Simple simple ->
         let body_env = Env.add_simple_to_substitute env id simple kind in
-        body acc body_env
+        let insert_phantom_let =
+          match user_visible with
+          | IR.Not_user_visible -> false
+          | IR.User_visible ->
+            Flambda_features.debug ()
+            && Flambda_features.Expert.phantom_lets ()
+            && not (Flambda_debug_uid.equal uid Flambda_debug_uid.none)
+        in
+        if not insert_phantom_let
+        then body acc body_env
+        else
+          let bound_pattern =
+            Bound_pattern.singleton (VB.create var uid Name_mode.phantom)
+          in
+          let named = Named.create_simple simple in
+          let acc, body_expr = body acc body_env in
+          Let_with_acc.create acc bound_pattern named ~body:body_expr
       | Prim ((Variadic (Begin_region _, _) | Unary (End_region _, _)), _)
         when not (Flambda_features.stack_allocation_enabled ()) ->
         (* We use [body_env] to ensure the region variables are still in the

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -699,14 +699,50 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
           body new_ids_with_kinds new_values acc ccenv)
       k_exn
   | Llet
-      ((Strict | Alias | StrictOpt), _layout, id, _duid, defining_expr, Lvar id')
-    when Ident.same id id' ->
-    (* CR sspies: To propagate the debug UID here correctly, insert a phantom
-       let here once they are available in the compiler. *)
+      ((Strict | Alias | StrictOpt), layout, id, duid, defining_expr, Lvar id')
+    when Ident.same id id' -> (
     (* Simplif already simplifies such bindings, but we can generate new ones
        when translating primitives (see the Lprim case below). *)
     (* This case must not be moved above the case for let-bound primitives. *)
-    cps acc env ccenv defining_expr k k_exn
+    let phantom_binding =
+      if
+        not
+          (Flambda_features.debug () && Flambda_features.Expert.phantom_lets ())
+      then None
+      else
+        match is_user_visible env id with
+        | Not_user_visible -> None
+        | User_visible -> (
+          match
+            Flambda_arity.Component_for_creation.from_lambda layout
+              ~machine_width:(Acc.machine_width acc)
+          with
+          | Singleton kind_with_subkind ->
+            let kind = Flambda_kind.With_subkind.kind kind_with_subkind in
+            let var =
+              Variable.create_with_same_name_as_ident ~user_visible:() id kind
+            in
+            let phantom_uid = Flambda_debug_uid.of_lambda_debug_uid duid in
+            let bound_pattern =
+              Bound_pattern.singleton
+                (Bound_var.create var phantom_uid Name_mode.phantom)
+            in
+            let named =
+              Flambda.Named.create_prim
+                (Flambda_primitive.Nullary (Optimised_out kind)) Debuginfo.none
+            in
+            Some (bound_pattern, named)
+          | Unboxed_product _ ->
+            (* This would need multiple phantom lets with projected debug uids;
+               not currently supported. *)
+            None)
+    in
+    match phantom_binding with
+    | None -> cps acc env ccenv defining_expr k k_exn
+    | Some (bound_pattern, named) ->
+      let acc, body_expr = cps acc env ccenv defining_expr k k_exn in
+      Closure_conversion_aux.Let_with_acc.create acc bound_pattern named
+        ~body:body_expr)
   | Llet ((Strict | Alias | StrictOpt), layout, id, duid, defining_expr, body)
     ->
     let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:false

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -691,7 +691,10 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
           Apply_cont_rewrite.print rewrite;
       let new_phantom_params =
         Bound_parameters.filter
-          (fun param -> NO.mem_var free_names (BP.var param))
+          (fun param ->
+            let var = BP.var param in
+            (UA.generate_phantom_lets uacc && Variable.user_visible var)
+            || NO.mem_var free_names var)
           (Apply_cont_rewrite.get_unused_params rewrite)
       in
       let handler, uacc =
@@ -792,7 +795,10 @@ let rebuild_single_recursive_handler cont
       in
       let new_phantom_params =
         Bound_parameters.filter
-          (fun param -> NO.mem_var free_names (BP.var param))
+          (fun param ->
+            let var = BP.var param in
+            (UA.generate_phantom_lets uacc && Variable.user_visible var)
+            || NO.mem_var free_names var)
           (Apply_cont_rewrite.get_unused_params rewrite)
       in
       let handler, uacc =


### PR DESCRIPTION
This PR improves the propagation of variable information in the compiler. 

In **lambda**, when `-gdwarf-may-alter-codegen` is enabled, it 
- disables the optimization `let v = e in v` -> `e` in `simplif.ml`  (leaving it to Flambda 2 to do the work)

In **Flambda 2**, when phantom lets are enabled, it 
- inserts a phantom let for the  `let v = e in v` -> `e` optimization
- inserts a phantom let for `let x = <simple>`
- inserts a phantom lets for for user visible continuation parameters
