### PR TITLE
Track staticity of functors and their applications

### DIFF
--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -558,7 +558,7 @@ let merge_functors ~scopes mexp coercion root_path =
   let rec merge ~scopes mexp coercion path acc inline_attribute =
     let finished = acc, mexp, path, coercion, inline_attribute in
     match mexp.mod_desc with
-    | Tmod_functor (param, body) ->
+    | Tmod_functor (param, body, _) ->
       let inline_attribute' =
         Translattribute.get_inline_attribute mexp.mod_attributes
       in
@@ -654,7 +654,7 @@ and transl_module ~scopes cc rootpath mexp =
   | Tmod_functor _ ->
       oo_wrap mexp.mod_env true (fun () ->
         compile_functor ~scopes mexp cc rootpath loc) ()
-  | Tmod_apply(funct, arg, ccarg, yielding) ->
+  | Tmod_apply(funct, arg, ccarg, yielding, _) ->
       let translated_arg = transl_module ~scopes ccarg None arg in
       transl_apply ~scopes ~loc ~cc mexp.mod_env funct ~yielding translated_arg
   | Tmod_apply_unit (funct, yielding) ->

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -3247,7 +3247,7 @@ and quote_module_exp ~transl stage loc env mod_exp =
   | Tmod_ident (path, _) ->
     let m = module_for_path loc env path in
     Module.ident loc m |> Module.wrap
-  | Tmod_apply (funct, arg, _, _) ->
+  | Tmod_apply (funct, arg, _, _, _) ->
     let transl_funct = quote_module_exp ~transl stage loc env funct in
     let transl_arg = quote_module_exp ~transl stage loc env arg in
     Module.apply loc transl_funct transl_arg |> Module.wrap

--- a/ocamldoc/odoc_ast.ml
+++ b/ocamldoc/odoc_ast.ml
@@ -1705,7 +1705,7 @@ module Analyser =
           { m_base with m_kind = Module_struct elements2 }
 
       | (Parsetree.Pmod_functor (param2, p_module_expr2),
-         Typedtree.Tmod_functor (param, tt_module_expr2)) ->
+         Typedtree.Tmod_functor (param, tt_module_expr2, _)) ->
            let loc, mp_name, mp_kind, mp_type =
              match param2, param with
              | Parsetree.Unit, Typedtree.Unit ->
@@ -1748,12 +1748,12 @@ module Analyser =
            { m_base with m_kind = Module_functor (param, kind) }
 
       | (Parsetree.Pmod_apply (p_module_expr1, p_module_expr2),
-         Typedtree.Tmod_apply (tt_module_expr1, tt_module_expr2, _, _))
+         Typedtree.Tmod_apply (tt_module_expr1, tt_module_expr2, _, _, _))
       | (Parsetree.Pmod_apply (p_module_expr1, p_module_expr2),
          Typedtree.Tmod_constraint
            ({ Typedtree.mod_desc =
                 Typedtree.Tmod_apply
-                  (tt_module_expr1, tt_module_expr2, _, _)}, _,
+                  (tt_module_expr1, tt_module_expr2, _, _, _)}, _,
             _, _)
         ) ->
           let m1 = analyse_module

--- a/testsuite/tests/typing-modes/staticity.ml
+++ b/testsuite/tests/typing-modes/staticity.ml
@@ -386,7 +386,7 @@ module M : sig val x : bool @@ dynamic end
 let x = Random.bool ()
 
 (* functor can always be defined to be static, even if close over dynamic things *)
-module (F @ static) (M : sig end) = struct
+module (F @ static) (M : sig end @ static) = struct
     let x = x
 end
 [%%expect{|
@@ -418,17 +418,187 @@ end
 Exception: Match_failure ("", 2, 23).
 |}]
 
-(* functor application are always dynamic. *)
-(* CR-soon zqian: remove this restriction *)
-module F (X : sig end) = struct
-end
+(* Staticity interacts with functors in two ways:
+   - a functor's own staticity, equal to its parameter's (generative functors
+     are always dynamic).
+   - the staticity of an application's result, which is the join of the
+     functor's staticity and its declared return staticity - so the result is
+     static only if both are. *)
+
+(* A static functor takes a static parameter. *)
+module (F @ static) (X : sig end @ static) = struct end
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+|}]
+
+(* Static functor, dynamic (unannotated) parameter: a contradiction. The error
+   relates the functor and its parameter. *)
+module (F @ static) (X : sig end) = struct end
+[%%expect{|
+Line 1, characters 20-46:
+1 | module (F @ static) (X : sig end) = struct end
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The module is "dynamic"
+         because it shares the staticity of the functor parameter at line 1, characters 21-22
+         which is "dynamic".
+       However, the module highlighted is expected to be "static".
+|}]
+
+(* Likewise with an explicitly dynamic parameter. *)
+module (F @ static) (X : sig end @ dynamic) = struct end
+[%%expect{|
+Line 1, characters 20-56:
+1 | module (F @ static) (X : sig end @ dynamic) = struct end
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The module is "dynamic"
+         because it shares the staticity of the functor parameter at line 1, characters 21-22
+         which is "dynamic".
+       However, the module highlighted is expected to be "static".
+|}]
+
+(* [@ dynamic] is only an upper bound; a static parameter still typechecks. *)
+module (F @ dynamic) (X : sig end @ static) = struct end
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+|}]
+
+(* Generative functors are always dynamic. *)
+module (F @ static) () = struct end
+[%%expect{|
+Line 1, characters 20-35:
+1 | module (F @ static) () = struct end
+                        ^^^^^^^^^^^^^^^
+Error: The module is "dynamic" because generative functors are always dynamic.
+       However, the module highlighted is expected to be "static".
+|}]
+
+(* A functor type declares its return's staticity independently of the
+   functor's own: a dynamic functor returning a static result... *)
+module F : functor (X : sig end) -> sig end @ static =
+  functor (X : sig end) -> struct end
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+|}]
+
+(* ...and a static functor returning a dynamic result. *)
+module F : functor (X : sig end @ static) -> sig end @ dynamic =
+  functor (X : sig end @ static) -> struct end
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+|}]
+
+(* A [module (_ @ static)] binding checks the result. Here
+   the return is not static, so the result is dynamic though F is static, and
+   the binding fails. *)
+module (F @ static) (X : sig end @ static) = struct end
+module (Y @ static) = F(struct end)
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+Line 2, characters 22-35:
+2 | module (Y @ static) = F(struct end)
+                          ^^^^^^^^^^^^^
+Error: The module is "dynamic" but is expected to be "static".
+|}]
+
+(* Dually, a static return does not help when the functor is
+   dynamic: the result joins in the functor's staticity, so it stays dynamic. *)
+module F : functor (X : sig end) -> sig end @ static =
+  functor (X : sig end) -> struct end
 module (Y @ static) = F(struct end)
 [%%expect{|
 module F : functor (X : sig end) -> sig end
 Line 3, characters 22-35:
 3 | module (Y @ static) = F(struct end)
                           ^^^^^^^^^^^^^
+Error: The module is "dynamic"
+         because it shares the staticity of the functor parameter at line 2, characters 11-12
+         which is "dynamic".
+       However, the module highlighted is expected to be "static".
+|}]
+
+(* With both a static functor and a static return, the
+   result is static; still usable at a dynamic binding. *)
+module F : functor (X : sig end @ static) -> sig end @ static =
+  functor (X : sig end @ static) -> struct end
+module Y = F(struct end)
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+module Y : sig end
+|}]
+
+(* A dynamic binding accepts a result of any staticity. *)
+module (F @ static) (X : sig end @ static) = struct end
+module Y = F(struct end)
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+module Y : sig end
+|}]
+
+(* Applying a dynamic functor succeeds; binding its dynamic
+   result at [static] is what fails. *)
+module F (X : sig end) = struct end
+module (Y @ static) = F(struct end)
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+Line 2, characters 22-35:
+2 | module (Y @ static) = F(struct end)
+                          ^^^^^^^^^^^^^
 Error: The module is "dynamic" but is expected to be "static".
