### PR TITLE
Harden and document `Cfg_simplify` and its contracts

### DIFF
--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -43,14 +43,18 @@ module type Forward_S = sig
 
   (** Perform the dataflow analysis on the passed CFG, returning [OK _] if a
       fix-point has been reached and [Error _] otherwise, where the nested value
-      is a partial map from labels to the domain values at the start of the
-      corresponding blocks. If [Error _] is returned then the contents of the
-      map is not guaranteed to be sound.
+      is a map binding each label of the CFG to the domain value at the start of
+      the corresponding block. The map has an entry for every block: entry
+      points are initially bound to [init], all other blocks to the domain's
+      [bot] value, and blocks never reached by the analysis keep their initial
+      binding. If [Error _] is returned then the contents of the map is not
+      guaranteed to be sound.
 
       A fix-point is not reached if there is still pending work after
-      [max_iteration] (defaulting to [max_int]) have been executed, and
-      iteration being the processing of one element from the working set. The
-      [init] value is the initial value of entry points. *)
+      [max_iteration] (defaulting to [max_int]) have been executed, an iteration
+      being the processing of one element from the working set. The [init] value
+      is the initial value of entry points: the entry block and, if
+      [handlers_are_entry_points] is [true], all trap handler blocks. *)
   val run :
     Cfg.t ->
     ?max_iteration:int ->

--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -45,16 +45,14 @@ module type Forward_S = sig
       fix-point has been reached and [Error _] otherwise, where the nested value
       is a map binding each label of the CFG to the domain value at the start of
       the corresponding block. The map has an entry for every block: entry
-      points are initially bound to [init], all other blocks to the domain's
-      [bot] value, and blocks never reached by the analysis keep their initial
-      binding. If [Error _] is returned then the contents of the map is not
-      guaranteed to be sound.
+      points are initially bound to [init] (entry points include all trap
+      handlers if [handlers_are_entry_points] is [true]), all other blocks to
+      the domain's [bot] value, and blocks never reached by the analysis keep
+      their initial binding.
 
       A fix-point is not reached if there is still pending work after
       [max_iteration] (defaulting to [max_int]) have been executed, an iteration
-      being the processing of one element from the working set. The [init] value
-      is the initial value of entry points: the entry block and, if
-      [handlers_are_entry_points] is [true], all trap handler blocks. *)
+      being the processing of one element from the working set. *)
   val run :
     Cfg.t ->
     ?max_iteration:int ->

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -137,6 +137,27 @@ let check_tailrec_position t =
            followingsuccessors:@.%a@."
           Label.print tailrec_label Label.Set.print successors
 
+let check_entry_predecessors t =
+  (* The only expected edges into the entry block are self tail calls, which can
+     occur when the tailrec entry point is the entry block itself. Passes such
+     as [Cfg_simplify.Merge_straightline_blocks] rely on the absence of other
+     kinds of edges into the entry block: they may delete a block whose unique
+     predecessor jumps to it, and the entry block must never be deleted. *)
+  let entry_block = Cfg.get_block_exn t.cfg t.cfg.entry_label in
+  List.iter
+    (fun predecessor ->
+      let pred_block = Cfg.get_block_exn t.cfg predecessor in
+      match pred_block.terminator.desc with
+      | Tailcall_self _ -> ()
+      | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+      | Int_test _ | Switch _ | Return | Raise _ | Tailcall_func _
+      | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
+        report t
+          "Block %a is a predecessor of the entry block, but its terminator is \
+           not a self tail call"
+          Label.print predecessor)
+    (Cfg.predecessor_labels entry_block)
+
 let check_terminator_arity t label block =
   let term = block.Cfg.terminator in
   let args = term.arg in
@@ -580,6 +601,7 @@ let run ppf cfg_with_layout =
   in
   check_layout t layout;
   Cfg.iter_blocks ~f:(check_block t) cfg;
+  check_entry_predecessors t;
   check_tailrec_position t;
   let cfg_with_infos = Cfg_with_infos.make cfg_with_layout in
   check_reducibility t cfg_with_infos;

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -727,8 +727,31 @@ end = struct
               Printreg.reg reg Reg.format_location reg.loc)
         before
 
