### PR TITLE
Make empty `let poly_` binding an error instead of a warning

### DIFF
--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -187,7 +187,7 @@ Line 3, characters 2-13:
 Error: All bindings in a "let" must be either all "poly_" or all non-"poly_"
 |}]
 
-(* Warning when poly_ binding generalizes no layout variables *)
+(* Error when poly_ binding generalizes no layout variables *)
 module M = struct
   let poly_ f = 42
 end
@@ -195,10 +195,8 @@ end
 Line 2, characters 12-13:
 2 |   let poly_ f = 42
                 ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
-Uncaught exception: Misc.Fatal_error
-
+Error: This binding has no layout variables, so "poly_" has no effect.
+       Consider using a regular "let" instead.
 |}]
 
 (* layout-polymorphic id is not included in regular id,
@@ -259,13 +257,9 @@ Error: This expression is not allowed in a "let poly_" definition;
 |}]
 
 (* variant: passing - no payload *)
-let poly_ f = `A
+let poly_ f _ = `A
 [%%expect{|
-Line 1, characters 10-11:
-1 | let poly_ f = `A
-              ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+>> Fatal error: layout: unexpected genvar
 Uncaught exception: Misc.Fatal_error
 
 |}]
@@ -326,14 +320,10 @@ Error: This expression is not allowed in a "let poly_" definition;
 
 (* record: passing when all fields are syntactic values *)
 type r = { a : int; b : int -> int }
-let poly_ f = { a = 42; b = fun x -> x }
+let poly_ f _ = { a = 42; b = fun x -> x }
 [%%expect{|
 type r = { a : int; b : int -> int; }
-Line 2, characters 10-11:
-2 | let poly_ f = { a = 42; b = fun x -> x }
-              ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+>> Fatal error: layout: unexpected genvar
 Uncaught exception: Misc.Fatal_error
 
 |}]
@@ -350,14 +340,10 @@ Error: This expression is not allowed in a "let poly_" definition;
 
 (* unboxed product record: passing when all fields are syntactic values *)
 type ur = #{ a : int; b : int }
-let poly_ f = #{ a = 42; b = 0 }
+let poly_ f _ = #{ a = 42; b = 0 }
 [%%expect{|
 type ur = #{ a : int; b : int; }
-Line 2, characters 10-11:
-2 | let poly_ f = #{ a = 42; b = 0 }
-              ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+>> Fatal error: layout: unexpected genvar
 Uncaught exception: Misc.Fatal_error
 
 |}]
@@ -431,19 +417,8 @@ end
 Line 4, characters 12-13:
 4 |   let poly_ f x = (x : (_ : value))
                 ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
-
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   let poly_ f x = (x : (_ : value))
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val f : 'a -> 'a end
-       is not included in
-         sig val f : int end
-       Values do not match: val f : 'a -> 'a is not included in val f : int
-       The type "'a -> 'a" is not compatible with the type "int"
+Error: This binding has no layout variables, so "poly_" has no effect.
+       Consider using a regular "let" instead.
 |}]
 
 (* [assert false] is layout poly *)
@@ -537,13 +512,13 @@ Error: Signature mismatch:
 (* [rec] prevents layout polymorphism, even for fake recursion (no
    self-reference). *)
 module M : sig
-  val f : 'a -> 'a
+  val f : 'b -> 'a -> 'a
 end = struct
-  let rec poly_ f x = x
+  let rec poly_ f _ x = x
 end
 [%%expect{|
 Line 4, characters 16-17:
-4 |   let rec poly_ f x = x
+4 |   let rec poly_ f _ x = x
                     ^
 Warning 218: poly_ has no effect in recursive bindings, which do not support layout polymorphism. Consider using a regular let rec instead.
 >> Fatal error: Translcore.transl_let
@@ -611,19 +586,16 @@ Error: All bindings in a "let" must be either all "poly_" or all non-"poly_"
    regional, and that makes the captured environment to be local, which makes [f] unable
    to escape the regiohn. *)
 let _bar (x @ local) =
-  let poly_ f = x in
+  let poly_ f _ = x in
   f
 [%%expect{|
-Line 2, characters 12-13:
-2 |   let poly_ f = x in
-                ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
-
 Line 3, characters 2-3:
 3 |   f
       ^
 Error: This value is "local"
-         because it is defined by a layout-polymorphic expression (at line 2, characters 12-13)
+         because it is allocated at line 2, characters 14-19 containing data
+         which is "local" to the parent region
+         because it closes over the value "x" at line 2, characters 18-19
          which is "local" to the parent region.
        However, the highlighted expression is expected to be "local" to the parent region or "global"
          because it is a function return value.
@@ -632,25 +604,16 @@ Error: This value is "local"
 
 (* multiple poly can be have different captured environment mode *)
 let f (x @ local) =
-  let poly_ f = x
-  and poly_ g = () in
+  let poly_ f _ = x
+  and poly_ g _ = () in
   g
 [%%expect{|
-Line 3, characters 12-13:
-3 |   and poly_ g = () in
-                ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
-
 Line 2, characters 12-13:
-2 |   let poly_ f = x
-                ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
-
-Line 2, characters 12-13:
-2 |   let poly_ f = x
+2 |   let poly_ f _ = x
                 ^
 Warning 26 [unused-var]: unused variable "f".
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
+>> Fatal error: Translcore: translation of layout-polymorphic instantiation is not yet supported
+(layout args: [value])
 Uncaught exception: Misc.Fatal_error
 
 |}]

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1695,10 +1695,8 @@ let poly_ id : 'a. 'a -> 'a = fun x -> x
 Line 1, characters 10-12:
 1 | let poly_ id : 'a. 'a -> 'a = fun x -> x
               ^^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
-Uncaught exception: Misc.Fatal_error
-
+Error: This binding has no layout variables, so "poly_" has no effect.
+       Consider using a regular "let" instead.
 |}]
 
 let poly_ id = fun x -> x
@@ -1713,10 +1711,8 @@ let poly_ const : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
 Line 1, characters 10-15:
 1 | let poly_ const : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
               ^^^^^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
-Uncaught exception: Misc.Fatal_error
-
+Error: This binding has no layout variables, so "poly_" has no effect.
+       Consider using a regular "let" instead.
 |}]
 
 module type S_poly = sig
@@ -1736,15 +1732,8 @@ and poly_ g : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
 Line 2, characters 10-11:
 2 | and poly_ g : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
               ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
-
-Line 1, characters 10-11:
-1 | let poly_ f : 'a. 'a -> 'a = fun x -> x
-              ^
-Warning 217: This binding has no layout variables, so poly_ has no effect. Consider using a regular let instead.
->> Fatal error: Matching: layout-poly patterns not yet supported (0 sort var(s))
-Uncaught exception: Misc.Fatal_error
-
+Error: This binding has no layout variables, so "poly_" has no effect.
+       Consider using a regular "let" instead.
 |}]
 
 (* Mixed poly and non-poly in mutually recursive bindings *)

--- a/testsuite/tests/warnings/mnemonics.reference
+++ b/testsuite/tests/warnings/mnemonics.reference
@@ -1,5 +1,4 @@
 Constructors without associated mnemonic:
 All_clauses_guarded
 Modal_axis_specified_twice
-Useless_lpoly
 Lpoly_in_letrec

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -319,6 +319,7 @@ type error =
   | Let_poly_not_yet_implemented
   | Let_poly_not_syntactic_value
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
+  | Useless_lpoly
 
 and invalid_layout_poly_inst_context =
   | Binding_op
@@ -11301,7 +11302,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
                 Jkind_types.Sort.generalize_with (fun () -> generalize ty)
               in
               if List.is_empty univars then
-                Location.prerr_warning loc Warnings.Useless_lpoly;
+                raise (Error (loc, env, Useless_lpoly));
               univars)
             pv_lpoly)
         ~f_mut:(unify_var env (newvar (Jkind.Builtin.any ~why:Dummy_jkind)))
@@ -13336,6 +13337,12 @@ let report_error ~loc env =
       Location.errorf ~loc
         "Instantiation of layout-polymorphic values is not yet supported \
          for %s." ctx_str
+  | Useless_lpoly ->
+      Location.errorf ~loc
+        "This binding has no layout variables, so %a has no effect.@ \
+         Consider using a regular %a instead."
+        Style.inline_code "poly_"
+        Style.inline_code "let"
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env ~error:true env

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -371,6 +371,7 @@ type error =
   | Let_poly_not_yet_implemented
   | Let_poly_not_syntactic_value
   | Layout_poly_inst_not_yet_supported of invalid_layout_poly_inst_context
+  | Useless_lpoly
 
 and invalid_layout_poly_inst_context =
   | Binding_op

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -249,7 +249,7 @@ and 'k pattern_desc =
       lpoly: Types.Lpoly.t;
       (** The sort variables abstracted over by this compile-time function, and
       the allocation mode of the captured environment. [pending] during
-      type-checking; guaranteed [determined] of (potentially empty) generic sort
+      type-checking; guaranteed [determined] of a non-empty list of generic sort
       variables after [type_let] returns. *)
       env_alloc_mode: alloc_mode;
       (** The allocation mode of the environment captured by the layout

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -157,7 +157,6 @@ type t =
   | Atomic_float_record_boxed               (* 214 *)
   | Implied_attribute of { implying: string; implied : string} (* 215 *)
   | Use_during_borrowing                    (* 216 *)
-  | Useless_lpoly                           (* 217 *)
   | Lpoly_in_letrec                         (* 218 *)
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -258,7 +257,6 @@ let number = function
   | Atomic_float_record_boxed -> 214
   | Implied_attribute _ -> 215
   | Use_during_borrowing -> 216
-  | Useless_lpoly -> 217
   | Lpoly_in_letrec -> 218
 ;;
 (* DO NOT REMOVE the ;; above: it is used by
@@ -1490,9 +1488,6 @@ let message = function
         Style.inline_code (Printf.sprintf "[@%s]" implying)
   | Use_during_borrowing ->
       msg "This value is used while being borrowed."
-  | Useless_lpoly ->
-      msg "This binding has no layout variables, so poly_ has no effect. \
-           Consider using a regular let instead."
   | Lpoly_in_letrec ->
       msg "poly_ has no effect in recursive bindings, which do not support \
            layout polymorphism. Consider using a regular let rec instead."

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -160,7 +160,6 @@ type t =
   | Atomic_float_record_boxed               (* 214 *)
   | Implied_attribute of { implying: string; implied : string} (* 215 *)
   | Use_during_borrowing                    (* 216 *)
-  | Useless_lpoly                           (* 217 *)
   | Lpoly_in_letrec                         (* 218 *)
 
 type alert = {kind:string; message:string; def:loc; use:loc}


### PR DESCRIPTION
A `let poly_` binding that generalizes no layout variables previously emitted warning 217 (`Useless_lpoly`) and complicates the code in lambda. This makes it a clean type error and removes the now-unused warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)