### PR TITLE
Rename array_size to array_length in documentation

### DIFF
--- a/jane/doc/extensions/_03-unboxed-types/01-intro.md
+++ b/jane/doc/extensions/_03-unboxed-types/01-intro.md
@@ -453,7 +453,7 @@ Here's the list of primitives that currently support `[@layout_poly]`:
 * `%array_safe_set`
 * `%array_unsafe_get`
 * `%array_unsafe_set`
-* `%array_size`
+* `%array_length`
 
 # Arrays of unboxed elements
 


### PR DESCRIPTION
While playing around with OxCaml I tried to use the "%array_size" primitive from the documentation and got compilation errors.
It turns out "%array_size" isn't mentioned in the codebase anywhere outside of the documentation. Instead, OxCaml uses "%array_length" in its standard library so I suspect the document should mention "length" not "size".
