### PR TITLE
Minimize some test outputs

### DIFF
--- a/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
+++ b/middle_end/flambda2/tests/algorithms/patricia_tree_tests.ml
@@ -1247,3 +1247,4 @@ let () =
       exit 1
     in
     ()
+  else Format.printf "No failure\n"

--- a/middle_end/flambda2/tests/lib/minicheck/runner.ml
+++ b/middle_end/flambda2/tests/lib/minicheck/runner.ml
@@ -2,11 +2,16 @@ let default_attempts = 1000
 
 let default_seed = 0
 
-let default_verbose = false
-
 (* Guard against non-terminating shrinkers. This should be quite large, as a
    well-reduced test case is worth waiting for. *)
 let max_shrink_steps = 100000
+
+type verbosity =
+  | Verbose
+  | Normal
+  | SilentSuccess
+
+let default_verbose = SilentSuccess
 
 module Failure = struct
   type t =
@@ -28,9 +33,11 @@ module Outcome = struct
 
   let is_success = function Success -> true | Failure _ -> false
 
-  let report t ~attempts ~duration =
+  let report ?(verbose = default_verbose) t ~attempts ~duration =
     match t with
-    | Success -> Format.eprintf "PASSED %d attempts (%f s)@." attempts duration
+    | Success ->
+      if verbose <> SilentSuccess
+      then Format.eprintf "PASSED %d attempts (%f s)@." attempts duration
     | Failure { failure; counterexample; arbitrary_impl; shrink_steps; attempt }
       ->
       let explanation =
@@ -69,18 +76,19 @@ let check_once _t ~f ~(arbitrary_impl : (_, 'repr) Arbitrary.t) (repr : 'repr) :
 
 let check0 ?(n = default_attempts) ?(seed = default_seed)
     ?(verbose = default_verbose) t ~arbitrary_impl ~f ~name =
-  Format.eprintf "%s: " name;
+  let print_name = lazy (Format.eprintf "%s: " name) in
   let start = Sys.time () in
   let r = Splittable_random.of_int seed in
   let i = ref 1 in
   let outcome = ref Outcome.Success in
   while Outcome.is_success !outcome && !i <= n do
     let repr = Arbitrary.generate_repr arbitrary_impl r in
-    if verbose
-    then
+    if verbose = Verbose
+    then (
+      Lazy.force print_name;
       Format.eprintf "@[<hov 2>Attempt %d/%d:@ %a@]@." !i n
         (Arbitrary.print arbitrary_impl)
-        repr;
+        repr);
     match check_once t ~f ~arbitrary_impl repr with
     | Success -> incr i
     | Failure failure ->
@@ -124,13 +132,15 @@ let check0 ?(n = default_attempts) ?(seed = default_seed)
   done;
   let finish = Sys.time () in
   let duration = finish -. start in
+  if verbose <> SilentSuccess || not (Outcome.is_success !outcome)
+  then Lazy.force print_name;
   Outcome.report !outcome ~attempts:n ~duration;
   t.outcomes_rev <- !outcome :: t.outcomes_rev
 
 let check : type a reprs.
     ?n:int ->
     ?seed:int ->
-    ?verbose:bool ->
+    ?verbose:verbosity ->
     t ->
     arbitrary_impls:(a, reprs, bool) Tuple.Of2(Arbitrary.T).t ->
     f:a ->

--- a/middle_end/flambda2/tests/lib/minicheck/runner.mli
+++ b/middle_end/flambda2/tests/lib/minicheck/runner.mli
@@ -1,5 +1,10 @@
 type t
 
+type verbosity =
+  | Verbose  (** Print all test cases *)
+  | Normal  (** Print only test outcome *)
+  | SilentSuccess  (** No print on success *)
+
 val create : unit -> t
 
 (*_ CR-someday lmaurer: Fix ocamlformat's handling of code/verbatim blocks in
@@ -19,7 +24,7 @@ val create : unit -> t
 val check :
   ?n:int (** Number of runs (default is 1000) *) ->
   ?seed:int (** Seed (default is 0) *) ->
-  ?verbose:bool (** Whether to print all test cases (default is false) *) ->
+  ?verbose:verbosity (** Printing level of detail (default is SilentSuccess) *) ->
   t ->
   arbitrary_impls:('a, _, bool) Tuple.Of2(Arbitrary.T).t ->
   f:'a ->


### PR DESCRIPTION
Add a verbosity level to suppress some dune-manned test output on success. Failures should be easier to pinpoint.