### PR TITLE
Fix backup thread running check

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1220,12 +1220,15 @@ static void install_backup_thread (dom_internal* di)
 #endif
 
   CAMLassert(di == domain_self);
-  if (!backup_thread_running(di)) {
-    uintnat msg;
-    msg = atomic_load_acquire(&di->backup_thread_msg);
-    CAMLassert (msg == BT_INIT || /* Using fresh domain */
-                msg == BT_TERMINATE); /* Reusing domain */
-
+  /* Guard on the message directly rather than [backup_thread_running]: the
+     latter is derived from [backup_thread_msg] and is also true for
+     BT_TERMINATE, i.e. a backup thread from a previous user of this reused
+     domain slot that has been asked to terminate but has not yet reached
+     BT_INIT. We must install in that case too (after waiting for the old
+     thread to finish), otherwise a reused domain is left with no backup
+     thread and STW sections requested while it blocks are never serviced. */
+  uintnat msg = atomic_load_acquire(&di->backup_thread_msg);
+  if (msg == BT_INIT || msg == BT_TERMINATE) {
     while (msg != BT_INIT) {
       /* Give a chance for backup thread on this domain to terminate */
       caml_domain_unlock_hook();
@@ -1259,8 +1262,12 @@ static void terminate_backup_thread(dom_internal *di)
 
   if (backup_thread_running(di)) {
     atomic_store_release(&di->backup_thread_msg, BT_TERMINATE);
-    /* Wakeup backup thread if it is sleeping */
+    /* Wakeup backup thread if it is sleeping. Hold the lock across the signal:
+       [backup_thread_func] checks the message and waits under this lock, so an
+       unlocked signal can be lost, stranding the thread at BT_TERMINATE. */
+    caml_plat_lock_blocking(&di->backup_thread_lock);
     caml_plat_signal(&di->backup_thread_cond);
+    caml_plat_unlock(&di->backup_thread_lock);
   }
 }
 


### PR DESCRIPTION
## Problem

On a reused domain slot, `backup_thread_running(di)` is now derived as `backup_thread_msg != BT_INIT` (an upstream 5.4 change, `fd3ff8455c`, that replaced the old explicit `int backup_thread_running` field), but `install_backup_thread` still uses the old oxcaml guard `if (!backup_thread_running(di))` — so when a freshly reused domain's *previous* backup thread has been signalled to terminate but hasn't yet finished (`backup_thread_msg == BT_TERMINATE`), the guard reads "already running" and **skips creating a backup thread entirely**. The old thread then exits, leaving the reused domain with `BT_INIT` and no backup thread, so when it enters a blocking section (`Unix.sleep` / semaphore) and another domain requests a stop-the-world (`Gc.full_major`), nobody services the STW interrupt on its behalf and the collection hangs. This is timing-dependent on whether the old thread has finished by reuse time, hence flaky and load/arm64-sensitive — and it explains why `major_gc_wait_backup.ml`'s first, non-reusing block passes while the second hangs, and why `backup_thread.ml` deliberately forces a reuse.

## Fix

The fix restores the proven 5.2 semantics by guarding `install_backup_thread` on the message directly (`if (msg == BT_INIT || msg == BT_TERMINATE)`) so it waits for the terminating thread to reach `BT_INIT` and then installs a fresh backup thread. I also hold `backup_thread_lock` across the wakeup in `terminate_backup_thread` (5.2 used the lock-held `caml_bt_signal`; the current unlocked `caml_plat_signal` has a lost-wakeup race that could otherwise strand the old thread at `BT_TERMINATE` and make the new install-wait spin forever).