+|}]
+
+(* The intermediate functor (the outer functor's return) is
+   dynamic by default, so it cannot satisfy the static inner parameter. *)
+module (F @ static) (A : sig end @ static) (B : sig end @ static) = struct end
+module (Y @ static) = F(struct end)(struct end)
+[%%expect{|
+module F : functor (A : sig end) (B : sig end) -> sig end
+Line 2, characters 22-35:
+2 | module (Y @ static) = F(struct end)(struct end)
+                          ^^^^^^^^^^^^^
+Error: The functor is "dynamic"
+       but is expected to be "static"
+         because it shares the staticity of a functor parameter
+         which is expected to be "static".
+|}]
+
+(* The intermediate functor is dynamic by default, matching
+   the dynamic inner parameter, so both applications succeed. *)
+module (F @ static) (A : sig end @ static) (B : sig end) = struct end
+module Y = F(struct end)(struct end)
+[%%expect{|
+module F : functor (A : sig end) (B : sig end) -> sig end
+module Y : sig end
+|}]
+
+(* Declaring each return static makes the intermediate
+   functor and result static, so the whole curried application is static. *)
+module F :
+  functor (A : sig end @ static)
+  -> (functor (B : sig end @ static) -> sig end @ static) @ static =
+  functor (A : sig end @ static) (B : sig end @ static) -> struct end
+module (Y @ static) = F(struct end)(struct end)
+[%%expect{|
+module F : functor (A : sig end) (B : sig end) -> sig end
+module Y : sig end
+|}]
+
+(* The functor's value is dynamic (implementation takes a
+   dynamic parameter) but its type promises a static parameter, so applying it
+   fails - even at a dynamic binding. *)
+module F : functor (X : sig end @ static) -> sig end =
+  functor (X : sig end) -> struct end
+module Y = F(struct end)
+[%%expect{|
+module F : functor (X : sig end) -> sig end
+Line 3, characters 11-12:
+3 | module Y = F(struct end)
+               ^
+Error: The functor is "dynamic"
+         because it shares the staticity of the functor parameter at line 2, characters 11-12
+         which is "dynamic".
+       However, the functor highlighted is expected to be "static"
+         because it shares the staticity of a functor parameter
+         which is expected to be "static".
 |}]
 
 (* persistent modules are currently dynamic. *)

--- a/testsuite/tests/typing-modes/staticity.ml
+++ b/testsuite/tests/typing-modes/staticity.ml
@@ -391,7 +391,7 @@ module (F @ static) (M : sig end @ static) = struct
 end
 [%%expect{|
 val x : bool = true
-module F : functor (M : sig end) -> sig val x : bool end
+module F : functor (M : sig end @ static) -> sig val x : bool end
 |}]
 
 module (M @ static) = struct
@@ -428,7 +428,7 @@ Exception: Match_failure ("", 2, 23).
 (* A static functor takes a static parameter. *)
 module (F @ static) (X : sig end @ static) = struct end
 [%%expect{|
-module F : functor (X : sig end) -> sig end
+module F : functor (X : sig end @ static) -> sig end
 |}]
 
 (* Static functor, dynamic (unannotated) parameter: a contradiction. The error
@@ -456,10 +456,10 @@ Error: The module is "dynamic"
        However, the module highlighted is expected to be "static".
 |}]
 
-(* [@ dynamic] is only an upper bound; a static parameter still typechecks. *)
+(* [F] is defined as [static] (due to the parameter) and weakened to [dynamic]. *)
 module (F @ dynamic) (X : sig end @ static) = struct end
 [%%expect{|
-module F : functor (X : sig end) -> sig end
+module F : functor (X : sig end @ static) -> sig end
 |}]
 
 (* Generative functors are always dynamic. *)
@@ -477,81 +477,63 @@ Error: The module is "dynamic" because generative functors are always dynamic.
 module F : functor (X : sig end) -> sig end @ static =
   functor (X : sig end) -> struct end
 [%%expect{|
-module F : functor (X : sig end) -> sig end
+module F : functor (X : sig end) -> sig end @ static
 |}]
 
 (* ...and a static functor returning a dynamic result. *)
 module F : functor (X : sig end @ static) -> sig end @ dynamic =
   functor (X : sig end @ static) -> struct end
 [%%expect{|
-module F : functor (X : sig end) -> sig end
+module F : functor (X : sig end @ static) -> sig end
 |}]
 
-(* A [module (_ @ static)] binding checks the result. Here
-   the return is not static, so the result is dynamic though F is static, and
-   the binding fails. *)
+(* The following fails: F's return mode is inferred, but zapped to legacy (dynamic)
+   due to being at top-level. *)
 module (F @ static) (X : sig end @ static) = struct end
 module (Y @ static) = F(struct end)
 [%%expect{|
-module F : functor (X : sig end) -> sig end
+module F : functor (X : sig end @ static) -> sig end
 Line 2, characters 22-35:
 2 | module (Y @ static) = F(struct end)
                           ^^^^^^^^^^^^^
 Error: The module is "dynamic" but is expected to be "static".
 |}]
 
