### PR TITLE
[5.4] Effect pattern-matching forces the enclosing function to legacy

### DIFF
--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -12,6 +12,16 @@ let use_portable : 'a @ portable -> unit = fun _ -> ()
 
 let use_portable_function : (unit -> unit) @ portable -> unit = fun _ -> ()
 
+let use_stateless : 'a @ stateless -> unit = fun _ -> ()
+
+let use_contended : 'a @ contended -> unit = fun _ -> ()
+
+let use_uncontended : 'a @ uncontended -> unit = fun _ -> ()
+
+let use_immutable : 'a @ immutable -> unit = fun _ -> ()
+
+let use_read_write : 'a @ read_write -> unit = fun _ -> ()
+
 type record = { a : int }
 
 type _ eff += Need_ref : int ref eff
@@ -23,6 +33,11 @@ type _ eff += Payload : int ref -> unit eff
 val use_unique : 'a @ unique -> unit = <fun>
 val use_portable : 'a @ portable -> unit = <fun>
 val use_portable_function : (unit -> unit) @ portable -> unit = <fun>
+val use_stateless : 'a @ stateless -> unit = <fun>
+val use_contended : 'a @ contended -> unit = <fun>
+val use_uncontended : 'a -> unit = <fun>
+val use_immutable : 'a @ immutable -> unit = <fun>
+val use_read_write : 'a -> unit = <fun>
 type record = { a : int; }
 type _ eff += Need_ref : int ref eff
 type _ eff += Need_unit : unit eff
