### PR TITLE
Don't store sorts for function returns

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -147,7 +147,6 @@ type texp_function =
 
 type texp_function_identifier =
   { alloc_mode : alloc_mode;
-    ret_sort : Jkind.sort;
     ret_mode : Alloc.l;
     zero_alloc : Zero_alloc.t
   }
@@ -170,7 +169,6 @@ let texp_function_param_identifier_defaults =
 
 let texp_function_defaults =
   { alloc_mode = dummy_alloc_mode;
-    ret_sort = Jkind.Sort.scannable;
     ret_mode = Alloc.disallow_right Alloc.legacy;
     zero_alloc = Zero_alloc.default
   }
@@ -223,7 +221,6 @@ let mkTexp_function ?(id = texp_function_defaults)
               fc_loc = Location.none
             });
       alloc_mode = id.alloc_mode;
-      ret_sort = id.ret_sort;
       ret_mode = { mode_modes = id.ret_mode; mode_desc = [] };
       zero_alloc = id.zero_alloc
     }
@@ -292,8 +289,7 @@ let view_texp (e : expression_desc) =
   | Texp_tuple (args, mode) ->
     let labels, args = List.split args in
     Texp_tuple (args, (labels, mode))
-  | Texp_function { params; body; alloc_mode; ret_sort; ret_mode; zero_alloc }
-    ->
+  | Texp_function { params; body; alloc_mode; ret_mode; zero_alloc } ->
     let params =
       List.map
         (fun param ->
@@ -337,7 +333,7 @@ let view_texp (e : expression_desc) =
     in
     Texp_function
       ( { params; body },
-        { alloc_mode; ret_sort; ret_mode = ret_mode.mode_modes; zero_alloc } )
+        { alloc_mode; ret_mode = ret_mode.mode_modes; zero_alloc } )
   | Texp_sequence (e1, sort, e2) -> Texp_sequence (e1, e2, sort)
   | Texp_match (e, sort, cases, _, partial) ->
     Texp_match (e, cases, partial, sort)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -47,6 +47,16 @@ let use_dup_for_constant_mutable_arrays_bigger_than = 4
 let layout_exp sort e = layout e.exp_env e.exp_loc sort e.exp_type
 let layout_pat sort p = layout p.pat_env p.pat_loc sort p.pat_type
 
+let layout_of_function_body body =
+  let env, loc, ty =
+    match body with
+    | Tfunction_body { exp_env; exp_loc; exp_type } ->
+      exp_env, exp_loc, exp_type
+    | Tfunction_cases { fc_ret_type; fc_loc; fc_env } ->
+      fc_env, fc_loc, fc_ret_type
+  in
+  Typeopt.layout_of_type env loc ty
+
 let field_offset_for_label lbl repres =
   match repres with
   | Record_boxed
@@ -246,7 +256,7 @@ let assert_failed loc ~scopes exp =
 type fusable_function =
   { params : function_param list
   ; body : function_body
-  ; return_sort : Jkind.Sort.Const.t
+  ; return_layout : Lambda.layout
   ; return_mode : locality_mode
   ; region : bool
   }
@@ -266,7 +276,7 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
   | { params = [ self_param ];
       return_mode = Alloc_heap;
       body =
-        Tfunction_body { exp_desc = Texp_function method_; exp_extra; }
+        Tfunction_body { exp_desc = Texp_function method_; exp_extra; _ }
     }
     when
       List.exists
@@ -288,11 +298,11 @@ let fuse_method_arity (parent : fusable_function) : fusable_function =
               Mode.Alloc.disallow_right Mode.Alloc.legacy }
         }
       in
-      let return_sort = Jkind.Sort.default_for_transl_and_get method_.ret_sort in
+      let return_layout = layout_of_function_body method_.body in
       { params = self_param :: method_.params;
         body = method_.body;
         return_mode = transl_alloc_mode_l method_.ret_mode.mode_modes;
-        return_sort;
+        return_layout;
         region = true;
       }
   | _ -> parent
@@ -386,7 +396,7 @@ and transl_exp1 ~scopes ~in_new_scope layout e =
   if eval_once then transl_exp0 ~scopes ~in_new_scope layout e else
   Translobj.oo_wrap e.exp_env true (transl_exp0 ~scopes ~in_new_scope layout) e
 
-and transl_exp0 ~in_new_scope ~scopes layout e =
+and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
   match e.exp_desc with
   | Texp_ident { path; desc; kind; _ } ->
       transl_ident (of_location ~scopes e.exp_loc)
@@ -407,11 +417,11 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
   | Texp_letmutable(pat_expr, body) ->
       transl_letmutable ~scopes ~return_layout:layout pat_expr
         (event_before ~scopes body (transl_exp ~scopes layout body))
-  | Texp_function { params; body; ret_sort; ret_mode; alloc_mode;
+  | Texp_function { params; body; ret_mode; alloc_mode;
                     zero_alloc } ->
-      let ret_sort = Jkind.Sort.default_for_transl_and_get ret_sort in
+      let ret_layout = layout_of_function_body body in
       transl_function ~in_new_scope ~scopes e params body
-        ~alloc_mode ~ret_mode ~ret_sort ~region:true ~zero_alloc
+        ~alloc_mode ~ret_mode ~ret_layout ~region:true ~zero_alloc
   | Texp_apply({ exp_desc = Texp_ident { path;
                                         desc = {val_kind = Val_prim p};
                                         kind = Id_prim (pmode, psort); _ };
@@ -1685,15 +1695,7 @@ and transl_apply ~scopes
    [trans_curried_function]).
 *)
 and transl_function_without_attributes
-    ~scopes ~return_sort ~return_mode ~mode ~region loc repr params body =
-  let return_layout =
-    match body with
-    | Tfunction_body exp ->
-        layout_exp return_sort exp
-    | Tfunction_cases cases ->
-        layout cases.fc_env cases.fc_loc return_sort cases.fc_ret_type
-
-  in
+    ~scopes ~return_layout ~return_mode ~mode ~region loc repr params body =
   match
     transl_tupled_function ~scopes loc params body
       ~return_mode ~return_layout ~mode ~region
@@ -2020,8 +2022,8 @@ and transl_curried_function ~scopes loc repr params body
     ((Curried { nlocal }, params, return_layout, region, return_mode ), body)
 
 and transl_function ~in_new_scope ~scopes e params body
-      ~alloc_mode ~ret_mode:sreturn_mode ~ret_sort:sreturn_sort ~region:sregion
-      ~zero_alloc =
+      ~alloc_mode ~ret_mode:sreturn_mode ~ret_layout:sreturn_layout
+      ~region:sregion ~zero_alloc =
   let attrs = e.exp_attributes in
   let mode = transl_alloc_mode alloc_mode in
   let zero_alloc = Zero_alloc.get zero_alloc in
@@ -2038,10 +2040,10 @@ and transl_function ~in_new_scope ~scopes e params body
     else enter_anonymous_function ~scopes ~assume_zero_alloc ~loc:e.exp_loc
   in
   let sreturn_mode = transl_alloc_mode_l sreturn_mode.mode_modes in
-  let { params; body; return_sort; return_mode; region } =
+  let { params; body; return_layout; return_mode; region } =
     fuse_method_arity
       { params; body;
-        return_sort = sreturn_sort;
+        return_layout = sreturn_layout;
         return_mode = sreturn_mode;
         region = sregion;
       }
@@ -2055,7 +2057,7 @@ and transl_function ~in_new_scope ~scopes e params body
     event_function ~scopes e
       (function repr ->
          transl_function_without_attributes
-           ~mode ~return_sort ~return_mode
+           ~mode ~return_layout ~return_mode
            ~scopes e.exp_loc repr ~region params body)
   in
   let zero_alloc : Lambda.zero_alloc_attribute =
@@ -2902,17 +2904,21 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
         (function repr ->
            let loc = case.c_rhs.exp_loc in
            let ghost_loc = { loc with loc_ghost = true } in
-           transl_function_without_attributes ~scopes ~region:true
-             ~return_sort:case_sort ~mode:alloc_heap ~return_mode
-             loc repr []
-             (Tfunction_cases
-                { fc_cases = [case]; fc_param = param;
+           let fc_cases = { fc_cases = [case]; fc_param = param;
                   fc_param_debug_uid = param_debug_uid; fc_partial = partial;
                   fc_loc = ghost_loc; fc_exp_extra = []; fc_attributes = [];
                   fc_arg_mode = Mode.Alloc.disallow_right Mode.Alloc.legacy;
                   fc_arg_sort = param_sort; fc_env = env;
                   fc_ret_type = case.c_rhs.exp_type;
-                }))
+                } in
+           let return_layout =
+             layout fc_cases.fc_env fc_cases.fc_loc case_sort
+               fc_cases.fc_ret_type
+           in
+           transl_function_without_attributes ~scopes ~region:true
+             ~return_layout ~mode:alloc_heap ~return_mode
+             loc repr []
+             (Tfunction_cases fc_cases))
     in
     let attr = function_attribute_disallowing_arity_fusion in
     let loc = of_location ~scopes case.c_rhs.exp_loc in