-(* Dually, a static return does not help when the functor is
-   dynamic: the result joins in the functor's staticity, so it stays dynamic. *)
-module F : functor (X : sig end) -> sig end @ static =
-  functor (X : sig end) -> struct end
-module (Y @ static) = F(struct end)
+(* The same binding inside a structure succeeds (no longer zapped by top-level) *)
+module M = struct
+  module F (X : sig end @ static) = struct end
+  module (Y @ static) = F(struct end)
+end
 [%%expect{|
-module F : functor (X : sig end) -> sig end
-Line 3, characters 22-35:
-3 | module (Y @ static) = F(struct end)
-                          ^^^^^^^^^^^^^
+module M :
+  sig
+    module F : functor (X : sig end @ static) -> sig end @ static
+    module Y : sig end
+  end
+|}]
+
+(* Dually, a dynamic functor returning at static; the application result is
+   still dynamic because the functor is. *)
+module M = struct
+  module F (X : sig end) = struct end
+  module (Y @ static) = F(struct end)
+end
+[%%expect{|
+Line 3, characters 24-37:
+3 |   module (Y @ static) = F(struct end)
+                            ^^^^^^^^^^^^^
 Error: The module is "dynamic"
-         because it shares the staticity of the functor parameter at line 2, characters 11-12
+         because it shares the staticity of the functor parameter at line 2, characters 12-13
          which is "dynamic".
        However, the module highlighted is expected to be "static".
 |}]
 
-(* With both a static functor and a static return, the
-   result is static; still usable at a dynamic binding. *)
-module F : functor (X : sig end @ static) -> sig end @ static =
-  functor (X : sig end @ static) -> struct end
-module Y = F(struct end)
-[%%expect{|
-module F : functor (X : sig end) -> sig end
-module Y : sig end
-|}]
-
-(* A dynamic binding accepts a result of any staticity. *)
-module (F @ static) (X : sig end @ static) = struct end
-module Y = F(struct end)
-[%%expect{|
-module F : functor (X : sig end) -> sig end
-module Y : sig end
-|}]
-
-(* Applying a dynamic functor succeeds; binding its dynamic
-   result at [static] is what fails. *)
-module F (X : sig end) = struct end
-module (Y @ static) = F(struct end)
-[%%expect{|
-module F : functor (X : sig end) -> sig end
-Line 2, characters 22-35:
-2 | module (Y @ static) = F(struct end)
-                          ^^^^^^^^^^^^^
-Error: The module is "dynamic" but is expected to be "static".
-|}]
-
-(* The intermediate functor (the outer functor's return) is
-   dynamic by default, so it cannot satisfy the static inner parameter. *)
+(* At top level, the outer functor's return - the intermediate functor - is
+   inferred but zapped to dynamic. *)
 module (F @ static) (A : sig end @ static) (B : sig end @ static) = struct end
 module (Y @ static) = F(struct end)(struct end)
 [%%expect{|
-module F : functor (A : sig end) (B : sig end) -> sig end
+module F : functor (A : sig end @ static) (B : sig end @ static) -> sig end
 Line 2, characters 22-35:
 2 | module (Y @ static) = F(struct end)(struct end)
                           ^^^^^^^^^^^^^
@@ -561,26 +543,21 @@ Error: The functor is "dynamic"
          which is expected to be "static".
 |}]
 
-(* The intermediate functor is dynamic by default, matching
-   the dynamic inner parameter, so both applications succeed. *)
-module (F @ static) (A : sig end @ static) (B : sig end) = struct end
-module Y = F(struct end)(struct end)
+(* The same definition inside a structure works fine. *)
+module M = struct
+  module F (A : sig end @ static) (B : sig end @ static) = struct end
+  module (Y @ static) = F(struct end)(struct end)
+end
 [%%expect{|
-module F : functor (A : sig end) (B : sig end) -> sig end
-module Y : sig end
+module M :
+  sig
+    module F :
+      functor (A : sig end @ static) ->
+        (functor (B : sig end @ static) -> sig end @ static) @ static
+    module Y : sig end
+  end
 |}]
 
-(* Declaring each return static makes the intermediate
-   functor and result static, so the whole curried application is static. *)
-module F :
-  functor (A : sig end @ static)
-  -> (functor (B : sig end @ static) -> sig end @ static) @ static =
-  functor (A : sig end @ static) (B : sig end @ static) -> struct end
-module (Y @ static) = F(struct end)(struct end)
-[%%expect{|
-module F : functor (A : sig end) (B : sig end) -> sig end
-module Y : sig end
-|}]
 
 (* The functor's value is dynamic (implementation takes a
    dynamic parameter) but its type promises a static parameter, so applying it
@@ -589,7 +566,7 @@ module F : functor (X : sig end @ static) -> sig end =
   functor (X : sig end) -> struct end
 module Y = F(struct end)
 [%%expect{|
-module F : functor (X : sig end) -> sig end
+module F : functor (X : sig end @ static) -> sig end
 Line 3, characters 11-12:
 3 | module Y = F(struct end)
                ^

--- a/testsuite/tests/typing-modes/staticity.ml
+++ b/testsuite/tests/typing-modes/staticity.ml
@@ -523,6 +523,8 @@ Line 3, characters 24-37:
 3 |   module (Y @ static) = F(struct end)
                             ^^^^^^^^^^^^^
 Error: The module is "dynamic"
+         because it is an application of the functor at line 3, characters 24-25
+         which is "dynamic"
          because it shares the staticity of the functor parameter at line 2, characters 12-13
          which is "dynamic".
        However, the module highlighted is expected to be "static".

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5506,7 +5506,12 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let submode_exn ?pp m1 m2 = submode ?pp m1 m2 |> Result.get_ok
 
-  let equate a b = try_with_log (equate_from_submode (submode_log ?pp:None) a b)
+  let equate ?pp a b = try_with_log (equate_from_submode (submode_log ?pp) a b)
+
+  let equate_err pp a b =
+    match equate ~pp a b with
+    | Ok () -> ()
+    | Error (_, e) -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
   let equate_exn m1 m2 = equate m1 m2 |> Result.get_ok
 
@@ -5608,7 +5613,12 @@ module Monadic_gen (Obj : Obj) = struct
 
   let submode_exn ?pp m1 m2 = submode ?pp m1 m2 |> Result.get_ok
 
-  let equate a b = try_with_log (equate_from_submode (submode_log ?pp:None) a b)
+  let equate ?pp a b = try_with_log (equate_from_submode (submode_log ?pp) a b)
+
+  let equate_err pp a b =
+    match equate ~pp a b with
+    | Ok () -> ()
+    | Error (_, e) -> raise (Submode_error_simple_context (pp, All (obj, e)))
 
   let equate_exn m1 m2 = equate m1 m2 |> Result.get_ok
 
@@ -6055,6 +6065,13 @@ module Comonadic_with (Areality : Areality) = struct
       let (Error (ax, _)) = to_simple_error e in
       raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
 
+  let equate_err pp a b =
+    match equate ~pp a b with
+    | Ok () -> ()
+    | Error (_, e) ->
+      let (Error (ax, _)) = to_simple_error e in
+      raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
+
   let print_error pp err =
     let (Error (ax, _)) = to_simple_error err in
     Error.print_proj pp Obj.obj ax err
@@ -6195,6 +6212,13 @@ module Monadic = struct
     match submode ~pp a b with
     | Ok () -> ()
     | Error e ->
+      let (Error (ax, _)) = to_simple_error e in
+      raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
+
+  let equate_err pp a b =
+    match equate ~pp a b with
+    | Ok () -> ()
+    | Error (_, e) ->
       let (Error (ax, _)) = to_simple_error e in
       raise (Submode_error_simple_context (pp, Proj (Obj.obj, ax, e)))
 
@@ -6693,7 +6717,11 @@ module Value_with (Areality : Areality) = struct
     Comonadic.submode_err pp a.comonadic b.comonadic;
     Monadic.submode_err pp a.monadic b.monadic
 
-  let equate a b = try_with_log (equate_from_submode (submode_log ?pp:None) a b)
+  let equate_err pp a b =
+    Comonadic.equate_err pp a.comonadic b.comonadic;
+    Monadic.equate_err pp a.monadic b.monadic
+
+  let equate ?pp a b = try_with_log (equate_from_submode (submode_log ?pp) a b)
 
   let submode_exn ?pp m1 m2 =
     match submode ?pp m1 m2 with

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -50,6 +50,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
         (loc, Functor_parameter), Functor_to_parameter (fst pp)
+      | Functor_to_application loc ->
+        (loc, Functor), Application_to_functor (fst pp)
       | Unknown -> (Location.none, Unknown), Unknown
       | Allocation_r loc -> pp, Allocation loc
       | Allocation loc -> pp, Allocation_l loc
@@ -76,6 +78,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         (loc, Functor), Parameter_to_functor (fst pp)
       | Parameter_to_functor loc ->
         (loc, Functor_parameter), Functor_to_parameter (fst pp)
+      | Application_to_functor loc ->
+        (loc, Module), Functor_to_application (fst pp)
       | Unknown -> (Location.none, Unknown), Unknown
       | Allocation_l loc -> pp, Allocation loc
       | Allocation loc -> pp, Allocation_r loc
@@ -101,6 +105,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Application_to_functor loc -> Application_to_functor loc
         | Allocation_l loc -> Allocation_l loc
         | Allocation loc -> Allocation loc
         | Contains_l (Comonadic, x) -> Contains_l (Comonadic, x)
@@ -118,6 +123,7 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Functor_to_application loc -> Functor_to_application loc
         | Allocation_r loc -> Allocation_r loc
         | Allocation loc -> Allocation loc
         | Contains_r (Comonadic, x) -> Contains_r (Comonadic, x)
@@ -137,6 +143,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Functor_to_application loc -> Functor_to_application loc
+        | Application_to_functor loc -> Application_to_functor loc
         | Allocation_r loc -> Allocation_r loc
         | Allocation_l loc -> Allocation_l loc
         | Allocation loc -> Allocation loc
@@ -159,6 +167,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Crossing -> Crossing
         | Functor_to_parameter p -> Functor_to_parameter p
         | Parameter_to_functor p -> Parameter_to_functor p
+        | Functor_to_application loc -> Functor_to_application loc
+        | Application_to_functor loc -> Application_to_functor loc
         | Allocation_l loc -> Allocation_l loc
         | Allocation_r loc -> Allocation_r loc
         | Allocation loc -> Allocation loc
@@ -5025,6 +5035,18 @@ module Report = struct
           ( Fmt.dprintf "shares the staticity of %t"
               (print_pp ~definite:true ~capitalize:false),
             param_pp ))
+    | Functor_to_application loc ->
+      Some
+        ( Fmt.dprintf "is an application of the functor at %a"
+            (Location.Doc.loc ~capitalize_first:false)
+            loc,
+          (loc, Functor) )
+    | Application_to_functor loc ->
+      Some
+        ( Fmt.dprintf "is applied at %a"
+            (Location.Doc.loc ~capitalize_first:false)
+            loc,
+          (loc, Module) )
     | Allocation_r alloc -> Some (print_allocation_r alloc, pp)
     | Allocation_l alloc -> Some (print_allocation_l alloc, pp)
     | Contains_l (_, contains) -> print_contains ~fixpoint contains
@@ -5147,7 +5169,8 @@ module Report = struct
     let fixpoint = equal_mode src obj a b in
     match hint with
     | Unknown | Close_over _ | Is_closed_by _ | Contains_l _ | Contains_r _
-    | Is_contained_by _ | Functor_to_parameter _ | Parameter_to_functor _ ->
+    | Is_contained_by _ | Functor_to_parameter _ | Parameter_to_functor _
+    | Functor_to_application _ | Application_to_functor _ ->
       (* These morphisms should never be skipped *)
       ~is_skip:false, ~fixpoint
     | Skip | Crossing ->

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -46,6 +46,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Is_closed_by (Monadic, co) -> co.closure, Close_over (Monadic, co)
       | Is_closed_by (Comonadic, co) -> co.closure, Close_over (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Functor_to_parameter loc ->
+        (loc, Functor), Parameter_to_functor (fst pp)
+      | Parameter_to_functor loc ->
+        (loc, Functor_parameter), Functor_to_parameter (fst pp)
       | Unknown -> (Location.none, Unknown), Unknown
       | Allocation_r loc -> pp, Allocation loc
       | Allocation loc -> pp, Allocation_l loc
@@ -68,6 +72,10 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
       | Close_over (Monadic, co) -> co.closed, Is_closed_by (Monadic, co)
       | Close_over (Comonadic, co) -> co.closed, Is_closed_by (Comonadic, co)
       | Crossing -> pp, Crossing
+      | Functor_to_parameter loc ->
+        (loc, Functor), Parameter_to_functor (fst pp)
+      | Parameter_to_functor loc ->
+        (loc, Functor_parameter), Functor_to_parameter (fst pp)
       | Unknown -> (Location.none, Unknown), Unknown
       | Allocation_l loc -> pp, Allocation loc
       | Allocation loc -> pp, Allocation_r loc
@@ -91,6 +99,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Close_over (Monadic, x) -> Close_over (Monadic, x)
         | Close_over (Comonadic, x) -> Close_over (Comonadic, x)
         | Crossing -> Crossing
+        | Functor_to_parameter p -> Functor_to_parameter p
+        | Parameter_to_functor p -> Parameter_to_functor p
         | Allocation_l loc -> Allocation_l loc
         | Allocation loc -> Allocation loc
         | Contains_l (Comonadic, x) -> Contains_l (Comonadic, x)
@@ -106,6 +116,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Is_closed_by (Monadic, x) -> Is_closed_by (Monadic, x)
         | Is_closed_by (Comonadic, x) -> Is_closed_by (Comonadic, x)
         | Crossing -> Crossing
+        | Functor_to_parameter p -> Functor_to_parameter p
+        | Parameter_to_functor p -> Parameter_to_functor p
         | Allocation_r loc -> Allocation_r loc
         | Allocation loc -> Allocation loc
         | Contains_r (Comonadic, x) -> Contains_r (Comonadic, x)
@@ -123,6 +135,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Is_closed_by (Monadic, x) -> Is_closed_by (Monadic, x)
         | Is_closed_by (Comonadic, x) -> Is_closed_by (Comonadic, x)
         | Crossing -> Crossing
+        | Functor_to_parameter p -> Functor_to_parameter p
+        | Parameter_to_functor p -> Parameter_to_functor p
         | Allocation_r loc -> Allocation_r loc
         | Allocation_l loc -> Allocation_l loc
         | Allocation loc -> Allocation loc
@@ -143,6 +157,8 @@ module Hint_for_solver (* : Solver_intf.Hint *) = struct
         | Is_closed_by (Monadic, x) -> Is_closed_by (Monadic, x)
         | Is_closed_by (Comonadic, x) -> Is_closed_by (Comonadic, x)
         | Crossing -> Crossing
+        | Functor_to_parameter p -> Functor_to_parameter p
+        | Parameter_to_functor p -> Parameter_to_functor p
         | Allocation_l loc -> Allocation_l loc
         | Allocation_r loc -> Allocation_r loc
         | Allocation loc -> Allocation loc
@@ -4668,6 +4684,8 @@ module Report = struct
             lid)
     | Function -> Some (print_article_noun Consonant "function")
     | Functor -> Some (print_article_noun Consonant "functor")
+    | Functor_parameter ->
+      Some (print_article_noun Consonant "functor parameter")
     | Lazy -> Some (print_article_noun Consonant "lazy expression")
     | Quote -> Some (print_article_noun Consonant "quoted expression")
     | Expression -> Some (print_article_noun Vowel "expression")
@@ -4723,6 +4741,7 @@ module Report = struct
   let print_always_dynamic = function
     | Application -> Fmt.dprintf "function applications"
     | Try_with -> Fmt.dprintf "try-with clauses"
+    | Generative_functor -> Fmt.dprintf "generative functors"
 
   let print_legacy = function
     | Toplevel -> print_article_noun Consonant "top-level clause"
@@ -4917,7 +4936,7 @@ module Report = struct
     | Module_allocated_on_heap ->
       (match pp_desc with
       | Ident { category = Module; _ }
-      | Functor | Module | Structure
+      | Functor | Functor_parameter | Module | Structure
       | Structure_item (Module, _) ->
         (* if we already said it's a module, we don't need to emphasize it again. *)
         Fmt.pp_print_string ppf "modules always need"
@@ -4992,6 +5011,20 @@ module Report = struct
               (print_pp ~definite:true ~capitalize:false),
             pp ))
     | Crossing -> Some (Fmt.dprintf "crosses with something", pp)
+    | Functor_to_parameter loc ->
+      let funct_pp = loc, Functor in
+      print_pinpoint funct_pp
+      |> Option.map (fun print_pp ->
+          ( Fmt.dprintf "shares the staticity of %t"
+              (print_pp ~definite:true ~capitalize:false),
+            funct_pp ))
+    | Parameter_to_functor loc ->
+      let param_pp = loc, Functor_parameter in
+      print_pinpoint param_pp
+      |> Option.map (fun print_pp ->
+          ( Fmt.dprintf "shares the staticity of %t"
+              (print_pp ~definite:true ~capitalize:false),
+            param_pp ))
     | Allocation_r alloc -> Some (print_allocation_r alloc, pp)
     | Allocation_l alloc -> Some (print_allocation_l alloc, pp)
     | Contains_l (_, contains) -> print_contains ~fixpoint contains
@@ -5114,7 +5147,7 @@ module Report = struct
     let fixpoint = equal_mode src obj a b in
     match hint with
     | Unknown | Close_over _ | Is_closed_by _ | Contains_l _ | Contains_r _
-    | Is_contained_by _ ->
+    | Is_contained_by _ | Functor_to_parameter _ | Parameter_to_functor _ ->
       (* These morphisms should never be skipped *)
       ~is_skip:false, ~fixpoint
     | Skip | Crossing ->
@@ -5333,6 +5366,7 @@ module type Common_axis_pos = sig
       with module Const := Const
        and type 'd t = (Const.t, 'd pos) mode
        and type 'd hint_const := 'd pos_hint_const
+       and type 'd hint_morph := 'd pos_hint_morph
 end
 
 module type Common_axis_neg = sig
@@ -5343,6 +5377,7 @@ module type Common_axis_neg = sig
       with module Const := Const
        and type 'd t = (Const.t, 'd neg) mode
        and type 'd hint_const := 'd neg_hint_const
