### PR TITLE
Method call in fexpr

### DIFF
--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -236,14 +236,12 @@ type function_call =
 (* Will translate to indirect_known_arity or indirect_unknown_arity depending on
    whether the apply record's arities field has a value *)
 
-type method_kind =
-  | Self
-  | Public
-  | Cached
-
 type call_kind =
   | Function of function_call
-  (* | Method of { kind : method_kind; obj : simple; } *)
+  | Method of
+      { kind : Call_kind.Method_kind.t;
+        obj : simple
+      }
   | C_call of { alloc : bool }
 
 type function_arities =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -844,6 +844,21 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
             return_arity )
         | None | Some { params_arity = None; ret_arity = _ } ->
           Misc.fatal_errorf "Must specify arities for C call")
+      | Method { kind; obj } ->
+        let params_arity =
+          (* CR mshinwell: This needs fixing to cope with the fact that the
+             arities have moved onto [Apply_expr] *)
+          Flambda_arity.create_singletons
+            (List.map (fun _ -> Flambda_kind.With_subkind.any_value) args)
+        in
+        let return_arity =
+          (* CR mshinwell: This needs fixing to cope with the fact that the
+             arities have moved onto [Apply_expr] *)
+          Flambda_arity.create_singletons [Flambda_kind.With_subkind.any_value]
+        in
+        ( Call_kind.method_call kind ~obj:(simple env obj),
+          params_arity,
+          return_arity )
     in
     let inlined : Inlined_attribute.t =
       match inlined with

--- a/middle_end/flambda2/parser/flambda_lex.mll
+++ b/middle_end/flambda2/parser/flambda_lex.mll
@@ -37,6 +37,10 @@ let keyword_table =
     "available", KWD_AVAILABLE;
     "boxed", KWD_BOXED;
     "ccall", KWD_CCALL;
+    "mcall", KWD_MCALL;
+    "self", KWD_SELF;
+    "public", KWD_PUBLIC;
+    "cached", KWD_CACHED;
     "closure", KWD_CLOSURE;
     "code", KWD_CODE;
     "cont", KWD_CONT;

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -4,7 +4,7 @@
 
 flambda_unit: KWD_APPLY SYMBOL LPAREN RPAREN KWD_WITH
 ##
-## Ends in an error in state: 472.
+## Ends in an error in state: 480.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -18,7 +18,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER IDENT KWD_WITH
 ##
-## Ends in an error in state: 474.
+## Ends in an error in state: 482.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -32,7 +32,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER KWD_WITH
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 481.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -46,7 +46,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 479.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
@@ -313,7 +313,7 @@ Examples of let expressions:
 
 flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 547.
+## Ends in an error in state: 555.
 ##
 ## flambda_unit -> module_ . EOF [ # ]
 ##
@@ -326,11 +326,11 @@ flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 11, spurious reduction of production option(PIPE) ->
 ## In state 35, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
-## In state 544, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
+## In state 552, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
 ## In state 34, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
-## In state 518, spurious reduction of production inner_expr -> inlined_expr
-## In state 483, spurious reduction of production expr -> inner_expr
-## In state 550, spurious reduction of production module_ -> expr
+## In state 526, spurious reduction of production inner_expr -> inlined_expr
+## In state 491, spurious reduction of production expr -> inner_expr
+## In state 558, spurious reduction of production module_ -> expr
 ##
 
 Expected one or more switch cases, separated by semicolons, surrounded by {}.
@@ -2660,9 +2660,58 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY KWD_DIRECT TILDE
+flambda_unit: KWD_APPLY KWD_MCALL TILDE
 ##
 ## Ends in an error in state: 402.
+##
+## call_kind -> KWD_MCALL . LPAREN method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_MCALL
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY KWD_MCALL LPAREN TILDE
+##
+## Ends in an error in state: 403.
+##
+## call_kind -> KWD_MCALL LPAREN . method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_MCALL LPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED TILDE
+##
+## Ends in an error in state: 407.
+##
+## call_kind -> KWD_MCALL LPAREN method_kind . simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## KWD_MCALL LPAREN method_kind
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT SYMBOL
+##
+## Ends in an error in state: 408.
+##
+## call_kind -> KWD_MCALL LPAREN method_kind simple . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## simple -> simple . TILDE coercion [ TILDE RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## KWD_MCALL LPAREN method_kind simple
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY KWD_DIRECT TILDE
+##
+## Ends in an error in state: 410.
 ##
 ## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2674,7 +2723,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 411.
 ##
 ## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2686,7 +2735,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 404.
