### PR TITLE
Account for recursive payload ikinds

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
@@ -160,14 +160,10 @@ type ('a : immutable_data) t = { x : 'a list; }
 |}]
 
 let foo (t : _ t @ contended) = use_uncontended t
-(* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}, Principal{|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @ contended) = use_uncontended t
-                                                    ^
-Error: This value is "contended" but is expected to be "uncontended".
+val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}]
 
 let foo (t : int t @ contended) = use_uncontended t
@@ -374,14 +370,10 @@ val foo : int t @ contended -> unit = <fun>
 |}]
 
 let foo (t : _ t @ contended) = use_uncontended t
-(* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}, Principal{|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @ contended) = use_uncontended t
-                                                    ^
-Error: This value is "contended" but is expected to be "uncontended".
+val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}]
 
 let foo (t : int t @ aliased) = use_unique t

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -30,6 +30,44 @@ type 'a require_nonnull
 type ('a : value mod external_) require_external
 |}]
 
+module Recursive_boxed_variant_with_bounded_parameter = struct
+  module Variable = struct
+    type ('v : value mod contended portable) t
+      : value mod contended portable with 'v
+  end
+
+  module Record_t = struct
+    type ('v : value mod contended portable) t
+      : value mod contended portable =
+      | Variable of 'v Variable.t
+      | Linear_combination of ('v t * int)
+      | Abs of 'v t * (int * (int * int))
+      | Max of { ts : ('v t * int) * ('v t * int) list }
+  end
+end
+[%%expect{|
+Lines 8-13, characters 4-56:
+ 8 | ....type ('v : value mod contended portable) t
+ 9 |       : value mod contended portable =
+10 |       | Variable of 'v Variable.t
+11 |       | Linear_combination of ('v t * int)
+12 |       | Abs of 'v t * (int * (int * int))
+13 |       | Max of { ts : ('v t * int) * ('v t * int) list }
+Error: The kind of type "t" is
+           immutable_data
+             with 'v Variable.t
+             with 'v t
+             with 'v t * int
+             with ('v t * int) * ('v t * int) list
+             with int * (int * int)
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type t.
+       Note: I gave up trying to find the simplest kind for the first,
+       as it is very large or deeply recursive.
+|}]
+
 (***********************************************************************)
 type 'a eq_int = Eq : int eq_int
 [%%expect{|

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -46,26 +46,22 @@ module Recursive_boxed_variant_with_bounded_parameter = struct
   end
 end
 [%%expect{|
-Lines 8-13, characters 4-56:
- 8 | ....type ('v : value mod contended portable) t
- 9 |       : value mod contended portable =
-10 |       | Variable of 'v Variable.t
-11 |       | Linear_combination of ('v t * int)
-12 |       | Abs of 'v t * (int * (int * int))
-13 |       | Max of { ts : ('v t * int) * ('v t * int) list }
-Error: The kind of type "t" is
-           immutable_data
-             with 'v Variable.t
-             with 'v t
-             with 'v t * int
-             with ('v t * int) * ('v t * int) list
-             with int * (int * int)
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type t.
-       Note: I gave up trying to find the simplest kind for the first,
-       as it is very large or deeply recursive.
+module Recursive_boxed_variant_with_bounded_parameter :
+  sig
+    module Variable :
+      sig
+        type ('v : value mod portable contended) t
+          : value mod portable contended with 'v
+      end
+    module Record_t :
+      sig
+        type ('v : value mod portable contended) t =
+            Variable of 'v Variable.t
+          | Linear_combination of ('v t * int)
+          | Abs of 'v t * (int * (int * int))
+          | Max of { ts : ('v t * int) * ('v t * int) list; }
+      end
+  end
 |}]
 
 (***********************************************************************)

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -546,16 +546,12 @@ let foo (t : _ t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
-(* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect {|
 type ('a : immutable_data) t = { x : 'a; }
 val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
 |}, Principal{|
 type ('a : immutable_data) t = { x : 'a; }
-Line 3, characters 15-16:
-3 |   use_portable t;
-                   ^
-Error: This value is "once" but is expected to be "many".
+val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
 |}]
 
 let foo (t : _ t @ local) = use_global t [@nontail]

--- a/testsuite/tests/typing-jkind-bounds/rectypes_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/rectypes_ikinds.ml
@@ -1,0 +1,14 @@
+(* TEST
+   flags = "-rectypes";
+   expect;
+*)
+
+type 'a t constraint 'a = 'a * 'a
+[%%expect{|
+type 'a t constraint 'a = 'a * 'a
+|}]
+
+type 'a u = int constraint 'a = 'a * 'a
+[%%expect{|
+type 'a u = int constraint 'a = 'a * 'a
+|}]

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -573,16 +573,12 @@ let foo (t : _ t @ nonportable contended once) =
   use_portable t;
   use_uncontended t;
   use_many t
-(* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect {|
 type ('a : immutable_data) t = Foo of { x : 'a; } | Bar of 'a
 val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
 |}, Principal{|
 type ('a : immutable_data) t = Foo of { x : 'a; } | Bar of 'a
-Line 3, characters 15-16:
-3 |   use_portable t;
-                   ^
-Error: This value is "once" but is expected to be "many".
+val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
 |}]
 
 let foo (t : _ t @ local) = use_global t [@nontail]

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -782,14 +782,10 @@ val foo : int t @ contended -> unit = <fun>
 |}]
 
 let foo (t : _ t @ contended) = use_uncontended t
-(* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}, Principal{|
-Line 1, characters 48-49:
-1 | let foo (t : _ t @ contended) = use_uncontended t
-                                                    ^
-Error: This value is "contended" but is expected to be "uncontended".
+val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}]
 
 let foo (t : int t @ nonportable) = use_portable t
@@ -958,14 +954,10 @@ val foo : int t -> unit = <fun>
 |}]
 
 let foo (t : _ t @ nonportable) = use_portable t
-(* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect {|
 val foo : ('a : immutable_data). 'a t -> unit = <fun>
 |}, Principal{|
-Line 1, characters 47-48:
-1 | let foo (t : _ t @ nonportable) = use_portable t
-                                                   ^
-Error: This value is "nonportable" but is expected to be "portable".
+val foo : ('a : immutable_data). 'a t -> unit = <fun>
 |}]
 
 let foo (t : int t @ aliased) = use_unique t

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -214,7 +214,11 @@ module Solver = struct
         (* We add the parameters to the TyTbl so that they will refer to
            rigid variables that represent them in the solver. *)
         List.iter2
-          (fun ty var -> TyTbl.add ctx.ty_to_kind ty (Ldd.node_of_var var))
+          (fun ty var ->
+            let param_kind =
+              Ldd.meet (Ldd.node_of_var var) (kind ~use_tables:true ctx ty)
+            in
+            TyTbl.add ctx.ty_to_kind ty param_kind)
           params rigid_vars;
         (* Compute body kind *)
         (* CR jujacobs: potential efficiency win:

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -118,7 +118,7 @@ module Solver = struct
     | Types.Tvariant _ -> true
     | Types.Tconstr _ -> true
     | Types.Tobject _ -> true
-    | _ -> false
+    | _ -> !Clflags.recursive_types
 
   let is_principal_type (ty : Types.type_expr) : bool =
     (not !Clflags.principal) || Types.get_level ty = Btype.generic_level

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -215,8 +215,20 @@ module Solver = struct
            rigid variables that represent them in the solver. *)
         List.iter2
           (fun ty var ->
+            (* Parameters written as plain type variables may have explicit
+               bounds, as in [('a : bound)]. Cap their rigid variables by those
+               bounds (needed for recursive payload ikinds). Other parameter
+               expressions do not have a written parameter bound to apply here,
+               so keep their rigid atoms bare. *)
             let param_kind =
-              Ldd.meet (Ldd.node_of_var var) (kind ~use_tables:true ctx ty)
+              match Types.get_desc ty with
+              | Types.Tvar { jkind; _ } ->
+                Ldd.meet (Ldd.node_of_var var) (ckind_of_jkind ctx jkind)
+              | Types.Tunivar _ ->
+                Misc.fatal_error
+                  ("Ikind.type_declaration_ikind_of_jkind: "
+                 ^ "unexpected Tunivar in parameter list")
+              | _ -> Ldd.node_of_var var
             in
             TyTbl.add ctx.ty_to_kind ty param_kind)
           params rigid_vars;


### PR DESCRIPTION
This fixes ikind computation for recursive payloads whose type parameter bounds matter.

The old ikind path seeded declaration parameters as unconstrained rigid variables. For direct type variables this missed the declared jkind bound, and for compound parameter expressions (which can occur due to constraints) it did not compute the expression's ikind at all. That made recursive boxed variants reject some cases unnecessarily.

This PR lattice-meets direct parameter variables with their declared jkind, and computes the ikind of non-variable parameter expressions before using them as declaration-parameter entries in the solver table. As a result, the ikind path also fixes several existing principal-mode internal ticket 5111 issues.

Review commit-by-commit:
- Commit 1: adds a failing test
- Commit 2: applies the fix and re-promotes test
