### PR TITLE
Add -alias flag to add a hidden persistent-module alias

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -81,6 +81,16 @@ let mk_cmi_file f =
   "-cmi-file", Arg.String f,
     "<file>  Use the <file> interface file to type-check"
 
+let mk_alias f =
+  let from = ref "" in
+  "-alias",
+    Arg.Tuple [
+      Arg.String (fun s -> from := s);
+      Arg.String (fun s -> f !from s);
+    ],
+    "<from> <to>  Add a hidden alias module <from> = <to> to the unit\n\
+    \     (may be given multiple times)"
+
 let mk_compact f =
   "-compact", Arg.Unit f, " Optimize code size rather than speed"
 
@@ -1201,6 +1211,7 @@ module type Compiler_options = sig
   val _cclib : string -> unit
   val _ccopt : string -> unit
   val _cmi_file : string -> unit
+  val _alias : string -> string -> unit
   val _config : unit -> unit
   val _config_var : string -> unit
   val _for_pack : string -> unit
@@ -1453,6 +1464,7 @@ struct
     mk_cclib F._cclib;
     mk_ccopt F._ccopt;
     mk_cmi_file F._cmi_file;
+    mk_alias F._alias;
     mk_color F._color;
     mk_error_style F._error_style;
     mk_compat_32 F._compat_32;
@@ -1709,6 +1721,7 @@ struct
     mk_cclib F._cclib;
     mk_ccopt F._ccopt;
     mk_cmi_file F._cmi_file;
+    mk_alias F._alias;
     mk_clambda_checks F._clambda_checks;
     mk_classic_inlining F._classic_inlining;
     mk_color F._color;
@@ -2051,6 +2064,7 @@ struct
     mk_ccopt F._ccopt;
     mk_classic_inlining F._classic_inlining;
     mk_cmi_file F._cmi_file;
+    mk_alias F._alias;
     mk_color F._color;
     mk_error_style F._error_style;
     mk_config F._config;
@@ -2513,6 +2527,8 @@ module Default = struct
     let _cclib s = Compenv.defer (ProcessObjects (Misc.rev_split_words s))
     let _ccopt s = Compenv.first_ccopts := (s :: (!Compenv.first_ccopts))
     let _cmi_file s = cmi_file := (Some s)
+    let _alias from to_ =
+      module_aliases := (!module_aliases @ [from, to_])
     let _config = Misc.show_config_and_exit
     let _config_var = Misc.show_config_variable_and_exit
     let _dprofile () = profile_columns := Profile.all_columns

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -111,6 +111,7 @@ module type Compiler_options = sig
   val _cclib : string -> unit
   val _ccopt : string -> unit
   val _cmi_file : string -> unit
+  val _alias : string -> string -> unit
   val _config : unit -> unit
   val _config_var : string -> unit
   val _for_pack : string -> unit

--- a/testsuite/tests/alias/alias_i.ocamlc.reference
+++ b/testsuite/tests/alias/alias_i.ocamlc.reference
@@ -1,0 +1,1 @@
+val y : Foo.t

--- a/testsuite/tests/alias/carrier.ml
+++ b/testsuite/tests/alias/carrier.ml
@@ -1,0 +1,4 @@
+(* Compiled with [-alias Foo Bar]: its .cmi records a hidden [module Foo = Bar]
+   even though [Foo] is unused here. A unit that [include]s [Carrier] then
+   inherits that hidden alias. *)
+let c = ()