+## Ends in an error in state: 412.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2698,7 +2747,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 405.
+## Ends in an error in state: 413.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2710,7 +2759,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP TILDE
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 414.
 ##
 ## alloc_mode_for_applications_opt -> AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2722,7 +2771,7 @@ flambda_unit: KWD_APPLY AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT TILDE
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 415.
 ##
 ## alloc_mode_for_applications_opt -> AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2734,7 +2783,7 @@ flambda_unit: KWD_APPLY AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 416.
 ##
 ## alloc_mode_for_applications_opt -> AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2746,7 +2795,7 @@ flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 418.
 ##
 ## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2758,7 +2807,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL TILDE
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 420.
 ##
 ## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
@@ -2770,7 +2819,7 @@ flambda_unit: KWD_APPLY KWD_CCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ##
-## Ends in an error in state: 415.
+## Ends in an error in state: 423.
 ##
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2784,7 +2833,7 @@ flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 424.
 ##
 ## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2796,7 +2845,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 425.
 ##
 ## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2808,7 +2857,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 426.
 ##
 ## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2820,7 +2869,7 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED TILDE
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 428.
 ##
 ## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2835,7 +2884,7 @@ flambda_unit: KWD_APPLY KWD_INLINED TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 429.
 ##
 ## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
@@ -2850,7 +2899,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 430.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2862,7 +2911,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 432.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2874,7 +2923,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 426.
+## Ends in an error in state: 434.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2886,7 +2935,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 428.
+## Ends in an error in state: 436.
 ##
 ## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
@@ -2898,7 +2947,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 438.
 ##
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2912,7 +2961,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 439.
 ##
 ## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2924,7 +2973,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 440.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2936,7 +2985,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 441.
 ##
 ## inlining_state_depth -> KWD_DEPTH . LPAREN plain_int RPAREN [ RPAREN ]
 ##
@@ -2948,7 +2997,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 442.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN . plain_int RPAREN [ RPAREN ]
 ##
@@ -2960,7 +3009,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 443.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN plain_int . RPAREN [ RPAREN ]
 ##
@@ -2972,7 +3021,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 445.
 ##
 ## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
 ##
@@ -2984,7 +3033,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TI
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 447.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2998,7 +3047,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RP
 
 flambda_unit: KWD_APPLY LPAREN TILDE
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 448.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ MINUSGREATER ]
@@ -3011,7 +3060,7 @@ flambda_unit: KWD_APPLY LPAREN TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 449.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
@@ -3026,7 +3075,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 450.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3038,7 +3087,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 453.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3050,7 +3099,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 454.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3062,7 +3111,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 455.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3074,7 +3123,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 456.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3086,7 +3135,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 457.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3098,7 +3147,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 458.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3110,7 +3159,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 460.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3122,7 +3171,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 453.
+## Ends in an error in state: 461.
 ##
 ## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3134,7 +3183,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 462.
 ##
 ## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3146,7 +3195,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 455.
+## Ends in an error in state: 463.
 ##
 ## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3158,7 +3207,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 464.
 ##
 ## exn_extra_arg -> simple . kind_with_subkind [ RPAREN COMMA ]
 ## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
@@ -3171,7 +3220,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 460.
+## Ends in an error in state: 468.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . [ RPAREN ]
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . COMMA separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
@@ -3184,7 +3233,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO 
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 469.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg COMMA . separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
 ##
@@ -3196,7 +3245,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COM
 
 flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 467.
+## Ends in an error in state: 475.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3208,7 +3257,7 @@ flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER TILDE
 ##
-## Ends in an error in state: 468.
+## Ends in an error in state: 476.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3220,7 +3269,7 @@ flambda_unit: KWD_APPLY MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 469.
+## Ends in an error in state: 477.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3232,7 +3281,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 
 flambda_unit: KWD_HCF TILDE
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 491.
 ##
 ## expr -> inner_expr . [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## where_expr -> inner_expr . KWD_WHERE cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -3245,7 +3294,7 @@ flambda_unit: KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE TILDE
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 492.
 ##
 ## where_expr -> inner_expr KWD_WHERE . cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3257,7 +3306,7 @@ flambda_unit: KWD_HCF KWD_WHERE TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 493.
 ##
 ## cont_recursive -> KWD_REC . kinded_args [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EOF ]
 ##
