### PR TITLE
Revert "Revert "[5.4] Preserve the frame pointer register at noalloc C calls""

### DIFF
--- a/backend/arm64/dsl_helpers.ml
+++ b/backend/arm64/dsl_helpers.ml
@@ -272,6 +272,9 @@ let reg_x reg =
     Misc.fatal_errorf "reg_x: expected integer register, got %a" Printreg.reg
       reg
 
+let gp_x_dwarf_encoding (op : gp_x) : int =
+  match op with Ast.Operand.Reg r -> Ast.Reg.gp_encoding r
+
 let reg_w reg =
   let index = reg_index reg in
   match reg.typ with

--- a/backend/arm64/dsl_helpers.mli
+++ b/backend/arm64/dsl_helpers.mli
@@ -67,6 +67,9 @@ val reg_w : Reg.t -> gp_w
 
 val reg_x : Reg.t -> gp_x
 
+(** DWARF register number for a GP-X operand for use in CFI directives. *)
+val gp_x_dwarf_encoding : gp_x -> int
+
 (** {1 Scalar FP/SIMD register operands} *)
 
 val reg_d : Reg.t -> scalar_d

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -293,6 +293,10 @@ let reg_stack_arg_begin = H.reg_x (phys_reg Int X20)
 
 let reg_stack_arg_end = H.reg_x (phys_reg Int X21)
 
+(* Callee-saved register used to store the OCaml stack pointer around a noalloc
+   external call. *)
+let reg_x_extcall_saved_sp = H.reg_x (phys_reg Int X19)
+
 (** Turn a Linear label into an assembly label. The section is checked against
     the section tracked by [D] when emitting label definitions. *)
 let label_to_asm_label (l : label) ~(section : Asm_targets.Asm_section.t) : L.t
@@ -1450,18 +1454,21 @@ let emit_instr env i =
       A.ins1 BL (runtime_function S.Predef.caml_c_call);
       record_frame env i.live (Dbg_other i.dbg))
     else (
-      (* Store OCaml stack pointer in the frame pointer register. No need to
-         store previous x29 because OCaml doesn't maintain frame pointers. *)
+      (* Store OCaml stack pointer in x19, a callee-save register that the C
+         call will preserve. We used to use x29 (frame pointer) here, but
+         caml_start_program leaves it pointing to its C stack for the unwinder,
+         so it can't be clobbered here. *)
       if Config.runtime5
       then (
-        A.ins_mov_from_sp ~dst:O.fp;
+        A.ins_mov_from_sp ~dst:reg_x_extcall_saved_sp;
         D.cfi_remember_state ();
-        D.cfi_def_cfa_register ~reg:(Int.to_string (R.gp_encoding R.fp));
+        D.cfi_def_cfa_register
+          ~reg:(Int.to_string (H.gp_x_dwarf_encoding reg_x_extcall_saved_sp));
         A.ins2 LDR reg_x_tmp1 (H.domainstate_field Domain_c_stack);
         A.ins_mov_to_sp ~src:reg_x_tmp1)
       else D.cfi_remember_state ();
       A.ins1 BL (symbol (Needs_reloc CALL26) (S.create_global func));
-      if Config.runtime5 then A.ins_mov_to_sp ~src:O.fp;
+      if Config.runtime5 then A.ins_mov_to_sp ~src:reg_x_extcall_saved_sp;
       D.cfi_restore_state ())
   | Lop (Stackoffset n) ->
     assert (n mod 16 = 0);

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -236,9 +236,9 @@ let domainstate_ptr_dwarf_register_number = 28
 (* Registers destroyed by operations *)
 
 let destroyed_at_c_noalloc_call =
-  (* x19-x28, d8-d15 preserved *)
+  (* x20-x28, d8-d15 preserved *)
   let int_regs_destroyed_at_c_noalloc_call =
-    Regs.[| X0;X1;X2;X3;X4;X5;X6;X7;X8;X9;X10;X11;X12;X13;X14;X15 |]
+    Regs.[| X0;X1;X2;X3;X4;X5;X6;X7;X8;X9;X10;X11;X12;X13;X14;X15;X19 |]
   in
   let float_regs_destroyed_at_c_noalloc_call =
     Regs.[|D0;D1;D2;D3;D4;D5;D6;D7;

--- a/testsuite/tests/native-debugger/macos-lldb-arm64.reference
+++ b/testsuite/tests/native-debugger/macos-lldb-arm64.reference
@@ -63,7 +63,12 @@ frame 2: meander`camlMeander__omain_1_code
 frame 3: meander`camlMeander__entry
 frame 4: meander`caml_program
 frame 5: meander`caml_start_program
-frame 6: meander`caml_program
+frame 6: meander`caml_startup_common
+frame 7: meander`caml_startup_exn
+frame 8: meander`caml_startup
+frame 9: meander`caml_main
+frame 10: meander`main
+frame 11: dyld`start
 (lldb) continue
 Process XXXX resuming
 Process XXXX stopped
@@ -89,5 +94,10 @@ frame 6: meander`camlMeander__omain_1_code
 frame 7: meander`camlMeander__entry
 frame 8: meander`caml_program
 frame 9: meander`caml_start_program
-frame 10: meander`caml_program
+frame 10: meander`caml_startup_common
+frame 11: meander`caml_startup_exn
+frame 12: meander`caml_startup
+frame 13: meander`caml_main
+frame 14: meander`main
+frame 15: dyld`start
 (lldb) quit


### PR DESCRIPTION
This PR reapplies #6118. It is not ready to be merged, because it appears there is a bug that surfaces as a segfault in one of the arm tests. 