### PR TITLE
Add a couple flags missing from the ocamlnat/expect.opt drivers

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1998,6 +1998,10 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_color F._color;
     mk_error_style F._error_style;
 
+    mk_dno_unique_ids F._dno_unique_ids;
+    mk_dunique_ids F._dunique_ids;
+    mk_dno_locations F._dno_locations;
+    mk_dlocations F._dlocations;
     mk_dsource F._dsource;
     mk_dparsetree F._dparsetree;
     mk_dtypedtree F._dtypedtree;


### PR DESCRIPTION
This just adds a couple flags (`-dno-unique-ids` and `-dno-locations`) to the `ocamlnat` driver (and therefore also `expect.opt` tests, where I wanted to use them).

I think it's just an oversight that these weren't present. They are perfectly sensible and work fine in local testing. I considered adding tests to the repo for them, but we definitely don't have tests for every possible combination of driver and flag, and that sounds like overkill to me.