### PR TITLE
[5.4] Miscellany from middle_end/backend

### DIFF
--- a/Makefile.upstream
+++ b/Makefile.upstream
@@ -692,9 +692,9 @@ compare:
 # The core system has to be rebuilt after bootstrap anyway, so strip ocamlc
 # and ocamllex, which means the artefacts should be identical.
 	mv ocamlc$(EXE) ocamlc.tmp
-	$(OCAMLRUN) tools/stripdebug -all ocamlc.tmp ocamlc$(EXE)
+	$(OCAMLRUN) tools/stripdebug$(EXE) -all ocamlc.tmp ocamlc$(EXE)
 	mv lex/ocamllex$(EXE) ocamllex.tmp
-	$(OCAMLRUN) tools/stripdebug -all ocamllex.tmp lex/ocamllex$(EXE)
+	$(OCAMLRUN) tools/stripdebug$(EXE) -all ocamllex.tmp lex/ocamllex$(EXE)
 	rm -f ocamllex.tmp ocamlc.tmp
 	@if $(CMPCMD) boot/ocamlc ocamlc$(EXE) \
          && $(CMPCMD) boot/ocamllex lex/ocamllex$(EXE); \
@@ -722,7 +722,7 @@ promote-cross: promote-common
 # Promote the newly compiled system to the rank of bootstrap compiler
 # (Runs on the new runtime, produces code for the new runtime)
 .PHONY: promote
-promote: PROMOTE = $(OCAMLRUN) tools/stripdebug -all
+promote: PROMOTE = $(OCAMLRUN) tools/stripdebug$(EXE) -all
 promote: promote-common
 	rm -f boot/ocamlrun$(EXE)
 	cp $(RUNTIME_DIR)/ocamlrun$(EXE) boot/ocamlrun$(EXE)
@@ -1973,6 +1973,9 @@ ocamltest/ocamltest.opt$(EXE): ocamlopt ocamlyacc ocamllex
 # (see #9797)
 ocamltest/%: \
   VPATH := $(filter-out $(unix_directory), $(VPATH))
+
+# runtime headers are necessary to link ocamltest in custom mode
+ocamltest/%: VPATH += runtime
 
 # Ocamltest_unix and the linking of the executable itself should include the
 # Unix library, if it's being built.

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2062,7 +2062,7 @@ let emit_instr ~first ~last ~fallthrough i =
         D.cfi_def_cfa_register ~reg:"r13";
         (* NB: gdb has asserts on contiguous stacks that mean it will not unwind
            through this unless we were to tag this calling frame with
-           cfi_signal_frame in it's definition. *)
+           cfi_signal_frame in its definition. *)
         I.mov (domain_field Domainstate.Domain_c_stack) rsp);
       emit_call (Cmm.global_symbol func);
       if switch_stacks

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -170,10 +170,6 @@ let destroyed_by_plt_stub_set = Reg.set_of_array destroyed_by_plt_stub
 
 let stack_slot slot ty = Reg.create_at_location ty (Stack slot)
 
-(* Instruction selection *)
-
-let word_addressed = false
-
 (* Calling conventions *)
 
 let size_domainstate_args = 64 * size_int

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -23,10 +23,6 @@ open Misc
 open Reg
 open Arch
 
-(* Instruction selection *)
-
-let word_addressed = false
-
 (* Registers available for register allocation *)
 
 (* Integer register map:

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1593,19 +1593,13 @@ let get_header_masked ptr dbg =
 let tag_offset = if big_endian then -1 else -size_int
 
 let get_tag ptr dbg =
-  if Proc.word_addressed
-  then
-    (* If byte loads are slow *)
-    Cop (Cand, [get_header ptr dbg; Cconst_int (255, dbg)], dbg)
-  else
-    (* If byte loads are efficient *)
-    (* Same comment as [get_header] above *)
-    Cop
-      ( (if Config.runtime5
-         then mk_load_immut Byte_unsigned
-         else mk_load_mut Byte_unsigned),
-        [Cop (Cadda, [ptr; Cconst_int (tag_offset, dbg)], dbg)],
-        dbg )
+  (* Same comment as [get_header] above *)
+  Cop
+    ( (if Config.runtime5
+       then mk_load_immut Byte_unsigned
+       else mk_load_mut Byte_unsigned),
+      [Cop (Cadda, [ptr; Cconst_int (tag_offset, dbg)], dbg)],
+      dbg )
 
 let get_size ptr dbg = lsr_const (get_header_masked ptr dbg) 10 dbg
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -530,6 +530,11 @@ let report_error_doc ppf = function
 
 let report_error = Format_doc.compat report_error_doc
 
+let () =
+  Location.register_error_of_exn (function
+    | Error err -> Some (Location.error_of_printer_file report_error_doc err)
+    | _ -> None)
+
 type preproc_stack_check_result =
   { max_frame_size : int;
     contains_nontail_calls : bool

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -17,9 +17,6 @@
 
 (* Processor descriptions *)
 
-(* Instruction selection *)
-val word_addressed : bool
-
 val phys_reg : Cmm.machtype_component -> Regs.Phys_reg.t -> Reg.t
 
 val precolored_regs : unit -> Reg.Set.t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -2796,16 +2796,16 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
                   - 1))) ]
       | Ostype_unix ->
         [ Simple
-            (Simple.const_bool machine_width (String.equal Sys.os_type "Unix"))
-        ]
+            (Simple.const_bool machine_width
+               (String.equal Config.target_os_type "Unix")) ]
       | Ostype_win32 ->
         [ Simple
-            (Simple.const_bool machine_width (String.equal Sys.os_type "Win32"))
-        ]
+            (Simple.const_bool machine_width
+               (String.equal Config.target_os_type "Win32")) ]
       | Ostype_cygwin ->
         [ Simple
             (Simple.const_bool machine_width
-               (String.equal Sys.os_type "Cygwin")) ]
+               (String.equal Config.target_os_type "Cygwin")) ]
       (* CR-someday gyorsh: replace string comparisons with dedicated types for
          [arch] and [os_type]. *)
       | Arch_amd64 ->


### PR DESCRIPTION
Various miscellaneous bits from #5460 
- ocaml/ocaml#13044 - see upstream PR :slightly_smiling_face:
- ocaml/ocaml#13251 - see upstream PR (printing bug affects us too)
- PR#13453 - one of the more important fixes of the 5.4 merge
- PR#13526 - some miscellaneous diff-reduction in `Makefile.upstream` and as we (sensibly) took `Config.target_os_type`, we should use it!