--- a/testsuite/tests/alias/collide.ml
+++ b/testsuite/tests/alias/collide.ml
@@ -1,0 +1,13 @@
+(* The unit defines its own [Foo] -- a generative functor, unlike the plain
+   module [Bar] that [-alias Foo Bar] points at. The real [Foo] must shadow the
+   injected alias both in the environment ([Foo ()] below instantiates the
+   functor) and in the unit's signature: previously the two same-named
+   components both reached the inclusion check, which failed with "modules do
+   not match" (a generative functor is not included in the alias target). *)
+module Foo () = struct
+  let here = ()
+end
+
+module Inst = Foo ()
+
+let _ = Inst.here

--- a/testsuite/tests/alias/collide_consumer.ml
+++ b/testsuite/tests/alias/collide_consumer.ml
@@ -1,0 +1,7 @@
+(* Without [-alias]: [Collide.Foo] must resolve to the unit's own generative
+   functor -- the visible component wins over the hidden [module Foo = Bar]
+   alias recorded in [collide.cmi] -- so it can be applied. Were it to resolve
+   to [Bar] (a plain module), the application below would be rejected. *)
+module I = Collide.Foo ()
+
+let _ = I.here

--- a/testsuite/tests/alias/consumer.ml
+++ b/testsuite/tests/alias/consumer.ml
@@ -1,0 +1,4 @@
+(* Compiled WITHOUT [-alias]: this type-checks because [use_foo.cmi] carries a
+   hidden [module Foo = Bar] alias, so [Use_foo.y : Foo.t] resolves to
+   [Bar.t]. *)
+let z : Bar.t = Use_foo.y

--- a/testsuite/tests/alias/consumer_mli.ml
+++ b/testsuite/tests/alias/consumer_mli.ml
@@ -1,0 +1,3 @@
+(* No [-alias]: resolves [Withmli.w : Foo.t] to [Bar.t] through the hidden
+   alias recorded in withmli.cmi. *)
+let zz : Bar.t = Withmli.w

--- a/testsuite/tests/alias/dup_alias.ml
+++ b/testsuite/tests/alias/dup_alias.ml
@@ -1,0 +1,3 @@
+(* [-alias Foo Bar -alias Foo Baz]: the later alias shadows the earlier one, so
+   [Foo] resolves to [Baz]. [Foo.only_baz] exists only in [Baz]. *)
+let y = Foo.only_baz

--- a/testsuite/tests/alias/dup_real.ml
+++ b/testsuite/tests/alias/dup_real.ml
@@ -1,0 +1,5 @@
+(* Two real modules of the same name still clash, even alongside [-alias Foo
+   Bar]: letting hidden aliases coexist must not weaken uniqueness of visible
+   components. *)
+module M = struct end
+module M = struct end

--- a/testsuite/tests/alias/leak.ml
+++ b/testsuite/tests/alias/leak.ml
@@ -1,0 +1,7 @@
+(* Defines its own [Foo] and [include]s [Carrier], whose .cmi carries a hidden
+   [module Foo = Bar]. The included hidden alias must coexist with this unit's
+   own [Foo] -- it must not clash ("Multiple definition of Foo") nor break the
+   signature inclusion check. *)
+module Foo = Bar
+include Carrier
+let _ = c

--- a/testsuite/tests/alias/leak_consumer.ml
+++ b/testsuite/tests/alias/leak_consumer.ml
@@ -1,0 +1,4 @@
+(* No [-alias]: resolves the included value and [Leak.Foo.x] through the
+   signature recorded in [leak.cmi]. *)
+let _ = Leak.c
+let _ : Bar.t = Leak.Foo.x

--- a/testsuite/tests/alias/lib/bar.ml
+++ b/testsuite/tests/alias/lib/bar.ml
@@ -1,0 +1,3 @@
+type t = T
+
+let x = T

--- a/testsuite/tests/alias/lib/baz.ml
+++ b/testsuite/tests/alias/lib/baz.ml
@@ -1,0 +1,5 @@
+type t = T
+
+let x = T
+
+let only_baz = T

--- a/testsuite/tests/alias/test.ml
+++ b/testsuite/tests/alias/test.ml
@@ -1,0 +1,135 @@
+(* TEST
+(* Tests the -alias flag.
+
+   [-alias <from> <to>] adds a hidden [module <from> = <to>] alias to the
+   compiled unit, so the source may refer to [<from>] as the persistent
+   module [<to>]. The alias is hidden: it is recorded in the .cmi (so a
+   consumer can resolve types that mention [<from>]) but omitted from the
+   interface printed by [-i].
+
+   Module [Bar] (in subdirectory [lib]) plays the role of [<to>]; the source
+   refers to a module [Foo] that only exists via [-alias Foo Bar]. *)
+
+ subdirectories = "lib";
+ readonly_files =
+   "use_foo.ml consumer.ml withmli.mli withmli.ml consumer_mli.ml \
+    collide.ml collide_consumer.ml dup_alias.ml \
+    carrier.ml leak.ml leak_consumer.ml dup_real.ml";
+
+ setup-ocamlc.byte-build-env;
+ flags = "-nostdlib -nopervasives -I lib";
+ module = "lib/bar.ml";
+ ocamlc.byte;
+
+ (* [-alias Foo Bar] lets [use_foo.ml] refer to [Foo]. *)
+ flags = "-nostdlib -nopervasives -I lib -alias Foo Bar";
+ module = "use_foo.ml";
+ ocamlc.byte;
+
+ (* A consumer compiled WITHOUT -alias still resolves [Use_foo.y], because the
+    hidden [module Foo = Bar] recorded in [use_foo.cmi] makes [Foo.t] resolve
+    to [Bar.t]. *)
+ flags = "-nostdlib -nopervasives -I lib";
+ module = "consumer.ml";
+ ocamlc.byte;
+
+ {
+   (* [-i] under [-alias] prints [val y : Foo.t] but omits the hidden
+      [module Foo = Bar] declaration. *)
+   setup-ocamlc.byte-build-env;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "lib/bar.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib -alias Foo Bar -i";
+   module = "use_foo.ml";
+   ocamlc.byte;
+   compiler_reference = "${test_source_directory}/alias_i.ocamlc.reference";
+   check-ocamlc.byte-output;
+ }{
+   (* Without -alias, [Foo] is unbound. *)
+   setup-ocamlc.byte-build-env;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "lib/bar.ml";
+   ocamlc.byte;
+   module = "use_foo.ml";
+   ocamlc_byte_exit_status = "2";
+   ocamlc.byte;
+   compiler_reference =
+     "${test_source_directory}/unbound_foo.ocamlc.reference";
+   check-ocamlc.byte-output;
+ }{
+   (* Separate .mli and .ml, both compiled with -alias: the alias resolves on
+      both sides, and the implementation matches the interface (the aliases
+      injected into each must denote the same module). A consumer then resolves
+      [Withmli.w] without any flag. *)
+   setup-ocamlc.byte-build-env;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "lib/bar.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib -alias Foo Bar";
+   module = "withmli.mli";
+   ocamlc.byte;
+   module = "withmli.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "consumer_mli.ml";
+   ocamlc.byte;
+ }{
+   (* The unit defines its own [Foo], colliding by name with [-alias Foo Bar].
+      The real [Foo] shadows the injected alias instead of leaving a duplicate-
+      named signature, so this compiles cleanly. *)
+   setup-ocamlc.byte-build-env;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "lib/bar.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib -alias Foo Bar";
+   module = "collide.ml";
+   ocamlc.byte;
+   (* A consumer (no -alias) sees [Collide.Foo] as the unit's own generative
+      functor -- the visible component wins over the hidden alias. *)
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "collide_consumer.ml";
+   ocamlc.byte;
+ }{
+   (* Repeated [-alias] for the same name: the last one wins, so [Foo] resolves
+      to [Baz] and [Foo.only_baz] (present only in [Baz]) type-checks. *)
+   setup-ocamlc.byte-build-env;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "lib/bar.ml";
+   ocamlc.byte;
+   module = "lib/baz.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib -alias Foo Bar -alias Foo Baz";
+   module = "dup_alias.ml";
+   ocamlc.byte;
+ }{
+   (* [Carrier], compiled with [-alias Foo Bar], records a hidden
+      [module Foo = Bar] in its .cmi. [leak.ml] [include]s [Carrier] -- so it
+      inherits that hidden alias -- and also defines its own [Foo]. The two
+      must coexist (no "Multiple definition", no broken inclusion check). A
+      consumer then resolves both the included value and [Leak.Foo.x]. *)
+   setup-ocamlc.byte-build-env;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "lib/bar.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib -alias Foo Bar";
+   module = "carrier.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "leak.ml";
+   ocamlc.byte;
+   module = "leak_consumer.ml";
+   ocamlc.byte;
+ }{
+   (* Two real modules of the same name still clash, even with [-alias]: hidden
+      aliases coexisting must not weaken uniqueness of visible components. *)
+   setup-ocamlc.byte-build-env;
+   flags = "-nostdlib -nopervasives -I lib";
+   module = "lib/bar.ml";
+   ocamlc.byte;
+   flags = "-nostdlib -nopervasives -I lib -alias Foo Bar";
+   module = "dup_real.ml";
+   ocamlc_byte_exit_status = "2";
+   ocamlc.byte;
+ }
+*)

--- a/testsuite/tests/alias/unbound_foo.ocamlc.reference
+++ b/testsuite/tests/alias/unbound_foo.ocamlc.reference
@@ -1,0 +1,4 @@
+File "use_foo.ml", line 2, characters 8-13:
+2 | let y = Foo.x
+            ^^^^^
+Error: Unbound module "Foo"

--- a/testsuite/tests/alias/use_foo.ml
+++ b/testsuite/tests/alias/use_foo.ml
@@ -1,0 +1,2 @@
+(* Refers to module [Foo], resolvable only via [-alias Foo Bar]. *)
+let y = Foo.x

--- a/testsuite/tests/alias/withmli.ml
+++ b/testsuite/tests/alias/withmli.ml
@@ -1,0 +1,4 @@
+(* References [Foo], resolved via [-alias Foo Bar]; checked against withmli.mli,
+   which was also compiled with -alias. The aliases injected into the .mli and
+   the .ml must resolve to the same module so the implementation matches. *)
+let w = Foo.x

--- a/testsuite/tests/alias/withmli.mli
+++ b/testsuite/tests/alias/withmli.mli
@@ -1,0 +1,2 @@
+(* References [Foo], resolved via [-alias Foo Bar] when compiling this .mli. *)
+val w : Foo.t

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2245,9 +2245,29 @@ let prefix_idents root prefixing_sub sg =
         rem
     | Sig_module(id, pres, md, rs, vis) :: rem ->
       let p = Pdot(root, Ident.name id) in
+      (* A [Hidden] module alias (a [-alias] declaration, possibly inherited
+         through an [include]) is redirected to its target rather than to
+         [root.name]: references to it then record the target path, so the
+         alias name is never needed and it claims no component-table slot (see
+         [add_comp]). The target is always a *persistent* module (see
+         [module_aliases_sig_and_env]) -- never another local alias of this
+         same signature -- so a single substitution suffices; there is no local
+         alias chain to chase down transitively. *)
+      let sub =
+        match vis, md.md_type with
+        | Hidden, Mty_alias target ->
+          (match target with
+           | Pident tid when Ident.is_global tid -> ()
+           | _ ->
+             Misc.fatal_error
+               "Env.prefix_idents: hidden module alias target is not \
+                persistent");
+          Subst.add_module id target prefixing_sub
+        | _ -> Subst.add_module id p prefixing_sub
+      in
       prefix_idents root
         ((Sig_module(id, pres, md, rs, vis), p) :: items_and_paths)
-        (Subst.add_module id p prefixing_sub)
+        sub
         rem
     | Sig_modtype(id, mtd, vis) :: rem ->
       let p = Pdot(root, Ident.name id) in
@@ -2355,7 +2375,25 @@ let rec components_of_module_maker
         incr pos;
         Lazy_backtrack.create addr
       in
+      (* Register a component under its name. [Hidden] components (e.g.
+         [-alias] declarations) take no name-keyed slot at all -- they are not
+         reachable by qualified access ([M.Foo]) nor by [open]. Internal
+         references to a hidden alias are redirected to its target by
+         [prefix_idents] (see the [Sig_module] case there), so they need no
+         name-keyed slot. *)
+      let add_comp add (vis : visibility) name data tbl =
+        match vis with
+        | Exported -> add name data tbl
+        | Hidden -> tbl
+      in
       List.iter (fun ((item : Subst.Lazy.signature_item), path) ->
+        let vis =
+          match item with
+          | Sig_value (_, _, vis) | Sig_type (_, _, _, vis)
+          | Sig_typext (_, _, _, vis) | Sig_module (_, _, _, _, vis)
+          | Sig_modtype (_, _, vis) | Sig_class (_, _, _, vis)
+          | Sig_class_type (_, _, _, vis) | Sig_jkind (_, _, vis) -> vis
+        in
         match item with
           Sig_value(id, decl, _) ->
             let decl' = Subst.Lazy.value_description sub decl in
@@ -2373,7 +2411,8 @@ let rec components_of_module_maker
               { vda_description = decl'; vda_address = addr;
                 vda_mode = cm_mode; vda_shape }
             in
-            c.comp_values <- NameMap.add (Ident.name id) vda c.comp_values;
+            c.comp_values <-
+              add_comp NameMap.add vis (Ident.name id) vda c.comp_values;
         | Sig_type(id, decl, _, _) ->
             let final_decl = Subst.type_declaration sub decl in
             Btype.set_static_row_name final_decl
@@ -2394,7 +2433,8 @@ let rec components_of_module_maker
                         cda_shape }
                       in
                       c.comp_constrs <-
-                        add_to_tbl descr.cstr_name cda c.comp_constrs
+                        add_comp add_to_tbl vis descr.cstr_name cda
+                          c.comp_constrs
                     ) cstrs;
                  Type_variant (cstrs, repr, umc)
               | Type_record (_, repr, umc) ->
