### PR TITLE
Fix the test suite with `--disable-flat-float-array`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,11 @@ jobs:
             os: warp-ubuntu-latest-x64-8x
             sysdeps: gdb
 
+          - name: no-flat-float-array (x86_64-linux)
+            config: --disable-flat-float-array
+            os: warp-ubuntu-latest-x64-8x
+            sysdeps: gdb
+
           # We use a custom install prefix for this workflow.
           # Consider renaming it to indicate as such when convenient.
           - name: dev (x86_64-linux)

--- a/testsuite/tests/backtrace/lazy.flambda.no-flat-float-array.reference
+++ b/testsuite/tests/backtrace/lazy.flambda.no-flat-float-array.reference
@@ -1,0 +1,29 @@
+Uncaught exception Not_found
+Raised at Lazy.l1 in file "lazy.ml", line 3, characters 28-45
+Called from CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Re-raised at CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Called from Lazy.test1 in file "lazy.ml", line 6, characters 11-24
+Called from Lazy.run in file "lazy.ml", line 15, characters 4-11
+Uncaught exception Not_found
+Raised at Lazy.l1 in file "lazy.ml", line 3, characters 28-45
+Called from CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Re-raised at CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Called from Lazy.test1 in file "lazy.ml", line 6, characters 11-24
+Called from Lazy.run in file "lazy.ml", line 15, characters 4-11
+Re-raised at Lazy.l2 in file "lazy.ml", line 8, characters 28-45
+Called from CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Re-raised at CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Called from Lazy.test2 in file "lazy.ml", line 11, characters 6-15
+Called from Lazy.run in file "lazy.ml", line 15, characters 4-11

--- a/testsuite/tests/backtrace/lazy.ml
+++ b/testsuite/tests/backtrace/lazy.ml
@@ -29,8 +29,15 @@ let () =
    no-flambda;
    native;
  }{
-   reference = "${test_source_directory}/lazy.flambda.reference";
    flambda;
-   native;
+   {
+     flat-float-array;
+     reference = "${test_source_directory}/lazy.flambda.reference";
+     native;
+   }{
+     no-flat-float-array;
+     reference = "${test_source_directory}/lazy.flambda.no-flat-float-array.reference";
+     native;
+   }
  }
 *)

--- a/testsuite/tests/backtrace/names.ml
+++ b/testsuite/tests/backtrace/names.ml
@@ -142,4 +142,13 @@ let () =
 
 (* TEST
  flags = "-g";
+ { bytecode; }
+ {
+   flat-float-array;
+   native;
+ }{
+   no-flat-float-array;
+   reference = "${test_source_directory}/names.no-flat-float-array.reference";
+   native;
+ }
 *)

--- a/testsuite/tests/backtrace/names.no-flat-float-array.reference
+++ b/testsuite/tests/backtrace/names.no-flat-float-array.reference
@@ -1,0 +1,36 @@
+Raised at Names.bang in file "names.ml", line 8, characters 29-39
+Called from Names.nontailcall in file "names.ml", line 112, characters 2-6
+Called from Names.lazy_ in file "names.ml", line 107, characters 41-45
+Called from CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Re-raised at CamlinternalLazy.<force>
+Called from CamlinternalLazy.force_gen_lazy_block in file "camlinternalLazy.ml", line 81, characters 9-27
+Called from CamlinternalLazy.<force>
+Called from Names.inline_object.object#othermeth in file "names.ml", line 102, characters 6-10
+Called from Names.inline_object.object#meth in file "names.ml", line 100, characters 6-26
+Called from Names.klass2#othermeth.(fun) in file "names.ml", line 94, characters 18-22
+Called from Names.klass2#othermeth in file "names.ml", line 94, characters 4-30
+Called from Names.klass#meth in file "names.ml", line 90, characters 4-27
+Called from Names.nested.(fun) in file "names.ml", line 85, characters 54-57
+Called from Names.flat in file "names.ml", line 84, characters 37-40
+Called from Names.(+@+) in file "names.ml", line 78, characters 31-35
+Called from Names.Rec2.fn in file "names.ml", line 75, characters 28-32
+Called from Names.Rec1.fn in file "names.ml", line 70, characters 28-34
+Called from Names.Functor.fn in file "names.ml", line 62, characters 28-32
+Called from Names.local_module.N.foo in file "names.ml", line 56, characters 6-10
+Called from Names.local_module.N in file "names.ml", line 57, characters 38-49
+Called from Names.local_no_arg.inner in file "names.ml", line 46, characters 16-20
+Called from Names.local_no_arg.(fun) in file "names.ml", line 47, characters 26-38
+Called from Names.double_local.inner1.inner2 in file "names.ml", line 41, characters 20-24
+Called from Names.double_local.inner1 in file "names.ml", line 42, characters 4-18
+Called from Names.double_local in file "names.ml", line 43, characters 2-16
+Called from Names.local.inner in file "names.ml", line 36, characters 32-36
+Called from Names.local in file "names.ml", line 37, characters 2-15
+Called from Names.double_anon.(fun) in file "names.ml", line 31, characters 6-10
+Called from Names.anon.(fun) in file "names.ml", line 25, characters 25-29
+Called from Names.Mod1.Nested.apply in file "names.ml", line 20, characters 33-37
+Called from Names.fn_poly in file "names.ml", line 16, characters 2-5
+Called from Names.fn_function in file "names.ml", line 13, characters 9-13
+Called from Names.fn_multi in file "names.ml", line 10, characters 36-40
+Called from Names in file "names.ml", lines 117-137, characters 4-543

