### PR TITLE
Manipulating variants requires all constructors to have determined layouts 

### DIFF
--- a/testsuite/tests/typing-layouts-err-msg/concrete.ml
+++ b/testsuite/tests/typing-layouts-err-msg/concrete.ml
@@ -44,10 +44,12 @@ Error: Constructor arguments being projected must be representable.
 (* Constructor_arg_assignment *)
 let _ = A (assert false)
 [%%expect {|
-Line 1, characters 10-24:
+Line 1, characters 8-24:
 1 | let _ = A (assert false)
-              ^^^^^^^^^^^^^^
-Error: Constructor arguments must be representable.
+            ^^^^^^^^^^^^^^^^
+Error: The representation of the constructor "A"
+       depends on the layout of its argument,
+       which this instantiation of the type t does not determine.
        The layout of t_any is any
          because of the definition of t_any at line 1, characters 0-16.
        But the layout of t_any must be representable

--- a/testsuite/tests/typing-layouts/any_in_variant.ml
+++ b/testsuite/tests/typing-layouts/any_in_variant.ml
@@ -460,7 +460,7 @@ Line 1, characters 10-14:
               ^^^^
 Error: The representation of the constructor "Gany"
        depends on the layout of the argument of constructor "Gint",
-       which this instantiation of the type int gadt does not determine.
+       which this instantiation of the type 'a gadt does not determine.
        The layout of abstract_any is any
          because of the definition of abstract_any at line 1, characters 0-23.
        But the layout of abstract_any must be representable
@@ -480,11 +480,19 @@ val ok : string g2 = M
 val ok : #(unit# * int) g2 = D <void>
 |}]
 
