### PR TITLE
Fix or_null array segfault

### DIFF
--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1229,7 +1229,10 @@ let unary_primitive env res dbg f arg =
     ( None,
       res,
       C.ite
-        (C.and_int arg (C.int 1 ~dbg) dbg)
+        (C.or_int
+           (C.and_int arg (C.int 1 ~dbg) dbg)
+           (C.eq arg (C.int 0 ~dbg) ~dbg)
+           dbg)
         ~dbg ~then_:(C.int 0 ~dbg) ~then_dbg:dbg
         ~else_:(C.eq (C.get_tag arg dbg) (C.int Obj.double_tag ~dbg) ~dbg)
         ~else_dbg:dbg )

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -304,7 +304,7 @@ let unary_exn ~env ~res (f : Flambda_primitive.unary_primitive) x =
   | Project_value_slot { project_from = _; value_slot } ->
     check_my_closure ~env x;
     Some (To_jsir_env.get_value_slot_exn env value_slot), env, res
-  | Is_boxed_float -> check_tag ~env ~res x ~tag:Obj.double_tag
+  | Is_boxed_float -> use_prim' (Extern "caml_is_boxed_float")
   | Is_flat_float_array -> check_tag ~env ~res x ~tag:Obj.double_array_tag
   | End_region _ | End_try_region _ -> no_op ~env ~res
   | Get_header ->

--- a/testsuite/tests/typing-layouts-or-null/segfault.ml
+++ b/testsuite/tests/typing-layouts-or-null/segfault.ml
@@ -13,3 +13,12 @@ let () =
       | This _ -> assert false)
     Null
 ;;
+
+(* This covers [Null] through generic array creation; the dynamic float-array
+   check must not inspect a null header. *)
+let[@inline never] local_array x = [| x |]
+
+let () =
+  let x = local_array Null in
+  ignore (x : int or_null array)
+;;


### PR DESCRIPTION
`Is_boxed_float` is called on the first element of a generic array, and its cmm code generation wasn't updated for null pointers. Normally, all or-null arrays are statically known to not contain floats, but it's possible to to trigger the issue with insufficient inlining.