@@ -2404,7 +2444,8 @@ let rec components_of_module_maker
                   List.iter
                     (fun descr ->
                       c.comp_labels <-
-                        add_to_tbl descr.lbl_name descr c.comp_labels)
+                        add_comp add_to_tbl vis descr.lbl_name descr
+                          c.comp_labels)
                     lbls;
                   Type_record (lbls, repr, umc)
               | Type_record_unboxed_product (_, repr, umc) ->
@@ -2414,7 +2455,8 @@ let rec components_of_module_maker
                   List.iter
                     (fun descr ->
                       c.comp_unboxed_labels <-
-                        add_to_tbl descr.lbl_name descr c.comp_unboxed_labels)
+                        add_comp add_to_tbl vis descr.lbl_name descr
+                          c.comp_unboxed_labels)
                     lbls;
                   Type_record_unboxed_product (lbls, repr, umc)
               | Type_abstract r -> Type_abstract r
@@ -2432,7 +2474,8 @@ let rec components_of_module_maker
                 tda_shape = shape;
                 tda_unboxed_version_descriptions = unboxed_descrs }
             in
-            c.comp_types <- NameMap.add (Ident.name id) tda c.comp_types;
+            c.comp_types <-
+              add_comp NameMap.add vis (Ident.name id) tda c.comp_types;
             env := store_type_infos ~tda_shape:shape id decl !env
         | Sig_typext(id, ext, _, _) ->
             let ext' = Subst.extension_constructor sub ext in
