### PR TITLE
Compute recursive decl jkinds in topological order

### DIFF
--- a/testsuite/tests/shape-index/index_constrs_records.reference
+++ b/testsuite/tests/shape-index/index_constrs_records.reference
@@ -1,35 +1,35 @@
 Indexed shapes:
-Resolved: Index_constrs_records.38 :
+Resolved: Index_constrs_records.40 :
   l_exn (File "index_constrs_records.ml", line 43, characters 21-26)
-Resolved: Index_constrs_records.34 :
+Resolved: Index_constrs_records.36 :
   l_exn (File "index_constrs_records.ml", line 43, characters 10-15)
-Resolved: Index_constrs_records.35 :
-  Exn (File "index_constrs_records.ml", line 43, characters 4-7)
 Resolved: Index_constrs_records.37 :
+  Exn (File "index_constrs_records.ml", line 43, characters 4-7)
+Resolved: Index_constrs_records.39 :
   e (File "index_constrs_records.ml", line 42, characters 14-15)
-Resolved: Index_constrs_records.34 :
+Resolved: Index_constrs_records.36 :
   l_exn (File "index_constrs_records.ml", line 41, characters 14-19)
-Resolved: Index_constrs_records.35 :
+Resolved: Index_constrs_records.37 :
   Exn (File "index_constrs_records.ml", line 41, characters 8-11)
-Resolved: Index_constrs_records.33 :
+Resolved: Index_constrs_records.35 :
   l_ext (File "index_constrs_records.ml", line 36, characters 21-26)
-Resolved: Index_constrs_records.28 :
+Resolved: Index_constrs_records.30 :
   l_ext (File "index_constrs_records.ml", line 36, characters 10-15)
-Resolved: Index_constrs_records.29 :
+Resolved: Index_constrs_records.31 :
   Ext (File "index_constrs_records.ml", line 36, characters 4-7)
-Resolved: Index_constrs_records.32 :
+Resolved: Index_constrs_records.34 :
   x (File "index_constrs_records.ml", line 35, characters 22-23)
-Resolved: Index_constrs_records.27 :
+Resolved: Index_constrs_records.29 :
   u (File "index_constrs_records.ml", line 35, characters 11-12)
-Resolved: Index_constrs_records.27 :
+Resolved: Index_constrs_records.29 :
   u (File "index_constrs_records.ml", line 33, characters 5-6)
-Resolved: Index_constrs_records.26 :
+Resolved: Index_constrs_records.28 :
   l (File "index_constrs_records.ml", line 30, characters 47-48)
 Resolved: Index_constrs_records.1 :
   lbl (File "index_constrs_records.ml", line 30, characters 49-52)
-Resolved: Index_constrs_records.25 :
+Resolved: Index_constrs_records.27 :
   lbl (File "index_constrs_records.ml", line 30, characters 41-44)
-Resolved: Index_constrs_records.24 :
+Resolved: Index_constrs_records.26 :
   l_c (File "index_constrs_records.ml", line 30, characters 35-38)
 Unresolved: CU Stdlib . "+"[value]  :
   (+) (File "index_constrs_records.ml", line 30, characters 39-40)
@@ -45,7 +45,7 @@ Resolved: Index_constrs_records.3 :
   l_c (File "index_constrs_records.ml", line 29, characters 12-15)
 Resolved: Index_constrs_records.4 :
   A (File "index_constrs_records.ml", line 29, characters 8-9)
-Resolved: Index_constrs_records.21 :
+Resolved: Index_constrs_records.23 :
   M (File "index_constrs_records.ml", line 27, characters 5-6)
 Resolved: Index_constrs_records.3 :
   l_c (File "index_constrs_records.ml", line 25, characters 14-17)
@@ -67,27 +67,27 @@ Index_constrs_records.3:
   l_c (File "index_constrs_records.ml", line 21, characters 18-21)
 Index_constrs_records.4:
   A (File "index_constrs_records.ml", line 21, characters 11-12)
-Index_constrs_records.11:
-  t (File "index_constrs_records.ml", line 19, characters 7-8)
 Index_constrs_records.12:
-  l_c (File "index_constrs_records.ml", line 19, characters 18-21)
+  t (File "index_constrs_records.ml", line 19, characters 7-8)
 Index_constrs_records.13:
+  l_c (File "index_constrs_records.ml", line 19, characters 18-21)
+Index_constrs_records.14:
   A (File "index_constrs_records.ml", line 19, characters 11-12)
-Index_constrs_records.21:
-  M (File "index_constrs_records.ml", line 18, characters 7-8)
 Index_constrs_records.23:
+  M (File "index_constrs_records.ml", line 18, characters 7-8)
+Index_constrs_records.25:
   f (File "index_constrs_records.ml", line 30, characters 4-5)
-Index_constrs_records.27:
-  u (File "index_constrs_records.ml", line 32, characters 5-6)
-Index_constrs_records.28:
-  l_ext (File "index_constrs_records.ml", line 33, characters 19-24)
 Index_constrs_records.29:
-  Ext (File "index_constrs_records.ml", line 33, characters 10-13)
+  u (File "index_constrs_records.ml", line 32, characters 5-6)
+Index_constrs_records.30:
+  l_ext (File "index_constrs_records.ml", line 33, characters 19-24)
 Index_constrs_records.31:
