### PR TITLE
Suppress out-of-fuel note for ikind errors

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/stall-once/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/stall-once/test.ml
@@ -46,8 +46,6 @@ Error: The value "t" has type "int list list list t"
 
        The first mode-crosses less than the second along:
          portability: mod portable with int list list list ≰ mod portable
-       Note: I gave up trying to find the simplest kind for the first,
-       as it is very large or deeply recursive.
 |}]
 
 (* Test the same scenario, except it requires remembering that we ran out of
@@ -81,6 +79,4 @@ Error: The value "t" has type "int list list list Foo.t"
 
        The first mode-crosses less than the second along:
          portability: mod portable with int list list list ≰ mod portable
-       Note: I gave up trying to find the simplest kind for the first,
-       as it is very large or deeply recursive.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/universal_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/universal_ikinds.ml
@@ -50,8 +50,6 @@ Error: The value "v" has type "'a t" but an expression was expected of type
          because of the definition of t at line 1, characters 0-28.
        But the kind of 'a t must be a subkind of immutable_data
          because of the definition of require_immutable_data at line 2, characters 27-58.
-       Note: I gave up trying to find the simplest kind for the first,
-       as it is very large or deeply recursive.
 |}]
 
 type 'a t : immutable_data = { f : 'b. 'b t }

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -1054,8 +1054,8 @@ type 'a many = Foo of ('a * 'a) many | Leaf
 Line 3, characters 39-40:
 3 | let f (x : M.t many) = cross_contended x
                                            ^
-Error: This expression has type "M.t many"
-       but an expression was expected of type "('a : value mod contended)"
+Error: The value "x" has type "M.t many" but an expression was expected of type
+         "('a : value mod contended)"
        The kind of M.t many is immutable_data with (M.t * M.t) many
          because of the definition of many at line 2, characters 0-43.
        But the kind of M.t many must be a subkind of value mod contended

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -1043,8 +1043,6 @@ Error: The value "x" has type "int t" but an expression was expected of type
          because of the definition of t at line 1, characters 0-39.
        But the kind of int t must be a subkind of value mod portable
          because of the definition of cross_portable at line 10, characters 57-68.
-       Note: I gave up trying to find the simplest kind for the first,
-       as it is very large or deeply recursive.
 |}]
 
 module M : sig type t end = struct type t = int end
@@ -1062,6 +1060,4 @@ Error: This expression has type "M.t many"
          because of the definition of many at line 2, characters 0-43.
        But the kind of M.t many must be a subkind of value mod contended
          because of the definition of cross_contended at line 9, characters 59-70.
-       Note: I gave up trying to find the simplest kind for the first,
-       as it is very large or deeply recursive.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -1046,3 +1046,22 @@ Error: The value "x" has type "int t" but an expression was expected of type
        Note: I gave up trying to find the simplest kind for the first,
        as it is very large or deeply recursive.
 |}]
+
+module M : sig type t end = struct type t = int end
+type 'a many = Foo of ('a * 'a) many | Leaf
+let f (x : M.t many) = cross_contended x
+[%%expect {|
+module M : sig type t end
+type 'a many = Foo of ('a * 'a) many | Leaf
+Line 3, characters 39-40:
+3 | let f (x : M.t many) = cross_contended x
+                                           ^
+Error: This expression has type "M.t many"
+       but an expression was expected of type "('a : value mod contended)"
+       The kind of M.t many is immutable_data with (M.t * M.t) many
+         because of the definition of many at line 2, characters 0-43.
+       But the kind of M.t many must be a subkind of value mod contended
+         because of the definition of cross_contended at line 9, characters 59-70.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
+|}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -3566,7 +3566,7 @@ module Violation = struct
     report_reason ppf t.violation;
     (* otherwise, we get notes for layout abbreviations that get omitted. *)
     report_layout_notes env ppf t.violation mismatch_type ~print_as_value_layout;
-    report_fuel ppf t.violation
+    if not !Clflags.ikinds then report_fuel ppf t.violation
 
   let pp_t ppf x = fprintf ppf "%t" x
 


### PR DESCRIPTION
This PR suppresses the extra diagnostic note saying the compiler gave up trying to find the simplest kind when ikinds are enabled, because ikinds do not use fuel. The main kind mismatch error still prints as before. The note is still emitted under `-no-ikinds`.

Commit structure:

- Add an ikinds regression test with the pre-fix expectation, using a recursive variant over `M.t` that triggers the fuel note.
- Suppress the fuel note under ikinds and re-promote the affected ikinds expectations.