@@ -523,4 +538,166 @@ let try_handler_global_capture () =
       continue k ()
 [%%expect {|
 val try_handler_global_capture : unit -> int = <fun>
+|}]
+
+(* A [match] with effect cases forces the enclosing function to be
+   nonportable, even when the result mode-crosses. *)
+let (match_in_portable_function @ portable) () =
+  match () with
+  | () -> ()
+  | effect Need_unit, _ -> ()
+[%%expect {|
+val match_in_portable_function : unit -> unit = <fun>
+|}]
+
+(* A [try] with effect cases forces the enclosing function to be
+   nonportable. *)
+let (try_in_portable_function @ portable) () =
+  try () with
+  | effect Need_unit, _ -> ()
+[%%expect {|
+val try_in_portable_function : unit -> unit = <fun>
+|}]
+
+(* The constraint applies across all enclosing closures: a handler nested in
+   an inner closure makes an outer portable function nonportable. *)
+let (nested_match_in_portable_function @ portable) () =
+  let g () =
+    match () with
+    | () -> ()
+    | effect Need_unit, _ -> ()
+  in
+  g ()
+[%%expect {|
+val nested_match_in_portable_function : unit -> unit = <fun>
+|}]
+
+(* The constraint also applies when the function's portability is an
+   expectation from the context. *)
+let () =
+  use_portable_function
+    (fun () ->
+       match () with
+       | () -> ()
+       | effect Need_unit, _ -> ())
+[%%expect {|
+|}]
+
+(* A [match] with effect cases is allowed in an ordinary, nonportable
+   function. *)
+let match_in_nonportable_function () =
+  match () with
+  | () -> ()
+  | effect Need_unit, _ -> ()
+[%%expect {|
+val match_in_nonportable_function : unit -> unit = <fun>
+|}]
+
+(* A [match] with effect cases forces the enclosing function to be
+   stateful. *)
+let (match_in_stateless_function @ stateless) () =
+  match () with
+  | () -> ()
+  | effect Need_unit, _ -> ()
+[%%expect {|
+val match_in_stateless_function : unit -> unit = <fun>
+|}]
+
+(* A [try] with effect cases forces the enclosing function to be stateful. *)
+let (try_in_stateless_function @ stateless) () =
+  try () with
+  | effect Need_unit, _ -> ()
+[%%expect {|
+val try_in_stateless_function : unit -> unit = <fun>
+|}]
+
+(* An effect continuation is stateful, not stateless. *)
+let () =
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k -> use_stateless k
+[%%expect {|
+Line 4, characters 41-42:
+4 |   | effect Need_unit, k -> use_stateless k
+                                             ^
+Error: This value is "stateful" but is expected to be "stateless".
+|}]
+
+(* An effect payload passed to [perform] must be uncontended. *)
+let contended_payload_to_perform (r @ contended) = perform (Payload r)
+[%%expect {|
+Line 1, characters 68-69:
+1 | let contended_payload_to_perform (r @ contended) = perform (Payload r)
+                                                                        ^
+Error: This value is "contended"
+       but is expected to be "uncontended"
+         because it is contained (via constructor "Payload") in the value at line 1, characters 59-70
+         which is expected to be "uncontended".
+|}]
+
+(* A payload captured by an effect pattern is uncontended and read-write. *)
+let write_captured_payload () =
+  match perform (Payload (ref 0)) with
+  | () -> ()
+  | effect (Payload r), k ->
+      r := 1;
+      continue k ()
+[%%expect {|
+val write_captured_payload : unit -> unit = <fun>
+|}]
+
+(* A contended value may cross the generated handler boundary. *)
+let contended_crosses_handler_boundary (r @ contended) =
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k ->
+      use_contended r;
+      continue k ()
+[%%expect {|
+val contended_crosses_handler_boundary : 'a @ contended -> unit = <fun>
+|}]
+
+(* The continuation may be used as uncontended. *)
+let k_is_uncontended () =
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k ->
+      use_uncontended k;
+      continue k ()
+[%%expect {|
+val k_is_uncontended : unit -> unit = <fun>
+|}]
+
+(* An effect payload passed to [perform] must be read-write. *)
+let immutable_payload_to_perform (r @ immutable) = perform (Payload r)
+[%%expect {|
+Line 1, characters 68-69:
+1 | let immutable_payload_to_perform (r @ immutable) = perform (Payload r)
+                                                                        ^
+Error: This value is "immutable"
+       but is expected to be "read_write"
+         because it is contained (via constructor "Payload") in the value at line 1, characters 59-70
+         which is expected to be "read_write".
+|}]
+
+(* An immutable value may cross the generated handler boundary. *)
+let immutable_crosses_handler_boundary (r @ immutable) =
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k ->
+      use_immutable r;
+      continue k ()
+[%%expect {|
+val immutable_crosses_handler_boundary : 'a @ immutable -> unit = <fun>
+|}]
+
+(* The continuation may be used as read-write. *)
+let k_is_read_write () =
+  match perform Need_unit with
+  | () -> ()
+  | effect Need_unit, k ->
+      use_read_write k;
+      continue k ()
+[%%expect {|
+val k_is_read_write : unit -> unit = <fun>
 |}]

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -547,7 +547,14 @@ let (match_in_portable_function @ portable) () =
   | () -> ()
   | effect Need_unit, _ -> ()
 [%%expect {|
-val match_in_portable_function : unit -> unit = <fun>
+Lines 2-4, characters 2-29:
+2 | ..match () with
+3 |   | () -> ()
+4 |   | effect Need_unit, _ -> ()
+Error: The pattern match with effect cases is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at lines 1-4, characters 44-29
+         which is expected to be "portable".
 |}]
 
 (* A [try] with effect cases forces the enclosing function to be
@@ -556,7 +563,13 @@ let (try_in_portable_function @ portable) () =
   try () with
   | effect Need_unit, _ -> ()
 [%%expect {|
-val try_in_portable_function : unit -> unit = <fun>
+Lines 2-3, characters 2-29:
+2 | ..try () with
+3 |   | effect Need_unit, _ -> ()
+Error: The try-with with effect cases is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at lines 1-3, characters 42-29
+         which is expected to be "portable".
 |}]
 
 (* The constraint applies across all enclosing closures: a handler nested in
@@ -569,7 +582,14 @@ let (nested_match_in_portable_function @ portable) () =
   in
   g ()
 [%%expect {|
-val nested_match_in_portable_function : unit -> unit = <fun>
+Lines 3-5, characters 4-31:
+3 | ....match () with
+4 |     | () -> ()
+5 |     | effect Need_unit, _ -> ()
+Error: The pattern match with effect cases is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at lines 1-7, characters 51-6
+         which is expected to be "portable".
 |}]
 
 (* The constraint also applies when the function's portability is an
@@ -581,6 +601,14 @@ let () =
        | () -> ()
        | effect Need_unit, _ -> ())
 [%%expect {|
+Lines 4-6, characters 7-34:
+4 | .......match () with
+5 |        | () -> ()
+6 |        | effect Need_unit, _ -> ().
+Error: The pattern match with effect cases is "nonportable"
+       but is expected to be "portable"
+         because it is used inside the function at lines 3-6, characters 4-35
+         which is expected to be "portable".
 |}]
 
 (* A [match] with effect cases is allowed in an ordinary, nonportable
@@ -600,7 +628,14 @@ let (match_in_stateless_function @ stateless) () =
   | () -> ()
   | effect Need_unit, _ -> ()
 [%%expect {|
-val match_in_stateless_function : unit -> unit = <fun>
+Lines 2-4, characters 2-29:
+2 | ..match () with
+3 |   | () -> ()
+4 |   | effect Need_unit, _ -> ()
+Error: The pattern match with effect cases is "stateful"
+       but is expected to be "stateless"
+         because it is used inside the function at lines 1-4, characters 46-29
+         which is expected to be "stateless".
 |}]
 
 (* A [try] with effect cases forces the enclosing function to be stateful. *)
@@ -608,7 +643,13 @@ let (try_in_stateless_function @ stateless) () =
   try () with
   | effect Need_unit, _ -> ()
 [%%expect {|
-val try_in_stateless_function : unit -> unit = <fun>
+Lines 2-3, characters 2-29:
+2 | ..try () with
+3 |   | effect Need_unit, _ -> ()
+Error: The try-with with effect cases is "stateful"
+       but is expected to be "stateless"
+         because it is used inside the function at lines 1-3, characters 44-29
+         which is expected to be "stateless".
 |}]
 
 (* An effect continuation is stateful, not stateless. *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -883,8 +883,9 @@ type lookup_error =
         container_class_type : string;
       }
   | Cannot_scrape_alias of Longident.t * Path.t
-  | Local_value_used_in_exclave of Mode.Hint.lock_item * Longident.t
-  | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
+  | Local_value_used_in_exclave of Mode.Hint.pinpoint_desc
+  | Non_value_used_in_object of
+      Mode.Hint.pinpoint_desc * type_expr * Jkind.Violation.t
   | No_unboxed_version of Longident.t * type_declaration
   | Error_from_persistent_env of Persistent_env.error
   | Mutable_value_used_in_closure of Mode.Hint.pinpoint
@@ -3742,7 +3743,7 @@ let const_closure_mode pp {Mode.monadic; comonadic}
   in
   {Mode.monadic; comonadic}
 
-let exclave_mode ~errors ~env ~loc ~item ~lid vmode =
+let exclave_mode ~errors ~env ~pp vmode =
   match
   Mode.Regionality.submode
     (Mode.Value.proj_comonadic Areality vmode)
@@ -3750,13 +3751,13 @@ let exclave_mode ~errors ~env ~loc ~item ~lid vmode =
 with
 | Ok () -> vmode |> Mode.value_to_alloc_r2l |> Mode.alloc_as_value
 | Error _ ->
-    may_lookup_error errors loc env
-      (Local_value_used_in_exclave (item, lid))
+    may_lookup_error errors (fst pp) env
+      (Local_value_used_in_exclave (snd pp))
 
 let region_mode vmode =
   vmode |> Mode.value_to_alloc_r2l |> Mode.alloc_to_value_l2r
 
-let unboxed_type ~errors ~env ~loc ~lid ty =
+let unboxed_type ~errors ~env ~pp ty =
   match ty with
   | None -> ()
   | Some ty ->
@@ -3772,7 +3773,8 @@ let unboxed_type ~errors ~env ~loc ~lid ty =
     with
     | Ok () -> ()
     | Result.Error err ->
-      may_lookup_error errors loc env (Non_value_used_in_object (lid, ty, err))
+      may_lookup_error errors (fst pp) env
+        (Non_value_used_in_object (snd pp, ty, err))
 
 (** Takes the [mode] and [ty] of a value at definition site, walks through the
     list of locks and constrains [mode] and [ty]. Return the access mode of the
@@ -3781,14 +3783,8 @@ let unboxed_type ~errors ~env ~loc ~lid ty =
     [ty] is optional as the function works on modules and classes as well, for
     which [ty] should be [None].
 
-    [pp] overrides the pinpoint used in closure lock errors; it defaults to the
-    identifier being looked up. *)
-let walk_locks ~errors ~env ~loc ?pp ~item ~lid mode ty locks =
-  let pp : Mode.Hint.pinpoint =
-    match pp with
-    | Some pp -> pp
-    | None -> (loc, Ident {category = item; lid})
-  in
+    [pp] is the pinpoint used in errors. *)
+let walk_locks ~errors ~env ~pp mode ty locks =
   List.fold_left
     (fun vmode lock ->
       match lock with
@@ -3798,9 +3794,9 @@ let walk_locks ~errors ~env ~loc ?pp ~item ~lid mode ty locks =
       | Closure_lock (closure_context, comonadic) ->
           closure_mode pp vmode closure_context comonadic
       | Exclave_lock ->
-          exclave_mode ~errors ~env ~loc ~item ~lid vmode
+          exclave_mode ~errors ~env ~pp vmode
       | Unboxed_lock ->
-          unboxed_type ~errors ~env ~loc ~lid ty;
+          unboxed_type ~errors ~env ~pp ty;
           vmode
     ) mode locks
 
@@ -3808,15 +3804,13 @@ let walk_locks ~errors ~env ~loc ?pp ~item ~lid mode ty locks =
     constraining every enclosing closure lock as if a legacy value defined at
     toplevel were used at the pinpoint's location. Used for constructs (e.g.
     effect handlers) that force enclosing functions to be nonportable and
-    stateful. The region, exclave and unboxed locks never constrain a legacy
-    value with no type, so [lid] is never used in errors. *)
+    stateful. *)
 let walk_locks_for_legacy_construct ~env pp =
   let locks = IdTbl.get_all_locks env.values in
   let _stage_locks, locks = partition_locks locks in
   ignore