+  Ext (File "index_constrs_records.ml", line 33, characters 10-13)
+Index_constrs_records.33:
   f (File "index_constrs_records.ml", line 35, characters 4-5)
-Index_constrs_records.34:
+Index_constrs_records.36:
   l_exn (File "index_constrs_records.ml", line 39, characters 18-23)
-Index_constrs_records.35:
-  Exn (File "index_constrs_records.ml", line 39, characters 10-13)
 Index_constrs_records.37:
+  Exn (File "index_constrs_records.ml", line 39, characters 10-13)
+Index_constrs_records.39:
   e (File "index_constrs_records.ml", line 41, characters 4-5)

--- a/testsuite/tests/shapes/nested_types.ml
+++ b/testsuite/tests/shapes/nested_types.ml
@@ -20,7 +20,7 @@ end
 [%%expect{|
 {
  "M"[module] ->
-   {<.39>
+   {<.41>
     "Exn"[extension constructor] -> {<.1>
                                      "lbl_exn"[label] -> <.0>;
                                      };

--- a/testsuite/tests/typing-layouts-products/recursive_repr.ml
+++ b/testsuite/tests/typing-layouts-products/recursive_repr.ml
@@ -1,0 +1,148 @@
+(* TEST
+ expect;
+*)
+
+(* Unboxed record contained in another unboxed record. *)
+module M_urecord_urecord : sig
+  type line = #{ p : point ; q : point }
+  and point = #{ i : int ; j : int }
+end = struct
+  type point = #{ i : int ; j : int }
+  type line = #{ p : point ; q : point }
+end
+[%%expect{|
+module M_urecord_urecord :
+  sig
+    type line = #{ p : point; q : point; }
+    and point = #{ i : int; j : int; }
+  end
+|}]
+
+(* Boxed variant outside, unboxed record inside. *)
+module M_variant_urecord : sig
+  type t = A of u
+  and u = #{ x : int ; y : int }
+end = struct
+  type u = #{ x : int ; y : int }
+  type t = A of u
+end
+[%%expect{|
+module M_variant_urecord :
+  sig type t = A of u and u = #{ x : int; y : int; } end
+|}]
+
+(* Boxed variant outside, unboxed version of a boxed record inside. *)
+module M_variant_uversion : sig
+  type t = A of u#
+  and u = { x : int ; y : int }
+end = struct
+  type u = { x : int ; y : int }
+  type t = A of u#
+end
+[%%expect{|
+module M_variant_uversion :
+  sig type t = A of u# and u = { x : int; y : int; } end
+|}]
+
+(* Boxed record outside, unboxed record inside. *)
+module M_record_urecord : sig
+  type t = { f : u }
+  and u = #{ x : int ; y : int }
+end = struct
+  type u = #{ x : int ; y : int }
+  type t = { f : u }
+end
+[%%expect{|
+module M_record_urecord :
+  sig type t = { f : u; } and u = #{ x : int; y : int; } end
+|}]
+
+(* Boxed record outside, unboxed version of a boxed record inside. *)
+module M_record_uversion : sig
+  type t = { f : u# }
+  and u = { x : int ; y : int }
+end = struct
+  type u = { x : int ; y : int }
+  type t = { f : u# }
+end
+[%%expect{|
+module M_record_uversion :
+  sig type t = { f : u#; } and u = { x : int; y : int; } end
+|}]
+
+(* A longer chain through several unboxed records. *)
+module M_chain : sig
+  type a = #{ x : b ; y : b }
+  and b = #{ x : c ; y : c }
+  and c = #{ i : int ; j : int }
+end = struct
+  type c = #{ i : int ; j : int }
+  type b = #{ x : c ; y : c }
+  type a = #{ x : b ; y : b }
+end
+[%%expect{|
+module M_chain :
+  sig
+    type a = #{ x : b; y : b; }
+    and b = #{ x : c; y : c; }
+    and c = #{ i : int; j : int; }
+  end
+|}]
+
+(* The contained type can be hidden behind an abbreviation, which we expand
+   rather than approximate by layout (so the abbreviation's own layout
+   annotation, [value & value] here, is irrelevant). *)
+type ('a : value & value) id = 'a
+[%%expect{|
+type ('a : value & value) id = 'a
+|}]
+
+module M_abbrev : sig
+  type t = A of u# id
+  and u = { x : int ; y : int }
+end = struct
+  type u = { x : int ; y : int }
+  type t = A of u# id
+end
+[%%expect{|
+module M_abbrev : sig type t = A of u# id and u = { x : int; y : int; } end
+|}]
+
+(* Same, with an [any]-layout abbreviation. *)
+type ('a : any) id = 'a
+[%%expect{|
+type ('a : any) id = 'a
+|}]
+
+module M_abbrev_any : sig
+  type t = A of u# id
+  and u = { x : int ; y : int }
+end = struct
+  type u = { x : int ; y : int }
+  type t = A of u# id
+end
+[%%expect{|
+module M_abbrev_any :
+  sig type t = A of u# id and u = { x : int; y : int; } end
+|}]
+
+(* An unboxed record may contain a boxed variant that in turn contains an
+   unboxed record: [x] does not depend on the boxed [t] (a value), but [t] still
+   depends on [u]. *)
+module M_through_box : sig
+  type x = #{ f : t ; g : int }
+  and t = A of u
+  and u = #{ a : int ; b : int }
+end = struct
+  type u = #{ a : int ; b : int }
+  type t = A of u
+  type x = #{ f : t ; g : int }
+end
+[%%expect{|
+module M_through_box :
+  sig
+    type x = #{ f : t; g : int; }
+    and t = A of u
+    and u = #{ a : int; b : int; }
+  end
+|}]

--- a/testsuite/tests/typing-layouts-scannable/mutual_recursion.ml
+++ b/testsuite/tests/typing-layouts-scannable/mutual_recursion.ml
@@ -10,24 +10,14 @@ type t_maybeptr_val : value_maybe_separable
 type t_nonptr_val : value non_pointer
 |}]
 
-(* CR layouts-scannable: The current approach does not play nicely with
-   mutually recursive declarations, as demonstrated by the following test: *)
-
 type a : value non_pointer & value non_pointer = #{ b : b }
 and b = #{ i : t_nonptr_val; j : t_nonptr_val }
 [%%expect{|
-Line 1, characters 0-59:
-1 | type a : value non_pointer & value non_pointer = #{ b : b }
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The layout of type "a" is any & any
-         because it is an unboxed record.
-       But the layout of type "a" must be a sublayout of
-           value non_pointer & value non_pointer
-         because of the annotation on the declaration of the type a.
-       Note: The layout of immediate is value non_pointer.
+type a = #{ b : b; }
+and b = #{ i : t_nonptr_val; j : t_nonptr_val; }
 |}]
 
-(* BUT adding in the additional kind annotation on [b] makes this work! *)
+(* An extra kind annotation on [b] also works. *)
 type a : value non_pointer & value non_pointer = #{ b : b }
 and b : value non_pointer & value non_pointer = #{ i : t_nonptr_val; j : t_nonptr_val }
 [%%expect{|
@@ -35,21 +25,13 @@ type a = #{ b : b; }
 and b = #{ i : t_nonptr_val; j : t_nonptr_val; }
 |}]
 
+(* As does an annotation in field position. *)
 type a : value non_pointer & value non_pointer
-       (* BUT an annotation here does not change anything... *)
        = #{ b : (b as (_ : value non_pointer & value non_pointer)) }
 and b = #{ i : t_nonptr_val; j : t_nonptr_val }
 [%%expect{|
-Lines 1-3, characters 0-68:
-1 | type a : value non_pointer & value non_pointer
-2 |        (* BUT an annotation here does not change anything... *)
-3 |        = #{ b : (b as (_ : value non_pointer & value non_pointer)) }
-Error: The layout of type "a" is any & any
-         because it is an unboxed record.
-       But the layout of type "a" must be a sublayout of
-           value non_pointer & value non_pointer
-         because of the annotation on the declaration of the type a.
-       Note: The layout of immediate is value non_pointer.
+type a = #{ b : b; }
+and b = #{ i : t_nonptr_val; j : t_nonptr_val; }
 |}]
 
 (* Same example as above, split across two recursive modules *)

--- a/testsuite/tests/typing-layouts/any_in_variant.ml
+++ b/testsuite/tests/typing-layouts/any_in_variant.ml
@@ -211,22 +211,6 @@ Error: Signature mismatch:
 |}]
 
 
-(* CR-soon rtjoa: This worked before the any-fields PR, because
-   1. In the temporary environment, [pt] gets a jkind made with
-      [product_of_sorts].
-   2. When updating the constructor [A], those sorts are defaulted to [value].
-
-   But after the first version of the any-fields PR,
-   1. In the temporary environment, [pt] gets a jkind made with
-      [product_of_anys].
-   2. When updating the constructor [A], we see those [any] jkinds, and think
-      erroneously that [t]'s representation is variable.
-   3. The struct gets correctly typechecked as havin a fixed representation, and
-      the mismatch gets reported.
-
-   Possible solution: when working with a temp env, don't use the jkind from the
-   decl of [pt] and instead compute the product of the jkinds of its fields
-*)
 module M : sig
   type pt = #{ x : int; y : int }
   and t = A of pt
@@ -235,27 +219,7 @@ end = struct
   type t = A of pt
 end
 [%%expect{|
-Lines 4-7, characters 6-3:
-4 | ......struct
-5 |   type pt = #{ x : int; y : int }
-6 |   type t = A of pt
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type pt = #{ x : int; y : int; } type t = A of pt end
-       is not included in
-         sig type pt = #{ x : int; y : int; } and t = A of pt end
-       Type declarations do not match:
-         type t = A of pt
-       is not included in
-         type t = A of pt
-       Constructors do not match:
-         "A of pt"
-       is not the same as:
-         "A of pt"
-       The first has a fixed representation and the second doesn't.
-       Hint: Is there a type that has a representable layout in the first
-         but has layout any in the second?
+module M : sig type pt = #{ x : int; y : int; } and t = A of pt end
 |}]
 
 module M : sig
@@ -266,30 +230,10 @@ end = struct
   type t = A of pt
 end
 [%%expect{|
-Lines 4-7, characters 6-3:
-4 | ......struct
-5 |   type pt = #{ x : unit#; y : unit# }
-6 |   type t = A of pt
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type pt = #{ x : unit#; y : unit#; } type t = A of pt end
-       is not included in
-         sig type pt = #{ x : unit#; y : unit#; } and t = A of pt end
-       Type declarations do not match:
-         type t = A of pt
-       is not included in
-         type t = A of pt
-       Constructors do not match:
-         "A of pt"
-       is not the same as:
-         "A of pt"
-       The first has a fixed representation and the second doesn't.
-       Hint: Is there a type that has a representable layout in the first
-         but has layout any in the second?
+module M : sig type pt = #{ x : unit#; y : unit#; } and t = A of pt end
 |}]
 
-(* CR-soon rtjoa: this one should also work *)
+(* The contained type may also be the unboxed version of a boxed record. *)
 module M : sig
   type pt = { x : int; y : int }
   and t = A of pt#
@@ -298,25 +242,5 @@ end = struct
   type t = A of pt#
 end
 [%%expect{|
-Lines 4-7, characters 6-3:
-4 | ......struct
-5 |   type pt = { x : int; y : int }
-6 |   type t = A of pt#
-7 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type pt = { x : int; y : int; } type t = A of pt# end
-       is not included in
-         sig type pt = { x : int; y : int; } and t = A of pt# end
-       Type declarations do not match:
-         type t = A of pt#
-       is not included in
-         type t = A of pt#
-       Constructors do not match:
-         "A of pt#"
-       is not the same as:
-         "A of pt#"
-       The first has a fixed representation and the second doesn't.
-       Hint: Is there a type that has a representable layout in the first
-         but has layout any in the second?
+module M : sig type pt = { x : int; y : int; } and t = A of pt# end
 |}]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -3136,8 +3136,7 @@ let check_unboxed_recursion ~abs_env env loc path0 ty0 to_check =
   let rec visit parents trace ty =
     match step_once parents ty with
     | Contained tys, parents ->
-      List.iter
-        (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys
+      List.iter (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys
     | Expanded_to ty', parents ->
       visit parents (Expands_to(ty,ty') :: trace) ty'
     | Is_cyclic, _ ->
@@ -3165,7 +3164,9 @@ let decl_jkind_affects_representations env path =
   | Type_record (_, Record_unboxed, _)
   | Type_variant (_, (Variant_unboxed | Variant_with_null), _) -> true
   | Type_record _ | Type_variant _ | Type_abstract _ | Type_open -> false
-  | exception Not_found -> false
+  | exception Not_found ->
+    (* We only call this on paths in the recursive group *)
+    Misc.fatal_error "Typedecl.decl_jkind_affects_representations"
 
 (* See Note [order of updating decl jkinds]. Returns the declarations'
    [Ident.t]s in an order where each declaration comes after every declaration

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2659,17 +2659,32 @@ let update_decls_jkind_reason decls =
 (* Note [order of updating decl jkinds].
 
    [order] is topological of type declarations in the graph where there's an
-   edge from decl [a] to [b] if [a] or [a#] is contained in [b] without
-   indirection. E.g., there is an [a->b] edge for the following:
+   edge from decl [a] to [b] if the layout of [a] or [a#] is necessary to
+   compute the representation of [b] without indirection.
+
+   Equivalently, there is an [a -> b] edge when [a] (or its unboxed version
+   [a#]) is contained "flatly" within [b], directly or nested through other
+   unboxed types. E.g., there is an [a -> b] edge for the following:
    {[
+     (* [a] is a field of the unboxed record [b] *)
      type a = #{ x : int; y : int }
-     and b = #{ a : a; other : string}
+     and b = #{ f : a; other : string }
+
+     (* [a]'s unboxed version is an argument to the variant [b] *)
+     type b = A of a#
+     and a = #{ x : int; y : int }
+
+     (* [a] is included in [b] through [c] *)
+     type b = { c : c }
+     and c = #{ a : a }
+     and a = #{ i : int; j : int }
    ]}
 
    We process the decls in this order and update the environment as we go, so
-   that when we update each decl jkind, we see the computed jkinds of the types
-   it unboxed-contains, rather than the dummy [any] jkinds assigned in
-   [transl_declaration]. See Note [Default jkinds in transl_declaration]. *)
+   that when we update each decl we see the computed jkinds of the types it
+   depends on, rather than the dummy [any] jkinds assigned in
+   [transl_declaration]. See Note [Default jkinds in transl_declaration].
+*)
 let update_decls_jkind env order decls =
   let decls_by_id = Ident.Map.of_list decls in
   let _env, results =
@@ -3073,7 +3088,7 @@ type step_result =
   | Contained of type_expr list
   | Expanded_to of type_expr
   | Is_cyclic
-let check_unboxed_recursion ~on_visit ~abs_env env loc path0 ty0 to_check =
+let check_unboxed_recursion ~abs_env env loc path0 ty0 to_check =
   let contained_parameters tyl layout =
     (* A type whose layout has [any] could contain all its parameters.
        CR layouts v11: update this function for [layout_of] layouts. *)
@@ -3118,40 +3133,86 @@ let check_unboxed_recursion ~on_visit ~abs_env env loc path0 ty0 to_check =
         end
     | _ -> Contained (Ctype.contained_without_boxing env ty), parents
   in
-  (* Called in post-order (after a node's whole containment subtree has been
-     visited) for every [Tconstr] in the recursive group, which visits a
-     particular declaration after all declarations that contain it without
-     indirection.
-
-     See Note [order of updating decl jkinds]. *)
   let rec visit parents trace ty =
-    begin match step_once parents ty with
+    match step_once parents ty with
     | Contained tys, parents ->
       List.iter
-        (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys;
+        (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys
     | Expanded_to ty', parents ->
-      visit parents (Expands_to(ty,ty') :: trace) ty';
+      visit parents (Expands_to(ty,ty') :: trace) ty'
     | Is_cyclic, _ ->
       raise (Error (loc, Unboxed_recursion (path0, abs_env, List.rev trace)))
-    end;
-    match get_desc ty with
-    | Tconstr (path, _, _) when to_check path -> on_visit path
-    | _ -> ()
   in
   Ctype.wrap_trace_gadt_instances env (visit Path.Set.empty []) ty0
 
-let check_unboxed_recursion_decl ~on_visit ~abs_env env loc path decl to_check =
+let check_unboxed_recursion_decl ~abs_env env loc path decl to_check =
   let decl = Ctype.generic_instance_declaration decl in
-  (match decl.type_unboxed_version with
-   | None -> ()
-   | Some udecl ->
-      let upath = Path.unboxed_version path in
-      let uty = Btype.newgenty (Tconstr (upath, udecl.type_params, ref Mnil)) in
-      check_unboxed_recursion ~on_visit ~abs_env env loc
-        (Path.name upath) uty to_check);
   let ty = Btype.newgenty (Tconstr (path, decl.type_params, ref Mnil)) in
-  check_unboxed_recursion ~on_visit ~abs_env env loc (Path.name path) ty
-    to_check
+  check_unboxed_recursion ~abs_env env loc (Path.name path) ty to_check;
+  match decl.type_unboxed_version with
+  | None -> ()
+  | Some decl ->
+      let path = Path.unboxed_version path in
+      let ty = Btype.newgenty (Tconstr (path, decl.type_params, ref Mnil)) in
+      check_unboxed_recursion ~abs_env env loc (Path.name path) ty to_check
+
+(* True for unboxed types, which are flattened into their container, so its
+   representation depends on this type's jkind (a boxed type just contributes a
+   [value]). *)
+let decl_jkind_affects_representations env path =
+  match (Env.find_type path env).type_kind with
+  | Type_record_unboxed_product _
+  | Type_record (_, Record_unboxed, _)
+  | Type_variant (_, (Variant_unboxed | Variant_with_null), _) -> true
+  | Type_record _ | Type_variant _ | Type_abstract _ | Type_open -> false
+  | exception Not_found -> false
+
+(* See Note [order of updating decl jkinds]. Returns the declarations'
+   [Ident.t]s in an order where each declaration comes after every declaration
+   in the group whose layout its representation depends on.
+
+   In particular, the representation of a {boxed,unboxed} {record,variant}
+   depends on the kinds of its fields/args, as well as all types transitively
+   contained-without-boxing in those args. *)
+let jkind_update_order env to_check decls =
+  let visited = ref Ident.Set.empty in
+  let order = ref [] in
+  (* Prepend [id] after visiting what it depends on; [order] is thus built in
+     reverse, and reversed at the end. *)
+  let rec visit id contained =
+    if not (Ident.Set.mem id !visited) then begin
+      visited := Ident.Set.add id !visited;
+      List.iter follow contained;
+      order := id :: !order
+    end
+  (* Reach the in-group types a container depends on: expand the head (so
+     [u# id] becomes [u#]), then look through what it contains without
+     boxing. *)
+  and follow ty =
+    let ty = Ctype.expand_head_opt env ty in
+    let contained = Ctype.contained_without_boxing env ty in
+    match get_desc ty with
+    | Tconstr ((Path.Pident id | Path.Pextra_ty (Path.Pident id, Punboxed_ty))
+               as path, _, _)
+      when to_check path && decl_jkind_affects_representations env path ->
+      visit id contained
+    | _ ->
+      (* In-group boxed types are recorded by the loop below instead (their args
+         hide behind the box); other types just pass their contents through. *)
+      List.iter follow contained
+  in
+  let snap = Btype.snapshot () in
+  List.iter
+    (fun (id, decl) ->
+       (* Read fields/args directly: a boxed variant/record's args are
+          flattened, but [contained_without_boxing] stops at the box. *)
+       let contained = ref (Option.to_list decl.type_manifest) in
+       Btype.iter_type_expr_kind
+         (fun ty -> contained := ty :: !contained) decl.type_kind;
+       visit id !contained)
+    decls;
+  Btype.backtrack snap;
+  List.rev !order
 
 (* Check for non-regular abbreviations; an abbreviation
    [type 'a t = ...] is non-regular if the expansion of [...]
@@ -3574,28 +3635,14 @@ let transl_type_decl env rec_flag sdecl_list =
     decls;
   List.iter
     (check_abbrev_regularity ~abs_env new_env id_loc_list to_check) tdecls;
-  (* When visiting declaration check for infinite-size unboxed types, we also
-     record the ordering of declarations in this recursive group in which to
-     compute their jkinds. See Note [order of updating decl jkinds]. *)
-  let jkind_update_order =
-    let visited = ref Ident.Set.empty in
-    let order = ref [] in
-    let on_visit path =
-      match path with
-      | Path.Pident id | Path.Pextra_ty (Path.Pident id, Punboxed_ty)
-        when not (Ident.Set.mem id !visited) ->
-        visited := Ident.Set.add id !visited;
-        order := id :: !order
-      | _ -> ()
-    in
-    List.iter (fun (id, decl) ->
-      check_unboxed_recursion_decl ~on_visit ~abs_env new_env
-        (List.assoc id id_loc_list)
-        (Path.Pident id)
-        decl to_check)
-      decls;
-    List.rev !order
-  in
+  List.iter (fun (id, decl) ->
+    check_unboxed_recursion_decl ~abs_env new_env (List.assoc id id_loc_list)
+      (Path.Pident id)
+      decl to_check)
+    decls;
+  (* Cycles through unboxed types are now ruled out, so this order exists. See
+     Note [order of updating decl jkinds]. *)
+  let jkind_update_order = jkind_update_order new_env to_check decls in
   (* Now that we've ruled out ill-formed types, we can perform the delayed
      jkind checks *)
   List.iter (fun (checks,loc) ->
@@ -4973,8 +5020,7 @@ let check_recmod_typedecl env loc recmod_ids path decl =
      (path, decl) is the type declaration to be checked. *)
   let to_check path = Path.exists_free recmod_ids path in
   check_well_founded_decl ~abs_env:env env loc path decl to_check;
-  check_unboxed_recursion_decl ~on_visit:(fun _ -> ()) ~abs_env:env env loc
-    path decl to_check;
+  check_unboxed_recursion_decl ~abs_env:env env loc path decl to_check;
   check_regularity ~abs_env:env env loc path decl to_check;
   (* additional coherence check, as one might build an incoherent signature,
      and use it to build an incoherent module, cf. #7851 *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2661,14 +2661,14 @@ let update_decls_jkind_reason decls =
    [order] is topological of type declarations in the graph where there's an
    edge from decl [a] to [b] if [a] or [a#] is contained in [b] without
    indirection. E.g., there is an [a->b] edge for the following:
-   [{
+   {[
      type a = #{ x : int; y : int }
      and b = #{ a : a; other : string}
-   }]
+   ]}
 
    We process the decls in this order and update the environment as we go, so
-   that when each decl jkind, we sees the computed jkinds of the types it
-   unboxed-contains, rather than the dummy [any] jkinds assigned in
+   that when we update each decl jkind, we see the computed jkinds of the types
+   it unboxed-contains, rather than the dummy [any] jkinds assigned in
    [transl_declaration]. See Note [Default jkinds in transl_declaration]. *)
 let update_decls_jkind env order decls =
   let decls_by_id = Ident.Map.of_list decls in
@@ -3073,8 +3073,7 @@ type step_result =
   | Contained of type_expr list
   | Expanded_to of type_expr
   | Is_cyclic
-let check_unboxed_recursion ~on_visit ~abs_env env loc
-      path0 ty0 to_check =
+let check_unboxed_recursion ~on_visit ~abs_env env loc path0 ty0 to_check =
   let contained_parameters tyl layout =
     (* A type whose layout has [any] could contain all its parameters.
        CR layouts v11: update this function for [layout_of] layouts. *)
@@ -3121,27 +3120,23 @@ let check_unboxed_recursion ~on_visit ~abs_env env loc
   in
   (* Called in post-order (after a node's whole containment subtree has been
      visited) for every [Tconstr] in the recursive group, which visits a
-     particlar declaration after all declarations that contain it without
+     particular declaration after all declarations that contain it without
      indirection.
 
-     See Note [order of updating decl jkinds].
-  *)
-  let record ty =
-    match get_desc ty with
-    | Tconstr (path, _, _) when to_check path -> on_visit path
-    | _ -> ()
-  in
+     See Note [order of updating decl jkinds]. *)
   let rec visit parents trace ty =
-    match step_once parents ty with
+    begin match step_once parents ty with
     | Contained tys, parents ->
       List.iter
         (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys;
-      record ty
     | Expanded_to ty', parents ->
       visit parents (Expands_to(ty,ty') :: trace) ty';
-      record ty
     | Is_cyclic, _ ->
       raise (Error (loc, Unboxed_recursion (path0, abs_env, List.rev trace)))
+    end;
+    match get_desc ty with
+    | Tconstr (path, _, _) when to_check path -> on_visit path
+    | _ -> ()
   in
   Ctype.wrap_trace_gadt_instances env (visit Path.Set.empty []) ty0
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2656,27 +2656,55 @@ let update_decls_jkind_reason decls =
     )
     decls
 
-let update_decls_jkind env decls =
+(* Note [order of updating decl jkinds].
+
+   [order] is topological of type declarations in the graph where there's an
+   edge from decl [a] to [b] if [a] or [a#] is contained in [b] without
+   indirection. E.g., there is an [a->b] edge for the following:
+   [{
+     type a = #{ x : int; y : int }
+     and b = #{ a : a; other : string}
+   }]
+
+   We process the decls in this order and update the environment as we go, so
+   that when each decl jkind, we sees the computed jkinds of the types it
+   unboxed-contains, rather than the dummy [any] jkinds assigned in
+   [transl_declaration]. See Note [Default jkinds in transl_declaration]. *)
+let update_decls_jkind env order decls =
+  let process env id decl =
+    Builtin_attributes.warning_scope decl.type_attributes (fun () ->
+      let allow_any_crossing =
+        Builtin_attributes.has_unsafe_allow_any_mode_crossing
+          decl.type_attributes
+      in
+
+      (* Check that the attribute is valid, if set (unconditionally, for
+         consistency). *)
+      if allow_any_crossing then begin
+        match decl.type_kind with
+        | Type_abstract _ | Type_open ->
+          raise(Error(
+            decl.type_loc, Unsafe_mode_crossing_on_invalid_type_kind))
+        | _ -> ()
+      end;
+
+      update_decl_jkind env (Pident id) decl, allow_any_crossing)
+  in
+  let decls_by_id = Ident.Map.of_list decls in
+  let _env, results =
+    List.fold_left
+      (fun (env, results) id ->
+         let decl = Ident.Map.find id decls_by_id in
+         let new_decl, allow_any_crossing = process env id decl in
+         let env = add_type ~check:false id new_decl env in
+         env, Ident.Map.add id (decl, allow_any_crossing, new_decl) results)
+      (env, Ident.Map.empty) order
+  in
+  (* Return the results in the original [decls] order. *)
   List.map
-    (fun (id, decl) ->
-       Builtin_attributes.warning_scope decl.type_attributes (fun () ->
-         let allow_any_crossing =
-           Builtin_attributes.has_unsafe_allow_any_mode_crossing
-             decl.type_attributes
-         in
-
-         (* Check that the attribute is valid, if set (unconditionally, for
-            consistency). *)
-         if allow_any_crossing then begin
-           match decl.type_kind with
-           | Type_abstract _ | Type_open ->
-             raise(Error(
-               decl.type_loc, Unsafe_mode_crossing_on_invalid_type_kind))
-           | _ -> ()
-         end;
-
-         let new_decl = update_decl_jkind env (Pident id) decl in
-         (id, decl, allow_any_crossing, new_decl)))
+    (fun (id, _decl) ->
+       let decl, allow_any_crossing, new_decl = Ident.Map.find id results in
+       (id, decl, allow_any_crossing, new_decl))
     decls
 
 (* See Note [Typechecking unboxed versions of types]. *)
@@ -3048,7 +3076,8 @@ type step_result =
   | Contained of type_expr list
   | Expanded_to of type_expr
   | Is_cyclic
-let check_unboxed_recursion ~abs_env env loc path0 ty0 to_check =
+let check_unboxed_recursion ~on_visit ~abs_env env loc
+      path0 ty0 to_check =
   let contained_parameters tyl layout =
     (* A type whose layout has [any] could contain all its parameters.
        CR layouts v11: update this function for [layout_of] layouts. *)
@@ -3093,27 +3122,44 @@ let check_unboxed_recursion ~abs_env env loc path0 ty0 to_check =
         end
     | _ -> Contained (Ctype.contained_without_boxing env ty), parents
   in
+  (* Called in post-order (after a node's whole containment subtree has been
+     visited) for every [Tconstr] in the recursive group, which visits a
+     particlar declaration after all declarations that contain it without
+     indirection.
+
+     See Note [order of updating decl jkinds].
+  *)
+  let record ty =
+    match get_desc ty with
+    | Tconstr (path, _, _) when to_check path -> on_visit path
+    | _ -> ()
+  in
   let rec visit parents trace ty =
     match step_once parents ty with
     | Contained tys, parents ->
-      List.iter (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys
+      List.iter
+        (fun ty' -> visit parents (Contains (ty, ty') :: trace) ty') tys;
+      record ty
     | Expanded_to ty', parents ->
-      visit parents (Expands_to(ty,ty') :: trace) ty'
+      visit parents (Expands_to(ty,ty') :: trace) ty';
+      record ty
     | Is_cyclic, _ ->
       raise (Error (loc, Unboxed_recursion (path0, abs_env, List.rev trace)))
   in
   Ctype.wrap_trace_gadt_instances env (visit Path.Set.empty []) ty0
 
-let check_unboxed_recursion_decl ~abs_env env loc path decl to_check =
+let check_unboxed_recursion_decl ~on_visit ~abs_env env loc path decl to_check =
   let decl = Ctype.generic_instance_declaration decl in
+  (match decl.type_unboxed_version with
+   | None -> ()
+   | Some udecl ->
+      let upath = Path.unboxed_version path in
+      let uty = Btype.newgenty (Tconstr (upath, udecl.type_params, ref Mnil)) in
+      check_unboxed_recursion ~on_visit ~abs_env env loc
+        (Path.name upath) uty to_check);
   let ty = Btype.newgenty (Tconstr (path, decl.type_params, ref Mnil)) in
-  check_unboxed_recursion ~abs_env env loc (Path.name path) ty to_check;
-  match decl.type_unboxed_version with
-  | None -> ()
-  | Some decl ->
-      let path = Path.unboxed_version path in
-      let ty = Btype.newgenty (Tconstr (path, decl.type_params, ref Mnil)) in
-      check_unboxed_recursion ~abs_env env loc (Path.name path) ty to_check
+  check_unboxed_recursion ~on_visit ~abs_env env loc (Path.name path) ty
+    to_check
 
 (* Check for non-regular abbreviations; an abbreviation
    [type 'a t = ...] is non-regular if the expansion of [...]
@@ -3536,11 +3582,28 @@ let transl_type_decl env rec_flag sdecl_list =
     decls;
   List.iter
     (check_abbrev_regularity ~abs_env new_env id_loc_list to_check) tdecls;
-  List.iter (fun (id, decl) ->
-    check_unboxed_recursion_decl ~abs_env new_env (List.assoc id id_loc_list)
-      (Path.Pident id)
-      decl to_check)
-    decls;
+  (* When visiting declaration check for infinite-size unboxed types, we also
+     record the ordering of declarations in this recursive group in which to
+     compute their jkinds. See Note [order of updating decl jkinds]. *)
+  let jkind_update_order =
+    let visited = ref Ident.Set.empty in
+    let order = ref [] in
+    let on_visit path =
+      match path with
+      | Path.Pident id | Path.Pextra_ty (Path.Pident id, Punboxed_ty)
+        when not (Ident.Set.mem id !visited) ->
+        visited := Ident.Set.add id !visited;
+        order := id :: !order
+      | _ -> ()
+    in
+    List.iter (fun (id, decl) ->
+      check_unboxed_recursion_decl ~on_visit ~abs_env new_env
+        (List.assoc id id_loc_list)
+        (Path.Pident id)
+        decl to_check)
+      decls;
+    List.rev !order
+  in
   (* Now that we've ruled out ill-formed types, we can perform the delayed
      jkind checks *)
   List.iter (fun (checks,loc) ->
@@ -3598,7 +3661,7 @@ let transl_type_decl env rec_flag sdecl_list =
         |> name_recursion_decls sdecl_list
         |> Typedecl_variance.update_decls env sdecl_list
         |> Typedecl_separability.update_decls env
-        |> update_decls_jkind new_env
+        |> update_decls_jkind new_env jkind_update_order
         |> normalize_decl_jkinds new_env
       in
       let removed, decls = remove_unboxed_versions decls in
@@ -4918,7 +4981,8 @@ let check_recmod_typedecl env loc recmod_ids path decl =
      (path, decl) is the type declaration to be checked. *)
   let to_check path = Path.exists_free recmod_ids path in
   check_well_founded_decl ~abs_env:env env loc path decl to_check;
-  check_unboxed_recursion_decl ~abs_env:env env loc path decl to_check;
+  check_unboxed_recursion_decl ~on_visit:(fun _ -> ()) ~abs_env:env env loc
+    path decl to_check;
   check_regularity ~abs_env:env env loc path decl to_check;
   (* additional coherence check, as one might build an incoherent signature,
      and use it to build an incoherent module, cf. #7851 *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2671,31 +2671,28 @@ let update_decls_jkind_reason decls =
    unboxed-contains, rather than the dummy [any] jkinds assigned in
    [transl_declaration]. See Note [Default jkinds in transl_declaration]. *)
 let update_decls_jkind env order decls =
-  let process env id decl =
-    Builtin_attributes.warning_scope decl.type_attributes (fun () ->
-      let allow_any_crossing =
-        Builtin_attributes.has_unsafe_allow_any_mode_crossing
-          decl.type_attributes
-      in
-
-      (* Check that the attribute is valid, if set (unconditionally, for
-         consistency). *)
-      if allow_any_crossing then begin
-        match decl.type_kind with
-        | Type_abstract _ | Type_open ->
-          raise(Error(
-            decl.type_loc, Unsafe_mode_crossing_on_invalid_type_kind))
-        | _ -> ()
-      end;
-
-      update_decl_jkind env (Pident id) decl, allow_any_crossing)
-  in
   let decls_by_id = Ident.Map.of_list decls in
   let _env, results =
     List.fold_left
       (fun (env, results) id ->
          let decl = Ident.Map.find id decls_by_id in
-         let new_decl, allow_any_crossing = process env id decl in
+         let new_decl, allow_any_crossing =
+           Builtin_attributes.warning_scope decl.type_attributes (fun () ->
+             let allow_any_crossing =
+               Builtin_attributes.has_unsafe_allow_any_mode_crossing
+                 decl.type_attributes
+             in
+             (* Check that the attribute is valid, if set (unconditionally, for
+               consistency). *)
+             if allow_any_crossing then begin
+               match decl.type_kind with
+               | Type_abstract _ | Type_open ->
+                 raise(Error(
+                   decl.type_loc, Unsafe_mode_crossing_on_invalid_type_kind))
+               | _ -> ()
+             end;
+             update_decl_jkind env (Pident id) decl, allow_any_crossing)
+         in
          let env = add_type ~check:false id new_decl env in
          env, Ident.Map.add id (decl, allow_any_crossing, new_decl) results)
       (env, Ident.Map.empty) order


### PR DESCRIPTION
Determine the jkinds of declarations in a recursive group in a topological order, such that the jkinds in all declarations contained without indirection by a particular declaration are computed before that declaration.

This fixes two issues:
1. Some declarations get variable representations when they shouldn't (exercising the codepaths from #5461), meaning their representations are computed per type expression rather than per declaration. (And this codepath currently results in fewer optimizations.)
2. This also fixes various mutually recursive types that previously failed to typecheck. (See CRs removed in tests.)

**Ordering.**
We visit declarations in topologial order for the graph where there is an edge from decl `a` to `b` if either `a` or `a#` is contained in `b` without indirection. E.g., there is an `a->b` edge for the following:
```ocaml
type a = #{ x : int; y : int }
and b = #{ a : a; other : string}
```