### PR TITLE
Fix a jkind-related bug in nondep

### DIFF
--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1769,3 +1769,32 @@ Error: This type "Branch_kinds_extra.t2'" should be an instance of type
            Branch_kinds_extra.k1
          because of the definition of branch_needs_k1_extra at line 1, characters 0-55.
 |}]
+
+(***************************************************)
+(* Test: Include and open bring kinds into scope *)
+
+module K = struct
+  kind_ k_open = any
+end
+[%%expect{|
+module K : sig kind_ k_open = any end
+|}]
+
+module Include_abstract_kind = struct
+  include K
+  type ('a : k_open) t
+end
+[%%expect{|
+module Include_abstract_kind : sig kind_ k_open = any type ('a : any) t end
+|}]
+
+module Open_abstract_kind_test = struct
+  open K
+  type ('a : k_open) t
+end
+[%%expect{|
+Line 3, characters 13-19:
+3 |   type ('a : k_open) t
+                 ^^^^^^
+Error: Unbound kind "k_open"
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1795,3 +1795,42 @@ end
 [%%expect{|
 module Open_abstract_kind_test : sig type ('a : any) t end
 |}]
+
+(*******************************************)
+(* Test: Regression test for bug in nondep *)
+
+(* Multiple applications of a functor whose result mentions the parameter's
+   abstract kind shouldn't affect each other. *)
+
+type ('a : any) id : value
+
+module F (X : sig kind_ ka end) : sig
+  val mk : ('a : X.ka). 'a id -> 'a id
+end = struct
+  let mk x = x
+end
+[%%expect{|
+type ('a : any) id
+module F :
+  functor (X : sig kind_ ka end) ->
+    sig val mk : ('a : X.ka). 'a id -> 'a id end
+|}]
+
+module _ = F (struct kind_ ka = value_or_null end)
+module M = F (struct kind_ ka = any end)
+[%%expect{|
+module M : sig val mk : 'a id -> 'a id end
+|}]
+
+let foo : ('a : any). 'a id -> 'a id = M.mk
+[%%expect{|
+Line 1, characters 39-43:
+1 | let foo : ('a : any). 'a id -> 'a id = M.mk
+                                           ^^^^
+Error: This definition has type "'b id -> 'b id" which is less general than
+         "('a : any). 'a id -> 'a id"
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be a value layout
+         because of the definition of mk at line 4, characters 2-38.
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1819,18 +1819,10 @@ module F :
 module _ = F (struct kind_ ka = value_or_null end)
 module M = F (struct kind_ ka = any end)
 [%%expect{|
-module M : sig val mk : 'a id -> 'a id end
+module M : sig val mk : ('a : any). 'a id -> 'a id end
 |}]
 
 let foo : ('a : any). 'a id -> 'a id = M.mk
 [%%expect{|
-Line 1, characters 39-43:
-1 | let foo : ('a : any). 'a id -> 'a id = M.mk
-                                           ^^^^
-Error: This definition has type "'b id -> 'b id" which is less general than
-         "('a : any). 'a id -> 'a id"
-       The layout of 'a is any
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must be a value layout
-         because of the definition of mk at line 4, characters 2-38.
+val foo : ('a : any). 'a id -> 'a id = <fun>
 |}]

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1793,8 +1793,5 @@ module Open_abstract_kind_test = struct
   type ('a : k_open) t
 end
 [%%expect{|
-Line 3, characters 13-19:
-3 |   type ('a : k_open) t
-                 ^^^^^^
-Error: Unbound kind "k_open"
+module Open_abstract_kind_test : sig type ('a : any) t end
 |}]

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1826,3 +1826,36 @@ let foo : ('a : any). 'a id -> 'a id = M.mk
 [%%expect{|
 val foo : ('a : any). 'a id -> 'a id = <fun>
 |}]
+
+(************************************************************)
+(* Test: Sharing a mutable cell across functor applications *)
+
+let cell = ref (None : (_ : any) id option)
+
+(* When G is applied to an anonymous argument, nondep will copy the weak type
+   variable in its output, but this test confirms that the subsequent inclusion
+   check unifies it back with the original. *)
+module G (X : sig kind_ ka end) = struct
+  let c = (cell : (_ : X.ka) id option ref)
+end
+
+module A = G (struct kind_ ka = value end)
+module B = G (struct kind_ ka = value end)
+[%%expect{|
+val cell : '_weak1 id option ref = {contents = None}
+module G :
+  functor (X : sig kind_ ka end) -> sig val c : '_weak1 id option ref end
+module A : sig val c : '_weak1 id option ref end
+module B : sig val c : '_weak1 id option ref end
+|}]
+
+let () = A.c := (None : int id option)
+let () = B.c := (None : bool id option)
+[%%expect{|
+Line 2, characters 16-39:
+2 | let () = B.c := (None : bool id option)
+                    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "bool id option"
+       but an expression was expected of type "int id option"
+       Type "bool" is not compatible with type "int"
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1811,18 +1811,10 @@ module F :
 module _ = F (struct kind_ ka = value_or_null end)
 module M = F (struct kind_ ka = any end)
 [%%expect{|
-module M : sig val mk : 'a id -> 'a id end
+module M : sig val mk : ('a : any). 'a id -> 'a id end
 |}]
 
 let foo : ('a : any). 'a id -> 'a id = M.mk
 [%%expect{|
-Line 1, characters 39-43:
-1 | let foo : ('a : any). 'a id -> 'a id = M.mk
-                                           ^^^^
-Error: This definition has type "'b id -> 'b id" which is less general than
-         "('a : any). 'a id -> 'a id"
-       The layout of 'a is any
-         because of the annotation on the universal variable 'a.
-       But the layout of 'a must be a value layout
-         because of the definition of mk at line 4, characters 2-38.
+val foo : ('a : any). 'a id -> 'a id = <fun>
 |}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1761,3 +1761,32 @@ Error: This type "Branch_kinds_extra.t2'" should be an instance of type
            Branch_kinds_extra.k1
          because of the definition of branch_needs_k1_extra at line 1, characters 0-55.
 |}]
+
+(***************************************************)
+(* Test: Include and open bring kinds into scope *)
+
+module K = struct
+  kind_ k_open = any
+end
+[%%expect{|
+module K : sig kind_ k_open = any end
+|}]
+
+module Include_abstract_kind = struct
+  include K
+  type ('a : k_open) t
+end
+[%%expect{|
+module Include_abstract_kind : sig kind_ k_open = any type ('a : any) t end
+|}]
+
+module Open_abstract_kind_test = struct
+  open K
+  type ('a : k_open) t
+end
+[%%expect{|
+Line 3, characters 13-19:
+3 |   type ('a : k_open) t
+                 ^^^^^^
+Error: Unbound kind "k_open"
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1785,8 +1785,5 @@ module Open_abstract_kind_test = struct
   type ('a : k_open) t
 end
 [%%expect{|
-Line 3, characters 13-19:
-3 |   type ('a : k_open) t
-                 ^^^^^^
-Error: Unbound kind "k_open"
+module Open_abstract_kind_test : sig type ('a : any) t end
 |}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1818,3 +1818,36 @@ let foo : ('a : any). 'a id -> 'a id = M.mk
 [%%expect{|
 val foo : ('a : any). 'a id -> 'a id = <fun>
 |}]
+
+(************************************************************)
+(* Test: Sharing a mutable cell across functor applications *)
+
+let cell = ref (None : (_ : any) id option)
+
+(* When G is applied to an anonymous argument, nondep will copy the weak type
+   variable in its output, but this test confirms that the subsequent inclusion
+   check unifies it back with the original. *)
+module G (X : sig kind_ ka end) = struct
+  let c = (cell : (_ : X.ka) id option ref)
+end
+
+module A = G (struct kind_ ka = value end)
+module B = G (struct kind_ ka = value end)
+[%%expect{|
+val cell : '_weak1 id option ref = {contents = None}
+module G :
+  functor (X : sig kind_ ka end) -> sig val c : '_weak1 id option ref end
+module A : sig val c : '_weak1 id option ref end
+module B : sig val c : '_weak1 id option ref end
+|}]
+
+let () = A.c := (None : int id option)
+let () = B.c := (None : bool id option)
+[%%expect{|
+Line 2, characters 16-39:
+2 | let () = B.c := (None : bool id option)
+                    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "bool id option"
+       but an expression was expected of type "int id option"
+       Type "bool" is not compatible with type "int"
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1787,3 +1787,42 @@ end
 [%%expect{|
 module Open_abstract_kind_test : sig type ('a : any) t end
 |}]
+
+(*******************************************)
+(* Test: Regression test for bug in nondep *)
+
+(* Multiple applications of a functor whose result mentions the parameter's
+   abstract kind shouldn't affect each other. *)
+
+type ('a : any) id : value
+
+module F (X : sig kind_ ka end) : sig
+  val mk : ('a : X.ka). 'a id -> 'a id
+end = struct
+  let mk x = x
+end
+[%%expect{|
+type ('a : any) id
+module F :
+  functor (X : sig kind_ ka end) ->
+    sig val mk : ('a : X.ka). 'a id -> 'a id end
+|}]
+
+module _ = F (struct kind_ ka = value_or_null end)
+module M = F (struct kind_ ka = any end)
+[%%expect{|
+module M : sig val mk : 'a id -> 'a id end
+|}]
+
+let foo : ('a : any). 'a id -> 'a id = M.mk
+[%%expect{|
+Line 1, characters 39-43:
+1 | let foo : ('a : any). 'a id -> 'a id = M.mk
+                                           ^^^^
+Error: This definition has type "'b id -> 'b id" which is less general than
+         "('a : any). 'a id -> 'a id"
+       The layout of 'a is any
+         because of the annotation on the universal variable 'a.
+       But the layout of 'a must be a value layout
+         because of the definition of mk at line 4, characters 2-38.
+|}]

--- a/testsuite/tests/typing-abstract-kinds/warnings.compilers.reference
+++ b/testsuite/tests/typing-abstract-kinds/warnings.compilers.reference
@@ -1,3 +1,9 @@
+File "warnings.ml", line 25, characters 2-8:
+25 |   open M
+       ^^^^^^
+Warning 44 [open-shadow-identifier]: this open statement shadows the
+  kind identifier k_shadowed (which is later used)
+
 File "warnings.ml", line 7, characters 2-9:
 7 |   kind_ k
       ^^^^^^^

--- a/testsuite/tests/typing-abstract-kinds/warnings.ml
+++ b/testsuite/tests/typing-abstract-kinds/warnings.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w +191 -no-ikinds";
+   flags = "-w +44+191 -no-ikinds";
 *)
 
 (* The unused kind decl warning exists *)
@@ -15,4 +15,13 @@ end
 module M3 : sig end = struct
   [@@@warning "-191"]
   kind_ k
+end
+
+(* Opening a module that shadows a kind triggers the open-shadow warning, just
+   as it does for types. *)
+module Shadowing = struct
+  kind_ k_shadowed = value
+  module M = struct kind_ k_shadowed = float64 end
+  open M
+  type after : k_shadowed = float#
 end

--- a/testsuite/tests/typing-abstract-kinds/warnings_ikinds.compilers.reference
+++ b/testsuite/tests/typing-abstract-kinds/warnings_ikinds.compilers.reference
@@ -1,3 +1,9 @@
+File "warnings_ikinds.ml", line 25, characters 2-8:
+25 |   open M
+       ^^^^^^
+Warning 44 [open-shadow-identifier]: this open statement shadows the
+  kind identifier k_shadowed (which is later used)
+
 File "warnings_ikinds.ml", line 7, characters 2-9:
 7 |   kind_ k
       ^^^^^^^

--- a/testsuite/tests/typing-abstract-kinds/warnings_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/warnings_ikinds.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-w +191";
+   flags = "-w +44+191";
 *)
 
 (* The unused kind decl warning exists *)
@@ -15,4 +15,13 @@ end
 module M3 : sig end = struct
   [@@@warning "-191"]
   kind_ k
+end
+
+(* Opening a module that shadows a kind triggers the open-shadow warning, just
+   as it does for types. *)
+module Shadowing = struct
+  kind_ k_shadowed = value
+  module M = struct kind_ k_shadowed = float64 end
+  open M
+  type after : k_shadowed = float#
 end

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8282,19 +8282,25 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
     if expand_private then try_expand_safe_opt env t
     else try_expand_safe env t
   in
-  match get_desc ty with
-    Tvar { name; jkind } ->
-    let jkind' = nondep_jkind_base env ids jkind in
-    if not (jkind' == jkind) then
-      set_type_desc ty (Tvar { name; jkind = jkind' });
-    ty
-  | Tunivar { name; jkind } ->
-    let jkind' = nondep_jkind_base env ids jkind in
-    if not (jkind' == jkind) then
-      set_type_desc ty (Tvar { name; jkind = jkind' });
-    ty
-  | _ -> try TypeHash.find nondep_hash ty
+  try TypeHash.find nondep_hash ty
   with Not_found ->
+  match get_desc ty with
+  | (Tvar {name; jkind} | Tunivar {name; jkind}) as desc ->
+    let jkind' = nondep_jkind_base env ids jkind in
+    if jkind' == jkind then ty
+    else
+      let desc =
+        match desc with
+        | Tvar _ -> Tvar {name; jkind = jkind'}
+        | Tunivar _ -> Tunivar {name; jkind = jkind'}
+        | _ -> assert false
+      in
+      let ty' =
+        newty3 ~level:(get_level ty) ~scope:(get_scope ty) desc
+      in
+      TypeHash.add nondep_hash ty ty';
+      ty'
+  | _ ->
     let ty' = newgenstub ~scope:(get_scope ty)
                 (Jkind.Builtin.any ~why:Dummy_jkind) in
     TypeHash.add nondep_hash ty ty';

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -966,9 +966,10 @@ let check_shadowing env = function
   | `Module_type (Some _) -> Some "module type"
   | `Class (Some _) -> Some "class"
   | `Class_type (Some _) -> Some "class type"
+  | `Jkind (Some _) -> Some "kind"
   | `Constructor _ | `Label _ | `Unboxed_label _
   | `Value None | `Type None | `Module None | `Module_type None
-  | `Class None | `Class_type None | `Component None ->
+  | `Class None | `Class_type None | `Component None | `Jkind None ->
       None
 
 let empty = {
@@ -4255,20 +4256,29 @@ let add_components slot root env0 comps (locks : locks) =
   let cltypes =
     add (fun x -> `Class_type x) comps.comp_cltypes env0.cltypes
   in
+  let jkinds =
+    add (fun x -> `Jkind x) comps.comp_jkinds env0.jkinds
+  in
   let modules =
     add_v (fun x -> `Module x) comps.comp_modules env0.modules
   in
-  { env0 with
-    summary = Env_open(env0.summary, root);
+  { values;
     constrs;
     labels;
     unboxed_labels;
-    values;
     types;
+    modules;
     modtypes;
     classes;
     cltypes;
-    modules;
+    functor_args = env0.functor_args;
+    jkinds;
+    summary = Env_open(env0.summary, root);
+    local_constraints = env0.local_constraints;
+    implicit_jkinds = env0.implicit_jkinds;
+    flags = env0.flags;
+    stage = env0.stage;
+    toplevel_scope = env0.toplevel_scope;
   }
 
 let open_signature_by_path path env0 =


### PR DESCRIPTION
This fixes a bug in nondep, introduced by the abstract kinds PRs, where we sometimes modify a type that should instead be copied.

Note that this PR includes #6268 just because they would otherwise have conflicty test changes. Just read the last two commits of this PR. Those commits are:

* First, demonstrate the bug: a second application of a functor results in a module with the wrong type because of some bad mutation happening during the first application.
* Second, fix the bug, by creating a new type variable in nondep rather than mutating the old one. (This also fixes a copy-paste bug where the Tunivar case returned a Tvar rather than a Tunivar)

Credit to @dvulakh for the report