@@ -3269,7 +3318,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 495.
 ##
 ## where_expr -> inner_expr KWD_WHERE cont_recursive . loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3281,7 +3330,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 498.
 ##
 ## continuation_binding -> continuation_id . continuation_sort kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3293,7 +3342,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 501.
 ##
 ## continuation_binding -> continuation_id continuation_sort . kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3305,7 +3354,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 494.
+## Ends in an error in state: 502.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args . EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3317,7 +3366,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 503.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args EQUAL . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3329,7 +3378,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 504.
 ##
 ## let_expr(continuation_body) -> KWD_LET . let_(continuation_body) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(continuation_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3342,7 +3391,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 506.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3354,7 +3403,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 507.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3366,7 +3415,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 514.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3378,7 +3427,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LB
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 507.
+## Ends in an error in state: 515.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3390,7 +3439,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILD
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 ##
-## Ends in an error in state: 509.
+## Ends in an error in state: 517.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . KWD_AND separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
@@ -3403,7 +3452,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 518.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding KWD_AND . separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -3415,7 +3464,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 ##
-## Ends in an error in state: 515.
+## Ends in an error in state: 523.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . KWD_ANDWHERE separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -3428,7 +3477,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 524.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding KWD_ANDWHERE . separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3440,7 +3489,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 529.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3452,7 +3501,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 522.
+## Ends in an error in state: 530.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3464,7 +3513,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 527.
+## Ends in an error in state: 535.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3476,7 +3525,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 536.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3488,7 +3537,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 534.
+## Ends in an error in state: 542.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3500,7 +3549,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WIT
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 535.
+## Ends in an error in state: 543.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3512,7 +3561,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN 
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 548.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . PIPE separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3525,7 +3574,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 ##
-## Ends in an error in state: 541.
+## Ends in an error in state: 549.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case PIPE . separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3537,7 +3586,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 
 flambda_unit: LPAREN KWD_HCF KWD_WITH
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 553.
 ##
 ## atomic_expr -> LPAREN expr . RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3548,7 +3597,7 @@ flambda_unit: LPAREN KWD_HCF KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 483, spurious reduction of production expr -> inner_expr
+## In state 491, spurious reduction of production expr -> inner_expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -120,6 +120,10 @@ let make_boxed_const_int (i, m) : static_data =
 %token KWD_AVAILABLE [@symbol "available"]
 %token KWD_BOXED [@symbol "boxed"]
 %token KWD_CCALL  [@symbol "ccall"]
+%token KWD_MCALL  [@symbol "mcall"]
+%token KWD_SELF  [@symbol "self"]
+%token KWD_PUBLIC  [@symbol "public"]
+%token KWD_CACHED  [@symbol "cached"]
 %token KWD_CLOSURE  [@symbol "closure"]
 %token KWD_CODE  [@symbol "code"]
 %token KWD_CONT  [@symbol "cont"]
@@ -585,6 +589,11 @@ apply_expr:
      } }
 ;
 
+method_kind:
+  | KWD_SELF { Call_kind.Method_kind.Self }
+  | KWD_PUBLIC { Call_kind.Method_kind.Public }
+  | KWD_CACHED { Call_kind.Method_kind.Cached }
+
 call_kind:
   | alloc = alloc_mode_for_applications_opt; { (Function Indirect, alloc) }
   | KWD_DIRECT; LPAREN;
@@ -595,6 +604,8 @@ call_kind:
     { (Function (Direct { code_id; function_slot; }), alloc) }
   | KWD_CCALL; noalloc = boption(KWD_NOALLOC)
     { (C_call { alloc = not noalloc }, (Heap : alloc_mode_for_applications)) }
+  | KWD_MCALL LPAREN; kind = method_kind; obj = simple; RPAREN
+    { (Method { kind; obj }, (Heap : alloc_mode_for_applications)) }
 ;
 
 inline:

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -621,7 +621,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
         { function_call = Indirect_unknown_arity | Indirect_known_arity _ } ->
       Function Indirect
     | C_call { needs_caml_c_call; _ } -> C_call { alloc = needs_caml_c_call }