-(* ... though at an undetermined instantiation, checking [D] pins the
-   instantiation to its result type. *)
+(* ... and an undetermined instantiation is not pinned to [D]'s result type:
+   since [D]'s occurrence is not implied here, it is checked at its own
+   result type, and [m] stays usable at every instantiation. *)
 let m = M
 [%%expect{|
-val m : #('a * int) g2 = M
+val m : ('a : any). 'a g2 = M
+|}]
+
+let _ = (m : string g2)
+let _ = (m : #(unit# * int) g2)
+[%%expect{|
+- : string g2 = M
+- : #(unit# * int) g2 = M
 |}]
 
 (* A constraint pinning the parameter to a type of layout [any] makes the

--- a/testsuite/tests/typing-layouts/any_in_variant.ml
+++ b/testsuite/tests/typing-layouts/any_in_variant.ml
@@ -58,7 +58,7 @@ val of_option : 'a option -> 'a t = <fun>
 
 let nope = Nope
 [%%expect{|
-val nope : ('a : any). 'a t = Nope
+val nope : 'a t = Nope
 |}]
 
 let nope : 'a. 'a t = Nope
@@ -243,4 +243,284 @@ end = struct
 end
 [%%expect{|
 module M : sig type pt = { x : int; y : int; } and t = A of pt# end
+|}]
+
+(******************************)
+(* Requiring representability *)
+
+(* Uses of constructors require the type of the variant to determine
+   representable layouts for *all* constructors, because which constructors are
+   constant, and hence the runtime tags of all constructors, will depend on
+   whether arguments of layout [any] are instantiated to voids. *)
+
+(* An unannotated use is constrained to a sort, which defaults to value *)
+let q = Nope
+let bad = (q : unit# t)
+[%%expect{|
+val q : 'a t = Nope
+Line 2, characters 11-12:
+2 | let bad = (q : unit# t)
+               ^
+Error: This expression has type "'a t" but an expression was expected of type
+         "unit# t"
+       The layout of unit# is void
+         because it is the unboxed version of the primitive type unit.
+       But the layout of unit# must be a value layout
+         because of the definition of q at line 1, characters 8-12.
+|}]
+
+let ok =
+  let q = Nope in
+  (q : unit# t)
+[%%expect{|
+val ok : unit# t = Nope
+|}]
+
+(* Uses at determined instantiations are fine, void or not. *)
+let nope_value : int t = Nope
+let nope_void : unit# t = Nope
+let nope_bits : int64# t = Nope
+[%%expect{|
+val nope_value : int t = Nope
+val nope_void : unit# t = Nope
+val nope_bits : int64# t = Nope
+|}]
+
+(* Error if the representation cannot be representable *)
+let is_nope (type a : any) (t : a t) =
+  match t with Nope -> true | _ -> false
+[%%expect{|
+Line 2, characters 15-19:
+2 |   match t with Nope -> true | _ -> false
+                   ^^^^
+Error: The representation of the constructor "Nope"
+       depends on the layout of the argument of constructor "Yeah",
+       which this instantiation of the type a t does not determine.
+       The layout of a is any
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable
+         because it's the type of a constructor argument being projected.
+|}]
+
+let nope (type a : any) () : a t = Nope
+[%%expect{|
+Line 1, characters 35-39:
+1 | let nope (type a : any) () : a t = Nope
+                                       ^^^^
+Error: The representation of the constructor "Nope"
+       depends on the layout of the argument of constructor "Yeah",
+       which this instantiation of the type a t does not determine.
+       The layout of a is any
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+type abstract_any : any
+let bad = (Nope : abstract_any t)
+[%%expect{|
+type abstract_any : any
+Line 2, characters 11-15:
+2 | let bad = (Nope : abstract_any t)
+               ^^^^
+Error: The representation of the constructor "Nope"
+       depends on the layout of the argument of constructor "Yeah",
+       which this instantiation of the type abstract_any t does not determine.
+       The layout of abstract_any is any
+         because of the definition of abstract_any at line 1, characters 0-23.
+       But the layout of abstract_any must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+(* Matching with a constant-constructor pattern likewise constrains the
+   instantiation to a sort. *)
+let _ = (fun x -> match x with Nope -> true | _ -> false) (Yeah #1L)
+[%%expect{|
+- : bool = false
+|}]
+
+let b =
+  let f x = match x with Nope -> true | _ -> false in
+  f (Yeah #1L)
+[%%expect{|
+val b : bool = false
+|}]
+
+(* Although at the top level it defaults to value *)
+let f x = match x with Nope -> true | _ -> false
+let bad = f (Yeah #1L)
+[%%expect{|
+val f : 'a t -> bool = <fun>
+Line 2, characters 18-21:
+2 | let bad = f (Yeah #1L)
+                      ^^^
+Error: This expression has type "int64#" but an expression was expected of type
+         "('a : value_or_null)"
+       The layout of int64# is bits64
+         because it is the unboxed version of the primitive type int64.
+       But the layout of int64# must be a value layout
+         because of the definition of f at line 1, characters 6-48.
+|}]
+
+(* The requirement applies to all of the variant's constructors, not just
+   constant ones: every constructor's tag depends on the variant's
+   representation. *)
+type ('a : any, 'b : any) two = T1 of 'a | T2 of 'b | T3 of int
+
+let ok = (T3 5 : (unit#, int) two)
+[%%expect{|
+type ('a : any, 'b : any) two = T1 of 'a | T2 of 'b | T3 of int
+val ok : (unit#, int) two = T3 5
+|}]
+
+let bad (type a : any) () : (a, int) two = T3 5
+[%%expect{|
+Line 1, characters 43-47:
+1 | let bad (type a : any) () : (a, int) two = T3 5
+                                               ^^^^
+Error: The representation of the constructor "T3"
+       depends on the layout of the argument of constructor "T1",
+       which this instantiation of the type (a, int) two does not determine.
+       The layout of a is any
+         because of the annotation on the abstract type declaration for a.
+       But the layout of a must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+(* An unannotated use gets sorts that default to value. *)
+let y = T3 5
+[%%expect{|
+val y : ('a, 'b) two = T3 5
+|}]
+let bad = (y : (unit#, int) two)
+[%%expect{|
+Line 1, characters 11-12:
+1 | let bad = (y : (unit#, int) two)
+               ^
+Error: This expression has type "('a, 'b) two"
+       but an expression was expected of type "(unit#, int) two"
+       The layout of unit# is void
+         because it is the unboxed version of the primitive type unit.
+       But the layout of unit# must be a value layout
+         because of the definition of y at line 1, characters 8-12.
+|}]
+
+let match_t3 x = match x with T3 n -> n | _ -> 0
+[%%expect{|
+val match_t3 : ('a, 'b) two -> int = <fun>
+|}]
+
+let match_nope x = match x with Nope -> true | _ -> false
+[%%expect{|
+val match_nope : 'a t -> bool = <fun>
+|}]
+
+(* A GADT constructor's argument layouts must be determined even at
+   instantiations where its result type says it cannot occur: [Gint]'s argument
+   is never representable, so no constructor of [gadt] is usable. *)
+type (_ : any) gadt =
+  | Gint : abstract_any -> int gadt
+  | Gany : 'a gadt
+[%%expect{|
+type (_ : any) gadt = Gint : abstract_any -> int gadt | Gany : 'a gadt
+|}]
+
+let bad = (Gany : string gadt)
+[%%expect{|
+Line 1, characters 11-15:
+1 | let bad = (Gany : string gadt)
+               ^^^^
+Error: The representation of the constructor "Gany"
+       depends on the layout of the argument of constructor "Gint",
+       which this instantiation of the type string gadt does not determine.
+       The layout of abstract_any is any
+         because of the definition of abstract_any at line 1, characters 0-23.
+       But the layout of abstract_any must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+let bad = (Gany : int gadt)
+[%%expect{|
+Line 1, characters 11-15:
+1 | let bad = (Gany : int gadt)
+               ^^^^
+Error: The representation of the constructor "Gany"
+       depends on the layout of the argument of constructor "Gint",
+       which this instantiation of the type int gadt does not determine.
+       The layout of abstract_any is any
+         because of the definition of abstract_any at line 1, characters 0-23.
+       But the layout of abstract_any must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+let bad = Gany
+[%%expect{|
+Line 1, characters 10-14:
+1 | let bad = Gany
+              ^^^^
+Error: The representation of the constructor "Gany"
+       depends on the layout of the argument of constructor "Gint",
+       which this instantiation of the type int gadt does not determine.
+       The layout of abstract_any is any
+         because of the definition of abstract_any at line 1, characters 0-23.
+       But the layout of abstract_any must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+(* By contrast, a GADT constructor whose argument layouts are determined by its
+   own result type does not poison instantiations where it cannot
+   occur... *)
+type (_ : any) g2 = M | D : ('a : any). 'a -> #('a * int) g2
+
+let ok = (M : string g2)
+let ok = (D #() : #(unit# * int) g2)
+[%%expect{|
+type (_ : any) g2 = M | D : ('a : any). 'a -> #('a * int) g2
+val ok : string g2 = M
+val ok : #(unit# * int) g2 = D <void>
+|}]
+
+(* ... though at an undetermined instantiation, checking [D] pins the
+   instantiation to its result type. *)
+let m = M
+[%%expect{|
+val m : #('a * int) g2 = M
+|}]
+
+(* A constraint pinning the parameter to a type of layout [any] makes the
+   argument unrepresentable. *)
+type ('a : any) c = K of 'a | N constraint 'a = abstract_any
+[%%expect{|
+type 'a c = K of 'a | N constraint 'a = abstract_any
+|}]
+
+let bad = (N : abstract_any c)
+[%%expect{|
+Line 1, characters 11-12:
+1 | let bad = (N : abstract_any c)
+               ^
+Error: The representation of the constructor "N"
+       depends on the layout of the argument of constructor "K",
+       which this instantiation of the type abstract_any c does not determine.
+       The layout of abstract_any is any
+         because of the definition of abstract_any at line 1, characters 0-23.
+       But the layout of abstract_any must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+type (_ : any) gadt2 =
+  | Ga : 'a -> 'a gadt2
+  | Gint : int gadt2
+[%%expect{|
+type (_ : any) gadt2 = Ga : 'a -> 'a gadt2 | Gint : int gadt2
+|}]
+
+let ga x = Ga x
+[%%expect{|
+val ga : 'a -> 'a gadt2 = <fun>
+|}]
+
+let gint = Gint
+[%%expect{|
+val gint : int gadt2 = Gint
 |}]

--- a/testsuite/tests/typing-layouts/any_in_variant.ml
+++ b/testsuite/tests/typing-layouts/any_in_variant.ml
@@ -480,19 +480,55 @@ val ok : string g2 = M
 val ok : #(unit# * int) g2 = D <void>
 |}]
 
-(* ... and an undetermined instantiation is not pinned to [D]'s result type:
-   since [D]'s occurrence is not implied here, it is checked at its own
-   result type, and [m] stays usable at every instantiation. *)
+(* ... and an undetermined instantiation is not pinned to [D]'s result type,
+   but is constrained to a sort, since [D]'s representation at refining
+   instantiations depends on it. The sort defaults to value. *)
 let m = M
 [%%expect{|
-val m : ('a : any). 'a g2 = M
+val m : 'a g2 = M
 |}]
 
-let _ = (m : string g2)
-let _ = (m : #(unit# * int) g2)
+let ok = (m : string g2)
 [%%expect{|
-- : string g2 = M
-- : #(unit# * int) g2 = M
+val ok : string g2 = M
+|}]
+
+let bad = (m : #(unit# * int) g2)
+[%%expect{|
+Line 1, characters 11-12:
+1 | let bad = (m : #(unit# * int) g2)
+               ^
+Error: This expression has type "'a g2" but an expression was expected of type
+         "#(unit# * int) g2"
+       The layout of #(unit# * int) is void & value non_pointer
+         because it is an unboxed tuple.
+       But the layout of #(unit# * int) must be a value layout
+         because of the definition of m at line 1, characters 8-9.
+       Note: The layout of immediate is value non_pointer.
+|}]
+
+let ok =
+  let m = M in
+  (m : #(unit# * int) g2)
+[%%expect{|
+val ok : #(unit# * int) g2 = M
+|}]
+
+(* When the instantiation already matches [D]'s result type, the sibling
+   check refines the part [D]'s argument depends on. *)
+let f (x : 'e) = (M : #('e * int) g2)
+[%%expect{|
+val f : 'e -> #('e * int) g2 = <fun>
+|}]
+
+(* An equality-refining sibling pins the parameters together and lowers the
+   shared variable to a sort. *)
+type (_ : any, _ : any) k = K2 | KE : ('a : any). 'a -> ('a, 'a) k
+
+let k2 = K2
+[%%expect{|
+type (_ : any, _ : any) k = K2 | KE : ('a : any). 'a -> ('a, 'a) k
+val k2 : ('a, 'a) k = K2
 |}]
 
 (* A constraint pinning the parameter to a type of layout [any] makes the
@@ -531,4 +567,82 @@ val ga : 'a -> 'a gadt2 = <fun>
 let gint = Gint
 [%%expect{|
 val gint : int gadt2 = Gint
+|}]
+
+(* An existential argument of layout [any] is determined by no instantiation,
+   so every constructor of the variant is unusable. *)
+(* CR layouts: this could be relaxed by giving such a constructor both a
+   constant and a non-constant tag, with each construction choosing by its
+   payload's layout, making [Ex #()] an immediate and [Ex 5] a block. *)
+type ex = Ex : ('a : any). 'a -> ex | Nil
+[%%expect{|
+type ex = Ex : ('a : any). 'a -> ex | Nil
+|}]
+
+let bad = Nil
+[%%expect{|
+Line 1, characters 10-13:
+1 | let bad = Nil
+              ^^^
+Error: The representation of the constructor "Nil"
+       depends on the layout of the argument of constructor "Ex",
+       which this instantiation of the type ex does not determine.
+       The layout of 'a is any
+         because of the definition of ex at line 1, characters 0-41.
+       But the layout of 'a must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+let bad = Ex #()
+[%%expect{|
+Line 1, characters 10-16:
+1 | let bad = Ex #()
+              ^^^^^^
+Error: The representation of the constructor "Ex"
+       depends on the layout of its argument,
+       which this instantiation of the type ex does not determine.
+       The layout of 'a is any
+         because of the definition of ex at line 1, characters 0-41.
+       But the layout of 'a must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+let bad = Ex 5
+[%%expect{|
+Line 1, characters 10-14:
+1 | let bad = Ex 5
+              ^^^^
+Error: The representation of the constructor "Ex"
+       depends on the layout of its argument,
+       which this instantiation of the type ex does not determine.
+       The layout of 'a is any
+         because of the definition of ex at line 1, characters 0-41.
+       But the layout of 'a must be representable
+         because it's the type of a constructor argument being assigned a value.
+|}]
+
+let bad v = match v with Nil -> true | _ -> false
+[%%expect{|
+Line 1, characters 25-28:
+1 | let bad v = match v with Nil -> true | _ -> false
+                             ^^^
+Error: The representation of the constructor "Nil"
+       depends on the layout of the argument of constructor "Ex",
+       which this instantiation of the type ex does not determine.
+       The layout of 'a is any
+         because of the definition of ex at line 1, characters 0-41.
+       But the layout of 'a must be representable
+         because it's the type of a constructor argument being projected.
+|}]
+
+let bad v = match v with Ex _ -> true | Nil -> false
+[%%expect{|
+Line 1, characters 28-29:
+1 | let bad v = match v with Ex _ -> true | Nil -> false
+                                ^
+Error: Constructor arguments being projected must be representable.
+       The layout of $a is any
+         because of the definition of ex at line 1, characters 0-41.
+       But the layout of $a must be representable
+         because it's the type of a constructor argument being projected.
 |}]

--- a/typing/parmatch.mli
+++ b/typing/parmatch.mli
@@ -89,6 +89,11 @@ val complete_constrs :
     constructor_description list ->
     constructor_description list
 
+(** The constructors of the variant type [ty]; fatal error if [ty] is not a
+    variant type. *)
+val get_variant_constructors :
+    Env.t -> type_expr -> constructor_description list
+
 (** [pats_of_type] builds a list of patterns from a given expected type,
     for explosion of wildcard patterns in Typecore.type_pat.
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2848,64 +2848,83 @@ end)
 type unrepresentable_arg =
   Unrepresentable_arg of Warnings.loc * type_expr * Jkind.Violation.t
 
-let require_constructor_instance_representable env constr ~loc ~why
-      ~containing_type =
-  let check_sibling (sibling : Types.constructor_description) =
-    match sibling.cstr_shape with
-    | Some _ -> ()
-    | None ->
+(* The sorts of the arguments of [cstr], a constructor of the variant type
+   [containing_type], when the use of constructor [used_cstr_name] requires
+   them to be determined. If [cstr]'s representation was not determined at
+   its declaration (it has an argument of layout [any]), the sorts are
+   computed at [containing_type] when it is an instance of [cstr]'s result
+   type ([cstr] occurs at this instantiation), and at [cstr]'s own result
+   type otherwise (a GADT constructor that cannot, or need not, occur
+   here). *)
+let constructor_argument_sorts env (cstr : Types.constructor_description)
+      ~containing_type ~why ~loc ~used_cstr_name =
+  match cstr.cstr_shape with
+  | Some _ ->
+      (* Determined at declaration. *)
+      begin match
+        Misc.Stdlib.List.map_option
+          (fun arg -> arg.ca_sort |> Option.map Jkind.Sort.of_const)
+          cstr.cstr_args
+      with
+      | Some sorts -> sorts
+      | None -> Misc.fatal_error "representable constructor missing a sort"
+      end
+  | None ->
       let (ty_args, ty_res, _) =
-        instance_constructor Keep_existentials_flexible sibling
+        instance_constructor Keep_existentials_flexible cstr
       in
-      let snap = Btype.snapshot () in
-      (* Refine the instance by the use-site instantiation when the two are
-         compatible. A GADT constructor whose result type does not match
-         cannot occur at this instantiation, but its arguments are checked
-         at its own result type all the same. *)
-      begin match unify env ty_res containing_type with
-      | () -> ()
-      | exception Unify _ -> Btype.backtrack snap
+      begin match
+        matches ~expand_error_trace:false env containing_type ty_res
+      with
+      | All_good -> unify env ty_res containing_type
+      | Unification_failure _ | Jkind_mismatch _ -> ()
       end;
-      List.iter
+      List.map
         (fun (ca : Types.constructor_argument) ->
            match type_sort ~why ~fixed:false env ca.ca_type with
-           | Ok _ -> ()
+           | Ok sort -> sort
            | Error violation ->
              raise (Error (loc, env,
                Constructor_representation_indeterminate
-                 { cstr_name = constr.cstr_name;
+                 { cstr_name = used_cstr_name;
                    containing_type;
-                   arg_cstr_name = sibling.cstr_name;
+                   arg_cstr_name = cstr.cstr_name;
                    arg_type = ca.ca_type;
                    violation })))
         ty_args
-  in
-  match constr.cstr_repr with
+
+let representation_for_tuple_constructor env constr ty_args ~loc ~types
+      ~containing_type ~why : _ Result.t =
+  (* When some constructor of the variant has an argument of layout [any]
+     ([Cstr_layout_variable]), which constructors are constant — and hence
+     the runtime tags of all of them — can depend on the instantiation, so
+     using any constructor requires every constructor's representation to be
+     determined at [containing_type]. The siblings' sorts are discarded for
+     now; resolving the variant's representation will consume them. *)
+  begin match constr.cstr_repr with
   | Variant_boxed layouts
     when Array.exists
            (function
              | Cstr_layout_variable -> true
              | Cstr_layout_known _ -> false)
            layouts ->
-    List.iter check_sibling
+    List.iter
+      (fun sibling ->
+         ignore
+           (constructor_argument_sorts env sibling ~containing_type ~why
+              ~loc ~used_cstr_name:constr.cstr_name
+            : Jkind.sort list))
       (Parmatch.get_variant_constructors env containing_type)
   | Variant_boxed _ | Variant_unboxed | Variant_with_null
   | Variant_extensible -> ()
-
-let representation_for_tuple_constructor env constr ty_args ~loc ~types
-      ~containing_type ~why : _ Result.t =
-  require_constructor_instance_representable env constr ~loc ~why
-    ~containing_type;
+  end;
+  (* The used constructor's own shape and sorts come from the types of the
+     arguments it is applied to, which can further determine existentials. *)
   match constr.cstr_shape with
   | Some shape ->
-      begin match
-        Misc.Stdlib.List.map_option
-          (fun arg -> arg.ca_sort |> Option.map Jkind.Sort.of_const)
-          constr.cstr_args
-      with
-      | Some sorts -> Ok (shape, sorts)
-      | None -> Misc.fatal_error "representable constructor missing a sort"
-      end
+      Ok (shape,
+          constructor_argument_sorts env constr ~containing_type ~why ~loc
+            ~used_cstr_name:constr.cstr_name)
   | None ->
       begin match
         Misc.Stdlib.List.mapi_result

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -297,6 +297,12 @@ type error =
   | Constructor_arg_value_not_rep of type_expr * Jkind.Violation.t
   | Indeterminate_record_layout of type_expr * string
   | Indeterminate_constructor_layout of type_expr * string * int
+  | Constructor_representation_indeterminate of
+      { cstr_name : string;
+        containing_type : type_expr;
+        arg_cstr_name : string;
+        arg_type : type_expr;
+        violation : Jkind.Violation.t }
   | Invalid_label_for_src_pos of arg_label
   | Nonoptional_call_pos_label of string
   | Unsupported_stack_allocation of unsupported_stack_allocation
@@ -2842,8 +2848,54 @@ end)
 type unrepresentable_arg =
   Unrepresentable_arg of Warnings.loc * type_expr * Jkind.Violation.t
 
+let require_constructor_instance_representable env constr ~loc ~why
+      ~containing_type =
+  let check_sibling (sibling : Types.constructor_description) =
+    match sibling.cstr_shape with
+    | Some _ -> ()
+    | None ->
+      let (ty_args, ty_res, _) =
+        instance_constructor Keep_existentials_flexible sibling
+      in
+      let snap = Btype.snapshot () in
+      (* Refine the instance by the use-site instantiation when the two are
+         compatible. A GADT constructor whose result type does not match
+         cannot occur at this instantiation, but its arguments are checked
+         at its own result type all the same. *)
+      begin match unify env ty_res containing_type with
+      | () -> ()
+      | exception Unify _ -> Btype.backtrack snap
+      end;
+      List.iter
+        (fun (ca : Types.constructor_argument) ->
+           match type_sort ~why ~fixed:false env ca.ca_type with
+           | Ok _ -> ()
+           | Error violation ->
+             raise (Error (loc, env,
+               Constructor_representation_indeterminate
+                 { cstr_name = constr.cstr_name;
+                   containing_type;
+                   arg_cstr_name = sibling.cstr_name;
+                   arg_type = ca.ca_type;
+                   violation })))
+        ty_args
+  in
+  match constr.cstr_repr with
+  | Variant_boxed layouts
+    when Array.exists
+           (function
+             | Cstr_layout_variable -> true
+             | Cstr_layout_known _ -> false)
+           layouts ->
+    List.iter check_sibling
+      (Parmatch.get_variant_constructors env containing_type)
+  | Variant_boxed _ | Variant_unboxed | Variant_with_null
+  | Variant_extensible -> ()
+
 let representation_for_tuple_constructor env constr ty_args ~loc ~types
       ~containing_type ~why : _ Result.t =
+  require_constructor_instance_representable env constr ~loc ~why
+    ~containing_type;
   match constr.cstr_shape with
   | Some shape ->
       begin match
@@ -12867,6 +12919,29 @@ let report_error ~loc env =
         Printtyp.type_expr ty
         cstr_name
         i
+  | Constructor_representation_indeterminate
+      { cstr_name; containing_type; arg_cstr_name; arg_type; violation } ->
+      let report =
+        Jkind.Violation.report_with_offender
+          ~offender:(fun ppf -> Printtyp.type_expr ppf arg_type) env
+      in
+      if String.equal cstr_name arg_cstr_name then
+        Location.errorf ~loc
+          "@[The representation of the constructor %a@ depends on the \
+           layout of its argument,@ which this instantiation of the type \
+           %a does not determine.@]@ %a"
+          Style.inline_code cstr_name
+          Printtyp.type_expr containing_type
+          report violation
+      else
+        Location.errorf ~loc
+          "@[The representation of the constructor %a@ depends on the \
+           layout of the argument of constructor %a,@ which this \
+           instantiation of the type %a does not determine.@]@ %a"
+          Style.inline_code cstr_name
+          Style.inline_code arg_cstr_name
+          Printtyp.type_expr containing_type
+          report violation
   | Invalid_label_for_src_pos arg_label ->
       Location.errorf ~loc
         "A position argument must not be %s."

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2848,6 +2848,27 @@ end)
 type unrepresentable_arg =
   Unrepresentable_arg of Warnings.loc * type_expr * Jkind.Violation.t
 
+(* Unify [ty_res], the result type of a constructor instance, with the
+   use-site type [containing_type] when that leaves [containing_type] alone,
+   as decided by inspecting its variables (cf. [Ctype.matches]). Otherwise
+   the unification is undone — the constructor cannot, or need not, occur at
+   this instantiation — and the variables of [containing_type] it would have
+   instantiated, on whose layouts the constructor's representation depends,
+   are returned. *)
+let refine_constructor_instance env ty_res ~containing_type =
+  let use_site_vars = free_variables containing_type in
+  let snap = Btype.snapshot () in
+  match unify env ty_res containing_type with
+  | exception Unify _ ->
+    Btype.backtrack snap;
+    []
+  | () ->
+    match List.filter (fun v -> not (is_Tvar v)) use_site_vars with
+    | [] -> []
+    | refined ->
+      Btype.backtrack snap;
+      refined
+
 (* The sorts of the arguments of [cstr], a constructor of the variant type
    [containing_type], raising if the use of constructor [used_cstr_name]
    does not determine them. *)
@@ -2885,27 +2906,9 @@ let constructor_argument_sorts env (cstr : Types.constructor_description)
         (fun (ty, _jkind) ->
            ignore (require_sort ~fixed:true ty : Jkind.sort))
         existentials;
-      (* Refine the instance by the use-site instantiation. Like
-         [Ctype.matches], unify and then inspect [containing_type]'s
-         variables, but keep the unification when it left them alone. *)
-      let use_site_vars = free_variables containing_type in
-      let snap = Btype.snapshot () in
-      begin match unify env ty_res containing_type with
-      | exception Unify _ ->
-        (* [cstr] cannot occur at this instantiation. *)
-        Btype.backtrack snap
-      | () ->
-        match List.filter (fun v -> not (is_Tvar v)) use_site_vars with
-        | [] -> ()
-        | refined ->
-          (* The unification made [containing_type] more specific, so
-             [cstr] need not occur here: undo it, but require sorts for the
-             refined variables, on which [cstr]'s representation depends. *)
-          Btype.backtrack snap;
-          List.iter
-            (fun v -> ignore (require_sort ~fixed:false v : Jkind.sort))
-            refined
-      end;
+      List.iter
+        (fun v -> ignore (require_sort ~fixed:false v : Jkind.sort))
+        (refine_constructor_instance env ty_res ~containing_type);
       List.map
         (fun (ca : Types.constructor_argument) ->
            require_sort ~fixed:false ca.ca_type)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -2849,13 +2849,8 @@ type unrepresentable_arg =
   Unrepresentable_arg of Warnings.loc * type_expr * Jkind.Violation.t
 
 (* The sorts of the arguments of [cstr], a constructor of the variant type
-   [containing_type], when the use of constructor [used_cstr_name] requires
-   them to be determined. If [cstr]'s representation was not determined at
-   its declaration (it has an argument of layout [any]), the sorts are
-   computed at [containing_type] when it is an instance of [cstr]'s result
-   type ([cstr] occurs at this instantiation), and at [cstr]'s own result
-   type otherwise (a GADT constructor that cannot, or need not, occur
-   here). *)
+   [containing_type], raising if the use of constructor [used_cstr_name]
+   does not determine them. *)
 let constructor_argument_sorts env (cstr : Types.constructor_description)
       ~containing_type ~why ~loc ~used_cstr_name =
   match cstr.cstr_shape with
@@ -2870,27 +2865,50 @@ let constructor_argument_sorts env (cstr : Types.constructor_description)
       | None -> Misc.fatal_error "representable constructor missing a sort"
       end
   | None ->
-      let (ty_args, ty_res, _) =
+      let (ty_args, ty_res, existentials) =
         instance_constructor Keep_existentials_flexible cstr
       in
-      begin match
-        matches ~expand_error_trace:false env containing_type ty_res
-      with
-      | All_good -> unify env ty_res containing_type
-      | Unification_failure _ | Jkind_mismatch _ -> ()
+      let require_sort ~fixed ty =
+        match type_sort ~why ~fixed env ty with
+        | Ok sort -> sort
+        | Error violation ->
+          raise (Error (loc, env,
+            Constructor_representation_indeterminate
+              { cstr_name = used_cstr_name;
+                containing_type;
+                arg_cstr_name = cstr.cstr_name;
+                arg_type = ty;
+                violation }))
+      in
+      (* An existential's layout is determined by no instantiation. *)
+      List.iter
+        (fun (ty, _jkind) ->
+           ignore (require_sort ~fixed:true ty : Jkind.sort))
+        existentials;
+      (* Refine the instance by the use-site instantiation. Like
+         [Ctype.matches], unify and then inspect [containing_type]'s
+         variables, but keep the unification when it left them alone. *)
+      let use_site_vars = free_variables containing_type in
+      let snap = Btype.snapshot () in
+      begin match unify env ty_res containing_type with
+      | exception Unify _ ->
+        (* [cstr] cannot occur at this instantiation. *)
+        Btype.backtrack snap
+      | () ->
+        match List.filter (fun v -> not (is_Tvar v)) use_site_vars with
+        | [] -> ()
+        | refined ->
+          (* The unification made [containing_type] more specific, so
+             [cstr] need not occur here: undo it, but require sorts for the
+             refined variables, on which [cstr]'s representation depends. *)
+          Btype.backtrack snap;
+          List.iter
+            (fun v -> ignore (require_sort ~fixed:false v : Jkind.sort))
+            refined
       end;
       List.map
         (fun (ca : Types.constructor_argument) ->
-           match type_sort ~why ~fixed:false env ca.ca_type with
-           | Ok sort -> sort
-           | Error violation ->
-             raise (Error (loc, env,
-               Constructor_representation_indeterminate
-                 { cstr_name = used_cstr_name;
-                   containing_type;
-                   arg_cstr_name = cstr.cstr_name;
-                   arg_type = ca.ca_type;
-                   violation })))
+           require_sort ~fixed:false ca.ca_type)
         ty_args
 
 let representation_for_tuple_constructor env constr ty_args ~loc ~types

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -345,6 +345,12 @@ type error =
   | Constructor_arg_value_not_rep of type_expr * Jkind.Violation.t
   | Indeterminate_record_layout of type_expr * string
   | Indeterminate_constructor_layout of type_expr * string * int
+  | Constructor_representation_indeterminate of
+      { cstr_name : string;
+        containing_type : type_expr;
+        arg_cstr_name : string;
+        arg_type : type_expr;
+        violation : Jkind.Violation.t }
   | Invalid_label_for_src_pos of arg_label
   | Nonoptional_call_pos_label of string
   | Unsupported_stack_allocation of unsupported_stack_allocation


### PR DESCRIPTION
**Not ready for review.**

Programs like this currently typecheck:
```ocaml
type ('a : any) t = A of 'a | B
let x : ('a : any). 'a t = B
let f : ('a : any). 'a t -> string = function B -> "b" | _ -> "other"
```

However, this isn't forward-compatible with changing constructors containing an `any`-refined-to-`void` to be immediates, because then, the constructor number of `B` depends on whether `A` contains `void` (as block and immediate constructors are numbered separately). So in that world, `x` and `f` won't be able to be polymorphic over `('a : any)`, and should instead be tied to sort variables.

In this PR, we make it so manipulating a constructor requires the type to imply all sibling constructors have determined representations.

We could relax this to only previous constructors, this leaks more info about the representation of variants into the type system. While it might be too useful to ban forever, we should at least wait until after changing the representation of constructors containing `any`-refined-to-`void` to see how that settles.