### PR TITLE
Optimise Typeopt.value_kind by caching results

### DIFF
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -1113,12 +1113,13 @@ let transl_implementation compilation_unit impl ~loc =
   Translprim.clear_used_primitives ();
   let scopes = enter_compilation_unit ~scopes:empty_scopes compilation_unit in
   let body, (repr, arg_block_idx) =
-    Translobj.transl_label_init (fun () ->
-      let body, repr, arg_block_idx =
-        transl_implementation_module ~loc ~scopes compilation_unit
-          impl
-      in
-      body, (repr, arg_block_idx))
+    Typeopt.with_cache (fun () ->
+      Translobj.transl_label_init (fun () ->
+        let body, repr, arg_block_idx =
+          transl_implementation_module ~loc ~scopes compilation_unit
+            impl
+        in
+        body, (repr, arg_block_idx)))
   in
   let body, main_module_block_format =
     match has_parameters () with

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -580,6 +580,45 @@ let add_nullability_from_ty env ty raw_kind =
 let fallback_if_missing_cmi ~default f =
   try f () with Missing_cmi_fallback -> default
 
+module Value_kind_cache = struct
+  type result = int * value_kind
+
+  let cache : (Types.type_declaration * result) Path.Tbl.t option ref =
+    ref None
+
+  let with_cache f =
+    let old = !cache in
+    cache := Some (Path.Tbl.create 20);
+    Fun.protect f ~finally:(fun () -> cache := old)
+
+  let add path decl res =
+    match !cache with
+    | None -> ()
+    | Some tbl -> Path.Tbl.replace tbl path (decl, res)
+
+  let find_opt ~env path =
+    match !cache with
+    | None -> None
+    | Some tbl ->
+       match Path.Tbl.find tbl path with
+       | exception Not_found -> None
+       | (decl, res) ->
+          (* Some paths can't have different bindings in different
+             environments, because they refer to global modules *)
+          let rec unique_path : Path.t -> bool = function
+            | Pident id -> Ident.is_global_or_predef id
+            | Pdot (p, _) | Pextra_ty (p, _) -> unique_path p
+            | Papply _ -> false
+          in
+          if unique_path path then
+            Some res
+          else
+            match Env.find_type path env with
+            | exception Not_found -> None
+            | decl' ->
+               if decl == decl' then Some res else None
+end
+
 (* CR layouts v2.5: It will be possible for subcomponents of types to be
    non-values for non-error reasons (e.g., [type t = { x : float# }
    [@@unboxed]).  And in later releases, this will also happen in normal
@@ -705,14 +744,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
          connection and will continue processing with e.g. ['a : value]
          instead of [string] when looking at a [string list]. This should
          probably just call a [type_jkind] function. Internal ticket 5101. *)
-      let decl =
-        try Env.find_type p env with Not_found -> raise Missing_cmi_fallback
-      in
-      if cannot_proceed () then
-        num_nodes_visited,
-        add_nullability_from_ty env scty
-          (value_kind_of_scannable_jkind env decl.type_jkind)
-      else
+      let value_kind_decl decl =
         let visited = Numbers.Int.Set.add (get_id ty) visited in
         (* Default of [Pgenval] is currently safe for the missing cmi fallback
            in the case of @@unboxed variant and records, due to the precondition
@@ -752,6 +784,22 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
           add_nullability_from_ty env scty
             (value_kind_of_scannable_jkind env decl.type_jkind)
         | Type_open -> num_nodes_visited, non_nullable Pgenval
+      in
+      match Value_kind_cache.find_opt ~env p with
+      | Some (num_nodes, k) ->
+         num_nodes_visited + num_nodes, k
+      | None ->
+         let decl =
+           try Env.find_type p env with Not_found -> raise Missing_cmi_fallback
+         in
+         if cannot_proceed () then
+           num_nodes_visited,
+           add_nullability_from_ty env scty
+             (value_kind_of_scannable_jkind env decl.type_jkind)
+         else
+           let visited', k = value_kind_decl decl in
+           Value_kind_cache.add p decl (visited' - num_nodes_visited, k);
+           visited', k
     end
   | Ttuple labeled_fields ->
     if cannot_proceed () then
@@ -1117,6 +1165,8 @@ let value_kind env loc ty =
   with
   | Missing_cmi_fallback ->
     raise (Error (loc, Non_value_layout (env, ty, None)))
+
+let with_cache = Value_kind_cache.with_cache
 
 let transl_mixed_block_element env loc ty mbe =
   try

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -591,14 +591,17 @@ module Value_kind_cache = struct
     cache := Some (Path.Tbl.create 20);
     Fun.protect f ~finally:(fun () -> cache := old)
 
-  let add path decl res =
-    match !cache with
-    | None -> ()
-    | Some tbl -> Path.Tbl.replace tbl path (decl, res)
+  let add ~env path decl res =
+    if not (Env.has_local_constraints env) then begin
+      match !cache with
+      | None -> ()
+      | Some tbl -> Path.Tbl.replace tbl path (decl, res)
+    end
 
   let find_opt ~env path =
     match !cache with
     | None -> None
+    | Some _ when Env.has_local_constraints env -> None
     | Some tbl ->
        match Path.Tbl.find tbl path with
        | exception Not_found -> None
@@ -798,7 +801,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
              (value_kind_of_scannable_jkind env decl.type_jkind)
          else
            let visited', k = value_kind_decl decl in
-           Value_kind_cache.add p decl (visited' - num_nodes_visited, k);
+           Value_kind_cache.add ~env p decl (visited' - num_nodes_visited, k);
            visited', k
     end
   | Ttuple labeled_fields ->

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -77,6 +77,9 @@ val function_arg_layout :
 
 val value_kind : Env.t -> Location.t -> Types.type_expr -> Lambda.value_kind
 
+(* Locally enable caching of [value_kind] *)
+val with_cache : (unit -> 'a) -> 'a
+
 val transl_mixed_block_element :
   Env.t -> Location.t -> Types.type_expr -> Types.mixed_block_element
   -> unit Lambda.mixed_block_element


### PR DESCRIPTION
This patch adds a cache for the result of `Typeopt.value_kind` for `Tconstr` nodes, indexed by their path. This prevents `Typeopt` from repeatedly traversing the same type definitions to construct a value_kind for them.

This makes the compiler compile `typecore.ml` 20% faster. I haven't checked on larger examples yet. (I expect the savings to be more modest elsewhere: Typecore uses a few very large type definitions such as the parsetree, so repeatedly computing value_kinds is expensive, perhaps unusually so)