-    (walk_locks ~errors:true ~env ~loc:(fst pp) ~pp ~item:Value
-       ~lid:(Lident "") (Mode.Value.disallow_right Mode.Value.legacy) None
-       locks
+    (walk_locks ~errors:true ~env ~pp
+       (Mode.Value.disallow_right Mode.Value.legacy) None locks
       : Mode.Value.l)
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
@@ -4539,7 +4533,8 @@ let lookup_class ~errors ~use ~loc lid env =
   in
   let vmode =
     if use then
-      walk_locks ~errors ~loc ~env ~item:Class ~lid clda_mode None locks
+      let pp : Mode.Hint.pinpoint = (loc, Ident {category = Class; lid}) in
+      walk_locks ~errors ~env ~pp clda_mode None locks
     else
       clda_mode
   in
@@ -4687,7 +4682,8 @@ let find_cltype_index id env = find_index_tbl id env.cltypes
 (* Ordinary lookup functions *)
 
 let walk_locks ~env ~loc lid ~item ty (mode, locks) =
-  walk_locks ~errors:true ~loc ~env ~item ~lid mode ty locks
+  let pp : Mode.Hint.pinpoint = (loc, Ident {category = item; lid}) in
+  walk_locks ~errors:true ~env ~pp mode ty locks
 
 let lookup_module_path ?(use=true) ~loc ~load lid env =
   lookup_module_path ~errors:true ~use ~loc ~load lid env
@@ -5097,20 +5093,9 @@ let extract_settable_variables env =
        | Val_ivar _ | Val_mut _ -> name :: acc
        | _ -> acc) None env []
 