@@ -2447,7 +2490,8 @@ let rec components_of_module_maker
             let cda =
               { cda_description = descr; cda_address = Some addr; cda_shape }
             in
-            c.comp_constrs <- add_to_tbl (Ident.name id) cda c.comp_constrs
+            c.comp_constrs <-
+              add_comp add_to_tbl vis (Ident.name id) cda c.comp_constrs
         | Sig_module(id, pres, md, _, _) ->
             let md, mode = Normalize_mode.md Normalize_exn md cm_mode in
             let md' =
@@ -2482,7 +2526,7 @@ let rec components_of_module_maker
                 mda_shape = shape; }
             in
             c.comp_modules <-
-              NameMap.add (Ident.name id) mda c.comp_modules;
+              add_comp NameMap.add vis (Ident.name id) mda c.comp_modules;
             env :=
               store_module ~update_summary:false ~check:None
                 id addr pres md mode shape locks_empty !env
@@ -2499,7 +2543,7 @@ let rec components_of_module_maker
                 mtda_shape = shape; }
             in
             c.comp_modtypes <-
-              NameMap.add (Ident.name id) mtda c.comp_modtypes;
+              add_comp NameMap.add vis (Ident.name id) mtda c.comp_modtypes;
             env := store_modtype ~update_summary:false id decl shape !env
         | Sig_class(id, decl, _, _) ->
             let decl' = Subst.class_declaration sub decl in
