### PR TITLE
Correct test for atomic marking of lazy headers in major GC.

### DIFF
--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1005,9 +1005,9 @@ Caml_inline header_t mark_header(value block, header_t hd, status marked)
   header_t marked_hd;
 again:
   marked_hd = With_status_hd(hd, marked);
-  if (Tag_hd(hd) == Lazy_tag && Tag_hd(hd) == Forcing_tag) {
+  if (Tag_hd(hd) == Lazy_tag || Tag_hd(hd) == Forcing_tag) {
     /* To detect and mitigate a race against some other domain
-     * short-circuiting alazy block, we compare-and-swap */
+     * short-circuiting a lazy block, we compare-and-swap */
     if (!atomic_compare_exchange_strong(Hp_atomic_val(block), &hd, marked_hd)) {
       hd = Hd_val(block);
       goto again;


### PR DESCRIPTION
From ocaml/ocaml#14856, correcting a bug introduced in #6109 : the broken code could potentially cause SEGVs or other corruption if two domains raced on a lazy block (one marking and one (e.g.) short-circuiting).