-let print_lock_item ppf (item, lid) =
-  match (item : Mode.Hint.lock_item) with
-  | Module ->
-      fprintf ppf "The module %a is"
-        quoted_longident lid
-  | Class ->
-      fprintf ppf "%a is a class, and classes are always"
-        quoted_longident lid
-  | Value ->
-      fprintf ppf "The value %a is"
-        quoted_longident lid
-  | Constructor ->
-      fprintf ppf "The constructor %a is"
-        quoted_longident lid
+let print_pinpoint_desc ppf desc =
+  (Mode.print_pinpoint_desc desc |> Option.get)
+    ~definite:true ~capitalize:true ppf
 
 let print_stage ppf stage =
   if stage = 0 then fprintf ppf "outside any quotations"
@@ -5392,15 +5377,22 @@ let report_lookup_error_doc loc env = function
         "The module %a is an alias for module %a, which %s"
         quoted_longident lid
         (Style.as_inline_code pp_path) p cause
-  | Local_value_used_in_exclave (item, lid) ->
+  | Local_value_used_in_exclave desc ->
       Location.errorf ~loc
-        "%a local, so it cannot be used inside an exclave_"
-        print_lock_item (item, lid)
-  | Non_value_used_in_object (lid, typ, err) ->
+        "%a is local, so it cannot be used inside an exclave_"
+        print_pinpoint_desc desc
+  | Non_value_used_in_object (desc, typ, err) ->
+      (* Identifiers are special-cased to preserve the historical
+         printing of this error. *)
+      let print_subject ppf (desc : Mode.Hint.pinpoint_desc) =
+        match desc with
+        | Ident {lid; _} -> quoted_longident ppf lid
+        | desc -> print_pinpoint_desc ppf desc
+      in
       Location.errorf ~loc
         "%a must have a type of layout value because it is captured by an \
          object.@ %a"