@@ -2510,18 +2554,20 @@ let rec components_of_module_maker
                 clda_address = addr;
                 clda_shape = shape; }
             in
-            c.comp_classes <- NameMap.add (Ident.name id) clda c.comp_classes
+            c.comp_classes <-
+              add_comp NameMap.add vis (Ident.name id) clda c.comp_classes
         | Sig_class_type(id, decl, _, _) ->
             let decl' = Subst.cltype_declaration sub decl in
             let shape = Shape.proj cm_shape (Shape.Item.class_type id) in
             let cltda = { cltda_declaration = decl'; cltda_shape = shape } in
             c.comp_cltypes <-
-              NameMap.add (Ident.name id) cltda c.comp_cltypes
+              add_comp NameMap.add vis (Ident.name id) cltda c.comp_cltypes
         | Sig_jkind(id, decl, _) ->
             let decl' = Subst.jkind_declaration sub decl in
             let shape = Shape.proj cm_shape (Shape.Item.jkind id) in
             let jkda = { jkda_declaration = decl'; jkda_shape = shape } in
-            c.comp_jkinds <- NameMap.add (Ident.name id) jkda c.comp_jkinds
+            c.comp_jkinds <-
+              add_comp NameMap.add vis (Ident.name id) jkda c.comp_jkinds
       )
         items_and_paths;
         Ok (Structure_comps c)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1295,6 +1295,15 @@ let find_pers_mod ~allow_hidden name ~allow_excess_args =
 let check_pers_mod ~allow_hidden ~loc name =
   Persistent_env.check ~allow_hidden !persistent_env read_sign_of_cmi ~loc name
 
+(* Register the target of a [-alias] declaration among this unit's globals.
+   References to the alias are redirected to this target (see [prefix_idents]),
+   so the target must be recorded (in [cmi_globals]/imports) for a consumer to
+   resolve and substitute it. This records an import and an approximate global
+   without loading the target's cmi -- the target may not exist yet (e.g. a
+   self-reference, or a sibling built later). *)
+let register_alias_target name =
+  check_pers_mod ~allow_hidden:true ~loc:Location.none name
+
 let crc_of_unit name =
   Persistent_env.crc_of_unit !persistent_env name
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -642,6 +642,12 @@ val is_imported_opaque: Compilation_unit.Name.t -> bool
 (* [register_import_as_opaque md] registers [md] as an opaque imported module *)
 val register_import_as_opaque: Compilation_unit.Name.t -> unit
 