-    | Method _ -> Misc.fatal_error "TODO: Method call kind"
+    | Method { kind; obj } -> Method { kind; obj = simple env obj }
     | Effect _ -> Misc.fatal_error "TODO: Effect call kind"
   in
   let param_arity = Apply_expr.args_arity app in
@@ -647,7 +647,10 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
       let ret_arity = arity return_arity in
       Some { params_arity; ret_arity }
     | Function { function_call = Indirect_unknown_arity } -> None
-    | Method _ | Effect _ -> assert false
+    | Method _ ->
+      (* CR keryan: maybe use the method kind *)
+      None
+    | Effect _ -> assert false
   in
   let inlined : Fexpr.inlined_attribute option =
     if Flambda2_terms.Inlined_attribute.is_default (Apply_expr.inlined app)

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -543,6 +543,12 @@ let static_closure_binding ppf (scb : static_closure_binding) =
     (fun_decl Flambda_colours.static_keyword)
     scb.fun_decl
 
+let method_kind ppf mk =
+  match (mk : Call_kind.Method_kind.t) with
+  | Self -> Format.pp_print_string ppf "self"
+  | Public -> Format.pp_print_string ppf "public"
+  | Cached -> Format.pp_print_string ppf "cached"
+
 let call_kind_and_alloc_mode ~space ppf (ck, alloc_mode) =
   match ck with
   | Function Indirect -> alloc_mode_for_applications_opt ppf alloc_mode ~space
@@ -557,6 +563,10 @@ let call_kind_and_alloc_mode ~space ppf (ck, alloc_mode) =
     pp_spaced ~space ppf "ccall%a"
       (pp_option ~space:Before Format.pp_print_string)
       noalloc_kwd
+  | Method { kind; obj } ->
+    pp_spaced ~space ppf "mcall(%a%a)" method_kind kind
+      (fun ppf -> pp_spaced ~space:Before ppf "%a" simple)
+      obj
 
 let inline_attribute ~space ppf (i : Inline_attribute.t) =
   let str =

--- a/middle_end/flambda2/terms/call_kind.mli
+++ b/middle_end/flambda2/terms/call_kind.mli
@@ -29,7 +29,7 @@ module Function_call : sig
 end
 
 module Method_kind : sig
-  type t = private
+  type t =
     | Self
     | Public
     | Cached

--- a/testsuite/tests/flambda/match_in_match_seq.simplify.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.simplify.reference
@@ -4,8 +4,8 @@ let code loopify(never) size(35) newer_version_of(foo_12)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self (0, 0)
-    where rec self (acc, s : val) =
+  cont `self` (0, 0)
+    where rec `self` (acc, s : val) =
       (cont self_1 (s)
          where rec self_1 (s_1 : val) =
            let prim = %int_comp.gt (s_1, 11) in
@@ -23,7 +23,7 @@ let code loopify(never) size(35) newer_version_of(foo_12)
            let s_2 = s_1 in
            let int_mul = %int_barith.mul (s_2, s_2) in
            let int_add_2 = %int_barith.add (acc, int_mul) in
-           cont self (int_add_2, int_add_1))
+           cont `self` (int_add_2, int_add_1))
 in
 let $camlMatch_in_match_seq__foo_22 = closure foo_12_1 @foo in
 let $camlMatch_in_match_seq__Pmakeblock899 =

--- a/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
@@ -5,8 +5,8 @@ in
 let $camlCode_id_join_b__const_block338 =
   Block 0 (0, $camlCode_id_join_b__const_block336)
 in
-cont self ($camlCode_id_join_b__const_block338)
-  where rec self (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+cont `self` ($camlCode_id_join_b__const_block338)
+  where rec `self` (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
     let prim = %is_int (param) in
     (switch prim
        | 0 -> k1
@@ -34,7 +34,7 @@ cont self ($camlCode_id_join_b__const_block338)
                    cont k1
                  where k1 =
                    let Pfield_1 = %block_load.[`1`] (param) in
-                   cont self (Pfield_1))))
+                   cont `self` (Pfield_1))))
   where k =
     let $camlCode_id_join_b = Block 0 () in
     cont done ($camlCode_id_join_b)

