### PR TITLE
Trace variable availability through the compiler

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -684,7 +684,9 @@ let end_gen_implementation unix ?toplevel ~ppf_dump ~sourcefile make_cmm =
             then None
             else Some (Cmm.global_symbol (Primitive.native_name prim)))
           !Translmod.primitive_declarations));
-  emit_end_assembly ~sourcefile ()
+  emit_end_assembly ~sourcefile ();
+  if !Clflags.dump_variable_availability
+  then Type_shape.Variable_availability.print_report ppf_dump
 
 type direct_to_cmm =
   ppf_dump:Format.formatter ->

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -755,7 +755,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       match emit_expr env sub_cfg e1 ~bound_name:(Some v) with
       | Never_returns -> Never_returns
       | Ok r1 -> emit_expr (bind_let env sub_cfg v r1) sub_cfg e2 ~bound_name)
-    | Cphantom_let (_var, _defining_expr, body) ->
+    | Cphantom_let (var, _defining_expr, body) ->
+      SU.record_cmm_observation_for_var var;
       emit_expr env sub_cfg body ~bound_name
     | Ctuple [] -> Ok [||]
     | Ctuple exp_list -> (
@@ -806,7 +807,9 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       match emit_expr env sub_cfg e1 ~bound_name:None with
       | Never_returns -> ()
       | Ok r1 -> emit_tail (bind_let env sub_cfg v r1) sub_cfg e2)
-    | Cphantom_let (_var, _defining_expr, body) -> emit_tail env sub_cfg body
+    | Cphantom_let (var, _defining_expr, body) ->
+      SU.record_cmm_observation_for_var var;
+      emit_tail env sub_cfg body
     | Cop ((Capply { result_type = ty; region = Rc_normal; _ } as op), args, dbg)
       ->
       emit_tail_apply env sub_cfg ty op args dbg
@@ -899,10 +902,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           then
             let bound_name = VP.var bound_name in
             let naming_op =
-              Operation.Name_for_debugger
-                { ident = bound_name; provenance; which_parameter = None; regs }
+              SU.make_name_for_debugger ~ident:bound_name ~which_parameter:None
+                ~provenance ~regs
             in
-            insert_debug env sub_cfg (Op naming_op) Debuginfo.none [||] [||]
+            insert_debug env sub_cfg naming_op Debuginfo.none [||] [||]
       in
       let ty = SU.oper_result_type op in
       let label_after = Cmm.new_label () in
@@ -1109,15 +1112,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                 then
                   let var = VP.var var in
                   let naming_op =
-                    Operation.Name_for_debugger
-                      { ident = var;
-                        provenance;
-                        which_parameter = None;
-                        regs = r
-                      }
+                    SU.make_name_for_debugger ~ident:var ~which_parameter:None
+                      ~provenance ~regs:r
                   in
-                  insert_debug new_env sub_cfg (Op naming_op) Debuginfo.none
-                    [||] [||])
+                  insert_debug new_env sub_cfg naming_op Debuginfo.none [||] [||])
               ids_and_rs)
       in
       (rs, label), (r, sub)
@@ -1389,15 +1387,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
                 then
                   let var = VP.var var in
                   let naming_op =
-                    Operation.Name_for_debugger
-                      { ident = var;
-                        provenance;
-                        which_parameter = None;
-                        regs = r
-                      }
+                    SU.make_name_for_debugger ~ident:var ~which_parameter:None
+                      ~provenance ~regs:r
                   in
-                  insert_debug new_env sub_cfg (Op naming_op) Debuginfo.none
-                    [||] [||])
+                  insert_debug new_env sub_cfg naming_op Debuginfo.none [||] [||])
               ids_and_rs)
       in
       Sub_cfg.add_empty_block_at_start seq ~label;
@@ -1468,16 +1461,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         if Option.is_some provenance
         then
           let naming_op =
-            Operation.Name_for_debugger
-              { ident = var;
-                provenance;
-                which_parameter = Some param_index;
-                regs = hard_regs_for_arg
-              }
+            SU.make_name_for_debugger ~ident:var
+              ~which_parameter:(Some param_index) ~provenance
+              ~regs:hard_regs_for_arg
           in
           DLL.add_end block.Cfg.body
-            (Sub_cfg.make_instr (Cfg.Op naming_op) hard_regs_for_arg [||]
-               Debuginfo.none))
+            (Sub_cfg.make_instr naming_op hard_regs_for_arg [||] Debuginfo.none))
       fun_args
 
   (* Sequentialization of a function definition *)

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
@@ -265,8 +265,26 @@ let dwarf_for_variable state ~value_type_proto_die ~function_symbol
       ~attribute_values:(type_and_name_attributes @ location_attribute_value)
       ()
 
+module VA = Type_shape.Variable_availability
+
+let observed_id_of_provenance p : VA.observed_id =
+  match V.Provenance.debug_uid p with
+  | Uid u -> Source_uid u
+  | Proj { uid; unboxed_field } ->
+    Projected_source_uid { source_uid = uid; field = unboxed_field }
+
+let record_va_observations_for_range range =
+  if !Clflags.dump_variable_availability
+  then
+    match ARV.Range_info.provenance (ARV.Range.info range) with
+    | None -> ()
+    | Some p ->
+      let id = observed_id_of_provenance p in
+      VA.record_observation ~checkpoint:Debug_info id
+
 let iterate_over_variable_like_things state ~available_ranges_vars ~f =
   ARV.iter available_ranges_vars ~f:(fun var range ->
+      record_va_observations_for_range range;
       let ident_for_type = Some (Compilation_unit.get_current_exn (), var) in
       f var ~ident_for_type ~range)
 

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -606,7 +606,24 @@ end
 
 let make_stack_offset stack_ofs = Cfg.Op (Stackoffset stack_ofs)
 
+let record_cmm_observation_for_provenance p =
+  let module VA = Type_shape.Variable_availability in
+  if !Clflags.dump_variable_availability
+  then
+    let id =
+      match Backend_var.Provenance.debug_uid p with
+      | Uid u -> VA.Source_uid u
+      | Proj { uid; unboxed_field } ->
+        VA.Projected_source_uid { source_uid = uid; field = unboxed_field }
+    in
+    VA.record_observation ~checkpoint:Cmm id
+
+let record_cmm_observation_for_var v =
+  Option.iter record_cmm_observation_for_provenance
+    (Backend_var.With_provenance.provenance v)
+
 let make_name_for_debugger ~ident ~which_parameter ~provenance ~regs =
+  Option.iter record_cmm_observation_for_provenance provenance;
   Cfg.Op
     (Operation.Name_for_debugger { ident; which_parameter; provenance; regs })
 
@@ -682,10 +699,10 @@ let maybe_emit_naming_op env sub_cfg ~bound_name regs =
     then
       let bound_name = Backend_var.With_provenance.var bound_name in
       let naming_op =
-        Operation.Name_for_debugger
-          { ident = bound_name; provenance; which_parameter = None; regs }
+        make_name_for_debugger ~ident:bound_name ~which_parameter:None
+          ~provenance ~regs
       in
-      insert_debug env sub_cfg (Cfg.Op naming_op) Debuginfo.none [||] [||]
+      insert_debug env sub_cfg naming_op Debuginfo.none [||] [||]
 
 let join env (opt_r1 : _ Or_never_returns.t) sub_cfg1
     (opt_r2 : _ Or_never_returns.t) sub_cfg2 ~bound_name : _ Or_never_returns.t

--- a/backend/select_utils.mli
+++ b/backend/select_utils.mli
@@ -190,6 +190,8 @@ end
 
 val make_stack_offset : int -> Cfg.basic
 
+val record_cmm_observation_for_var : Backend_var.With_provenance.t -> unit
+
 val make_name_for_debugger :
   ident:Ident.t ->
   which_parameter:int option ->

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -446,6 +446,8 @@ let read_one_param ppf position name v =
 
   | "flambda-verbose" ->
       set "flambda-verbose" [ dump_flambda_verbose ] v
+  | "variable-availability" ->
+      set "variable-availability" [ dump_variable_availability ] v
   | "flambda-invariants" ->
     set_flambda_invariants ppf ~name v flambda_invariant_checks
   | "cmm-invariants" ->

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -937,6 +937,10 @@ let mk_dletreclambda f =
   "-dletreclambda", Arg.Unit f,
   " Dump Lambda terms going into Value_rec_compiler"
 
+let mk_dvariable_availability f =
+  "-dvariable-availability", Arg.Unit f,
+  " Dump source-variable availability across compilation passes"
+
 let mk_drawclambda f =
   "-drawclambda", Arg.Unit f, " (undocumented)"
 
@@ -1214,6 +1218,7 @@ module type Core_options = sig
   val _dlambda : unit -> unit
   val _dblambda : unit -> unit
   val _dletreclambda : unit -> unit
+  val _dvariable_availability : unit -> unit
 
 end
 
@@ -1612,6 +1617,7 @@ struct
     mk_dlambda F._dlambda;
     mk_dblambda F._dblambda;
     mk_dletreclambda F._dletreclambda;
+    mk_dvariable_availability F._dvariable_availability;
     mk_dinstr F._dinstr;
     mk_dcamlprimc F._dcamlprimc;
     mk_dtimings F._dtimings;
@@ -1720,6 +1726,7 @@ struct
     mk_dlambda F._dlambda;
     mk_dblambda F._dblambda;
     mk_dletreclambda F._dletreclambda;
+    mk_dvariable_availability F._dvariable_availability;
     mk_dinstr F._dinstr;
     mk_debug_ocaml F._debug_ocaml;
 
@@ -1903,6 +1910,7 @@ struct
     mk_dlambda F._dlambda;
     mk_dblambda F._dblambda;
     mk_dletreclambda F._dletreclambda;
+    mk_dvariable_availability F._dvariable_availability;
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
     mk_dcmm_invariants F._dcmm_invariants;
