### PR TITLE
Use ikind provenance for declaration bound errors

### DIFF
--- a/external/merlin/src/ocaml/typing/axis_lattice.ml
+++ b/external/merlin/src/ocaml/typing/axis_lattice.ml
@@ -187,6 +187,11 @@ let co_sub (a : t) (b : t) : t =
   let r = a land lnot b in
   r lor ((r land chain3_hi_mask) lsr 1)
 
+let imply (a : t) (b : t) : t =
+  let r = lnot a lor b land top in
+  let invalid_chain3_hi_bits = r land chain3_hi_mask land lnot (r lsl 1) in
+  r land lnot invalid_chain3_hi_bits
+
 (* Build a mask from a set of relevant axes. *)
 let of_axis_set (set : Jkind_axis.Axis_set.t) : t =
   let set : int = Obj.magic set in

--- a/external/merlin/src/ocaml/typing/axis_lattice.mli
+++ b/external/merlin/src/ocaml/typing/axis_lattice.mli
@@ -27,6 +27,8 @@ val leq : t -> t -> bool
 
 val co_sub : t -> t -> t
 
+val imply : t -> t -> t
+
 val equal : t -> t -> bool
 
 val hash : t -> int

--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -8836,11 +8836,13 @@ let constrain_decl_jkind env decl jkind =
       Ikind.sub_or_error ~type_equal ~context env
         decl.type_jkind jkind
     with
-    | Ok () as ok -> ok
-    | Error _ as err ->
+    | Ok () -> Ok ()
+    | Error err ->
         match decl.type_manifest with
-        | None -> err
-        | Some ty -> constrain_type_jkind env ty jkind
+        | None -> Error (Ikind.Jkind_error err)
+        | Some ty ->
+          constrain_type_jkind env ty jkind
+          |> Result.map_error (fun err -> Ikind.Jkind_error err)
 
 let exn_constructor_crossing env lid ~args locks =
   let vmode =

--- a/external/merlin/src/ocaml/typing/ctype.mli
+++ b/external/merlin/src/ocaml/typing/ctype.mli
@@ -749,9 +749,9 @@ val type_jkind_and_sort :
    but correct: they are used to implement the module inclusion check, where
    we can be sure that the l-jkind has no undetermined variables. *)
 val check_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 val constrain_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 
 (* Compare two types for equality, with no renaming. This is useful for
    the [type_equal] function that must be passed to certain jkind functions. *)

--- a/external/merlin/src/ocaml/typing/ikind.ml
+++ b/external/merlin/src/ocaml/typing/ikind.ml
@@ -38,6 +38,47 @@ let fresh_unknown_uid () : Types.Uid.t =
   in
   Types.Uid.mk ~current_unit
 
+module Provenance = struct
+  let next_id = ref 0
+
+  let names : Ldd.Name.t list ref = ref []
+
+  let register_doc ~plural ty : Ldd.Name.t =
+    let id = !next_id in
+    next_id := id + 1;
+    let name = Ldd.Name.provenance ~id ~ty ~plural in
+    names := name :: !names;
+    name
+
+  let register_text ~plural text =
+    register_doc ~plural (Format_doc.doc_printf "%s" text)
+
+  let register (ty : Types.type_expr) : Ldd.Name.t =
+    (* A surviving residual for an occurrence reflects only the head
+       constructor's own contribution (the decomposition zeroes anything
+       flowing through a separately-tracked inner type or parameter), so
+       name the head rather than the full type expression: the constructor
+       for [Tconstr], a class-of-types phrase for the built-in shapes. *)
+    let register_type ty =
+      Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
+      |> register_doc ~plural:false
+    in
+    match Types.get_desc ty with
+    | Types.Tarrow _ -> register_text ~plural:true "functions"
+    | Types.Ttuple _ -> register_text ~plural:true "tuples"
+    | Types.Tunboxed_tuple _ -> register_text ~plural:true "unboxed tuples"
+    | Types.Tobject _ -> register_text ~plural:true "objects"
+    | Types.Tvariant _ -> register_text ~plural:true "polymorphic variants"
+    | Types.Tpackage _ -> register_text ~plural:true "first-class modules"
+    | Types.Tconstr (path, _ :: _, _) ->
+      register_type (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
+    | _ -> register_type ty
+
+  let reset () = names := []
+
+  let all_names () = List.rev !names
+end
+
 (** A kind solver specialized to [Types.Ldd] and [Types.type_expr].
 
     The solver computes LDD polynomials of the form base ⊔ Σ_i (arg_i ⊓ coeff_i)
@@ -81,6 +122,7 @@ module Solver = struct
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
+      add_provenance : bool;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -90,28 +132,44 @@ module Solver = struct
   let global_constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t =
     ConstrTbl.create 1
 
-  let create_ctx ~(mode : mode) ~(env : Env.t option)
+  let create_ctx ~(mode : mode) ~(env : Env.t option) ~add_provenance
       ~(lookup_of_env : Env.t -> Path.t -> constr_decl) =
     TyTbl.clear global_ty_to_kind;
     ConstrTbl.clear global_constr_to_coeffs;
     { env;
       lookup_of_env;
       mode;
+      add_provenance;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
+  let reset_for_provenance (ctx : ctx) ~(add_provenance : bool) : ctx =
+    { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
+
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
-    match ctx.mode with
-    | Normal -> Ldd.node_of_var (Ldd.rigid name)
-    | Round_up -> Ldd.const Axis_lattice.top
+    match ctx.mode, name with
+    | Normal, _ | Round_up, Provenance _ -> Ldd.node_of_var (Ldd.rigid name)
+    | Round_up, _ -> Ldd.const Axis_lattice.top
 
   (** A rigid variable corresponding to a type parameter [t]. *)
   let rigid (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
     let param_id = Types.get_id ty in
     rigid_name ctx (Ldd.Name.param param_id)
+
+  let provenance (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
+    rigid_name ctx (Provenance.register ty)
+
+  let provenance_text (ctx : ctx) (text : string) : Ldd.node =
+    rigid_name ctx (Provenance.register_text ~plural:true text)
+
+  let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
+      : Ldd.node =
+    if ctx.add_provenance
+    then Ldd.meet poly (provenance_text ctx (text ()))
+    else poly
 
   let rec type_may_be_circular (ty : Types.type_expr) : bool =
     match Types.get_desc ty with
@@ -165,7 +223,7 @@ module Solver = struct
            [c] are kept rigid to avoid infinite expansion. *)
         let instantiate (name : Ldd.Name.t) : Ldd.node =
           match name with
-          | Param _ | Unknown _ -> rigid_name ctx name
+          | Param _ | Provenance _ | Unknown _ -> rigid_name ctx name
           | KAtom kpath -> (
             match ctx.env with
             | None -> rigid_name ctx name
@@ -278,9 +336,21 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr (ctx : ctx) (path : Path.t) (args : Types.type_expr list) :
-      Ldd.node =
-    let base, coeffs = constr_kind ctx ~min_arity:(List.length args) path in
+  and constr ~self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
+      : Ldd.node =
+    let constr_ctx =
+      if ctx.add_provenance
+      then reset_for_provenance ctx ~add_provenance:false
+      else ctx
+    in
+    let base, coeffs =
+      constr_kind constr_ctx ~min_arity:(List.length args) path
+    in
+    let base =
+      if ctx.add_provenance
+      then Ldd.meet base (provenance ctx self_ty)
+      else base
+    in
     let rec loop acc remaining i =
       if i = Array.length coeffs
       then acc
@@ -422,87 +492,89 @@ module Solver = struct
     (* Compute the ikind polynomial for an arbitrary [type_expr]. This is the
        semantic counterpart of [Jkind.jkind_of_type], but expressed in LDD
        form. *)
-    let kind_poly =
-      (* [ty] is expected to be representative: no links/substs/fields/nil. *)
-      match Types.get_desc ty with
-      | Types.Tvar { name = _name; jkind }
-      | Types.Tunivar { name = _name; jkind } ->
-        (* Keep a rigid param, but cap it by its annotated jkind. *)
-        Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind)
-      | Types.Tconstr (path, args, _abbrev_memo) -> constr ctx path args
-      | Types.Tmod (ty, mod_bounds) ->
-        Ldd.meet
-          (kind ~use_tables:true ctx ty)
-          (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
-      | Types.Ttuple elts ->
-        (* Boxed tuples: immutable_data base + per-element contributions
-           under id modality. *)
-        let base = Ldd.const Axis_lattice.immutable_data in
-        Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
-      | Types.Tunboxed_tuple elts ->
-        (* Unboxed tuples: per-element contributions; shallow axes relevant
-           only for arity = 1. *)
-        Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
-            kind ~use_tables:true ctx t)
-      | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
-        (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
-        Ldd.const Axis_lattice.arrow
-      | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
-      | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
-      | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
-      | Types.Tpoly (ty, univars) ->
-        (* CR ikinds: this is sound but not fully precise.
-          Internal ticket 5746. *)
-        let ty = !instance_poly_for_jkind' univars ty in
-        (* We intentionally skip the principality check here. Enforcing it
-           breaks the stdlib build, and the old env-var escape hatch never had
-           a viable setting in practice. Track removing this workaround as part
-           of internal ticket 5746. *)
-        kind ~check_principality:false ~use_tables:true ctx ty
-      | Types.Tof_kind jkind -> ckind_of_jkind ctx jkind
-      | Types.Tobject _ -> Ldd.const Axis_lattice.object_legacy
-      | Types.Tbox t ->
-        let base = Ldd.const Axis_lattice.mutable_data in
-        Ldd.join base (kind ~use_tables:true ctx t)
-      | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
-      | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
-      | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
-        (* Treat quoted/spliced/evaluated quoted types conservatively as
-           boxed values. *)
-        Ldd.const Axis_lattice.value
-      | Types.Tvariant row ->
-        if Btype.tvariant_not_immediate row
-        then
-          if Btype.static_row row
-          then
-            (* Closed, boxed polymorphic variant: immutable_data base plus
-               per-constructor args. *)
-            let base = Ldd.const Axis_lattice.immutable_data in
-            Btype.fold_row
-              (fun acc ty ->
-                let ty_kind = kind ~use_tables:true ctx ty in
-                Ldd.join acc ty_kind)
-              base row
-          else
-            (* CR ikinds: open rows get conservative non-float value (boxed)
-               intersected with an unknown rigid so the solver treats it as an
-               unknown element. This can be improved. Internal ticket 6205. *)
-            let unknown =
-              rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-            in
-            Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
-        else
-          (* All-constant (immediate) polymorphic variant. *)
-          Ldd.const Axis_lattice.immediate
-      | Types.Tpackage _ ->
-        (* Like open polymorphic variants, model first-class modules as boxed
-           values intersected with an unknown so they behave as not-best. *)
-        let unknown =
-          rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-        in
-        Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
+    let self_provenance poly =
+      if ctx.add_provenance then Ldd.meet poly (provenance ctx ty) else poly
     in
-    kind_poly
+    (* [ty] is expected to be representative: no links/substs/fields/nil.
+       Provenance is attached only to the contribution introduced by this
+       node, not to recursive child contributions. *)
+    match Types.get_desc ty with
+    | Types.Tvar { name = _name; jkind } | Types.Tunivar { name = _name; jkind }
+      ->
+      (* Keep a rigid param, but cap it by its annotated jkind. *)
+      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind))
+    | Types.Tconstr (path, args, _abbrev_memo) ->
+      constr ~self_ty:ty ctx path args
+    | Types.Tmod (ty, mod_bounds) ->
+      Ldd.meet
+        (kind ~use_tables:true ctx ty)
+        (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
+    | Types.Ttuple elts ->
+      (* Boxed tuples: immutable_data base + per-element contributions
+         under id modality. *)
+      let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
+    | Types.Tunboxed_tuple elts ->
+      (* Unboxed tuples: per-element contributions; shallow axes relevant
+         only for arity = 1. *)
+      Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
+          kind ~use_tables:true ctx t)
+    | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
+      (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
+      self_provenance (Ldd.const Axis_lattice.arrow)
+    | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
+    | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
+    | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
+    | Types.Tpoly (ty, univars) ->
+      (* CR ikinds: this is sound but not fully precise.
+        Internal ticket 5746. *)
+      let ty = !instance_poly_for_jkind' univars ty in
+      (* We intentionally skip the principality check here. Enforcing it
+         breaks the stdlib build, and the old env-var escape hatch never had
+         a viable setting in practice. Track removing this workaround as part
+         of internal ticket 5746. *)
+      kind ~check_principality:false ~use_tables:true ctx ty
+    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind ctx jkind)
+    | Types.Tobject _ -> self_provenance (Ldd.const Axis_lattice.object_legacy)
+    | Types.Tbox t ->
+      let base = self_provenance (Ldd.const Axis_lattice.mutable_data) in
+      Ldd.join base (kind ~use_tables:true ctx t)
+    | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
+    | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
+    | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
+      (* Treat quoted/spliced/evaluated quoted types conservatively as
+         boxed values. *)
+      self_provenance (Ldd.const Axis_lattice.value)
+    | Types.Tvariant row ->
+      if Btype.tvariant_not_immediate row
+      then
+        if Btype.static_row row
+        then
+          (* Closed, boxed polymorphic variant: immutable_data base plus
+             per-constructor args. *)
+          let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+          Btype.fold_row
+            (fun acc ty ->
+              let ty_kind = kind ~use_tables:true ctx ty in
+              Ldd.join acc ty_kind)
+            base row
+        else
+          (* CR ikinds: open rows get conservative non-float value (boxed)
+             intersected with an unknown rigid so the solver treats it as an
+             unknown element. This can be improved. Internal ticket 6205. *)
+          let unknown =
+            rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
+          in
+          self_provenance
+            (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
+      else
+        (* All-constant (immediate) polymorphic variant. *)
+        self_provenance (Ldd.const Axis_lattice.immediate)
+    | Types.Tpackage _ ->
+      (* Like open polymorphic variants, model first-class modules as boxed
+         values intersected with an unknown so they behave as not-best. *)
+      let unknown = rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ())) in
+      self_provenance (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
 
   (* Evaluate a ckind in [ctx] and flush pending GFP constraints. *)
   let normalize (kind_poly : Ldd.node) : Ldd.node =
@@ -547,18 +619,252 @@ let pp_axes (axes : Jkind_axis.Axis.packed list) : string =
   |> List.map (fun (Jkind_axis.Axis.Pack ax) -> Jkind_axis.Axis.name ax)
   |> String.concat ", "
 
+let axis_name (Jkind_axis.Axis.Pack ax) = Jkind_axis.Axis.name ax
+
+let pp_axis_name ppf axis = Format_doc.fprintf ppf "%s" (axis_name axis)
+
+let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
+  match axes with
+  | [] -> Format_doc.fprintf ppf "<none>"
+  | [axis] -> pp_axis_name ppf axis
+  | [axis1; axis2] ->
+    Format_doc.fprintf ppf "%a and %a" pp_axis_name axis1 pp_axis_name axis2
+  | _ ->
+    let rec split_last = function
+      | [] -> assert false
+      | [last] -> [], last
+      | x :: xs ->
+        let init, last = split_last xs in
+        x :: init, last
+    in
+    let init, last = split_last axes in
+    Format_doc.fprintf ppf "%a,@ and %a"
+      (Format_doc.pp_print_list
+         ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf ",@ ")
+         pp_axis_name)
+      init pp_axis_name last
+
+let is_bot_poly poly = Axis_lattice.equal (Ldd.round_up poly) Axis_lattice.bot
+
+let axes_in_violation_order ~violating_axes axes =
+  (* Keep only axes that the overall comparison actually failed on, ordered as
+     in [violating_axes]. A fragment residual can be non-top on a non-violating
+     axis because [round_down] under-approximates the symbolic implication, so
+     intersecting here prevents blaming a fragment on an axis the whole
+     comparison passes on. *)
+  List.filter
+    (fun violating_axis ->
+      List.exists (Jkind_axis.Axis.equal violating_axis) axes)
+    violating_axes
+
+type mode_crossing_error =
+  { printing_env : Env.t;
+    super_jkind : Types.jkind_l;
+    sub_poly : Ldd.node;
+    super_poly : Ldd.node;
+    provenance_names : Ldd.Name.t list;
+    violating_axes : Jkind_axis.Axis.packed list
+  }
+
+type subjkind_error =
+  | Jkind_error of Jkind.Violation.t
+  | Mode_crossing_error of mode_crossing_error
+
+let subjkind_error_printing_env = function
+  | Jkind_error _ -> None
+  | Mode_crossing_error { printing_env; _ } -> Some printing_env
+
+let map_jkind_error result =
+  Result.map_error (fun error -> Jkind_error error) result
+
+type provenance_residual =
+  { ty : Format_doc.doc;
+    plural : bool;
+    mode_bounds : Axis_lattice.t;
+    axes : Jkind_axis.Axis.packed list
+  }
+
+let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
+    =
+  (* Deduplicate identical entries (e.g. two fields of type [int ref] under
+     the same bound), keeping first-occurrence order. Entries that merely
+     share a printed name (e.g. two constructor-local existentials both
+     rendered ['a]) can have different requirements and must stay separate. *)
+  let duplicate other =
+    String.equal
+      (Format_doc.asprintf "%a" Format_doc.pp_doc other.ty)
+      (Format_doc.asprintf "%a" Format_doc.pp_doc ty)
+    && Bool.equal other.plural plural
+    && Axis_lattice.equal other.mode_bounds mode_bounds
+    && List.length other.axes = List.length axes
+    && List.for_all
+         (fun axis -> List.exists (Jkind_axis.Axis.equal axis) other.axes)
+         axes
+  in
+  if List.exists duplicate entries then entries else entries @ [entry]
+
+let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+    =
+  let provenance_vars = List.map Ldd.rigid provenance_names in
+  (* For a declaration [type t : bound = rhs], ikind checking compares the
+     inferred ikind polynomial for [rhs] against the polynomial for [bound].
+     When that comparison fails, we recompute [rhs] with provenance variables
+     inserted by meeting a fresh variable into each local contribution. For a
+     contribution [coeff] tagged by provenance variable [p], the error
+     reporting question is:
+
+       What is the largest assignment to [p] that would make this contribution
+       satisfy the required bound?
+
+     This is the right question because the provenance variable stands for the
+     mode-crossing behavior we need from the source type. It gives the least
+     restrictive bound that would still make the original lattice comparison
+     pass.
+
+     We answer the question by first decomposing the provenance-annotated
+     polynomial into an untracked base plus one coefficient per provenance
+     variable. If the base alone does not satisfy [super_poly], then provenance
+     cannot explain the error. Otherwise, for each coefficient [coeff], we need
+     the greatest [h] such that:
+
+       meet coeff h <= super_poly
+
+     This is exactly [Ldd.imply coeff super_poly]. The result may still contain
+     symbolic variables, so we round it down to a conservative concrete mode
+     bound for printing. *)
+  let base, coeffs =
+    Ldd.decompose_into_linear_terms ~universe:provenance_vars sub_poly
+  in
+  match Ldd.leq_with_reason base super_poly with
+  | _ :: _ -> None
+  | [] ->
+    List.combine provenance_names coeffs
+    |> List.filter_map (fun (name, coeff) ->
+        match (name : Ldd.Name.t) with
+        | Atom _ | KAtom _ | Param _ | Unknown _ -> None
+        | Provenance { ty; plural; _ } -> (
+          if is_bot_poly coeff
+          then None
+          else
+            let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
+            let non_top_bounds =
+              Axis_lattice.co_sub Axis_lattice.top mode_bounds
+            in
+            if Axis_lattice.equal non_top_bounds Axis_lattice.bot
+            then None
+            else
+              let axes =
+                non_top_bounds |> Axis_lattice.non_bot_axes
+                |> List.map Axis_lattice.axis_number_to_axis_packed
+                |> axes_in_violation_order ~violating_axes
+              in
+              (* [round_down] under-approximation can leave a residual
+                 non-top only on non-violating axes; such an entry has no
+                 axes left to report. *)
+              match axes with
+              | [] -> None
+              | _ :: _ -> Some { ty; plural; mode_bounds; axes }))
+    |> List.fold_left add_provenance_residual []
+    |> Option.some
+
+let residual_mode_strings { mode_bounds; axes; _ } =
+  (* Restrict the required bounds to the reported axes (the residual can be
+     non-top on other axes; see [axes_in_violation_order]), then let
+     [Typemode] drop implied modes (e.g. [aliased] when [global] is
+     required) the same way jkind annotations are printed. *)
+  let reported =
+    List.fold_left
+      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+      Jkind_axis.Axis_set.empty axes
+  in
+  let restricted =
+    Axis_lattice.join mode_bounds
+      (Axis_lattice.of_axis_set (Jkind_axis.Axis_set.complement reported))
+  in
+  Jkind.Mod_bounds.of_axis_lattice restricted
+  |> Typemode.close_implied_mod_bounds
+  |> Typemode.untransl_mod_bounds ~verbose:false
+  |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
+
+let pp_provenance_residual ppf ({ ty; plural; _ } as residual) =
+  (* Phrase subjects ("mutable fields", "boxed records") are plural noun
+     phrases; type-expression subjects read as singular. *)
+  let verb = if plural then "are" else "is" in
+  let modes = residual_mode_strings residual in
+  Format_doc.fprintf ppf "@[<hov 2>%a %s not mod %a@]" Format_doc.pp_doc ty verb
+    (Format_doc.pp_print_list
+       ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
+       Format_doc.pp_print_string)
+    modes
+
+let pp_provenance_residual_bullets ppf entries =
+  List.iteri
+    (fun i entry ->
+      if i > 0 then Format_doc.fprintf ppf "@;";
+      Format_doc.fprintf ppf "- %a" pp_provenance_residual entry)
+    entries
+
+let pp_type_definition_kind_annotation env ppf super_jkind =
+  Format_doc.fprintf ppf
+    "@[<hov 2>This type definition does not satisfy its kind annotation@ %a,@]"
+    (Jkind.format env) super_jkind
+
+let report_provenance_mode_crossing_error env ppf
+    { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =
+  match
+    provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+  with
+  | None | Some [] -> None
+  | Some [entry] ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because %a.@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual entry)
+  | Some entries ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because@;%a@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual_bullets entries)
+
+let report_mode_crossing_error ~offender ppf err =
+  match report_provenance_mode_crossing_error err.printing_env ppf err with
+  | Some () -> ()
+  | None ->
+    Format_doc.fprintf ppf
+      "@[<v>The mode crossing of %t is not allowed here.@;\
+       @[<hov 2>The inferred kind is not below the required kind along %a.@]@]"
+      offender pp_axis_list_prose err.violating_axes
+
+let report_subjkind_error_with_offender ~offender env ppf = function
+  | Jkind_error err ->
+    Jkind.Violation.report_with_offender ~offender env ppf err
+  | Mode_crossing_error err -> report_mode_crossing_error ~offender ppf err
+
+let report_subjkind_error_with_name ~name env ppf err =
+  report_subjkind_error_with_offender
+    ~offender:(fun ppf -> Format_doc.fprintf ppf "%s" name)
+    env ppf err
+
 let axis_disagreement_reasons (axes : Jkind_axis.Axis.packed list) :
     Jkind.Sub_failure_reason.t list =
   List.map (fun axis -> Jkind.Sub_failure_reason.Axis_disagreement axis) axes
 
-let label_mutability_contribution (lbl : Types.label_declaration) =
-  Ldd.const
-    (match lbl.ld_mutable with
-    | Immutable -> Axis_lattice.immediate
-    | Mutable { atomic = Atomic; _ } -> Axis_lattice.sync_data
-    | Mutable { atomic = Nonatomic; _ } -> Axis_lattice.mutable_data)
+let label_mutability_contribution (ctx : Solver.ctx)
+    (lbl : Types.label_declaration) =
+  match lbl.ld_mutable with
+  (* [immediate] is below every base this is summed into, so omitting it keeps
+     immutable fields out of the untracked part of a provenance residual. *)
+  | Immutable -> Ldd.bot
+  | Mutable { atomic = Atomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () -> "atomic mutable fields")
+      (Ldd.const Axis_lattice.sync_data)
+  | Mutable { atomic = Nonatomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () -> "mutable fields")
+      (Ldd.const Axis_lattice.mutable_data)
 
-let sum_record_label_contributions ~(base : Ldd.node)
+let sum_record_label_contributions ~(ctx : Solver.ctx) ~(base : Ldd.node)
     ~(payload_kind : Types.type_expr -> Ldd.node)
     ~(validate_label : Types.label_declaration -> unit)
     (lbls : Types.label_declaration list) : Ldd.node =
@@ -566,7 +872,7 @@ let sum_record_label_contributions ~(base : Ldd.node)
       validate_label lbl;
       let mask = Axis_lattice.mask_of_modality lbl.ld_modalities in
       Ldd.join
-        (label_mutability_contribution lbl)
+        (label_mutability_contribution ctx lbl)
         (Ldd.meet (Ldd.const mask) (payload_kind lbl.ld_type)))
 
 let no_validation (_ : Types.label_declaration) = ()
@@ -576,6 +882,9 @@ let validate_immutable_unboxed_label (lbl : Types.label_declaration) =
   | Immutable -> ()
   | Mutable _ ->
     failwith "ikind: mutable fields in unboxed records are not supported"
+
+let decl_base_provenance (ctx : Solver.ctx) source poly =
+  Solver.with_provenance_text ctx (fun () -> source) poly
 
 (* Gather constructor-local vars from [tys]. *)
 let collect_type_vars (tys : Types.type_expr list) :
@@ -688,7 +997,8 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
                   | Some bound -> bound
                   | None -> Ldd.const Axis_lattice.top
                 else Solver.node_of_name ctx name)
-            | Ldd.Name.Unknown _ | Ldd.Name.Atom _ | Ldd.Name.KAtom _ ->
+            | Ldd.Name.Unknown _ | Ldd.Name.Provenance _ | Ldd.Name.Atom _
+            | Ldd.Name.KAtom _ ->
               Solver.node_of_name ctx name
           in
           fun ty ->
@@ -697,6 +1007,115 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
       | _ ->
         failwith
           "ikind: expected GADT constructor result to be a type constructor")
+
+let type_decl_allows_any_crossing (decl : Types.type_declaration) =
+  match decl.type_kind with
+  | Types.Type_record (_, _, umc_opt)
+  | Types.Type_record_unboxed_product (_, _, umc_opt)
+  | Types.Type_variant (_, _, umc_opt) ->
+    Option.is_some umc_opt
+  | Types.Type_abstract _ | Types.Type_open -> false
+
+let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
+    Ldd.node =
+  match decl.type_manifest with
+  | Some body_ty -> Solver.kind ~use_tables:true ctx body_ty
+  | None -> (
+    let use_decl_jkind () = Solver.ckind_of_jkind ctx decl.type_jkind in
+    match decl.type_kind with
+    (* For abstract types and allow_any_crossing types, derive the ikind from
+       the jkind annotation instead of computing it from the type declaration's
+       body. *)
+    | _ when type_decl_allows_any_crossing decl -> use_decl_jkind ()
+    | Types.Type_abstract _ | Types.Type_open -> use_decl_jkind ()
+    | Types.Type_record (lbls, rep, _umc_opt) ->
+      let base =
+        let base_lat, source =
+          match rep with
+          | Types.Record_unboxed -> Axis_lattice.immediate, "unboxed records"
+          (* CR box: This will no longer be [non_float] once we update the
+             representation of singleton float64 records *)
+          | _ -> Axis_lattice.immutable_data, "boxed records"
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx source
+      in
+      sum_record_label_contributions ~ctx ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~validate_label:no_validation lbls
+    | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
+      let base =
+        Ldd.const Axis_lattice.immediate
+        |> decl_base_provenance ctx "unboxed records"
+      in
+      sum_record_label_contributions ~ctx ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~validate_label:validate_immutable_unboxed_label lbls
+    | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
+      (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
+         captured by its constructors: nullability/separability and
+         mode-crossing are baked into its representation. We defer to jkinds
+         because ikinds cannot express this today. This deferral can be removed
+         once separability and nullability become layout properties rather than
+         modal axes. *)
+      use_decl_jkind ()
+    | Types.Type_variant (cstrs, rep, _umc_opt) ->
+      (* Choose base: immediate for void-only variants; otherwise immutable. *)
+      let all_args_void =
+        List.for_all
+          (fun (c : Types.constructor_declaration) ->
+            match c.cd_args with
+            | Types.Cstr_tuple args ->
+              List.for_all
+                (fun (arg : Types.constructor_argument) ->
+                  match arg.ca_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                args
+            | Types.Cstr_record lbls ->
+              List.for_all
+                (fun (lbl : Types.label_declaration) ->
+                  match lbl.ld_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                lbls)
+          cstrs
+      in
+      let base =
+        let base_lat, source =
+          match rep with
+          | Types.Variant_unboxed -> Axis_lattice.immediate, "unboxed variants"
+          | _ ->
+            if all_args_void
+            then Axis_lattice.immediate, "enumeration variants"
+            else Axis_lattice.immutable_data, "boxed variants"
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx source
+      in
+      let payload_kind_of_constructor =
+        make_gadt_payload_projector ~decl_params:decl.type_params ctx
+      in
+      let constructor_contrib (c : Types.constructor_declaration) =
+        let payload_kind = payload_kind_of_constructor c in
+        match c.cd_args with
+        | Types.Cstr_tuple args ->
+          Ldd.sum args ~base:Ldd.bot
+            ~f:(fun (arg : Types.constructor_argument) ->
+              let mask = Axis_lattice.mask_of_modality arg.ca_modalities in
+              Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
+        | Types.Cstr_record lbls ->
+          sum_record_label_contributions ~ctx ~base:Ldd.bot ~payload_kind
+            ~validate_label:no_validation lbls
+      in
+      Ldd.sum cstrs ~base ~f:constructor_contrib)
+
+let type_decl_constr_decl (decl : Types.type_declaration) : Solver.constr_decl =
+  let abstract =
+    match decl.type_manifest, decl.type_kind with
+    | None, Types.Type_abstract _ -> not (Jkind.is_best decl.type_jkind)
+    | _ -> false
+  in
+  let kind ctx = type_decl_rhs_kind_poly ctx decl in
+  Solver.Ty { args = decl.type_params; kind; abstract }
 
 (* Lookup function supplied to the solver.
    We prefer a stored ikind (when present) and otherwise recompute from the
@@ -718,144 +1137,9 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
   | type_decl ->
     (* Here we can switch to using the cached ikind or not. *)
     let fallback () =
-      (* When we have no stored ikind, we go to this fallback and compute. *)
-      match type_decl.type_manifest with
-      | Some body_ty ->
-        (* Concrete: compute kind of body. *)
-        let args = type_decl.type_params in
-        let kind : Solver.ckind =
-         fun ctx -> Solver.kind ~use_tables:true ctx body_ty
-        in
-        Solver.Ty { args; kind; abstract = false }
-      | None -> (
-        (* No manifest: may still be "concrete" (record/variant/...).
-           Build ckind. *)
-        let allow_any_crossing =
-          match type_decl.type_kind with
-          | Types.Type_record (_, _, umc_opt)
-          | Types.Type_record_unboxed_product (_, _, umc_opt)
-          | Types.Type_variant (_, _, umc_opt) ->
-            Option.is_some umc_opt
-          | Types.Type_abstract _ | Types.Type_open -> false
-        in
-        let use_decl_jkind ~treat_as_abstract =
-          let kind : Solver.ckind =
-           fun ctx -> Solver.ckind_of_jkind ctx type_decl.type_jkind
-          in
-          Solver.Ty
-            { args = type_decl.type_params; kind; abstract = treat_as_abstract }
-        in
-        match type_decl.type_kind with
-        (* For abstract types and allow_any_crossing types, we derive the
-           ikind from the jkind annotation, instead of computing it from
-           the type declaration's body: *)
-        | _ when allow_any_crossing -> use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_abstract _ ->
-          use_decl_jkind
-            ~treat_as_abstract:(not (Jkind.is_best type_decl.type_jkind))
-        (* For other cases, we compute the ikind from the type definition{} *)
-        | Types.Type_record (lbls, rep, _umc_opt) ->
-          (* Build from components: base (non-float value) + per-label
-             contributions. *)
-          let immutable_base =
-            Ldd.const
-              (match rep with
-              | Types.Record_unboxed -> Axis_lattice.immediate
-              (* CR box: This will no longer be [non_float] once we update the
-                 representation of singleton float64 records *)
-              | _ -> Axis_lattice.immutable_data)
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            sum_record_label_contributions ~base:immutable_base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:no_validation lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base = Ldd.const Axis_lattice.immediate in
-            sum_record_label_contributions ~base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:validate_immutable_unboxed_label lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
-          (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
-             captured by its constructors: nullability/separability and
-             mode-crossing are baked into its representation. We defer to
-             jkinds because ikinds cannot express this today. This deferral
-             can be removed once separability and nullability become layout
-             properties rather than modal axes. *)
-          use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_variant (cstrs, rep, _umc_opt) ->
-          (* Choose base: immediate for void-only variants; sync if any record
-             field is atomic; mutable if any non-atomic mutable field appears;
-             otherwise immutable. *)
-          let all_args_void =
-            List.for_all
-              (fun (c : Types.constructor_declaration) ->
-                match c.cd_args with
-                | Types.Cstr_tuple args ->
-                  List.for_all
-                    (fun (arg : Types.constructor_argument) ->
-                      match arg.ca_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    args
-                | Types.Cstr_record lbls ->
-                  List.for_all
-                    (fun (lbl : Types.label_declaration) ->
-                      match lbl.ld_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    lbls)
-              cstrs
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base_lat0 =
-              match rep with
-              | Types.Variant_unboxed -> Axis_lattice.immediate
-              | _ ->
-                if all_args_void
-                then Axis_lattice.immediate
-                else Axis_lattice.immutable_data
-            in
-            let payload_kind_of_constructor =
-              make_gadt_payload_projector ~decl_params:type_decl.type_params ctx
-            in
-            let constructor_contrib (c : Types.constructor_declaration) =
-              let payload_kind = payload_kind_of_constructor c in
-              match c.cd_args with
-              | Types.Cstr_tuple args ->
-                Ldd.sum args ~base:Ldd.bot
-                  ~f:(fun (arg : Types.constructor_argument) ->
-                    let mask =
-                      Axis_lattice.mask_of_modality arg.ca_modalities
-                    in
-                    Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
-              | Types.Cstr_record lbls ->
-                sum_record_label_contributions ~base:Ldd.bot ~payload_kind
-                  ~validate_label:no_validation lbls
-            in
-            Ldd.sum cstrs ~base:(Ldd.const base_lat0) ~f:constructor_contrib
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_open ->
-          (* Use the stored jkind here in case it is `exn`,
-             which is special. *)
-          use_decl_jkind ~treat_as_abstract:false
-        (*
-           (* This is the code we'd use otherwise *)
-           let kind : Solver.ckind =
-            fun _ctx ->
-             Ldd.const Axis_lattice.nonfloat_value
-           in
-           Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        *)
-        )
+      (* When we have no stored ikind, compute from the declaration through the
+         same RHS builder used for bound diagnostics. *)
+      type_decl_constr_decl type_decl
     in
     (* Prefer a stored constructor ikind if one is present and enabled. *)
     let ikind =
@@ -885,8 +1169,8 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
 
 (* Package the above into a full evaluation context. *)
 let create_ctx ~(mode : Solver.mode) ~(env : Env.t option) =
-  Solver.create_ctx ~mode ~env ~lookup_of_env:(fun env path ->
-      lookup_of_env ~env path)
+  Solver.create_ctx ~mode ~env ~add_provenance:false
+    ~lookup_of_env:(fun env path -> lookup_of_env ~env path)
 
 let normalize ~(env : Env.t option) (jkind : Types.jkind_l) : Ldd.node =
   let ctx = create_ctx ~mode:Solver.Normal ~env in
@@ -959,13 +1243,10 @@ type subcheck_polys =
     fast_path : subcheck_fast_path
   }
 
-(* Compute polynomials for a subcheck:
-   - compute [super] in Normal mode
-   - fast path: if [super] is constant top, no need to compute [sub]
-   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
-   - otherwise, only round up [sub] if [super] is constant *)
-let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
-    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+let compute_bound_polys env (super : ('l2 * 'r2) Types.jkind)
+    ~(lhs_floor : (Solver.ctx -> Ldd.node option) option)
+    ~(lhs : Solver.ctx -> Ldd.node) : subcheck_polys =
+  Provenance.reset ();
   let ctx = create_ctx ~mode:Solver.Normal ~env:(Some env) in
   let super_poly = Solver.ckind_of_jkind ctx super in
   let super_is_constant =
@@ -984,16 +1265,19 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     let floor_fast_path =
       if super_is_constant
       then
-        match Solver.mod_bounds_floor_of_jkind ctx sub with
+        match lhs_floor with
         | None -> None
-        | Some lhs_floor ->
-          let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
-          if
-            Axis_lattice.equal
-              (Ldd.round_up lhs_floor_or_super)
-              Axis_lattice.top
-          then Some lhs_floor
-          else None
+        | Some lhs_floor -> (
+          match lhs_floor ctx with
+          | None -> None
+          | Some lhs_floor ->
+            let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
+            if
+              Axis_lattice.equal
+                (Ldd.round_up lhs_floor_or_super)
+                Axis_lattice.top
+            then Some lhs_floor
+            else None)
       else None
     in
     match floor_fast_path with
@@ -1003,36 +1287,119 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
         fast_path = Lhs_mod_bounds_floor_fast_path
       }
     | None ->
-      let sub_ctx =
+      let lhs_ctx =
         if super_is_constant
         then Solver.reset_for_mode ctx ~mode:Solver.Round_up
         else ctx
       in
-      let sub_poly = Solver.ckind_of_jkind sub_ctx sub in
-      { lhs_for_leq = sub_poly;
+      let lhs_poly = lhs lhs_ctx in
+      { lhs_for_leq = lhs_poly;
         rhs_for_leq = super_poly;
         fast_path = No_fast_path
       }
 
-let sub_jkind_l ?allow_any_crossing ?origin
+(* Compute polynomials for a subcheck:
+   - compute [super] in Normal mode
+   - fast path: if [super] is constant top, no need to compute [sub]
+   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
+   - otherwise, only round up [sub] if [super] is constant *)
+let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
+    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+  compute_bound_polys env super
+    ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
+    ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
+
+let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
+    (bound : Types.jkind_l) : subcheck_polys =
+  compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
+      let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
+      lhs ctx)
+
+let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
+    { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path = _ } =
+  let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
+  match violating_axes with
+  | [] -> Ok ()
+  | _ ->
+    Error
+      (Mode_crossing_error
+         { printing_env;
+           super_jkind;
+           sub_poly;
+           super_poly;
+           provenance_names = Provenance.all_names ();
+           violating_axes
+         })
+
+let subjkind_error_has_provenance_residuals = function
+  | Jkind_error _ -> false
+  | Mode_crossing_error
+      { sub_poly; super_poly; provenance_names; violating_axes; _ } -> (
+    match
+      provenance_residuals ~provenance_names ~violating_axes ~sub_poly
+        ~super_poly
+    with
+    | None | Some [] -> false
+    | Some (_ :: _) -> true)
+
+let same_axis_set axes1 axes2 =
+  let of_list =
+    List.fold_left
+      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+      Jkind_axis.Axis_set.empty
+  in
+  Jkind_axis.Axis_set.equal (of_list axes1) (of_list axes2)
+
+let subjkind_errors_have_same_violating_axes error1 error2 =
+  match error1, error2 with
+  | ( Mode_crossing_error { violating_axes = axes1; _ },
+      Mode_crossing_error { violating_axes = axes2; _ } ) ->
+    same_axis_set axes1 axes2
+  | Jkind_error _, _ | _, Jkind_error _ -> false
+
+let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
+    ~printing_env actual_error make_polys =
+  let fallback error =
+    match fallback_error () with
+    | None -> Error error
+    | Some fallback_error -> Error fallback_error
+  in
+  let provenance_check =
+    match make_polys () with
+    | provenance_polys ->
+      check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind ~printing_env
+        provenance_polys
+    | exception
+        ((Misc.Fatal_error _ | Stack_overflow | Out_of_memory | Sys.Break) as exn)
+      ->
+      raise exn
+    | exception _ -> Ok ()
+  in
+  match provenance_check with
+  | Ok () -> fallback actual_error
+  | Error provenance_error ->
+    if
+      subjkind_errors_have_same_violating_axes actual_error provenance_error
+      && subjkind_error_has_provenance_residuals provenance_error
+    then Error provenance_error
+    else fallback actual_error
+
+let sub_jkind_l ?(allow_any_crossing = false) ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)
     ~(context : Jkind.jkind_context) env (sub : Types.jkind_l)
-    (super : Types.jkind_l) : (unit, Jkind.Violation.t) result =
+    (super : Types.jkind_l) : (unit, subjkind_error) result =
   let open Misc.Stdlib.Monad.Result.Syntax in
   if not (enable_sub_jkind_l && !Clflags.ikinds)
-  then Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
+  then
+    Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env sub super
+    |> map_jkind_error
   else
     (* Check layouts first; if that fails, print both sides with full
        info and return the error. *)
     let* () =
-      match Jkind.sub_layout_or_error ~context env sub super with
-      | Ok () -> Ok ()
-      | Error v -> Error v
+      Jkind.sub_layout_or_error ~context env sub super |> map_jkind_error
     in
-    let allow_any =
-      match allow_any_crossing with Some true -> true | _ -> false
-    in
-    if allow_any
+    if allow_any_crossing
     then (
       (if !Clflags.ikinds_debug
        then
@@ -1040,40 +1407,74 @@ let sub_jkind_l ?allow_any_crossing ?origin
          Format.eprintf "[ikind-subjkind] call%s allow_any=true@." origin_suffix);
       Ok ())
     else
-      let { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
-        compute_subcheck_polys ~context env sub super
-      in
-      let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
-      (if !Clflags.ikinds_debug
-       then
-         let origin_suffix = origin_suffix_of origin in
-         let fast_path =
-           match fast_path with
-           | No_fast_path -> "none"
-           | Rhs_top_fast_path -> "rhs_top"
-           | Lhs_mod_bounds_floor_fast_path -> "lhs_mod_bounds_floor"
-         in
-         Format.eprintf
-           "[ikind-subjkind] call%s allow_any=false fast_path=%s@;\
-            @;\
-            sub_poly=%s@;\
-            super_poly=%s@."
-           origin_suffix fast_path (Ldd.pp sub_poly) (Ldd.pp super_poly));
-      match violating_axes with
-      | [] -> Ok ()
-      | _ ->
-        let () =
-          if !Clflags.ikinds_debug
-          then
-            let axes = pp_axes violating_axes in
-            Format.eprintf "[ikind-subjkind] failure on axes: %s@." axes
+      let subcheck_polys = compute_subcheck_polys ~context env sub super in
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:sub ~super_jkind:super
+          ~printing_env:env subcheck_polys
+      with
+      | Ok () -> Ok ()
+      | Error ikind_error -> (
+        if !Clflags.ikinds_debug
+        then Error ikind_error
+        else
+          match
+            Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env sub
+              super
+          with
+          | Ok () -> Error ikind_error
+          | Error jkind_error -> Error (Jkind_error jkind_error))
+
+let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs =
+  if not (enable_sub_jkind_l && !Clflags.ikinds)
+  then
+    sub_jkind_l ~allow_any_crossing ?origin ~type_equal ~context env actual
+      bound
+  else
+    let open Misc.Stdlib.Monad.Result.Syntax in
+    let* () =
+      Jkind.sub_layout_or_error ~context env actual bound |> map_jkind_error
+    in
+    if allow_any_crossing
+    then Ok ()
+    else
+      let actual_polys = compute_subcheck_polys ~context env actual bound in
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:actual ~super_jkind:bound
+          ~printing_env:env actual_polys
+      with
+      | Ok () -> Ok ()
+      | Error actual_error ->
+        let fallback_error () =
+          match
+            Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env
+              actual bound
+          with
+          | Ok () ->
+            let violating_axes =
+              match actual_error with
+              | Mode_crossing_error { violating_axes; _ } -> violating_axes
+              | Jkind_error _ -> []
+            in
+            let axis_reasons = axis_disagreement_reasons violating_axes in
+            Some
+              (Jkind_error
+                 (Jkind.Violation.of_ ~context env
+                    (Jkind.Violation.Not_a_subjkind (actual, bound, axis_reasons))))
+          | Error jkind_error -> Some (Jkind_error jkind_error)
         in
-        (* Do not try to adjust allowances; Violation.Not_a_subjkind
-           accepts an r-jkind. *)
-        let axis_reasons = axis_disagreement_reasons violating_axes in
-        Error
-          (Jkind.Violation.of_ ~context env
-             (Jkind.Violation.Not_a_subjkind (sub, super, axis_reasons)))
+        best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
+          ~super_jkind:bound ~printing_env:env actual_error (fun () ->
+            compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
+
+let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
+  check_bound ?origin ~type_equal ~context env ~actual ~bound
+    ~provenance_lhs:(fun ctx -> Solver.kind ~use_tables:true ctx ty)
+
+let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
+    ~decl ~actual ~bound =
+  check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =
@@ -1308,6 +1709,7 @@ let substitute_decl_ikind_with_lookup
     and map_name (expanding : Path.Set.t) (name : Ldd.Name.t) : Ldd.node =
       match name with
       | Param _ -> Ldd.node_of_var (Ldd.rigid name)
+      | Provenance _ -> Ldd.node_of_var (Ldd.rigid name)
       | Unknown _ -> Ldd.node_of_var (Ldd.rigid name)
       | KAtom path -> (
         match lookup_jkind path with

--- a/external/merlin/src/ocaml/typing/ikind.mli
+++ b/external/merlin/src/ocaml/typing/ikind.mli
@@ -21,6 +21,24 @@ val type_declaration_ikind_of_jkind :
   Types.jkind_l ->
   Types.type_ikind
 
+type mode_crossing_error
+
+type subjkind_error =
+  | Jkind_error of Jkind.Violation.t
+  | Mode_crossing_error of mode_crossing_error
+
+val subjkind_error_printing_env : subjkind_error -> Env.t option
+
+val report_subjkind_error_with_offender :
+  offender:(Format_doc.formatter -> unit) ->
+  Env.t ->
+  Format_doc.formatter ->
+  subjkind_error ->
+  unit
+
+val report_subjkind_error_with_name :
+  name:string -> Env.t -> Format_doc.formatter -> subjkind_error -> unit
+
 val sub_jkind_l :
   ?allow_any_crossing:bool ->
   ?origin:string ->
@@ -29,7 +47,28 @@ val sub_jkind_l :
   Env.t ->
   Types.jkind_l ->
   Types.jkind_l ->
-  (unit, Jkind.Violation.t) result
+  (unit, subjkind_error) result
+
+val check_type_expr_bound :
+  ?origin:string ->
+  type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
+  context:Jkind.jkind_context ->
+  Env.t ->
+  ty:Types.type_expr ->
+  actual:Types.jkind_l ->
+  bound:Types.jkind_l ->
+  (unit, subjkind_error) result
+
+val check_type_decl_bound :
+  ?allow_any_crossing:bool ->
+  ?origin:string ->
+  type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
+  context:Jkind.jkind_context ->
+  Env.t ->
+  decl:Types.type_declaration ->
+  actual:Types.jkind_l ->
+  bound:Types.jkind_l ->
+  (unit, subjkind_error) result
 
 val crossing_of_jkind :
   context:Jkind.jkind_context ->

--- a/external/merlin/src/ocaml/typing/includecore.ml
+++ b/external/merlin/src/ocaml/typing/includecore.ml
@@ -434,7 +434,7 @@ type type_mismatch =
   | Extensible_representation of position
   | With_null_representation of position
   | Fixed_representation of position
-  | Jkind of Jkind.Violation.t
+  | Jkind of Ikind.subjkind_error
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 type jkind_mismatch =
@@ -856,8 +856,13 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a fixed representation while the other varies"
   | Jkind v ->
-      Jkind.Violation.report_with_name ~name:first
-        env ppf v
+      let report () =
+        Ikind.report_subjkind_error_with_name ~name:first env ppf v
+      in
+      (match Ikind.subjkind_error_printing_env v with
+       | None -> report ()
+       | Some printing_env ->
+         Printtyp.wrap_printing_env ~error:true printing_env report)
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,@[<v 2>%a@]"
       (fun ppf (first, second, mismatch) ->

--- a/external/merlin/src/ocaml/typing/includecore.mli
+++ b/external/merlin/src/ocaml/typing/includecore.mli
@@ -144,7 +144,7 @@ type type_mismatch =
   | Extensible_representation of position
   | With_null_representation of position
   | Fixed_representation of position
-  | Jkind of Jkind.Violation.t
+  | Jkind of Ikind.subjkind_error
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 type jkind_mismatch =

--- a/external/merlin/src/ocaml/typing/jkind.ml
+++ b/external/merlin/src/ocaml/typing/jkind.ml
@@ -25,6 +25,8 @@ let print_type_expr : type_expr Fmt.printer ref = ref (fun _ _ -> assert false)
 
 let set_print_type_expr p = print_type_expr := p
 
+let format_type_expr ppf ty = !print_type_expr ppf ty
+
 let raw_type_expr : (Format.formatter -> type_expr -> unit) ref =
   ref (fun _ _ -> assert false)
 

--- a/external/merlin/src/ocaml/typing/jkind.mli
+++ b/external/merlin/src/ocaml/typing/jkind.mli
@@ -736,6 +736,8 @@ val set_printtyp_path : (Format_doc.formatter -> Path.t -> unit) -> unit
     module. *)
 val set_print_type_expr : Types.type_expr Format_doc.printer -> unit
 
+val format_type_expr : Types.type_expr Format_doc.printer
+
 (** Provides the [raw_type_expr] formatter back up the dependency chain to this
     module. *)
 val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit

--- a/external/merlin/src/ocaml/typing/jkind_axis.ml
+++ b/external/merlin/src/ocaml/typing/jkind_axis.ml
@@ -149,6 +149,15 @@ module Axis = struct
       (* CR-soon zqian: call [Mode.Crossing.Axis.all] for modal axes *)
       Pack (Nonmodal Externality) ]
 
+  let equal (Pack axis1) (Pack axis2) =
+    match axis1, axis2 with
+    | Modal axis1, Modal axis2 ->
+      let axis1 = Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis1) in
+      let axis2 = Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis2) in
+      Int.equal (Mode.Modality.Axis.compare axis1 axis2) 0
+    | Nonmodal Externality, Nonmodal Externality -> true
+    | Modal _, Nonmodal _ | Nonmodal _, Modal _ -> false
+
   let name (type a) : a t -> string = function
     | Modal ax ->
       let (P ax) =

--- a/external/merlin/src/ocaml/typing/jkind_axis.mli
+++ b/external/merlin/src/ocaml/typing/jkind_axis.mli
@@ -71,6 +71,8 @@ module Axis : sig
 
   val all : packed list
 
+  val equal : packed -> packed -> bool
+
   val name : _ t -> string
 end
 

--- a/external/merlin/src/ocaml/typing/ldd.ml
+++ b/external/merlin/src/ocaml/typing/ldd.ml
@@ -352,6 +352,43 @@ module Make (V : Ordered) = struct
     then meet_with_leaf b a
     else meet' a b
 
+  let top_var (node : node) : var option =
+    if is_leaf node then None else Some (Unsafe.node_block node).v
+
+  let min_top_var (a : node) (b : node) : var =
+    match top_var a, top_var b with
+    | None, None -> invalid_arg "Ldd.imply: expected a non-leaf node"
+    | Some v, None | None, Some v -> v
+    | Some v1, Some v2 -> if compare_var v1 v2 <= 0 then v1 else v2
+
+  let rec split_on_var (v : var) (node0 : node) : node * node =
+    if is_leaf node0
+    then node0, node0
+    else
+      let block = Unsafe.node_block node0 in
+      let order = compare_var v block.v in
+      if order < 0
+      then node0, node0
+      else if order = 0
+      then block.lo, join block.lo block.hi
+      else
+        let lo_bot, lo_top = split_on_var v block.lo in
+        let hi_bot, hi_top = split_on_var v block.hi in
+        node block.v ~lo:lo_bot ~hi:hi_bot, node block.v ~lo:lo_top ~hi:hi_top
+
+  let rec imply_rec (a : node) (b : node) : node =
+    if a == b || a == bot || b == top
+    then top
+    else if is_leaf a && is_leaf b
+    then leaf (Axis_lattice.imply (Unsafe.leaf_value a) (Unsafe.leaf_value b))
+    else
+      let v = min_top_var a b in
+      let a_bot, a_top = split_on_var v a in
+      let b_bot, b_top = split_on_var v b in
+      let h_top = imply_rec a_top b_top in
+      let h_bot = meet (imply_rec a_bot b_bot) h_top in
+      node v ~lo:h_bot ~hi:h_top
+
   (* --------- public constructors --------- *)
   let[@inline] const (c : Axis_lattice.t) = leaf c
 
@@ -465,7 +502,7 @@ module Make (V : Ordered) = struct
     canonicalize ~hi:(inline_solved_vars a) ~lo:(inline_solved_vars b)
 
   let solve_lfp (var : var) (rhs_raw : node) : unit =
-    (* Solve the least fixpoint equation var := rhs_raw. 
+    (* Solve the least fixpoint equation var := rhs_raw.
        The rhs in general contains the var itself, and the
        fixpoint solution is var := rhs_raw[var := bot].
        We must also inline solved vars, because var itself
@@ -475,12 +512,12 @@ module Make (V : Ordered) = struct
     | Rigid _ -> invalid_arg "solve_lfp: rigid variable"
     | Solved _ -> invalid_arg "solve_lfp: solved variable"
     | Unsolved ->
-      (* For efficiency, we use assign_bot_inline to 
+      (* For efficiency, we use assign_bot_inline to
          simultaneously inline solved vars and assign bot. *)
       var.state <- Solved (assign_bot_inline ~var rhs_raw)
 
   let solve_gfp (var : var) (rhs_raw : node) : unit =
-    (* Solve the greatest fixpoint equation var := rhs_raw. 
+    (* Solve the greatest fixpoint equation var := rhs_raw.
        The rhs in general contains the var itself, and the
        fixpoint solution is var := rhs_raw[var := top].
        We must also inline solved vars, because var itself
@@ -490,7 +527,7 @@ module Make (V : Ordered) = struct
     | Rigid _ -> invalid_arg "solve_gfp: rigid variable"
     | Solved _ -> invalid_arg "solve_gfp: solved variable"
     | Unsolved ->
-      (* gfp's are less performance critical, so we use two 
+      (* gfp's are less performance critical, so we use two
          separate steps to inline solved vars and assign top. *)
       let rhs_forced = inline_solved_vars rhs_raw in
       var.state <- Solved (assign_top ~var rhs_forced)
@@ -506,6 +543,10 @@ module Make (V : Ordered) = struct
     List.iter (fun (var, rhs_raw) -> solve_gfp var rhs_raw) pending
 
   let solve_pending () : unit = solve_pending_gfps ()
+
+  let imply (a : node) (b : node) : node =
+    solve_pending ();
+    imply_rec (inline_solved_vars a) (inline_solved_vars b)
 
   (** Decompose into linear terms over [universe]. *)
   let decompose_into_linear_terms ~(universe : var list) (n : node) =
@@ -528,6 +569,11 @@ module Make (V : Ordered) = struct
     solve_pending ();
     let node = inline_solved_vars node in
     up0 node
+
+  let round_down (node : node) =
+    solve_pending ();
+    let node = inline_solved_vars node in
+    down0 node
 
   let is_const (node : node) : bool =
     let node = inline_solved_vars node in

--- a/external/merlin/src/ocaml/typing/ldd_intf.ml
+++ b/external/merlin/src/ocaml/typing/ldd_intf.ml
@@ -41,10 +41,13 @@ module type S = sig
 
   val node_of_var : var -> node
 
-  (** Boolean algebra over nodes. *)
+  (** Lattice operations over nodes. *)
   val join : node -> node -> node
 
   val meet : node -> node -> node
+
+  (** [imply a b] is the greatest [h] such that [meet a h <= b]. *)
+  val imply : node -> node -> node
 
   val sum : 'a list -> base:node -> f:('a -> node) -> node
 
@@ -70,6 +73,8 @@ module type S = sig
   val leq_with_reason : node -> node -> Jkind_axis.Axis.packed list
 
   val round_up : node -> Axis_lattice.t
+
+  val round_down : node -> Axis_lattice.t
 
   val is_const : node -> bool
 

--- a/external/merlin/src/ocaml/typing/typedecl.ml
+++ b/external/merlin/src/ocaml/typing/typedecl.ml
@@ -115,8 +115,8 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of Env.t * type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Env.t * Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of Env.t * type_expr * Ikind.subjkind_error
+  | Jkind_mismatch_of_path of Env.t * Path.t * Ikind.subjkind_error
   | Jkind_mismatch_due_to_bad_inference of
       Env.t * type_expr * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of
@@ -232,7 +232,10 @@ let constrain_or_null_payload ~env ~path payload_ty payload_loc =
   match Ctype.constrain_type_jkind env payload_ty required with
   | Ok () -> ()
   | Error err ->
-    raise (Error (payload_loc, Jkind_mismatch_of_type (env, payload_ty, err)))
+    raise
+      (Error
+         ( payload_loc,
+           Jkind_mismatch_of_type (env, payload_ty, Ikind.Jkind_error err) ))
 
 (* [make_params] creates sort variables - these can be defaulted away (as in
    transl_type_decl) or unified with existing sort-variable-free types (as in
@@ -1732,15 +1735,16 @@ let narrow_to_manifest_jkind env loc path decl =
         let type_equal = Ctype.type_equal env in
         let context = Ctype.mk_jkind_context_always_principal env in
         (match
-           Ikind.sub_jkind_l
+           Ikind.check_type_expr_bound
              ~origin:(Format.asprintf
                         "typedecl:manifest_vs_decl %a"
                         Location.print_loc decl.type_loc)
              ~type_equal
              ~context
              env
-             manifest_jkind
-             decl.type_jkind
+             ~ty
+             ~actual:manifest_jkind
+             ~bound:decl.type_jkind
          with
          | Ok () -> ()
          | Error v ->
@@ -1763,7 +1767,10 @@ let narrow_to_manifest_jkind env loc path decl =
                Format.eprintf
                  "[ikind-narrow] path=%a branch=constrain_type_jkind error@."
                  (Format_doc.compat Path.print) path;
-             raise (Error (loc, Jkind_mismatch_of_type (env, ty, v))))
+             raise
+               (Error
+                  (loc,
+                   Jkind_mismatch_of_type (env, ty, Jkind_error v))))
     end;
     let type_ikind =
       Ikind.type_declaration_ikind_gated ~env:(Some env) ~path
@@ -2782,7 +2789,10 @@ let rec update_decl_jkind env dpath decl =
   with
   | Ok () -> new_decl
   | Error err ->
-    raise (Error (decl.type_loc, Jkind_mismatch_of_path (env, dpath, err)))
+    raise
+      (Error
+         (decl.type_loc,
+          Jkind_mismatch_of_path (env, dpath, Jkind_error err)))
 
 let update_decls_jkind_reason decls =
   List.map
@@ -3589,7 +3599,7 @@ let normalize_decl_jkinds env decls =
       match
         (* CR layouts v2.8: Consider making a function that doesn't compute
            histories for this use-case, which doesn't need it. *)
-        Ikind.sub_jkind_l
+        Ikind.check_type_decl_bound
           ~origin:(Format.asprintf
                      "typedecl:normalize %a (%a)"
                      (Format_doc.compat Path.print) path
@@ -3598,8 +3608,9 @@ let normalize_decl_jkinds env decls =
           ~context
           ~allow_any_crossing
           env
-          decl.type_jkind
-          original_decl.type_jkind
+          ~decl
+          ~actual:decl.type_jkind
+          ~bound:original_decl.type_jkind
       with
       | Ok _ ->
         if allow_any_crossing then
@@ -5771,14 +5782,24 @@ let report_error ~loc = function
       fprintf ppf "type %a" Style.inline_code path_end
     in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
-        env ppf v)
+      let report () =
+        Ikind.report_subjkind_error_with_offender ~offender env ppf v
+      in
+      match Ikind.subjkind_error_printing_env v with
+      | None -> report ()
+      | Some printing_env ->
+        Printtyp.wrap_printing_env ~error:true printing_env report)
   | Jkind_mismatch_of_type (env, ty, v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
-        env ppf v)
+      let report () =
+        Ikind.report_subjkind_error_with_offender ~offender env ppf v
+      in
+      match Ikind.subjkind_error_printing_env v with
+      | None -> report ()
+      | Some printing_env ->
+        Printtyp.wrap_printing_env ~error:true printing_env report)
   | Jkind_sort {env; kloc; typ; err} ->
     let s =
       match kloc with

--- a/external/merlin/src/ocaml/typing/typedecl.mli
+++ b/external/merlin/src/ocaml/typing/typedecl.mli
@@ -213,8 +213,8 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of Env.t * type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Env.t * Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of Env.t * type_expr * Ikind.subjkind_error
+  | Jkind_mismatch_of_path of Env.t * Path.t * Ikind.subjkind_error
   | Jkind_mismatch_due_to_bad_inference of
       Env.t * type_expr * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of

--- a/external/merlin/src/ocaml/typing/typemode.ml
+++ b/external/merlin/src/ocaml/typing/typemode.ml
@@ -160,19 +160,18 @@ end
    [global] must imply [aliased] for soundness of borrowing. *)
 let implied_modalities (Atom (ax, a) : Modality.atom) : Modality.atom list =
   match[@warning "-18"] ax, a with
-  | Comonadic Areality, Meet_const a ->
-    let f, y, u =
-      match a with
-      | Global ->
-        ( Forkable.Const.Forkable,
-          Yielding.Const.Unyielding,
-          [Uniqueness.Const.Aliased] )
-      | Local -> Forkable.Const.Unforkable, Yielding.Const.Yielding, []
-      | Regional -> assert false
-    in
-    [ Modality.Atom (Comonadic Forkable, Meet_const f);
-      Atom (Comonadic Yielding, Meet_const y) ]
-    @ List.map (fun x -> Modality.Atom (Monadic Uniqueness, Join_const x)) u
+  | Comonadic Areality, Meet_const a -> (
+    match a with
+    | Global ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Forkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Unyielding);
+        Atom (Monadic Uniqueness, Join_const Uniqueness.Const.Aliased) ]
+    | Local ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Unforkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Yielding) ]
+    (* [regional] cannot be written in an annotation, but bounds computed by
+       the ikind engine can reach here. It implies nothing. *)
+    | Regional -> [])
   | Monadic Visibility, Join_const a ->
     let b : Contention.Const.t =
       match a with
@@ -377,7 +376,13 @@ let least_modalities ~include_implied ~mut (t : Modality.Const.t) =
     List.filter_map
       (fun (Modality.Atom (ax, m_implied)) ->
         let m_projected = Modality.Const.proj ax t in
-        if m_projected <> m_implied || include_implied
+        let already_listed =
+          List.exists
+            (fun (Modality.Atom (ax', _)) ->
+              Modality.Axis.P ax' = Modality.Axis.P ax)
+            exclude_implied
+        in
+        if (m_projected <> m_implied || include_implied) && not already_listed
         then Some (Modality.Atom (ax, m_projected))
         else None)
       implied
@@ -676,6 +681,38 @@ let transl_mod_bounds ?(warn = true) annots =
   in
   let crossing = Crossing.modality modality Crossing.max in
   create crossing ~externality, (nonmodal.nullability, nonmodal.separability)
+
+let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
+    =
+  (* Bounds computed axis-by-axis (as in ikind provenance reporting) lack the
+     implied bounds that [transl_mod_bounds] inserts for user-written
+     annotations, e.g. [aliased forkable unyielding] for [global].
+     [untransl_mod_bounds] relies on those implications being present in order
+     to omit the implied modes when printing, so close the bounds first. *)
+  let crossing = Jkind.Mod_bounds.crossing bounds in
+  let modality = Crossing.to_modality crossing in
+  let annotated = Modality.Const.diff Modality.Const.id modality in
+  let implied = List.concat_map implied_modalities annotated in
+  let axis_is_explicit ax =
+    let projected =
+      Modality.Const.set ax (Modality.Const.proj ax modality) Modality.Const.id
+    in
+    match Modality.Const.equate projected Modality.Const.id with
+    | Ok () -> false
+    | Error _ -> true
+  in
+  let crossing =
+    List.fold_left
+      (fun crossing (Modality.Atom (ax, a)) ->
+        (* As in [transl_mod_bounds], an explicit bound on an axis wins over
+           a bound implied by another axis. *)
+        if axis_is_explicit ax
+        then crossing
+        else
+          Crossing.modality (Modality.Const.set ax a Modality.Const.id) crossing)
+      crossing implied
+  in
+  Jkind.Mod_bounds.set_crossing crossing bounds
 
 let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
     Parsetree.modes =

--- a/external/merlin/src/ocaml/typing/typemode.mli
+++ b/external/merlin/src/ocaml/typing/typemode.mli
@@ -81,6 +81,13 @@ val transl_mod_bounds :
   * (Jkind_axis.Nullability.t Location.loc option
     * Jkind_axis.Separability.t Location.loc option)
 
+(** Close mod-bounds under implied modalities, as [transl_mod_bounds] does for
+    user-written annotations (e.g. a [global] bound also bounds [aliased],
+    [forkable] and [unyielding]). Bounds computed axis-by-axis may lack these
+    implications, which [untransl_mod_bounds] relies on to omit implied modes
+    when printing. *)
+val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
+
 (** Translate an algebraic representation of mod bounds into user syntax. If
     [verbose] is true, redundant annotations are included. *)
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes

--- a/external/merlin/src/ocaml/typing/types.ml
+++ b/external/merlin/src/ocaml/typing/types.ml
@@ -28,6 +28,11 @@ module Rigid_name = struct
         }
     | KAtom of Path.t
     | Param of int
+    | Provenance of
+        { id : int;
+          ty : Format_doc.doc;
+          plural : bool
+        }
     | Unknown of unknown_id
 
   let compare a b =
@@ -40,13 +45,16 @@ module Rigid_name = struct
         if h != 0 then h else Int.compare a1.arg_index a2.arg_index
       | KAtom p1, KAtom p2 -> Path.compare p1 p2
       | Param x, Param y -> Int.compare x y
+      | Provenance x, Provenance y -> Int.compare x.id y.id
       | Atom _, _ -> -1
       | _, Atom _ -> 1
       | KAtom _, _ -> -1
       | _, KAtom _ -> 1
+      | Param _, _ -> -1
+      | _, Param _ -> 1
+      | Provenance _, _ -> -1
+      | _, Provenance _ -> 1
       | Unknown x, Unknown y -> Shape.Uid.compare x y
-      | Unknown _, _ -> 1
-      | _, Unknown _ -> -1
 
   let to_string = function
     | Atom { constr; arg_index } ->
@@ -56,6 +64,8 @@ module Rigid_name = struct
       let path_s = Format_doc.asprintf "%a" Path.print path in
       Printf.sprintf "katom[%s]" path_s
     | Param i -> Printf.sprintf "param[%d]" i
+    | Provenance { id; ty; plural = _ } ->
+      Format_doc.asprintf "provenance[%d:%a]" id Format_doc.pp_doc ty
     | Unknown id ->
       Format.asprintf "unknown[%a]" Shape.Uid.print id
 
@@ -64,6 +74,8 @@ module Rigid_name = struct
   let katom path = KAtom path
 
   let param i = Param i
+
+  let provenance ~id ~ty ~plural = Provenance { id; ty; plural }
 
   let unknown uid = Unknown uid
 end

--- a/external/merlin/src/ocaml/typing/types.mli
+++ b/external/merlin/src/ocaml/typing/types.mli
@@ -111,6 +111,20 @@ module Rigid_name : sig
         (** [Param id] only occurs in formulas for type constructors. Refers to
             a type-parameter of the constructor, where [id] is the
             [Types.get_id] of the type variable representing the parameter. *)
+    | Provenance of
+        { id : int;
+          (** Identifies this provenance occurrence. *)
+
+          ty : Format_doc.doc;
+          (** The type expression or descriptive noun phrase, retained as a
+              formatting document so its line-breaking instructions survive
+              until the diagnostic is printed. *)
+
+          plural : bool
+          (** Whether [ty] is a plural noun phrase rather than a type. *)
+        }
+        (** A diagnostic-only provenance variable. These variables must not
+            appear in stored [type_ikind]s. *)
     | Unknown of unknown_id
         (** An unknown quantity with a given id. Used to model not-best in
             ikinds. This is used when we couldn't compute a precise ikind,
@@ -127,6 +141,8 @@ module Rigid_name : sig
   val katom : Path.t -> t
 
   val param : int -> t
+
+  val provenance : id:int -> ty:Format_doc.doc -> plural:bool -> t
 
   val unknown : Shape.Uid.t -> t
 

--- a/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.ml
@@ -187,6 +187,11 @@ let co_sub (a : t) (b : t) : t =
   let r = a land lnot b in
   r lor ((r land chain3_hi_mask) lsr 1)
 
+let imply (a : t) (b : t) : t =
+  let r = lnot a lor b land top in
+  let invalid_chain3_hi_bits = r land chain3_hi_mask land lnot (r lsl 1) in
+  r land lnot invalid_chain3_hi_bits
+
 (* Build a mask from a set of relevant axes. *)
 let of_axis_set (set : Jkind_axis.Axis_set.t) : t =
   let set : int = Obj.magic set in

--- a/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/axis_lattice.mli
@@ -27,6 +27,8 @@ val leq : t -> t -> bool
 
 val co_sub : t -> t -> t
 
+val imply : t -> t -> t
+
 val equal : t -> t -> bool
 
 val hash : t -> int

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -8804,11 +8804,13 @@ let constrain_decl_jkind env decl jkind =
       Ikind.sub_or_error ~type_equal ~context env
         decl.type_jkind jkind
     with
-    | Ok () as ok -> ok
-    | Error _ as err ->
+    | Ok () -> Ok ()
+    | Error err ->
         match decl.type_manifest with
-        | None -> err
-        | Some ty -> constrain_type_jkind env ty jkind
+        | None -> Error (Ikind.Jkind_error err)
+        | Some ty ->
+          constrain_type_jkind env ty jkind
+          |> Result.map_error (fun err -> Ikind.Jkind_error err)
 
 let exn_constructor_crossing env lid ~args locks =
   let vmode =

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.mli
@@ -744,9 +744,9 @@ val type_jkind_and_sort :
    but correct: they are used to implement the module inclusion check, where
    we can be sure that the l-jkind has no undetermined variables. *)
 val check_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 val constrain_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 
 (* Compare two types for equality, with no renaming. This is useful for
    the [type_equal] function that must be passed to certain jkind functions. *)

--- a/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
@@ -38,6 +38,47 @@ let fresh_unknown_uid () : Types.Uid.t =
   in
   Types.Uid.mk ~current_unit
 
+module Provenance = struct
+  let next_id = ref 0
+
+  let names : Ldd.Name.t list ref = ref []
+
+  let register_doc ~plural ty : Ldd.Name.t =
+    let id = !next_id in
+    next_id := id + 1;
+    let name = Ldd.Name.provenance ~id ~ty ~plural in
+    names := name :: !names;
+    name
+
+  let register_text ~plural text =
+    register_doc ~plural (Format_doc.doc_printf "%s" text)
+
+  let register (ty : Types.type_expr) : Ldd.Name.t =
+    (* A surviving residual for an occurrence reflects only the head
+       constructor's own contribution (the decomposition zeroes anything
+       flowing through a separately-tracked inner type or parameter), so
+       name the head rather than the full type expression: the constructor
+       for [Tconstr], a class-of-types phrase for the built-in shapes. *)
+    let register_type ty =
+      Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
+      |> register_doc ~plural:false
+    in
+    match Types.get_desc ty with
+    | Types.Tarrow _ -> register_text ~plural:true "functions"
+    | Types.Ttuple _ -> register_text ~plural:true "tuples"
+    | Types.Tunboxed_tuple _ -> register_text ~plural:true "unboxed tuples"
+    | Types.Tobject _ -> register_text ~plural:true "objects"
+    | Types.Tvariant _ -> register_text ~plural:true "polymorphic variants"
+    | Types.Tpackage _ -> register_text ~plural:true "first-class modules"
+    | Types.Tconstr (path, _ :: _, _) ->
+      register_type (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
+    | _ -> register_type ty
+
+  let reset () = names := []
+
+  let all_names () = List.rev !names
+end
+
 (** A kind solver specialized to [Types.Ldd] and [Types.type_expr].
 
     The solver computes LDD polynomials of the form base ⊔ Σ_i (arg_i ⊓ coeff_i)
@@ -81,6 +122,7 @@ module Solver = struct
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
+      add_provenance : bool;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -90,28 +132,44 @@ module Solver = struct
   let global_constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t =
     ConstrTbl.create 1
 
-  let create_ctx ~(mode : mode) ~(env : Env.t option)
+  let create_ctx ~(mode : mode) ~(env : Env.t option) ~add_provenance
       ~(lookup_of_env : Env.t -> Path.t -> constr_decl) =
     TyTbl.clear global_ty_to_kind;
     ConstrTbl.clear global_constr_to_coeffs;
     { env;
       lookup_of_env;
       mode;
+      add_provenance;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
+  let reset_for_provenance (ctx : ctx) ~(add_provenance : bool) : ctx =
+    { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
+
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
-    match ctx.mode with
-    | Normal -> Ldd.node_of_var (Ldd.rigid name)
-    | Round_up -> Ldd.const Axis_lattice.top
+    match ctx.mode, name with
+    | Normal, _ | Round_up, Provenance _ -> Ldd.node_of_var (Ldd.rigid name)
+    | Round_up, _ -> Ldd.const Axis_lattice.top
 
   (** A rigid variable corresponding to a type parameter [t]. *)
   let rigid (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
     let param_id = Types.get_id ty in
     rigid_name ctx (Ldd.Name.param param_id)
+
+  let provenance (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
+    rigid_name ctx (Provenance.register ty)
+
+  let provenance_text (ctx : ctx) (text : string) : Ldd.node =
+    rigid_name ctx (Provenance.register_text ~plural:true text)
+
+  let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
+      : Ldd.node =
+    if ctx.add_provenance
+    then Ldd.meet poly (provenance_text ctx (text ()))
+    else poly
 
   let rec type_may_be_circular (ty : Types.type_expr) : bool =
     match Types.get_desc ty with
@@ -165,7 +223,7 @@ module Solver = struct
            [c] are kept rigid to avoid infinite expansion. *)
         let instantiate (name : Ldd.Name.t) : Ldd.node =
           match name with
-          | Param _ | Unknown _ -> rigid_name ctx name
+          | Param _ | Provenance _ | Unknown _ -> rigid_name ctx name
           | KAtom kpath -> (
             match ctx.env with
             | None -> rigid_name ctx name
@@ -278,9 +336,21 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr (ctx : ctx) (path : Path.t) (args : Types.type_expr list) :
-      Ldd.node =
-    let base, coeffs = constr_kind ctx ~min_arity:(List.length args) path in
+  and constr ~self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
+      : Ldd.node =
+    let constr_ctx =
+      if ctx.add_provenance
+      then reset_for_provenance ctx ~add_provenance:false
+      else ctx
+    in
+    let base, coeffs =
+      constr_kind constr_ctx ~min_arity:(List.length args) path
+    in
+    let base =
+      if ctx.add_provenance
+      then Ldd.meet base (provenance ctx self_ty)
+      else base
+    in
     let rec loop acc remaining i =
       if i = Array.length coeffs
       then acc
@@ -422,87 +492,89 @@ module Solver = struct
     (* Compute the ikind polynomial for an arbitrary [type_expr]. This is the
        semantic counterpart of [Jkind.jkind_of_type], but expressed in LDD
        form. *)
-    let kind_poly =
-      (* [ty] is expected to be representative: no links/substs/fields/nil. *)
-      match Types.get_desc ty with
-      | Types.Tvar { name = _name; jkind }
-      | Types.Tunivar { name = _name; jkind } ->
-        (* Keep a rigid param, but cap it by its annotated jkind. *)
-        Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind)
-      | Types.Tconstr (path, args, _abbrev_memo) -> constr ctx path args
-      | Types.Tmod (ty, mod_bounds) ->
-        Ldd.meet
-          (kind ~use_tables:true ctx ty)
-          (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
-      | Types.Ttuple elts ->
-        (* Boxed tuples: immutable_data base + per-element contributions
-           under id modality. *)
-        let base = Ldd.const Axis_lattice.immutable_data in
-        Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
-      | Types.Tunboxed_tuple elts ->
-        (* Unboxed tuples: per-element contributions; shallow axes relevant
-           only for arity = 1. *)
-        Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
-            kind ~use_tables:true ctx t)
-      | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
-        (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
-        Ldd.const Axis_lattice.arrow
-      | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
-      | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
-      | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
-      | Types.Tpoly (ty, univars) ->
-        (* CR ikinds: this is sound but not fully precise.
-          Internal ticket 5746. *)
-        let ty = !instance_poly_for_jkind' univars ty in
-        (* We intentionally skip the principality check here. Enforcing it
-           breaks the stdlib build, and the old env-var escape hatch never had
-           a viable setting in practice. Track removing this workaround as part
-           of internal ticket 5746. *)
-        kind ~check_principality:false ~use_tables:true ctx ty
-      | Types.Tof_kind jkind -> ckind_of_jkind ctx jkind
-      | Types.Tobject _ -> Ldd.const Axis_lattice.object_legacy
-      | Types.Tbox t ->
-        let base = Ldd.const Axis_lattice.mutable_data in
-        Ldd.join base (kind ~use_tables:true ctx t)
-      | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
-      | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
-      | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
-        (* Treat quoted/spliced/evaluated quoted types conservatively as
-           boxed values. *)
-        Ldd.const Axis_lattice.value
-      | Types.Tvariant row ->
-        if Btype.tvariant_not_immediate row
-        then
-          if Btype.static_row row
-          then
-            (* Closed, boxed polymorphic variant: immutable_data base plus
-               per-constructor args. *)
-            let base = Ldd.const Axis_lattice.immutable_data in
-            Btype.fold_row
-              (fun acc ty ->
-                let ty_kind = kind ~use_tables:true ctx ty in
-                Ldd.join acc ty_kind)
-              base row
-          else
-            (* CR ikinds: open rows get conservative non-float value (boxed)
-               intersected with an unknown rigid so the solver treats it as an
-               unknown element. This can be improved. Internal ticket 6205. *)
-            let unknown =
-              rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-            in
-            Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
-        else
-          (* All-constant (immediate) polymorphic variant. *)
-          Ldd.const Axis_lattice.immediate
-      | Types.Tpackage _ ->
-        (* Like open polymorphic variants, model first-class modules as boxed
-           values intersected with an unknown so they behave as not-best. *)
-        let unknown =
-          rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-        in
-        Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
+    let self_provenance poly =
+      if ctx.add_provenance then Ldd.meet poly (provenance ctx ty) else poly
     in
-    kind_poly
+    (* [ty] is expected to be representative: no links/substs/fields/nil.
+       Provenance is attached only to the contribution introduced by this
+       node, not to recursive child contributions. *)
+    match Types.get_desc ty with
+    | Types.Tvar { name = _name; jkind } | Types.Tunivar { name = _name; jkind }
+      ->
+      (* Keep a rigid param, but cap it by its annotated jkind. *)
+      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind))
+    | Types.Tconstr (path, args, _abbrev_memo) ->
+      constr ~self_ty:ty ctx path args
+    | Types.Tmod (ty, mod_bounds) ->
+      Ldd.meet
+        (kind ~use_tables:true ctx ty)
+        (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
+    | Types.Ttuple elts ->
+      (* Boxed tuples: immutable_data base + per-element contributions
+         under id modality. *)
+      let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
+    | Types.Tunboxed_tuple elts ->
+      (* Unboxed tuples: per-element contributions; shallow axes relevant
+         only for arity = 1. *)
+      Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
+          kind ~use_tables:true ctx t)
+    | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
+      (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
+      self_provenance (Ldd.const Axis_lattice.arrow)
+    | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
+    | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
+    | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
+    | Types.Tpoly (ty, univars) ->
+      (* CR ikinds: this is sound but not fully precise.
+        Internal ticket 5746. *)
+      let ty = !instance_poly_for_jkind' univars ty in
+      (* We intentionally skip the principality check here. Enforcing it
+         breaks the stdlib build, and the old env-var escape hatch never had
+         a viable setting in practice. Track removing this workaround as part
+         of internal ticket 5746. *)
+      kind ~check_principality:false ~use_tables:true ctx ty
+    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind ctx jkind)
+    | Types.Tobject _ -> self_provenance (Ldd.const Axis_lattice.object_legacy)
+    | Types.Tbox t ->
+      let base = self_provenance (Ldd.const Axis_lattice.mutable_data) in
+      Ldd.join base (kind ~use_tables:true ctx t)
+    | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
+    | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
+    | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
+      (* Treat quoted/spliced/evaluated quoted types conservatively as
+         boxed values. *)
+      self_provenance (Ldd.const Axis_lattice.value)
+    | Types.Tvariant row ->
+      if Btype.tvariant_not_immediate row
+      then
+        if Btype.static_row row
+        then
+          (* Closed, boxed polymorphic variant: immutable_data base plus
+             per-constructor args. *)
+          let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+          Btype.fold_row
+            (fun acc ty ->
+              let ty_kind = kind ~use_tables:true ctx ty in
+              Ldd.join acc ty_kind)
+            base row
+        else
+          (* CR ikinds: open rows get conservative non-float value (boxed)
+             intersected with an unknown rigid so the solver treats it as an
+             unknown element. This can be improved. Internal ticket 6205. *)
+          let unknown =
+            rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
+          in
+          self_provenance
+            (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
+      else
+        (* All-constant (immediate) polymorphic variant. *)
+        self_provenance (Ldd.const Axis_lattice.immediate)
+    | Types.Tpackage _ ->
+      (* Like open polymorphic variants, model first-class modules as boxed
+         values intersected with an unknown so they behave as not-best. *)
+      let unknown = rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ())) in
+      self_provenance (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
 
   (* Evaluate a ckind in [ctx] and flush pending GFP constraints. *)
   let normalize (kind_poly : Ldd.node) : Ldd.node =
@@ -547,18 +619,252 @@ let pp_axes (axes : Jkind_axis.Axis.packed list) : string =
   |> List.map (fun (Jkind_axis.Axis.Pack ax) -> Jkind_axis.Axis.name ax)
   |> String.concat ", "
 
+let axis_name (Jkind_axis.Axis.Pack ax) = Jkind_axis.Axis.name ax
+
+let pp_axis_name ppf axis = Format_doc.fprintf ppf "%s" (axis_name axis)
+
+let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
+  match axes with
+  | [] -> Format_doc.fprintf ppf "<none>"
+  | [axis] -> pp_axis_name ppf axis
+  | [axis1; axis2] ->
+    Format_doc.fprintf ppf "%a and %a" pp_axis_name axis1 pp_axis_name axis2
+  | _ ->
+    let rec split_last = function
+      | [] -> assert false
+      | [last] -> [], last
+      | x :: xs ->
+        let init, last = split_last xs in
+        x :: init, last
+    in
+    let init, last = split_last axes in
+    Format_doc.fprintf ppf "%a,@ and %a"
+      (Format_doc.pp_print_list
+         ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf ",@ ")
+         pp_axis_name)
+      init pp_axis_name last
+
+let is_bot_poly poly = Axis_lattice.equal (Ldd.round_up poly) Axis_lattice.bot
+
+let axes_in_violation_order ~violating_axes axes =
+  (* Keep only axes that the overall comparison actually failed on, ordered as
+     in [violating_axes]. A fragment residual can be non-top on a non-violating
+     axis because [round_down] under-approximates the symbolic implication, so
+     intersecting here prevents blaming a fragment on an axis the whole
+     comparison passes on. *)
+  List.filter
+    (fun violating_axis ->
+      List.exists (Jkind_axis.Axis.equal violating_axis) axes)
+    violating_axes
+
+type mode_crossing_error =
+  { printing_env : Env.t;
+    super_jkind : Types.jkind_l;
+    sub_poly : Ldd.node;
+    super_poly : Ldd.node;
+    provenance_names : Ldd.Name.t list;
+    violating_axes : Jkind_axis.Axis.packed list
+  }
+
+type subjkind_error =
+  | Jkind_error of Jkind.Violation.t
+  | Mode_crossing_error of mode_crossing_error
+
+let subjkind_error_printing_env = function
+  | Jkind_error _ -> None
+  | Mode_crossing_error { printing_env; _ } -> Some printing_env
+
+let map_jkind_error result =
+  Result.map_error (fun error -> Jkind_error error) result
+
+type provenance_residual =
+  { ty : Format_doc.doc;
+    plural : bool;
+    mode_bounds : Axis_lattice.t;
+    axes : Jkind_axis.Axis.packed list
+  }
+
+let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
+    =
+  (* Deduplicate identical entries (e.g. two fields of type [int ref] under
+     the same bound), keeping first-occurrence order. Entries that merely
+     share a printed name (e.g. two constructor-local existentials both
+     rendered ['a]) can have different requirements and must stay separate. *)
+  let duplicate other =
+    String.equal
+      (Format_doc.asprintf "%a" Format_doc.pp_doc other.ty)
+      (Format_doc.asprintf "%a" Format_doc.pp_doc ty)
+    && Bool.equal other.plural plural
+    && Axis_lattice.equal other.mode_bounds mode_bounds
+    && List.length other.axes = List.length axes
+    && List.for_all
+         (fun axis -> List.exists (Jkind_axis.Axis.equal axis) other.axes)
+         axes
+  in
+  if List.exists duplicate entries then entries else entries @ [entry]
+
+let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+    =
+  let provenance_vars = List.map Ldd.rigid provenance_names in
+  (* For a declaration [type t : bound = rhs], ikind checking compares the
+     inferred ikind polynomial for [rhs] against the polynomial for [bound].
+     When that comparison fails, we recompute [rhs] with provenance variables
+     inserted by meeting a fresh variable into each local contribution. For a
+     contribution [coeff] tagged by provenance variable [p], the error
+     reporting question is:
+
+       What is the largest assignment to [p] that would make this contribution
+       satisfy the required bound?
+
+     This is the right question because the provenance variable stands for the
+     mode-crossing behavior we need from the source type. It gives the least
+     restrictive bound that would still make the original lattice comparison
+     pass.
+
+     We answer the question by first decomposing the provenance-annotated
+     polynomial into an untracked base plus one coefficient per provenance
+     variable. If the base alone does not satisfy [super_poly], then provenance
+     cannot explain the error. Otherwise, for each coefficient [coeff], we need
+     the greatest [h] such that:
+
+       meet coeff h <= super_poly
+
+     This is exactly [Ldd.imply coeff super_poly]. The result may still contain
+     symbolic variables, so we round it down to a conservative concrete mode
+     bound for printing. *)
+  let base, coeffs =
+    Ldd.decompose_into_linear_terms ~universe:provenance_vars sub_poly
+  in
+  match Ldd.leq_with_reason base super_poly with
+  | _ :: _ -> None
+  | [] ->
+    List.combine provenance_names coeffs
+    |> List.filter_map (fun (name, coeff) ->
+        match (name : Ldd.Name.t) with
+        | Atom _ | KAtom _ | Param _ | Unknown _ -> None
+        | Provenance { ty; plural; _ } -> (
+          if is_bot_poly coeff
+          then None
+          else
+            let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
+            let non_top_bounds =
+              Axis_lattice.co_sub Axis_lattice.top mode_bounds
+            in
+            if Axis_lattice.equal non_top_bounds Axis_lattice.bot
+            then None
+            else
+              let axes =
+                non_top_bounds |> Axis_lattice.non_bot_axes
+                |> List.map Axis_lattice.axis_number_to_axis_packed
+                |> axes_in_violation_order ~violating_axes
+              in
+              (* [round_down] under-approximation can leave a residual
+                 non-top only on non-violating axes; such an entry has no
+                 axes left to report. *)
+              match axes with
+              | [] -> None
+              | _ :: _ -> Some { ty; plural; mode_bounds; axes }))
+    |> List.fold_left add_provenance_residual []
+    |> Option.some
+
+let residual_mode_strings { mode_bounds; axes; _ } =
+  (* Restrict the required bounds to the reported axes (the residual can be
+     non-top on other axes; see [axes_in_violation_order]), then let
+     [Typemode] drop implied modes (e.g. [aliased] when [global] is
+     required) the same way jkind annotations are printed. *)
+  let reported =
+    List.fold_left
+      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+      Jkind_axis.Axis_set.empty axes
+  in
+  let restricted =
+    Axis_lattice.join mode_bounds
+      (Axis_lattice.of_axis_set (Jkind_axis.Axis_set.complement reported))
+  in
+  Jkind.Mod_bounds.of_axis_lattice restricted
+  |> Typemode.close_implied_mod_bounds
+  |> Typemode.untransl_mod_bounds ~verbose:false
+  |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
+
+let pp_provenance_residual ppf ({ ty; plural; _ } as residual) =
+  (* Phrase subjects ("mutable fields", "boxed records") are plural noun
+     phrases; type-expression subjects read as singular. *)
+  let verb = if plural then "are" else "is" in
+  let modes = residual_mode_strings residual in
+  Format_doc.fprintf ppf "@[<hov 2>%a %s not mod %a@]" Format_doc.pp_doc ty verb
+    (Format_doc.pp_print_list
+       ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
+       Format_doc.pp_print_string)
+    modes
+
+let pp_provenance_residual_bullets ppf entries =
+  List.iteri
+    (fun i entry ->
+      if i > 0 then Format_doc.fprintf ppf "@;";
+      Format_doc.fprintf ppf "- %a" pp_provenance_residual entry)
+    entries
+
+let pp_type_definition_kind_annotation env ppf super_jkind =
+  Format_doc.fprintf ppf
+    "@[<hov 2>This type definition does not satisfy its kind annotation@ %a,@]"
+    (Jkind.format env) super_jkind
+
+let report_provenance_mode_crossing_error env ppf
+    { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =
+  match
+    provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+  with
+  | None | Some [] -> None
+  | Some [entry] ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because %a.@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual entry)
+  | Some entries ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because@;%a@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual_bullets entries)
+
+let report_mode_crossing_error ~offender ppf err =
+  match report_provenance_mode_crossing_error err.printing_env ppf err with
+  | Some () -> ()
+  | None ->
+    Format_doc.fprintf ppf
+      "@[<v>The mode crossing of %t is not allowed here.@;\
+       @[<hov 2>The inferred kind is not below the required kind along %a.@]@]"
+      offender pp_axis_list_prose err.violating_axes
+
+let report_subjkind_error_with_offender ~offender env ppf = function
+  | Jkind_error err ->
+    Jkind.Violation.report_with_offender ~offender env ppf err
+  | Mode_crossing_error err -> report_mode_crossing_error ~offender ppf err
+
+let report_subjkind_error_with_name ~name env ppf err =
+  report_subjkind_error_with_offender
+    ~offender:(fun ppf -> Format_doc.fprintf ppf "%s" name)
+    env ppf err
+
 let axis_disagreement_reasons (axes : Jkind_axis.Axis.packed list) :
     Jkind.Sub_failure_reason.t list =
   List.map (fun axis -> Jkind.Sub_failure_reason.Axis_disagreement axis) axes
 
-let label_mutability_contribution (lbl : Types.label_declaration) =
-  Ldd.const
-    (match lbl.ld_mutable with
-    | Immutable -> Axis_lattice.immediate
-    | Mutable { atomic = Atomic; _ } -> Axis_lattice.sync_data
-    | Mutable { atomic = Nonatomic; _ } -> Axis_lattice.mutable_data)
+let label_mutability_contribution (ctx : Solver.ctx)
+    (lbl : Types.label_declaration) =
+  match lbl.ld_mutable with
+  (* [immediate] is below every base this is summed into, so omitting it keeps
+     immutable fields out of the untracked part of a provenance residual. *)
+  | Immutable -> Ldd.bot
+  | Mutable { atomic = Atomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () -> "atomic mutable fields")
+      (Ldd.const Axis_lattice.sync_data)
+  | Mutable { atomic = Nonatomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () -> "mutable fields")
+      (Ldd.const Axis_lattice.mutable_data)
 
-let sum_record_label_contributions ~(base : Ldd.node)
+let sum_record_label_contributions ~(ctx : Solver.ctx) ~(base : Ldd.node)
     ~(payload_kind : Types.type_expr -> Ldd.node)
     ~(validate_label : Types.label_declaration -> unit)
     (lbls : Types.label_declaration list) : Ldd.node =
@@ -566,7 +872,7 @@ let sum_record_label_contributions ~(base : Ldd.node)
       validate_label lbl;
       let mask = Axis_lattice.mask_of_modality lbl.ld_modalities in
       Ldd.join
-        (label_mutability_contribution lbl)
+        (label_mutability_contribution ctx lbl)
         (Ldd.meet (Ldd.const mask) (payload_kind lbl.ld_type)))
 
 let no_validation (_ : Types.label_declaration) = ()
@@ -576,6 +882,9 @@ let validate_immutable_unboxed_label (lbl : Types.label_declaration) =
   | Immutable -> ()
   | Mutable _ ->
     failwith "ikind: mutable fields in unboxed records are not supported"
+
+let decl_base_provenance (ctx : Solver.ctx) source poly =
+  Solver.with_provenance_text ctx (fun () -> source) poly
 
 (* Gather constructor-local vars from [tys]. *)
 let collect_type_vars (tys : Types.type_expr list) :
@@ -688,7 +997,8 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
                   | Some bound -> bound
                   | None -> Ldd.const Axis_lattice.top
                 else Solver.node_of_name ctx name)
-            | Ldd.Name.Unknown _ | Ldd.Name.Atom _ | Ldd.Name.KAtom _ ->
+            | Ldd.Name.Unknown _ | Ldd.Name.Provenance _ | Ldd.Name.Atom _
+            | Ldd.Name.KAtom _ ->
               Solver.node_of_name ctx name
           in
           fun ty ->
@@ -697,6 +1007,115 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
       | _ ->
         failwith
           "ikind: expected GADT constructor result to be a type constructor")
+
+let type_decl_allows_any_crossing (decl : Types.type_declaration) =
+  match decl.type_kind with
+  | Types.Type_record (_, _, umc_opt)
+  | Types.Type_record_unboxed_product (_, _, umc_opt)
+  | Types.Type_variant (_, _, umc_opt) ->
+    Option.is_some umc_opt
+  | Types.Type_abstract _ | Types.Type_open -> false
+
+let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
+    Ldd.node =
+  match decl.type_manifest with
+  | Some body_ty -> Solver.kind ~use_tables:true ctx body_ty
+  | None -> (
+    let use_decl_jkind () = Solver.ckind_of_jkind ctx decl.type_jkind in
+    match decl.type_kind with
+    (* For abstract types and allow_any_crossing types, derive the ikind from
+       the jkind annotation instead of computing it from the type declaration's
+       body. *)
+    | _ when type_decl_allows_any_crossing decl -> use_decl_jkind ()
+    | Types.Type_abstract _ | Types.Type_open -> use_decl_jkind ()
+    | Types.Type_record (lbls, rep, _umc_opt) ->
+      let base =
+        let base_lat, source =
+          match rep with
+          | Types.Record_unboxed -> Axis_lattice.immediate, "unboxed records"
+          (* CR box: This will no longer be [non_float] once we update the
+             representation of singleton float64 records *)
+          | _ -> Axis_lattice.immutable_data, "boxed records"
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx source
+      in
+      sum_record_label_contributions ~ctx ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~validate_label:no_validation lbls
+    | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
+      let base =
+        Ldd.const Axis_lattice.immediate
+        |> decl_base_provenance ctx "unboxed records"
+      in
+      sum_record_label_contributions ~ctx ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~validate_label:validate_immutable_unboxed_label lbls
+    | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
+      (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
+         captured by its constructors: nullability/separability and
+         mode-crossing are baked into its representation. We defer to jkinds
+         because ikinds cannot express this today. This deferral can be removed
+         once separability and nullability become layout properties rather than
+         modal axes. *)
+      use_decl_jkind ()
+    | Types.Type_variant (cstrs, rep, _umc_opt) ->
+      (* Choose base: immediate for void-only variants; otherwise immutable. *)
+      let all_args_void =
+        List.for_all
+          (fun (c : Types.constructor_declaration) ->
+            match c.cd_args with
+            | Types.Cstr_tuple args ->
+              List.for_all
+                (fun (arg : Types.constructor_argument) ->
+                  match arg.ca_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                args
+            | Types.Cstr_record lbls ->
+              List.for_all
+                (fun (lbl : Types.label_declaration) ->
+                  match lbl.ld_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                lbls)
+          cstrs
+      in
+      let base =
+        let base_lat, source =
+          match rep with
+          | Types.Variant_unboxed -> Axis_lattice.immediate, "unboxed variants"
+          | _ ->
+            if all_args_void
+            then Axis_lattice.immediate, "enumeration variants"
+            else Axis_lattice.immutable_data, "boxed variants"
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx source
+      in
+      let payload_kind_of_constructor =
+        make_gadt_payload_projector ~decl_params:decl.type_params ctx
+      in
+      let constructor_contrib (c : Types.constructor_declaration) =
+        let payload_kind = payload_kind_of_constructor c in
+        match c.cd_args with
+        | Types.Cstr_tuple args ->
+          Ldd.sum args ~base:Ldd.bot
+            ~f:(fun (arg : Types.constructor_argument) ->
+              let mask = Axis_lattice.mask_of_modality arg.ca_modalities in
+              Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
+        | Types.Cstr_record lbls ->
+          sum_record_label_contributions ~ctx ~base:Ldd.bot ~payload_kind
+            ~validate_label:no_validation lbls
+      in
+      Ldd.sum cstrs ~base ~f:constructor_contrib)
+
+let type_decl_constr_decl (decl : Types.type_declaration) : Solver.constr_decl =
+  let abstract =
+    match decl.type_manifest, decl.type_kind with
+    | None, Types.Type_abstract _ -> not (Jkind.is_best decl.type_jkind)
+    | _ -> false
+  in
+  let kind ctx = type_decl_rhs_kind_poly ctx decl in
+  Solver.Ty { args = decl.type_params; kind; abstract }
 
 (* Lookup function supplied to the solver.
    We prefer a stored ikind (when present) and otherwise recompute from the
@@ -718,144 +1137,9 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
   | type_decl ->
     (* Here we can switch to using the cached ikind or not. *)
     let fallback () =
-      (* When we have no stored ikind, we go to this fallback and compute. *)
-      match type_decl.type_manifest with
-      | Some body_ty ->
-        (* Concrete: compute kind of body. *)
-        let args = type_decl.type_params in
-        let kind : Solver.ckind =
-         fun ctx -> Solver.kind ~use_tables:true ctx body_ty
-        in
-        Solver.Ty { args; kind; abstract = false }
-      | None -> (
-        (* No manifest: may still be "concrete" (record/variant/...).
-           Build ckind. *)
-        let allow_any_crossing =
-          match type_decl.type_kind with
-          | Types.Type_record (_, _, umc_opt)
-          | Types.Type_record_unboxed_product (_, _, umc_opt)
-          | Types.Type_variant (_, _, umc_opt) ->
-            Option.is_some umc_opt
-          | Types.Type_abstract _ | Types.Type_open -> false
-        in
-        let use_decl_jkind ~treat_as_abstract =
-          let kind : Solver.ckind =
-           fun ctx -> Solver.ckind_of_jkind ctx type_decl.type_jkind
-          in
-          Solver.Ty
-            { args = type_decl.type_params; kind; abstract = treat_as_abstract }
-        in
-        match type_decl.type_kind with
-        (* For abstract types and allow_any_crossing types, we derive the
-           ikind from the jkind annotation, instead of computing it from
-           the type declaration's body: *)
-        | _ when allow_any_crossing -> use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_abstract _ ->
-          use_decl_jkind
-            ~treat_as_abstract:(not (Jkind.is_best type_decl.type_jkind))
-        (* For other cases, we compute the ikind from the type definition{} *)
-        | Types.Type_record (lbls, rep, _umc_opt) ->
-          (* Build from components: base (non-float value) + per-label
-             contributions. *)
-          let immutable_base =
-            Ldd.const
-              (match rep with
-              | Types.Record_unboxed -> Axis_lattice.immediate
-              (* CR box: This will no longer be [non_float] once we update the
-                 representation of singleton float64 records *)
-              | _ -> Axis_lattice.immutable_data)
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            sum_record_label_contributions ~base:immutable_base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:no_validation lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base = Ldd.const Axis_lattice.immediate in
-            sum_record_label_contributions ~base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:validate_immutable_unboxed_label lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
-          (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
-             captured by its constructors: nullability/separability and
-             mode-crossing are baked into its representation. We defer to
-             jkinds because ikinds cannot express this today. This deferral
-             can be removed once separability and nullability become layout
-             properties rather than modal axes. *)
-          use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_variant (cstrs, rep, _umc_opt) ->
-          (* Choose base: immediate for void-only variants; sync if any record
-             field is atomic; mutable if any non-atomic mutable field appears;
-             otherwise immutable. *)
-          let all_args_void =
-            List.for_all
-              (fun (c : Types.constructor_declaration) ->
-                match c.cd_args with
-                | Types.Cstr_tuple args ->
-                  List.for_all
-                    (fun (arg : Types.constructor_argument) ->
-                      match arg.ca_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    args
-                | Types.Cstr_record lbls ->
-                  List.for_all
-                    (fun (lbl : Types.label_declaration) ->
-                      match lbl.ld_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    lbls)
-              cstrs
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base_lat0 =
-              match rep with
-              | Types.Variant_unboxed -> Axis_lattice.immediate
-              | _ ->
-                if all_args_void
-                then Axis_lattice.immediate
-                else Axis_lattice.immutable_data
-            in
-            let payload_kind_of_constructor =
-              make_gadt_payload_projector ~decl_params:type_decl.type_params ctx
-            in
-            let constructor_contrib (c : Types.constructor_declaration) =
-              let payload_kind = payload_kind_of_constructor c in
-              match c.cd_args with
-              | Types.Cstr_tuple args ->
-                Ldd.sum args ~base:Ldd.bot
-                  ~f:(fun (arg : Types.constructor_argument) ->
-                    let mask =
-                      Axis_lattice.mask_of_modality arg.ca_modalities
-                    in
-                    Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
-              | Types.Cstr_record lbls ->
-                sum_record_label_contributions ~base:Ldd.bot ~payload_kind
-                  ~validate_label:no_validation lbls
-            in
-            Ldd.sum cstrs ~base:(Ldd.const base_lat0) ~f:constructor_contrib
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_open ->
-          (* Use the stored jkind here in case it is `exn`,
-             which is special. *)
-          use_decl_jkind ~treat_as_abstract:false
-        (*
-           (* This is the code we'd use otherwise *)
-           let kind : Solver.ckind =
-            fun _ctx ->
-             Ldd.const Axis_lattice.nonfloat_value
-           in
-           Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        *)
-        )
+      (* When we have no stored ikind, compute from the declaration through the
+         same RHS builder used for bound diagnostics. *)
+      type_decl_constr_decl type_decl
     in
     (* Prefer a stored constructor ikind if one is present and enabled. *)
     let ikind =
@@ -885,8 +1169,8 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
 
 (* Package the above into a full evaluation context. *)
 let create_ctx ~(mode : Solver.mode) ~(env : Env.t option) =
-  Solver.create_ctx ~mode ~env ~lookup_of_env:(fun env path ->
-      lookup_of_env ~env path)
+  Solver.create_ctx ~mode ~env ~add_provenance:false
+    ~lookup_of_env:(fun env path -> lookup_of_env ~env path)
 
 let normalize ~(env : Env.t option) (jkind : Types.jkind_l) : Ldd.node =
   let ctx = create_ctx ~mode:Solver.Normal ~env in
@@ -959,13 +1243,10 @@ type subcheck_polys =
     fast_path : subcheck_fast_path
   }
 
-(* Compute polynomials for a subcheck:
-   - compute [super] in Normal mode
-   - fast path: if [super] is constant top, no need to compute [sub]
-   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
-   - otherwise, only round up [sub] if [super] is constant *)
-let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
-    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+let compute_bound_polys env (super : ('l2 * 'r2) Types.jkind)
+    ~(lhs_floor : (Solver.ctx -> Ldd.node option) option)
+    ~(lhs : Solver.ctx -> Ldd.node) : subcheck_polys =
+  Provenance.reset ();
   let ctx = create_ctx ~mode:Solver.Normal ~env:(Some env) in
   let super_poly = Solver.ckind_of_jkind ctx super in
   let super_is_constant =
@@ -984,16 +1265,19 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     let floor_fast_path =
       if super_is_constant
       then
-        match Solver.mod_bounds_floor_of_jkind ctx sub with
+        match lhs_floor with
         | None -> None
-        | Some lhs_floor ->
-          let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
-          if
-            Axis_lattice.equal
-              (Ldd.round_up lhs_floor_or_super)
-              Axis_lattice.top
-          then Some lhs_floor
-          else None
+        | Some lhs_floor -> (
+          match lhs_floor ctx with
+          | None -> None
+          | Some lhs_floor ->
+            let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
+            if
+              Axis_lattice.equal
+                (Ldd.round_up lhs_floor_or_super)
+                Axis_lattice.top
+            then Some lhs_floor
+            else None)
       else None
     in
     match floor_fast_path with
@@ -1003,36 +1287,119 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
         fast_path = Lhs_mod_bounds_floor_fast_path
       }
     | None ->
-      let sub_ctx =
+      let lhs_ctx =
         if super_is_constant
         then Solver.reset_for_mode ctx ~mode:Solver.Round_up
         else ctx
       in
-      let sub_poly = Solver.ckind_of_jkind sub_ctx sub in
-      { lhs_for_leq = sub_poly;
+      let lhs_poly = lhs lhs_ctx in
+      { lhs_for_leq = lhs_poly;
         rhs_for_leq = super_poly;
         fast_path = No_fast_path
       }
 
-let sub_jkind_l ?allow_any_crossing ?origin
+(* Compute polynomials for a subcheck:
+   - compute [super] in Normal mode
+   - fast path: if [super] is constant top, no need to compute [sub]
+   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
+   - otherwise, only round up [sub] if [super] is constant *)
+let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
+    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+  compute_bound_polys env super
+    ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
+    ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
+
+let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
+    (bound : Types.jkind_l) : subcheck_polys =
+  compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
+      let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
+      lhs ctx)
+
+let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
+    { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path = _ } =
+  let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
+  match violating_axes with
+  | [] -> Ok ()
+  | _ ->
+    Error
+      (Mode_crossing_error
+         { printing_env;
+           super_jkind;
+           sub_poly;
+           super_poly;
+           provenance_names = Provenance.all_names ();
+           violating_axes
+         })
+
+let subjkind_error_has_provenance_residuals = function
+  | Jkind_error _ -> false
+  | Mode_crossing_error
+      { sub_poly; super_poly; provenance_names; violating_axes; _ } -> (
+    match
+      provenance_residuals ~provenance_names ~violating_axes ~sub_poly
+        ~super_poly
+    with
+    | None | Some [] -> false
+    | Some (_ :: _) -> true)
+
+let same_axis_set axes1 axes2 =
+  let of_list =
+    List.fold_left
+      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+      Jkind_axis.Axis_set.empty
+  in
+  Jkind_axis.Axis_set.equal (of_list axes1) (of_list axes2)
+
+let subjkind_errors_have_same_violating_axes error1 error2 =
+  match error1, error2 with
+  | ( Mode_crossing_error { violating_axes = axes1; _ },
+      Mode_crossing_error { violating_axes = axes2; _ } ) ->
+    same_axis_set axes1 axes2
+  | Jkind_error _, _ | _, Jkind_error _ -> false
+
+let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
+    ~printing_env actual_error make_polys =
+  let fallback error =
+    match fallback_error () with
+    | None -> Error error
+    | Some fallback_error -> Error fallback_error
+  in
+  let provenance_check =
+    match make_polys () with
+    | provenance_polys ->
+      check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind ~printing_env
+        provenance_polys
+    | exception
+        ((Misc.Fatal_error | Stack_overflow | Out_of_memory | Sys.Break) as exn)
+      ->
+      raise exn
+    | exception _ -> Ok ()
+  in
+  match provenance_check with
+  | Ok () -> fallback actual_error
+  | Error provenance_error ->
+    if
+      subjkind_errors_have_same_violating_axes actual_error provenance_error
+      && subjkind_error_has_provenance_residuals provenance_error
+    then Error provenance_error
+    else fallback actual_error
+
+let sub_jkind_l ?(allow_any_crossing = false) ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)
     ~(context : Jkind.jkind_context) env (sub : Types.jkind_l)
-    (super : Types.jkind_l) : (unit, Jkind.Violation.t) result =
+    (super : Types.jkind_l) : (unit, subjkind_error) result =
   let open Misc.Stdlib.Monad.Result.Syntax in
   if not (enable_sub_jkind_l && !Clflags.ikinds)
-  then Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
+  then
+    Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env sub super
+    |> map_jkind_error
   else
     (* Check layouts first; if that fails, print both sides with full
        info and return the error. *)
     let* () =
-      match Jkind.sub_layout_or_error ~context env sub super with
-      | Ok () -> Ok ()
-      | Error v -> Error v
+      Jkind.sub_layout_or_error ~context env sub super |> map_jkind_error
     in
-    let allow_any =
-      match allow_any_crossing with Some true -> true | _ -> false
-    in
-    if allow_any
+    if allow_any_crossing
     then (
       (if !Clflags.ikinds_debug
        then
@@ -1040,40 +1407,74 @@ let sub_jkind_l ?allow_any_crossing ?origin
          Format.eprintf "[ikind-subjkind] call%s allow_any=true@." origin_suffix);
       Ok ())
     else
-      let { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
-        compute_subcheck_polys ~context env sub super
-      in
-      let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
-      (if !Clflags.ikinds_debug
-       then
-         let origin_suffix = origin_suffix_of origin in
-         let fast_path =
-           match fast_path with
-           | No_fast_path -> "none"
-           | Rhs_top_fast_path -> "rhs_top"
-           | Lhs_mod_bounds_floor_fast_path -> "lhs_mod_bounds_floor"
-         in
-         Format.eprintf
-           "[ikind-subjkind] call%s allow_any=false fast_path=%s@;\
-            @;\
-            sub_poly=%s@;\
-            super_poly=%s@."
-           origin_suffix fast_path (Ldd.pp sub_poly) (Ldd.pp super_poly));
-      match violating_axes with
-      | [] -> Ok ()
-      | _ ->
-        let () =
-          if !Clflags.ikinds_debug
-          then
-            let axes = pp_axes violating_axes in
-            Format.eprintf "[ikind-subjkind] failure on axes: %s@." axes
+      let subcheck_polys = compute_subcheck_polys ~context env sub super in
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:sub ~super_jkind:super
+          ~printing_env:env subcheck_polys
+      with
+      | Ok () -> Ok ()
+      | Error ikind_error -> (
+        if !Clflags.ikinds_debug
+        then Error ikind_error
+        else
+          match
+            Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env sub
+              super
+          with
+          | Ok () -> Error ikind_error
+          | Error jkind_error -> Error (Jkind_error jkind_error))
+
+let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs =
+  if not (enable_sub_jkind_l && !Clflags.ikinds)
+  then
+    sub_jkind_l ~allow_any_crossing ?origin ~type_equal ~context env actual
+      bound
+  else
+    let open Misc.Stdlib.Monad.Result.Syntax in
+    let* () =
+      Jkind.sub_layout_or_error ~context env actual bound |> map_jkind_error
+    in
+    if allow_any_crossing
+    then Ok ()
+    else
+      let actual_polys = compute_subcheck_polys ~context env actual bound in
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:actual ~super_jkind:bound
+          ~printing_env:env actual_polys
+      with
+      | Ok () -> Ok ()
+      | Error actual_error ->
+        let fallback_error () =
+          match
+            Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env
+              actual bound
+          with
+          | Ok () ->
+            let violating_axes =
+              match actual_error with
+              | Mode_crossing_error { violating_axes; _ } -> violating_axes
+              | Jkind_error _ -> []
+            in
+            let axis_reasons = axis_disagreement_reasons violating_axes in
+            Some
+              (Jkind_error
+                 (Jkind.Violation.of_ ~context env
+                    (Jkind.Violation.Not_a_subjkind (actual, bound, axis_reasons))))
+          | Error jkind_error -> Some (Jkind_error jkind_error)
         in
-        (* Do not try to adjust allowances; Violation.Not_a_subjkind
-           accepts an r-jkind. *)
-        let axis_reasons = axis_disagreement_reasons violating_axes in
-        Error
-          (Jkind.Violation.of_ ~context env
-             (Jkind.Violation.Not_a_subjkind (sub, super, axis_reasons)))
+        best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
+          ~super_jkind:bound ~printing_env:env actual_error (fun () ->
+            compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
+
+let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
+  check_bound ?origin ~type_equal ~context env ~actual ~bound
+    ~provenance_lhs:(fun ctx -> Solver.kind ~use_tables:true ctx ty)
+
+let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
+    ~decl ~actual ~bound =
+  check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =
@@ -1308,6 +1709,7 @@ let substitute_decl_ikind_with_lookup
     and map_name (expanding : Path.Set.t) (name : Ldd.Name.t) : Ldd.node =
       match name with
       | Param _ -> Ldd.node_of_var (Ldd.rigid name)
+      | Provenance _ -> Ldd.node_of_var (Ldd.rigid name)
       | Unknown _ -> Ldd.node_of_var (Ldd.rigid name)
       | KAtom path -> (
         match lookup_jkind path with

--- a/external/merlin/upstream/ocaml_flambda/typing/ikind.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/ikind.mli
@@ -21,6 +21,24 @@ val type_declaration_ikind_of_jkind :
   Types.jkind_l ->
   Types.type_ikind
 
+type mode_crossing_error
+
+type subjkind_error =
+  | Jkind_error of Jkind.Violation.t
+  | Mode_crossing_error of mode_crossing_error
+
+val subjkind_error_printing_env : subjkind_error -> Env.t option
+
+val report_subjkind_error_with_offender :
+  offender:(Format_doc.formatter -> unit) ->
+  Env.t ->
+  Format_doc.formatter ->
+  subjkind_error ->
+  unit
+
+val report_subjkind_error_with_name :
+  name:string -> Env.t -> Format_doc.formatter -> subjkind_error -> unit
+
 val sub_jkind_l :
   ?allow_any_crossing:bool ->
   ?origin:string ->
@@ -29,7 +47,28 @@ val sub_jkind_l :
   Env.t ->
   Types.jkind_l ->
   Types.jkind_l ->
-  (unit, Jkind.Violation.t) result
+  (unit, subjkind_error) result
+
+val check_type_expr_bound :
+  ?origin:string ->
+  type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
+  context:Jkind.jkind_context ->
+  Env.t ->
+  ty:Types.type_expr ->
+  actual:Types.jkind_l ->
+  bound:Types.jkind_l ->
+  (unit, subjkind_error) result
+
+val check_type_decl_bound :
+  ?allow_any_crossing:bool ->
+  ?origin:string ->
+  type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
+  context:Jkind.jkind_context ->
+  Env.t ->
+  decl:Types.type_declaration ->
+  actual:Types.jkind_l ->
+  bound:Types.jkind_l ->
+  (unit, subjkind_error) result
 
 val crossing_of_jkind :
   context:Jkind.jkind_context ->

--- a/external/merlin/upstream/ocaml_flambda/typing/includecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/includecore.ml
@@ -434,7 +434,7 @@ type type_mismatch =
   | Extensible_representation of position
   | With_null_representation of position
   | Fixed_representation of position
-  | Jkind of Jkind.Violation.t
+  | Jkind of Ikind.subjkind_error
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 type jkind_mismatch =
@@ -858,8 +858,13 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a fixed representation while the other varies"
   | Jkind v ->
-      Jkind.Violation.report_with_name ~name:first
-        env ppf v
+      let report () =
+        Ikind.report_subjkind_error_with_name ~name:first env ppf v
+      in
+      (match Ikind.subjkind_error_printing_env v with
+       | None -> report ()
+       | Some printing_env ->
+         Printtyp.wrap_printing_env ~error:true printing_env report)
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,@[<v 2>%a@]"
       (fun ppf (first, second, mismatch) ->

--- a/external/merlin/upstream/ocaml_flambda/typing/includecore.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/includecore.mli
@@ -144,7 +144,7 @@ type type_mismatch =
   | Extensible_representation of position
   | With_null_representation of position
   | Fixed_representation of position
-  | Jkind of Jkind.Violation.t
+  | Jkind of Ikind.subjkind_error
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 type jkind_mismatch =

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
@@ -25,6 +25,8 @@ let print_type_expr : type_expr Fmt.printer ref = ref (fun _ _ -> assert false)
 
 let set_print_type_expr p = print_type_expr := p
 
+let format_type_expr ppf ty = !print_type_expr ppf ty
+
 let raw_type_expr : (Format.formatter -> type_expr -> unit) ref =
   ref (fun _ _ -> assert false)
 

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.mli
@@ -736,6 +736,8 @@ val set_printtyp_path : (Format_doc.formatter -> Path.t -> unit) -> unit
     module. *)
 val set_print_type_expr : Types.type_expr Format_doc.printer -> unit
 
+val format_type_expr : Types.type_expr Format_doc.printer
+
 (** Provides the [raw_type_expr] formatter back up the dependency chain to this
     module. *)
 val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_axis.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_axis.ml
@@ -149,6 +149,15 @@ module Axis = struct
       (* CR-soon zqian: call [Mode.Crossing.Axis.all] for modal axes *)
       Pack (Nonmodal Externality) ]
 
+  let equal (Pack axis1) (Pack axis2) =
+    match axis1, axis2 with
+    | Modal axis1, Modal axis2 ->
+      let axis1 = Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis1) in
+      let axis2 = Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis2) in
+      Int.equal (Mode.Modality.Axis.compare axis1 axis2) 0
+    | Nonmodal Externality, Nonmodal Externality -> true
+    | Modal _, Nonmodal _ | Nonmodal _, Modal _ -> false
+
   let name (type a) : a t -> string = function
     | Modal ax ->
       let (P ax) =

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_axis.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_axis.mli
@@ -71,6 +71,8 @@ module Axis : sig
 
   val all : packed list
 
+  val equal : packed -> packed -> bool
+
   val name : _ t -> string
 end
 

--- a/external/merlin/upstream/ocaml_flambda/typing/ldd.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ldd.ml
@@ -352,6 +352,43 @@ module Make (V : Ordered) = struct
     then meet_with_leaf b a
     else meet' a b
 
+  let top_var (node : node) : var option =
+    if is_leaf node then None else Some (Unsafe.node_block node).v
+
+  let min_top_var (a : node) (b : node) : var =
+    match top_var a, top_var b with
+    | None, None -> invalid_arg "Ldd.imply: expected a non-leaf node"
+    | Some v, None | None, Some v -> v
+    | Some v1, Some v2 -> if compare_var v1 v2 <= 0 then v1 else v2
+
+  let rec split_on_var (v : var) (node0 : node) : node * node =
+    if is_leaf node0
+    then node0, node0
+    else
+      let block = Unsafe.node_block node0 in
+      let order = compare_var v block.v in
+      if order < 0
+      then node0, node0
+      else if order = 0
+      then block.lo, join block.lo block.hi
+      else
+        let lo_bot, lo_top = split_on_var v block.lo in
+        let hi_bot, hi_top = split_on_var v block.hi in
+        node block.v ~lo:lo_bot ~hi:hi_bot, node block.v ~lo:lo_top ~hi:hi_top
+
+  let rec imply_rec (a : node) (b : node) : node =
+    if a == b || a == bot || b == top
+    then top
+    else if is_leaf a && is_leaf b
+    then leaf (Axis_lattice.imply (Unsafe.leaf_value a) (Unsafe.leaf_value b))
+    else
+      let v = min_top_var a b in
+      let a_bot, a_top = split_on_var v a in
+      let b_bot, b_top = split_on_var v b in
+      let h_top = imply_rec a_top b_top in
+      let h_bot = meet (imply_rec a_bot b_bot) h_top in
+      node v ~lo:h_bot ~hi:h_top
+
   (* --------- public constructors --------- *)
   let[@inline] const (c : Axis_lattice.t) = leaf c
 
@@ -465,7 +502,7 @@ module Make (V : Ordered) = struct
     canonicalize ~hi:(inline_solved_vars a) ~lo:(inline_solved_vars b)
 
   let solve_lfp (var : var) (rhs_raw : node) : unit =
-    (* Solve the least fixpoint equation var := rhs_raw. 
+    (* Solve the least fixpoint equation var := rhs_raw.
        The rhs in general contains the var itself, and the
        fixpoint solution is var := rhs_raw[var := bot].
        We must also inline solved vars, because var itself
@@ -475,12 +512,12 @@ module Make (V : Ordered) = struct
     | Rigid _ -> invalid_arg "solve_lfp: rigid variable"
     | Solved _ -> invalid_arg "solve_lfp: solved variable"
     | Unsolved ->
-      (* For efficiency, we use assign_bot_inline to 
+      (* For efficiency, we use assign_bot_inline to
          simultaneously inline solved vars and assign bot. *)
       var.state <- Solved (assign_bot_inline ~var rhs_raw)
 
   let solve_gfp (var : var) (rhs_raw : node) : unit =
-    (* Solve the greatest fixpoint equation var := rhs_raw. 
+    (* Solve the greatest fixpoint equation var := rhs_raw.
        The rhs in general contains the var itself, and the
        fixpoint solution is var := rhs_raw[var := top].
        We must also inline solved vars, because var itself
@@ -490,7 +527,7 @@ module Make (V : Ordered) = struct
     | Rigid _ -> invalid_arg "solve_gfp: rigid variable"
     | Solved _ -> invalid_arg "solve_gfp: solved variable"
     | Unsolved ->
-      (* gfp's are less performance critical, so we use two 
+      (* gfp's are less performance critical, so we use two
          separate steps to inline solved vars and assign top. *)
       let rhs_forced = inline_solved_vars rhs_raw in
       var.state <- Solved (assign_top ~var rhs_forced)
@@ -506,6 +543,10 @@ module Make (V : Ordered) = struct
     List.iter (fun (var, rhs_raw) -> solve_gfp var rhs_raw) pending
 
   let solve_pending () : unit = solve_pending_gfps ()
+
+  let imply (a : node) (b : node) : node =
+    solve_pending ();
+    imply_rec (inline_solved_vars a) (inline_solved_vars b)
 
   (** Decompose into linear terms over [universe]. *)
   let decompose_into_linear_terms ~(universe : var list) (n : node) =
@@ -528,6 +569,11 @@ module Make (V : Ordered) = struct
     solve_pending ();
     let node = inline_solved_vars node in
     up0 node
+
+  let round_down (node : node) =
+    solve_pending ();
+    let node = inline_solved_vars node in
+    down0 node
 
   let is_const (node : node) : bool =
     let node = inline_solved_vars node in

--- a/external/merlin/upstream/ocaml_flambda/typing/ldd_intf.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ldd_intf.ml
@@ -41,10 +41,13 @@ module type S = sig
 
   val node_of_var : var -> node
 
-  (** Boolean algebra over nodes. *)
+  (** Lattice operations over nodes. *)
   val join : node -> node -> node
 
   val meet : node -> node -> node
+
+  (** [imply a b] is the greatest [h] such that [meet a h <= b]. *)
+  val imply : node -> node -> node
 
   val sum : 'a list -> base:node -> f:('a -> node) -> node
 
@@ -70,6 +73,8 @@ module type S = sig
   val leq_with_reason : node -> node -> Jkind_axis.Axis.packed list
 
   val round_up : node -> Axis_lattice.t
+
+  val round_down : node -> Axis_lattice.t
 
   val is_const : node -> bool
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
@@ -115,8 +115,8 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of Env.t * type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Env.t * Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of Env.t * type_expr * Ikind.subjkind_error
+  | Jkind_mismatch_of_path of Env.t * Path.t * Ikind.subjkind_error
   | Jkind_mismatch_due_to_bad_inference of
       Env.t * type_expr * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of
@@ -232,7 +232,10 @@ let constrain_or_null_payload ~env ~path payload_ty payload_loc =
   match Ctype.constrain_type_jkind env payload_ty required with
   | Ok () -> ()
   | Error err ->
-    raise (Error (payload_loc, Jkind_mismatch_of_type (env, payload_ty, err)))
+    raise
+      (Error
+         ( payload_loc,
+           Jkind_mismatch_of_type (env, payload_ty, Ikind.Jkind_error err) ))
 
 (* [make_params] creates sort variables - these can be defaulted away (as in
    transl_type_decl) or unified with existing sort-variable-free types (as in
@@ -1729,15 +1732,16 @@ let narrow_to_manifest_jkind env loc path decl =
         let type_equal = Ctype.type_equal env in
         let context = Ctype.mk_jkind_context_always_principal env in
         (match
-           Ikind.sub_jkind_l
+           Ikind.check_type_expr_bound
              ~origin:(Format.asprintf
                         "typedecl:manifest_vs_decl %a"
                         Location.print_loc decl.type_loc)
              ~type_equal
              ~context
              env
-             manifest_jkind
-             decl.type_jkind
+             ~ty
+             ~actual:manifest_jkind
+             ~bound:decl.type_jkind
          with
          | Ok () -> ()
          | Error v ->
@@ -1760,7 +1764,10 @@ let narrow_to_manifest_jkind env loc path decl =
                Format.eprintf
                  "[ikind-narrow] path=%a branch=constrain_type_jkind error@."
                  (Format_doc.compat Path.print) path;
-             raise (Error (loc, Jkind_mismatch_of_type (env, ty, v))))
+             raise
+               (Error
+                  (loc,
+                   Jkind_mismatch_of_type (env, ty, Jkind_error v))))
     end;
     let type_ikind =
       Ikind.type_declaration_ikind_gated ~env:(Some env) ~path
@@ -2779,7 +2786,10 @@ let rec update_decl_jkind env dpath decl =
   with
   | Ok () -> new_decl
   | Error err ->
-    raise (Error (decl.type_loc, Jkind_mismatch_of_path (env, dpath, err)))
+    raise
+      (Error
+         (decl.type_loc,
+          Jkind_mismatch_of_path (env, dpath, Jkind_error err)))
 
 let update_decls_jkind_reason decls =
   List.map
@@ -3586,7 +3596,7 @@ let normalize_decl_jkinds env decls =
       match
         (* CR layouts v2.8: Consider making a function that doesn't compute
            histories for this use-case, which doesn't need it. *)
-        Ikind.sub_jkind_l
+        Ikind.check_type_decl_bound
           ~origin:(Format.asprintf
                      "typedecl:normalize %a (%a)"
                      (Format_doc.compat Path.print) path
@@ -3595,8 +3605,9 @@ let normalize_decl_jkinds env decls =
           ~context
           ~allow_any_crossing
           env
-          decl.type_jkind
-          original_decl.type_jkind
+          ~decl
+          ~actual:decl.type_jkind
+          ~bound:original_decl.type_jkind
       with
       | Ok _ ->
         if allow_any_crossing then
@@ -5763,14 +5774,24 @@ let report_error ~loc = function
       fprintf ppf "type %a" Style.inline_code path_end
     in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
-        env ppf v)
+      let report () =
+        Ikind.report_subjkind_error_with_offender ~offender env ppf v
+      in
+      match Ikind.subjkind_error_printing_env v with
+      | None -> report ()
+      | Some printing_env ->
+        Printtyp.wrap_printing_env ~error:true printing_env report)
   | Jkind_mismatch_of_type (env, ty, v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
-        env ppf v)
+      let report () =
+        Ikind.report_subjkind_error_with_offender ~offender env ppf v
+      in
+      match Ikind.subjkind_error_printing_env v with
+      | None -> report ()
+      | Some printing_env ->
+        Printtyp.wrap_printing_env ~error:true printing_env report)
   | Jkind_sort {env; kloc; typ; err} ->
     let s =
       match kloc with

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl.mli
@@ -213,8 +213,8 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of Env.t * type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Env.t * Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of Env.t * type_expr * Ikind.subjkind_error
+  | Jkind_mismatch_of_path of Env.t * Path.t * Ikind.subjkind_error
   | Jkind_mismatch_due_to_bad_inference of
       Env.t * type_expr * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of

--- a/external/merlin/upstream/ocaml_flambda/typing/typemode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemode.ml
@@ -160,19 +160,18 @@ end
    [global] must imply [aliased] for soundness of borrowing. *)
 let implied_modalities (Atom (ax, a) : Modality.atom) : Modality.atom list =
   match[@warning "-18"] ax, a with
-  | Comonadic Areality, Meet_const a ->
-    let f, y, u =
-      match a with
-      | Global ->
-        ( Forkable.Const.Forkable,
-          Yielding.Const.Unyielding,
-          [Uniqueness.Const.Aliased] )
-      | Local -> Forkable.Const.Unforkable, Yielding.Const.Yielding, []
-      | Regional -> assert false
-    in
-    [ Modality.Atom (Comonadic Forkable, Meet_const f);
-      Atom (Comonadic Yielding, Meet_const y) ]
-    @ List.map (fun x -> Modality.Atom (Monadic Uniqueness, Join_const x)) u
+  | Comonadic Areality, Meet_const a -> (
+    match a with
+    | Global ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Forkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Unyielding);
+        Atom (Monadic Uniqueness, Join_const Uniqueness.Const.Aliased) ]
+    | Local ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Unforkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Yielding) ]
+    (* [regional] cannot be written in an annotation, but bounds computed by
+       the ikind engine can reach here. It implies nothing. *)
+    | Regional -> [])
   | Monadic Visibility, Join_const a ->
     let b : Contention.Const.t =
       match a with
@@ -377,7 +376,13 @@ let least_modalities ~include_implied ~mut (t : Modality.Const.t) =
     List.filter_map
       (fun (Modality.Atom (ax, m_implied)) ->
         let m_projected = Modality.Const.proj ax t in
-        if m_projected <> m_implied || include_implied
+        let already_listed =
+          List.exists
+            (fun (Modality.Atom (ax', _)) ->
+              Modality.Axis.P ax' = Modality.Axis.P ax)
+            exclude_implied
+        in
+        if (m_projected <> m_implied || include_implied) && not already_listed
         then Some (Modality.Atom (ax, m_projected))
         else None)
       implied
@@ -676,6 +681,38 @@ let transl_mod_bounds ?(warn = true) annots =
   in
   let crossing = Crossing.modality modality Crossing.max in
   create crossing ~externality, (nonmodal.nullability, nonmodal.separability)
+
+let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
+    =
+  (* Bounds computed axis-by-axis (as in ikind provenance reporting) lack the
+     implied bounds that [transl_mod_bounds] inserts for user-written
+     annotations, e.g. [aliased forkable unyielding] for [global].
+     [untransl_mod_bounds] relies on those implications being present in order
+     to omit the implied modes when printing, so close the bounds first. *)
+  let crossing = Jkind.Mod_bounds.crossing bounds in
+  let modality = Crossing.to_modality crossing in
+  let annotated = Modality.Const.diff Modality.Const.id modality in
+  let implied = List.concat_map implied_modalities annotated in
+  let axis_is_explicit ax =
+    let projected =
+      Modality.Const.set ax (Modality.Const.proj ax modality) Modality.Const.id
+    in
+    match Modality.Const.equate projected Modality.Const.id with
+    | Ok () -> false
+    | Error _ -> true
+  in
+  let crossing =
+    List.fold_left
+      (fun crossing (Modality.Atom (ax, a)) ->
+        (* As in [transl_mod_bounds], an explicit bound on an axis wins over
+           a bound implied by another axis. *)
+        if axis_is_explicit ax
+        then crossing
+        else
+          Crossing.modality (Modality.Const.set ax a Modality.Const.id) crossing)
+      crossing implied
+  in
+  Jkind.Mod_bounds.set_crossing crossing bounds
 
 let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
     Parsetree.modes =

--- a/external/merlin/upstream/ocaml_flambda/typing/typemode.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemode.mli
@@ -81,6 +81,13 @@ val transl_mod_bounds :
   * (Jkind_axis.Nullability.t Location.loc option
     * Jkind_axis.Separability.t Location.loc option)
 
+(** Close mod-bounds under implied modalities, as [transl_mod_bounds] does for
+    user-written annotations (e.g. a [global] bound also bounds [aliased],
+    [forkable] and [unyielding]). Bounds computed axis-by-axis may lack these
+    implications, which [untransl_mod_bounds] relies on to omit implied modes
+    when printing. *)
+val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
+
 (** Translate an algebraic representation of mod bounds into user syntax. If
     [verbose] is true, redundant annotations are included. *)
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes

--- a/external/merlin/upstream/ocaml_flambda/typing/types.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/types.ml
@@ -28,6 +28,11 @@ module Rigid_name = struct
         }
     | KAtom of Path.t
     | Param of int
+    | Provenance of
+        { id : int;
+          ty : Format_doc.doc;
+          plural : bool
+        }
     | Unknown of unknown_id
 
   let compare a b =
@@ -40,13 +45,16 @@ module Rigid_name = struct
         if h != 0 then h else Int.compare a1.arg_index a2.arg_index
       | KAtom p1, KAtom p2 -> Path.compare p1 p2
       | Param x, Param y -> Int.compare x y
+      | Provenance x, Provenance y -> Int.compare x.id y.id
       | Atom _, _ -> -1
       | _, Atom _ -> 1
       | KAtom _, _ -> -1
       | _, KAtom _ -> 1
+      | Param _, _ -> -1
+      | _, Param _ -> 1
+      | Provenance _, _ -> -1
+      | _, Provenance _ -> 1
       | Unknown x, Unknown y -> Shape.Uid.compare x y
-      | Unknown _, _ -> 1
-      | _, Unknown _ -> -1
 
   let to_string = function
     | Atom { constr; arg_index } ->
@@ -56,6 +64,8 @@ module Rigid_name = struct
       let path_s = Format_doc.asprintf "%a" Path.print path in
       Printf.sprintf "katom[%s]" path_s
     | Param i -> Printf.sprintf "param[%d]" i
+    | Provenance { id; ty; plural = _ } ->
+      Format_doc.asprintf "provenance[%d:%a]" id Format_doc.pp_doc ty
     | Unknown id ->
       Format.asprintf "unknown[%a]" Shape.Uid.print id
 
@@ -64,6 +74,8 @@ module Rigid_name = struct
   let katom path = KAtom path
 
   let param i = Param i
+
+  let provenance ~id ~ty ~plural = Provenance { id; ty; plural }
 
   let unknown uid = Unknown uid
 end

--- a/external/merlin/upstream/ocaml_flambda/typing/types.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/types.mli
@@ -111,6 +111,20 @@ module Rigid_name : sig
         (** [Param id] only occurs in formulas for type constructors. Refers to
             a type-parameter of the constructor, where [id] is the
             [Types.get_id] of the type variable representing the parameter. *)
+    | Provenance of
+        { id : int;
+          (** Identifies this provenance occurrence. *)
+
+          ty : Format_doc.doc;
+          (** The type expression or descriptive noun phrase, retained as a
+              formatting document so its line-breaking instructions survive
+              until the diagnostic is printed. *)
+
+          plural : bool
+          (** Whether [ty] is a plural noun phrase rather than a type. *)
+        }
+        (** A diagnostic-only provenance variable. These variables must not
+            appear in stored [type_ikind]s. *)
     | Unknown of unknown_id
         (** An unknown quantity with a given id. Used to model not-best in
             ikinds. This is used when we couldn't compute a precise ikind,
@@ -127,6 +141,8 @@ module Rigid_name : sig
   val katom : Path.t -> t
 
   val param : int -> t
+
+  val provenance : id:int -> ty:Format_doc.doc -> plural:bool -> t
 
   val unknown : Shape.Uid.t -> t
 

--- a/oxcaml/tests/typing/axis_lattice_roundtrip_test.ml
+++ b/oxcaml/tests/typing/axis_lattice_roundtrip_test.ml
@@ -130,6 +130,14 @@ let co_sub_reference_impl (type t)
     (fun acc c -> if Axis.le a (Axis.join b c) then Axis.meet acc c else acc)
     Axis.max all_values
 
+let imply_reference_impl (type t)
+    (module Axis : Mode_intf.Lattice with type t = t) (all_values : t list)
+    (a : t) (b : t) =
+  (* imply(a, b) = join { c | meet(a, c) <= b } *)
+  List.fold_left
+    (fun acc c -> if Axis.le (Axis.meet a c) b then Axis.join acc c else acc)
+    Axis.min all_values
+
 let check_operations (type t) (module Axis : Mode_intf.Lattice with type t = t)
     label update extract (all_values : t list) =
   List.iter
@@ -158,6 +166,11 @@ let check_operations (type t) (module Axis : Mode_intf.Lattice with type t = t)
               expect_value "co_sub"
                 (extract (co_sub lhs rhs))
                 (co_sub_reference_impl
+                   (module Axis)
+                   all_values lhs_value rhs_value);
+              expect_value "imply"
+                (extract (imply lhs rhs))
+                (imply_reference_impl
                    (module Axis)
                    all_values lhs_value rhs_value);
               let expected_leq = Axis.le lhs_value rhs_value in

--- a/oxcaml/tests/typing/dune
+++ b/oxcaml/tests/typing/dune
@@ -1,3 +1,3 @@
 (tests
- (names global_module_test axis_lattice_roundtrip_test)
+ (names global_module_test axis_lattice_roundtrip_test ldd_imply_test)
  (libraries ocamlcommon))

--- a/oxcaml/tests/typing/dune
+++ b/oxcaml/tests/typing/dune
@@ -1,3 +1,3 @@
 (tests
- (names global_module_test axis_lattice_roundtrip_test)
+ (names global_module_test axis_lattice_roundtrip_test ldd_imply_test)
  (libraries ocamlfrontend))

--- a/oxcaml/tests/typing/ldd_imply_test.ml
+++ b/oxcaml/tests/typing/ldd_imply_test.ml
@@ -1,0 +1,90 @@
+module L = Ldd.Make (struct
+  type t = string
+
+  let compare = String.compare
+
+  let to_string x = x
+end)
+
+let leq a b = L.leq_with_reason a b = []
+
+let assert_equiv label a b =
+  if not (leq a b && leq b a)
+  then
+    failwith
+      (Printf.sprintf "LDD equivalence failed for %s:\nleft:  %s\nright: %s"
+         label (L.pp a) (L.pp b))
+
+let assert_bool label actual expected =
+  if actual <> expected
+  then failwith (Printf.sprintf "LDD check failed for %s" label)
+
+let assert_axis_lattice label actual expected =
+  if not (Axis_lattice.equal actual expected)
+  then
+    failwith
+      (Printf.sprintf
+         "Axis_lattice check failed for %s:\nactual:   %s\nexpected: %s" label
+         (Axis_lattice.to_string actual)
+         (Axis_lattice.to_string expected))
+
+let var name = L.node_of_var (L.rigid name)
+
+let () =
+  let top = L.const Axis_lattice.top in
+  let x = var "x" in
+  let y = var "y" in
+  let z = var "z" in
+  assert_equiv "bot => x" (L.imply L.bot x) top;
+  assert_equiv "x => x" (L.imply x x) top;
+  assert_equiv "x => bot" (L.imply x L.bot) L.bot;
+  assert_equiv "(x meet y) => x" (L.imply (L.meet x y) x) top;
+  assert_equiv "x => (x meet y)" (L.imply x (L.meet x y)) y;
+  assert_equiv "(x join y) => x" (L.imply (L.join x y) x) x;
+  let pending_gfp = L.new_var () in
+  let pending_gfp_node = L.node_of_var pending_gfp in
+  L.enqueue_gfp pending_gfp L.bot;
+  assert_equiv "pending gfp is solved before implication"
+    (L.imply pending_gfp_node L.bot)
+    top;
+  let immutable_data = Axis_lattice.immutable_data in
+  let c = L.const immutable_data in
+  let d = L.const Axis_lattice.value in
+  assert_equiv "provenance variable implies constant" (L.imply x c) c;
+  let implication_with_other_provenance = L.imply x (L.join c y) in
+  assert_axis_lattice "round_down ignores other provenance"
+    (L.round_down implication_with_other_provenance)
+    immutable_data;
+  assert_axis_lattice "round_up includes other provenance"
+    (L.round_up implication_with_other_provenance)
+    Axis_lattice.top;
+  let terms =
+    [ L.bot;
+      top;
+      c;
+      d;
+      x;
+      y;
+      z;
+      L.join x y;
+      L.join x c;
+      L.join (L.meet x y) z;
+      L.meet x y;
+      L.meet x c;
+      L.meet (L.join x y) (L.join y z) ]
+  in
+  List.iteri
+    (fun i a ->
+      List.iteri
+        (fun j b ->
+          let a_implies_b = L.imply a b in
+          List.iteri
+            (fun k h ->
+              let lhs = leq (L.meet a h) b in
+              let rhs = leq h a_implies_b in
+              assert_bool
+                (Printf.sprintf "adjunction a=%d b=%d h=%d" i j k)
+                lhs rhs)
+            terms)
+        terms)
+    terms

--- a/oxcaml/tests/typing/ldd_imply_test.ml
+++ b/oxcaml/tests/typing/ldd_imply_test.ml
@@ -6,7 +6,7 @@ module L = Ldd.Make (struct
   let to_string x = x
 end)
 
-let leq a b = L.leq_with_reason a b = []
+let leq a b = List.is_empty (L.leq_with_reason a b)
 
 let assert_equiv label a b =
   if not (leq a b && leq b a)

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1208,6 +1208,73 @@ Error: The kind of type "t" is immutable_data with t_value
          because of the annotation on the declaration of the type t.
 |}]
 
+type t : value mod shareable = { x : t_value }
+[%%expect {|
+Line 1, characters 0-46:
+1 | type t : value mod shareable = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod shareable
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod shared = { x : t_value }
+[%%expect {|
+Line 1, characters 0-43:
+1 | type t : value mod shared = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod shared
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod reading = { x : t_value }
+[%%expect {|
+Line 1, characters 0-44:
+1 | type t : value mod reading = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod reading
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod read = { x : t_value }
+[%%expect {|
+Line 1, characters 0-41:
+1 | type t : value mod read = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod read
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod read corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-51:
+1 | type t : value mod read corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod read corrupted
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod immutable corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-56:
+1 | type t : value mod immutable corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of
+           value mod immutable corrupted
+         because of the annotation on the declaration of the type t.
+|}]
+
 type t : value mod external_ = { x : t_value }
 [%%expect {|
 Line 1, characters 0-46:

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -1214,6 +1214,73 @@ Error: The kind of type "t" is immutable_data with t_value
          because of the annotation on the declaration of the type t.
 |}]
 
+type t : value mod shareable = { x : t_value }
+[%%expect {|
+Line 1, characters 0-46:
+1 | type t : value mod shareable = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod shareable
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod shared = { x : t_value }
+[%%expect {|
+Line 1, characters 0-43:
+1 | type t : value mod shared = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod shared
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod reading = { x : t_value }
+[%%expect {|
+Line 1, characters 0-44:
+1 | type t : value mod reading = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod reading
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod read = { x : t_value }
+[%%expect {|
+Line 1, characters 0-41:
+1 | type t : value mod read = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod read
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod read corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-51:
+1 | type t : value mod read corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod read corrupted
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod immutable corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-56:
+1 | type t : value mod immutable corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with t_value
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of
+           value mod immutable corrupted
+         because of the annotation on the declaration of the type t.
+|}]
+
 type t : value mod external_ = { x : t_value }
 [%%expect {|
 Line 1, characters 0-46:

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -1120,7 +1120,7 @@ Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 type t : any mod portable = { x : float }
@@ -1156,8 +1156,8 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this record type is not mod global aliased
-       - t_value is not mod global aliased forkable unyielding
+       - boxed records are not mod global
+       - t_value is not mod global
 |}]
 
 type t : value mod aliased = { x : t_value }
@@ -1167,7 +1167,7 @@ Line 1, characters 0-44:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
        because
-       - this record type is not mod aliased
+       - boxed records are not mod aliased
        - t_value is not mod aliased
 |}]
 
@@ -1222,7 +1222,7 @@ Line 1, characters 0-44:
 1 | type t : value mod reading = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod reading,
-       because t_value is not mod shareable reading.
+       because t_value is not mod reading.
 |}]
 
 type t : value mod read = { x : t_value }
@@ -1231,7 +1231,27 @@ Line 1, characters 0-41:
 1 | type t : value mod read = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod read,
-       because t_value is not mod shared read.
+       because t_value is not mod read.
+|}]
+
+type t : value mod read corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-51:
+1 | type t : value mod read corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod read corrupted,
+       because t_value is not mod read corrupted.
+|}]
+
+type t : value mod immutable corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-56:
+1 | type t : value mod immutable corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod immutable corrupted,
+       because t_value is not mod immutable corrupted.
 |}]
 
 type t : value mod external_ = { x : t_value }
@@ -1241,7 +1261,7 @@ Line 1, characters 0-46:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
        because
-       - this record type is not mod external_
+       - boxed records are not mod external_
        - t_value is not mod external_
 |}]
 
@@ -1266,7 +1286,7 @@ Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this variant type is not mod global aliased.
+       because boxed variants are not mod global.
 |}]
 
 type t : any mod portable = Foo of float
@@ -1323,8 +1343,8 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this variant type is not mod global aliased
-       - t_value is not mod global aliased forkable unyielding
+       - boxed variants are not mod global
+       - t_value is not mod global
 |}]
 
 type t : value mod aliased = Foo of t_value
@@ -1334,7 +1354,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
        because
-       - this variant type is not mod aliased
+       - boxed variants are not mod aliased
        - t_value is not mod aliased
 |}]
 
@@ -1372,7 +1392,7 @@ Line 1, characters 0-45:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
        because
-       - this variant type is not mod external_
+       - boxed variants are not mod external_
        - t_value is not mod external_
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -1119,10 +1119,8 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this record type is not mod global aliased.
 |}]
 
 type t : any mod portable = { x : float }
@@ -1156,10 +1154,10 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this record type is not mod global aliased
+       - t_value is not mod global aliased forkable unyielding
 |}]
 
 type t : value mod aliased = { x : t_value }
@@ -1167,10 +1165,10 @@ type t : value mod aliased = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : value mod aliased = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because
+       - this record type is not mod aliased
+       - t_value is not mod aliased
 |}]
 
 type t : value mod many = { x : t_value }
@@ -1178,10 +1176,8 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because t_value is not mod many.
 |}]
 
 type t : value mod portable = { x : t_value }
@@ -1189,10 +1185,8 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because t_value is not mod portable.
 |}]
 
 type t : value mod contended = { x : t_value }
@@ -1200,10 +1194,44 @@ type t : value mod contended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because t_value is not mod contended.
+|}]
+
+type t : value mod shareable = { x : t_value }
+[%%expect {|
+Line 1, characters 0-46:
+1 | type t : value mod shareable = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod shareable,
+       because t_value is not mod shareable.
+|}]
+
+type t : value mod shared = { x : t_value }
+[%%expect {|
+Line 1, characters 0-43:
+1 | type t : value mod shared = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod shared,
+       because t_value is not mod shared.
+|}]
+
+type t : value mod reading = { x : t_value }
+[%%expect {|
+Line 1, characters 0-44:
+1 | type t : value mod reading = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod reading,
+       because t_value is not mod shareable reading.
+|}]
+
+type t : value mod read = { x : t_value }
+[%%expect {|
+Line 1, characters 0-41:
+1 | type t : value mod read = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod read,
+       because t_value is not mod shared read.
 |}]
 
 type t : value mod external_ = { x : t_value }
@@ -1211,10 +1239,10 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because
+       - this record type is not mod external_
+       - t_value is not mod external_
 |}]
 
 (***************************************)
@@ -1237,10 +1265,8 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this variant type is not mod global aliased.
 |}]
 
 type t : any mod portable = Foo of float
@@ -1295,10 +1321,10 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this variant type is not mod global aliased
+       - t_value is not mod global aliased forkable unyielding
 |}]
 
 type t : value mod aliased = Foo of t_value
@@ -1306,10 +1332,10 @@ type t : value mod aliased = Foo of t_value
 Line 1, characters 0-43:
 1 | type t : value mod aliased = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because
+       - this variant type is not mod aliased
+       - t_value is not mod aliased
 |}]
 
 type t : value mod many = Foo of t_value
@@ -1317,10 +1343,8 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because t_value is not mod many.
 |}]
 
 type t : value mod portable = Foo of t_value
@@ -1328,10 +1352,8 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because t_value is not mod portable.
 |}]
 
 type t : value mod contended = Foo of t_value
@@ -1339,10 +1361,8 @@ type t : value mod contended = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod contended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because t_value is not mod contended.
 |}]
 
 type t : value mod external_ = Foo of t_value
@@ -1350,10 +1370,10 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because
+       - this variant type is not mod external_
+       - t_value is not mod external_
 |}]
 
 (***************************************)

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -1125,10 +1125,8 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this record type is not mod global aliased.
 |}]
 
 type t : any mod portable = { x : float }
@@ -1162,10 +1160,10 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this record type is not mod global aliased
+       - t_value is not mod global aliased forkable unyielding
 |}]
 
 type t : value mod aliased = { x : t_value }
@@ -1173,10 +1171,10 @@ type t : value mod aliased = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : value mod aliased = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because
+       - this record type is not mod aliased
+       - t_value is not mod aliased
 |}]
 
 type t : value mod many = { x : t_value }
@@ -1184,10 +1182,8 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because t_value is not mod many.
 |}]
 
 type t : value mod portable = { x : t_value }
@@ -1195,10 +1191,8 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because t_value is not mod portable.
 |}]
 
 type t : value mod contended = { x : t_value }
@@ -1206,10 +1200,44 @@ type t : value mod contended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because t_value is not mod contended.
+|}]
+
+type t : value mod shareable = { x : t_value }
+[%%expect {|
+Line 1, characters 0-46:
+1 | type t : value mod shareable = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod shareable,
+       because t_value is not mod shareable.
+|}]
+
+type t : value mod shared = { x : t_value }
+[%%expect {|
+Line 1, characters 0-43:
+1 | type t : value mod shared = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod shared,
+       because t_value is not mod shared.
+|}]
+
+type t : value mod reading = { x : t_value }
+[%%expect {|
+Line 1, characters 0-44:
+1 | type t : value mod reading = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod reading,
+       because t_value is not mod shareable reading.
+|}]
+
+type t : value mod read = { x : t_value }
+[%%expect {|
+Line 1, characters 0-41:
+1 | type t : value mod read = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod read,
+       because t_value is not mod shared read.
 |}]
 
 type t : value mod external_ = { x : t_value }
@@ -1217,10 +1245,10 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because
+       - this record type is not mod external_
+       - t_value is not mod external_
 |}]
 
 (***************************************)
@@ -1243,10 +1271,8 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this variant type is not mod global aliased.
 |}]
 
 type t : any mod portable = Foo of float
@@ -1301,10 +1327,10 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this variant type is not mod global aliased
+       - t_value is not mod global aliased forkable unyielding
 |}]
 
 type t : value mod aliased = Foo of t_value
@@ -1312,10 +1338,10 @@ type t : value mod aliased = Foo of t_value
 Line 1, characters 0-43:
 1 | type t : value mod aliased = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because
+       - this variant type is not mod aliased
+       - t_value is not mod aliased
 |}]
 
 type t : value mod many = Foo of t_value
@@ -1323,10 +1349,8 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because t_value is not mod many.
 |}]
 
 type t : value mod portable = Foo of t_value
@@ -1334,10 +1358,8 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because t_value is not mod portable.
 |}]
 
 type t : value mod contended = Foo of t_value
@@ -1345,10 +1367,8 @@ type t : value mod contended = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod contended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because t_value is not mod contended.
 |}]
 
 type t : value mod external_ = Foo of t_value
@@ -1356,10 +1376,10 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because
+       - this variant type is not mod external_
+       - t_value is not mod external_
 |}]
 
 (***************************************)

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -1126,7 +1126,7 @@ Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 type t : any mod portable = { x : float }
@@ -1162,8 +1162,8 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this record type is not mod global aliased
-       - t_value is not mod global aliased forkable unyielding
+       - boxed records are not mod global
+       - t_value is not mod global
 |}]
 
 type t : value mod aliased = { x : t_value }
@@ -1173,7 +1173,7 @@ Line 1, characters 0-44:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
        because
-       - this record type is not mod aliased
+       - boxed records are not mod aliased
        - t_value is not mod aliased
 |}]
 
@@ -1228,7 +1228,7 @@ Line 1, characters 0-44:
 1 | type t : value mod reading = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod reading,
-       because t_value is not mod shareable reading.
+       because t_value is not mod reading.
 |}]
 
 type t : value mod read = { x : t_value }
@@ -1237,7 +1237,27 @@ Line 1, characters 0-41:
 1 | type t : value mod read = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod read,
-       because t_value is not mod shared read.
+       because t_value is not mod read.
+|}]
+
+type t : value mod read corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-51:
+1 | type t : value mod read corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod read corrupted,
+       because t_value is not mod read corrupted.
+|}]
+
+type t : value mod immutable corrupted = { x : t_value }
+[%%expect {|
+Line 1, characters 0-56:
+1 | type t : value mod immutable corrupted = { x : t_value }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod immutable corrupted,
+       because t_value is not mod immutable corrupted.
 |}]
 
 type t : value mod external_ = { x : t_value }
@@ -1247,7 +1267,7 @@ Line 1, characters 0-46:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
        because
-       - this record type is not mod external_
+       - boxed records are not mod external_
        - t_value is not mod external_
 |}]
 
@@ -1272,7 +1292,7 @@ Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this variant type is not mod global aliased.
+       because boxed variants are not mod global.
 |}]
 
 type t : any mod portable = Foo of float
@@ -1329,8 +1349,8 @@ Line 1, characters 0-42:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this variant type is not mod global aliased
-       - t_value is not mod global aliased forkable unyielding
+       - boxed variants are not mod global
+       - t_value is not mod global
 |}]
 
 type t : value mod aliased = Foo of t_value
@@ -1340,7 +1360,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
        because
-       - this variant type is not mod aliased
+       - boxed variants are not mod aliased
        - t_value is not mod aliased
 |}]
 
@@ -1378,7 +1398,7 @@ Line 1, characters 0-45:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
        because
-       - this variant type is not mod external_
+       - boxed variants are not mod external_
        - t_value is not mod external_
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -1125,7 +1125,8 @@ type t : value mod global = { x : int}
 Line 1, characters 0-38:
 1 | type t : value mod global = { x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because boxed records are not mod global.
 |}]
 
@@ -1160,7 +1161,8 @@ type t : value mod global = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because
        - boxed records are not mod global
        - t_value is not mod global
@@ -1171,7 +1173,8 @@ type t : value mod aliased = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : value mod aliased = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased,
        because
        - boxed records are not mod aliased
        - t_value is not mod aliased
@@ -1182,7 +1185,8 @@ type t : value mod many = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod many,
+Error: This type definition does not satisfy its kind annotation
+         value mod many,
        because t_value is not mod many.
 |}]
 
@@ -1191,7 +1195,8 @@ type t : value mod portable = { x : t_value }
 Line 1, characters 0-45:
 1 | type t : value mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod portable,
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
        because t_value is not mod portable.
 |}]
 
@@ -1200,7 +1205,8 @@ type t : value mod contended = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because t_value is not mod contended.
 |}]
 
@@ -1209,7 +1215,8 @@ type t : value mod shareable = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod shareable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod shareable,
+Error: This type definition does not satisfy its kind annotation
+         value mod shareable,
        because t_value is not mod shareable.
 |}]
 
@@ -1218,7 +1225,8 @@ type t : value mod shared = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : value mod shared = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod shared,
+Error: This type definition does not satisfy its kind annotation
+         value mod shared,
        because t_value is not mod shared.
 |}]
 
@@ -1227,7 +1235,8 @@ type t : value mod reading = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : value mod reading = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod reading,
+Error: This type definition does not satisfy its kind annotation
+         value mod reading,
        because t_value is not mod reading.
 |}]
 
@@ -1236,7 +1245,8 @@ type t : value mod read = { x : t_value }
 Line 1, characters 0-41:
 1 | type t : value mod read = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod read,
+Error: This type definition does not satisfy its kind annotation
+         value mod read,
        because t_value is not mod read.
 |}]
 
@@ -1265,7 +1275,8 @@ type t : value mod external_ = { x : t_value }
 Line 1, characters 0-46:
 1 | type t : value mod external_ = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod external_,
+Error: This type definition does not satisfy its kind annotation
+         value mod external_,
        because
        - boxed records are not mod external_
        - t_value is not mod external_
@@ -1291,7 +1302,8 @@ type t : value mod global = Foo of int
 Line 1, characters 0-38:
 1 | type t : value mod global = Foo of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because boxed variants are not mod global.
 |}]
 
@@ -1347,7 +1359,8 @@ type t : value mod global = Foo of t_value
 Line 1, characters 0-42:
 1 | type t : value mod global = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because
        - boxed variants are not mod global
        - t_value is not mod global
@@ -1358,7 +1371,8 @@ type t : value mod aliased = Foo of t_value
 Line 1, characters 0-43:
 1 | type t : value mod aliased = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased,
        because
        - boxed variants are not mod aliased
        - t_value is not mod aliased
@@ -1369,7 +1383,8 @@ type t : value mod many = Foo of t_value
 Line 1, characters 0-40:
 1 | type t : value mod many = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod many,
+Error: This type definition does not satisfy its kind annotation
+         value mod many,
        because t_value is not mod many.
 |}]
 
@@ -1378,7 +1393,8 @@ type t : value mod portable = Foo of t_value
 Line 1, characters 0-44:
 1 | type t : value mod portable = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod portable,
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
        because t_value is not mod portable.
 |}]
 
@@ -1387,7 +1403,8 @@ type t : value mod contended = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod contended = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because t_value is not mod contended.
 |}]
 
@@ -1396,7 +1413,8 @@ type t : value mod external_ = Foo of t_value
 Line 1, characters 0-45:
 1 | type t : value mod external_ = Foo of t_value
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod external_,
+Error: This type definition does not satisfy its kind annotation
+         value mod external_,
        because
        - boxed variants are not mod external_
        - t_value is not mod external_

--- a/testsuite/tests/typing-jkind-bounds/atomic_mutability.ml
+++ b/testsuite/tests/typing-jkind-bounds/atomic_mutability.ml
@@ -12,6 +12,18 @@ type t : sync_data =
 type t = { mutable x : int [@atomic]; mutable y : int [@atomic]; }
 |}]
 
+(* Records: atomic fields are not immutable_data. *)
+type t : immutable_data = { mutable x : int [@atomic] }
+[%%expect {|
+Line 1, characters 0-55:
+1 | type t : immutable_data = { mutable x : int [@atomic] }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is sync_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+|}]
+
 (* Records: any non-atomic mutable field is not sync_data. *)
 type t : sync_data = { mutable x : int }
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/atomic_mutability.ml
+++ b/testsuite/tests/typing-jkind-bounds/atomic_mutability.ml
@@ -48,6 +48,41 @@ Error: The kind of type "t" is mutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
+(* Two offending fields: identical subjects merge, distinct ones do not. *)
+type t : immutable_data =
+  { mutable x : int [@atomic]; mutable y : int [@atomic] }
+[%%expect {|
+Lines 1-2, characters 0-58:
+1 | type t : immutable_data =
+2 |   { mutable x : int [@atomic]; mutable y : int [@atomic] }
+Error: The kind of type "t" is sync_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : immutable_data = { mutable x : int [@atomic]; mutable y : int }
+[%%expect {|
+Line 1, characters 0-72:
+1 | type t : immutable_data = { mutable x : int [@atomic]; mutable y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : immutable_data = { mutable x : int; mutable y : int }
+[%%expect {|
+Line 1, characters 0-62:
+1 | type t : immutable_data = { mutable x : int; mutable y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+|}]
+
 (* Variants: atomic record payloads are sync_data. *)
 type t : sync_data = A of { mutable x : int [@atomic] } | B
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
@@ -11,16 +11,24 @@ type t : sync_data =
 type t = { mutable x : int [@atomic]; mutable y : int [@atomic]; }
 |}]
 
+(* Records: atomic fields are not immutable_data. *)
+type t : immutable_data = { mutable x : int [@atomic] }
+[%%expect {|
+Line 1, characters 0-55:
+1 | type t : immutable_data = { mutable x : int [@atomic] }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because mutable field x : int [@atomic] is not mod immutable.
+|}]
+
 (* Records: any non-atomic mutable field is not sync_data. *)
 type t : sync_data = { mutable x : int }
 [%%expect {|
 Line 1, characters 0-40:
 1 | type t : sync_data = { mutable x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because mutable field x : int is not mod contended.
 |}]
 
 type t : sync_data =
@@ -29,10 +37,8 @@ type t : sync_data =
 Lines 1-2, characters 0-48:
 1 | type t : sync_data =
 2 |   { mutable x : int; mutable y : int [@atomic] }
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because mutable field x : int is not mod contended.
 |}]
 
 (* Variants: atomic record payloads are sync_data. *)
@@ -47,10 +53,8 @@ type t : sync_data = A of { mutable x : int } | B
 Line 1, characters 0-49:
 1 | type t : sync_data = A of { mutable x : int } | B
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because mutable field x : int is not mod contended.
 |}]
 
 type t : sync_data =
@@ -59,8 +63,6 @@ type t : sync_data =
 Lines 1-2, characters 0-53:
 1 | type t : sync_data =
 2 |   A of { mutable x : int; mutable y : int [@atomic] }
-Error: The kind of type "t" is mutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because mutable field x : int is not mod contended.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
@@ -18,7 +18,7 @@ Line 1, characters 0-55:
 1 | type t : immutable_data = { mutable x : int [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because mutable field x : int [@atomic] is not mod immutable.
+       because atomic mutable fields are not mod immutable.
 |}]
 
 (* Records: any non-atomic mutable field is not sync_data. *)
@@ -28,7 +28,7 @@ Line 1, characters 0-40:
 1 | type t : sync_data = { mutable x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation sync_data,
-       because mutable field x : int is not mod contended.
+       because mutable fields are not mod contended.
 |}]
 
 type t : sync_data =
@@ -38,7 +38,7 @@ Lines 1-2, characters 0-48:
 1 | type t : sync_data =
 2 |   { mutable x : int; mutable y : int [@atomic] }
 Error: This type definition does not satisfy its kind annotation sync_data,
-       because mutable field x : int is not mod contended.
+       because mutable fields are not mod contended.
 |}]
 
 (* Variants: atomic record payloads are sync_data. *)
@@ -54,7 +54,7 @@ Line 1, characters 0-49:
 1 | type t : sync_data = A of { mutable x : int } | B
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation sync_data,
-       because mutable field x : int is not mod contended.
+       because mutable fields are not mod contended.
 |}]
 
 type t : sync_data =
@@ -64,5 +64,5 @@ Lines 1-2, characters 0-53:
 1 | type t : sync_data =
 2 |   A of { mutable x : int; mutable y : int [@atomic] }
 Error: This type definition does not satisfy its kind annotation sync_data,
-       because mutable field x : int is not mod contended.
+       because mutable fields are not mod contended.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
@@ -41,6 +41,37 @@ Error: This type definition does not satisfy its kind annotation sync_data,
        because mutable fields are not mod contended.
 |}]
 
+(* Two offending fields: identical subjects merge, distinct ones do not. *)
+type t : immutable_data =
+  { mutable x : int [@atomic]; mutable y : int [@atomic] }
+[%%expect {|
+Lines 1-2, characters 0-58:
+1 | type t : immutable_data =
+2 |   { mutable x : int [@atomic]; mutable y : int [@atomic] }
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because atomic mutable fields are not mod immutable.
+|}]
+
+type t : immutable_data = { mutable x : int [@atomic]; mutable y : int }
+[%%expect {|
+Line 1, characters 0-72:
+1 | type t : immutable_data = { mutable x : int [@atomic]; mutable y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because
+       - atomic mutable fields are not mod immutable
+       - mutable fields are not mod immutable
+|}]
+
+type t : immutable_data = { mutable x : int; mutable y : int }
+[%%expect {|
+Line 1, characters 0-62:
+1 | type t : immutable_data = { mutable x : int; mutable y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because mutable fields are not mod immutable.
+|}]
+
 (* Variants: atomic record payloads are sync_data. *)
 type t : sync_data = A of { mutable x : int [@atomic] } | B
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/atomic_mutability_ikinds.ml
@@ -17,7 +17,8 @@ type t : immutable_data = { mutable x : int [@atomic] }
 Line 1, characters 0-55:
 1 | type t : immutable_data = { mutable x : int [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because atomic mutable fields are not mod immutable.
 |}]
 
@@ -48,7 +49,8 @@ type t : immutable_data =
 Lines 1-2, characters 0-58:
 1 | type t : immutable_data =
 2 |   { mutable x : int [@atomic]; mutable y : int [@atomic] }
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because atomic mutable fields are not mod immutable.
 |}]
 
@@ -57,7 +59,8 @@ type t : immutable_data = { mutable x : int [@atomic]; mutable y : int }
 Line 1, characters 0-72:
 1 | type t : immutable_data = { mutable x : int [@atomic]; mutable y : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because
        - atomic mutable fields are not mod immutable
        - mutable fields are not mod immutable
@@ -68,7 +71,8 @@ type t : immutable_data = { mutable x : int; mutable y : int }
 Line 1, characters 0-62:
 1 | type t : immutable_data = { mutable x : int; mutable y : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because mutable fields are not mod immutable.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -839,6 +839,19 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
+(* Fields failing on different axes produce one bullet each, each carrying
+   only its own violating axes. *)
+type t : immutable_data = { mutable a : int; f : int -> int }
+[%%expect{|
+Line 1, characters 0-61:
+1 | type t : immutable_data = { mutable a : int; f : int -> int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value non_float
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+|}]
+
 type t : any mod external_ = { x : int }
 [%%expect {|
 Line 1, characters 0-40:
@@ -1964,6 +1977,103 @@ Error: The kind of type "c" is immutable_data with 'a a with 'b a
        But the kind of type "c" must be a subkind of
            value mod portable contended
          because of the annotation on the declaration of the type c.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-49:
+2 | type 'a t : immutable_data with 'a r = { x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data with 'a r
+         because of the annotation on the declaration of the type t.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-61:
+2 | type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with 'a @@ portable
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data with 'a r
+         because of the annotation on the declaration of the type t.
+
+       The first mode-crosses less than the second along:
+         linearity: mod many with 'a ≰ mod many with 'a r
+         contention: mod contended with 'a ≰ mod contended with 'a r
+         forkable: mod forkable with 'a ≰ mod forkable with 'a r
+         yielding: mod unyielding with 'a ≰ mod unyielding with 'a r
+         statefulness: mod stateless with 'a ≰ mod stateless with 'a r
+         visibility: mod immutable with 'a ≰ mod immutable with 'a r
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable contended =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable contended =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: The kind of type "r" is
+           value
+             non_float
+             mod portable contended
+             with q @@ contended
+             with t @@ portable
+         because it's a boxed variant type.
+       But the kind of type "r" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type r.
+
+       The first mode-crosses less than the second along:
+         contention: mod contended with t ≰ mod contended
+         portability: mod portable with q ≰ mod portable
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable shared =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable shared =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: The kind of type "r" is
+           value
+             non_float
+             mod portable contended
+             with q @@ contended
+             with t @@ portable
+         because it's a boxed variant type.
+       But the kind of type "r" must be a subkind of value mod portable shared
+         because of the annotation on the declaration of the type r.
+
+       The first mode-crosses less than the second along:
+         contention: mod contended with t ≰ mod shared
+         portability: mod portable with q ≰ mod portable
 |}]
 
 type t : value mod contended

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -849,6 +849,19 @@ Error: The kind of type "t" is immutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
+(* Fields failing on different axes produce one bullet each, each carrying
+   only its own violating axes. *)
+type t : immutable_data = { mutable a : int; f : int -> int }
+[%%expect{|
+Line 1, characters 0-61:
+1 | type t : immutable_data = { mutable a : int; f : int -> int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value non_float
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+|}]
+
 type t : any mod external_ = { x : int }
 [%%expect {|
 Line 1, characters 0-40:
@@ -1974,6 +1987,103 @@ Error: The kind of type "c" is immutable_data with 'a a with 'b a
        But the kind of type "c" must be a subkind of
            value mod portable contended
          because of the annotation on the declaration of the type c.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-49:
+2 | type 'a t : immutable_data with 'a r = { x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data with 'a r
+         because of the annotation on the declaration of the type t.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-61:
+2 | type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with 'a @@ portable
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of immutable_data with 'a r
+         because of the annotation on the declaration of the type t.
+
+       The first mode-crosses less than the second along:
+         linearity: mod many with 'a ≰ mod many with 'a r
+         contention: mod contended with 'a ≰ mod contended with 'a r
+         forkable: mod forkable with 'a ≰ mod forkable with 'a r
+         yielding: mod unyielding with 'a ≰ mod unyielding with 'a r
+         statefulness: mod stateless with 'a ≰ mod stateless with 'a r
+         visibility: mod immutable with 'a ≰ mod immutable with 'a r
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable contended =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable contended =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: The kind of type "r" is
+           value
+             non_float
+             mod portable contended
+             with q @@ contended
+             with t @@ portable
+         because it's a boxed variant type.
+       But the kind of type "r" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type r.
+
+       The first mode-crosses less than the second along:
+         contention: mod contended with t ≰ mod contended
+         portability: mod portable with q ≰ mod portable
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable shared =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable shared =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: The kind of type "r" is
+           value
+             non_float
+             mod portable contended
+             with q @@ contended
+             with t @@ portable
+         because it's a boxed variant type.
+       But the kind of type "r" must be a subkind of value mod portable shared
+         because of the annotation on the declaration of the type r.
+
+       The first mode-crosses less than the second along:
+         contention: mod contended with t ≰ mod shared
+         portability: mod portable with q ≰ mod portable
 |}]
 
 type t : value mod contended

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -715,10 +715,10 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because
+       - this record type is not mod global aliased
+       - string is not mod global aliased
 |}]
 
 type t : any mod aliased = { x : string }
@@ -726,10 +726,10 @@ type t : any mod aliased = { x : string }
 Line 1, characters 0-41:
 1 | type t : any mod aliased = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because
+       - this record type is not mod aliased
+       - string is not mod aliased
 |}]
 
 type t : any mod external_ = { x : string }
@@ -737,10 +737,10 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because
+       - this record type is not mod external_
+       - string is not mod external_
 |}]
 
 type t : any mod many = { x : string }
@@ -757,10 +757,8 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod many,
+       because t_value is not mod many.
 |}]
 
 type t : any mod contended = { x : t_value }
@@ -768,10 +766,8 @@ type t : any mod contended = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : any mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod contended,
+       because t_value is not mod contended.
 |}]
 
 type t : any mod portable = { x : t_value }
@@ -779,10 +775,8 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod portable,
+       because t_value is not mod portable.
 |}]
 
 type t : any mod many contended portable global = { x : t_value }
@@ -790,11 +784,12 @@ type t : any mod many contended portable global = { x : t_value }
 Line 1, characters 0-65:
 1 | type t : any mod many contended portable global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of
-           any mod global many portable contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         any mod global many portable contended,
+       because
+       - this record type is not mod global aliased
+       - t_value is not mod global aliased many contended portable forkable
+           unyielding
 |}]
 
 type u : immediate
@@ -833,10 +828,21 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because this record type is not mod global aliased.
+|}]
+
+(* Fields failing on different axes produce one bullet each, each carrying
+   only its own violating axes. *)
+type t : immutable_data = { mutable a : int; f : int -> int }
+[%%expect{|
+Line 1, characters 0-61:
+1 | type t : immutable_data = { mutable a : int; f : int -> int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because
+       - mutable field a : int is not mod contended immutable
+       - int -> int is not mod many portable forkable unyielding stateless
 |}]
 
 type t : any mod external_ = { x : int }
@@ -844,10 +850,8 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because this record type is not mod external_.
 |}]
 
 type t : any mod aliased = { x : int }
@@ -855,10 +859,8 @@ type t : any mod aliased = { x : int }
 Line 1, characters 0-38:
 1 | type t : any mod aliased = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because this record type is not mod aliased.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
@@ -905,10 +907,8 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because u is not mod global aliased forkable unyielding.
 |}]
 
 type t : any mod portable = { x : u } [@@unboxed]
@@ -916,10 +916,8 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod portable,
+       because u is not mod portable.
 |}]
 
 type t : any mod contended = { x : u } [@@unboxed]
@@ -927,10 +925,8 @@ type t : any mod contended = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod contended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod contended,
+       because u is not mod contended.
 |}]
 
 type t : any mod external_ = { x : u } [@@unboxed]
@@ -938,10 +934,8 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because u is not mod external_.
 |}]
 
 type t : any mod many = { x : u } [@@unboxed]
@@ -949,10 +943,8 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod many,
+       because u is not mod many.
 |}]
 
 type t : any mod aliased = { x : u } [@@unboxed]
@@ -960,10 +952,8 @@ type t : any mod aliased = { x : u } [@@unboxed]
 Line 1, characters 0-48:
 1 | type t : any mod aliased = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because u is not mod aliased.
 |}]
 
 type t : value mod global = { x : int } [@@unboxed]
@@ -985,14 +975,10 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         locality: mod local ≰ mod global
-         uniqueness: mod unique ≰ mod aliased
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this record type is not mod global aliased
+       - mutable field x : 'a is not mod global aliased
 |}]
 
 type ('a : immediate) t : value mod aliased = { mutable x : 'a }
@@ -1000,13 +986,10 @@ type ('a : immediate) t : value mod aliased = { mutable x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : immediate) t : value mod aliased = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         uniqueness: mod unique ≰ mod aliased
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because
+       - this record type is not mod aliased
+       - mutable field x : 'a is not mod aliased
 |}]
 
 type ('a : immediate) t : value mod contended = { mutable x : 'a }
@@ -1014,13 +997,8 @@ type ('a : immediate) t : value mod contended = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod uncontended ≰ mod contended
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because mutable field x : 'a is not mod contended.
 |}]
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
@@ -1028,13 +1006,10 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         externality: mod internal ≰ mod external_
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because
+       - this record type is not mod external_
+       - mutable field x : 'a is not mod external_
 |}]
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
@@ -1042,13 +1017,10 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external64
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         externality: mod internal ≰ mod external64
+Error: This type definition does not satisfy its kind annotation value mod external64,
+       because
+       - this record type is not mod external64
+       - mutable field x : 'a is not mod external64
 |}]
 
 (*************************************)
@@ -1083,10 +1055,8 @@ type t : any mod aliased = Foo of int | Bar
 Line 1, characters 0-43:
 1 | type t : any mod aliased = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because this variant type is not mod aliased.
 |}]
 
 type t : any mod global = Foo of int | Bar
@@ -1094,10 +1064,8 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because this variant type is not mod global aliased.
 |}]
 
 
@@ -1106,10 +1074,8 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because this variant type is not mod external_.
 |}]
 
 type t : any mod portable = Foo of bool [@@unboxed]
@@ -1139,10 +1105,8 @@ type t : any mod portable = Foo of t_value [@@unboxed]
 Line 1, characters 0-54:
 1 | type t : any mod portable = Foo of t_value [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type "t" must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod portable,
+       because t_value is not mod portable.
 |}]
 
 (***********************************************)
@@ -1241,10 +1205,8 @@ type 'a t : value mod aliased = { x : 'a @@ aliased }
 Line 1, characters 0-53:
 1 | type 'a t : value mod aliased = { x : 'a @@ aliased }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because this record type is not mod aliased.
 |}]
 
 type 'a t : value mod global = { x : 'a @@ global }
@@ -1252,14 +1214,8 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a @@ forkable unyielding
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         locality: mod local ≰ mod global
-         uniqueness: mod unique ≰ mod aliased
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this record type is not mod global aliased.
 |}]
 
 (*****************************)
@@ -1537,11 +1493,8 @@ type 'a t : value mod global = Foo of 'a [@@unboxed]
 Line 1, characters 0-52:
 1 | type 'a t : value mod global = Foo of 'a [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because it instantiates an unannotated type parameter of t,
-         chosen to have kind value.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because 'a is not mod global aliased forkable unyielding.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
   value mod global. Internal ticket 5120. *)
@@ -1551,10 +1504,10 @@ type 'a t : value mod global = { x : 'a }
 Line 1, characters 0-41:
 1 | type 'a t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this record type is not mod global aliased
+       - 'a is not mod global aliased forkable unyielding
 |}]
 
 type 'a t : value mod many = { x : 'a }
@@ -1562,10 +1515,8 @@ type 'a t : value mod many = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because 'a is not mod many.
 |}]
 
 (*************************************)
@@ -1840,11 +1791,81 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-49:
+2 | type 'a t : immutable_data with 'a r = { x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a r,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-61:
+2 | type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a r,
+       because 'a is not mod many contended forkable unyielding stateless
+                 immutable.
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable contended =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable contended =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - t is not mod contended
+       - q is not mod portable
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable shared =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable shared =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: This type definition does not satisfy its kind annotation
+         value mod portable shared,
+       because
+       - t is not mod shared
+       - q is not mod portable
 |}]
 
 type t : value mod contended
@@ -1858,11 +1879,9 @@ type b = { a : a; }
 Line 4, characters 0-67:
 4 | type c : value mod portable contended = A of a @@ portable | B of b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed variant type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1878,11 +1897,9 @@ type b = { b0 : b0; } [@@unboxed]
 Line 5, characters 0-67:
 5 | type c : value mod portable contended = A of a @@ portable | B of b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed variant type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1896,11 +1913,9 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { b : b; a : a @@ portable }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1914,11 +1929,9 @@ and a = t
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type 'a t : value mod contended
@@ -1932,11 +1945,11 @@ type 'a b = Foo of 'a a
 Line 4, characters 0-77:
 4 | type 'a c : value mod portable contended = { a : 'a a @@ portable; b : 'a b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with 'a a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - 'a is not mod portable
+       - 'a b is not mod portable
 |}]
 
 type 'a t : value mod contended portable with 'a
@@ -1959,11 +1972,9 @@ Lines 4-9, characters 0-3:
 7 |   ; a : 'a a
 8 |   ; c : 'b b
 9 |   }
-Error: The kind of type "c" is immutable_data with 'a a with 'b a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because 'b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1977,11 +1988,9 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with t
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1995,11 +2004,9 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with t
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -2022,11 +2029,11 @@ type d = Bar of c
 Lines 9-10, characters 0-56:
  9 | type e : value mod portable contended =
 10 |   { a : a @@ portable; b : b; c : c @@ portable; d : d }
-Error: The kind of type "e" is immutable_data with a with c
-         because it's a boxed record type.
-       But the kind of type "e" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type e.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - b is not mod portable
+       - d is not mod portable
 |}]
 
 type t : value mod contended
@@ -2040,11 +2047,9 @@ type b = Foo of a
 Line 4, characters 0-74:
 4 | type c : value mod portable contended = { a : a * int @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -2058,9 +2063,7 @@ type b = Foo of a
 Line 4, characters 0-74:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b * int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -717,8 +717,8 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
        because
-       - this record type is not mod global aliased
-       - string is not mod global aliased
+       - boxed records are not mod global
+       - string is not mod global
 |}]
 
 type t : any mod aliased = { x : string }
@@ -728,7 +728,7 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod aliased,
        because
-       - this record type is not mod aliased
+       - boxed records are not mod aliased
        - string is not mod aliased
 |}]
 
@@ -739,7 +739,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod external_,
        because
-       - this record type is not mod external_
+       - boxed records are not mod external_
        - string is not mod external_
 |}]
 
@@ -787,9 +787,8 @@ Line 1, characters 0-65:
 Error: This type definition does not satisfy its kind annotation
          any mod global many portable contended,
        because
-       - this record type is not mod global aliased
-       - t_value is not mod global aliased many contended portable forkable
-           unyielding
+       - boxed records are not mod global
+       - t_value is not mod global many portable contended
 |}]
 
 type u : immediate
@@ -829,7 +828,7 @@ Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 (* Fields failing on different axes produce one bullet each, each carrying
@@ -841,8 +840,8 @@ Line 1, characters 0-61:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
        because
-       - mutable field a : int is not mod contended immutable
-       - int -> int is not mod many portable forkable unyielding stateless
+       - mutable fields are not mod immutable
+       - int -> int is not mod forkable unyielding many stateless
 |}]
 
 type t : any mod external_ = { x : int }
@@ -851,7 +850,7 @@ Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod external_,
-       because this record type is not mod external_.
+       because boxed records are not mod external_.
 |}]
 
 type t : any mod aliased = { x : int }
@@ -860,7 +859,7 @@ Line 1, characters 0-38:
 1 | type t : any mod aliased = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod aliased,
-       because this record type is not mod aliased.
+       because boxed records are not mod aliased.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
@@ -908,7 +907,7 @@ Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
-       because u is not mod global aliased forkable unyielding.
+       because u is not mod global.
 |}]
 
 type t : any mod portable = { x : u } [@@unboxed]
@@ -977,8 +976,8 @@ Line 1, characters 0-63:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this record type is not mod global aliased
-       - mutable field x : 'a is not mod global aliased
+       - boxed records are not mod global
+       - mutable fields are not mod global
 |}]
 
 type ('a : immediate) t : value mod aliased = { mutable x : 'a }
@@ -988,8 +987,8 @@ Line 1, characters 0-64:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
        because
-       - this record type is not mod aliased
-       - mutable field x : 'a is not mod aliased
+       - boxed records are not mod aliased
+       - mutable fields are not mod aliased
 |}]
 
 type ('a : immediate) t : value mod contended = { mutable x : 'a }
@@ -998,7 +997,7 @@ Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod contended,
-       because mutable field x : 'a is not mod contended.
+       because mutable fields are not mod contended.
 |}]
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
@@ -1008,8 +1007,8 @@ Line 1, characters 0-66:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
        because
-       - this record type is not mod external_
-       - mutable field x : 'a is not mod external_
+       - boxed records are not mod external_
+       - mutable fields are not mod external_
 |}]
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
@@ -1019,8 +1018,8 @@ Line 1, characters 0-67:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external64,
        because
-       - this record type is not mod external64
-       - mutable field x : 'a is not mod external64
+       - boxed records are not mod external64
+       - mutable fields are not mod external64
 |}]
 
 (*************************************)
@@ -1056,7 +1055,7 @@ Line 1, characters 0-43:
 1 | type t : any mod aliased = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod aliased,
-       because this variant type is not mod aliased.
+       because boxed variants are not mod aliased.
 |}]
 
 type t : any mod global = Foo of int | Bar
@@ -1065,7 +1064,7 @@ Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
-       because this variant type is not mod global aliased.
+       because boxed variants are not mod global.
 |}]
 
 
@@ -1075,7 +1074,7 @@ Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod external_,
-       because this variant type is not mod external_.
+       because boxed variants are not mod external_.
 |}]
 
 type t : any mod portable = Foo of bool [@@unboxed]
@@ -1206,7 +1205,7 @@ Line 1, characters 0-53:
 1 | type 'a t : value mod aliased = { x : 'a @@ aliased }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
-       because this record type is not mod aliased.
+       because boxed records are not mod aliased.
 |}]
 
 type 'a t : value mod global = { x : 'a @@ global }
@@ -1215,7 +1214,7 @@ Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 (*****************************)
@@ -1494,7 +1493,7 @@ Line 1, characters 0-52:
 1 | type 'a t : value mod global = Foo of 'a [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because 'a is not mod global aliased forkable unyielding.
+       because 'a is not mod global.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
   value mod global. Internal ticket 5120. *)
@@ -1506,8 +1505,8 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this record type is not mod global aliased
-       - 'a is not mod global aliased forkable unyielding
+       - boxed records are not mod global
+       - 'a is not mod global
 |}]
 
 type 'a t : value mod many = { x : 'a }
@@ -1805,8 +1804,7 @@ Line 2, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          immutable_data with 'a r,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type 'a r : immutable_data with 'a @@ portable
@@ -1818,8 +1816,7 @@ Line 2, characters 0-61:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          immutable_data with 'a r,
-       because 'a is not mod many contended forkable unyielding stateless
-                 immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type 'a portable = { portable : 'a @@ portable }

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -841,7 +841,7 @@ Line 1, characters 0-61:
 Error: This type definition does not satisfy its kind annotation immutable_data,
        because
        - mutable fields are not mod immutable
-       - int -> int is not mod forkable unyielding many stateless
+       - functions are not mod forkable unyielding many stateless
 |}]
 
 type t : any mod external_ = { x : int }
@@ -1946,7 +1946,7 @@ Error: This type definition does not satisfy its kind annotation
          value mod portable contended,
        because
        - 'a is not mod portable
-       - 'a b is not mod portable
+       - b is not mod portable
 |}]
 
 type 'a t : value mod contended portable with 'a

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -725,10 +725,10 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because
+       - this record type is not mod global aliased
+       - string is not mod global aliased
 |}]
 
 type t : any mod aliased = { x : string }
@@ -736,10 +736,10 @@ type t : any mod aliased = { x : string }
 Line 1, characters 0-41:
 1 | type t : any mod aliased = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because
+       - this record type is not mod aliased
+       - string is not mod aliased
 |}]
 
 type t : any mod external_ = { x : string }
@@ -747,10 +747,10 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because
+       - this record type is not mod external_
+       - string is not mod external_
 |}]
 
 type t : any mod many = { x : string }
@@ -767,10 +767,8 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod many,
+       because t_value is not mod many.
 |}]
 
 type t : any mod contended = { x : t_value }
@@ -778,10 +776,8 @@ type t : any mod contended = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : any mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod contended,
+       because t_value is not mod contended.
 |}]
 
 type t : any mod portable = { x : t_value }
@@ -789,10 +785,8 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod portable,
+       because t_value is not mod portable.
 |}]
 
 type t : any mod many contended portable global = { x : t_value }
@@ -800,11 +794,12 @@ type t : any mod many contended portable global = { x : t_value }
 Line 1, characters 0-65:
 1 | type t : any mod many contended portable global = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with t_value
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of
-           any mod global many portable contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         any mod global many portable contended,
+       because
+       - this record type is not mod global aliased
+       - t_value is not mod global aliased many contended portable forkable
+           unyielding
 |}]
 
 type u : immediate
@@ -843,10 +838,21 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because this record type is not mod global aliased.
+|}]
+
+(* Fields failing on different axes produce one bullet each, each carrying
+   only its own violating axes. *)
+type t : immutable_data = { mutable a : int; f : int -> int }
+[%%expect{|
+Line 1, characters 0-61:
+1 | type t : immutable_data = { mutable a : int; f : int -> int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because
+       - mutable field a : int is not mod contended immutable
+       - int -> int is not mod many portable forkable unyielding stateless
 |}]
 
 type t : any mod external_ = { x : int }
@@ -854,10 +860,8 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because this record type is not mod external_.
 |}]
 
 type t : any mod aliased = { x : int }
@@ -865,10 +869,8 @@ type t : any mod aliased = { x : int }
 Line 1, characters 0-38:
 1 | type t : any mod aliased = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because this record type is not mod aliased.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
@@ -915,10 +917,8 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because u is not mod global aliased forkable unyielding.
 |}]
 
 type t : any mod portable = { x : u } [@@unboxed]
@@ -926,10 +926,8 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod portable,
+       because u is not mod portable.
 |}]
 
 type t : any mod contended = { x : u } [@@unboxed]
@@ -937,10 +935,8 @@ type t : any mod contended = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod contended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod contended,
+       because u is not mod contended.
 |}]
 
 type t : any mod external_ = { x : u } [@@unboxed]
@@ -948,10 +944,8 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because u is not mod external_.
 |}]
 
 type t : any mod many = { x : u } [@@unboxed]
@@ -959,10 +953,8 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod many,
+       because u is not mod many.
 |}]
 
 type t : any mod aliased = { x : u } [@@unboxed]
@@ -970,10 +962,8 @@ type t : any mod aliased = { x : u } [@@unboxed]
 Line 1, characters 0-48:
 1 | type t : any mod aliased = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of u at line 1, characters 0-14.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because u is not mod aliased.
 |}]
 
 type t : value mod global = { x : int } [@@unboxed]
@@ -995,14 +985,10 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         locality: mod local ≰ mod global
-         uniqueness: mod unique ≰ mod aliased
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this record type is not mod global aliased
+       - mutable field x : 'a is not mod global aliased
 |}]
 
 type ('a : immediate) t : value mod aliased = { mutable x : 'a }
@@ -1010,13 +996,10 @@ type ('a : immediate) t : value mod aliased = { mutable x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : immediate) t : value mod aliased = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         uniqueness: mod unique ≰ mod aliased
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because
+       - this record type is not mod aliased
+       - mutable field x : 'a is not mod aliased
 |}]
 
 type ('a : immediate) t : value mod contended = { mutable x : 'a }
@@ -1024,13 +1007,8 @@ type ('a : immediate) t : value mod contended = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod uncontended ≰ mod contended
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because mutable field x : 'a is not mod contended.
 |}]
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
@@ -1038,13 +1016,10 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         externality: mod internal ≰ mod external_
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because
+       - this record type is not mod external_
+       - mutable field x : 'a is not mod external_
 |}]
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
@@ -1052,13 +1027,10 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external64
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         externality: mod internal ≰ mod external64
+Error: This type definition does not satisfy its kind annotation value mod external64,
+       because
+       - this record type is not mod external64
+       - mutable field x : 'a is not mod external64
 |}]
 
 (*************************************)
@@ -1093,10 +1065,8 @@ type t : any mod aliased = Foo of int | Bar
 Line 1, characters 0-43:
 1 | type t : any mod aliased = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of any mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod aliased,
+       because this variant type is not mod aliased.
 |}]
 
 type t : any mod global = Foo of int | Bar
@@ -1104,10 +1074,8 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of any mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod global,
+       because this variant type is not mod global aliased.
 |}]
 
 
@@ -1116,10 +1084,8 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of any mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod external_,
+       because this variant type is not mod external_.
 |}]
 
 type t : any mod portable = Foo of bool [@@unboxed]
@@ -1149,10 +1115,8 @@ type t : any mod portable = Foo of t_value [@@unboxed]
 Line 1, characters 0-54:
 1 | type t : any mod portable = Foo of t_value [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because of the definition of t_value at line 1, characters 0-20.
-       But the kind of type "t" must be a subkind of any mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation any mod portable,
+       because t_value is not mod portable.
 |}]
 
 (***********************************************)
@@ -1251,10 +1215,8 @@ type 'a t : value mod aliased = { x : 'a @@ aliased }
 Line 1, characters 0-53:
 1 | type 'a t : value mod aliased = { x : 'a @@ aliased }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because this record type is not mod aliased.
 |}]
 
 type 'a t : value mod global = { x : 'a @@ global }
@@ -1262,14 +1224,8 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a @@ forkable unyielding
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         locality: mod local ≰ mod global
-         uniqueness: mod unique ≰ mod aliased
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this record type is not mod global aliased.
 |}]
 
 (*****************************)
@@ -1547,11 +1503,8 @@ type 'a t : value mod global = Foo of 'a [@@unboxed]
 Line 1, characters 0-52:
 1 | type 'a t : value mod global = Foo of 'a [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value
-         because it instantiates an unannotated type parameter of t,
-         chosen to have kind value.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because 'a is not mod global aliased forkable unyielding.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
   value mod global. Internal ticket 5120. *)
@@ -1561,10 +1514,10 @@ type 'a t : value mod global = { x : 'a }
 Line 1, characters 0-41:
 1 | type 'a t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because
+       - this record type is not mod global aliased
+       - 'a is not mod global aliased forkable unyielding
 |}]
 
 type 'a t : value mod many = { x : 'a }
@@ -1572,10 +1525,8 @@ type 'a t : value mod many = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because 'a is not mod many.
 |}]
 
 (*************************************)
@@ -1850,11 +1801,81 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-49:
+2 | type 'a t : immutable_data with 'a r = { x : 'a }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a r,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
+|}]
+
+type 'a r : immutable_data with 'a @@ portable
+type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+[%%expect {|
+type 'a r : immutable_data with 'a @@ portable
+Line 2, characters 0-61:
+2 | type 'a t : immutable_data with 'a r = { x : 'a @@ portable }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a r,
+       because 'a is not mod many contended forkable unyielding stateless
+                 immutable.
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable contended =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable contended =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - t is not mod contended
+       - q is not mod portable
+|}]
+
+type 'a portable = { portable : 'a @@ portable }
+type 'a contended = { contended : 'a @@ contended }
+type t : value
+type q = t
+type r : value mod portable shared =
+  | Foo of int * (t * (bool -> string)) portable
+  | Bar of string * (int ref * q) contended
+[%%expect {|
+type 'a portable = { portable : 'a @@ portable; }
+type 'a contended = { contended : 'a @@ contended; }
+type t
+type q = t
+Lines 5-7, characters 0-43:
+5 | type r : value mod portable shared =
+6 |   | Foo of int * (t * (bool -> string)) portable
+7 |   | Bar of string * (int ref * q) contended
+Error: This type definition does not satisfy its kind annotation
+         value mod portable shared,
+       because
+       - t is not mod shared
+       - q is not mod portable
 |}]
 
 type t : value mod contended
@@ -1868,11 +1889,9 @@ type b = { a : a; }
 Line 4, characters 0-67:
 4 | type c : value mod portable contended = A of a @@ portable | B of b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed variant type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1888,11 +1907,9 @@ type b = { b0 : b0; } [@@unboxed]
 Line 5, characters 0-67:
 5 | type c : value mod portable contended = A of a @@ portable | B of b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed variant type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1906,11 +1923,9 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { b : b; a : a @@ portable }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1924,11 +1939,9 @@ and a = t
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type 'a t : value mod contended
@@ -1942,11 +1955,11 @@ type 'a b = Foo of 'a a
 Line 4, characters 0-77:
 4 | type 'a c : value mod portable contended = { a : 'a a @@ portable; b : 'a b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with 'a a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - 'a is not mod portable
+       - 'a b is not mod portable
 |}]
 
 type 'a t : value mod contended portable with 'a
@@ -1969,11 +1982,9 @@ Lines 4-9, characters 0-3:
 7 |   ; a : 'a a
 8 |   ; c : 'b b
 9 |   }
-Error: The kind of type "c" is immutable_data with 'a a with 'b a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because 'b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -1987,11 +1998,9 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with t
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -2005,11 +2014,9 @@ type b = Foo of a
 Line 4, characters 0-68:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with t
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -2032,11 +2039,11 @@ type d = Bar of c
 Lines 9-10, characters 0-56:
  9 | type e : value mod portable contended =
 10 |   { a : a @@ portable; b : b; c : c @@ portable; d : d }
-Error: The kind of type "e" is immutable_data with a with c
-         because it's a boxed record type.
-       But the kind of type "e" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type e.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - b is not mod portable
+       - d is not mod portable
 |}]
 
 type t : value mod contended
@@ -2050,11 +2057,9 @@ type b = Foo of a
 Line 4, characters 0-74:
 4 | type c : value mod portable contended = { a : a * int @@ portable; b : b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]
 
 type t : value mod contended
@@ -2068,9 +2073,7 @@ type b = Foo of a
 Line 4, characters 0-74:
 4 | type c : value mod portable contended = { a : a @@ portable; b : b * int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "c" is immutable_data with a
-         because it's a boxed record type.
-       But the kind of type "c" must be a subkind of
-           value mod portable contended
-         because of the annotation on the declaration of the type c.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -851,7 +851,7 @@ Line 1, characters 0-61:
 Error: This type definition does not satisfy its kind annotation immutable_data,
        because
        - mutable fields are not mod immutable
-       - int -> int is not mod forkable unyielding many stateless
+       - functions are not mod forkable unyielding many stateless
 |}]
 
 type t : any mod external_ = { x : int }
@@ -1956,7 +1956,7 @@ Error: This type definition does not satisfy its kind annotation
          value mod portable contended,
        because
        - 'a is not mod portable
-       - 'a b is not mod portable
+       - b is not mod portable
 |}]
 
 type 'a t : value mod contended portable with 'a

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -725,7 +725,8 @@ type t : any mod global = { x : string }
 Line 1, characters 0-40:
 1 | type t : any mod global = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod global,
+Error: This type definition does not satisfy its kind annotation
+         any mod global,
        because
        - boxed records are not mod global
        - string is not mod global
@@ -736,7 +737,8 @@ type t : any mod aliased = { x : string }
 Line 1, characters 0-41:
 1 | type t : any mod aliased = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         any mod aliased,
        because
        - boxed records are not mod aliased
        - string is not mod aliased
@@ -747,7 +749,8 @@ type t : any mod external_ = { x : string }
 Line 1, characters 0-43:
 1 | type t : any mod external_ = { x : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod external_,
+Error: This type definition does not satisfy its kind annotation
+         any mod external_,
        because
        - boxed records are not mod external_
        - string is not mod external_
@@ -767,7 +770,8 @@ type t : any mod many = { x : t_value }
 Line 1, characters 0-39:
 1 | type t : any mod many = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod many,
+Error: This type definition does not satisfy its kind annotation
+         any mod many,
        because t_value is not mod many.
 |}]
 
@@ -776,7 +780,8 @@ type t : any mod contended = { x : t_value }
 Line 1, characters 0-44:
 1 | type t : any mod contended = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod contended,
+Error: This type definition does not satisfy its kind annotation
+         any mod contended,
        because t_value is not mod contended.
 |}]
 
@@ -785,7 +790,8 @@ type t : any mod portable = { x : t_value }
 Line 1, characters 0-43:
 1 | type t : any mod portable = { x : t_value }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod portable,
+Error: This type definition does not satisfy its kind annotation
+         any mod portable,
        because t_value is not mod portable.
 |}]
 
@@ -837,7 +843,8 @@ type t : any mod global = { x : int }
 Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod global,
+Error: This type definition does not satisfy its kind annotation
+         any mod global,
        because boxed records are not mod global.
 |}]
 
@@ -848,7 +855,8 @@ type t : immutable_data = { mutable a : int; f : int -> int }
 Line 1, characters 0-61:
 1 | type t : immutable_data = { mutable a : int; f : int -> int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because
        - mutable fields are not mod immutable
        - functions are not mod forkable unyielding many stateless
@@ -859,7 +867,8 @@ type t : any mod external_ = { x : int }
 Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod external_,
+Error: This type definition does not satisfy its kind annotation
+         any mod external_,
        because boxed records are not mod external_.
 |}]
 
@@ -868,7 +877,8 @@ type t : any mod aliased = { x : int }
 Line 1, characters 0-38:
 1 | type t : any mod aliased = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         any mod aliased,
        because boxed records are not mod aliased.
 |}]
 
@@ -916,7 +926,8 @@ type t : any mod global = { x : u } [@@unboxed]
 Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod global,
+Error: This type definition does not satisfy its kind annotation
+         any mod global,
        because u is not mod global.
 |}]
 
@@ -925,7 +936,8 @@ type t : any mod portable = { x : u } [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : any mod portable = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod portable,
+Error: This type definition does not satisfy its kind annotation
+         any mod portable,
        because u is not mod portable.
 |}]
 
@@ -934,7 +946,8 @@ type t : any mod contended = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod contended = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod contended,
+Error: This type definition does not satisfy its kind annotation
+         any mod contended,
        because u is not mod contended.
 |}]
 
@@ -943,7 +956,8 @@ type t : any mod external_ = { x : u } [@@unboxed]
 Line 1, characters 0-50:
 1 | type t : any mod external_ = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod external_,
+Error: This type definition does not satisfy its kind annotation
+         any mod external_,
        because u is not mod external_.
 |}]
 
@@ -952,7 +966,8 @@ type t : any mod many = { x : u } [@@unboxed]
 Line 1, characters 0-45:
 1 | type t : any mod many = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod many,
+Error: This type definition does not satisfy its kind annotation
+         any mod many,
        because u is not mod many.
 |}]
 
@@ -961,7 +976,8 @@ type t : any mod aliased = { x : u } [@@unboxed]
 Line 1, characters 0-48:
 1 | type t : any mod aliased = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         any mod aliased,
        because u is not mod aliased.
 |}]
 
@@ -984,7 +1000,8 @@ type ('a : immediate) t : value mod global = { mutable x : 'a }
 Line 1, characters 0-63:
 1 | type ('a : immediate) t : value mod global = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because
        - boxed records are not mod global
        - mutable fields are not mod global
@@ -995,7 +1012,8 @@ type ('a : immediate) t : value mod aliased = { mutable x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : immediate) t : value mod aliased = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased,
        because
        - boxed records are not mod aliased
        - mutable fields are not mod aliased
@@ -1006,7 +1024,8 @@ type ('a : immediate) t : value mod contended = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because mutable fields are not mod contended.
 |}]
 
@@ -1015,7 +1034,8 @@ type ('a : immediate) t : value mod external_ = { mutable x : 'a }
 Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod external_ = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod external_,
+Error: This type definition does not satisfy its kind annotation
+         value mod external_,
        because
        - boxed records are not mod external_
        - mutable fields are not mod external_
@@ -1026,7 +1046,8 @@ type ('a : immediate) t : value mod external64 = { mutable x : 'a }
 Line 1, characters 0-67:
 1 | type ('a : immediate) t : value mod external64 = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod external64,
+Error: This type definition does not satisfy its kind annotation
+         value mod external64,
        because
        - boxed records are not mod external64
        - mutable fields are not mod external64
@@ -1064,7 +1085,8 @@ type t : any mod aliased = Foo of int | Bar
 Line 1, characters 0-43:
 1 | type t : any mod aliased = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         any mod aliased,
        because boxed variants are not mod aliased.
 |}]
 
@@ -1073,7 +1095,8 @@ type t : any mod global = Foo of int | Bar
 Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod global,
+Error: This type definition does not satisfy its kind annotation
+         any mod global,
        because boxed variants are not mod global.
 |}]
 
@@ -1083,7 +1106,8 @@ type t : any mod external_ = Foo of int | Bar
 Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod external_,
+Error: This type definition does not satisfy its kind annotation
+         any mod external_,
        because boxed variants are not mod external_.
 |}]
 
@@ -1114,7 +1138,8 @@ type t : any mod portable = Foo of t_value [@@unboxed]
 Line 1, characters 0-54:
 1 | type t : any mod portable = Foo of t_value [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation any mod portable,
+Error: This type definition does not satisfy its kind annotation
+         any mod portable,
        because t_value is not mod portable.
 |}]
 
@@ -1214,7 +1239,8 @@ type 'a t : value mod aliased = { x : 'a @@ aliased }
 Line 1, characters 0-53:
 1 | type 'a t : value mod aliased = { x : 'a @@ aliased }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased,
        because boxed records are not mod aliased.
 |}]
 
@@ -1223,7 +1249,8 @@ type 'a t : value mod global = { x : 'a @@ global }
 Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because boxed records are not mod global.
 |}]
 
@@ -1502,7 +1529,8 @@ type 'a t : value mod global = Foo of 'a [@@unboxed]
 Line 1, characters 0-52:
 1 | type 'a t : value mod global = Foo of 'a [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because 'a is not mod global.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
@@ -1513,7 +1541,8 @@ type 'a t : value mod global = { x : 'a }
 Line 1, characters 0-41:
 1 | type 'a t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because
        - boxed records are not mod global
        - 'a is not mod global
@@ -1524,7 +1553,8 @@ type 'a t : value mod many = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod many,
+Error: This type definition does not satisfy its kind annotation
+         value mod many,
        because 'a is not mod many.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -727,8 +727,8 @@ Line 1, characters 0-40:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
        because
-       - this record type is not mod global aliased
-       - string is not mod global aliased
+       - boxed records are not mod global
+       - string is not mod global
 |}]
 
 type t : any mod aliased = { x : string }
@@ -738,7 +738,7 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod aliased,
        because
-       - this record type is not mod aliased
+       - boxed records are not mod aliased
        - string is not mod aliased
 |}]
 
@@ -749,7 +749,7 @@ Line 1, characters 0-43:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod external_,
        because
-       - this record type is not mod external_
+       - boxed records are not mod external_
        - string is not mod external_
 |}]
 
@@ -797,9 +797,8 @@ Line 1, characters 0-65:
 Error: This type definition does not satisfy its kind annotation
          any mod global many portable contended,
        because
-       - this record type is not mod global aliased
-       - t_value is not mod global aliased many contended portable forkable
-           unyielding
+       - boxed records are not mod global
+       - t_value is not mod global many portable contended
 |}]
 
 type u : immediate
@@ -839,7 +838,7 @@ Line 1, characters 0-37:
 1 | type t : any mod global = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 (* Fields failing on different axes produce one bullet each, each carrying
@@ -851,8 +850,8 @@ Line 1, characters 0-61:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
        because
-       - mutable field a : int is not mod contended immutable
-       - int -> int is not mod many portable forkable unyielding stateless
+       - mutable fields are not mod immutable
+       - int -> int is not mod forkable unyielding many stateless
 |}]
 
 type t : any mod external_ = { x : int }
@@ -861,7 +860,7 @@ Line 1, characters 0-40:
 1 | type t : any mod external_ = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod external_,
-       because this record type is not mod external_.
+       because boxed records are not mod external_.
 |}]
 
 type t : any mod aliased = { x : int }
@@ -870,7 +869,7 @@ Line 1, characters 0-38:
 1 | type t : any mod aliased = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod aliased,
-       because this record type is not mod aliased.
+       because boxed records are not mod aliased.
 |}]
 
 type t : any mod global = { x : int } [@@unboxed]
@@ -918,7 +917,7 @@ Line 1, characters 0-47:
 1 | type t : any mod global = { x : u } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
-       because u is not mod global aliased forkable unyielding.
+       because u is not mod global.
 |}]
 
 type t : any mod portable = { x : u } [@@unboxed]
@@ -987,8 +986,8 @@ Line 1, characters 0-63:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this record type is not mod global aliased
-       - mutable field x : 'a is not mod global aliased
+       - boxed records are not mod global
+       - mutable fields are not mod global
 |}]
 
 type ('a : immediate) t : value mod aliased = { mutable x : 'a }
@@ -998,8 +997,8 @@ Line 1, characters 0-64:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
        because
-       - this record type is not mod aliased
-       - mutable field x : 'a is not mod aliased
+       - boxed records are not mod aliased
+       - mutable fields are not mod aliased
 |}]
 
 type ('a : immediate) t : value mod contended = { mutable x : 'a }
@@ -1008,7 +1007,7 @@ Line 1, characters 0-66:
 1 | type ('a : immediate) t : value mod contended = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod contended,
-       because mutable field x : 'a is not mod contended.
+       because mutable fields are not mod contended.
 |}]
 
 type ('a : immediate) t : value mod external_ = { mutable x : 'a }
@@ -1018,8 +1017,8 @@ Line 1, characters 0-66:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
        because
-       - this record type is not mod external_
-       - mutable field x : 'a is not mod external_
+       - boxed records are not mod external_
+       - mutable fields are not mod external_
 |}]
 
 type ('a : immediate) t : value mod external64 = { mutable x : 'a }
@@ -1029,8 +1028,8 @@ Line 1, characters 0-67:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external64,
        because
-       - this record type is not mod external64
-       - mutable field x : 'a is not mod external64
+       - boxed records are not mod external64
+       - mutable fields are not mod external64
 |}]
 
 (*************************************)
@@ -1066,7 +1065,7 @@ Line 1, characters 0-43:
 1 | type t : any mod aliased = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod aliased,
-       because this variant type is not mod aliased.
+       because boxed variants are not mod aliased.
 |}]
 
 type t : any mod global = Foo of int | Bar
@@ -1075,7 +1074,7 @@ Line 1, characters 0-42:
 1 | type t : any mod global = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod global,
-       because this variant type is not mod global aliased.
+       because boxed variants are not mod global.
 |}]
 
 
@@ -1085,7 +1084,7 @@ Line 1, characters 0-45:
 1 | type t : any mod external_ = Foo of int | Bar
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation any mod external_,
-       because this variant type is not mod external_.
+       because boxed variants are not mod external_.
 |}]
 
 type t : any mod portable = Foo of bool [@@unboxed]
@@ -1216,7 +1215,7 @@ Line 1, characters 0-53:
 1 | type 'a t : value mod aliased = { x : 'a @@ aliased }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
-       because this record type is not mod aliased.
+       because boxed records are not mod aliased.
 |}]
 
 type 'a t : value mod global = { x : 'a @@ global }
@@ -1225,7 +1224,7 @@ Line 1, characters 0-51:
 1 | type 'a t : value mod global = { x : 'a @@ global }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 (*****************************)
@@ -1504,7 +1503,7 @@ Line 1, characters 0-52:
 1 | type 'a t : value mod global = Foo of 'a [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because 'a is not mod global aliased forkable unyielding.
+       because 'a is not mod global.
 |}]
 (* CR layouts v2.8: this should be accepted; 'a should be inferred to have kind
   value mod global. Internal ticket 5120. *)
@@ -1516,8 +1515,8 @@ Line 1, characters 0-41:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
        because
-       - this record type is not mod global aliased
-       - 'a is not mod global aliased forkable unyielding
+       - boxed records are not mod global
+       - 'a is not mod global
 |}]
 
 type 'a t : value mod many = { x : 'a }
@@ -1815,8 +1814,7 @@ Line 2, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          immutable_data with 'a r,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type 'a r : immutable_data with 'a @@ portable
@@ -1828,8 +1826,7 @@ Line 2, characters 0-61:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          immutable_data with 'a r,
-       because 'a is not mod many contended forkable unyielding stateless
-                 immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type 'a portable = { portable : 'a @@ portable }

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -288,8 +288,7 @@ Lines 1-2, characters 0-25:
 1 | type 'a u : immutable_data =
 2 | | P1 : ('b, 'a) t -> 'a u
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'b is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'b is not mod forkable unyielding many stateless immutable.
 |}]
 
 (* CR layouts v2.8: It'd also be OK to infer or accept [immutable_data with 'y] here. Internal ticket 4973. *)

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -287,10 +287,9 @@ type 'a u : immutable_data =
 Lines 1-2, characters 0-25:
 1 | type 'a u : immutable_data =
 2 | | P1 : ('b, 'a) t -> 'a u
-Error: The kind of type "u" is value non_float
-         because it's a boxed variant type.
-       But the kind of type "u" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type u.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'b is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 (* CR layouts v2.8: It'd also be OK to infer or accept [immutable_data with 'y] here. Internal ticket 4973. *)

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -287,7 +287,8 @@ type 'a u : immutable_data =
 Lines 1-2, characters 0-25:
 1 | type 'a u : immutable_data =
 2 | | P1 : ('b, 'a) t -> 'a u
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'b is not mod forkable unyielding many stateless immutable.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
@@ -24,10 +24,9 @@ type 'a t : immutable_data = A of 'a
 Line 1, characters 0-36:
 1 | type 'a t : immutable_data = A of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 type ('a, 'b) t : immutable_data with 'a = { a : 'a; b : 'b }
@@ -35,10 +34,9 @@ type ('a, 'b) t : immutable_data with 'a = { a : 'a; b : 'b }
 Line 1, characters 0-61:
 1 | type ('a, 'b) t : immutable_data with 'a = { a : 'a; b : 'b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a with 'b
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because 'b is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 type 'a t : immutable_data = Foo of 'a @@ portable
@@ -46,18 +44,9 @@ type 'a t : immutable_data = Foo of 'a @@ portable
 Line 1, characters 0-50:
 1 | type 'a t : immutable_data = Foo of 'a @@ portable
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a @@ portable
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         linearity: mod many with 'a ≰ mod many
-         contention: mod contended with 'a ≰ mod contended
-         forkable: mod forkable with 'a ≰ mod forkable
-         yielding: mod unyielding with 'a ≰ mod unyielding
-         statefulness: mod stateless with 'a ≰ mod stateless
-         visibility: mod immutable with 'a ≰ mod immutable
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod many contended forkable unyielding stateless
+                 immutable.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
@@ -25,8 +25,7 @@ Line 1, characters 0-36:
 1 | type 'a t : immutable_data = A of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type ('a, 'b) t : immutable_data with 'a = { a : 'a; b : 'b }
@@ -35,8 +34,7 @@ Line 1, characters 0-61:
 1 | type ('a, 'b) t : immutable_data with 'a = { a : 'a; b : 'b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'b is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'b is not mod forkable unyielding many stateless immutable.
 |}]
 
 type 'a t : immutable_data = Foo of 'a @@ portable
@@ -45,8 +43,7 @@ Line 1, characters 0-50:
 1 | type 'a t : immutable_data = Foo of 'a @@ portable
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod many contended forkable unyielding stateless
-                 immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 module M : sig

--- a/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
@@ -24,7 +24,8 @@ type 'a t : immutable_data = A of 'a
 Line 1, characters 0-36:
 1 | type 'a t : immutable_data = A of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -33,7 +34,8 @@ type ('a, 'b) t : immutable_data with 'a = { a : 'a; b : 'b }
 Line 1, characters 0-61:
 1 | type ('a, 'b) t : immutable_data with 'a = { a : 'a; b : 'b }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because 'b is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -42,7 +44,8 @@ type 'a t : immutable_data = Foo of 'a @@ portable
 Line 1, characters 0-50:
 1 | type 'a t : immutable_data = Foo of 'a @@ portable
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -144,8 +144,7 @@ Line 1, characters 0-39:
 1 | type 'a t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type 'a t : immutable_data = { mutable x : 'a }
@@ -155,8 +154,8 @@ Line 1, characters 0-47:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
        because
-       - 'a is not mod contended portable stateless immutable
-       - mutable field x : 'a is not mod contended immutable
+       - 'a is not mod stateless immutable
+       - mutable fields are not mod immutable
 |}]
 
 type t : immutable_data = { x : int ref }
@@ -165,7 +164,7 @@ Line 1, characters 0-41:
 1 | type t : immutable_data = { x : int ref }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because int ref is not mod contended immutable.
+       because int ref is not mod immutable.
 |}]
 
 type t : immutable_data = { x : unit -> unit }
@@ -174,8 +173,7 @@ Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because unit -> unit is not mod many portable forkable unyielding
-                 stateless.
+       because unit -> unit is not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : immutable_data = { x : 'a option }
@@ -184,8 +182,7 @@ Line 1, characters 0-46:
 1 | type 'a t : immutable_data = { x : 'a option }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type t : immutable_data = { x : int; y : int; mutable z : int }
@@ -194,7 +191,7 @@ Line 1, characters 0-63:
 1 | type t : immutable_data = { x : int; y : int; mutable z : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because mutable field z : int is not mod contended immutable.
+       because mutable fields are not mod immutable.
 |}]
 
 type t : mutable_data = { x : unit -> unit }
@@ -203,8 +200,7 @@ Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation mutable_data,
-       because unit -> unit is not mod many portable forkable unyielding
-                 stateless.
+       because unit -> unit is not mod forkable unyielding many stateless.
 |}]
 
 type ('a : value mod portable) t : value mod many = { x : 'a }
@@ -222,7 +218,7 @@ Line 1, characters 0-62:
 1 | type ('a : value mod global) t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 type ('a : value mod aliased) t : value mod aliased = { x : 'a }
@@ -231,7 +227,7 @@ Line 1, characters 0-64:
 1 | type ('a : value mod aliased) t : value mod aliased = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
-       because this record type is not mod aliased.
+       because boxed records are not mod aliased.
 |}]
 
 type ('a : value mod external_) t : value mod external_ = { x : 'a }
@@ -240,7 +236,7 @@ Line 1, characters 0-68:
 1 | type ('a : value mod external_) t : value mod external_ = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
-       because this record type is not mod external_.
+       because boxed records are not mod external_.
 |}]
 
 type t : sync_data = { mutable x : int ref [@atomic] }
@@ -295,7 +291,7 @@ Line 1, characters 0-55:
 1 | type 'a t : immutable_data with 'a = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because mutable field x : 'a is not mod contended immutable.
+       because mutable fields are not mod immutable.
 |}]
 
 type 'a t : immutable_data with 'a = { x : 'a -> 'a }
@@ -304,8 +300,7 @@ Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a -> 'a is not mod many portable forkable unyielding
-                 stateless.
+       because 'a -> 'a is not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : value mod global with 'a = { x : 'a }
@@ -315,7 +310,7 @@ Line 1, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod global with 'a,
-       because this record type is not mod global aliased.
+       because boxed records are not mod global.
 |}]
 
 type 'a t : value mod aliased with 'a = { x : 'a }
@@ -325,7 +320,7 @@ Line 1, characters 0-50:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod aliased with 'a,
-       because this record type is not mod aliased.
+       because boxed records are not mod aliased.
 |}]
 
 type 'a t : value mod external_ with 'a = { x : 'a }
@@ -335,7 +330,7 @@ Line 1, characters 0-52:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod external_ with 'a,
-       because this record type is not mod external_.
+       because boxed records are not mod external_.
 |}]
 
 (**** Test 3: Record values cross when appropriate ****)

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -164,7 +164,7 @@ Line 1, characters 0-41:
 1 | type t : immutable_data = { x : int ref }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because int ref is not mod immutable.
+       because ref is not mod immutable.
 |}]
 
 type t : immutable_data = { x : unit -> unit }
@@ -173,7 +173,7 @@ Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because unit -> unit is not mod forkable unyielding many stateless.
+       because functions are not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : immutable_data = { x : 'a option }
@@ -200,7 +200,7 @@ Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation mutable_data,
-       because unit -> unit is not mod forkable unyielding many stateless.
+       because functions are not mod forkable unyielding many stateless.
 |}]
 
 type ('a : value mod portable) t : value mod many = { x : 'a }
@@ -245,7 +245,7 @@ Line 1, characters 0-54:
 1 | type t : sync_data = { mutable x : int ref [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation sync_data,
-       because int ref is not mod contended.
+       because ref is not mod contended.
 |}]
 
 type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
@@ -300,7 +300,7 @@ Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a -> 'a is not mod forkable unyielding many stateless.
+       because functions are not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : value mod global with 'a = { x : 'a }

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -143,10 +143,9 @@ type 'a t : immutable_data = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 type 'a t : immutable_data = { mutable x : 'a }
@@ -154,16 +153,10 @@ type 'a t : immutable_data = { mutable x : 'a }
 Line 1, characters 0-47:
 1 | type 'a t : immutable_data = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod uncontended ≰ mod contended
-         portability: mod portable with 'a ≰ mod portable
-         statefulness: mod stateless with 'a ≰ mod stateless
-         visibility: mod read_write ≰ mod immutable
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because
+       - 'a is not mod contended portable stateless immutable
+       - mutable field x : 'a is not mod contended immutable
 |}]
 
 type t : immutable_data = { x : int ref }
@@ -171,10 +164,8 @@ type t : immutable_data = { x : int ref }
 Line 1, characters 0-41:
 1 | type t : immutable_data = { x : int ref }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because int ref is not mod contended immutable.
 |}]
 
 type t : immutable_data = { x : unit -> unit }
@@ -182,10 +173,9 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because unit -> unit is not mod many portable forkable unyielding
+                 stateless.
 |}]
 
 type 'a t : immutable_data = { x : 'a option }
@@ -193,10 +183,9 @@ type 'a t : immutable_data = { x : 'a option }
 Line 1, characters 0-46:
 1 | type 'a t : immutable_data = { x : 'a option }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 type t : immutable_data = { x : int; y : int; mutable z : int }
@@ -204,10 +193,8 @@ type t : immutable_data = { x : int; y : int; mutable z : int }
 Line 1, characters 0-63:
 1 | type t : immutable_data = { x : int; y : int; mutable z : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because mutable field z : int is not mod contended immutable.
 |}]
 
 type t : mutable_data = { x : unit -> unit }
@@ -215,10 +202,9 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of mutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation mutable_data,
+       because unit -> unit is not mod many portable forkable unyielding
+                 stateless.
 |}]
 
 type ('a : value mod portable) t : value mod many = { x : 'a }
@@ -226,10 +212,8 @@ type ('a : value mod portable) t : value mod many = { x : 'a }
 Line 1, characters 0-62:
 1 | type ('a : value mod portable) t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because 'a is not mod many.
 |}]
 
 type ('a : value mod global) t : value mod global = { x : 'a }
@@ -237,10 +221,8 @@ type ('a : value mod global) t : value mod global = { x : 'a }
 Line 1, characters 0-62:
 1 | type ('a : value mod global) t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this record type is not mod global aliased.
 |}]
 
 type ('a : value mod aliased) t : value mod aliased = { x : 'a }
@@ -248,10 +230,8 @@ type ('a : value mod aliased) t : value mod aliased = { x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : value mod aliased) t : value mod aliased = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because this record type is not mod aliased.
 |}]
 
 type ('a : value mod external_) t : value mod external_ = { x : 'a }
@@ -259,10 +239,8 @@ type ('a : value mod external_) t : value mod external_ = { x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : value mod external_) t : value mod external_ = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because this record type is not mod external_.
 |}]
 
 type t : sync_data = { mutable x : int ref [@atomic] }
@@ -270,10 +248,8 @@ type t : sync_data = { mutable x : int ref [@atomic] }
 Line 1, characters 0-54:
 1 | type t : sync_data = { mutable x : int ref [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because int ref is not mod contended.
 |}]
 
 type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
@@ -281,13 +257,8 @@ type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
 Line 1, characters 0-69:
 1 | type ('a : mutable_data) t : sync_data = { mutable x : 'a [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is sync_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod contended with 'a ≰ mod contended
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because 'a is not mod contended.
 |}]
 
 (**** Test 2: Annotations with "with" are accepted when appropriate ****)
@@ -323,14 +294,8 @@ type 'a t : immutable_data with 'a = { mutable x : 'a }
 Line 1, characters 0-55:
 1 | type 'a t : immutable_data with 'a = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data with 'a
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod uncontended ≰ mod contended with 'a
-         visibility: mod read_write ≰ mod immutable with 'a
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because mutable field x : 'a is not mod contended immutable.
 |}]
 
 type 'a t : immutable_data with 'a = { x : 'a -> 'a }
@@ -338,10 +303,9 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because 'a -> 'a is not mod many portable forkable unyielding
+                 stateless.
 |}]
 
 type 'a t : value mod global with 'a = { x : 'a }
@@ -349,10 +313,9 @@ type 'a t : value mod global with 'a = { x : 'a }
 Line 1, characters 0-49:
 1 | type 'a t : value mod global with 'a = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod global with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         value mod global with 'a,
+       because this record type is not mod global aliased.
 |}]
 
 type 'a t : value mod aliased with 'a = { x : 'a }
@@ -360,10 +323,9 @@ type 'a t : value mod aliased with 'a = { x : 'a }
 Line 1, characters 0-50:
 1 | type 'a t : value mod aliased with 'a = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod aliased with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased with 'a,
+       because this record type is not mod aliased.
 |}]
 
 type 'a t : value mod external_ with 'a = { x : 'a }
@@ -371,11 +333,9 @@ type 'a t : value mod external_ with 'a = { x : 'a }
 Line 1, characters 0-52:
 1 | type 'a t : value mod external_ with 'a = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of
-           value mod external_ with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         value mod external_ with 'a,
+       because this record type is not mod external_.
 |}]
 
 (**** Test 3: Record values cross when appropriate ****)

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -143,7 +143,8 @@ type 'a t : immutable_data = { x : 'a }
 Line 1, characters 0-39:
 1 | type 'a t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -152,7 +153,8 @@ type 'a t : immutable_data = { mutable x : 'a }
 Line 1, characters 0-47:
 1 | type 'a t : immutable_data = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because
        - 'a is not mod stateless immutable
        - mutable fields are not mod immutable
@@ -163,7 +165,8 @@ type t : immutable_data = { x : int ref }
 Line 1, characters 0-41:
 1 | type t : immutable_data = { x : int ref }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because ref is not mod immutable.
 |}]
 
@@ -172,7 +175,8 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because functions are not mod forkable unyielding many stateless.
 |}]
 
@@ -181,7 +185,8 @@ type 'a t : immutable_data = { x : 'a option }
 Line 1, characters 0-46:
 1 | type 'a t : immutable_data = { x : 'a option }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -190,7 +195,8 @@ type t : immutable_data = { x : int; y : int; mutable z : int }
 Line 1, characters 0-63:
 1 | type t : immutable_data = { x : int; y : int; mutable z : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because mutable fields are not mod immutable.
 |}]
 
@@ -199,7 +205,8 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation mutable_data,
+Error: This type definition does not satisfy its kind annotation
+         mutable_data,
        because functions are not mod forkable unyielding many stateless.
 |}]
 
@@ -208,7 +215,8 @@ type ('a : value mod portable) t : value mod many = { x : 'a }
 Line 1, characters 0-62:
 1 | type ('a : value mod portable) t : value mod many = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod many,
+Error: This type definition does not satisfy its kind annotation
+         value mod many,
        because 'a is not mod many.
 |}]
 
@@ -217,7 +225,8 @@ type ('a : value mod global) t : value mod global = { x : 'a }
 Line 1, characters 0-62:
 1 | type ('a : value mod global) t : value mod global = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because boxed records are not mod global.
 |}]
 
@@ -226,7 +235,8 @@ type ('a : value mod aliased) t : value mod aliased = { x : 'a }
 Line 1, characters 0-64:
 1 | type ('a : value mod aliased) t : value mod aliased = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased,
        because boxed records are not mod aliased.
 |}]
 
@@ -235,7 +245,8 @@ type ('a : value mod external_) t : value mod external_ = { x : 'a }
 Line 1, characters 0-68:
 1 | type ('a : value mod external_) t : value mod external_ = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod external_,
+Error: This type definition does not satisfy its kind annotation
+         value mod external_,
        because boxed records are not mod external_.
 |}]
 
@@ -290,7 +301,8 @@ type 'a t : immutable_data with 'a = { mutable x : 'a }
 Line 1, characters 0-55:
 1 | type 'a t : immutable_data with 'a = { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because mutable fields are not mod immutable.
 |}]
 
@@ -299,7 +311,8 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because functions are not mod forkable unyielding many stateless.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/no_annot_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/no_annot_ikinds.ml
@@ -12,10 +12,7 @@ Lines 1-3, characters 0-11:
 1 | type ('a : value_or_null) aliased_t : value_or_null mod aliased =
 2 |   { aliased : 'a }
 3 | [@@unboxed]
-Error: The kind of type "aliased_t" is value_or_null
-         because of the annotation on 'a in the declaration of the type
-                                      aliased_t.
-       But the kind of type "aliased_t" must be a subkind of
-           value_or_null mod aliased
-         because of the annotation on the declaration of the type aliased_t.
+Error: This type definition does not satisfy its kind annotation
+         value_or_null mod aliased,
+       because 'a is not mod aliased.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback.ml
@@ -3,10 +3,8 @@
    expect;
 *)
 
-(* Regression test: immutable record fields contribute an untracked
-   [Axis_lattice.immediate], so [provenance_residuals] gives up and the error
-   falls back. Only [mod dynamic] is affected: [immediate] is bottom on every
-   other axis. *)
+(* Immutable record fields used to contribute an untracked [immediate] to the
+   provenance residual, suppressing the error for the one bound it obstructs. *)
 
 type t : value mod dynamic = { mutable x : int }
 [%%expect {|
@@ -19,7 +17,6 @@ Error: The kind of type "t" is mutable_data
          because of the annotation on the declaration of the type t.
 |}]
 
-(* Same, plus one immutable field. *)
 type t : value mod dynamic = { mutable x : int; y : int }
 [%%expect {|
 Line 1, characters 0-57:
@@ -53,7 +50,6 @@ Error: The kind of type "t" is immediate
          because of the annotation on the declaration of the type t.
 |}]
 
-(* Tuple payloads have no immutable-label contribution. *)
 type t : value mod dynamic = A of int
 [%%expect {|
 Line 1, characters 0-37:
@@ -96,4 +92,93 @@ Error: The kind of type "t" is mutable_data
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
          because of the annotation on the declaration of the type t.
+|}]
+
+(* Each base value has its own wording; these all pick [immediate]. *)
+
+type t : value mod dynamic = { x : int } [@@unboxed]
+[%%expect {|
+Line 1, characters 0-52:
+1 | type t : value mod dynamic = { x : int } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immediate
+         because it is the primitive type int.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = A of int [@@unboxed]
+[%%expect {|
+Line 1, characters 0-49:
+1 | type t : value mod dynamic = A of int [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immediate
+         because it is the primitive type int.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = A | B
+[%%expect {|
+Line 1, characters 0-34:
+1 | type t : value mod dynamic = A | B
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immediate
+         because it's an enumeration variant type (all constructors are constant).
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type void_t : void
+type t : value mod dynamic = A of void_t [@immediate_all_void_constructor]
+[%%expect {|
+type void_t : void
+Line 2, characters 0-74:
+2 | type t : value mod dynamic = A of void_t [@immediate_all_void_constructor]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immediate with void_t
+         because it's an enumeration variant type (all constructors are constant).
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* A manifest with a plain mod-bounds annotation still bypasses provenance:
+   [narrow_to_manifest_jkind] routes it through [constrain_type_jkind]. *)
+
+type t : value mod dynamic = int * int
+[%%expect {|
+Line 1, characters 0-38:
+1 | type t : value mod dynamic = int * int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int * int" is immutable_data
+         because it's a tuple type.
+       But the kind of type "int * int" must be a subkind of value mod dynamic
+         because of the definition of t at line 1, characters 0-38.
+|}]
+
+type t : value mod contended = int ref
+[%%expect {|
+Line 1, characters 0-38:
+1 | type t : value mod contended = int ref
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int ref" is mutable_data.
+       But the kind of type "int ref" must be a subkind of value mod contended
+         because of the definition of t at line 1, characters 0-38.
+|}]
+
+(* A with-bounds annotation takes the ikind route. *)
+type 'a t : immutable_data with 'a = 'a ref
+[%%expect {|
+Line 1, characters 0-43:
+1 | type 'a t : immutable_data with 'a = 'a ref
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "'a ref" is
+           mutable_data with 'a @@ forkable unyielding many.
+       But the kind of type "'a ref" must be a subkind of
+           immutable_data with 'a
+         because of the definition of t at line 1, characters 0-43.
+
+       The first mode-crosses less than the second along:
+         contention: mod uncontended ≰ mod contended with 'a
+         visibility: mod read_write ≰ mod immutable with 'a
 |}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback.ml
@@ -1,0 +1,99 @@
+(* TEST
+   flags = "-no-ikinds";
+   expect;
+*)
+
+(* Regression test: immutable record fields contribute an untracked
+   [Axis_lattice.immediate], so [provenance_residuals] gives up and the error
+   falls back. Only [mod dynamic] is affected: [immediate] is bottom on every
+   other axis. *)
+
+type t : value mod dynamic = { mutable x : int }
+[%%expect {|
+Line 1, characters 0-48:
+1 | type t : value mod dynamic = { mutable x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Same, plus one immutable field. *)
+type t : value mod dynamic = { mutable x : int; y : int }
+[%%expect {|
+Line 1, characters 0-57:
+1 | type t : value mod dynamic = { mutable x : int; y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = { x : int }
+[%%expect {|
+Line 1, characters 0-40:
+1 | type t : value mod dynamic = { x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = #{ x : int }
+[%%expect {|
+Line 1, characters 0-41:
+1 | type t : value mod dynamic = #{ x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immediate
+         because it is an unboxed record.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Tuple payloads have no immutable-label contribution. *)
+type t : value mod dynamic = A of int
+[%%expect {|
+Line 1, characters 0-37:
+1 | type t : value mod dynamic = A of int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = A of { x : int }
+[%%expect {|
+Line 1, characters 0-45:
+1 | type t : value mod dynamic = A of { x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = A of { mutable x : int }
+[%%expect {|
+Line 1, characters 0-53:
+1 | type t : value mod dynamic = A of { mutable x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod contended = { mutable x : int; y : int }
+[%%expect {|
+Line 1, characters 0-59:
+1 | type t : value mod contended = { mutable x : int; y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback_ikinds.ml
@@ -1,0 +1,96 @@
+(* TEST
+   expect;
+*)
+
+(* Regression test: immutable record fields contribute an untracked
+   [Axis_lattice.immediate], so [provenance_residuals] gives up and the error
+   falls back. Only [mod dynamic] is affected: [immediate] is bottom on every
+   other axis. *)
+
+type t : value mod dynamic = { mutable x : int }
+[%%expect {|
+Line 1, characters 0-48:
+1 | type t : value mod dynamic = { mutable x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - boxed records are not mod dynamic
+       - mutable fields are not mod dynamic
+|}]
+
+(* Same, plus one immutable field. *)
+type t : value mod dynamic = { mutable x : int; y : int }
+[%%expect {|
+Line 1, characters 0-57:
+1 | type t : value mod dynamic = { mutable x : int; y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = { x : int }
+[%%expect {|
+Line 1, characters 0-40:
+1 | type t : value mod dynamic = { x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = #{ x : int }
+[%%expect {|
+Line 1, characters 0-41:
+1 | type t : value mod dynamic = #{ x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immediate
+         because it is an unboxed record.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Tuple payloads have no immutable-label contribution. *)
+type t : value mod dynamic = A of int
+[%%expect {|
+Line 1, characters 0-37:
+1 | type t : value mod dynamic = A of int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - boxed variants are not mod dynamic
+       - int is not mod dynamic
+|}]
+
+type t : value mod dynamic = A of { x : int }
+[%%expect {|
+Line 1, characters 0-45:
+1 | type t : value mod dynamic = A of { x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod dynamic
+         because of the annotation on the declaration of the type t.
+|}]
+
+type t : value mod dynamic = A of { mutable x : int }
+[%%expect {|
+Line 1, characters 0-53:
+1 | type t : value mod dynamic = A of { mutable x : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - boxed variants are not mod dynamic
+       - mutable fields are not mod dynamic
+|}]
+
+type t : value mod contended = { mutable x : int; y : int }
+[%%expect {|
+Line 1, characters 0-59:
+1 | type t : value mod contended = { mutable x : int; y : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because mutable fields are not mod contended.
+|}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback_ikinds.ml
@@ -2,10 +2,8 @@
    expect;
 *)
 
-(* Regression test: immutable record fields contribute an untracked
-   [Axis_lattice.immediate], so [provenance_residuals] gives up and the error
-   falls back. Only [mod dynamic] is affected: [immediate] is bottom on every
-   other axis. *)
+(* Immutable record fields used to contribute an untracked [immediate] to the
+   provenance residual, suppressing the error for the one bound it obstructs. *)
 
 type t : value mod dynamic = { mutable x : int }
 [%%expect {|
@@ -18,16 +16,16 @@ Error: This type definition does not satisfy its kind annotation value mod dynam
        - mutable fields are not mod dynamic
 |}]
 
-(* Same, plus one immutable field. *)
 type t : value mod dynamic = { mutable x : int; y : int }
 [%%expect {|
 Line 1, characters 0-57:
 1 | type t : value mod dynamic = { mutable x : int; y : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod dynamic
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - boxed records are not mod dynamic
+       - mutable fields are not mod dynamic
+       - int is not mod dynamic
 |}]
 
 type t : value mod dynamic = { x : int }
@@ -35,10 +33,10 @@ type t : value mod dynamic = { x : int }
 Line 1, characters 0-40:
 1 | type t : value mod dynamic = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod dynamic
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - boxed records are not mod dynamic
+       - int is not mod dynamic
 |}]
 
 type t : value mod dynamic = #{ x : int }
@@ -46,13 +44,12 @@ type t : value mod dynamic = #{ x : int }
 Line 1, characters 0-41:
 1 | type t : value mod dynamic = #{ x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immediate
-         because it is an unboxed record.
-       But the kind of type "t" must be a subkind of value mod dynamic
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - unboxed records are not mod dynamic
+       - int is not mod dynamic
 |}]
 
-(* Tuple payloads have no immutable-label contribution. *)
 type t : value mod dynamic = A of int
 [%%expect {|
 Line 1, characters 0-37:
@@ -69,10 +66,10 @@ type t : value mod dynamic = A of { x : int }
 Line 1, characters 0-45:
 1 | type t : value mod dynamic = A of { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod dynamic
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - boxed variants are not mod dynamic
+       - int is not mod dynamic
 |}]
 
 type t : value mod dynamic = A of { mutable x : int }
@@ -93,4 +90,84 @@ Line 1, characters 0-59:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod contended,
        because mutable fields are not mod contended.
+|}]
+
+(* Each base value has its own wording; these all pick [immediate]. *)
+
+type t : value mod dynamic = { x : int } [@@unboxed]
+[%%expect {|
+Line 1, characters 0-52:
+1 | type t : value mod dynamic = { x : int } [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - unboxed records are not mod dynamic
+       - int is not mod dynamic
+|}]
+
+type t : value mod dynamic = A of int [@@unboxed]
+[%%expect {|
+Line 1, characters 0-49:
+1 | type t : value mod dynamic = A of int [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - unboxed variants are not mod dynamic
+       - int is not mod dynamic
+|}]
+
+type t : value mod dynamic = A | B
+[%%expect {|
+Line 1, characters 0-34:
+1 | type t : value mod dynamic = A | B
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because enumeration variants are not mod dynamic.
+|}]
+
+type void_t : void
+type t : value mod dynamic = A of void_t [@immediate_all_void_constructor]
+[%%expect {|
+type void_t : void
+Line 2, characters 0-74:
+2 | type t : value mod dynamic = A of void_t [@immediate_all_void_constructor]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod dynamic,
+       because
+       - enumeration variants are not mod dynamic
+       - void_t is not mod dynamic
+|}]
+
+(* A manifest with a plain mod-bounds annotation still bypasses provenance:
+   [narrow_to_manifest_jkind] routes it through [constrain_type_jkind]. *)
+
+type t : value mod dynamic = int * int
+[%%expect {|
+Line 1, characters 0-38:
+1 | type t : value mod dynamic = int * int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int * int" is immutable_data
+         because it's a tuple type.
+       But the kind of type "int * int" must be a subkind of value mod dynamic
+         because of the definition of t at line 1, characters 0-38.
+|}]
+
+type t : value mod contended = int ref
+[%%expect {|
+Line 1, characters 0-38:
+1 | type t : value mod contended = int ref
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "int ref" is mutable_data.
+       But the kind of type "int ref" must be a subkind of value mod contended
+         because of the definition of t at line 1, characters 0-38.
+|}]
+
+(* A with-bounds annotation takes the ikind route. *)
+type 'a t : immutable_data with 'a = 'a ref
+[%%expect {|
+Line 1, characters 0-43:
+1 | type 'a t : immutable_data with 'a = 'a ref
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because ref is not mod immutable.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/provenance_fallback_ikinds.ml
@@ -10,7 +10,8 @@ type t : value mod dynamic = { mutable x : int }
 Line 1, characters 0-48:
 1 | type t : value mod dynamic = { mutable x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - boxed records are not mod dynamic
        - mutable fields are not mod dynamic
@@ -21,7 +22,8 @@ type t : value mod dynamic = { mutable x : int; y : int }
 Line 1, characters 0-57:
 1 | type t : value mod dynamic = { mutable x : int; y : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - boxed records are not mod dynamic
        - mutable fields are not mod dynamic
@@ -33,7 +35,8 @@ type t : value mod dynamic = { x : int }
 Line 1, characters 0-40:
 1 | type t : value mod dynamic = { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - boxed records are not mod dynamic
        - int is not mod dynamic
@@ -44,7 +47,8 @@ type t : value mod dynamic = #{ x : int }
 Line 1, characters 0-41:
 1 | type t : value mod dynamic = #{ x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - unboxed records are not mod dynamic
        - int is not mod dynamic
@@ -55,7 +59,8 @@ type t : value mod dynamic = A of int
 Line 1, characters 0-37:
 1 | type t : value mod dynamic = A of int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - boxed variants are not mod dynamic
        - int is not mod dynamic
@@ -66,7 +71,8 @@ type t : value mod dynamic = A of { x : int }
 Line 1, characters 0-45:
 1 | type t : value mod dynamic = A of { x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - boxed variants are not mod dynamic
        - int is not mod dynamic
@@ -77,7 +83,8 @@ type t : value mod dynamic = A of { mutable x : int }
 Line 1, characters 0-53:
 1 | type t : value mod dynamic = A of { mutable x : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - boxed variants are not mod dynamic
        - mutable fields are not mod dynamic
@@ -88,7 +95,8 @@ type t : value mod contended = { mutable x : int; y : int }
 Line 1, characters 0-59:
 1 | type t : value mod contended = { mutable x : int; y : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because mutable fields are not mod contended.
 |}]
 
@@ -99,7 +107,8 @@ type t : value mod dynamic = { x : int } [@@unboxed]
 Line 1, characters 0-52:
 1 | type t : value mod dynamic = { x : int } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - unboxed records are not mod dynamic
        - int is not mod dynamic
@@ -110,7 +119,8 @@ type t : value mod dynamic = A of int [@@unboxed]
 Line 1, characters 0-49:
 1 | type t : value mod dynamic = A of int [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - unboxed variants are not mod dynamic
        - int is not mod dynamic
@@ -121,7 +131,8 @@ type t : value mod dynamic = A | B
 Line 1, characters 0-34:
 1 | type t : value mod dynamic = A | B
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because enumeration variants are not mod dynamic.
 |}]
 
@@ -132,7 +143,8 @@ type void_t : void
 Line 2, characters 0-74:
 2 | type t : value mod dynamic = A of void_t [@immediate_all_void_constructor]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod dynamic,
+Error: This type definition does not satisfy its kind annotation
+         value mod dynamic,
        because
        - enumeration variants are not mod dynamic
        - void_t is not mod dynamic
@@ -168,6 +180,7 @@ type 'a t : immutable_data with 'a = 'a ref
 Line 1, characters 0-43:
 1 | type 'a t : immutable_data with 'a = 'a ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because ref is not mod immutable.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/recmod_with_bounds_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/recmod_with_bounds_ikinds.ml
@@ -53,8 +53,6 @@ end =
 Line 7, characters 2-48:
 7 |   type t : value mod portable = { x : int T1.t }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with int T1.t
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because T1.t is not mod portable.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/regression-tests/recmod_with_bounds_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/regression-tests/recmod_with_bounds_ikinds.ml
@@ -53,6 +53,7 @@ end =
 Line 7, characters 2-48:
 7 |   type t : value mod portable = { x : int T1.t }
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod portable,
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
        because T1.t is not mod portable.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -170,8 +170,8 @@ Line 1, characters 0-66:
 1 | type ('a, 'b) t : immutable_data with 'a = [< `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because [< `X | `Y of 'a ] is not mod many contended portable forkable
-                 unyielding stateless immutable.
+       because [< `X | `Y of 'a ] is not mod forkable unyielding many
+                 stateless immutable.
 |}]
 type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
 [%%expect{|
@@ -179,8 +179,8 @@ Line 1, characters 0-66:
 1 | type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because [> `X | `Y of 'a ] is not mod many contended portable forkable
-                 unyielding stateless immutable.
+       because [> `X | `Y of 'a ] is not mod forkable unyielding many
+                 stateless immutable.
 |}]
 
 (* less-than rows *)
@@ -206,8 +206,8 @@ Line 2, characters 2-83:
 2 |   type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because [< `A of 'a | `B of 'a * 'a | `C ] is not mod many contended
-                 portable forkable unyielding stateless immutable.
+       because [< `A of 'a | `B of 'a * 'a | `C ] is not mod forkable
+                 unyielding many stateless immutable.
 |}]
 
 (* Tunivar-ified row variables *)
@@ -329,8 +329,8 @@ Line 1, characters 0-78:
 Error: This type definition does not satisfy its kind annotation
          value mod everything non_float with [ `A of string ] t1,
        because
-       - this variant type is not mod global aliased external_
-       - string is not mod global aliased external_
+       - boxed variants are not mod global external_
+       - string is not mod global external_
 |}]
 
 type 'a t1 = [> `A of string | `B of int ] as 'a
@@ -359,8 +359,8 @@ Line 1, characters 0-96:
 Error: This type definition does not satisfy its kind annotation
          value mod everything non_float with [ `A of string | `B of int | `C ] t1,
        because
-       - this variant type is not mod global aliased external_
-       - string is not mod global aliased external_
+       - boxed variants are not mod global external_
+       - string is not mod global external_
 |}]
 
 module type S = sig

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -170,7 +170,7 @@ Line 1, characters 0-66:
 1 | type ('a, 'b) t : immutable_data with 'a = [< `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because [< `X | `Y of 'a ] is not mod forkable unyielding many
+       because polymorphic variants are not mod forkable unyielding many
                  stateless immutable.
 |}]
 type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
@@ -179,7 +179,7 @@ Line 1, characters 0-66:
 1 | type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because [> `X | `Y of 'a ] is not mod forkable unyielding many
+       because polymorphic variants are not mod forkable unyielding many
                  stateless immutable.
 |}]
 
@@ -206,8 +206,8 @@ Line 2, characters 2-83:
 2 |   type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because [< `A of 'a | `B of 'a * 'a | `C ] is not mod forkable
-                 unyielding many stateless immutable.
+       because polymorphic variants are not mod forkable unyielding many
+                 stateless immutable.
 |}]
 
 (* Tunivar-ified row variables *)

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -169,22 +169,18 @@ type ('a, 'b) t : immutable_data with 'a = [< `X | `Y of 'a] as 'b
 Line 1, characters 0-66:
 1 | type ('a, 'b) t : immutable_data with 'a = [< `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[< `X | `Y of 'a ]" is value non_float
-         because it's a polymorphic variant type.
-       But the kind of type "[< `X | `Y of 'a ]" must be a subkind of
-           immutable_data with 'a
-         because of the definition of t at line 1, characters 0-66.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because [< `X | `Y of 'a ] is not mod many contended portable forkable
+                 unyielding stateless immutable.
 |}]
 type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
 [%%expect{|
 Line 1, characters 0-66:
 1 | type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[> `X | `Y of 'a ]" is value non_float
-         because it's a polymorphic variant type.
-       But the kind of type "[> `X | `Y of 'a ]" must be a subkind of
-           immutable_data with 'a
-         because of the definition of u at line 1, characters 0-66.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because [> `X | `Y of 'a ] is not mod many contended portable forkable
+                 unyielding stateless immutable.
 |}]
 
 (* less-than rows *)
@@ -209,11 +205,9 @@ end
 Line 2, characters 2-83:
 2 |   type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" is value non_float
-         because it's a polymorphic variant type.
-       But the kind of type "[< `A of 'a | `B of 'a * 'a | `C ]" must be a subkind of
-         immutable_data with 'a
-         because of the definition of t at line 2, characters 2-83.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because [< `A of 'a | `B of 'a * 'a | `C ] is not mod many contended
+                 portable forkable unyielding stateless immutable.
 |}]
 
 (* Tunivar-ified row variables *)
@@ -332,10 +326,11 @@ type t3 : value non_float mod everything with [ `A of string] t1 = C of string  
 Line 1, characters 0-78:
 1 | type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t3" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t3" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t3.
+Error: This type definition does not satisfy its kind annotation
+         value mod everything non_float with [ `A of string ] t1,
+       because
+       - this variant type is not mod global aliased external_
+       - string is not mod global aliased external_
 |}]
 
 type 'a t1 = [> `A of string | `B of int ] as 'a
@@ -361,10 +356,11 @@ type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] 
 Line 1, characters 0-96:
 1 | type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t3" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t3" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t3.
+Error: This type definition does not satisfy its kind annotation
+         value mod everything non_float with [ `A of string | `B of int | `C ] t1,
+       because
+       - this variant type is not mod global aliased external_
+       - string is not mod global aliased external_
 |}]
 
 module type S = sig

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -169,7 +169,8 @@ type ('a, 'b) t : immutable_data with 'a = [< `X | `Y of 'a] as 'b
 Line 1, characters 0-66:
 1 | type ('a, 'b) t : immutable_data with 'a = [< `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because polymorphic variants are not mod forkable unyielding many
                  stateless immutable.
 |}]
@@ -178,7 +179,8 @@ type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
 Line 1, characters 0-66:
 1 | type ('a, 'b) u : immutable_data with 'a = [> `X | `Y of 'a] as 'b
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because polymorphic variants are not mod forkable unyielding many
                  stateless immutable.
 |}]
@@ -205,7 +207,8 @@ end
 Line 2, characters 2-83:
 2 |   type 'a t : immutable_data with 'a = private [< `A of 'a | `B of ('a * 'a) | `C ]
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because polymorphic variants are not mod forkable unyielding many
                  stateless immutable.
 |}]
@@ -357,7 +360,9 @@ Line 1, characters 0-96:
 1 | type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
-         value mod everything non_float with [ `A of string | `B of int | `C ] t1,
+         value mod everything
+           non_float
+           with [ `A of string | `B of int | `C ] t1,
        because
        - boxed variants are not mod global external_
        - string is not mod global external_

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
@@ -125,11 +125,9 @@ type ('a, 'b) u : immutable_data with 'a with 'b
 Line 2, characters 0-53:
 2 | type ('a, 'b) t : immutable_data with 'a = ('a, 'b) u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "('a, 'b) u" is immutable_data with 'a with 'b
-         because of the definition of u at line 1, characters 0-48.
-       But the kind of type "('a, 'b) u" must be a subkind of
-           immutable_data with 'a
-         because of the definition of t at line 2, characters 0-53.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because 'b is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 type ('a, 'b) t : immutable_data with 'a with 'b
@@ -586,11 +584,23 @@ type r
 Line 3, characters 0-62:
 3 | type should_fail_too : immutable_data with r = [`A of int ref]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[ `A of int ref ]" is mutable_data
-         because it's a polymorphic variant type.
-       But the kind of type "[ `A of int ref ]" must be a subkind of
-           immutable_data with r
-         because of the definition of should_fail_too at line 3, characters 0-62.
+Error: This type definition does not satisfy its kind annotation immutable_data with r,
+       because int ref is not mod contended immutable.
+|}]
+
+module M : sig
+  type r
+  type t : immutable_data with r = int ref
+end = struct
+  type r = int
+  type t = int ref
+end
+[%%expect{|
+Line 3, characters 2-42:
+3 |   type t : immutable_data with r = int ref
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data with r,
+       because int ref is not mod contended immutable.
 |}]
 
 type should_likewise_fail : immutable_data = (int ref * (int -> int))

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
@@ -126,8 +126,7 @@ Line 2, characters 0-53:
 2 | type ('a, 'b) t : immutable_data with 'a = ('a, 'b) u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'b is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'b is not mod forkable unyielding many stateless immutable.
 |}]
 
 type ('a, 'b) t : immutable_data with 'a with 'b
@@ -585,7 +584,7 @@ Line 3, characters 0-62:
 3 | type should_fail_too : immutable_data with r = [`A of int ref]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with r,
-       because int ref is not mod contended immutable.
+       because int ref is not mod immutable.
 |}]
 
 module M : sig
@@ -600,7 +599,7 @@ Line 3, characters 2-42:
 3 |   type t : immutable_data with r = int ref
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with r,
-       because int ref is not mod contended immutable.
+       because int ref is not mod immutable.
 |}]
 
 type should_likewise_fail : immutable_data = (int ref * (int -> int))

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
@@ -584,7 +584,7 @@ Line 3, characters 0-62:
 3 | type should_fail_too : immutable_data with r = [`A of int ref]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with r,
-       because int ref is not mod immutable.
+       because ref is not mod immutable.
 |}]
 
 module M : sig
@@ -599,7 +599,7 @@ Line 3, characters 2-42:
 3 |   type t : immutable_data with r = int ref
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with r,
-       because int ref is not mod immutable.
+       because ref is not mod immutable.
 |}]
 
 type should_likewise_fail : immutable_data = (int ref * (int -> int))

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
@@ -125,7 +125,8 @@ type ('a, 'b) u : immutable_data with 'a with 'b
 Line 2, characters 0-53:
 2 | type ('a, 'b) t : immutable_data with 'a = ('a, 'b) u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because 'b is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -583,7 +584,8 @@ type r
 Line 3, characters 0-62:
 3 | type should_fail_too : immutable_data with r = [`A of int ref]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with r,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with r,
        because ref is not mod immutable.
 |}]
 
@@ -598,7 +600,8 @@ end
 Line 3, characters 2-42:
 3 |   type t : immutable_data with r = int ref
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with r,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with r,
        because ref is not mod immutable.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
@@ -59,7 +59,7 @@ Line 4, characters 0-48:
 4 | type 'a t : immutable_data with 'a = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a F(Ref).t is not mod contended immutable.
+       because 'a F(Ref).t is not mod immutable.
 |}]
 
 module Ref = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
@@ -58,16 +58,8 @@ module Ref : sig type 'a t = 'a ref end
 Line 4, characters 0-48:
 4 | type 'a t : immutable_data with 'a = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "'a F(Ref).t" is
-           mutable_data with 'a @@ forkable unyielding many
-         because of the definition of t at line 2, characters 2-40.
-       But the kind of type "'a F(Ref).t" must be a subkind of
-           immutable_data with 'a
-         because of the definition of t at line 4, characters 0-48.
-
-       The first mode-crosses less than the second along:
-         contention: mod uncontended ≰ mod contended with 'a
-         visibility: mod read_write ≰ mod immutable with 'a
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because 'a F(Ref).t is not mod contended immutable.
 |}]
 
 module Ref = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
@@ -59,7 +59,7 @@ Line 4, characters 0-48:
 4 | type 'a t : immutable_data with 'a = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a F(Ref).t is not mod immutable.
+       because F(Ref).t is not mod immutable.
 |}]
 
 module Ref = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
@@ -58,7 +58,8 @@ module Ref : sig type 'a t = 'a ref end
 Line 4, characters 0-48:
 4 | type 'a t : immutable_data with 'a = 'a F(Ref).t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because F(Ref).t is not mod immutable.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality_ikinds.ml
@@ -101,10 +101,9 @@ type u
 Line 4, characters 0-36:
 4 | type t : value mod global with a = u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "u" is value
-         because of the definition of u at line 3, characters 0-6.
-       But the kind of type "u" must be a subkind of value mod global with a
-         because of the definition of t at line 4, characters 0-36.
+Error: This type definition does not satisfy its kind annotation
+         value mod global with a,
+       because u is not mod global aliased forkable unyielding.
 |}]
 
 module F (M : sig type t end) = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/quality_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/quality_ikinds.ml
@@ -103,7 +103,7 @@ Line 4, characters 0-36:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod global with a,
-       because u is not mod global aliased forkable unyielding.
+       because u is not mod global.
 |}]
 
 module F (M : sig type t end) = struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
@@ -71,8 +71,8 @@ Line 2, characters 2-70:
 2 |   type 'a t : immutable_data with 'a = Nil | Cons of 'a * 'a My_list.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a My_list.t is not mod many contended portable forkable
-                 unyielding stateless immutable.
+       because 'a My_list.t is not mod forkable unyielding many stateless
+                 immutable.
 |}]
 
 module rec My_list : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
@@ -71,7 +71,7 @@ Line 2, characters 2-70:
 2 |   type 'a t : immutable_data with 'a = Nil | Cons of 'a * 'a My_list.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a My_list.t is not mod forkable unyielding many stateless
+       because My_list.t is not mod forkable unyielding many stateless
                  immutable.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
@@ -70,10 +70,9 @@ end = My_list
 Line 2, characters 2-70:
 2 |   type 'a t : immutable_data with 'a = Nil | Cons of 'a * 'a My_list.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a with 'a My_list.t
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because 'a My_list.t is not mod many contended portable forkable
+                 unyielding stateless immutable.
 |}]
 
 module rec My_list : sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/recursive_ikinds.ml
@@ -70,7 +70,8 @@ end = My_list
 Line 2, characters 2-70:
 2 |   type 'a t : immutable_data with 'a = Nil | Cons of 'a * 'a My_list.t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because My_list.t is not mod forkable unyielding many stateless
                  immutable.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -173,8 +173,7 @@ Line 1, characters 0-38:
 1 | type 'a t : immutable_data = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type 'a t : immutable_data = Foo of { mutable x : 'a }
@@ -184,8 +183,8 @@ Line 1, characters 0-54:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
        because
-       - 'a is not mod contended portable stateless immutable
-       - mutable field x : 'a is not mod contended immutable
+       - 'a is not mod stateless immutable
+       - mutable fields are not mod immutable
 |}]
 
 type t : immutable_data = Foo | Bar of int ref
@@ -194,7 +193,7 @@ Line 1, characters 0-46:
 1 | type t : immutable_data = Foo | Bar of int ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because int ref is not mod contended immutable.
+       because int ref is not mod immutable.
 |}]
 
 type t : immutable_data = Foo of (unit -> unit)
@@ -203,8 +202,7 @@ Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because unit -> unit is not mod many portable forkable unyielding
-                 stateless.
+       because unit -> unit is not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : immutable_data = Foo of 'a option
@@ -213,8 +211,7 @@ Line 1, characters 0-45:
 1 | type 'a t : immutable_data = Foo of 'a option
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 type t : immutable_data = Foo of int * int | Bar of { mutable z : int }
@@ -223,7 +220,7 @@ Line 1, characters 0-71:
 1 | type t : immutable_data = Foo of int * int | Bar of { mutable z : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because mutable field z : int is not mod contended immutable.
+       because mutable fields are not mod immutable.
 |}]
 
 type t : mutable_data = Foo of { x : unit -> unit }
@@ -232,8 +229,7 @@ Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation mutable_data,
-       because unit -> unit is not mod many portable forkable unyielding
-                 stateless.
+       because unit -> unit is not mod forkable unyielding many stateless.
 |}]
 
 type ('a : value mod portable) t : value mod many = Foo of 'a
@@ -251,7 +247,7 @@ Line 1, characters 0-61:
 1 | type ('a : value mod global) t : value mod global = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod global,
-       because this variant type is not mod global aliased.
+       because boxed variants are not mod global.
 |}]
 
 type ('a : value mod aliased) t : value mod aliased = Foo of 'a
@@ -260,7 +256,7 @@ Line 1, characters 0-63:
 1 | type ('a : value mod aliased) t : value mod aliased = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod aliased,
-       because this variant type is not mod aliased.
+       because boxed variants are not mod aliased.
 |}]
 
 type ('a : value mod external_) t : value mod external_ = Foo of 'a
@@ -269,7 +265,7 @@ Line 1, characters 0-67:
 1 | type ('a : value mod external_) t : value mod external_ = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod external_,
-       because this variant type is not mod external_.
+       because boxed variants are not mod external_.
 |}]
 
 type t : sync_data = Foo of { mutable x : int ref [@atomic] }
@@ -322,7 +318,7 @@ Line 1, characters 0-62:
 1 | type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because mutable field x : 'a is not mod contended immutable.
+       because mutable fields are not mod immutable.
 |}]
 
 type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
@@ -331,8 +327,7 @@ Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a -> 'a is not mod many portable forkable unyielding
-                 stateless.
+       because 'a -> 'a is not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : value mod global with 'a = Foo of 'a
@@ -342,7 +337,7 @@ Line 1, characters 0-48:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod global with 'a,
-       because this variant type is not mod global aliased.
+       because boxed variants are not mod global.
 |}]
 
 type 'a t : value mod aliased with 'a = Foo of 'a
@@ -352,7 +347,7 @@ Line 1, characters 0-49:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod aliased with 'a,
-       because this variant type is not mod aliased.
+       because boxed variants are not mod aliased.
 |}]
 
 type 'a t : value mod external_ with 'a = Foo of 'a
@@ -362,7 +357,7 @@ Line 1, characters 0-51:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod external_ with 'a,
-       because this variant type is not mod external_.
+       because boxed variants are not mod external_.
 |}]
 
 (**** Test 3: Variant values cross when appropriate ****)

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -193,7 +193,7 @@ Line 1, characters 0-46:
 1 | type t : immutable_data = Foo | Bar of int ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because int ref is not mod immutable.
+       because ref is not mod immutable.
 |}]
 
 type t : immutable_data = Foo of (unit -> unit)
@@ -202,7 +202,7 @@ Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because unit -> unit is not mod forkable unyielding many stateless.
+       because functions are not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : immutable_data = Foo of 'a option
@@ -229,7 +229,7 @@ Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation mutable_data,
-       because unit -> unit is not mod forkable unyielding many stateless.
+       because functions are not mod forkable unyielding many stateless.
 |}]
 
 type ('a : value mod portable) t : value mod many = Foo of 'a
@@ -274,7 +274,7 @@ Line 1, characters 0-61:
 1 | type t : sync_data = Foo of { mutable x : int ref [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation sync_data,
-       because int ref is not mod contended.
+       because ref is not mod contended.
 |}]
 
 type ('a : mutable_data) t : sync_data = Foo of { mutable x : 'a [@atomic] }
@@ -327,7 +327,7 @@ Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
-       because 'a -> 'a is not mod forkable unyielding many stateless.
+       because functions are not mod forkable unyielding many stateless.
 |}]
 
 type 'a t : value mod global with 'a = Foo of 'a

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -172,10 +172,9 @@ type 'a t : immutable_data = Foo of 'a
 Line 1, characters 0-38:
 1 | type 'a t : immutable_data = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 type 'a t : immutable_data = Foo of { mutable x : 'a }
@@ -183,16 +182,10 @@ type 'a t : immutable_data = Foo of { mutable x : 'a }
 Line 1, characters 0-54:
 1 | type 'a t : immutable_data = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod uncontended ≰ mod contended
-         portability: mod portable with 'a ≰ mod portable
-         statefulness: mod stateless with 'a ≰ mod stateless
-         visibility: mod read_write ≰ mod immutable
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because
+       - 'a is not mod contended portable stateless immutable
+       - mutable field x : 'a is not mod contended immutable
 |}]
 
 type t : immutable_data = Foo | Bar of int ref
@@ -200,10 +193,8 @@ type t : immutable_data = Foo | Bar of int ref
 Line 1, characters 0-46:
 1 | type t : immutable_data = Foo | Bar of int ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because int ref is not mod contended immutable.
 |}]
 
 type t : immutable_data = Foo of (unit -> unit)
@@ -211,10 +202,9 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because unit -> unit is not mod many portable forkable unyielding
+                 stateless.
 |}]
 
 type 'a t : immutable_data = Foo of 'a option
@@ -222,10 +212,9 @@ type 'a t : immutable_data = Foo of 'a option
 Line 1, characters 0-45:
 1 | type 'a t : immutable_data = Foo of 'a option
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 type t : immutable_data = Foo of int * int | Bar of { mutable z : int }
@@ -233,10 +222,8 @@ type t : immutable_data = Foo of int * int | Bar of { mutable z : int }
 Line 1, characters 0-71:
 1 | type t : immutable_data = Foo of int * int | Bar of { mutable z : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because mutable field z : int is not mod contended immutable.
 |}]
 
 type t : mutable_data = Foo of { x : unit -> unit }
@@ -244,10 +231,9 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of mutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation mutable_data,
+       because unit -> unit is not mod many portable forkable unyielding
+                 stateless.
 |}]
 
 type ('a : value mod portable) t : value mod many = Foo of 'a
@@ -255,10 +241,8 @@ type ('a : value mod portable) t : value mod many = Foo of 'a
 Line 1, characters 0-61:
 1 | type ('a : value mod portable) t : value mod many = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod many
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod many,
+       because 'a is not mod many.
 |}]
 
 type ('a : value mod global) t : value mod global = Foo of 'a
@@ -266,10 +250,8 @@ type ('a : value mod global) t : value mod global = Foo of 'a
 Line 1, characters 0-61:
 1 | type ('a : value mod global) t : value mod global = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod global
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod global,
+       because this variant type is not mod global aliased.
 |}]
 
 type ('a : value mod aliased) t : value mod aliased = Foo of 'a
@@ -277,10 +259,8 @@ type ('a : value mod aliased) t : value mod aliased = Foo of 'a
 Line 1, characters 0-63:
 1 | type ('a : value mod aliased) t : value mod aliased = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod aliased
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod aliased,
+       because this variant type is not mod aliased.
 |}]
 
 type ('a : value mod external_) t : value mod external_ = Foo of 'a
@@ -288,10 +268,8 @@ type ('a : value mod external_) t : value mod external_ = Foo of 'a
 Line 1, characters 0-67:
 1 | type ('a : value mod external_) t : value mod external_ = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod external_
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod external_,
+       because this variant type is not mod external_.
 |}]
 
 type t : sync_data = Foo of { mutable x : int ref [@atomic] }
@@ -299,10 +277,8 @@ type t : sync_data = Foo of { mutable x : int ref [@atomic] }
 Line 1, characters 0-61:
 1 | type t : sync_data = Foo of { mutable x : int ref [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because int ref is not mod contended.
 |}]
 
 type ('a : mutable_data) t : sync_data = Foo of { mutable x : 'a [@atomic] }
@@ -310,13 +286,8 @@ type ('a : mutable_data) t : sync_data = Foo of { mutable x : 'a [@atomic] }
 Line 1, characters 0-76:
 1 | type ('a : mutable_data) t : sync_data = Foo of { mutable x : 'a [@atomic] }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is sync_data with 'a @@ forkable unyielding many
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of sync_data
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod contended with 'a ≰ mod contended
+Error: This type definition does not satisfy its kind annotation sync_data,
+       because 'a is not mod contended.
 |}]
 
 (**** Test 2: Annotations with "with" are accepted when appropriate ****)
@@ -350,14 +321,8 @@ type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
 Line 1, characters 0-62:
 1 | type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data with 'a
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         contention: mod uncontended ≰ mod contended with 'a
-         visibility: mod read_write ≰ mod immutable with 'a
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because mutable field x : 'a is not mod contended immutable.
 |}]
 
 type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
@@ -365,10 +330,9 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+       because 'a -> 'a is not mod many portable forkable unyielding
+                 stateless.
 |}]
 
 type 'a t : value mod global with 'a = Foo of 'a
@@ -376,10 +340,9 @@ type 'a t : value mod global with 'a = Foo of 'a
 Line 1, characters 0-48:
 1 | type 'a t : value mod global with 'a = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod global with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         value mod global with 'a,
+       because this variant type is not mod global aliased.
 |}]
 
 type 'a t : value mod aliased with 'a = Foo of 'a
@@ -387,10 +350,9 @@ type 'a t : value mod aliased with 'a = Foo of 'a
 Line 1, characters 0-49:
 1 | type 'a t : value mod aliased with 'a = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of value mod aliased with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased with 'a,
+       because this variant type is not mod aliased.
 |}]
 
 type 'a t : value mod external_ with 'a = Foo of 'a
@@ -398,11 +360,9 @@ type 'a t : value mod external_ with 'a = Foo of 'a
 Line 1, characters 0-51:
 1 | type 'a t : value mod external_ with 'a = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of
-           value mod external_ with 'a
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         value mod external_ with 'a,
+       because this variant type is not mod external_.
 |}]
 
 (**** Test 3: Variant values cross when appropriate ****)

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -172,7 +172,8 @@ type 'a t : immutable_data = Foo of 'a
 Line 1, characters 0-38:
 1 | type 'a t : immutable_data = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -181,7 +182,8 @@ type 'a t : immutable_data = Foo of { mutable x : 'a }
 Line 1, characters 0-54:
 1 | type 'a t : immutable_data = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because
        - 'a is not mod stateless immutable
        - mutable fields are not mod immutable
@@ -192,7 +194,8 @@ type t : immutable_data = Foo | Bar of int ref
 Line 1, characters 0-46:
 1 | type t : immutable_data = Foo | Bar of int ref
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because ref is not mod immutable.
 |}]
 
@@ -201,7 +204,8 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because functions are not mod forkable unyielding many stateless.
 |}]
 
@@ -210,7 +214,8 @@ type 'a t : immutable_data = Foo of 'a option
 Line 1, characters 0-45:
 1 | type 'a t : immutable_data = Foo of 'a option
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -219,7 +224,8 @@ type t : immutable_data = Foo of int * int | Bar of { mutable z : int }
 Line 1, characters 0-71:
 1 | type t : immutable_data = Foo of int * int | Bar of { mutable z : int }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because mutable fields are not mod immutable.
 |}]
 
@@ -228,7 +234,8 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation mutable_data,
+Error: This type definition does not satisfy its kind annotation
+         mutable_data,
        because functions are not mod forkable unyielding many stateless.
 |}]
 
@@ -237,7 +244,8 @@ type ('a : value mod portable) t : value mod many = Foo of 'a
 Line 1, characters 0-61:
 1 | type ('a : value mod portable) t : value mod many = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod many,
+Error: This type definition does not satisfy its kind annotation
+         value mod many,
        because 'a is not mod many.
 |}]
 
@@ -246,7 +254,8 @@ type ('a : value mod global) t : value mod global = Foo of 'a
 Line 1, characters 0-61:
 1 | type ('a : value mod global) t : value mod global = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod global,
+Error: This type definition does not satisfy its kind annotation
+         value mod global,
        because boxed variants are not mod global.
 |}]
 
@@ -255,7 +264,8 @@ type ('a : value mod aliased) t : value mod aliased = Foo of 'a
 Line 1, characters 0-63:
 1 | type ('a : value mod aliased) t : value mod aliased = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod aliased,
+Error: This type definition does not satisfy its kind annotation
+         value mod aliased,
        because boxed variants are not mod aliased.
 |}]
 
@@ -264,7 +274,8 @@ type ('a : value mod external_) t : value mod external_ = Foo of 'a
 Line 1, characters 0-67:
 1 | type ('a : value mod external_) t : value mod external_ = Foo of 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod external_,
+Error: This type definition does not satisfy its kind annotation
+         value mod external_,
        because boxed variants are not mod external_.
 |}]
 
@@ -317,7 +328,8 @@ type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
 Line 1, characters 0-62:
 1 | type 'a t : immutable_data with 'a = Foo of { mutable x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because mutable fields are not mod immutable.
 |}]
 
@@ -326,7 +338,8 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data with 'a,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data with 'a,
        because functions are not mod forkable unyielding many stateless.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -640,6 +640,23 @@ Error: The kind of type "t" is immutable_data with 'a u
          because of the annotation on the declaration of the type t.
 |}]
 
+(* A residual for a type-constructor occurrence covers only the
+   constructor's own contribution: [w] is blamed for the axes it fails on
+   any instantiation, while the parameter's flow is blamed on ['a]. *)
+type 'a w = { mutable x : int; y : 'a }
+type 'a c : value mod portable contended = { f : 'a w }
+[%%expect {|
+type 'a w = { mutable x : int; y : 'a; }
+Line 2, characters 0-55:
+2 | type 'a c : value mod portable contended = { f : 'a w }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is mutable_data with 'a
+         because it's a boxed record type.
+       But the kind of type "c" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type c.
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -592,6 +592,97 @@ Error: The kind of type "t" is immutable_data with 'a
          because of the annotation on the declaration of the type t.
 |}]
 
+(* The offending type is behind an alias. *)
+type u = int ref
+type t : value mod contended = {
+  a : u;
+}
+[%%expect {|
+type u = int ref
+Lines 2-4, characters 0-1:
+2 | type t : value mod contended = {
+3 |   a : u;
+4 | }
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* The same offending type occurs twice. *)
+type t : value mod contended = {
+  a : int ref;
+  b : int ref;
+}
+[%%expect {|
+Lines 1-4, characters 0-1:
+1 | type t : value mod contended = {
+2 |   a : int ref;
+3 |   b : int ref;
+4 | }
+Error: The kind of type "t" is mutable_data
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* The offending type is an alias whose kind depends on its parameter. *)
+type 'a u : immutable_data with 'a
+type 'a t : immutable_data = Foo of 'a u
+[%%expect {|
+type 'a u : immutable_data with 'a
+Line 2, characters 0-40:
+2 | type 'a t : immutable_data = Foo of 'a u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with 'a u
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* GADTs: only the offending constructor's payload is reported. *)
+type _ t : value mod contended =
+  | I : int -> int t
+  | R : int ref -> string t
+[%%expect {|
+Lines 1-3, characters 0-27:
+1 | type _ t : value mod contended =
+2 |   | I : int -> int t
+3 |   | R : int ref -> string t
+Error: The kind of type "t" is mutable_data
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* GADTs: existential payloads. *)
+type t : value mod portable = Pack : ('a -> 'a) -> t
+[%%expect {|
+Line 1, characters 0-52:
+1 | type t : value mod portable = Pack : ('a -> 'a) -> t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value non_float mod immutable
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* GADTs: a payload that mentions the index parameter. *)
+type 'a t : value mod contended =
+  | A : 'b ref -> 'b t
+[%%expect {|
+Lines 1-2, characters 0-22:
+1 | type 'a t : value mod contended =
+2 |   | A : 'b ref -> 'b t
+Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+
+       The first mode-crosses less than the second along:
+         contention: mod uncontended ≰ mod contended
+|}]
+
 (***************)
 (* TEST: Loops *)
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -700,6 +700,28 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
          contention: mod uncontended ≰ mod contended
 |}]
 
+type t : value mod portable = Pack : 'a -> t
+[%%expect {|
+Line 1, characters 0-44:
+1 | type t : value mod portable = Pack : 'a -> t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value non_float
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+type 'a t : value mod portable = A : 'b -> 'b t
+[%%expect {|
+Line 1, characters 0-47:
+1 | type 'a t : value mod portable = A : 'b -> 'b t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with 'a
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
 (***************)
 (* TEST: Loops *)
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -614,7 +614,7 @@ Lines 1-4, characters 0-1:
 3 |   b : int ref;
 4 | }
 Error: This type definition does not satisfy its kind annotation value mod contended,
-       because int ref is not mod contended.
+       because ref is not mod contended.
 |}]
 
 (* The offending type is an alias whose kind depends on its parameter. *)
@@ -629,6 +629,23 @@ Error: This type definition does not satisfy its kind annotation immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
+(* A residual for a type-constructor occurrence covers only the
+   constructor's own contribution: [w] is blamed for the axes it fails on
+   any instantiation, while the parameter's flow is blamed on ['a]. *)
+type 'a w = { mutable x : int; y : 'a }
+type 'a c : value mod portable contended = { f : 'a w }
+[%%expect {|
+type 'a w = { mutable x : int; y : 'a; }
+Line 2, characters 0-55:
+2 | type 'a c : value mod portable contended = { f : 'a w }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - w is not mod contended
+       - 'a is not mod portable
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t
@@ -639,7 +656,7 @@ Lines 1-3, characters 0-27:
 2 |   | I : int -> int t
 3 |   | R : int ref -> string t
 Error: This type definition does not satisfy its kind annotation value mod contended,
-       because int ref is not mod contended.
+       because ref is not mod contended.
 |}]
 
 (* GADTs: existential payloads. *)
@@ -649,7 +666,7 @@ Line 1, characters 0-52:
 1 | type t : value mod portable = Pack : ('a -> 'a) -> t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod portable,
-       because 'a -> 'a is not mod portable.
+       because functions are not mod portable.
 |}]
 
 (* GADTs: a payload that mentions the index parameter. *)
@@ -660,7 +677,7 @@ Lines 1-2, characters 0-22:
 1 | type 'a t : value mod contended =
 2 |   | A : 'b ref -> 'b t
 Error: This type definition does not satisfy its kind annotation value mod contended,
-       because 'b ref is not mod contended.
+       because ref is not mod contended.
 |}]
 
 (***************)

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -575,7 +575,7 @@ Line 1, characters 0-44:
 1 | type t : immutable_data = { mutable x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because mutable field x : int is not mod contended immutable.
+       because mutable fields are not mod immutable.
 |}]
 
 type ('a : mutable_data) t : immutable_data = { x : 'a }
@@ -584,7 +584,83 @@ Line 1, characters 0-56:
 1 | type ('a : mutable_data) t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod contended immutable.
+       because 'a is not mod immutable.
+|}]
+
+(* The offending type is behind an alias. *)
+type u = int ref
+type t : value mod contended = {
+  a : u;
+}
+[%%expect {|
+type u = int ref
+Lines 2-4, characters 0-1:
+2 | type t : value mod contended = {
+3 |   a : u;
+4 | }
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because u is not mod contended.
+|}]
+
+(* The same offending type occurs twice. *)
+type t : value mod contended = {
+  a : int ref;
+  b : int ref;
+}
+[%%expect {|
+Lines 1-4, characters 0-1:
+1 | type t : value mod contended = {
+2 |   a : int ref;
+3 |   b : int ref;
+4 | }
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because int ref is not mod contended.
+|}]
+
+(* The offending type is an alias whose kind depends on its parameter. *)
+type 'a u : immutable_data with 'a
+type 'a t : immutable_data = Foo of 'a u
+[%%expect {|
+type 'a u : immutable_data with 'a
+Line 2, characters 0-40:
+2 | type 'a t : immutable_data = Foo of 'a u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod forkable unyielding many stateless immutable.
+|}]
+
+(* GADTs: only the offending constructor's payload is reported. *)
+type _ t : value mod contended =
+  | I : int -> int t
+  | R : int ref -> string t
+[%%expect {|
+Lines 1-3, characters 0-27:
+1 | type _ t : value mod contended =
+2 |   | I : int -> int t
+3 |   | R : int ref -> string t
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because int ref is not mod contended.
+|}]
+
+(* GADTs: existential payloads. *)
+type t : value mod portable = Pack : ('a -> 'a) -> t
+[%%expect {|
+Line 1, characters 0-52:
+1 | type t : value mod portable = Pack : ('a -> 'a) -> t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because 'a -> 'a is not mod portable.
+|}]
+
+(* GADTs: a payload that mentions the index parameter. *)
+type 'a t : value mod contended =
+  | A : 'b ref -> 'b t
+[%%expect {|
+Lines 1-2, characters 0-22:
+1 | type 'a t : value mod contended =
+2 |   | A : 'b ref -> 'b t
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because 'b ref is not mod contended.
 |}]
 
 (***************)
@@ -1008,8 +1084,7 @@ Line 2, characters 0-53:
 2 | type 'a t : immutable_data = 'a u = Foo of { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immutable_data,
-       because 'a is not mod many contended portable forkable unyielding
-                 stateless immutable.
+       because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
 (**********************************)

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -574,10 +574,8 @@ type t : immutable_data = { mutable x : int}
 Line 1, characters 0-44:
 1 | type t : immutable_data = { mutable x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because mutable field x : int is not mod contended immutable.
 |}]
 
 type ('a : mutable_data) t : immutable_data = { x : 'a }
@@ -585,10 +583,8 @@ type ('a : mutable_data) t : immutable_data = { x : 'a }
 Line 1, characters 0-56:
 1 | type ('a : mutable_data) t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod contended immutable.
 |}]
 
 (***************)
@@ -1011,10 +1007,9 @@ type 'a u = Foo of { x : 'a; }
 Line 2, characters 0-53:
 2 | type 'a t : immutable_data = 'a u = Foo of { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is immutable_data with 'a
-         because it's a boxed variant type.
-       But the kind of type "t" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation immutable_data,
+       because 'a is not mod many contended portable forkable unyielding
+                 stateless immutable.
 |}]
 
 (**********************************)

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -680,6 +680,24 @@ Error: This type definition does not satisfy its kind annotation value mod conte
        because ref is not mod contended.
 |}]
 
+type t : value mod portable = Pack : 'a -> t
+[%%expect {|
+Line 1, characters 0-44:
+1 | type t : value mod portable = Pack : 'a -> t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because 'a is not mod portable.
+|}]
+
+type 'a t : value mod portable = A : 'b -> 'b t
+[%%expect {|
+Line 1, characters 0-47:
+1 | type 'a t : value mod portable = A : 'b -> 'b t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because 'b is not mod portable.
+|}]
+
 (***************)
 (* TEST: Loops *)
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -574,7 +574,8 @@ type t : immutable_data = { mutable x : int}
 Line 1, characters 0-44:
 1 | type t : immutable_data = { mutable x : int}
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because mutable fields are not mod immutable.
 |}]
 
@@ -583,7 +584,8 @@ type ('a : mutable_data) t : immutable_data = { x : 'a }
 Line 1, characters 0-56:
 1 | type ('a : mutable_data) t : immutable_data = { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod immutable.
 |}]
 
@@ -598,7 +600,8 @@ Lines 2-4, characters 0-1:
 2 | type t : value mod contended = {
 3 |   a : u;
 4 | }
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because u is not mod contended.
 |}]
 
@@ -613,7 +616,8 @@ Lines 1-4, characters 0-1:
 2 |   a : int ref;
 3 |   b : int ref;
 4 | }
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because ref is not mod contended.
 |}]
 
@@ -625,7 +629,8 @@ type 'a u : immutable_data with 'a
 Line 2, characters 0-40:
 2 | type 'a t : immutable_data = Foo of 'a u
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 
@@ -655,7 +660,8 @@ Lines 1-3, characters 0-27:
 1 | type _ t : value mod contended =
 2 |   | I : int -> int t
 3 |   | R : int ref -> string t
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because ref is not mod contended.
 |}]
 
@@ -665,7 +671,8 @@ type t : value mod portable = Pack : ('a -> 'a) -> t
 Line 1, characters 0-52:
 1 | type t : value mod portable = Pack : ('a -> 'a) -> t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod portable,
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
        because functions are not mod portable.
 |}]
 
@@ -676,7 +683,8 @@ type 'a t : value mod contended =
 Lines 1-2, characters 0-22:
 1 | type 'a t : value mod contended =
 2 |   | A : 'b ref -> 'b t
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because ref is not mod contended.
 |}]
 
@@ -685,7 +693,8 @@ type t : value mod portable = Pack : 'a -> t
 Line 1, characters 0-44:
 1 | type t : value mod portable = Pack : 'a -> t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod portable,
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
        because 'a is not mod portable.
 |}]
 
@@ -694,7 +703,8 @@ type 'a t : value mod portable = A : 'b -> 'b t
 Line 1, characters 0-47:
 1 | type 'a t : value mod portable = A : 'b -> 'b t
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod portable,
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
        because 'b is not mod portable.
 |}]
 
@@ -1118,7 +1128,8 @@ type 'a u = Foo of { x : 'a; }
 Line 2, characters 0-53:
 2 | type 'a t : immutable_data = 'a u = Foo of { x : 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation immutable_data,
+Error: This type definition does not satisfy its kind annotation
+         immutable_data,
        because 'a is not mod forkable unyielding many stateless immutable.
 |}]
 

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -443,13 +443,9 @@ Lines 8-11, characters 0-11:
  9 |   | Null_noncrossing_void of nonportable_void
 10 |   | This_noncrossing_void of int
 11 | [@@or_null]
-Error: The kind of type "noncrossing_void_null" is
-           immediate_or_null with nonportable_void
-         because an [@@or_null] type gets the kind of or_null
-         applied to its payload type.
-       But the kind of type "noncrossing_void_null" must be a subkind of
-           value_or_null mod portable
-         because of the annotation on the declaration of the type noncrossing_void_null.
+Error: This type definition does not satisfy its kind annotation
+         value_or_null mod portable,
+       because nonportable_void is not mod portable.
 |}]
 
 type two_nullary =

--- a/testsuite/tests/typing-layouts-or-null/separability_bug.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_bug.ml
@@ -48,17 +48,9 @@ type 'a bad : value_or_null mod global  = #{ i : 'a or_null @@ portable }
 Line 1, characters 0-73:
 1 | type 'a bad : value_or_null mod global  = #{ i : 'a or_null @@ portable }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is
-           value_or_null mod everything with 'a @@ portable
-         because it is an unboxed record.
-       But the kind of type "bad" must be a subkind of value_or_null mod global
-         because of the annotation on the declaration of the type bad.
-
-       The first mode-crosses less than the second along:
-         locality: mod global with 'a ≰ mod global
-         uniqueness: mod aliased with 'a ≰ mod aliased
-         forkable: mod forkable with 'a ≰ mod forkable
-         yielding: mod unyielding with 'a ≰ mod unyielding
+Error: This type definition does not satisfy its kind annotation
+         value_or_null mod global,
+       because 'a is not mod global aliased forkable unyielding.
 |}]
 
 (* This is a regression test for an intermediate version of the bug fix that

--- a/testsuite/tests/typing-layouts-or-null/separability_bug.ml
+++ b/testsuite/tests/typing-layouts-or-null/separability_bug.ml
@@ -50,7 +50,7 @@ Line 1, characters 0-73:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value_or_null mod global,
-       because 'a is not mod global aliased forkable unyielding.
+       because 'a is not mod global.
 |}]
 
 (* This is a regression test for an intermediate version of the bug fix that

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2341,10 +2341,8 @@ Lines 1-6, characters 0-30:
 4 |     c : #(int64# * #(float# * (bool -> bool) * 'b ));
 5 |     d : char }
 6 |   constraint 'b = int * string
-Error: The kind of type "record" is value non_float mod immutable with 'a
-         because it's a boxed record type.
-       But the kind of type "record" must be a subkind of value mod portable
-         because of the annotation on the declaration of the type record.
+Error: This type definition does not satisfy its kind annotation value mod portable,
+       because bool -> bool is not mod portable.
 |}]
 
 (****************************************************************************)

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2342,7 +2342,7 @@ Lines 1-6, characters 0-30:
 5 |     d : char }
 6 |   constraint 'b = int * string
 Error: This type definition does not satisfy its kind annotation value mod portable,
-       because bool -> bool is not mod portable.
+       because functions are not mod portable.
 |}]
 
 (****************************************************************************)

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2341,7 +2341,8 @@ Lines 1-6, characters 0-30:
 4 |     c : #(int64# * #(float# * (bool -> bool) * 'b ));
 5 |     d : char }
 6 |   constraint 'b = int * string
-Error: This type definition does not satisfy its kind annotation value mod portable,
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
        because functions are not mod portable.
 |}]
 

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -765,9 +765,7 @@ Line 1, characters 0-61:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          any mod portable & any mod portable,
-       because
-       - int -> int is not mod portable
-       - int -> q is not mod portable
+       because functions are not mod portable.
 |}]
 (* CR layouts v2.8: That error message is incomprehensible without
    with-bounds. Internal ticket 5096. *)

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -763,13 +763,11 @@ type q : any mod portable = #{ x : int -> int; y : int -> q }
 Line 1, characters 0-61:
 1 | type q : any mod portable = #{ x : int -> int; y : int -> q }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "q" is
-           value non_float mod aliased immutable
-           & value non_float mod aliased immutable
-         because it is an unboxed record.
-       But the kind of type "q" must be a subkind of
-           any mod portable & any mod portable
-         because of the annotation on the declaration of the type q.
+Error: This type definition does not satisfy its kind annotation
+         any mod portable & any mod portable,
+       because
+       - int -> int is not mod portable
+       - int -> q is not mod portable
 |}]
 (* CR layouts v2.8: That error message is incomprehensible without
    with-bounds. Internal ticket 5096. *)

--- a/testsuite/tests/typing-layouts-void/basics_void.ml
+++ b/testsuite/tests/typing-layouts-void/basics_void.ml
@@ -72,8 +72,7 @@ Line 1, characters 0-65:
 1 | type bad : immediate = A of key [@immediate_all_void_constructor]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immediate,
-       because key is not mod global aliased many contended portable forkable
-                 unyielding stateless immutable.
+       because key is not mod global many stateless immutable.
 |}]
 type bad : immediate = A of #(unit_u * key r) [@immediate_all_void_constructor]
 [%%expect{|
@@ -81,8 +80,7 @@ Line 1, characters 0-79:
 1 | type bad : immediate = A of #(unit_u * key r) [@immediate_all_void_constructor]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation immediate,
-       because key is not mod global aliased many contended portable forkable
-                 unyielding stateless immutable.
+       because key is not mod global many stateless immutable.
 |}]
 
 
@@ -118,8 +116,7 @@ Lines 1-3, characters 0-59:
 2 |   | A of v1 [@immediate_all_void_constructor]
 3 |   | B of #(unit_u * v2 r) [@immediate_all_void_constructor]
 Error: This type definition does not satisfy its kind annotation immediate with v1,
-       because v2 is not mod global aliased many contended portable forkable
-                 unyielding stateless immutable.
+       because v2 is not mod global many stateless immutable.
 |}]
 
 type vme : void

--- a/testsuite/tests/typing-layouts-void/basics_void.ml
+++ b/testsuite/tests/typing-layouts-void/basics_void.ml
@@ -71,20 +71,18 @@ type bad : immediate = A of key [@immediate_all_void_constructor]
 Line 1, characters 0-65:
 1 | type bad : immediate = A of key [@immediate_all_void_constructor]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is immediate with key
-         because it's an enumeration variant type (all constructors are constant).
-       But the kind of type "bad" must be a subkind of immediate
-         because of the annotation on the declaration of the type bad.
+Error: This type definition does not satisfy its kind annotation immediate,
+       because key is not mod global aliased many contended portable forkable
+                 unyielding stateless immutable.
 |}]
 type bad : immediate = A of #(unit_u * key r) [@immediate_all_void_constructor]
 [%%expect{|
 Line 1, characters 0-79:
 1 | type bad : immediate = A of #(unit_u * key r) [@immediate_all_void_constructor]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "bad" is immediate with key with unit_u
-         because it's an enumeration variant type (all constructors are constant).
-       But the kind of type "bad" must be a subkind of immediate
-         because of the annotation on the declaration of the type bad.
+Error: This type definition does not satisfy its kind annotation immediate,
+       because key is not mod global aliased many contended portable forkable
+                 unyielding stateless immutable.
 |}]
 
 
@@ -119,10 +117,9 @@ Lines 1-3, characters 0-59:
 1 | type bad : immediate with v1 =
 2 |   | A of v1 [@immediate_all_void_constructor]
 3 |   | B of #(unit_u * v2 r) [@immediate_all_void_constructor]
-Error: The kind of type "bad" is immediate with unit_u with v1 with v2
-         because it's an enumeration variant type (all constructors are constant).
-       But the kind of type "bad" must be a subkind of immediate with v1
-         because of the annotation on the declaration of the type bad.
+Error: This type definition does not satisfy its kind annotation immediate with v1,
+       because v2 is not mod global aliased many contended portable forkable
+                 unyielding stateless immutable.
 |}]
 
 type vme : void

--- a/testsuite/tests/typing-layouts-void/basics_void.ml
+++ b/testsuite/tests/typing-layouts-void/basics_void.ml
@@ -115,7 +115,8 @@ Lines 1-3, characters 0-59:
 1 | type bad : immediate with v1 =
 2 |   | A of v1 [@immediate_all_void_constructor]
 3 |   | B of #(unit_u * v2 r) [@immediate_all_void_constructor]
-Error: This type definition does not satisfy its kind annotation immediate with v1,
+Error: This type definition does not satisfy its kind annotation
+         immediate with v1,
        because v2 is not mod global many stateless immutable.
 |}]
 

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -14,10 +14,8 @@ val use_uncontended : 'a -> 'a = <fun>
 Line 5, characters 0-60:
 5 | type t : value mod contended = { mutable contents : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because mutable field contents : string is not mod contended.
 |}]
 
 (* On the other hand, if we set the attribute, we shouldn't get an error. *)

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -15,7 +15,7 @@ Line 5, characters 0-60:
 5 | type t : value mod contended = { mutable contents : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod contended,
-       because mutable field contents : string is not mod contended.
+       because mutable fields are not mod contended.
 |}]
 
 (* On the other hand, if we set the attribute, we shouldn't get an error. *)

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -14,7 +14,8 @@ val use_uncontended : 'a -> 'a = <fun>
 Line 5, characters 0-60:
 5 | type t : value mod contended = { mutable contents : string }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because mutable fields are not mod contended.
 |}]
 

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -846,7 +846,7 @@ Line 1, characters 0-56:
 1 | type t : value mod contended = { x : int ref @@ shared }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation value mod contended,
-       because int ref is not mod contended.
+       because ref is not mod contended.
 |}]
 
 type ('a : value mod contended) require_contended

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -845,10 +845,8 @@ type t : value mod contended = { x : int ref @@ shared }
 Line 1, characters 0-56:
 1 | type t : value mod contended = { x : int ref @@ shared }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is mutable_data
-         because it's a boxed record type.
-       But the kind of type "t" must be a subkind of value mod contended
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation value mod contended,
+       because int ref is not mod contended.
 |}]
 
 type ('a : value mod contended) require_contended

--- a/testsuite/tests/typing-modal-kinds/basics.ml
+++ b/testsuite/tests/typing-modal-kinds/basics.ml
@@ -845,7 +845,8 @@ type t : value mod contended = { x : int ref @@ shared }
 Line 1, characters 0-56:
 1 | type t : value mod contended = { x : int ref @@ shared }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod contended,
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
        because ref is not mod contended.
 |}]
 

--- a/testsuite/tests/typing-modal-kinds/unboxed.ml
+++ b/testsuite/tests/typing-modal-kinds/unboxed.ml
@@ -237,22 +237,9 @@ type 'a t : value & value mod portable =
 Lines 1-2, characters 0-43:
 1 | type 'a t : value & value mod portable =
 2 |   #{ x : 'a contended; y : 'a @@ portable }
-Error: The kind of type "t" is
-           value mod everything
-             mod dynamic
-             with 'a @@ portable
-             with 'a contended
-           & value mod everything
-               mod dynamic
-               with 'a @@ portable
-               with 'a contended
-         because it is an unboxed record.
-       But the kind of type "t" must be a subkind of
-           value mod portable & value mod portable
-         because of the annotation on the declaration of the type t.
-
-       The first mode-crosses less than the second along:
-         portability: mod portable with 'a contended ≰ mod portable
+Error: This type definition does not satisfy its kind annotation
+         value mod portable & value mod portable,
+       because 'a is not mod portable.
 |}]
 
 type 'a t : value & value mod portable =
@@ -262,17 +249,7 @@ type 'a t : value & value mod portable =
 Lines 1-2, characters 0-40:
 1 | type 'a t : value & value mod portable =
 2 |   #{ x : 'a contended; y : 'a portable }
-Error: The kind of type "t" is
-           value mod everything
-             mod dynamic
-             with 'a contended
-             with 'a portable
-           & value mod everything
-               mod dynamic
-               with 'a contended
-               with 'a portable
-         because it is an unboxed record.
-       But the kind of type "t" must be a subkind of
-           value mod portable & value mod portable
-         because of the annotation on the declaration of the type t.
+Error: This type definition does not satisfy its kind annotation
+         value mod portable & value mod portable,
+       because 'a is not mod portable.
 |}]

--- a/testsuite/tests/typing-modes/shareable.ml
+++ b/testsuite/tests/typing-modes/shareable.ml
@@ -129,8 +129,6 @@ type t
 Line 4, characters 0-65:
 4 | type s : value mod shareable = { v : t @@ shareable } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "s" is value
-         because of the definition of t at line 1, characters 0-6.
-       But the kind of type "s" must be a subkind of value mod shareable
-         because of the annotation on the declaration of the type s.
+Error: This type definition does not satisfy its kind annotation value mod shareable,
+       because t is not mod shareable.
 |}]

--- a/testsuite/tests/typing-modes/shareable.ml
+++ b/testsuite/tests/typing-modes/shareable.ml
@@ -129,6 +129,7 @@ type t
 Line 4, characters 0-65:
 4 | type s : value mod shareable = { v : t @@ shareable } [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This type definition does not satisfy its kind annotation value mod shareable,
+Error: This type definition does not satisfy its kind annotation
+         value mod shareable,
        because t is not mod shareable.
 |}]

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -187,6 +187,11 @@ let co_sub (a : t) (b : t) : t =
   let r = a land lnot b in
   r lor ((r land chain3_hi_mask) lsr 1)
 
+let imply (a : t) (b : t) : t =
+  let r = lnot a lor b land top in
+  let invalid_chain3_hi_bits = r land chain3_hi_mask land lnot (r lsl 1) in
+  r land lnot invalid_chain3_hi_bits
+
 (* Build a mask from a set of relevant axes. *)
 let of_axis_set (set : Jkind_axis.Axis_set.t) : t =
   let set : int = Obj.magic set in

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -188,7 +188,7 @@ let co_sub (a : t) (b : t) : t =
   r lor ((r land chain3_hi_mask) lsr 1)
 
 let imply (a : t) (b : t) : t =
-  let r = (lnot a lor b) land top in
+  let r = lnot a lor b land top in
   let invalid_chain3_hi_bits = r land chain3_hi_mask land lnot (r lsl 1) in
   r land lnot invalid_chain3_hi_bits
 

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -188,7 +188,7 @@ let co_sub (a : t) (b : t) : t =
   r lor ((r land chain3_hi_mask) lsr 1)
 
 let imply (a : t) (b : t) : t =
-  let r = lnot a lor b land top in
+  let r = (lnot a lor b) land top in
   let invalid_chain3_hi_bits = r land chain3_hi_mask land lnot (r lsl 1) in
   r land lnot invalid_chain3_hi_bits
 

--- a/typing/axis_lattice.mli
+++ b/typing/axis_lattice.mli
@@ -27,6 +27,8 @@ val leq : t -> t -> bool
 
 val co_sub : t -> t -> t
 
+val imply : t -> t -> t
+
 val equal : t -> t -> bool
 
 val hash : t -> int

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8739,11 +8739,13 @@ let constrain_decl_jkind env decl jkind =
       Ikind.sub_or_error ~type_equal ~context env
         decl.type_jkind jkind
     with
-    | Ok () as ok -> ok
-    | Error _ as err ->
+    | Ok () -> Ok ()
+    | Error err ->
         match decl.type_manifest with
-        | None -> err
-        | Some ty -> constrain_type_jkind env ty jkind
+        | None -> Error (Ikind.Jkind_error err)
+        | Some ty ->
+          constrain_type_jkind env ty jkind
+          |> Result.map_error (fun err -> Ikind.Jkind_error err)
 
 let exn_constructor_crossing env lid ~args locks =
   let vmode =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8804,11 +8804,13 @@ let constrain_decl_jkind env decl jkind =
       Ikind.sub_or_error ~type_equal ~context env
         decl.type_jkind jkind
     with
-    | Ok () as ok -> ok
-    | Error _ as err ->
+    | Ok () -> Ok ()
+    | Error err ->
         match decl.type_manifest with
-        | None -> err
-        | Some ty -> constrain_type_jkind env ty jkind
+        | None -> Error (Ikind.Jkind_error err)
+        | Some ty ->
+          constrain_type_jkind env ty jkind
+          |> Result.map_error (fun err -> Ikind.Jkind_error err)
 
 let exn_constructor_crossing env lid ~args locks =
   let vmode =

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -739,9 +739,9 @@ val type_jkind_and_sort :
    but correct: they are used to implement the module inclusion check, where
    we can be sure that the l-jkind has no undetermined variables. *)
 val check_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 val constrain_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 
 (* Compare two types for equality, with no renaming. This is useful for
    the [type_equal] function that must be passed to certain jkind functions. *)

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -744,9 +744,9 @@ val type_jkind_and_sort :
    but correct: they are used to implement the module inclusion check, where
    we can be sure that the l-jkind has no undetermined variables. *)
 val check_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 val constrain_decl_jkind :
-  Env.t -> type_declaration -> jkind_l -> (unit, Jkind.Violation.t) result
+  Env.t -> type_declaration -> jkind_l -> (unit, Ikind.subjkind_error) result
 
 (* Compare two types for equality, with no renaming. This is useful for
    the [type_equal] function that must be passed to certain jkind functions. *)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -38,6 +38,28 @@ let fresh_unknown_uid () : Types.Uid.t =
   in
   Types.Uid.mk ~current_unit
 
+module Provenance = struct
+  let next_id = ref 0
+
+  let names : Ldd.Name.t list ref = ref []
+
+  let register_text ty : Ldd.Name.t =
+    let id = !next_id in
+    next_id := id + 1;
+    let name = Ldd.Name.provenance ~id ~ty in
+    names := name :: !names;
+    name
+
+  let register (ty : Types.type_expr) : Ldd.Name.t =
+    Format_doc.asprintf "%a" Jkind.format_type_expr ty
+    |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
+    |> register_text
+
+  let reset () = names := []
+
+  let all_names () = List.rev !names
+end
+
 (** A kind solver specialized to [Types.Ldd] and [Types.type_expr].
 
     The solver computes LDD polynomials of the form base ⊔ Σ_i (arg_i ⊓ coeff_i)
@@ -81,6 +103,7 @@ module Solver = struct
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
+      add_provenance : bool;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -90,28 +113,46 @@ module Solver = struct
   let global_constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t =
     ConstrTbl.create 1
 
-  let create_ctx ~(mode : mode) ~(env : Env.t option)
+  let create_ctx ~(mode : mode) ~(env : Env.t option) ~add_provenance
       ~(lookup_of_env : Env.t -> Path.t -> constr_decl) =
     TyTbl.clear global_ty_to_kind;
     ConstrTbl.clear global_constr_to_coeffs;
     { env;
       lookup_of_env;
       mode;
+      add_provenance;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
+  let reset_for_provenance (ctx : ctx) ~(add_provenance : bool) : ctx =
+    { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
+
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode with
     | Normal -> Ldd.node_of_var (Ldd.rigid name)
+    | Round_up when match name with Provenance _ -> true | _ -> false ->
+      Ldd.node_of_var (Ldd.rigid name)
     | Round_up -> Ldd.const Axis_lattice.top
 
   (** A rigid variable corresponding to a type parameter [t]. *)
   let rigid (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
     let param_id = Types.get_id ty in
     rigid_name ctx (Ldd.Name.param param_id)
+
+  let provenance (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
+    rigid_name ctx (Provenance.register ty)
+
+  let provenance_text (ctx : ctx) (text : string) : Ldd.node =
+    rigid_name ctx (Provenance.register_text text)
+
+  let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
+      : Ldd.node =
+    if ctx.add_provenance
+    then Ldd.meet poly (provenance_text ctx (text ()))
+    else poly
 
   let type_may_be_circular (ty : Types.type_expr) : bool =
     match Types.get_desc ty with
@@ -164,7 +205,7 @@ module Solver = struct
            [c] are kept rigid to avoid infinite expansion. *)
         let instantiate (name : Ldd.Name.t) : Ldd.node =
           match name with
-          | Param _ | Unknown _ -> rigid_name ctx name
+          | Param _ | Provenance _ | Unknown _ -> rigid_name ctx name
           | KAtom kpath -> (
             match ctx.env with
             | None -> rigid_name ctx name
@@ -277,9 +318,21 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr (ctx : ctx) (path : Path.t) (args : Types.type_expr list) :
-      Ldd.node =
-    let base, coeffs = constr_kind ctx ~min_arity:(List.length args) path in
+  and constr ?self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
+      : Ldd.node =
+    let constr_ctx =
+      if ctx.add_provenance
+      then reset_for_provenance ctx ~add_provenance:false
+      else ctx
+    in
+    let base, coeffs =
+      constr_kind constr_ctx ~min_arity:(List.length args) path
+    in
+    let base =
+      match self_ty with
+      | Some ty when ctx.add_provenance -> Ldd.meet base (provenance ctx ty)
+      | Some _ | None -> base
+    in
     let rec loop acc remaining i =
       if i = Array.length coeffs
       then acc
@@ -421,83 +474,85 @@ module Solver = struct
     (* Compute the ikind polynomial for an arbitrary [type_expr]. This is the
        semantic counterpart of [Jkind.jkind_of_type], but expressed in LDD
        form. *)
-    let kind_poly =
-      (* [ty] is expected to be representative: no links/substs/fields/nil. *)
-      match Types.get_desc ty with
-      | Types.Tvar { name = _name; jkind }
-      | Types.Tunivar { name = _name; jkind } ->
-        (* Keep a rigid param, but cap it by its annotated jkind. *)
-        Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind)
-      | Types.Tconstr (path, args, _abbrev_memo) -> constr ctx path args
-      | Types.Ttuple elts ->
-        (* Boxed tuples: immutable_data base + per-element contributions
-           under id modality. *)
-        let base = Ldd.const Axis_lattice.immutable_data in
-        Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
-      | Types.Tunboxed_tuple elts ->
-        (* Unboxed tuples: per-element contributions; shallow axes relevant
-           only for arity = 1. *)
-        Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
-            kind ~use_tables:true ctx t)
-      | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
-        (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
-        Ldd.const Axis_lattice.arrow
-      | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
-      | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
-      | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
-      | Types.Tpoly (ty, univars) ->
-        (* CR ikinds: this is sound but not fully precise.
-          Internal ticket 5746. *)
-        let ty = !instance_poly_for_jkind' univars ty in
-        (* We intentionally skip the principality check here. Enforcing it
-           breaks the stdlib build, and the old env-var escape hatch never had
-           a viable setting in practice. Track removing this workaround as part
-           of internal ticket 5746. *)
-        kind ~check_principality:false ~use_tables:true ctx ty
-      | Types.Tof_kind jkind -> ckind_of_jkind ctx jkind
-      | Types.Tobject _ -> Ldd.const Axis_lattice.object_legacy
-      | Types.Tbox t ->
-        let base = Ldd.const Axis_lattice.mutable_data in
-        Ldd.join base (kind ~use_tables:true ctx t)
-      | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
-      | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
-      | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
-        (* Treat quoted/spliced/evaluated quoted types conservatively as
-           boxed values. *)
-        Ldd.const Axis_lattice.value
-      | Types.Tvariant row ->
-        if Btype.tvariant_not_immediate row
-        then
-          if Btype.static_row row
-          then
-            (* Closed, boxed polymorphic variant: immutable_data base plus
-               per-constructor args. *)
-            let base = Ldd.const Axis_lattice.immutable_data in
-            Btype.fold_row
-              (fun acc ty ->
-                let ty_kind = kind ~use_tables:true ctx ty in
-                Ldd.join acc ty_kind)
-              base row
-          else
-            (* CR ikinds: open rows get conservative non-float value (boxed)
-               intersected with an unknown rigid so the solver treats it as an
-               unknown element. This can be improved. Internal ticket 6205. *)
-            let unknown =
-              rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-            in
-            Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
-        else
-          (* All-constant (immediate) polymorphic variant. *)
-          Ldd.const Axis_lattice.immediate
-      | Types.Tpackage _ ->
-        (* Like open polymorphic variants, model first-class modules as boxed
-           values intersected with an unknown so they behave as not-best. *)
-        let unknown =
-          rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-        in
-        Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
+    let self_provenance poly =
+      if ctx.add_provenance then Ldd.meet poly (provenance ctx ty) else poly
     in
-    kind_poly
+    (* [ty] is expected to be representative: no links/substs/fields/nil.
+       Provenance is attached only to the contribution introduced by this
+       node, not to recursive child contributions. *)
+    match Types.get_desc ty with
+    | Types.Tvar { name = _name; jkind } | Types.Tunivar { name = _name; jkind }
+      ->
+      (* Keep a rigid param, but cap it by its annotated jkind. *)
+      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind))
+    | Types.Tconstr (path, args, _abbrev_memo) ->
+      constr ~self_ty:ty ctx path args
+    | Types.Ttuple elts ->
+      (* Boxed tuples: immutable_data base + per-element contributions
+         under id modality. *)
+      let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
+    | Types.Tunboxed_tuple elts ->
+      (* Unboxed tuples: per-element contributions; shallow axes relevant
+         only for arity = 1. *)
+      Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
+          kind ~use_tables:true ctx t)
+    | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
+      (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
+      self_provenance (Ldd.const Axis_lattice.arrow)
+    | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
+    | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
+    | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
+    | Types.Tpoly (ty, univars) ->
+      (* CR ikinds: this is sound but not fully precise.
+        Internal ticket 5746. *)
+      let ty = !instance_poly_for_jkind' univars ty in
+      (* We intentionally skip the principality check here. Enforcing it
+         breaks the stdlib build, and the old env-var escape hatch never had
+         a viable setting in practice. Track removing this workaround as part
+         of internal ticket 5746. *)
+      kind ~check_principality:false ~use_tables:true ctx ty
+    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind ctx jkind)
+    | Types.Tobject _ -> self_provenance (Ldd.const Axis_lattice.object_legacy)
+    | Types.Tbox t ->
+      let base = self_provenance (Ldd.const Axis_lattice.mutable_data) in
+      Ldd.join base (kind ~use_tables:true ctx t)
+    | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
+    | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
+    | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
+      (* Treat quoted/spliced/evaluated quoted types conservatively as
+         boxed values. *)
+      self_provenance (Ldd.const Axis_lattice.value)
+    | Types.Tvariant row ->
+      if Btype.tvariant_not_immediate row
+      then
+        if Btype.static_row row
+        then
+          (* Closed, boxed polymorphic variant: immutable_data base plus
+             per-constructor args. *)
+          let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+          Btype.fold_row
+            (fun acc ty ->
+              let ty_kind = kind ~use_tables:true ctx ty in
+              Ldd.join acc ty_kind)
+            base row
+        else
+          (* CR ikinds: open rows get conservative non-float value (boxed)
+             intersected with an unknown rigid so the solver treats it as an
+             unknown element. This can be improved. Internal ticket 6205. *)
+          let unknown =
+            rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
+          in
+          self_provenance
+            (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
+      else
+        (* All-constant (immediate) polymorphic variant. *)
+        self_provenance (Ldd.const Axis_lattice.immediate)
+    | Types.Tpackage _ ->
+      (* Like open polymorphic variants, model first-class modules as boxed
+         values intersected with an unknown so they behave as not-best. *)
+      let unknown = rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ())) in
+      self_provenance (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
 
   (* Evaluate a ckind in [ctx] and flush pending GFP constraints. *)
   let normalize (kind_poly : Ldd.node) : Ldd.node =
@@ -542,6 +597,369 @@ let pp_axes (axes : Jkind_axis.Axis.packed list) : string =
   |> List.map (fun (Jkind_axis.Axis.Pack ax) -> Jkind_axis.Axis.name ax)
   |> String.concat ", "
 
+let axis_name (Jkind_axis.Axis.Pack ax) = Jkind_axis.Axis.name ax
+
+let same_axis a b = String.equal (axis_name a) (axis_name b)
+
+let pp_axis_name ppf axis = Format_doc.fprintf ppf "%s" (axis_name axis)
+
+let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
+  match axes with
+  | [] -> Format_doc.fprintf ppf "<none>"
+  | [axis] -> pp_axis_name ppf axis
+  | [axis1; axis2] ->
+    Format_doc.fprintf ppf "%a and %a" pp_axis_name axis1 pp_axis_name axis2
+  | _ ->
+    let rec split_last = function
+      | [] -> assert false
+      | [last] -> [], last
+      | x :: xs ->
+        let init, last = split_last xs in
+        x :: init, last
+    in
+    let init, last = split_last axes in
+    Format_doc.fprintf ppf "%a,@ and %a"
+      (Format_doc.pp_print_list
+         ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf ",@ ")
+         pp_axis_name)
+      init pp_axis_name last
+
+let collapse_whitespace s =
+  let b = Buffer.create (String.length s) in
+  let pending_space = ref false in
+  String.iter
+    (function
+      | ' ' | '\n' | '\r' | '\t' ->
+        if Buffer.length b > 0 then pending_space := true
+      | c ->
+        if !pending_space
+        then (
+          Buffer.add_char b ' ';
+          pending_space := false);
+        Buffer.add_char b c)
+    s;
+  Buffer.contents b
+
+let remove_numeric_path_stamps s =
+  let b = Buffer.create (String.length s) in
+  let is_digit = function '0' .. '9' -> true | _ -> false in
+  let rec loop i =
+    if i >= String.length s
+    then ()
+    else
+      match s.[i] with
+      | '/' when i + 1 < String.length s && is_digit s.[i + 1] ->
+        let rec skip_digits j =
+          if j < String.length s && is_digit s.[j]
+          then skip_digits (j + 1)
+          else j
+        in
+        loop (skip_digits (i + 1))
+      | c ->
+        Buffer.add_char b c;
+        loop (i + 1)
+  in
+  loop 0;
+  Buffer.contents b
+
+let format_jkind_single_line env jkind =
+  Format_doc.asprintf "%a" (Jkind.format env) jkind
+  |> collapse_whitespace |> remove_numeric_path_stamps
+
+let pp_breakable_words ppf s =
+  s |> String.split_on_char ' '
+  |> List.filter (fun s -> not (String.equal s ""))
+  |> Format_doc.pp_print_list
+       ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
+       Format_doc.pp_print_string ppf
+
+let split_on_first_substring ~sub s =
+  let len = String.length s in
+  let sub_len = String.length sub in
+  let rec loop i =
+    if i + sub_len > len
+    then None
+    else if String.equal (String.sub s i sub_len) sub
+    then
+      let before = String.sub s 0 i in
+      let after = String.sub s (i + sub_len) (len - i - sub_len) in
+      Some (before, after)
+    else loop (i + 1)
+  in
+  loop 0
+
+let pp_breakable_jkind_annotation ppf s =
+  match split_on_first_substring ~sub:" with " s with
+  | None -> pp_breakable_words ppf s
+  | Some (before, after) ->
+    Format_doc.fprintf ppf "@[<v 2>%s@;with %s@]" before after
+
+let is_bot_poly poly = Axis_lattice.equal (Ldd.round_up poly) Axis_lattice.bot
+
+let axes_in_violation_order ~violating_axes axes =
+  (* Keep only axes that the overall comparison actually failed on, ordered as
+     in [violating_axes]. A fragment residual can be non-top on a non-violating
+     axis because [round_down] under-approximates the symbolic implication, so
+     intersecting here prevents blaming a fragment on an axis the whole
+     comparison passes on. *)
+  List.filter
+    (fun violating_axis -> List.exists (same_axis violating_axis) axes)
+    violating_axes
+
+type mode_crossing_error =
+  { origin : string option;
+    sub_jkind : Types.jkind_l;
+    super_jkind : Types.jkind_l;
+    sub_poly : Ldd.node;
+    super_poly : Ldd.node;
+    failing_poly : Ldd.node;
+    fast_path : string;
+    provenance_names : Ldd.Name.t list;
+    violating_axes : Jkind_axis.Axis.packed list
+  }
+
+type subjkind_error =
+  | Jkind_error of Jkind.Violation.t
+  | Mode_crossing_error of mode_crossing_error
+
+type provenance_residual =
+  { ty : string;
+    mode_bounds : Axis_lattice.t;
+    axes : Jkind_axis.Axis.packed list
+  }
+
+let provenance_ty_of_name (name : Ldd.Name.t) =
+  match name with
+  | Provenance { ty; _ } -> Some ty
+  | Atom _ | KAtom _ | Param _ | Unknown _ -> None
+
+let add_provenance_residual entries { ty; mode_bounds; axes } =
+  match List.partition (fun entry -> String.equal entry.ty ty) entries with
+  | [], rest -> { ty; mode_bounds; axes } :: rest
+  | matching, rest ->
+    let axes =
+      List.fold_left
+        (fun axes entry ->
+          List.fold_left
+            (fun axes axis ->
+              if List.exists (same_axis axis) axes then axes else axes @ [axis])
+            axes entry.axes)
+        axes matching
+    in
+    let mode_bounds =
+      List.fold_left
+        (fun mode_bounds entry ->
+          Axis_lattice.meet mode_bounds entry.mode_bounds)
+        mode_bounds matching
+    in
+    { ty; mode_bounds; axes } :: rest
+
+let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+    =
+  let provenance_vars = List.map Ldd.rigid provenance_names in
+  (* For a declaration [type t : bound = rhs], ikind checking compares the
+     inferred ikind polynomial for [rhs] against the polynomial for [bound].
+     When that comparison fails, we recompute [rhs] with provenance variables
+     inserted by meeting a fresh variable into each local contribution. For a
+     contribution [coeff] tagged by provenance variable [p], the error
+     reporting question is:
+
+       What is the largest assignment to [p] that would make this contribution
+       satisfy the required bound?
+
+     This is the right question because the provenance variable stands for the
+     mode-crossing behavior we need from the source type. It gives the least
+     restrictive bound that would still make the original lattice comparison
+     pass.
+
+     We answer the question by first decomposing the provenance-annotated
+     polynomial into an untracked base plus one coefficient per provenance
+     variable. If the base alone does not satisfy [super_poly], then provenance
+     cannot explain the error. Otherwise, for each coefficient [coeff], we need
+     the greatest [h] such that:
+
+       meet coeff h <= super_poly
+
+     This is exactly [Ldd.imply coeff super_poly]. The result may still contain
+     symbolic variables, so we round it down to a conservative concrete mode
+     bound for printing. *)
+  let base, coeffs =
+    Ldd.decompose_into_linear_terms ~universe:provenance_vars sub_poly
+  in
+  if Ldd.leq_with_reason base super_poly <> []
+  then None
+  else
+    List.combine provenance_names coeffs
+    |> List.filter_map (fun (name, coeff) ->
+        if is_bot_poly coeff
+        then None
+        else
+          match provenance_ty_of_name name with
+          | None -> None
+          | Some ty ->
+            let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
+            let non_top_bounds =
+              Axis_lattice.co_sub Axis_lattice.top mode_bounds
+            in
+            if Axis_lattice.equal non_top_bounds Axis_lattice.bot
+            then None
+            else
+              let axes =
+                non_top_bounds |> Axis_lattice.non_bot_axes
+                |> List.map Axis_lattice.axis_number_to_axis_packed
+                |> axes_in_violation_order ~violating_axes
+              in
+              Some { ty; mode_bounds; axes })
+    |> List.fold_left add_provenance_residual []
+    |> List.rev |> Option.some
+
+let string_of_required_bound required_bounds (Jkind_axis.Axis.Pack axis) =
+  match axis with
+  | Modal (Monadic Uniqueness) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Uniqueness.Const.print
+         (Axis_lattice.uniqueness required_bounds))
+  | Modal (Monadic Contention) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Contention.Const.print
+         (Axis_lattice.contention required_bounds))
+  | Modal (Monadic Visibility) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Visibility.Const.print
+         (Axis_lattice.visibility required_bounds))
+  | Modal (Monadic Staticity) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Staticity.Const.print
+         (Axis_lattice.staticity required_bounds))
+  | Modal (Comonadic Areality) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Regionality.Const.print
+         (Axis_lattice.areality required_bounds))
+  | Modal (Comonadic Linearity) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Linearity.Const.print
+         (Axis_lattice.linearity required_bounds))
+  | Modal (Comonadic Portability) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Portability.Const.print
+         (Axis_lattice.portability required_bounds))
+  | Modal (Comonadic Forkable) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Forkable.Const.print
+         (Axis_lattice.forkable required_bounds))
+  | Modal (Comonadic Yielding) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Yielding.Const.print
+         (Axis_lattice.yielding required_bounds))
+  | Modal (Comonadic Statefulness) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Statefulness.Const.print
+         (Axis_lattice.statefulness required_bounds))
+  | Nonmodal Externality ->
+    Some
+      (Format_doc.asprintf "%a" Jkind_axis.Externality.print
+         (Axis_lattice.externality required_bounds))
+
+let pp_provenance_residual ppf { ty; mode_bounds; axes; _ } =
+  let modes = List.filter_map (string_of_required_bound mode_bounds) axes in
+  Format_doc.fprintf ppf "@[<hov 2>%s is not mod %a@]" ty
+    (Format_doc.pp_print_list
+       ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
+       Format_doc.pp_print_string)
+    modes
+
+let pp_provenance_residual_bullets ppf entries =
+  List.iteri
+    (fun i entry ->
+      if i > 0 then Format_doc.fprintf ppf "@;";
+      Format_doc.fprintf ppf "- %a" pp_provenance_residual entry)
+    entries
+
+let pp_type_definition_kind_annotation env ppf super_jkind =
+  let super_jkind_single_line = format_jkind_single_line env super_jkind in
+  let single_line_prefix =
+    "Error: This type definition does not satisfy its kind annotation "
+  in
+  let error_prefix_width = String.length "Error: " in
+  let continuation_indent = 2 in
+  let continuation_prefix_width = error_prefix_width + continuation_indent in
+  if
+    String.length single_line_prefix + String.length super_jkind_single_line + 1
+    <= 88
+  then
+    Format_doc.fprintf ppf
+      "This type definition does not satisfy its kind annotation %s,"
+      super_jkind_single_line
+  else if
+    continuation_prefix_width + String.length super_jkind_single_line + 1 <= 88
+  then
+    Format_doc.fprintf ppf
+      "@[<v 2>This type definition does not satisfy its kind annotation@;%s,@]"
+      super_jkind_single_line
+  else
+    Format_doc.fprintf ppf
+      "@[<v 2>This type definition does not satisfy its kind annotation@;\
+       @[<hov>%a,@]@]"
+      pp_breakable_jkind_annotation super_jkind_single_line
+
+let report_provenance_mode_crossing_error env ppf
+    { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =
+  match
+    provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+  with
+  | None | Some [] -> None
+  | Some [entry] ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because %a.@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual entry)
+  | Some entries ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because@;%a@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual_bullets entries)
+
+let report_mode_crossing_error ~offender env ppf
+    { origin;
+      sub_jkind;
+      super_jkind;
+      sub_poly;
+      super_poly;
+      failing_poly;
+      fast_path;
+      provenance_names;
+      violating_axes
+    } =
+  let err =
+    { origin;
+      sub_jkind;
+      super_jkind;
+      sub_poly;
+      super_poly;
+      failing_poly;
+      fast_path;
+      provenance_names;
+      violating_axes
+    }
+  in
+  match report_provenance_mode_crossing_error env ppf err with
+  | Some () -> ()
+  | None ->
+    Format_doc.fprintf ppf
+      "@[<v>The mode crossing of %t is not allowed here.@;\
+       @[<hov 2>The inferred kind is not below the required kind along %a.@]@]"
+      offender pp_axis_list_prose violating_axes
+
+let report_subjkind_error_with_offender ~offender env ppf = function
+  | Jkind_error err ->
+    Jkind.Violation.report_with_offender ~offender env ppf err
+  | Mode_crossing_error err -> report_mode_crossing_error ~offender env ppf err
+
+let report_subjkind_error_with_name ~name env ppf err =
+  report_subjkind_error_with_offender
+    ~offender:(fun ppf -> Format_doc.fprintf ppf "%s" name)
+    env ppf err
+
 let axis_disagreement_reasons (axes : Jkind_axis.Axis.packed list) :
     Jkind.Sub_failure_reason.t list =
   List.map (fun axis -> Jkind.Sub_failure_reason.Axis_disagreement axis) axes
@@ -555,13 +973,15 @@ let label_mutability_contribution (lbl : Types.label_declaration) =
 
 let sum_record_label_contributions ~(base : Ldd.node)
     ~(payload_kind : Types.type_expr -> Ldd.node)
+    ?(label_mutability_provenance =
+      fun (_ : Types.label_declaration) (poly : Ldd.node) -> poly)
     ~(validate_label : Types.label_declaration -> unit)
     (lbls : Types.label_declaration list) : Ldd.node =
   Ldd.sum lbls ~base ~f:(fun (lbl : Types.label_declaration) ->
       validate_label lbl;
       let mask = Axis_lattice.mask_of_modality lbl.ld_modalities in
       Ldd.join
-        (label_mutability_contribution lbl)
+        (label_mutability_provenance lbl (label_mutability_contribution lbl))
         (Ldd.meet (Ldd.const mask) (payload_kind lbl.ld_type)))
 
 let no_validation (_ : Types.label_declaration) = ()
@@ -571,6 +991,30 @@ let validate_immutable_unboxed_label (lbl : Types.label_declaration) =
   | Immutable -> ()
   | Mutable _ ->
     failwith "ikind: mutable fields in unboxed records are not supported"
+
+let format_type_expr_single_line ty =
+  Format_doc.asprintf "%a" Jkind.format_type_expr ty
+  |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
+
+let label_mutability_provenance (ctx : Solver.ctx)
+    (lbl : Types.label_declaration) (poly : Ldd.node) : Ldd.node =
+  match lbl.ld_mutable with
+  | Immutable -> poly
+  | Mutable { atomic = Nonatomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () ->
+        Format.sprintf "mutable field %s : %s" (Ident.name lbl.ld_id)
+          (format_type_expr_single_line lbl.ld_type))
+      poly
+  | Mutable { atomic = Atomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () ->
+        Format.sprintf "mutable field %s : %s [@atomic]" (Ident.name lbl.ld_id)
+          (format_type_expr_single_line lbl.ld_type))
+      poly
+
+let decl_base_provenance (ctx : Solver.ctx) source poly =
+  Solver.with_provenance_text ctx (fun () -> source) poly
 
 (* Gather constructor-local vars from [tys]. *)
 let collect_type_vars (tys : Types.type_expr list) :
@@ -683,7 +1127,8 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
                   | Some bound -> bound
                   | None -> Ldd.const Axis_lattice.top
                 else Solver.node_of_name ctx name)
-            | Ldd.Name.Unknown _ | Ldd.Name.Atom _ | Ldd.Name.KAtom _ ->
+            | Ldd.Name.Unknown _ | Ldd.Name.Provenance _ | Ldd.Name.Atom _
+            | Ldd.Name.KAtom _ ->
               Solver.node_of_name ctx name
           in
           fun ty ->
@@ -692,6 +1137,117 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
       | _ ->
         failwith
           "ikind: expected GADT constructor result to be a type constructor")
+
+let type_decl_allows_any_crossing (decl : Types.type_declaration) =
+  match decl.type_kind with
+  | Types.Type_record (_, _, umc_opt)
+  | Types.Type_record_unboxed_product (_, _, umc_opt)
+  | Types.Type_variant (_, _, umc_opt) ->
+    Option.is_some umc_opt
+  | Types.Type_abstract _ | Types.Type_open -> false
+
+let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
+    Ldd.node =
+  match decl.type_manifest with
+  | Some body_ty -> Solver.kind ~use_tables:true ctx body_ty
+  | None -> (
+    let use_decl_jkind () = Solver.ckind_of_jkind ctx decl.type_jkind in
+    match decl.type_kind with
+    (* For abstract types and allow_any_crossing types, derive the ikind from
+       the jkind annotation instead of computing it from the type declaration's
+       body. *)
+    | _ when type_decl_allows_any_crossing decl -> use_decl_jkind ()
+    | Types.Type_abstract _ | Types.Type_open -> use_decl_jkind ()
+    | Types.Type_record (lbls, rep, _umc_opt) ->
+      let base =
+        Ldd.const
+          (match rep with
+          | Types.Record_unboxed -> Axis_lattice.immediate
+          (* CR box: This will no longer be [non_float] once we update the
+             representation of singleton float64 records *)
+          | _ -> Axis_lattice.immutable_data)
+        |> decl_base_provenance ctx "this record type"
+      in
+      sum_record_label_contributions ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~label_mutability_provenance:(label_mutability_provenance ctx)
+        ~validate_label:no_validation lbls
+    | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
+      let base =
+        Ldd.const Axis_lattice.immediate
+        |> decl_base_provenance ctx "this unboxed record type"
+      in
+      sum_record_label_contributions ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~label_mutability_provenance:(label_mutability_provenance ctx)
+        ~validate_label:validate_immutable_unboxed_label lbls
+    | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
+      (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
+         captured by its constructors: nullability/separability and
+         mode-crossing are baked into its representation. We defer to jkinds
+         because ikinds cannot express this today. This deferral can be removed
+         once separability and nullability become layout properties rather than
+         modal axes. *)
+      use_decl_jkind ()
+    | Types.Type_variant (cstrs, rep, _umc_opt) ->
+      (* Choose base: immediate for void-only variants; otherwise immutable. *)
+      let all_args_void =
+        List.for_all
+          (fun (c : Types.constructor_declaration) ->
+            match c.cd_args with
+            | Types.Cstr_tuple args ->
+              List.for_all
+                (fun (arg : Types.constructor_argument) ->
+                  match arg.ca_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                args
+            | Types.Cstr_record lbls ->
+              List.for_all
+                (fun (lbl : Types.label_declaration) ->
+                  match lbl.ld_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                lbls)
+          cstrs
+      in
+      let base =
+        let base_lat =
+          match rep with
+          | Types.Variant_unboxed -> Axis_lattice.immediate
+          | _ ->
+            if all_args_void
+            then Axis_lattice.immediate
+            else Axis_lattice.immutable_data
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx "this variant type"
+      in
+      let payload_kind_of_constructor =
+        make_gadt_payload_projector ~decl_params:decl.type_params ctx
+      in
+      let constructor_contrib (c : Types.constructor_declaration) =
+        let payload_kind = payload_kind_of_constructor c in
+        match c.cd_args with
+        | Types.Cstr_tuple args ->
+          Ldd.sum args ~base:Ldd.bot
+            ~f:(fun (arg : Types.constructor_argument) ->
+              let mask = Axis_lattice.mask_of_modality arg.ca_modalities in
+              Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
+        | Types.Cstr_record lbls ->
+          sum_record_label_contributions ~base:Ldd.bot ~payload_kind
+            ~label_mutability_provenance:(label_mutability_provenance ctx)
+            ~validate_label:no_validation lbls
+      in
+      Ldd.sum cstrs ~base ~f:constructor_contrib)
+
+let type_decl_constr_decl (decl : Types.type_declaration) : Solver.constr_decl =
+  let abstract =
+    match decl.type_manifest, decl.type_kind with
+    | None, Types.Type_abstract _ -> not (Jkind.is_best decl.type_jkind)
+    | _ -> false
+  in
+  let kind ctx = type_decl_rhs_kind_poly ctx decl in
+  Solver.Ty { args = decl.type_params; kind; abstract }
 
 (* Lookup function supplied to the solver.
    We prefer a stored ikind (when present) and otherwise recompute from the
@@ -713,144 +1269,9 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
   | type_decl ->
     (* Here we can switch to using the cached ikind or not. *)
     let fallback () =
-      (* When we have no stored ikind, we go to this fallback and compute. *)
-      match type_decl.type_manifest with
-      | Some body_ty ->
-        (* Concrete: compute kind of body. *)
-        let args = type_decl.type_params in
-        let kind : Solver.ckind =
-         fun ctx -> Solver.kind ~use_tables:true ctx body_ty
-        in
-        Solver.Ty { args; kind; abstract = false }
-      | None -> (
-        (* No manifest: may still be "concrete" (record/variant/...).
-           Build ckind. *)
-        let allow_any_crossing =
-          match type_decl.type_kind with
-          | Types.Type_record (_, _, umc_opt)
-          | Types.Type_record_unboxed_product (_, _, umc_opt)
-          | Types.Type_variant (_, _, umc_opt) ->
-            Option.is_some umc_opt
-          | Types.Type_abstract _ | Types.Type_open -> false
-        in
-        let use_decl_jkind ~treat_as_abstract =
-          let kind : Solver.ckind =
-           fun ctx -> Solver.ckind_of_jkind ctx type_decl.type_jkind
-          in
-          Solver.Ty
-            { args = type_decl.type_params; kind; abstract = treat_as_abstract }
-        in
-        match type_decl.type_kind with
-        (* For abstract types and allow_any_crossing types, we derive the
-           ikind from the jkind annotation, instead of computing it from
-           the type declaration's body: *)
-        | _ when allow_any_crossing -> use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_abstract _ ->
-          use_decl_jkind
-            ~treat_as_abstract:(not (Jkind.is_best type_decl.type_jkind))
-        (* For other cases, we compute the ikind from the type definition{} *)
-        | Types.Type_record (lbls, rep, _umc_opt) ->
-          (* Build from components: base (non-float value) + per-label
-             contributions. *)
-          let immutable_base =
-            Ldd.const
-              (match rep with
-              | Types.Record_unboxed -> Axis_lattice.immediate
-              (* CR box: This will no longer be [non_float] once we update the
-                 representation of singleton float64 records *)
-              | _ -> Axis_lattice.immutable_data)
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            sum_record_label_contributions ~base:immutable_base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:no_validation lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base = Ldd.const Axis_lattice.immediate in
-            sum_record_label_contributions ~base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:validate_immutable_unboxed_label lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
-          (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
-             captured by its constructors: nullability/separability and
-             mode-crossing are baked into its representation. We defer to
-             jkinds because ikinds cannot express this today. This deferral
-             can be removed once separability and nullability become layout
-             properties rather than modal axes. *)
-          use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_variant (cstrs, rep, _umc_opt) ->
-          (* Choose base: immediate for void-only variants; sync if any record
-             field is atomic; mutable if any non-atomic mutable field appears;
-             otherwise immutable. *)
-          let all_args_void =
-            List.for_all
-              (fun (c : Types.constructor_declaration) ->
-                match c.cd_args with
-                | Types.Cstr_tuple args ->
-                  List.for_all
-                    (fun (arg : Types.constructor_argument) ->
-                      match arg.ca_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    args
-                | Types.Cstr_record lbls ->
-                  List.for_all
-                    (fun (lbl : Types.label_declaration) ->
-                      match lbl.ld_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    lbls)
-              cstrs
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base_lat0 =
-              match rep with
-              | Types.Variant_unboxed -> Axis_lattice.immediate
-              | _ ->
-                if all_args_void
-                then Axis_lattice.immediate
-                else Axis_lattice.immutable_data
-            in
-            let payload_kind_of_constructor =
-              make_gadt_payload_projector ~decl_params:type_decl.type_params ctx
-            in
-            let constructor_contrib (c : Types.constructor_declaration) =
-              let payload_kind = payload_kind_of_constructor c in
-              match c.cd_args with
-              | Types.Cstr_tuple args ->
-                Ldd.sum args ~base:Ldd.bot
-                  ~f:(fun (arg : Types.constructor_argument) ->
-                    let mask =
-                      Axis_lattice.mask_of_modality arg.ca_modalities
-                    in
-                    Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
-              | Types.Cstr_record lbls ->
-                sum_record_label_contributions ~base:Ldd.bot ~payload_kind
-                  ~validate_label:no_validation lbls
-            in
-            Ldd.sum cstrs ~base:(Ldd.const base_lat0) ~f:constructor_contrib
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_open ->
-          (* Use the stored jkind here in case it is `exn`,
-             which is special. *)
-          use_decl_jkind ~treat_as_abstract:false
-        (*
-           (* This is the code we'd use otherwise *)
-           let kind : Solver.ckind =
-            fun _ctx ->
-             Ldd.const Axis_lattice.nonfloat_value
-           in
-           Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        *)
-        )
+      (* When we have no stored ikind, compute from the declaration through the
+         same RHS builder used for bound diagnostics. *)
+      type_decl_constr_decl type_decl
     in
     (* Prefer a stored constructor ikind if one is present and enabled. *)
     let ikind =
@@ -880,8 +1301,8 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
 
 (* Package the above into a full evaluation context. *)
 let create_ctx ~(mode : Solver.mode) ~(env : Env.t option) =
-  Solver.create_ctx ~mode ~env ~lookup_of_env:(fun env path ->
-      lookup_of_env ~env path)
+  Solver.create_ctx ~mode ~env ~add_provenance:false
+    ~lookup_of_env:(fun env path -> lookup_of_env ~env path)
 
 let normalize ~(env : Env.t option) (jkind : Types.jkind_l) : Ldd.node =
   let ctx = create_ctx ~mode:Solver.Normal ~env in
@@ -948,19 +1369,21 @@ type subcheck_fast_path =
   | Rhs_top_fast_path
   | Lhs_mod_bounds_floor_fast_path
 
+let string_of_subcheck_fast_path = function
+  | No_fast_path -> "none"
+  | Rhs_top_fast_path -> "rhs_top"
+  | Lhs_mod_bounds_floor_fast_path -> "lhs_mod_bounds_floor"
+
 type subcheck_polys =
   { lhs_for_leq : Ldd.node;
     rhs_for_leq : Ldd.node;
     fast_path : subcheck_fast_path
   }
 
-(* Compute polynomials for a subcheck:
-   - compute [super] in Normal mode
-   - fast path: if [super] is constant top, no need to compute [sub]
-   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
-   - otherwise, only round up [sub] if [super] is constant *)
-let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
-    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+let compute_bound_polys env (super : ('l2 * 'r2) Types.jkind)
+    ~(lhs_floor : (Solver.ctx -> Ldd.node option) option)
+    ~(lhs : Solver.ctx -> Ldd.node) : subcheck_polys =
+  Provenance.reset ();
   let ctx = create_ctx ~mode:Solver.Normal ~env:(Some env) in
   let super_poly = Solver.ckind_of_jkind ctx super in
   let super_is_constant =
@@ -979,16 +1402,19 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     let floor_fast_path =
       if super_is_constant
       then
-        match Solver.mod_bounds_floor_of_jkind ctx sub with
+        match lhs_floor with
         | None -> None
-        | Some lhs_floor ->
-          let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
-          if
-            Axis_lattice.equal
-              (Ldd.round_up lhs_floor_or_super)
-              Axis_lattice.top
-          then Some lhs_floor
-          else None
+        | Some lhs_floor -> (
+          match lhs_floor ctx with
+          | None -> None
+          | Some lhs_floor ->
+            let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
+            if
+              Axis_lattice.equal
+                (Ldd.round_up lhs_floor_or_super)
+                Axis_lattice.top
+            then Some lhs_floor
+            else None)
       else None
     in
     match floor_fast_path with
@@ -998,31 +1424,117 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
         fast_path = Lhs_mod_bounds_floor_fast_path
       }
     | None ->
-      let sub_ctx =
+      let lhs_ctx =
         if super_is_constant
         then Solver.reset_for_mode ctx ~mode:Solver.Round_up
         else ctx
       in
-      let sub_poly = Solver.ckind_of_jkind sub_ctx sub in
-      { lhs_for_leq = sub_poly;
+      let lhs_poly = lhs lhs_ctx in
+      { lhs_for_leq = lhs_poly;
         rhs_for_leq = super_poly;
         fast_path = No_fast_path
       }
 
+(* Compute polynomials for a subcheck:
+   - compute [super] in Normal mode
+   - fast path: if [super] is constant top, no need to compute [sub]
+   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
+   - otherwise, only round up [sub] if [super] is constant *)
+let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
+    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+  compute_bound_polys env super
+    ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
+    ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
+
+let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
+    (bound : Types.jkind_l) : subcheck_polys =
+  compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
+      let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
+      lhs ctx)
+
+let check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind
+    { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
+  let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
+  let failing_poly = Ldd.sub_subsets sub_poly super_poly in
+  match violating_axes with
+  | [] -> Ok ()
+  | _ ->
+    Error
+      (Mode_crossing_error
+         { origin;
+           sub_jkind;
+           super_jkind;
+           sub_poly;
+           super_poly;
+           failing_poly;
+           fast_path = string_of_subcheck_fast_path fast_path;
+           provenance_names = Provenance.all_names ();
+           violating_axes
+         })
+
+let subjkind_error_has_provenance_residuals = function
+  | Jkind_error _ -> false
+  | Mode_crossing_error
+      { sub_poly; super_poly; provenance_names; violating_axes; _ } -> (
+    match
+      provenance_residuals ~provenance_names ~violating_axes ~sub_poly
+        ~super_poly
+    with
+    | None | Some [] -> false
+    | Some (_ :: _) -> true)
+
+let same_axis_set axes1 axes2 =
+  List.length axes1 = List.length axes2
+  && List.for_all (fun axis1 -> List.exists (same_axis axis1) axes2) axes1
+
+let subjkind_errors_have_same_violating_axes error1 error2 =
+  match error1, error2 with
+  | ( Mode_crossing_error { violating_axes = axes1; _ },
+      Mode_crossing_error { violating_axes = axes2; _ } ) ->
+    same_axis_set axes1 axes2
+  | Jkind_error _, _ | _, Jkind_error _ -> false
+
+let best_effort_provenance_error ?fallback_error ~origin ~sub_jkind ~super_jkind
+    actual_error make_polys =
+  let fallback error =
+    match fallback_error with
+    | None -> Error error
+    | Some fallback_error -> (
+      match fallback_error () with
+      | None -> Error error
+      | Some fallback_error -> Error fallback_error)
+  in
+  let provenance_check =
+    match make_polys () with
+    | provenance_polys ->
+      check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind provenance_polys
+    | exception _ -> Ok ()
+  in
+  match provenance_check with
+  | Ok () -> fallback actual_error
+  | Error provenance_error ->
+    if
+      subjkind_errors_have_same_violating_axes actual_error provenance_error
+      && subjkind_error_has_provenance_residuals provenance_error
+    then Error provenance_error
+    else fallback actual_error
+
 let sub_jkind_l ?allow_any_crossing ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)
     ~(context : Jkind.jkind_context) env (sub : Types.jkind_l)
-    (super : Types.jkind_l) : (unit, Jkind.Violation.t) result =
+    (super : Types.jkind_l) : (unit, subjkind_error) result =
   let open Misc.Stdlib.Monad.Result.Syntax in
   if not (enable_sub_jkind_l && !Clflags.ikinds)
-  then Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
+  then
+    Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
+    |> Result.map_error (fun err -> Jkind_error err)
   else
     (* Check layouts first; if that fails, print both sides with full
        info and return the error. *)
     let* () =
       match Jkind.sub_layout_or_error ~context env sub super with
       | Ok () -> Ok ()
-      | Error v -> Error v
+      | Error v -> Error (Jkind_error v)
     in
     let allow_any =
       match allow_any_crossing with Some true -> true | _ -> false
@@ -1038,37 +1550,78 @@ let sub_jkind_l ?allow_any_crossing ?origin
       let { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
         compute_subcheck_polys ~context env sub super
       in
-      let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
-      (if !Clflags.ikinds_debug
-       then
-         let origin_suffix = origin_suffix_of origin in
-         let fast_path =
-           match fast_path with
-           | No_fast_path -> "none"
-           | Rhs_top_fast_path -> "rhs_top"
-           | Lhs_mod_bounds_floor_fast_path -> "lhs_mod_bounds_floor"
-         in
-         Format.eprintf
-           "[ikind-subjkind] call%s allow_any=false fast_path=%s@;\
-            @;\
-            sub_poly=%s@;\
-            super_poly=%s@."
-           origin_suffix fast_path (Ldd.pp sub_poly) (Ldd.pp super_poly));
-      match violating_axes with
-      | [] -> Ok ()
-      | _ ->
-        let () =
-          if !Clflags.ikinds_debug
-          then
-            let axes = pp_axes violating_axes in
-            Format.eprintf "[ikind-subjkind] failure on axes: %s@." axes
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:sub ~super_jkind:super
+          { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path }
+      with
+      | Ok () -> Ok ()
+      | Error ikind_error -> (
+        if !Clflags.ikinds_debug
+        then Error ikind_error
+        else
+          match
+            Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub
+              super
+          with
+          | Ok () -> Error ikind_error
+          | Error jkind_error -> Error (Jkind_error jkind_error))
+
+let check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+    ~bound ~provenance_lhs =
+  if not (enable_sub_jkind_l && !Clflags.ikinds)
+  then
+    sub_jkind_l ?allow_any_crossing ?origin ~type_equal ~context env actual
+      bound
+  else
+    let open Misc.Stdlib.Monad.Result.Syntax in
+    let* () =
+      match Jkind.sub_layout_or_error ~context env actual bound with
+      | Ok () -> Ok ()
+      | Error v -> Error (Jkind_error v)
+    in
+    let allow_any =
+      match allow_any_crossing with Some true -> true | _ -> false
+    in
+    if allow_any
+    then Ok ()
+    else
+      let actual_polys = compute_subcheck_polys ~context env actual bound in
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:actual ~super_jkind:bound
+          actual_polys
+      with
+      | Ok () -> Ok ()
+      | Error actual_error ->
+        let fallback_error () =
+          match
+            Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env
+              actual bound
+          with
+          | Ok () ->
+            let violating_axes =
+              match actual_error with
+              | Mode_crossing_error { violating_axes; _ } -> violating_axes
+              | Jkind_error _ -> []
+            in
+            let axis_reasons = axis_disagreement_reasons violating_axes in
+            Some
+              (Jkind_error
+                 (Jkind.Violation.of_ ~context env
+                    (Jkind.Violation.Not_a_subjkind (actual, bound, axis_reasons))))
+          | Error jkind_error -> Some (Jkind_error jkind_error)
         in
-        (* Do not try to adjust allowances; Violation.Not_a_subjkind
-           accepts an r-jkind. *)
-        let axis_reasons = axis_disagreement_reasons violating_axes in
-        Error
-          (Jkind.Violation.of_ ~context env
-             (Jkind.Violation.Not_a_subjkind (sub, super, axis_reasons)))
+        best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
+          ~super_jkind:bound actual_error (fun () ->
+            compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
+
+let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
+  check_bound ?origin ~type_equal ~context env ~actual ~bound
+    ~provenance_lhs:(fun ctx -> Solver.kind ~use_tables:true ctx ty)
+
+let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
+    ~decl ~actual ~bound =
+  check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =
@@ -1303,6 +1856,7 @@ let substitute_decl_ikind_with_lookup
     and map_name (expanding : Path.Set.t) (name : Ldd.Name.t) : Ldd.node =
       match name with
       | Param _ -> Ldd.node_of_var (Ldd.rigid name)
+      | Provenance _ -> Ldd.node_of_var (Ldd.rigid name)
       | Unknown _ -> Ldd.node_of_var (Ldd.rigid name)
       | KAtom path -> (
         match lookup_jkind path with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -38,22 +38,38 @@ let fresh_unknown_uid () : Types.Uid.t =
   in
   Types.Uid.mk ~current_unit
 
+let collapse_whitespace s =
+  let b = Buffer.create (String.length s) in
+  let pending_space = ref false in
+  String.iter
+    (function
+      | ' ' | '\n' | '\r' | '\t' ->
+        if Buffer.length b > 0 then pending_space := true
+      | c ->
+        if !pending_space
+        then (
+          Buffer.add_char b ' ';
+          pending_space := false);
+        Buffer.add_char b c)
+    s;
+  Buffer.contents b
+
 module Provenance = struct
   let next_id = ref 0
 
   let names : Ldd.Name.t list ref = ref []
 
-  let register_text ty : Ldd.Name.t =
+  let register_text ~phrase ty : Ldd.Name.t =
     let id = !next_id in
     next_id := id + 1;
-    let name = Ldd.Name.provenance ~id ~ty in
+    let name = Ldd.Name.provenance ~id ~ty ~phrase in
     names := name :: !names;
     name
 
   let register (ty : Types.type_expr) : Ldd.Name.t =
     Format_doc.asprintf "%a" Jkind.format_type_expr ty
-    |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
-    |> register_text
+    |> collapse_whitespace
+    |> register_text ~phrase:false
 
   let reset () = names := []
 
@@ -146,7 +162,7 @@ module Solver = struct
     rigid_name ctx (Provenance.register ty)
 
   let provenance_text (ctx : ctx) (text : string) : Ldd.node =
-    rigid_name ctx (Provenance.register_text text)
+    rigid_name ctx (Provenance.register_text ~phrase:true text)
 
   let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
       : Ldd.node =
@@ -624,22 +640,6 @@ let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
          pp_axis_name)
       init pp_axis_name last
 
-let collapse_whitespace s =
-  let b = Buffer.create (String.length s) in
-  let pending_space = ref false in
-  String.iter
-    (function
-      | ' ' | '\n' | '\r' | '\t' ->
-        if Buffer.length b > 0 then pending_space := true
-      | c ->
-        if !pending_space
-        then (
-          Buffer.add_char b ' ';
-          pending_space := false);
-        Buffer.add_char b c)
-    s;
-  Buffer.contents b
-
 let remove_numeric_path_stamps s =
   let b = Buffer.create (String.length s) in
   let is_digit = function '0' .. '9' -> true | _ -> false in
@@ -724,35 +724,30 @@ type subjkind_error =
 
 type provenance_residual =
   { ty : string;
+    phrase : bool;
     mode_bounds : Axis_lattice.t;
     axes : Jkind_axis.Axis.packed list
   }
 
 let provenance_ty_of_name (name : Ldd.Name.t) =
   match name with
-  | Provenance { ty; _ } -> Some ty
+  | Provenance { ty; phrase; _ } -> Some (ty, phrase)
   | Atom _ | KAtom _ | Param _ | Unknown _ -> None
 
-let add_provenance_residual entries { ty; mode_bounds; axes } =
-  match List.partition (fun entry -> String.equal entry.ty ty) entries with
-  | [], rest -> { ty; mode_bounds; axes } :: rest
-  | matching, rest ->
-    let axes =
-      List.fold_left
-        (fun axes entry ->
-          List.fold_left
-            (fun axes axis ->
-              if List.exists (same_axis axis) axes then axes else axes @ [axis])
-            axes entry.axes)
-        axes matching
-    in
-    let mode_bounds =
-      List.fold_left
-        (fun mode_bounds entry ->
-          Axis_lattice.meet mode_bounds entry.mode_bounds)
-        mode_bounds matching
-    in
-    { ty; mode_bounds; axes } :: rest
+let add_provenance_residual entries ({ ty; phrase; mode_bounds; axes } as entry)
+    =
+  (* Deduplicate identical entries (e.g. two fields of type [int ref] under
+     the same bound), keeping first-occurrence order. Entries that merely
+     share a printed name (e.g. two constructor-local existentials both
+     rendered ['a]) can have different requirements and must stay separate. *)
+  let duplicate other =
+    String.equal other.ty ty
+    && Bool.equal other.phrase phrase
+    && Axis_lattice.equal other.mode_bounds mode_bounds
+    && List.length other.axes = List.length axes
+    && List.for_all (fun axis -> List.exists (same_axis axis) other.axes) axes
+  in
+  if List.exists duplicate entries then entries else entries @ [entry]
 
 let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
     =
@@ -796,7 +791,7 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
         else
           match provenance_ty_of_name name with
           | None -> None
-          | Some ty ->
+          | Some (ty, phrase) -> (
             let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
             let non_top_bounds =
               Axis_lattice.co_sub Axis_lattice.top mode_bounds
@@ -809,60 +804,40 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                 |> List.map Axis_lattice.axis_number_to_axis_packed
                 |> axes_in_violation_order ~violating_axes
               in
-              Some { ty; mode_bounds; axes })
+              (* [round_down] under-approximation can leave a residual
+                 non-top only on non-violating axes; such an entry has no
+                 axes left to report. *)
+              match axes with
+              | [] -> None
+              | _ :: _ -> Some { ty; phrase; mode_bounds; axes }))
     |> List.fold_left add_provenance_residual []
-    |> List.rev |> Option.some
+    |> Option.some
 
-let string_of_required_bound required_bounds (Jkind_axis.Axis.Pack axis) =
-  match axis with
-  | Modal (Monadic Uniqueness) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Uniqueness.Const.print
-         (Axis_lattice.uniqueness required_bounds))
-  | Modal (Monadic Contention) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Contention.Const.print
-         (Axis_lattice.contention required_bounds))
-  | Modal (Monadic Visibility) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Visibility.Const.print
-         (Axis_lattice.visibility required_bounds))
-  | Modal (Monadic Staticity) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Staticity.Const.print
-         (Axis_lattice.staticity required_bounds))
-  | Modal (Comonadic Areality) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Regionality.Const.print
-         (Axis_lattice.areality required_bounds))
-  | Modal (Comonadic Linearity) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Linearity.Const.print
-         (Axis_lattice.linearity required_bounds))
-  | Modal (Comonadic Portability) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Portability.Const.print
-         (Axis_lattice.portability required_bounds))
-  | Modal (Comonadic Forkable) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Forkable.Const.print
-         (Axis_lattice.forkable required_bounds))
-  | Modal (Comonadic Yielding) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Yielding.Const.print
-         (Axis_lattice.yielding required_bounds))
-  | Modal (Comonadic Statefulness) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Statefulness.Const.print
-         (Axis_lattice.statefulness required_bounds))
-  | Nonmodal Externality ->
-    Some
-      (Format_doc.asprintf "%a" Jkind_axis.Externality.print
-         (Axis_lattice.externality required_bounds))
+let residual_mode_strings { mode_bounds; axes; _ } =
+  (* Restrict the required bounds to the reported axes (the residual can be
+     non-top on other axes; see [axes_in_violation_order]), then let
+     [Typemode] drop implied modes (e.g. [aliased] when [global] is
+     required) the same way jkind annotations are printed. *)
+  let reported =
+    List.fold_left
+      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+      Jkind_axis.Axis_set.empty axes
+  in
+  let restricted =
+    Axis_lattice.join mode_bounds
+      (Axis_lattice.of_axis_set (Jkind_axis.Axis_set.complement reported))
+  in
+  Jkind.Mod_bounds.of_axis_lattice restricted
+  |> Typemode.close_implied_mod_bounds
+  |> Typemode.untransl_mod_bounds ~verbose:false
+  |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let pp_provenance_residual ppf { ty; mode_bounds; axes; _ } =
-  let modes = List.filter_map (string_of_required_bound mode_bounds) axes in
-  Format_doc.fprintf ppf "@[<hov 2>%s is not mod %a@]" ty
+let pp_provenance_residual ppf ({ ty; phrase; _ } as residual) =
+  (* Phrase subjects ("mutable fields", "boxed records") are plural noun
+     phrases; type-expression subjects read as singular. *)
+  let verb = if phrase then "are" else "is" in
+  let modes = residual_mode_strings residual in
+  Format_doc.fprintf ppf "@[<hov 2>%s %s not mod %a@]" ty verb
     (Format_doc.pp_print_list
        ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
        Format_doc.pp_print_string)
@@ -992,26 +967,14 @@ let validate_immutable_unboxed_label (lbl : Types.label_declaration) =
   | Mutable _ ->
     failwith "ikind: mutable fields in unboxed records are not supported"
 
-let format_type_expr_single_line ty =
-  Format_doc.asprintf "%a" Jkind.format_type_expr ty
-  |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
-
 let label_mutability_provenance (ctx : Solver.ctx)
     (lbl : Types.label_declaration) (poly : Ldd.node) : Ldd.node =
   match lbl.ld_mutable with
   | Immutable -> poly
   | Mutable { atomic = Nonatomic; _ } ->
-    Solver.with_provenance_text ctx
-      (fun () ->
-        Format.sprintf "mutable field %s : %s" (Ident.name lbl.ld_id)
-          (format_type_expr_single_line lbl.ld_type))
-      poly
+    Solver.with_provenance_text ctx (fun () -> "mutable fields") poly
   | Mutable { atomic = Atomic; _ } ->
-    Solver.with_provenance_text ctx
-      (fun () ->
-        Format.sprintf "mutable field %s : %s [@atomic]" (Ident.name lbl.ld_id)
-          (format_type_expr_single_line lbl.ld_type))
-      poly
+    Solver.with_provenance_text ctx (fun () -> "atomic mutable fields") poly
 
 let decl_base_provenance (ctx : Solver.ctx) source poly =
   Solver.with_provenance_text ctx (fun () -> source) poly
@@ -1166,7 +1129,7 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
           (* CR box: This will no longer be [non_float] once we update the
              representation of singleton float64 records *)
           | _ -> Axis_lattice.immutable_data)
-        |> decl_base_provenance ctx "this record type"
+        |> decl_base_provenance ctx "boxed records"
       in
       sum_record_label_contributions ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
@@ -1175,7 +1138,7 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
     | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
       let base =
         Ldd.const Axis_lattice.immediate
-        |> decl_base_provenance ctx "this unboxed record type"
+        |> decl_base_provenance ctx "unboxed records"
       in
       sum_record_label_contributions ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
@@ -1220,7 +1183,7 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
             then Axis_lattice.immediate
             else Axis_lattice.immutable_data
         in
-        Ldd.const base_lat |> decl_base_provenance ctx "this variant type"
+        Ldd.const base_lat |> decl_base_provenance ctx "boxed variants"
       in
       let payload_kind_of_constructor =
         make_gadt_payload_projector ~decl_params:decl.type_params ctx
@@ -1455,10 +1418,10 @@ let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
 let check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind
     { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
   let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
-  let failing_poly = Ldd.sub_subsets sub_poly super_poly in
   match violating_axes with
   | [] -> Ok ()
   | _ ->
+    let failing_poly = Ldd.sub_subsets sub_poly super_poly in
     Error
       (Mode_crossing_error
          { origin;
@@ -1508,6 +1471,10 @@ let best_effort_provenance_error ?fallback_error ~origin ~sub_jkind ~super_jkind
     match make_polys () with
     | provenance_polys ->
       check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind provenance_polys
+    | exception
+        ((Misc.Fatal_error | Stack_overflow | Out_of_memory | Sys.Break) as exn)
+      ->
+      raise exn
     | exception _ -> Ok ()
   in
   match provenance_check with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -67,9 +67,26 @@ module Provenance = struct
     name
 
   let register (ty : Types.type_expr) : Ldd.Name.t =
-    Format_doc.asprintf "%a" Jkind.format_type_expr ty
-    |> collapse_whitespace
-    |> register_text ~phrase:false
+    (* A surviving residual for an occurrence reflects only the head
+       constructor's own contribution (the decomposition zeroes anything
+       flowing through a separately-tracked inner type or parameter), so
+       name the head rather than the full type expression: the constructor
+       for [Tconstr], a class-of-types phrase for the built-in shapes. *)
+    let register_type ty =
+      Format_doc.asprintf "%a" Jkind.format_type_expr ty
+      |> collapse_whitespace
+      |> register_text ~phrase:false
+    in
+    match Types.get_desc ty with
+    | Types.Tarrow _ -> register_text ~phrase:true "functions"
+    | Types.Ttuple _ -> register_text ~phrase:true "tuples"
+    | Types.Tunboxed_tuple _ -> register_text ~phrase:true "unboxed tuples"
+    | Types.Tobject _ -> register_text ~phrase:true "objects"
+    | Types.Tvariant _ -> register_text ~phrase:true "polymorphic variants"
+    | Types.Tpackage _ -> register_text ~phrase:true "first-class modules"
+    | Types.Tconstr (path, _ :: _, _) ->
+      register_type (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
+    | _ -> register_type ty
 
   let reset () = names := []
 

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -957,11 +957,12 @@ let axis_disagreement_reasons (axes : Jkind_axis.Axis.packed list) :
   List.map (fun axis -> Jkind.Sub_failure_reason.Axis_disagreement axis) axes
 
 let label_mutability_contribution (lbl : Types.label_declaration) =
-  Ldd.const
-    (match lbl.ld_mutable with
-    | Immutable -> Axis_lattice.immediate
-    | Mutable { atomic = Atomic; _ } -> Axis_lattice.sync_data
-    | Mutable { atomic = Nonatomic; _ } -> Axis_lattice.mutable_data)
+  match lbl.ld_mutable with
+  (* [immediate] is below every base this is summed into, so omitting it keeps
+     immutable fields out of the untracked part of a provenance residual. *)
+  | Immutable -> Ldd.bot
+  | Mutable { atomic = Atomic; _ } -> Ldd.const Axis_lattice.sync_data
+  | Mutable { atomic = Nonatomic; _ } -> Ldd.const Axis_lattice.mutable_data
 
 let sum_record_label_contributions ~(base : Ldd.node)
     ~(payload_kind : Types.type_expr -> Ldd.node)
@@ -1140,13 +1141,14 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
     | Types.Type_abstract _ | Types.Type_open -> use_decl_jkind ()
     | Types.Type_record (lbls, rep, _umc_opt) ->
       let base =
-        Ldd.const
-          (match rep with
-          | Types.Record_unboxed -> Axis_lattice.immediate
+        let base_lat, source =
+          match rep with
+          | Types.Record_unboxed -> Axis_lattice.immediate, "unboxed records"
           (* CR box: This will no longer be [non_float] once we update the
              representation of singleton float64 records *)
-          | _ -> Axis_lattice.immutable_data)
-        |> decl_base_provenance ctx "boxed records"
+          | _ -> Axis_lattice.immutable_data, "boxed records"
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx source
       in
       sum_record_label_contributions ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
@@ -1192,15 +1194,15 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
           cstrs
       in
       let base =
-        let base_lat =
+        let base_lat, source =
           match rep with
-          | Types.Variant_unboxed -> Axis_lattice.immediate
+          | Types.Variant_unboxed -> Axis_lattice.immediate, "unboxed variants"
           | _ ->
             if all_args_void
-            then Axis_lattice.immediate
-            else Axis_lattice.immutable_data
+            then Axis_lattice.immediate, "enumeration variants"
+            else Axis_lattice.immutable_data, "boxed variants"
         in
-        Ldd.const base_lat |> decl_base_provenance ctx "boxed variants"
+        Ldd.const base_lat |> decl_base_provenance ctx source
       in
       let payload_kind_of_constructor =
         make_gadt_payload_projector ~decl_params:decl.type_params ctx

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -38,22 +38,38 @@ let fresh_unknown_uid () : Types.Uid.t =
   in
   Types.Uid.mk ~current_unit
 
+let collapse_whitespace s =
+  let b = Buffer.create (String.length s) in
+  let pending_space = ref false in
+  String.iter
+    (function
+      | ' ' | '\n' | '\r' | '\t' ->
+        if Buffer.length b > 0 then pending_space := true
+      | c ->
+        if !pending_space
+        then (
+          Buffer.add_char b ' ';
+          pending_space := false);
+        Buffer.add_char b c)
+    s;
+  Buffer.contents b
+
 module Provenance = struct
   let next_id = ref 0
 
   let names : Ldd.Name.t list ref = ref []
 
-  let register_text ty : Ldd.Name.t =
+  let register_text ~phrase ty : Ldd.Name.t =
     let id = !next_id in
     next_id := id + 1;
-    let name = Ldd.Name.provenance ~id ~ty in
+    let name = Ldd.Name.provenance ~id ~ty ~phrase in
     names := name :: !names;
     name
 
   let register (ty : Types.type_expr) : Ldd.Name.t =
     Format_doc.asprintf "%a" Jkind.format_type_expr ty
-    |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
-    |> register_text
+    |> collapse_whitespace
+    |> register_text ~phrase:false
 
   let reset () = names := []
 
@@ -146,7 +162,7 @@ module Solver = struct
     rigid_name ctx (Provenance.register ty)
 
   let provenance_text (ctx : ctx) (text : string) : Ldd.node =
-    rigid_name ctx (Provenance.register_text text)
+    rigid_name ctx (Provenance.register_text ~phrase:true text)
 
   let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
       : Ldd.node =
@@ -629,22 +645,6 @@ let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
          pp_axis_name)
       init pp_axis_name last
 
-let collapse_whitespace s =
-  let b = Buffer.create (String.length s) in
-  let pending_space = ref false in
-  String.iter
-    (function
-      | ' ' | '\n' | '\r' | '\t' ->
-        if Buffer.length b > 0 then pending_space := true
-      | c ->
-        if !pending_space
-        then (
-          Buffer.add_char b ' ';
-          pending_space := false);
-        Buffer.add_char b c)
-    s;
-  Buffer.contents b
-
 let remove_numeric_path_stamps s =
   let b = Buffer.create (String.length s) in
   let is_digit = function '0' .. '9' -> true | _ -> false in
@@ -729,35 +729,30 @@ type subjkind_error =
 
 type provenance_residual =
   { ty : string;
+    phrase : bool;
     mode_bounds : Axis_lattice.t;
     axes : Jkind_axis.Axis.packed list
   }
 
 let provenance_ty_of_name (name : Ldd.Name.t) =
   match name with
-  | Provenance { ty; _ } -> Some ty
+  | Provenance { ty; phrase; _ } -> Some (ty, phrase)
   | Atom _ | KAtom _ | Param _ | Unknown _ -> None
 
-let add_provenance_residual entries { ty; mode_bounds; axes } =
-  match List.partition (fun entry -> String.equal entry.ty ty) entries with
-  | [], rest -> { ty; mode_bounds; axes } :: rest
-  | matching, rest ->
-    let axes =
-      List.fold_left
-        (fun axes entry ->
-          List.fold_left
-            (fun axes axis ->
-              if List.exists (same_axis axis) axes then axes else axes @ [axis])
-            axes entry.axes)
-        axes matching
-    in
-    let mode_bounds =
-      List.fold_left
-        (fun mode_bounds entry ->
-          Axis_lattice.meet mode_bounds entry.mode_bounds)
-        mode_bounds matching
-    in
-    { ty; mode_bounds; axes } :: rest
+let add_provenance_residual entries ({ ty; phrase; mode_bounds; axes } as entry)
+    =
+  (* Deduplicate identical entries (e.g. two fields of type [int ref] under
+     the same bound), keeping first-occurrence order. Entries that merely
+     share a printed name (e.g. two constructor-local existentials both
+     rendered ['a]) can have different requirements and must stay separate. *)
+  let duplicate other =
+    String.equal other.ty ty
+    && Bool.equal other.phrase phrase
+    && Axis_lattice.equal other.mode_bounds mode_bounds
+    && List.length other.axes = List.length axes
+    && List.for_all (fun axis -> List.exists (same_axis axis) other.axes) axes
+  in
+  if List.exists duplicate entries then entries else entries @ [entry]
 
 let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
     =
@@ -801,7 +796,7 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
         else
           match provenance_ty_of_name name with
           | None -> None
-          | Some ty ->
+          | Some (ty, phrase) -> (
             let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
             let non_top_bounds =
               Axis_lattice.co_sub Axis_lattice.top mode_bounds
@@ -814,60 +809,40 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                 |> List.map Axis_lattice.axis_number_to_axis_packed
                 |> axes_in_violation_order ~violating_axes
               in
-              Some { ty; mode_bounds; axes })
+              (* [round_down] under-approximation can leave a residual
+                 non-top only on non-violating axes; such an entry has no
+                 axes left to report. *)
+              match axes with
+              | [] -> None
+              | _ :: _ -> Some { ty; phrase; mode_bounds; axes }))
     |> List.fold_left add_provenance_residual []
-    |> List.rev |> Option.some
+    |> Option.some
 
-let string_of_required_bound required_bounds (Jkind_axis.Axis.Pack axis) =
-  match axis with
-  | Modal (Monadic Uniqueness) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Uniqueness.Const.print
-         (Axis_lattice.uniqueness required_bounds))
-  | Modal (Monadic Contention) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Contention.Const.print
-         (Axis_lattice.contention required_bounds))
-  | Modal (Monadic Visibility) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Visibility.Const.print
-         (Axis_lattice.visibility required_bounds))
-  | Modal (Monadic Staticity) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Staticity.Const.print
-         (Axis_lattice.staticity required_bounds))
-  | Modal (Comonadic Areality) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Regionality.Const.print
-         (Axis_lattice.areality required_bounds))
-  | Modal (Comonadic Linearity) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Linearity.Const.print
-         (Axis_lattice.linearity required_bounds))
-  | Modal (Comonadic Portability) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Portability.Const.print
-         (Axis_lattice.portability required_bounds))
-  | Modal (Comonadic Forkable) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Forkable.Const.print
-         (Axis_lattice.forkable required_bounds))
-  | Modal (Comonadic Yielding) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Yielding.Const.print
-         (Axis_lattice.yielding required_bounds))
-  | Modal (Comonadic Statefulness) ->
-    Some
-      (Format_doc.asprintf "%a" Mode.Statefulness.Const.print
-         (Axis_lattice.statefulness required_bounds))
-  | Nonmodal Externality ->
-    Some
-      (Format_doc.asprintf "%a" Jkind_axis.Externality.print
-         (Axis_lattice.externality required_bounds))
+let residual_mode_strings { mode_bounds; axes; _ } =
+  (* Restrict the required bounds to the reported axes (the residual can be
+     non-top on other axes; see [axes_in_violation_order]), then let
+     [Typemode] drop implied modes (e.g. [aliased] when [global] is
+     required) the same way jkind annotations are printed. *)
+  let reported =
+    List.fold_left
+      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+      Jkind_axis.Axis_set.empty axes
+  in
+  let restricted =
+    Axis_lattice.join mode_bounds
+      (Axis_lattice.of_axis_set (Jkind_axis.Axis_set.complement reported))
+  in
+  Jkind.Mod_bounds.of_axis_lattice restricted
+  |> Typemode.close_implied_mod_bounds
+  |> Typemode.untransl_mod_bounds ~verbose:false
+  |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let pp_provenance_residual ppf { ty; mode_bounds; axes; _ } =
-  let modes = List.filter_map (string_of_required_bound mode_bounds) axes in
-  Format_doc.fprintf ppf "@[<hov 2>%s is not mod %a@]" ty
+let pp_provenance_residual ppf ({ ty; phrase; _ } as residual) =
+  (* Phrase subjects ("mutable fields", "boxed records") are plural noun
+     phrases; type-expression subjects read as singular. *)
+  let verb = if phrase then "are" else "is" in
+  let modes = residual_mode_strings residual in
+  Format_doc.fprintf ppf "@[<hov 2>%s %s not mod %a@]" ty verb
     (Format_doc.pp_print_list
        ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
        Format_doc.pp_print_string)
@@ -997,26 +972,14 @@ let validate_immutable_unboxed_label (lbl : Types.label_declaration) =
   | Mutable _ ->
     failwith "ikind: mutable fields in unboxed records are not supported"
 
-let format_type_expr_single_line ty =
-  Format_doc.asprintf "%a" Jkind.format_type_expr ty
-  |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
-
 let label_mutability_provenance (ctx : Solver.ctx)
     (lbl : Types.label_declaration) (poly : Ldd.node) : Ldd.node =
   match lbl.ld_mutable with
   | Immutable -> poly
   | Mutable { atomic = Nonatomic; _ } ->
-    Solver.with_provenance_text ctx
-      (fun () ->
-        Format.sprintf "mutable field %s : %s" (Ident.name lbl.ld_id)
-          (format_type_expr_single_line lbl.ld_type))
-      poly
+    Solver.with_provenance_text ctx (fun () -> "mutable fields") poly
   | Mutable { atomic = Atomic; _ } ->
-    Solver.with_provenance_text ctx
-      (fun () ->
-        Format.sprintf "mutable field %s : %s [@atomic]" (Ident.name lbl.ld_id)
-          (format_type_expr_single_line lbl.ld_type))
-      poly
+    Solver.with_provenance_text ctx (fun () -> "atomic mutable fields") poly
 
 let decl_base_provenance (ctx : Solver.ctx) source poly =
   Solver.with_provenance_text ctx (fun () -> source) poly
@@ -1171,7 +1134,7 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
           (* CR box: This will no longer be [non_float] once we update the
              representation of singleton float64 records *)
           | _ -> Axis_lattice.immutable_data)
-        |> decl_base_provenance ctx "this record type"
+        |> decl_base_provenance ctx "boxed records"
       in
       sum_record_label_contributions ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
@@ -1180,7 +1143,7 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
     | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
       let base =
         Ldd.const Axis_lattice.immediate
-        |> decl_base_provenance ctx "this unboxed record type"
+        |> decl_base_provenance ctx "unboxed records"
       in
       sum_record_label_contributions ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
@@ -1225,7 +1188,7 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
             then Axis_lattice.immediate
             else Axis_lattice.immutable_data
         in
-        Ldd.const base_lat |> decl_base_provenance ctx "this variant type"
+        Ldd.const base_lat |> decl_base_provenance ctx "boxed variants"
       in
       let payload_kind_of_constructor =
         make_gadt_payload_projector ~decl_params:decl.type_params ctx
@@ -1460,10 +1423,10 @@ let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
 let check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind
     { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
   let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
-  let failing_poly = Ldd.sub_subsets sub_poly super_poly in
   match violating_axes with
   | [] -> Ok ()
   | _ ->
+    let failing_poly = Ldd.sub_subsets sub_poly super_poly in
     Error
       (Mode_crossing_error
          { origin;
@@ -1513,6 +1476,10 @@ let best_effort_provenance_error ?fallback_error ~origin ~sub_jkind ~super_jkind
     match make_polys () with
     | provenance_polys ->
       check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind provenance_polys
+    | exception
+        ((Misc.Fatal_error | Stack_overflow | Out_of_memory | Sys.Break) as exn)
+      ->
+      raise exn
     | exception _ -> Ok ()
   in
   match provenance_check with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -1510,12 +1510,10 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
          Format.eprintf "[ikind-subjkind] call%s allow_any=true@." origin_suffix);
       Ok ())
     else
-      let { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
-        compute_subcheck_polys ~context env sub super
-      in
+      let subcheck_polys = compute_subcheck_polys ~context env sub super in
       match
         check_mode_crossing_polys ~origin ~sub_jkind:sub ~super_jkind:super
-          { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path }
+          subcheck_polys
       with
       | Ok () -> Ok ()
       | Error ikind_error -> (

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -151,9 +151,7 @@ module Solver = struct
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode, name with
-    | Normal, _
-    | Round_up, Provenance _ ->
-      Ldd.node_of_var (Ldd.rigid name)
+    | Normal, _ | Round_up, Provenance _ -> Ldd.node_of_var (Ldd.rigid name)
     | Round_up, _ -> Ldd.const Axis_lattice.top
 
   (** A rigid variable corresponding to a type parameter [t]. *)
@@ -744,7 +742,7 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
     |> List.filter_map (fun (name, coeff) ->
         match (name : Ldd.Name.t) with
         | Atom _ | KAtom _ | Param _ | Unknown _ -> None
-        | Provenance { ty; plural; _ } ->
+        | Provenance { ty; plural; _ } -> (
           if is_bot_poly coeff
           then None
           else
@@ -765,7 +763,7 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                  axes left to report. *)
               match axes with
               | [] -> None
-              | _ :: _ -> Some { ty; plural; mode_bounds; axes })
+              | _ :: _ -> Some { ty; plural; mode_bounds; axes }))
     |> List.fold_left add_provenance_residual []
     |> Option.some
 
@@ -1347,8 +1345,7 @@ let subjkind_error_has_provenance_residuals = function
 let same_axis_set axes1 axes2 =
   let of_list =
     List.fold_left
-      (fun set (Jkind_axis.Axis.Pack axis) ->
-        Jkind_axis.Axis_set.add set axis)
+      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
       Jkind_axis.Axis_set.empty
   in
   Jkind_axis.Axis_set.equal (of_list axes1) (of_list axes2)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -356,7 +356,7 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr ?self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
+  and constr ~self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
       : Ldd.node =
     let constr_ctx =
       if ctx.add_provenance
@@ -367,9 +367,9 @@ module Solver = struct
       constr_kind constr_ctx ~min_arity:(List.length args) path
     in
     let base =
-      match self_ty with
-      | Some ty when ctx.add_provenance -> Ldd.meet base (provenance ctx ty)
-      | Some _ | None -> base
+      if ctx.add_provenance
+      then Ldd.meet base (provenance ctx self_ty)
+      else base
     in
     let rec loop acc remaining i =
       if i = Array.length coeffs

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -641,8 +641,6 @@ let pp_axes (axes : Jkind_axis.Axis.packed list) : string =
 
 let axis_name (Jkind_axis.Axis.Pack ax) = Jkind_axis.Axis.name ax
 
-let same_axis a b = String.equal (axis_name a) (axis_name b)
-
 let pp_axis_name ppf axis = Format_doc.fprintf ppf "%s" (axis_name axis)
 
 let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
@@ -729,7 +727,8 @@ let axes_in_violation_order ~violating_axes axes =
      intersecting here prevents blaming a fragment on an axis the whole
      comparison passes on. *)
   List.filter
-    (fun violating_axis -> List.exists (same_axis violating_axis) axes)
+    (fun violating_axis ->
+      List.exists (Jkind_axis.Axis.equal violating_axis) axes)
     violating_axes
 
 type mode_crossing_error =
@@ -769,7 +768,9 @@ let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
     && Bool.equal other.plural plural
     && Axis_lattice.equal other.mode_bounds mode_bounds
     && List.length other.axes = List.length axes
-    && List.for_all (fun axis -> List.exists (same_axis axis) other.axes) axes
+    && List.for_all
+         (fun axis -> List.exists (Jkind_axis.Axis.equal axis) other.axes)
+         axes
   in
   if List.exists duplicate entries then entries else entries @ [entry]
 
@@ -1444,8 +1445,13 @@ let subjkind_error_has_provenance_residuals = function
     | Some (_ :: _) -> true)
 
 let same_axis_set axes1 axes2 =
-  List.length axes1 = List.length axes2
-  && List.for_all (fun axis1 -> List.exists (same_axis axis1) axes2) axes1
+  let of_list =
+    List.fold_left
+      (fun set (Jkind_axis.Axis.Pack axis) ->
+        Jkind_axis.Axis_set.add set axis)
+      Jkind_axis.Axis_set.empty
+  in
+  Jkind_axis.Axis_set.equal (of_list axes1) (of_list axes2)
 
 let subjkind_errors_have_same_violating_axes error1 error2 =
   match error1, error2 with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -1463,15 +1463,12 @@ let subjkind_errors_have_same_violating_axes error1 error2 =
     same_axis_set axes1 axes2
   | Jkind_error _, _ | _, Jkind_error _ -> false
 
-let best_effort_provenance_error ?fallback_error ~origin ~sub_jkind ~super_jkind
+let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
     actual_error make_polys =
   let fallback error =
-    match fallback_error with
+    match fallback_error () with
     | None -> Error error
-    | Some fallback_error -> (
-      match fallback_error () with
-      | None -> Error error
-      | Some fallback_error -> Error fallback_error)
+    | Some fallback_error -> Error fallback_error
   in
   let provenance_check =
     match make_polys () with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -38,22 +38,6 @@ let fresh_unknown_uid () : Types.Uid.t =
   in
   Types.Uid.mk ~current_unit
 
-let collapse_whitespace s =
-  let b = Buffer.create (String.length s) in
-  let pending_space = ref false in
-  String.iter
-    (function
-      | ' ' | '\n' | '\r' | '\t' ->
-        if Buffer.length b > 0 then pending_space := true
-      | c ->
-        if !pending_space
-        then (
-          Buffer.add_char b ' ';
-          pending_space := false);
-        Buffer.add_char b c)
-    s;
-  Buffer.contents b
-
 module Provenance = struct
   let next_id = ref 0
 
@@ -662,38 +646,6 @@ let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
          pp_axis_name)
       init pp_axis_name last
 
-let format_jkind_single_line env jkind =
-  Format_doc.asprintf "%a" (Jkind.format env) jkind
-  |> collapse_whitespace
-
-let pp_breakable_words ppf s =
-  s |> String.split_on_char ' '
-  |> List.filter (fun s -> not (String.equal s ""))
-  |> Format_doc.pp_print_list
-       ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
-       Format_doc.pp_print_string ppf
-
-let split_on_first_substring ~sub s =
-  let len = String.length s in
-  let sub_len = String.length sub in
-  let rec loop i =
-    if i + sub_len > len
-    then None
-    else if String.equal (String.sub s i sub_len) sub
-    then
-      let before = String.sub s 0 i in
-      let after = String.sub s (i + sub_len) (len - i - sub_len) in
-      Some (before, after)
-    else loop (i + 1)
-  in
-  loop 0
-
-let pp_breakable_jkind_annotation ppf s =
-  match split_on_first_substring ~sub:" with " s with
-  | None -> pp_breakable_words ppf s
-  | Some (before, after) ->
-    Format_doc.fprintf ppf "@[<v 2>%s@;with %s@]" before after
-
 let is_bot_poly poly = Axis_lattice.equal (Ldd.round_up poly) Axis_lattice.bot
 
 let axes_in_violation_order ~violating_axes axes =
@@ -855,31 +807,9 @@ let pp_provenance_residual_bullets ppf entries =
     entries
 
 let pp_type_definition_kind_annotation env ppf super_jkind =
-  let super_jkind_single_line = format_jkind_single_line env super_jkind in
-  let single_line_prefix =
-    "Error: This type definition does not satisfy its kind annotation "
-  in
-  let error_prefix_width = String.length "Error: " in
-  let continuation_indent = 2 in
-  let continuation_prefix_width = error_prefix_width + continuation_indent in
-  if
-    String.length single_line_prefix + String.length super_jkind_single_line + 1
-    <= 88
-  then
-    Format_doc.fprintf ppf
-      "This type definition does not satisfy its kind annotation %s,"
-      super_jkind_single_line
-  else if
-    continuation_prefix_width + String.length super_jkind_single_line + 1 <= 88
-  then
-    Format_doc.fprintf ppf
-      "@[<v 2>This type definition does not satisfy its kind annotation@;%s,@]"
-      super_jkind_single_line
-  else
-    Format_doc.fprintf ppf
-      "@[<v 2>This type definition does not satisfy its kind annotation@;\
-       @[<hov>%a,@]@]"
-      pp_breakable_jkind_annotation super_jkind_single_line
+  Format_doc.fprintf ppf
+    "@[<hov 2>This type definition does not satisfy its kind annotation@ %a,@]"
+    (Jkind.format env) super_jkind
 
 let report_provenance_mode_crossing_error env ppf
     { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -59,12 +59,15 @@ module Provenance = struct
 
   let names : Ldd.Name.t list ref = ref []
 
-  let register_text ~plural ty : Ldd.Name.t =
+  let register_doc ~plural ty : Ldd.Name.t =
     let id = !next_id in
     next_id := id + 1;
     let name = Ldd.Name.provenance ~id ~ty ~plural in
     names := name :: !names;
     name
+
+  let register_text ~plural text =
+    register_doc ~plural (Format_doc.doc_printf "%s" text)
 
   let register (ty : Types.type_expr) : Ldd.Name.t =
     (* A surviving residual for an occurrence reflects only the head
@@ -73,9 +76,8 @@ module Provenance = struct
        name the head rather than the full type expression: the constructor
        for [Tconstr], a class-of-types phrase for the built-in shapes. *)
     let register_type ty =
-      Format_doc.asprintf "%a" Jkind.format_type_expr ty
-      |> collapse_whitespace
-      |> register_text ~plural:false
+      Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
+      |> register_doc ~plural:false
     in
     match Types.get_desc ty with
     | Types.Tarrow _ -> register_text ~plural:true "functions"
@@ -743,7 +745,7 @@ let map_jkind_error result =
   Result.map_error (fun error -> Jkind_error error) result
 
 type provenance_residual =
-  { ty : string;
+  { ty : Format_doc.doc;
     plural : bool;
     mode_bounds : Axis_lattice.t;
     axes : Jkind_axis.Axis.packed list
@@ -756,7 +758,9 @@ let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
      share a printed name (e.g. two constructor-local existentials both
      rendered ['a]) can have different requirements and must stay separate. *)
   let duplicate other =
-    String.equal other.ty ty
+    String.equal
+      (Format_doc.asprintf "%a" Format_doc.pp_doc other.ty)
+      (Format_doc.asprintf "%a" Format_doc.pp_doc ty)
     && Bool.equal other.plural plural
     && Axis_lattice.equal other.mode_bounds mode_bounds
     && List.length other.axes = List.length axes
@@ -854,7 +858,7 @@ let pp_provenance_residual ppf ({ ty; plural; _ } as residual) =
      phrases; type-expression subjects read as singular. *)
   let verb = if plural then "are" else "is" in
   let modes = residual_mode_strings residual in
-  Format_doc.fprintf ppf "@[<hov 2>%s %s not mod %a@]" ty verb
+  Format_doc.fprintf ppf "@[<hov 2>%a %s not mod %a@]" Format_doc.pp_doc ty verb
     (Format_doc.pp_print_list
        ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
        Format_doc.pp_print_string)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -1487,14 +1487,14 @@ let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
     then Error provenance_error
     else fallback actual_error
 
-let sub_jkind_l ?allow_any_crossing ?origin
+let sub_jkind_l ?(allow_any_crossing = false) ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)
     ~(context : Jkind.jkind_context) env (sub : Types.jkind_l)
     (super : Types.jkind_l) : (unit, subjkind_error) result =
   let open Misc.Stdlib.Monad.Result.Syntax in
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
-    Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
+    Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env sub super
     |> map_jkind_error
   else
     (* Check layouts first; if that fails, print both sides with full
@@ -1502,10 +1502,7 @@ let sub_jkind_l ?allow_any_crossing ?origin
     let* () =
       Jkind.sub_layout_or_error ~context env sub super |> map_jkind_error
     in
-    let allow_any =
-      match allow_any_crossing with Some true -> true | _ -> false
-    in
-    if allow_any
+    if allow_any_crossing
     then (
       (if !Clflags.ikinds_debug
        then
@@ -1526,27 +1523,24 @@ let sub_jkind_l ?allow_any_crossing ?origin
         then Error ikind_error
         else
           match
-            Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub
+            Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env sub
               super
           with
           | Ok () -> Error ikind_error
           | Error jkind_error -> Error (Jkind_error jkind_error))
 
-let check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
-    ~bound ~provenance_lhs =
+let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs =
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
-    sub_jkind_l ?allow_any_crossing ?origin ~type_equal ~context env actual
+    sub_jkind_l ~allow_any_crossing ?origin ~type_equal ~context env actual
       bound
   else
     let open Misc.Stdlib.Monad.Result.Syntax in
     let* () =
       Jkind.sub_layout_or_error ~context env actual bound |> map_jkind_error
     in
-    let allow_any =
-      match allow_any_crossing with Some true -> true | _ -> false
-    in
-    if allow_any
+    if allow_any_crossing
     then Ok ()
     else
       let actual_polys = compute_subcheck_polys ~context env actual bound in
@@ -1558,7 +1552,7 @@ let check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
       | Error actual_error ->
         let fallback_error () =
           match
-            Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env
+            Jkind.sub_jkind_l ~allow_any_crossing ~type_equal ~context env
               actual bound
           with
           | Ok () ->

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -662,31 +662,9 @@ let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
          pp_axis_name)
       init pp_axis_name last
 
-let remove_numeric_path_stamps s =
-  let b = Buffer.create (String.length s) in
-  let is_digit = function '0' .. '9' -> true | _ -> false in
-  let rec loop i =
-    if i >= String.length s
-    then ()
-    else
-      match s.[i] with
-      | '/' when i + 1 < String.length s && is_digit s.[i + 1] ->
-        let rec skip_digits j =
-          if j < String.length s && is_digit s.[j]
-          then skip_digits (j + 1)
-          else j
-        in
-        loop (skip_digits (i + 1))
-      | c ->
-        Buffer.add_char b c;
-        loop (i + 1)
-  in
-  loop 0;
-  Buffer.contents b
-
 let format_jkind_single_line env jkind =
   Format_doc.asprintf "%a" (Jkind.format env) jkind
-  |> collapse_whitespace |> remove_numeric_path_stamps
+  |> collapse_whitespace
 
 let pp_breakable_words ppf s =
   s |> String.split_on_char ' '
@@ -730,7 +708,8 @@ let axes_in_violation_order ~violating_axes axes =
     violating_axes
 
 type mode_crossing_error =
-  { super_jkind : Types.jkind_l;
+  { printing_env : Env.t;
+    super_jkind : Types.jkind_l;
     sub_poly : Ldd.node;
     super_poly : Ldd.node;
     provenance_names : Ldd.Name.t list;
@@ -740,6 +719,10 @@ type mode_crossing_error =
 type subjkind_error =
   | Jkind_error of Jkind.Violation.t
   | Mode_crossing_error of mode_crossing_error
+
+let subjkind_error_printing_env = function
+  | Jkind_error _ -> None
+  | Mode_crossing_error { printing_env; _ } -> Some printing_env
 
 let map_jkind_error result =
   Result.map_error (fun error -> Jkind_error error) result
@@ -915,8 +898,8 @@ let report_provenance_mode_crossing_error env ppf
          (pp_type_definition_kind_annotation env)
          super_jkind pp_provenance_residual_bullets entries)
 
-let report_mode_crossing_error ~offender env ppf err =
-  match report_provenance_mode_crossing_error env ppf err with
+let report_mode_crossing_error ~offender ppf err =
+  match report_provenance_mode_crossing_error err.printing_env ppf err with
   | Some () -> ()
   | None ->
     Format_doc.fprintf ppf
@@ -927,7 +910,7 @@ let report_mode_crossing_error ~offender env ppf err =
 let report_subjkind_error_with_offender ~offender env ppf = function
   | Jkind_error err ->
     Jkind.Violation.report_with_offender ~offender env ppf err
-  | Mode_crossing_error err -> report_mode_crossing_error ~offender env ppf err
+  | Mode_crossing_error err -> report_mode_crossing_error ~offender ppf err
 
 let report_subjkind_error_with_name ~name env ppf err =
   report_subjkind_error_with_offender
@@ -1404,7 +1387,7 @@ let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
       let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
       lhs ctx)
 
-let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind
+let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
     { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path = _ } =
   let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
   match violating_axes with
@@ -1412,7 +1395,8 @@ let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind
   | _ ->
     Error
       (Mode_crossing_error
-         { super_jkind;
+         { printing_env;
+           super_jkind;
            sub_poly;
            super_poly;
            provenance_names = Provenance.all_names ();
@@ -1447,7 +1431,7 @@ let subjkind_errors_have_same_violating_axes error1 error2 =
   | Jkind_error _, _ | _, Jkind_error _ -> false
 
 let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
-    actual_error make_polys =
+    ~printing_env actual_error make_polys =
   let fallback error =
     match fallback_error () with
     | None -> Error error
@@ -1456,7 +1440,8 @@ let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
   let provenance_check =
     match make_polys () with
     | provenance_polys ->
-      check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind provenance_polys
+      check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind ~printing_env
+        provenance_polys
     | exception
         ((Misc.Fatal_error | Stack_overflow | Out_of_memory | Sys.Break) as exn)
       ->
@@ -1498,7 +1483,7 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
       let subcheck_polys = compute_subcheck_polys ~context env sub super in
       match
         check_mode_crossing_polys ~origin ~sub_jkind:sub ~super_jkind:super
-          subcheck_polys
+          ~printing_env:env subcheck_polys
       with
       | Ok () -> Ok ()
       | Error ikind_error -> (
@@ -1529,7 +1514,7 @@ let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
       let actual_polys = compute_subcheck_polys ~context env actual bound in
       match
         check_mode_crossing_polys ~origin ~sub_jkind:actual ~super_jkind:bound
-          actual_polys
+          ~printing_env:env actual_polys
       with
       | Ok () -> Ok ()
       | Error actual_error ->
@@ -1552,7 +1537,7 @@ let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
           | Error jkind_error -> Some (Jkind_error jkind_error)
         in
         best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
-          ~super_jkind:bound actual_error (fun () ->
+          ~super_jkind:bound ~printing_env:env actual_error (fun () ->
             compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
 
 let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -164,13 +164,9 @@ module Solver = struct
     { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
-    match ctx.mode with
-    | Normal -> Ldd.node_of_var (Ldd.rigid name)
-    | Round_up when match name with Provenance _ -> true | _ -> false ->
-      Ldd.node_of_var (Ldd.rigid name)
     match ctx.mode, name with
     | Normal, _
-    | Round_up, Provenance ->
+    | Round_up, Provenance _ ->
       Ldd.node_of_var (Ldd.rigid name)
     | Round_up, _ -> Ldd.const Axis_lattice.top
 
@@ -732,13 +728,9 @@ let axes_in_violation_order ~violating_axes axes =
     violating_axes
 
 type mode_crossing_error =
-  { origin : string option;
-    sub_jkind : Types.jkind_l;
-    super_jkind : Types.jkind_l;
+  { super_jkind : Types.jkind_l;
     sub_poly : Ldd.node;
     super_poly : Ldd.node;
-    failing_poly : Ldd.node;
-    fast_path : string;
     provenance_names : Ldd.Name.t list;
     violating_axes : Jkind_axis.Axis.packed list
   }
@@ -926,7 +918,7 @@ let report_mode_crossing_error ~offender env ppf err =
     Format_doc.fprintf ppf
       "@[<v>The mode crossing of %t is not allowed here.@;\
        @[<hov 2>The inferred kind is not below the required kind along %a.@]@]"
-      offender pp_axis_list_prose violating_axes
+      offender pp_axis_list_prose err.violating_axes
 
 let report_subjkind_error_with_offender ~offender env ppf = function
   | Jkind_error err ->
@@ -1330,11 +1322,6 @@ type subcheck_fast_path =
   | Rhs_top_fast_path
   | Lhs_mod_bounds_floor_fast_path
 
-let string_of_subcheck_fast_path = function
-  | No_fast_path -> "none"
-  | Rhs_top_fast_path -> "rhs_top"
-  | Lhs_mod_bounds_floor_fast_path -> "lhs_mod_bounds_floor"
-
 type subcheck_polys =
   { lhs_for_leq : Ldd.node;
     rhs_for_leq : Ldd.node;
@@ -1413,22 +1400,17 @@ let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
       let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
       lhs ctx)
 
-let check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind
-    { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
+let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind
+    { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path = _ } =
   let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
   match violating_axes with
   | [] -> Ok ()
   | _ ->
-    let failing_poly = Ldd.sub_subsets sub_poly super_poly in
     Error
       (Mode_crossing_error
-         { origin;
-           sub_jkind;
-           super_jkind;
+         { super_jkind;
            sub_poly;
            super_poly;
-           failing_poly;
-           fast_path = string_of_subcheck_fast_path fast_path;
            provenance_names = Provenance.all_names ();
            violating_axes
          })

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -748,6 +748,9 @@ type subjkind_error =
   | Jkind_error of Jkind.Violation.t
   | Mode_crossing_error of mode_crossing_error
 
+let map_jkind_error result =
+  Result.map_error (fun error -> Jkind_error error) result
+
 type provenance_residual =
   { ty : string;
     plural : bool;
@@ -1492,14 +1495,12 @@ let sub_jkind_l ?allow_any_crossing ?origin
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
     Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
-    |> Result.map_error (fun err -> Jkind_error err)
+    |> map_jkind_error
   else
     (* Check layouts first; if that fails, print both sides with full
        info and return the error. *)
     let* () =
-      match Jkind.sub_layout_or_error ~context env sub super with
-      | Ok () -> Ok ()
-      | Error v -> Error (Jkind_error v)
+      Jkind.sub_layout_or_error ~context env sub super |> map_jkind_error
     in
     let allow_any =
       match allow_any_crossing with Some true -> true | _ -> false
@@ -1540,9 +1541,7 @@ let check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
   else
     let open Misc.Stdlib.Monad.Result.Syntax in
     let* () =
-      match Jkind.sub_layout_or_error ~context env actual bound with
-      | Ok () -> Ok ()
-      | Error v -> Error (Jkind_error v)
+      Jkind.sub_layout_or_error ~context env actual bound |> map_jkind_error
     in
     let allow_any =
       match allow_any_crossing with Some true -> true | _ -> false

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -59,10 +59,10 @@ module Provenance = struct
 
   let names : Ldd.Name.t list ref = ref []
 
-  let register_text ~phrase ty : Ldd.Name.t =
+  let register_text ~plural ty : Ldd.Name.t =
     let id = !next_id in
     next_id := id + 1;
-    let name = Ldd.Name.provenance ~id ~ty ~phrase in
+    let name = Ldd.Name.provenance ~id ~ty ~plural in
     names := name :: !names;
     name
 
@@ -75,15 +75,15 @@ module Provenance = struct
     let register_type ty =
       Format_doc.asprintf "%a" Jkind.format_type_expr ty
       |> collapse_whitespace
-      |> register_text ~phrase:false
+      |> register_text ~plural:false
     in
     match Types.get_desc ty with
-    | Types.Tarrow _ -> register_text ~phrase:true "functions"
-    | Types.Ttuple _ -> register_text ~phrase:true "tuples"
-    | Types.Tunboxed_tuple _ -> register_text ~phrase:true "unboxed tuples"
-    | Types.Tobject _ -> register_text ~phrase:true "objects"
-    | Types.Tvariant _ -> register_text ~phrase:true "polymorphic variants"
-    | Types.Tpackage _ -> register_text ~phrase:true "first-class modules"
+    | Types.Tarrow _ -> register_text ~plural:true "functions"
+    | Types.Ttuple _ -> register_text ~plural:true "tuples"
+    | Types.Tunboxed_tuple _ -> register_text ~plural:true "unboxed tuples"
+    | Types.Tobject _ -> register_text ~plural:true "objects"
+    | Types.Tvariant _ -> register_text ~plural:true "polymorphic variants"
+    | Types.Tpackage _ -> register_text ~plural:true "first-class modules"
     | Types.Tconstr (path, _ :: _, _) ->
       register_type (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
     | _ -> register_type ty
@@ -183,7 +183,7 @@ module Solver = struct
     rigid_name ctx (Provenance.register ty)
 
   let provenance_text (ctx : ctx) (text : string) : Ldd.node =
-    rigid_name ctx (Provenance.register_text ~phrase:true text)
+    rigid_name ctx (Provenance.register_text ~plural:true text)
 
   let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
       : Ldd.node =
@@ -750,12 +750,12 @@ type subjkind_error =
 
 type provenance_residual =
   { ty : string;
-    phrase : bool;
+    plural : bool;
     mode_bounds : Axis_lattice.t;
     axes : Jkind_axis.Axis.packed list
   }
 
-let add_provenance_residual entries ({ ty; phrase; mode_bounds; axes } as entry)
+let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
     =
   (* Deduplicate identical entries (e.g. two fields of type [int ref] under
      the same bound), keeping first-occurrence order. Entries that merely
@@ -763,7 +763,7 @@ let add_provenance_residual entries ({ ty; phrase; mode_bounds; axes } as entry)
      rendered ['a]) can have different requirements and must stay separate. *)
   let duplicate other =
     String.equal other.ty ty
-    && Bool.equal other.phrase phrase
+    && Bool.equal other.plural plural
     && Axis_lattice.equal other.mode_bounds mode_bounds
     && List.length other.axes = List.length axes
     && List.for_all (fun axis -> List.exists (same_axis axis) other.axes) axes
@@ -809,7 +809,7 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
     |> List.filter_map (fun (name, coeff) ->
         match (name : Ldd.Name.t) with
         | Atom _ | KAtom _ | Param _ | Unknown _ -> None
-        | Provenance { ty; phrase; _ } ->
+        | Provenance { ty; plural; _ } ->
           if is_bot_poly coeff
           then None
           else
@@ -830,7 +830,7 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                  axes left to report. *)
               match axes with
               | [] -> None
-              | _ :: _ -> Some { ty; phrase; mode_bounds; axes })
+              | _ :: _ -> Some { ty; plural; mode_bounds; axes })
     |> List.fold_left add_provenance_residual []
     |> Option.some
 
@@ -853,10 +853,10 @@ let residual_mode_strings { mode_bounds; axes; _ } =
   |> Typemode.untransl_mod_bounds ~verbose:false
   |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let pp_provenance_residual ppf ({ ty; phrase; _ } as residual) =
+let pp_provenance_residual ppf ({ ty; plural; _ } as residual) =
   (* Phrase subjects ("mutable fields", "boxed records") are plural noun
      phrases; type-expression subjects read as singular. *)
-  let verb = if phrase then "are" else "is" in
+  let verb = if plural then "are" else "is" in
   let modes = residual_mode_strings residual in
   Format_doc.fprintf ppf "@[<hov 2>%s %s not mod %a@]" ty verb
     (Format_doc.pp_print_list

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -962,11 +962,12 @@ let axis_disagreement_reasons (axes : Jkind_axis.Axis.packed list) :
   List.map (fun axis -> Jkind.Sub_failure_reason.Axis_disagreement axis) axes
 
 let label_mutability_contribution (lbl : Types.label_declaration) =
-  Ldd.const
-    (match lbl.ld_mutable with
-    | Immutable -> Axis_lattice.immediate
-    | Mutable { atomic = Atomic; _ } -> Axis_lattice.sync_data
-    | Mutable { atomic = Nonatomic; _ } -> Axis_lattice.mutable_data)
+  match lbl.ld_mutable with
+  (* [immediate] is below every base this is summed into, so omitting it keeps
+     immutable fields out of the untracked part of a provenance residual. *)
+  | Immutable -> Ldd.bot
+  | Mutable { atomic = Atomic; _ } -> Ldd.const Axis_lattice.sync_data
+  | Mutable { atomic = Nonatomic; _ } -> Ldd.const Axis_lattice.mutable_data
 
 let sum_record_label_contributions ~(base : Ldd.node)
     ~(payload_kind : Types.type_expr -> Ldd.node)
@@ -1145,13 +1146,14 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
     | Types.Type_abstract _ | Types.Type_open -> use_decl_jkind ()
     | Types.Type_record (lbls, rep, _umc_opt) ->
       let base =
-        Ldd.const
-          (match rep with
-          | Types.Record_unboxed -> Axis_lattice.immediate
+        let base_lat, source =
+          match rep with
+          | Types.Record_unboxed -> Axis_lattice.immediate, "unboxed records"
           (* CR box: This will no longer be [non_float] once we update the
              representation of singleton float64 records *)
-          | _ -> Axis_lattice.immutable_data)
-        |> decl_base_provenance ctx "boxed records"
+          | _ -> Axis_lattice.immutable_data, "boxed records"
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx source
       in
       sum_record_label_contributions ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
@@ -1197,15 +1199,15 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
           cstrs
       in
       let base =
-        let base_lat =
+        let base_lat, source =
           match rep with
-          | Types.Variant_unboxed -> Axis_lattice.immediate
+          | Types.Variant_unboxed -> Axis_lattice.immediate, "unboxed variants"
           | _ ->
             if all_args_void
-            then Axis_lattice.immediate
-            else Axis_lattice.immutable_data
+            then Axis_lattice.immediate, "enumeration variants"
+            else Axis_lattice.immutable_data, "boxed variants"
         in
-        Ldd.const base_lat |> decl_base_provenance ctx "boxed variants"
+        Ldd.const base_lat |> decl_base_provenance ctx source
       in
       let payload_kind_of_constructor =
         make_gadt_payload_projector ~decl_params:decl.type_params ctx

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -755,11 +755,6 @@ type provenance_residual =
     axes : Jkind_axis.Axis.packed list
   }
 
-let provenance_ty_of_name (name : Ldd.Name.t) =
-  match name with
-  | Provenance { ty; phrase; _ } -> Some (ty, phrase)
-  | Atom _ | KAtom _ | Param _ | Unknown _ -> None
-
 let add_provenance_residual entries ({ ty; phrase; mode_bounds; axes } as entry)
     =
   (* Deduplicate identical entries (e.g. two fields of type [int ref] under
@@ -812,12 +807,12 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
   else
     List.combine provenance_names coeffs
     |> List.filter_map (fun (name, coeff) ->
-        if is_bot_poly coeff
-        then None
-        else
-          match provenance_ty_of_name name with
-          | None -> None
-          | Some (ty, phrase) -> (
+        match (name : Ldd.Name.t) with
+        | Atom _ | KAtom _ | Param _ | Unknown _ -> None
+        | Provenance { ty; phrase; _ } ->
+          if is_bot_poly coeff
+          then None
+          else
             let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
             let non_top_bounds =
               Axis_lattice.co_sub Axis_lattice.top mode_bounds
@@ -835,7 +830,7 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                  axes left to report. *)
               match axes with
               | [] -> None
-              | _ :: _ -> Some { ty; phrase; mode_bounds; axes }))
+              | _ :: _ -> Some { ty; phrase; mode_bounds; axes })
     |> List.fold_left add_provenance_residual []
     |> Option.some
 

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -941,25 +941,30 @@ let axis_disagreement_reasons (axes : Jkind_axis.Axis.packed list) :
     Jkind.Sub_failure_reason.t list =
   List.map (fun axis -> Jkind.Sub_failure_reason.Axis_disagreement axis) axes
 
-let label_mutability_contribution (lbl : Types.label_declaration) =
+let label_mutability_contribution (ctx : Solver.ctx)
+    (lbl : Types.label_declaration) =
   match lbl.ld_mutable with
   (* [immediate] is below every base this is summed into, so omitting it keeps
      immutable fields out of the untracked part of a provenance residual. *)
   | Immutable -> Ldd.bot
-  | Mutable { atomic = Atomic; _ } -> Ldd.const Axis_lattice.sync_data
-  | Mutable { atomic = Nonatomic; _ } -> Ldd.const Axis_lattice.mutable_data
+  | Mutable { atomic = Atomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () -> "atomic mutable fields")
+      (Ldd.const Axis_lattice.sync_data)
+  | Mutable { atomic = Nonatomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () -> "mutable fields")
+      (Ldd.const Axis_lattice.mutable_data)
 
-let sum_record_label_contributions ~(base : Ldd.node)
+let sum_record_label_contributions ~(ctx : Solver.ctx) ~(base : Ldd.node)
     ~(payload_kind : Types.type_expr -> Ldd.node)
-    ?(label_mutability_provenance =
-      fun (_ : Types.label_declaration) (poly : Ldd.node) -> poly)
     ~(validate_label : Types.label_declaration -> unit)
     (lbls : Types.label_declaration list) : Ldd.node =
   Ldd.sum lbls ~base ~f:(fun (lbl : Types.label_declaration) ->
       validate_label lbl;
       let mask = Axis_lattice.mask_of_modality lbl.ld_modalities in
       Ldd.join
-        (label_mutability_provenance lbl (label_mutability_contribution lbl))
+        (label_mutability_contribution ctx lbl)
         (Ldd.meet (Ldd.const mask) (payload_kind lbl.ld_type)))
 
 let no_validation (_ : Types.label_declaration) = ()
@@ -969,15 +974,6 @@ let validate_immutable_unboxed_label (lbl : Types.label_declaration) =
   | Immutable -> ()
   | Mutable _ ->
     failwith "ikind: mutable fields in unboxed records are not supported"
-
-let label_mutability_provenance (ctx : Solver.ctx)
-    (lbl : Types.label_declaration) (poly : Ldd.node) : Ldd.node =
-  match lbl.ld_mutable with
-  | Immutable -> poly
-  | Mutable { atomic = Nonatomic; _ } ->
-    Solver.with_provenance_text ctx (fun () -> "mutable fields") poly
-  | Mutable { atomic = Atomic; _ } ->
-    Solver.with_provenance_text ctx (fun () -> "atomic mutable fields") poly
 
 let decl_base_provenance (ctx : Solver.ctx) source poly =
   Solver.with_provenance_text ctx (fun () -> source) poly
@@ -1135,18 +1131,16 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
         in
         Ldd.const base_lat |> decl_base_provenance ctx source
       in
-      sum_record_label_contributions ~base
+      sum_record_label_contributions ~ctx ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-        ~label_mutability_provenance:(label_mutability_provenance ctx)
         ~validate_label:no_validation lbls
     | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
       let base =
         Ldd.const Axis_lattice.immediate
         |> decl_base_provenance ctx "unboxed records"
       in
-      sum_record_label_contributions ~base
+      sum_record_label_contributions ~ctx ~base
         ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-        ~label_mutability_provenance:(label_mutability_provenance ctx)
         ~validate_label:validate_immutable_unboxed_label lbls
     | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
       (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
@@ -1201,8 +1195,7 @@ let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
               let mask = Axis_lattice.mask_of_modality arg.ca_modalities in
               Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
         | Types.Cstr_record lbls ->
-          sum_record_label_contributions ~base:Ldd.bot ~payload_kind
-            ~label_mutability_provenance:(label_mutability_provenance ctx)
+          sum_record_label_contributions ~ctx ~base:Ldd.bot ~payload_kind
             ~validate_label:no_validation lbls
       in
       Ldd.sum cstrs ~base ~f:constructor_contrib)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -168,7 +168,11 @@ module Solver = struct
     | Normal -> Ldd.node_of_var (Ldd.rigid name)
     | Round_up when match name with Provenance _ -> true | _ -> false ->
       Ldd.node_of_var (Ldd.rigid name)
-    | Round_up -> Ldd.const Axis_lattice.top
+    match ctx.mode, name with
+    | Normal, _
+    | Round_up, Provenance ->
+      Ldd.node_of_var (Ldd.rigid name)
+    | Round_up, _ -> Ldd.const Axis_lattice.top
 
   (** A rigid variable corresponding to a type parameter [t]. *)
   let rigid (ctx : ctx) (ty : Types.type_expr) : Ldd.node =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -920,29 +920,7 @@ let report_provenance_mode_crossing_error env ppf
          (pp_type_definition_kind_annotation env)
          super_jkind pp_provenance_residual_bullets entries)
 
-let report_mode_crossing_error ~offender env ppf
-    { origin;
-      sub_jkind;
-      super_jkind;
-      sub_poly;
-      super_poly;
-      failing_poly;
-      fast_path;
-      provenance_names;
-      violating_axes
-    } =
-  let err =
-    { origin;
-      sub_jkind;
-      super_jkind;
-      sub_poly;
-      super_poly;
-      failing_poly;
-      fast_path;
-      provenance_names;
-      violating_axes
-    }
-  in
+let report_mode_crossing_error ~offender env ppf err =
   match report_provenance_mode_crossing_error env ppf err with
   | Some () -> ()
   | None ->

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -805,9 +805,9 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
   let base, coeffs =
     Ldd.decompose_into_linear_terms ~universe:provenance_vars sub_poly
   in
-  if Ldd.leq_with_reason base super_poly <> []
-  then None
-  else
+  match Ldd.leq_with_reason base super_poly with
+  | _ :: _ -> None
+  | [] ->
     List.combine provenance_names coeffs
     |> List.filter_map (fun (name, coeff) ->
         match (name : Ldd.Name.t) with

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -38,6 +38,28 @@ let fresh_unknown_uid () : Types.Uid.t =
   in
   Types.Uid.mk ~current_unit
 
+module Provenance = struct
+  let next_id = ref 0
+
+  let names : Ldd.Name.t list ref = ref []
+
+  let register_text ty : Ldd.Name.t =
+    let id = !next_id in
+    next_id := id + 1;
+    let name = Ldd.Name.provenance ~id ~ty in
+    names := name :: !names;
+    name
+
+  let register (ty : Types.type_expr) : Ldd.Name.t =
+    Format_doc.asprintf "%a" Jkind.format_type_expr ty
+    |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
+    |> register_text
+
+  let reset () = names := []
+
+  let all_names () = List.rev !names
+end
+
 (** A kind solver specialized to [Types.Ldd] and [Types.type_expr].
 
     The solver computes LDD polynomials of the form base ⊔ Σ_i (arg_i ⊓ coeff_i)
@@ -81,6 +103,7 @@ module Solver = struct
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
+      add_provenance : bool;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -90,28 +113,46 @@ module Solver = struct
   let global_constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t =
     ConstrTbl.create 1
 
-  let create_ctx ~(mode : mode) ~(env : Env.t option)
+  let create_ctx ~(mode : mode) ~(env : Env.t option) ~add_provenance
       ~(lookup_of_env : Env.t -> Path.t -> constr_decl) =
     TyTbl.clear global_ty_to_kind;
     ConstrTbl.clear global_constr_to_coeffs;
     { env;
       lookup_of_env;
       mode;
+      add_provenance;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
+  let reset_for_provenance (ctx : ctx) ~(add_provenance : bool) : ctx =
+    { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
+
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode with
     | Normal -> Ldd.node_of_var (Ldd.rigid name)
+    | Round_up when match name with Provenance _ -> true | _ -> false ->
+      Ldd.node_of_var (Ldd.rigid name)
     | Round_up -> Ldd.const Axis_lattice.top
 
   (** A rigid variable corresponding to a type parameter [t]. *)
   let rigid (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
     let param_id = Types.get_id ty in
     rigid_name ctx (Ldd.Name.param param_id)
+
+  let provenance (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
+    rigid_name ctx (Provenance.register ty)
+
+  let provenance_text (ctx : ctx) (text : string) : Ldd.node =
+    rigid_name ctx (Provenance.register_text text)
+
+  let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
+      : Ldd.node =
+    if ctx.add_provenance
+    then Ldd.meet poly (provenance_text ctx (text ()))
+    else poly
 
   let rec type_may_be_circular (ty : Types.type_expr) : bool =
     match Types.get_desc ty with
@@ -165,7 +206,7 @@ module Solver = struct
            [c] are kept rigid to avoid infinite expansion. *)
         let instantiate (name : Ldd.Name.t) : Ldd.node =
           match name with
-          | Param _ | Unknown _ -> rigid_name ctx name
+          | Param _ | Provenance _ | Unknown _ -> rigid_name ctx name
           | KAtom kpath -> (
             match ctx.env with
             | None -> rigid_name ctx name
@@ -278,9 +319,21 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr (ctx : ctx) (path : Path.t) (args : Types.type_expr list) :
-      Ldd.node =
-    let base, coeffs = constr_kind ctx ~min_arity:(List.length args) path in
+  and constr ?self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
+      : Ldd.node =
+    let constr_ctx =
+      if ctx.add_provenance
+      then reset_for_provenance ctx ~add_provenance:false
+      else ctx
+    in
+    let base, coeffs =
+      constr_kind constr_ctx ~min_arity:(List.length args) path
+    in
+    let base =
+      match self_ty with
+      | Some ty when ctx.add_provenance -> Ldd.meet base (provenance ctx ty)
+      | Some _ | None -> base
+    in
     let rec loop acc remaining i =
       if i = Array.length coeffs
       then acc
@@ -422,87 +475,89 @@ module Solver = struct
     (* Compute the ikind polynomial for an arbitrary [type_expr]. This is the
        semantic counterpart of [Jkind.jkind_of_type], but expressed in LDD
        form. *)
-    let kind_poly =
-      (* [ty] is expected to be representative: no links/substs/fields/nil. *)
-      match Types.get_desc ty with
-      | Types.Tvar { name = _name; jkind }
-      | Types.Tunivar { name = _name; jkind } ->
-        (* Keep a rigid param, but cap it by its annotated jkind. *)
-        Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind)
-      | Types.Tconstr (path, args, _abbrev_memo) -> constr ctx path args
-      | Types.Tmod (ty, mod_bounds) ->
-        Ldd.meet
-          (kind ~use_tables:true ctx ty)
-          (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
-      | Types.Ttuple elts ->
-        (* Boxed tuples: immutable_data base + per-element contributions
-           under id modality. *)
-        let base = Ldd.const Axis_lattice.immutable_data in
-        Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
-      | Types.Tunboxed_tuple elts ->
-        (* Unboxed tuples: per-element contributions; shallow axes relevant
-           only for arity = 1. *)
-        Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
-            kind ~use_tables:true ctx t)
-      | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
-        (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
-        Ldd.const Axis_lattice.arrow
-      | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
-      | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
-      | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
-      | Types.Tpoly (ty, univars) ->
-        (* CR ikinds: this is sound but not fully precise.
-          Internal ticket 5746. *)
-        let ty = !instance_poly_for_jkind' univars ty in
-        (* We intentionally skip the principality check here. Enforcing it
-           breaks the stdlib build, and the old env-var escape hatch never had
-           a viable setting in practice. Track removing this workaround as part
-           of internal ticket 5746. *)
-        kind ~check_principality:false ~use_tables:true ctx ty
-      | Types.Tof_kind jkind -> ckind_of_jkind ctx jkind
-      | Types.Tobject _ -> Ldd.const Axis_lattice.object_legacy
-      | Types.Tbox t ->
-        let base = Ldd.const Axis_lattice.mutable_data in
-        Ldd.join base (kind ~use_tables:true ctx t)
-      | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
-      | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
-      | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
-        (* Treat quoted/spliced/evaluated quoted types conservatively as
-           boxed values. *)
-        Ldd.const Axis_lattice.value
-      | Types.Tvariant row ->
-        if Btype.tvariant_not_immediate row
-        then
-          if Btype.static_row row
-          then
-            (* Closed, boxed polymorphic variant: immutable_data base plus
-               per-constructor args. *)
-            let base = Ldd.const Axis_lattice.immutable_data in
-            Btype.fold_row
-              (fun acc ty ->
-                let ty_kind = kind ~use_tables:true ctx ty in
-                Ldd.join acc ty_kind)
-              base row
-          else
-            (* CR ikinds: open rows get conservative non-float value (boxed)
-               intersected with an unknown rigid so the solver treats it as an
-               unknown element. This can be improved. Internal ticket 6205. *)
-            let unknown =
-              rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-            in
-            Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
-        else
-          (* All-constant (immediate) polymorphic variant. *)
-          Ldd.const Axis_lattice.immediate
-      | Types.Tpackage _ ->
-        (* Like open polymorphic variants, model first-class modules as boxed
-           values intersected with an unknown so they behave as not-best. *)
-        let unknown =
-          rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
-        in
-        Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown
+    let self_provenance poly =
+      if ctx.add_provenance then Ldd.meet poly (provenance ctx ty) else poly
     in
-    kind_poly
+    (* [ty] is expected to be representative: no links/substs/fields/nil.
+       Provenance is attached only to the contribution introduced by this
+       node, not to recursive child contributions. *)
+    match Types.get_desc ty with
+    | Types.Tvar { name = _name; jkind } | Types.Tunivar { name = _name; jkind }
+      ->
+      (* Keep a rigid param, but cap it by its annotated jkind. *)
+      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind))
+    | Types.Tconstr (path, args, _abbrev_memo) ->
+      constr ~self_ty:ty ctx path args
+    | Types.Tmod (ty, mod_bounds) ->
+      Ldd.meet
+        (kind ~use_tables:true ctx ty)
+        (Ldd.const (Jkind.Mod_bounds.to_axis_lattice mod_bounds))
+    | Types.Ttuple elts ->
+      (* Boxed tuples: immutable_data base + per-element contributions
+         under id modality. *)
+      let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
+    | Types.Tunboxed_tuple elts ->
+      (* Unboxed tuples: per-element contributions; shallow axes relevant
+         only for arity = 1. *)
+      Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
+          kind ~use_tables:true ctx t)
+    | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
+      (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
+      self_provenance (Ldd.const Axis_lattice.arrow)
+    | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
+    | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
+    | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
+    | Types.Tpoly (ty, univars) ->
+      (* CR ikinds: this is sound but not fully precise.
+        Internal ticket 5746. *)
+      let ty = !instance_poly_for_jkind' univars ty in
+      (* We intentionally skip the principality check here. Enforcing it
+         breaks the stdlib build, and the old env-var escape hatch never had
+         a viable setting in practice. Track removing this workaround as part
+         of internal ticket 5746. *)
+      kind ~check_principality:false ~use_tables:true ctx ty
+    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind ctx jkind)
+    | Types.Tobject _ -> self_provenance (Ldd.const Axis_lattice.object_legacy)
+    | Types.Tbox t ->
+      let base = self_provenance (Ldd.const Axis_lattice.mutable_data) in
+      Ldd.join base (kind ~use_tables:true ctx t)
+    | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
+    | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
+    | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
+      (* Treat quoted/spliced/evaluated quoted types conservatively as
+         boxed values. *)
+      self_provenance (Ldd.const Axis_lattice.value)
+    | Types.Tvariant row ->
+      if Btype.tvariant_not_immediate row
+      then
+        if Btype.static_row row
+        then
+          (* Closed, boxed polymorphic variant: immutable_data base plus
+             per-constructor args. *)
+          let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
+          Btype.fold_row
+            (fun acc ty ->
+              let ty_kind = kind ~use_tables:true ctx ty in
+              Ldd.join acc ty_kind)
+            base row
+        else
+          (* CR ikinds: open rows get conservative non-float value (boxed)
+             intersected with an unknown rigid so the solver treats it as an
+             unknown element. This can be improved. Internal ticket 6205. *)
+          let unknown =
+            rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ()))
+          in
+          self_provenance
+            (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
+      else
+        (* All-constant (immediate) polymorphic variant. *)
+        self_provenance (Ldd.const Axis_lattice.immediate)
+    | Types.Tpackage _ ->
+      (* Like open polymorphic variants, model first-class modules as boxed
+         values intersected with an unknown so they behave as not-best. *)
+      let unknown = rigid_name ctx (Ldd.Name.unknown (fresh_unknown_uid ())) in
+      self_provenance (Ldd.meet (Ldd.const Axis_lattice.nonfloat_value) unknown)
 
   (* Evaluate a ckind in [ctx] and flush pending GFP constraints. *)
   let normalize (kind_poly : Ldd.node) : Ldd.node =
@@ -547,6 +602,369 @@ let pp_axes (axes : Jkind_axis.Axis.packed list) : string =
   |> List.map (fun (Jkind_axis.Axis.Pack ax) -> Jkind_axis.Axis.name ax)
   |> String.concat ", "
 
+let axis_name (Jkind_axis.Axis.Pack ax) = Jkind_axis.Axis.name ax
+
+let same_axis a b = String.equal (axis_name a) (axis_name b)
+
+let pp_axis_name ppf axis = Format_doc.fprintf ppf "%s" (axis_name axis)
+
+let pp_axis_list_prose ppf (axes : Jkind_axis.Axis.packed list) =
+  match axes with
+  | [] -> Format_doc.fprintf ppf "<none>"
+  | [axis] -> pp_axis_name ppf axis
+  | [axis1; axis2] ->
+    Format_doc.fprintf ppf "%a and %a" pp_axis_name axis1 pp_axis_name axis2
+  | _ ->
+    let rec split_last = function
+      | [] -> assert false
+      | [last] -> [], last
+      | x :: xs ->
+        let init, last = split_last xs in
+        x :: init, last
+    in
+    let init, last = split_last axes in
+    Format_doc.fprintf ppf "%a,@ and %a"
+      (Format_doc.pp_print_list
+         ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf ",@ ")
+         pp_axis_name)
+      init pp_axis_name last
+
+let collapse_whitespace s =
+  let b = Buffer.create (String.length s) in
+  let pending_space = ref false in
+  String.iter
+    (function
+      | ' ' | '\n' | '\r' | '\t' ->
+        if Buffer.length b > 0 then pending_space := true
+      | c ->
+        if !pending_space
+        then (
+          Buffer.add_char b ' ';
+          pending_space := false);
+        Buffer.add_char b c)
+    s;
+  Buffer.contents b
+
+let remove_numeric_path_stamps s =
+  let b = Buffer.create (String.length s) in
+  let is_digit = function '0' .. '9' -> true | _ -> false in
+  let rec loop i =
+    if i >= String.length s
+    then ()
+    else
+      match s.[i] with
+      | '/' when i + 1 < String.length s && is_digit s.[i + 1] ->
+        let rec skip_digits j =
+          if j < String.length s && is_digit s.[j]
+          then skip_digits (j + 1)
+          else j
+        in
+        loop (skip_digits (i + 1))
+      | c ->
+        Buffer.add_char b c;
+        loop (i + 1)
+  in
+  loop 0;
+  Buffer.contents b
+
+let format_jkind_single_line env jkind =
+  Format_doc.asprintf "%a" (Jkind.format env) jkind
+  |> collapse_whitespace |> remove_numeric_path_stamps
+
+let pp_breakable_words ppf s =
+  s |> String.split_on_char ' '
+  |> List.filter (fun s -> not (String.equal s ""))
+  |> Format_doc.pp_print_list
+       ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
+       Format_doc.pp_print_string ppf
+
+let split_on_first_substring ~sub s =
+  let len = String.length s in
+  let sub_len = String.length sub in
+  let rec loop i =
+    if i + sub_len > len
+    then None
+    else if String.equal (String.sub s i sub_len) sub
+    then
+      let before = String.sub s 0 i in
+      let after = String.sub s (i + sub_len) (len - i - sub_len) in
+      Some (before, after)
+    else loop (i + 1)
+  in
+  loop 0
+
+let pp_breakable_jkind_annotation ppf s =
+  match split_on_first_substring ~sub:" with " s with
+  | None -> pp_breakable_words ppf s
+  | Some (before, after) ->
+    Format_doc.fprintf ppf "@[<v 2>%s@;with %s@]" before after
+
+let is_bot_poly poly = Axis_lattice.equal (Ldd.round_up poly) Axis_lattice.bot
+
+let axes_in_violation_order ~violating_axes axes =
+  (* Keep only axes that the overall comparison actually failed on, ordered as
+     in [violating_axes]. A fragment residual can be non-top on a non-violating
+     axis because [round_down] under-approximates the symbolic implication, so
+     intersecting here prevents blaming a fragment on an axis the whole
+     comparison passes on. *)
+  List.filter
+    (fun violating_axis -> List.exists (same_axis violating_axis) axes)
+    violating_axes
+
+type mode_crossing_error =
+  { origin : string option;
+    sub_jkind : Types.jkind_l;
+    super_jkind : Types.jkind_l;
+    sub_poly : Ldd.node;
+    super_poly : Ldd.node;
+    failing_poly : Ldd.node;
+    fast_path : string;
+    provenance_names : Ldd.Name.t list;
+    violating_axes : Jkind_axis.Axis.packed list
+  }
+
+type subjkind_error =
+  | Jkind_error of Jkind.Violation.t
+  | Mode_crossing_error of mode_crossing_error
+
+type provenance_residual =
+  { ty : string;
+    mode_bounds : Axis_lattice.t;
+    axes : Jkind_axis.Axis.packed list
+  }
+
+let provenance_ty_of_name (name : Ldd.Name.t) =
+  match name with
+  | Provenance { ty; _ } -> Some ty
+  | Atom _ | KAtom _ | Param _ | Unknown _ -> None
+
+let add_provenance_residual entries { ty; mode_bounds; axes } =
+  match List.partition (fun entry -> String.equal entry.ty ty) entries with
+  | [], rest -> { ty; mode_bounds; axes } :: rest
+  | matching, rest ->
+    let axes =
+      List.fold_left
+        (fun axes entry ->
+          List.fold_left
+            (fun axes axis ->
+              if List.exists (same_axis axis) axes then axes else axes @ [axis])
+            axes entry.axes)
+        axes matching
+    in
+    let mode_bounds =
+      List.fold_left
+        (fun mode_bounds entry ->
+          Axis_lattice.meet mode_bounds entry.mode_bounds)
+        mode_bounds matching
+    in
+    { ty; mode_bounds; axes } :: rest
+
+let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+    =
+  let provenance_vars = List.map Ldd.rigid provenance_names in
+  (* For a declaration [type t : bound = rhs], ikind checking compares the
+     inferred ikind polynomial for [rhs] against the polynomial for [bound].
+     When that comparison fails, we recompute [rhs] with provenance variables
+     inserted by meeting a fresh variable into each local contribution. For a
+     contribution [coeff] tagged by provenance variable [p], the error
+     reporting question is:
+
+       What is the largest assignment to [p] that would make this contribution
+       satisfy the required bound?
+
+     This is the right question because the provenance variable stands for the
+     mode-crossing behavior we need from the source type. It gives the least
+     restrictive bound that would still make the original lattice comparison
+     pass.
+
+     We answer the question by first decomposing the provenance-annotated
+     polynomial into an untracked base plus one coefficient per provenance
+     variable. If the base alone does not satisfy [super_poly], then provenance
+     cannot explain the error. Otherwise, for each coefficient [coeff], we need
+     the greatest [h] such that:
+
+       meet coeff h <= super_poly
+
+     This is exactly [Ldd.imply coeff super_poly]. The result may still contain
+     symbolic variables, so we round it down to a conservative concrete mode
+     bound for printing. *)
+  let base, coeffs =
+    Ldd.decompose_into_linear_terms ~universe:provenance_vars sub_poly
+  in
+  if Ldd.leq_with_reason base super_poly <> []
+  then None
+  else
+    List.combine provenance_names coeffs
+    |> List.filter_map (fun (name, coeff) ->
+        if is_bot_poly coeff
+        then None
+        else
+          match provenance_ty_of_name name with
+          | None -> None
+          | Some ty ->
+            let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
+            let non_top_bounds =
+              Axis_lattice.co_sub Axis_lattice.top mode_bounds
+            in
+            if Axis_lattice.equal non_top_bounds Axis_lattice.bot
+            then None
+            else
+              let axes =
+                non_top_bounds |> Axis_lattice.non_bot_axes
+                |> List.map Axis_lattice.axis_number_to_axis_packed
+                |> axes_in_violation_order ~violating_axes
+              in
+              Some { ty; mode_bounds; axes })
+    |> List.fold_left add_provenance_residual []
+    |> List.rev |> Option.some
+
+let string_of_required_bound required_bounds (Jkind_axis.Axis.Pack axis) =
+  match axis with
+  | Modal (Monadic Uniqueness) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Uniqueness.Const.print
+         (Axis_lattice.uniqueness required_bounds))
+  | Modal (Monadic Contention) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Contention.Const.print
+         (Axis_lattice.contention required_bounds))
+  | Modal (Monadic Visibility) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Visibility.Const.print
+         (Axis_lattice.visibility required_bounds))
+  | Modal (Monadic Staticity) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Staticity.Const.print
+         (Axis_lattice.staticity required_bounds))
+  | Modal (Comonadic Areality) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Regionality.Const.print
+         (Axis_lattice.areality required_bounds))
+  | Modal (Comonadic Linearity) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Linearity.Const.print
+         (Axis_lattice.linearity required_bounds))
+  | Modal (Comonadic Portability) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Portability.Const.print
+         (Axis_lattice.portability required_bounds))
+  | Modal (Comonadic Forkable) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Forkable.Const.print
+         (Axis_lattice.forkable required_bounds))
+  | Modal (Comonadic Yielding) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Yielding.Const.print
+         (Axis_lattice.yielding required_bounds))
+  | Modal (Comonadic Statefulness) ->
+    Some
+      (Format_doc.asprintf "%a" Mode.Statefulness.Const.print
+         (Axis_lattice.statefulness required_bounds))
+  | Nonmodal Externality ->
+    Some
+      (Format_doc.asprintf "%a" Jkind_axis.Externality.print
+         (Axis_lattice.externality required_bounds))
+
+let pp_provenance_residual ppf { ty; mode_bounds; axes; _ } =
+  let modes = List.filter_map (string_of_required_bound mode_bounds) axes in
+  Format_doc.fprintf ppf "@[<hov 2>%s is not mod %a@]" ty
+    (Format_doc.pp_print_list
+       ~pp_sep:(fun ppf () -> Format_doc.fprintf ppf "@ ")
+       Format_doc.pp_print_string)
+    modes
+
+let pp_provenance_residual_bullets ppf entries =
+  List.iteri
+    (fun i entry ->
+      if i > 0 then Format_doc.fprintf ppf "@;";
+      Format_doc.fprintf ppf "- %a" pp_provenance_residual entry)
+    entries
+
+let pp_type_definition_kind_annotation env ppf super_jkind =
+  let super_jkind_single_line = format_jkind_single_line env super_jkind in
+  let single_line_prefix =
+    "Error: This type definition does not satisfy its kind annotation "
+  in
+  let error_prefix_width = String.length "Error: " in
+  let continuation_indent = 2 in
+  let continuation_prefix_width = error_prefix_width + continuation_indent in
+  if
+    String.length single_line_prefix + String.length super_jkind_single_line + 1
+    <= 88
+  then
+    Format_doc.fprintf ppf
+      "This type definition does not satisfy its kind annotation %s,"
+      super_jkind_single_line
+  else if
+    continuation_prefix_width + String.length super_jkind_single_line + 1 <= 88
+  then
+    Format_doc.fprintf ppf
+      "@[<v 2>This type definition does not satisfy its kind annotation@;%s,@]"
+      super_jkind_single_line
+  else
+    Format_doc.fprintf ppf
+      "@[<v 2>This type definition does not satisfy its kind annotation@;\
+       @[<hov>%a,@]@]"
+      pp_breakable_jkind_annotation super_jkind_single_line
+
+let report_provenance_mode_crossing_error env ppf
+    { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =
+  match
+    provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+  with
+  | None | Some [] -> None
+  | Some [entry] ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because %a.@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual entry)
+  | Some entries ->
+    Some
+      (Format_doc.fprintf ppf "@[<v>%a@;because@;%a@]"
+         (pp_type_definition_kind_annotation env)
+         super_jkind pp_provenance_residual_bullets entries)
+
+let report_mode_crossing_error ~offender env ppf
+    { origin;
+      sub_jkind;
+      super_jkind;
+      sub_poly;
+      super_poly;
+      failing_poly;
+      fast_path;
+      provenance_names;
+      violating_axes
+    } =
+  let err =
+    { origin;
+      sub_jkind;
+      super_jkind;
+      sub_poly;
+      super_poly;
+      failing_poly;
+      fast_path;
+      provenance_names;
+      violating_axes
+    }
+  in
+  match report_provenance_mode_crossing_error env ppf err with
+  | Some () -> ()
+  | None ->
+    Format_doc.fprintf ppf
+      "@[<v>The mode crossing of %t is not allowed here.@;\
+       @[<hov 2>The inferred kind is not below the required kind along %a.@]@]"
+      offender pp_axis_list_prose violating_axes
+
+let report_subjkind_error_with_offender ~offender env ppf = function
+  | Jkind_error err ->
+    Jkind.Violation.report_with_offender ~offender env ppf err
+  | Mode_crossing_error err -> report_mode_crossing_error ~offender env ppf err
+
+let report_subjkind_error_with_name ~name env ppf err =
+  report_subjkind_error_with_offender
+    ~offender:(fun ppf -> Format_doc.fprintf ppf "%s" name)
+    env ppf err
+
 let axis_disagreement_reasons (axes : Jkind_axis.Axis.packed list) :
     Jkind.Sub_failure_reason.t list =
   List.map (fun axis -> Jkind.Sub_failure_reason.Axis_disagreement axis) axes
@@ -560,13 +978,15 @@ let label_mutability_contribution (lbl : Types.label_declaration) =
 
 let sum_record_label_contributions ~(base : Ldd.node)
     ~(payload_kind : Types.type_expr -> Ldd.node)
+    ?(label_mutability_provenance =
+      fun (_ : Types.label_declaration) (poly : Ldd.node) -> poly)
     ~(validate_label : Types.label_declaration -> unit)
     (lbls : Types.label_declaration list) : Ldd.node =
   Ldd.sum lbls ~base ~f:(fun (lbl : Types.label_declaration) ->
       validate_label lbl;
       let mask = Axis_lattice.mask_of_modality lbl.ld_modalities in
       Ldd.join
-        (label_mutability_contribution lbl)
+        (label_mutability_provenance lbl (label_mutability_contribution lbl))
         (Ldd.meet (Ldd.const mask) (payload_kind lbl.ld_type)))
 
 let no_validation (_ : Types.label_declaration) = ()
@@ -576,6 +996,30 @@ let validate_immutable_unboxed_label (lbl : Types.label_declaration) =
   | Immutable -> ()
   | Mutable _ ->
     failwith "ikind: mutable fields in unboxed records are not supported"
+
+let format_type_expr_single_line ty =
+  Format_doc.asprintf "%a" Jkind.format_type_expr ty
+  |> String.map (function '\n' | '\r' | '\t' -> ' ' | c -> c)
+
+let label_mutability_provenance (ctx : Solver.ctx)
+    (lbl : Types.label_declaration) (poly : Ldd.node) : Ldd.node =
+  match lbl.ld_mutable with
+  | Immutable -> poly
+  | Mutable { atomic = Nonatomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () ->
+        Format.sprintf "mutable field %s : %s" (Ident.name lbl.ld_id)
+          (format_type_expr_single_line lbl.ld_type))
+      poly
+  | Mutable { atomic = Atomic; _ } ->
+    Solver.with_provenance_text ctx
+      (fun () ->
+        Format.sprintf "mutable field %s : %s [@atomic]" (Ident.name lbl.ld_id)
+          (format_type_expr_single_line lbl.ld_type))
+      poly
+
+let decl_base_provenance (ctx : Solver.ctx) source poly =
+  Solver.with_provenance_text ctx (fun () -> source) poly
 
 (* Gather constructor-local vars from [tys]. *)
 let collect_type_vars (tys : Types.type_expr list) :
@@ -688,7 +1132,8 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
                   | Some bound -> bound
                   | None -> Ldd.const Axis_lattice.top
                 else Solver.node_of_name ctx name)
-            | Ldd.Name.Unknown _ | Ldd.Name.Atom _ | Ldd.Name.KAtom _ ->
+            | Ldd.Name.Unknown _ | Ldd.Name.Provenance _ | Ldd.Name.Atom _
+            | Ldd.Name.KAtom _ ->
               Solver.node_of_name ctx name
           in
           fun ty ->
@@ -697,6 +1142,117 @@ let make_gadt_payload_projector ~(decl_params : Types.type_expr list)
       | _ ->
         failwith
           "ikind: expected GADT constructor result to be a type constructor")
+
+let type_decl_allows_any_crossing (decl : Types.type_declaration) =
+  match decl.type_kind with
+  | Types.Type_record (_, _, umc_opt)
+  | Types.Type_record_unboxed_product (_, _, umc_opt)
+  | Types.Type_variant (_, _, umc_opt) ->
+    Option.is_some umc_opt
+  | Types.Type_abstract _ | Types.Type_open -> false
+
+let type_decl_rhs_kind_poly (ctx : Solver.ctx) (decl : Types.type_declaration) :
+    Ldd.node =
+  match decl.type_manifest with
+  | Some body_ty -> Solver.kind ~use_tables:true ctx body_ty
+  | None -> (
+    let use_decl_jkind () = Solver.ckind_of_jkind ctx decl.type_jkind in
+    match decl.type_kind with
+    (* For abstract types and allow_any_crossing types, derive the ikind from
+       the jkind annotation instead of computing it from the type declaration's
+       body. *)
+    | _ when type_decl_allows_any_crossing decl -> use_decl_jkind ()
+    | Types.Type_abstract _ | Types.Type_open -> use_decl_jkind ()
+    | Types.Type_record (lbls, rep, _umc_opt) ->
+      let base =
+        Ldd.const
+          (match rep with
+          | Types.Record_unboxed -> Axis_lattice.immediate
+          (* CR box: This will no longer be [non_float] once we update the
+             representation of singleton float64 records *)
+          | _ -> Axis_lattice.immutable_data)
+        |> decl_base_provenance ctx "this record type"
+      in
+      sum_record_label_contributions ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~label_mutability_provenance:(label_mutability_provenance ctx)
+        ~validate_label:no_validation lbls
+    | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
+      let base =
+        Ldd.const Axis_lattice.immediate
+        |> decl_base_provenance ctx "this unboxed record type"
+      in
+      sum_record_label_contributions ~base
+        ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
+        ~label_mutability_provenance:(label_mutability_provenance ctx)
+        ~validate_label:validate_immutable_unboxed_label lbls
+    | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
+      (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
+         captured by its constructors: nullability/separability and
+         mode-crossing are baked into its representation. We defer to jkinds
+         because ikinds cannot express this today. This deferral can be removed
+         once separability and nullability become layout properties rather than
+         modal axes. *)
+      use_decl_jkind ()
+    | Types.Type_variant (cstrs, rep, _umc_opt) ->
+      (* Choose base: immediate for void-only variants; otherwise immutable. *)
+      let all_args_void =
+        List.for_all
+          (fun (c : Types.constructor_declaration) ->
+            match c.cd_args with
+            | Types.Cstr_tuple args ->
+              List.for_all
+                (fun (arg : Types.constructor_argument) ->
+                  match arg.ca_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                args
+            | Types.Cstr_record lbls ->
+              List.for_all
+                (fun (lbl : Types.label_declaration) ->
+                  match lbl.ld_sort with
+                  | Some sort -> Jkind_types.Sort.Const.all_void sort
+                  | None -> false)
+                lbls)
+          cstrs
+      in
+      let base =
+        let base_lat =
+          match rep with
+          | Types.Variant_unboxed -> Axis_lattice.immediate
+          | _ ->
+            if all_args_void
+            then Axis_lattice.immediate
+            else Axis_lattice.immutable_data
+        in
+        Ldd.const base_lat |> decl_base_provenance ctx "this variant type"
+      in
+      let payload_kind_of_constructor =
+        make_gadt_payload_projector ~decl_params:decl.type_params ctx
+      in
+      let constructor_contrib (c : Types.constructor_declaration) =
+        let payload_kind = payload_kind_of_constructor c in
+        match c.cd_args with
+        | Types.Cstr_tuple args ->
+          Ldd.sum args ~base:Ldd.bot
+            ~f:(fun (arg : Types.constructor_argument) ->
+              let mask = Axis_lattice.mask_of_modality arg.ca_modalities in
+              Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
+        | Types.Cstr_record lbls ->
+          sum_record_label_contributions ~base:Ldd.bot ~payload_kind
+            ~label_mutability_provenance:(label_mutability_provenance ctx)
+            ~validate_label:no_validation lbls
+      in
+      Ldd.sum cstrs ~base ~f:constructor_contrib)
+
+let type_decl_constr_decl (decl : Types.type_declaration) : Solver.constr_decl =
+  let abstract =
+    match decl.type_manifest, decl.type_kind with
+    | None, Types.Type_abstract _ -> not (Jkind.is_best decl.type_jkind)
+    | _ -> false
+  in
+  let kind ctx = type_decl_rhs_kind_poly ctx decl in
+  Solver.Ty { args = decl.type_params; kind; abstract }
 
 (* Lookup function supplied to the solver.
    We prefer a stored ikind (when present) and otherwise recompute from the
@@ -718,144 +1274,9 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
   | type_decl ->
     (* Here we can switch to using the cached ikind or not. *)
     let fallback () =
-      (* When we have no stored ikind, we go to this fallback and compute. *)
-      match type_decl.type_manifest with
-      | Some body_ty ->
-        (* Concrete: compute kind of body. *)
-        let args = type_decl.type_params in
-        let kind : Solver.ckind =
-         fun ctx -> Solver.kind ~use_tables:true ctx body_ty
-        in
-        Solver.Ty { args; kind; abstract = false }
-      | None -> (
-        (* No manifest: may still be "concrete" (record/variant/...).
-           Build ckind. *)
-        let allow_any_crossing =
-          match type_decl.type_kind with
-          | Types.Type_record (_, _, umc_opt)
-          | Types.Type_record_unboxed_product (_, _, umc_opt)
-          | Types.Type_variant (_, _, umc_opt) ->
-            Option.is_some umc_opt
-          | Types.Type_abstract _ | Types.Type_open -> false
-        in
-        let use_decl_jkind ~treat_as_abstract =
-          let kind : Solver.ckind =
-           fun ctx -> Solver.ckind_of_jkind ctx type_decl.type_jkind
-          in
-          Solver.Ty
-            { args = type_decl.type_params; kind; abstract = treat_as_abstract }
-        in
-        match type_decl.type_kind with
-        (* For abstract types and allow_any_crossing types, we derive the
-           ikind from the jkind annotation, instead of computing it from
-           the type declaration's body: *)
-        | _ when allow_any_crossing -> use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_abstract _ ->
-          use_decl_jkind
-            ~treat_as_abstract:(not (Jkind.is_best type_decl.type_jkind))
-        (* For other cases, we compute the ikind from the type definition{} *)
-        | Types.Type_record (lbls, rep, _umc_opt) ->
-          (* Build from components: base (non-float value) + per-label
-             contributions. *)
-          let immutable_base =
-            Ldd.const
-              (match rep with
-              | Types.Record_unboxed -> Axis_lattice.immediate
-              (* CR box: This will no longer be [non_float] once we update the
-                 representation of singleton float64 records *)
-              | _ -> Axis_lattice.immutable_data)
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            sum_record_label_contributions ~base:immutable_base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:no_validation lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_record_unboxed_product (lbls, _rep, _umc_opt) ->
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base = Ldd.const Axis_lattice.immediate in
-            sum_record_label_contributions ~base
-              ~payload_kind:(fun ty -> Solver.kind ~use_tables:true ctx ty)
-              ~validate_label:validate_immutable_unboxed_label lbls
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_variant (_cstrs, Types.Variant_with_null, _umc_opt) ->
-          (* [Variant_with_null] (i.e. [or_null]) has semantics that are not
-             captured by its constructors: nullability/separability and
-             mode-crossing are baked into its representation. We defer to
-             jkinds because ikinds cannot express this today. This deferral
-             can be removed once separability and nullability become layout
-             properties rather than modal axes. *)
-          use_decl_jkind ~treat_as_abstract:false
-        | Types.Type_variant (cstrs, rep, _umc_opt) ->
-          (* Choose base: immediate for void-only variants; sync if any record
-             field is atomic; mutable if any non-atomic mutable field appears;
-             otherwise immutable. *)
-          let all_args_void =
-            List.for_all
-              (fun (c : Types.constructor_declaration) ->
-                match c.cd_args with
-                | Types.Cstr_tuple args ->
-                  List.for_all
-                    (fun (arg : Types.constructor_argument) ->
-                      match arg.ca_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    args
-                | Types.Cstr_record lbls ->
-                  List.for_all
-                    (fun (lbl : Types.label_declaration) ->
-                      match lbl.ld_sort with
-                      | Some sort -> Jkind_types.Sort.Const.all_void sort
-                      | None -> false)
-                    lbls)
-              cstrs
-          in
-          let kind : Solver.ckind =
-           fun (ctx : Solver.ctx) ->
-            let base_lat0 =
-              match rep with
-              | Types.Variant_unboxed -> Axis_lattice.immediate
-              | _ ->
-                if all_args_void
-                then Axis_lattice.immediate
-                else Axis_lattice.immutable_data
-            in
-            let payload_kind_of_constructor =
-              make_gadt_payload_projector ~decl_params:type_decl.type_params ctx
-            in
-            let constructor_contrib (c : Types.constructor_declaration) =
-              let payload_kind = payload_kind_of_constructor c in
-              match c.cd_args with
-              | Types.Cstr_tuple args ->
-                Ldd.sum args ~base:Ldd.bot
-                  ~f:(fun (arg : Types.constructor_argument) ->
-                    let mask =
-                      Axis_lattice.mask_of_modality arg.ca_modalities
-                    in
-                    Ldd.meet (Ldd.const mask) (payload_kind arg.ca_type))
-              | Types.Cstr_record lbls ->
-                sum_record_label_contributions ~base:Ldd.bot ~payload_kind
-                  ~validate_label:no_validation lbls
-            in
-            Ldd.sum cstrs ~base:(Ldd.const base_lat0) ~f:constructor_contrib
-          in
-          Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        | Types.Type_open ->
-          (* Use the stored jkind here in case it is `exn`,
-             which is special. *)
-          use_decl_jkind ~treat_as_abstract:false
-        (*
-           (* This is the code we'd use otherwise *)
-           let kind : Solver.ckind =
-            fun _ctx ->
-             Ldd.const Axis_lattice.nonfloat_value
-           in
-           Solver.Ty { args = type_decl.type_params; kind; abstract = false }
-        *)
-        )
+      (* When we have no stored ikind, compute from the declaration through the
+         same RHS builder used for bound diagnostics. *)
+      type_decl_constr_decl type_decl
     in
     (* Prefer a stored constructor ikind if one is present and enabled. *)
     let ikind =
@@ -885,8 +1306,8 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
 
 (* Package the above into a full evaluation context. *)
 let create_ctx ~(mode : Solver.mode) ~(env : Env.t option) =
-  Solver.create_ctx ~mode ~env ~lookup_of_env:(fun env path ->
-      lookup_of_env ~env path)
+  Solver.create_ctx ~mode ~env ~add_provenance:false
+    ~lookup_of_env:(fun env path -> lookup_of_env ~env path)
 
 let normalize ~(env : Env.t option) (jkind : Types.jkind_l) : Ldd.node =
   let ctx = create_ctx ~mode:Solver.Normal ~env in
@@ -953,19 +1374,21 @@ type subcheck_fast_path =
   | Rhs_top_fast_path
   | Lhs_mod_bounds_floor_fast_path
 
+let string_of_subcheck_fast_path = function
+  | No_fast_path -> "none"
+  | Rhs_top_fast_path -> "rhs_top"
+  | Lhs_mod_bounds_floor_fast_path -> "lhs_mod_bounds_floor"
+
 type subcheck_polys =
   { lhs_for_leq : Ldd.node;
     rhs_for_leq : Ldd.node;
     fast_path : subcheck_fast_path
   }
 
-(* Compute polynomials for a subcheck:
-   - compute [super] in Normal mode
-   - fast path: if [super] is constant top, no need to compute [sub]
-   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
-   - otherwise, only round up [sub] if [super] is constant *)
-let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
-    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+let compute_bound_polys env (super : ('l2 * 'r2) Types.jkind)
+    ~(lhs_floor : (Solver.ctx -> Ldd.node option) option)
+    ~(lhs : Solver.ctx -> Ldd.node) : subcheck_polys =
+  Provenance.reset ();
   let ctx = create_ctx ~mode:Solver.Normal ~env:(Some env) in
   let super_poly = Solver.ckind_of_jkind ctx super in
   let super_is_constant =
@@ -984,16 +1407,19 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     let floor_fast_path =
       if super_is_constant
       then
-        match Solver.mod_bounds_floor_of_jkind ctx sub with
+        match lhs_floor with
         | None -> None
-        | Some lhs_floor ->
-          let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
-          if
-            Axis_lattice.equal
-              (Ldd.round_up lhs_floor_or_super)
-              Axis_lattice.top
-          then Some lhs_floor
-          else None
+        | Some lhs_floor -> (
+          match lhs_floor ctx with
+          | None -> None
+          | Some lhs_floor ->
+            let lhs_floor_or_super = Ldd.join lhs_floor super_poly in
+            if
+              Axis_lattice.equal
+                (Ldd.round_up lhs_floor_or_super)
+                Axis_lattice.top
+            then Some lhs_floor
+            else None)
       else None
     in
     match floor_fast_path with
@@ -1003,31 +1429,117 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
         fast_path = Lhs_mod_bounds_floor_fast_path
       }
     | None ->
-      let sub_ctx =
+      let lhs_ctx =
         if super_is_constant
         then Solver.reset_for_mode ctx ~mode:Solver.Round_up
         else ctx
       in
-      let sub_poly = Solver.ckind_of_jkind sub_ctx sub in
-      { lhs_for_leq = sub_poly;
+      let lhs_poly = lhs lhs_ctx in
+      { lhs_for_leq = lhs_poly;
         rhs_for_leq = super_poly;
         fast_path = No_fast_path
       }
 
+(* Compute polynomials for a subcheck:
+   - compute [super] in Normal mode
+   - fast path: if [super] is constant top, no need to compute [sub]
+   - otherwise, if [super] is constant, try the lhs mod-bounds floor fast path
+   - otherwise, only round up [sub] if [super] is constant *)
+let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
+    (super : ('l2 * 'r2) Types.jkind) : subcheck_polys =
+  compute_bound_polys env super
+    ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
+    ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
+
+let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
+    (bound : Types.jkind_l) : subcheck_polys =
+  compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
+      let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
+      lhs ctx)
+
+let check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind
+    { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
+  let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
+  let failing_poly = Ldd.sub_subsets sub_poly super_poly in
+  match violating_axes with
+  | [] -> Ok ()
+  | _ ->
+    Error
+      (Mode_crossing_error
+         { origin;
+           sub_jkind;
+           super_jkind;
+           sub_poly;
+           super_poly;
+           failing_poly;
+           fast_path = string_of_subcheck_fast_path fast_path;
+           provenance_names = Provenance.all_names ();
+           violating_axes
+         })
+
+let subjkind_error_has_provenance_residuals = function
+  | Jkind_error _ -> false
+  | Mode_crossing_error
+      { sub_poly; super_poly; provenance_names; violating_axes; _ } -> (
+    match
+      provenance_residuals ~provenance_names ~violating_axes ~sub_poly
+        ~super_poly
+    with
+    | None | Some [] -> false
+    | Some (_ :: _) -> true)
+
+let same_axis_set axes1 axes2 =
+  List.length axes1 = List.length axes2
+  && List.for_all (fun axis1 -> List.exists (same_axis axis1) axes2) axes1
+
+let subjkind_errors_have_same_violating_axes error1 error2 =
+  match error1, error2 with
+  | ( Mode_crossing_error { violating_axes = axes1; _ },
+      Mode_crossing_error { violating_axes = axes2; _ } ) ->
+    same_axis_set axes1 axes2
+  | Jkind_error _, _ | _, Jkind_error _ -> false
+
+let best_effort_provenance_error ?fallback_error ~origin ~sub_jkind ~super_jkind
+    actual_error make_polys =
+  let fallback error =
+    match fallback_error with
+    | None -> Error error
+    | Some fallback_error -> (
+      match fallback_error () with
+      | None -> Error error
+      | Some fallback_error -> Error fallback_error)
+  in
+  let provenance_check =
+    match make_polys () with
+    | provenance_polys ->
+      check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind provenance_polys
+    | exception _ -> Ok ()
+  in
+  match provenance_check with
+  | Ok () -> fallback actual_error
+  | Error provenance_error ->
+    if
+      subjkind_errors_have_same_violating_axes actual_error provenance_error
+      && subjkind_error_has_provenance_residuals provenance_error
+    then Error provenance_error
+    else fallback actual_error
+
 let sub_jkind_l ?allow_any_crossing ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)
     ~(context : Jkind.jkind_context) env (sub : Types.jkind_l)
-    (super : Types.jkind_l) : (unit, Jkind.Violation.t) result =
+    (super : Types.jkind_l) : (unit, subjkind_error) result =
   let open Misc.Stdlib.Monad.Result.Syntax in
   if not (enable_sub_jkind_l && !Clflags.ikinds)
-  then Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
+  then
+    Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub super
+    |> Result.map_error (fun err -> Jkind_error err)
   else
     (* Check layouts first; if that fails, print both sides with full
        info and return the error. *)
     let* () =
       match Jkind.sub_layout_or_error ~context env sub super with
       | Ok () -> Ok ()
-      | Error v -> Error v
+      | Error v -> Error (Jkind_error v)
     in
     let allow_any =
       match allow_any_crossing with Some true -> true | _ -> false
@@ -1043,37 +1555,78 @@ let sub_jkind_l ?allow_any_crossing ?origin
       let { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path } =
         compute_subcheck_polys ~context env sub super
       in
-      let violating_axes = Ldd.leq_with_reason sub_poly super_poly in
-      (if !Clflags.ikinds_debug
-       then
-         let origin_suffix = origin_suffix_of origin in
-         let fast_path =
-           match fast_path with
-           | No_fast_path -> "none"
-           | Rhs_top_fast_path -> "rhs_top"
-           | Lhs_mod_bounds_floor_fast_path -> "lhs_mod_bounds_floor"
-         in
-         Format.eprintf
-           "[ikind-subjkind] call%s allow_any=false fast_path=%s@;\
-            @;\
-            sub_poly=%s@;\
-            super_poly=%s@."
-           origin_suffix fast_path (Ldd.pp sub_poly) (Ldd.pp super_poly));
-      match violating_axes with
-      | [] -> Ok ()
-      | _ ->
-        let () =
-          if !Clflags.ikinds_debug
-          then
-            let axes = pp_axes violating_axes in
-            Format.eprintf "[ikind-subjkind] failure on axes: %s@." axes
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:sub ~super_jkind:super
+          { lhs_for_leq = sub_poly; rhs_for_leq = super_poly; fast_path }
+      with
+      | Ok () -> Ok ()
+      | Error ikind_error -> (
+        if !Clflags.ikinds_debug
+        then Error ikind_error
+        else
+          match
+            Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env sub
+              super
+          with
+          | Ok () -> Error ikind_error
+          | Error jkind_error -> Error (Jkind_error jkind_error))
+
+let check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+    ~bound ~provenance_lhs =
+  if not (enable_sub_jkind_l && !Clflags.ikinds)
+  then
+    sub_jkind_l ?allow_any_crossing ?origin ~type_equal ~context env actual
+      bound
+  else
+    let open Misc.Stdlib.Monad.Result.Syntax in
+    let* () =
+      match Jkind.sub_layout_or_error ~context env actual bound with
+      | Ok () -> Ok ()
+      | Error v -> Error (Jkind_error v)
+    in
+    let allow_any =
+      match allow_any_crossing with Some true -> true | _ -> false
+    in
+    if allow_any
+    then Ok ()
+    else
+      let actual_polys = compute_subcheck_polys ~context env actual bound in
+      match
+        check_mode_crossing_polys ~origin ~sub_jkind:actual ~super_jkind:bound
+          actual_polys
+      with
+      | Ok () -> Ok ()
+      | Error actual_error ->
+        let fallback_error () =
+          match
+            Jkind.sub_jkind_l ?allow_any_crossing ~type_equal ~context env
+              actual bound
+          with
+          | Ok () ->
+            let violating_axes =
+              match actual_error with
+              | Mode_crossing_error { violating_axes; _ } -> violating_axes
+              | Jkind_error _ -> []
+            in
+            let axis_reasons = axis_disagreement_reasons violating_axes in
+            Some
+              (Jkind_error
+                 (Jkind.Violation.of_ ~context env
+                    (Jkind.Violation.Not_a_subjkind (actual, bound, axis_reasons))))
+          | Error jkind_error -> Some (Jkind_error jkind_error)
         in
-        (* Do not try to adjust allowances; Violation.Not_a_subjkind
-           accepts an r-jkind. *)
-        let axis_reasons = axis_disagreement_reasons violating_axes in
-        Error
-          (Jkind.Violation.of_ ~context env
-             (Jkind.Violation.Not_a_subjkind (sub, super, axis_reasons)))
+        best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
+          ~super_jkind:bound actual_error (fun () ->
+            compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
+
+let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
+  check_bound ?origin ~type_equal ~context env ~actual ~bound
+    ~provenance_lhs:(fun ctx -> Solver.kind ~use_tables:true ctx ty)
+
+let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
+    ~decl ~actual ~bound =
+  check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =
@@ -1308,6 +1861,7 @@ let substitute_decl_ikind_with_lookup
     and map_name (expanding : Path.Set.t) (name : Ldd.Name.t) : Ldd.node =
       match name with
       | Param _ -> Ldd.node_of_var (Ldd.rigid name)
+      | Provenance _ -> Ldd.node_of_var (Ldd.rigid name)
       | Unknown _ -> Ldd.node_of_var (Ldd.rigid name)
       | KAtom path -> (
         match lookup_jkind path with

--- a/typing/ikind.mli
+++ b/typing/ikind.mli
@@ -21,6 +21,22 @@ val type_declaration_ikind_of_jkind :
   Types.jkind_l ->
   Types.type_ikind
 
+type mode_crossing_error
+
+type subjkind_error =
+  | Jkind_error of Jkind.Violation.t
+  | Mode_crossing_error of mode_crossing_error
+
+val report_subjkind_error_with_offender :
+  offender:(Format_doc.formatter -> unit) ->
+  Env.t ->
+  Format_doc.formatter ->
+  subjkind_error ->
+  unit
+
+val report_subjkind_error_with_name :
+  name:string -> Env.t -> Format_doc.formatter -> subjkind_error -> unit
+
 val sub_jkind_l :
   ?allow_any_crossing:bool ->
   ?origin:string ->
@@ -29,7 +45,28 @@ val sub_jkind_l :
   Env.t ->
   Types.jkind_l ->
   Types.jkind_l ->
-  (unit, Jkind.Violation.t) result
+  (unit, subjkind_error) result
+
+val check_type_expr_bound :
+  ?origin:string ->
+  type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
+  context:Jkind.jkind_context ->
+  Env.t ->
+  ty:Types.type_expr ->
+  actual:Types.jkind_l ->
+  bound:Types.jkind_l ->
+  (unit, subjkind_error) result
+
+val check_type_decl_bound :
+  ?allow_any_crossing:bool ->
+  ?origin:string ->
+  type_equal:(Types.type_expr -> Types.type_expr -> bool) ->
+  context:Jkind.jkind_context ->
+  Env.t ->
+  decl:Types.type_declaration ->
+  actual:Types.jkind_l ->
+  bound:Types.jkind_l ->
+  (unit, subjkind_error) result
 
 val crossing_of_jkind :
   context:Jkind.jkind_context ->

--- a/typing/ikind.mli
+++ b/typing/ikind.mli
@@ -27,6 +27,8 @@ type subjkind_error =
   | Jkind_error of Jkind.Violation.t
   | Mode_crossing_error of mode_crossing_error
 
+val subjkind_error_printing_env : subjkind_error -> Env.t option
+
 val report_subjkind_error_with_offender :
   offender:(Format_doc.formatter -> unit) ->
   Env.t ->

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -416,7 +416,7 @@ type type_mismatch =
   | Extensible_representation of position
   | With_null_representation of position
   | Fixed_representation of position
-  | Jkind of Jkind.Violation.t
+  | Jkind of Ikind.subjkind_error
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 type jkind_mismatch =
@@ -840,7 +840,7 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a fixed representation while the other varies"
   | Jkind v ->
-      Jkind.Violation.report_with_name ~name:first
+      Ikind.report_subjkind_error_with_name ~name:first
         env ppf v
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,@[<v 2>%a@]"

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -858,8 +858,13 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a fixed representation while the other varies"
   | Jkind v ->
-      Ikind.report_subjkind_error_with_name ~name:first
-        env ppf v
+      let report () =
+        Ikind.report_subjkind_error_with_name ~name:first env ppf v
+      in
+      (match Ikind.subjkind_error_printing_env v with
+       | None -> report ()
+       | Some printing_env ->
+         Printtyp.wrap_printing_env ~error:true printing_env report)
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,@[<v 2>%a@]"
       (fun ppf (first, second, mismatch) ->

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -434,7 +434,7 @@ type type_mismatch =
   | Extensible_representation of position
   | With_null_representation of position
   | Fixed_representation of position
-  | Jkind of Jkind.Violation.t
+  | Jkind of Ikind.subjkind_error
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 type jkind_mismatch =
@@ -858,7 +858,7 @@ let report_type_mismatch first second decl env ppf err =
          (choose ord first second) decl
          "has a fixed representation while the other varies"
   | Jkind v ->
-      Jkind.Violation.report_with_name ~name:first
+      Ikind.report_subjkind_error_with_name ~name:first
         env ppf v
   | Unsafe_mode_crossing mismatch ->
     pr "They have different unsafe mode crossing behavior:@,@[<v 2>%a@]"

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -144,7 +144,7 @@ type type_mismatch =
   | Extensible_representation of position
   | With_null_representation of position
   | Fixed_representation of position
-  | Jkind of Jkind.Violation.t
+  | Jkind of Ikind.subjkind_error
   | Unsafe_mode_crossing of unsafe_mode_crossing_mismatch
 
 type jkind_mismatch =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -25,6 +25,8 @@ let print_type_expr : type_expr Fmt.printer ref = ref (fun _ _ -> assert false)
 
 let set_print_type_expr p = print_type_expr := p
 
+let format_type_expr ppf ty = !print_type_expr ppf ty
+
 let raw_type_expr : (Format.formatter -> type_expr -> unit) ref =
   ref (fun _ _ -> assert false)
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -712,6 +712,8 @@ val set_printtyp_path : (Format_doc.formatter -> Path.t -> unit) -> unit
     module. *)
 val set_print_type_expr : Types.type_expr Format_doc.printer -> unit
 
+val format_type_expr : Types.type_expr Format_doc.printer
+
 (** Provides the [raw_type_expr] formatter back up the dependency chain to this
     module. *)
 val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -736,6 +736,8 @@ val set_printtyp_path : (Format_doc.formatter -> Path.t -> unit) -> unit
     module. *)
 val set_print_type_expr : Types.type_expr Format_doc.printer -> unit
 
+val format_type_expr : Types.type_expr Format_doc.printer
+
 (** Provides the [raw_type_expr] formatter back up the dependency chain to this
     module. *)
 val set_raw_type_expr : (Format.formatter -> Types.type_expr -> unit) -> unit

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -152,15 +152,9 @@ module Axis = struct
   let equal (Pack axis1) (Pack axis2) =
     match axis1, axis2 with
     | Modal axis1, Modal axis2 ->
-      let axis1 =
-        Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis1)
-      in
-      let axis2 =
-        Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis2)
-      in
-      Int.equal
-        (Mode.Modality.Axis.compare axis1 axis2)
-        0
+      let axis1 = Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis1) in
+      let axis2 = Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis2) in
+      Int.equal (Mode.Modality.Axis.compare axis1 axis2) 0
     | Nonmodal Externality, Nonmodal Externality -> true
     | Modal _, Nonmodal _ | Nonmodal _, Modal _ -> false
 

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -149,6 +149,21 @@ module Axis = struct
       (* CR-soon zqian: call [Mode.Crossing.Axis.all] for modal axes *)
       Pack (Nonmodal Externality) ]
 
+  let equal (Pack axis1) (Pack axis2) =
+    match axis1, axis2 with
+    | Modal axis1, Modal axis2 ->
+      let axis1 =
+        Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis1)
+      in
+      let axis2 =
+        Mode.Crossing.Axis.to_modality (Mode.Crossing.Axis.P axis2)
+      in
+      Int.equal
+        (Mode.Modality.Axis.compare axis1 axis2)
+        0
+    | Nonmodal Externality, Nonmodal Externality -> true
+    | Modal _, Nonmodal _ | Nonmodal _, Modal _ -> false
+
   let name (type a) : a t -> string = function
     | Modal ax ->
       let (P ax) =

--- a/typing/jkind_axis.mli
+++ b/typing/jkind_axis.mli
@@ -71,6 +71,8 @@ module Axis : sig
 
   val all : packed list
 
+  val equal : packed -> packed -> bool
+
   val name : _ t -> string
 end
 

--- a/typing/ldd.ml
+++ b/typing/ldd.ml
@@ -352,6 +352,43 @@ module Make (V : Ordered) = struct
     then meet_with_leaf b a
     else meet' a b
 
+  let top_var (node : node) : var option =
+    if is_leaf node then None else Some (Unsafe.node_block node).v
+
+  let min_top_var (a : node) (b : node) : var =
+    match top_var a, top_var b with
+    | None, None -> invalid_arg "Ldd.imply: expected a non-leaf node"
+    | Some v, None | None, Some v -> v
+    | Some v1, Some v2 -> if compare_var v1 v2 <= 0 then v1 else v2
+
+  let rec split_on_var (v : var) (node0 : node) : node * node =
+    if is_leaf node0
+    then node0, node0
+    else
+      let block = Unsafe.node_block node0 in
+      let order = compare_var v block.v in
+      if order < 0
+      then node0, node0
+      else if order = 0
+      then block.lo, join block.lo block.hi
+      else
+        let lo_bot, lo_top = split_on_var v block.lo in
+        let hi_bot, hi_top = split_on_var v block.hi in
+        node block.v ~lo:lo_bot ~hi:hi_bot, node block.v ~lo:lo_top ~hi:hi_top
+
+  let rec imply_rec (a : node) (b : node) : node =
+    if a == b || a == bot || b == top
+    then top
+    else if is_leaf a && is_leaf b
+    then leaf (Axis_lattice.imply (Unsafe.leaf_value a) (Unsafe.leaf_value b))
+    else
+      let v = min_top_var a b in
+      let a_bot, a_top = split_on_var v a in
+      let b_bot, b_top = split_on_var v b in
+      let h_top = imply_rec a_top b_top in
+      let h_bot = meet (imply_rec a_bot b_bot) h_top in
+      node v ~lo:h_bot ~hi:h_top
+
   (* --------- public constructors --------- *)
   let[@inline] const (c : Axis_lattice.t) = leaf c
 
@@ -507,6 +544,10 @@ module Make (V : Ordered) = struct
 
   let solve_pending () : unit = solve_pending_gfps ()
 
+  let imply (a : node) (b : node) : node =
+    solve_pending ();
+    imply_rec (inline_solved_vars a) (inline_solved_vars b)
+
   (** Decompose into linear terms over [universe]. *)
   let decompose_into_linear_terms ~(universe : var list) (n : node) =
     (* Successive restriction over [universe]. *)
@@ -528,6 +569,11 @@ module Make (V : Ordered) = struct
     solve_pending ();
     let node = inline_solved_vars node in
     up0 node
+
+  let round_down (node : node) =
+    solve_pending ();
+    let node = inline_solved_vars node in
+    down0 node
 
   let is_const (node : node) : bool =
     let node = inline_solved_vars node in

--- a/typing/ldd.ml
+++ b/typing/ldd.ml
@@ -502,7 +502,7 @@ module Make (V : Ordered) = struct
     canonicalize ~hi:(inline_solved_vars a) ~lo:(inline_solved_vars b)
 
   let solve_lfp (var : var) (rhs_raw : node) : unit =
-    (* Solve the least fixpoint equation var := rhs_raw. 
+    (* Solve the least fixpoint equation var := rhs_raw.
        The rhs in general contains the var itself, and the
        fixpoint solution is var := rhs_raw[var := bot].
        We must also inline solved vars, because var itself
@@ -512,12 +512,12 @@ module Make (V : Ordered) = struct
     | Rigid _ -> invalid_arg "solve_lfp: rigid variable"
     | Solved _ -> invalid_arg "solve_lfp: solved variable"
     | Unsolved ->
-      (* For efficiency, we use assign_bot_inline to 
+      (* For efficiency, we use assign_bot_inline to
          simultaneously inline solved vars and assign bot. *)
       var.state <- Solved (assign_bot_inline ~var rhs_raw)
 
   let solve_gfp (var : var) (rhs_raw : node) : unit =
-    (* Solve the greatest fixpoint equation var := rhs_raw. 
+    (* Solve the greatest fixpoint equation var := rhs_raw.
        The rhs in general contains the var itself, and the
        fixpoint solution is var := rhs_raw[var := top].
        We must also inline solved vars, because var itself
@@ -527,7 +527,7 @@ module Make (V : Ordered) = struct
     | Rigid _ -> invalid_arg "solve_gfp: rigid variable"
     | Solved _ -> invalid_arg "solve_gfp: solved variable"
     | Unsolved ->
-      (* gfp's are less performance critical, so we use two 
+      (* gfp's are less performance critical, so we use two
          separate steps to inline solved vars and assign top. *)
       let rhs_forced = inline_solved_vars rhs_raw in
       var.state <- Solved (assign_top ~var rhs_forced)

--- a/typing/ldd_intf.ml
+++ b/typing/ldd_intf.ml
@@ -41,10 +41,13 @@ module type S = sig
 
   val node_of_var : var -> node
 
-  (** Boolean algebra over nodes. *)
+  (** Lattice operations over nodes. *)
   val join : node -> node -> node
 
   val meet : node -> node -> node
+
+  (** [imply a b] is the greatest [h] such that [meet a h <= b]. *)
+  val imply : node -> node -> node
 
   val sum : 'a list -> base:node -> f:('a -> node) -> node
 
@@ -70,6 +73,8 @@ module type S = sig
   val leq_with_reason : node -> node -> Jkind_axis.Axis.packed list
 
   val round_up : node -> Axis_lattice.t
+
+  val round_down : node -> Axis_lattice.t
 
   val is_const : node -> bool
 

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -115,8 +115,8 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of Env.t * type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Env.t * Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of Env.t * type_expr * Ikind.subjkind_error
+  | Jkind_mismatch_of_path of Env.t * Path.t * Ikind.subjkind_error
   | Jkind_mismatch_due_to_bad_inference of
       Env.t * type_expr * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of
@@ -238,7 +238,10 @@ let constrain_or_null_payload ~env ~path payload_ty payload_loc =
   match Ctype.constrain_type_jkind env payload_ty required with
   | Ok () -> ()
   | Error err ->
-    raise (Error (payload_loc, Jkind_mismatch_of_type (env, payload_ty, err)))
+    raise
+      (Error
+         ( payload_loc,
+           Jkind_mismatch_of_type (env, payload_ty, Ikind.Jkind_error err) ))
 
 (* [make_params] creates sort variables - these can be defaulted away (as in
    transl_type_decl) or unified with existing sort-variable-free types (as in
@@ -1714,15 +1717,16 @@ let narrow_to_manifest_jkind env loc path decl =
         let type_equal = Ctype.type_equal env in
         let context = Ctype.mk_jkind_context_always_principal env in
         (match
-           Ikind.sub_jkind_l
+           Ikind.check_type_expr_bound
              ~origin:(Format.asprintf
                         "typedecl:manifest_vs_decl %a"
                         Location.print_loc decl.type_loc)
              ~type_equal
              ~context
              env
-             manifest_jkind
-             decl.type_jkind
+             ~ty
+             ~actual:manifest_jkind
+             ~bound:decl.type_jkind
          with
          | Ok () -> ()
          | Error v ->
@@ -1745,7 +1749,10 @@ let narrow_to_manifest_jkind env loc path decl =
                Format.eprintf
                  "[ikind-narrow] path=%a branch=constrain_type_jkind error@."
                  (Format_doc.compat Path.print) path;
-             raise (Error (loc, Jkind_mismatch_of_type (env, ty, v))))
+             raise
+               (Error
+                  (loc,
+                   Jkind_mismatch_of_type (env, ty, Ikind.Jkind_error v))))
     end;
     let type_ikind =
       Ikind.type_declaration_ikind_gated ~env:(Some env) ~path
@@ -2732,7 +2739,10 @@ let rec update_decl_jkind env dpath decl =
   with
   | Ok () -> new_decl
   | Error err ->
-    raise (Error (decl.type_loc, Jkind_mismatch_of_path (env, dpath, err)))
+    raise
+      (Error
+         (decl.type_loc,
+          Jkind_mismatch_of_path (env, dpath, Ikind.Jkind_error err)))
 
 let update_decls_jkind_reason decls =
   List.map
@@ -3539,7 +3549,7 @@ let normalize_decl_jkinds env decls =
       match
         (* CR layouts v2.8: Consider making a function that doesn't compute
            histories for this use-case, which doesn't need it. *)
-        Ikind.sub_jkind_l
+        Ikind.check_type_decl_bound
           ~origin:(Format.asprintf
                      "typedecl:normalize %a (%a)"
                      (Format_doc.compat Path.print) path
@@ -3548,8 +3558,9 @@ let normalize_decl_jkinds env decls =
           ~context
           ~allow_any_crossing
           env
-          decl.type_jkind
-          original_decl.type_jkind
+          ~decl
+          ~actual:decl.type_jkind
+          ~bound:original_decl.type_jkind
       with
       | Ok _ ->
         if allow_any_crossing then
@@ -5714,13 +5725,13 @@ let report_error ~loc = function
       fprintf ppf "type %a" Style.inline_code path_end
     in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
+      Ikind.report_subjkind_error_with_offender ~offender
         env ppf v)
   | Jkind_mismatch_of_type (env, ty, v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
+      Ikind.report_subjkind_error_with_offender ~offender
         env ppf v)
   | Jkind_sort {env; kloc; typ; err} ->
     let s =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -5774,14 +5774,24 @@ let report_error ~loc = function
       fprintf ppf "type %a" Style.inline_code path_end
     in
     Location.errorf ~loc "%t" (fun ppf ->
-      Ikind.report_subjkind_error_with_offender ~offender
-        env ppf v)
+      let report () =
+        Ikind.report_subjkind_error_with_offender ~offender env ppf v
+      in
+      match Ikind.subjkind_error_printing_env v with
+      | None -> report ()
+      | Some printing_env ->
+        Printtyp.wrap_printing_env ~error:true printing_env report)
   | Jkind_mismatch_of_type (env, ty, v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
     Location.errorf ~loc "%t" (fun ppf ->
-      Ikind.report_subjkind_error_with_offender ~offender
-        env ppf v)
+      let report () =
+        Ikind.report_subjkind_error_with_offender ~offender env ppf v
+      in
+      match Ikind.subjkind_error_printing_env v with
+      | None -> report ()
+      | Some printing_env ->
+        Printtyp.wrap_printing_env ~error:true printing_env report)
   | Jkind_sort {env; kloc; typ; err} ->
     let s =
       match kloc with

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1767,7 +1767,7 @@ let narrow_to_manifest_jkind env loc path decl =
              raise
                (Error
                   (loc,
-                   Jkind_mismatch_of_type (env, ty, Ikind.Jkind_error v))))
+                   Jkind_mismatch_of_type (env, ty, Jkind_error v))))
     end;
     let type_ikind =
       Ikind.type_declaration_ikind_gated ~env:(Some env) ~path

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2789,7 +2789,7 @@ let rec update_decl_jkind env dpath decl =
     raise
       (Error
          (decl.type_loc,
-          Jkind_mismatch_of_path (env, dpath, Ikind.Jkind_error err)))
+          Jkind_mismatch_of_path (env, dpath, Jkind_error err)))
 
 let update_decls_jkind_reason decls =
   List.map

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -115,8 +115,8 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of Env.t * type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Env.t * Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of Env.t * type_expr * Ikind.subjkind_error
+  | Jkind_mismatch_of_path of Env.t * Path.t * Ikind.subjkind_error
   | Jkind_mismatch_due_to_bad_inference of
       Env.t * type_expr * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of
@@ -232,7 +232,10 @@ let constrain_or_null_payload ~env ~path payload_ty payload_loc =
   match Ctype.constrain_type_jkind env payload_ty required with
   | Ok () -> ()
   | Error err ->
-    raise (Error (payload_loc, Jkind_mismatch_of_type (env, payload_ty, err)))
+    raise
+      (Error
+         ( payload_loc,
+           Jkind_mismatch_of_type (env, payload_ty, Ikind.Jkind_error err) ))
 
 (* [make_params] creates sort variables - these can be defaulted away (as in
    transl_type_decl) or unified with existing sort-variable-free types (as in
@@ -1729,15 +1732,16 @@ let narrow_to_manifest_jkind env loc path decl =
         let type_equal = Ctype.type_equal env in
         let context = Ctype.mk_jkind_context_always_principal env in
         (match
-           Ikind.sub_jkind_l
+           Ikind.check_type_expr_bound
              ~origin:(Format.asprintf
                         "typedecl:manifest_vs_decl %a"
                         Location.print_loc decl.type_loc)
              ~type_equal
              ~context
              env
-             manifest_jkind
-             decl.type_jkind
+             ~ty
+             ~actual:manifest_jkind
+             ~bound:decl.type_jkind
          with
          | Ok () -> ()
          | Error v ->
@@ -1760,7 +1764,10 @@ let narrow_to_manifest_jkind env loc path decl =
                Format.eprintf
                  "[ikind-narrow] path=%a branch=constrain_type_jkind error@."
                  (Format_doc.compat Path.print) path;
-             raise (Error (loc, Jkind_mismatch_of_type (env, ty, v))))
+             raise
+               (Error
+                  (loc,
+                   Jkind_mismatch_of_type (env, ty, Ikind.Jkind_error v))))
     end;
     let type_ikind =
       Ikind.type_declaration_ikind_gated ~env:(Some env) ~path
@@ -2779,7 +2786,10 @@ let rec update_decl_jkind env dpath decl =
   with
   | Ok () -> new_decl
   | Error err ->
-    raise (Error (decl.type_loc, Jkind_mismatch_of_path (env, dpath, err)))
+    raise
+      (Error
+         (decl.type_loc,
+          Jkind_mismatch_of_path (env, dpath, Ikind.Jkind_error err)))
 
 let update_decls_jkind_reason decls =
   List.map
@@ -3586,7 +3596,7 @@ let normalize_decl_jkinds env decls =
       match
         (* CR layouts v2.8: Consider making a function that doesn't compute
            histories for this use-case, which doesn't need it. *)
-        Ikind.sub_jkind_l
+        Ikind.check_type_decl_bound
           ~origin:(Format.asprintf
                      "typedecl:normalize %a (%a)"
                      (Format_doc.compat Path.print) path
@@ -3595,8 +3605,9 @@ let normalize_decl_jkinds env decls =
           ~context
           ~allow_any_crossing
           env
-          decl.type_jkind
-          original_decl.type_jkind
+          ~decl
+          ~actual:decl.type_jkind
+          ~bound:original_decl.type_jkind
       with
       | Ok _ ->
         if allow_any_crossing then
@@ -5763,13 +5774,13 @@ let report_error ~loc = function
       fprintf ppf "type %a" Style.inline_code path_end
     in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
+      Ikind.report_subjkind_error_with_offender ~offender
         env ppf v)
   | Jkind_mismatch_of_type (env, ty, v) ->
     let offender ppf = fprintf ppf "type %a"
         (Style.as_inline_code Printtyp.type_expr) ty in
     Location.errorf ~loc "%t" (fun ppf ->
-      Jkind.Violation.report_with_offender ~offender
+      Ikind.report_subjkind_error_with_offender ~offender
         env ppf v)
   | Jkind_sort {env; kloc; typ; err} ->
     let s =

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -213,8 +213,8 @@ type error =
   | Multiple_native_repr_attributes
   | Cannot_unbox_or_untag_type of native_repr_kind
   | Deep_unbox_or_untag_attribute of native_repr_kind
-  | Jkind_mismatch_of_type of Env.t * type_expr * Jkind.Violation.t
-  | Jkind_mismatch_of_path of Env.t * Path.t * Jkind.Violation.t
+  | Jkind_mismatch_of_type of Env.t * type_expr * Ikind.subjkind_error
+  | Jkind_mismatch_of_path of Env.t * Path.t * Ikind.subjkind_error
   | Jkind_mismatch_due_to_bad_inference of
       Env.t * type_expr * Jkind.Violation.t * bad_jkind_inference_location
   | Jkind_sort of

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -220,19 +220,18 @@ end
    [global] must imply [aliased] for soundness of borrowing. *)
 let implied_modalities (Atom (ax, a) : Modality.atom) : Modality.atom list =
   match[@warning "-18"] ax, a with
-  | Comonadic Areality, Meet_const a ->
-    let f, y, u =
-      match a with
-      | Global ->
-        ( Forkable.Const.Forkable,
-          Yielding.Const.Unyielding,
-          [Uniqueness.Const.Aliased] )
-      | Local -> Forkable.Const.Unforkable, Yielding.Const.Yielding, []
-      | Regional -> assert false
-    in
-    [ Modality.Atom (Comonadic Forkable, Meet_const f);
-      Atom (Comonadic Yielding, Meet_const y) ]
-    @ List.map (fun x -> Modality.Atom (Monadic Uniqueness, Join_const x)) u
+  | Comonadic Areality, Meet_const a -> (
+    match a with
+    | Global ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Forkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Unyielding);
+        Atom (Monadic Uniqueness, Join_const Uniqueness.Const.Aliased) ]
+    | Local ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Unforkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Yielding) ]
+    (* [regional] cannot be written in an annotation, but bounds computed by
+       the ikind engine can reach here. It implies nothing. *)
+    | Regional -> [])
   | Monadic Visibility, Join_const a ->
     let b : Contention.Const.t =
       match a with
@@ -561,12 +560,46 @@ let least_modalities ~include_implied ~mut (t : Modality.Const.t) =
     List.filter_map
       (fun (Modality.Atom (ax, m_implied)) ->
         let m_projected = Modality.Const.proj ax t in
-        if m_projected <> m_implied || include_implied
+        let already_listed =
+          List.exists
+            (fun (Modality.Atom (ax', _)) ->
+              Modality.Axis.P ax' = Modality.Axis.P ax)
+            exclude_implied
+        in
+        if (m_projected <> m_implied || include_implied) && not already_listed
         then Some (Modality.Atom (ax, m_projected))
         else None)
       implied
   in
   exclude_implied @ overridden
+
+let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
+    =
+  (* Bounds computed axis-by-axis (as in ikind provenance reporting) lack the
+     implied bounds that [transl_mod_bounds] inserts for user-written
+     annotations, e.g. [aliased forkable unyielding] for [global].
+     [untransl_mod_bounds] relies on those implications being present in order
+     to omit the implied modes when printing, so close the bounds first. *)
+  let crossing = Jkind.Mod_bounds.crossing bounds in
+  let annotated =
+    Modality.Const.diff Modality.Const.id (Crossing.to_modality crossing)
+  in
+  let modality = Crossing.to_modality crossing in
+  let implied = List.concat_map implied_modalities annotated in
+  let crossing =
+    List.fold_left
+      (fun crossing (Modality.Atom (ax, a)) ->
+        (* As in [transl_mod_bounds], an explicit bound on an axis wins over
+           a bound implied by another axis. *)
+        if
+          Modality.Const.proj ax modality
+          <> Modality.Const.proj ax Modality.Const.id
+        then crossing
+        else
+          Crossing.modality (Modality.Const.set ax a Modality.Const.id) crossing)
+      crossing implied
+  in
+  Jkind.Mod_bounds.set_crossing crossing bounds
 
 let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
     Parsetree.modes =

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -691,15 +691,11 @@ let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
      to omit the implied modes when printing, so close the bounds first. *)
   let crossing = Jkind.Mod_bounds.crossing bounds in
   let modality = Crossing.to_modality crossing in
-  let annotated =
-    Modality.Const.diff Modality.Const.id modality
-  in
+  let annotated = Modality.Const.diff Modality.Const.id modality in
   let implied = List.concat_map implied_modalities annotated in
   let axis_is_explicit ax =
     let projected =
-      Modality.Const.set ax
-        (Modality.Const.proj ax modality)
-        Modality.Const.id
+      Modality.Const.set ax (Modality.Const.proj ax modality) Modality.Const.id
     in
     match Modality.Const.equate projected Modality.Const.id with
     | Ok () -> false

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -690,10 +690,10 @@ let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
      [untransl_mod_bounds] relies on those implications being present in order
      to omit the implied modes when printing, so close the bounds first. *)
   let crossing = Jkind.Mod_bounds.crossing bounds in
-  let annotated =
-    Modality.Const.diff Modality.Const.id (Crossing.to_modality crossing)
-  in
   let modality = Crossing.to_modality crossing in
+  let annotated =
+    Modality.Const.diff Modality.Const.id modality
+  in
   let implied = List.concat_map implied_modalities annotated in
   let crossing =
     List.fold_left

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -160,19 +160,18 @@ end
    [global] must imply [aliased] for soundness of borrowing. *)
 let implied_modalities (Atom (ax, a) : Modality.atom) : Modality.atom list =
   match[@warning "-18"] ax, a with
-  | Comonadic Areality, Meet_const a ->
-    let f, y, u =
-      match a with
-      | Global ->
-        ( Forkable.Const.Forkable,
-          Yielding.Const.Unyielding,
-          [Uniqueness.Const.Aliased] )
-      | Local -> Forkable.Const.Unforkable, Yielding.Const.Yielding, []
-      | Regional -> assert false
-    in
-    [ Modality.Atom (Comonadic Forkable, Meet_const f);
-      Atom (Comonadic Yielding, Meet_const y) ]
-    @ List.map (fun x -> Modality.Atom (Monadic Uniqueness, Join_const x)) u
+  | Comonadic Areality, Meet_const a -> (
+    match a with
+    | Global ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Forkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Unyielding);
+        Atom (Monadic Uniqueness, Join_const Uniqueness.Const.Aliased) ]
+    | Local ->
+      [ Modality.Atom (Comonadic Forkable, Meet_const Forkable.Const.Unforkable);
+        Atom (Comonadic Yielding, Meet_const Yielding.Const.Yielding) ]
+    (* [regional] cannot be written in an annotation, but bounds computed by
+       the ikind engine can reach here. It implies nothing. *)
+    | Regional -> [])
   | Monadic Visibility, Join_const a ->
     let b : Contention.Const.t =
       match a with
@@ -377,7 +376,13 @@ let least_modalities ~include_implied ~mut (t : Modality.Const.t) =
     List.filter_map
       (fun (Modality.Atom (ax, m_implied)) ->
         let m_projected = Modality.Const.proj ax t in
-        if m_projected <> m_implied || include_implied
+        let already_listed =
+          List.exists
+            (fun (Modality.Atom (ax', _)) ->
+              Modality.Axis.P ax' = Modality.Axis.P ax)
+            exclude_implied
+        in
+        if (m_projected <> m_implied || include_implied) && not already_listed
         then Some (Modality.Atom (ax, m_projected))
         else None)
       implied
@@ -676,6 +681,34 @@ let transl_mod_bounds ?(warn = true) annots =
   in
   let crossing = Crossing.modality modality Crossing.max in
   create crossing ~externality, (nonmodal.nullability, nonmodal.separability)
+
+let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
+    =
+  (* Bounds computed axis-by-axis (as in ikind provenance reporting) lack the
+     implied bounds that [transl_mod_bounds] inserts for user-written
+     annotations, e.g. [aliased forkable unyielding] for [global].
+     [untransl_mod_bounds] relies on those implications being present in order
+     to omit the implied modes when printing, so close the bounds first. *)
+  let crossing = Jkind.Mod_bounds.crossing bounds in
+  let annotated =
+    Modality.Const.diff Modality.Const.id (Crossing.to_modality crossing)
+  in
+  let modality = Crossing.to_modality crossing in
+  let implied = List.concat_map implied_modalities annotated in
+  let crossing =
+    List.fold_left
+      (fun crossing (Modality.Atom (ax, a)) ->
+        (* As in [transl_mod_bounds], an explicit bound on an axis wins over
+           a bound implied by another axis. *)
+        if
+          Modality.Const.proj ax modality
+          <> Modality.Const.proj ax Modality.Const.id
+        then crossing
+        else
+          Crossing.modality (Modality.Const.set ax a Modality.Const.id) crossing)
+      crossing implied
+  in
+  Jkind.Mod_bounds.set_crossing crossing bounds
 
 let untransl_mod_bounds ?(verbose = false) (bounds : Jkind.Mod_bounds.t) :
     Parsetree.modes =

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -695,14 +695,22 @@ let close_implied_mod_bounds (bounds : Jkind.Mod_bounds.t) : Jkind.Mod_bounds.t
     Modality.Const.diff Modality.Const.id modality
   in
   let implied = List.concat_map implied_modalities annotated in
+  let axis_is_explicit ax =
+    let projected =
+      Modality.Const.set ax
+        (Modality.Const.proj ax modality)
+        Modality.Const.id
+    in
+    match Modality.Const.equate projected Modality.Const.id with
+    | Ok () -> false
+    | Error _ -> true
+  in
   let crossing =
     List.fold_left
       (fun crossing (Modality.Atom (ax, a)) ->
         (* As in [transl_mod_bounds], an explicit bound on an axis wins over
            a bound implied by another axis. *)
-        if
-          Modality.Const.proj ax modality
-          <> Modality.Const.proj ax Modality.Const.id
+        if axis_is_explicit ax
         then crossing
         else
           Crossing.modality (Modality.Const.set ax a Modality.Const.id) crossing)

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -80,6 +80,13 @@ val transl_mod_bounds :
   * (Jkind_axis.Nullability.t Location.loc option
     * Jkind_axis.Separability.t Location.loc option)
 
+(** Close mod-bounds under implied modalities, as [transl_mod_bounds] does for
+    user-written annotations (e.g. a [global] bound also bounds [aliased],
+    [forkable] and [unyielding]). Bounds computed axis-by-axis may lack these
+    implications, which [untransl_mod_bounds] relies on to omit implied modes
+    when printing. *)
+val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
+
 (** Translate an algebraic representation of mod bounds into user syntax. If
     [verbose] is true, redundant annotations are included. *)
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -81,6 +81,13 @@ val transl_mod_bounds :
   * (Jkind_axis.Nullability.t Location.loc option
     * Jkind_axis.Separability.t Location.loc option)
 
+(** Close mod-bounds under implied modalities, as [transl_mod_bounds] does for
+    user-written annotations (e.g. a [global] bound also bounds [aliased],
+    [forkable] and [unyielding]). Bounds computed axis-by-axis may lack these
+    implications, which [untransl_mod_bounds] relies on to omit implied modes
+    when printing. *)
+val close_implied_mod_bounds : Jkind.Mod_bounds.t -> Jkind.Mod_bounds.t
+
 (** Translate an algebraic representation of mod bounds into user syntax. If
     [verbose] is true, redundant annotations are included. *)
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -28,6 +28,10 @@ module Rigid_name = struct
         }
     | KAtom of Path.t
     | Param of int
+    | Provenance of
+        { id : int;
+          ty : string
+        }
     | Unknown of unknown_id
 
   let compare a b =
@@ -40,13 +44,16 @@ module Rigid_name = struct
         if h != 0 then h else Int.compare a1.arg_index a2.arg_index
       | KAtom p1, KAtom p2 -> Path.compare p1 p2
       | Param x, Param y -> Int.compare x y
+      | Provenance x, Provenance y -> Int.compare x.id y.id
       | Atom _, _ -> -1
       | _, Atom _ -> 1
       | KAtom _, _ -> -1
       | _, KAtom _ -> 1
+      | Param _, _ -> -1
+      | _, Param _ -> 1
+      | Provenance _, _ -> -1
+      | _, Provenance _ -> 1
       | Unknown x, Unknown y -> Shape.Uid.compare x y
-      | Unknown _, _ -> 1
-      | _, Unknown _ -> -1
 
   let to_string = function
     | Atom { constr; arg_index } ->
@@ -56,6 +63,7 @@ module Rigid_name = struct
       let path_s = Format_doc.asprintf "%a" Path.print path in
       Printf.sprintf "katom[%s]" path_s
     | Param i -> Printf.sprintf "param[%d]" i
+    | Provenance { id; ty } -> Printf.sprintf "provenance[%d:%s]" id ty
     | Unknown id ->
       Format.asprintf "unknown[%a]" Shape.Uid.print id
 
@@ -64,6 +72,8 @@ module Rigid_name = struct
   let katom path = KAtom path
 
   let param i = Param i
+
+  let provenance ~id ~ty = Provenance { id; ty }
 
   let unknown uid = Unknown uid
 end

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -30,7 +30,8 @@ module Rigid_name = struct
     | Param of int
     | Provenance of
         { id : int;
-          ty : string
+          ty : string;
+          phrase : bool
         }
     | Unknown of unknown_id
 
@@ -63,7 +64,8 @@ module Rigid_name = struct
       let path_s = Format_doc.asprintf "%a" Path.print path in
       Printf.sprintf "katom[%s]" path_s
     | Param i -> Printf.sprintf "param[%d]" i
-    | Provenance { id; ty } -> Printf.sprintf "provenance[%d:%s]" id ty
+    | Provenance { id; ty; phrase = _ } ->
+      Printf.sprintf "provenance[%d:%s]" id ty
     | Unknown id ->
       Format.asprintf "unknown[%a]" Shape.Uid.print id
 
@@ -73,7 +75,7 @@ module Rigid_name = struct
 
   let param i = Param i
 
-  let provenance ~id ~ty = Provenance { id; ty }
+  let provenance ~id ~ty ~phrase = Provenance { id; ty; phrase }
 
   let unknown uid = Unknown uid
 end

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -30,7 +30,7 @@ module Rigid_name = struct
     | Param of int
     | Provenance of
         { id : int;
-          ty : string;
+          ty : Format_doc.doc;
           plural : bool
         }
     | Unknown of unknown_id
@@ -65,7 +65,7 @@ module Rigid_name = struct
       Printf.sprintf "katom[%s]" path_s
     | Param i -> Printf.sprintf "param[%d]" i
     | Provenance { id; ty; plural = _ } ->
-      Printf.sprintf "provenance[%d:%s]" id ty
+      Format_doc.asprintf "provenance[%d:%a]" id Format_doc.pp_doc ty
     | Unknown id ->
       Format.asprintf "unknown[%a]" Shape.Uid.print id
 

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -31,7 +31,7 @@ module Rigid_name = struct
     | Provenance of
         { id : int;
           ty : string;
-          phrase : bool
+          plural : bool
         }
     | Unknown of unknown_id
 
@@ -64,7 +64,7 @@ module Rigid_name = struct
       let path_s = Format_doc.asprintf "%a" Path.print path in
       Printf.sprintf "katom[%s]" path_s
     | Param i -> Printf.sprintf "param[%d]" i
-    | Provenance { id; ty; phrase = _ } ->
+    | Provenance { id; ty; plural = _ } ->
       Printf.sprintf "provenance[%d:%s]" id ty
     | Unknown id ->
       Format.asprintf "unknown[%a]" Shape.Uid.print id
@@ -75,7 +75,7 @@ module Rigid_name = struct
 
   let param i = Param i
 
-  let provenance ~id ~ty ~phrase = Provenance { id; ty; phrase }
+  let provenance ~id ~ty ~plural = Provenance { id; ty; plural }
 
   let unknown uid = Unknown uid
 end

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -111,6 +111,14 @@ module Rigid_name : sig
         (** [Param id] only occurs in formulas for type constructors. Refers to
             a type-parameter of the constructor, where [id] is the
             [Types.get_id] of the type variable representing the parameter. *)
+    | Provenance of
+        { id : int;
+          ty : string
+        }
+        (** A provenance variable introduced while translating a type expression
+            for error reporting. The integer identifies the occurrence, and
+            [ty] describes the corresponding type expression. These variables
+            are diagnostic-only and must not appear in stored [type_ikind]s. *)
     | Unknown of unknown_id
         (** An unknown quantity with a given id. Used to model not-best in
             ikinds. This is used when we couldn't compute a precise ikind,
@@ -127,6 +135,8 @@ module Rigid_name : sig
   val katom : Path.t -> t
 
   val param : int -> t
+
+  val provenance : id:int -> ty:string -> t
 
   val unknown : Shape.Uid.t -> t
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -113,12 +113,16 @@ module Rigid_name : sig
             [Types.get_id] of the type variable representing the parameter. *)
     | Provenance of
         { id : int;
-          ty : string
+          ty : string;
+          phrase : bool
         }
         (** A provenance variable introduced while translating a type expression
             for error reporting. The integer identifies the occurrence, and
-            [ty] describes the corresponding type expression. These variables
-            are diagnostic-only and must not appear in stored [type_ikind]s. *)
+            [ty] describes the corresponding type expression — or, when
+            [phrase] is true, a plural noun phrase describing a class of
+            contributions (e.g. "mutable fields") rather than a printed type
+            expression. These variables are diagnostic-only and must not
+            appear in stored [type_ikind]s. *)
     | Unknown of unknown_id
         (** An unknown quantity with a given id. Used to model not-best in
             ikinds. This is used when we couldn't compute a precise ikind,
@@ -136,7 +140,7 @@ module Rigid_name : sig
 
   val param : int -> t
 
-  val provenance : id:int -> ty:string -> t
+  val provenance : id:int -> ty:string -> phrase:bool -> t
 
   val unknown : Shape.Uid.t -> t
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -118,7 +118,7 @@ module Rigid_name : sig
           ty : string;
           (** The printed type expression or descriptive noun phrase. *)
 
-          phrase : bool
+          plural : bool
           (** Whether [ty] is a plural noun phrase rather than a type. *)
         }
         (** A diagnostic-only provenance variable. These variables must not
@@ -140,7 +140,7 @@ module Rigid_name : sig
 
   val param : int -> t
 
-  val provenance : id:int -> ty:string -> phrase:bool -> t
+  val provenance : id:int -> ty:string -> plural:bool -> t
 
   val unknown : Shape.Uid.t -> t
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -113,15 +113,15 @@ module Rigid_name : sig
             [Types.get_id] of the type variable representing the parameter. *)
     | Provenance of
         { id : int;
+          (** Identifies this provenance occurrence. *)
+
           ty : string;
+          (** The printed type expression or descriptive noun phrase. *)
+
           phrase : bool
+          (** Whether [ty] is a plural noun phrase rather than a type. *)
         }
-        (** A provenance variable introduced while translating a type expression
-            for error reporting. The integer identifies the occurrence, and
-            [ty] describes the corresponding type expression — or, when
-            [phrase] is true, a plural noun phrase describing a class of
-            contributions (e.g. "mutable fields") rather than a printed type
-            expression. These variables are diagnostic-only and must not
+        (** A diagnostic-only provenance variable. These variables must not
             appear in stored [type_ikind]s. *)
     | Unknown of unknown_id
         (** An unknown quantity with a given id. Used to model not-best in

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -115,8 +115,10 @@ module Rigid_name : sig
         { id : int;
           (** Identifies this provenance occurrence. *)
 
-          ty : string;
-          (** The printed type expression or descriptive noun phrase. *)
+          ty : Format_doc.doc;
+          (** The type expression or descriptive noun phrase, retained as a
+              formatting document so its line-breaking instructions survive
+              until the diagnostic is printed. *)
 
           plural : bool
           (** Whether [ty] is a plural noun phrase rather than a type. *)
@@ -140,7 +142,7 @@ module Rigid_name : sig
 
   val param : int -> t
 
-  val provenance : id:int -> ty:string -> plural:bool -> t
+  val provenance : id:int -> ty:Format_doc.doc -> plural:bool -> t
 
   val unknown : Shape.Uid.t -> t
 


### PR DESCRIPTION
This PR improves kind errors for type definitions (`type t : bound = RHS`) with kind annotations.

It does so by adding RHS provenance so that we can report exactly what in `RHS` failed to satisfy the bound.

The ikind translation now attached provenance variables while walking a type expression. Path lookups disable recursive provenance, so the reported provenance points at the type expression in `RHS` being checked rather than expanding through referenced declarations. The declaration-bound check uses that provenance to compute a residual and print the RHS fragments that do not cross the required axes.

The error now has the shape:

```text
Error: This type definition does not satisfy its kind annotation ..., because
       - <RHS subexpression 1> does not cross <axis 1>
       - <RHS subexpression 2> does not cross <axis 2>
       - ...
```

Layout errors still use the existing jkind machinery.