### PR TITLE
A few fixes in the last rounds of 5.4 merge conflict resolutions

### DIFF
--- a/testsuite/tests/typing-layouts-bits16/basics.ml
+++ b/testsuite/tests/typing-layouts-bits16/basics.ml
@@ -440,7 +440,7 @@ external f10_9 : (int16#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int16#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -449,7 +449,7 @@ external f10_10 : string -> (int16#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int16#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits32/basics.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics.ml
@@ -446,7 +446,7 @@ external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -455,7 +455,7 @@ external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits32/basics_alpha.ml
@@ -439,7 +439,7 @@ external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -448,7 +448,7 @@ external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int32#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits64/basics.ml
+++ b/testsuite/tests/typing-layouts-bits64/basics.ml
@@ -446,7 +446,7 @@ external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -455,7 +455,7 @@ external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-bits64/basics_alpha.ml
@@ -439,7 +439,7 @@ external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (int64#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -448,7 +448,7 @@ external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (int64#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-bits8/basics.ml
+++ b/testsuite/tests/typing-layouts-bits8/basics.ml
@@ -440,7 +440,7 @@ external f10_9 : (int8#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-23:
 1 | external f10_9 : (int8#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -449,7 +449,7 @@ external f10_10 : string -> (int8#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-34:
 1 | external f10_10 : string -> (int8#[@untagged])  = "foo" "bar";;
                                  ^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-float32/basics.ml
+++ b/testsuite/tests/typing-layouts-float32/basics.ml
@@ -498,7 +498,7 @@ external f10_9 : (float32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-26:
 1 | external f10_9 : (float32#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -507,7 +507,7 @@ external f10_10 : string -> (float32#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-37:
 1 | external f10_10 : string -> (float32#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-float64/basics.ml
+++ b/testsuite/tests/typing-layouts-float64/basics.ml
@@ -503,7 +503,7 @@ external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-24:
 1 | external f10_9 : (float#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -512,7 +512,7 @@ external f10_10 : string -> (float#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-35:
 1 | external f10_10 : string -> (float#[@untagged])  = "foo" "bar";;
                                  ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-or-null/untagged.compilers.reference
+++ b/testsuite/tests/typing-layouts-or-null/untagged.compilers.reference
@@ -1,5 +1,5 @@
 File "untagged.ml", line 15, characters 8-19:
 15 |     :  (int_or_null [@untagged])
              ^^^^^^^^^^^
-Error: Don't know how to untag this type. Only int8, int16, int, and
+Error: Don't know how to untag this type. Only int, and
        other immediate types can be untagged.

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -1164,7 +1164,7 @@ external ext_tuple_arg_with_attr_t : (#(int * bool) [@untagged]) -> int = "foo"
 Line 1, characters 38-51:
 1 | external ext_tuple_arg_with_attr_t : (#(int * bool) [@untagged]) -> int = "foo"
                                           ^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 
@@ -1205,7 +1205,7 @@ external ext_product_arg_with_attr_t : (t_product [@untagged]) -> int = "foo"
 Line 1, characters 40-49:
 1 | external ext_product_arg_with_attr_t : (t_product [@untagged]) -> int = "foo"
                                             ^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 
@@ -1251,7 +1251,7 @@ external ext_tuple_return_with_attr_t :
 Line 2, characters 10-23:
 2 |   int -> (#(int * bool) [@untagged]) = "foo"
               ^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 
@@ -1286,7 +1286,7 @@ external ext_product_return_with_attr_t : int -> (t_product [@untagged]) = "foo"
 Line 1, characters 50-59:
 1 | external ext_product_return_with_attr_t : int -> (t_product [@untagged]) = "foo"
                                                       ^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 
@@ -1354,7 +1354,7 @@ external ext_record_arg_with_attr_t :
 Line 2, characters 3-29:
 2 |   (ext_record_arg_attr_record [@untagged]) -> int = "foo"
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 
@@ -1420,7 +1420,7 @@ external ext_record_return_with_attr_t : int -> (t [@untagged]) = "foo"
 Line 1, characters 49-50:
 1 | external ext_record_return_with_attr_t : int -> (t [@untagged]) = "foo"
                                                      ^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 

--- a/testsuite/tests/typing-layouts-untagged-immediate/basics.ml
+++ b/testsuite/tests/typing-layouts-untagged-immediate/basics.ml
@@ -457,7 +457,7 @@ external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-22:
 1 | external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -466,7 +466,7 @@ external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-33:
 1 | external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
                                  ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-untagged-immediate/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-untagged-immediate/basics_alpha.ml
@@ -452,7 +452,7 @@ external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-22:
 1 | external f10_9 : (int#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -461,7 +461,7 @@ external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-33:
 1 | external f10_10 : string -> (int#[@untagged])  = "foo" "bar";;
                                  ^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-vec128/basics.ml
+++ b/testsuite/tests/typing-layouts-vec128/basics.ml
@@ -442,7 +442,7 @@ external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-26:
 1 | external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -451,7 +451,7 @@ external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-37:
 1 | external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-vec128/basics_alpha.ml
@@ -437,7 +437,7 @@ external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-26:
 1 | external f10_9 : (int64x2#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -446,7 +446,7 @@ external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-37:
 1 | external f10_10 : string -> (int64x2#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-word/basics.ml
+++ b/testsuite/tests/typing-layouts-word/basics.ml
@@ -444,7 +444,7 @@ external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-28:
 1 | external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -453,7 +453,7 @@ external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-39:
 1 | external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts-word/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-word/basics_alpha.ml
@@ -437,7 +437,7 @@ external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 18-28:
 1 | external f10_9 : (nativeint#[@untagged]) -> bool -> string  = "foo" "bar";;
                       ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -446,7 +446,7 @@ external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
 Line 1, characters 29-39:
 1 | external f10_10 : string -> (nativeint#[@untagged])  = "foo" "bar";;
                                  ^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts/erasable_annot.ml
+++ b/testsuite/tests/typing-layouts/erasable_annot.ml
@@ -278,7 +278,7 @@ external f_6 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 16-22:
 1 | external f_6 : (int32#[@untagged]) -> bool -> string  = "foo" "bar";;
                     ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -287,7 +287,7 @@ external f_7 : string -> (int64#[@untagged])  = "foo" "bar";;
 Line 1, characters 26-32:
 1 | external f_7 : string -> (int64#[@untagged])  = "foo" "bar";;
                               ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -360,7 +360,7 @@ external f_6 : (int32'[@untagged]) -> bool -> string  = "foo" "bar";;
 Line 1, characters 16-22:
 1 | external f_6 : (int32'[@untagged]) -> bool -> string  = "foo" "bar";;
                     ^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 
@@ -369,7 +369,7 @@ external f_7 : string -> (int64# int64'#[@untagged])  = "foo" "bar";;
 Line 1, characters 26-40:
 1 | external f_7 : string -> (int64# int64'#[@untagged])  = "foo" "bar";;
                               ^^^^^^^^^^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}];;
 

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -570,7 +570,7 @@ external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@untagged]
 Line 1, characters 40-42:
 1 | external[@layout_poly] id : ('a : any). 'a -> 'a = "%identity" [@@untagged]
                                             ^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 

--- a/testsuite/tests/typing-unboxed/test.ml
+++ b/testsuite/tests/typing-unboxed/test.ml
@@ -636,7 +636,7 @@ external g : (float [@untagged]) -> float = "g" "g_nat";;
 Line 1, characters 14-19:
 1 | external g : (float [@untagged]) -> float = "g" "g_nat";;
                   ^^^^^
-Error: Don't know how to untag this type. Only "int8", "int16", "int", and
+Error: Don't know how to untag this type. Only "int", and
        other immediate types can be untagged.
 |}]
 external h : (int [@unboxed]) -> float = "h" "h_nat";;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7414,19 +7414,20 @@ and type_expect_
       Language_extension.assert_enabled ~loc Layouts Language_extension.Stable;
       type_expect_record ~overwrite Unboxed_product lid_sexp_list opt_sexp
   | Pexp_field(srecord, lid) ->
-      let (record, record_sort, _record_sorts, rmode, label, _, ambiguity,
-           ty_arg, record_repres) =
-        type_label_projection Legacy loc env srecord lid
+      let record, record_sort, _record_sorts, mode, label, _, ambiguity,
+          ty_arg, record_repres =
+        solve_Pexp_field ~label_usage:Env.Projection loc env sexp srecord Legacy
+          lid
       in
       check_project_mutability ~loc:record.exp_loc ~env
-        (Record_field label.lbl_name) label.lbl_mut rmode;
+        (Record_field label.lbl_name) label.lbl_mut mode;
       let is_contained_by : Mode.Hint.is_contained_by =
         { containing = Record (label.lbl_name, Modality);
           container = (record.exp_loc, Expression) }
       in
       let mode =
         apply_left_is_contained_by is_contained_by
-          ~modalities:label.lbl_modalities rmode
+          ~modalities:label.lbl_modalities mode
       in
       let boxing : texp_field_boxing =
         let is_float_boxing =
@@ -7481,9 +7482,10 @@ and type_expect_
         exp_env = env }
   | Pexp_unboxed_field(srecord, lid) ->
       Language_extension.assert_enabled ~loc Layouts Language_extension.Stable;
-      let (record, record_sort, record_sorts, rmode, label, _, ambiguity,
-           ty_arg, record_repres) =
-        type_label_projection Unboxed_product loc env srecord lid
+      let record, record_sort, record_sorts, mode, label, _, ambiguity,
+          ty_arg, record_repres =
+        solve_Pexp_field ~label_usage:Env.Projection loc env sexp srecord
+          Unboxed_product lid
       in
       if Types.is_mutable label.lbl_mut then
         fatal_error
@@ -7494,7 +7496,7 @@ and type_expect_
       in
       let mode =
         apply_left_is_contained_by is_contained_by
-          ~modalities:label.lbl_modalities rmode
+          ~modalities:label.lbl_modalities mode
       in
       let mode = cross_left env ty_arg mode in
       submode ~loc ~env mode expected_mode;
@@ -8441,8 +8443,8 @@ and type_expect_
                     { pexp_desc = Pexp_field (srecord, lid); _ } as sexp, _
                   )
                } ] ->
-          let record, record_sort, rmode, label, ambiguity, ty_arg =
-            solve_Pexp_field ~label_usage:Env.Mutation env sexp srecord
+          let record, record_sort, _, rmode, label, _, ambiguity, ty_arg, _ =
+            solve_Pexp_field ~label_usage:Env.Mutation loc env sexp srecord
               Legacy lid
           in
           Env.mark_label_used Env.Projection label.lbl_uid;
@@ -9514,30 +9516,11 @@ and type_label_access
    label, expected_type, ambiguity)
 
 and solve_Pexp_field
-  : 'rep . label_usage:_ -> _ -> _ -> _ -> 'rep record_form -> _ ->
-    _ * _ * _ * 'rep gen_label_description * _ * _ =
-  fun ~label_usage env sexp srecord form lid ->
-  let (record, record_sort, rmode, label, _, ambiguity) =
-    type_label_access form env srecord label_usage lid
-  in
-  let ty_arg =
-    with_local_level_generalize_structure_if_principal begin fun () ->
-      (* [ty_arg] is the type of field, [ty_res] is the type of record, they
-       could share type variables, which are now instantiated *)
-      let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
-      (* we now link the two record types *)
-      unify_exp ~sexp env record ty_res;
-      ty_arg
-    end
-  in
-  (record, record_sort, rmode, label, ambiguity, ty_arg)
-
-and type_label_projection
-  : 'rep . 'rep record_form -> _ -> _ -> _ -> _ ->
-    _ * _ * _ * _ * 'rep gen_label_description * _ * _ * _ * 'rep
-  = fun record_form loc env srecord lid ->
-  let record, record_sort, mode, label, expected_type, ambiguity =
-    type_label_access record_form env srecord Env.Projection lid
+  : 'rep . label_usage:_ -> _ -> _ -> _ -> _ -> 'rep record_form -> _ ->
+    _ * _ * _ * _ * 'rep gen_label_description * _ * _ * _ * 'rep =
+  fun ~label_usage loc env sexp srecord record_form lid ->
+  let (record, record_sort, rmode, label, expected_type, ambiguity) =
+    type_label_access record_form env srecord label_usage lid
   in
   let ty_arg, record_sorts, record_repres =
     (* XXX Not clear to me why this can't be done in [type_label_access] so that
@@ -9547,10 +9530,10 @@ and type_label_projection
        [Texp_setfield] call does not. *)
     with_local_level_generalize_structure_if_principal begin fun () ->
       (* [ty_arg] is the type of field, [ty_res] is the type of record, they
-         could share type variables, which are now instantiated *)
+       could share type variables, which are now instantiated *)
       let (_, ty_arg, ty_res) = instance_label ~fixed:false label in
       (* we now link the two record types *)
-      unify_exp ~sexp:srecord env record ty_res;
+      unify_exp ~sexp env record ty_res;
       let record_sorts, record_repres =
         (* This redundantly calculates the sort again. But calling
            [type_sort] above let us infer that the type is representable,
@@ -9565,8 +9548,7 @@ and type_label_projection
       ty_arg, record_sorts, record_repres
     end
   in
-  (record, record_sort, record_sorts,
-   Mode.Value.disallow_right mode, label, expected_type,
+  (record, record_sort, record_sorts, rmode, label, expected_type,
    ambiguity, ty_arg, record_repres)
 
 (* Typing format strings for printing or reading.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7414,7 +7414,7 @@ and type_expect_
       Language_extension.assert_enabled ~loc Layouts Language_extension.Stable;
       type_expect_record ~overwrite Unboxed_product lid_sexp_list opt_sexp
   | Pexp_field(srecord, lid) ->
-      let record, record_sort, _record_sorts, mode, label, _, ambiguity,
+      let record, record_sort, _record_sorts, mode, label, ambiguity,
           ty_arg, record_repres =
         solve_Pexp_field ~label_usage:Env.Projection loc env sexp srecord Legacy
           lid
@@ -7482,7 +7482,7 @@ and type_expect_
         exp_env = env }
   | Pexp_unboxed_field(srecord, lid) ->
       Language_extension.assert_enabled ~loc Layouts Language_extension.Stable;
-      let record, record_sort, record_sorts, mode, label, _, ambiguity,
+      let record, record_sort, record_sorts, mode, label, ambiguity,
           ty_arg, record_repres =
         solve_Pexp_field ~label_usage:Env.Projection loc env sexp srecord
           Unboxed_product lid
@@ -8443,7 +8443,7 @@ and type_expect_
                     { pexp_desc = Pexp_field (srecord, lid); _ } as sexp, _
                   )
                } ] ->
-          let record, record_sort, _, rmode, label, _, ambiguity, ty_arg, _ =
+          let record, record_sort, _, rmode, label, ambiguity, ty_arg, _ =
             solve_Pexp_field ~label_usage:Env.Mutation loc env sexp srecord
               Legacy lid
           in
@@ -9517,9 +9517,9 @@ and type_label_access
 
 and solve_Pexp_field
   : 'rep . label_usage:_ -> _ -> _ -> _ -> _ -> 'rep record_form -> _ ->
-    _ * _ * _ * _ * 'rep gen_label_description * _ * _ * _ * 'rep =
+    _ * _ * _ * _ * 'rep gen_label_description * _ * _ * 'rep =
   fun ~label_usage loc env sexp srecord record_form lid ->
-  let (record, record_sort, rmode, label, expected_type, ambiguity) =
+  let (record, record_sort, rmode, label, _expected_type, ambiguity) =
     type_label_access record_form env srecord label_usage lid
   in
   let ty_arg, record_sorts, record_repres =
@@ -9548,7 +9548,7 @@ and solve_Pexp_field
       ty_arg, record_sorts, record_repres
     end
   in
-  (record, record_sort, record_sorts, rmode, label, expected_type,
+  (record, record_sort, record_sorts, rmode, label,
    ambiguity, ty_arg, record_repres)
 
 (* Typing format strings for printing or reading.

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -5612,10 +5612,8 @@ let report_error ~loc = function
         Style.inline_code "nativeint"
   | Cannot_unbox_or_untag_type Untagged ->
       Location.errorf ~loc
-        "Don't know how to untag this type. Only %a, %a, %a, \
+        "Don't know how to untag this type. Only %a, \
          and@ other immediate types can be untagged."
-        Style.inline_code "int8"
-        Style.inline_code "int16"
         Style.inline_code "int"
   | Cannot_unbox_or_untag_type Unpacked ->
       Location.errorf ~loc

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1863,7 +1863,7 @@ let report_error_doc loc env = function
         explanation reason
   | Bad_univar_jkind { name; jkind_info; inferred_jkind } ->
       Location.errorf ~loc
-        "@[<hov>The universal type variable %a was %s to have kind %a.@;%a@]"
+        "The universal type variable %a was %s to have kind %a.@;%a"
         Pprintast.Doc.tyvar name
         (if jkind_info.defaulted then "defaulted" else "declared")
         (Jkind.format env) jkind_info.original_jkind
@@ -1884,9 +1884,9 @@ let report_error_doc loc env = function
         inferred_jkind
   | Mismatched_jkind_annotation { name; explicit_jkind; implicit_jkind } ->
       Location.errorf ~loc
-        "@[<hov>The type variable %a has conflicting kind annotations.@;\
+        "The type variable %a has conflicting kind annotations.@;\
          It has an explicit annotation %a@ \
-         but was already implicitly annotated with %a@]"
+         but was already implicitly annotated with %a"
         Pprintast.Doc.tyvar name
         (Jkind.format env) explicit_jkind
         (Jkind.format env) implicit_jkind
@@ -1906,10 +1906,10 @@ let report_error_doc loc env = function
              Some p -> fprintf ppf "@ %a" (Style.as_inline_code path) p
            | None -> fprintf ppf "") nm
   | Not_an_object ty ->
-      Location.errorf ~loc "@[The type %a@ is not an object type@]"
+      Location.errorf ~loc "The type %a@ is not an object type"
         pp_type ty
   | Repeated_tuple_label l ->
-      Location.errorf ~loc "@[This tuple type has two labels named %a@]"
+      Location.errorf ~loc "This tuple type has two labels named %a"
         Style.inline_code l
   | Unsupported_extension ext ->
       let ext = Language_extension.to_string ext in
@@ -1917,7 +1917,7 @@ let report_error_doc loc env = function
         "The %s extension is disabled@ \
          To enable it, pass the '-extension %s' flag@]" ext ext
   | Polymorphic_optional_param ->
-      Location.errorf ~loc "@[Optional parameters cannot be polymorphic@]"
+      Location.errorf ~loc "Optional parameters cannot be polymorphic"
   | Non_value {vloc; typ; err} ->
     let s =
       match vloc with


### PR DESCRIPTION
This fixes three minor issues in the latest few rounds of typing merge conflict resolutions:

1) #6063 was not correctly merged, leading to inaccurate error messages about `@untagged` on externals involving `int8` or `int16`.
2) Some format strings in `typetexp.ml` were not updated for the new error printing paths
3) Typechecking for record field access in typecore was not merged in what I'd consider the best way. In particular, upstream has added `solve_Pexp_field`, and we have separately added `type_label_projection`. These functions basically serve the same purpose, but the merge kept both and called them in different places. This PR unifies them into one function (picking the upstream name).