+(* [register_alias_target name] records the target of a [-alias] declaration
+   among this unit's globals (imports and [cmi_globals]) so that references
+   redirected to it resolve and substitute correctly in a consumer. The
+   target's cmi is not loaded, so the target need not exist yet. *)
+val register_alias_target: Global_module.Name.t -> unit
+
 (* [is_parameter_unit md] returns true if [md] was compiled with
    -as-parameter *)
 val is_parameter_unit: Global_module.Name.t -> bool

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -491,6 +491,17 @@ let pair_components subst sig1_comps sig2 =
   let rec pair subst paired unpaired = function
     | [] ->
       paired, unpaired, subst
+  | item2 :: rem when item_visibility item2 = Hidden ->
+      (* A [Hidden] item is identified only by ident, never by name, so it
+         takes no part in the (name-based) inclusion pairing. The [-alias]
+         declarations that produce such items are non-runtime ([Mp_absent]); a
+         runtime [Hidden] item would occupy a coercion slot we'd need to
+         preserve, which isn't handled here -- it shouldn't reach this point
+         (target signatures are post-[simplify]), so fail loudly if it does. *)
+      if is_runtime_component item2 then
+        Misc.fatal_error
+          "Includemod.pair_components: unexpected runtime hidden component";
+      pair subst paired unpaired rem
   | item2 :: rem ->
       let (id2, _loc, name2) = item_ident_name item2 in
       let name2, report =
@@ -878,7 +889,12 @@ and signatures ~direction ~loc env subst ~modes sig1 sig2 mod_shape =
   let sig1 = force_signature_once sig1 in
   let sig2 = force_signature_once sig2 in
   let new_env =
-    Env.add_signature_lazy sig1 (Env.in_signature true env) in
+    (* [sig2]'s [Hidden] items (e.g. [-alias] declarations) take no part in the
+       name-based pairing, but [sig2]'s visible components may still mention
+       them by ident (e.g. [val w : Foo.t] where [Foo] is hidden). Add them to
+       the environment so such references resolve. *)
+    let hidden_sig2 = List.filter (fun i -> item_visibility i = Hidden) sig2 in
+    Env.add_signature_lazy (sig1 @ hidden_sig2) (Env.in_signature true env) in
   (* Keep ids for module aliases *)
   let (id_pos_list,_) =
     List.fold_left

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -2913,13 +2913,26 @@ and tree_of_signature_rec ?abbrev ?max_items env' sg =
 and trees_of_recursive_sigitem_group ?abbrev env
     (syntactic_group: Signature_group.rec_group) =
   let display (x:Signature_group.sig_item) = x.src, tree_of_sigitem ?abbrev x.src in
+  (* [Hidden] items (e.g. shadowed bindings, or the alias added by [-alias])
+     are not part of the printed interface. They stay in the environment so
+     that references to them still resolve, but are not displayed. *)
+  let is_hidden (x : Signature_group.sig_item) =
+    match x.Signature_group.src with
+    | Sig_value (_, _, Hidden) | Sig_type (_, _, _, Hidden)
+    | Sig_typext (_, _, _, Hidden) | Sig_module (_, _, _, _, Hidden)
+    | Sig_modtype (_, _, Hidden) | Sig_class (_, _, _, Hidden)
+    | Sig_class_type (_, _, _, Hidden) | Sig_jkind (_, _, Hidden) -> true
+    | _ -> false
+  in
+  let display_visible x = if is_hidden x then [] else [display x] in
   let env = Env.add_signature syntactic_group.pre_ghosts env in
   match syntactic_group.group with
-  | Not_rec x -> add_sigitem env x, [display x]
+  | Not_rec x -> add_sigitem env x, display_visible x
   | Rec_group items ->
       let ids = List.map (fun x -> ident_sigitem x.Signature_group.src) items in
       List.fold_left add_sigitem env items,
-      with_hidden_items ids (fun () -> List.map display items)
+      with_hidden_items ids
+        (fun () -> List.concat_map display_visible items)
 
 and tree_of_sigitem ?abbrev = function
   | Sig_value(id, decl, _) ->

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -1893,10 +1893,19 @@ end = struct
 
   let check_sig_item ?info names loc (item:Signature_group.rec_group) =
     let check ?info names loc item =
-      let all = List.map classify (Signature_group.flatten item) in
+      let items = Signature_group.flatten item in
+      let all = List.map classify items in
       let group = List.map snd all in
-      List.iter (fun (kind,id) -> check_item ?info names loc kind id group)
-        all
+      List.iter2 (fun sig_item (kind,id) ->
+          match info, Types.item_visibility sig_item with
+          | None, Hidden ->
+              (* A [Hidden] item (e.g. a [-alias] declaration carried in an
+                 included module's signature) is identified only by ident, never
+                 by name, so it takes no part in the (name-based) uniqueness
+                 check: leave it to coexist with any same-named component. *)
+              ()
+          | _ -> check_item ?info names loc kind id group)
+        items all
     in
     (* we can ignore x.pre_ghosts: they are eliminated by strengthening, and
        thus never appear in includes *)
@@ -4393,6 +4402,36 @@ let check_argument_type_if_given env sourcefile ~actual_staticity actual_sig
              ai_coercion_from_primary = coercion;
            }
 
+(* [-alias <from> <to>] adds a [module from = to] alias to the unit being
+   compiled: the source may refer to [from] as the persistent module [to]. The
+   alias is added both to [env] (so the rest of the structure/signature type-
+   checks) and, as a [Hidden] item, to the outcome signature (so it is recorded
+   in the .cmi for consumers but omitted from the printed interface). It has no
+   runtime presence ([Mp_absent]). Returns the [Hidden] items (in reverse
+   order, ready to [List.rev_append] onto the inferred signature) and the
+   augmented environment. *)
+let module_aliases_sig_and_env env =
+  List.fold_left
+    (fun (items, env) (from_, to_) ->
+       let id = Ident.create_local from_ in
+       let to_path =
+         Pident (Ident.create_global (Global_module.Name.create_no_args to_))
+       in
+       let md =
+         { md_type = Mty_alias to_path;
+           md_modalities = Mode.Modality.(Const.id |> of_const);
+           md_attributes = [];
+           md_loc = Location.none;
+           md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
+         }
+       in
+       let env =
+         Env.add_module_declaration ~check:false id Mp_absent md
+           ~mode:Value.legacy env
+       in
+       (Sig_module (id, Mp_absent, md, Trec_not, Hidden) :: items, env))
+    ([], env) !Clflags.module_aliases
+
 let type_implementation target modulename initial_env ast =
   let sourcefile = Unit_info.original_source_file target in
   let error e =
@@ -4419,9 +4458,13 @@ let type_implementation target modulename initial_env ast =
         ignore @@ Warnings.parse_options false "-32-34-37-38-60-191";
       if !Clflags.as_parameter then
         error Cannot_compile_implementation_as_parameter;
-      let (str, sg, mode, names, shape, finalenv) =
-        Profile.record_call "infer" (fun () -> type_structure initial_env ast)
+      let alias_sig_items, alias_env =
+        module_aliases_sig_and_env initial_env
       in
+      let (str, sg, mode, names, shape, finalenv) =
+        Profile.record_call "infer" (fun () -> type_structure alias_env ast)
+      in
+      let sg = List.rev_append alias_sig_items sg in
       Value.submode_err (Location.in_file sourcefile, Structure)
         mode (Env.mode_unit ~staticity:Staticity.Dynamic);
       let uid = Uid.of_compilation_unit_id modulename in
@@ -4639,7 +4682,11 @@ let type_interface ~sourcefile modulename env ast =
     let uid = Shape.Uid.of_compilation_unit_id modulename in
     cms_register_toplevel_signature_attributes ~uid ~sourcefile ast
   end;
-  let sg = transl_signature env ast in
+  let alias_sig_items, alias_env = module_aliases_sig_and_env env in
+  let sg = transl_signature alias_env ast in
+  let sg =
+    { sg with sig_type = List.rev_append alias_sig_items sg.sig_type }
+  in
   let arg_type =
     !Clflags.as_argument_for
     |> Option.map Global_module.Parameter_name.of_string

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -4414,9 +4414,11 @@ let module_aliases_sig_and_env env =
   List.fold_left
     (fun (items, env) (from_, to_) ->
        let id = Ident.create_local from_ in
-       let to_path =
-         Pident (Ident.create_global (Global_module.Name.create_no_args to_))
-       in
+       let to_name = Global_module.Name.create_no_args to_ in
+       (* Record [to_] among the unit's globals so references redirected to it
+          (see [Env.prefix_idents]) resolve in a consumer's [cmi_globals]. *)
+       Env.register_alias_target to_name;
+       let to_path = Pident (Ident.create_global to_name) in
        let md =
          { md_type = Mty_alias to_path;
            md_modalities = Mode.Modality.(Const.id |> of_const);

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -44,6 +44,11 @@ and dllibs = ref ([] : string list)     (* .so and -dllib -lxxx *)
 
 let cmi_file = ref None
 
+(* Module aliases [(from, to)], one per [-alias <from> <to>] flag: a hidden
+   declaration [module from = to] is added to the compiled unit, so its source
+   may refer to [from] as the persistent module [to]. *)
+let module_aliases = ref ([] : (string * string) list)
+
 type profile_column = [ `Time | `Alloc | `Top_heap | `Abs_top_heap | `Counters ]
 type profile_granularity_level = File_level | Function_level | Block_level
 type flambda_invariant_checks = No_checks | Light_checks | Heavy_checks

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -79,6 +79,7 @@ val objfiles : string list ref
 val ccobjs : string list ref
 val dllibs : string list ref
 val cmi_file : string option ref
+val module_aliases : (string * string) list ref
 val compile_only : bool ref
 val output_name : string option ref
 val include_dirs : visible_include list ref


### PR DESCRIPTION
`-alias <from> <to>` adds a hidden `module from = to` alias to the unit being compiled, so its source may refer to `from` as the persistent module `to`. The alias is recorded in the `.cmi` (so consumers can resolve types that mention `from`) but omitted from the printed interface, and has no runtime presence (`Mp_absent`).

The alias items are plainly prepended to the inferred signature. The guiding principle is that a `Hidden` item is identified by its ident, never by its string name, so name-based machinery treats it specially:

- `Signature_names.check_sig_item` does not police a `Hidden` item carried in via `include` for name uniqueness, so a same-named real component (or an alias inherited from an included `.cmi`) coexists instead of raising `Repeated_name`.
- `Includemod.pair_components` skips `Hidden` (non-runtime) items — they are never matched by name in the inclusion check — and `Includemod.signatures` adds the interface's `Hidden` items to the inclusion environment so visible components that mention them by ident (e.g. `val w : Foo.t`) still resolve.
- `Env.prefix_idents` redirects a `Hidden` module alias to its target rather than to `root.name`, so references record the canonical target path; a consumer thus resolves `from` to `to`'s type. The target is always a persistent module (asserted), never another local alias, so a single substitution pass suffices — there is no alias chain to chase.
- `Env.components_of_module_maker` gives a `Hidden` item no name-keyed slot at all: hidden is hidden, reachable neither by qualified access (`M.Foo`) nor by `open`. Internal references are handled by the `prefix_idents` redirect above, so no slot is needed.
