### PR TITLE
[DRAFT] Modes on val and module declarations in signatures

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -450,7 +450,7 @@ let mk_value_description ~val_type ~val_kind ~val_attributes =
   { val_type;
     val_kind;
     val_loc = Location.none;
-    val_modalities = Mode.Modality.(Const.id |> of_const);
+    val_modes = Types.Sig_item_modes.Modality Mode.Modality.(Const.id |> of_const);
     val_attributes;
     val_uid = Uid.internal_not_actually_unique;
     val_zero_alloc = Zero_alloc.default;

--- a/file_formats/cmi_format.ml
+++ b/file_formats/cmi_format.ml
@@ -111,7 +111,7 @@ let deserialize data =
     Subst.Lazy.{
       val_type;
       val_lpoly;
-      val_modalities = vd.val_modalities;
+      val_modes = vd.val_modes;
       val_kind = vd.val_kind;
       val_zero_alloc = vd.val_zero_alloc;
       val_attributes = vd.val_attributes;
@@ -146,7 +146,7 @@ let serialize oc base =
     Serialized.{
       val_type = marshal (vars, ty);
       val_lpoly = -1; (* invalid offset *)
-      val_modalities = vd.val_modalities;
+      val_modes = vd.val_modes;
       val_kind = vd.val_kind;
       val_zero_alloc = vd.val_zero_alloc;
       val_attributes = vd.val_attributes;

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -2031,7 +2031,7 @@ let build_substs update_env ?(freshen_bound_variables = false) s =
                to be [max] for conservative soundness. [new_env] is only used
                for printing in debugger. *)
             let vd = Env.find_value (Path.Pident id) old_env in
-            let vd = {vd with val_modalities = Mode.Modality.undefined} in
+            let vd = {vd with val_modes = Types.Sig_item_modes.Normalized} in
             let mode = Mode.Value.max |> Mode.Value.disallow_right in
             (vd, mode)
           in

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -476,10 +476,11 @@ end
 
 module Val = struct
   let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
-        ?(prim = []) ?(poly = false) ?(modalities=[]) name typ =
+        ?(prim = []) ?(poly = false) ?(modes=[]) ?(modalities=[]) name typ =
     {
      pval_poly = poly;
      pval_name = name;
+     pval_modes = modes;
      pval_type = typ;
      pval_attributes = add_docs_attrs docs attrs;
      pval_modalities = modalities;
@@ -489,10 +490,11 @@ module Val = struct
 end
 
 module Md = struct
-  let mk ?(loc = !default_loc) ?(attrs = [])
-        ?(docs = empty_docs) ?(text = []) ?(modalities=[]) name typ =
+  let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs) ?(text = [])
+        ?(modes=[]) ?(modalities=[]) name typ =
     {
      pmd_name = name;
+     pmd_modes = modes;
      pmd_type = typ;
      pmd_modalities = modalities;
      pmd_attributes =

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -241,7 +241,8 @@ module Exp:
 module Val:
   sig
     val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?prim:string list ->
-      ?poly:bool -> ?modalities:modality with_loc list -> str -> core_type ->
+      ?poly:bool -> ?modes:mode with_loc list ->
+      ?modalities:modality with_loc list -> str -> core_type ->
       value_description
   end
 
@@ -392,7 +393,8 @@ module Str:
 (** Module declarations *)
 module Md:
   sig
-    val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?text:text -> ?modalities:modalities ->
+    val mk: ?loc:loc -> ?attrs:attrs -> ?docs:docs -> ?text:text ->
+      ?modes:modes -> ?modalities:modalities ->
       str_opt -> module_type -> module_declaration
   end
 

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -717,9 +717,11 @@ let default_iterator =
     type_exception = T.iter_type_exception;
     extension_constructor = T.iter_extension_constructor;
     value_description =
-      (fun this {pval_name; pval_type; pval_modalities; pval_prim = _;
+      (fun this {pval_name; pval_modes; pval_type; pval_modalities;
+                 pval_prim = _;
                  pval_poly=_; pval_loc; pval_attributes} ->
         iter_loc this pval_name;
+        this.modes this pval_modes;
         this.typ this pval_type;
         this.location this pval_loc;
         this.modalities this pval_modalities;
@@ -731,9 +733,12 @@ let default_iterator =
     binding_op = E.iter_binding_op;
 
     module_declaration =
-      (fun this {pmd_name; pmd_type; pmd_attributes; pmd_loc} ->
+      (fun this {pmd_name; pmd_modes; pmd_type; pmd_modalities;
+                 pmd_attributes; pmd_loc} ->
          iter_loc this pmd_name;
+         this.modes this pmd_modes;
          this.module_type this pmd_type;
+         this.modalities this pmd_modalities;
          this.location this pmd_loc;
          this.attributes this pmd_attributes;
       );

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -806,14 +806,15 @@ let default_mapper =
     type_exception = T.map_type_exception;
     extension_constructor = T.map_extension_constructor;
     value_description =
-      (fun this {pval_name; pval_type; pval_modalities; pval_prim; pval_poly;
-                 pval_loc; pval_attributes} ->
+      (fun this {pval_name; pval_modes; pval_type; pval_modalities; pval_prim;
+                 pval_poly; pval_loc; pval_attributes} ->
         Val.mk
           (map_loc this pval_name)
           (this.typ this pval_type)
           ~attrs:(this.attributes this pval_attributes)
           ~loc:(this.location this pval_loc)
           ~poly:pval_poly
+          ~modes:(this.modes this pval_modes)
           ~modalities:(this.modalities this pval_modalities)
           ~prim:pval_prim
       );
@@ -823,12 +824,14 @@ let default_mapper =
     binding_op = E.map_binding_op;
 
     module_declaration =
-      (fun this {pmd_name; pmd_type; pmd_modalities; pmd_attributes; pmd_loc} ->
+      (fun this {pmd_name; pmd_modes; pmd_type; pmd_modalities; pmd_attributes;
+                 pmd_loc} ->
          Md.mk
            (map_loc this pmd_name)
            (this.module_type this pmd_type)
            ~attrs:(this.attributes this pmd_attributes)
            ~loc:(this.location this pmd_loc)
+           ~modes:(this.modes this pmd_modes)
            ~modalities:(this.modalities this pmd_modalities)
       );
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -2149,6 +2149,7 @@ signature_item:
   MODULE
   ext = ext attrs1 = attributes
   name_ = module_name_modal(atat_modalities_expr)
+  modes = optional_at_mode_expr
   body = module_declaration_body(
     module_type optional_atat_modalities_expr { ($1, $2) }
   )
@@ -2160,7 +2161,7 @@ signature_item:
     let name, modalities' = name_ in
     let mty, modalities = body in
     let modalities = modalities' @ modalities in
-    Md.mk name mty ~attrs ~loc ~docs ~modalities, ext
+    Md.mk name mty ~attrs ~loc ~docs ~modes ~modalities, ext
   }
 ;
 
@@ -3899,6 +3900,7 @@ value_description:
   attrs1 = attributes
   poly_flag = poly_flag
   id = mkrhs(val_ident)
+  modes = optional_at_mode_expr
   COLON
   ty = possibly_poly(core_type)
   modalities = optional_atat_modalities_expr
@@ -3906,7 +3908,7 @@ value_description:
     { let attrs = attrs1 @ attrs2 in
       let loc = make_loc $sloc in
       let docs = symbol_docs $sloc in
-      Val.mk id ty ~poly:poly_flag ~attrs ~modalities ~loc ~docs,
+      Val.mk id ty ~poly:poly_flag ~attrs ~modes ~modalities ~loc ~docs,
       ext }
 ;
 
@@ -3917,6 +3919,7 @@ primitive_declaration:
   ext = ext
   attrs1 = attributes
   id = mkrhs(val_ident)
+  modes = optional_at_mode_expr
   COLON
   ty = possibly_poly(core_type)
   modalities = optional_atat_modalities_expr
@@ -3926,7 +3929,7 @@ primitive_declaration:
     { let attrs = attrs1 @ attrs2 in
       let loc = make_loc $sloc in
       let docs = symbol_docs $sloc in
-      Val.mk id ty ~prim ~attrs ~modalities ~loc ~docs,
+      Val.mk id ty ~prim ~attrs ~modes ~modalities ~loc ~docs,
       ext }
 ;
 

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -708,6 +708,7 @@ and value_description =
     {
      pval_poly: bool; (** val poly_ *)
      pval_name: string loc;
+     pval_modes : modes;
      pval_type: core_type;
      pval_modalities : modalities;
      pval_prim: string list;
@@ -715,9 +716,9 @@ and value_description =
      pval_loc: Location.t;
     }
 (** Values of type {!value_description} represents:
-    - [val x: T],
+    - [val x @ modes : T @@ modalities],
             when {{!value_description.pval_prim}[pval_prim]} is [[]]
-    - [external x: T = "s1" ... "sn"]
+    - [external x @ modes : T @@ modalities = "s1" ... "sn"]
             when {{!value_description.pval_prim}[pval_prim]} is [["s1";..."sn"]]
 *)
 
@@ -1156,12 +1157,14 @@ and signature_item_desc =
 and module_declaration =
     {
      pmd_name: string option loc;
+     pmd_modes: modes;
      pmd_type: module_type;
      pmd_modalities: modalities;
      pmd_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      pmd_loc: Location.t;
     }
-(** Values of type [module_declaration] represents [S : MT] *)
+(** Values of type [module_declaration] represents
+    [S @ modes : MT @@ modalities] *)
 
 and module_substitution =
     {

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1541,8 +1541,9 @@ and signature_item ctxt f x : unit =
       let intro = if vd.pval_prim = [] then "val" else "external" in
       if vd.pval_prim <> [] then assert (not vd.pval_poly);
       let poly_str = if vd.pval_poly then "poly_ " else "" in
-      pp f "@[<2>%s@ %s%a@ :@ %a@]%a" intro poly_str
+      pp f "@[<2>%s@ %s%a%a@ :@ %a@]%a" intro poly_str
         ident_of_name vd.pval_name.txt
+        optional_at_modes vd.pval_modes
         (value_description ctxt) vd
         (item_attributes ctxt) vd.pval_attributes
   | Psig_typext te ->
@@ -1568,14 +1569,16 @@ and signature_item ctxt f x : unit =
       end
   | Psig_module ({pmd_type={pmty_desc=Pmty_alias alias;
                             pmty_attributes=[]; _}; _} as pmd) ->
-      pp f "@[<hov>module@ %s@ =@ %a%a@]%a"
+      pp f "@[<hov>module@ %s%a@ =@ %a%a@]%a"
         (Option.value pmd.pmd_name.txt ~default:"_")
+        optional_at_modes pmd.pmd_modes
         longident_loc alias
         optional_space_atat_modalities pmd.pmd_modalities
         (item_attributes ctxt) pmd.pmd_attributes
   | Psig_module pmd ->
-      pp f "@[<hov>module@ %s@ :@ %a%a@]%a"
+      pp f "@[<hov>module@ %s%a@ :@ %a%a@]%a"
         (Option.value pmd.pmd_name.txt ~default:"_")
+        optional_at_modes pmd.pmd_modes
         (module_type ctxt) pmd.pmd_type
         optional_space_atat_modalities pmd.pmd_modalities
         (item_attributes ctxt) pmd.pmd_attributes
@@ -1614,14 +1617,16 @@ and signature_item ctxt f x : unit =
         | [] -> () ;
         | pmd :: tl ->
             if not first then
-              pp f "@ @[<hov2>and@ %s:@ %a%a@]%a"
+              pp f "@ @[<hov2>and@ %s%a:@ %a%a@]%a"
                 (Option.value pmd.pmd_name.txt ~default:"_")
+                optional_at_modes pmd.pmd_modes
                 (module_type1 ctxt) pmd.pmd_type
                 optional_space_atat_modalities pmd.pmd_modalities
                 (item_attributes ctxt) pmd.pmd_attributes
             else
-              pp f "@[<hov2>module@ rec@ %s:@ %a%a@]%a"
+              pp f "@[<hov2>module@ rec@ %s%a:@ %a%a@]%a"
                 (Option.value pmd.pmd_name.txt ~default:"_")
+                optional_at_modes pmd.pmd_modes
                 (module_type1 ctxt) pmd.pmd_type
                 optional_space_atat_modalities pmd.pmd_modalities
                 (item_attributes ctxt) pmd.pmd_attributes;
@@ -1934,8 +1939,9 @@ and structure_item ctxt f x =
   | Pstr_class_type l -> class_type_declaration_list ctxt f l
   | Pstr_primitive vd ->
       assert (not vd.pval_poly);
-      pp f "@[<hov2>external@ %a@ :@ %a@]%a"
+      pp f "@[<hov2>external@ %a%a@ :@ %a@]%a"
         ident_of_name vd.pval_name.txt
+        optional_at_modes vd.pval_modes
         (value_description ctxt) vd
         (item_attributes ctxt) vd.pval_attributes
   | Pstr_include incl ->

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -619,6 +619,7 @@ and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_string_loc
        x.pval_name fmt_location x.pval_loc;
   attributes i ppf x.pval_attributes;
+  modes (i+1) ppf x.pval_modes;
   core_type (i+1) ppf x.pval_type;
   modalities (i+1) ppf x.pval_modalities;
   list (i+1) string ppf x.pval_prim
@@ -956,6 +957,7 @@ and signature_item i ppf x =
   | Psig_module pmd ->
       line i ppf "Psig_module %a\n" fmt_str_opt_loc pmd.pmd_name;
       attributes i ppf pmd.pmd_attributes;
+      modes i ppf pmd.pmd_modes;
       module_type i ppf pmd.pmd_type;
       modalities i ppf pmd.pmd_modalities
   | Psig_modsubst pms ->
@@ -1145,6 +1147,7 @@ and structure_item i ppf x =
 and module_declaration i ppf pmd =
   str_opt_loc i ppf pmd.pmd_name;
   attributes i ppf pmd.pmd_attributes;
+  modes (i+1) ppf pmd.pmd_modes;
   module_type (i+1) ppf pmd.pmd_type;
   modalities (i+1) ppf pmd.pmd_modalities
 

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -647,6 +647,7 @@ and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_string_loc
        x.pval_name fmt_location x.pval_loc;
   attributes i ppf x.pval_attributes;
+  modes (i+1) ppf x.pval_modes;
   core_type (i+1) ppf x.pval_type;
   list (i+1) string ppf x.pval_prim;
   modalities (i+1) ppf x.pval_modalities;
@@ -1003,7 +1004,9 @@ and signature_item i ppf x =
   | Psig_module pmd ->
       line i ppf "Psig_module %a\n" fmt_str_opt_loc pmd.pmd_name;
       attributes i ppf pmd.pmd_attributes;
-      module_type i ppf pmd.pmd_type
+      modes i ppf pmd.pmd_modes;
+      module_type i ppf pmd.pmd_type;
+      modalities i ppf pmd.pmd_modalities
   | Psig_modsubst pms ->
       line i ppf "Psig_modsubst %a = %a\n"
         fmt_string_loc pms.pms_name
@@ -1196,7 +1199,9 @@ and structure_item i ppf x =
 and module_declaration i ppf pmd =
   str_opt_loc i ppf pmd.pmd_name;
   attributes i ppf pmd.pmd_attributes;
+  modes (i+1) ppf pmd.pmd_modes;
   module_type (i+1) ppf pmd.pmd_type;
+  modalities (i+1) ppf pmd.pmd_modalities;
 
 and module_binding i ppf x =
   str_opt_loc i ppf x.pmb_name;

--- a/stdlib/ephemeron.ml
+++ b/stdlib/ephemeron.ml
@@ -416,11 +416,11 @@ module GenHashTable = struct
 
     module Rng : sig
       val bits : unit -> int
-    end = struct
-      (* This is safe since [bits] is a C call that cannot be preempted, 
+    end @ portable = struct
+      (* This is safe since [bits] is a C call that cannot be preempted,
          we do not yield, and we do not borrow the state. *)
       let key = Domain.Safe.DLS.new_key Random.State.make_self_init
-      let[@inline] bits () = 
+      let[@inline] bits () =
         Random.State.bits (Obj.magic_uncontended (Domain.Safe.DLS.get key))
     end
 

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -337,8 +337,8 @@ module DLS = Domain.Safe.DLS
 
 module Rng : sig
   val bits : unit -> int
-end = struct
-  (* This is safe since [bits] is a C call that cannot be preempted, 
+end @ portable = struct
+  (* This is safe since [bits] is a C call that cannot be preempted,
      we do not yield, and we do not borrow the state. *)
   let key = DLS.new_key Random.State.make_self_init
   let[@inline] bits () = Random.State.bits (Obj.magic_uncontended (DLS.get key))

--- a/stdlib/hashtbl.ml
+++ b/stdlib/hashtbl.ml
@@ -64,7 +64,7 @@ let is_randomized () = Atomic.get randomized
 
 module Rng : sig
   val bits : unit -> int
-end = struct
+end @ portable = struct
   (* This is safe since [bits] is a C call that cannot be preempted,
      we do not yield, and we do not borrow the state. *)
   let key = Domain.Safe.DLS.new_key Random.State.make_self_init

--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -61,6 +61,7 @@ module Example = struct
   let signature_item   = { psig_desc =
                              Psig_module
                                { pmd_name = located (Some "M")
+                               ; pmd_modes = []
                                ; pmd_type = module_type
                                ; pmd_attributes = []
                                ; pmd_modalities = []

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -679,7 +679,7 @@ module F : S @ portable -> sig end @@ stateless
 
 module M' = (M : S @ portable)
 [%%expect{|
-module M' : S @@ stateless
+module M' : S @@ portable
 |}]
 
 module F (M : S @ portable) : S @ portable = struct
@@ -700,28 +700,45 @@ module F : functor (M : S @ portable) -> sig end @@ stateless
   be an binary operator *)
 module M' = (M @ portable)
 [%%expect{|
-module M' = M @@ stateless
+module M' = M @@ portable
 |}]
 
 module M' = (M : S @ portable)
 [%%expect{|
-module M' : S @@ stateless
+module M' : S @@ portable
 |}]
 
 module M @ portable = struct end
 [%%expect{|
-module M : sig end @@ stateless
+module M : sig end @@ portable
 |}]
 
 module M : S @ portable = struct end
 [%%expect{|
-module M : S @@ stateless
+module M : S @@ portable
 |}]
 
 module type S' = functor () (M : S @ portable) (_ : S @ portable) -> S @ portable
 [%%expect{|
 module type S' =
   functor () (M : S @ portable) -> S @ portable -> S @ portable
+|}]
+
+(* Modes on val and module declarations in signatures parse and print. *)
+module type S = sig
+  val foo @ portable : int -> int
+  external baz @ portable : int -> int = "%identity"
+  module M @ portable : sig val x : int end
+  module N @ portable : sig val x : int end @@ portable
+end
+[%%expect{|
+module type S =
+  sig
+    val foo @ portable : int -> int
+    external baz @ portable : int -> int = "%identity"
+    module M : sig val x : int end
+    module N : sig val x : int @@ portable end
+  end
 |}]
 
 
@@ -741,7 +758,7 @@ module type S'' = S @ local -> S -> S
 
 module (F @ portable) () = struct end
 [%%expect{|
-module F : functor () -> sig end @@ stateless
+module F : functor () -> sig end @@ portable
 |}]
 
 module (G @ portable) () = F
@@ -754,12 +771,12 @@ module (G @ portable) (F : (S @ unique -> S @ once) @ local) @ contended = struc
 [%%expect{|
 module G :
   functor (F : (S @ unique -> S @ once) @ local) -> sig end @ contended @@
-  stateless
+  portable
 |}]
 
 module (G' @ portable) = F
 [%%expect{|
-module G' = F @@ stateless
+module G' = F @@ portable
 |}]
 
 module rec (F @ portable) () = struct end
@@ -975,7 +992,7 @@ module M :
   sig
     val f : (x:int * string) -> x:int * string
     val mk : unit -> x:bool * y:string
-  end @@ stateless
+  end
 module X_int_int : sig type t = x:int * int end @@ stateless
 |}]
 
@@ -1354,7 +1371,7 @@ module M :
     kind_ immutable = value
     kind_ data = value mod many
     kind_ abstract
-  end @@ stateless
+  end
 |}]
 
 module type S = sig kind_ k end

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -13,7 +13,7 @@ module M : sig
   val save : 'a @ global -> unit
   val free : 'a @ unique -> unit
   val send : 'a @ portable -> unit
-end = struct
+end @ portable = struct
   type t = string
   let x = "default"
   let x_unique = fun () -> "unique"

--- a/testsuite/tests/shadow_include/artificial.ml
+++ b/testsuite/tests/shadow_include/artificial.ml
@@ -63,8 +63,8 @@ end
 module type Extended =
   sig
     type t = Foo.t
-    val to_ : t -> Foo.Bar.t @@ stateless
-    val from : Foo.Bar.t -> t @@ stateless
+    val to_ : t -> Foo.Bar.t
+    val from : Foo.Bar.t -> t
     module Bar : sig type t = Foo.Bar.t val int : int end
   end
 |}]

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -423,7 +423,7 @@ module type X =
   end
 |}]
 
-module Xm : X = struct
+module Xm : X @ portable = struct
   type t = int ref
 
   let create n = ref n

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
@@ -423,7 +423,7 @@ module type X =
   end
 |}]
 
-module Xm : X = struct
+module Xm : X @ portable = struct
   type t = int ref
 
   let create n = ref n

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -145,7 +145,7 @@ end = struct
 end
 
 [%%expect{|
-module M : sig type t : immediate_or_null end @@ stateless
+module M : sig type t : immediate_or_null end
 |}]
 
 (* Tests for [immediate64_or_null]. *)
@@ -250,7 +250,7 @@ end = struct
 end
 
 [%%expect{|
-module M64 : sig type t : immediate64_or_null end @@ stateless
+module M64 : sig type t : immediate64_or_null end
 |}]
 
 module Fails : sig

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -703,9 +703,16 @@ Line 3, characters 10-11:
 3 |   (module M : S)
               ^
 Error: Signature mismatch:
-       Got "local" to the parent region
-       but expected "global"
-         because it is a module and thus needs to be allocated on the heap.
+       Modules do not match:
+         sig val s : string end @ regional
+       is not included in
+         S @ global
+       Values do not match:
+         val s : string (* in a structure at regional *)
+       is not included in
+         val s : string (* in a structure at global *)
+       The first is "local" to the parent region
+       but the second is "global".
 |}]
 
 (* Don't escape through a lazy value *)

--- a/testsuite/tests/typing-modes/functor.ml
+++ b/testsuite/tests/typing-modes/functor.ml
@@ -70,7 +70,7 @@ module F : S -> T = functor (M : S) -> struct
   let g = M.f
 end
 [%%expect{|
-module F : S -> T @@ stateless
+module F : S -> T
 |}]
 
 module F (M : S @ portable) (M' : S) = struct
@@ -202,7 +202,39 @@ Error: Modules do not match: sig val f : unit -> unit end @ nonportable
      However, the second is "portable".
 |}]
 
-(* testing generative functor *)
+(* Testing how a functor's return module-type / mode annotations affect
+   inference. The same rules apply to generative and applicative functors.
+
+   Case 1: no return module-type annotation. The return is fully inferred and
+   takes the most permissive mode (portable here, because the structure
+   contains only portable items). *)
+let () =
+    let module F () = struct
+        let f () = ()
+    end in
+    let module M = F () in
+    use_portable M.f
+[%%expect{|
+|}]
+
+(* Case 2: return module-type annotated, AND the mode annotated [@ portable].
+   The return is at [portable], so [use_portable M.f] works. *)
+let () =
+    let module F () : sig
+        val f : unit -> unit
+    end @ portable = struct
+        let f () = ()
+    end in
+    let module M = F () in
+    use_portable M.f
+[%%expect{|
+|}]
+
+(* Case 3: return module-type annotated, but the mode is NOT annotated. The
+   unspecified axes default to legacy (nonportable), so [M.f] is at
+   [nonportable] and [use_portable M.f] fails. To make this work, you must
+   either omit the return module-type (Case 1) or annotate the mode
+   (Case 2). *)
 let () =
     let module F () : sig
         val f : unit -> unit
@@ -212,7 +244,53 @@ let () =
     let module M = F () in
     use_portable M.f
 [%%expect{|
+Line 8, characters 17-20:
+8 |     use_portable M.f
+                     ^^^
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
+
+(* The same three cases hold for applicative functors. *)
+
+(* Case 1 (applicative): no return module-type annotation, fully inferred. *)
+let () =
+    let module F (X : sig end) = struct
+        let f () = ()
+    end in
+    let module M = F (struct end) in
+    use_portable M.f
+[%%expect{|
+|}]
+
+(* Case 2 (applicative): return module-type annotated, with [@ portable]. *)
+let () =
+    let module F (X : sig end) : sig
+        val f : unit -> unit
+    end @ portable = struct
+        let f () = ()
+    end in
+    let module M = F (struct end) in
+    use_portable M.f
+[%%expect{|
+|}]
+
+(* Case 3 (applicative): return module-type annotated, no mode annotation.
+   Defaults to legacy / nonportable, so [use_portable M.f] fails. *)
+let () =
+    let module F (X : sig end) : sig
+        val f : unit -> unit
+    end = struct
+        let f () = ()
+    end in
+    let module M = F (struct end) in
+    use_portable M.f
+[%%expect{|
+Line 8, characters 17-20:
+8 |     use_portable M.f
+                     ^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
 
 (* testing include functor in signature *)
 module type FT = S @ portable -> T @ portable
@@ -955,7 +1033,7 @@ let (foo @ portable) () =
   let _ : F(M).t = 42 in
   ()
 [%%expect{|
-module F = F @@ stateless nonportable
+module F = F
 module M = M
 val foo : unit -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-modes/md_modalities.ml
+++ b/testsuite/tests/typing-modes/md_modalities.ml
@@ -110,7 +110,7 @@ module type S = sig @@ portable
   module M' = M
 end
 [%%expect{|
-module M : T @@ stateless nonportable
+module M : T
 module type S = sig module M' = M end
 |}]
 
@@ -131,10 +131,7 @@ Lines 1-3, characters 15-3:
 2 |   module M' = M
 3 | end
 Error: Signature mismatch:
-       Modules do not match:
-         sig module M' = M @@ stateless nonportable end
-       is not included in
-         S
+       Modules do not match: sig module M' = M end is not included in S
        In module "M'":
        Modules do not match:
          sig val foo : 'a -> 'a end @ nonportable

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -161,7 +161,7 @@ module M : S = struct
 end
 [%%expect{|
 module type S = sig val foo : 'a -> 'a val baz : 'a -> 'a @@ portable end
-module M : S @@ stateless nonportable
+module M : S
 |}]
 
 let (bar @ portable) () =
@@ -393,7 +393,7 @@ end
 [%%expect{|
 module F :
   functor (X : sig val x : int -> int end) -> sig val bar : int -> int end @@
-  stateless
+  portable
 |}]
 
 

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -108,7 +108,7 @@ module (M @ uncontended) = struct
     let x @ contended = "hello"
 end
 [%%expect{|
-module M : sig val x : string @@ contended end @@ stateless
+module M : sig val x : string @@ stateless contended end
 |}]
 
 (* Testing the defaulting behaviour.
@@ -222,6 +222,10 @@ Line 9, characters 17-18:
 Error: The module is "contended" but is expected to be "uncontended".
 |}]
 
+(* The nested case: [M] has [N] with [y] at [uncontended], and [M'] tries to
+   provide [y] at [contended].  Under the new defaulting (module memaddr modes
+   default to legacy / uncontended), the inclusion check correctly rejects
+   the mismatch on the inner module. *)
 module Module_type_nested = struct
     module M = struct
         let x @ portable = fun t -> t
@@ -242,33 +246,67 @@ https://github.com/oxcaml/oxcaml/pull/3922#discussion_r2059000469
 *)
 (* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect{|
-module Module_type_nested :
-  sig
-    module M :
-      sig
-        val x : 'a -> 'a @@ stateless
-        module N : sig val y : string ref @@ stateless end
-      end
-    module M' :
-      sig
-        val x : 'a -> 'a @@ stateless
-        module N : sig val y : string ref @@ stateless end
-      end @@ stateless contended
-  end
+Lines 8-13, characters 35-7:
+ 8 | ...................................struct
+ 9 |         let x @ portable = fun t -> t
+10 |         module N = struct
+11 |             let y @ contended = ref "hello"
+12 |         end
+13 |     end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val x : 'a -> 'a @@ stateless
+           module N : sig val y : string ref @@ contended end @@ stateless
+         end @ uncontended
+       is not included in
+         sig
+           val x : 'a -> 'a @@ stateless
+           module N : sig val y : string ref @@ stateless end
+         end @ uncontended
+       In module "N":
+       Modules do not match:
+         sig val y : string ref @@ stateless contended end @ uncontended
+       is not included in
+         sig val y : string ref @@ stateless end @ uncontended
+       In module "N":
+       Values do not match:
+         val y : string ref @@ stateless contended (* in a structure at uncontended *)
+       is not included in
+         val y : string ref @@ stateless (* in a structure at uncontended *)
+       The first is "contended"
+       but the second is "uncontended".
 |}, Principal{|
-module Module_type_nested :
-  sig
-    module M :
-      sig
-        val x : 'a -> 'a @@ stateless
-        module N : sig val y : string ref end
-      end
-    module M' :
-      sig
-        val x : 'a -> 'a @@ stateless
-        module N : sig val y : string ref end
-      end @@ stateless contended
-  end
+Lines 8-13, characters 35-7:
+ 8 | ...................................struct
+ 9 |         let x @ portable = fun t -> t
+10 |         module N = struct
+11 |             let y @ contended = ref "hello"
+12 |         end
+13 |     end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           val x : 'a -> 'a @@ stateless
+           module N : sig val y : string ref @@ contended end
+         end @ uncontended
+       is not included in
+         sig
+           val x : 'a -> 'a @@ stateless
+           module N : sig val y : string ref end
+         end @ uncontended
+       In module "N":
+       Modules do not match:
+         sig val y : string ref @@ contended end @ uncontended
+       is not included in
+         sig val y : string ref end @ uncontended
+       In module "N":
+       Values do not match:
+         val y : string ref @@ contended (* in a structure at uncontended *)
+       is not included in
+         val y : string ref (* in a structure at uncontended *)
+       The first is "contended"
+       but the second is "uncontended".
 |}]
 
 (* When defaulting, prioritize modes in arrow types over modalities. *)
@@ -309,11 +347,28 @@ module Inclusion_fail = struct
         let x @ contended = ref "hello"
     end
 end
-(* For this to type check, M has to be at [contended] *)
+(* Under the new defaulting, [M] is at [uncontended] (legacy). The sig says
+   [val x : string ref] with no modality, so [x] is expected at the
+   surrounding mode, namely [uncontended]. But the structure provides [x] at
+   [contended], which doesn't submode [uncontended]. To make this type check,
+   [M] would have to be annotated [@ contended]. *)
 (* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect{|
-module Inclusion_fail :
-  sig module M : sig val x : string ref end @@ contended end @@ stateless
+Lines 4-6, characters 10-7:
+4 | ..........struct
+5 |         let x @ contended = ref "hello"
+6 |     end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val x : string ref @@ contended end @ uncontended
+       is not included in
+         sig val x : string ref end @ uncontended
+       Values do not match:
+         val x : string ref @@ contended (* in a structure at uncontended *)
+       is not included in
+         val x : string ref (* in a structure at uncontended *)
+       The first is "contended"
+       but the second is "uncontended".
 |}]
 
 module Inclusion_fail = struct
@@ -381,10 +436,15 @@ module Inclusion_weakens_comonadic = struct
   end
   let _ = portable_use M.x
 end
-(* [M] is inferred to be [portable] in order to type check *)
+(* The signature [sig val x : 'a -> 'a end] no longer says anything about [x]'s
+   portability; the surrounding module defaults to legacy / nonportable, so
+   projecting [M.x] at portable is rejected. (Previously, [M] would have been
+   inferred as portable to make this typecheck.) *)
 [%%expect{|
-module Inclusion_weakens_comonadic :
-  sig module M : sig val x : 'a -> 'a end end @@ stateless
+Line 7, characters 23-26:
+7 |   let _ = portable_use M.x
+                           ^^^
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 module Inclusion_weakens_comonadic = struct
@@ -412,8 +472,7 @@ module Inclusion_match = struct
 end
 (* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect{|
-module Inclusion_match : sig module M : sig val x : int ref end end @@
-  stateless
+module Inclusion_match : sig module M : sig val x : int ref end end
 |}]
 
 (* [foo] closes over [M.x] instead of [M]. This is better ergonomics. *)
@@ -440,7 +499,7 @@ end = struct
   let mk = ()
 end
 [%%expect {|
-module M : sig type t val mk : t @@ portable end @@ stateless
+module M : sig type t val mk : t @@ portable end
 |}]
 
 module Close_over_value_monadic = struct
@@ -521,8 +580,7 @@ end
 let _ = portable_use M.length
 [%%expect{|
 module M :
-  sig external length : string -> int @@ portable = "%string_length" end @@
-  portable
+  sig external length : string -> int @@ portable = "%string_length" end
 - : unit = ()
 |}]
 
@@ -536,8 +594,11 @@ end
 (* the whole module is portable *)
 let () = portable_use M.length
 [%%expect{|
-module M : sig external length : string -> int = "%string_length" end @@
-  portable
+module M : sig external length : string -> int = "%string_length" end
+Line 8, characters 22-30:
+8 | let () = portable_use M.length
+                          ^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
 |}]
 
 module M' = (M @ nonportable)
@@ -578,7 +639,7 @@ module N :
   sig
     module Plain : sig val f : int -> int end
     module type S_plain = sig module M : sig val f : int -> int end end
-  end @@ portable
+  end
 |}]
 
 (* This revised version of that example does not typecheck. It would be nice if
@@ -653,7 +714,7 @@ end = struct
   include (struct let foo x = x end : sig val foo : 'a -> 'a end)
 end
 [%%expect{|
-module M : sig val foo : 'a -> 'a @@ global many end @@ stateless
+module M : sig val foo : 'a -> 'a @@ global many end
 |}]
 
 (* module declaration inclusion check looks at the mode of the enclosing
@@ -664,8 +725,7 @@ end = struct
   module N : sig val foo : 'a -> 'a end = struct let foo x = x end
 end
 [%%expect{|
-module M : sig module N : sig val foo : 'a -> 'a @@ global many end end @@
-  stateless
+module M : sig module N : sig val foo : 'a -> 'a @@ global many end end
 |}]
 
 (* inclusion check should cross modes, if we are comparing modes (instead of
@@ -676,7 +736,7 @@ end = struct
   let foo @ nonportable contended = 42
 end
 [%%expect{|
-module M : sig val foo : int @@ portable end @@ stateless
+module M : sig val foo : int @@ portable end
 |}]
 
 (* The RHS type (expected type) is used for mode crossing. The following still
@@ -689,7 +749,7 @@ end = struct
   let t @ nonportable contended = 42
 end
 [%%expect{|
-module M : sig type t val t : t @@ portable end @@ stateless
+module M : sig type t val t : t @@ portable end
 |}]
 
 (* LHS type is a subtype of RHS type, which means more type-level information.
@@ -702,7 +762,7 @@ end = struct
   let t @ nonportable contended = `Foo
 end
 [%%expect{|
-module M : sig val t : [ `Bar | `Foo ] @@ portable end @@ stateless
+module M : sig val t : [ `Bar | `Foo ] @@ portable end
 |}]
 
 module M : sig
@@ -783,8 +843,7 @@ module F : (sig val foo : 'a -> 'a end) -> (sig val bar : 'a -> 'a @@ global man
 functor (M : sig val foo : 'a -> 'a @@ global many end) -> struct let bar = M.foo end
 [%%expect{|
 module F :
-  sig val foo : 'a -> 'a end -> sig val bar : 'a -> 'a @@ global many end @@
-  stateless
+  sig val foo : 'a -> 'a end -> sig val bar : 'a -> 'a @@ global many end
 |}]
 
 (* CR zqian: package subtyping doesn't look at the package mode for simplicity.
@@ -976,8 +1035,7 @@ end = struct
 end
 [%%expect{|
 module M :
-  sig module type F = sig val foo : 'a @@ global many end -> sig end end @@
-  stateless
+  sig module type F = sig val foo : 'a @@ global many end -> sig end end
 |}]
 
 module M : sig
@@ -988,8 +1046,7 @@ end = struct
     (sig end) -> (sig val foo : 'a @@ global many end)
 end
 [%%expect{|
-module M : sig module type F = sig end -> sig val foo : 'a end end @@
-  stateless
+module M : sig module type F = sig end -> sig val foo : 'a end end
 |}]
 
 module type T = sig @@ portable
@@ -1207,14 +1264,18 @@ let (bar @ portable) () =
 val bar : unit -> unit = <fun>
 |}]
 
-(* Pmod_constraint gives portable, if all required items are portable *)
+(* Pmod_constraint no longer infers portability from the sig: the surrounding
+   module ([M]) defaults to legacy / nonportable, so the constraint fails. *)
 let (bar @ portable) () =
   let module _ = struct
     module N @ portable = (M : Func_portable)
   end in
   ()
 [%%expect{|
-val bar : unit -> unit = <fun>
+Line 3, characters 26-45:
+3 |     module N @ portable = (M : Func_portable)
+                              ^^^^^^^^^^^^^^^^^^^
+Error: The module is "nonportable" but is expected to be "portable".
 |}]
 
 (* We will now only use Pmod_pack as example; Pmod_apply and Pexp_constraint are
@@ -1279,7 +1340,9 @@ let _ =
 - : unit -> (module Empty) = <fun>
 |}]
 
-(* Functor crosses uniqueness and contention *)
+(* Functor crosses uniqueness and contention. (Portability no longer crosses
+   on functor modules under the new default-to-legacy behaviour, so the
+   functor [M] is rejected at portable.) *)
 let _ =
   let module (M @ unique uncontended) (X : Empty) = struct end in
   let (foo @ many portable) () =
@@ -1288,7 +1351,13 @@ let _ =
   in
   foo
 [%%expect{|
-- : unit -> unit = <fun>
+Line 4, characters 41-42:
+4 |     let _ @ unique uncontended = (module M : E2E) in
+                                             ^
+Error: The module "M" is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at lines 3-5, characters 28-6
+         which is expected to be "portable".
 |}]
 
 (* closing over M.x crosses modes *)
@@ -1309,8 +1378,14 @@ let (bar @ portable) () =
   let k = (module M_Func_portable : Func_portable) in
   k
 [%%expect{|
-module M_Func_portable : Func_portable @@ portable
-val bar : unit -> (module Func_portable) @ contended = <fun>
+module M_Func_portable : Func_portable
+Line 6, characters 18-33:
+6 |   let k = (module M_Func_portable : Func_portable) in
+                      ^^^^^^^^^^^^^^^
+Error: The module "M_Func_portable" is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at lines 5-7, characters 21-3
+         which is expected to be "portable".
 |}]
 
 module M_Func_portable' @ nonportable = M_Func_portable
@@ -1378,7 +1453,7 @@ let (bar @ portable) () =
   k
 [%%expect{|
 module type F = sig end -> sig end
-module F : functor (X : sig end) -> sig end @@ stateless nonportable
+module F : functor (X : sig end) -> sig end
 Line 4, characters 18-19:
 4 |   let k = (module F : F) in
                       ^
@@ -1396,7 +1471,7 @@ let (bar @ portable) () =
   k
 [%%expect{|
 module type F = sig end -> sig end
-module F : functor (X : sig end) -> sig end @@ stateless
+module F : functor (X : sig end) -> sig end @@ portable
 val bar : unit -> (module F) = <fun>
 |}]
 
@@ -1404,17 +1479,12 @@ val bar : unit -> (module F) = <fun>
 let (bar @ portable) () =
   let k = (module M : Class) in
   k
-(* CR-someday zqian: This test should say that [M.cla] is nonportable because [M] is
-nonportable because [M] contains a class [cla] that is nonportable becaues classes are
-always legacy. *)
 [%%expect{|
 Line 2, characters 18-19:
 2 |   let k = (module M : Class) in
                       ^
 Error: The class "M.cla" is "nonportable"
-         because it contains the class "cla" defined as the class at line 38, characters 2-24
-         which is "nonportable" because classes are always at the legacy modes.
-       However, the class "M.cla" highlighted is expected to be "portable"
+       but is expected to be "portable"
          because it is used inside the function at lines 1-3, characters 21-3
          which is expected to be "portable".
 |}]
@@ -1546,7 +1616,7 @@ end = struct
   module type S = sig module N : sig end end
 end
 [%%expect{|
-module M : sig module type S = sig module N : sig end end end @@ stateless
+module M : sig module type S = sig module N : sig end end end
 |}]
 
 (* class makes a structure to be nonportable *)
@@ -1578,9 +1648,7 @@ Error: Signature mismatch:
          sig class foo : object  end end @ portable
        Class declarations foo do not match:
        First is "nonportable"
-         because it contains the class "foo" defined as the class at line 1, characters 32-54
-         which is "nonportable" because classes are always at the legacy modes.
-       However, second is "portable".
+       but second is "portable".
 |}]
 
 module M = struct

--- a/testsuite/tests/typing-modes/val_modes.ml
+++ b/testsuite/tests/typing-modes/val_modes.ml
@@ -1,0 +1,289 @@
+(* TEST
+    flags += "-extension mode_alpha";
+    expect;
+*)
+
+(* The semantics of [val_modes] (modes annotated on a value description in a
+   signature). On each annotated axis, the mode overrides whatever is derived
+   from the surrounding structure's mode and [val_modalities]. *)
+
+(* Basic: [@ portable] on val *)
+module type S = sig
+  val foo @ portable : 'a -> 'a
+end
+[%%expect{|
+module type S = sig val foo @ portable : 'a -> 'a end
+|}]
+
+(* [val_modes] combines with surrounding signature default modalities. *)
+module type S = sig @@ contended
+  val foo @ portable : 'a -> 'a
+end
+[%%expect{|
+module type S = sig val foo @ portable : 'a -> 'a end
+|}]
+
+(* [val_modes] overrides on the specified axis: outer is portable, val
+   annotates portable on its own axis (idempotent). *)
+module type S = sig @@ portable
+  val foo @ portable : 'a -> 'a
+end
+[%%expect{|
+module type S = sig val foo @ portable : 'a -> 'a end
+|}]
+
+(* It is an error to specify both [val_modes] and [val_modalities] on a
+   value description. *)
+module type S = sig
+  val foo @ portable : 'a -> 'a @@ contended
+end
+[%%expect{|
+Line 2, characters 2-44:
+2 |   val foo @ portable : 'a -> 'a @@ contended
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: A value description cannot have both mode annotations ( ...) and
+       modality annotations (@ ...).
+|}]
+
+(* external supports [val_modes] too *)
+module type S = sig
+  external foo @ portable : 'a -> 'a = "%identity"
+end
+[%%expect{|
+module type S = sig external foo @ portable : 'a -> 'a = "%identity" end
+|}]
+
+(* Inclusion check: a value annotated [@ portable] is more permissive than the
+   default (nonportable), so the structure must actually provide a portable
+   value to satisfy the signature. *)
+module type S = sig
+  val foo @ portable : 'a -> 'a
+end
+
+module M : S = struct
+  let foo x = x
+end
+[%%expect{|
+module type S = sig val foo @ portable : 'a -> 'a end
+module M : S
+|}]
+
+(* Inclusion check: signature without [val_modes] (default legacy) cannot
+   include a more restrictive signature with [@ portable]. *)
+module type S_legacy = sig
+  val foo : 'a -> 'a
+end
+
+module type S_portable = sig
+  val foo @ portable : 'a -> 'a
+end
+
+module M : S_legacy = struct
+  let (foo @ nonportable) x = x
+end
+
+module M' : S_portable = (M : S_legacy)
+[%%expect{|
+module type S_legacy = sig val foo : 'a -> 'a end
+module type S_portable = sig val foo @ portable : 'a -> 'a end
+module M : S_legacy
+Line 13, characters 25-39:
+13 | module M' : S_portable = (M : S_legacy)
+                              ^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         S_legacy @ nonportable
+       is not included in
+         S_portable @ nonportable
+       Values do not match:
+         val foo : 'a -> 'a (* in a structure at nonportable *)
+       is not included in
+         val foo @ portable : 'a -> 'a (* in a structure at nonportable *)
+       The first is "nonportable"
+       but the second is "portable".
+|}]
+
+(* Tests for the structure-memaddr-mode check at module inclusion.
+
+   When no coercion happens ([Tcoerce_none]), the structure memaddr mode of the
+   implementation must submode the expected one.
+
+   When a coercion happens, a new memory block is constructed, so the RHS
+   memaddr mode is not constrained by the LHS memaddr mode. *)
+
+(* Tcoerce_none branch: signature matches the implementation exactly, no
+   coercion. The memory-block mode submode check applies. *)
+module type S_empty = sig end
+
+module M1 : S_empty = struct end
+[%%expect{|
+module type S_empty = sig end
+module M1 : S_empty
+|}]
+
+(* Tcoerce_none branch where the submode check fails: a functor that takes a
+   local module and returns it as global. The body is the (local) parameter
+   itself, so no coercion is generated, and the memaddr submode check fires
+   on local vs. global. *)
+module F (M : sig end @ local) : sig end @ global = M
+[%%expect{|
+Line 1, characters 52-53:
+1 | module F (M : sig end @ local) : sig end @ global = M
+                                                        ^
+Error: Signature mismatch:
+       Got "local"
+       but expected "global".
+|}]
+
+(* Tcoerce_structure branch: when a coercion happens, a new memory block is
+   constructed, so the LHS memaddr mode does NOT need to submode the RHS.
+   Here the functor argument is at [local] but the result type is [global];
+   because the argument has an extra item (y), a coercion is generated, and
+   the local-vs-global submode check is skipped. *)
+module F (M : sig val x : int val y : int end @ local)
+  : sig val x : int end @ global = M
+[%%expect{|
+module F :
+  functor (M : sig val x : int val y : int end @ local) ->
+    sig val x : int end
+  @@ stateless
+|}]
+
+(* Incompleteness mentioned in the CR-someday comment in [includemod.ml]:
+   the surface-mode submode check rejects this functor even though the
+   program is morally sound. Both sides have [x @ local], so all items are
+   already local; the module's "real" memaddr mode is local on both sides
+   and the program is sound. But the current check looks only at the surface
+   mode (local vs global) and rejects it. *)
+module F (M : sig val x @ local : int -> int end @ local)
+  : sig val x @ local : int -> int end @ global = M
+[%%expect{|
+Line 2, characters 50-51:
+2 |   : sig val x @ local : int -> int end @ global = M
+                                                      ^
+Error: Signature mismatch:
+       Got "local"
+       but expected "global".
+|}]
+
+(* [val_modes] on multiple axes: each axis is overridden independently. *)
+module type S = sig
+  val foo @ portable contended : 'a -> 'a
+end
+[%%expect{|
+module type S = sig val foo @ portable contended : 'a -> 'a end
+|}]
+
+(* [val_modes] overrides only the specified axes; other axes still come from
+   the surrounding signature's default. Here, [contended] is from the sig
+   default, [portable] is from [val_modes]. *)
+module type S = sig @@ contended
+  val foo @ portable : 'a -> 'a
+end
+
+module M : S = struct
+  let (foo @ portable) x = x
+end
+[%%expect{|
+module type S = sig val foo @ portable : 'a -> 'a end
+module M : S
+|}]
+
+(* Inclusion between two signatures, both using [val_modes]: matching
+   annotations pass. *)
+module type S1 = sig
+  val foo @ portable : 'a -> 'a
+end
+
+module type S2 = sig
+  val foo @ portable : 'a -> 'a
+end
+
+module F (M : S1) : S2 = M
+[%%expect{|
+module type S1 = sig val foo @ portable : 'a -> 'a end
+module type S2 = sig val foo @ portable : 'a -> 'a end
+module F : functor (M : S1) -> S2 @@ stateless
+|}]
+
+(* Module type equivalence check uses the [All] branch in
+   [child_modes_with_val_modes]. When both sides have [val_modes] (Overriding)
+   but annotate different axes, the per-axis mismatch is detected. *)
+module type S1 = sig
+  module type T = sig val foo @ portable : 'a -> 'a end
+end
+
+module type S2 = sig
+  module type T = sig val foo @ contended : 'a -> 'a end
+end
+
+module F (M : S1) : S2 = M
+[%%expect{|
+module type S1 =
+  sig module type T = sig val foo @ portable : 'a -> 'a end end
+module type S2 =
+  sig module type T = sig val foo @ contended : 'a -> 'a end end
+Line 9, characters 25-26:
+9 | module F (M : S1) : S2 = M
+                             ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type T = sig val foo @ portable : 'a -> 'a end end
+       is not included in
+         S2
+       Module type declarations do not match:
+         module type T = sig val foo @ portable : 'a -> 'a end
+       does not match
+         module type T = sig val foo @ contended : 'a -> 'a end
+       At position "module type T = <here>"
+       Module types do not match:
+         sig val foo @ portable : 'a -> 'a end
+       is not equal to
+         sig val foo @ contended : 'a -> 'a end
+       At position "module type T = <here>"
+       Mode annotations on foo do not match:
+       Mode annotations on axis portability differ: one is annotated,
+       the other is not.
+|}]
+
+(* Module type equivalence: both sides annotate the same axis but with values
+   that do not submode each other. Triggers the [Val_modes_le_failure]
+   error via the [All] branch. *)
+module type S1 = sig
+  module type T = sig val foo @ contended : 'a -> 'a end
+end
+
+module type S2 = sig
+  module type T = sig val foo @ uncontended : 'a -> 'a end
+end
+
+module F (M : S1) : S2 = M
+[%%expect{|
+module type S1 =
+  sig module type T = sig val foo @ contended : 'a -> 'a end end
+module type S2 =
+  sig module type T = sig val foo @ uncontended : 'a -> 'a end end
+Line 9, characters 25-26:
+9 | module F (M : S1) : S2 = M
+                             ^
+Error: Signature mismatch:
+       Modules do not match:
+         sig module type T = sig val foo @ contended : 'a -> 'a end end
+       is not included in
+         S2
+       Module type declarations do not match:
+         module type T = sig val foo @ contended : 'a -> 'a end
+       does not match
+         module type T = sig val foo @ uncontended : 'a -> 'a end
+       The first module type is not included in the second
+       At position "module type T = <here>"
+       Module types do not match:
+         sig val foo @ contended : 'a -> 'a end
+       is not equal to
+         sig val foo @ uncontended : 'a -> 'a end
+       At position "module type T = <here>"
+       Mode annotations on foo do not match:
+       Mode annotations differ:
+       the first is contended,
+       the second is uncontended.
+|}]

--- a/testsuite/tests/typing-warnings/pr7553.ml
+++ b/testsuite/tests/typing-warnings/pr7553.ml
@@ -49,5 +49,5 @@ Line 4, characters 6-12:
           ^^^^^^
 Warning 33 [unused-open]: unused open A.
 
-module rec D : sig module M : sig module X : sig end @@ stateless end end
+module rec D : sig module M : sig module X : sig end end end
 |}]

--- a/testsuite/tests/typing-zero-alloc/cmi_test.ml
+++ b/testsuite/tests/typing-zero-alloc/cmi_test.ml
@@ -23,7 +23,7 @@ Error: Signature mismatch:
            val f_unconstrained_variable : int -> int @@ portable
            module M_constrained_variable =
              Cmi_test_lib.M_constrained_variable
-           module M_no_variable = Cmi_test_lib.M_no_variable @@ portable
+           module M_no_variable = Cmi_test_lib.M_no_variable
          end
        is not included in
          sig val f_unconstrained_variable : int -> int [@@zero_alloc] end

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -416,7 +416,7 @@ let name_expression ~loc ~attrs sort exp =
       val_loc = loc;
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
-      val_modalities = Mode.Modality.(Const.id |> of_const);
+      val_modes = Types.Sig_item_modes.Modality Mode.Modality.(Const.id |> of_const);
       val_uid = Uid.internal_not_actually_unique;
       val_lpoly = Lpoly.determined []; }
   in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1059,48 +1059,26 @@ let scrape_alias =
         t -> Subst.Lazy.module_type -> Subst.Lazy.module_type)
 
 let md md_type =
-  {md_type; md_modalities = Mode.Modality.undefined; md_attributes=[];
+  {md_type; md_modes = Sig_item_modes.Normalized; md_attributes=[];
    md_loc=Location.none; md_uid = Uid.internal_not_actually_unique}
 
-(** The caller is not interested in modes, and thus [val_modalities] is
+(** The caller is not interested in modes, and thus [val_modes] is
 invalidated. *)
 let vda_description vda =
   let vda_description = vda.vda_description in
-  {vda_description with val_modalities = Mode.Modality.undefined}
+  {vda_description with val_modes = Sig_item_modes.Normalized}
 
 module Normalize_mode = struct
-  type t =
-    | Normalize_exn (** Normalize a mode; raise if already normalized. *)
-    | Assert_normalized
-      (** Assert that the mode is already normalized, and return the mode *)
-    | Normalize
-      (** Normalize a mode; do nothing if already normalized.
-          Use the other two instead whenever possible *)
-
-  let modality t modality mode =
-    let normalized = Mode.Modality.is_undefined modality in
-    match t, normalized with
-    | Normalize, true -> modality, mode
-    | Normalize_exn, true ->
-        Misc.fatal_error "mode is already normalized but expected otherwise"
-    | Assert_normalized, true -> modality, mode
-    | (Normalize | Normalize_exn), false ->
-        Mode.Modality.undefined,
-        Mode.Modality.apply ~hint:{monadic = Unknown; comonadic = Unknown}
-          modality mode
-    | Assert_normalized, false ->
-        Misc.fatal_error "mode is not already normalized but expected otherwise"
-
   let vd t (vd : Subst.Lazy.value_description) mode =
-    let val_modalities, mode = modality t vd.val_modalities mode in
-    let vd = {vd with val_modalities} in
+    let mode = Types.Sig_item_modes.apply t vd.val_modes mode in
+    let vd = {vd with val_modes = Normalized} in
     vd, mode
 
   let vda norm vda = vd norm vda.vda_description vda.vda_mode
 
   let md t (md : Subst.Lazy.module_declaration) mode =
-    let md_modalities, mode = modality t md.md_modalities mode in
-    let md = {md with md_modalities} in
+    let mode = Types.Sig_item_modes.apply t md.md_modes mode in
+    let md = {md with md_modes = Normalized} in
     md, mode
 
   let mda norm mda = md norm mda.mda_declaration mda.mda_mode
@@ -1244,7 +1222,7 @@ let read_sign_of_cmi sign name uid ~shape ~address:addr ~flags =
   in
   let md =
     { Subst.Lazy.md_type = Mty_signature sign;
-      md_modalities = Mode.Modality.undefined;
+      md_modes = Sig_item_modes.Normalized;
       md_loc = Location.none;
       md_attributes = [];
       md_uid = uid;
@@ -2941,7 +2919,7 @@ and add_cltype ?shape id ty env =
 
 let add_module_lazy ~update_summary id presence mty ?mode env =
   let md = Subst.Lazy.{md_type = mty;
-                       md_modalities = Mode.Modality.undefined;
+                       md_modes = Sig_item_modes.Normalized;
                        md_attributes = [];
                        md_loc = Location.none;
                        md_uid = Uid.internal_not_actually_unique}

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -48,7 +48,7 @@ type value_mismatch =
   | Not_a_primitive
   | Type of Errortrace.moregen_error
   | Zero_alloc of Zero_alloc.error
-  | Modality of Mode.Modality.error
+  | Sig_item_modes of Types.Sig_item_modes.sub_error
   | Mode of Mode.Value.error
   | Layout_poly_coercion of layout_poly_coercion
 
@@ -72,25 +72,29 @@ let child_modes id = function
     let c = child_close_over_coercion_opt id c in
     Specific ((m0, c), m1)
 
-let child_modes_with_modalities id ~modalities:(moda0, moda1) = function
+let child_modes_with_sig_item_modes id ~modes:(sim0, sim1) = function
   | All ->
-    begin match Mode.Modality.sub moda0 moda1 with
+    begin match Types.Sig_item_modes.sub sim0 sim1 with
       | Ok () -> Ok All
       | Error e -> Error e
     end
   | Specific ((m0, c), m1)->
     let c = child_close_over_coercion_opt id c in
-    begin match Mode.Modality.to_const_opt moda1 with
+    begin match Types.Sig_item_modes.to_const_opt sim1 with
     | None ->
       (* [wrap_constraint_with_shape] invokes inclusion check with
           identical modes and inferred modalities, which we workaround *)
-      assert (moda0 == moda1);
+      (match (sim0 : Types.Sig_item_modes.t),
+             (sim1 : Types.Sig_item_modes.t) with
+       | Modality moda0, Modality moda1 -> assert (moda0 == moda1)
+       | _ -> assert false);
       Mode.Value.submode_exn m0 m1;
-      (* For children, we only check modality inclusion *)
       Ok All
-    | Some moda1 ->
-      let m0 = Mode.Modality.apply moda0 m0 in
-      let m1 = Mode.Modality.Const.apply moda1 m1 in
+    | Some sim1_const ->
+      let m0 = Types.Sig_item_modes.apply Normalize_exn sim0 m0 in
+      let m1 =
+        Types.Sig_item_modes.Const.apply Normalize_exn sim1_const m1
+      in
       Ok (Specific ((m0, c), m1))
     end
 
@@ -201,11 +205,11 @@ let value_descriptions ~loc env name
   | Error e -> raise (Dont_match (Zero_alloc e))
   end;
   let crossing = Ctype.crossing_of_ty env vd2.val_type in
-  let modalities = vd1.val_modalities, vd2.val_modalities in
+  let sig_item_modes = vd1.val_modes, vd2.val_modes in
   let modes =
-    match child_modes_with_modalities name ~modalities mmodes with
+    match child_modes_with_sig_item_modes name ~modes:sig_item_modes mmodes with
     | Ok modes -> modes
-    | Error e -> raise (Dont_match (Modality e))
+    | Error e -> raise (Dont_match (Sig_item_modes e))
   in
   begin match check_modes env ~crossing ~item:Value ~typ:vd1.val_type modes with
   | Ok () -> ()
@@ -455,6 +459,24 @@ let report_primitive_mismatch first second ppf err =
   | Layout_poly_attr ->
       pr "The two primitives have different [@@layout_poly] attributes"
 
+let report_sig_item_modes_sub_error first second ppf
+      (e : Types.Sig_item_modes.sub_error) =
+  let pr fmt = Fmt.fprintf ppf fmt in
+  match e with
+  | Modality_error e -> report_modality_sub_error first second ppf e
+  | Axis_mismatch (P ax) ->
+      pr "Mode annotations on axis %a differ: one is annotated,@ \
+          the other is not."
+        Mode.Value.Axis.print ax
+  | Le_failure (ax, v0, v1) ->
+      let print_axis ppf v =
+        match ax with
+        | Comonadic ax -> Mode.Value.Comonadic.Const.Per_axis.print ax ppf v
+        | Monadic ax -> Mode.Value.Monadic.Const.Per_axis.print ax ppf v
+      in
+      pr "Mode annotations differ:@ %s is %a,@ %s is %a."
+        first print_axis v0 second print_axis v1
+
 let report_value_mismatch ~pp first second env ppf err =
   let pr fmt = Fmt.fprintf ppf fmt in
   pr "@ ";
@@ -469,7 +491,8 @@ let report_value_mismatch ~pp first second env ppf err =
         (msg "The type")
         (msg "is not compatible with the type")
   | Zero_alloc e -> Zero_alloc.print_error ppf e
-  | Modality e -> report_modality_sub_error first second ppf e
+  | Sig_item_modes e ->
+      report_sig_item_modes_sub_error first second ppf e
   | Mode e ->
       let got = first ^ " is" in
       let expected = second ^ " is" in

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -50,7 +50,7 @@ type value_mismatch =
   | Not_a_primitive
   | Type of Errortrace.moregen_error
   | Zero_alloc of Zero_alloc.error
-  | Modality of Mode.Modality.error
+  | Sig_item_modes of Types.Sig_item_modes.sub_error
   | Mode of Mode.Value.error
   | Layout_poly_coercion of layout_poly_coercion
 
@@ -178,10 +178,11 @@ val child_modes: string -> mmodes -> mmodes
 
 (** Gives the modes suitable for the inclusion check of a child item. Takes the
     modes suitable for the inclusion check of the parent item, and both hands'
-    modalities between the parent and the child. *)
-val child_modes_with_modalities:
-  string -> modalities:(Mode.Modality.t * Mode.Modality.t) ->
-  mmodes -> (mmodes, Mode.Modality.error) Result.t
+    [Sig_item_modes.t] (the unified mode-related information on the child). *)
+val child_modes_with_sig_item_modes:
+  string ->
+  modes:(Types.Sig_item_modes.t * Types.Sig_item_modes.t) ->
+  mmodes -> (mmodes, Types.Sig_item_modes.sub_error) Result.t
 
 (** Claim the current item is included by the RHS and its mode checked. *)
 val check_modes : Env.t -> ?crossing:Mode.Crossing.t ->
@@ -224,8 +225,9 @@ val report_type_mismatch :
   Env.t ->
   type_mismatch Format_doc.printer
 
-val report_modality_sub_error :
-  string -> string -> Format_doc.formatter -> Mode.Modality.error -> unit
+val report_sig_item_modes_sub_error :
+  string -> string -> Format_doc.formatter ->
+  Types.Sig_item_modes.sub_error -> unit
 
 val report_mode_sub_error :
   pp:Mode.Hint.pinpoint ->

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -74,7 +74,7 @@ module Error = struct
         (class_type_declaration, Ctype.class_match_failure list) diff
     | Class_declarations of
         (class_declaration, class_declaration_symptom) mdiff
-    | Modalities of Mode.Modality.error
+    | Sig_item_modes of Types.Sig_item_modes.sub_error
     | Jkind_declarations of
         (jkind_declaration, Includecore.jkind_mismatch) diff
 
@@ -687,15 +687,27 @@ and try_modtypes ~direction ~loc env subst ~modes
         end
     end
   | (Mty_signature sig1, Mty_signature sig2) ->
-      let* () =
-        Includecore.check_modes env ~item:Module
-          ~crossing:Ctype.mode_crossing_structure_memaddr modes
-        |> map_error (fun e -> Error.Mode e)
-      in
       begin match
         signatures ~direction ~loc env subst ~modes sig1 sig2 orig_shape
       with
-      | Ok _ as ok -> ok
+      | Ok (Tcoerce_none, _) as ok ->
+        (* the "real mode" of a structure (the mode of the memory block) is
+        defined as the meet (for comonadic axes) or join (for monadic axes) of
+        all its items and the structure's surface mode. Therefore, it suffices
+        to check submode for all its items as well as the surface modes. *)
+        (* CR-someday zqian: check the "real mode" instead of the "surface mode"
+           to allow more programs. *)
+        begin match
+          Includecore.check_modes env ~item:Module
+            ~crossing:Ctype.mode_crossing_structure_memaddr modes
+        with
+        | Ok () -> ok
+        | Error e -> Error (Error.Mode e)
+        end
+      | Ok _ as ok ->
+        (* coercion happens and a new memory block constructed, therefore, the
+           RHS memaddr mode is not constrained by the LHS memaddr mode. *)
+        ok
       | Error e -> Error (Error.Signature e)
       end
 
@@ -1113,11 +1125,13 @@ and module_declarations ~direction ~loc env subst id1 ~mmodes md1 md2 orig_shape
   let p1 = Path.Pident id1 in
   if Directionality.mark_as_used direction then
     Env.mark_module_used md1.md_uid;
-  let modalities = md1.md_modalities, md2.md_modalities in
+  let modes : Types.Sig_item_modes.t * Types.Sig_item_modes.t =
+    md1.md_modes, md2.md_modes
+  in
   let id = Ident.name id1 in
   let* modes =
-    Includecore.child_modes_with_modalities id ~modalities mmodes
-    |> map_error (fun e -> Error.(Core (Modalities e)))
+    Includecore.child_modes_with_sig_item_modes id ~modes mmodes
+    |> map_error (fun e -> Error.(Core (Sig_item_modes e)))
   in
   strengthened_modtypes ~direction ~loc ~aliasable:true env subst ~modes
     md1.md_type p1 md2.md_type orig_shape

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -58,7 +58,7 @@ module Error: sig
         (Types.class_type_declaration, Ctype.class_match_failure list) diff
     | Class_declarations of
         (Types.class_declaration, class_declaration_symptom) mdiff
-    | Modalities of Mode.Modality.error
+    | Sig_item_modes of Types.Sig_item_modes.sub_error
     | Jkind_declarations of (jkind_declaration, Includecore.jkind_mismatch) diff
 
   type core_module_type_symptom =

--- a/typing/includemod_errorprinter.ml
+++ b/typing/includemod_errorprinter.ml
@@ -247,7 +247,7 @@ module Is_modal = struct
     | Value_descriptions d -> value_mismatch d.symptom
     | Class_declarations d -> class_declaration_symptom d.symptom
     | Type_declarations _ | Extension_constructors _ | Class_type_declarations _
-    | Modalities _ | Jkind_declarations _ -> None
+    | Sig_item_modes _ | Jkind_declarations _ -> None
 
   and class_declaration_symptom = function
     | Class_mode e ->
@@ -779,13 +779,20 @@ let subcase_list l ppf = match l with
         (Fmt.pp_print_list ~pp_sep:space pp_msg)
         (List.rev l)
 
+let report_sig_item_modes_with_id id (e : Types.Sig_item_modes.sub_error) =
+  let prefix = match e with
+    | Modality_error _ -> "Modalities on "
+    | Axis_mismatch _ | Le_failure _ -> "Mode annotations on "
+  in
+  Fmt.dprintf "@[<hv>%s:@;%a@]"
+    (prefix ^ (Ident.name id) ^ " do not match")
+    (Includecore.report_sig_item_modes_sub_error "the first" "the second") e
+
 (* Printers for leaves *)
 let core env id x =
   match x with
-  | Err.Value_descriptions {symptom = Modality e} ->
-      Fmt.dprintf "@[<hv>%s:@;%a@]"
-        ("Modalities on " ^ (Ident.name id) ^ " do not match")
-        (Includecore.report_modality_sub_error "the first" "the second") e
+  | Err.Value_descriptions {symptom = Sig_item_modes e} ->
+      report_sig_item_modes_with_id id e
   | Err.Value_descriptions diff ->
       let is_modal = Is_modal.value_mismatch diff.symptom in
       let mode1, mode2 =
@@ -805,10 +812,8 @@ let core env id x =
            "the first" "the second" env) diff.symptom
         show_locs (diff.got.val_loc, diff.expected.val_loc)
         Printtyp.Conflicts.print_explanations
-  | Err.Modalities e ->
-      Fmt.dprintf "@[<hv>%s:@;%a@]"
-        ("Modalities on " ^ (Ident.name id) ^ " do not match")
-        (Includecore.report_modality_sub_error "the first" "the second") e
+  | Err.Sig_item_modes e ->
+      report_sig_item_modes_with_id id e
   | Err.Type_declarations diff ->
       Fmt.dprintf "@[<v>@[<hv>%s:@;<1 2>%a@ %s@;<1 2>%a@]%a%a%t@]"
         "Type declarations do not match"

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3012,6 +3012,8 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let to_const_exn m = S.to_const_exn obj m
 
+  let to_loose_const_exn m = S.to_loose_const_exn obj m
+
   let unhint = S.Unhint.unhint
 
   let hint ?hint = S.Unhint.hint obj ?hint
@@ -3113,6 +3115,8 @@ module Monadic_gen (Obj : Obj) = struct
    fun ?hint a -> S.of_const ?hint obj a
 
   let to_const_exn m = S.to_const_exn obj m
+
+  let to_loose_const_exn m = S.to_loose_const_exn obj m
 
   let unhint = S.Unhint.unhint
 
@@ -3815,6 +3819,12 @@ module Value_with (Areality : Areality) = struct
     let monadic = Monadic.to_const_exn monadic in
     { comonadic; monadic } |> merge
 
+  let to_loose_const_exn m =
+    let { comonadic; monadic } = m in
+    let comonadic = Comonadic.to_loose_const_exn comonadic in
+    let monadic = Monadic.to_loose_const_exn monadic in
+    { comonadic; monadic } |> merge
+
   let unhint { monadic; comonadic } =
     let comonadic = Comonadic.unhint comonadic in
     let monadic = Monadic.unhint monadic in
@@ -3913,6 +3923,29 @@ module Value_with (Areality : Areality) = struct
           visibility = None;
           staticity = None
         }
+
+      let is_none
+          { areality;
+            uniqueness;
+            linearity;
+            portability;
+            contention;
+            forkable;
+            yielding;
+            statefulness;
+            visibility;
+            staticity
+          } =
+        Option.is_none areality
+        && Option.is_none uniqueness
+        && Option.is_none linearity
+        && Option.is_none portability
+        && Option.is_none contention
+        && Option.is_none forkable
+        && Option.is_none yielding
+        && Option.is_none statefulness
+        && Option.is_none visibility
+        && Option.is_none staticity
 
       let value opt ~default =
         let areality = Option.value opt.areality ~default:default.areality in
@@ -4368,6 +4401,32 @@ module Const = struct
       | Right ax -> P ax
   end
 
+  let alloc_option_as_value
+      ({ areality;
+         linearity;
+         portability;
+         uniqueness;
+         contention;
+         forkable;
+         yielding;
+         statefulness;
+         visibility;
+         staticity
+       } :
+        Alloc.Const.Option.t) : Value.Const.Option.t =
+    let areality = Option.map C.locality_as_regionality areality in
+    { areality;
+      linearity;
+      portability;
+      uniqueness;
+      contention;
+      forkable;
+      yielding;
+      statefulness;
+      visibility;
+      staticity
+    }
+
   let locality_as_regionality = C.locality_as_regionality
 end
 
@@ -4527,6 +4586,9 @@ module Modality = struct
        fun ?(hint = Hint.Unknown) t x ->
         match t with Join_const c -> Mode.join_const ~hint c x
 
+      let apply_const t x =
+        match t with Join_const c -> Mode.Const.join c x
+
       let proj ax (Join_const c) : _ Atom.t = Join_const (Axis.proj ax c)
 
       let set ax (Join_const a : _ Atom.t) (Join_const c) =
@@ -4539,7 +4601,6 @@ module Modality = struct
     type t =
       | Const of Const.t
       | Diff of Mode.lr * Mode.lr  (** See "Inferred modalities" comments *)
-      | Undefined
 
     let sub_log left right ~log : (unit, error) Result.t =
       match left, right with
@@ -4567,8 +4628,6 @@ module Modality = struct
       | Const _, Diff _ ->
         Misc.fatal_error
           "inferred modality Diff should not be on the RHS of sub."
-      | Undefined, _ | _, Undefined ->
-        Misc.fatal_error "modality Undefined should not be in sub."
 
     let apply : type r.
         ?hint:(allowed * r) neg Hint.morph ->
@@ -4578,13 +4637,10 @@ module Modality = struct
      fun ?hint t x ->
       match t with
       | Const c -> Const.apply ?hint c x |> Mode.disallow_right
-      | Undefined ->
-        Misc.fatal_error "modality Undefined should not be applied."
       | Diff (_, m) -> Mode.join [Mode.allow_right m; x]
 
     let print ppf = function
       | Const c -> Const.print ppf c
-      | Undefined -> Fmt.fprintf ppf "undefined"
       | Diff _ -> Fmt.fprintf ppf "diff"
 
     (* All zapping functions mutate [mm] and [m] to the degree that's sufficient
@@ -4593,7 +4649,6 @@ module Modality = struct
 
     let zap_to_floor = function
       | Const c -> c
-      | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
       | Diff (mm, m) ->
         (* Ideally we will take [c = subtract_mm m] and zap it to floor.
            However, [subtract] requires [mm] to be constant. We get the ceil of
@@ -4618,8 +4673,6 @@ module Modality = struct
 
     let to_const_opt = function
       | Const c -> Some c
-      | Undefined ->
-        Misc.fatal_error "modality Undefined should not be looked at"
       | Diff _ -> None
 
     let of_const c = Const c
@@ -4673,6 +4726,9 @@ module Modality = struct
        fun ?(hint = Hint.Unknown) t x ->
         match t with Meet_const c -> Mode.meet_const ~hint c x
 
+      let apply_const t x =
+        match t with Meet_const c -> Mode.Const.meet c x
+
       let proj ax (Meet_const c) : _ Atom.t = Meet_const (Axis.proj ax c)
 
       let set ax (Meet_const a : _ Atom.t) (Meet_const c) =
@@ -4684,7 +4740,6 @@ module Modality = struct
 
     type t =
       | Const of Const.t
-      | Undefined
       | Exactly of Mode.lr * Mode.lr  (** See "Inferred modalities" comments *)
 
     let sub_log left right ~log : (unit, error) Result.t =
@@ -4716,8 +4771,6 @@ module Modality = struct
       | Const _, Exactly _ ->
         Misc.fatal_error
           "inferred modaltiy Exactly should not be on the RHS of sub."
-      | Undefined, _ | _, Undefined ->
-        Misc.fatal_error "modality Undefined should not be in sub."
 
     let apply : type r.
         ?hint:(allowed * r) pos Hint.morph ->
@@ -4727,8 +4780,6 @@ module Modality = struct
      fun ?hint t x ->
       match t with
       | Const c -> Const.apply ?hint c x |> Mode.disallow_right
-      | Undefined ->
-        Misc.fatal_error "modality Undefined should not be applied."
       | Exactly (_mm, m) ->
         (* Ideally want to return [meet_(imply_mm m) x], which we can't do
            without binary mode solver, so instead we return [meet_m x] (See
@@ -4738,7 +4789,6 @@ module Modality = struct
 
     let print ppf = function
       | Const c -> Const.print ppf c
-      | Undefined -> Fmt.fprintf ppf "undefined"
       | Exactly _ -> Fmt.fprintf ppf "exactly"
 
     let infer ~md_mode ~mode = Exactly (md_mode, mode)
@@ -4751,7 +4801,6 @@ module Modality = struct
 
     let zap_to_ceil = function
       | Const c -> c
-      | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
       | Exactly (mm, m) ->
         (* Ideally we will take [c = imply_mm m] and zap it to ceil. However,
            [imply] requires [mm] to be constant. We get the floor of [mm] to
@@ -4776,7 +4825,6 @@ module Modality = struct
 
     let zap_to_floor = function
       | Const c -> c
-      | Undefined -> Misc.fatal_error "modality Undefined should not be zapped."
       | Exactly (mm, m) ->
         (* The following zaps [mm] to ceil, which might conflict with future
            mode constraints on [mm]. We find constraining [mm] to [legacy] a
@@ -4790,8 +4838,6 @@ module Modality = struct
 
     let to_const_opt = function
       | Const c -> Some c
-      | Undefined ->
-        Misc.fatal_error "modality Undefined should not be looked at"
       | Exactly _ -> None
 
     let of_const c = Const c
@@ -4878,6 +4924,12 @@ module Modality = struct
       in
       { monadic; comonadic }
 
+    let apply_const t (x : Value.Const.t) : Value.Const.t =
+      let { monadic; comonadic } = Value.Const.split x in
+      let monadic = Monadic.apply_const t.monadic monadic in
+      let comonadic = Comonadic.apply_const t.comonadic comonadic in
+      Value.Const.merge { monadic; comonadic }
+
     let concat ~then_ t =
       let monadic = Monadic.concat ~then_:then_.monadic t.monadic in
       let comonadic = Comonadic.concat ~then_:then_.comonadic t.comonadic in
@@ -4907,13 +4959,6 @@ module Modality = struct
   end
 
   type t = (Monadic.t, Comonadic.t) monadic_comonadic
-
-  let undefined : t = { monadic = Undefined; comonadic = Undefined }
-
-  let is_undefined : t -> bool = function
-    | { monadic = Undefined; comonadic = Undefined } -> true
-    | _ -> false
-  [@@ocaml.warning "-4"]
 
   let apply ?hint t { monadic; comonadic } =
     let monadic =

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -676,6 +676,9 @@ module type S = sig
 
         val none : t
 
+        (** [true] iff [t] is [none] (all axes are [None]). *)
+        val is_none : t -> bool
+
         val value : t -> default:some -> some
 
         val print : Fmt.formatter -> t -> unit
@@ -738,6 +741,12 @@ module type S = sig
       ('l * 'r) t
 
     val to_const_exn : lr -> Const.t
+
+    (** Similar to [to_const_exn], but works on modes of any allowance.
+        "Loose" refers to the bounds being over-approximations rather than the
+        tight bounds [to_const_exn] uses; for modes that are already constants
+        the result is exact. *)
+    val to_loose_const_exn : ('l * 'r) t -> Const.t
 
     module List : sig
       (* No new types exposed to avoid too many type names *)
@@ -805,6 +814,9 @@ module type S = sig
 
   module Const : sig
     val alloc_as_value : Alloc.Const.t -> Value.Const.t
+
+    val alloc_option_as_value :
+      Alloc.Const.Option.t -> Value.Const.Option.t
 
     module Axis : sig
       val alloc_as_value : Alloc.Axis.packed -> Value.Axis.packed
@@ -926,6 +938,9 @@ module type S = sig
         ('l * 'r) Value.t ->
         ('l * 'r) Value.t
 
+      (** Apply a constant modality on a constant mode. *)
+      val apply_const : t -> Value.Const.t -> Value.Const.t
+
       (** [concat ~then t] returns the modality that is [then_] after [t]. *)
       val concat : then_:t -> t -> t
 
@@ -950,15 +965,6 @@ module type S = sig
     (** A modality that acts on [Value] modes. Conceptually it is a record where
         individual fields can be [set] or [proj]. *)
     type t
-
-    (* CR-someday zqian: [undefined] is only used for [val_modalities] and
-       [md_modalities]. Consider moving the logic there. *)
-
-    (** The undefined modality. *)
-    val undefined : t
-
-    (** Check if the given modality is [undefined]. *)
-    val is_undefined : t -> bool
 
     (* CR zqian: note that currently, [apply] and [sub] and [zap] are NOT
        coherent for comonadic axes. That is, we do NOT have

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -958,7 +958,7 @@ and print_out_sig_item ppf =
            | Orec_first -> "type"
            | Orec_next  -> "and")
           ppf td
-  | Osig_value { oval_name; oval_type; oval_modalities;
+  | Osig_value { oval_name; oval_modes; oval_type; oval_modalities;
                  oval_prims; oval_attributes } ->
       let kwd = if oval_prims = [] then "val" else "external" in
       let pr_prims ppf =
@@ -968,7 +968,8 @@ and print_out_sig_item ppf =
             fprintf ppf "@ = \"%s\"" s;
             List.iter (fun s -> fprintf ppf "@ \"%s\"" s) sl
       in
-      fprintf ppf "@[<2>%s %a :@ %a%a%a%a@]" kwd value_ident oval_name
+      fprintf ppf "@[<2>%s %a%a :@ %a%a%a%a@]" kwd value_ident oval_name
+        print_out_modes oval_modes
         !out_type oval_type
         print_out_modalities oval_modalities
         pr_prims oval_prims

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -231,6 +231,7 @@ and out_type_extension =
     otyext_private: Asttypes.private_flag }
 and out_val_decl =
   { oval_name: string;
+    oval_modes: out_mode list;
     oval_type: out_type;
     oval_modalities : out_modality list;
     (* Modalities on value descriptions are always new, even for [global_] *)

--- a/typing/printtyp.ml
+++ b/typing/printtyp.ml
@@ -1453,6 +1453,22 @@ let tree_of_modalities mut t =
   |> List.map (fun (Atom (ax, m) : Modality.atom) ->
       Fmt.asprintf "%a" (Modality.Per_axis.print ax) m)
 
+let tree_of_value_modes_option (modes : Mode.Value.Const.Option.t) =
+  let print_to_string_opt print a = Option.map (Fmt.asprintf "%a" print) a in
+  let modes =
+    [ print_to_string_opt Mode.Regionality.Const.print modes.areality
+    ; print_to_string_opt Mode.Uniqueness.Const.print modes.uniqueness
+    ; print_to_string_opt Mode.Linearity.Const.print modes.linearity
+    ; print_to_string_opt Mode.Portability.Const.print modes.portability
+    ; print_to_string_opt Mode.Contention.Const.print modes.contention
+    ; print_to_string_opt Mode.Forkable.Const.print modes.forkable
+    ; print_to_string_opt Mode.Yielding.Const.print modes.yielding
+    ; print_to_string_opt Mode.Statefulness.Const.print modes.statefulness
+    ; print_to_string_opt Mode.Visibility.Const.print modes.visibility ]
+  in
+  List.filter_map (fun x -> x) modes
+
+
 let tree_of_modes (modes : Mode.Alloc.Const.t) =
   (* Step 1: Compute the modes to print *)
   let diff =
@@ -2422,12 +2438,13 @@ let tree_of_value_description id decl =
   (* Important: process the fvs *after* the type; tree_of_type_scheme
      resets the naming context *)
   wrap_mutation (fun () ->
-  let moda =
-    if Mode.Modality.is_undefined decl.val_modalities then
-      Mode.Modality.Const.id
-    else
-      Ctype.zap_modalities_to_floor_if_modes_enabled_at Alpha
-        decl.val_modalities
+  let moda, modes =
+    match (decl.val_modes : Sig_item_modes.t) with
+    | Modality m ->
+        Ctype.zap_modalities_to_floor_if_modes_enabled_at Alpha m,
+        Mode.Value.Const.Option.none
+    | Overriding o -> Mode.Modality.Const.id, o
+    | Normalized -> Mode.Modality.Const.id, Mode.Value.Const.Option.none
   in
   let qsvs, qtvs =
     (* Important: process the fvs *after* the type; tree_of_type_scheme
@@ -2472,6 +2489,7 @@ let tree_of_value_description id decl =
   in
   let vd =
     { oval_name = id;
+      oval_modes = tree_of_value_modes_option modes;
       oval_type = Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty));
       oval_modalities = tree_of_modalities Immutable moda;
       oval_prims = [];
@@ -2954,12 +2972,12 @@ and tree_of_modtype_declaration ?abbrev id decl =
 
 and tree_of_module ?abbrev id md rs = wrap_mutation (fun () ->
   let moda =
-    if Mode.Modality.is_undefined md.md_modalities then
-      Mode.Modality.Const.id
-    else
-      Ctype.zap_modalities_to_floor_if_at_least Alpha md.md_modalities
+    match (md.md_modes : Sig_item_modes.t) with
+    | Modality m -> Ctype.zap_modalities_to_floor_if_at_least Alpha m
+    | Overriding _ | Normalized -> Mode.Modality.Const.id
   in
-    Osig_module (Ident.name id, tree_of_modtype ?abbrev md.md_type,
+    Osig_module (Ident.name id,
+    tree_of_modtype ?abbrev md.md_type,
     tree_of_modalities Immutable moda,
     tree_of_rec rs)
   )

--- a/typing/solver.ml
+++ b/typing/solver.ml
@@ -1136,6 +1136,18 @@ module Solver_mono (H : Hint) (C : Lattices_mono) = struct
         (Fmt.compat (C.print obj))
         ceil
 
+  let to_loose_const_exn obj m =
+    let floor = get_loose_floor obj m in
+    let ceil = get_loose_ceil obj m in
+    if C.le obj ceil floor
+    then ceil
+    else
+      Misc.fatal_errorf "mode is not tight: floor = %a, ceil = %a"
+        (Fmt.compat (C.print obj))
+        floor
+        (Fmt.compat (C.print obj))
+        ceil
+
   let print : type a l r.
       ?verbose:bool -> a C.obj -> Fmt.formatter -> (a, l * r) mode -> unit =
    fun ?verbose (obj : a C.obj) ppf m ->

--- a/typing/solver_intf.mli
+++ b/typing/solver_intf.mli
@@ -220,6 +220,10 @@ module type Solver_mono = sig
       Raises exception if the condition does not hold. *)
   val to_const_exn : 'a obj -> ('a, allowed * allowed) mode -> 'a
 
+  (** Similar to [to_const_exn], but uses [get_loose_floor]/[get_loose_ceil] so
+      it works on modes of any allowance. *)
+  val to_loose_const_exn : 'a obj -> ('a, 'l * 'r) mode -> 'a
+
   (** The minimum mode in the lattice *)
   val min : 'a obj -> ('a, 'l * 'r) mode
 

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -1136,7 +1136,7 @@ let to_lazy =
     Lazy_types.{
       val_type = Wrap.of_value vd.val_type;
       val_lpoly = Wrap.of_value vd.val_lpoly;
-      val_modalities = vd.val_modalities;
+      val_modes = vd.val_modes;
       val_kind = vd.val_kind;
       val_zero_alloc = vd.val_zero_alloc;
       val_attributes = vd.val_attributes;
@@ -1166,14 +1166,17 @@ let force_lpoly lpoly = Wrap.force (fun _ s lpoly ->
   Types.Lpoly.determined vars) lpoly
 
 let rec subst_lazy_value_description s descr =
-  let val_modalities =
-    match s.additional_action with
-    | Prepare_for_saving { prepare_modality; _ } ->
-        prepare_modality descr.val_modalities
-    | _ -> descr.val_modalities
+  let val_modes : Types.Sig_item_modes.t =
+    match descr.val_modes with
+    | Modality m -> (
+      match s.additional_action with
+      | Prepare_for_saving { prepare_modality; _ } ->
+          Modality (prepare_modality m)
+      | _ -> Modality m)
+    | Overriding _ | Normalized -> descr.val_modes
   in
   { val_type = Wrap.substitute ~compose Keep s descr.val_type;
-    val_modalities;
+    val_modes;
     val_kind = descr.val_kind;
     val_lpoly = Wrap.substitute ~compose Keep s descr.val_lpoly;
     val_loc = loc s descr.val_loc;
@@ -1194,14 +1197,17 @@ let rec subst_lazy_value_description s descr =
 
 and subst_lazy_module_decl scoping s md =
   let md_type = subst_lazy_modtype scoping s md.md_type in
-  let md_modalities =
-    match s.additional_action with
-    | Prepare_for_saving { prepare_modality; _ } ->
-        prepare_modality md.md_modalities
-    | _ -> md.md_modalities
+  let md_modes : Types.Sig_item_modes.t =
+    match md.md_modes with
+    | Modality m -> (
+      match s.additional_action with
+      | Prepare_for_saving { prepare_modality; _ } ->
+          Modality (prepare_modality m)
+      | _ -> Modality m)
+    | Overriding _ | Normalized -> md.md_modes
   in
   { md_type;
-    md_modalities;
+    md_modes;
     md_attributes = attrs s md.md_attributes;
     md_loc = loc s md.md_loc;
     md_uid = md.md_uid }
@@ -1342,7 +1348,7 @@ and from_lazy =
     Types.{
       val_type = force_type_expr vd.val_type;
       val_lpoly = force_lpoly vd.val_lpoly;
-      val_modalities = vd.val_modalities;
+      val_modes = vd.val_modes;
       val_kind = vd.val_kind;
       val_zero_alloc = vd.val_zero_alloc;
       val_attributes = vd.val_attributes;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -489,7 +489,8 @@ let enter_ancestor_met ~loc name ~sign ~meths ~cl_num ~ty ~attrs met_env =
   let check s = Warnings.Unused_ancestor s in
   let kind = Val_anc (sign, meths, cl_num) in
   let desc =
-    { val_type = ty; val_modalities = Modality.undefined; val_kind = kind;
+    { val_type = ty; val_modes = Sig_item_modes.Normalized;
+      val_kind = kind;
       val_lpoly = Lpoly.determined [];
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
@@ -506,7 +507,8 @@ let add_self_met loc id sign self_var_kind vars cl_num
   in
   let kind = Val_self (sign, self_var_kind, vars, cl_num) in
   let desc =
-    { val_type = ty; val_modalities = Modality.undefined; val_kind = kind;
+    { val_type = ty; val_modes = Sig_item_modes.Normalized;
+      val_kind = kind;
       val_lpoly = Lpoly.determined [];
       val_attributes = attrs;
       val_zero_alloc = Zero_alloc.default;
@@ -523,7 +525,8 @@ let add_instance_var_met loc label id sign cl_num attrs met_env =
   in
   let kind = Val_ivar (mut, cl_num) in
   let desc =
-    { val_type = ty; val_modalities = Modality.undefined; val_kind = kind;
+    { val_type = ty; val_modes = Sig_item_modes.Normalized;
+      val_kind = kind;
       val_lpoly = Lpoly.determined [];
       val_attributes = attrs;
       Types.val_loc = loc;
@@ -1485,7 +1488,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
              in
              let desc =
                {val_type = expr.exp_type;
-                val_modalities = Modality.undefined;
+                val_modes = Sig_item_modes.Normalized;
                 val_kind = Val_ivar (Immutable, cl_num);
                 val_lpoly = Lpoly.determined [];
                 val_attributes = [];

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1436,7 +1436,8 @@ let add_pattern_variables ?check ?check_as env pv =
        Env.add_value ?check ~mode:pv_mode pv_id
          {val_type = pv_type; val_kind = pv_kind; val_lpoly = pv_lpoly;
           Types.val_loc = pv_loc;
-          val_attributes = pv_attributes; val_modalities = Modality.undefined;
+          val_attributes = pv_attributes;
+          val_modes = Sig_item_modes.Normalized;
           val_zero_alloc = Zero_alloc.default;
           val_uid = pv_uid
          } env
@@ -1473,7 +1474,7 @@ let add_module_variables env module_variables =
       in
       let md =
         { md_type = modl.mod_type; md_attributes = [];
-          md_modalities = Mode.Modality.undefined;
+          md_modes = Sig_item_modes.Normalized;
           md_loc = mv_name.loc;
           md_uid = mv_uid; }
       in
@@ -3627,7 +3628,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_lpoly = Lpoly.determined []
             ; val_attributes = pv_attributes
             ; val_zero_alloc = Zero_alloc.default
-            ; val_modalities = Modality.undefined
+            ; val_modes = Sig_item_modes.Normalized
             ; val_loc = pv_loc
             ; val_uid = pv_uid
             }
@@ -3640,7 +3641,7 @@ let type_class_arg_pattern cl_num val_env met_env l spat =
             ; val_lpoly = Lpoly.determined []
             ; val_attributes = pv_attributes
             ; val_zero_alloc = Zero_alloc.default
-            ; val_modalities = Modality.undefined
+            ; val_modes = Sig_item_modes.Normalized
             ; val_loc = pv_loc
             ; val_uid = pv_uid
             }
@@ -7470,7 +7471,7 @@ and type_expect_
               let md_shape = Shape.set_uid_if_none md_shape md_uid in
               let md =
                 { md_type = modl.mod_type; md_attributes = [];
-                  md_modalities = Modality.undefined;
+                  md_modes = Sig_item_modes.Normalized;
                   md_loc = name.loc;
                   md_uid; }
               in
@@ -9310,7 +9311,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
             val_lpoly = Lpoly.determined [];
             val_attributes = [];
             val_zero_alloc = Zero_alloc.default;
-            val_modalities = Modality.undefined;
+            val_modes = Sig_item_modes.Normalized;
             val_loc = Location.none;
             val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
           }

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -141,6 +141,7 @@ type error =
   | Zero_alloc_attr_unsupported of Builtin_attributes.zero_alloc_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity
+  | Val_modes_and_modalities
   | Invalid_reexport of
       { definition: Path.t
       ; expected: Path.t
@@ -4207,7 +4208,9 @@ type transl_value_decl_modal =
 
 (* Translate a value declaration *)
 let transl_value_decl env loc ~modal ~why valdecl =
-  let mode, val_modalities, val_modal_info =
+  if valdecl.pval_modes <> [] && valdecl.pval_modalities <> []
+  then raise (Error (loc, Val_modes_and_modalities));
+  let mode, val_modes_from_modalities, val_modal_info =
     match modal with
     | Str_primitive ->
         assert (not valdecl.pval_poly);
@@ -4221,7 +4224,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
           |> Mode.Alloc.of_const
           |> Mode.alloc_as_value
         in
-        mode, Mode.Modality.undefined, Valmi_str_primitive modes
+        mode, Sig_item_modes.Normalized, Valmi_str_primitive modes
     | Sig_value (md_mode, sig_modalities) ->
         if valdecl.pval_poly then begin
           Language_extension.assert_enabled ~loc Layout_poly
@@ -4235,7 +4238,16 @@ let transl_value_decl env loc ~modal ~why valdecl =
         let modalities =
           Mode.Modality.of_const raw_modalities.moda_modalities
         in
-        md_mode, modalities, Valmi_sig_value raw_modalities
+        md_mode, Sig_item_modes.Modality modalities,
+        Valmi_sig_value raw_modalities
+  in
+  let val_modes : Sig_item_modes.t =
+    if valdecl.pval_modes <> []
+    then
+      Overriding
+        (Mode.Const.alloc_option_as_value
+           (Typemode.transl_mode_annots valdecl.pval_modes).mode_modes)
+    else val_modes_from_modalities
   in
   let lpoly, cty = Typetexp.transl_type_scheme env valdecl.pval_type in
   let sort =
@@ -4298,7 +4310,8 @@ let transl_value_decl env loc ~modal ~why valdecl =
         val_kind = Val_reg sort;
         val_lpoly = Lpoly.determined lpoly;
         Types.val_loc = loc;
-        val_attributes = valdecl.pval_attributes; val_modalities;
+        val_attributes = valdecl.pval_attributes;
+        val_modes;
         val_zero_alloc = zero_alloc;
         val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
       }
@@ -4343,7 +4356,8 @@ let transl_value_decl env loc ~modal ~why valdecl =
       { val_type = ty; val_kind = Val_prim prim;
         val_lpoly = Lpoly.determined lpoly;
         Types.val_loc = loc;
-        val_attributes = valdecl.pval_attributes; val_modalities;
+        val_attributes = valdecl.pval_attributes;
+        val_modes;
         val_zero_alloc = Zero_alloc.default;
         val_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
       }
@@ -5395,6 +5409,10 @@ let report_error_doc ppf = function
   | Zero_alloc_attr_bad_user_arity ->
     fprintf ppf
       "@[Invalid zero_alloc attribute: arity must be greater than 0.@]"
+  | Val_modes_and_modalities ->
+    fprintf ppf
+      "@[A value description cannot have both mode annotations (@ ...) and@ \
+         modality annotations (@@ ...).@]"
   | Invalid_reexport {definition; expected} ->
     fprintf ppf
       "@[Invalid reexport declaration.\

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -209,6 +209,7 @@ type error =
   | Zero_alloc_attr_unsupported of Builtin_attributes.zero_alloc_attribute
   | Zero_alloc_attr_non_function
   | Zero_alloc_attr_bad_user_arity
+  | Val_modes_and_modalities
   | Invalid_reexport of
       { definition: Path.t
       ; expected: Path.t

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -106,14 +106,6 @@ type error =
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
 
-let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
-  let mode = Mode.Value.newvar () in
-  let min = Alloc.Const.Option.value ~default:Alloc.Const.min m in
-  let max = Alloc.Const.Option.value ~default:Alloc.Const.max m in
-  Value.submode_exn (min |> Alloc.of_const |> alloc_as_value) mode;
-  Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value);
-  mode
-
 let register_allocation () =
   let m, _ =
     Value.(newvar_below (of_const
@@ -174,45 +166,41 @@ let infer_modalities pp ~loc_md item ~md_mode ~mode =
     would be allowed to performed on the module (and extended to the
     values) that's disallowed for the values.
 
-    For monadic (descriptive) axes, the restriction is not on the
-    construction but on the projection, which is modelled by the
-    [Diff] modality in [mode.ml]. *)
+    For monadic (descriptive) axes, the memory block's mode on
+    construction is pinned to [Value.Monadic.min] in
+    [register_allocation], so soundness is trivial. Projection from the
+    structure to items is still modelled by the [Diff] modality in
+    [mode.ml]. *)
     let mode' = md_mode |> apply_is_contained_by ~loc_md item in
     Value.Comonadic.submode_err pp mode.comonadic mode'.comonadic;
     Mode.Modality.infer ~md_mode ~mode
 
 (** For an [include M] clause where [M] is at [mode] and [loc], and an [item] in
-[M] with [modalities] on it, calculate the modalities on the [item] to be used
-in the enclosing structure which is at [md_mode] and [loc_md]. *)
-let rebase_modalities ~loc ~loc_md item ~md_mode ~mode modalities =
+[M] with [Sig_item_modes.t] on it, calculate the [Sig_item_modes.t] on the
+[item] to be used in the enclosing structure which is at [md_mode] and
+[loc_md]. *)
+let rebase_sig_item_modes ~loc ~loc_md item ~md_mode ~mode
+      (sim : Types.Sig_item_modes.t) : Types.Sig_item_modes.t =
   let pp : Hint.pinpoint = (loc, Structure_item item) in
-  let is_contained_by : Hint.is_contained_by =
-    { containing = Structure (item, Modality);
-      container = (loc, Structure)}
+  let mode =
+    Types.Sig_item_modes.apply ~loc_struct:loc ~item Normalize_exn sim mode
   in
-  let hint =
-    { monadic = Hint.Is_contained_by (Monadic, is_contained_by);
-      comonadic = Hint.Is_contained_by (Comonadic, is_contained_by) }
-  in
-  let mode = Modality.apply ~hint modalities mode in
-  infer_modalities pp ~loc_md item ~md_mode ~mode
+  Modality (infer_modalities pp ~loc_md item ~md_mode ~mode)
 
-(** Similiar to [rebase_modalities] but lifted to signatures. *)
-let rebase_modalities_sg ~loc ~loc_md ~md_mode ~mode sg =
+(** Similiar to [rebase_sig_item_modes] but lifted to signatures. *)
+let rebase_sig_item_modes_sg ~loc ~loc_md ~md_mode ~mode sg =
   List.map (function
     | Sig_value (id, vd, vis) ->
-        let val_modalities =
-          vd.val_modalities
-          |> rebase_modalities ~loc ~loc_md (Value, id) ~md_mode ~mode
+        let val_modes =
+          rebase_sig_item_modes ~loc ~loc_md (Value, id) ~md_mode ~mode vd.val_modes
         in
-        let vd = {vd with val_modalities} in
+        let vd = {vd with val_modes} in
         Sig_value (id, vd, vis)
     | Sig_module (id, pres, md, rec_, vis) ->
-        let md_modalities =
-          md.md_modalities
-          |> rebase_modalities ~loc ~loc_md (Module, id) ~md_mode ~mode
+        let md_modes =
+          rebase_sig_item_modes ~loc ~loc_md (Module, id) ~md_mode ~mode md.md_modes
         in
-        let md = {md with md_modalities} in
+        let md = {md with md_modes} in
         Sig_module (id, pres, md, rec_, vis)
     | item -> item
     ) sg
@@ -726,23 +714,29 @@ let params_are_constrained =
 let rec remove_modality_and_zero_alloc_variables_sg env ~zap_modality sg =
   let sg_item = function
     | Sig_value (id, desc, vis) ->
-        let val_modalities =
-          desc.val_modalities |> zap_modality |> Mode.Modality.of_const
+        let val_modes : Types.Sig_item_modes.t =
+          match desc.val_modes with
+          | Modality m ->
+              Modality (m |> zap_modality |> Mode.Modality.of_const)
+          | (Overriding _ | Normalized) as vm -> vm
         in
         let val_zero_alloc =
           Zero_alloc.create_const (Zero_alloc.get desc.val_zero_alloc)
         in
-        let desc = {desc with val_modalities; val_zero_alloc} in
+        let desc = {desc with val_modes; val_zero_alloc} in
         Sig_value (id, desc, vis)
     | Sig_module (id, pres, md, re, vis) ->
         let md_type =
           remove_modality_and_zero_alloc_variables_mty env ~zap_modality
             md.md_type
         in
-        let md_modalities =
-          md.md_modalities |> zap_modality |> Mode.Modality.of_const
+        let md_modes : Types.Sig_item_modes.t =
+          match md.md_modes with
+          | Modality m ->
+              Modality (m |> zap_modality |> Mode.Modality.of_const)
+          | (Overriding _ | Normalized) as vm -> vm
         in
-        let md = {md with md_type; md_modalities} in
+        let md = {md with md_type; md_modes} in
         Sig_module (id, pres, md, re, vis)
     | item -> item
   in
@@ -1122,9 +1116,16 @@ module Merge = struct
               remove_modality_and_zero_alloc_variables_mty sig_env
                 ~zap_modality:Mode.Modality.zap_to_id mty
             in
-            assert (Modality.is_undefined md'.md_modalities);
-            let modalities = Modality.(Const.id |> of_const) in
-            let md'' = { md' with md_type = mty; md_modalities = modalities} in
+            (match md'.md_modes with
+             | Normalized -> ()
+             | Modality _ | Overriding _ ->
+               Misc.fatal_error
+                 "expected md_modes = Normalized here");
+            let md'' =
+              { md' with
+                md_type = mty;
+                md_modes = Modality Modality.(Const.id |> of_const) }
+            in
             let newmd =
               Mtype.strengthen_decl ~aliasable:false md'' path in
             (* Inclusion check with the original signature *)
@@ -1362,13 +1363,18 @@ let rec apply_modalities_signature ~recursive env modalities sg =
   let env = Env.add_signature sg env in
   List.map (function
   | Sig_value (id, vd, vis) ->
-      let val_modalities =
-        vd.val_modalities
-        |> Mode.Modality.to_const_exn
-        |> (fun then_ -> Mode.Modality.Const.concat ~then_ modalities)
-        |> Mode.Modality.of_const
+      let val_modes : Types.Sig_item_modes.t =
+        match vd.val_modes with
+        | Modality m ->
+            Modality
+              (m
+              |> Mode.Modality.to_const_exn
+              |> (fun then_ ->
+                   Mode.Modality.Const.concat ~then_ modalities)
+              |> Mode.Modality.of_const)
+        | (Overriding _ | Normalized) as vm -> vm
       in
-      let vd = {vd with val_modalities} in
+      let vd = {vd with val_modes} in
       Sig_value (id, vd, vis)
   | Sig_module (id, pres, md, rec_, vis) when recursive ->
       let md_type = apply_modalities_module_type env modalities md.md_type in
@@ -1513,7 +1519,7 @@ let rec approx_modtype env smty =
 and approx_module_declaration env pmd =
   {
     Types.md_type = approx_modtype env pmd.pmd_type;
-    md_modalities = Mode.Modality.(Const.id |> of_const);
+    md_modes = Modality Mode.Modality.(Const.id |> of_const);
     md_attributes = pmd.pmd_attributes;
     md_loc = pmd.pmd_loc;
     md_uid = Uid.internal_not_actually_unique;
@@ -2065,7 +2071,7 @@ and transl_modtype_aux env smty =
               let id, newenv =
                 let arg_md =
                   { md_type = arg.mty_type;
-                    md_modalities = Mode.Modality.undefined;
+                    md_modes = Normalized;
                     md_attributes = [];
                     md_loc = param.loc;
                     md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -2203,7 +2209,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
         in
         let sg =
           sg
-          |> rebase_modalities_sg ~loc:smty.pmty_loc ~loc_md:psg_loc
+          |> rebase_sig_item_modes_sg ~loc:smty.pmty_loc ~loc_md:psg_loc
               ~md_mode ~mode
           |> remove_modality_and_zero_alloc_variables_sg env ~zap_modality
         in
@@ -2339,7 +2345,8 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
         in
         let md = {
           md_type=tmty.mty_type;
-          md_modalities = Modality.of_const md_modalities.moda_modalities;
+          md_modes =
+            Modality (Modality.of_const md_modalities.moda_modalities);
           md_attributes=pmd.pmd_attributes;
           md_loc=pmd.pmd_loc;
           md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -2382,7 +2389,7 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
             md
           else
             { md_type = Mty_alias path;
-              md_modalities = Mode.Modality.(Const.id |> of_const);
+              md_modes = Modality Mode.Modality.(Const.id |> of_const);
               md_attributes = pms.pms_attributes;
               md_loc = pms.pms_loc;
               md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());
@@ -2431,8 +2438,10 @@ and transl_signature env {psg_items; psg_modalities; psg_loc} =
         let sig_items =
           map_rec (fun rs (id, md, uid) ->
             let d = {Types.md_type = md.md_type.mty_type;
-                     md_modalities =
-                       Mode.Modality.of_const md.md_modalities.moda_modalities;
+                     md_modes =
+                       Modality
+                         (Mode.Modality.of_const
+                            md.md_modalities.moda_modalities);
                      md_attributes = md.md_attributes;
                      md_loc = md.md_loc;
                      md_uid = uid;
@@ -2623,7 +2632,8 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
         let md =
           { md with
             Types.md_type = tmty.mty_type;
-            md_modalities = Modality.of_const md_modalities.moda_modalities
+            md_modes =
+              Modality (Modality.of_const md_modalities.moda_modalities)
           }
         in
         (id_shape, id_loc, md, mmode, md_modalities, tmty))
@@ -2663,7 +2673,7 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
          let md_modalities = Modality.of_const md_modalities.moda_modalities in
          let md =
            { md_type;
-             md_modalities;
+             md_modes = Modality md_modalities;
              md_loc = pmd.pmd_loc;
              md_attributes = pmd.pmd_attributes;
              md_uid }
@@ -3175,7 +3185,7 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
               let md_uid =  Uid.mk ~current_unit:(Env.get_unit_name ()) in
               let arg_md =
                 { md_type = mty.mty_type;
-                  md_modalities = Modality.undefined;
+                  md_modes = Normalized;
                   md_attributes = [];
                   md_loc = param.loc;
                   md_uid;
@@ -3219,9 +3229,10 @@ and type_module_aux ~alias ~hold_locks sttn funct_body anchor env smod =
   | Pmod_constraint(sarg, smty, smode) ->
       (* Only hold locks if coercion *)
       let hold_locks = Option.is_some smty in
-      let tmode = Typemode.transl_mode_annots smode in
+      let tmode = Typemode.transl_alloc_mode smode in
       let mode =
-        { tmode with mode_modes = new_mode_var_from_annots tmode.mode_modes }
+        { tmode with mode_modes = tmode.mode_modes |> Alloc.of_const
+                                  |> alloc_as_value }
       in
       let arg, arg_shape =
         type_module_maybe_hold_locks ~alias ~hold_locks true funct_body
@@ -3610,10 +3621,22 @@ and type_open_decl_aux ?used_slot ?toplevel funct_body names env od =
     open_descr, mode, sg, newenv
 
 and type_structure ?(toplevel = None) funct_body anchor env sstr =
+  (* [md_mode] tracks the "real mode of the memory block" of this structure:
+     it is constrained by the items inside the structure (via inferred
+     modalities) and by the heap allocation invariant. The caller of
+     [type_structure] simply takes this real mode as the surface mode of the
+     module ([Tmod_structure.mod_mode]). That is sound because the consumer
+     of the module derives item modes and the memaddr mode from the surface
+     mode plus the per-item modalities. *)
   (* CR implicit-types: implement implicit variable jkinds in structures. *)
   let env = Env.clear_implicit_jkinds env in
   let names = Signature_names.create () in
   let _, md_mode = register_allocation () in
+  (* c0 story: the memory block's monadic axes on construction are pinned
+     to the strongest mode ([Value.Monadic.min]); soundness on monadic
+     follows trivially. Comonadic axes are still constrained per-item via
+     [infer_modalities]. *)
+  Value.Monadic.submode_exn md_mode.monadic Value.Monadic.min;
   let loc_md = location_of_structure sstr in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
@@ -3642,7 +3665,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         modl_shape sg ~mode env
     in
     let sg =
-      rebase_modalities_sg ~loc:smodl.pmod_loc ~loc_md ~md_mode ~mode sg
+      rebase_sig_item_modes_sg ~loc:smodl.pmod_loc ~loc_md ~md_mode ~mode sg
     in
     Signature_group.iter (Signature_names.check_sig_item names loc) sg;
     let incl =
@@ -3717,7 +3740,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
               let vd =
                 { vd with
                   val_zero_alloc = zero_alloc;
-                  val_modalities = modalities }
+                  val_modes = Types.Sig_item_modes.Modality modalities }
               in
               Sig_value(id, vd, Exported) :: acc,
               Shape.Map.add_value shape_map id vd.val_uid
@@ -3736,12 +3759,18 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           Typedecl.transl_value_decl env ~modal:Str_primitive
             ~why:Structure_item loc sdesc
         in
-        assert (desc.val_val.val_modalities |> Modality.is_undefined);
+        (match desc.val_val.val_modes with
+         | Normalized -> ()
+         | Modality _ | Overriding _ ->
+           Misc.fatal_error
+             "Pstr_primitive: expected val_modes = Normalized");
         let pp : Mode.Hint.pinpoint = (desc.val_loc, Expression) in
         let val_modalities =
           infer_modalities pp ~loc_md (Value, desc.val_id) ~md_mode ~mode
         in
-        let val_val = {desc.val_val with val_modalities} in
+        let val_val =
+          {desc.val_val with val_modes = Modality val_modalities}
+        in
         let desc = {desc with val_val} in
         Signature_names.check_value names desc.val_loc desc.val_id;
         Tstr_primitive desc,
@@ -3821,7 +3850,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
         let mode = mode_without_locks_exn modl.mod_mode in
         let md =
           { md_type = enrich_module_type anchor name.txt modl.mod_type env;
-            md_modalities = Modality.undefined;
+            md_modes = Normalized;
             md_attributes = attrs;
             md_loc = pmb_loc;
             md_uid;
@@ -3845,7 +3874,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
             Some id, e,
             [Sig_module(id, pres,
                         {md_type = modl.mod_type;
-                         md_modalities;
+                         md_modes = Modality md_modalities;
                          md_attributes = attrs;
                          md_loc = pmb_loc;
                          md_uid;
@@ -3881,7 +3910,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           transl_recmodule_modtypes env
             ~sig_modalities:Mode.Modality.Const.id
             (List.map (fun (name, smty, smode, _smodl, attrs, loc) ->
-                 ({pmd_name=name; pmd_type=smty;
+                 ({pmd_name=name; pmd_modes=[]; pmd_type=smty;
                    pmd_attributes=attrs; pmd_loc=loc; pmd_modalities=[]}
                   , Some smode)) sbind
             ) in
@@ -3915,7 +3944,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
                    let mdecl =
                      {
                        md_type = mty.mty_type;
-                       md_modalities = Modality.undefined;
+                       md_modes = Normalized;
                        md_attributes = attrs;
                        md_loc = loc;
                        md_uid = uid;
@@ -3947,7 +3976,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
             in
             Sig_module(id, Mp_present, {
                 md_type=mb.mb_expr.mod_type;
-                md_modalities;
+                md_modes = Modality md_modalities;
                 md_attributes=mb.mb_attributes;
                 md_loc=mb.mb_loc;
                 md_uid = uid;
@@ -3968,7 +3997,7 @@ and type_structure ?(toplevel = None) funct_body anchor env sstr =
           type_open_decl ~toplevel funct_body names env sod
         in
         let sg =
-          rebase_modalities_sg ~loc:sod.popen_expr.pmod_loc ~loc_md
+          rebase_sig_item_modes_sg ~loc:sod.popen_expr.pmod_loc ~loc_md
             ~md_mode ~mode sg
         in
         Tstr_open od, sg, shape_map, newenv
@@ -4645,7 +4674,7 @@ let package_signatures units =
       let sg = Subst.signature Make_local subst sg in
       let md =
         { md_type=Mty_signature sg;
-          md_modalities=Modality.(Const.id |> of_const);
+          md_modes = Modality Modality.(Const.id |> of_const);
           md_attributes=[];
           md_loc=Location.none;
           md_uid = Uid.mk ~current_unit:(Env.get_unit_name ());

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -462,6 +462,39 @@ let mode_annot_to_modality_annot mode_annot =
       | Monadic ax -> Atom (Monadic ax, Join_const mode))
     mode_annot
 
+let modality_of_mode_annot_option (opt : Alloc.Const.Option.t)
+  : Modality.Const.t =
+  let atom_of_axis (type a) (ax : a Alloc.Axis.t) (v : a option)
+    : Modality.atom option =
+    Option.map
+      (fun v ->
+        let (Atom (ax, v) : Mode.Value.atom) =
+          Mode_axis_pair.to_value (Atom (ax, v))
+        in
+        match[@warning "-18"] ax with
+        | Comonadic ax -> (Atom (Comonadic ax, Meet_const v) : Modality.atom)
+        | Monadic ax -> (Atom (Monadic ax, Join_const v) : Modality.atom))
+      v
+  in
+  let atoms =
+    List.filter_map
+      (fun x -> x)
+      [ atom_of_axis (Comonadic Areality) opt.areality;
+        atom_of_axis (Comonadic Linearity) opt.linearity;
+        atom_of_axis (Comonadic Portability) opt.portability;
+        atom_of_axis (Comonadic Forkable) opt.forkable;
+        atom_of_axis (Comonadic Yielding) opt.yielding;
+        atom_of_axis (Comonadic Statefulness) opt.statefulness;
+        atom_of_axis (Monadic Uniqueness) opt.uniqueness;
+        atom_of_axis (Monadic Contention) opt.contention;
+        atom_of_axis (Monadic Visibility) opt.visibility;
+        atom_of_axis (Monadic Staticity) opt.staticity
+      ]
+  in
+  List.fold_left
+    (fun t (Modality.Atom (ax, a)) -> Modality.Const.set ax a t)
+    Modality.Const.id atoms
+
 let transl_modality ~maturity { txt = Parsetree.Modality modality; loc } =
   Language_extension.assert_enabled ~loc Mode maturity;
   let mode =

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -17,6 +17,12 @@ type modalities =
 *)
 val transl_mode_annots : Parsetree.modes -> Mode.Alloc.Const.Option.t modes
 
+(** Convert a partial mode annotation (only some axes specified) into a modality
+    that meets/joins with the specified values on those axes and is the identity
+    on the unspecified axes. *)
+val modality_of_mode_annot_option :
+  Mode.Alloc.Const.Option.t -> Mode.Modality.Const.t
+
 val untransl_mode : _ modes -> Parsetree.modes
 
 (** Interpret mode syntax as alloc mode (on arrow types), where axes are set to

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -662,12 +662,138 @@ module Lpoly = struct
     | Determined _ -> on_determined ()
 end
 
+module Sig_item_modes = struct
+  type t =
+    | Overriding of Mode.Value.Const.Option.t
+    | Modality of Mode.Modality.t
+    | Normalized
+
+  type normalize =
+    | Normalize_exn
+    | Assert_normalized
+    | Normalize
+
+  module Const = struct
+    type t =
+      | Overriding of Mode.Value.Const.Option.t
+      | Modality of Mode.Modality.Const.t
+      | Normalized
+
+    let apply : type l r.
+        normalize -> t -> (l * r) Mode.Value.t -> (l * r) Mode.Value.t =
+      fun n sim m ->
+      match n, sim with
+      | Normalize, Normalized -> m
+      | Normalize_exn, Normalized ->
+          Misc.fatal_error "mode is already normalized but expected otherwise"
+      | Assert_normalized, Normalized -> m
+      | (Normalize | Normalize_exn), Modality mc ->
+          Mode.Modality.Const.apply mc m
+      | (Normalize | Normalize_exn), Overriding o ->
+          (* Per the invariant: when [val_modes] is [Overriding], the
+             surrounding mode is constant, so the zap is safe. *)
+          let c = Mode.Value.to_loose_const_exn m in
+          let c = Mode.Value.Const.Option.value o ~default:c in
+          Mode.Value.of_const c
+      | Assert_normalized, (Modality _ | Overriding _) ->
+          Misc.fatal_error "mode is not already normalized but expected otherwise"
+  end
+
+  let apply ?(loc_struct : Location.t option)
+        ?(item : Mode.Hint.structure_item option) (n : normalize) (vm : t)
+        mode =
+    match n, vm with
+    | Normalize, Normalized -> Mode.Value.disallow_right mode
+    | Normalize_exn, Normalized ->
+        Misc.fatal_error "mode is already normalized but expected otherwise"
+    | Assert_normalized, Normalized -> Mode.Value.disallow_right mode
+    | (Normalize | Normalize_exn), Modality m ->
+        let hint : _ Mode.monadic_comonadic =
+          match loc_struct, item with
+          | Some loc_struct, Some item ->
+              let is_contained_by : Mode.Hint.is_contained_by =
+                { containing = Structure (item, Modality);
+                  container = (loc_struct, Structure) }
+              in
+              { monadic = Mode.Hint.Is_contained_by (Monadic, is_contained_by);
+                comonadic =
+                  Mode.Hint.Is_contained_by (Comonadic, is_contained_by) }
+          | _ ->
+              {monadic = Mode.Hint.Unknown; comonadic = Mode.Hint.Unknown}
+        in
+        Mode.Modality.apply ~hint m mode
+    | (Normalize | Normalize_exn), Overriding o ->
+        let c = Mode.Value.to_loose_const_exn mode in
+        let c = Mode.Value.Const.Option.value o ~default:c in
+        Mode.Value.of_const c |> Mode.Value.disallow_right
+    | Assert_normalized, (Modality _ | Overriding _) ->
+        Misc.fatal_error "mode is not already normalized but expected otherwise"
+
+  let to_const_opt (sim : t) : Const.t option =
+    match sim with
+    | Overriding o -> Some (Const.Overriding o)
+    | Modality m ->
+      (match Mode.Modality.to_const_opt m with
+       | None -> None
+       | Some m -> Some (Const.Modality m))
+    | Normalized -> Some Const.Normalized
+
+  type sub_error =
+    | Modality_error of Mode.Modality.error
+    | Axis_mismatch of Mode.Value.Axis.packed
+    | Le_failure : 'a Mode.Value.Axis.t * 'a * 'a -> sub_error
+
+  (* Check that for each axis, either both [modes0] and [modes1] are [None],
+     or both are [Some] with [modes0 <= modes1] on that axis. *)
+  let sub_overriding (modes0 : Mode.Value.Const.Option.t)
+        (modes1 : Mode.Value.Const.Option.t) : (unit, sub_error) result =
+    let exception Sub_error of sub_error in
+    let check_axis : type a.
+        a Mode.Value.Axis.t -> a option -> a option -> unit =
+      fun ax v0 v1 ->
+        match v0, v1 with
+        | None, None -> ()
+        | Some v0, Some v1 ->
+          let le =
+            match ax with
+            | Comonadic ax -> Mode.Value.Comonadic.Const.Per_axis.le ax v0 v1
+            | Monadic ax -> Mode.Value.Monadic.Const.Per_axis.le ax v0 v1
+          in
+          if not le then raise (Sub_error (Le_failure (ax, v0, v1)))
+        | None, Some _ | Some _, None ->
+          raise (Sub_error (Axis_mismatch (P ax)))
+    in
+    try
+      List.iter
+        (fun (Mode.Value.Axis.P ax) ->
+          let v0 = Mode.Value.Const.Option.proj ax modes0 in
+          let v1 = Mode.Value.Const.Option.proj ax modes1 in
+          check_axis ax v0 v1)
+        Mode.Value.Axis.all;
+      Ok ()
+    with Sub_error e -> Error e
+
+  let sub (sim0 : t) (sim1 : t) : (unit, sub_error) result =
+    match sim0, sim1 with
+    | Modality m0, Modality m1 ->
+      (match Mode.Modality.sub m0 m1 with
+       | Ok () -> Ok ()
+       | Error e -> Error (Modality_error e))
+    | Overriding o0, Overriding o1 -> sub_overriding o0 o1
+    | Normalized, Normalized -> Ok ()
+    | (Modality _ | Overriding _ | Normalized),
+      (Modality _ | Overriding _ | Normalized) ->
+      Misc.fatal_error
+        "Sig_item_modes.sub: mismatched constructors"
+
+end
+
 module type Wrapped = sig
   type 'a wrapped
 
   type value_description =
     { val_type: type_expr wrapped;                (* Type of the value *)
-      val_modalities : Mode.Modality.t;     (* Modalities on the value *)
+      val_modes : Sig_item_modes.t;
       val_kind: value_kind;
       val_lpoly: Lpoly.t wrapped;
       val_loc: Location.t;
@@ -704,7 +830,7 @@ module type Wrapped = sig
   and module_declaration =
   {
     md_type: module_type;
-    md_modalities: Mode.Modality.t;
+    md_modes : Sig_item_modes.t;
     md_attributes: Parsetree.attributes;
     md_loc: Location.t;
     md_uid: Uid.t;
@@ -779,11 +905,11 @@ module Map_wrapped(From : Wrapped)(To : Wrapped) = struct
 
   let value_description m vd = m.map_value_description m vd
 
-  let module_declaration m {md_type; md_modalities; md_attributes;
+  let module_declaration m {md_type; md_modes; md_attributes;
     md_loc; md_uid} =
     To.{
       md_type = module_type m md_type;
-      md_modalities;
+      md_modes;
       md_attributes;
       md_loc;
       md_uid;

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -1136,20 +1136,151 @@ module Lpoly : sig
     -> unit
 end
 
+module Sig_item_modes : sig
+  (** The mode-related information on a signature item (value description or
+      module declaration).
+
+      Note: in the discussion below, "structure's mode" / "surrounding
+      mode" refers to the "surface mode" (the mode the user annotates and
+      sees), as distinct from the real "memory block" mode of the
+      structure described later.
+
+      Conceptually, the mode at which an item is exposed from its surrounding
+      structure can be derived in two ways:
+      - From the structure's mode plus a modality ([Modality]).
+      - From an explicit per-axis annotation that overrides the surrounding
+        mode ([Overriding]).
+
+      After this information has been consumed (i.e., the item's actual mode
+      has been computed), the field is replaced with [Normalized] to prevent
+      double-consumption.
+
+      Invariant: if an item has [Overriding _], then the surrounding
+      structure must have a constant mode. In particular,
+      [Mode.Value.to_loose_const_exn] applied to that mode is guaranteed to
+      succeed.
+
+      Note on the "memory block of the structure" mode (aka the real mode):
+      - For comonadic axes, upon constructing the structure, the memory
+        block's mode is the join of (a) all the items' modes inside (for
+        soundness) and (b) the surface mode of the module (for user
+        flexibility).
+      - For monadic axes, upon consuming/accessing the structure, the
+        memory block's mode is the meet of (a) all the items'
+        consume/access modes and (b) the surface mode of the module (for
+        user flexibility).
+      - Soundness additionally requires that the memory block is not
+        consumed/accessed at modes stronger than how it was constructed.
+        However, the memory block's mode is not reflected in types (and so
+        not passed around during type-checking). So we rely on the items'
+        modes and the surface mode to carry that information. On
+        construction, the comonadic axes are described above as [m0]; for
+        monadic axes we just take the strongest mode allowed (some
+        constant [c0]). On consumption, the monadic axes are described
+        above as [m1]; for comonadic axes we just take the weakest mode
+        allowed (some constant [c1]). Then we just have to ensure that
+        [c0 <= m1] and [m0 <= c1]. *)
+
+  type t =
+    | Overriding of Mode.Value.Const.Option.t
+        (** On each axis where the option is [Some], the mode overrides
+            whatever is derived from the surrounding structure's mode.
+            By the invariant above, the surrounding mode is constant on every
+            axis. *)
+    | Modality of Mode.Modality.t
+        (** A modality from the surrounding structure's mode to the item's
+            mode. *)
+    | Normalized
+        (** This field has been consumed and shouldn't be consumed again. *)
+
+  (** Operation modes for normalizing an item: i.e., consuming its
+      [Sig_item_modes.t] by applying it to the surrounding mode, and replacing
+      the field with [Normalized]. *)
+  type normalize =
+    | Normalize_exn
+        (** Normalize a mode; raise if already normalized. *)
+    | Assert_normalized
+        (** Assert that the mode is already normalized, and return the mode. *)
+    | Normalize
+        (** Normalize a mode; do nothing if already normalized. Use the other
+            two instead whenever possible. *)
+
+  (** Constant version of [t]: same constructors, but [Modality] holds a
+      constant [Mode.Modality.Const.t] instead of a variable
+      [Mode.Modality.t]. *)
+  module Const : sig
+    type t =
+      | Overriding of Mode.Value.Const.Option.t
+      | Modality of Mode.Modality.Const.t
+      | Normalized
+
+    (** [apply n sim m] computes the item's mode given the surrounding
+        structure's mode [m] and the [sim] on the item:
+        - For [Modality mc], applies [mc] to [m].
+        - For [Overriding o], overrides [m] on the axes specified by [o]
+          ([m] is required to be constant by the [Overriding] invariant).
+        - For [Normalized], returns [m] unchanged.
+
+        [n] controls behavior when [sim] is [Normalized] (already normalized)
+        or when [sim] is [Modality]/[Overriding] (not yet normalized). See
+        [normalize] for details.
+
+        Preserves allowances on both sides. *)
+    val apply :
+      normalize ->
+      t -> ('l * 'r) Mode.Value.t -> ('l * 'r) Mode.Value.t
+  end
+
+  (** [apply ?loc_struct ?item n sim mode] computes the item's mode given
+      the surrounding structure's [mode] and the [sim] on the item.
+      [loc_struct] is the location of the enclosing structure (not the
+      item).
+      - For [Modality m], applies [m] to [mode]. When both [loc_struct] and
+        [item] are provided, uses them for the [Is_contained_by] hint;
+        otherwise uses [Unknown].
+      - For [Overriding o], overrides [mode] on the axes specified by [o]
+        (the unspecified axes of [mode] must be a constant).
+      - For [Normalized], returns [mode] unchanged.
+
+      [n] controls behavior when [sim] is [Normalized] (already normalized)
+      or when [sim] is [Modality]/[Overriding] (not yet normalized). See
+      the [normalize] type for details.
+
+      Loses right-allowance because the [Modality m] case requires that. *)
+  (* CR-someday zqian: [loc_struct] and [item] should be mandatory. *)
+  val apply :
+    ?loc_struct:Location.t ->
+    ?item:Mode.Hint.structure_item ->
+    normalize ->
+    t -> (Allowance.allowed * 'r) Mode.Value.t -> Mode.Value.l
+
+  (** Convert to the constant version. Returns [None] when [Modality m] but
+      [m] is not constant; otherwise returns [Some _]. *)
+  val to_const_opt : t -> Const.t option
+
+  type sub_error =
+    | Modality_error of Mode.Modality.error
+        (** Modality submode check failed (both sides are [Modality]). *)
+    | Axis_mismatch of Mode.Value.Axis.packed
+        (** Both sides are [Overriding]; one specifies the axis, the other
+            does not. *)
+    | Le_failure : 'a Mode.Value.Axis.t * 'a * 'a -> sub_error
+        (** Both sides are [Overriding] and specify the axis, but [<=] does
+            not hold. *)
+
+  (** [sub sim0 sim1] checks that [sim0] is more permissive than [sim1] at
+      the same surface mode. Both must be the same constructor (otherwise
+      raises [Misc.Fatal_error]). *)
+  val sub : t -> t -> (unit, sub_error) result
+
+end
+
 module type Wrapped = sig
   type 'a wrapped
 
   type value_description =
     { val_type: type_expr wrapped;                (* Type of the value *)
-      val_modalities: Mode.Modality.t;
-   (** The modalities on the value in a signature. It is [undefined] in several
-      cases:
-    - The value is not in a structure, so there is no modalities
-      to talk about. For example, adding [let x = ... in] to the environment
-      will have [val_modalities] set to [undefined].
-    - The value was from a structure, but the original modalities
-      have been applied and we have the real mode of the value. The original
-      modalities shouldn't be looked again and is replaced by [undefined]. *)
+      val_modes : Sig_item_modes.t;
       val_kind: value_kind;
       val_lpoly: Lpoly.t wrapped;
       (** Guaranteed [determined] for all values visible outside [type_let].
@@ -1189,8 +1320,7 @@ module type Wrapped = sig
   and module_declaration =
   {
     md_type: module_type;
-    md_modalities : Mode.Modality.t;
-    (** Similiar to [val_modalities]; see comments there. *)
+    md_modes : Sig_item_modes.t;
     md_attributes: Parsetree.attributes;
     md_loc: Location.t;
     md_uid: Uid.t;


### PR DESCRIPTION
## Summary

Adds first-class mode annotations on value descriptions and module declarations in signatures:
- `val foo @ portable : 'a -> 'a` — annotates `foo` at the given modes regardless of surrounding structure mode
- `module M @ portable : sig ... end` — similarly for module declarations
- Unifies the `val_modalities`/`val_modes` and `md_modalities`/`md_modes` fields into a single `Sig_item_modes.t` (`Overriding` | `Modality` | `Normalized`)
- Adds the structure-memaddr-mode submode check in `try_modtypes` (gated by `Tcoerce_none`)

## Open design questions

1. **`Overriding` and `Modality` interpret the surrounding structure's mode differently.**
   - `Modality m` reads the structure's mode and applies a modality to get the item's mode.
   - `Overriding o` ignores the structure's mode on annotated axes and uses `o` directly.
   - Both can now coexist in a signature, so when we see "the module's mode," it's ambiguous whether that's the *surface* mode (what users see) or the *real* mode (the memory block's mode used internally). We should pick a discipline here.
   - **Do we allow a single signature to mix items with `Overriding` and items with `Modality`?** Currently nothing prevents it, but the semantics are subtle.

2. **First-class modules and surface vs. real modes.**
   - On *pack* (`(module M : MT)`): the resulting first-class module is a regular value, whose mode is the *real* mode of the module being packed. This is consistent with \"values only have one mode.\"
   - On *unpack* (`module M = (val expr)`): we need to decide what the *surface* mode of the resulting module is. Currently `mod_mode` is set to the value's mode (so surface = real = value's mode), but it's worth documenting that choice and confirming it's what we want.

## Other follow-ups (CR-someday)

- `Sig_item_modes.apply`'s `?loc_struct` / `?item` should be mandatory.
- `Sig_item_modes.apply` should also take mode hints in its `normalize` branch (currently only the `Modality` branch uses them).
- Structure-memaddr-mode check uses the surface mode; a real-mode check would accept more sound programs (see CR-someday in `includemod.ml`).
- Move to the c0/c1 soundness story: pin construction monadic to `min` (attempted; breaks stdlib at the unpack-then-pack-back boundary — needs design work on surface-vs-real for unpacked modules first).

## Test plan

- [ ] \`make -s test\` passes (currently 11 failures from message changes / pre-existing test updates — see test diffs in the PR)
- [ ] New tests in \`testsuite/tests/typing-modes/val_modes.ml\` cover the basic syntax, error paths, and the \`Tcoerce_none\` vs. coercion-elided structure-memaddr-mode check

🤖 Generated with [Claude Code](https://claude.com/claude-code)