--- a/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
@@ -24,15 +24,15 @@ and code loopify(done) size(15) newer_version_of(aux_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self
-    where rec self =
+  cont `self`
+    where rec `self` =
       let env_2 =
         %project_value_slot.[aux].[env_1] ($camlDeleted_code_printing__aux_3)
       in
       let Popaque = %opaque (0) in
       ((let untagged = %untag_imm (Popaque) in
         switch untagged
-          | 0 -> self
+          | 0 -> `self`
           | 1 -> k2)
          where k2 =
            let Pfield = %block_load.mut.[`0`] (env_2) in

--- a/testsuite/tests/flambda2/examples/functor_call.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functor_call.simplify.reference
@@ -15,15 +15,15 @@ let code loopify(done) size(16) newer_version_of(foo_1_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self (x)
-    where rec self (x_1 : imm tagged) =
+  cont `self` (x)
+    where rec `self` (x_1 : imm tagged) =
       let prim = %int_comp.gt (x_1, 0) in
       (switch prim
          | 0 -> k2
          | 1 -> k (x_1)
          where k2 =
            let int_add = %int_barith.add (x_1, 1) in
-           cont self (int_add))
+           cont `self` (int_add))
 in
 let $camlFunctor_call__foo_5 =
   closure foo_1 @foo

--- a/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
@@ -4,8 +4,8 @@ let code loopify(never) size(17) newer_version_of(foo_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self (x, y)
-    where rec self (accu, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+  cont `self` (x, y)
+    where rec `self` (accu, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let prim = %is_int (l) in
       (switch prim
          | 0 -> k2
@@ -14,7 +14,7 @@ let code loopify(never) size(17) newer_version_of(foo_1)
            let Pfield = %block_load.[`1`] (l) in
            let Pfield_1 = %block_load.[`0`] (l) in
            let int_add = %int_barith.add (accu, Pfield_1) in
-           cont self (int_add, Pfield))
+           cont `self` (int_add, Pfield))
 in
 let $camlPartial_closure__foo_5 = closure foo_1_1 @foo in
 let $camlPartial_closure = Block 0 ($camlPartial_closure__foo_5) in

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -20,8 +20,8 @@ let code loopify(done) size(16) newer_version_of(length_aux_0)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self (len, param)
-    where rec self
+  cont `self` (len, param)
+    where rec `self`
                 (len_1 : imm tagged,
                  param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let prim = %is_int (param_1) in
@@ -31,7 +31,7 @@ let code loopify(done) size(16) newer_version_of(length_aux_0)
          where k2 =
            let Pfield = %block_load.[`1`] (param_1) in
            let int_add = %int_barith.add (len_1, 1) in
-           cont self (int_add, Pfield))
+           cont `self` (int_add, Pfield))
 in
 let $camlTests9__length_aux_12 = closure length_aux_0_1 @length_aux in
 let code loopify(never) size(4) newer_version_of(length_1)
@@ -50,8 +50,8 @@ let code loopify(done) size(22) newer_version_of(rev_append_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  cont self (l1, l2)
-    where rec self
+  cont `self` (l1, l2)
+    where rec `self`
                 (l1_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  l2_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let prim = %is_int (l1_1) in
@@ -62,7 +62,7 @@ let code loopify(done) size(22) newer_version_of(rev_append_2)
            let Pfield = %block_load.[`0`] (l1_1) in
            let Pmakeblock = %block.[`0`] (Pfield, l2_1) in
            let Pfield_1 = %block_load.[`1`] (l1_1) in
-           cont self (Pfield_1, Pmakeblock))
+           cont `self` (Pfield_1, Pmakeblock))
 in
 let $camlTests9__rev_append_14 = closure rev_append_2_1 @rev_append in
 let code loopify(done) size(28) newer_version_of(chop_3)
@@ -71,8 +71,8 @@ let code loopify(done) size(28) newer_version_of(chop_3)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  cont self (k, l)
-    where rec self
+  cont `self` (k, l)
+    where rec `self`
                 (k_1 : imm tagged,
                  l_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let prim = %phys_eq (k_1, 0) in
@@ -87,7 +87,7 @@ let code loopify(done) size(28) newer_version_of(chop_3)
               where k2 =
                 let Pfield = %block_load.[`1`] (l_1) in
                 let int_sub = %int_barith.sub (k_1, 1) in
-                cont self (int_sub, Pfield)))
+                cont `self` (int_sub, Pfield)))
 in
 let $camlTests9__chop_15 = closure chop_3_1 @chop in
 let code loopify(done) size(90) newer_version_of(rev_merge_5)