-        quoted_longident lid
+        print_subject desc
         (fun ppf v -> !report_jkind_violation_with_offender
            ~offender:(fun ppf -> !print_type_expr ppf typ)
            env ppf v)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3714,9 +3714,7 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
       path, (mode, locks), a
     end
 
-let closure_mode ~loc ~item ~lid
-  {Mode.monadic; comonadic} closure_context comonadic0 =
-  let pp : Mode.Hint.pinpoint = (loc, Ident {category = item; lid}) in
+let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
   let hint_comonadic : _ Mode.Hint.morph =
     Is_closed_by (Comonadic, {closure = closure_context; closed = pp})
   in
@@ -3732,9 +3730,8 @@ let closure_mode ~loc ~item ~lid
   in
   {Mode.monadic; comonadic}
 
-let const_closure_mode ~loc ~item ~lid {Mode.monadic; comonadic}
+let const_closure_mode pp {Mode.monadic; comonadic}
   closure_context comonadic0 =
-  let pp : Mode.Hint.pinpoint = (loc, Ident {category = item; lid}) in
   Mode.Value.Comonadic.(submode_err pp comonadic
     (of_const ~hint:(Is_used_in closure_context) comonadic0));
   let monadic =
@@ -3782,22 +3779,45 @@ let unboxed_type ~errors ~env ~loc ~lid ty =
     value allowed by the locks.
 
     [ty] is optional as the function works on modules and classes as well, for
-    which [ty] should be [None]. *)
-let walk_locks ~errors ~env ~loc ~item ~lid mode ty locks =
+    which [ty] should be [None].
+
+    [pp] overrides the pinpoint used in closure lock errors; it defaults to the
+    identifier being looked up. *)
+let walk_locks ~errors ~env ~loc ?pp ~item ~lid mode ty locks =
+  let pp : Mode.Hint.pinpoint =
+    match pp with
+    | Some pp -> pp
+    | None -> (loc, Ident {category = item; lid})
+  in
   List.fold_left
     (fun vmode lock ->
       match lock with
       | Region_lock -> region_mode vmode
       | Const_closure_lock (_, closure_context, comonadic) ->
-          const_closure_mode ~loc ~item ~lid vmode closure_context comonadic
+          const_closure_mode pp vmode closure_context comonadic
       | Closure_lock (closure_context, comonadic) ->
-          closure_mode ~loc ~item ~lid vmode closure_context comonadic
+          closure_mode pp vmode closure_context comonadic
       | Exclave_lock ->
           exclave_mode ~errors ~env ~loc ~item ~lid vmode
       | Unboxed_lock ->
           unboxed_type ~errors ~env ~loc ~lid ty;
           vmode
     ) mode locks
+
+(** Registers a use of a construct that is at legacy comonadic modes,
+    constraining every enclosing closure lock as if a legacy value defined at
+    toplevel were used at the pinpoint's location. Used for constructs (e.g.
+    effect handlers) that force enclosing functions to be nonportable and
+    stateful. The region, exclave and unboxed locks never constrain a legacy
+    value with no type, so [lid] is never used in errors. *)
+let walk_locks_for_legacy_construct ~env pp =
+  let locks = IdTbl.get_all_locks env.values in
+  let _stage_locks, locks = partition_locks locks in
+  ignore
+    (walk_locks ~errors:true ~env ~loc:(fst pp) ~pp ~item:Value
+       ~lid:(Lident "") (Mode.Value.disallow_right Mode.Value.legacy) None
+       locks
+      : Mode.Value.l)
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
   and [locks] which is the locks between the declaration and the usage (either

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -884,8 +884,7 @@ type lookup_error =
       }
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_used_in_exclave of Mode.Hint.pinpoint_desc
-  | Non_value_used_in_object of
-      Mode.Hint.pinpoint_desc * type_expr * Jkind.Violation.t
+  | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
   | No_unboxed_version of Longident.t * type_declaration
   | Error_from_persistent_env of Persistent_env.error
   | Mutable_value_used_in_closure of Mode.Hint.pinpoint
