### PR TITLE
Fix bug where open didn't bring kind declarations into scope

### DIFF
--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1769,3 +1769,32 @@ Error: This type "Branch_kinds_extra.t2'" should be an instance of type
            Branch_kinds_extra.k1
          because of the definition of branch_needs_k1_extra at line 1, characters 0-55.
 |}]
+
+(***************************************************)
+(* Test: Include and open bring kinds into scope *)
+
+module K = struct
+  kind_ k_open = any
+end
+[%%expect{|
+module K : sig kind_ k_open = any end
+|}]
+
+module Include_abstract_kind = struct
+  include K
+  type ('a : k_open) t
+end
+[%%expect{|
+module Include_abstract_kind : sig kind_ k_open = any type ('a : any) t end
+|}]
+
+module Open_abstract_kind_test = struct
+  open K
+  type ('a : k_open) t
+end
+[%%expect{|
+Line 3, characters 13-19:
+3 |   type ('a : k_open) t
+                 ^^^^^^
+Error: Unbound kind "k_open"
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1793,8 +1793,5 @@ module Open_abstract_kind_test = struct
   type ('a : k_open) t
 end
 [%%expect{|
-Line 3, characters 13-19:
-3 |   type ('a : k_open) t
-                 ^^^^^^
-Error: Unbound kind "k_open"
+module Open_abstract_kind_test : sig type ('a : any) t end
 |}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1761,3 +1761,32 @@ Error: This type "Branch_kinds_extra.t2'" should be an instance of type
            Branch_kinds_extra.k1
          because of the definition of branch_needs_k1_extra at line 1, characters 0-55.
 |}]
+
+(***************************************************)
+(* Test: Include and open bring kinds into scope *)
+
+module K = struct
+  kind_ k_open = any
+end
+[%%expect{|
+module K : sig kind_ k_open = any end
+|}]
+
+module Include_abstract_kind = struct
+  include K
+  type ('a : k_open) t
+end
+[%%expect{|
+module Include_abstract_kind : sig kind_ k_open = any type ('a : any) t end
+|}]
+
+module Open_abstract_kind_test = struct
+  open K
+  type ('a : k_open) t
+end
+[%%expect{|
+Line 3, characters 13-19:
+3 |   type ('a : k_open) t
+                 ^^^^^^
+Error: Unbound kind "k_open"
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1785,8 +1785,5 @@ module Open_abstract_kind_test = struct
   type ('a : k_open) t
 end
 [%%expect{|
-Line 3, characters 13-19:
-3 |   type ('a : k_open) t
-                 ^^^^^^
-Error: Unbound kind "k_open"
+module Open_abstract_kind_test : sig type ('a : any) t end
 |}]

--- a/testsuite/tests/typing-abstract-kinds/warnings.compilers.reference
+++ b/testsuite/tests/typing-abstract-kinds/warnings.compilers.reference
@@ -1,3 +1,9 @@
+File "warnings.ml", line 25, characters 2-8:
+25 |   open M
+       ^^^^^^
+Warning 44 [open-shadow-identifier]: this open statement shadows the
+  kind identifier k_shadowed (which is later used)
+
 File "warnings.ml", line 7, characters 2-9:
 7 |   kind_ k
       ^^^^^^^

--- a/testsuite/tests/typing-abstract-kinds/warnings.ml
+++ b/testsuite/tests/typing-abstract-kinds/warnings.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w +191 -no-ikinds";
+   flags = "-w +44+191 -no-ikinds";
 *)
 
 (* The unused kind decl warning exists *)
@@ -15,4 +15,13 @@ end
 module M3 : sig end = struct
   [@@@warning "-191"]
   kind_ k
+end
+
+(* Opening a module that shadows a kind triggers the open-shadow warning, just
+   as it does for types. *)
+module Shadowing = struct
+  kind_ k_shadowed = value
+  module M = struct kind_ k_shadowed = float64 end
+  open M
+  type after : k_shadowed = float#
 end

--- a/testsuite/tests/typing-abstract-kinds/warnings_ikinds.compilers.reference
+++ b/testsuite/tests/typing-abstract-kinds/warnings_ikinds.compilers.reference
@@ -1,3 +1,9 @@
+File "warnings_ikinds.ml", line 25, characters 2-8:
+25 |   open M
+       ^^^^^^
+Warning 44 [open-shadow-identifier]: this open statement shadows the
+  kind identifier k_shadowed (which is later used)
+
 File "warnings_ikinds.ml", line 7, characters 2-9:
 7 |   kind_ k
       ^^^^^^^

--- a/testsuite/tests/typing-abstract-kinds/warnings_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/warnings_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w +191";
+   flags = "-w +44+191";
 *)
 
 (* The unused kind decl warning exists *)
@@ -15,4 +15,13 @@ end
 module M3 : sig end = struct
   [@@@warning "-191"]
   kind_ k
+end
+
+(* Opening a module that shadows a kind triggers the open-shadow warning, just
+   as it does for types. *)
+module Shadowing = struct
+  kind_ k_shadowed = value
+  module M = struct kind_ k_shadowed = float64 end
+  open M
+  type after : k_shadowed = float#
 end

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -966,9 +966,10 @@ let check_shadowing env = function
   | `Module_type (Some _) -> Some "module type"
   | `Class (Some _) -> Some "class"
   | `Class_type (Some _) -> Some "class type"
+  | `Jkind (Some _) -> Some "kind"
   | `Constructor _ | `Label _ | `Unboxed_label _
   | `Value None | `Type None | `Module None | `Module_type None
-  | `Class None | `Class_type None | `Component None ->
+  | `Class None | `Class_type None | `Component None | `Jkind None ->
       None
 
 let empty = {
@@ -4255,20 +4256,29 @@ let add_components slot root env0 comps (locks : locks) =
   let cltypes =
     add (fun x -> `Class_type x) comps.comp_cltypes env0.cltypes
   in
+  let jkinds =
+    add (fun x -> `Jkind x) comps.comp_jkinds env0.jkinds
+  in
   let modules =
     add_v (fun x -> `Module x) comps.comp_modules env0.modules
   in
-  { env0 with
-    summary = Env_open(env0.summary, root);
+  { values;
     constrs;
     labels;
     unboxed_labels;
-    values;
     types;
+    modules;
     modtypes;
     classes;
     cltypes;
-    modules;
+    functor_args = env0.functor_args;
+    jkinds;
+    summary = Env_open(env0.summary, root);
+    local_constraints = env0.local_constraints;
+    implicit_jkinds = env0.implicit_jkinds;
+    flags = env0.flags;
+    stage = env0.stage;
+    toplevel_scope = env0.toplevel_scope;
   }
 
 let open_signature_by_path path env0 =


### PR DESCRIPTION
Two commits:

* The first adds a test demonstrating the bug
* The second fixes the bug (and tries to make it a little harder to write a similar bug in the future by making the relevant `env` function less brittle). It also adds a test for warning 44, which is newly reachable with kinds.

(Thanks @dvulakh for the bug report)