+  let check_entry_predecessors t =
+    (* The only expected edges into the entry block are self tail calls, which
+       can occur when the tailrec entry point is the entry block itself. Passes
+       such as [Cfg_simplify.Merge_straightline_blocks] rely on the absence of
+       other kinds of edges into the entry block: they may delete a block whose
+       unique predecessor jumps to it, and the entry block must never be
+       deleted. *)
+    let entry_block = Cfg.get_block_exn t.cfg t.cfg.entry_label in
+    List.iter
+      (fun predecessor ->
+        let pred_block = Cfg.get_block_exn t.cfg predecessor in
+        match pred_block.terminator.desc with
+        | Tailcall_self _ -> ()
+        | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+        | Int_test _ | Switch _ | Return | Raise _ | Tailcall_func _
+        | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
+          report t
+            "Block %a is a predecessor of the entry block, but its terminator \
+             is not a self tail call"
+            Label.print predecessor)
+      (Cfg.predecessor_labels entry_block)
+
   let check_all t cfg_with_layout =
     let cfg_with_infos = Cfg_with_infos.make cfg_with_layout in
+    check_entry_predecessors t;
     check_reducibility t cfg_with_infos;
     check_liveness t cfg_with_infos
 end

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -207,7 +207,7 @@ module Merge_straightline_blocks : sig
   val run : Cfg_with_layout.t -> Label.Set.t
 end = struct
   (* Two blocks `b1` and `b2` can be merged if:
-   * - `b1` is not the entry block;
+   * - neither `b1` nor `b2` is the entry block;
    * - `b1` has only one non-exceptional successor, `b2`;
    * - `b1` cannot raise;
    * - `b2` has only one predecessor, `b1`;
@@ -246,6 +246,9 @@ end = struct
             let b2_predecessors = Cfg.predecessor_labels b2_block in
             if
               (not (Label.equal b1_label cfg.entry_label))
+              (* the merge deletes `b2`, and the entry block must never be
+                 deleted (`cfg.entry_label` would be left dangling) *)
+              && (not (Label.equal b2_label cfg.entry_label))
               && (not (Label.equal b1_label b2_label))
               && List.compare_length_with b2_predecessors 1 = 0
               && Cfg.is_pure_terminator b1_block.terminator.desc
@@ -296,6 +299,9 @@ let run cfg_with_layout =
      [Eliminate_fallthrough_blocks] because merging blocks creates more
      opportunities for terminator simplification. *)
   Simplify_terminator.run (Cfg_with_layout.cfg cfg_with_layout);
+  (* [Simplify_terminator] can change successor sets, e.g. by short-circuiting
+     jumps to empty blocks, possibly making some blocks unreachable: hence the
+     second round of dead code elimination. *)
   Eliminate_dead_code.run cfg_with_layout |> acc;
   Cfg_with_layout.remove_blocks cfg_with_layout !dead_labels;
   cfg_with_layout

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -211,7 +211,7 @@ module Merge_straightline_blocks : sig
   val run : Cfg_with_layout.t -> Label.Set.t
 end = struct
   (* Two blocks `b1` and `b2` can be merged if:
-   * - `b1` is not the entry block;
+   * - neither `b1` nor `b2` is the entry block;
    * - `b1` has only one non-exceptional successor, `b2`;
    * - `b1` cannot raise;
    * - `b2` has only one predecessor, `b1`;
@@ -250,6 +250,9 @@ end = struct
             let b2_predecessors = Cfg.predecessor_labels b2_block in
             if
               (not (Label.equal b1_label cfg.entry_label))
+              (* the merge deletes `b2`, and the entry block must never be
+                 deleted (`cfg.entry_label` would be left dangling) *)
+              && (not (Label.equal b2_label cfg.entry_label))
               && (not (Label.equal b1_label b2_label))
               && List.compare_length_with b2_predecessors 1 = 0
               && Cfg.is_pure_terminator b1_block.terminator.desc
@@ -300,6 +303,9 @@ let run cfg_with_layout =
      [Eliminate_fallthrough_blocks] because merging blocks creates more
      opportunities for terminator simplification. *)
   Simplify_terminator.run (Cfg_with_layout.cfg cfg_with_layout);
+  (* [Simplify_terminator] can change successor sets, e.g. by short-circuiting
+     jumps to empty blocks, possibly making some blocks unreachable: hence the
+     second round of dead code elimination. *)
   Eliminate_dead_code.run cfg_with_layout |> acc;
   Cfg_with_layout.remove_blocks cfg_with_layout !dead_labels;
   cfg_with_layout

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -250,8 +250,6 @@ end = struct
             let b2_predecessors = Cfg.predecessor_labels b2_block in
             if
               (not (Label.equal b1_label cfg.entry_label))
-              (* the merge deletes `b2`, and the entry block must never be
-                 deleted (`cfg.entry_label` would be left dangling) *)
               && (not (Label.equal b2_label cfg.entry_label))
               && (not (Label.equal b1_label b2_label))
               && List.compare_length_with b2_predecessors 1 = 0

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -448,6 +448,12 @@ let block_known_values (cfg : Cfg.t) (block : C.basic_block)
       true)
   else false
 
