### PR TITLE
Account for GADT result jkind bounds

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -32,6 +32,169 @@ type ('a : value mod external_) require_external
 |}]
 
 (***********************************************************************)
+(* GADT result-argument projection should apply only to direct variables,
+   and the effective bound for a direct variable should be the intersection
+   of the declaration parameter's bound and the constructor-local bound. *)
+
+module Direct_projection_same_bound = struct
+  type ('a : value mod portable) t : value mod portable =
+    | K : ('b : value mod portable). 'b -> 'b t
+end
+[%%expect{|
+module Direct_projection_same_bound :
+  sig
+    type ('a : value mod portable) t =
+        K : ('b : value mod portable). 'b -> 'b t
+  end
+|}]
+
+(* CR layouts v2.8: This should be accepted. The check should use the
+   constructor-local bound when the GADT result argument is a direct variable. *)
+module Direct_projection_constructor_stricter = struct
+  type ('a : value mod portable) t : value mod portable contended =
+    | K : ('b : value mod portable contended). 'b -> 'b t
+end
+[%%expect{|
+Lines 2-3, characters 2-57:
+2 | ..type ('a : value mod portable) t : value mod portable contended =
+3 |     | K : ('b : value mod portable contended). 'b -> 'b t
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+module Direct_projection_constructor_stricter_with_bound = struct
+  type ('a : value mod portable) t : value mod portable contended with 'a =
+    | K : ('b : value mod portable contended). 'b -> 'b t
+end
+[%%expect{|
+module Direct_projection_constructor_stricter_with_bound :
+  sig
+    type ('a : value mod portable) t =
+        K : ('b : value mod portable contended). 'b -> 'b t
+  end
+|}]
+
+(* CR layouts v2.8: This should be accepted. The effective bound is the
+   intersection of the declaration parameter bound and constructor-local bound. *)
+module Direct_projection_constructor_weaker = struct
+  type ('a : value mod portable contended) t : value mod portable contended =
+    | K : ('b : value mod portable). 'b -> 'b t
+end
+[%%expect{|
+Line 3, characters 4-47:
+3 |     | K : ('b : value mod portable). 'b -> 'b t
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'b was declared to have kind value
+                                                                  mod
+                                                                  portable.
+       But it was inferred to have kind value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: This should be accepted. The effective bound is the
+   intersection of the declaration parameter bound and constructor-local bound. *)
+module Direct_projection_constructor_incomparable = struct
+  type ('a : value mod portable) t : value mod portable contended =
+    | K : ('b : value mod contended). 'b -> 'b t
+end
+[%%expect{|
+Line 3, characters 4-48:
+3 |     | K : ('b : value mod contended). 'b -> 'b t
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'b was declared to have kind value
+                                                                  mod
+                                                                  contended.
+       But it was inferred to have kind value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: This should be accepted. The effective bound is the
+   intersection of the declaration parameter bound and constructor-local bound. *)
+module Direct_projection_constructor_weaker_immutable = struct
+  type ('a : value mod contended) t
+    : immutable_data with 'a @@ portable contended =
+    | K : ('b : value mod portable). 'b -> 'b t
+end
+[%%expect{|
+Line 4, characters 4-47:
+4 |     | K : ('b : value mod portable). 'b -> 'b t
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'b was declared to have kind value
+                                                                  mod
+                                                                  portable.
+       But it was inferred to have kind value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+module Compound_result_argument_without_parameter_bound = struct
+  type 'a t =
+    | K : ('b : value mod portable). 'b -> 'b option t
+end
+[%%expect{|
+module Compound_result_argument_without_parameter_bound :
+  sig type 'a t = K : ('b : value mod portable). 'b -> 'b option t end
+|}]
+
+(* CR layouts v2.8: Should this be accepted by using the projected bound on
+   ['b], or is rejecting compound result arguments the intended behavior? *)
+module Compound_result_argument_checks_whole_argument = struct
+  type ('a : value mod portable) t : value mod portable =
+    | K : ('b : value mod portable). 'b -> 'b option t
+end
+[%%expect{|
+Line 3, characters 43-52:
+3 |     | K : ('b : value mod portable). 'b -> 'b option t
+                                               ^^^^^^^^^
+Error: This type "'b option" should be an instance of type
+         "('a : value mod portable)"
+       The kind of 'b option is immutable_data with 'b
+         because it's a boxed variant type.
+       But the kind of 'b option must be a subkind of value mod portable
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: Should this be accepted by using the projected bound on
+   ['b], or is rejecting compound result arguments the intended behavior? *)
+module Compound_result_argument_is_not_projected = struct
+  type ('a : value mod portable contended) t : value mod portable contended =
+    | K : ('b : value mod portable). 'b -> 'b option t
+end
+[%%expect{|
+Line 3, characters 43-52:
+3 |     | K : ('b : value mod portable). 'b -> 'b option t
+                                               ^^^^^^^^^
+Error: This type "'b option" should be an instance of type
+         "('a : value mod portable contended)"
+       The kind of 'b option is immutable_data with 'b
+         because it's a boxed variant type.
+       But the kind of 'b option must be a subkind of
+           value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: This should be accepted. Repeated direct projections of
+   the same result variable should contribute all projected bounds. *)
+module Repeated_direct_projection_uses_first_argument = struct
+  type ('a : value mod portable, 'c : value mod contended) t
+    : value mod portable contended =
+    | K : ('b : value mod portable contended). 'b -> ('b, 'b) t
+end
+[%%expect{|
+Lines 2-4, characters 2-63:
+2 | ..type ('a : value mod portable, 'c : value mod contended) t
+3 |     : value mod portable contended =
+4 |     | K : ('b : value mod portable contended). 'b -> ('b, 'b) t
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+(***********************************************************************)
 type 'a eq_int = Eq : int eq_int
 [%%expect{|
 type 'a eq_int = Eq : int eq_int
@@ -147,7 +310,6 @@ type 'a t : value mod contended portable =
   | Shared : ('b : value mod contended portable). 'b  -> 'b t
   | Unshared : (unit -> 'c) @@ portable               -> 'c t
 ;;
-(* CR layouts v2.8: This should be accepted. Internal ticket 4973. *)
 [%%expect{|
 Lines 1-3, characters 0-61:
 1 | type 'a t : value mod contended portable =

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -99,15 +99,8 @@ module Recursive_annotated_list_payload = struct
     A of ('a t list as (_ : any mod contended portable))
 end
 [%%expect{|
-Line 3, characters 28-54:
-3 |     A of ('a t list as (_ : any mod contended portable))
-                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Bad layout annotation:
-         The kind of "'a t list" is immutable_data with 'a t
-           because it's a boxed variant type.
-         But the kind of "'a t list" must be a subkind of
-             any mod portable contended
-           because of the annotation on the wildcard _ at line 3, characters 28-54.
+module Recursive_annotated_list_payload :
+  sig type ('a : value mod portable contended) t = A of 'a t list end
 |}]
 
 (***********************************************************************)

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -30,6 +30,253 @@ type 'a require_nonnull
 type ('a : value mod external_) require_external
 |}]
 
+module Plain_mode_constrained_existential = struct
+  type 'a t : value mod contended portable =
+    | Shared : ('a : value mod contended portable). 'a -> 'a t
+end
+[%%expect{|
+Lines 2-3, characters 2-62:
+2 | ..type 'a t : value mod contended portable =
+3 |     | Shared : ('a : value mod contended portable). 'a -> 'a t
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+module Nested_mode_constrained_existential = struct
+  type 'a t : value mod contended portable =
+    | Shared : ('a : value mod contended portable). 'a option -> 'a t
+end
+[%%expect{|
+Lines 2-3, characters 2-69:
+2 | ..type 'a t : value mod contended portable =
+3 |     | Shared : ('a : value mod contended portable). 'a option -> 'a t
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+module Recursive_boxed_variant_with_bounded_parameter = struct
+  module Variable = struct
+    type ('v : value mod contended portable) t
+      : value mod contended portable with 'v
+  end
+
+  module Record_t = struct
+    type ('v : value mod contended portable) t
+      : value mod contended portable =
+      | Variable of 'v Variable.t
+      | Linear_combination of ('v t * int)
+      | Abs of 'v t * (int * (int * int))
+      | Max of { ts : ('v t * int) * ('v t * int) list }
+  end
+end
+[%%expect{|
+Lines 8-13, characters 4-56:
+ 8 | ....type ('v : value mod contended portable) t
+ 9 |       : value mod contended portable =
+10 |       | Variable of 'v Variable.t
+11 |       | Linear_combination of ('v t * int)
+12 |       | Abs of 'v t * (int * (int * int))
+13 |       | Max of { ts : ('v t * int) * ('v t * int) list }
+Error: The kind of type "t" is
+           immutable_data
+             with 'v Variable.t
+             with 'v t
+             with 'v t * int
+             with ('v t * int) * ('v t * int) list
+             with int * (int * int)
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
+|}]
+
+module Recursive_annotated_list_payload = struct
+  type ('a : value mod contended portable) t : value mod contended portable =
+    A of ('a t list as (_ : any mod contended portable))
+end
+[%%expect{|
+Line 3, characters 28-54:
+3 |     A of ('a t list as (_ : any mod contended portable))
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Bad layout annotation:
+         The kind of "'a t/2 list" is immutable_data with 'a t/2
+           because it's a boxed variant type.
+         But the kind of "'a t/2 list" must be a subkind of
+             any mod portable contended
+           because of the annotation on the wildcard _ at line 3, characters 28-54.
+|}]
+
+(***********************************************************************)
+(* GADT result-argument projection should apply only to direct variables,
+   and the effective bound for a direct variable should be the intersection
+   of the declaration parameter's bound and the constructor-local bound. *)
+
+module Direct_projection_same_bound = struct
+  type ('a : value mod portable) t : value mod portable =
+    | K : ('b : value mod portable). 'b -> 'b t
+end
+[%%expect{|
+module Direct_projection_same_bound :
+  sig
+    type ('a : value mod portable) t =
+        K : ('b : value mod portable). 'b -> 'b t
+  end
+|}]
+
+(* CR layouts v2.8: This should be accepted. The check should use the
+   constructor-local bound when the GADT result argument is a direct variable. *)
+module Direct_projection_constructor_stricter = struct
+  type ('a : value mod portable) t : value mod portable contended =
+    | K : ('b : value mod portable contended). 'b -> 'b t
+end
+[%%expect{|
+Lines 2-3, characters 2-57:
+2 | ..type ('a : value mod portable) t : value mod portable contended =
+3 |     | K : ('b : value mod portable contended). 'b -> 'b t
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+module Direct_projection_constructor_stricter_with_bound = struct
+  type ('a : value mod portable) t : value mod portable contended with 'a =
+    | K : ('b : value mod portable contended). 'b -> 'b t
+end
+[%%expect{|
+module Direct_projection_constructor_stricter_with_bound :
+  sig
+    type ('a : value mod portable) t =
+        K : ('b : value mod portable contended). 'b -> 'b t
+  end
+|}]
+
+(* CR layouts v2.8: This should be accepted. The effective bound is the
+   intersection of the declaration parameter bound and constructor-local bound. *)
+module Direct_projection_constructor_weaker = struct
+  type ('a : value mod portable contended) t : value mod portable contended =
+    | K : ('b : value mod portable). 'b -> 'b t
+end
+[%%expect{|
+Line 3, characters 4-47:
+3 |     | K : ('b : value mod portable). 'b -> 'b t
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'b was declared to have kind value
+                                                                  mod
+                                                                  portable.
+       But it was inferred to have kind value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: This should be accepted. The effective bound is the
+   intersection of the declaration parameter bound and constructor-local bound. *)
+module Direct_projection_constructor_incomparable = struct
+  type ('a : value mod portable) t : value mod portable contended =
+    | K : ('b : value mod contended). 'b -> 'b t
+end
+[%%expect{|
+Line 3, characters 4-48:
+3 |     | K : ('b : value mod contended). 'b -> 'b t
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'b was declared to have kind value
+                                                                  mod
+                                                                  contended.
+       But it was inferred to have kind value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: This should be accepted. The effective bound is the
+   intersection of the declaration parameter bound and constructor-local bound. *)
+module Direct_projection_constructor_weaker_immutable = struct
+  type ('a : value mod contended) t
+    : immutable_data with 'a @@ portable contended =
+    | K : ('b : value mod portable). 'b -> 'b t
+end
+[%%expect{|
+Line 4, characters 4-47:
+4 |     | K : ('b : value mod portable). 'b -> 'b t
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The universal type variable 'b was declared to have kind value
+                                                                  mod
+                                                                  portable.
+       But it was inferred to have kind value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+module Compound_result_argument_without_parameter_bound = struct
+  type 'a t =
+    | K : ('b : value mod portable). 'b -> 'b option t
+end
+[%%expect{|
+module Compound_result_argument_without_parameter_bound :
+  sig type 'a t = K : ('b : value mod portable). 'b -> 'b option t end
+|}]
+
+(* CR layouts v2.8: Should this be accepted by using the projected bound on
+   ['b], or is rejecting compound result arguments the intended behavior? *)
+module Compound_result_argument_checks_whole_argument = struct
+  type ('a : value mod portable) t : value mod portable =
+    | K : ('b : value mod portable). 'b -> 'b option t
+end
+[%%expect{|
+Line 3, characters 43-52:
+3 |     | K : ('b : value mod portable). 'b -> 'b option t
+                                               ^^^^^^^^^
+Error: This type "'b option" should be an instance of type
+         "('a : value mod portable)"
+       The kind of 'b option is immutable_data with 'b
+         because it's a boxed variant type.
+       But the kind of 'b option must be a subkind of value mod portable
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: Should this be accepted by using the projected bound on
+   ['b], or is rejecting compound result arguments the intended behavior? *)
+module Compound_result_argument_is_not_projected = struct
+  type ('a : value mod portable contended) t : value mod portable contended =
+    | K : ('b : value mod portable). 'b -> 'b option t
+end
+[%%expect{|
+Line 3, characters 43-52:
+3 |     | K : ('b : value mod portable). 'b -> 'b option t
+                                               ^^^^^^^^^
+Error: This type "'b option" should be an instance of type
+         "('a : value mod portable contended)"
+       The kind of 'b option is immutable_data with 'b
+         because it's a boxed variant type.
+       But the kind of 'b option must be a subkind of
+           value mod portable contended
+         because of the annotation on 'a in the declaration of the type t.
+|}]
+
+(* CR layouts v2.8: This should be accepted. Repeated direct projections of
+   the same result variable should contribute all projected bounds. *)
+module Repeated_direct_projection_uses_first_argument = struct
+  type ('a : value mod portable, 'c : value mod contended) t
+    : value mod portable contended =
+    | K : ('b : value mod portable contended). 'b -> ('b, 'b) t
+end
+[%%expect{|
+Lines 2-4, characters 2-63:
+2 | ..type ('a : value mod portable, 'c : value mod contended) t
+3 |     : value mod portable contended =
+4 |     | K : ('b : value mod portable contended). 'b -> ('b, 'b) t
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+|}]
+
 (***********************************************************************)
 type 'a eq_int = Eq : int eq_int
 [%%expect{|
@@ -146,7 +393,6 @@ type 'a t : value mod contended portable =
   | Shared : ('b : value mod contended portable). 'b  -> 'b t
   | Unshared : (unit -> 'c) @@ portable               -> 'c t
 ;;
-(* CR layouts v2.8: This should be accepted. Internal ticket 4973. *)
 [%%expect{|
 Lines 1-3, characters 0-61:
 1 | type 'a t : value mod contended portable =

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -76,26 +76,22 @@ module Recursive_boxed_variant_with_bounded_parameter = struct
   end
 end
 [%%expect{|
-Lines 8-13, characters 4-56:
- 8 | ....type ('v : value mod contended portable) t
- 9 |       : value mod contended portable =
-10 |       | Variable of 'v Variable.t
-11 |       | Linear_combination of ('v t * int)
-12 |       | Abs of 'v t * (int * (int * int))
-13 |       | Max of { ts : ('v t * int) * ('v t * int) list }
-Error: The kind of type "t" is
-           immutable_data
-             with 'v Variable.t
-             with 'v t
-             with 'v t * int
-             with ('v t * int) * ('v t * int) list
-             with int * (int * int)
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type t.
-       Note: I gave up trying to find the simplest kind for the first,
-       as it is very large or deeply recursive.
+module Recursive_boxed_variant_with_bounded_parameter :
+  sig
+    module Variable :
+      sig
+        type ('v : value mod portable contended) t
+          : value mod portable contended with 'v
+      end
+    module Record_t :
+      sig
+        type ('v : value mod portable contended) t =
+            Variable of 'v Variable.t
+          | Linear_combination of ('v t * int)
+          | Abs of 'v t * (int * (int * int))
+          | Max of { ts : ('v t * int) * ('v t * int) list; }
+      end
+  end
 |}]
 
 module Recursive_annotated_list_payload = struct
@@ -107,9 +103,9 @@ Line 3, characters 28-54:
 3 |     A of ('a t list as (_ : any mod contended portable))
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Bad layout annotation:
-         The kind of "'a t/2 list" is immutable_data with 'a t/2
+         The kind of "'a t list" is immutable_data with 'a t
            because it's a boxed variant type.
-         But the kind of "'a t/2 list" must be a subkind of
+         But the kind of "'a t list" must be a subkind of
              any mod portable contended
            because of the annotation on the wildcard _ at line 3, characters 28-54.
 |}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -3384,6 +3384,15 @@ let check_type_jkind env ty jkind =
 let constrain_type_jkind env ty jkind =
   constrain_type_jkind ~fixed:false env ty jkind
 
+let constrain_type_jkind_for_alias env ty jkind =
+  let ty = Btype.proxy ty in
+  if match get_desc ty with
+    | Tconstr _ ->
+      Ikind.type_expr_sub_jkind ~check_principality:false env ty jkind
+    | _ -> false
+  then Ok ()
+  else constrain_type_jkind env ty jkind
+
 let () =
   Env.constrain_type_jkind := constrain_type_jkind
 

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -736,6 +736,9 @@ val check_type_jkind :
 val constrain_type_jkind :
   Env.t -> type_expr -> ('l * allowed) jkind -> (unit, Jkind.Violation.t) result
 
+val constrain_type_jkind_for_alias :
+  Env.t -> type_expr -> ('l * allowed) jkind -> (unit, Jkind.Violation.t) result
+
 (* Check whether a type's externality's upper bound is less than some target.
    Potentially cheaper than just calling [type_jkind], because this can stop
    expansion once it succeeds. *)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -219,7 +219,14 @@ module Solver = struct
         (* We add the parameters to the TyTbl so that they will refer to
            rigid variables that represent them in the solver. *)
         List.iter2
-          (fun ty var -> TyTbl.add ctx.ty_to_kind ty (Ldd.node_of_var var))
+          (fun ty var ->
+            let param_kind =
+              match Types.get_desc ty with
+              | Types.Tvar { jkind; _ } | Types.Tunivar { jkind; _ } ->
+                Ldd.meet (Ldd.node_of_var var) (ckind_of_jkind ctx jkind)
+              | _ -> Ldd.node_of_var var
+            in
+            TyTbl.add ctx.ty_to_kind ty param_kind)
           params rigid_vars;
         (* Compute body kind *)
         (* CR jujacobs: potential efficiency win:
@@ -614,15 +621,20 @@ let local_var_bounds (ctx : Solver.ctx)
     local_vars;
   bounds
 
-(* For a plain-variable result argument, map it directly to [lhs_kind]. *)
-let add_plain_var_projection ~(local_vars : ('a, Types.type_expr) Hashtbl.t)
+(* For a plain-variable result argument, map it to the intersection of the
+   declaration parameter's kind and the result variable's own jkind. *)
+let add_plain_var_projection ~(ctx : Solver.ctx)
+    ~(local_vars : ('a, Types.type_expr) Hashtbl.t)
     ~(local_subst : ('a, Ldd.node) Hashtbl.t) ~(lhs_kind : Ldd.node)
     (res_arg : Types.type_expr) : unit =
   match Types.get_desc res_arg with
-  | Types.Tvar _ | Types.Tunivar _ ->
+  | Types.Tvar { jkind; _ } | Types.Tunivar { jkind; _ } ->
     let id = Types.get_id res_arg in
-    if Hashtbl.mem local_vars id && not (Hashtbl.mem local_subst id)
-    then Hashtbl.add local_subst id lhs_kind
+    if Hashtbl.mem local_vars id && not (Hashtbl.mem local_subst id) then
+      let projected_kind =
+        Ldd.meet lhs_kind (Solver.ckind_of_jkind ctx jkind)
+      in
+      Hashtbl.add local_subst id projected_kind
   | _ -> ()
 
 let make_gadt_payload_projector
@@ -668,6 +680,7 @@ let make_gadt_payload_projector
           List.iter2
             (fun decl_param res_arg ->
               add_plain_var_projection
+                ~ctx
                 ~local_vars
                 ~local_subst
                 ~lhs_kind:(Solver.kind ~use_tables:true ctx decl_param)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -83,6 +83,7 @@ module Solver = struct
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
+      check_principality : bool;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -101,6 +102,7 @@ module Solver = struct
       env;
       lookup_of_env;
       mode;
+      check_principality = true;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
@@ -389,9 +391,8 @@ module Solver = struct
    fun ctx jkind -> mod_bounds_floor_of_jkind_desc ctx jkind.jkind
 
   (** Compute the kind for [t]. *)
-  and kind ?(check_principality = true) ~use_tables
-      (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
-    if check_principality && not (is_principal_type ty)
+  and kind ~use_tables (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
+    if ctx.check_principality && not (is_principal_type ty)
     then Ldd.const Axis_lattice.top
     else
     match TyTbl.find_opt ctx.ty_to_kind ty with
@@ -456,7 +457,7 @@ module Solver = struct
            breaks the stdlib build, and the old env-var escape hatch never had
            a viable setting in practice. Track removing this workaround as part
            of internal ticket 5746. *)
-        kind ~check_principality:false ~use_tables:true ctx ty
+        kind ~use_tables:true { ctx with check_principality = false } ty
       | Types.Tof_kind jkind -> ckind_of_jkind ctx jkind
       | Types.Tobject _ -> Ldd.const Axis_lattice.object_legacy
       | Types.Tfield _ ->
@@ -1343,6 +1344,21 @@ let sub_or_error ?origin:_origin
     | _ ->
       (* Delegate to Jkind for detailed error reporting. *)
       Jkind.sub_or_error ~type_equal ~context env t1 t2
+
+let type_expr_sub_jkind ?(check_principality = true) env ty
+    (jkind : ('l * Allowance.allowed) Types.jkind) =
+  if not !Clflags.ikinds
+  then false
+  else
+    let ctx =
+      create_ctx ~mode:Solver.Normal ~env:(Some env)
+    in
+    let ctx = { ctx with Solver.check_principality } in
+    let sub_poly =
+      Solver.normalize (Solver.kind ~use_tables:true ctx ty)
+    in
+    let super_poly = Solver.normalize (Solver.ckind_of_jkind ctx jkind) in
+    Ldd.leq_with_reason sub_poly super_poly = []
 
 (** Substitute constructor ikinds according to [lookup] without requiring
     Env. *)

--- a/typing/ikind.mli
+++ b/typing/ikind.mli
@@ -64,6 +64,13 @@ val sub_or_error :
   ('l2 * Allowance.allowed) Types.jkind ->
   (unit, Jkind.Violation.t) result
 
+val type_expr_sub_jkind :
+  ?check_principality:bool ->
+  Env.t ->
+  Types.type_expr ->
+  ('l * Allowance.allowed) Types.jkind ->
+  bool
+
 (** Apply path substitutions to a constructor ikind. *)
 val substitute_decl_ikind_with_lookup :
   lookup_type:(Path.t -> Subst.Ikind_substitution.type_lookup_result) ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -368,6 +368,12 @@ in
         Btype.newgenvar ?name jkind)
       sdecl.ptype_params
   in
+  let type_ikind =
+    Ikind.type_declaration_ikind_of_jkind
+      ~env:(Some env)
+      ~params:type_params
+      type_jkind
+  in
   (* In the temporary environment, all types get an unboxed version.
      See Note [Typechecking unboxed versions of types]. *)
   let type_unboxed_version =
@@ -375,7 +381,7 @@ in
       type_arity = arity;
       type_kind = Type_abstract abstract_source;
       type_jkind;
-      type_ikind = Types.ikinds_todo "transl_declaration initial unboxed";
+      type_ikind;
       type_private = sdecl.ptype_private;
       type_manifest = unboxed_type_manifest;
       type_variance = Variance.unknown_signature ~injective:false ~arity;
@@ -394,7 +400,7 @@ in
       type_arity = arity;
       type_kind = Type_abstract abstract_source;
       type_jkind;
-      type_ikind = Types.ikinds_todo "transl_declaration initial";
+      type_ikind;
       type_private = sdecl.ptype_private;
       type_manifest;
       type_variance = Variance.unknown_signature ~injective:false ~arity;

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1398,7 +1398,7 @@ and transl_type_alias env ~row_context ~policy mode attrs styp_loc styp name_opt
         jkind_of_annotation env (Type_wildcard jkind_annot.pjka_loc)
           attrs jkind_annot
       in
-      begin match constrain_type_jkind env cty_expr jkind with
+      begin match constrain_type_jkind_for_alias env cty_expr jkind with
       | Ok () -> ()
       | Error err ->
         raise (Error(jkind_annot.pjka_loc, env,


### PR DESCRIPTION
GADT constructors introduce their own type variables, even when they use the same names as the type declaration parameters.

When computing with-bounds for GADT payloads, we project direct result variables back to the corresponding declaration parameter. This projection was dropping modal bounds from the constructor-local variable, so some valid GADTs were rejected.

This changes the projection to preserve the constructor-local modal bounds when they differ from the declaration parameter, and does the same in the ikind payload projection path.

The tests cover direct result-variable projection, compound result arguments, repeated result variables, and constructor-local bounds that are stricter, weaker, or on a different axis from the declaration parameter bound.