@@ -2065,6 +2073,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_dlambda F._dlambda;
     mk_dblambda F._dblambda;
     mk_dletreclambda F._dletreclambda;
+    mk_dvariable_availability F._dvariable_availability;
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
     mk_dcmm_invariants F._dcmm_invariants;
@@ -2209,6 +2218,7 @@ struct
     mk_dlambda F._dlambda;
     mk_dblambda F._dblambda;
     mk_dletreclambda F._dletreclambda;
+    mk_dvariable_availability F._dvariable_availability;
     mk_dtimings F._dtimings;
     mk_dtimings_precision F._dtimings_precision;
     mk_dcounters F._dcounters;
@@ -2437,6 +2447,7 @@ module Default = struct
     let _dlambda = set dump_lambda
     let _dblambda = set dump_blambda
     let _dletreclambda = set dump_letreclambda
+    let _dvariable_availability = set dump_variable_availability
     let _dparsetree = set dump_parsetree
     let _dtlambda = set dump_tlambda
     let _dslambda = set dump_slambda

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -100,6 +100,7 @@ module type Core_options = sig
   val _dlambda : unit -> unit
   val _dblambda : unit -> unit
   val _dletreclambda : unit -> unit
+  val _dvariable_availability : unit -> unit
 
 end
 

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -61,6 +61,8 @@ let main unix argv ppf ~flambda2 =
     Clflags.Opt_flag_handler.set Oxcaml_flags.opt_flag_handler;
     Compenv.parse_arguments (ref argv) Compenv.anonymous "ocamlopt";
     Compmisc.read_clflags_from_env ();
+    if !Clflags.dump_variable_availability then
+      Optcompile.register_debug_variable_availability_hooks_without_flambda2 ();
     (* Set platform-appropriate DWARF fission default when oxcaml-dwarf is
        enabled *)
     if Config.oxcaml_dwarf &&

--- a/dune
+++ b/dune
@@ -188,6 +188,7 @@
   language_extension
   zero_alloc_utils
   zero_alloc_annotations
+  variable_availability
   ;; PARSING
   location
   longident
@@ -243,6 +244,7 @@
   envaux
   includecore
   type_shape
+  debug_variable_availability
   tast_iterator
   tast_mapper
   signature_group
@@ -879,6 +881,7 @@
    %{dep:external/gc-timings/gc_timings.a}
    %{dep:ocamloptcomp.a}
    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.a}
+   %{dep:middle_end/flambda2/debug/flambda2_debug.a}
    %{dep:middle_end/flambda2/flambda2.a})))
 
 (rule
@@ -921,6 +924,7 @@
    %{dep:external/gc-timings/gc_timings.cma}
    %{dep:ocamloptcomp.cma}
    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.cma}
+   %{dep:middle_end/flambda2/debug/flambda2_debug.cma}
    %{dep:middle_end/flambda2/flambda2.cma})))
 
 (rule
@@ -963,6 +967,7 @@
    %{dep:external/gc-timings/gc_timings.cmxa}
    %{dep:ocamloptcomp.cmxa}
    %{dep:middle_end/flambda2/to_cmm/flambda2_to_cmm.cmxa}
+   %{dep:middle_end/flambda2/debug/flambda2_debug.cmxa}
    %{dep:middle_end/flambda2/flambda2.cmxa})))
 
 (install

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1882,7 +1882,14 @@ and precompile_or (cls : Simple.clause list) ors args def k =
               (* variables bound in the or-pattern
                  that are used in the orpm actions *)
               Typedtree.pat_bound_idents_full orp
-              |> List.filter (fun (id, _, _, _, _) -> Ident.Set.mem id pm_fv)
+              |> List.filter (fun (id, _, _, uid, _) ->
+                  let is_free = Ident.Set.mem id pm_fv in
+                  if not is_free then
+                    Type_shape.Variable_availability
+                    .register_ok_drop ~uid
+                      ~reason:Ignored_variable;
+                  is_free
+                  )
               |> List.map (fun (id, _, ty, uid, id_sort) ->
                   (id, uid, Typeopt.layout orp.pat_env orp.pat_loc id_sort ty))
             in

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -663,14 +663,20 @@ let simplify_lets lam ~restrict_to_upstream_dwarf ~gdwarf_may_alter_codegen =
       end
   | Llet(Alias, kind, v, duid, l1, l2) ->
       begin match count_var v with
-        0 -> simplif l2
+        0 ->
+          Type_shape.Variable_availability.register_ok_drop
+            ~uid:duid ~reason:Ignored_variable;
+          simplif l2
       | 1 when optimize_except_alias_bindings ->
           Hashtbl.add subst v (simplif l1); simplif l2
       | _ -> Llet(Alias, kind, v, duid, simplif l1, simplif l2)
       end
   | Llet(StrictOpt, kind, v, duid, l1, l2) ->
       begin match count_var v with
-        0 -> simplif l2
+        0 ->
+          Type_shape.Variable_availability.register_ok_drop
+            ~uid:duid ~reason:Ignored_variable;
+          simplif l2
       | _ -> mklet StrictOpt kind v duid (simplif l1) (simplif l2)
       end
   | Llet(str, kind, v, duid, l1, l2) ->
@@ -1122,7 +1128,9 @@ let simplify_local_functions lam =
   let rec rewrite lam0 =
     let lam =
       match lam0 with
-      | Llet (_, _, id, _duid, _, cont) when Hashtbl.mem static_id id ->
+      | Llet (_, _, id, duid, _, cont) when Hashtbl.mem static_id id ->
+          Type_shape.Variable_availability.register_ok_drop
+            ~uid:duid ~reason:Function_became_catch;
           rewrite cont
       | Lapply {ap_func = Lvar id; ap_args; _} when Hashtbl.mem static_id id ->
          let st = Hashtbl.find static_id id in

--- a/middle_end/flambda2/debug/debug_variable_availability.ml
+++ b/middle_end/flambda2/debug/debug_variable_availability.ml
@@ -1,0 +1,113 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Simon Spies, Jane Street                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module VA = Type_shape.Variable_availability
+
+let observed_id_of_duid (duid : Flambda_debug_uid.t) : VA.observed_id =
+  match duid with
+  | Uid uid -> Source_uid uid
+  | Proj { uid; unboxed_field } ->
+    Projected_source_uid { source_uid = uid; field = unboxed_field }
+
+let record_uid ~checkpoint duid =
+  VA.record_observation ~checkpoint (observed_id_of_duid duid)
+
+let record_bound_var ~checkpoint bv =
+  record_uid ~checkpoint (Bound_var.debug_uid bv)
+
+let record_bound_params ~checkpoint ps =
+  List.iter
+    (fun p ->
+      let _, duid = Bound_parameter.var_and_uid p in
+      record_uid ~checkpoint duid)
+    (Bound_parameters.to_list ps)
+
+let rec walk_expr ~(checkpoint : Variable_availability.Checkpoint.t) e =
+  match Flambda.Expr.descr e with
+  | Let l -> walk_let ~checkpoint l
+  | Let_cont lc -> walk_let_cont ~checkpoint lc
+  | Apply _ | Apply_cont _ | Switch _ | Invalid _ -> ()
+
+and walk_let ~checkpoint l =
+  Flambda.Let_expr.pattern_match l ~f:(fun bound ~body ->
+      Bound_pattern.fold_all_bound_vars bound ~init:() ~f:(fun () bv ->
+          record_bound_var ~checkpoint bv);
+      walk_named ~checkpoint (Flambda.Let_expr.defining_expr l);
+      walk_expr ~checkpoint body)
+
+and walk_named ~checkpoint (n : Flambda.Named.t) =
+  match n with
+  | Simple _ | Prim _ | Rec_info _ | Set_of_closures _ -> ()
+  | Static_consts scg ->
+    List.iter (walk_code ~checkpoint)
+      (Flambda.Static_const_group.pieces_of_code' scg)
+
+and walk_let_cont ~checkpoint (lc : Flambda.Let_cont_expr.t) =
+  match lc with
+  | Non_recursive { handler; _ } ->
+    Flambda.Non_recursive_let_cont_handler.pattern_match handler
+      ~f:(fun _cont ~body ->
+        walk_expr ~checkpoint body;
+        walk_cont_handler ~checkpoint
+          (Flambda.Non_recursive_let_cont_handler.handler handler))
+  | Recursive handlers ->
+    Flambda.Recursive_let_cont_handlers.pattern_match handlers
+      ~f:(fun ~invariant_params ~body cont_handlers ->
+        record_bound_params ~checkpoint invariant_params;
+        walk_expr ~checkpoint body;
+        Continuation.Lmap.iter
+          (fun _ h -> walk_cont_handler ~checkpoint h)
+          (Flambda.Continuation_handlers.to_map cont_handlers))
+
+and walk_cont_handler ~checkpoint h =
+  Flambda.Continuation_handler.pattern_match h ~f:(fun params ~handler ->
+      record_bound_params ~checkpoint params;
+      walk_expr ~checkpoint handler)
+
+and walk_code ~checkpoint code0 =
+  Flambda.Function_params_and_body.pattern_match (Code0.params_and_body code0)
+    ~f:(fun
+        ~return_continuation:_
+        ~exn_continuation:_
+        params
+        ~body
+        ~my_closure:_
+        ~is_my_closure_used:_
+        ~my_alloc_mode:_
+        ~my_depth:_
+        ~free_names_of_body:_
+      ->
+      record_bound_params ~checkpoint params;
+      walk_expr ~checkpoint body)
+
+let observe ~checkpoint ?all_code unit =
+  if !Clflags.dump_variable_availability
+  then begin
+    walk_expr ~checkpoint (Flambda_unit.body unit);
+    Option.iter (Exported_code.iter_code ~f:(walk_code ~checkpoint)) all_code
+  end

--- a/middle_end/flambda2/debug/debug_variable_availability.mli
+++ b/middle_end/flambda2/debug/debug_variable_availability.mli
@@ -1,0 +1,40 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Simon Spies, Jane Street                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Observe the variables bound in a Flambda 2 [unit] body, and in [all_code]
+    when given, recording them for the [Variable_availability] diagnostic at
+    [checkpoint] (gated on [Clflags.dump_variable_availability]).
+
+    [all_code] holds the function bodies that simplification lifts out of the
+    unit into a side table. It is omitted only for the raw normal-mode unit,
+    whose code is still inline. *)
+val observe :
+  checkpoint:Variable_availability.Checkpoint.t ->
+  ?all_code:Exported_code.t ->
+  Flambda_unit.t ->
+  unit

--- a/middle_end/flambda2/debug/dune
+++ b/middle_end/flambda2/debug/dune
@@ -1,0 +1,30 @@
+(include_subdirs unqualified)
+
+(library
+ (name flambda2_debug)
+ (wrapped true)
+ (instrumentation
+  (backend bisect_ppx))
+ (flags
+  (:standard
+   -open
+   Flambda2_bound_identifiers
+   -open
+   Flambda2_cmx
+   -open
+   Flambda2_identifiers
+   -open
+   Flambda2_terms))
+ (ocamlopt_flags
+  (:standard
+   (:include %{project_root}/ocamlopt_flags.sexp)
+   -O3
+   -open
+   Int_replace_polymorphic_compare))
+ (libraries
+  ocamlcommon
+  ocamloptcomp
+  flambda2_bound_identifiers
+  flambda2_cmx
+  flambda2_identifiers
+  flambda2_terms))

--- a/middle_end/flambda2/dune
+++ b/middle_end/flambda2/dune
@@ -41,6 +41,7 @@
   ocamlcommon
   ocamlbytecomp
   ocamloptcomp
+  flambda2_debug
   flambda2_lattices
   flambda2_cmx
   flambda2_from_lambda

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -167,8 +167,15 @@ let flambda_to_flambda0 : type m.
            Inlining_report.output_then_forget_decisions ~output_prefix
          in
          Compiler_hooks.execute Inlining_tree inlining_tree);
