### PR TITLE
[5.4] GC "ramp" functions are portable

### DIFF
--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -248,5 +248,5 @@ type suspended_collection_work = int
 external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ portable
   = "caml_ml_gc_ramp_up"
 
-external ramp_down : suspended_collection_work -> unit
+external ramp_down : suspended_collection_work -> unit @@ portable
   = "caml_ml_gc_ramp_down"

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -245,8 +245,8 @@ type suspended_collection_work = int
    type.
 *)
 
-external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ nonportable
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
   = "caml_ml_gc_ramp_up"
 
-external ramp_down : suspended_collection_work -> unit @@ nonportable
+external ramp_down : suspended_collection_work -> unit
   = "caml_ml_gc_ramp_down"

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -245,7 +245,7 @@ type suspended_collection_work = int
    type.
 *)
 
-external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ portable
   = "caml_ml_gc_ramp_up"
 
 external ramp_down : suspended_collection_work -> unit

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -789,7 +789,7 @@ end
 
 type suspended_collection_work
 
-external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ nonportable
+external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work
   = "caml_ml_gc_ramp_up"
 (** In general, the OCaml GC assumes that the program runs in
     a "steady state" where peak memory usage remains constant: for
@@ -832,7 +832,7 @@ external ramp_up : (unit -> 'a) -> 'a * suspended_collection_work @@ nonportable
     [Effect.Unhandled] exception is thrown instead.
 *)
 
-external ramp_down : suspended_collection_work -> unit @@ nonportable
+external ramp_down : suspended_collection_work -> unit
   = "caml_ml_gc_ramp_down"
 (** Notify the GC about some amount of collection work that was
     suspended during a ramp-up phase, to be resumed now. *)


### PR DESCRIPTION
These two functions (new in OCaml 5.4) are `portable`: `Gc.ramp_down` just takes an int so cannot be `nonportable`. `Gc.ramp_up` takes a function but simply applies it and returns the result so that is also surely `portable`.