--- a/testsuite/tests/codegen/arrays-flat-float-array.ml
+++ b/testsuite/tests/codegen/arrays-flat-float-array.ml
@@ -1,0 +1,630 @@
+(* TEST
+ readonly_files = "intrinsics.ml";
+ setup-ocamlopt.opt-build-env;
+ all_modules = "intrinsics.ml";
+ compile_only = "true";
+ ocamlopt.opt;
+
+ only-default-codegen;
+ flat-float-array;
+ flags = " -O3 -I ocamlopt.opt";
+ flags += " -experimental-optimizations";
+ expect.opt;
+*)
+
+open Intrinsics
+
+type 'a vec = #{
+  size : int;
+  buffer : 'a array;
+}
+
+(* CR ttebbi:
+  - Array bounds checks need a lot of instructions.
+  - We could inline a write-barrier fast path (like when the
+    target object is young). This is the only way to do something
+    like creating short arrays of pointers efficiently. *)
+(* using option to avoid the float array case *)
+let push (vec : 'a option vec) x =
+  let #{size; buffer} = vec in
+  buffer.(size) <- x;
+  #{vec with size = size + 1}
+;;
+[%%expect_asm X86_64{|
+push:
+  subq  $8, %rsp
+  movq  %rax, %r12
+  movq  %rdi, %rsi
+  movq  -8(%rbx), %rax
+  salq  $8, %rax
+  shrq  $17, %rax
+  cmpq  %rax, %r12
+  jae   .L0
+  leaq  -4(%rbx,%r12,4), %rdi
+  call  caml_modify@PLT
+  leaq  2(%r12), %rax
+  addq  $8, %rsp
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+
+external int64_u_unsafe_get
+    : ('a : any mod separable).
+    ('a array[@local_opt]) -> (Int64_u.t[@local_opt]) -> 'a
+    @@ portable
+    = "%array_unsafe_get_indexed_by_int64#"
+  [@@layout_poly]
+
+(* CR ttebbi: When indexing with an untagged index,
+   there is no need to first tag the index. *)
+let int32_unsafe_get_indexed_by_int64 (x : Int32_u.t array) (i : Int64_u.t) =
+  int64_u_unsafe_get x i |> Int32_u.to_int32 |> Int64_u.of_int32
+;;
+[%%expect_asm X86_64{|
+int32_unsafe_get_indexed_by_int64:
+  leaq  1(%rbx,%rbx), %rbx
+  movslq -2(%rax,%rbx,2), %rax
+  ret
+|}]
+
+(* Unsafe get/set for each element type *)
+
+let int_unsafe_get (a : int array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+int_unsafe_get:
+  movq  -4(%rax,%rbx,4), %rax
+  ret
+|}]
+
+let int_unsafe_set (a : int array) (i : int) (v : int) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+int_unsafe_set:
+  movq  %rdi, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]
+
+let ref_unsafe_get (a : string array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+ref_unsafe_get:
+  movq  -4(%rax,%rbx,4), %rax
+  ret
+|}]
+
+let ref_unsafe_set (a : string array) (i : int) (v : string) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+ref_unsafe_set:
+  subq  $8, %rsp
+  movq  %rdi, %rsi
+  leaq  -4(%rax,%rbx,4), %rdi
+  call  caml_modify@PLT
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+|}]
+
+(* CR ttebbi: Stackframe creation is only necessary on the GC-calling path.
+   In this case, this would require moving the stackframe creation into the
+   hidden block where the GC is actually called. *)
+let poly_unsafe_get (a : 'a array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+poly_unsafe_get:
+  movq  %rax, %rdi
+  movzbq -8(%rdi), %rax
+  cmpq  $254, %rax
+  jne   .L1
+  subq  $8, %rsp
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    <hidden GC jump pad>
+.L0:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd -4(%rdi,%rbx,4), %xmm0
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L1:
+  movq  -4(%rdi,%rbx,4), %rax
+  ret
+|}]
+
+let poly_unsafe_set (a : 'a array) (i : int) (v : 'a) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+poly_unsafe_set:
+  movq  %rdi, %rsi
+  movzbq -8(%rax), %rdi
+  cmpq  $254, %rdi
+  jne   .L0
+  vmovsd (%rsi), %xmm0
+  vmovsd %xmm0, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+.L0:
+  subq  $8, %rsp
+  leaq  -4(%rax,%rbx,4), %rdi
+  call  caml_modify@PLT
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+|}]
+
+let int32_unsafe_get (a : int32# array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+int32_unsafe_get:
+  movslq -2(%rax,%rbx,2), %rax
+  ret
+|}]
+
+let int32_unsafe_set (a : int32# array) (i : int) (v : int32#) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+int32_unsafe_set:
+  movl  %edi, -2(%rax,%rbx,2)
+  movl  $1, %eax
+  ret
+|}]
+
+let int64_unsafe_get (a : int64# array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+int64_unsafe_get:
+  movq  -4(%rax,%rbx,4), %rax
+  ret
+|}]
+
+let int64_unsafe_set (a : int64# array) (i : int) (v : int64#) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+int64_unsafe_set:
+  movq  %rdi, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]
+
+let float_unsafe_get (a : float# array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+float_unsafe_get:
+  vmovsd -4(%rax,%rbx,4), %xmm0
+  ret
+|}]
+
+let float_unsafe_set (a : float# array) (i : int) (v : float#) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+float_unsafe_set:
+  vmovsd %xmm0, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]
+
+let float_unsafe_get_plain (a : float array) (i : int) =
+  Float_u.of_float (Array.unsafe_get a i)
+[%%expect_asm X86_64{|
+float_unsafe_get_plain:
+  vmovsd -4(%rax,%rbx,4), %xmm0
+  ret
+|}]
+
+let float_unsafe_set_plain (a : float array) (i : int) (v : float#) =
+  Array.unsafe_set a i (Float_u.to_float v)
+[%%expect_asm X86_64{|
+float_unsafe_set_plain:
+  vmovsd %xmm0, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]
+
+let nativeint_unsafe_get (a : nativeint# array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+nativeint_unsafe_get:
+  movq  -4(%rax,%rbx,4), %rax
+  ret
+|}]
+
+let nativeint_unsafe_set (a : nativeint# array) (i : int)
+    (v : nativeint#) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+nativeint_unsafe_set:
+  movq  %rdi, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]
+
+let floatarray_unsafe_get (a : floatarray) (i : int) =
+  Float_u.of_float (Floatarray.unsafe_get a i)
+[%%expect_asm X86_64{|
+floatarray_unsafe_get:
+  vmovsd -4(%rax,%rbx,4), %xmm0
+  ret
+|}]
+
+let floatarray_unsafe_set (a : floatarray) (i : int) (v : float#) =
+  Floatarray.unsafe_set a i (Float_u.to_float v)
+[%%expect_asm X86_64{|
+floatarray_unsafe_set:
+  vmovsd %xmm0, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]
+
+let float32_unsafe_get (a : float32# array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+float32_unsafe_get:
+  vmovss -2(%rax,%rbx,2), %xmm0
+  ret
+|}]
+
+let float32_unsafe_set (a : float32# array) (i : int) (v : float32#) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+float32_unsafe_set:
+  vmovss %xmm0, -2(%rax,%rbx,2)
+  movl  $1, %eax
+  ret
+|}]
+
+let int8_unsafe_get (a : int8# array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+int8_unsafe_get:
+  sarq  $1, %rbx
+  movsbq (%rax,%rbx), %rax
+  ret
+|}]
+
+let int8_unsafe_set (a : int8# array) (i : int) (v : int8#) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+int8_unsafe_set:
+  sarq  $1, %rbx
+  movb  %dil, (%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+let int16_unsafe_get (a : int16# array) (i : int) =
+  Array.unsafe_get a i
+[%%expect_asm X86_64{|
+int16_unsafe_get:
+  movswq -1(%rax,%rbx), %rax
+  ret
+|}]
+
+let int16_unsafe_set (a : int16# array) (i : int) (v : int16#) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+int16_unsafe_set:
+  movw  %di, -1(%rax,%rbx)
+  movl  $1, %eax
+  ret
+|}]
+
+(* Array length *)
+
+let int_length (a : int array) = Array.length a
+[%%expect_asm X86_64{|
+int_length:
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $17, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+let poly_length (a : 'a array) = Array.length a
+[%%expect_asm X86_64{|
+poly_length:
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $17, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+(* CR ttebbi: The header is loaded twice. Also, extracting the bits can be done
+    better. Also for other arrays with element size < 8 below. *)
+let int32_length (a : int32# array) = Array.length a
+[%%expect_asm X86_64{|
+int32_length:
+  movzbq -8(%rax), %rbx
+  andl  $1, %ebx
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $18, %rax
+  salq  $1, %rax
+  subq  %rbx, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let int64_length (a : int64# array) = Array.length a
+[%%expect_asm X86_64{|
+int64_length:
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $18, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let float_length (a : float# array) = Array.length a
+[%%expect_asm X86_64{|
+float_length:
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $17, %rax
+  orq   $1, %rax
+  ret
+|}]
+
+let float32_length (a : float32# array) = Array.length a
+[%%expect_asm X86_64{|
+float32_length:
+  movzbq -8(%rax), %rbx
+  andl  $1, %ebx
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $18, %rax
+  salq  $1, %rax
+  subq  %rbx, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let int16_length (a : int16# array) = Array.length a
+[%%expect_asm X86_64{|
+int16_length:
+  movzbq -8(%rax), %rbx
+  andl  $3, %ebx
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $18, %rax
+  salq  $2, %rax
+  subq  %rbx, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+let int8_length (a : int8# array) = Array.length a
+[%%expect_asm X86_64{|
+int8_length:
+  movzbq -8(%rax), %rbx
+  andl  $7, %ebx
+  movq  -8(%rax), %rax
+  salq  $8, %rax
+  shrq  $18, %rax
+  salq  $3, %rax
+  subq  %rbx, %rax
+  leaq  1(%rax,%rax), %rax
+  ret
+|}]
+
+(* Safe (bounds-checked) array access *)
+
+let int_safe_get (a : int array) (i : int) =
+  Array.get a i
+[%%expect_asm X86_64{|
+int_safe_get:
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L0
+  movq  -4(%rax,%rbx,4), %rax
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+let ref_safe_set (a : string array) (i : int) (v : string) =
+  Array.set a i v
+[%%expect_asm X86_64{|
+ref_safe_set:
+  subq  $8, %rsp
+  movq  %rdi, %rsi
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L0
+  leaq  -4(%rax,%rbx,4), %rdi
+  call  caml_modify@PLT
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+(* CR ttebbi: The header is loaded twice: once for the bounds check and once
+   for the tag check (to distingish float arrays). The non-float case should
+   be the inline one for code compactness.
+*)
+let poly_safe_get (a : 'a array) (i : int) =
+  Array.get a i
+[%%expect_asm X86_64{|
+poly_safe_get:
+  movq  %rax, %rdi
+  movq  -8(%rdi), %rax
+  salq  $8, %rax
+  shrq  $17, %rax
+  cmpq  %rax, %rbx
+  jae   .L2
+  movzbq -8(%rdi), %rax
+  cmpq  $254, %rax
+  jne   .L1
+  subq  $8, %rsp
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    <hidden GC jump pad>
+.L0:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd -4(%rdi,%rbx,4), %xmm0
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L1:
+  movq  -4(%rdi,%rbx,4), %rax
+  ret
+.L2:
+  subq  $8, %rsp
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+let poly_safe_set (a : 'a array) (i : int) (v : 'a) =
+  Array.set a i v
+[%%expect_asm X86_64{|
+poly_safe_set:
+  movq  %rdi, %rsi
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L1
+  movzbq -8(%rax), %rdi
+  cmpq  $254, %rdi
+  jne   .L0
+  vmovsd (%rsi), %xmm0
+  vmovsd %xmm0, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+.L0:
+  subq  $8, %rsp
+  leaq  -4(%rax,%rbx,4), %rdi
+  call  caml_modify@PLT
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+.L1:
+  subq  $8, %rsp
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+(* CR ttebbi: shrq $18 followed by salq $1 could be shrq $17. *)
+let int64_safe_get (a : int64# array) (i : int) =
+  Array.get a i
+[%%expect_asm X86_64{|
+int64_safe_get:
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $18, %rdi
+  salq  $1, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L0
+  movq  -4(%rax,%rbx,4), %rax
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+let float_safe_get (a : float# array) (i : int) =
+  Array.get a i
+[%%expect_asm X86_64{|
+float_safe_get:
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L0
+  vmovsd -4(%rax,%rbx,4), %xmm0
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+let float_safe_get_plain (a : float array) (i : int) =
+  Float_u.of_float (Array.get a i)
+[%%expect_asm X86_64{|
+float_safe_get_plain:
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L0
+  vmovsd -4(%rax,%rbx,4), %xmm0
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+let int32_safe_get (a : int32# array) (i : int) =
+  Array.get a i
+[%%expect_asm X86_64{|
+int32_safe_get:
+  movzbq -8(%rax), %rdi
+  andl  $1, %edi
+  movq  -8(%rax), %rsi
+  salq  $8, %rsi
+  shrq  $18, %rsi
+  salq  $1, %rsi
+  subq  %rdi, %rsi
+  salq  $1, %rsi
+  cmpq  %rsi, %rbx
+  jae   .L0
+  movslq -2(%rax,%rbx,2), %rax
+  ret
+.L0:
+  movq  <hidden PC-relative offset>(%rip), %rax
+  movq  48(%r14), %rsp
+  popq  48(%r14)
+  popq  %r11
+  jmp   *%r11
+|}]
+
+(* [float# box] gets optimized like [float] *)
+let float_u_box_unsafe_set (a : float# box array) (i : int) (v : float# box) =
+  Array.unsafe_set a i v
+[%%expect_asm X86_64{|
+float_u_box_unsafe_set:
+  vmovsd (%rdi), %xmm0
+  vmovsd %xmm0, -4(%rax,%rbx,4)
+  movl  $1, %eax
+  ret
+|}]

--- a/testsuite/tests/codegen/arrays-no-flat-float-array.ml
+++ b/testsuite/tests/codegen/arrays-no-flat-float-array.ml
@@ -6,8 +6,13 @@
  ocamlopt.opt;
 
  only-default-codegen;
+ no-flat-float-array;
  flags = " -O3 -I ocamlopt.opt";
- flags += " -experimental-optimizations";
+ flags += " -cfg-prologue-shrink-wrap";
+ flags += " -x86-peephole-optimize";
+ flags += " -regalloc-param SPLIT_AROUND_LOOPS:on";
+ flags += " -regalloc-param AFFINITY:on -regalloc irc";
+ flags += " -cfg-merge-blocks";
  expect.opt;
 *)
 
@@ -119,23 +124,7 @@ let poly_unsafe_get (a : 'a array) (i : int) =
   Array.unsafe_get a i
 [%%expect_asm X86_64{|
 poly_unsafe_get:
-  movq  %rax, %rdi
-  movzbq -8(%rdi), %rax
-  cmpq  $254, %rax
-  jne   .L1
-  subq  $8, %rsp
-  subq  $16, %r15
-  cmpq  (%r14), %r15
-  jb    <hidden GC jump pad>
-.L0:
-  leaq  8(%r15), %rax
-  movq  $1277, -8(%rax)
-  vmovsd -4(%rdi,%rbx,4), %xmm0
-  vmovsd %xmm0, (%rax)
-  addq  $8, %rsp
-  ret
-.L1:
-  movq  -4(%rdi,%rbx,4), %rax
+  movq  -4(%rax,%rbx,4), %rax
   ret
 |}]
 
@@ -143,16 +132,8 @@ let poly_unsafe_set (a : 'a array) (i : int) (v : 'a) =
   Array.unsafe_set a i v
 [%%expect_asm X86_64{|
 poly_unsafe_set:
-  movq  %rdi, %rsi
-  movzbq -8(%rax), %rdi
-  cmpq  $254, %rdi
-  jne   .L0
-  vmovsd (%rsi), %xmm0
-  vmovsd %xmm0, -4(%rax,%rbx,4)
-  movl  $1, %eax
-  ret
-.L0:
   subq  $8, %rsp
+  movq  %rdi, %rsi
   leaq  -4(%rax,%rbx,4), %rdi
   call  caml_modify@PLT
   movl  $1, %eax
@@ -215,7 +196,8 @@ let float_unsafe_get_plain (a : float array) (i : int) =
   Float_u.of_float (Array.unsafe_get a i)
 [%%expect_asm X86_64{|
 float_unsafe_get_plain:
-  vmovsd -4(%rax,%rbx,4), %xmm0
+  movq  -4(%rax,%rbx,4), %rax
+  vmovsd (%rax), %xmm0
   ret
 |}]
 
@@ -223,8 +205,18 @@ let float_unsafe_set_plain (a : float array) (i : int) (v : float#) =
   Array.unsafe_set a i (Float_u.to_float v)
 [%%expect_asm X86_64{|
 float_unsafe_set_plain:
-  vmovsd %xmm0, -4(%rax,%rbx,4)
+  subq  $8, %rsp
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    <hidden GC jump pad>
+.L0:
+  leaq  8(%r15), %rsi
+  movq  $1277, -8(%rsi)
+  vmovsd %xmm0, (%rsi)
+  leaq  -4(%rax,%rbx,4), %rdi
+  call  caml_modify@PLT
   movl  $1, %eax
+  addq  $8, %rsp
   ret
 |}]
 
@@ -469,31 +461,14 @@ let poly_safe_get (a : 'a array) (i : int) =
   Array.get a i
 [%%expect_asm X86_64{|
 poly_safe_get:
-  movq  %rax, %rdi
-  movq  -8(%rdi), %rax
-  salq  $8, %rax
-  shrq  $17, %rax
-  cmpq  %rax, %rbx
-  jae   .L2
-  movzbq -8(%rdi), %rax
-  cmpq  $254, %rax
-  jne   .L1
-  subq  $8, %rsp
-  subq  $16, %r15
-  cmpq  (%r14), %r15
-  jb    <hidden GC jump pad>
+  movq  -8(%rax), %rdi
+  salq  $8, %rdi
+  shrq  $17, %rdi
+  cmpq  %rdi, %rbx
+  jae   .L0
+  movq  -4(%rax,%rbx,4), %rax
+  ret
 .L0:
-  leaq  8(%r15), %rax
-  movq  $1277, -8(%rax)
-  vmovsd -4(%rdi,%rbx,4), %xmm0
-  vmovsd %xmm0, (%rax)
-  addq  $8, %rsp
-  ret
-.L1:
-  movq  -4(%rdi,%rbx,4), %rax
-  ret
-.L2:
-  subq  $8, %rsp
   movq  <hidden PC-relative offset>(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -505,28 +480,19 @@ let poly_safe_set (a : 'a array) (i : int) (v : 'a) =
   Array.set a i v
 [%%expect_asm X86_64{|
 poly_safe_set:
+  subq  $8, %rsp
   movq  %rdi, %rsi
   movq  -8(%rax), %rdi
   salq  $8, %rdi
   shrq  $17, %rdi
   cmpq  %rdi, %rbx
-  jae   .L1
-  movzbq -8(%rax), %rdi
-  cmpq  $254, %rdi
-  jne   .L0
-  vmovsd (%rsi), %xmm0
-  vmovsd %xmm0, -4(%rax,%rbx,4)
-  movl  $1, %eax
-  ret
-.L0:
-  subq  $8, %rsp
+  jae   .L0
   leaq  -4(%rax,%rbx,4), %rdi
   call  caml_modify@PLT
   movl  $1, %eax
   addq  $8, %rsp
   ret
-.L1:
-  subq  $8, %rsp
+.L0:
   movq  <hidden PC-relative offset>(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
@@ -583,7 +549,8 @@ float_safe_get_plain:
   shrq  $17, %rdi
   cmpq  %rdi, %rbx
   jae   .L0
-  vmovsd -4(%rax,%rbx,4), %xmm0
+  movq  -4(%rax,%rbx,4), %rax
+  vmovsd (%rax), %xmm0
   ret
 .L0:
   movq  <hidden PC-relative offset>(%rip), %rax
@@ -615,15 +582,4 @@ int32_safe_get:
   popq  48(%r14)
   popq  %r11
   jmp   *%r11
-|}]
-
-(* [float# box] gets optimized like [float] *)
-let float_u_box_unsafe_set (a : float# box array) (i : int) (v : float# box) =
-  Array.unsafe_set a i v
-[%%expect_asm X86_64{|
-float_u_box_unsafe_set:
-  vmovsd (%rdi), %xmm0
-  vmovsd %xmm0, -4(%rax,%rbx,4)
-  movl  $1, %eax
-  ret
 |}]

--- a/testsuite/tests/flambda2/array_element_kind_meet.ml
+++ b/testsuite/tests/flambda2/array_element_kind_meet.ml
@@ -4,7 +4,14 @@
  flambda2;
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-simplify;
- check-fexpr-dump;
+ {
+   flat-float-array;
+   check-fexpr-dump;
+ }{
+   no-flat-float-array;
+   fexpr_reference_suffix = "no-flat-float-array.reference";
+   check-fexpr-dump;
+ }
 *)
 
 (* When a record field is known to be a value array, Is_flat_float_array

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
@@ -1,0 +1,44 @@
+let code sum_0 deleted in
+let code loopify(never) size(49) newer_version_of(sum_0)
+      sum_0_1 (t : [ 0 of imm tagged * imm tagged * val array ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pfield = %block_load.[`2`] (t) in
+  let Parraylength = %array_length (Pfield) in
+  let for_stop = %int_barith.sub (Parraylength, 1) in
+  let prim = %int_comp.le (0, for_stop) in
+  switch prim
+    | 0 -> k (0)
+    | 1 -> k2
+    where k2 =
+      let prim_1 = %untag_imm (for_stop) in
+      let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
+      (cont k2 (0L, 0)
+         where rec k2 (for_counter_naked : int64, r_441_unboxed0) =
+           let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
+           let i = %tag_imm (prim_2) in
+           let Parrayrefu = %array_load.mut (Pfield, i) in
+           ((let prim_3 = %is_int (Parrayrefu) in
+             switch prim_3
+               | 0 -> k4
+               | 1 -> k3 (r_441_unboxed0)
+               where k4 =
+                 let int_add = %int_barith.add (r_441_unboxed0, 1) in
+                 cont k3 (int_add))
+              where k3 (return_val0) =
+                let for_next_naked =
+                  %int_barith.`int64`.add (for_counter_naked, 1L)
+                in
+                let prim_3 =
+                  %int_comp.`int64`.le (for_next_naked, for_stop_naked)
+                in
+                switch prim_3
+                  | 0 -> k (return_val0)
+                  | 1 -> k2 (for_next_naked, return_val0)))
+in
+let $camlArray_element_kind_meet__sum_2 = closure sum_0_1 @sum in
+let $camlArray_element_kind_meet =
+  Block 0 ($camlArray_element_kind_meet__sum_2)
+in
+cont done ($camlArray_element_kind_meet)

--- a/testsuite/tests/flambda2/examples/array_kind.ml
+++ b/testsuite/tests/flambda2/examples/array_kind.ml
@@ -4,7 +4,14 @@
  ocamlopt_flags = "-dlambda -dcanonical-ids -dcmm";
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte;
- check-ocamlopt.byte-output;
+ {
+   flat-float-array;
+   check-ocamlopt.byte-output;
+ }{
+   no-flat-float-array;
+   compiler_reference = "${test_source_directory}/array_kind.no-flat-float-array.compilers.reference";
+   check-ocamlopt.byte-output;
+ }
 *)
 
 (* Lambda output:

--- a/testsuite/tests/flambda2/examples/array_kind.no-flat-float-array.compilers.reference
+++ b/testsuite/tests/flambda2/examples/array_kind.no-flat-float-array.compilers.reference
@@ -2,7 +2,7 @@
   (f/0 =
      (function {nlocal = 0} a/0[value<addrarray>]
        : (consts (0)) (non_consts ([0: ?]))
-       (array.get[gen indexed by int] a/0 0)))
+       (array.get[addr indexed by int] a/0 0)))
   (makeblock 0 f/0))
 (data global "camlArray_kind__gc_roots": int 0)
 (data int 1792 global "camlArray_kind": addr G:"camlArray_kind__f_1")

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.ml
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.ml
@@ -3,7 +3,15 @@
  flambda2;
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-simplify;
- check-fexpr-dump;
+ {
+   flat-float-array;
+   check-fexpr-dump;
+ }{
+   no-flat-float-array;
+   fexpr_reference_suffix = "no-flat-float-array.reference";
+   check-fexpr-dump;
+ }
+
 *)
 
 (* Generic get primitive, on an array of Values. Should be simplified to a

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.no-flat-float-array.reference
@@ -1,0 +1,72 @@
+let $camlArray_specialisation_examples__string11 = "index out of bounds" in
+let $camlArray_specialisation_examples__block13 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument,
+           $camlArray_specialisation_examples__string11)
+in
+let code f_0 deleted in
+let code g_1 deleted in
+let code h_2 deleted in
+let code i_3 deleted in
+let code loopify(never) size(19) newer_version_of(f_0)
+      f_0_1 (arr : val array)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : [ 0 | 0 of val ] =
+  (let prim = %array_length (arr) in
+   let prim_1 = %int_comp.unsigned.lt (0, prim) in
+   switch prim_1
+     | 0 -> k2
+     | 1 -> k3)
+    where k3 =
+      let Parrayrefs = %array_load.mut (arr, 0) in
+      cont k (Parrayrefs)
+    where k2 =
+      cont k1 pop(regular k1) ($camlArray_specialisation_examples__block13)
+in
+let $camlArray_specialisation_examples__f_4 = closure f_0_1 @f in
+let code loopify(never) size(8) newer_version_of(g_1)
+      g_1_1 (x : [ 0 | 0 of val ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : [ 0 | 0 of val ] =
+  let a = %array.mut (x) in
+  let Parrayrefs = %array_load.mut (a, 0) in
+  cont k (Parrayrefs)
+in
+let $camlArray_specialisation_examples__g_5 = closure g_1_1 @g in
+let code loopify(never) size(8) newer_version_of(h_2)
+      h_2_1 (x : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let a = %array.mut (x) in
+  let Parrayrefs = %array_load.`imm`.mut (a, 0) in
+  cont k (Parrayrefs)
+in
+let $camlArray_specialisation_examples__h_6 = closure h_2_1 @h in
+let code loopify(never) size(22) newer_version_of(i_3)
+      i_3_1 (w : imm tagged, x : val)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `region` = %begin_region () in
+  (let a = %array.mut.`local`[`region`] (x) in
+   (let untagged = %untag_imm (w) in
+    switch untagged
+      | 0 -> k3
+      | 1 -> k2 (0))
+     where k3 =
+       let Parrayrefs = %array_load.`imm`.mut (a, 0) in
+       cont k2 (Parrayrefs))
+    where k2 (region_return : imm tagged) =
+      let `unit` = %end_region (`region`) in
+      cont k (region_return)
+in
+let $camlArray_specialisation_examples__i_7 = closure i_3_1 @i in
+let $camlArray_specialisation_examples =
+  Block 0 ($camlArray_specialisation_examples__f_4,
+           $camlArray_specialisation_examples__g_5,
+           $camlArray_specialisation_examples__h_6,
+           $camlArray_specialisation_examples__i_7)
+in
+cont done ($camlArray_specialisation_examples)

--- a/testsuite/tests/flambda2/examples/invalid.ml
+++ b/testsuite/tests/flambda2/examples/invalid.ml
@@ -4,8 +4,17 @@
  ocamlopt_flags = "-dcmm";
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-simplify;
- check-fexpr-dump;
- check-ocamlopt.byte-output;
+ {
+   flat-float-array;
+   check-fexpr-dump;
+   check-ocamlopt.byte-output;
+ }{
+   no-flat-float-array;
+   fexpr_reference_suffix = "no-flat-float-array.reference";
+   compiler_reference = "${test_source_directory}/invalid.no-flat-float-array.compilers.reference";
+   check-fexpr-dump;
+   check-ocamlopt.byte-output;
+ }
 *)
 
 (* This example showed an isntance where [Simplify] produced an invalid, which

--- a/testsuite/tests/flambda2/examples/invalid.no-flat-float-array.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.no-flat-float-array.compilers.reference
@@ -11,15 +11,6 @@
  addr G:"camlInvalid__foo_2_5_code"
  int 108086391056891909)
 (data
- int 21500
- "camlInvalid__invalid177":
- string "(Defining_expr_of_let (bound_pattern prim/110N)
- (defining_expr
-  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)
-   invalid.ml:29,2--23)))"
- skip 7
- byte 7)
-(data
  int 4087
  global "camlInvalid__bar_4":
  addr G:"caml_curry2"
@@ -33,10 +24,11 @@
  addr G:"camlInvalid__check_0_3_code")
 (data
  int 2816
- "camlInvalid__Pmakeblock71":
+ "camlInvalid__Pmakeblock69":
  addr G:"caml_exn_Failure"
  addr L:"camlInvalid__immstring17")
-(data int 768 "camlInvalid__empty_array41":)
+(data int 2045 "camlInvalid__float43": double 1.)
+(data int 768 "camlInvalid__empty_array40":)
 (data int 2044 "camlInvalid__immstring17": string "lengths" skip 0 byte 0)
 (function{invalid.ml:24,25-96} camlInvalid__check_0_3_code
      (t1/366: val t2/367: val) : int
@@ -44,7 +36,7 @@
    (!= (or (>>u (<< (load_mut int (+a t1/366 -8)) 8) 17) 1)
      (or (>>u (<< (load_mut int (+a t2/367 -8)) 8) 17) 1))
    (raise_notrace{invalid.ml:25,45-63;stdlib.ml:39,17-33}
-     L:"camlInvalid__Pmakeblock71")
+     L:"camlInvalid__Pmakeblock69")
    1) )
 
 (function{invalid.ml:27,17-68} camlInvalid__bar_1_4_code
@@ -53,19 +45,21 @@
    param/373
      (app{invalid.ml:28,2-13} G:"camlInvalid__check_0_3_code" t1/371 t2/372
        int)
-   (+ (<< (==f (load_mut float64 t2/372) 0.) 1) 1)) )
+   (+ (<< (==f (load float64 (load_mut val t2/372)) 0.) 1) 1)) )
 
 (function{invalid.ml:31,8-30} camlInvalid__foo_2_5_code
-     (param/377: int) : int
+     (param/378: int) : int
  (let
-   (Pmakearray/378 (alloc{invalid.ml:31,17-25} 1278 1.)
-    param/379
+   (Pmakearray/379 (alloc{invalid.ml:31,17-25} 1024 L:"camlInvalid__float43")
+    param/380
       (app{invalid.ml:31,13-30;invalid.ml:28,2-13}
-        G:"camlInvalid__check_0_3_code" Pmakearray/378
-        L:"camlInvalid__empty_array41" int))
-   (invalid
-     "(Defining_expr_of_let (bound_pattern prim/110N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)\n   invalid.ml:29,2--23)))"
-     L:"camlInvalid__invalid177")) )
+        G:"camlInvalid__check_0_3_code" Pmakearray/379
+        L:"camlInvalid__empty_array40" int))
+   (+
+     (<<
+       (==f (load float64 (load_mut val L:"camlInvalid__empty_array40")) 0.)
+       1)
+     1)) )
 
 (function no_cse reduce_code_size linscan camlInvalid__entry () : val
  (catch (exit 7 G:"camlInvalid") with(7 *ret*/364: val) 1) )

--- a/testsuite/tests/flambda2/examples/invalid.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/invalid.simplify.no-flat-float-array.reference
@@ -1,26 +1,27 @@
 let $camlInvalid__immstring17 = "lengths" in
 let code check_0 deleted in
 let code bar_1 deleted in
-let $camlInvalid__empty_array41 = Empty_array in
+let $camlInvalid__empty_array40 = Empty_array in
+let $camlInvalid__float43 = 0x1p+0 in
 let code foo_2 deleted in
-let $camlInvalid__Pmakeblock71 =
+let $camlInvalid__Pmakeblock69 =
   Block 0 ($`*predef*`.caml_exn_Failure, $camlInvalid__immstring17)
 in
-let code inline(never) loopify(never) size(22) newer_version_of(check_0)
-      check_0_1 (t1 : any array, t2 : any array)
+let code inline(never) loopify(never) size(16) newer_version_of(check_0)
+      check_0_1 (t1 : val array, t2 : val array)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let Parraylength = %array_length.generic (t2) in
-  let Parraylength_1 = %array_length.generic (t1) in
+  let Parraylength = %array_length (t2) in
+  let Parraylength_1 = %array_length (t1) in
   let prim = %phys_ne (Parraylength_1, Parraylength) in
   switch prim
     | 0 -> k (0)
-    | 1 -> k1 pop(reraise k1) ($camlInvalid__Pmakeblock71)
+    | 1 -> k1 pop(reraise k1) ($camlInvalid__Pmakeblock69)
 in
 let $camlInvalid__check_3 = closure check_0_1 @check in
-let code inline(always) loopify(never) size(11) newer_version_of(bar_1)
-      bar_1_1 (t1 : any array, t2 : float array)
+let code inline(always) loopify(never) size(12) newer_version_of(bar_1)
+      bar_1_1 (t1 : val array, t2 : val array)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -29,26 +30,32 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar_1)
     where k3 (param : imm tagged) =
       cont k2
     where k2 =
-      let prim = %array_load.`float`.mut (t2, 0) in
+      let Parrayrefu = %array_load.mut (t2, 0) in
+      let prim = %unbox_num.`float` (Parrayrefu) in
       let prim_1 = %float_comp.eq (prim, 0x0p+0) in
       let float_ordered_and_equal = %tag_imm (prim_1) in
       cont k (float_ordered_and_equal)
 in
 let $camlInvalid__bar_4 = closure bar_1_1 @bar in
-let code loopify(never) size(11) newer_version_of(foo_2)
+let code loopify(never) size(18) newer_version_of(foo_2)
       foo_2_1 (param : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  let Pmakearray = %array.`float`.mut (0x1p+0) in
+  let Pmakearray = %array.mut ($camlInvalid__float43) in
   apply direct(check_0_1) inlining_state(depth(1))
     ($camlInvalid__check_3 : _ -> imm tagged)
-      (Pmakearray, $camlInvalid__empty_array41)
+      (Pmakearray, $camlInvalid__empty_array40)
       -> k3 * k1
     where k3 (param_1 : imm tagged) =
       cont k2
     where k2 =
-      invalid "(Defining_expr_of_let (bound_pattern prim/110N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)\n   invalid.ml:29,2--23)))"
+      let Parrayrefu = %array_load.`imm`.mut ($camlInvalid__empty_array40, 0)
+      in
+      let prim = %unbox_num.`float` (Parrayrefu) in
+      let prim_1 = %float_comp.eq (prim, 0x0p+0) in
+      let float_ordered_and_equal = %tag_imm (prim_1) in
+      cont k (float_ordered_and_equal)
 in
 let $camlInvalid__foo_5 = closure foo_2_1 @foo in
 let $camlInvalid =

--- a/testsuite/tests/flambda2/examples/tests15.ml
+++ b/testsuite/tests/flambda2/examples/tests15.ml
@@ -3,7 +3,15 @@
  flambda2;
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-raw, dump-simplify;
- check-fexpr-dump;
+ {
+   flat-float-array;
+   check-fexpr-dump;
+ }{
+   no-flat-float-array;
+   fexpr_reference_suffix = "no-flat-float-array.reference";
+   check-fexpr-dump;
+ }
+
 *)
 
 (* Exercise empty array *)

--- a/testsuite/tests/flambda2/examples/tests15.raw.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests15.raw.no-flat-float-array.reference
@@ -10,7 +10,7 @@
        list_to_array_0 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure _region _ghost_region my_depth
          -> k1 * k2
-         : any array =
+         : val array =
    let next_depth = rec_info (succ my_depth) in
    (let prim = %is_int (param) in
     let Pisint = %tag_imm (prim) in

--- a/testsuite/tests/flambda2/examples/tests15.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests15.simplify.no-flat-float-array.reference
@@ -17,7 +17,7 @@ let code loopify(never) size(11) newer_version_of(list_to_array_0)
       list_to_array_0_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
-        : any array =
+        : val array =
   let prim = %is_int (param) in
   switch prim
     | 0 -> k1 pop(regular k1) ($camlTests15__Pmakeblock18)

--- a/testsuite/tests/flambda2/examples/tests3.ml
+++ b/testsuite/tests/flambda2/examples/tests3.ml
@@ -3,7 +3,15 @@
  flambda2;
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-raw, dump-simplify;
- check-fexpr-dump;
+ {
+   flat-float-array;
+   check-fexpr-dump;
+ }{
+   no-flat-float-array;
+   fexpr_reference_suffix = "no-flat-float-array.reference";
+   check-fexpr-dump;
+ }
+
 *)
 
 external ( + ) : int -> int -> int = "%addint"

--- a/testsuite/tests/flambda2/examples/tests3.raw.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests3.raw.no-flat-float-array.reference
@@ -1,0 +1,78 @@
+(let $camlTests3__string14 = "index out of bounds" in
+ let $camlTests3__block16 =
+   Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string14)
+ in
+ let code size(48)
+       foo_0 (arr : val array, f : val, i : imm tagged)
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   (let prim = %array_length (arr) in
+    let prim_1 = %int_comp.unsigned.lt (i, prim) in
+    switch prim_1
+      | 0 -> k5
+      | 1 -> k6)
+     where k6 =
+       cont k4
+     where k5 =
+       cont k2 pop(regular k2) ($camlTests3__block16)
+     where k4 =
+       let Parrayrefs = %array_load.mut (arr, i) in
+       apply f (Parrayrefs) -> k3 * k2
+     where k3 (apply_result : val) =
+       ((let prim = %array_length (arr) in
+         let prim_1 = %int_comp.unsigned.lt (i, prim) in
+         switch prim_1
+           | 0 -> k4
+           | 1 -> k5)
+          where k5 =
+            cont k3
+          where k4 =
+            cont k2 pop(regular k2) ($camlTests3__block16)
+          where k3 =
+            let Parraysets = %array_set (arr, i, apply_result) in
+            cont k1 (Parraysets))
+ in
+ let code size(41)
+       f_1 (c : imm tagged, m, n, x' : imm tagged, y' : imm tagged)
+         my_closure _region _ghost_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   (let prim = %int_comp.lt (c, 0) in
+    let int_lessthan = %tag_imm (prim) in
+    (let untagged = %untag_imm (int_lessthan) in
+     switch untagged
+       | 0 -> k5
+       | 1 -> k3 (x'))
+      where k5 =
+        cont k4)
+     where k4 =
+       let int_add = %int_barith.add (x', 10) in
+       cont k3 (int_add)
+     where k3 (x : imm tagged) =
+       ((let prim = %int_comp.lt (c, 0) in
+         let int_lessthan = %tag_imm (prim) in
+         (let untagged = %untag_imm (int_lessthan) in
+          switch untagged
+            | 0 -> k5
+            | 1 -> k3 (y'))
+           where k5 =
+             cont k4)
+          where k4 =
+            let int_add = %int_barith.add (y', 20) in
+            cont k3 (int_add)
+          where k3 (y : imm tagged) =
+            let int_add = %int_barith.add (x, y) in
+            cont k1 (int_add))
+ in
+ let foo = closure foo_0 @foo in
+ let f = closure f_1 @f in
+ let Pmakeblock = %block.[`0`] (foo, f) in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in
+    let $camlTests3 = Block 0 (field_0, field_1) in
+    cont done ($camlTests3)

--- a/testsuite/tests/flambda2/examples/tests3.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/tests3.simplify.no-flat-float-array.reference
@@ -1,0 +1,53 @@
+let $camlTests3__string14 = "index out of bounds" in
+let $camlTests3__block16 =
+  Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTests3__string14)
+in
+let code foo_0 deleted in
+let code f_1 deleted in
+let code loopify(never) size(29) newer_version_of(foo_0)
+      foo_0_1 (arr : val array, f : val, i : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %array_length (arr) in
+   let prim_1 = %int_comp.unsigned.lt (i, prim) in
+   switch prim_1
+     | 0 -> k3
+     | 1 -> k4)
+    where k4 =
+      let Parrayrefs = %array_load.mut (arr, i) in
+      apply f (Parrayrefs) -> k2 * k1
+    where k3 =
+      cont k1 pop(regular k1) ($camlTests3__block16)
+    where k2 (apply_result : val) =
+      let Parraysets = %array_set (arr, i, apply_result) in
+      cont k (0)
+in
+let $camlTests3__foo_2 = closure foo_0_1 @foo in
+let code loopify(never) size(33) newer_version_of(f_1)
+      f_1_1 (c : imm tagged, m, n, x' : imm tagged, y' : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %int_comp.lt (c, 0) in
+   switch prim
+     | 0 -> k3
+     | 1 -> k2 (x')
+     where k3 =
+       let int_add = %int_barith.add (x', 10) in
+       cont k2 (int_add))
+    where k2 (x : imm tagged) =
+      ((let prim = %int_comp.lt (c, 0) in
+        switch prim
+          | 0 -> k3
+          | 1 -> k2 (y')
+          where k3 =
+            let int_add = %int_barith.add (y', 20) in
+            cont k2 (int_add))
+         where k2 (y : imm tagged) =
+           let int_add = %int_barith.add (x, y) in
+           cont k (int_add))
+in
+let $camlTests3__f_3 = closure f_1_1 @f in
+let $camlTests3 = Block 0 ($camlTests3__foo_2, $camlTests3__f_3) in
+cont done ($camlTests3)

--- a/testsuite/tests/flambda2/examples/unknown/array_set_bottom.ml
+++ b/testsuite/tests/flambda2/examples/unknown/array_set_bottom.ml
@@ -3,7 +3,15 @@
  flambda2;
  setup-ocamlopt.byte-build-env;
  ocamlopt.byte with dump-simplify;
- check-fexpr-dump;
+ {
+   flat-float-array;
+   check-fexpr-dump;
+ }{
+   no-flat-float-array;
+   fexpr_reference_suffix = "no-flat-float-array.reference";
+   check-fexpr-dump;
+ }
+
 *)
 
 (* This test was extracted from the hdf5 package. It tests the case where the

--- a/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.no-flat-float-array.reference
@@ -1,0 +1,13 @@
+let code f_0 deleted in
+let code loopify(never) size(5) newer_version_of(f_0)
+      f_0_1 (a : imm tagged, v : float boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pobj_magic = %opaque (a) in
+  let Parraysetu = %array_set (Pobj_magic, 0, v) in
+  cont k (0)
+in
+let $camlArray_set_bottom__f_1 = closure f_0_1 @f in
+let $camlArray_set_bottom = Block 0 ($camlArray_set_bottom__f_1) in
+cont done ($camlArray_set_bottom)

--- a/testsuite/tests/letrec-check/no_flat_float_array.ml
+++ b/testsuite/tests/letrec-check/no_flat_float_array.ml
@@ -22,7 +22,7 @@ val f : bytes -> bytes array = <fun>
 (* Generic case (element may or may not be float), no dynamic test. *)
 let f z = let rec x = [| y; z |] and y = z in x;;
 [%%expect {|
-val f : 'a -> 'a array = <fun>
+val f : ('a : value_maybe_null). 'a -> 'a array = <fun>
 |}]
 
 (* Float case, no unboxing. *)

--- a/testsuite/tests/lib-array/test_iarray_typeopt-flat-float-array.ml
+++ b/testsuite/tests/lib-array/test_iarray_typeopt-flat-float-array.ml
@@ -1,0 +1,35 @@
+(* TEST
+   include stdlib_stable;
+   flags = "-dlambda";
+   flat-float-array;
+   expect;
+*)
+
+module Array = Stdlib.Array
+open Stdlib_stable.IarrayLabels
+
+[%%expect {|
+0
+module Array = Array
+0
+|}]
+
+(* Regression test showing that an [i]array of iarrays
+   has element kind [addr].
+
+   With the flat float array optimization enabled, an [: :] of
+   polymorphic element type specializes to [gen]. *)
+
+let _ = [: [: :] :];;
+
+[%%expect {|
+(makearray_imm[addr] (makearray_imm[gen]))
+- : 'a iarray iarray = [:[::]:]
+|}]
+
+let _ = [| [: :] |];;
+
+[%%expect {|
+(makearray[addr] (makearray_imm[gen]))
+- : '_weak1 iarray array = [|[::]|]
+|}]

--- a/testsuite/tests/lib-array/test_iarray_typeopt-no-flat-float-array.ml
+++ b/testsuite/tests/lib-array/test_iarray_typeopt-no-flat-float-array.ml
@@ -1,0 +1,36 @@
+(* TEST
+   include stdlib_stable;
+   flags = "-dlambda";
+   no-flat-float-array;
+   expect;
+*)
+
+module Array = Stdlib.Array
+open Stdlib_stable.IarrayLabels
+
+[%%expect {|
+0
+module Array = Array
+0
+|}]
+
+(* Regression test showing that an [i]array of iarrays
+   has element kind [addr].
+
+   In no-flat-float-array mode, an [: :] of polymorphic element type
+   specializes to [addr] rather than [gen].
+ *)
+
+let _ = [: [: :] :];;
+
+[%%expect {|
+(makearray_imm[addr] (makearray_imm[addr]))
+- : 'a iarray iarray = [:[::]:]
+|}]
+
+let _ = [| [: :] |];;
+
+[%%expect {|
+(makearray[addr] (makearray_imm[addr]))
+- : '_weak1 iarray array = [|[::]|]
+|}]

--- a/testsuite/tests/lib-array/test_iarray_typeopt.ml
+++ b/testsuite/tests/lib-array/test_iarray_typeopt.ml
@@ -13,23 +13,8 @@ module Array = Array
 0
 |}]
 
-(* Regression test showing that an [i]array of iarrays
-   has element kind [addr].
- *)
-
-let _ = [: [: :] :];;
-
-[%%expect {|
-(makearray_imm[addr] (makearray_imm[gen]))
-- : 'a iarray iarray = [:[::]:]
-|}]
-
-let _ = [| [: :] |];;
-
-[%%expect {|
-(makearray[addr] (makearray_imm[gen]))
-- : '_weak1 iarray array = [|[::]|]
-|}]
+(* See test_iarray_typeopt-no-flat-float-array.ml for tests of [: [: :] :] that depend on
+   the flat float array optimization. *)
 
 (* Test that reading from an iarray generates an immutable load (iarray.get) *)
 

--- a/testsuite/tests/statmemprof/callstacks.no-flat-float-array.byte.reference
+++ b/testsuite/tests/statmemprof/callstacks.no-flat-float-array.byte.reference
@@ -1,70 +1,70 @@
 -----------
-Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 18, characters 30-53
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 19, characters 30-53
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 21, characters 30-76
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 22, characters 30-76
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 26, characters 12-66
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 27, characters 12-66
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 29, characters 30-60
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 30, characters 30-60
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 32, characters 30-55
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 33, characters 30-55
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 36, characters 12-62
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 37, characters 12-62
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 39, characters 22-27
-Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 41, characters 30-65
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 40, characters 22-27
+Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 42, characters 30-65
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 44, characters 30-69
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 45, characters 30-69
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 47, characters 30-73
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 48, characters 30-73
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 51, characters 30-43
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 52, characters 30-43
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
 No callstack
 -----------
-Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml", line 68, characters 9-35
-Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 62, characters 12-87
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml", line 78, characters 9-35
+Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 63, characters 12-87
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 65, characters 30-59
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 66, characters 30-59
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 68, characters 37-43
-Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 70, characters 30-49
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 69, characters 37-43
+Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 71, characters 30-49
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21

--- a/testsuite/tests/statmemprof/callstacks.no-flat-float-array.opt.reference
+++ b/testsuite/tests/statmemprof/callstacks.no-flat-float-array.opt.reference
@@ -1,71 +1,71 @@
 -----------
-Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 18, characters 30-53
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_list_literal in file "callstacks.ml", line 19, characters 30-53
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 21, characters 30-76
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_pair in file "callstacks.ml", line 22, characters 30-76
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 26, characters 12-66
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_record in file "callstacks.ml", line 27, characters 12-66
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 29, characters 30-60
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_some in file "callstacks.ml", line 30, characters 30-60
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 32, characters 30-55
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_array_literal in file "callstacks.ml", line 33, characters 30-55
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 36, characters 12-62
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_float_array_literal in file "callstacks.ml", line 37, characters 12-62
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 39, characters 22-27
-Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 41, characters 30-65
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.do_alloc_unknown_array_literal in file "callstacks.ml", line 40, characters 22-27
+Called from Callstacks.alloc_unknown_array_literal in file "callstacks.ml", line 42, characters 30-65
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 44, characters 30-69
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_small_array in file "callstacks.ml", line 45, characters 30-69
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 47, characters 30-73
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_large_array in file "callstacks.ml", line 48, characters 30-73
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 51, characters 30-43
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_closure.(fun) in file "callstacks.ml", line 52, characters 30-43
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
 No callstack
 -----------
-Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml" (inlined), line 68, characters 9-35
-Called from Stdlib__Marshal.from_string in file "marshal.ml", line 74, characters 2-46
-Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 62, characters 12-87
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Stdlib__Marshal.from_bytes in file "marshal.ml" (inlined), line 78, characters 9-35
+Called from Stdlib__Marshal.from_string in file "marshal.ml", line 84, characters 2-46
+Called from Callstacks.alloc_unmarshal in file "callstacks.ml", line 63, characters 12-87
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 65, characters 30-59
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.alloc_ref in file "callstacks.ml", line 66, characters 30-59
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21
 -----------
-Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 68, characters 37-43
-Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 70, characters 30-49
-Called from Callstacks.test in file "callstacks.ml", line 92, characters 2-10
-Called from Stdlib__List.iter in file "list.ml", line 110, characters 12-15
-Called from Callstacks in file "callstacks.ml", line 99, characters 2-27
+Raised by primitive operation at Callstacks.prod_floats in file "callstacks.ml", line 69, characters 37-43
+Called from Callstacks.alloc_boxedfloat in file "callstacks.ml", line 71, characters 30-49
+Called from Callstacks.test in file "callstacks.ml", line 94, characters 2-10
+Called from Callstacks.test_all in file "callstacks.ml", line 105, characters 17-23
+Called from Callstacks in file "callstacks.ml", line 107, characters 2-21

--- a/testsuite/tests/translprim/module_coercion.compilers.no-flat.reference
+++ b/testsuite/tests/translprim/module_coercion.compilers.no-flat.reference
@@ -1,146 +1,162 @@
-(setglobal Module_coercion!
-  (let (M = (makeblock 0))
-    (makeblock 0 M
-      (makeblock 0
-        (function {nlocal = 0} prim[intarray] stub (array.length[int] prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          (array.get[int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] stub
-          (array.unsafe_get[int] prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          (array.set[int] prim prim prim))
-        (function {nlocal = 0} prim[intarray] prim[int] prim[int] stub
-          (array.unsafe_set[int] prim prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub
-          (compare_ints prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (== prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (!= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (< prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (> prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (<= prim prim))
-        (function {nlocal = 0} prim[int] prim[int] stub (>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[float] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[float] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int
-          (compare_floats float prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.== prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.!= prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.< prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.> prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.<= prim prim))
-        (function {nlocal = 0} prim[float] prim[float] stub
-          ignore assert all zero_alloc : int (Float.>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_compare prim prim))
-        (function {nlocal = 0} prim prim stub (caml_string_equal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_notequal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_lessthan prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_greaterthan prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_lessequal prim prim))
-        (function {nlocal = 0} prim prim stub
-          (caml_string_greaterequal prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int32] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (compare_bints int32 prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.== prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.!= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.< prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.> prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.<= prim prim))
-        (function {nlocal = 0} prim[int32] prim[int32] stub
-          (Int32.>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[int64] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (compare_bints int64 prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.== prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.!= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.< prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.> prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.<= prim prim))
-        (function {nlocal = 0} prim[int64] prim[int64] stub
-          (Int64.>= prim prim)))
-      (makeblock 0
-        (function {nlocal = 0} prim[addrarray] stub
-          (array.length[addr] prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] stub
-          (array.unsafe_get[addr] prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          (array.set[addr] prim prim prim))
-        (function {nlocal = 0} prim[addrarray] prim[int] prim[nativeint] stub
-          (array.unsafe_set[addr] prim prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (compare_bints nativeint prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.== prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.!= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.< prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.> prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.<= prim prim))
-        (function {nlocal = 0} prim[nativeint] prim[nativeint] stub
-          (Nativeint.>= prim prim))))))
+(let (M = (makeblock 0))
+  (makeblock 0 M
+    (makeblock 0
+      (function {nlocal = 0} prim[value<intarray>] stub : int
+        (array.length[int] prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+        : int (array.get[int indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>] stub
+        : int (array.unsafe_get[int indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+        prim[value<int>] stub : int
+        (array.set[int indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<intarray>] prim[value<int>]
+        prim[value<int>] stub : int
+        (array.unsafe_set[int indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_compare prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%eq prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%noteq prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_lessthan prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_lessequal prim prim))
+      (function {nlocal = 0} prim[value<int>] prim[value<int>] stub : int
+        (%int_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : float (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : float (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<float>] stub : int
+        (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<float>] stub : int
+        (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_compare prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_equal prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_unordered_or_notequal prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_lessthan prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_lessequal prim prim))
+      (function {nlocal = 0} prim[value<float>] prim[value<float>] stub : int
+        (%float_ordered_and_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+        stub : int (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] prim
+        stub : int (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_compare prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_equal prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_notequal prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_lessthan prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_greaterthan prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_lessequal prim prim))
+      (function {nlocal = 0} prim prim stub : int
+        (caml_string_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int32 (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int32 (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int32>] stub : int
+        (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int32>] stub : int
+        (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_compare prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_equal prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_notequal prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_lessthan prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_lessequal prim prim))
+      (function {nlocal = 0} prim[value<int32>] prim[value<int32>] stub : int
+        (%int32_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int64 (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : int64 (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int64>] stub : int
+        (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<int64>] stub : int
+        (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_compare prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_equal prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_notequal prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_lessthan prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_lessequal prim prim))
+      (function {nlocal = 0} prim[value<int64>] prim[value<int64>] stub : int
+        (%int64_greaterequal prim prim)))
+    (makeblock 0
+      (function {nlocal = 0} prim[value<addrarray>] stub : int
+        (array.length[addr] prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : nativeint (array.get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>] stub
+        : nativeint (array.unsafe_get[addr indexed by int] prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<nativeint>] stub : int
+        (array.set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<addrarray>] prim[value<int>]
+        prim[value<nativeint>] stub : int
+        (array.unsafe_set[addr indexed by int] prim prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_compare prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_equal prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_notequal prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_lessthan prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_greaterthan prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_lessequal prim prim))
+      (function {nlocal = 0} prim[value<nativeint>] prim[value<nativeint>]
+        stub : int (%nativeint_greaterequal prim prim)))))

--- a/testsuite/tests/typing-layouts-arrays/array_element_size_in_bytes.ml
+++ b/testsuite/tests/typing-layouts-arrays/array_element_size_in_bytes.ml
@@ -1,5 +1,6 @@
 (* TEST
  modules = "block_checks.ml";
+ include ocamlcommon;
  flambda2;
  stack-allocation;
  {
@@ -78,9 +79,18 @@ let check_floatu ~init ~element_size =
   let check_one n =
     let x = makearray_dynamic n init in
     assert ((element_size * n / bytes_per_word) = (Obj.size (Obj.repr x)));
-    (* float# arrays use Double_array_tag (254) when non-empty, tag 0 when empty *)
+    (* float# arrays use Double_array_tag (254) when non-empty, tag 0 when empty.
+       In bytecode without flat-float-array, [%makearray_dynamic] falls through
+       to [caml_array_make] which produces tag 0 in that configuration. *)
     let tag = Obj.tag (Obj.repr x) in
-    let expected_tag = if n = 0 then 0 else 254 in
+    let expected_tag =
+      if n = 0 then 0
+      else
+        match Sys.backend_type with
+        | Native -> 254
+        | Bytecode -> if Config.flat_float_array then 254 else 0
+        | Other _ -> failwith "Don't know what to do"
+    in
     assert (tag = expected_tag)
   in
   List.iter check_one array_sizes_to_check

--- a/testsuite/tests/typing-layouts-arrays/test_float_u_array.ml
+++ b/testsuite/tests/typing-layouts-arrays/test_float_u_array.ml
@@ -6,6 +6,7 @@
  modules = "${readonly_files} stubs.c";
  flambda2;
  {
+   flat-float-array;
    bytecode;
  }
  {

--- a/testsuite/tests/typing-layouts-or-null/non_float_array-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array-flat-float-array.ml
@@ -1,0 +1,38 @@
+(* TEST
+ flags = "-dlambda -dno-unique-ids -extension-universe upstream_compatible";
+ flat-float-array;
+ expect;
+*)
+
+(* Normal arrays are [genarray]s. Due to the float array optimization,
+   they must check whether their elements are float or non-float on
+   creation, [get] and [set].
+
+   We can see what kind of array we are getting by looking at Lambda. *)
+
+let mk_gen (x : 'a) = [| x |]
+[%%expect{|
+(let (mk_gen = (function {nlocal = 0} x? : genarray (makearray[gen] x)))
+  (apply (field_imm 1 (global Toploop!)) "mk_gen" mk_gen))
+val mk_gen : ('a : value_maybe_null). 'a -> 'a array = <fun>
+|}]
+
+let get_gen (xs : 'a array) i = xs.(i)
+[%%expect{|
+(let
+  (get_gen =
+     (function {nlocal = 0} xs[value<genarray>] i[value<int>]
+       (array.get[gen indexed by int] xs i)))
+  (apply (field_imm 1 (global Toploop!)) "get_gen" get_gen))
+val get_gen : ('a : value_maybe_null). 'a array -> int -> 'a = <fun>
+|}]
+
+let set_gen (xs : 'a array) x i = xs.(i) <- x
+[%%expect{|
+(let
+  (set_gen =
+     (function {nlocal = 0} xs[value<genarray>] x? i[value<int>] : int
+       (array.set[gen indexed by int] xs i x)))
+  (apply (field_imm 1 (global Toploop!)) "set_gen" set_gen))
+val set_gen : ('a : value_maybe_null). 'a array -> 'a -> int -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-layouts-or-null/non_float_array-no-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array-no-flat-float-array.ml
@@ -1,0 +1,36 @@
+(* TEST
+ flags = "-dlambda -dno-unique-ids -extension-universe upstream_compatible";
+ no-flat-float-array;
+ expect;
+*)
+
+(* With the flat float array optimization disabled, a polymorphic value
+   array ['a array] is represented as an [addrarray]: there is no need
+   to check whether its elements are floats. *)
+
+let mk_gen (x : 'a) = [| x |]
+[%%expect{|
+(let (mk_gen = (function {nlocal = 0} x? : addrarray (makearray[addr] x)))
+  (apply (field_imm 1 (global Toploop!)) "mk_gen" mk_gen))
+val mk_gen : ('a : value_maybe_null). 'a -> 'a array = <fun>
+|}]
+
+let get_gen (xs : 'a array) i = xs.(i)
+[%%expect{|
+(let
+  (get_gen =
+     (function {nlocal = 0} xs[value<addrarray>] i[value<int>]
+       (array.get[addr indexed by int] xs i)))
+  (apply (field_imm 1 (global Toploop!)) "get_gen" get_gen))
+val get_gen : ('a : value_maybe_null). 'a array -> int -> 'a = <fun>
+|}]
+
+let set_gen (xs : 'a array) x i = xs.(i) <- x
+[%%expect{|
+(let
+  (set_gen =
+     (function {nlocal = 0} xs[value<addrarray>] x? i[value<int>] : int
+       (array.set[addr indexed by int] xs i x)))
+  (apply (field_imm 1 (global Toploop!)) "set_gen" set_gen))
+val set_gen : ('a : value_maybe_null). 'a array -> 'a -> int -> unit = <fun>
+|}]

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -3,38 +3,11 @@
  expect;
 *)
 
-(* Normal arrays are [genarray]s. Due to the float array optimization,
-   they must check whether their elements are float or non-float on
-   creation, [get] and [set].
-
-   We can see what kind of array we are getting by looking at Lambda. *)
-
-let mk_gen (x : 'a) = [| x |]
-[%%expect{|
-(let (mk_gen = (function {nlocal = 0} x? : genarray (makearray[gen] x)))
-  (apply (field_imm 1 (global Toploop!)) "mk_gen" mk_gen))
-val mk_gen : ('a : value_maybe_null). 'a -> 'a array = <fun>
-|}]
-
-let get_gen (xs : 'a array) i = xs.(i)
-[%%expect{|
-(let
-  (get_gen =
-     (function {nlocal = 0} xs[value<genarray>] i[value<int>]
-       (array.get[gen indexed by int] xs i)))
-  (apply (field_imm 1 (global Toploop!)) "get_gen" get_gen))
-val get_gen : ('a : value_maybe_null). 'a array -> int -> 'a = <fun>
-|}]
-
-let set_gen (xs : 'a array) x i = xs.(i) <- x
-[%%expect{|
-(let
-  (set_gen =
-     (function {nlocal = 0} xs[value<genarray>] x? i[value<int>] : int
-       (array.set[gen indexed by int] xs i x)))
-  (apply (field_imm 1 (global Toploop!)) "set_gen" set_gen))
-val set_gen : ('a : value_maybe_null). 'a array -> 'a -> int -> unit = <fun>
-|}]
+(* For tests of [genarray] (polymorphic ['a array]), see
+   non_float_array-no-flat-float-array.ml: under the float array optimization a
+   polymorphic value array specializes to [genarray] (with dynamic
+   float-tag checks), whereas with the optimization disabled it
+   specializes to [addrarray] like a [non_float] array. *)
 
 (* [non_float] arrays are [addrarray]s. Operations on [addrarray]s
    skip checks related to floats.
@@ -84,7 +57,7 @@ end = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "X/378"
+(apply (field_imm 1 (global Toploop!)) "X/366"
   (let
     (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
        [0: "first" 1]
@@ -107,7 +80,7 @@ let () =
 
 [%%expect{|
 (let
-  (X =? (apply (field_imm 0 (global Toploop!)) "X/378")
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/366")
    *match* =[value<int>]
      (let (xs =[value<addrarray>] (caml_array_make 4 (field_imm 0 X)))
        (seq (array.set[addr indexed by int] xs 1 (field_imm 1 X))

--- a/testsuite/tests/typing-layouts-or-null/separability-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability-flat-float-array.ml
@@ -1,0 +1,26 @@
+(* TEST
+ flat-float-array;
+ expect;
+*)
+
+(* Separability and [@@unboxed] existential types whose acceptance
+   depends on the flat float array optimization.
+   See separability.ml for tests that are independent of the
+   optimization. *)
+
+(* Some [@@unboxed] existentials are non-separable and thus forbidden. *)
+(* CR separability: mark them as non-separable instead. *)
+
+type 'a abstract
+
+type packed = P : 'a abstract -> packed [@@unboxed]
+[%%expect{|
+type 'a abstract
+Line 3, characters 0-51:
+3 | type packed = P : 'a abstract -> packed [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]

--- a/testsuite/tests/typing-layouts-or-null/separability-no-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability-no-flat-float-array.ml
@@ -1,0 +1,18 @@
+(* TEST
+ no-flat-float-array;
+ expect;
+*)
+
+(* See separability.ml for the bulk of separability tests. This file
+   collects the cases that depend on the flat float array optimization
+   being disabled: with the optimization off, [@@unboxed] existentials
+   that might contain both float and non-float values are accepted
+   because there is no float array optimization to break. *)
+
+type 'a abstract
+
+type packed = P : 'a abstract -> packed [@@unboxed]
+[%%expect{|
+type 'a abstract
+type packed = P : 'a abstract -> packed [@@unboxed]
+|}]

--- a/testsuite/tests/typing-layouts-or-null/separability.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability.ml
@@ -1002,24 +1002,9 @@ Error: Signature mismatch:
 
 (* Separability and [@@unboxed] existential types. *)
 
-(* Some [@@unboxed] existentials are non-separable and thus forbidden. *)
-(* CR separability: mark them as non-separable instead. *)
-
-type 'a abstract
-
-type packed = P : 'a abstract -> packed [@@unboxed]
-[%%expect{|
-type 'a abstract
-Line 3, characters 0-51:
-3 | type packed = P : 'a abstract -> packed [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
-
-(* [non_float] annotations allow us to bypass this check. *)
+(* Some [@@unboxed] existentials are non-separable and thus forbidden;
+   see separability-no-flat-float-array.ml for those cases (they only fire when the
+   flat float array optimization is enabled). *)
 
 type 'a non_float : value mod non_float
 

--- a/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible-flat-float-array.ml
@@ -1,0 +1,26 @@
+(* TEST
+ flags = "-extension-universe upstream_compatible";
+ flat-float-array;
+ expect;
+*)
+
+(* See separability_upstream_compatible.ml for the bulk of the tests.
+   This file collects the cases that depend on the flat float array
+   optimization being enabled. *)
+
+(* Some [@@unboxed] existentials are non-separable and thus forbidden. *)
+(* CR separability: mark them as non-separable instead. *)
+
+type 'a abstract
+
+type packed = P : 'a abstract -> packed [@@unboxed]
+[%%expect{|
+type 'a abstract
+Line 3, characters 0-51:
+3 | type packed = P : 'a abstract -> packed [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]

--- a/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible-no-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible-no-flat-float-array.ml
@@ -1,0 +1,17 @@
+(* TEST
+ flags = "-extension-universe upstream_compatible";
+ no-flat-float-array;
+ expect;
+*)
+
+(* See separability_upstream_compatible.ml for the bulk of the tests. This
+   file collects the cases that depend on the flat float array optimization
+   being disabled. *)
+
+type 'a abstract
+
+type packed = P : 'a abstract -> packed [@@unboxed]
+[%%expect{|
+type 'a abstract
+type packed = P : 'a abstract -> packed [@@unboxed]
+|}]

--- a/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_upstream_compatible.ml
@@ -3,22 +3,8 @@
  expect;
 *)
 
-(* Some [@@unboxed] existentials are non-separable and thus forbidden. *)
-(* CR separability: mark them as non-separable instead. *)
-
-type 'a abstract
-
-type packed = P : 'a abstract -> packed [@@unboxed]
-[%%expect{|
-type 'a abstract
-Line 3, characters 0-51:
-3 | type packed = P : 'a abstract -> packed [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
+(* For tests of [@@unboxed] existentials whose acceptance depends on the
+   flat float array optimization, see separability_upstream_compatible-no-flat-float-array.ml. *)
 
 (* [non_float] annotations allow us to bypass this check, but are erased. *)
 type 'a non_float : value mod non_float

--- a/testsuite/tests/typing-layouts-products/separability-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-products/separability-flat-float-array.ml
@@ -1,0 +1,65 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ flat-float-array;
+ {
+   expect;
+ }
+*)
+
+(* See separability.ml for the bulk of separability tests. This file
+   collects the cases that depend on the flat float array optimization
+   being enabled: with the optimization on, [@@unboxed] existentials
+   that might contain both float and non-float values are rejected. *)
+
+type 'a r = #{ a : 'a }
+type bad = F : 'a r -> bad [@@unboxed]
+[%%expect{|
+type 'a r = #{ a : 'a; }
+Line 2, characters 0-38:
+2 | type bad = F : 'a r -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]
+
+type 'a r = #{ a : 'a }
+type bad = F : { x : 'a r } -> bad [@@unboxed]
+[%%expect{|
+type 'a r = #{ a : 'a; }
+Line 2, characters 0-46:
+2 | type bad = F : { x : 'a r } -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]
+
+type 'a r = #{ a : 'a }
+and 'a r2 = #{ a : 'a r }
+and bad = F : 'a r2 -> bad [@@unboxed]
+[%%expect{|
+Line 3, characters 0-38:
+3 | and bad = F : 'a r2 -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]
+
+type 'a r = #{ a : 'a }
+and bad = F : { x : 'a r } -> bad [@@unboxed]
+[%%expect{|
+Line 2, characters 0-45:
+2 | and bad = F : { x : 'a r } -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]

--- a/testsuite/tests/typing-layouts-products/separability-no-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-products/separability-no-flat-float-array.ml
@@ -1,0 +1,45 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ no-flat-float-array;
+ {
+   expect;
+ }
+*)
+
+(* See separability.ml for the bulk of separability tests. This file
+   collects the cases that depend on the flat float array optimization
+   being disabled: with the optimization off, [@@unboxed] existentials
+   that might contain both float and non-float values are accepted
+   because there is no float array optimization to break. *)
+
+type 'a r = #{ a : 'a }
+type bad = F : 'a r -> bad [@@unboxed]
+[%%expect{|
+type 'a r = #{ a : 'a; }
+type bad = F : 'a r -> bad [@@unboxed]
+|}]
+
+type 'a r = #{ a : 'a }
+type bad = F : { x : 'a r } -> bad [@@unboxed]
+[%%expect{|
+type 'a r = #{ a : 'a; }
+type bad = F : { x : 'a r; } -> bad [@@unboxed]
+|}]
+
+type 'a r = #{ a : 'a }
+and 'a r2 = #{ a : 'a r }
+and bad = F : 'a r2 -> bad [@@unboxed]
+[%%expect{|
+type 'a r = #{ a : 'a; }
+and 'a r2 = #{ a : 'a r; }
+and bad = F : 'a r2 -> bad [@@unboxed]
+|}]
+
+type 'a r = #{ a : 'a }
+and bad = F : { x : 'a r } -> bad [@@unboxed]
+[%%expect{|
+type 'a r = #{ a : 'a; }
+and bad = F : { x : 'a r; } -> bad [@@unboxed]
+|}]

--- a/testsuite/tests/typing-layouts-products/separability.ml
+++ b/testsuite/tests/typing-layouts-products/separability.ml
@@ -24,56 +24,10 @@ type 'a r = #{ a : 'a; }
 and 'a ok = F : { x : 'a r; } -> 'a ok [@@unboxed]
 |}]
 
-type 'a r = #{ a : 'a }
-type bad = F : 'a r -> bad [@@unboxed]
-[%%expect{|
-type 'a r = #{ a : 'a; }
-Line 2, characters 0-38:
-2 | type bad = F : 'a r -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
 
-type 'a r = #{ a : 'a }
-type bad = F : { x : 'a r } -> bad [@@unboxed]
-[%%expect{|
-type 'a r = #{ a : 'a; }
-Line 2, characters 0-46:
-2 | type bad = F : { x : 'a r } -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
+(* See separability-no-flat-float-array.ml for [@@unboxed] existential tests whose
+   acceptance depends on the flat float array optimization. *)
 
-type 'a r = #{ a : 'a }
-and 'a r2 = #{ a : 'a r }
-and bad = F : 'a r2 -> bad [@@unboxed]
-[%%expect{|
-Line 3, characters 0-38:
-3 | and bad = F : 'a r2 -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
-
-type 'a r = #{ a : 'a }
-and bad = F : { x : 'a r } -> bad [@@unboxed]
-[%%expect{|
-Line 2, characters 0-45:
-2 | and bad = F : { x : 'a r } -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
 
 (* #(value & void) and similar kinds are always considered separable,
    since we don't apply the float array optimization for them. *)

--- a/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records-flat-float-array.ml
@@ -1,0 +1,64 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ flat-float-array;
+ {
+   expect;
+ }
+*)
+
+(* See separability_implicit_unboxed_records.ml for the bulk of the tests.
+   This file collects the cases that depend on the flat float array
+   optimization being enabled. *)
+
+type 'a r = { a : 'a }
+type bad = F : 'a r# -> bad [@@unboxed]
+[%%expect{|
+type 'a r = { a : 'a; }
+Line 2, characters 0-39:
+2 | type bad = F : 'a r# -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]
+
+type 'a r = { a : 'a }
+type bad = F : { x : 'a r# } -> bad [@@unboxed]
+[%%expect{|
+type 'a r = { a : 'a; }
+Line 2, characters 0-47:
+2 | type bad = F : { x : 'a r# } -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]
+
+type 'a r = { a : 'a }
+and 'a r2 = { a : 'a r# }
+and bad = F : 'a r2# -> bad [@@unboxed]
+[%%expect{|
+Line 3, characters 0-39:
+3 | and bad = F : 'a r2# -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]
+
+type 'a r = { a : 'a }
+and bad = F : { x : 'a r# } -> bad [@@unboxed]
+[%%expect{|
+Line 2, characters 0-46:
+2 | and bad = F : { x : 'a r# } -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]

--- a/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records-no-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records-no-flat-float-array.ml
@@ -1,0 +1,43 @@
+(* TEST
+ flambda2;
+ include stdlib_upstream_compatible;
+ flags = "-extension layouts_alpha";
+ no-flat-float-array;
+ {
+   expect;
+ }
+*)
+
+(* See separability_implicit_unboxed_records.ml for the bulk of the tests.
+   This file collects the cases that depend on the flat float array
+   optimization being disabled. *)
+
+type 'a r = { a : 'a }
+type bad = F : 'a r# -> bad [@@unboxed]
+[%%expect{|
+type 'a r = { a : 'a; }
+type bad = F : 'a r# -> bad [@@unboxed]
+|}]
+
+type 'a r = { a : 'a }
+type bad = F : { x : 'a r# } -> bad [@@unboxed]
+[%%expect{|
+type 'a r = { a : 'a; }
+type bad = F : { x : 'a r#; } -> bad [@@unboxed]
+|}]
+
+type 'a r = { a : 'a }
+and 'a r2 = { a : 'a r# }
+and bad = F : 'a r2# -> bad [@@unboxed]
+[%%expect{|
+type 'a r = { a : 'a; }
+and 'a r2 = { a : 'a r#; }
+and bad = F : 'a r2# -> bad [@@unboxed]
+|}]
+
+type 'a r = { a : 'a }
+and bad = F : { x : 'a r# } -> bad [@@unboxed]
+[%%expect{|
+type 'a r = { a : 'a; }
+and bad = F : { x : 'a r#; } -> bad [@@unboxed]
+|}]

--- a/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/separability_implicit_unboxed_records.ml
@@ -24,56 +24,11 @@ type 'a r = { a : 'a; }
 and 'a ok = F : { x : 'a r#; } -> 'a ok [@@unboxed]
 |}]
 
-type 'a r = { a : 'a }
-type bad = F : 'a r# -> bad [@@unboxed]
-[%%expect{|
-type 'a r = { a : 'a; }
-Line 2, characters 0-39:
-2 | type bad = F : 'a r# -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
 
-type 'a r = { a : 'a }
-type bad = F : { x : 'a r# } -> bad [@@unboxed]
-[%%expect{|
-type 'a r = { a : 'a; }
-Line 2, characters 0-47:
-2 | type bad = F : { x : 'a r# } -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
+(* See separability_implicit_unboxed_records-no-flat-float-array.ml for [@@unboxed]
+   existential tests whose acceptance depends on the flat float array
+   optimization. *)
 
-type 'a r = { a : 'a }
-and 'a r2 = { a : 'a r# }
-and bad = F : 'a r2# -> bad [@@unboxed]
-[%%expect{|
-Line 3, characters 0-39:
-3 | and bad = F : 'a r2# -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
-
-type 'a r = { a : 'a }
-and bad = F : { x : 'a r# } -> bad [@@unboxed]
-[%%expect{|
-Line 2, characters 0-46:
-2 | and bad = F : { x : 'a r# } -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
 
 (* #(value & void) and similar kinds are always considered separable,
    since we don't apply the float array optimization for them. *)

--- a/testsuite/tests/typing-layouts/hash_types-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts/hash_types-flat-float-array.ml
@@ -1,0 +1,20 @@
+(* TEST
+ flags = "-extension layouts_beta";
+ flat-float-array;
+ expect;
+*)
+
+(* See hash_types.ml for the bulk of the tests. This file collects the
+   case that depends on the flat float array optimization being enabled. *)
+
+type 'a t = { i : 'a }
+and bad = P : 'a t# -> bad [@@unboxed]
+[%%expect{|
+Line 2, characters 0-38:
+2 | and bad = P : 'a t# -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]

--- a/testsuite/tests/typing-layouts/hash_types-no-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts/hash_types-no-flat-float-array.ml
@@ -1,0 +1,15 @@
+(* TEST
+ flags = "-extension layouts_beta";
+ no-flat-float-array;
+ expect;
+*)
+
+(* See hash_types.ml for the bulk of the tests. This file collects the
+   case that depends on the flat float array optimization being disabled. *)
+
+type 'a t = { i : 'a }
+and bad = P : 'a t# -> bad [@@unboxed]
+[%%expect{|
+type 'a t = { i : 'a; }
+and bad = P : 'a t# -> bad [@@unboxed]
+|}]

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -1301,18 +1301,8 @@ type ('a, 'b) s = ('a, 'b) t
 type packed = T : ('a, 'b) s# -> packed [@@unboxed]
 |}]
 
-(* This one is rejected, but it should be *)
-type 'a t = { i : 'a }
-and bad = P : 'a t# -> bad [@@unboxed]
-[%%expect{|
-Line 2, characters 0-38:
-2 | and bad = P : 'a t# -> bad [@@unboxed]
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type cannot be unboxed because
-       it might contain both float and non-float values,
-       depending on the instantiation of the existential variable "'a".
-       You should annotate it with "[@@ocaml.boxed]".
-|}]
+(* See hash_types-no-flat-float-array.ml for the [@@unboxed] existential test that is
+   rejected only when the flat float array optimization is enabled. *)
 
 type ('a, 'b) t = { a : 'a }
 type ('a, 'b) s = ('a, 'b) t

--- a/testsuite/tests/typing-local/float_iarray.heap.no-flat.reference
+++ b/testsuite/tests/typing-local/float_iarray.heap.no-flat.reference
@@ -1,0 +1,4 @@
+    access from literal: No Allocation
+access from Iarray.init: No Allocation
+       match on literal: No Allocation
+   match on Iarray.init: No Allocation

--- a/testsuite/tests/typing-local/float_iarray.ml
+++ b/testsuite/tests/typing-local/float_iarray.ml
@@ -1,18 +1,30 @@
 (* TEST
  include stdlib_stable;
  {
-   reference = "${test_source_directory}/float_iarray.heap.reference";
-   bytecode;
+   flat-float-array;
+   {
+     reference = "${test_source_directory}/float_iarray.heap.reference";
+     bytecode;
+   }{
+     stack-allocation;
+     reference = "${test_source_directory}/float_iarray.stack.reference";
+     native;
+   }{
+     no-stack-allocation;
+     reference = "${test_source_directory}/float_iarray.heap.reference";
+     native;
+   }
  }{
-   stack-allocation;
-   reference = "${test_source_directory}/float_iarray.stack.reference";
-   native;
- }{
-   no-stack-allocation;
-   reference = "${test_source_directory}/float_iarray.heap.reference";
-   native;
+   no-flat-float-array;
+   reference = "${test_source_directory}/float_iarray.heap.no-flat.reference";
+   {
+     bytecode;
+   }{
+     native;
+   }
  }
 *)
+
 
 (* Testing that local [float iarray]s don't allocate on access.  This is a
    question because for flat float arrays, accesses have to box the float. *)

--- a/testsuite/tests/typing-separability/separability-bug.ml
+++ b/testsuite/tests/typing-separability/separability-bug.ml
@@ -1,4 +1,5 @@
 (* TEST
+   flat-float-array;
    expect;
 *)
 

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -535,9 +535,12 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                   if !printer_steps < 0 || depth < 0 then
                     Oval_ellipsis :: tree_list
                   else if i < length then
-                    let tree = nest tree_of_val (depth - 1)
-                                    (O.field obj i) ty_arg
+                    let elt =
+                      let is_double_array = O.tag obj = O.double_array_tag in
+                      if is_double_array then O.repr (O.double_field obj i)
+                      else O.field obj i
                     in
+                    let tree = nest tree_of_val (depth - 1) elt ty_arg in
                     tree_of_items (tree :: tree_list) (i + 1)
                   else tree_list
                 in


### PR DESCRIPTION
(includes commits for #6101 and #6128)

This PR makes the test suite (ours and upstream) pass with `--disable-flat-float-array`.  It also adds a CI check so that `--disable-flat-float-array` keeps building in the future.

The reasons tests where failing fall into 3 categories:

1. some tests produce different outputs with `--disable-flat-float-array`. In these cases I simply commited the reference file for the no flat float array mode and compared it to the normal reference file to check that the differences between the two modes were sensible
2. same as 1 but for expect tests. Often, not all the expect tests in a file have two different expectations. In general it is only a few tests that do, so I extracted these into a separate file and duplicated this separate file so we can have two different expectations depending on the mode. I also checked the differences between the two to ensure they were expected
3. Two tests had the wrong expectation about `%makearray_dynamic` in bytecode with `--disable-flat-float-array`, I corrected the expectation in one case and disabled the tests for this particular configuration in the other
   
Regarding 3, in native mode `%makearray_dynamic` produces an array whose layout depends on the context. So for instance:

- if called with `makearray_dynamic 5 0`, it will create a normal array
- if called with `makearray_dynamic 5 #0L`, it will create an unboxed array of int64s
- if called with `makearray_dynamic 5 #0.0`, it will create a unboxed array of floats

However, this behavior is not implemented in bytecode (as per the comment in `bytecomp/blambda_of_lambda.ml:885`). In bytecode it will always create a normal array, except, of course, when the argument is a float in which case it will create a flat float array in order to satisfy the flat float array optimization (this is done in a C stub). As expected, this behavior is disabled with `--disable-flat-float-array` in which case `%makearray_dynamic` always produces a normal array in bytecode.

So far, tests for unboxed floats using `%makearray_dynamic` happened to work in both native code and byte code because of the float array optimization. Tests for unboxed/untagged integer arrays already had the right expectation depending on `Sys.backend_type`.

I corrected the expectation for `float# array` in `typing-layouts-arrays/array_element_size_in_bytes.ml`. For `typing-layouts-arrays/test_float_u_array.ml`, I felt that it was better to simply disable the test in bytecode with `--disable-flat-float-array`: these tests are for unboxed float arrays, so making them work with boxed arrays does not seem valuable.

Following are summaries of updated tests for 1 and 2.

## Tests with multiple reference files

| Test | Added |
|---|---|
| `backtrace/lazy.ml` | `lazy.flambda.no-flat-float-array.reference` |
| `backtrace/names.ml` | `names.no-flat-float-array.reference` |
| `flambda2/array_element_kind_meet.ml` | `.simplify.no-flat-float-array.reference` |
| `flambda2/examples/array_kind.ml` | `.no-flat-float-array.compilers.reference` |
| `flambda2/examples/array_specialisation_examples.ml` | `.simplify.no-flat-float-array.reference` |
| `flambda2/examples/invalid.ml` | `.no-flat-float-array.compilers.reference` + `.simplify.no-flat-float-array.reference` |
| `flambda2/examples/tests15.ml` | `.raw.no-flat-float-array.reference` + `.simplify.no-flat-float-array.reference` |
| `flambda2/examples/tests3.ml` | `.raw.no-flat-float-array.reference` + `.simplify.no-flat-float-array.reference` |
| `flambda2/examples/unknown/array_set_bottom.ml` | `.simplify.no-flat-float-array.reference` |
| `typing-local/float_iarray.ml` | `.heap.no-flat.reference` |
| `statmemprof/callstacks.ml` | promoted `.no-flat-float-array.{byte,opt}.reference` |
| `lib-modules/module_coercion.ml` | `.compilers.no-flat.reference` |

## Expect tests extracted into separate files

| Original test | Pair created |
|---|---|
| `lib-array/test_iarray_typeopt.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `typing-layouts-or-null/non_float_array.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `typing-layouts-or-null/separability.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `typing-layouts-or-null/separability_upstream_compatible.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `typing-layouts-products/separability.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `typing-layouts-products/separability_implicit_unboxed_records.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `typing-layouts/hash_types.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `typing-separability/separability-bug.ml` | `-flat-float-array.ml` + `-no-flat-float-array.ml` |
| `codegen/arrays.ml` | renamed to `arrays-flat-float-array.ml` + new `arrays-no-flat-float-array.ml` |