+      Flambda2_debug.Debug_variable_availability.observe
+        ~checkpoint:Flambda2_input ~all_code:code raw_flambda;
       raw_flambda, offsets, reachable_names, cmx, code
     | Normal, Normal ->
+      (* The raw-flambda unit still carries its code inline (unlike classic
+         mode, where closure conversion lifts it into a separate
+         [Exported_code.t]), so there is no [all_code] to observe yet. *)
+      Flambda2_debug.Debug_variable_availability.observe
+        ~checkpoint:Flambda2_input raw_flambda;
       let round = 0 in
       let { Simplify.free_names;
             final_typing_env;
@@ -188,6 +195,8 @@ let flambda_to_flambda0 : type m.
          in
          Compiler_hooks.execute Inlining_tree inlining_tree);
       Compiler_hooks.execute Flambda2 flambda;
+      Flambda2_debug.Debug_variable_availability.observe
+        ~checkpoint:Flambda2_simplified ~all_code flambda;
       let last_pass_name = "simplify" in
       print_flambda last_pass_name
         (Flambda_features.dump_simplify ())
@@ -239,6 +248,8 @@ let flambda_to_flambda0 : type m.
           slot_offsets
       in
       Compiler_hooks.execute Reaped_flambda2 flambda;
+      Flambda2_debug.Debug_variable_availability.observe
+        ~checkpoint:Flambda2_output ~all_code flambda;
       flambda, exported_offsets, reachable_names, cmx, all_code
   in
   (match cmx with

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -535,10 +535,12 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
     CC.close_let_rec acc ccenv ~function_declarations:[func] ~body
       ~current_region:
         (Env.current_region env |> Option.map Env.Region_stack_element.region)
-  | Lmutlet (layout, id, _duid, defining_expr, body) ->
+  | Lmutlet (layout, id, duid, defining_expr, body) ->
     (* CR sspies: Mutable lets currently do not propagate debugging uids
        correctly. *)
     (* CR mshinwell: user-visibleness needs thinking about here *)
+    Type_shape.Variable_availability.register_gap ~uid:duid
+      ~cause:Lmutlet_handler_loses_duid;
     let temp_id = Ident.create_local "let_mutable" in
     let temp_id_duid = Lambda.debug_uid_none in
     let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler:false
@@ -699,13 +701,15 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
           body new_ids_with_kinds new_values acc ccenv)
       k_exn
   | Llet
