### PR TITLE
[5.4] Tweak the locations displayed with sub-messages

### DIFF
--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -925,7 +925,15 @@ let batch_mode_printer : report_printer =
   in
   let pp_submsg self report ppf { loc; txt } =
     if loc.loc_ghost then
-      Format.fprintf ppf "@[%a@]" (self.pp_submsg_txt self report) txt
+      (* FIXME This change from ocaml/ocaml#13838 results in some very sad error
+               messages from some of our ppxes. We've tweaked it for now, but
+               intend to coordinate with upstream as to a more proper fix. *)
+      if is_none loc then
+        Format.fprintf ppf "@[%a@]" (self.pp_submsg_txt self report) txt
+      else
+        Format.fprintf ppf "%a@[%a@]"
+          (self.pp_submsg_loc self report) loc
+          (self.pp_submsg_txt self report) txt
     else
       Format.fprintf ppf "%a  @[%a@]"
         (self.pp_submsg_loc self report) loc

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -41,6 +41,9 @@ Line 1, characters 40-41:
 1 | let dup (x @ unique) = ((x : @ unique), x, x)
                                             ^
 Error: This value is used here, but it is also being used as unique at:
+Line 1, characters 24-38:
+1 | let dup (x @ unique) = ((x : @ unique), x, x)
+                            ^^^^^^^^^^^^^^
 
 |}]
 
@@ -63,6 +66,9 @@ Line 1, characters 40-41:
 1 | let dup (x @ unique) = ((x : @ unique), x)
                                             ^
 Error: This value is used here, but it is also being used as unique at:
+Line 1, characters 24-38:
+1 | let dup (x @ unique) = ((x : @ unique), x)
+                            ^^^^^^^^^^^^^^
 
 |}]
 


### PR DESCRIPTION
ocaml/ocaml#13838 changed the machinery used for hints and altered the printing of submissions to exclude locations from anything marked `loc_ghost`. This results in a few of our ppxes ceasing to display _useful_ information with sub-messages. This tweaks it so that the message is formatted differently for `loc_ghost` (otherwise the hint machinery needs changing as well) but still displays the location unless the location given is `none`.