@@ -98,8 +98,8 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  cont self (l1, l2, accu)
-    where rec self
+  cont `self` (l1, l2, accu)
+    where rec `self`
                 (l1_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  l2_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  accu_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
@@ -138,7 +138,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
                         | 1 -> k3
                         where k3 =
                           let Pmakeblock = %block.[`0`] (h1, accu_1) in
-                          cont self (t1, t2, Pmakeblock)
+                          cont `self` (t1, t2, Pmakeblock)
                         where k2 =
                           let prim_3 = %int_comp.lt (c, 0) in
                           (switch prim_3
@@ -146,10 +146,10 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
                              | 1 -> k3
                              where k3 =
                                let Pmakeblock = %block.[`0`] (h1, accu_1) in
-                               cont self (t1, l2_1, Pmakeblock)
+                               cont `self` (t1, l2_1, Pmakeblock)
                              where k2 =
                                let Pmakeblock = %block.[`0`] (h2, accu_1) in
-                               cont self (l1_1, t2, Pmakeblock))))))
+                               cont `self` (l1_1, t2, Pmakeblock))))))
 in
 let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
       rev_merge_rev_6_1
@@ -159,8 +159,8 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  cont self (l1, l2, accu)
-    where rec self
+  cont `self` (l1, l2, accu)
+    where rec `self`
                 (l1_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  l2_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                  accu_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
@@ -199,7 +199,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
                         | 1 -> k3
                         where k3 =
                           let Pmakeblock = %block.[`0`] (h1, accu_1) in
-                          cont self (t1, t2, Pmakeblock)
+                          cont `self` (t1, t2, Pmakeblock)
                         where k2 =
                           let prim_3 = %int_comp.gt (c, 0) in
                           (switch prim_3
@@ -207,10 +207,10 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
                              | 1 -> k3
                              where k3 =
                                let Pmakeblock = %block.[`0`] (h1, accu_1) in
-                               cont self (t1, l2_1, Pmakeblock)
+                               cont `self` (t1, l2_1, Pmakeblock)
                              where k2 =
                                let Pmakeblock = %block.[`0`] (h2, accu_1) in
-                               cont self (l1_1, t2, Pmakeblock))))))
+                               cont `self` (l1_1, t2, Pmakeblock))))))
 in
 let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
       rev_sort_8_1

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
@@ -107,9 +107,9 @@ let Popaque = %opaque ($camlData_flow_bug__immstring19) in
                                                  let Pstringrefs =
                                                    %tag_imm (prim)
                                                  in
-                                                 (cont self
+                                                 (cont `self`
                                                          ($camlData_flow_bug__const_block14)
-                                                    where rec self
+                                                    where rec `self`
                                                                 (param :
                                                                    [ 0
                                                                    | 
@@ -156,7 +156,7 @@ let Popaque = %opaque ($camlData_flow_bug__immstring19) in
                                                                     (param)
                                                                     in
                                                                     cont 
-                                                                    self
+                                                                    `self`
                                                                     (Pfield_1)))))
                                                where k1 =
                                                  cont error

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -62,8 +62,8 @@ let code loopify(done) size(121) newer_version_of(emit_2)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self (param)
-    where rec self (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+  cont `self` (param)
+    where rec `self` (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let `region` = %begin_region () in
       let ghost_region = %begin_ghost_region () in
       ((let prim = %is_int (param_1) in
@@ -97,7 +97,7 @@ let code loopify(done) size(121) newer_version_of(emit_2)
                       let Pfield = %block_load.[`1`] (param_1) in
                       let `unit` = %end_region (`region`) in
                       let unit_1 = %end_ghost_region (ghost_region) in
-                      cont self (Pfield))
+                      cont `self` (Pfield))
                where k4 =
                  let `*match*` = %block_load.[`1`] (param_1) in
                  let prim_1 = %is_int (`*match*`) in
@@ -139,7 +139,7 @@ let code loopify(done) size(121) newer_version_of(emit_2)
                                      let unit_1 =
                                        %end_ghost_region (ghost_region)
                                      in
-                                     cont self (Pfield_1)))))
+                                     cont `self` (Pfield_1)))))
                where k3 =
                  (apply direct(emit_instr_1_1 &`region` &ghost_region)
                     ($camlEmitcode_repro__emit_instr_4 : _ -> imm tagged)
@@ -151,7 +151,7 @@ let code loopify(done) size(121) newer_version_of(emit_2)
                       let Pfield = %block_load.[`1`] (param_1) in
                       let `unit` = %end_region (`region`) in
                       let unit_1 = %end_ghost_region (ghost_region) in
-                      cont self (Pfield))))
+                      cont `self` (Pfield))))
          where k2 =
            let `unit` = %end_region (`region`) in
            let unit_1 = %end_ghost_region (ghost_region) in

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -152,8 +152,8 @@ apply direct(length_2_1)
                       my_closure my_region my_ghost_region my_depth
                       -> k * k1
                       : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] local =
