### PR TITLE
Don't fatal error if OCAMLRUNPARAM=d= value is too high

### DIFF
--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -199,13 +199,16 @@ static void parse_ocamlrunparam(char_os* opt)
     }
   }
 
+  /* TODO: Better general OCAMLRUNPARAM validation. */
   /* Validate */
   if (params.max_domains < 1) {
     caml_fatal_error("OCAMLRUNPARAM: max_domains(d) must be at least 1");
   }
   if (params.max_domains > Max_domains_max) {
-    caml_fatal_error("OCAMLRUNPARAM: max_domains(d) is too large. "
-                     "The maximum value is %d.", Max_domains_max);
+    /* Silently clamp to the maximum. Don't fatal error: we don't want
+       to kill executables built with a --disable-multidomain compiler
+       if they happen to be passed an otherwise-reasonable value. */
+    params.max_domains = Max_domains_max;
   }
 }
 


### PR DESCRIPTION
Clamp any `OCAMLRUNPARAM=d=` setting to the hardwired maximum number of domains.
If configured with `--disable-multidomain`, the runtime cannot function with multiple domains, and `Max_domains_max` is hardwired to 1. But such an executable shouldn't fail hard in the presence of an `OCAMLRUNPARAM=d=16` environment variable.
In general, more validation of `OCAMLRUNPARAM` is probably a good idea, but not with hard failures.