### PR TITLE
Fix topological jkind updates for `[@@unsafe_allow_any_mode_crossing]`

### DIFF
--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -56,6 +56,21 @@ Error: The layout of type "t" is value non_float
        the layout value non_float.
 |}]
 
+(* Can't change the layout for mutually recursive types. This *should*
+   typecheck; i.e. allow_any_mode_crossing shouldn't replace [t]'s layout with
+   [any]. *)
+type ('a : float64) require_f64
+
+type t : any = #{ f : float# }
+[@@unsafe_allow_any_mode_crossing]
+
+and s : value = t require_f64
+[%%expect{|
+type ('a : float64) require_f64
+type t : float64 = #{ f : float#; } [@@unsafe_allow_any_mode_crossing]
+and s = t require_f64
+|}]
+
 (* Annotations with with-bounds are allowed *)
 type 'a t : value mod contended with 'a = { mutable contents : 'a }
 [@@unsafe_allow_any_mode_crossing]
@@ -569,7 +584,7 @@ let f (type a b) (eq : ((a, b) M7.t, (a, b) M9.t) eq) = match eq with Refl -> ()
 val f : (('a, 'b) M7.t, ('a, 'b) M9.t) eq -> unit = <fun>
 |}]
 
-module M : sig 
+module M : sig
   type t : immutable_data
 end = struct
   type q : immutable_data = { bar : int ref }

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -580,7 +580,7 @@ end
 module M : sig type t : immutable_data end
 |}]
 
-module M : sig 
+module M : sig
   type t : immutable_data
 end = struct
   type q : immutable_data = { bar : int ref }
@@ -589,4 +589,15 @@ end = struct
 end
 [%%expect{|
 module M : sig type t : immutable_data end
+|}]
+
+(* A type in the same mutually recursive group sees the crossed jkind of an
+   [@@unsafe_allow_any_mode_crossing] type, not its structural one. *)
+type t : value mod contended = { mutable i : int }
+[@@unsafe_allow_any_mode_crossing]
+and s : value mod contended = { t : t } [@@unboxed]
+[%%expect{|
+type t : value non_float mod contended = { mutable i : int; }
+[@@unsafe_allow_any_mode_crossing]
+and s = { t : t; } [@@unboxed]
 |}]

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2737,7 +2737,17 @@ let update_decls_jkind env order decls =
              end;
              update_decl_jkind env (Pident id) decl, allow_any_crossing)
          in
-         let env = add_type ~check:false id new_decl env in
+         (* In the temporary env that gets updated jkinds, we should reflect
+            the overriden kind from [@@unsafe_allow_any_mode_crossing] *)
+         let env_decl =
+           if allow_any_crossing then
+             { new_decl with
+               type_jkind =
+                 Jkind.unsafely_set_bounds env ~from:decl.type_jkind
+                   new_decl.type_jkind }
+           else new_decl
+         in
+         let env = add_type ~check:false id env_decl env in
          env, Ident.Map.add id (decl, allow_any_crossing, new_decl) results)
       (env, Ident.Map.empty) order
   in


### PR DESCRIPTION
https://github.com/oxcaml/oxcaml/pull/6177 makes it so we thread an env through `update_decls_jkind`, which we update for each decl as we go. However, this env doesn't account for "magic'd" mode crossings that come from `[@@unsafe_allow_any_mode_crossing]`, leading to spurious type errors.