### PR TITLE
Add a C preprocessor symbol to distinguish OxCaml runtimes

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -16,6 +16,9 @@
 #ifndef CAML_CONFIG_H
 #define CAML_CONFIG_H
 
+/* This runtime provides some OxCaml-specific features */
+#define OXCAML_RUNTIME 1
+
 /* CR ocaml 5 all-runtime5: remove this and all uses of it */
 #define CAML_RUNTIME_5
 


### PR DESCRIPTION
External stubs need a specific mechanism to determine whether they are compiled against an OxCaml runtime (at the moment there is a hotchpotch of CAML_RUNTIME_5, OCAML_5_MINUS, etc).