-      ((Strict | Alias | StrictOpt), _layout, id, _duid, defining_expr, Lvar id')
+      ((Strict | Alias | StrictOpt), _layout, id, duid, defining_expr, Lvar id')
     when Ident.same id id' ->
     (* CR sspies: To propagate the debug UID here correctly, insert a phantom
        let here once they are available in the compiler. *)
     (* Simplif already simplifies such bindings, but we can generate new ones
        when translating primitives (see the Lprim case below). *)
     (* This case must not be moved above the case for let-bound primitives. *)
+    Type_shape.Variable_availability.register_gap ~uid:duid
+      ~cause:Missing_phantom_let_for_let_optimization;
     cps acc env ccenv defining_expr k k_exn
   | Llet ((Strict | Alias | StrictOpt), layout, id, duid, defining_expr, body)
     ->

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -887,7 +887,19 @@ and let_expr env res let_expr =
       | Normal ->
         let_expr0 env res let_expr bound_pattern
           ~num_normal_occurrences_of_bound_vars ~body
-      | Phantom -> expr env res body
+      | Phantom ->
+        if Type_shape.Variable_availability.is_enabled ()
+        then
+          Bound_pattern.fold_all_bound_vars bound_pattern ~init:()
+            ~f:(fun () bv ->
+              let source_uid =
+                match Bound_var.debug_uid bv with
+                | Uid u -> u
+                | Proj { uid; _ } -> uid
+              in
+              Type_shape.Variable_availability.register_gap ~uid:source_uid
+                ~cause:Phantom_let_dropped_in_to_cmm);
+        expr env res body
       | In_types ->
         Misc.fatal_errorf "Cannot bind In_types variables in terms:@ %a"
           Let.print let_expr)

--- a/optcomp/optcompile.ml
+++ b/optcomp/optcompile.ml
@@ -54,6 +54,28 @@ module type S = sig
     ppf_dump:Format.formatter -> Env.t -> string list -> string -> unit
 end
 
+(* Register [Compiler_hooks] callbacks for the [Variable_availability]
+   diagnostic. The caller is expected to gate this on
+   [Clflags.dump_variable_availability] so that no hooks are installed when the
+   diagnostic is off. Only the Typedtree- and Lambda-level checkpoints are
+   registered here. The Flambda 2 checkpoints are recorded by direct
+   [Debug_variable_availability.observe] calls inside
+   [Flambda2.flambda_to_flambda0], because [ocamloptcomp] cannot reference the
+   Flambda 2 lib directly. *)
+let register_debug_variable_availability_hooks_without_flambda2 () =
+  let module CH = Compiler_hooks in
+  CH.register CH.Typed_tree_impl (fun impl ->
+      let unit_name =
+        Compilation_unit.full_path_as_string
+          (Compilation_unit.get_current_exn ())
+      in
+      Type_shape.Variable_availability.reset ();
+      Debug_variable_availability.collect_from_typedtree ~unit_name impl);
+  CH.register CH.Raw_lambda
+    (Debug_variable_availability.observe_lambda_program ~checkpoint:Raw_lambda);
+  CH.register CH.Lambda
+    (Debug_variable_availability.observe_lambda_program ~checkpoint:Lambda)
+
 module Make (Backend : Optcomp_intf.Backend) : S = struct
   let tool_name = "ocamlopt"
 

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -137,6 +137,7 @@
   value_rec_types
   btype
   lazy_backtrack
+  variable_availability
   type_shape
   zero_alloc_utils
   diffing
@@ -269,6 +270,8 @@
 (copy_files ../../utils/lazy_backtrack.ml)
 
 (copy_files ../../utils/zero_alloc_utils.ml)
+
+(copy_files ../../utils/variable_availability.ml)
 
 (copy_files ../../utils/diffing.ml)
 
@@ -474,6 +477,8 @@
 (copy_files ../../utils/lazy_backtrack.mli)
 
 (copy_files ../../utils/zero_alloc_utils.mli)
+
+(copy_files ../../utils/variable_availability.mli)
 
 (copy_files ../../utils/diffing.mli)
 
@@ -765,6 +770,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Parser_types.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Parser.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Persistent_env.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Variable_availability.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Type_shape.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Env.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Jkind.cmo
@@ -890,6 +896,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Parser_types.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Parser.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Persistent_env.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Variable_availability.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Type_shape.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Env.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Jkind.cmx

--- a/oxcaml/testsuite/tests/asmcomp/variable_availability.compilers.reference
+++ b/oxcaml/testsuite/tests/asmcomp/variable_availability.compilers.reference
@@ -1,0 +1,83 @@
+Variable availability for Variable_availability
+
+Module Variable_availability  _none_:0
+      arith | local          12:4-9          dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+    branchy | local          17:4-11         dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+    counted | local          27:4-11         dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+destructure | local          35:4-15         dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+  capturing | local          39:4-13         dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+     merged | local          54:4-10         dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+  local_fun | local          61:4-13         dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+    ignored | local          67:4-11         dropped  flambda2-in->flambda2-simpl   [ok]   module-level
+
+Function arith  variable_availability.ml:12-15:0-29
+x | param[0]       12:10-11        present
+y | param[1]       12:12-13        present
+z | local          13:6-7          present
+w | local          14:6-7          present
+
+Function branchy  variable_availability.ml:17-25:0-31
+a | param[0]       17:12-13        present
+b | param[1]       17:14-15        present
+c | local          18:6-7          present
+d | local          21:8-9          present
+e | local          24:8-9          present
+
+Function counted  variable_availability.ml:27-33:0-26
+   n | param[0]       27:12-13        present
+ acc | local          28:6-9          dropped  lambda->flambda2-in           [gap]  lmutlet-loses-duid
+   i | for            29:6-7          present
+step | local          30:8-12         present
+
+Function destructure  variable_availability.ml:35-37:0-29
+pair | param[0]       35:16-20        present
+   x | local          36:6-7          dropped  raw-lambda->lambda            [gap]  (unknown)
+   y | local          36:9-10         dropped  raw-lambda->lambda            [gap]  (unknown)
+
+Function capturing  variable_availability.ml:39-45:0-28
+  init | param[0]       39:14-18        present
+  base | local          40:6-10         present
+bumped | local          41:6-12         dropped  flambda2-in->flambda2-simpl   [gap]  (unknown)
+  bump | local          42:8-12         dropped  flambda2-in->flambda2-simpl   [gap]  (unknown)
+
+Function bump  variable_availability.ml:42:4-47
+n | param[0]       42:13-14        dropped  flambda2-in->flambda2-simpl   [gap]  (unknown)
+
+Function merged  variable_availability.ml:54-56:0-45
+e | param[0]       54:11-12        present
+x | local          56:9-10         dropped  raw-lambda->lambda            [gap]  (unknown)
+x | local          56:19-20        dropped  typing->raw-lambda            [ok]   merged-with-x
+
+Function local_fun  variable_availability.ml:61-63:0-47
+cond | param[0]       61:14-18        present
+   x | param[1]       61:19-20        present
+   g | local          62:6-7          dropped  raw-lambda->lambda            [ok]   became-static-catch
+
+Function g  variable_availability.ml:62:2-39
+y | param[0]       62:8-9          present
+
+Function ignored  variable_availability.ml:67-69:0-32
+   pair | param[0]       67:12-16        present
+   kept | local          68:6-10         dropped  raw-lambda->lambda            [gap]  (unknown)
+_unused | local          68:12-19        dropped  raw-lambda->lambda            [ok]   ignored
+
+Compilation-unit summary: 39 total variables; 11 excluded (ok-drops); 20/28 reach debug info (71.43%)
+
+Pass-by-pass survival:
+  typing          28  (100.00%)
+  raw-lambda      28  (100.00%)
+  lambda          24  ( 85.71%)  (-4)
+  flambda2-in     23  ( 82.14%)  (-1)
+  flambda2-simpl  20  ( 71.43%)  (-3)
+  flambda2-out    20  ( 71.43%)
+  cmm             20  ( 71.43%)
+  debug-info      20  ( 71.43%)
+
+Drop reasons:
+became-static-catch | 1  (ok)
+            ignored | 1  (ok)
+             merged | 1  (ok)
+       module-level | 8  (ok)
+          (unknown) | 7  (gap)
+ lmutlet-loses-duid | 1  (gap)
+

--- a/oxcaml/testsuite/tests/asmcomp/variable_availability.ml
+++ b/oxcaml/testsuite/tests/asmcomp/variable_availability.ml
@@ -1,0 +1,69 @@
+(* TEST
+ flags = "-g -gno-upstream-dwarf -dvariable-availability";
+ native;
+*)
+
+(* Exercises the source-variable availability diagnostic. The
+   [Sys.opaque_identity] calls keep the bindings alive past Flambda 2
+   simplification so the Cmm and debug-info checkpoints have something to
+   observe. The variables below cover parameters, let-bindings, pattern
+   destructuring, [for] loops, captures, and conditional branches. *)
+
+let arith x y =
+  let z = Sys.opaque_identity (x + y) in
+  let w = Sys.opaque_identity (z * 2) in
+  Sys.opaque_identity (w + x)
+
+let branchy a b =
+  let c = Sys.opaque_identity (a + b) in
+  if Sys.opaque_identity (c > 0)
+  then
+    let d = Sys.opaque_identity (c * c) in
+    Sys.opaque_identity (d - a)
+  else
+    let e = Sys.opaque_identity (b - c) in
+    Sys.opaque_identity (e + a)
+
+let counted n =
+  let acc = ref 0 in
+  for i = 1 to n do
+    let step = Sys.opaque_identity (i * i) in
+    acc := Sys.opaque_identity (!acc + step)
+  done;
+  Sys.opaque_identity !acc
+
+let destructure pair =
+  let x, y = Sys.opaque_identity pair in
+  Sys.opaque_identity (x + y)
+
+let capturing init =
+  let base = Sys.opaque_identity init in
+  let bumped =
+    let bump n = Sys.opaque_identity (base + n) in
+    Sys.opaque_identity (bump 1, bump 2)
+  in
+  Sys.opaque_identity bumped
+
+(* An or-pattern binds [x] in both arms; typing unifies the two binders, so
+   one is an [ok] "merged" drop and the other survives as the named
+   binding. *)
+type either =
+  | Left of int
+  | Right of int
+
+let merged e =
+  match e with
+  | Left x | Right x -> Sys.opaque_identity x
+
+(* [g] is a local function that is only ever applied, so
+   [simplify_local_functions] turns it into a static-catch handler and its
+   name becomes an [ok] "became-static-catch" drop. *)
+let local_fun cond x =
+  let g y = Sys.opaque_identity (x + y) in
+  if Sys.opaque_identity cond then g 1 else g 2
+
+(* [_unused] is never read, so [simplify_lets] removes it as an [ok]
+   "ignored" drop. *)
+let ignored pair =
+  let kept, _unused = Sys.opaque_identity pair in
+  Sys.opaque_identity (kept + 1)

--- a/typing/.ocamlformat-enable
+++ b/typing/.ocamlformat-enable
@@ -24,6 +24,8 @@ vicuna_traverse_typed_tree.ml
 vicuna_traverse_typed_tree.mli
 type_shape.mli
 type_shape.ml
+debug_variable_availability.ml
+debug_variable_availability.mli
 scalar.ml
 scalar.mli
 ikinds/*

--- a/typing/debug_variable_availability.ml
+++ b/typing/debug_variable_availability.ml
@@ -1,0 +1,260 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Simon Spies, Jane Street                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module VA = Type_shape.Variable_availability
+
+module Walk = struct
+  (* [seen_idents] records the first [Shape.Uid.t] under which each
+     [Ident.t] was registered. When a later registration uses the same
+     [Ident.t] with a different uid, the new variable has been merged
+     with the original (e.g. by [enter_orpat_variables] alpha-renaming
+     the right arm of an or-pattern). Same-id-same-uid revisits are
+     just the iterator re-entering a node already registered by an
+     enclosing handler (function parameters, comprehension indices,
+     etc.) and are ignored. *)
+  type t =
+    { mutable current_function : VA.source_definition;
+      seen_idents : (Ident.t, Shape.Uid.t) Hashtbl.t
+    }
+
+  let note_ident t ~id ~uid =
+    match Hashtbl.find_opt t.seen_idents id with
+    | None -> Hashtbl.add t.seen_idents id uid
+    | Some prev_uid ->
+      if not (Shape.Uid.equal prev_uid uid)
+      then VA.register_ok_drop ~uid ~reason:(Merged_with prev_uid)
+
+  let register_var t ~id ~uid ~name ~location ~kind =
+    VA.register_source_variable t.current_function ~uid ~name ~location ~kind;
+    note_ident t ~id ~uid
+
+  let enter_function ~display_name ~location =
+    VA.register_source_function ~display_name ~location
+
+  let with_function t f body =
+    let prev = t.current_function in
+    t.current_function <- f;
+    let r = body () in
+    t.current_function <- prev;
+    r
+
+  let function_param t it (p : Typedtree.function_param) ~index =
+    register_var t ~id:p.fp_param ~uid:p.fp_param_debug_uid
+      ~name:(Ident.name p.fp_param) ~location:p.fp_loc ~kind:(Parameter index);
+    match p.fp_kind with
+    | Tparam_pat pat -> it.Tast_iterator.pat it pat
+    | Tparam_optional_default (pat, default, _sort) ->
+      it.Tast_iterator.pat it pat;
+      it.Tast_iterator.expr it default
+
+  let function_cases t it (fc : Typedtree.function_cases) ~index =
+    register_var t ~id:fc.fc_param ~uid:fc.fc_param_debug_uid
+      ~name:(Ident.name fc.fc_param) ~location:fc.fc_loc ~kind:(Parameter index);
+    List.iter (it.Tast_iterator.case it) fc.fc_cases
+
+  let comprehension t it (c : Typedtree.comprehension) =
+    List.iter
+      (fun cl ->
+        match cl with
+        | Typedtree.Texp_comp_when e -> it.Tast_iterator.expr it e
+        | Typedtree.Texp_comp_for bindings ->
+          List.iter
+            (fun { Typedtree.comp_cb_iterator; comp_cb_attributes = _ } ->
+              match comp_cb_iterator with
+              | Typedtree.Texp_comp_range
+                  { ident;
+                    ident_debug_uid;
+                    pattern;
+                    start;
+                    stop;
+                    direction = _
+                  } ->
+                register_var t ~id:ident ~uid:ident_debug_uid
+                  ~name:(Ident.name ident) ~location:pattern.ppat_loc
+                  ~kind:Comprehension_index;
+                it.Tast_iterator.expr it start;
+                it.Tast_iterator.expr it stop
+              | Texp_comp_in { pattern; sequence } ->
+                it.Tast_iterator.pat it pattern;
+                it.Tast_iterator.expr it sequence)
+            bindings)
+      c.comp_clauses;
+    it.Tast_iterator.expr it c.comp_body
+
+  let enter_anonymous_function t it (e : Typedtree.expression) params body =
+    let display_name =
+      Format.asprintf "<anon at %a>" Location.print_loc e.exp_loc
+    in
+    let f = enter_function ~display_name ~location:e.exp_loc in
+    with_function t f (fun () ->
+        List.iteri (fun i p -> function_param t it p ~index:i) params;
+        match (body : Typedtree.function_body) with
+        | Tfunction_body e -> it.Tast_iterator.expr it e
+        | Tfunction_cases fc ->
+          function_cases t it fc ~index:(List.length params))
+
+  let expr t it (e : Typedtree.expression) =
+    match e.exp_desc with
+    | Texp_function { params; body; _ } ->
+      enter_anonymous_function t it e params body
+    | Texp_for { for_id; for_debug_uid; for_pat; for_from; for_to; for_body; _ }
+      ->
+      register_var t ~id:for_id ~uid:for_debug_uid ~name:(Ident.name for_id)
+        ~location:for_pat.ppat_loc ~kind:For_index;
+      it.Tast_iterator.expr it for_from;
+      it.Tast_iterator.expr it for_to;
+      it.Tast_iterator.expr it for_body
+    | Texp_letop { let_; ands; param; param_debug_uid; body; _ } ->
+      it.Tast_iterator.binding_op it let_;
+      List.iter (it.Tast_iterator.binding_op it) ands;
+      register_var t ~id:param ~uid:param_debug_uid ~name:(Ident.name param)
+        ~location:body.c_lhs.pat_loc ~kind:Letop_param;
+      it.Tast_iterator.case it body
+    | Texp_list_comprehension c -> comprehension t it c
+    | Texp_array_comprehension (_, _, c) -> comprehension t it c
+    | _ -> Tast_iterator.default_iterator.expr it e
+
+  let display_name_from_pat (pat : Typedtree.pattern) =
+    match pat.pat_desc with Tpat_var { name; _ } -> Some name.txt | _ -> None
+
+  let value_binding t it (vb : Typedtree.value_binding) =
+    match display_name_from_pat vb.vb_pat, vb.vb_expr.exp_desc with
+    | Some name, Texp_function { params; body; _ } ->
+      it.Tast_iterator.pat it vb.vb_pat;
+      let f = enter_function ~display_name:name ~location:vb.vb_loc in
+      with_function t f (fun () ->
+          List.iteri (fun i p -> function_param t it p ~index:i) params;
+          match body with
+          | Tfunction_body e -> it.Tast_iterator.expr it e
+          | Tfunction_cases fc ->
+            function_cases t it fc ~index:(List.length params))
+    | _ -> Tast_iterator.default_iterator.value_binding it vb
+
+  let pat (type k) t it (pat : k Typedtree.general_pattern) =
+    (match pat.pat_desc with
+    | Tpat_var { id; name; uid; _ } ->
+      register_var t ~id ~uid ~name:name.txt ~location:pat.pat_loc ~kind:Local
+    | Tpat_alias { id; name; uid; _ } ->
+      register_var t ~id ~uid ~name:name.txt ~location:pat.pat_loc ~kind:Alias
+    | Tpat_fun_layout { id; name; uid; _ } ->
+      register_var t ~id ~uid ~name:name.txt ~location:pat.pat_loc ~kind:Local
+    | _ -> ());
+    Tast_iterator.default_iterator.pat it pat
+
+  let implementation ~unit_name (impl : Typedtree.implementation) =
+    VA.set_unit_name unit_name;
+    let module_scope =
+      VA.register_source_module ~display_name:unit_name ~location:Location.none
+    in
+    let t =
+      { current_function = module_scope; seen_idents = Hashtbl.create 64 }
+    in
+    let open Tast_iterator in
+    (* The handlers need open recursion through the iterator, so we tie
+       the knot via a ref rather than a let-rec. *)
+    let it = ref default_iterator in
+    it
+      := { default_iterator with
+           pat = (fun it p -> pat t it p);
+           expr = (fun it e -> expr t it e);
+           value_binding = (fun it vb -> value_binding t it vb)
+         };
+    !it.structure !it impl.structure
+end
+
+let collect_from_typedtree ~unit_name impl =
+  if VA.is_enabled () then Walk.implementation ~unit_name impl
+
+let record_lambda_uid ~checkpoint uid =
+  if not (Shape.Uid.equal uid Shape.Uid.internal_not_actually_unique)
+  then VA.record_observation ~checkpoint (VA.Source_uid uid)
+
+let rec walk_lambda ~checkpoint (l : Lambda.lambda) =
+  match l with
+  | Lvar _ | Lmutvar _ | Lconst _ | Lsplice _ -> ()
+  | Lapply { ap_func; ap_args; _ } ->
+    walk_lambda ~checkpoint ap_func;
+    List.iter (walk_lambda ~checkpoint) ap_args
+  | Lfunction { params; body; _ } ->
+    List.iter
+      (fun (p : Lambda.lparam) -> record_lambda_uid ~checkpoint p.debug_uid)
+      params;
+    walk_lambda ~checkpoint body
+  | Llet (_, _, _id, duid, def, body) | Lmutlet (_, _id, duid, def, body) ->
+    record_lambda_uid ~checkpoint duid;
+    walk_lambda ~checkpoint def;
+    walk_lambda ~checkpoint body
+  | Lletrec (bindings, body) ->
+    List.iter
+      (fun (b : Lambda.rec_binding) ->
+        record_lambda_uid ~checkpoint b.debug_uid;
+        walk_lambda ~checkpoint (Lambda.Lfunction b.def))
+      bindings;
+    walk_lambda ~checkpoint body
+  | Lprim (_, args, _) -> List.iter (walk_lambda ~checkpoint) args
+  | Lswitch (arg, sw, _, _) ->
+    walk_lambda ~checkpoint arg;
+    List.iter (fun (_, e) -> walk_lambda ~checkpoint e) sw.sw_consts;
+    List.iter (fun (_, e) -> walk_lambda ~checkpoint e) sw.sw_blocks;
+    Option.iter (walk_lambda ~checkpoint) sw.sw_failaction
+  | Lstringswitch (arg, cases, default, _, _) ->
+    walk_lambda ~checkpoint arg;
+    List.iter (fun (_, e) -> walk_lambda ~checkpoint e) cases;
+    Option.iter (walk_lambda ~checkpoint) default
+  | Lstaticraise (_, args) -> List.iter (walk_lambda ~checkpoint) args
+  | Lstaticcatch (body, (_, params), handler, _, _) ->
+    walk_lambda ~checkpoint body;
+    List.iter (fun (_, duid, _) -> record_lambda_uid ~checkpoint duid) params;
+    walk_lambda ~checkpoint handler
+  | Ltrywith (body, _id, duid, handler, _) ->
+    walk_lambda ~checkpoint body;
+    record_lambda_uid ~checkpoint duid;
+    walk_lambda ~checkpoint handler
+  | Lifthenelse (c, t, e, _) ->
+    walk_lambda ~checkpoint c;
+    walk_lambda ~checkpoint t;
+    walk_lambda ~checkpoint e
+  | Lsequence (a, b) ->
+    walk_lambda ~checkpoint a;
+    walk_lambda ~checkpoint b
+  | Lwhile { wh_cond; wh_body } ->
+    walk_lambda ~checkpoint wh_cond;
+    walk_lambda ~checkpoint wh_body
+  | Lfor { for_debug_uid; for_from; for_to; for_body; _ } ->
+    record_lambda_uid ~checkpoint for_debug_uid;
+    walk_lambda ~checkpoint for_from;
+    walk_lambda ~checkpoint for_to;
+    walk_lambda ~checkpoint for_body
+  | Lassign (_, e) -> walk_lambda ~checkpoint e
+  | Lsend (_, met, obj, args, _, _, _, _) ->
+    List.iter (walk_lambda ~checkpoint) (met :: obj :: args)
+  | Levent (e, _) | Lifused (_, e) | Lregion (e, _) | Lexclave e ->
+    walk_lambda ~checkpoint e
+
+let observe_lambda_program ~checkpoint (program : Lambda.program) =
+  if VA.is_enabled () then walk_lambda ~checkpoint program.code

--- a/typing/debug_variable_availability.mli
+++ b/typing/debug_variable_availability.mli
@@ -1,0 +1,37 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Simon Spies, Jane Street                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Walk a typed implementation, registering source functions and the value
+    binders defined in each. No-op when the diagnostic flag is disabled. *)
+val collect_from_typedtree :
+  unit_name:string -> Typedtree.implementation -> unit
+
+(** Walk a Lambda program and record an observation at [checkpoint] for every
+    binder carrying a debug uid. No-op when the diagnostic flag is disabled. *)
+val observe_lambda_program :
+  checkpoint:Variable_availability.Checkpoint.t -> Lambda.program -> unit

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -1149,6 +1149,39 @@ let add_to_type_shapes var_uid type_expr type_layout ~name:type_name uid_of_path
   let type_shape = Type_shape.of_type_expr type_expr uid_of_path in
   Uid.Tbl.add all_type_shapes var_uid { type_shape; type_name; type_layout }
 
+module Variable_availability =
+  Variable_availability.Make
+    (struct
+      type t = Shape.Uid.t
+
+      let equal = Shape.Uid.equal
+
+      let hash = Hashtbl.hash
+
+      let print = Shape.Uid.print
+
+      let no_uid = Shape.Uid.internal_not_actually_unique
+    end)
+    (struct
+      type t = Location.t
+
+      let print_compact ppf (loc : Location.t) =
+        let s = loc.loc_start and e = loc.loc_end in
+        if s.pos_cnum < 0
+        then Format.fprintf ppf "%d" s.pos_lnum
+        else
+          let col p = p.Lexing.pos_cnum - p.Lexing.pos_bol in
+          if s.pos_lnum = e.pos_lnum
+          then Format.fprintf ppf "%d:%d-%d" s.pos_lnum (col s) (col e)
+          else
+            Format.fprintf ppf "%d-%d:%d-%d" s.pos_lnum e.pos_lnum (col s)
+              (col e)
+
+      let print_with_file ppf (loc : Location.t) =
+        Format.fprintf ppf "%s:%a" loc.loc_start.Lexing.pos_fname print_compact
+          loc
+    end)
+
 let print_table_all_type_decls ppf =
   let entries = Uid.Tbl.to_list all_type_decls in
   let entries = List.sort (fun (a, _) (b, _) -> Uid.compare a b) entries in

--- a/typing/type_shape.mli
+++ b/typing/type_shape.mli
@@ -128,3 +128,8 @@ val print_table_all_type_decls : Format.formatter -> unit
 val print_table_all_type_shapes : Format.formatter -> unit
 
 val print_debug_uid_tables : Format.formatter -> unit
+
+(** Instance of the [Variable_availability] diagnostic, owned by this module.
+    Holds the table of registered source variables and observation points. *)
+module Variable_availability :
+  Variable_availability.S with type uid = Shape.Uid.t and type loc = Location.t

--- a/utils/.ocamlformat-enable
+++ b/utils/.ocamlformat-enable
@@ -18,3 +18,5 @@ priority_queue.ml
 priority_queue.mli
 structured_mangling.ml
 structured_mangling.mli
+variable_availability.ml
+variable_availability.mli

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -195,6 +195,7 @@ and dump_flambda_let = ref (None : int option) (* -dflambda-let=... *)
 and dump_flambda_verbose = ref false    (* -dflambda-verbose *)
 and dump_jsir = ref false               (* -djsir *)
 and dump_instr = ref false              (* -dinstr *)
+and dump_variable_availability = ref false  (* -dvariable-availability *)
 and keep_camlprimc_file = ref false     (* -dcamlprimc *)
 
 let keyword_edition: string option ref = ref None

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -185,6 +185,7 @@ val dump_rawflambda : bool ref
 val dump_flambda : bool ref
 val dump_flambda_let : int option ref
 val dump_instr : bool ref
+val dump_variable_availability : bool ref
 val keep_camlprimc_file : bool ref
 val keep_asm_file : bool ref
 val optimize_for_speed : bool ref

--- a/utils/variable_availability.ml
+++ b/utils/variable_availability.ml
@@ -1,0 +1,571 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Simon Spies, Jane Street                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module Checkpoint = struct
+  type t =
+    | Typedtree
+    | Raw_lambda
+    | Lambda
+    | Flambda2_input
+    | Flambda2_simplified
+    | Flambda2_output
+    | Cmm
+    | Debug_info
+
+  let all =
+    [ Typedtree;
+      Raw_lambda;
+      Lambda;
+      Flambda2_input;
+      Flambda2_simplified;
+      Flambda2_output;
+      Cmm;
+      Debug_info ]
+
+  let all_array = Array.of_list all
+
+  let count = Array.length all_array
+
+  let index = function
+    | Typedtree -> 0
+    | Raw_lambda -> 1
+    | Lambda -> 2
+    | Flambda2_input -> 3
+    | Flambda2_simplified -> 4
+    | Flambda2_output -> 5
+    | Cmm -> 6
+    | Debug_info -> 7
+
+  let of_index i = all_array.(i)
+
+  let display = function
+    | Typedtree -> "typing"
+    | Raw_lambda -> "raw-lambda"
+    | Lambda -> "lambda"
+    | Flambda2_input -> "flambda2-in"
+    | Flambda2_simplified -> "flambda2-simpl"
+    | Flambda2_output -> "flambda2-out"
+    | Cmm -> "cmm"
+    | Debug_info -> "debug-info"
+end
+
+type source_kind =
+  | Parameter of int
+  | Local
+  | For_index
+  | Comprehension_index
+  | Letop_param
+  | Alias
+
+let string_of_source_kind = function
+  | Parameter i -> Printf.sprintf "param[%d]" i
+  | Local -> "local"
+  | For_index -> "for"
+  | Comprehension_index -> "comprehension"
+  | Letop_param -> "letop"
+  | Alias -> "alias"
+
+module type Uid = sig
+  type t
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
+
+  val print : Format.formatter -> t -> unit
+
+  val no_uid : t
+end
+
+module type Loc = sig
+  type t
+
+  val print_compact : Format.formatter -> t -> unit
+
+  val print_with_file : Format.formatter -> t -> unit
+end
+
+module type S = sig
+  type uid
+
+  type loc
+
+  type observed_id =
+    | Source_uid of uid
+    | Projected_source_uid of
+        { source_uid : uid;
+          field : int
+        }
+
+  type source_definition
+
+  val is_enabled : unit -> bool
+
+  val reset : unit -> unit
+
+  val set_unit_name : string -> unit
+
+  val register_source_function :
+    display_name:string -> location:loc -> source_definition
+
+  val register_source_module :
+    display_name:string -> location:loc -> source_definition
+
+  val register_source_variable :
+    source_definition ->
+    uid:uid ->
+    name:string ->
+    location:loc ->
+    kind:source_kind ->
+    unit
+
+  val record_observation : checkpoint:Checkpoint.t -> observed_id -> unit
+
+  type ok_drop_reason =
+    | Merged_with of uid
+    | Ignored_variable
+    | Function_became_catch
+    | Module_level
+
+  val register_ok_drop : uid:uid -> reason:ok_drop_reason -> unit
+
+  type gap_cause =
+    | Phantom_let_dropped_in_to_cmm
+    | Missing_phantom_let_for_let_optimization
+    | Lmutlet_handler_loses_duid
+
+  val register_gap : uid:uid -> cause:gap_cause -> unit
+
+  val print_report : Format.formatter -> unit
+end
+
+module Make (Uid : Uid) (Loc : Loc) :
+  S with type uid = Uid.t and type loc = Loc.t = struct
+  type uid = Uid.t
+
+  type loc = Loc.t
+
+  type observed_id =
+    | Source_uid of uid
+    | Projected_source_uid of
+        { source_uid : uid;
+          field : int
+        }
+
+  module Uid_tbl = Hashtbl.Make (struct
+    type t = uid
+
+    let equal = Uid.equal
+
+    let hash = Uid.hash
+  end)
+
+  type ok_drop_reason =
+    | Merged_with of uid
+    | Ignored_variable
+    | Function_became_catch
+    | Module_level
+
+  type gap_cause =
+    | Phantom_let_dropped_in_to_cmm
+    | Missing_phantom_let_for_let_optimization
+    | Lmutlet_handler_loses_duid
+
+  type drop =
+    | Ok of ok_drop_reason
+    | Gap of gap_cause
+
+  type source_definition_kind =
+    | Module
+    | Function
+
+  type source_variable =
+    { uid : uid;
+      name : string;
+      location : loc;
+      kind : source_kind;
+      (* [seen.(Checkpoint.index cp)] is whether [uid] was observed at [cp]. The
+         whole set is kept (not just the furthest point) so a non-monotonic
+         trace shows as a [(+N)] in the summary. *)
+      seen : bool array
+    }
+
+  type source_definition =
+    { kind : source_definition_kind;
+      display_name : string;
+      location : loc;
+      mutable variables : source_variable list
+    }
+
+  type state =
+    { mutable unit_name : string option;
+      mutable source_definitions : source_definition list;
+      uid_to_variable : source_variable Uid_tbl.t;
+      (* How each eliminated uid was dropped: lossless ([Ok]) or a coverage gap
+         ([Gap]). A dropped uid absent here is an unexplained gap. *)
+      drops : drop Uid_tbl.t
+    }
+
+  let fresh_state () =
+    { unit_name = None;
+      source_definitions = [];
+      uid_to_variable = Uid_tbl.create 32;
+      drops = Uid_tbl.create 32
+    }
+
+  let state = ref (fresh_state ())
+
+  let is_enabled () = !Clflags.dump_variable_availability
+
+  let reset () = state := fresh_state ()
+
+  let set_unit_name name = if is_enabled () then !state.unit_name <- Some name
+
+  let register_source kind ~display_name ~location =
+    let f = { kind; display_name; location; variables = [] } in
+    let s = !state in
+    s.source_definitions <- f :: s.source_definitions;
+    f
+
+  let register_source_function = register_source Function
+
+  let register_source_module = register_source Module
+
+  let uid_of_observed_id = function
+    | Source_uid u -> u
+    | Projected_source_uid { source_uid; _ } -> source_uid
+
+  let record_observation ~checkpoint id =
+    if is_enabled ()
+    then
+      let uid = uid_of_observed_id id in
+      if not (Uid.equal uid Uid.no_uid)
+      then
+        match Uid_tbl.find_opt !state.uid_to_variable uid with
+        | None -> ()
+        | Some v -> v.seen.(Checkpoint.index checkpoint) <- true
+
+  (* First-registered wins: the earliest classification is canonical (e.g. the
+     original survivor for a merge); later passes that try to reclassify the
+     same uid are ignored. *)
+  let add_drop ~uid drop =
+    if not (Uid.equal uid Uid.no_uid)
+    then
+      let s = !state in
+      if Uid_tbl.mem s.drops uid then () else Uid_tbl.add s.drops uid drop
+
+  let register_ok_drop ~uid ~reason =
+    if is_enabled ()
+    then
+      match reason with
+      | Merged_with surviving
+        when Uid.equal surviving Uid.no_uid || Uid.equal surviving uid ->
+        ()
+      | Merged_with _ | Ignored_variable | Function_became_catch | Module_level
+        ->
+        add_drop ~uid (Ok reason)
+
+  let register_gap ~uid ~cause = if is_enabled () then add_drop ~uid (Gap cause)
+
+  let register_source_variable f ~uid ~name ~location ~kind =
+    if (not (is_enabled ())) || Uid.equal uid Uid.no_uid
+    then ()
+    else
+      let s = !state in
+      (* A caller may register the same uid more than once (e.g. an enclosing
+         handler registers a binder that a later traversal step then revisits);
+         keep the first registration and skip duplicates. *)
+      if Uid_tbl.mem s.uid_to_variable uid
+      then ()
+      else begin
+        let v =
+          { uid;
+            name;
+            location;
+            kind;
+            seen = Array.make Checkpoint.count false
+          }
+        in
+        f.variables <- v :: f.variables;
+        Uid_tbl.add s.uid_to_variable uid v;
+        v.seen.(Checkpoint.index Checkpoint.Typedtree) <- true;
+        (* Module-scope bindings are top-level lets, not runtime locals, so
+           their absence from DWARF locals is expected: classify them as an
+           ok-drop rather than leave them to surface as a coverage gap. *)
+        match f.kind with
+        | Module -> add_drop ~uid (Ok Module_level)
+        | Function -> ()
+      end
+
+  (* The outcome of a variable, derived from its trace: [Present] if it reached
+     the last checkpoint, otherwise [Dropped] across the edge after the furthest
+     checkpoint it did reach. A non-monotonic trace (a uid re-observed after a
+     gap) is not called out per-variable; it shows up as a [(+N)] increment in
+     the pass-by-pass funnel. *)
+  type outcome =
+    | Present
+    | Dropped of
+        { from_ : Checkpoint.t;
+          to_ : Checkpoint.t
+        }
+
+  let outcome_of_seen seen =
+    let n = Array.length seen in
+    if seen.(n - 1)
+    then Present
+    else begin
+      let furthest = ref 0 in
+      for i = 0 to n - 1 do
+        if seen.(i) then furthest := i
+      done;
+      Dropped
+        { from_ = Checkpoint.of_index !furthest;
+          to_ = Checkpoint.of_index (!furthest + 1)
+        }
+    end
+
+  let drop_for uid = Uid_tbl.find_opt !state.drops uid
+
+  let is_ok_drop uid =
+    match drop_for uid with Some (Ok _) -> true | Some (Gap _) | None -> false
+
+  let reached seen cp = seen.(Checkpoint.index cp)
+
+  let all_variables () =
+    List.concat_map
+      (fun (f : source_definition) -> f.variables)
+      !state.source_definitions
+
+  module Printing = struct
+    let row_ok_reason = function
+      | Merged_with surviving -> (
+        match Uid_tbl.find_opt !state.uid_to_variable surviving with
+        | Some v -> Printf.sprintf "merged-with-%s" v.name
+        | None -> "merged")
+      | Ignored_variable -> "ignored"
+      | Function_became_catch -> "became-static-catch"
+      | Module_level -> "module-level"
+
+    (* Like [row_ok_reason] but aggregates all merges under one bucket. *)
+    let tally_ok_reason = function
+      | Merged_with _ -> "merged"
+      | Ignored_variable -> "ignored"
+      | Function_became_catch -> "became-static-catch"
+      | Module_level -> "module-level"
+
+    let gap_cause_token = function
+      | Phantom_let_dropped_in_to_cmm -> "phantom-let-dropped-in-to_cmm"
+      | Missing_phantom_let_for_let_optimization ->
+        "missing-phantom-let-for-let-opt"
+      | Lmutlet_handler_loses_duid -> "lmutlet-loses-duid"
+
+    (* Dropped uid with no registered cause: a coverage gap whose responsible
+       site has not been attributed with [register_gap] yet. Observed sources
+       include tuple/record pattern destructuring lowered by
+       [lambda/matching.ml] (the binders are dropped at the raw-lambda->lambda
+       edge). *)
+    let unknown_gap_token = "(unknown)"
+
+    let percent n d =
+      if d = 0
+      then "0.00%"
+      else Printf.sprintf "%.2f%%" (100. *. float n /. float d)
+
+    let edge_str from_ to_ =
+      Printf.sprintf "%s->%s" (Checkpoint.display from_)
+        (Checkpoint.display to_)
+
+    (* outcome / edge / verdict / reason cells of one variable's row. *)
+    let cells_of_variable (v : source_variable) =
+      match outcome_of_seen v.seen with
+      | Present -> "present", "", "", ""
+      | Dropped { from_; to_ } -> (
+        let edge = edge_str from_ to_ in
+        match drop_for v.uid with
+        | Some (Ok reason) -> "dropped", edge, "[ok]", row_ok_reason reason
+        | Some (Gap cause) -> "dropped", edge, "[gap]", gap_cause_token cause
+        | None -> "dropped", edge, "[gap]", unknown_gap_token)
+
+    let rstrip s =
+      let n = ref (String.length s) in
+      while !n > 0 && s.[!n - 1] = ' ' do
+        decr n
+      done;
+      String.sub s 0 !n
+
+    (* Fixed column widths keep each column at the same offset across functions
+       and files, so report diffs move only where the data did. These are
+       minimum widths sized for the common case: kind 13 ("comprehension"); loc
+       14 (single-line "100000:999-999"); outcome 7 ("dropped"); edge 28
+       ("flambda2-simpl->flambda2-out"); verdict 5 ("[gap]"). A longer value
+       overflows its column for that row -- notably a multi-line loc, which
+       prints as "line-line:col-col" -- shifting the later columns right on that
+       line only. The reason trails, and trailing padding is stripped. *)
+    let render_data (v : source_variable) =
+      let outcome, edge, verdict, reason = cells_of_variable v in
+      rstrip
+        (Printf.sprintf "%-13s  %-14s  %-7s  %-28s  %-5s  %s"
+           (string_of_source_kind v.kind)
+           (Format.asprintf "%a" Loc.print_compact v.location)
+           outcome edge verdict reason)
+
+    let scope_word = function Module -> "Module" | Function -> "Function"
+
+    let print_source_definition ppf (f : source_definition) =
+      let vars = List.rev f.variables in
+      Format.fprintf ppf "@,%s %s  %a@," (scope_word f.kind) f.display_name
+        Loc.print_with_file f.location;
+      let rows = List.map (fun v -> v.name, render_data v) vars in
+      Format_doc.compat (Format_doc.pp_two_columns ~sep:"|") ppf rows
+
+    (* Survivors reaching each checkpoint, with the per-edge delta. A [(+N)]
+       increment is only possible for a non-monotonic trace (a uid re-observed
+       after a gap), which means an observation hook is missing. *)
+    let print_funnel ppf ~tracked ~n_tracked =
+      Format.fprintf ppf "@,Pass-by-pass survival:@,";
+      let counts =
+        List.map
+          (fun cp ->
+            ( cp,
+              List.fold_left
+                (fun acc v -> if reached v.seen cp then acc + 1 else acc)
+                0 tracked ))
+          Checkpoint.all
+      in
+      let w_name =
+        List.fold_left
+          (fun w (cp, _) -> max w (String.length (Checkpoint.display cp)))
+          0 counts
+      in
+      let w_count = String.length (string_of_int n_tracked) in
+      let _ : int option =
+        List.fold_left
+          (fun prev (cp, n) ->
+            let delta =
+              match prev with
+              | Some p when n < p -> Printf.sprintf "  (-%d)" (p - n)
+              | Some p when n > p -> Printf.sprintf "  (+%d)" (n - p)
+              | Some _ | None -> ""
+            in
+            Format.fprintf ppf "  %-*s  %*d  (%7s)%s@," w_name
+              (Checkpoint.display cp) w_count n (percent n n_tracked) delta;
+            Some n)
+          None counts
+      in
+      ()
+
+    let bump tbl key =
+      Hashtbl.replace tbl key
+        (1 + try Hashtbl.find tbl key with Not_found -> 0)
+
+    (* Sorted alphabetically so the row order does not depend on counts. *)
+    let sorted_buckets tbl =
+      Hashtbl.fold (fun reason count acc -> (reason, count) :: acc) tbl []
+      |> List.sort (fun (r1, _) (r2, _) -> compare r1 r2)
+
+    let print_drop_reasons ppf ~ok_drops ~tracked =
+      let ok_tbl = Hashtbl.create 8 in
+      List.iter
+        (fun v ->
+          match drop_for v.uid with
+          | Some (Ok reason) -> bump ok_tbl (tally_ok_reason reason)
+          | Some (Gap _) | None -> ())
+        ok_drops;
+      let gap_tbl = Hashtbl.create 8 in
+      List.iter
+        (fun v ->
+          match outcome_of_seen v.seen with
+          | Dropped _ -> (
+            match drop_for v.uid with
+            | Some (Gap cause) -> bump gap_tbl (gap_cause_token cause)
+            | Some (Ok _) | None -> bump gap_tbl unknown_gap_token)
+          | Present -> ())
+        tracked;
+      let ok_rows = sorted_buckets ok_tbl in
+      let gap_rows = sorted_buckets gap_tbl in
+      if ok_rows = [] && gap_rows = []
+      then ()
+      else begin
+        let w_count =
+          List.fold_left
+            (fun w (_, c) -> max w (String.length (string_of_int c)))
+            1 (ok_rows @ gap_rows)
+        in
+        let rows =
+          List.map
+            (fun (r, c) -> r, Printf.sprintf "%*d  (ok)" w_count c)
+            ok_rows
+          @ List.map
+              (fun (r, c) -> r, Printf.sprintf "%*d  (gap)" w_count c)
+              gap_rows
+        in
+        Format.fprintf ppf "@,Drop reasons:@,";
+        Format_doc.compat (Format_doc.pp_two_columns ~sep:"|") ppf rows
+      end
+
+    let print_unit_summary ppf =
+      let all_vars = all_variables () in
+      let ok_drops, tracked =
+        List.partition (fun v -> is_ok_drop v.uid) all_vars
+      in
+      let total = List.length all_vars in
+      if total = 0
+      then ()
+      else begin
+        let n_excluded = List.length ok_drops in
+        let n_tracked = List.length tracked in
+        let reach =
+          List.fold_left
+            (fun acc v ->
+              if reached v.seen Checkpoint.Debug_info then acc + 1 else acc)
+            0 tracked
+        in
+        Format.fprintf ppf
+          "@,\
+           Compilation-unit summary: %d total variables; %d excluded \
+           (ok-drops); %d/%d reach debug info (%s)@,"
+          total n_excluded reach n_tracked (percent reach n_tracked);
+        print_funnel ppf ~tracked ~n_tracked;
+        print_drop_reasons ppf ~ok_drops ~tracked
+      end
+
+    let print_report ppf =
+      if is_enabled ()
+      then begin
+        let s = !state in
+        let unit_name = Option.value s.unit_name ~default:"<unknown>" in
+        Format.fprintf ppf "@[<v 0>Variable availability for %s@," unit_name;
+        let fns = List.rev s.source_definitions in
+        List.iter (print_source_definition ppf) fns;
+        print_unit_summary ppf;
+        Format.fprintf ppf "@]@."
+      end
+  end
+
+  let print_report = Printing.print_report
+end

--- a/utils/variable_availability.mli
+++ b/utils/variable_availability.mli
@@ -1,0 +1,206 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                        Simon Spies, Jane Street                            *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Diagnostic tracking source-level variables through compilation passes,
+    active only when [!Clflags.dump_variable_availability] is set. Most entry
+    points self-check the flag and do nothing when it is off, so no variable
+    data accumulates. The exceptions are [register_source_function] and
+    [register_source_module], which return a scope value and so cannot be
+    no-ops; they rely on their callers to gate them. Callers may still check
+    [is_enabled] first to avoid building up arguments that would be discarded.
+
+    For each source variable we keep its {e trace} -- the checkpoints at which
+    its uid was observed -- plus an optional {e drop} classification from the
+    pass that eliminated it. The trace gives the outcome ([present] / [dropped]
+    across a pipeline edge); the classification says whether a disappearance is
+    an [[ok]] drop (never expected in DWARF) or a real coverage [[gap]].
+
+    [Make] introduces top-level state for the table. *)
+
+(** The pipeline checkpoints at which observations may be recorded. [Raw_lambda]
+    and [Lambda] are populated from the like-named [Compiler_hooks] passes;
+    [Typedtree] from [Compiler_hooks.Typed_tree_impl]; [Flambda2_input],
+    [Flambda2_simplified] and [Flambda2_output] from direct [observe] calls in
+    [Flambda2.flambda_to_flambda0]; and [Cmm] and [Debug_info] from direct calls
+    in the backend ([select_utils]/ [cfg_selectgen] and the DWARF emitter
+    respectively). *)
+module Checkpoint : sig
+  type t =
+    | Typedtree
+    | Raw_lambda
+    | Lambda
+    | Flambda2_input
+    | Flambda2_simplified
+    | Flambda2_output
+    | Cmm
+    | Debug_info
+end
+
+type source_kind =
+  | Parameter of int
+  | Local
+  | For_index
+  | Comprehension_index
+  | Letop_param
+  | Alias
+
+module type Uid = sig
+  type t
+
+  val equal : t -> t -> bool
+
+  val hash : t -> int
+
+  val print : Format.formatter -> t -> unit
+
+  (** Sentinel value used to recognize "no stable identity" uids. Source
+      variables registered with this uid are silently skipped, and observations
+      recorded against this uid are silently dropped. *)
+  val no_uid : t
+end
+
+module type Loc = sig
+  type t
+
+  (** Compact ["line:cols"] form without a filename, for per-variable rows where
+      the file is constant across the compilation unit. *)
+  val print_compact : Format.formatter -> t -> unit
+
+  (** Compact ["file:line:cols"] form, for the per-function header. *)
+  val print_with_file : Format.formatter -> t -> unit
+end
+
+module type S = sig
+  type uid
+
+  type loc
+
+  type observed_id =
+    | Source_uid of uid
+    | Projected_source_uid of
+        { source_uid : uid;
+          field : int
+        }
+
+  type source_definition
+
+  (** [is_enabled ()] is [!Clflags.dump_variable_availability]. *)
+  val is_enabled : unit -> bool
+
+  (** Reset per-compilation-unit state. Idempotent. *)
+  val reset : unit -> unit
+
+  (** Set the unit name shown at the top of the report. *)
+  val set_unit_name : string -> unit
+
+  (** Register a function-scope binder under which source variables can then be
+      registered. [display_name] is shown in the report. *)
+  val register_source_function :
+    display_name:string -> location:loc -> source_definition
+
+  (** Register a module-scope binder. Variables registered under it are
+      module-level [let] bindings rather than runtime locals; they are
+      automatically classified as [Module_level] ok-drops (so they are excluded
+      from the coverage totals, since their absence from DWARF locals is
+      expected). *)
+  val register_source_module :
+    display_name:string -> location:loc -> source_definition
+
+  (** Register a source-level value binder under a function. Calls with the
+      sentinel uid [Uid.no_uid] are silently skipped. Duplicate registrations
+      (same uid) are also silently skipped. The variable's trace starts with an
+      observation at checkpoint [Typedtree]. *)
+  val register_source_variable :
+    source_definition ->
+    uid:uid ->
+    name:string ->
+    location:loc ->
+    kind:source_kind ->
+    unit
+
+  (** Record that the uid was seen at this pipeline checkpoint. Calls with the
+      sentinel [Uid.no_uid] (or a projection thereof), calls for uids that were
+      never registered as source variables, and calls made while the diagnostic
+      is disabled are all silently dropped. *)
+  val record_observation : checkpoint:Checkpoint.t -> observed_id -> unit
+
+  (** Reason a source binding disappears in a way that does not lose coverage:
+      the user should not expect such a binding in DWARF, so the drop is
+      reported as [[ok]] and the binding is excluded from the coverage totals.
+  *)
+  type ok_drop_reason =
+    | Merged_with of uid
+        (** The same [Ident.t] was reused with a fresh debug uid (e.g. an
+            or-pattern arm whose bindings have been unified by typing). The
+            named survivor's source location carries the binding. *)
+    | Ignored_variable
+        (** Pattern variable not used by the body (e.g. [_x]): either [Matching]
+            never emitted a binding for it, or [simplify_lets] eliminated the
+            binding because the use count was zero. *)
+    | Function_became_catch
+        (** Local function whose name was eliminated because all of its call
+            sites were rewritten as [Lstaticcatch] / [Lstaticraise]
+            continuations by [simplify_local_functions]. *)
+    | Module_level
+        (** Module-level [let] binding, not a runtime local. Applied
+            automatically to variables registered under a module scope. *)
+
+  (** Record that source uid [uid] was dropped losslessly for the given
+      [reason]. Calls involving the sentinel [Uid.no_uid], or a [Merged_with]
+      whose survivor equals [uid], are silently dropped. The earliest-registered
+      classification wins. *)
+  val register_ok_drop : uid:uid -> reason:ok_drop_reason -> unit
+
+  (** Code site that is known to drop a source uid in a way that loses coverage.
+      Each constructor names one specific spot in the compiler so the report can
+      direct an investigator to the relevant file. New entries should describe
+      the site, not the symptom, so they can be deleted once the underlying
+      cause is fixed. *)
+  type gap_cause =
+    | Phantom_let_dropped_in_to_cmm
+        (** [to_cmm_expr.ml]: a [Let_expr] at [Name_mode.phantom] is discarded
+            by [to_cmm] instead of producing a [Cphantom_let]. *)
+    | Missing_phantom_let_for_let_optimization
+        (** [lambda_to_flambda.ml]: the [let v = e in v] optimization drops the
+            source duid because no phantom let preserves it. *)
+    | Lmutlet_handler_loses_duid
+        (** [lambda_to_flambda.ml]: the [Lmutlet] handler introduces a fresh
+            temporary with [Lambda.debug_uid_none]. *)
+
+  (** Record that source uid [uid] was dropped at a known code site that loses
+      coverage. The cause is shown in the per-variable row (and the drop counts
+      as a [[gap]] in the totals) so an investigator can navigate to the
+      responsible code. Calls with [Uid.no_uid] are silently dropped. The
+      earliest-registered classification wins. *)
+  val register_gap : uid:uid -> cause:gap_cause -> unit
+
+  val print_report : Format.formatter -> unit
+end
+
+module Make (Uid : Uid) (Loc : Loc) :
+  S with type uid = Uid.t and type loc = Loc.t


### PR DESCRIPTION
This PR instruments the compiler with tracing of variable information. More specifically, it collects all binders at the typed tree level alongside their UIDs and then observes which of these UIDs persist across the different IRs of the compiler. 

It additionally adds explanations in certain key places where we know debug information is dropped, classifying them into `ok` (acceptable loss or no loss at all) and `gap` (leading to worse debug info).

To get a sense, below is the current statistic for compiling `typecore.ml` with `-g -gno-upstream-dwarf -gdwarf-may-alter-codegen -flambda2-expert-phantom-lets -dvariable-availability`:

```
Compilation-unit summary: 5799 total variables; 506 excluded (ok-drops); 3007/5293 reach debug info (56.81%)

Pass-by-pass survival:
  typing          5293  (100.00%)
  raw-lambda      5282  ( 99.79%)  (-11)
  lambda          5037  ( 95.16%)  (-245)
  flambda2-in     5026  ( 94.96%)  (-11)
  flambda2-simpl  4920  ( 92.95%)  (-106)
  flambda2-out    4920  ( 92.95%)
  cmm             3095  ( 58.47%)  (-1825)
  debug-info      3007  ( 56.81%)  (-88)

Drop reasons:
          became-static-catch |   29  (ok)
                      ignored |   46  (ok)
                       merged |   68  (ok)
                 module-level |  363  (ok)
                    (unknown) | 2213  (gap)
           lmutlet-loses-duid |    1  (gap)
phantom-let-dropped-in-to_cmm |   72  (gap)
```