+       and type 'd hint_morph := 'd neg_hint_morph
 end
 
 (** Representing a single object *)

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -31,6 +31,7 @@ type pinpoint_desc =
   | Function  (** A function definition *)
   | Module  (** A module definition *)
   | Functor  (** A functor definition *)
+  | Functor_parameter  (** A functor parameter *)
   | Structure  (** A structure definition *)
   | Lazy  (** A lazy expression *)
   | Quote  (** A quoted expression *)
@@ -58,6 +59,7 @@ type mutable_part =
 type always_dynamic =
   | Application
   | Try_with
+  | Generative_functor
 
 type legacy =
   | Compilation_unit
@@ -170,6 +172,12 @@ type 'd morph =
      submode calls, each constructor only needs to store the info of its source
      pinpoint. *)
   | Crossing : ('l * 'r) morph
+  | Functor_to_parameter : Location.t -> ('l * 'r) morph
+      (** The identity morphism connecting a functor's staticity to its
+          parameter's. Carries the functor's location. *)
+  | Parameter_to_functor : Location.t -> ('l * 'r) morph
+      (** The identity morphism connecting a parameter's staticity to the
+          functor's. Carries the parameter's location. *)
   | Allocation_r : allocation -> (disallowed * 'r) morph
   | Allocation_l : allocation -> ('l * disallowed) morph
   | Allocation : allocation -> ('l * 'r) morph

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -178,6 +178,13 @@ type 'd morph =
   | Parameter_to_functor : Location.t -> ('l * 'r) morph
       (** The identity morphism connecting a parameter's staticity to the
           functor's. Carries the parameter's location. *)
+  | Functor_to_application : Location.t -> ('l * disallowed) neg morph
+      (** The identity morphism from a functor's staticity to its application
+          result's staticity (a monadic axis, hence [neg]). Carries the
+          application's location. *)
+  | Application_to_functor : Location.t -> (disallowed * 'r) neg morph
+      (** The dual of [Functor_to_application]: from the result's staticity back
+          to the functor's. Carries the application's location. *)
   | Allocation_r : allocation -> (disallowed * 'r) morph
   | Allocation_l : allocation -> ('l * disallowed) morph
   | Allocation : allocation -> ('l * 'r) morph

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -181,7 +181,7 @@ type 'd morph =
   | Functor_to_application : Location.t -> ('l * disallowed) neg morph
       (** The identity morphism from a functor's staticity to its application
           result's staticity (a monadic axis, hence [neg]). Carries the
-          application's location. *)
+          functor's location. *)
   | Application_to_functor : Location.t -> (disallowed * 'r) neg morph
       (** The dual of [Functor_to_application]: from the result's staticity back
           to the functor's. Carries the application's location. *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -205,6 +205,10 @@ module type Common_axis = sig
   type 'd hint_const constraint 'd = 'l * 'r
 
   val of_const : ?hint:'d hint_const -> Const.t -> 'd t
+
+  type 'd hint_morph constraint 'd = 'l * 'r
+
+  val apply_hint : 'd hint_morph -> 'd t -> 'd t
 end
 
 module type Axis = sig
@@ -360,6 +364,7 @@ module type S = sig
         with module Const := Const
          and type 'd t = (Const.t, 'd pos) mode
          and type 'd hint_const := 'd pos_hint_const
+         and type 'd hint_morph := 'd pos_hint_morph
   end
 
   module type Common_axis_neg = sig
@@ -370,6 +375,7 @@ module type S = sig
         with module Const := Const
          and type 'd t = (Const.t, 'd neg) mode
          and type 'd hint_const := 'd neg_hint_const
+         and type 'd hint_morph := 'd neg_hint_morph
   end
 
   module Locality : sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -170,7 +170,11 @@ module type Common = sig
   val submode_err :
     Mode_hint.pinpoint -> (allowed * 'r) t -> ('l * allowed) t -> unit
 
-  val equate : lr -> lr -> (unit, equate_error) result
+  (** Similar to [submode_err], but checks the two modes are equal by submoding
+      in both directions. *)
+  val equate_err : Mode_hint.pinpoint -> lr -> lr -> unit
+
+  val equate : ?pp:Mode_hint.pinpoint -> lr -> lr -> (unit, equate_error) result
 
   (** Similiar to [submode], but crashes the compiler if errors. Use this
       function if the submode is guaranteed to succeed. *)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -1294,15 +1294,15 @@ and module_expr i ppf x =
   | Tmod_structure (s) ->
       line i ppf "Tmod_structure\n";
       structure i ppf s;
-  | Tmod_functor (Unit, me) ->
+  | Tmod_functor (Unit, me, _) ->
       line i ppf "Tmod_functor ()\n";
       module_expr i ppf me;
-  | Tmod_functor (Named (s, _, mt, ma), me) ->
+  | Tmod_functor (Named (s, _, mt, ma), me, _) ->
       line i ppf "Tmod_functor \"%a\"\n" fmt_modname s;
       module_type i ppf mt;
       module_expr i ppf me;
       alloc_modes i ppf ma;
-  | Tmod_apply (me1, me2, _, _) ->
+  | Tmod_apply (me1, me2, _, _, _) ->
       line i ppf "Tmod_apply\n";
       module_expr i ppf me1;
       module_expr i ppf me2;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -652,10 +652,10 @@ let module_expr sub {mod_loc; mod_desc; mod_mode; mod_env; mod_attributes; _} =
   match mod_desc with
   | Tmod_ident (_, lid) -> iter_loc_lid sub lid
   | Tmod_structure st -> sub.structure sub st
-  | Tmod_functor (arg, mexpr) ->
+  | Tmod_functor (arg, mexpr, _) ->
       functor_parameter sub arg;
       sub.module_expr sub mexpr
-  | Tmod_apply (mexp1, mexp2, c, _) ->
+  | Tmod_apply (mexp1, mexp2, c, _, _) ->
       sub.module_expr sub mexp1;
       sub.module_expr sub mexp2;
       sub.module_coercion sub c

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -911,14 +911,15 @@ let module_expr sub x =
     match x.mod_desc with
     | Tmod_ident (path, lid) -> Tmod_ident (path, map_loc_lid sub lid)
     | Tmod_structure st -> Tmod_structure (sub.structure sub st)
-    | Tmod_functor (arg, mexpr) ->
-        Tmod_functor (functor_parameter sub arg, sub.module_expr sub mexpr)
-    | Tmod_apply (mexp1, mexp2, c, yielding) ->
+    | Tmod_functor (arg, mexpr, s) ->
+        Tmod_functor (functor_parameter sub arg, sub.module_expr sub mexpr, s)
+    | Tmod_apply (mexp1, mexp2, c, yielding, s) ->
         Tmod_apply (
           sub.module_expr sub mexp1,
           sub.module_expr sub mexp2,
           sub.module_coercion sub c,
-          yielding
+          yielding,
+          s
         )
     | Tmod_apply_unit (mexp1, yielding) ->
         Tmod_apply_unit (sub.module_expr sub mexp1, yielding)

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -911,15 +911,16 @@ let module_expr sub x =
     match x.mod_desc with
     | Tmod_ident (path, lid) -> Tmod_ident (path, map_loc_lid sub lid)
     | Tmod_structure st -> Tmod_structure (sub.structure sub st)
-    | Tmod_functor (arg, mexpr, s) ->
-        Tmod_functor (functor_parameter sub arg, sub.module_expr sub mexpr, s)
-    | Tmod_apply (mexp1, mexp2, c, yielding, s) ->
+    | Tmod_functor (arg, mexpr, staticity) ->
+        Tmod_functor
+          (functor_parameter sub arg, sub.module_expr sub mexpr, staticity)
+    | Tmod_apply (mexp1, mexp2, c, yielding, staticity) ->
         Tmod_apply (
           sub.module_expr sub mexp1,
           sub.module_expr sub mexp2,
           sub.module_coercion sub c,
           yielding,
-          s
+          staticity
         )
     | Tmod_apply_unit (mexp1, yielding) ->
         Tmod_apply_unit (sub.module_expr sub mexp1, yielding)

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -634,9 +634,10 @@ and functor_parameter =
 and module_expr_desc =
     Tmod_ident of Path.t * Longident.t loc
   | Tmod_structure of structure
-  | Tmod_functor of functor_parameter * module_expr
+  | Tmod_functor of functor_parameter * module_expr * Mode.Staticity.r
   | Tmod_apply of
       module_expr * module_expr * module_coercion * Mode.Yielding.l
+      * Mode.Staticity.r
   | Tmod_apply_unit of module_expr * Mode.Yielding.l
   | Tmod_constraint of
       module_expr * Types.module_type * module_type_constraint * module_coercion

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1011,34 +1011,39 @@ and functor_parameter =
              Mode.Alloc.Const.t modes
 
 
-(* Staticity of functors
+(* Note [Staticity of functors]
 
-By the generic mode weakening rule, a functor that takes a [dynamic] parameter
-can be weakened into taking a [static] parameter. However, this weakening is not
-admitted by the actual implementation - these two kinds of functors are
-incompatible.
+   There are two kinds of functors, whose machine representations are
+   constructed and consumed differently, making them incompatible:
+   1. regular functors, which take [dynamic] parameters;
+   2. template functors, which take [static] parameters.
 
-To make this work, upon functor definition we equate the staticity of the
-functor and its parameter, giving [module F : (functor (M @ m) -> ...) @ m].
+   This incompatibility must be reflected in the type system. Differentiating
+   them by the parameter's staticity alone is not sufficient, since the generic
+   mode weakening rule would allow (1) to be used as (2).
 
-Upon application of [F : (functor (M @ m0) -> ...) @ m1], where [m0 <= m] and
-[m1 >= m] due to weakening, we restore the original [m] by requiring [m1 <= m0],
-which forces [m0 = m1 = m]. *)
+   Our workaround is as follows. Upon functor definition, we equate the
+   staticity of the functor and its parameter, giving
+   [module F : (functor (M @ m) -> ...) @ m].
+
+   Upon application of [F : (functor (M @ m0) -> ...) @ m1], where [m0 <= m] and
+   [m1 >= m] due to weakening, we restore the original [m] by requiring
+   [m1 <= m0], which forces [m0 = m1 = m]. *)
 
 and module_expr_desc =
     Tmod_ident of Path.t * Longident.t loc
   | Tmod_structure of structure
   | Tmod_functor of functor_parameter * module_expr * Mode.Staticity.r
     (** The [Mode.Staticity.r] specifies which kind of functor is constructed;
-    see "Staticity of functors". *)
+        see Note [Staticity of functors]. *)
   | Tmod_apply of
       module_expr * module_expr * module_coercion * Mode.Yielding.l
       * Mode.Staticity.r
         (** The [Mode.Yielding.l] is the join of the yielding modes of the
             functor and its argument: if it is [Unyielding], applying the
             functor can never perform a free effect. The [Mode.Staticity.r]
-            specifies which kind of functor is applied; see "Staticity of
-            functors". *)
+            specifies which kind of functor is applied; see Note [Staticity of
+            functors]. *)
   | Tmod_apply_unit of module_expr * Mode.Yielding.l
   | Tmod_constraint of
       module_expr * Types.module_type * module_type_constraint * module_coercion

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1013,12 +1013,15 @@ and functor_parameter =
 and module_expr_desc =
     Tmod_ident of Path.t * Longident.t loc
   | Tmod_structure of structure
-  | Tmod_functor of functor_parameter * module_expr
+  | Tmod_functor of functor_parameter * module_expr * Mode.Staticity.r
+    (** The [Mode.Staticity.r] is the staticity of the functor. *)
   | Tmod_apply of
       module_expr * module_expr * module_coercion * Mode.Yielding.l
+      * Mode.Staticity.r
         (** The [Mode.Yielding.l] is the join of the yielding modes of the
             functor and its argument: if it is [Unyielding], applying the
-            functor can never perform a free effect. *)
+            functor can never perform a free effect. The [Mode.Staticity.r] is
+            the staticity of the application. *)
   | Tmod_apply_unit of module_expr * Mode.Yielding.l
   | Tmod_constraint of
       module_expr * Types.module_type * module_type_constraint * module_coercion

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1010,18 +1010,35 @@ and functor_parameter =
   | Named of Ident.t option * string option loc * module_type *
              Mode.Alloc.Const.t modes
 
+
+(* Staticity of functors
+
+By the generic mode weakening rule, a functor that takes a [dynamic] parameter
+can be weakened into taking a [static] parameter. However, this weakening is not
+admitted by the actual implementation - these two kinds of functors are
+incompatible.
+
+To make this work, upon functor definition we equate the staticity of the
+functor and its parameter, giving [module F : (functor (M @ m) -> ...) @ m].
+
+Upon application of [F : (functor (M @ m0) -> ...) @ m1], where [m0 <= m] and
+[m1 >= m] due to weakening, we restore the original [m] by requiring [m1 <= m0],
+which forces [m0 = m1 = m]. *)
+
 and module_expr_desc =
     Tmod_ident of Path.t * Longident.t loc
   | Tmod_structure of structure
   | Tmod_functor of functor_parameter * module_expr * Mode.Staticity.r
-    (** The [Mode.Staticity.r] is the staticity of the functor. *)
+    (** The [Mode.Staticity.r] specifies which kind of functor is constructed;
+    see "Staticity of functors". *)
   | Tmod_apply of
       module_expr * module_expr * module_coercion * Mode.Yielding.l
       * Mode.Staticity.r
         (** The [Mode.Yielding.l] is the join of the yielding modes of the
             functor and its argument: if it is [Unyielding], applying the
-            functor can never perform a free effect. The [Mode.Staticity.r] is
-            the staticity of the application. *)
+            functor can never perform a free effect. The [Mode.Staticity.r]
+            specifies which kind of functor is applied; see "Staticity of
+            functors". *)
   | Tmod_apply_unit of module_expr * Mode.Yielding.l
   | Tmod_constraint of
       module_expr * Types.module_type * module_type_constraint * module_coercion

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3251,7 +3251,7 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
             Staticity.apply_hint (Parameter_to_functor param.loc)
               (Alloc.proj_monadic Staticity mode)
           in
-          (* See "Staticity of functors" in [typedtree.mli] *)
+          (* See Note [Staticity of functors] in [typedtree.mli] *)
           Staticity.equate_err (smod.pmod_loc, Functor) staticity param_st;
           let mty = transl_modtype_functor_arg env smty in
           let scope = Ctype.create_scope () in
@@ -3621,7 +3621,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       let mode_funct = mode_without_locks_exn funct.mod_mode in
       let funct_staticity = Value.proj_monadic Staticity mode_funct in
       (* The following [submode] recovers the functor's original staticity [m].
-         See "Staticity of functors" in [typedtree.mli]  *)
+         See Note [Staticity of functors] in [typedtree.mli] *)
       let staticity =
         Staticity.apply_hint (Parameter_to_functor Location.none)
           (Value.proj_monadic Staticity mm_param)

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3649,7 +3649,9 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       let mode_res =
         Value.join
           [ Value.disallow_right mm_res;
-            Value.min_with_monadic Staticity funct_staticity ]
+            Value.min_with_monadic Staticity
+              (Staticity.apply_hint (Functor_to_application funct.mod_loc)
+                 funct_staticity) ]
       in
       { mod_desc =
           Tmod_apply

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3627,7 +3627,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
           (Value.proj_monadic Staticity mm_param)
       in
       Staticity.submode_err (funct.mod_loc, Functor) funct_staticity staticity;
-      let mode_res =
+      let mm_res =
         Value.join
           [ Value.disallow_right mm_res;
             Value.min_with_monadic Staticity
@@ -3641,7 +3641,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
                ~arg_mode:(fst arg.mod_mode),
              Staticity.disallow_left staticity);
         mod_type = mty_appl;
-        mod_mode = mode_res, None;
+        mod_mode = mm_res, None;
         mod_env = env;
         mod_attributes = app_attributes;
         mod_loc = app_loc },

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -3234,23 +3234,10 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
           (smod.pmod_loc, Functor)
           closed_over_mode.comonadic env
       in
-      (* A functor that takes a [dynamic] parameter and one that takes a
-         [static] parameter are incompatible: they cannot be converted in
-         either direction. They are morally distinct types, rather than being
-         related by modes.
-
-         As an approximation, upon functor definition we equate the staticity
-         of the functor and its parameter, giving
-         [module F : (functor (M @ m) -> ...) @ m].
-
-         Upon application of [F] we see [(functor (M @ m0) -> ...) @ m1], where
-         [m0 <= m] and [m1 >= m] due to weakening. To restore the original [m]
-         we require [m1 <= m0], which forces [m0 = m1 = m]. *)
       let staticity = Value.proj_monadic Staticity closed_over_mode in
       let t_arg, ty_arg, newenv, funct_shape_param, funct_body =
         match arg_opt with
         | Unit ->
-          (* Generative functors are always dynamic. *)
           Staticity.submode_err (smod.pmod_loc, Functor)
             (Staticity.of_const ~hint:(Always_dynamic Generative_functor)
                Dynamic)
@@ -3260,15 +3247,12 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
           (* unspecified mode axes defaults to legacy *)
           let tmode = Typemode.transl_alloc_mode smode in
           let mode = Alloc.of_const tmode.mode_modes in
-          let functor_pp : Mode.Hint.pinpoint = (smod.pmod_loc, Functor) in
-          (* View the parameter's staticity as the functor's, then equate. *)
-          let functor_st = staticity in
           let param_st =
             Staticity.apply_hint (Parameter_to_functor param.loc)
               (Alloc.proj_monadic Staticity mode)
           in
-          Staticity.submode_err functor_pp functor_st param_st;
-          Staticity.submode_err functor_pp param_st functor_st;
+          (* See "Staticity of functors" in [typedtree.mli] *)
+          Staticity.equate_err (smod.pmod_loc, Functor) staticity param_st;
           let mty = transl_modtype_functor_arg env smty in
           let scope = Ctype.create_scope () in
           let (id, newenv, var) =
@@ -3636,17 +3620,13 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
         ~mode_arg:(Some mm_param);
       let mode_funct = mode_without_locks_exn funct.mod_mode in
       let funct_staticity = Value.proj_monadic Staticity mode_funct in
-      (* Require [m1 <= m0] (see [Pmod_functor]) to recover the functor's
-         staticity [m], which we attach to [Tmod_apply]. The functor's location
-         is known, but its parameter's is not (we only have the argument's), so
-         we view the parameter as the functor with an unknown pinpoint. *)
+      (* The following [submode] recovers the functor's original staticity [m].
+         See "Staticity of functors" in [typedtree.mli]  *)
       let staticity =
         Staticity.apply_hint (Parameter_to_functor Location.none)
           (Value.proj_monadic Staticity mm_param)
       in
       Staticity.submode_err (funct.mod_loc, Functor) funct_staticity staticity;
-      (* The result is at least as dynamic as the functor: evaluating it
-         requires evaluating the functor. *)
       let mode_res =
         Value.join
           [ Value.disallow_right mm_res;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2759,7 +2759,7 @@ exception Not_a_path
 let rec path_of_module mexp =
   match mexp.mod_desc with
   | Tmod_ident (p,_) -> p
-  | Tmod_apply(funct, arg, _coercion, _) when !Clflags.applicative_functors ->
+  | Tmod_apply(funct, arg, _coercion, _, _) when !Clflags.applicative_functors ->
       Papply(path_of_module funct, path_of_module arg)
   | Tmod_constraint (mexp, _, _, _) ->
       path_of_module mexp
@@ -3233,14 +3233,41 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
           (smod.pmod_loc, Functor)
           closed_over_mode.comonadic env
       in
+      (* A functor that takes a [dynamic] parameter and one that takes a
+         [static] parameter are incompatible: they cannot be converted in
+         either direction. They are morally distinct types, rather than being
+         related by modes.
+
+         As an approximation, upon functor definition we equate the staticity
+         of the functor and its parameter, giving
+         [module F : (functor (M @ m) -> ...) @ m].
+
+         Upon application of [F] we see [(functor (M @ m0) -> ...) @ m1], where
+         [m0 <= m] and [m1 >= m] due to weakening. To restore the original [m]
+         we require [m1 <= m0], which forces [m0 = m1 = m]. *)
+      let staticity = Value.proj_monadic Staticity closed_over_mode in
       let t_arg, ty_arg, newenv, funct_shape_param, funct_body =
         match arg_opt with
         | Unit ->
+          (* Generative functors are always dynamic. *)
+          Staticity.submode_err (smod.pmod_loc, Functor)
+            (Staticity.of_const ~hint:(Always_dynamic Generative_functor)
+               Dynamic)
+            staticity;
           Unit, Types.Unit, newenv, Shape.for_unnamed_functor_param, false
         | Named (param, smty, smode) ->
           (* unspecified mode axes defaults to legacy *)
           let tmode = Typemode.transl_alloc_mode smode in
           let mode = Alloc.of_const tmode.mode_modes in
+          let functor_pp : Mode.Hint.pinpoint = (smod.pmod_loc, Functor) in
+          (* View the parameter's staticity as the functor's, then equate. *)
+          let functor_st = staticity in
+          let param_st =
+            Staticity.apply_hint (Parameter_to_functor param.loc)
+              (Alloc.proj_monadic Staticity mode)
+          in
+          Staticity.submode_err functor_pp functor_st param_st;
+          Staticity.submode_err functor_pp param_st functor_st;
           let mty = transl_modtype_functor_arg env smty in
           let scope = Ctype.create_scope () in
           let (id, newenv, var) =
@@ -3284,7 +3311,8 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
             Alloc.submode_exn (Alloc.close_over param_mode) ret_mode);
          Alloc.submode_exn (Alloc.partial_apply alloc_mode) ret_mode
        | _ -> ());
-      { mod_desc = Tmod_functor(t_arg, body);
+      { mod_desc =
+          Tmod_functor (t_arg, body, Staticity.disallow_left staticity);
         mod_type = Mty_functor(ty_arg, body.mod_type, ret_mode);
         mod_mode = Value.disallow_right closed_over_mode, None;
         mod_env = env;
@@ -3605,13 +3633,32 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
       check_curried_application_complete
         ~loc:app_loc ~mty_res:mty_appl ~mode_res:mm_res
         ~mode_arg:(Some mm_param);
+      let mode_funct = mode_without_locks_exn funct.mod_mode in
+      let funct_staticity = Value.proj_monadic Staticity mode_funct in
+      (* Require [m1 <= m0] (see [Pmod_functor]) to recover the functor's
+         staticity [m], which we attach to [Tmod_apply]. The functor's location
+         is known, but its parameter's is not (we only have the argument's), so
+         we view the parameter as the functor with an unknown pinpoint. *)
+      let staticity =
+        Staticity.apply_hint (Parameter_to_functor Location.none)
+          (Value.proj_monadic Staticity mm_param)
+      in
+      Staticity.submode_err (funct.mod_loc, Functor) funct_staticity staticity;
+      (* The result is at least as dynamic as the functor: evaluating it
+         requires evaluating the functor. *)
+      let mode_res =
+        Value.join
+          [ Value.disallow_right mm_res;
+            Value.min_with_monadic Staticity funct_staticity ]
+      in
       { mod_desc =
           Tmod_apply
             (funct, arg, coercion,
              functor_application_yielding ~funct
-               ~arg_mode:(fst arg.mod_mode));
+               ~arg_mode:(fst arg.mod_mode),
+             Staticity.disallow_left staticity);
         mod_type = mty_appl;
-        mod_mode = Value.disallow_right mm_res, None;
+        mod_mode = mode_res, None;
         mod_env = env;
         mod_attributes = app_attributes;
         mod_loc = app_loc },

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2759,7 +2759,8 @@ exception Not_a_path
 let rec path_of_module mexp =
   match mexp.mod_desc with
   | Tmod_ident (p,_) -> p
-  | Tmod_apply(funct, arg, _coercion, _, _) when !Clflags.applicative_functors ->
+  | Tmod_apply (funct, arg, _coercion, _, _)
+    when !Clflags.applicative_functors ->
       Papply(path_of_module funct, path_of_module arg)
   | Tmod_constraint (mexp, _, _, _) ->
       path_of_module mexp

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -1014,10 +1014,10 @@ let module_expr (sub : mapper) mexpr =
         let desc = match mexpr.mod_desc with
             Tmod_ident (_p, lid) -> Pmod_ident (map_loc sub lid)
           | Tmod_structure st -> Pmod_structure (sub.structure sub st)
-          | Tmod_functor (arg, mexpr) ->
+          | Tmod_functor (arg, mexpr, _) ->
               Pmod_functor
                 (functor_parameter sub arg, sub.module_expr sub mexpr)
-          | Tmod_apply (mexp1, mexp2, _, _) ->
+          | Tmod_apply (mexp1, mexp2, _, _, _) ->
               Pmod_apply (sub.module_expr sub mexp1,
                           sub.module_expr sub mexp2)
           | Tmod_apply_unit (mexp1, _) ->

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -1197,9 +1197,9 @@ and modexp : Typedtree.module_expr -> term_judg =
       path pth
     | Tmod_structure s ->
       structure s
-    | Tmod_functor (_, e) ->
+    | Tmod_functor (_, e, _) ->
       modexp e << Delay
-    | Tmod_apply (f, p, _, _) ->
+    | Tmod_apply (f, p, _, _, _) ->
       join [
         modexp f << Dereference;
         modexp p << Dereference;


### PR DESCRIPTION
A functor's staticity equals its parameter's: a functor taking a static parameter is static, one taking a dynamic parameter is dynamic, and generative functors are always dynamic. On application, the functor's original staticity is recovered (its own staticity must be below the parameter's) and attached to `Tmod_apply`; the functor's own staticity is attached to `Tmod_functor`.

Adds the `Functor_to_parameter`/`Parameter_to_functor` morph hints (converting a staticity between being about the functor and about its parameter) and exposes `apply_hint` on single mode axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)