--- a/testsuite/tests/basic/patmatch_for_multiple.ml
+++ b/testsuite/tests/basic/patmatch_for_multiple.ml
@@ -385,7 +385,8 @@ let _ =fun a b -> match a, b with
 (function {nlocal = 0} a/9[value<int>]
   b/9[value<
        (consts (0))
-        (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+        (non_consts ([0:
+                      value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch
@@ -402,7 +403,8 @@ let _ =fun a b -> match a, b with
 (function {nlocal = 0} a/9[value<int>]
   b/9[value<
        (consts (0))
-        (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+        (non_consts ([0:
+                      value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch (if a/9 (if b/9 (field_imm 0 b/9) (exit 42)) (exit 42)) with (42)
@@ -418,7 +420,8 @@ let _ = fun a b -> match a, b with
 (function {nlocal = 0} a/10[value<int>]
   b/10[value<
         (consts (0))
-         (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+         (non_consts ([0:
+                       value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch
@@ -443,7 +446,8 @@ let _ = fun a b -> match a, b with
 (function {nlocal = 0} a/10[value<int>]
   b/10[value<
         (consts (0))
-         (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+         (non_consts ([0:
+                       value<(consts ()) (non_consts ([0: value<int>, *]))>]))>]
   : (consts ())
      (non_consts ([0: value<int>, value<(consts (0)) (non_consts ([0: *]))>]))
   (catch

--- a/testsuite/tests/flambda/match_in_match_seq.raw.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.raw.reference
@@ -167,7 +167,7 @@ let $camlMatch_in_match_seq__first_const = Block 0 () in
        `fn[match_in_match_seq.ml:55,11--63]_9` (i : imm tagged)
          my_closure _region _ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * val ] =
+         : [ 0 | 0 of imm tagged * imm tagged ] =
    let next_depth = rec_info (succ my_depth) in
    let hi =
      %project_value_slot.[`fn[match_in_match_seq.ml:55,11--63]`].[hi]

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
@@ -11,7 +11,7 @@ let code loopify(never) size(22) newer_version_of(f_0)
       f_0_1 (arr : val array)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of imm tagged ] =
   (let prim = %array_length.generic (arr) in
    let prim_1 = %int_comp.unsigned.lt (0, prim) in
    switch prim_1
@@ -25,10 +25,10 @@ let code loopify(never) size(22) newer_version_of(f_0)
 in
 let $camlArray_specialisation_examples__f_4 = closure f_0_1 @f in
 let code loopify(never) size(8) newer_version_of(g_1)
-      g_1_1 (x : [ 0 | 0 of val ])
+      g_1_1 (x : [ 0 | 0 of imm tagged ])
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of imm tagged ] =
   let a = %array.mut (x) in
   let ifnot_result = %array_load.mut (a, 0) in
   cont k (ifnot_result)

--- a/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
+++ b/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
@@ -37,7 +37,7 @@ let $camlFrom_odoc_texi__foo_3 = closure foo_1_1 @foo in
           in
           let Pmakeblock_1 = %block.[`0`] (Pmakeblock, 0) in
           cont k (Pmakeblock_1)))
-  where k (y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+  where k (y : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ]) =
     let $camlFrom_odoc_texi =
       Block 0 ($`camlFrom_odoc_texi__!_2`,
                esc_8bits,

--- a/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
@@ -1,6 +1,8 @@
 let code foo_1 deleted in
 let code loopify(never) size(17) newer_version_of(foo_1)
-      foo_1_1 (x : imm tagged, y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      foo_1_1
+        (x : imm tagged,
+         y : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/examples/tests.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests.raw.reference
@@ -10,8 +10,8 @@ let $camlTests__first_const = Block 0 () in
  let code size(79)
        f_1
          (c : imm tagged,
-          m : [ 0 | 0 of val ],
-          n : [ 0 | 0 of val ],
+          m : [ 0 | 0 of imm tagged ],
+          n : [ 0 | 0 of imm tagged ],
           x' : imm tagged,
           y' : imm tagged)
          my_closure _region _ghost_region my_depth

--- a/testsuite/tests/flambda2/examples/tests.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests.simplify.reference
@@ -11,8 +11,8 @@ let $camlTests__to_inline_2 = closure to_inline_0_1 @to_inline in
 let code loopify(never) size(22) newer_version_of(f_1)
       f_1_1
         (c : imm tagged,
-         m : [ 0 | 0 of val ],
-         n : [ 0 | 0 of val ],
+         m : [ 0 | 0 of imm tagged ],
+         n : [ 0 | 0 of imm tagged ],
          x' : imm tagged,
          y' : imm tagged)
         my_closure _region _ghost_region my_depth

--- a/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
@@ -114,7 +114,7 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
       inv_3_1 (param : [ 0 | 0 of val * val ], param_1, param_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
+        : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ] =
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
@@ -154,10 +154,13 @@ let code loopify(never) size(11) newer_version_of(div_4)
    let tuple_field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (i2) in
    let tuple_field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (i2) in
    apply direct(inv_3_1)
-     ($camlAlt_ergo__inv_8 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+     ($camlAlt_ergo__inv_8
+      : _ -> [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ])
        (tuple_field, tuple_field_1, tuple_field_2)
        -> k3 * k1
-     where k3 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+     where k3
+             (param :
+                [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ]) =
        cont k2)
     where k2 =
       cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock106)

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -58,12 +58,20 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
 in
 let $camlEmitcode_repro__emit_instr_4 = closure emit_instr_1_1 @emit_instr in
 let code loopify(done) size(121) newer_version_of(emit_2)
-      emit_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      emit_2_1
+        (param :
+           [ 0
+           | 0 of [ 0 |1 | 0 of imm tagged |1 of imm tagged ] *
+               [ 0 | 0 of val * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
-    where rec `self` (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+    where rec `self`
+                (param_1 :
+                   [ 0
+                   | 0 of [ 0 |1 | 0 of imm tagged |1 of imm tagged ] *
+                       [ 0 | 0 of val * val ] ]) =
       let `region` = %begin_region () in
       let ghost_region = %begin_ghost_region () in
       ((let prim = %is_int (param_1) in

--- a/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
@@ -1,6 +1,6 @@
 let code f_0 deleted in
 let code loopify(never) size(48) newer_version_of(f_0)
-      f_0_1 (read : val, x : [ 0 | 0 of val ])
+      f_0_1 (read : val, x : [ 0 | 0 of imm tagged ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
@@ -40,7 +40,7 @@ let code loopify(never) size(44) newer_version_of(test_3)
       test_3_1 (x)
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of [ 0 of val * val ] ] =
   apply direct(f_1_1)
     ($camlGadt_meet__f_6 : _ -> [ 0 of [ 0 of imm tagged ] |1 of imm tagged ]
      )
@@ -68,7 +68,7 @@ let code loopify(never) size(44) newer_version_of(test_3)
                      cont k (Pmakeblock_1))))
 in
 let $camlGadt_meet__test_8 = closure test_3_1 @test in
-let $camlGadt_meet__Pmakeblock146 =
+let $camlGadt_meet__Pmakeblock149 =
   Block 0 ($`*predef*`.caml_exn_Failure, $camlGadt_meet__immstring59)
 in
 let code loopify(never) size(17) newer_version_of(foo_4)
@@ -77,12 +77,14 @@ let code loopify(never) size(17) newer_version_of(foo_4)
         -> k * k1
         : [ 0 of imm tagged * [ 0 of val |1 of imm tagged ] ] =
   apply direct(test_3_1)
-    ($camlGadt_meet__test_8 : _ -> [ 0 | 0 of val ]) (0) -> k2 * k1
-    where k2 (`*match*` : [ 0 | 0 of val ]) =
+    ($camlGadt_meet__test_8 : _ -> [ 0 | 0 of [ 0 of imm tagged * val ] ])
+      (0)
+      -> k2 * k1
+    where k2 (`*match*` : [ 0 | 0 of [ 0 of imm tagged * val ] ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock146)
+         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock149)
          where k2 =
            let Pfield = %block_load.[`0`] (`*match*`) in
            cont k (Pfield))

--- a/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
@@ -11,7 +11,7 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
            [ 0 of [ 0 |1 | 0 of imm tagged * imm tagged |1 of imm tagged ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val ] =
+        : [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ] =
   let `*match*` = %block_load.[`0`] (x) in
   let `*match*_1` = %block_load.[`0`] (y) in
   (let prim = %is_int (`*match*_1`) in
@@ -90,11 +90,12 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
 in
 let $camlIncludecore_repro__f_1 = closure f_0_1 @f in
 apply direct(f_0_1)
-  ($camlIncludecore_repro__f_1 : _ -> [ 0 | 0 of val ])
+  ($camlIncludecore_repro__f_1
+   : _ -> [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ])
     ($camlIncludecore_repro__const_block61,
      $camlIncludecore_repro__const_block61)
     -> k1 * error
-  where k1 (param : [ 0 | 0 of val ]) =
+  where k1 (param : [ 0 | 0 of [ 0 of imm tagged * imm tagged ] ]) =
     cont k
   where k =
     let $camlIncludecore_repro = Block 0 ($camlIncludecore_repro__f_1) in

--- a/testsuite/tests/flambda2/examples/unknown/local.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.raw.reference
@@ -5,7 +5,7 @@
        return_local_0 (param : imm tagged)
          my_closure my_region my_ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+         : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
    cont k1 ($camlLocal__const_block15)
  in
@@ -154,7 +154,7 @@
          (break_here : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure my_region my_ghost_region my_depth
          -> k1 * k2
-         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+         : [ 0 | 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ] local =
    let next_depth = rec_info (succ my_depth) in
    let rev_app = %project_value_slot.[spans].[rev_app] (my_closure) in
    let find_span = %project_function_slot.[spans].[find_span] (my_closure) in
@@ -178,12 +178,17 @@
             ((let Pfield = %block_load.[`1`] (`*match*`) in
               apply direct(spans_5 &my_region &my_ghost_region)
                 (my_closure ~ depth my_depth -> next_depth
-                 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                 : _ ->
+                   [ 0 | 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ]
+                   ]
+                 )
                   (break_here, Pfield)
                   -> k3 * k2)
                where k3
                        (apply_result :
-                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                          [ 0
+                          | 0 of [ 0 | 0 of val * val ] *
+                              [ 0 | 0 of val * val ] ]) =
                  ((let Pfield = %block_load.[`0`] (`*match*`) in
                    apply direct(rev_app_4 &my_region &my_ghost_region)
                      (rev_app
@@ -262,10 +267,13 @@
      ((let `region` = %begin_region () in
        let ghost_region = %begin_ghost_region () in
        apply direct(return_local_0 &`region` &ghost_region)
-         (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+         (return_local
+          : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
            (0)
            -> k5 * error
-         where k5 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+         where k5
+                 (apply_result :
+                    [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]) =
            apply direct(length_2) unroll(3)
              (length : _ -> imm tagged) (apply_result) -> k4 * error
          where k4 (apply_result : imm tagged) =
@@ -287,20 +295,32 @@
           ((let `region` = %begin_region () in
             let ghost_region = %begin_ghost_region () in
             apply direct(return_local_0 &`region` &ghost_region)
-              (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+              (return_local
+               : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]
+               )
                 (0)
                 -> k3 * error
-              where k3 (ns : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+              where k3
+                      (ns :
+                         [ 0
+                         | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ]) =
                 ((let `fn[local.ml:32,27--43]` =
                     closure `fn[local.ml:32,27--43]_3`
                       @`fn[local.ml:32,27--43]`
                   in
                   apply direct(map_local_1 &`region` &ghost_region)
                     (map_local
-                     : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                     : _ ->
+                       [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ]
+                       ]
+                     )
                       (`fn[local.ml:32,27--43]`, ns)
                       -> k3 * error)
-                   where k3 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                   where k3
+                           (ms :
+                              [ 0
+                              | 0 of imm tagged *
+                                  [ 0 | 0 of imm tagged * val ] ]) =
                      (apply direct(length_2)
                         (length : _ -> imm tagged) (ms) -> k4 * error
                         where k4 (apply_result : imm tagged) =
@@ -330,12 +350,19 @@
                ((let `region` = %begin_region () in
                  let ghost_region = %begin_ghost_region () in
                  apply direct(spans_5 &`region` &ghost_region)
-                   (spans : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                   (spans
+                    : _ ->
+                      [ 0
+                      | 0 of [ 0 | 0 of imm tagged * val ] *
+                          [ 0 | 0 of val * val ] ]
+                    )
                      (is_even, $camlLocal__const_block176)
                      -> k3 * error
                    where k3
                            (even_spans :
-                              [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                              [ 0
+                              | 0 of [ 0 | 0 of imm tagged * val ] *
+                                  [ 0 | 0 of val * val ] ]) =
                      (apply direct(length_2)
                         (length : _ -> imm tagged) (even_spans) -> k4 * error
                         where k4 (apply_result : imm tagged) =

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -36,7 +36,7 @@ let code loopify(never) size(1) newer_version_of(return_local_0)
       return_local_0_1 (param : imm tagged)
         my_closure my_region my_ghost_region my_depth
         -> k * k1
-        : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+        : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ] local =
   cont k ($camlLocal__const_block15)
 in
 let $camlLocal__return_local_8 = closure return_local_0_1 @return_local in
@@ -129,11 +129,14 @@ apply direct(length_2_1)
            in
            apply direct(map_local_1_1 &`region` &ghost_region)
              ($camlLocal__map_local_9
-              : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+              : _ -> [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
                ($`camlLocal__fn[local.ml:32,27--43]_11`,
                 $camlLocal__const_block15)
                -> k1 * error)
-            where k1 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+            where k1
+                    (ms :
+                       [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ]
+                       ]) =
               (apply direct(length_2_1)
                  ($camlLocal__length_10 : _ -> imm tagged) (ms) -> k1 * error
                  where k1 (apply_result : imm tagged) =
@@ -227,7 +230,9 @@ apply direct(length_2_1)
                        l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       my_closure my_region my_ghost_region my_depth
                       -> k * k1
-                      : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
+                      : [ 0
+                        | 0 of [ 0 | 0 of val * val ] *
+                            [ 0 | 0 of val * val ] ] local =
                 let prim = %is_int (l) in
                 switch prim
                   | 0 -> k2
@@ -251,14 +256,17 @@ apply direct(length_2_1)
                                   &my_region &my_ghost_region)
                              ($camlLocal__spans_13 ~ depth my_depth -> succ my_depth
                               : _ ->
-                                [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
+                                [ 0
+                                | 0 of [ 0 | 0 of val * val ] *
+                                    [ 0 | 0 of val * val ] ]
                               )
                                (break_here, Pfield)
                                -> k2 * k1)
                             where k2
                                     (apply_result :
                                        [ 0
-                                       | 0 of val * [ 0 | 0 of val * val ] ]) =
+                                       | 0 of [ 0 | 0 of val * val ] *
+                                           [ 0 | 0 of val * val ] ]) =
                               ((let Pfield = %block_load.[`0`] (`*match*`) in
                                 apply
                                        direct(rev_app_4_1
@@ -296,12 +304,18 @@ apply direct(length_2_1)
               let ghost_region_1 = %begin_ghost_region () in
               (apply direct(spans_5_1 &region_1 &ghost_region_1)
                  ($camlLocal__spans_13
-                  : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+                  : _ ->
+                    [ 0
+                    | 0 of [ 0 | 0 of imm tagged * val ] *
+                        [ 0 | 0 of val * val ] ]
+                  )
                    ($camlLocal__is_even_15, $camlLocal__const_block176)
                    -> k1 * error
                  where k1
                          (even_spans :
-                            [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+                            [ 0
+                            | 0 of [ 0 | 0 of imm tagged * val ] *
+                                [ 0 | 0 of val * val ] ]) =
                    (apply direct(length_2_1)
                       ($camlLocal__length_10 : _ -> imm tagged)
                         (even_spans)

--- a/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
@@ -41,7 +41,8 @@ let $`camlProtect_refs__fn[protect_refs.ml:28,24--50]_8` =
 in
 let code loopify(never) size(11) newer_version_of(`fn[protect_refs.ml:29,2--43]_3`)
       `fn[protect_refs.ml:29,2--43]_3_1`
-        (refs : [ 0 | 0 of val * [ 0 | 0 of val * val ] ], f : val)
+        (refs : [ 0 | 0 of [ 0 of val * val ] * [ 0 | 0 of val * val ] ],
+         f : val)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   apply direct(iter_0_1) inlining_state(depth(10))

--- a/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
@@ -21,6 +21,6 @@ let $camlOpt_flags__immstring26 = "foo" in
       | 0 -> k (99)
       | 1 -> k (-1)
   where k (y : imm tagged) =
-    let $camlOpt_flags__Pmakeblock138 = Block 0 (42, y, 1701) in
-    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock138) in
+    let $camlOpt_flags__Pmakeblock139 = Block 0 (42, y, 1701) in
+    let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock139) in
     cont done ($camlOpt_flags)

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -25,7 +25,9 @@ let code loopify(never) size(10) newer_version_of(h_2)
       cont k (int_add_1)
 in
 let code loopify(never) size(58) newer_version_of(f_0)
-      f_0_1 (x : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
+      f_0_1
+        (x : imm tagged,
+         l : [ 0 | 0 of imm tagged * [ 0 | 0 of imm tagged * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =

--- a/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
+++ b/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
@@ -416,7 +416,8 @@ in
 let code loopify(never) size(2) newer_version_of(match_symbol_tagged_or_null_22)
       match_symbol_tagged_or_null_22_1 (t : imm tagged)
         my_closure _region _ghost_region my_depth
-        -> k * k1 =
+        -> k * k1
+        : [ 0 |1 | 0 of imm tagged |1 of val ] =
   let arg = %array_load ($camlTOP15__switch_block467, t) in
   cont k (arg)
 in

--- a/testsuite/tests/match-side-effects/partiality.ml
+++ b/testsuite/tests/match-side-effects/partiality.ml
@@ -152,7 +152,7 @@ Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
      (function {nlocal = 0} r/0 : int
        (region
          (let
-           (*match*/5 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/5 =[value<(consts (0)) (non_consts ([0: *]))>]
               (makelocalblock 0 (*) r/0))
            (catch
              (if *match*/5
@@ -191,8 +191,13 @@ type _ t = Int : int -> int t | Bool : bool -> bool t
 (let
   (test/0 =
      (function {nlocal = 0}
-       param/0[value<(consts (0)) (non_consts ([0: ?]))>] : int
-       (if param/0 (field_imm 0 (field_imm 0 param/0)) 0)))
+       param/0[value<
+                (consts (0))
+                 (non_consts ([0:
+                               value<
+                                (consts ()) (non_consts ([1: value<int>]
+                                 [0: value<int>]))>]))>]
+       : int (if param/0 (field_imm 0 (field_imm 0 param/0)) 0)))
   (apply (field_imm 1 (global Toploop!)) "test" test/0))
 val test : int t option -> int = <fun>
 |}]
@@ -240,7 +245,11 @@ type _ t = Int : int -> int t | Bool : bool -> bool t
      (function {nlocal = 0} n/0? : int
        (region
          (let
-           (*match*/9 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/9 =[value<
+                         (consts (0))
+                          (non_consts ([0:
+                                        value<
+                                         (consts ()) (non_consts ([0: *, *]))>]))>]
               (makelocalblock 0 (value<
                                   (consts ())
                                    (non_consts ([0: *,
@@ -301,7 +310,7 @@ Warning 74 [degraded-to-partial-match]: This pattern-matching is compiled as
      (function {nlocal = 0} r/1 : int
        (region
          (let
-           (*match*/12 =[value<(consts (0)) (non_consts ([0: ?]))>]
+           (*match*/12 =[value<(consts (0)) (non_consts ([0: *]))>]
               (makelocalblock 0 (*) r/1))
            (catch
              (if *match*/12
@@ -518,16 +527,18 @@ let check_results r1 r2 =
 (let
   (check_results/0 =
      (function {nlocal = 0} r1/0 r2/0?
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: *] [0: ?]))
        (let
          (*match*/16 =[value<
                         (consts ())
                          (non_consts ([0:
                                        value<
-                                        (consts ()) (non_consts ([1: ?]
+                                        (consts ())
+                                         (non_consts ([1: value<int>]
                                          [0: ?]))>,
                                        value<
-                                        (consts ()) (non_consts ([1: ?]
+                                        (consts ())
+                                         (non_consts ([1: value<int>]
                                          [0: ?]))>]))>]
             (apply r1/0 r2/0))
          (catch
@@ -555,7 +566,7 @@ let check_results r1 r2 =
                 with (52) (exit 50 (field_imm 1 *match*/16))))
             with (50 r/3[value<(consts ()) (non_consts ([1: ?] [0: ?]))>])
              r/3)
-          with (51 r/4[value<(consts ()) (non_consts ([1: ?] [0: ?]))>]) r/4))))
+          with (51 r/4[value<(consts ()) (non_consts ([1: *] [0: ?]))>]) r/4))))
   (apply (field_imm 1 (global Toploop!)) "check_results" check_results/0))
 val check_results :
   ('a -> ('b, [< `A | `B ]) result * ('b, [< `A | `B ]) result) ->

--- a/testsuite/tests/match-side-effects/test_contexts_code.ml
+++ b/testsuite/tests/match-side-effects/test_contexts_code.ml
@@ -34,13 +34,14 @@ let example_1 () =
 (let
   (example_1/0 =
      (function {nlocal = 0} param/0[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/0 =
               (makelocalmutable 0 (value<int>,value<
                                                (consts ())
-                                                (non_consts ([1: ?] [0: ?]))>)
+                                                (non_consts ([1: value<int>]
+                                                [0: value<int>]))>)
                 1 [0: 1]))
            (if (field_int 0 input/0)
              (let (*match*/0 =o? (field_mut 1 input/0))
@@ -89,14 +90,15 @@ let example_2 () =
 (let
   (example_2/0 =
      (function {nlocal = 0} param/1[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/1 =[value<(consts ()) (non_consts ([0: value<int>, *]))>]
               (makelocalblock 0 (value<int>,*) 1
                 (makelocalmutable 0 (value<
-                                      (consts ()) (non_consts ([1: ?]
-                                       [0: ?]))>)
+                                      (consts ())
+                                       (non_consts ([1: value<int>]
+                                       [0: value<int>]))>)
                   [0: 1])))
            (if (field_int 0 input/1)
              (let (*match*/2 =o? (field_mut 0 (field_imm 1 input/1)))
@@ -147,15 +149,16 @@ let example_3 () =
 (let
   (example_3/0 =
      (function {nlocal = 0} param/2[value<int>]
-       : (consts ()) (non_consts ([1: ?] [0: ?]))
+       : (consts ()) (non_consts ([1: value<int>] [0: value<int>]))
        (region
          (let
            (input/2 =mut[value<
                           (consts ())
                            (non_consts ([0: value<int>,
                                          value<
-                                          (consts ()) (non_consts ([1: ?]
-                                           [0: ?]))>]))>]
+                                          (consts ())
+                                           (non_consts ([1: value<int>]
+                                           [0: value<int>]))>]))>]
               [0: 1 [0: 1]]
             *match*/4 =o? *input/2)
            (if (field_imm 0 *match*/4)

--- a/testsuite/tests/quotation/typing/eval/reductions.ml
+++ b/testsuite/tests/quotation/typing/eval/reductions.ml
@@ -120,8 +120,7 @@ val f :
 |}]
 let f (x : <[?l:$('a) -> $('b)]> expr) : ?l:('a eval) -> 'b eval = eval x
 [%%expect {|
-val f :
-  ('a : any) ('b : any). <[?l:$('a) -> $('b)]> expr -> ?l:'a eval -> 'b eval =
+val f : 'a ('b : any). <[?l:$('a) -> $('b)]> expr -> ?l:'a eval -> 'b eval =
   <fun>
 |}]
 let f (x : <[$('a) @ local -> $('b) @ local]> expr)

--- a/testsuite/tests/tmc/readable_output.ml
+++ b/testsuite/tests/tmc/readable_output.ml
@@ -75,32 +75,50 @@ let[@tail_mod_cons] rec rec_map f = function
 (letrec
   (rec_map
      (function {nlocal = 0} f
-       param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
-       : (consts (0)) (non_consts ([0: ?]))
+       param[value<
+              (consts (0))
+               (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+       tail_mod_cons
+       : (consts (0))
+          (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))
        (if param
          (let (*match* =a? (field_imm 0 param))
            (makeblock 0 (value<
                           (consts ())
                            (non_consts ([0: *,
                                          value<
-                                          (consts (0)) (non_consts ([0: ?]))>]))>)
+                                          (consts (0)) (non_consts ([0: *]))>]))>)
              (let
                (block =
-                  (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+                  (makemutable 0 (*,value<
+                                     (consts (0))
+                                      (non_consts ([0:
+                                                    value<
+                                                     (consts ())
+                                                      (non_consts ([0: *, *]))>]))>)
                     (apply f (field_imm 0 *match*)) 24029))
                (seq (apply rec_map_dps block 1 f (field_imm 1 *match*))
                  block))))
          0))
     rec_map_dps
       (function {nlocal = 0} dst offset[value<int>] f
-        param[value<(consts (0)) (non_consts ([0: ?]))>] tail_mod_cons
-        : (consts (0)) (non_consts ([0: ?]))
+        param[value<
+               (consts (0))
+                (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))>]
+        tail_mod_cons
+        : (consts (0))
+           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>]))
         (if param
           (let
             (*match* =a? (field_imm 0 param)
              block1_arg0 =? (apply f (field_imm 0 *match*))
              block =
-               (makemutable 0 (*,value<(consts (0)) (non_consts ([0: ?]))>)
+               (makemutable 0 (*,value<
+                                  (consts (0))
+                                   (non_consts ([0:
+                                                 value<
+                                                  (consts ())
+                                                   (non_consts ([0: *, *]))>]))>)
                  block1_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
@@ -109,7 +127,7 @@ let[@tail_mod_cons] rec rec_map f = function
                                 (non_consts ([0: *,
                                               value<
                                                (consts (0))
-                                                (non_consts ([0: ?]))>]))>)
+                                                (non_consts ([0: *]))>]))>)
                   block))
               (apply rec_map_dps block 1 f (field_imm 1 *match*) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -134,21 +152,27 @@ let[@tail_mod_cons] rec trip = function
                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
        tail_mod_cons
        : (consts (0))
-          (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
+          (non_consts ([0:
+                        value<(consts ()) (non_consts ([0: ?, value<int>]))>,
+                        value<(consts (0)) (non_consts ([0: *, *]))>]))
        (if param
          (let (x =a? (field_imm 0 param))
            (makeblock 0 (value<(consts ()) (non_consts ([0: ?, value<int>]))>,
              value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+               (non_consts ([0:
+                             value<
+                              (consts ()) (non_consts ([0: ?, value<int>]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>)
              (makeblock 0 (?,value<int>) x 0)
              (makeblock 0 (value<
                             (consts ()) (non_consts ([0: ?, value<int>]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<
+                                (consts ()) (non_consts ([0: ?, value<int>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (?,value<int>) x 1)
                (let
                  (block =
@@ -157,9 +181,12 @@ let[@tail_mod_cons] rec trip = function
                                       (non_consts ([0: ?, value<int>]))>,
                       value<
                        (consts (0))
-                        (non_consts ([0: ?,
+                        (non_consts ([0:
                                       value<
-                                       (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                       (consts ())
+                                        (non_consts ([0: ?, value<int>]))>,
+                                      value<
+                                       (consts (0)) (non_consts ([0: *, *]))>]))>)
                       (makeblock 0 (?,value<int>) x 2) 24029))
                  (seq (apply trip_dps block 1 (field_imm 1 param)) block)))))
          0))
@@ -171,7 +198,9 @@ let[@tail_mod_cons] rec trip = function
                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
         tail_mod_cons
         : (consts (0))
-           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
+           (non_consts ([0:
+                         value<(consts ()) (non_consts ([0: ?, value<int>]))>,
+                         value<(consts (0)) (non_consts ([0: *, *]))>]))
         (if param
           (let
             (x =a? (field_imm 0 param)
@@ -183,8 +212,11 @@ let[@tail_mod_cons] rec trip = function
                                 (consts ()) (non_consts ([0: ?, value<int>]))>,
                  value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (non_consts ([0:
+                                 value<
+                                  (consts ())
+                                   (non_consts ([0: ?, value<int>]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                  block2_arg0 24029))
             (seq
               (setfield_ptr(heap-init)_computed dst offset
@@ -192,18 +224,24 @@ let[@tail_mod_cons] rec trip = function
                                (consts ()) (non_consts ([0: ?, value<int>]))>,
                   value<
                    (consts (0))
-                    (non_consts ([0: ?,
+                    (non_consts ([0:
                                   value<
-                                   (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                   (consts ())
+                                    (non_consts ([0: ?, value<int>]))>,
+                                  value<
+                                   (consts (0)) (non_consts ([0: *, *]))>]))>)
                   block0_arg0
                   (makeblock 0 (value<
                                  (consts ())
                                   (non_consts ([0: ?, value<int>]))>,
                     value<
                      (consts (0))
-                      (non_consts ([0: ?,
+                      (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                     (consts ())
+                                      (non_consts ([0: ?, value<int>]))>,
+                                    value<
+                                     (consts (0)) (non_consts ([0: *, *]))>]))>)
                     block1_arg0 block)))
               (apply trip_dps block 1 (field_imm 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
@@ -224,8 +262,8 @@ let[@tail_mod_cons] rec effects f = function
      (function {nlocal = 0} f
        param[value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+               (non_consts ([0: value<(consts ()) (non_consts ([0: ?, ?]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>]
        tail_mod_cons
        : (consts (0))
           (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))
@@ -253,8 +291,8 @@ let[@tail_mod_cons] rec effects f = function
       (function {nlocal = 0} dst offset[value<int>] f
         param[value<
                (consts (0))
-                (non_consts ([0: ?,
-                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                (non_consts ([0: value<(consts ()) (non_consts ([0: ?, ?]))>,
+                              value<(consts (0)) (non_consts ([0: *, *]))>]))>]
         tail_mod_cons
         : (consts (0))
            (non_consts ([0: ?, value<(consts (0)) (non_consts ([0: ?, *]))>]))

--- a/testsuite/tests/translprim/comparison_table.stack.reference
+++ b/testsuite/tests/translprim/comparison_table.stack.reference
@@ -342,54 +342,77 @@
        stub : int (%nativeint_greaterequal prim prim))
    int_vec =[value<
               (consts (0))
-               (non_consts ([0: ?,
-                             value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+               (non_consts ([0:
+                             value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>,
+                             value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1 1] [0: [0: 1 2] [0: [0: 2 1] 0]]]
    bool_vec =[value<
                (consts (0))
-                (non_consts ([0: ?,
-                              value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                (non_consts ([0:
+                              value<
+                               (consts ())
+                                (non_consts ([0: value<int>, value<int>]))>,
+                              value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
    intlike_vec =[value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                   (non_consts ([0:
+                                 value<
+                                  (consts ())
+                                   (non_consts ([0: value<int>, value<int>]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 0 0] [0: [0: 0 1] [0: [0: 1 0] 0]]]
    float_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<float>, value<float>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1. 1.] [0: [0: 1. 2.] [0: [0: 2. 1.] 0]]]
    string_vec =[value<
                  (consts (0))
-                  (non_consts ([0: ?,
-                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                  (non_consts ([0:
+                                value<(consts ()) (non_consts ([0: *, *]))>,
+                                value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: "1" "1"] [0: [0: "1" "2"] [0: [0: "2" "1"] 0]]]
    int32_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<int32>, value<int32>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1l 1l] [0: [0: 1l 2l] [0: [0: 2l 1l] 0]]]
    int64_vec =[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<
+                                (consts ())
+                                 (non_consts ([0: value<int64>, value<int64>]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1L 1L] [0: [0: 1L 2L] [0: [0: 2L 1L] 0]]]
    nativeint_vec =[value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                                    (consts ())
+                                     (non_consts ([0: value<nativeint>,
+                                                   value<nativeint>]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>]
      [0: [0: 1n 1n] [0: [0: 1n 2n] [0: [0: 2n 1n] 0]]]
    test_vec =
      (function {nlocal = 0} cmp eq ne lt gt le ge
        vec[value<
             (consts (0))
-             (non_consts ([0: ?,
-                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+             (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                           value<(consts (0)) (non_consts ([0: *, *]))>]))>]
        : (consts ())
           (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                        value<(consts (0)) (non_consts ([0: ?, *]))>]))
+                        value<(consts (0)) (non_consts ([0: *, *]))>]))
        (let
          (uncurry =
             (function {nlocal = 0} f
@@ -399,8 +422,9 @@
             (function {nlocal = 2} f
               l[value<
                  (consts (0))
-                  (non_consts ([0: ?,
-                                value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                  (non_consts ([0:
+                                value<(consts ()) (non_consts ([0: ?, ?]))>,
+                                value<(consts (0)) (non_consts ([0: *, *]))>]))>]
               : (consts (0))
                  (non_consts ([0: ?,
                                value<(consts (0)) (non_consts ([0: ?, *]))>]))
@@ -410,19 +434,20 @@
                         (consts ())
                          (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>,
+                                        (consts (0))
+                                         (non_consts ([0: value<int>, *]))>,
                                        value<
                                         (consts (0)) (non_consts ([0: ?, *]))>]))>,
            value<
             (consts (0))
-             (non_consts ([0: ?,
-                           value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+             (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
+                           value<(consts (0)) (non_consts ([0: *, *]))>]))>)
            (makeblock 0 (value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0: value<int>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>,
+                                           (non_consts ([0: value<int>, *]))>]))>,
              value<
               (consts (0))
                (non_consts ([0: ?,
@@ -432,14 +457,17 @@
              (function {nlocal = 2} gen spec
                : (consts ())
                   (non_consts ([0:
-                                value<(consts (0)) (non_consts ([0: ?, *]))>,
+                                value<
+                                 (consts (0))
+                                  (non_consts ([0: value<int>, *]))>,
                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))
                (makeblock 0 (value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0: value<int>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>,
+                                               (non_consts ([0: value<int>,
+                                                             *]))>]))>,
                  value<
                   (consts (0))
                    (non_consts ([0: ?,
@@ -448,45 +476,56 @@
              (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (*,*) gen_eq eq)
                (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                  value<
                   (consts (0))
-                   (non_consts ([0: ?,
-                                 value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                   (non_consts ([0:
+                                 value<(consts ()) (non_consts ([0: *, *]))>,
+                                 value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                  (makeblock 0 (*,*) gen_ne ne)
                  (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                    value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>)
                    (makeblock 0 (*,*) gen_lt lt)
                    (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                      value<
                       (consts (0))
-                       (non_consts ([0: ?,
+                       (non_consts ([0:
                                      value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                                     value<
+                                      (consts (0)) (non_consts ([0: *, *]))>]))>)
                      (makeblock 0 (*,*) gen_gt gt)
                      (makeblock 0 (value<
                                     (consts ()) (non_consts ([0: *, *]))>,
                        value<
                         (consts (0))
-                         (non_consts ([0: ?,
+                         (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                                       value<
+                                        (consts (0)) (non_consts ([0: *, *]))>]))>)
                        (makeblock 0 (*,*) gen_le le)
                        (makeblock 0 (value<
                                       (consts ()) (non_consts ([0: *, *]))>,
                          value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0:
+                                         value<
+                                          (consts ())
+                                           (non_consts ([0: *, *]))>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>)
+                                           (non_consts ([0: *, *]))>]))>)
                          (makeblock 0 (*,*) gen_ge ge) 0)))))))))))
   (seq
     (apply test_vec int_cmp int_eq int_ne int_lt int_gt int_le int_ge
@@ -510,11 +549,12 @@
          (function {nlocal = 0} cmp eq ne lt gt le ge
            vec[value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>]
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>]
            : (consts ())
               (non_consts ([0: value<(consts ()) (non_consts ([0: *, *]))>,
-                            value<(consts (0)) (non_consts ([0: ?, *]))>]))
+                            value<(consts (0)) (non_consts ([0: *, *]))>]))
            (let
              (uncurry =
                 (function {nlocal = 0} f
@@ -524,9 +564,11 @@
                 (function {nlocal = 2} f
                   l[value<
                      (consts (0))
-                      (non_consts ([0: ?,
+                      (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>]))>]
+                                     (consts ()) (non_consts ([0: ?, ?]))>,
+                                    value<
+                                     (consts (0)) (non_consts ([0: *, *]))>]))>]
                   : (consts (0))
                      (non_consts ([0: ?,
                                    value<
@@ -538,20 +580,22 @@
                              (non_consts ([0:
                                            value<
                                             (consts (0))
-                                             (non_consts ([0: ?, *]))>,
+                                             (non_consts ([0: value<int>, *]))>,
                                            value<
                                             (consts (0))
                                              (non_consts ([0: ?, *]))>]))>,
                value<
                 (consts (0))
-                 (non_consts ([0: ?,
-                               value<(consts (0)) (non_consts ([0: ?, *]))>]))>)
+                 (non_consts ([0:
+                               value<(consts ()) (non_consts ([0: *, *]))>,
+                               value<(consts (0)) (non_consts ([0: *, *]))>]))>)
                (makeblock 0 (value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0: value<int>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>,
+                                               (non_consts ([0: value<int>,
+                                                             *]))>]))>,
                  value<
                   (consts (0))
                    (non_consts ([0: ?,
@@ -562,15 +606,18 @@
                    : (consts ())
                       (non_consts ([0:
                                     value<
-                                     (consts (0)) (non_consts ([0: ?, *]))>,
+                                     (consts (0))
+                                      (non_consts ([0: value<int>, *]))>,
                                     value<
                                      (consts (0)) (non_consts ([0: ?, *]))>]))
                    (makeblock 0 (value<
                                   (consts (0))
-                                   (non_consts ([0: ?,
+                                   (non_consts ([0: value<int>,
                                                  value<
                                                   (consts (0))
-                                                   (non_consts ([0: ?, *]))>]))>,
+                                                   (non_consts ([0:
+                                                                 value<int>,
+                                                                 *]))>]))>,
                      value<
                       (consts (0))
                        (non_consts ([0: ?,
@@ -580,52 +627,67 @@
                  (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                    value<
                     (consts (0))
-                     (non_consts ([0: ?,
+                     (non_consts ([0:
                                    value<
-                                    (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                    (consts ()) (non_consts ([0: *, *]))>,
+                                   value<
+                                    (consts (0)) (non_consts ([0: *, *]))>]))>)
                    (makeblock 0 (*,*) eta_gen_eq eq)
                    (makeblock 0 (value<(consts ()) (non_consts ([0: *, *]))>,
                      value<
                       (consts (0))
-                       (non_consts ([0: ?,
+                       (non_consts ([0:
                                      value<
-                                      (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                      (consts ()) (non_consts ([0: *, *]))>,
+                                     value<
+                                      (consts (0)) (non_consts ([0: *, *]))>]))>)
                      (makeblock 0 (*,*) eta_gen_ne ne)
                      (makeblock 0 (value<
                                     (consts ()) (non_consts ([0: *, *]))>,
                        value<
                         (consts (0))
-                         (non_consts ([0: ?,
+                         (non_consts ([0:
                                        value<
-                                        (consts (0)) (non_consts ([0: ?, *]))>]))>)
+                                        (consts ()) (non_consts ([0: *, *]))>,
+                                       value<
+                                        (consts (0)) (non_consts ([0: *, *]))>]))>)
                        (makeblock 0 (*,*) eta_gen_lt lt)
                        (makeblock 0 (value<
                                       (consts ()) (non_consts ([0: *, *]))>,
                          value<
                           (consts (0))
-                           (non_consts ([0: ?,
+                           (non_consts ([0:
+                                         value<
+                                          (consts ())
+                                           (non_consts ([0: *, *]))>,
                                          value<
                                           (consts (0))
-                                           (non_consts ([0: ?, *]))>]))>)
+                                           (non_consts ([0: *, *]))>]))>)
                          (makeblock 0 (*,*) eta_gen_gt gt)
                          (makeblock 0 (value<
                                         (consts ()) (non_consts ([0: *, *]))>,
                            value<
                             (consts (0))
-                             (non_consts ([0: ?,
+                             (non_consts ([0:
+                                           value<
+                                            (consts ())
+                                             (non_consts ([0: *, *]))>,
                                            value<
                                             (consts (0))
-                                             (non_consts ([0: ?, *]))>]))>)
+                                             (non_consts ([0: *, *]))>]))>)
                            (makeblock 0 (*,*) eta_gen_le le)
                            (makeblock 0 (value<
                                           (consts ())
                                            (non_consts ([0: *, *]))>,
                              value<
                               (consts (0))
-                               (non_consts ([0: ?,
+                               (non_consts ([0:
+                                             value<
+                                              (consts ())
+                                               (non_consts ([0: *, *]))>,
                                              value<
                                               (consts (0))
-                                               (non_consts ([0: ?, *]))>]))>)
+                                               (non_consts ([0: *, *]))>]))>)
                              (makeblock 0 (*,*) eta_gen_ge ge) 0)))))))))))
       (seq
         (apply eta_test_vec eta_int_cmp eta_int_eq eta_int_ne eta_int_lt

--- a/testsuite/tests/typing-layouts-caml-modify/immediate_or_null_record.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/immediate_or_null_record.ml
@@ -1,0 +1,40 @@
+(* TEST
+ modules = "replace_caml_modify.c";
+ {
+   not-macos;
+   flags = "-cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify \
+            -cclib -Xlinker -cclib --wrap -cclib -Xlinker -cclib caml_modify_local";
+   native;
+ }
+*)
+
+(* This test verifies that setting an immediate_or_null field in a mixed record
+   doesn't call [caml_modify]. See [typing-layouts-caml-modify/basics.ml]
+   for an explanation how stubbing [caml_modify] works. *)
+
+external called_caml_modify : unit -> int
+  = "replace_caml_modify_called_modify" [@@noalloc]
+external reset : unit -> unit = "replace_caml_modify_reset" [@@noalloc]
+
+let test ~(call_pos : [%call_pos]) ~expect_caml_modifies f =
+  reset ();
+  f ();
+  let actual_modifies = called_caml_modify () in
+  if not (expect_caml_modifies = actual_modifies) then
+    failwith @@
+      Format.sprintf
+        "On line %d, expected %d calls to caml_modify, but saw %d"
+        call_pos.pos_lnum expect_caml_modifies actual_modifies
+
+type t =
+  { mutable a : int or_null
+  ; mutable b : int64#
+  }
+
+let set t ~a =
+  t.a <- a
+
+let () =
+  let t = { a = Null; b = #0L } in
+  test ~expect_caml_modifies:0
+    (fun () -> set t ~a:(This 5))

--- a/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
+++ b/testsuite/tests/typing-layouts-scannable/external_array_operations.ml
@@ -34,3 +34,31 @@ external product_edge_case : ('a : any separable). #('a * 'a) array -> int
 val product_edge_case : ('a : value_maybe_null). #('a * 'a) array -> int =
   <fun>
 |}]
+
+type ('a : any mod separable) unboxed_record : any mod separable =
+  { field : 'a array } [@@unboxed]
+external unboxed_record_edge_case
+  : ('a : any mod separable). 'a unboxed_record array -> int
+  = "%identity"
+let unboxed_record_edge_case x = unboxed_record_edge_case x
+[%%expect{|
+type ('a : any separable) unboxed_record = { field : 'a array; } [@@unboxed]
+external unboxed_record_edge_case :
+  ('a : any separable). 'a unboxed_record array -> int = "%identity"
+val unboxed_record_edge_case :
+  ('a : any separable). 'a unboxed_record array -> int = <fun>
+|}]
+
+type ('a : any mod separable) unboxed_variant : any mod separable =
+  | Unboxed_variant of 'a array [@@unboxed]
+external unboxed_variant_edge_case
+  : ('a : any mod separable). 'a unboxed_variant array -> int
+  = "%identity"
+let unboxed_variant_edge_case x = unboxed_variant_edge_case x
+[%%expect{|
+type ('a : any separable) unboxed_variant = Unboxed_variant of 'a array [@@unboxed]
+external unboxed_variant_edge_case :
+  ('a : any separable). 'a unboxed_variant array -> int = "%identity"
+val unboxed_variant_edge_case :
+  ('a : any separable). 'a unboxed_variant array -> int = <fun>
+|}]

--- a/testsuite/tests/typing-layouts/any_gadt_value_kind.ml
+++ b/testsuite/tests/typing-layouts/any_gadt_value_kind.ml
@@ -1,0 +1,20 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+(* Regression test: a locally abstract type with layout [any] that is refined
+   to [value] by a GADT match may legitimately be used where a [value] is
+   required (here as the argument of a [value]-kinded type constructor). *)
+
+type ('a : value) t = A of 'a | B
+
+type (_ : any) w = W : ('a : value). 'a w
+
+let f : type (a : any). a w -> unit = function
+  | W -> (fun _ -> ()) (B : a t)
+[%%expect{|
+type 'a t = A of 'a | B
+type (_ : any) w = W : 'a w
+val f : ('a : any). 'a w -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-layouts/optional_arg_value_kind.ml
+++ b/testsuite/tests/typing-layouts/optional_arg_value_kind.ml
@@ -1,0 +1,31 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+(* Regression test: the content type of an optional argument must be
+   constrained to [value_or_null]. When the content type is left
+   unconstrained (here written as [_]), its layout must default
+   rather than leaking [any] into [value_kind]. *)
+
+let f (g : ?opt:_ -> _ -> _) x = g x
+let _ = f
+[%%expect{|
+val f : (?opt:'a -> 'b -> 'c) -> 'b -> 'c = <fun>
+- : (?opt:'a -> 'b -> 'c) -> 'b -> 'c = <fun>
+|}]
+
+(* An explicitly non-value optional content type is rejected with a layout
+   error, rather than panicking in [value_kind]. *)
+
+let g (h : ?opt:(_ : float64) -> _ -> _) x = h x
+[%%expect{|
+Line 1, characters 16-29:
+1 | let g (h : ?opt:(_ : float64) -> _ -> _) x = h x
+                    ^^^^^^^^^^^^^
+Error: Optional argument types must have layout value.
+       The layout of "'a" is float64
+         because of the annotation on the wildcard _ at line 1, characters 16-29.
+       But the layout of "'a" must be a value layout
+         because the type argument of option has layout value_or_null.
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2994,15 +2994,24 @@ and estimate_type_jkind ~expand_components ~ignore_mod_bounds env ty =
           when expand_components ->
           (* This is an unboxed product with at least one [any] field, so we
              need to recompute the jkind if we want it to be precise *)
+          (* Instance and unify at the level of [ty], like [jkind_subst]:
+             [current_level] may be lower than the scope of local abstract
+             types appearing in [args] when this is called after typechecking
+             (e.g. from [Typeopt]), and unifying fresh variables created at
+             that level with [args] would raise a spurious [Escape]. *)
+          let old_level = !current_level in
+          current_level := get_level ty;
           let label_params_and_tys, record_params =
             instance_label_declarations ~fixed:false (Array.of_list lbls)
               ~params:type_decl.type_params
           in
           let uenv = Expression { env; in_subst = false } in
           begin try
-            List.iter2 (!unify' uenv) record_params args
+            List.iter2 (!unify' uenv) record_params args;
+            current_level := old_level
           with
           | Unify_trace _ ->
+            current_level := old_level;
             (* Shouldn't happen, since [record_params] should just be type
                variables *)
             Misc.fatal_errorf "failed to unify %a"

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -548,12 +548,12 @@ let expr sub x =
         Texp_let (rec_flag, list, sub.expr sub exp)
     | Texp_letmutable (vb, exp) ->
         Texp_letmutable (sub.value_binding sub vb, sub.expr sub exp)
-    | Texp_function { params; body; alloc_mode; ret_mode; ret_sort;
+    | Texp_function { params; body; alloc_mode; ret_mode;
                       zero_alloc } ->
         let params = List.map (function_param sub) params in
         let body = function_body sub body in
         let ret_mode = sub.modes sub ret_mode in
-        Texp_function { params; body; alloc_mode; ret_mode; ret_sort;
+        Texp_function { params; body; alloc_mode; ret_mode;
                         zero_alloc }
     | Texp_apply (exp, list, pos, am, za) ->
         Texp_apply (

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6161,7 +6161,6 @@ type split_function_ty =
     *)
     filtered_arrow: filtered_arrow;
     arg_sort : Jkind.sort;
-    ret_sort : Jkind.sort;
     (* An instance of [a_i], unless [x_i] is annotated as polymorphic,
        in which case it's just [a_i] (not an instance).
     *)
@@ -6275,9 +6274,9 @@ let split_function_ty
     | Error err -> raise (Error (loc_fun, env, Function_type_not_rep (ty, err)))
   in
   let arg_sort = type_sort ~why:Function_argument ty_arg in
-  let ret_sort = type_sort ~why:Function_result ty_ret in
+  let _ret_sort = type_sort ~why:Function_result ty_ret in
   env,
-  { filtered_arrow; arg_sort; ret_sort;
+  { filtered_arrow; arg_sort;
     alloc_mode; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
     really_poly
@@ -6317,8 +6316,6 @@ type type_function_result =
 and type_function_ret_info =
   { (* The mode the function returns at. *)
     ret_mode: Mode.Alloc.l modes;
-    (* The sort returned by the function. *)
-    ret_sort: Jkind.sort;
   }
 
 (* value binding elaboration *)
@@ -9193,7 +9190,7 @@ and type_function
       in
       let env,
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
-            arg_sort; ret_sort;
+            arg_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
             alloc_mode; really_poly
           } =
@@ -9382,7 +9379,7 @@ and type_function
           let ret_mode =
             {ret_mode_annots with mode_modes = Alloc.disallow_right ret_mode }
           in
-          Some { ret_sort ; ret_mode }
+          Some { ret_mode }
       in
       { function_ = exp_type, param :: params, body;
         newtypes = []; params_contain_gadt = contains_gadt;
@@ -10050,7 +10047,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
           raise(Error(sarg.pexp_loc, env, Function_type_not_rep (ty, err)))
       in
       let arg_sort = type_sort ~why:Function_argument ty_arg in
-      let ret_sort = type_sort ~why:Function_result ty_res in
+      let _ret_sort = type_sort ~why:Function_result ty_res in
       let eta_pat, eta_var = var_pair ~mode:eta_mode "eta" ty_arg arg_sort in
       (* CR layouts v10: When we add abstract jkinds, the eta expansion here
          becomes impossible in some cases - we'll need better errors.  For test
@@ -10084,7 +10081,6 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
                   };
               ret_mode =
                 { mode_modes = Alloc.disallow_right mret; mode_desc = [] };
-              ret_sort;
               alloc_mode;
               zero_alloc = Zero_alloc.default
             }
@@ -11027,7 +11023,7 @@ and type_function_cases_expect
   Builtin_attributes.warning_scope attrs begin fun () ->
     let env,
         { filtered_arrow = { ty_arg; ty_ret; arg_mode; ret_mode };
-          arg_sort; ret_sort;
+          arg_sort;
           ty_arg_mono; expected_pat_mode; expected_inner_mode; alloc_mode;
         } =
       split_function_ty env expected_mode ty_expected loc ~arg_label:Nolabel
@@ -11062,8 +11058,7 @@ and type_function_cases_expect
       }
     in
     cases, ty_fun, alloc_mode,
-      { ret_sort;
-        ret_mode =
+      { ret_mode =
           {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} }
   end
 
@@ -11608,7 +11603,7 @@ and type_n_ary_function
       type_function env expected_mode ty_expected params constraint_ body
         ~in_function ~first:true
     in
-    let fun_alloc_mode, { ret_mode; ret_sort } =
+    let fun_alloc_mode, { ret_mode } =
       match fun_alloc_mode, ret_info with
       | Some x, Some y -> x, y
       | None, _ ->
@@ -11709,7 +11704,7 @@ and type_n_ary_function
     re
       { exp_desc =
           Texp_function
-            { params; body; ret_sort;
+            { params; body;
               alloc_mode; ret_mode;
               zero_alloc
             };

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -291,7 +291,6 @@ and expression_desc =
       { params : function_param list;
         body : function_body;
         ret_mode : Mode.Alloc.l modes;
-        ret_sort : Jkind.sort;
         alloc_mode : alloc_mode;
         zero_alloc : Zero_alloc.t;
       }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -488,7 +488,6 @@ and expression_desc =
         ret_mode : Mode.Alloc.l modes;
         (* Mode where the function allocates, ie local for a function of
            type 'a -> local_ 'b, and heap for a function of type 'a -> 'b *)
-        ret_sort : Jkind.sort;
         alloc_mode : alloc_mode;
         (* Mode at which the closure is allocated *)
         zero_alloc : Zero_alloc.t;

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1248,6 +1248,15 @@ let layout_of_sort loc sort =
     | Genvar _ -> assert false
     )
 
+let layout_of_type env loc ty =
+  let jkind = Ctype.type_jkind_purely env ty in
+  match Jkind.get_layout_defaulting_to_scannable env jkind with
+  | None -> Lambda.Ptop
+  | Some layout_const ->
+    match Jkind.Layout.Const.get_sort layout_const with
+    | Some sort -> layout env loc sort ty
+    | None -> Lambda.Ptop
+
 let layout_of_non_void_sort c =
   layout_of_const_sort_generic
     c

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -590,6 +590,13 @@ let add_nullability_from_ty env ty raw_kind =
 let fallback_if_missing_cmi ~default f =
   try f () with Missing_cmi_fallback -> default
 
+let instantiate_decl_field env type_params args =
+  match args with
+  | [] -> Fun.id
+  | _ :: _ ->
+    fun ty -> (try Ctype.apply env type_params ty args
+               with Ctype.Cannot_apply -> ty)
+
 (* CR layouts v2.5: It will be possible for subcomponents of types to be
    non-values for non-error reasons (e.g., [type t = { x : float# }
    [@@unboxed]).  And in later releases, this will also happen in normal
@@ -710,7 +717,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
           || Path.same p Predef.path_iarray) ->
     let ak = array_type_kind ~elt_ty:(Some arg) env loc ty in
     num_nodes_visited, non_nullable (Parrayval ak)
-  | Tconstr(p, _, _) -> begin
+  | Tconstr(p, args, _) -> begin
       (* CR layouts v2.8: The uses of [decl.type_jkind] here are suspect:
          with with-kinds, [decl.type_jkind] will mention variables bound
          by the parameters of the declaration. The code below loses this
@@ -720,6 +727,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
       let decl =
         try Env.find_type p env with Not_found -> raise Missing_cmi_fallback
       in
+      let instantiate = instantiate_decl_field env decl.type_params args in
       if cannot_proceed () then
         num_nodes_visited,
         add_nullability_from_ty env scty
@@ -736,7 +744,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
           fallback_if_missing_cmi
             ~default:(num_nodes_visited, nullable Pgenval)
             (fun () -> value_kind_variant env ~loc ~visited ~depth
-                         ~num_nodes_visited cstrs rep)
+                         ~num_nodes_visited ~instantiate cstrs rep)
         | Type_record (_, Record_variable, _) ->
           num_nodes_visited, non_nullable Pgenval
         | Type_record (labels, rep, _) ->
@@ -744,7 +752,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
           fallback_if_missing_cmi
             ~default:(num_nodes_visited, nullable Pgenval)
             (fun () -> value_kind_record env ~loc ~visited ~depth
-                         ~num_nodes_visited labels rep)
+                         ~num_nodes_visited ~instantiate labels rep)
         | Type_record_unboxed_product (_, Record_unboxed_product_variable, _) ->
           num_nodes_visited, nullable Pgenval
         | Type_record_unboxed_product ([{ld_type}],
@@ -844,11 +852,9 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
           | exception Not_found -> unknown ()
           | { type_kind = Type_record_unboxed_product (lbls, _, _);
               type_params; _ } ->
-            let type_of_ld { Types.ld_type } =
-              try Some (Ctype.apply env type_params ld_type args)
-              with Ctype.Cannot_apply -> None
-            in
-            Misc.Stdlib.Array.of_list_map type_of_ld lbls
+            let instantiate = instantiate_decl_field env type_params args in
+            Misc.Stdlib.Array.of_list_map
+              (fun { Types.ld_type } -> Some (instantiate ld_type)) lbls
           | { type_kind =
                 Type_variant _ | Type_record _ | Type_abstract _ | Type_open;
               _ } ->
@@ -889,13 +895,14 @@ and value_kind_mixed_block
   in
   num_nodes_visited, Constructor_mixed (Array.of_list shape)
 
-and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
+and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited ~instantiate
       (cstrs : Types.constructor_declaration list) rep =
   match rep with
   | Variant_extensible -> assert false
   | Variant_with_null -> begin
     match Datarepr.find_variant_with_null_payload cstrs with
     | Some { payload_arg = { Types.ca_type = ty; _ }; _ } ->
+      let ty = instantiate ty in
       let num_nodes_visited, kind =
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       in
@@ -909,7 +916,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
       match cstrs with
       | [{cd_args=Cstr_tuple [{ca_type=ty}]}]
       | [{cd_args=Cstr_record [{ld_type=ty}]}] ->
-        value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
+        value_kind env ~loc ~visited ~depth ~num_nodes_visited (instantiate ty)
       | _ -> assert false
     end
   | Variant_boxed cstr_layouts ->
@@ -933,7 +940,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
       let num_nodes_visited = num_nodes_visited + 1 in
       match constructor.cd_args with
       | Cstr_tuple fields ->
-        let field_to_type { Types.ca_type } = ca_type in
+        let field_to_type { Types.ca_type } = instantiate ca_type in
         let num_nodes_visited, fields =
           match cstr_shape with
           | Constructor_uniform_value ->
@@ -945,7 +952,9 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
         in
         (false, num_nodes_visited), fields
       | Cstr_record labels ->
-        let field_to_type (lbl:Types.label_declaration) = lbl.ld_type in
+        let field_to_type (lbl:Types.label_declaration) =
+          instantiate lbl.ld_type
+        in
         let is_mutable =
           List.exists
             (fun (lbl:Types.label_declaration) ->
@@ -1033,7 +1042,7 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
     in
     num_nodes_visited, non_nullable raw_kind
 
-and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
+and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited ~instantiate
       (labels : Types.label_declaration list) rep =
   match rep with
   | (Record_unboxed | (Record_inlined (_, _, Variant_unboxed))) -> begin
@@ -1042,7 +1051,8 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
          needed when we deal with missing cmis. *)
       match labels with
       | [{ld_type}] ->
-        value_kind env ~loc ~visited ~depth ~num_nodes_visited ld_type
+        value_kind env ~loc ~visited ~depth ~num_nodes_visited
+          (instantiate ld_type)
       | [] | _ :: _ :: _ -> assert false
     end
   | Record_dummy _ ->
@@ -1083,7 +1093,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
                         non_nullable (Pboxedfloatval Boxed_float64)
                       | Record_inlined _ | Record_boxed ->
                           value_kind env ~loc ~visited ~depth ~num_nodes_visited
-                            label.ld_type
+                            (instantiate label.ld_type)
                       | Record_mixed _ | Record_unboxed | Record_dummy _
                       | Record_variable ->
                           (* The outer match guards against this *)
@@ -1097,7 +1107,7 @@ and value_kind_record env ~loc ~visited ~depth ~num_nodes_visited
           | Record_mixed shape ->
             let types = List.map (fun label -> label.Types.ld_type) labels in
             value_kind_mixed_block env ~loc ~visited ~depth ~num_nodes_visited
-              ~shape (List.map (fun t -> Some t) types)
+              ~shape (List.map (fun t -> Some (instantiate t)) types)
         in
         let non_consts =
           match rep with

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -52,6 +52,9 @@ val bigarray_specialize_kind_and_layout :
 val layout :
   Env.t -> Location.t -> Jkind.Sort.Const.t -> Types.type_expr -> Lambda.layout
 
+val layout_of_type :
+  Env.t -> Location.t -> Types.type_expr -> Lambda.layout
+
 (* These translate a type system sort to a lambda layout.  The function [layout]
    gives a more precise result---this should only be used when the kind is
    needed for compilation but the precise Lambda.layout isn't needed for

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -45,7 +45,7 @@ type unbound_variable_reason = | Upstream_compatibility
 type jkind_initialization_choice = Sort | Any
 
 type value_loc =
-    Tuple | Poly_variant | Object_field
+    Tuple | Poly_variant | Object_field | Optional_arg
 
 type sort_loc =
     Fun_arg | Fun_ret
@@ -922,8 +922,17 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             else begin
               if not (Btype.tpoly_is_mono arg_ty) then
                 raise (Error (arg.ptyp_loc, env, Polymorphic_optional_param));
-              newmono
-                (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
+              let arg_content_ty = Btype.tpoly_get_mono arg_ty in
+              (match
+                 constrain_type_jkind env arg_content_ty
+                   Predef.option_argument_jkind
+               with
+               | Ok _ -> ()
+               | Error err ->
+                 raise (Error (arg.ptyp_loc, env,
+                               Non_value {vloc = Optional_arg;
+                                          typ = arg_content_ty; err})));
+              newmono (newconstr Predef.path_option [arg_content_ty])
             end
           in
           let arg_mode_desc = Alloc.of_const arg_mode.mode_modes in
@@ -1946,6 +1955,7 @@ let report_error_doc loc env = function
       | Tuple -> "Tuple element"
       | Poly_variant -> "Polymorphic variant constructor argument"
       | Object_field -> "Object field"
+      | Optional_arg -> "Optional argument"
     in
     Location.errorf ~loc "%s types must have layout value.@ %a"
       s (Jkind.Violation.report_with_offender

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -150,7 +150,7 @@ val get_type_param_name: Parsetree.core_type -> string option
 exception Already_bound
 
 type value_loc =
-    Tuple | Poly_variant | Object_field
+    Tuple | Poly_variant | Object_field | Optional_arg
 
 type sort_loc =
     Fun_arg | Fun_ret


### PR DESCRIPTION
Don't store sorts of function returns in the typed AST, and instead compute the return layouts in lambda. Necessary for `any` for function returns.