@@ -3757,10 +3756,10 @@ with
 let region_mode vmode =
   vmode |> Mode.value_to_alloc_r2l |> Mode.alloc_to_value_l2r
 
-let unboxed_type ~errors ~env ~pp ty =
-  match ty with
+let unboxed_type ~errors ~env ~loc ty_and_lid =
+  match ty_and_lid with
   | None -> ()
-  | Some ty ->
+  | Some (ty, lid) ->
     (* The type is the type of a variable in the environment. It thus is likely
        generic. Despite the fact that instantiated variables work better in
        [constrain_type_jkind] (because they can be assigned more specific
@@ -3773,18 +3772,18 @@ let unboxed_type ~errors ~env ~pp ty =
     with
     | Ok () -> ()
     | Result.Error err ->
-      may_lookup_error errors (fst pp) env
-        (Non_value_used_in_object (snd pp, ty, err))
+      may_lookup_error errors loc env
+        (Non_value_used_in_object (lid, ty, err))
 
 (** Takes the [mode] and [ty] of a value at definition site, walks through the
     list of locks and constrains [mode] and [ty]. Return the access mode of the
     value allowed by the locks.
 
-    [ty] is optional as the function works on modules and classes as well, for
-    which [ty] should be [None].
+    [ty_and_lid] is the type of the value paired with its identifier; it is
+    [None] when the function is used on modules and classes.
 
     [pp] is the pinpoint used in errors. *)
-let walk_locks ~errors ~env ~pp mode ty locks =
+let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
   List.fold_left
     (fun vmode lock ->
       match lock with
@@ -3796,7 +3795,7 @@ let walk_locks ~errors ~env ~pp mode ty locks =
       | Exclave_lock ->
           exclave_mode ~errors ~env ~pp vmode
       | Unboxed_lock ->
-          unboxed_type ~errors ~env ~pp ty;
+          unboxed_type ~errors ~env ~loc:(fst pp) ty_and_lid;
           vmode
     ) mode locks
 
@@ -4683,7 +4682,8 @@ let find_cltype_index id env = find_index_tbl id env.cltypes
 
 let walk_locks ~env ~loc lid ~item ty (mode, locks) =
   let pp : Mode.Hint.pinpoint = (loc, Ident {category = item; lid}) in
-  walk_locks ~errors:true ~env ~pp mode ty locks
+  let ty_and_lid = Option.map (fun ty -> (ty, lid)) ty in
+  walk_locks ~errors:true ~env ~pp mode ty_and_lid locks
 
 let lookup_module_path ?(use=true) ~loc ~load lid env =
   lookup_module_path ~errors:true ~use ~loc ~load lid env
@@ -5381,18 +5381,11 @@ let report_lookup_error_doc loc env = function
       Location.errorf ~loc
         "%a is local, so it cannot be used inside an exclave_"
         print_pinpoint_desc desc
-  | Non_value_used_in_object (desc, typ, err) ->
-      (* Identifiers are special-cased to preserve the historical
-         printing of this error. *)
-      let print_subject ppf (desc : Mode.Hint.pinpoint_desc) =
-        match desc with
-        | Ident {lid; _} -> quoted_longident ppf lid
-        | desc -> print_pinpoint_desc ppf desc
-      in
+  | Non_value_used_in_object (lid, typ, err) ->
       Location.errorf ~loc
         "%a must have a type of layout value because it is captured by an \
          object.@ %a"
-        print_subject desc
+        quoted_longident lid
         (fun ppf v -> !report_jkind_violation_with_offender
            ~offender:(fun ppf -> !print_type_expr ppf typ)
            env ppf v)

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -286,8 +286,9 @@ type lookup_error =
         container_class_type : string
       }
   | Cannot_scrape_alias of Longident.t * Path.t
-  | Local_value_used_in_exclave of Mode.Hint.lock_item * Longident.t
-  | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
+  | Local_value_used_in_exclave of Mode.Hint.pinpoint_desc
+  | Non_value_used_in_object of
+      Mode.Hint.pinpoint_desc * type_expr * Jkind.Violation.t
   | No_unboxed_version of Longident.t * type_declaration
   | Error_from_persistent_env of Persistent_env.error
   | Mutable_value_used_in_closure of Mode.Hint.pinpoint

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -286,6 +286,7 @@ type lookup_error =
         container_class_type : string
       }
   | Cannot_scrape_alias of Longident.t * Path.t