-                cont self (l1, l2)
-                  where rec self
+                cont `self` (l1, l2)
+                  where rec `self`
                               (l1_1 :
                                  [ 0 | 0 of val * [ 0 | 0 of val * val ] ],
                                l2_1 :
@@ -168,7 +168,7 @@ apply direct(length_2_1)
                            %block.[`0`].`local`[my_region] (Pfield, l2_1)
                          in
                          let Pfield_1 = %block_load.[`1`] (l1_1) in
-                         cont self (Pfield_1, Pmakeblock))
+                         cont `self` (Pfield_1, Pmakeblock))
               in
               let $camlLocal__rev_app_12 = closure rev_app_4_1 @rev_app in
               let $camlLocal__spans_13 =

--- a/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
@@ -33,8 +33,8 @@ let code loopify(done) size(26) newer_version_of(min_binding_1)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self (param)
-    where rec self
+  cont `self` (param)
+    where rec `self`
                 (param_1 :
                    [ 0
                    | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
@@ -47,7 +47,7 @@ let code loopify(done) size(26) newer_version_of(min_binding_1)
            let l = %block_load.[`0`] (param_1) in
            let prim_1 = %is_int (l) in
            (switch prim_1
-              | 0 -> self (l)
+              | 0 -> `self` (l)
               | 1 -> k2
               where k2 =
                 let Pfield = %block_load.[`1`] (param_1) in

--- a/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
@@ -8,8 +8,8 @@ let code loopify(done) size(22) newer_version_of(iter_0)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
-  cont self (param)
-    where rec self (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+  cont `self` (param)
+    where rec `self` (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let f_1 = f in
       let prim = %is_int (param_1) in
       (switch prim
@@ -22,7 +22,7 @@ let code loopify(done) size(22) newer_version_of(iter_0)
                  cont k2)
               where k2 =
                 let Pfield = %block_load.[`1`] (param_1) in
-                cont self (Pfield)))
+                cont `self` (Pfield)))
 in
 let $camlProtect_refs__iter_6 = closure iter_0_1 @iter in
 let code loopify(never) size(7) newer_version_of(`fn[protect_refs.ml:28,24--50]_2`)

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -31,8 +31,8 @@ let code loopify(never) size(58) newer_version_of(f_0)
         : imm tagged =
   let g = closure g_1_1 @g with { x = x } in
   let h = closure h_2_1 @h with { g = g } in
-  cont self (0, l)
-    where rec self (accu, l_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+  cont `self` (0, l)
+    where rec `self` (accu, l_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       let prim = %is_int (l_1) in
       (switch prim
          | 0 -> k2
@@ -43,7 +43,7 @@ let code loopify(never) size(58) newer_version_of(f_0)
              apply direct(h_2_1) inlining_state(depth(10))
                h (accu, Pfield_1) -> k2 * k1)
               where k2 (apply_result) =
-                cont self (apply_result, Pfield)))
+                cont `self` (apply_result, Pfield)))
 in
 let $camlStatic__f_3 = closure f_0_1 @f in
 let $camlStatic = Block 0 ($camlStatic__f_3) in


### PR DESCRIPTION
Implement method call kind. We can now generate fexpr files for every ml files handled by `make`.

Not sure about the added keywords though.