+(* [block cfg b] simplifies the terminator of [b], and returns [true] when the
+    simplification may have changed the set of successor labels of [b]. In that
+    case it is the caller's responsibility to make predecessor sets consistent
+    again, e.g. via [Cfg.register_predecessors_for_all_blocks].  If it returns
+    [false], successor sets are unchanged, even though the terminator may have
+    been rewritten. *)
 (* CR-someday gyorsh: merge (Lbranch | Lcondbranch | Lcondbranch3)+ into a
    single terminator when the argments are the same. Enables reordering of
    branch instructions and save cmp instructions. The main problem is that it

--- a/backend/cfg/simplify_terminator.mli
+++ b/backend/cfg/simplify_terminator.mli
@@ -23,11 +23,25 @@
  * SOFTWARE.                                                                      *
  *                                                                                *
  **********************************************************************************)
-(** Merge successors that go to the same label and simplify their conditions.
-    Modifies the terminators in place. Does not merge blocks. *)
+(** Simplify the terminators of blocks: merge successors that go to the same
+    label, simplify conditions whose value is statically known, and
+    short-circuit jumps to empty blocks. Modifies the terminators in place. Does
+    not merge blocks.
+
+    Simplification can change the set of successor labels of a block, and can
+    hence make other blocks unreachable. [run] re-registers the predecessors of
+    all blocks whenever that may have happened, so that predecessor sets are
+    consistent with successor sets when it returns. *)
 
 [@@@ocaml.warning "+a-40-41-42"]
 
+(** [block cfg b] simplifies the terminator of [b], and returns [true] when the
+    simplification may have changed the set of successor labels of [b]. In that
+    case it is the caller's responsibility to make predecessor sets consistent
+    again, e.g. via [Cfg.register_predecessors_for_all_blocks] (after first
+    clearing the predecessor sets, since that function only ever adds elements).
+    If it returns [false], successor sets are unchanged, even though the
+    terminator may have been rewritten. *)
 val block : Cfg.t -> Cfg.basic_block -> bool
 
 val run : Cfg.t -> unit

--- a/backend/cfg/simplify_terminator.mli
+++ b/backend/cfg/simplify_terminator.mli
@@ -26,22 +26,12 @@
 (** Simplify the terminators of blocks: merge successors that go to the same
     label, simplify conditions whose value is statically known, and
     short-circuit jumps to empty blocks. Modifies the terminators in place. Does
-    not merge blocks.
-
-    Simplification can change the set of successor labels of a block, and can
-    hence make other blocks unreachable. [run] re-registers the predecessors of
-    all blocks whenever that may have happened, so that predecessor sets are
-    consistent with successor sets when it returns. *)
+    not merge blocks. *)
 
 [@@@ocaml.warning "+a-40-41-42"]
 
-(** [block cfg b] simplifies the terminator of [b], and returns [true] when the
-    simplification may have changed the set of successor labels of [b]. In that
-    case it is the caller's responsibility to make predecessor sets consistent
-    again, e.g. via [Cfg.register_predecessors_for_all_blocks] (after first
-    clearing the predecessor sets, since that function only ever adds elements).
-    If it returns [false], successor sets are unchanged, even though the
-    terminator may have been rewritten. *)
-val block : Cfg.t -> Cfg.basic_block -> bool
-
+(** Simplification can change the set of successor labels of a block, and can
+    hence make other blocks unreachable. [run] re-registers the predecessors of
+    all blocks whenever that may have happened, so that predecessor sets are
+    consistent with successor sets when it returns. *)
 val run : Cfg.t -> unit


### PR DESCRIPTION
Follow-ups from a correctness review (by Fable) of `backend/cfg/cfg_simplify.ml`:

- `Merge_straightline_blocks`: guard against merging away the entry block (`b2 = entry` would leave `cfg.entry_label` dangling). The shape requires an edge into the entry block, which is not currently generated, so this is defensive.
- `Cfg_invariants`: new `check_entry_predecessors` check that the only edges into the entry block come from `Tailcall_self` terminators, making the above assumption checkable under `-dcfg-invariants`.
- `Simplify_terminator`: document that simplification can change successor sets and that run re-registers predecessors when needed; document the meaning of block's return value. Explain in `Cfg_simplify.run` why a second round of dead code elimination follows.
- `Cfg_dataflow`: document that the forward analysis result map has an entry for every block (it is not a "partial map").