+    (* CR modes: merge into mode error hints. *)
   | Local_value_used_in_exclave of Mode.Hint.pinpoint_desc
   | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
   | No_unboxed_version of Longident.t * type_declaration

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -318,6 +318,13 @@ val walk_locks : env:t -> loc:Location.t -> Longident.t ->
   item:Mode.Hint.lock_item ->
   type_expr option -> mode_with_locks -> Mode.Value.l
 
+(** Registers a use of a construct that is at legacy comonadic modes,
+    constraining every enclosing closure lock as if a legacy value defined at
+    toplevel were used at the pinpoint's location. Used for constructs (e.g.
+    effect handlers) that force enclosing functions to be nonportable and
+    stateful. *)
+val walk_locks_for_legacy_construct : env:t -> Mode.Hint.pinpoint -> unit
+
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * value_description * mode_with_locks

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -287,8 +287,7 @@ type lookup_error =
       }
   | Cannot_scrape_alias of Longident.t * Path.t
   | Local_value_used_in_exclave of Mode.Hint.pinpoint_desc
-  | Non_value_used_in_object of
-      Mode.Hint.pinpoint_desc * type_expr * Jkind.Violation.t
+  | Non_value_used_in_object of Longident.t * type_expr * Jkind.Violation.t
   | No_unboxed_version of Longident.t * type_declaration
   | Error_from_persistent_env of Persistent_env.error
   | Mutable_value_used_in_closure of Mode.Hint.pinpoint

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5176,6 +5176,8 @@ end
 
 let print_pinpoint = Report.print_pinpoint
 
+let print_pinpoint_desc = Report.print_pinpoint_desc
+
 type changes = S.changes
 
 let undo_changes = S.undo_changes

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -325,6 +325,12 @@ module type S = sig
     Hint.pinpoint ->
     (definite:bool -> capitalize:bool -> Fmt.formatter -> unit) option
 
+  (** Same as [print_pinpoint], but prints only the description, without the
+      location. *)
+  val print_pinpoint_desc :
+    Hint.pinpoint_desc ->
+    (definite:bool -> capitalize:bool -> Fmt.formatter -> unit) option
+
   type nonrec 'a simple_error = 'a simple_error
 
   type changes

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -768,6 +768,7 @@ let tuple_pat_mode mode tuple_modes =
   { mode; tuple_modes }
 
 let effect_handler_modes loc pinpoint env expected_mode =
+  Env.walk_locks_for_legacy_construct ~env (loc, pinpoint);
   let env =
     Env.add_const_closure_lock (loc, pinpoint) Value.Comonadic.Const.legacy env
   in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -767,10 +767,10 @@ let tuple_pat_mode mode tuple_modes =
   let tuple_modes = Some (Value.List.disallow_right tuple_modes) in
   { mode; tuple_modes }
 
-let effect_handler_modes loc pinpoint env expected_mode =
-  Env.walk_locks_for_legacy_construct ~env (loc, pinpoint);
+let effect_handler_modes pinpoint env expected_mode =
+  Env.walk_locks_for_legacy_construct ~env pinpoint;
   let env =
-    Env.add_const_closure_lock (loc, pinpoint) Value.Comonadic.Const.legacy env
+    Env.add_const_closure_lock pinpoint Value.Comonadic.Const.legacy env
   in
   env, simple_pat_mode Value.legacy, mode_effect_handler_body mode_legacy,
   mode_effect_handler_body expected_mode
@@ -7278,7 +7278,7 @@ and type_expect_
           in
           env, arg_pat_mode, arg_expected_mode, expected_mode
         | _ :: _ ->
-          effect_handler_modes loc Effect_match env expected_mode
+          effect_handler_modes (loc, Effect_match) env expected_mode
       in
       let arg, sort =
         with_local_level_generalize begin fun () ->
@@ -7332,7 +7332,7 @@ and type_expect_
           expected_mode
         | _ :: _ ->
           let env, arg_mode, _, expected_mode =
-            effect_handler_modes loc Effect_try env expected_mode
+            effect_handler_modes (loc, Effect_try) env expected_mode
           in
           env, arg_mode, expected_mode, expected_mode
       in


### PR DESCRIPTION
To avoid potential unsoundness, type effect pattern-matching as if it was accessing a legacy value at toplevel.

I'm not sure putting `walk_locks_for_legacy_construct` in `Env` is the best approach, but it works.