### PR TITLE
flambda2: Add BFS meet strategy

### DIFF
--- a/middle_end/flambda2/tests/api_tests/extension_meet.expected
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.expected
@@ -50,3 +50,61 @@ New environment:
     {([0m[38;5;111;1mz/2N[0m ([0m[38;5;111;1mx/0N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m)) ([0m[38;5;111;1my/1N[0m ([0m[38;5;111;1mx/0N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
    (aliases_of_canonical_names {([0m[38;5;111;1mx/0N[0m {(Normal {([0m[38;5;111;1mz/2N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1my/1N[0m [0m[38;5;243;1mid[0m)})})})
    (aliases_of_consts {}))))
+Environment: ((defined_symbols { }) (code_age_relation {})
+              (levels
+               ((scope 1) (defined_vars
+                {([0m[38;5;111;1mx/3N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/4N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mz/5N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+               ((defined_vars { x/3N y/4N z/5N })
+                (equations
+                 ([0m[38;5;111;1mx/3N[0m :
+                   (Val!
+                    (Variant
+                     (blocks (alloc_mode Heap)
+                      (known
+                       {(tag_0 => (Known 2), ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1my/4N[0m)) (Val [0m[38;5;37;1m⊤[0m)))}))))
+                  [0m[38;5;111;1my/4N[0m :
+                   (Val!
+                    (Variant
+                     (blocks (alloc_mode Heap)
+                      (known
+                       {(tag_0 => (Known 2),
+                         ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/5N[0m))
+                          (Val!
+                           (Variant
+                            (tagged_imms (Naked_immediate ({ 0 1 })))))))}))))
+                  [0m[38;5;111;1mz/5N[0m :
+                   (Val!
+                    (Variant
+                     (blocks (alloc_mode Heap)
+                      (known
+                       {(tag_0 => (Known 2),
+                         ((Val [0m[38;5;37;1m⊤[0m)
+                          (Val!
+                           (Variant
+                            (tagged_imms (Naked_immediate ({ 1 2 })))))))})))))))))
+              (aliases
+               ((canonical_elements {}) (aliases_of_canonical_names {})
+                (aliases_of_consts {}))))
+Result type: (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/3N[0m))
+New environment:
+((defined_symbols { }) (code_age_relation {})
+ (levels
+  ((scope 1) (defined_vars
+   {([0m[38;5;111;1mx/3N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1my/4N[0m :: [0m[38;5;37;1m𝕍[0m Normal) ([0m[38;5;111;1mz/5N[0m :: [0m[38;5;37;1m𝕍[0m Normal)}))
+  ((defined_vars { x/3N y/4N z/5N })
+   (equations
+    ([0m[38;5;111;1mx/3N[0m :
+      (Val!
+       (Variant
+        (blocks (alloc_mode Heap)
+         (known
+          {(tag_0 => (Known 2),
+            ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/5N[0m))
+             (Val! (Variant (tagged_imms (Naked_immediate ({ 0 1 })))))))}))))
+     [0m[38;5;111;1my/4N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/3N[0m))
+     [0m[38;5;111;1mz/5N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/3N[0m)))))))
+ (aliases
+  ((canonical_elements
+    {([0m[38;5;111;1my/4N[0m ([0m[38;5;111;1mx/3N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m)) ([0m[38;5;111;1mz/5N[0m ([0m[38;5;111;1mx/3N[0m [0m[38;5;243;1m(coercion [0m[38;5;243;1mid[0m[38;5;243;1m)[0m))})
+   (aliases_of_canonical_names {([0m[38;5;111;1mx/3N[0m {(Normal {([0m[38;5;111;1my/4N[0m [0m[38;5;243;1mid[0m) ([0m[38;5;111;1mz/5N[0m [0m[38;5;243;1mid[0m)})})})
+   (aliases_of_consts {}))))

--- a/middle_end/flambda2/tests/api_tests/extension_meet.expected
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.expected
@@ -70,8 +70,7 @@ Environment: ((defined_symbols { }) (code_age_relation {})
                        {(tag_0 => (Known 2),
                          ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/5N[0m))
                           (Val!
-                           (Variant
-                            (tagged_imms (Naked_immediate ({ 0 1 })))))))}))))
+                           (Variant (tagged_imms (Naked_immediate { 0 1 }))))))}))))
                   [0m[38;5;111;1mz/5N[0m :
                    (Val!
                     (Variant
@@ -80,8 +79,7 @@ Environment: ((defined_symbols { }) (code_age_relation {})
                        {(tag_0 => (Known 2),
                          ((Val [0m[38;5;37;1m⊤[0m)
                           (Val!
-                           (Variant
-                            (tagged_imms (Naked_immediate ({ 1 2 })))))))})))))))))
+                           (Variant (tagged_imms (Naked_immediate { 1 2 }))))))})))))))))
               (aliases
                ((canonical_elements {}) (aliases_of_canonical_names {})
                 (aliases_of_consts {}))))
@@ -100,7 +98,7 @@ New environment:
          (known
           {(tag_0 => (Known 2),
             ((Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mz/5N[0m))
-             (Val! (Variant (tagged_imms (Naked_immediate ({ 0 1 })))))))}))))
+             (Val! (Variant (tagged_imms (Naked_immediate { 0 1 }))))))}))))
      [0m[38;5;111;1my/4N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/3N[0m))
      [0m[38;5;111;1mz/5N[0m : (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1mx/3N[0m)))))))
  (aliases

--- a/middle_end/flambda2/tests/api_tests/extension_meet.ml
+++ b/middle_end/flambda2/tests/api_tests/extension_meet.ml
@@ -170,6 +170,59 @@ let test_double_recursion () =
       env
   | Bottom -> Format.eprintf "Bottom@."
 
+let test_precision_loss () =
+  (* This test demonstrates a case where the BFS meet strategy is required in
+     order to avoid loss of precision -- we expect the second field of the block
+     to have the singleton `{ 1 }` as a type, but with the DFS meet strategy it
+     has the pair `{ 0, 1 }` as a type instead). *)
+  let env = TE.create ~resolver:(fun _ -> None) ~machine_width:Sixty_four in
+  let machine_width = TE.machine_width env in
+  let var_x = Variable.create "x" Flambda_kind.value in
+  let var_y = Variable.create "y" Flambda_kind.value in
+  let var_z = Variable.create "z" Flambda_kind.value in
+  let n_x = Name.var var_x in
+  let n_y = Name.var var_y in
+  let n_z = Name.var var_z in
+  let nb_x = Bound_name.create n_x Name_mode.normal in
+  let nb_y = Bound_name.create n_y Name_mode.normal in
+  let nb_z = Bound_name.create n_z Name_mode.normal in
+  let env = TE.add_definition env nb_x Flambda_kind.value in
+  let env = TE.add_definition env nb_y Flambda_kind.value in
+  let env = TE.add_definition env nb_z Flambda_kind.value in
+  let alias name = T.alias_type_of Flambda_kind.value (Simple.name name) in
+  let one_of ints =
+    T.these_tagged_immediates
+      (Target_ocaml_int.Set.of_list
+         (List.map (Target_ocaml_int.of_int machine_width) ints))
+  in
+  let ty_x =
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
+      ~fields:[alias n_y; T.any_value]
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
+  in
+  let ty_y =
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
+      ~fields:[alias n_z; one_of [0; 1]]
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
+  in
+  let ty_z =
+    T.immutable_block ~is_unique:false Tag.zero
+      ~shape:(Flambda_kind.Block_shape.Scannable Value_only)
+      ~fields:[T.any_value; one_of [1; 2]]
+      Alloc_mode.For_types.heap ~machine_width:Sixty_four
+  in
+  let env = TE.add_equation env n_x ty_x in
+  let env = TE.add_equation env n_y ty_y in
+  let env = TE.add_equation env n_z ty_z in
+  Format.eprintf "Environment: %a@." TE.print env;
+  match T.meet env (alias n_x) (alias n_y) with
+  | Ok (ty, env) ->
+    Format.eprintf "Result type: %a@.New environment:@ %a@." T.print ty TE.print
+      env
+  | Bottom -> Format.eprintf "Bottom@."
+
 let _ =
   let comp_unit =
     let linkage_name = Compilation_unit.Name.of_string "camlTest" in
@@ -177,4 +230,5 @@ let _ =
   in
   let unit_info = Unit_info.make_dummy ~input_name:"camlTest" comp_unit in
   Env.set_current_unit unit_info;
-  test_double_recursion ()
+  test_double_recursion ();
+  test_precision_loss ()

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1849,11 +1849,11 @@ let cut_for_join typing_env ~cut_after =
   incremental_equations, symbol_projections
 
 let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
-    source_env joined_envs equations_to_join symbol_projections_to_join =
+    source_env source_tenv joined_envs equations_to_join
+    symbol_projections_to_join =
   try
     let empty_bindings =
-      Bindings_in_target_env.from_source_env
-        (Source_env.create (ME.typing_env source_env))
+      Bindings_in_target_env.from_source_env (Source_env.create source_tenv)
     in
     let joined_envs = Joined_envs.create equations_to_join in
     let concrete_equations_to_join, bindings =
@@ -2118,7 +2118,7 @@ module Analysis = struct
 end
 
 let cut_and_n_way_join ~n_way_join_type ~meet_expanded_head ~cut_after
-    source_env joined_envs =
+    source_env source_tenv joined_envs =
   let joined_envs, equations_to_join, symbol_projections_to_join =
     Index.fold_list
       (fun index typing_env
@@ -2141,12 +2141,13 @@ let cut_and_n_way_join ~n_way_join_type ~meet_expanded_head ~cut_after
   in
   let target_env, _ =
     cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
-      source_env joined_envs equations_to_join symbol_projections_to_join
+      source_env source_tenv joined_envs equations_to_join
+      symbol_projections_to_join
   in
   target_env
 
 let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
-    ~cut_after source_env joined_envs =
+    ~cut_after source_tenv joined_envs =
   let external_ids, joined_envs, equations_to_join, symbol_projections_to_join =
     Index.fold_list
       (fun index (external_id, typing_env)
@@ -2170,12 +2171,13 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
       joined_envs
       (Index.Map.empty, Index.Map.empty, Index.Map.empty, Index.Map.empty)
   in
-  let source_env = ME.create source_env in
+  let source_env = ME.create source_tenv in
   let target_env, bindings =
     cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
-      source_env joined_envs equations_to_join symbol_projections_to_join
+      source_env source_tenv joined_envs equations_to_join
+      symbol_projections_to_join
   in
-  let target_env = ME.typing_env target_env in
+  let target_env = ME.final_typing_env ~meet_expanded_head target_env in
   let join_analysis = Analysis.create ~external_ids ~joined_envs bindings in
   target_env, join_analysis
 
@@ -2226,8 +2228,9 @@ let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
         let cut_after = TE.current_scope parent_env in
         let typing_env = TE.increment_scope parent_env in
         match
-          ME.add_env_extension_strict ~meet_expanded_head (ME.create typing_env)
-            extension
+          ME.use_meet_env_strict ~meet_expanded_head typing_env
+            ~f:(fun meet_env ->
+              ME.add_env_extension ~meet_expanded_head meet_env extension)
         with
         | Bottom ->
           (* We can reach bottom here if the extension was created in a more
@@ -2235,10 +2238,8 @@ let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
              reachable. *)
           joined_envs_and_extensions
         | Ok env ->
-          let level = ME.cut env ~cut_after in
-          Index.Map.add index
-            (ME.typing_env env, level)
-            joined_envs_and_extensions)
+          let level = TE.cut env ~cut_after in
+          Index.Map.add index (env, level) joined_envs_and_extensions)
       Index.Map.empty extensions
   in
   Index.Map.mapi

--- a/middle_end/flambda2/types/env/join_env.mli
+++ b/middle_end/flambda2/types/env/join_env.mli
@@ -41,6 +41,7 @@ val cut_and_n_way_join :
   meet_expanded_head:Meet_env.meet_expanded_head ->
   cut_after:Scope.t ->
   Meet_env.t ->
+  Typing_env.t ->
   Typing_env.t list ->
   Meet_env.t
 

--- a/middle_end/flambda2/types/env/meet_env.ml
+++ b/middle_end/flambda2/types/env/meet_env.ml
@@ -529,6 +529,8 @@ let[@inline always] meet_type env t1 t2 ~meet_expanded_head : TG.t meet_result =
   map_result ~f:ET.to_type
     ((meet [@inlined never]) env t1 t2 ~meet_expanded_head)
 
+let current_typing_env t = t.typing_env
+
 let rec final_typing_env_exn ~meet_expanded_head ({ delayed_equations; _ } as t)
     =
   match delayed_equations with

--- a/middle_end/flambda2/types/env/meet_env.ml
+++ b/middle_end/flambda2/types/env/meet_env.ml
@@ -21,9 +21,19 @@ module TEL = Typing_env_level
 module K = Flambda_kind
 module ET = Expand_head.Expanded_type
 
+type meet_strategy =
+  | Dfs
+  | Bfs
+  | Hybrid
+
+let meet_strategy =
+  Oxcaml_args.Extra_options.symbol __LOC__ "flambda2-meet-strategy" Dfs
+    ["dfs", Dfs; "bfs", Bfs; "hybrid", Hybrid]
+
 type t =
   { typing_env : TE.t;
-    adding_equations_for_names : Name.Set.t
+    adding_equations_for_names : Name.Set.t;
+    delayed_equations : (Simple.t * ET.t) list
   }
 
 type 'a meet_return_value =
@@ -46,51 +56,24 @@ let map_result ~f = function
   | Ok (New_result x, env) -> Ok (New_result (f x), env)
 
 let create typing_env =
-  { typing_env; adding_equations_for_names = Name.Set.empty }
+  { typing_env;
+    adding_equations_for_names = Name.Set.empty;
+    delayed_equations = []
+  }
 
-let typing_env { typing_env; _ } = typing_env
-
-let code_age_relation env = TE.code_age_relation (typing_env env)
+let code_age_relation env = TE.code_age_relation env.typing_env
 
 let code_age_relation_resolver env =
-  TE.code_age_relation_resolver (typing_env env)
+  TE.code_age_relation_resolver env.typing_env
 
-let machine_width env = TE.machine_width (typing_env env)
+let machine_width env = TE.machine_width env.typing_env
 
 let with_typing_env t typing_env = { t with typing_env }
 
-let use_meet_env t ~f = typing_env (f (create t))
+let map_typing_env t ~f = { t with typing_env = f t.typing_env }
 
-let use_meet_env_strict t ~f : _ Or_bottom.t =
-  if TE.is_bottom t
-  then Bottom
-  else
-    let t = f (create t) in
-    let tenv = typing_env t in
-    if TE.is_bottom tenv then Bottom else Ok tenv
-
-let map_typing_env t ~f = with_typing_env t (f (typing_env t))
-
-let adding_equation_for_name t name ~f =
-  (* If we were to add an equation on [x] while already adding an equation on
-     [x], either the inner equation would get overriden by the outer equation
-     and would not be visible, or it would get captured in an env extension.
-
-     That env extension would then likely end up stored on [x] itself, which
-     currently would cause an infinite loop next time we try to add an equation
-     on [x].
-
-     Instead, we simply ignore such recursive equations. *)
-  (* CR bclement: Implement support for recursive extensions (i.e. extensions
-     stored on [x] that can contain equations on [x]), then get rid of this. *)
-  if Name.Set.mem name t.adding_equations_for_names
-  then t
-  else
-    let adding_equations_for_names =
-      Name.Set.add name t.adding_equations_for_names
-    in
-    let t' = f { t with adding_equations_for_names } in
-    { t' with adding_equations_for_names = t.adding_equations_for_names }
+let delay_equation_on_simple t simple ty =
+  { t with delayed_equations = (simple, ty) :: t.delayed_equations }
 
 let replace_concrete_equation t name ty =
   match TG.must_be_singleton ty with
@@ -125,8 +108,85 @@ let replace_concrete_equation t name ty =
 
 exception Bottom_equation
 
-let add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
+let add_concrete_equation_on_canonical_name ~raise_on_bottom t name ~coercion ty
     ~(meet_expanded_head : meet_expanded_head) =
+  let ty =
+    (* [ty] applies to [(coerce name coercion)], so the type of [name] is
+       [(coerce ty (inverse coercion))] *)
+    if Coercion.is_id coercion
+    then ty
+    else
+      ET.of_non_alias_type (ET.to_type ty) ~coercion:(Coercion.inverse coercion)
+  in
+  let kind = ET.kind ty in
+  (* Note: this will check that the [existing_ty] has the expected kind. *)
+  let existing_ty_of_name = TE.find t.typing_env name (Some kind) in
+  (* Since [name] is known to be canonical, it must have a concrete type. *)
+  let existing_ty = ET.of_non_alias_type existing_ty_of_name in
+  match meet_expanded_head t ty existing_ty with
+  | Bottom _ ->
+    if raise_on_bottom
+    then raise Bottom_equation
+    else
+      map_typing_env t ~f:(fun t ->
+          TE.replace_equation t name (MTC.bottom kind))
+  | Ok ((Right_input | Both_inputs), env) -> env
+  | Ok (Left_input, env) ->
+    map_typing_env env ~f:(fun env ->
+        replace_concrete_equation env name (ET.to_type ty))
+  | Ok (New_result ty', env) ->
+    map_typing_env env ~f:(fun env ->
+        replace_concrete_equation env name (ET.to_type ty'))
+
+let adding_equation_for_name t name ~f =
+  let adding_equations_for_names = t.adding_equations_for_names in
+  let t =
+    { t with
+      adding_equations_for_names = Name.Set.add name adding_equations_for_names
+    }
+  in
+  { (f t) with adding_equations_for_names }
+
+let add_or_delay_concrete_equation_on_canonical_name ~raise_on_bottom t name
+    ~coercion ty ~meet_expanded_head =
+  (* If we were to add an equation on [x] while already adding an equation on
+     [x], either the inner equation would get overriden by the outer equation
+     and would not be visible, or it would get captured in an env extension.
+
+     That env extension would then likely end up stored on [x] itself, which
+     currently would cause an infinite loop next time we try to add an equation
+     on [x].
+
+     Instead, we simply ignore such recursive equations. *)
+  (* CR bclement: Implement support for recursive extensions (i.e. extensions
+     stored on [x] that can contain equations on [x]), then get rid of this. *)
+  if Name.Set.mem name t.adding_equations_for_names
+  then
+    match meet_strategy () with
+    | Dfs -> t
+    | Bfs | Hybrid ->
+      delay_equation_on_simple t
+        (Simple.with_coercion (Simple.name name) coercion)
+        ty
+  else
+    match meet_strategy () with
+    | Bfs ->
+      delay_equation_on_simple t
+        (Simple.with_coercion (Simple.name name) coercion)
+        ty
+    | Dfs | Hybrid ->
+      adding_equation_for_name t name ~f:(fun t ->
+          add_concrete_equation_on_canonical_name ~raise_on_bottom t name
+            ~coercion ty ~meet_expanded_head)
+
+let add_concrete_equation_on_const ~raise_on_bottom t const ty
+    ~(meet_expanded_head : meet_expanded_head) =
+  match meet_expanded_head t ty (ET.create_const const) with
+  | Ok (_, env) -> env
+  | Bottom _ -> if raise_on_bottom then raise Bottom_equation else t
+
+let add_or_delay_concrete_equation_on_canonical ~raise_on_bottom t simple ty
+    ~meet_expanded_head =
   (* When adding a type to a canonical name, we need to call [meet] with the
      existing type for that name in order to ensure we record the most precise
      type available.
@@ -146,38 +206,22 @@ let add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
      Note also that [p] and [x] may have different name modes! *)
   Simple.pattern_match simple
     ~const:(fun const ->
-      match meet_expanded_head t ty (ET.create_const const) with
-      | Ok (_, env) -> env
-      | Bottom _ -> if raise_on_bottom then raise Bottom_equation else t)
+      add_concrete_equation_on_const ~raise_on_bottom t const ty
+        ~meet_expanded_head)
     ~name:(fun name ~coercion ->
-      adding_equation_for_name t name ~f:(fun t ->
-          let kind = ET.kind ty in
-          (* Note: this will check that the [existing_ty] has the expected
-             kind. *)
-          let existing_ty_of_name = TE.find (typing_env t) name (Some kind) in
-          (* If [name] has type [existing_ty], then [(coerce name coercion)] has
-             type [(coerce ty coercion)]. *)
-          let existing_ty_of_simple =
-            TG.apply_coercion existing_ty_of_name coercion
-          in
-          let existing_ty =
-            Expand_head.expand_head0 (typing_env t) existing_ty_of_simple
-              ~known_canonical_simple_at_in_types_mode:(Some simple)
-          in
-          match meet_expanded_head t ty existing_ty with
-          | Bottom _ ->
-            if raise_on_bottom
-            then raise Bottom_equation
-            else
-              map_typing_env t ~f:(fun t ->
-                  TE.replace_equation t name (MTC.bottom kind))
-          | Ok ((Right_input | Both_inputs), env) -> env
-          | Ok (Left_input, env) ->
-            map_typing_env env ~f:(fun env ->
-                replace_concrete_equation env name (ET.to_type ty))
-          | Ok (New_result ty', env) ->
-            map_typing_env env ~f:(fun env ->
-                replace_concrete_equation env name (ET.to_type ty'))))
+      add_or_delay_concrete_equation_on_canonical_name ~raise_on_bottom t name
+        ~coercion ty ~meet_expanded_head)
+
+let add_concrete_equation_on_simple ~raise_on_bottom t simple ty
+    ~meet_expanded_head =
+  match meet_strategy () with
+  | Dfs | Hybrid ->
+    let canonical =
+      TE.get_canonical_simple_ignoring_name_mode t.typing_env simple
+    in
+    add_or_delay_concrete_equation_on_canonical ~raise_on_bottom t canonical ty
+      ~meet_expanded_head
+  | Bfs -> delay_equation_on_simple t simple ty
 
 let record_demotion ~raise_on_bottom t kind demoted canonical
     ~meet_expanded_head =
@@ -187,7 +231,7 @@ let record_demotion ~raise_on_bottom t kind demoted canonical
      We now need to record that information in the types structure, and add the
      previous type of [demoted] to [canonical] to ensure we do not lose
      information that was only stored on the type of [demoted]. *)
-  let ty_of_demoted = TE.find (typing_env t) demoted (Some kind) in
+  let ty_of_demoted = TE.find t.typing_env demoted (Some kind) in
   (if Flambda_features.check_light_invariants ()
    then
      match TG.get_alias_opt ty_of_demoted with
@@ -201,11 +245,11 @@ let record_demotion ~raise_on_bottom t kind demoted canonical
         TE.replace_equation t demoted (TG.alias_type_of kind canonical))
   in
   let ty_of_demoted =
-    Expand_head.expand_head0 (typing_env t) ty_of_demoted
+    Expand_head.expand_head0 t.typing_env ty_of_demoted
       ~known_canonical_simple_at_in_types_mode:(Some (Simple.name demoted))
   in
-  add_concrete_equation_on_canonical ~raise_on_bottom t canonical ty_of_demoted
-    ~meet_expanded_head
+  add_or_delay_concrete_equation_on_canonical ~raise_on_bottom t canonical
+    ty_of_demoted ~meet_expanded_head
 
 let add_alias_between_canonicals ~raise_on_bottom t kind canonical_element1
     canonical_element2 ~meet_expanded_head =
@@ -220,9 +264,7 @@ let add_alias_between_canonicals ~raise_on_bottom t kind canonical_element1
   if Simple.equal canonical_element1 canonical_element2
   then t
   else
-    match
-      TE.add_alias (typing_env t) ~canonical_element1 ~canonical_element2
-    with
+    match TE.add_alias t.typing_env ~canonical_element1 ~canonical_element2 with
     | Bottom -> if raise_on_bottom then raise Bottom_equation else t
     | Unknown ->
       (* Addition of aliases between names that are both in external compilation
@@ -234,9 +276,9 @@ let add_alias_between_canonicals ~raise_on_bottom t kind canonical_element1
       record_demotion ~raise_on_bottom t kind demoted_name canonical_element
         ~meet_expanded_head
 
-let add_equation_on_canonical ~raise_on_bottom t simple ty ~meet_expanded_head =
-  (* We are adding a type [ty] to [simple], which must be canonical. There are
-     two general cases to consider:
+let add_equation_on_simple ~raise_on_bottom t simple ty ~meet_expanded_head =
+  (* We are adding a type [ty] to [simple]. There are two general cases to
+     consider:
 
      - Either [ty] is a concrete (non-alias) type, to be recorded in the types
      structure on the [canonical_simple];
@@ -246,20 +288,17 @@ let add_equation_on_canonical ~raise_on_bottom t simple ty ~meet_expanded_head =
   match TG.get_alias_opt ty with
   | None ->
     let ty = ET.of_non_alias_type ty in
-    add_concrete_equation_on_canonical ~raise_on_bottom t simple ty
+    add_concrete_equation_on_simple ~raise_on_bottom t simple ty
       ~meet_expanded_head
   | Some alias ->
-    let alias =
-      TE.get_canonical_simple_ignoring_name_mode (typing_env t) alias
+    let canonical_element1 =
+      TE.get_canonical_simple_ignoring_name_mode t.typing_env simple
     in
-    add_alias_between_canonicals ~raise_on_bottom t (TG.kind ty) simple alias
-      ~meet_expanded_head
-
-let add_equation_on_simple ~raise_on_bottom t simple ty ~meet_expanded_head =
-  let canonical =
-    TE.get_canonical_simple_ignoring_name_mode (typing_env t) simple
-  in
-  add_equation_on_canonical ~raise_on_bottom t canonical ty ~meet_expanded_head
+    let canonical_element2 =
+      TE.get_canonical_simple_ignoring_name_mode t.typing_env alias
+    in
+    add_alias_between_canonicals ~raise_on_bottom t (TG.kind ty)
+      canonical_element1 canonical_element2 ~meet_expanded_head
 
 let add_equation ~raise_on_bottom t name ty ~meet_expanded_head =
   add_equation_on_simple ~raise_on_bottom t (Simple.name name) ty
@@ -306,7 +345,7 @@ let add_env_extension_from_level t level ~meet_expanded_head =
         t)
 
 let add_equation_strict t name ty ~meet_expanded_head : _ Or_bottom.t =
-  if TE.is_bottom (typing_env t)
+  if TE.is_bottom t.typing_env
   then Bottom
   else
     try Ok (add_equation ~raise_on_bottom:true t name ty ~meet_expanded_head)
@@ -314,7 +353,7 @@ let add_equation_strict t name ty ~meet_expanded_head : _ Or_bottom.t =
 
 let add_env_extension_strict t env_extension ~meet_expanded_head : _ Or_bottom.t
     =
-  if TE.is_bottom (typing_env t)
+  if TE.is_bottom t.typing_env
   then Bottom
   else
     try
@@ -360,9 +399,16 @@ let add_equations_on_params t ~params ~param_types ~meet_expanded_head =
     (Bound_parameters.to_list params)
     param_types
 
-let current_scope env = TE.current_scope (typing_env env)
-
-let increment_scope env = map_typing_env env ~f:TE.increment_scope
+let[@inline] enter_scope env =
+  let tenv = env.typing_env in
+  let current_scope = TE.current_scope tenv in
+  let env =
+    { typing_env = TE.increment_scope tenv;
+      adding_equations_for_names = env.adding_equations_for_names;
+      delayed_equations = []
+    }
+  in
+  current_scope, tenv, env
 
 let add_definition env bound_name kind =
   map_typing_env env ~f:(fun env -> TE.add_definition env bound_name kind)
@@ -371,21 +417,16 @@ let add_symbol_projection env var symbol_projection =
   map_typing_env env ~f:(fun env ->
       TE.add_symbol_projection env var symbol_projection)
 
-let cut env ~cut_after = TE.cut (typing_env env) ~cut_after
-
-let cut_as_extension env ~cut_after =
-  TE.cut_as_extension (typing_env env) ~cut_after
-
 let add_variable_definition env var kind name_mode =
   map_typing_env env ~f:(fun env ->
       TE.add_variable_definition env var kind name_mode)
 
 let add_alias ~raise_on_bottom env simple1 simple2 ~meet_expanded_head =
   let canonical1 =
-    TE.get_canonical_simple_ignoring_name_mode (typing_env env) simple1
+    TE.get_canonical_simple_ignoring_name_mode env.typing_env simple1
   in
   let canonical2 =
-    TE.get_canonical_simple_ignoring_name_mode (typing_env env) simple2
+    TE.get_canonical_simple_ignoring_name_mode env.typing_env simple2
   in
   add_alias_between_canonicals ~raise_on_bottom env (Simple.kind canonical1)
     canonical1 canonical2 ~meet_expanded_head
@@ -406,7 +447,7 @@ let meet env (t1 : TG.t) (t2 : TG.t) ~(meet_expanded_head : meet_expanded_head)
     Misc.fatal_errorf "Kind mismatch upon meet:@ %a@ versus@ %a" TG.print t1
       TG.print t2;
   let kind = TG.kind t1 in
-  let tenv = typing_env env in
+  let tenv = env.typing_env in
   let simple1 =
     match
       TE.get_alias_then_canonical_simple_exn tenv t1
@@ -444,8 +485,8 @@ let meet env (t1 : TG.t) (t2 : TG.t) ~(meet_expanded_head : meet_expanded_head)
          [add_equation] will meet [expanded1] with the existing type of
          [simple2]. *)
       match
-        add_concrete_equation_on_canonical ~raise_on_bottom:true env simple2
-          expanded1 ~meet_expanded_head
+        add_or_delay_concrete_equation_on_canonical ~raise_on_bottom:true env
+          simple2 expanded1 ~meet_expanded_head
       with
       | exception Bottom_equation -> Bottom (New_result ())
       | env -> Ok (Right_input, env)))
@@ -458,8 +499,8 @@ let meet env (t1 : TG.t) (t2 : TG.t) ~(meet_expanded_head : meet_expanded_head)
       in
       (* We always return [Left_input] (see comment above) *)
       match
-        add_concrete_equation_on_canonical ~raise_on_bottom:true env simple1
-          expanded2 ~meet_expanded_head
+        add_or_delay_concrete_equation_on_canonical ~raise_on_bottom:true env
+          simple1 expanded2 ~meet_expanded_head
       with
       | exception Bottom_equation -> Bottom (New_result ())
       | env -> Ok (Left_input, env))
@@ -487,3 +528,61 @@ let meet env (t1 : TG.t) (t2 : TG.t) ~(meet_expanded_head : meet_expanded_head)
 let[@inline always] meet_type env t1 t2 ~meet_expanded_head : TG.t meet_result =
   map_result ~f:ET.to_type
     ((meet [@inlined never]) env t1 t2 ~meet_expanded_head)
+
+let rec final_typing_env_exn ~meet_expanded_head ({ delayed_equations; _ } as t)
+    =
+  match delayed_equations with
+  | [] -> t.typing_env
+  | _ :: _ ->
+    (* For a nested scope, this is the set of names that we were adding when
+       entering the scope.
+
+       We currently have no way of preventing an equation added on these names
+       within the scope from looping (it would require being able to extract the
+       [meet] of env extensions outside of the [meet] of the type that contain
+       them), so we always forbid them. See also the comment in
+       [add_or_delay_concrete_equation_on_canonical_name] for non-delayed
+       equations. *)
+    let adding_equations_for_names = t.adding_equations_for_names in
+    let t = { t with delayed_equations = [] } in
+    let t =
+      List.fold_left
+        (fun t (simple, ty) ->
+          let canonical =
+            TE.get_canonical_simple_ignoring_name_mode t.typing_env simple
+          in
+          Simple.pattern_match canonical
+            ~const:(fun const ->
+              add_concrete_equation_on_const ~raise_on_bottom:true t const ty
+                ~meet_expanded_head)
+            ~name:(fun name ~coercion ->
+              if Name.Set.mem name adding_equations_for_names
+              then t
+              else
+                adding_equation_for_name t name ~f:(fun t ->
+                    add_concrete_equation_on_canonical_name
+                      ~raise_on_bottom:true t name ~coercion ty
+                      ~meet_expanded_head)))
+        t delayed_equations
+    in
+    final_typing_env_exn ~meet_expanded_head t
+
+let final_typing_env_strict ~meet_expanded_head t : _ Or_bottom.t =
+  match final_typing_env_exn ~meet_expanded_head t with
+  | exception Bottom_equation -> Bottom
+  | t -> Ok t
+
+let final_typing_env ~meet_expanded_head t =
+  try final_typing_env_exn ~meet_expanded_head t
+  with Bottom_equation -> TE.make_bottom t.typing_env
+
+let use_meet_env ~meet_expanded_head t ~f =
+  final_typing_env ~meet_expanded_head (f (create t))
+
+let use_meet_env_strict ~meet_expanded_head t ~f : _ Or_bottom.t =
+  if TE.is_bottom t
+  then Bottom
+  else
+    let t = f (create t) in
+    let tenv = final_typing_env ~meet_expanded_head t in
+    if TE.is_bottom tenv then Bottom else Ok tenv

--- a/middle_end/flambda2/types/env/meet_env.mli
+++ b/middle_end/flambda2/types/env/meet_env.mli
@@ -38,15 +38,21 @@ val create : Typing_env.t -> t
     performing a meet or adding equations to a typing environment.
 
     It returns the modified typing environment with all new equations added. *)
-val use_meet_env : Typing_env.t -> f:(t -> t) -> Typing_env.t
+val use_meet_env :
+  meet_expanded_head:meet_expanded_head ->
+  Typing_env.t ->
+  f:(t -> t) ->
+  Typing_env.t
 
 (** [use_meet_env_strict] is similar to [use_meet_env], except that it detects
     inconsistencies and returns [Bottom] if the input typing env is inconsistent
     (in which case [f] is not applied), or if it becomes inconsistent while
     applying [f]. *)
-val use_meet_env_strict : Typing_env.t -> f:(t -> t) -> Typing_env.t Or_bottom.t
-
-val typing_env : t -> Typing_env.t
+val use_meet_env_strict :
+  meet_expanded_head:meet_expanded_head ->
+  Typing_env.t ->
+  f:(t -> t) ->
+  Typing_env.t Or_bottom.t
 
 val add_equation :
   t -> Name.t -> Type_grammar.t -> meet_expanded_head:meet_expanded_head -> t
@@ -96,10 +102,6 @@ val add_env_extension_from_level :
 (* The functions below only manipulate the underlying typing env and are
    provided for convenience. *)
 
-val current_scope : t -> Scope.t
-
-val increment_scope : t -> t
-
 val code_age_relation : t -> Code_age_relation.t
 
 val code_age_relation_resolver :
@@ -111,9 +113,30 @@ val add_definition : t -> Bound_name.t -> Flambda_kind.t -> t
 
 val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
-val cut : t -> cut_after:Scope.t -> Typing_env_level.t
+(** Complete the meet and return the resulting typing env.
 
-val cut_as_extension : t -> cut_after:Scope.t -> Typing_env_extension.t
+    The meet environment is allowed to delay the processing of some equations
+    (typically to avoid loops), and calling [final_typing_env] will process
+    these equations.
+
+    {b Note}: If the meet environment is a nested environment (i.e. created with
+    [enter_scope]), only equations added within the nested environment are
+    considered. *)
+val final_typing_env :
+  meet_expanded_head:meet_expanded_head -> t -> Typing_env.t
+
+val final_typing_env_strict :
+  meet_expanded_head:meet_expanded_head -> t -> Typing_env.t Or_bottom.t
+
+(** Enter a new scope adequate for computing the meet within sub-environments
+    such as those introduced by env extensions.
+
+    Returns a [Scope.t] that can be used to [cut] the [final_typing_env] inside
+    the scope, and the current version of the typing env outside the scope (that
+    is more precise than the typing environment initially passed to [create] or
+    [use_meet_env], but might be less precise than the result of calling
+    [final_typing_env]). *)
+val enter_scope : t -> Scope.t * Typing_env.t * t
 
 val add_variable_definition :
   t -> Variable.t -> Flambda_kind.t -> Name_mode.t -> t

--- a/middle_end/flambda2/types/env/meet_env.mli
+++ b/middle_end/flambda2/types/env/meet_env.mli
@@ -113,6 +113,13 @@ val add_definition : t -> Bound_name.t -> Flambda_kind.t -> t
 
 val add_symbol_projection : t -> Variable.t -> Symbol_projection.t -> t
 
+(** Return the current typing env at this stage of the meet, while there may
+    still be pending equations.
+
+    This should only be used during the meet when accessor functions on the
+    typing env (e.g. to get canonical simples) are required. *)
+val current_typing_env : t -> Typing_env.t
+
 (** Complete the meet and return the resulting typing env.
 
     The meet environment is allowed to delay the processing of some equations

--- a/middle_end/flambda2/types/equal_types_for_debug.ml
+++ b/middle_end/flambda2/types/equal_types_for_debug.ml
@@ -67,18 +67,22 @@ let extension_env env left_env right_env = { env with left_env; right_env }
 
 let add_env_extension env ext1 ext2 =
   extension_env env
-    (ME.use_meet_env env.left_env ~f:(fun left_env ->
+    (ME.use_meet_env ~meet_expanded_head:env.meet_expanded_head env.left_env
+       ~f:(fun left_env ->
          ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head
            left_env ext1))
-    (ME.use_meet_env env.right_env ~f:(fun right_env ->
+    (ME.use_meet_env ~meet_expanded_head:env.meet_expanded_head env.right_env
+       ~f:(fun right_env ->
          ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head
            right_env ext2))
 
 let add_env_extension_strict env ext1 ext2 =
-  ( ME.use_meet_env_strict env.left_env ~f:(fun left_env ->
+  ( ME.use_meet_env_strict ~meet_expanded_head:env.meet_expanded_head
+      env.left_env ~f:(fun left_env ->
         ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head left_env
           ext1),
-    ME.use_meet_env_strict env.right_env ~f:(fun right_env ->
+    ME.use_meet_env_strict ~meet_expanded_head:env.meet_expanded_head
+      env.right_env ~f:(fun right_env ->
         ME.add_env_extension ~meet_expanded_head:env.meet_expanded_head
           right_env ext2) )
 

--- a/middle_end/flambda2/types/flambda2_types.ml
+++ b/middle_end/flambda2/types/flambda2_types.ml
@@ -27,7 +27,8 @@ module Typing_env = struct
 
   let add_is_null_relation t name ~scrutinee =
     let machine_width = machine_width t in
-    ME.use_meet_env t ~f:(fun t ->
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) t
+      ~f:(fun t ->
         let t =
           add_equation t name (Type_grammar.is_null ~machine_width ~scrutinee)
         in
@@ -44,7 +45,8 @@ module Typing_env = struct
 
   let add_is_int_relation t name ~scrutinee =
     let machine_width = machine_width t in
-    ME.use_meet_env t ~f:(fun t ->
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) t
+      ~f:(fun t ->
         let t =
           add_equation t name
             (Type_grammar.is_int_for_scrutinee ~machine_width ~scrutinee)
@@ -66,7 +68,8 @@ module Typing_env = struct
             add_equation_on_simple t scrutinee scrutinee_ty))
 
   let add_get_tag_relation t name ~scrutinee =
-    ME.use_meet_env t ~f:(fun t ->
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) t
+      ~f:(fun t ->
         let t =
           add_equation t name (Type_grammar.get_tag_for_block ~block:scrutinee)
         in
@@ -90,20 +93,24 @@ module Typing_env = struct
             add_equation_on_simple t scrutinee scrutinee_ty))
 
   let add_equation t name ty =
-    ME.use_meet_env t ~f:(fun t -> add_equation t name ty)
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) t
+      ~f:(fun t -> add_equation t name ty)
 
   let add_equations_on_params t ~params ~param_types =
-    ME.use_meet_env t ~f:(fun t ->
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) t
+      ~f:(fun t ->
         ME.add_equations_on_params t ~params ~param_types
           ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   let add_env_extension t extension =
-    ME.use_meet_env t ~f:(fun t ->
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) t
+      ~f:(fun t ->
         ME.add_env_extension t extension
           ~meet_expanded_head:(Meet.meet_expanded_head ()))
 
   let add_env_extension_with_extra_variables t extension =
-    ME.use_meet_env t ~f:(fun t ->
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) t
+      ~f:(fun t ->
         ME.add_env_extension_with_extra_variables t extension
           ~meet_expanded_head:(Meet.meet_expanded_head ()))
 

--- a/middle_end/flambda2/types/join_levels.ml
+++ b/middle_end/flambda2/types/join_levels.ml
@@ -120,7 +120,8 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
        Format.eprintf "@[Names with distinct types:@ %a@]" Name.Set.print
          distinct_names;
        Format.eprintf "@]@\n%s@." (String.make 60 '=')));
-    ( Meet_env.use_meet_env definition_typing_env ~f:(fun target_env ->
+    ( Meet_env.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ())
+        definition_typing_env ~f:(fun target_env ->
           Meet_env.add_env_extension_from_level target_env new_joined_level
             ~meet_expanded_head:(Meet.meet_expanded_head ())),
       analysis )

--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -89,7 +89,8 @@ let join_types ~env_at_fork envs_with_levels =
         (* CR vlaviron: This is very likely quadratic (number of uses times
            number of variables in all uses). However it's hard to know how we
            could do better. *)
-        ME.use_meet_env base_env ~f:(fun base_env ->
+        ME.use_meet_env ~meet_expanded_head:Meet_and_join.meet_expanded_head
+          base_env ~f:(fun base_env ->
             ME.add_env_extension_maybe_bottom base_env
               (TEE.from_map joined_types)
               ~meet_expanded_head:Meet_and_join.meet_expanded_head)
@@ -337,7 +338,8 @@ let cut_and_n_way_join definition_typing_env ts_and_use_ids ~params ~cut_after
       ~extra_lifted_consts_in_use_envs ~extra_allowed_names
   in
   let result_env =
-    ME.use_meet_env definition_typing_env ~f:(fun target_env ->
+    ME.use_meet_env ~meet_expanded_head:Meet_and_join.meet_expanded_head
+      definition_typing_env ~f:(fun target_env ->
         ME.add_env_extension_from_level target_env level
           ~meet_expanded_head:Meet_and_join.meet_expanded_head)
   in

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -1394,8 +1394,8 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     TG.head_of_kind_naked_immediate meet_result =
   let module I = Target_ocaml_int in
   match
-    ( reduce_head_of_kind_naked_immediate (ME.typing_env env) t1,
-      reduce_head_of_kind_naked_immediate (ME.typing_env env) t2 )
+    ( reduce_head_of_kind_naked_immediate (ME.current_typing_env env) t1,
+      reduce_head_of_kind_naked_immediate (ME.current_typing_env env) t2 )
   with
   | Bottom, Bottom -> Bottom Both_inputs
   | Bottom, Ok _ -> Bottom Left_input

--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -60,13 +60,6 @@ let map_result ~f = function
   | Ok (Both_inputs, env) -> Ok (Both_inputs, env)
   | Ok (New_result x, env) -> Ok (New_result (f x), env)
 
-let map_env ~f = function
-  | Bottom r -> Bottom r
-  | Ok (r, env) -> (
-    match (f env : _ Or_bottom.t) with
-    | Bottom -> Bottom (map_return_value (fun _ -> ()) r)
-    | Ok env -> Ok (r, env))
-
 let extract_value res left right =
   match res with
   | Left_input -> left
@@ -262,16 +255,17 @@ type ext =
 let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
     ~meet_expanded_head ~join_env_extension initial_env val_a1 val_b1
     extensions1 val_a2 val_b2 extensions2 =
-  let join_scope = ME.current_scope initial_env in
-  let env = ME.increment_scope initial_env in
+  let join_scope, initial_tenv, env = ME.enter_scope initial_env in
   let to_extension scoped_env =
-    ME.cut scoped_env ~cut_after:join_scope
-    |> Typing_env_level.as_extension_without_bindings
+    TE.cut_as_extension scoped_env ~cut_after:join_scope
   in
-  let direct_return r =
-    map_env r ~f:(fun scoped_env ->
-        ME.add_env_extension_strict initial_env (to_extension scoped_env)
-          ~meet_expanded_head)
+  let direct_return result scoped_env : _ meet_result =
+    let scoped_ext = to_extension scoped_env in
+    match
+      ME.add_env_extension_strict initial_env scoped_ext ~meet_expanded_head
+    with
+    | Bottom -> Bottom (map_return_value (fun _ -> ()) result)
+    | Ok env -> Ok (result, env)
   in
   let env_a, env_b = Or_bottom.Ok env, Or_bottom.Ok env in
   let env_a, env_b =
@@ -292,15 +286,32 @@ let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
         Or_bottom.bind env_b ~f:(fun env ->
             ME.add_env_extension_strict env when_b ~meet_expanded_head) )
   in
-  let a_result : _ meet_result =
+  let module Extension_meet = struct
+    type 'a meet_result =
+      | Bottom of unit meet_return_value
+      | Ok of 'a meet_return_value * TE.t
+  end in
+  let a_result : _ Extension_meet.meet_result =
     match env_a with
     | Bottom -> Bottom (New_result ())
-    | Ok env -> meet_a env val_a1 val_a2
+    | Ok env -> (
+      match meet_a env val_a1 val_a2 with
+      | Bottom r -> Bottom r
+      | Ok (result, env) -> (
+        match ME.final_typing_env_strict ~meet_expanded_head env with
+        | Bottom -> Bottom (New_result ())
+        | Ok env -> Ok (result, env)))
   in
-  let b_result : _ meet_result =
+  let b_result : _ Extension_meet.meet_result =
     match env_b with
     | Bottom -> Bottom (New_result ())
-    | Ok env -> meet_b env val_b1 val_b2
+    | Ok env -> (
+      match meet_b env val_b1 val_b2 with
+      | Bottom r -> Bottom r
+      | Ok (result, env) -> (
+        match ME.final_typing_env_strict ~meet_expanded_head env with
+        | Bottom -> Bottom (New_result ())
+        | Ok env -> Ok (result, env)))
   in
   match a_result, b_result with
   | Bottom r1, Bottom r2 ->
@@ -312,7 +323,7 @@ let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
           let val_b = bottom_b () in
           val_a, val_b, No_extensions)
     in
-    direct_return (Ok (result, env))
+    direct_return result env
   | Bottom a, Ok (b_result, env) ->
     let result =
       combine_meet_return_values a b_result (fun () ->
@@ -320,7 +331,7 @@ let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
           let val_a = bottom_a () in
           val_a, val_b, No_extensions)
     in
-    direct_return (Ok (result, env))
+    direct_return result env
   | Ok (a_result, env_a), Ok (b_result, env_b) ->
     let when_a = to_extension env_a in
     let when_b = to_extension env_b in
@@ -355,9 +366,7 @@ let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
           val_a, val_b, extensions)
     in
     let join_env =
-      Join_env.create
-        (ME.typing_env initial_env)
-        ~left_env:(ME.typing_env env_a) ~right_env:(ME.typing_env env_b)
+      Join_env.create initial_tenv ~left_env:env_a ~right_env:env_b
     in
     let result_extension = join_env_extension join_env when_a when_b in
     let result_env =
@@ -399,10 +408,10 @@ let[@inline] meet_row_like :
      ~is_empty_map_known ~get_singleton_map_known ~merge_map_known
      ~join_env_extension ~meet_expanded_head initial_env ~known1 ~known2 ~other1
      ~other2 ->
-  let common_scope = ME.current_scope initial_env in
-  let base_env = ME.increment_scope initial_env in
+  let common_scope, _initial_tenv, base_env = ME.enter_scope initial_env in
+  let base_tenv = ME.final_typing_env ~meet_expanded_head base_env in
   let extract_extension scoped_env =
-    ME.cut_as_extension scoped_env ~cut_after:common_scope
+    TE.cut_as_extension scoped_env ~cut_after:common_scope
   in
   let open struct
     type result_env =
@@ -458,9 +467,7 @@ let[@inline] meet_row_like :
         assert need_join;
         let ext2 = extract_extension scoped_env in
         let join_env =
-          Join_env.create (ME.typing_env base_env)
-            ~left_env:(ME.typing_env base_env)
-            ~right_env:(ME.typing_env scoped_env)
+          Join_env.create base_tenv ~left_env:base_tenv ~right_env:scoped_env
         in
         let extension = join_env_extension join_env ext1 ext2 in
         Extension extension
@@ -526,6 +533,9 @@ let[@inline] meet_row_like :
             ME.add_env_extension_strict env case2.env_extension
               ~meet_expanded_head
         in
+        let env =
+          Or_bottom.bind env ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+        in
         match env with
         | Bottom -> bottom_case (New_result ())
         | Ok env ->
@@ -573,8 +583,10 @@ let[@inline] meet_row_like :
         match case1 with
         | Unknown -> (
           match
-            ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_expanded_head
+            Or_bottom.bind
+              ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+              (ME.add_env_extension_strict base_env other_case.env_extension
+                 ~meet_expanded_head)
           with
           | Bottom -> None
           | Ok env ->
@@ -592,8 +604,10 @@ let[@inline] meet_row_like :
         match case2 with
         | Unknown -> (
           match
-            ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_expanded_head
+            Or_bottom.bind
+              ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+              (ME.add_env_extension_strict base_env other_case.env_extension
+                 ~meet_expanded_head)
           with
           | Bottom -> None
           | Ok env ->
@@ -605,12 +619,14 @@ let[@inline] meet_row_like :
     | Some case1, Some case2 -> (
       match case1, case2 with
       | Unknown, Unknown ->
-        join_result_env base_env;
+        join_result_env base_tenv;
         Some Unknown
       | Known case, Unknown -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension
-            ~meet_expanded_head
+          Or_bottom.bind
+            ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+            (ME.add_env_extension_strict base_env case.env_extension
+               ~meet_expanded_head)
         with
         | Bottom -> None
         | Ok env ->
@@ -619,8 +635,10 @@ let[@inline] meet_row_like :
           Some (Known case))
       | Unknown, Known case -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension
-            ~meet_expanded_head
+          Or_bottom.bind
+            ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+            (ME.add_env_extension_strict base_env case.env_extension
+               ~meet_expanded_head)
         with
         | Bottom -> None
         | Ok env ->
@@ -1315,7 +1333,7 @@ and reduce_inverse_relations env naked_immediates inverse_relations :
   let module I = struct
     include Target_ocaml_int
 
-    let machine_width = TE.machine_width (ME.typing_env env)
+    let machine_width = ME.machine_width env
 
     let zero = zero machine_width
 
@@ -2457,6 +2475,9 @@ let meet env ty1 ty2 : _ Or_bottom.t =
     match meet (ME.create env) ty1 ty2 with
     | Bottom _ -> Bottom
     | Ok (r, env) ->
-      let env = ME.typing_env env in
       let res_ty = extract_value r ty1 ty2 in
-      if TG.is_obviously_bottom res_ty then Bottom else Ok (res_ty, env)
+      if TG.is_obviously_bottom res_ty
+      then Bottom
+      else
+        Or_bottom.map (ME.final_typing_env_strict ~meet_expanded_head env)
+          ~f:(fun env -> res_ty, env)

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -56,13 +56,6 @@ let map_result ~f = function
   | Ok (Both_inputs, env) -> Ok (Both_inputs, env)
   | Ok (New_result x, env) -> Ok (New_result (f x), env)
 
-let map_env ~f = function
-  | Bottom r -> Bottom r
-  | Ok (r, env) -> (
-    match (f env : _ Or_bottom.t) with
-    | Bottom -> Bottom (map_return_value (fun _ -> ()) r)
-    | Ok env -> Ok (r, env))
-
 let extract_value res left right =
   match res with
   | Left_input -> left
@@ -271,15 +264,15 @@ let add_defined_vars env level =
 let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
     ~meet_expanded_head ~n_way_join initial_env val_a1 val_b1 extensions1 val_a2
     val_b2 extensions2 =
-  let join_scope = ME.current_scope initial_env in
-  let env = ME.increment_scope initial_env in
-  let direct_return r =
-    map_env r ~f:(fun scoped_env ->
-        (* Need to cut as a level because we could have added new variables. *)
-        let level = ME.cut scoped_env ~cut_after:join_scope in
-        let initial_env = add_defined_vars initial_env level in
-        let ext = TEE.from_map (TEL.equations level) in
-        ME.add_env_extension_strict initial_env ext ~meet_expanded_head)
+  let join_scope, initial_tenv, env = ME.enter_scope initial_env in
+  let direct_return result scoped_env =
+    (* Need to cut as a level because we could have added new variables. *)
+    let level = TE.cut scoped_env ~cut_after:join_scope in
+    let initial_env = add_defined_vars initial_env level in
+    let ext = TEE.from_map (TEL.equations level) in
+    match ME.add_env_extension_strict initial_env ext ~meet_expanded_head with
+    | Bottom -> Bottom (map_return_value (fun _ -> ()) result)
+    | Ok env -> Ok (result, env)
   in
   let env_a, env_b = Or_bottom.Ok env, Or_bottom.Ok env in
   let env_a, env_b =
@@ -300,15 +293,32 @@ let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
         Or_bottom.bind env_b ~f:(fun env ->
             ME.add_env_extension_strict env when_b ~meet_expanded_head) )
   in
-  let a_result : _ meet_result =
+  let module Extension_meet = struct
+    type 'a meet_result =
+      | Bottom of unit meet_return_value
+      | Ok of 'a meet_return_value * TE.t
+  end in
+  let a_result : _ Extension_meet.meet_result =
     match env_a with
     | Bottom -> Bottom (New_result ())
-    | Ok env -> meet_a env val_a1 val_a2
+    | Ok env -> (
+      match meet_a env val_a1 val_a2 with
+      | Bottom r -> Bottom r
+      | Ok (result, env) -> (
+        match ME.final_typing_env_strict ~meet_expanded_head env with
+        | Bottom -> Bottom (New_result ())
+        | Ok env -> Ok (result, env)))
   in
-  let b_result : _ meet_result =
+  let b_result : _ Extension_meet.meet_result =
     match env_b with
     | Bottom -> Bottom (New_result ())
-    | Ok env -> meet_b env val_b1 val_b2
+    | Ok env -> (
+      match meet_b env val_b1 val_b2 with
+      | Bottom r -> Bottom r
+      | Ok (result, env) -> (
+        match ME.final_typing_env_strict ~meet_expanded_head env with
+        | Bottom -> Bottom (New_result ())
+        | Ok env -> Ok (result, env)))
   in
   match a_result, b_result with
   | Bottom r1, Bottom r2 ->
@@ -320,7 +330,7 @@ let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
           let val_b = bottom_b () in
           val_a, val_b, No_extensions)
     in
-    direct_return (Ok (result, env))
+    direct_return result env
   | Bottom a, Ok (b_result, env) ->
     let result =
       combine_meet_return_values a b_result (fun () ->
@@ -328,17 +338,17 @@ let[@inline] meet_disjunction ~meet_a ~meet_b ~bottom_a ~bottom_b
           let val_a = bottom_a () in
           val_a, val_b, No_extensions)
     in
-    direct_return (Ok (result, env))
-  | Ok (a_result, env_a), Ok (b_result, env_b) ->
+    direct_return result env
+  | Ok (a_result, tenv_a), Ok (b_result, tenv_b) ->
     let result_env =
       (* Not strict, as we don't expect to be able to get bottom equations from
          joining non-bottom ones *)
       Join_env.cut_and_n_way_join ~meet_expanded_head
         ~n_way_join_type:n_way_join ~cut_after:join_scope initial_env
-        [ME.typing_env env_a; ME.typing_env env_b]
+        initial_tenv [tenv_a; tenv_b]
     in
-    let when_a_level = ME.cut env_a ~cut_after:join_scope in
-    let when_b_level = ME.cut env_b ~cut_after:join_scope in
+    let when_a_level = TE.cut tenv_a ~cut_after:join_scope in
+    let when_b_level = TE.cut tenv_b ~cut_after:join_scope in
     (* New variables introduced by either [meet_a] or [meet_b] are not
        guaranteed to end up in the [result_env] (in fact, they will probably get
        renamed), but they can still appear in [a_result] and [b_result], so we
@@ -412,13 +422,13 @@ let[@inline] meet_row_like :
      ~is_empty_map_known ~get_singleton_map_known ~merge_map_known
      ~n_way_join_type ~meet_expanded_head initial_env ~known1 ~known2 ~other1
      ~other2 ->
-  let common_scope = ME.current_scope initial_env in
+  let common_scope, initial_tenv, base_env = ME.enter_scope initial_env in
+  let base_tenv = ME.final_typing_env ~meet_expanded_head base_env in
   (* Keep track of the variables used by all extensions and lift them to the
      result env in [extract_and_join_extensions]. *)
   let extra_variables = ref Variable.Map.empty in
-  let base_env = ME.increment_scope initial_env in
   let add_extra_variables_and_extract_extension scoped_env =
-    let level = ME.cut scoped_env ~cut_after:common_scope in
+    let level = TE.cut scoped_env ~cut_after:common_scope in
     extra_variables
       := Variable.Map.union_total_shared
            (fun var k1 k2 ->
@@ -436,7 +446,7 @@ let[@inline] meet_row_like :
        envs. *)
     let result_env =
       Join_env.cut_and_n_way_join ~n_way_join_type ~meet_expanded_head
-        ~cut_after:common_scope initial_env scoped_envs
+        ~cut_after:common_scope initial_env initial_tenv scoped_envs
     in
     Variable.Map.fold
       (fun var kind env ->
@@ -495,7 +505,6 @@ let[@inline] meet_row_like :
       result_is_t2 := false
   in
   let join_result_env scoped_env =
-    let scoped_env = ME.typing_env scoped_env in
     let new_result_env =
       match !result_env with
       | No_result -> Extension [scoped_env]
@@ -564,6 +573,9 @@ let[@inline] meet_row_like :
             ME.add_env_extension_strict env case2.env_extension
               ~meet_expanded_head
         in
+        let env =
+          Or_bottom.bind env ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+        in
         match env with
         | Bottom -> bottom_case (New_result ())
         | Ok env ->
@@ -613,8 +625,10 @@ let[@inline] meet_row_like :
         match case1 with
         | Unknown -> (
           match
-            ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_expanded_head
+            Or_bottom.bind
+              ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+              (ME.add_env_extension_strict base_env other_case.env_extension
+                 ~meet_expanded_head)
           with
           | Bottom -> None
           | Ok env ->
@@ -632,8 +646,10 @@ let[@inline] meet_row_like :
         match case2 with
         | Unknown -> (
           match
-            ME.add_env_extension_strict base_env other_case.env_extension
-              ~meet_expanded_head
+            Or_bottom.bind
+              ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+              (ME.add_env_extension_strict base_env other_case.env_extension
+                 ~meet_expanded_head)
           with
           | Bottom -> None
           | Ok env ->
@@ -645,12 +661,14 @@ let[@inline] meet_row_like :
     | Some case1, Some case2 -> (
       match case1, case2 with
       | Unknown, Unknown ->
-        join_result_env base_env;
+        join_result_env base_tenv;
         Some Unknown
       | Known case, Unknown -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension
-            ~meet_expanded_head
+          Or_bottom.bind
+            ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+            (ME.add_env_extension_strict base_env case.env_extension
+               ~meet_expanded_head)
         with
         | Bottom -> None
         | Ok env ->
@@ -659,8 +677,10 @@ let[@inline] meet_row_like :
           Some (Known case))
       | Unknown, Known case -> (
         match
-          ME.add_env_extension_strict base_env case.env_extension
-            ~meet_expanded_head
+          Or_bottom.bind
+            ~f:(ME.final_typing_env_strict ~meet_expanded_head)
+            (ME.add_env_extension_strict base_env case.env_extension
+               ~meet_expanded_head)
         with
         | Bottom -> None
         | Ok env ->
@@ -1487,7 +1507,7 @@ and reduce_inverse_relations env naked_immediates inverse_relations :
   let module I = struct
     include Target_ocaml_int
 
-    let machine_width = TE.machine_width (ME.typing_env env)
+    let machine_width = ME.machine_width env
 
     let zero = zero machine_width
 
@@ -3065,6 +3085,9 @@ let meet env ty1 ty2 : _ Or_bottom.t =
     match meet (ME.create env) ty1 ty2 with
     | Bottom _ -> Bottom
     | Ok (r, env) ->
-      let env = ME.typing_env env in
       let res_ty = extract_value r ty1 ty2 in
-      if TG.is_obviously_bottom res_ty then Bottom else Ok (res_ty, env)
+      if TG.is_obviously_bottom res_ty
+      then Bottom
+      else
+        Or_bottom.map (ME.final_typing_env_strict ~meet_expanded_head env)
+          ~f:(fun env -> res_ty, env)

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -1568,8 +1568,8 @@ and meet_head_of_kind_naked_immediate env (t1 : TG.head_of_kind_naked_immediate)
     TG.head_of_kind_naked_immediate meet_result =
   let module I = Target_ocaml_int in
   match
-    ( reduce_head_of_kind_naked_immediate (ME.typing_env env) t1,
-      reduce_head_of_kind_naked_immediate (ME.typing_env env) t2 )
+    ( reduce_head_of_kind_naked_immediate (ME.current_typing_env env) t1,
+      reduce_head_of_kind_naked_immediate (ME.current_typing_env env) t2 )
   with
   | Bottom, Bottom -> Bottom Both_inputs
   | Bottom, Ok _ -> Bottom Left_input

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -1335,7 +1335,8 @@ struct
         live_vars env
     in
     let env =
-      ME.use_meet_env env ~f:(fun env ->
+      ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) env
+        ~f:(fun env ->
           ME.add_env_extension_with_extra_variables
             ~meet_expanded_head:(Meet.meet_expanded_head ())
             env extension)
@@ -1386,7 +1387,8 @@ struct
         aliases_of_names base_env
     in
     let final_env =
-      ME.use_meet_env base_env ~f:(fun env ->
+      ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) base_env
+        ~f:(fun env ->
           Name.Map.fold
             (fun name ty env ->
               ME.add_equation env name ty
@@ -1456,7 +1458,8 @@ struct
             aliases_of_name base_env)
         aliases_of_names base_env
     in
-    ME.use_meet_env base_env ~f:(fun env ->
+    ME.use_meet_env ~meet_expanded_head:(Meet.meet_expanded_head ()) base_env
+      ~f:(fun env ->
         Name.Map.fold
           (fun name ty env ->
             ME.add_equation env name ty


### PR DESCRIPTION
Currently, the meet of flambda2 types is done by performing a
depth-first exploration of the types. For instance, if we have an
equation `x : (Pair t1 t2)` and we then introduce another equation
`(Pair t1' t2')` on `x`, we will compute the meet of `t1` and `t1'`,
then compute the meet of `t2` and `t2'`, then replace the equation on
`x` with a new `Pair` type.

If doing these recursive meets on the components of the pair introduce a
new equation, that equation will be immediately processed in the same
way as part of the recursive meets. If this adds a new equation on `x`,
it will ultimately be lose when we override the equation for `x` with
the new `Pair` type at the toplevel; this currently occurs rarely (and I
don't think we currently can actually lose precision when it happens),
but is expected to happen more often as we introduce more relations in
the typing env, which could cause unreliable precision.

This is a depth-first exploration: we update the types of all the
variables transitively reachable from the meet of `t1` and `t1'` before
processing those reachable from the meet of `t2` and `t2'`.

This PR introduces a different strategy, the breadth-first strategy, for
dealing with equations added during a meet: instead of processing the
equation immediately, it is delayed, and there is a saturation fixpoint
at the end of the meet to process all the delayed equations (this can,
recursively, cause new "deeper" equations to be delayed, which will be
processed in the next iteration of the fixpoint).

This is closer to a breadth-first exploration because we first process
all the variables at a given depth (`x`, then the variables explictly
occuring in the components of `x`, etc.) before moving to the next
depth.

The PR also introduces a "hybrid" strategy: the hybrid strategy is
similar to the dfs strategy, but delays equation processing (like the
bfs strategy) when a loop is detected, i.e. when delaying the equation
is required to avoid losing the result of a meet. This is (slightly)
more efficient than the bfs strategy, because it doesn't have the extra
bookkeeping of delaying equations unless it is necessary.

The meet strategy can be selected using either an `OCAMLPARAM` or a
flag:

```console
$ ocamlopt -X flambda2-meet-strategy=bfs ...

$ OCAMLPARAM=_,Xflambda2-meet-strategy=bfs ocamlopt ...
```

The choice of meet strategy currently does not impact the code
generation when building the compiler. The hybrid strategy has the same
performance as the dfs strategy (as stated, the cases where they differ
are currently very rare, but they do occur when building the compiler),
and the bfs strategy is slightly slower, about 0.5% slower on the whole
compiler build in my tests (reproduced across multiple runs).

The PR currently keeps the DFS meet strategy as default, but we might
want to set the BFS or hybrid strategy at the default. We might also not
want to keep a flag at all, and just use the hybrid strategy.