### PR TITLE
fix: Deal with variables created by a nested join 

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -821,12 +821,12 @@ module Bindings_in_target_env : sig
   val alias_types_in_target_env :
     t -> Type_in_target_env.t Name_in_source_env.Map.t
 
-  (* Assuming that [since] derives from [t], returns the definitions of local
+  (* Assuming that [t] derives from [since], returns the definitions of local
      variables that have been added to [t] after [since]. *)
   val new_bindings :
     t -> since:t -> definition_in_joined_envs Name_in_target_env.Map.t
 
-  (* Assuming that [since] derives from [t], extract the created variables from
+  (* Assuming that [t] derives from [since], extract the created variables from
      [t], adding them to [since]. Any information about the created variables
      besides their kind (in particular, their [definition_in_joined_env]) is
      forgotten, and they won't appear in the [new_bindings]. *)
@@ -1979,6 +1979,13 @@ let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
         Joined_envs.equations_in_nth_joined_env joined_envs index
       in
       let diff_equations =
+        (* Note that we forget the potential newly created variables here, but
+           they could end up in the [Bindings_in_target_env] and cause issue if
+           they are ever used in the parent environment.
+
+           This is fine, however, because we drop any possible information about
+           these variables by calling [forget_definition_of_created_variables]
+           in [n_way_join_env_extension]. *)
         Type_in_one_joined_env.create_equations (TEL.equations diff_level)
       in
       (* The call below to [replay_definition_of_aliases_in_target_env] is only
@@ -2188,7 +2195,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
          extension), but not incorrect, only slighly inefficient. *)
       let bindings =
         Bindings_in_target_env.forget_definition_of_created_variables
-          bindings_after_extension ~since:bindings
+          bindings_after_extension ~since:t.bindings
       in
       Ok
         ( TEE.from_map

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -826,6 +826,12 @@ module Bindings_in_target_env : sig
   val new_bindings :
     t -> since:t -> definition_in_joined_envs Name_in_target_env.Map.t
 
+  (* Assuming that [since] derives from [t], extract the created variables from
+     [t], adding them to [since]. Any information about the created variables
+     besides their kind (in particular, their [definition_in_joined_env]) is
+     forgotten, and they won't appear in the [new_bindings]. *)
+  val forget_definition_of_created_variables : t -> since:t -> t
+
   val fold_created_variables :
     (Variable_in_target_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
 
@@ -944,6 +950,11 @@ end = struct
     Name_in_target_env.Map.diff_shared
       (fun _ new_definition _old_definition -> Some new_definition)
       t.definitions_in_joined_envs since.definitions_in_joined_envs
+
+  let forget_definition_of_created_variables t ~since =
+    (* We still need to record the fact that we created those variables in order
+       to add them to the target environment at the end of the join. *)
+    { since with created_variables = t.created_variables }
 
   let source_env { source_env; _ } = source_env
 
@@ -1957,19 +1968,18 @@ let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
           joined_envs_and_extensions
         | Ok env ->
           let level = ME.cut env ~cut_after in
-          let extension = TEL.as_extension_without_bindings level in
           Index.Map.add index
-            (ME.typing_env env, extension)
+            (ME.typing_env env, level)
             joined_envs_and_extensions)
       Index.Map.empty extensions
   in
   Index.Map.mapi
-    (fun index (env, diff_ext) ->
+    (fun index (env, diff_level) ->
       let previous_equations =
         Joined_envs.equations_in_nth_joined_env joined_envs index
       in
       let diff_equations =
-        Type_in_one_joined_env.create_equations (TEE.to_map diff_ext)
+        Type_in_one_joined_env.create_equations (TEL.equations diff_level)
       in
       (* The call below to [replay_definition_of_aliases_in_target_env] is only
          relevant when doing a nested join (join of env extensions); for a
@@ -2159,9 +2169,26 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
          join of env extensions, we might need additional rounds for
          completeness (see comment in [n_way_join_simples]) -- in practice one
          round should be plenty. *)
-      let equations, { bindings; _ } =
+      let equations, { bindings = bindings_after_extension; _ } =
         n_way_join_round ~n_way_join_type { joined_envs; bindings }
           concrete_types_to_join alias_types_in_target_env
+      in
+      (* It is possible for the call to [add_env_extension] in
+         [prepare_nested_join] above to create new variables, which do not exist
+         in the parent environments. These variables must not leak into the
+         [bindings]: since they don't exist in the parent joined environments,
+         we won't be able to find a type for them in the target environment
+         outside of the extension.
+
+         For now, we avoid this problem by simply forgetting about the
+         definition of new variables (in the target env) during the join of
+         extensions. This means that in some cases we might create the same
+         variable twice (e.g. we might create a variable to represent {0, 1}
+         inside an env extension and then another one outside of the env
+         extension), but not incorrect, only slighly inefficient. *)
+      let bindings =
+        Bindings_in_target_env.forget_definition_of_created_variables
+          bindings_after_extension ~since:bindings
       in
       Ok
         ( TEE.from_map

--- a/testsuite/tests/flambda2/simplify/join_of_zero_types.ml
+++ b/testsuite/tests/flambda2/simplify/join_of_zero_types.ml
@@ -1,0 +1,27 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   ocamlopt_flags += " -flambda2-join-algorithm=n-way";
+   setup-ocamlopt.opt-build-env;
+   ocamlopt.opt;
+ *)
+
+[@@@ocaml.flambda_o3]
+
+external __dummy2__ : unit -> 'a = "%opaque"
+
+type t = TSeq of unit | TExp of unit
+
+let _ =
+ fun z ->
+  (let x = __dummy2__ () in
+   fun y ->
+     (__dummy2__ ())
+       ((fun y ->
+          match x with
+          | None -> None
+          | Some (TExp _) -> Some (TExp y)
+          | _ -> Some (TSeq y))
+          y))
+    z ()
+


### PR DESCRIPTION
When computing the join of env extensions, we first add the joined
extensions to the corresponding parent environment. This causes us to
compute the `meet` of types between the parent environment and the
extension, which in turn might add new variables to the joined
environment due to the `meet` calling a nested `join` when dealing with
equations on a variant that itself has env extensions.

This causes crashes when trying to later compute a type for these
variables outside of the env extension (and if one of these variables
gets imported, we won't find a type for it in any of the parent
environments, causing a "join of zero types" error).

We could deal with these variables precisely, but this is a very
specific edge case, and it's not even clear that we should be creating
these variables in the first place, so this patch provides a
straightforward fix: we simply forget about the definition of variables
created during the join of env extensions.