### PR TITLE
flambda: Add poison value to terms

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -228,6 +228,10 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
               | Naked_vec512 _ ->
                 Misc.fatal_errorf
                   "Unboxed constants are not allowed inside of Const_block: %a"
+                  Printlambda.structured_constant const
+              | Poison _ ->
+                Misc.fatal_errorf
+                  "[declare_const] returned a poison constant for %a"
                   Printlambda.structured_constant const);
           acc, field)
         acc consts
@@ -1560,11 +1564,28 @@ let close_let acc env let_bound_ids_with_kinds user_visible defining_expr
                         ~const:(fun cst ->
                           match Reg_width_const.descr cst with
                           | Naked_float f -> Or_variable.Const f
+                          | Poison (Naked_number Naked_float, _name) ->
+                            (* Unfortunately, we can't put poison in the static
+                               block. Use a signaling NaN instead, to cause
+                               traps if the value is ever used. *)
+                            Or_variable.Const
+                              (Numeric_types.Float_by_bit_pattern.of_bits
+                                 0x7FF0DEAD_DEADDEAD_L)
                           | Tagged_immediate _ | Naked_immediate _
                           | Naked_float32 _ | Naked_int8 _ | Naked_int16 _
                           | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
                           | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _
-                          | Null ->
+                          | Null
+                          | Poison
+                              ( ( Value
+                                | Naked_number
+                                    ( Naked_immediate | Naked_float32
+                                    | Naked_int8 | Naked_int16 | Naked_int32
+                                    | Naked_int64 | Naked_nativeint
+                                    | Naked_vec128 | Naked_vec256 | Naked_vec512
+                                      )
+                                | Region | Rec_info ),
+                                _ ) ->
                             Misc.fatal_errorf
                               "Binding of %a to %a contains the constant %a \
                                inside a float record, whereas only naked \

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -53,6 +53,7 @@ module Const_data = struct
     | Naked_vec256 of Vector_types.Vec256.Bit_pattern.t
     | Naked_vec512 of Vector_types.Vec512.Bit_pattern.t
     | Null
+    | Poison of Flambda_kind.t * string
 
   let flags = const_flags
 
@@ -127,6 +128,12 @@ module Const_data = struct
         Format.fprintf ppf "%t#null%t"
           Flambda_colours.naked_number
           Flambda_colours.pop
+      | Poison (kind, name) ->
+        Format.fprintf ppf "%t#poison[%s][%a]%t"
+          Flambda_colours.invalid_keyword
+          name
+          Flambda_kind.print kind
+          Flambda_colours.pop
 
     let compare t1 t2 =
       match t1, t2 with
@@ -149,6 +156,9 @@ module Const_data = struct
       | Naked_vec512 v1, Naked_vec512 v2 ->
         Vector_types.Vec512.Bit_pattern.compare v1 v2
       | Null, Null -> 0
+      | Poison (kind1, name1), Poison (kind2, name2) ->
+        let c = Flambda_kind.compare kind1 kind2 in
+        if c <> 0 then c else String.compare name1 name2
       | Naked_immediate _, _ -> -1
       | _, Naked_immediate _ -> 1
       | Tagged_immediate _, _ -> -1
@@ -173,6 +183,8 @@ module Const_data = struct
       | _, Naked_vec256 _ -> 1
       | Naked_vec512 _, _ -> -1
       | _, Naked_vec512 _ -> 1
+      | Poison _, _ -> -1
+      | _, Poison _ -> 1
 
     let equal t1 t2 =
       if t1 == t2
@@ -198,10 +210,12 @@ module Const_data = struct
         | Naked_vec512 v1, Naked_vec512 v2 ->
           Vector_types.Vec512.Bit_pattern.equal v1 v2
         | Null, Null -> true
+        | Poison (kind1, name1), Poison (kind2, name2) ->
+          Flambda_kind.equal kind1 kind2 && String.equal name1 name2
         | ( ( Naked_immediate _ | Tagged_immediate _ | Naked_float _
             | Naked_float32 _ | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _
             | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
-            | Naked_nativeint _ | Null ),
+            | Naked_nativeint _ | Null | Poison _ ),
             _ ) ->
           false
 
@@ -220,6 +234,8 @@ module Const_data = struct
       | Naked_vec256 v -> Vector_types.Vec256.Bit_pattern.hash v
       | Naked_vec512 v -> Vector_types.Vec512.Bit_pattern.hash v
       | Null -> Hashtbl.hash 0
+      | Poison (kind, name) ->
+        Hashtbl.hash (Flambda_kind.hash kind, String.hash name)
   end)
 end
 
@@ -406,6 +422,8 @@ module Const = struct
   let const_unit machine_width = const_zero machine_width
 
   let const_null = create Null
+
+  let const_poison kind name = create (Poison (kind, name))
 
   let descr t = find_data t
 

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -47,6 +47,8 @@ module Const : sig
 
   val const_null : t
 
+  val const_poison : Flambda_kind.t -> string -> t
+
   (** [naked_immediate] is similar to [naked_nativeint], but represents integers
       of width [n - 1] bits, where [n] is the native machine width. (By
       contrast, [naked_nativeint] represents integers of width [n] bits.) *)
@@ -89,6 +91,7 @@ module Const : sig
       | Naked_vec256 of Vector_types.Vec256.Bit_pattern.t
       | Naked_vec512 of Vector_types.Vec512.Bit_pattern.t
       | Null
+      | Poison of Flambda_kind.t * string
 
     include Container_types.S with type t := t
   end

--- a/middle_end/flambda2/identifiers/reg_width_const.ml
+++ b/middle_end/flambda2/identifiers/reg_width_const.ml
@@ -31,6 +31,7 @@ let of_descr (descr : Descr.t) =
   | Naked_vec256 v -> naked_vec256 v
   | Naked_vec512 v -> naked_vec512 v
   | Null -> const_null
+  | Poison (kind, name) -> const_poison kind name
 
 let is_null t = equal t const_null
 
@@ -39,7 +40,7 @@ let is_naked_immediate t =
   | Naked_immediate i -> Some i
   | Tagged_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int8 _
   | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_tagged_immediate t =
@@ -47,7 +48,7 @@ let is_tagged_immediate t =
   | Tagged_immediate i -> Some i
   | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int8 _
   | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_float32 t =
@@ -55,7 +56,7 @@ let is_naked_float32 t =
   | Naked_float32 f -> Some f
   | Naked_float _ | Naked_immediate _ | Tagged_immediate _ | Naked_int8 _
   | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_float t =
@@ -63,7 +64,7 @@ let is_naked_float t =
   | Naked_float f -> Some f
   | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _ | Naked_int8 _
   | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_int8 t =
@@ -71,7 +72,7 @@ let is_naked_int8 t =
   | Naked_int8 i -> Some i
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_int16 t =
@@ -79,7 +80,7 @@ let is_naked_int16 t =
   | Naked_int16 i -> Some i
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int8 _ | Naked_int32 _ | Naked_int64 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_int32 t =
@@ -87,7 +88,7 @@ let is_naked_int32 t =
   | Naked_int32 i -> Some i
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int8 _ | Naked_int16 _ | Naked_int64 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_int64 t =
@@ -95,7 +96,7 @@ let is_naked_int64 t =
   | Naked_int64 i -> Some i
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_nativeint _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_nativeint t =
@@ -103,7 +104,7 @@ let is_naked_nativeint t =
   | Naked_nativeint i -> Some i
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
-  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_vec128 t =
@@ -111,7 +112,7 @@ let is_naked_vec128 t =
   | Naked_vec128 v -> Some v
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
-  | Naked_nativeint _ | Naked_vec256 _ | Naked_vec512 _ | Null ->
+  | Naked_nativeint _ | Naked_vec256 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_vec256 t =
@@ -119,7 +120,7 @@ let is_naked_vec256 t =
   | Naked_vec256 v -> Some v
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
-  | Naked_nativeint _ | Naked_vec128 _ | Naked_vec512 _ | Null ->
+  | Naked_nativeint _ | Naked_vec128 _ | Naked_vec512 _ | Null | Poison _ ->
     None
 
 let is_naked_vec512 t =
@@ -127,7 +128,16 @@ let is_naked_vec512 t =
   | Naked_vec512 v -> Some v
   | Naked_float _ | Naked_float32 _ | Naked_immediate _ | Tagged_immediate _
   | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
-  | Naked_nativeint _ | Naked_vec128 _ | Naked_vec256 _ | Null ->
+  | Naked_nativeint _ | Naked_vec128 _ | Naked_vec256 _ | Null | Poison _ ->
+    None
+
+let is_poison t =
+  match descr t with
+  | Poison (kind, name) -> Some (kind, name)
+  | Naked_immediate _ | Tagged_immediate _ | Naked_float32 _ | Naked_float _
+  | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
+  | Naked_nativeint _ | Naked_vec128 _ | Naked_vec256 _ | Naked_vec512 _ | Null
+    ->
     None
 
 let kind t =
@@ -144,6 +154,7 @@ let kind t =
   | Naked_vec128 _ -> Flambda_kind.naked_vec128
   | Naked_vec256 _ -> Flambda_kind.naked_vec256
   | Naked_vec512 _ -> Flambda_kind.naked_vec512
+  | Poison (kind, _) -> kind
 
 let of_int_of_kind machine_width (kind : Flambda_kind.t) i =
   match kind with

--- a/middle_end/flambda2/identifiers/reg_width_const.mli
+++ b/middle_end/flambda2/identifiers/reg_width_const.mli
@@ -48,6 +48,8 @@ val is_naked_vec256 : t -> Vector_types.Vec256.Bit_pattern.t option
 
 val is_naked_vec512 : t -> Vector_types.Vec512.Bit_pattern.t option
 
+val is_poison : t -> (Flambda_kind.t * string) option
+
 (** Create a numeric constant of the given kind ([Region] and [Rec_info] are
     forbidden). *)
 val of_int_of_kind : Target_system.Machine_width.t -> Flambda_kind.t -> int -> t

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -51,6 +51,35 @@ type region =
   | Named of variable
   | Toplevel
 
+type tag_scannable = int
+
+type subkind =
+  | Anything
+  | Boxed_float32
+  | Boxed_float
+  | Boxed_int32
+  | Boxed_int64
+  | Boxed_nativeint
+  | Boxed_vec128
+  | Boxed_vec256
+  | Boxed_vec512
+  | Tagged_immediate
+  | Variant of
+      { consts : targetint list;
+        non_consts : (tag_scannable * kind_with_subkind list) list
+      }
+  | Float_block of { num_fields : int }
+  | Float_array
+  | Immediate_array
+  | Value_array
+  | Generic_array
+
+and kind_with_subkind =
+  | Value of subkind
+  | Naked_number of Flambda_kind.Naked_number_kind.t
+  | Region
+  | Rec_info
+
 type const =
   | Naked_immediate of immediate
   | Tagged_immediate of immediate
@@ -66,6 +95,7 @@ type const =
   | Naked_vec512 of Vector_types.Vec512.Bit_pattern.bits
   | Naked_nativeint of targetint
   | Null
+  | Poison of kind_with_subkind * string
 
 type field_of_block =
   | Symbol of symbol
@@ -75,8 +105,6 @@ type field_of_block =
 type is_recursive =
   | Nonrecursive
   | Recursive
-
-type tag_scannable = int
 
 type mutability = Mutability.t =
   | Mutable
@@ -122,33 +150,6 @@ type static_data =
   | Empty_array of empty_array_kind
   | Mutable_string of { initial_value : string }
   | Immutable_string of string
-
-type subkind =
-  | Anything
-  | Boxed_float32
-  | Boxed_float
-  | Boxed_int32
-  | Boxed_int64
-  | Boxed_nativeint
-  | Boxed_vec128
-  | Boxed_vec256
-  | Boxed_vec512
-  | Tagged_immediate
-  | Variant of
-      { consts : targetint list;
-        non_consts : (tag_scannable * kind_with_subkind list) list
-      }
-  | Float_block of { num_fields : int }
-  | Float_array
-  | Immediate_array
-  | Value_array
-  | Generic_array
-
-and kind_with_subkind =
-  | Value of subkind
-  | Naked_number of Flambda_kind.Naked_number_kind.t
-  | Region
-  | Rec_info
 
 type static_data_binding =
   { symbol : symbol;

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -98,6 +98,9 @@ let const (c : Fexpr.const) : Reg_width_const.t =
   | Naked_vec256 bits -> Reg_width_const.naked_vec256 (bits |> vec256)
   | Naked_vec512 bits -> Reg_width_const.naked_vec512 (bits |> vec512)
   | Null -> Reg_width_const.const_null
+  | Poison (kind, name) ->
+    let kind = Flambda_kind.With_subkind.kind (value_kind_with_subkind kind) in
+    Reg_width_const.const_poison kind name
 
 let rec rec_info env (ri : Fexpr.rec_info) : Rec_info_expr.t =
   let module US = Rec_info_expr.Unrolling_state in

--- a/middle_end/flambda2/parser/flambda_lex.mll
+++ b/middle_end/flambda2/parser/flambda_lex.mll
@@ -80,6 +80,7 @@ let keyword_table =
     "notrace", KWD_NOTRACE;
     "null", KWD_NULL;
     "of", KWD_OF;
+    "poison", KWD_POISON;
     "pop", KWD_POP;
     "push", KWD_PUSH;
     "rec", KWD_REC;

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -4,7 +4,7 @@
 
 flambda_unit: KWD_APPLY SYMBOL LPAREN RPAREN KWD_WITH
 ##
-## Ends in an error in state: 480.
+## Ends in an error in state: 485.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -18,7 +18,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER IDENT KWD_WITH
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 487.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -32,7 +32,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL MINUSGREATER KWD_WITH
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 486.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -46,7 +46,7 @@ Example of an application:
 
 flambda_unit: KWD_APPLY SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 484.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
@@ -63,7 +63,7 @@ Examples of applications:
 
 flambda_unit: KWD_APPLY KWD_WITH
 ##
-## Ends in an error in state: 401.
+## Ends in an error in state: 406.
 ##
 ## atomic_expr -> KWD_APPLY . apply_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -78,7 +78,7 @@ Example of an application:
 
 flambda_unit: KWD_CONT IDENT LPAREN SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 195.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
 ## separated_nonempty_list(COMMA,simple) -> simple . COMMA separated_nonempty_list(COMMA,simple) [ RPAREN ]
@@ -92,7 +92,7 @@ Expected a simple value (a symbol, variable, or literal).
 
 flambda_unit: KWD_CONT IDENT LPAREN KWD_WITH
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 194.
 ##
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ RPAREN PIPE MINUSGREATER KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -109,7 +109,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT IDENT KWD_VAL
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 388.
 ##
 ## apply_cont_expr -> continuation . option(trap_action) simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -125,7 +125,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT KWD_WITH
 ##
-## Ends in an error in state: 378.
+## Ends in an error in state: 383.
 ##
 ## atomic_expr -> KWD_CONT . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -151,7 +151,7 @@ Example of a continuation call:
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_WITH
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 169.
 ##
 ## deleted_code -> KWD_CODE code_id . KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -171,7 +171,7 @@ Examples of argument lists:
 
 flambda_unit: KWD_LET KWD_CODE KWD_REC KWD_HCF
 ##
-## Ends in an error in state: 77.
+## Ends in an error in state: 126.
 ##
 ## code_header -> KWD_CODE recursive . option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -183,7 +183,7 @@ Expected a code id.
 
 flambda_unit: KWD_LET KWD_CODE KWD_WITH
 ##
-## Ends in an error in state: 75.
+## Ends in an error in state: 124.
 ##
 ## code_header -> KWD_CODE . recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ## deleted_code -> KWD_CODE . code_id KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
@@ -203,7 +203,7 @@ Examples of code definitions:
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND KWD_WITH
 ##
-## Ends in an error in state: 156.
+## Ends in an error in state: 205.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding KWD_AND . separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -215,7 +215,7 @@ Expected "code" or "symbol".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 204.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . KWD_AND separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
@@ -227,18 +227,18 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_END
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 45, spurious reduction of production function_slot_opt ->
-## In state 49, spurious reduction of production alloc_mode_for_allocations_opt ->
-## In state 54, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
-## In state 55, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
-## In state 294, spurious reduction of production symbol_binding -> static_closure_binding
+## In state 94, spurious reduction of production function_slot_opt ->
+## In state 98, spurious reduction of production alloc_mode_for_allocations_opt ->
+## In state 103, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
+## In state 104, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
+## In state 343, spurious reduction of production symbol_binding -> static_closure_binding
 ##
 
 Expected "and", "with", or "in".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN KWD_WITH
 ##
-## Ends in an error in state: 374.
+## Ends in an error in state: 379.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -250,7 +250,7 @@ Expected an expression.
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_VAL
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 94.
 ##
 ## fun_decl -> KWD_CLOSURE code_id . function_slot_opt alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -262,7 +262,7 @@ Expected "with", "in", "end", or "and".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_WITH
 ##
-## Ends in an error in state: 158.
+## Ends in an error in state: 207.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol EQUAL . static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -279,7 +279,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 157.
+## Ends in an error in state: 206.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol . EQUAL static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -296,7 +296,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET KWD_WITH
 ##
-## Ends in an error in state: 371.
+## Ends in an error in state: 376.
 ##
 ## let_expr(expr) -> KWD_LET . let_(expr) [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## let_symbol(expr) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
@@ -313,7 +313,7 @@ Examples of let expressions:
 
 flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 560.
 ##
 ## flambda_unit -> module_ . EOF [ # ]
 ##
@@ -324,13 +324,13 @@ flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 11, spurious reduction of production option(PIPE) ->
-## In state 35, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
-## In state 552, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
-## In state 34, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
-## In state 526, spurious reduction of production inner_expr -> inlined_expr
-## In state 491, spurious reduction of production expr -> inner_expr
-## In state 558, spurious reduction of production module_ -> expr
+## In state 62, spurious reduction of production option(PIPE) ->
+## In state 85, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
+## In state 557, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
+## In state 84, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
+## In state 531, spurious reduction of production inner_expr -> inlined_expr
+## In state 496, spurious reduction of production expr -> inner_expr
+## In state 563, spurious reduction of production module_ -> expr
 ##
 
 Expected one or more switch cases, separated by semicolons, surrounded by {}.
@@ -585,9 +585,296 @@ flambda_unit: KWD_SWITCH TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_SWITCH FLOAT SYMBOL
+flambda_unit: KWD_SWITCH KWD_POISON TILDE
+##
+## Ends in an error in state: 5.
+##
+## const -> KWD_POISON . DOT kind_with_subkind DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POISON
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT TILDE
+##
+## Ends in an error in state: 6.
+##
+## const -> KWD_POISON DOT . kind_with_subkind DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POISON DOT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK TILDE
+##
+## Ends in an error in state: 7.
+##
+## subkind -> LBRACK . ctors RBRACK [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## LBRACK
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT TILDE
+##
+## Ends in an error in state: 8.
+##
+## tag -> INT . [ KWD_OF ]
+## targetint -> INT . [ RBRACK PIPE ]
+##
+## The known suffix of the stack is as follows:
+## INT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT PIPE TILDE
+##
+## Ends in an error in state: 10.
+##
+## ctors_nonempty -> targetint PIPE . ctors_nonempty [ RBRACK ]
+##
+## The known suffix of the stack is as follows:
+## targetint PIPE
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT PIPE INT TILDE
 ##
 ## Ends in an error in state: 11.
+##
+## nonconst_ctor -> tag . KWD_OF kinds_with_subkinds_nonempty [ RBRACK PIPE ]
+##
+## The known suffix of the stack is as follows:
+## tag
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF TILDE
+##
+## Ends in an error in state: 12.
+##
+## nonconst_ctor -> tag KWD_OF . kinds_with_subkinds_nonempty [ RBRACK PIPE ]
+##
+## The known suffix of the stack is as follows:
+## tag KWD_OF
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_VAL TILDE
+##
+## Ends in an error in state: 13.
+##
+## subkind -> KWD_VAL . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_VAL . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_VAL
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_NATIVEINT TILDE
+##
+## Ends in an error in state: 17.
+##
+## naked_number_kind -> KWD_NATIVEINT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_NATIVEINT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_NATIVEINT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT64 TILDE
+##
+## Ends in an error in state: 19.
+##
+## naked_number_kind -> KWD_INT64 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_INT64 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_INT64
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT32 TILDE
+##
+## Ends in an error in state: 21.
+##
+## naked_number_kind -> KWD_INT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_INT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_INT32
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_IMM TILDE
+##
+## Ends in an error in state: 23.
+##
+## naked_number_kind -> KWD_IMM . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_IMM . KWD_TAGGED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_IMM . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_IMM
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT32 TILDE
+##
+## Ends in an error in state: 26.
+##
+## naked_number_kind -> KWD_FLOAT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_FLOAT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_FLOAT32
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT TILDE
+##
+## Ends in an error in state: 28.
+##
+## naked_number_kind -> KWD_FLOAT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_FLOAT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_FLOAT . CARET plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+## subkind -> KWD_FLOAT . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_FLOAT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT CARET TILDE
+##
+## Ends in an error in state: 31.
+##
+## subkind -> KWD_FLOAT CARET . plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_FLOAT CARET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_ANY TILDE
+##
+## Ends in an error in state: 34.
+##
+## subkind -> KWD_ANY . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_ANY
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
+##
+## Ends in an error in state: 40.
+##
+## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
+## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . STAR separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
+##
+## The known suffix of the stack is as follows:
+## kind_with_subkind
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
+##
+## Ends in an error in state: 41.
+##
+## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind STAR . separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
+##
+## The known suffix of the stack is as follows:
+## kind_with_subkind STAR
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT RPAREN
+##
+## Ends in an error in state: 45.
+##
+## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . [ RBRACK ]
+## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . PIPE separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
+##
+## The known suffix of the stack is as follows:
+## nonconst_ctor
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 28, spurious reduction of production naked_number_kind -> KWD_FLOAT
+## In state 38, spurious reduction of production kind_with_subkind -> naked_number_kind
+## In state 40, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
+## In state 37, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 39, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT PIPE TILDE
+##
+## Ends in an error in state: 46.
+##
+## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor PIPE . separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
+##
+## The known suffix of the stack is as follows:
+## nonconst_ctor PIPE
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_REC_INFO TILDE
+##
+## Ends in an error in state: 53.
+##
+## const -> KWD_POISON DOT kind_with_subkind . DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POISON DOT kind_with_subkind
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT DOT TILDE
+##
+## Ends in an error in state: 54.
+##
+## const -> KWD_POISON DOT kind_with_subkind DOT . STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## KWD_POISON DOT kind_with_subkind DOT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH FLOAT SYMBOL
+##
+## Ends in an error in state: 62.
 ##
 ## inlined_expr -> KWD_SWITCH simple . switch [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND INT EOF ]
@@ -600,7 +887,7 @@ flambda_unit: KWD_SWITCH FLOAT SYMBOL
 
 flambda_unit: KWD_SWITCH FLOAT TILDE TILDE
 ##
-## Ends in an error in state: 12.
+## Ends in an error in state: 63.
 ##
 ## simple -> simple TILDE . coercion [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -612,7 +899,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 14.
+## Ends in an error in state: 65.
 ##
 ## coercion -> KWD_DEPTH . rec_info MINUSGREATER rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -624,7 +911,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN TILDE
 ##
-## Ends in an error in state: 15.
+## Ends in an error in state: 66.
 ##
 ## rec_info_atom -> LPAREN . rec_info RPAREN [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -636,7 +923,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 16.
+## Ends in an error in state: 67.
 ##
 ## rec_info -> KWD_UNROLL . plain_int rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -648,7 +935,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL INT TILDE
 ##
-## Ends in an error in state: 18.
+## Ends in an error in state: 68.
 ##
 ## rec_info -> KWD_UNROLL plain_int . rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -660,7 +947,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_SUCC TILDE
 ##
-## Ends in an error in state: 24.
+## Ends in an error in state: 74.
 ##
 ## rec_info -> KWD_SUCC . rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -672,7 +959,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_SUCC TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN INT TILDE
 ##
-## Ends in an error in state: 27.
+## Ends in an error in state: 77.
 ##
 ## rec_info_atom -> LPAREN rec_info . RPAREN [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -684,7 +971,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT TILDE
 ##
-## Ends in an error in state: 29.
+## Ends in an error in state: 79.
 ##
 ## coercion -> KWD_DEPTH rec_info . MINUSGREATER rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -696,7 +983,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 80.
 ##
 ## coercion -> KWD_DEPTH rec_info MINUSGREATER . rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
@@ -708,7 +995,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT MINUSGREATER TILDE
 
 flambda_unit: KWD_SWITCH FLOAT PIPE TILDE
 ##
-## Ends in an error in state: 35.
+## Ends in an error in state: 85.
 ##
 ## switch -> option(PIPE) . loption(separated_nonempty_list(PIPE,switch_case)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -720,7 +1007,7 @@ flambda_unit: KWD_SWITCH FLOAT PIPE TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT TILDE
 ##
-## Ends in an error in state: 37.
+## Ends in an error in state: 86.
 ##
 ## switch_case -> tag . MINUSGREATER apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## switch_case -> tag . MINUSGREATER atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -733,7 +1020,7 @@ flambda_unit: KWD_SWITCH FLOAT INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 38.
+## Ends in an error in state: 87.
 ##
 ## switch_case -> tag MINUSGREATER . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## switch_case -> tag MINUSGREATER . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -746,7 +1033,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET TILDE
 ##
-## Ends in an error in state: 39.
+## Ends in an error in state: 88.
 ##
 ## let_expr(atomic_body) -> KWD_LET . let_(atomic_body) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(atomic_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -759,7 +1046,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES TILDE
 ##
-## Ends in an error in state: 40.
+## Ends in an error in state: 89.
 ##
 ## static_set_of_closures -> KWD_SET_OF_CLOSURES . separated_nonempty_list(KWD_AND,static_closure_binding) with_value_slots_opt KWD_END [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -771,7 +1058,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL TILDE
 ##
-## Ends in an error in state: 41.
+## Ends in an error in state: 90.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_END KWD_AND ]
 ##
@@ -783,7 +1070,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL TILDE
 ##
-## Ends in an error in state: 42.
+## Ends in an error in state: 91.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_END KWD_AND ]
 ##
@@ -795,7 +1082,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE TILDE
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 92.
 ##
 ## fun_decl -> KWD_CLOSURE . code_id function_slot_opt alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -807,7 +1094,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT TILDE
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 95.
 ##
 ## function_slot_opt -> AT . function_slot [ RPAREN KWD_WITH KWD_IN KWD_END KWD_AND AMP ]
 ##
@@ -819,7 +1106,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 49.
+## Ends in an error in state: 98.
 ##
 ## fun_decl -> KWD_CLOSURE code_id function_slot_opt . alloc_mode_for_allocations_opt [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -831,7 +1118,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AT IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 ##
-## Ends in an error in state: 50.
+## Ends in an error in state: 99.
 ##
 ## alloc_mode_for_allocations_opt -> AMP . region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -843,7 +1130,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN
 ##
-## Ends in an error in state: 56.
+## Ends in an error in state: 105.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . [ KWD_WITH KWD_END ]
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . KWD_AND separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
@@ -855,17 +1142,17 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_IN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 45, spurious reduction of production function_slot_opt ->
-## In state 49, spurious reduction of production alloc_mode_for_allocations_opt ->
-## In state 54, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
-## In state 55, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
+## In state 94, spurious reduction of production function_slot_opt ->
+## In state 98, spurious reduction of production alloc_mode_for_allocations_opt ->
+## In state 103, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations_opt
+## In state 104, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND TILDE
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 106.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding KWD_AND . separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
 ##
@@ -877,7 +1164,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_AND
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 109.
 ##
 ## with_value_slots_opt -> KWD_WITH . LBRACE loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -889,7 +1176,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 110.
 ##
 ## with_value_slots_opt -> KWD_WITH LBRACE . loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -901,7 +1188,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 ##
-## Ends in an error in state: 63.
+## Ends in an error in state: 112.
 ##
 ## value_slot -> value_slot_for_projection . EQUAL simple [ SEMICOLON RBRACE ]
 ##
@@ -913,7 +1200,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 64.
+## Ends in an error in state: 113.
 ##
 ## value_slot -> value_slot_for_projection EQUAL . simple [ SEMICOLON RBRACE ]
 ##
@@ -925,7 +1212,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 65.
+## Ends in an error in state: 114.
 ##
 ## simple -> simple . TILDE coercion [ TILDE SEMICOLON RBRACE ]
 ## value_slot -> value_slot_for_projection EQUAL simple . [ SEMICOLON RBRACE ]
@@ -938,7 +1225,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 117.
 ##
 ## separated_nonempty_list(SEMICOLON,value_slot) -> value_slot SEMICOLON . separated_nonempty_list(SEMICOLON,value_slot) [ RBRACE ]
 ##
@@ -950,7 +1237,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOL
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 73.
+## Ends in an error in state: 122.
 ##
 ## static_set_of_closures -> KWD_SET_OF_CLOSURES separated_nonempty_list(KWD_AND,static_closure_binding) with_value_slots_opt . KWD_END [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -962,7 +1249,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT KWD_WIT
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 78.
+## Ends in an error in state: 127.
 ##
 ## inline -> KWD_UNROLL . LPAREN plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -974,7 +1261,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 128.
 ##
 ## inline -> KWD_UNROLL LPAREN . plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -986,7 +1273,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 129.
 ##
 ## inline -> KWD_UNROLL LPAREN plain_int . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -998,7 +1285,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 131.
 ##
 ## inline -> KWD_INLINE . LPAREN KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE . LPAREN KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1013,7 +1300,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 132.
 ##
 ## inline -> KWD_INLINE LPAREN . KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE LPAREN . KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1028,7 +1315,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 133.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_NEVER . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1040,7 +1327,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 86.
+## Ends in an error in state: 135.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_DEFAULT . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1052,7 +1339,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 137.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_AVAILABLE . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1064,7 +1351,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 90.
+## Ends in an error in state: 139.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_ALWAYS . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1076,7 +1363,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 92.
+## Ends in an error in state: 141.
 ##
 ## code_header -> KWD_CODE recursive option(inline) . loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1088,7 +1375,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 142.
 ##
 ## loopify_opt -> KWD_LOOPIFY . LPAREN loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1100,7 +1387,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 ##
-## Ends in an error in state: 94.
+## Ends in an error in state: 143.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN . loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1112,7 +1399,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 97.
+## Ends in an error in state: 146.
 ##
 ## loopify -> KWD_DEFAULT . KWD_TAILREC [ RPAREN ]
 ## loopify -> KWD_DEFAULT . [ RPAREN ]
@@ -1125,7 +1412,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 149.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN loopify . RPAREN [ KWD_SIZE ]
 ##
@@ -1137,7 +1424,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 102.
+## Ends in an error in state: 151.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt . KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1149,7 +1436,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 152.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE . LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1161,7 +1448,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 ##
-## Ends in an error in state: 104.
+## Ends in an error in state: 153.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN . code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1173,7 +1460,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 ##
-## Ends in an error in state: 106.
+## Ends in an error in state: 155.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size . RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1185,7 +1472,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 156.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN . option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1197,7 +1484,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF TILDE
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 157.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF . LPAREN code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1209,7 +1496,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF T
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN TILDE
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 158.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN . code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1221,7 +1508,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 159.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN code_id . RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1233,7 +1520,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 161.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) . boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1245,7 +1532,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 163.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) . boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1257,7 +1544,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_STUB TILDE
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 165.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) . code_id [ LPAREN IDENT ]
 ##
@@ -1269,7 +1556,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_STUB TILDE
 
 flambda_unit: KWD_LET IDENT TILDE
 ##
-## Ends in an error in state: 122.
+## Ends in an error in state: 171.
 ##
 ## let_binding -> variable . EQUAL named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1281,7 +1568,7 @@ flambda_unit: KWD_LET IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 172.
 ##
 ## let_binding -> variable EQUAL . named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1293,7 +1580,7 @@ flambda_unit: KWD_LET IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 173.
 ##
 ## prim_op -> PRIM . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1305,7 +1592,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 174.
 ##
 ## list(pair(DOT,prim_param)) -> DOT . prim_param list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1317,7 +1604,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 175.
 ##
 ## prim_param -> LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
@@ -1329,7 +1616,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 ##
-## Ends in an error in state: 131.
+## Ends in an error in state: 180.
 ##
 ## prim_param -> prim_param_val . [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ## prim_param -> prim_param_val . LBRACK separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
@@ -1342,7 +1629,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 181.
 ##
 ## prim_param -> prim_param_val LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
@@ -1354,7 +1641,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 184.
 ##
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param . [ RBRACK ]
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param . COMMA separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
@@ -1366,14 +1653,14 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 131, spurious reduction of production prim_param -> prim_param_val
+## In state 180, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
 ##
-## Ends in an error in state: 136.
+## Ends in an error in state: 185.
 ##
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param COMMA . separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
 ##
@@ -1385,7 +1672,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
 ##
-## Ends in an error in state: 138.
+## Ends in an error in state: 187.
 ##
 ## list(pair(DOT,prim_param)) -> DOT prim_param . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1396,14 +1683,14 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 131, spurious reduction of production prim_param -> prim_param_val
+## In state 180, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 190.
 ##
 ## named -> KWD_REC_INFO . rec_info_atom [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1415,7 +1702,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 143.
+## Ends in an error in state: 192.
 ##
 ## named -> simple . [ KWD_WITH KWD_IN KWD_AND ]
 ## simple -> simple . TILDE coercion [ TILDE KWD_WITH KWD_IN KWD_AND ]
@@ -1428,7 +1715,7 @@ flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 196.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple COMMA . separated_nonempty_list(COMMA,simple) [ RPAREN ]
 ##
@@ -1440,7 +1727,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COMMA TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 209.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1452,7 +1739,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 210.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1464,7 +1751,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT TILDE
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 216.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . SEMICOLON separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
@@ -1477,7 +1764,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 217.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block SEMICOLON . separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
 ##
@@ -1489,7 +1776,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT SEM
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY TILDE
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 220.
 ##
 ## static_data -> STATIC_CONST_NATIVEINT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(nativeint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1501,7 +1788,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 172.
+## Ends in an error in state: 221.
 ##
 ## static_data -> STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(nativeint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1513,7 +1800,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 225.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(nativeint)) [ RBRACKPIPE ]
@@ -1526,7 +1813,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 226.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(nativeint)) [ RBRACKPIPE ]
 ##
@@ -1538,7 +1825,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT S
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY TILDE
 ##
-## Ends in an error in state: 182.
+## Ends in an error in state: 231.
 ##
 ## static_data -> STATIC_CONST_INT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(targetint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1550,7 +1837,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 232.
 ##
 ## static_data -> STATIC_CONST_INT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(targetint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1562,7 +1849,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 237.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(targetint)) [ RBRACKPIPE ]
@@ -1575,7 +1862,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 238.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(targetint)) [ RBRACKPIPE ]
 ##
@@ -1587,7 +1874,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT SEMICOL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY TILDE
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 242.
 ##
 ## static_data -> STATIC_CONST_INT8_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int8))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1599,7 +1886,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 243.
 ##
 ## static_data -> STATIC_CONST_INT8_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int8))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1611,7 +1898,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 247.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int8)) [ RBRACKPIPE ]
@@ -1624,7 +1911,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 248.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int8)) [ RBRACKPIPE ]
 ##
@@ -1636,7 +1923,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT SEMICO
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY TILDE
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 253.
 ##
 ## static_data -> STATIC_CONST_INT64_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int64))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1648,7 +1935,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 254.
 ##
 ## static_data -> STATIC_CONST_INT64_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int64))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1660,7 +1947,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 258.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int64)) [ RBRACKPIPE ]
@@ -1673,7 +1960,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 259.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int64)) [ RBRACKPIPE ]
 ##
@@ -1685,7 +1972,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY TILDE
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 264.
 ##
 ## static_data -> STATIC_CONST_INT32_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int32))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1697,7 +1984,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 265.
 ##
 ## static_data -> STATIC_CONST_INT32_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int32))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1709,7 +1996,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 269.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int32)) [ RBRACKPIPE ]
@@ -1722,7 +2009,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 221.
+## Ends in an error in state: 270.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int32)) [ RBRACKPIPE ]
 ##
@@ -1734,7 +2021,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY TILDE
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 275.
 ##
 ## static_data -> STATIC_CONST_INT16_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int16))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1746,7 +2033,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 276.
 ##
 ## static_data -> STATIC_CONST_INT16_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int16))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1758,7 +2045,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 280.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int16)) [ RBRACKPIPE ]
@@ -1771,7 +2058,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 281.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int16)) [ RBRACKPIPE ]
 ##
@@ -1783,7 +2070,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 286.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK . LPAREN loption(separated_nonempty_list(COMMA,or_variable(float))) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1795,7 +2082,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 287.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK LPAREN . loption(separated_nonempty_list(COMMA,or_variable(float))) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1807,7 +2094,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT TILDE
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 291.
 ##
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) . [ RPAREN ]
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) . COMMA separated_nonempty_list(COMMA,or_variable(float)) [ RPAREN ]
@@ -1820,7 +2107,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 292.
 ##
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) COMMA . separated_nonempty_list(COMMA,or_variable(float)) [ RPAREN ]
 ##
@@ -1832,7 +2119,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT COMMA T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 297.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1844,7 +2131,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 298.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1856,7 +2143,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT TILDE
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 300.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(float)) [ RBRACKPIPE ]
@@ -1869,7 +2156,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 301.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(float)) [ RBRACKPIPE ]
 ##
@@ -1881,7 +2168,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT S
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY TILDE
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 305.
 ##
 ## static_data -> STATIC_CONST_FLOAT32_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1893,7 +2180,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 306.
 ##
 ## static_data -> STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1905,7 +2192,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 311.
 ##
 ## static_data -> STATIC_CONST_BLOCK . mutability tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1917,7 +2204,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 314.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability . tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1929,7 +2216,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 315.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag . LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1941,7 +2228,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 316.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag LPAREN . loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1953,7 +2240,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT TILDE
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 320.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . [ RPAREN ]
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . COMMA separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
@@ -1966,7 +2253,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 321.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block COMMA . separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
 ##
@@ -1978,7 +2265,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT COMMA TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 323.
 ##
 ## static_data -> KWD_MUTABLE . STRING [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1990,7 +2277,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 327.
 ##
 ## static_data -> variable . COLON static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2002,7 +2289,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 328.
 ##
 ## static_data -> variable COLON . static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2014,7 +2301,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 329.
 ##
 ## static_data_kind -> KWD_NATIVEINT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2026,7 +2313,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 282.
+## Ends in an error in state: 331.
 ##
 ## static_data_kind -> KWD_INT64 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2038,7 +2325,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 284.
+## Ends in an error in state: 333.
 ##
 ## static_data_kind -> KWD_INT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2050,7 +2337,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 335.
 ##
 ## static_data_kind -> KWD_FLOAT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2062,7 +2349,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 337.
 ##
 ## static_data_kind -> KWD_FLOAT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2074,7 +2361,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 ##
-## Ends in an error in state: 297.
+## Ends in an error in state: 346.
 ##
 ## code -> code_header . kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2086,7 +2373,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 347.
 ##
 ## kinded_args -> LPAREN . separated_nonempty_list(COMMA,kinded_variable) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EQUAL EOF ]
 ##
@@ -2098,7 +2385,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 348.
 ##
 ## kinded_variable -> variable . kind_with_subkind_opt [ RPAREN COMMA ]
 ##
@@ -2110,7 +2397,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 349.
 ##
 ## kind_with_subkind_opt -> COLON . kind_with_subkind [ RPAREN COMMA ]
 ##
@@ -2120,248 +2407,9 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK TILDE
-##
-## Ends in an error in state: 301.
-##
-## subkind -> LBRACK . ctors RBRACK [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## LBRACK
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT TILDE
-##
-## Ends in an error in state: 302.
-##
-## tag -> INT . [ KWD_OF ]
-## targetint -> INT . [ RBRACK PIPE ]
-##
-## The known suffix of the stack is as follows:
-## INT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT PIPE TILDE
-##
-## Ends in an error in state: 304.
-##
-## ctors_nonempty -> targetint PIPE . ctors_nonempty [ RBRACK ]
-##
-## The known suffix of the stack is as follows:
-## targetint PIPE
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE INT TILDE
-##
-## Ends in an error in state: 305.
-##
-## nonconst_ctor -> tag . KWD_OF kinds_with_subkinds_nonempty [ RBRACK PIPE ]
-##
-## The known suffix of the stack is as follows:
-## tag
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF TILDE
-##
-## Ends in an error in state: 306.
-##
-## nonconst_ctor -> tag KWD_OF . kinds_with_subkinds_nonempty [ RBRACK PIPE ]
-##
-## The known suffix of the stack is as follows:
-## tag KWD_OF
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_VAL TILDE
-##
-## Ends in an error in state: 307.
-##
-## subkind -> KWD_VAL . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_VAL . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_VAL
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_NATIVEINT TILDE
-##
-## Ends in an error in state: 311.
-##
-## naked_number_kind -> KWD_NATIVEINT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_NATIVEINT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_NATIVEINT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT64 TILDE
-##
-## Ends in an error in state: 313.
-##
-## naked_number_kind -> KWD_INT64 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_INT64 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_INT64
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_INT32 TILDE
-##
-## Ends in an error in state: 315.
-##
-## naked_number_kind -> KWD_INT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_INT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_INT32
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_IMM TILDE
-##
-## Ends in an error in state: 317.
-##
-## naked_number_kind -> KWD_IMM . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_IMM . KWD_TAGGED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_IMM . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_IMM
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT32 TILDE
-##
-## Ends in an error in state: 320.
-##
-## naked_number_kind -> KWD_FLOAT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_FLOAT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_FLOAT32
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT TILDE
-##
-## Ends in an error in state: 322.
-##
-## naked_number_kind -> KWD_FLOAT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_FLOAT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_FLOAT . CARET plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-## subkind -> KWD_FLOAT . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_FLOAT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT CARET TILDE
-##
-## Ends in an error in state: 325.
-##
-## subkind -> KWD_FLOAT CARET . plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_FLOAT CARET
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_ANY TILDE
-##
-## Ends in an error in state: 327.
-##
-## subkind -> KWD_ANY . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL COMMA ]
-##
-## The known suffix of the stack is as follows:
-## KWD_ANY
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_REC_INFO TILDE
-##
-## Ends in an error in state: 333.
-##
-## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
-## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . STAR separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
-##
-## The known suffix of the stack is as follows:
-## kind_with_subkind
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT STAR TILDE
-##
-## Ends in an error in state: 334.
-##
-## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind STAR . separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL ]
-##
-## The known suffix of the stack is as follows:
-## kind_with_subkind STAR
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT RPAREN
-##
-## Ends in an error in state: 338.
-##
-## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . [ RBRACK ]
-## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . PIPE separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
-##
-## The known suffix of the stack is as follows:
-## nonconst_ctor
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 322, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 331, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 333, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 330, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 332, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-flambda_unit: KWD_APPLY LPAREN FLOAT COLON LBRACK INT KWD_OF KWD_FLOAT PIPE TILDE
-##
-## Ends in an error in state: 339.
-##
-## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor PIPE . separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
-##
-## The known suffix of the stack is as follows:
-## nonconst_ctor PIPE
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 354.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . COMMA separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
@@ -2374,7 +2422,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 355.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable COMMA . separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
 ##
@@ -2386,7 +2434,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 357.
 ##
 ## code -> code_header kinded_args . variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2398,7 +2446,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPA
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 358.
 ##
 ## code -> code_header kinded_args variable . variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2410,7 +2458,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 359.
 ##
 ## code -> code_header kinded_args variable variable . variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2422,7 +2470,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT TILD
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 360.
 ##
 ## code -> code_header kinded_args variable variable variable . variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2434,7 +2482,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT TILDE
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 361.
 ##
 ## code -> code_header kinded_args variable variable variable variable . MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2446,7 +2494,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 362.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER . continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2458,7 +2506,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 364.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id . exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2470,7 +2518,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 360.
+## Ends in an error in state: 365.
 ##
 ## exn_continuation_id -> STAR . continuation_id [ KWD_LOCAL EQUAL COLON ]
 ##
@@ -2482,7 +2530,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 362.
+## Ends in an error in state: 367.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id . return_arity boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2494,7 +2542,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON TILDE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 368.
 ##
 ## return_arity -> COLON . kinds_with_subkinds [ KWD_LOCAL EQUAL ]
 ##
@@ -2506,7 +2554,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 372.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity . boption(KWD_LOCAL) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2518,7 +2566,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT KWD_LOCAL TILDE
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 374.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) . EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2530,7 +2578,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDENT IDENT MINUSGREATER IDENT STAR IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 375.
 ##
 ## code -> code_header kinded_args variable variable variable variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_LOCAL) EQUAL . expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2542,7 +2590,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT IDENT IDEN
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 378.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -2554,7 +2602,7 @@ flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_INVALID TILDE
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 380.
 ##
 ## atomic_expr -> KWD_INVALID . STRING [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2566,7 +2614,7 @@ flambda_unit: KWD_INVALID TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 ##
-## Ends in an error in state: 384.
+## Ends in an error in state: 389.
 ##
 ## trap_action -> KWD_PUSH . LPAREN continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2578,7 +2626,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 ##
-## Ends in an error in state: 385.
+## Ends in an error in state: 390.
 ##
 ## trap_action -> KWD_PUSH LPAREN . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2590,7 +2638,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 391.
 ##
 ## trap_action -> KWD_PUSH LPAREN continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2602,7 +2650,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 ##
-## Ends in an error in state: 388.
+## Ends in an error in state: 393.
 ##
 ## trap_action -> KWD_POP . LPAREN option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2614,7 +2662,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 ##
-## Ends in an error in state: 389.
+## Ends in an error in state: 394.
 ##
 ## trap_action -> KWD_POP LPAREN . option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2626,7 +2674,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 ##
-## Ends in an error in state: 394.
+## Ends in an error in state: 399.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2638,7 +2686,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 400.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2650,7 +2698,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 403.
 ##
 ## apply_cont_expr -> continuation option(trap_action) . simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -2662,9 +2710,9 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL TILDE
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 407.
 ##
-## call_kind -> KWD_MCALL . LPAREN method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL . LPAREN method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL
@@ -2674,9 +2722,9 @@ flambda_unit: KWD_APPLY KWD_MCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN TILDE
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 408.
 ##
-## call_kind -> KWD_MCALL LPAREN . method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN . method_kind simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN
@@ -2686,9 +2734,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED TILDE
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 412.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind . simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind . simple RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN method_kind
@@ -2698,9 +2746,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT SYMBOL
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 413.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind simple . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind simple . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2711,9 +2759,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 415.
 ##
-## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT
@@ -2723,9 +2771,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 416.
 ##
-## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN
@@ -2735,9 +2783,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 417.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id
@@ -2747,9 +2795,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 418.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications_opt RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id function_slot_opt
@@ -2759,9 +2807,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP TILDE
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 419.
 ##
-## alloc_mode_for_applications_opt -> AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications_opt -> AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP
@@ -2771,9 +2819,9 @@ flambda_unit: KWD_APPLY AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT TILDE
 ##
-## Ends in an error in state: 415.
+## Ends in an error in state: 420.
 ##
-## alloc_mode_for_applications_opt -> AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications_opt -> AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region
@@ -2783,9 +2831,9 @@ flambda_unit: KWD_APPLY AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 421.
 ##
-## alloc_mode_for_applications_opt -> AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications_opt -> AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region AMP
@@ -2795,9 +2843,9 @@ flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 423.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications_opt
@@ -2807,9 +2855,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL TILDE
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 425.
 ##
-## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CCALL
@@ -2819,7 +2867,7 @@ flambda_unit: KWD_APPLY KWD_CCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 428.
 ##
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2833,9 +2881,9 @@ flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 429.
 ##
-## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL
@@ -2845,9 +2893,9 @@ flambda_unit: KWD_APPLY KWD_UNROLL TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 430.
 ##
-## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL LPAREN
@@ -2857,9 +2905,9 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 426.
+## Ends in an error in state: 431.
 ##
-## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL LPAREN plain_int
@@ -2869,12 +2917,12 @@ flambda_unit: KWD_APPLY KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED TILDE
 ##
-## Ends in an error in state: 428.
+## Ends in an error in state: 433.
 ##
-## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED . LPAREN KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED . LPAREN KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED
@@ -2884,12 +2932,12 @@ flambda_unit: KWD_APPLY KWD_INLINED TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 434.
 ##
-## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED LPAREN . KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED LPAREN . KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN
@@ -2899,9 +2947,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 435.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_NEVER
@@ -2911,9 +2959,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 437.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_HINT
@@ -2923,9 +2971,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_HINT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 439.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_DEFAULT
@@ -2935,9 +2983,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 441.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_ALWAYS
@@ -2947,7 +2995,7 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 443.
 ##
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -2961,9 +3009,9 @@ flambda_unit: KWD_APPLY KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 444.
 ##
-## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
+## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINING_STATE
@@ -2973,9 +3021,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 445.
 ##
-## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
+## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINING_STATE LPAREN
@@ -2985,7 +3033,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 446.
 ##
 ## inlining_state_depth -> KWD_DEPTH . LPAREN plain_int RPAREN [ RPAREN ]
 ##
@@ -2997,7 +3045,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 447.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN . plain_int RPAREN [ RPAREN ]
 ##
@@ -3009,7 +3057,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 448.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN plain_int . RPAREN [ RPAREN ]
 ##
@@ -3021,9 +3069,9 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 450.
 ##
-## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_NULL INT IDENT FLOAT ]
+## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINING_STATE LPAREN inlining_state_depth
@@ -3033,7 +3081,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TI
 
 flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 452.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3047,7 +3095,7 @@ flambda_unit: KWD_APPLY KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RP
 
 flambda_unit: KWD_APPLY LPAREN TILDE
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 453.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ MINUSGREATER ]
@@ -3060,7 +3108,7 @@ flambda_unit: KWD_APPLY LPAREN TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 454.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
@@ -3075,7 +3123,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 455.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3087,7 +3135,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 453.
+## Ends in an error in state: 458.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3099,7 +3147,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 459.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3111,7 +3159,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 ##
-## Ends in an error in state: 455.
+## Ends in an error in state: 460.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3123,7 +3171,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 461.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3135,7 +3183,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 462.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3147,7 +3195,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 463.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3159,7 +3207,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 460.
+## Ends in an error in state: 465.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3171,7 +3219,7 @@ flambda_unit: KWD_APPLY LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAR
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 466.
 ##
 ## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3183,7 +3231,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 467.
 ##
 ## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3195,7 +3243,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 468.
 ##
 ## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3207,7 +3255,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 469.
 ##
 ## exn_extra_arg -> simple . kind_with_subkind [ RPAREN COMMA ]
 ## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VAL KWD_REGION KWD_REC_INFO KWD_NATIVEINT KWD_INT64 KWD_INT32 KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
@@ -3220,7 +3268,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 468.
+## Ends in an error in state: 473.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . [ RPAREN ]
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . COMMA separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
@@ -3233,7 +3281,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO 
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 469.
+## Ends in an error in state: 474.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg COMMA . separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
 ##
@@ -3245,7 +3293,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COM
 
 flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 480.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3257,7 +3305,7 @@ flambda_unit: KWD_APPLY LPAREN RPAREN TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER TILDE
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 481.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3269,7 +3317,7 @@ flambda_unit: KWD_APPLY MINUSGREATER TILDE
 
 flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 482.
 ##
 ## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3281,7 +3329,7 @@ flambda_unit: KWD_APPLY MINUSGREATER IDENT TILDE
 
 flambda_unit: KWD_HCF TILDE
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 496.
 ##
 ## expr -> inner_expr . [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## where_expr -> inner_expr . KWD_WHERE cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -3294,7 +3342,7 @@ flambda_unit: KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE TILDE
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 497.
 ##
 ## where_expr -> inner_expr KWD_WHERE . cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3306,7 +3354,7 @@ flambda_unit: KWD_HCF KWD_WHERE TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 498.
 ##
 ## cont_recursive -> KWD_REC . kinded_args [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EOF ]
 ##
@@ -3318,7 +3366,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 500.
 ##
 ## where_expr -> inner_expr KWD_WHERE cont_recursive . loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3330,7 +3378,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 503.
 ##
 ## continuation_binding -> continuation_id . continuation_sort kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3342,7 +3390,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 ##
-## Ends in an error in state: 501.
+## Ends in an error in state: 506.
 ##
 ## continuation_binding -> continuation_id continuation_sort . kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3354,7 +3402,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 507.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args . EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3366,7 +3414,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 508.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args EQUAL . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3378,7 +3426,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 509.
 ##
 ## let_expr(continuation_body) -> KWD_LET . let_(continuation_body) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(continuation_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3391,7 +3439,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 511.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3403,7 +3451,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 507.
+## Ends in an error in state: 512.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3415,7 +3463,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 514.
+## Ends in an error in state: 519.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3427,7 +3475,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LB
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 515.
+## Ends in an error in state: 520.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3439,7 +3487,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILD
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 ##
-## Ends in an error in state: 517.
+## Ends in an error in state: 522.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . KWD_AND separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
@@ -3452,7 +3500,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 523.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding KWD_AND . separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -3464,7 +3512,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 ##
-## Ends in an error in state: 523.
+## Ends in an error in state: 528.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . KWD_ANDWHERE separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -3477,7 +3525,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 529.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding KWD_ANDWHERE . separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -3489,7 +3537,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 534.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3501,7 +3549,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 535.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3513,7 +3561,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 535.
+## Ends in an error in state: 540.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3525,7 +3573,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 536.
+## Ends in an error in state: 541.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3537,7 +3585,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 547.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3549,7 +3597,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WIT
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 548.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3561,7 +3609,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN 
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 553.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . PIPE separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -3574,7 +3622,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 554.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case PIPE . separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3586,7 +3634,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 
 flambda_unit: LPAREN KWD_HCF KWD_WITH
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 558.
 ##
 ## atomic_expr -> LPAREN expr . RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3597,7 +3645,7 @@ flambda_unit: LPAREN KWD_HCF KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 491, spurious reduction of production expr -> inner_expr
+## In state 496, spurious reduction of production expr -> inner_expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -164,6 +164,7 @@ let make_boxed_const_int (i, m) : static_data =
 %token KWD_NOTRACE [@symbol "notrace"]
 %token KWD_NULL [@symbol "null"]
 %token KWD_OF     [@symbol "of"]
+%token KWD_POISON [@symbol "poison"]
 %token KWD_POP    [@symbol "pop"]
 %token KWD_PUSH   [@symbol "push"]
 %token KWD_REC    [@symbol "rec"]
@@ -812,6 +813,7 @@ const:
     | Some 's' -> Naked_float32 (fst f)
     | Some c -> Misc.fatal_errorf "Invalid float modifier '%c'" c }
   | KWD_NULL { Null }
+  | KWD_POISON; DOT; k = kind_with_subkind; DOT; s = STRING { Poison (k, s) }
 ;
 
 %inline func_name_with_optional_arities:

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -20,37 +20,6 @@ let vec512 v = v |> Vector_types.Vec512.Bit_pattern.to_bits
 
 let targetint i = i |> Targetint_32_64.to_int64
 
-let const c : Fexpr.const =
-  match Reg_width_const.descr c with
-  | Naked_immediate imm ->
-    Naked_immediate
-      (* CR mshinwell: machine_width should be passed through properly here *)
-      (let machine_width = Target_system.Machine_width.Sixty_four in
-       imm
-       |> Target_ocaml_int.to_targetint machine_width
-       |> Targetint_32_64.to_string)
-  | Tagged_immediate imm ->
-    Tagged_immediate
-      (* CR mshinwell: machine_width should be passed through properly here *)
-      (let machine_width = Target_system.Machine_width.Sixty_four in
-       imm
-       |> Target_ocaml_int.to_targetint machine_width
-       |> Targetint_32_64.to_string)
-  | Naked_float f -> Naked_float (f |> float)
-  | Naked_float32 f -> Naked_float32 (f |> float32)
-  | Naked_int8 i -> Naked_int8 i
-  | Naked_int16 i -> Naked_int16 i
-  | Naked_int32 i -> Naked_int32 i
-  | Naked_int64 i -> Naked_int64 i
-  | Naked_vec128 bits ->
-    Naked_vec128 (Vector_types.Vec128.Bit_pattern.to_bits bits)
-  | Naked_vec256 bits ->
-    Naked_vec256 (Vector_types.Vec256.Bit_pattern.to_bits bits)
-  | Naked_vec512 bits ->
-    Naked_vec512 (Vector_types.Vec512.Bit_pattern.to_bits bits)
-  | Naked_nativeint i -> Naked_nativeint (i |> targetint)
-  | Null -> Null
-
 let depth_or_infinity (d : int Or_infinity.t) : Fexpr.rec_info =
   match d with Finite d -> Depth d | Infinity -> Infinity
 
@@ -78,19 +47,6 @@ let coercion env (co : Coercion.t) : Fexpr.coercion =
     let from = rec_info env from in
     let to_ = rec_info env to_ in
     Change_depth { from; to_ }
-
-let simple env s =
-  Simple.pattern_match s
-    ~name:(fun n ~coercion:co : Fexpr.simple ->
-      let s : Fexpr.simple =
-        match name env n with Var v -> Var v | Symbol s -> Symbol s
-      in
-      if Coercion.is_id co
-      then s
-      else
-        let co = coercion env co in
-        Coerce (s, co))
-    ~const:(fun c -> Fexpr.Const (const c))
 
 let is_default_kind_with_subkind (k : Flambda_kind.With_subkind.t) =
   Flambda_kind.is_value (Flambda_kind.With_subkind.kind k)
@@ -168,6 +124,53 @@ let kinded_parameter env (kp : Bound_parameter.t) :
   let k = Bound_parameter.kind kp |> kind_with_subkind_opt in
   let param, env = Env.bind_var env (Bound_parameter.var kp) in
   { param; kind = k }, env
+
+let const c : Fexpr.const =
+  match Reg_width_const.descr c with
+  | Naked_immediate imm ->
+    Naked_immediate
+      (* CR mshinwell: machine_width should be passed through properly here *)
+      (let machine_width = Target_system.Machine_width.Sixty_four in
+       imm
+       |> Target_ocaml_int.to_targetint machine_width
+       |> Targetint_32_64.to_string)
+  | Tagged_immediate imm ->
+    Tagged_immediate
+      (* CR mshinwell: machine_width should be passed through properly here *)
+      (let machine_width = Target_system.Machine_width.Sixty_four in
+       imm
+       |> Target_ocaml_int.to_targetint machine_width
+       |> Targetint_32_64.to_string)
+  | Naked_float f -> Naked_float (f |> float)
+  | Naked_float32 f -> Naked_float32 (f |> float32)
+  | Naked_int8 i -> Naked_int8 i
+  | Naked_int16 i -> Naked_int16 i
+  | Naked_int32 i -> Naked_int32 i
+  | Naked_int64 i -> Naked_int64 i
+  | Naked_vec128 bits ->
+    Naked_vec128 (Vector_types.Vec128.Bit_pattern.to_bits bits)
+  | Naked_vec256 bits ->
+    Naked_vec256 (Vector_types.Vec256.Bit_pattern.to_bits bits)
+  | Naked_vec512 bits ->
+    Naked_vec512 (Vector_types.Vec512.Bit_pattern.to_bits bits)
+  | Naked_nativeint i -> Naked_nativeint (i |> targetint)
+  | Null -> Null
+  | Poison (kind, name) ->
+    let kind = kind_with_subkind (Flambda_kind.With_subkind.anything kind) in
+    Poison (kind, name)
+
+let simple env s =
+  Simple.pattern_match s
+    ~name:(fun n ~coercion:co : Fexpr.simple ->
+      let s : Fexpr.simple =
+        match name env n with Var v -> Var v | Symbol s -> Symbol s
+      in
+      if Coercion.is_id co
+      then s
+      else
+        let co = coercion env co in
+        Coerce (s, co))
+    ~const:(fun c -> Fexpr.Const (const c))
 
 let recursive_flag (r : Recursive.t) : Fexpr.is_recursive =
   match r with Recursive -> Recursive | Non_recursive -> Nonrecursive

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -171,26 +171,6 @@ let vec512 ppf
     "vec512[%016Lx:%016Lx:%016Lx:%016Lx:%016Lx:%016Lx:%016Lx:%016Lx]" word0
     word1 word2 word3 word4 word5 word6 word7
 
-let const ppf (c : Fexpr.const) =
-  match c with
-  | Naked_immediate i ->
-    Format.fprintf ppf "%t%si%t" Flambda_colours.naked_number i
-      Flambda_colours.pop
-  | Tagged_immediate i ->
-    Format.fprintf ppf "%t%s%t" Flambda_colours.tagged_immediate i
-      Flambda_colours.pop
-  | Naked_float f -> float ppf f
-  | Naked_float32 f -> float32 ppf f
-  | Naked_int8 i -> int8 ppf i
-  | Naked_int16 i -> int16 ppf i
-  | Naked_int32 i -> int32 ppf i
-  | Naked_int64 i -> int64 ppf i
-  | Naked_nativeint i -> nativeint ppf i
-  | Naked_vec128 v -> vec128 ppf v
-  | Naked_vec256 v -> vec256 ppf v
-  | Naked_vec512 v -> vec512 ppf v
-  | Null -> Format.fprintf ppf "null"
-
 let naked_number_kind ppf (nnk : Flambda_kind.Naked_number_kind.t) =
   Format.pp_print_string ppf
   @@
@@ -258,6 +238,29 @@ and kind_with_subkind ppf (k : kind_with_subkind) =
 
 let kind_with_subkind ppf k =
   directive Flambda_colours.kind kind_with_subkind ppf k
+
+let const ppf (c : Fexpr.const) =
+  match c with
+  | Naked_immediate i ->
+    Format.fprintf ppf "%t%si%t" Flambda_colours.naked_number i
+      Flambda_colours.pop
+  | Tagged_immediate i ->
+    Format.fprintf ppf "%t%s%t" Flambda_colours.tagged_immediate i
+      Flambda_colours.pop
+  | Naked_float f -> float ppf f
+  | Naked_float32 f -> float32 ppf f
+  | Naked_int8 i -> int8 ppf i
+  | Naked_int16 i -> int16 ppf i
+  | Naked_int32 i -> int32 ppf i
+  | Naked_int64 i -> int64 ppf i
+  | Naked_nativeint i -> nativeint ppf i
+  | Naked_vec128 v -> vec128 ppf v
+  | Naked_vec256 v -> vec256 ppf v
+  | Naked_vec512 v -> vec512 ppf v
+  | Null -> Format.fprintf ppf "null"
+  | Poison (kind, name) ->
+    Format.fprintf ppf "%tpoison.%a.%s%t" Flambda_colours.invalid_keyword
+      kind_with_subkind kind name Flambda_colours.pop
 
 let arity ppf (a : arity) =
   match a with

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -19,17 +19,34 @@ module TE = Flambda2_types.Typing_env
 module TI = Target_ocaml_int
 module Alias_set = TE.Alias_set
 
+type alias_set =
+  | Aliases of Alias_set.t
+  | Poison of Flambda_kind.t
+
 type mergeable_arms =
   | No_arms
   | Mergeable of
       { cont : Continuation.t;
-        args : Alias_set.t list
+        args : alias_set list
       }
   | Not_mergeable
 
+let inter_alias_set alias1 alias2 =
+  match alias1, alias2 with
+  | Aliases alias1, Aliases alias2 -> Aliases (Alias_set.inter alias1 alias2)
+  | Aliases alias, Poison _ | Poison _, Aliases alias -> Aliases alias
+  | Poison kind1, Poison kind2 ->
+    if Flambda_kind.equal kind1 kind2
+    then Poison kind1
+    else
+      Misc.fatal_errorf
+        "[inter_alias_set]: intersection of poison with different kinds %a and \
+         %a"
+        Flambda_kind.print kind1 Flambda_kind.print kind2
+
 let find_all_aliases env arg =
   let find_all_aliases () =
-    TE.aliases_of_simple env ~min_name_mode:NM.normal arg
+    Aliases (TE.aliases_of_simple env ~min_name_mode:NM.normal arg)
   in
   Simple.pattern_match'
     ~var:(fun _var ~coercion:_ ->
@@ -53,9 +70,12 @@ let find_all_aliases env arg =
          of continuations to variables that where not in scope during the
          downward traversal. In particular for the alias rewriting provided by
          data_flow *)
-      TE.Alias_set.singleton arg)
+      Aliases (TE.Alias_set.singleton arg))
     ~symbol:(fun _sym ~coercion:_ -> find_all_aliases ())
-    ~const:(fun _cst -> find_all_aliases ())
+    ~const:(fun cst ->
+      match Reg_width_const.is_poison cst with
+      | Some (kind, _name) -> Poison kind
+      | None -> find_all_aliases ())
     arg
 
 let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
@@ -151,7 +171,7 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
               let args =
                 List.map2
                   (fun arg_set arg ->
-                    Alias_set.inter (find_all_aliases env_at_use arg) arg_set)
+                    inter_alias_set (find_all_aliases env_at_use arg) arg_set)
                   args (Apply_cont.args action)
               in
               ( new_let_conts,
@@ -183,9 +203,16 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
                 let not_arms = TI.Map.add arm action not_arms in
                 maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
               else maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
+          | Poison (Value, _) ->
+            (* Poison can both be considered as an identity and as a not arm,
+               depending on what's best for us. *)
+            let identity_arms = TI.Map.add arm action identity_arms in
+            let not_arms = TI.Map.add arm action not_arms in
+            maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
           | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int8 _
           | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _
-          | Naked_vec256 _ | Naked_vec512 _ | Naked_nativeint _ | Null ->
+          | Naked_vec256 _ | Naked_vec512 _ | Naked_nativeint _ | Null
+          | Poison ((Naked_number _ | Region | Rec_info), _) ->
             maybe_mergeable ~mergeable_arms ~identity_arms ~not_arms
         in
         Simple.pattern_match arg ~const ~name:(fun _ ~coercion:_ ->
@@ -197,13 +224,17 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
     new_let_conts, arms, Not_mergeable, identity_arms, not_arms
 
 let filter_and_choose_alias required_names alias_set =
-  let available_alias_set =
-    Alias_set.filter alias_set ~f:(fun alias ->
-        Simple.pattern_match alias
-          ~name:(fun name ~coercion:_ -> Name.Set.mem name required_names)
-          ~const:(fun _ -> true))
-  in
-  Alias_set.find_best available_alias_set
+  match alias_set with
+  | Poison kind ->
+    Some (Simple.const (Reg_width_const.const_poison kind "rebuild_switch"))
+  | Aliases alias_set ->
+    let available_alias_set =
+      Alias_set.filter alias_set ~f:(fun alias ->
+          Simple.pattern_match alias
+            ~name:(fun name ~coercion:_ -> Name.Set.mem name required_names)
+            ~const:(fun _ -> true))
+    in
+    Alias_set.find_best available_alias_set
 
 let find_cse_simple ?(required = true) dacc required_names prim =
   match P.Eligible_for_cse.create prim with

--- a/middle_end/flambda2/simplify/unboxing/unboxers.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.ml
@@ -36,7 +36,7 @@ module type Number_S = sig
 
   val unboxing_prim : Simple.t -> P.t
 
-  val unboxer : Target_system.Machine_width.t -> unboxer
+  val unboxer : unboxer
 end
 
 module Immediate = struct
@@ -48,11 +48,11 @@ module Immediate = struct
 
   let unboxing_prim simple = P.(Unary (Untag_immediate, simple))
 
-  let unboxer machine_width =
+  let unboxer =
     { var_name = "naked_immediate";
       var_kind = K.naked_immediate;
       poison_const =
-        Const.naked_immediate (Target_ocaml_int.of_int machine_width 0xabcd);
+        Const.const_poison K.naked_immediate "variant_unboxing_naked_immediate";
       unboxing_prim;
       prove_simple = T.meet_tagging_of_simple
     }
@@ -67,11 +67,11 @@ module Float32 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_float32, simple))
 
-  let unboxer _machine_width =
+  let unboxer =
     { var_name = "unboxed_float32";
       var_kind = K.naked_float32;
       poison_const =
-        Const.naked_float32 Numeric_types.Float32_by_bit_pattern.zero;
+        Const.const_poison K.naked_float32 "variant_unboxing_float32";
       unboxing_prim;
       prove_simple = T.meet_boxed_float32_containing_simple
     }
@@ -86,10 +86,10 @@ module Float = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_float, simple))
 
-  let unboxer _machine_width =
+  let unboxer =
     { var_name = "unboxed_float";
       var_kind = K.naked_float;
-      poison_const = Const.naked_float Numeric_types.Float_by_bit_pattern.zero;
+      poison_const = Const.const_poison K.naked_float "variant_unboxing_float";
       unboxing_prim;
       prove_simple = T.meet_boxed_float_containing_simple
     }
@@ -104,10 +104,10 @@ module Int32 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_int32, simple))
 
-  let unboxer _machine_width =
+  let unboxer =
     { var_name = "unboxed_int32";
       var_kind = K.naked_int32;
-      poison_const = Const.naked_int32 Int32.(div 0xabcd0l 2l);
+      poison_const = Const.const_poison K.naked_int32 "variant_unboxing_int32";
       unboxing_prim;
       prove_simple = T.meet_boxed_int32_containing_simple
     }
@@ -122,10 +122,10 @@ module Int64 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_int64, simple))
 
-  let unboxer _machine_width =
+  let unboxer =
     { var_name = "unboxed_int64";
       var_kind = K.naked_int64;
-      poison_const = Const.naked_int64 Int64.(div 0xdcba0L 2L);
+      poison_const = Const.const_poison K.naked_int64 "variant_unboxing_int64";
       unboxing_prim;
       prove_simple = T.meet_boxed_int64_containing_simple
     }
@@ -140,10 +140,11 @@ module Nativeint = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_nativeint, simple))
 
-  let unboxer machine_width =
+  let unboxer =
     { var_name = "unboxed_nativeint";
       var_kind = K.naked_nativeint;
-      poison_const = Const.naked_nativeint (Targetint_32_64.zero machine_width);
+      poison_const =
+        Const.const_poison K.naked_nativeint "variant_unboxing_nativeint";
       unboxing_prim;
       prove_simple = T.meet_boxed_nativeint_containing_simple
     }
@@ -158,10 +159,10 @@ module Vec128 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_vec128, simple))
 
-  let unboxer _machine_width =
+  let unboxer =
     { var_name = "unboxed_vec128";
       var_kind = K.naked_vec128;
-      poison_const = Const.naked_vec128 Vector_types.Vec128.Bit_pattern.zero;
+      poison_const = Const.const_poison K.naked_vec128 "variant_unboxing_vec128";
       unboxing_prim;
       prove_simple = T.meet_boxed_vec128_containing_simple
     }
@@ -176,10 +177,10 @@ module Vec256 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_vec256, simple))
 
-  let unboxer _machine_width =
+  let unboxer =
     { var_name = "unboxed_vec256";
       var_kind = K.naked_vec256;
-      poison_const = Const.naked_vec256 Vector_types.Vec256.Bit_pattern.zero;
+      poison_const = Const.const_poison K.naked_vec256 "variant_unxboing_vec256";
       unboxing_prim;
       prove_simple = T.meet_boxed_vec256_containing_simple
     }
@@ -194,10 +195,10 @@ module Vec512 = struct
 
   let unboxing_prim simple = P.(Unary (Unbox_number Naked_vec512, simple))
 
-  let unboxer _machine_width =
+  let unboxer =
     { var_name = "unboxed_vec512";
       var_kind = K.naked_vec512;
-      poison_const = Const.naked_vec512 Vector_types.Vec512.Bit_pattern.zero;
+      poison_const = Const.const_poison K.naked_vec512 "variant_unboxing_vec512";
       unboxing_prim;
       prove_simple = T.meet_boxed_vec512_containing_simple
     }
@@ -225,11 +226,13 @@ module Closure_field = struct
     P.Unary
       (Project_value_slot { project_from = function_slot; value_slot }, closure)
 
-  let unboxer machine_width function_slot value_slot =
+  let unboxer function_slot value_slot =
     { var_name = "closure_field_at_use";
       var_kind = Value_slot.kind value_slot;
       poison_const =
-        Const.of_int_of_kind machine_width (Value_slot.kind value_slot) 0;
+        Const.const_poison
+          (Value_slot.kind value_slot)
+          "variant_unboxing_closure_field";
       unboxing_prim =
         (fun closure -> unboxing_prim function_slot ~closure value_slot);
       prove_simple =

--- a/middle_end/flambda2/simplify/unboxing/unboxers.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxers.mli
@@ -45,8 +45,7 @@ end
 module Closure_field : sig
   val unboxing_prim : Function_slot.t -> closure:Simple.t -> Value_slot.t -> P.t
 
-  val unboxer :
-    Target_system.Machine_width.t -> Function_slot.t -> Value_slot.t -> unboxer
+  val unboxer : Function_slot.t -> Value_slot.t -> unboxer
 end
 
 (* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -59,7 +58,7 @@ module type Number_S = sig
 
   val unboxing_prim : Simple.t -> P.t
 
-  val unboxer : Target_system.Machine_width.t -> unboxer
+  val unboxer : unboxer
 end
 
 module Immediate : Number_S

--- a/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_epa.ml
@@ -165,9 +165,9 @@ let extra_args_for_const_ctor_of_variant
 (* *************************** *)
 
 let compute_extra_arg_for_number kind unboxer epa rewrite_id ~typing_env_at_use
-    ~machine_width arg_being_unboxed : U.decision =
+    arg_being_unboxed : U.decision =
   let extra_arg, _new_arg_being_unboxed =
-    unbox_arg (unboxer machine_width) ~typing_env_at_use arg_being_unboxed
+    unbox_arg unboxer ~typing_env_at_use arg_being_unboxed
   in
   let epa = Extra_param_and_args.update_param_args epa rewrite_id extra_arg in
   Unbox (Number (kind, epa))
@@ -175,7 +175,7 @@ let compute_extra_arg_for_number kind unboxer epa rewrite_id ~typing_env_at_use
 (* Helpers for the block case *)
 (* ************************** *)
 
-let access_kind_and_dummy_const machine_width tag shape fields index :
+let access_kind_and_poison_const machine_width tag shape fields index :
     P.Block_access_kind.t * _ =
   let size =
     Or_unknown.Known
@@ -188,10 +188,10 @@ let access_kind_and_dummy_const machine_width tag shape fields index :
           tag = Known (Option.get (Tag.Scannable.of_tag tag));
           field_kind = Any_value
         },
-      Const.const_zero machine_width )
+      Const.const_poison K.value "variant_unboxing_field" )
   | Float_record ->
     ( Naked_floats { size },
-      Const.naked_float Numeric_types.Float_by_bit_pattern.zero )
+      Const.const_poison K.naked_float "variant_unboxing_float_record" )
   | Scannable (Mixed_record shape) ->
     let field_kind, const =
       if index < K.Mixed_block_shape.value_prefix_size shape
@@ -210,9 +210,9 @@ let access_kind_and_dummy_const machine_width tag shape fields index :
           (K.Mixed_block_shape.flat_suffix shape).(flat_suffix_index)
         in
         ( P.Mixed_block_access_field_kind.Flat_suffix field_kind,
-          Const.of_int_of_kind machine_width
+          Const.const_poison
             (K.Flat_suffix_element.kind field_kind)
-            0 )
+            "variant_unboxing_mixed_block_field" )
     in
     let tag = Or_unknown.Known (Option.get (Tag.Scannable.of_tag tag)) in
     Mixed { tag; size; shape; field_kind }, const
@@ -264,33 +264,33 @@ and compute_extra_args_for_one_decision_and_use_aux ~(pass : U.pass) rewrite_id
           ~non_const_ctors_with_sizes_at_use:non_const_ctors_with_sizes))
   | Unbox (Number (Naked_float32, epa)) ->
     compute_extra_arg_for_number Naked_float32 Unboxers.Float32.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number (Naked_float, epa)) ->
     compute_extra_arg_for_number Naked_float Unboxers.Float.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number ((Naked_int8 | Naked_int16), _epa)) ->
     U.Do_not_unbox U.Not_beneficial
   | Unbox (Number (Naked_int32, epa)) ->
     compute_extra_arg_for_number Naked_int32 Unboxers.Int32.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number (Naked_int64, epa)) ->
     compute_extra_arg_for_number Naked_int64 Unboxers.Int64.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number (Naked_nativeint, epa)) ->
     compute_extra_arg_for_number Naked_nativeint Unboxers.Nativeint.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number (Naked_immediate, epa)) ->
     compute_extra_arg_for_number Naked_immediate Unboxers.Immediate.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number (Naked_vec128, epa)) ->
     compute_extra_arg_for_number Naked_vec128 Unboxers.Vec128.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number (Naked_vec256, epa)) ->
     compute_extra_arg_for_number Naked_vec256 Unboxers.Vec256.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
   | Unbox (Number (Naked_vec512, epa)) ->
     compute_extra_arg_for_number Naked_vec512 Unboxers.Vec512.unboxer epa
-      rewrite_id ~typing_env_at_use ~machine_width arg_being_unboxed
+      rewrite_id ~typing_env_at_use arg_being_unboxed
 
 and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
     ~machine_width arg_being_unboxed tag (shape : K.Block_shape.t) fields :
@@ -300,7 +300,7 @@ and compute_extra_args_for_block ~pass rewrite_id ~typing_env_at_use
       (fun field_nth ({ epa; decision; kind } : U.field_decision) :
            (_ * U.field_decision) ->
         let bak, poison_const =
-          access_kind_and_dummy_const machine_width tag shape fields
+          access_kind_and_poison_const machine_width tag shape fields
             (Target_ocaml_int.to_int field_nth)
         in
         let unboxer =
@@ -330,9 +330,7 @@ and compute_extra_args_for_closure ~pass rewrite_id ~typing_env_at_use
     Value_slot.Map.mapi
       (fun var ({ epa; decision; kind } : U.field_decision) : U.field_decision
          ->
-        let unboxer =
-          Unboxers.Closure_field.unboxer machine_width function_slot var
-        in
+        let unboxer = Unboxers.Closure_field.unboxer function_slot var in
         let new_extra_arg, new_arg_being_unboxed =
           unbox_arg unboxer ~typing_env_at_use arg_being_unboxed
         in
@@ -409,7 +407,7 @@ and compute_extra_args_for_variant ~pass rewrite_id ~typing_env_at_use
             (fun (new_decisions, field_nth)
                  ({ epa; decision; kind } : U.field_decision) ->
               let bak, poison_const =
-                access_kind_and_dummy_const machine_width
+                access_kind_and_poison_const machine_width
                   (Tag.Scannable.to_tag tag_decision)
                   shape block_fields
                   (Target_ocaml_int.to_int field_nth)

--- a/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
+++ b/middle_end/flambda2/simplify/unboxing/unboxing_types.mli
@@ -39,6 +39,8 @@ module Extra_param_and_args : sig
     name:string -> debug_uid:Flambda_debug_uid.t -> Flambda_kind.t -> t
 
   val update_param_args : t -> Apply_cont_rewrite_id.t -> EPA.Extra_arg.t -> t
+
+  val print : Format.formatter -> t -> unit
 end
 
 type unboxing_decision =

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -187,7 +187,7 @@ let name0 ?consider_inlining_effectful_expressions env res name =
 
 let name env name = name0 env name
 
-let const ~dbg cst =
+let rec const ~dbg cst =
   match Reg_width_const.descr cst with
   | Naked_immediate i ->
     targetint ~dbg (Target_ocaml_int.to_targetint Sixty_four i)
@@ -225,6 +225,9 @@ let const ~dbg cst =
     vec512 ~dbg { word0; word1; word2; word3; word4; word5; word6; word7 }
   | Naked_nativeint t -> targetint ~dbg t
   | Null -> targetint ~dbg (Targetint_32_64.zero Sixty_four)
+  | Poison (kind, name) ->
+    const ~dbg
+      (Reg_width_const.of_int_of_kind Sixty_four kind (String.hash name))
 
 let simple ?consider_inlining_effectful_expressions ~dbg env res s =
   Simple.pattern_match s
@@ -247,7 +250,7 @@ let name_static res name =
     ~symbol:(fun s ->
       `Static_data [symbol_address (To_cmm_result.symbol res s)])
 
-let const_static cst : Cmm.data_item list =
+let rec const_static cst : Cmm.data_item list =
   match Reg_width_const.descr cst with
   | Naked_immediate i ->
     [cint (nativeint_of_targetint (Target_ocaml_int.to_targetint Sixty_four i))]
@@ -300,6 +303,9 @@ let const_static cst : Cmm.data_item list =
     in
     [cvec512 { word0; word1; word2; word3; word4; word5; word6; word7 }]
   | Null -> [cint 0n]
+  | Poison (kind, name) ->
+    const_static
+      (Reg_width_const.of_int_of_kind Sixty_four kind (String.hash name))
 
 let simple_static res s =
   Simple.pattern_match s

--- a/middle_end/flambda2/to_jsir/to_jsir_shared.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_shared.ml
@@ -74,7 +74,7 @@ let int64_to_jsir_const int64 : Jsir.constant = Int64 int64
 let nativeint_to_jsir_const nativeint : Jsir.constant =
   Int32 (Targetint_32_64.to_int32 nativeint)
 
-let reg_width_const const : Jsir.constant =
+let rec reg_width_const const : Jsir.constant =
   match Reg_width_const.descr const with
   | Naked_immediate targetint | Tagged_immediate targetint ->
     target_ocaml_int_to_jsir_const targetint
@@ -84,6 +84,10 @@ let reg_width_const const : Jsir.constant =
   | Naked_int64 int64 -> int64_to_jsir_const int64
   | Naked_nativeint nativeint -> nativeint_to_jsir_const nativeint
   | Null -> Jsir.Null
+  | Poison (kind, name) ->
+    reg_width_const
+      (Reg_width_const.of_int_of_kind Thirty_two_no_gc_tag_bit kind
+         (String.hash name))
   | Naked_int8 _ | Naked_int16 _ | Naked_vec128 _ | Naked_vec256 _
   | Naked_vec512 _ ->
     (* CR selee: smallints and SIMD *)

--- a/middle_end/flambda2/types/expand_head.ml
+++ b/middle_end/flambda2/types/expand_head.ml
@@ -210,6 +210,10 @@ end = struct
     | Naked_vec512 i ->
       create_naked_vec512 (TG.Head_of_kind_naked_vec512.create i)
     | Null -> create_value TG.Head_of_kind_value.null
+    | Poison (kind, _) ->
+      (* CR ncourant: for now [Poison] has the conservative type "unknown"; but
+         should be tracked more precisely in the future. *)
+      create_unknown kind
 
   let bottom_like t = create_bottom t.kind
 

--- a/middle_end/flambda2/types/grammar/more_type_creators.ml
+++ b/middle_end/flambda2/types/grammar/more_type_creators.ml
@@ -444,6 +444,10 @@ let type_for_const const =
   | Naked_vec256 n -> TG.this_naked_vec256 n
   | Naked_vec512 n -> TG.this_naked_vec512 n
   | Null -> TG.null
+  | Poison (kind, _) ->
+    (* CR ncourant: for now [Poison] has the conservative type "unknown"; but
+       should be tracked more precisely in the future. *)
+    unknown kind
 
 let kind_for_const const = TG.kind (type_for_const const)
 

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -4471,10 +4471,20 @@ let rec must_be_singleton t ~machine_width : RWC.t option =
             | Some const -> (
               match RWC.descr const with
               | Naked_immediate i -> Some (RWC.tagged_immediate i)
+              | Poison (Naked_number Naked_immediate, name) ->
+                Some (RWC.const_poison Flambda_kind.value name)
               | Tagged_immediate _ | Naked_float _ | Naked_float32 _
               | Naked_int8 _ | Naked_int16 _ | Naked_int32 _ | Naked_int64 _
               | Naked_nativeint _ | Naked_vec128 _ | Naked_vec256 _
-              | Naked_vec512 _ | Null ->
+              | Naked_vec512 _ | Null
+              | Poison
+                  ( ( Value
+                    | Naked_number
+                        ( Naked_float | Naked_float32 | Naked_int8 | Naked_int16
+                        | Naked_int32 | Naked_int64 | Naked_nativeint
+                        | Naked_vec128 | Naked_vec256 | Naked_vec512 )
+                    | Region | Rec_info ),
+                    _ ) ->
                 Misc.fatal_errorf
                   "Immediates case returned wrong kind of constant:@ %a"
                   Reg_width_const.print const)))))

--- a/testsuite/tests/flambda2/examples/variant_ah.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_ah.simplify.reference
@@ -20,7 +20,7 @@ let code loopify(never) size(33) newer_version_of(shouldn't_alloc_1)
         -> k * k1 =
   (let untagged = %untag_imm (b) in
    switch untagged
-     | 0 -> k2 (1i, 0)
+     | 0 -> k2 (1i, poison.val.variant_unboxing_field)
      | 1 -> k2 (0i, x))
     where k2 (is_int : imm, unboxed_field_0_0) =
       (switch is_int

--- a/testsuite/tests/flambda2/examples/variant_unboxed.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_unboxed.simplify.reference
@@ -24,11 +24,28 @@ let code loopify(never) size(48) newer_version_of(foo_0)
     where k4 =
       let untagged = %untag_imm (b') in
       switch untagged
-        | 0 -> k2 (0i, 0x0p+0, 0, x1, x2)
-        | 1 -> k2 (0i, 0x0p+0, 0, x2, x1)
+        | 0 ->
+          k2
+            (0i,
+             poison.float.variant_unboxing_float,
+             poison.val.variant_unboxing_field,
+             x1,
+             x2)
+        | 1 ->
+          k2
+            (0i,
+             poison.float.variant_unboxing_float,
+             poison.val.variant_unboxing_field,
+             x2,
+             x1)
     where k3 =
       let unboxed_float = %unbox_num.`float` (y) in
-      cont k2 (1i, unboxed_float, x2, 0, 0)
+      cont k2
+             (1i,
+              unboxed_float,
+              x2,
+              poison.val.variant_unboxing_field,
+              poison.val.variant_unboxing_field)
     where k2
             (tag : imm,
              unboxed_float : float,

--- a/testsuite/tests/flambda2/examples/variant_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_unboxing.simplify.reference
@@ -1,15 +1,13 @@
 let code f1_0 deleted in
 let code f2_1 deleted in
 let code f3_returning_a_2 deleted in
-let code loopify(never) size(21) newer_version_of(f1_0)
+let code loopify(never) size(11) newer_version_of(f1_0)
       f1_0_1 (b : imm tagged, x : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
   (let untagged = %untag_imm (b) in
-   switch untagged
-     | 0 -> k2 (0i, x)
-     | 1 -> k2 (1i, 0))
+   cont k2 (untagged, x))
     where k2 (is_int : imm, unboxed_field_0_0) =
       switch is_int
         | 0 -> k (unboxed_field_0_0)
@@ -28,7 +26,13 @@ let code loopify(never) size(94) newer_version_of(f2_1)
      | 1 -> k5)
     where k5 =
       let Pnot = %boolean_not (y) in
-      cont k3 (Pnot, 0i, 1i, 0, 0, 0)
+      cont k3
+             (Pnot,
+              0i,
+              1i,
+              poison.val.variant_unboxing_field,
+              poison.val.variant_unboxing_field,
+              poison.val.variant_unboxing_field)
     where k4 =
       ((let untagged = %untag_imm (y) in
         switch untagged
@@ -36,7 +40,13 @@ let code loopify(never) size(94) newer_version_of(f2_1)
           | 1 -> k5)
          where k5 =
            let Pmakeblock = %block.[`0`].`local`[`region`] (a) in
-           cont k3 (Pmakeblock, 0i, 0i, 0, 0, a)
+           cont k3
+                  (Pmakeblock,
+                   0i,
+                   0i,
+                   poison.val.variant_unboxing_field,
+                   poison.val.variant_unboxing_field,
+                   a)
          where k4 =
            let Popaque = %opaque (0) in
            ((let untagged = %untag_imm (Popaque) in
@@ -45,10 +55,22 @@ let code loopify(never) size(94) newer_version_of(f2_1)
                | 1 -> k5)
               where k5 =
                 let Pmakeblock = %block.[`0`].`local`[`region`] (b) in
-                cont k3 (Pmakeblock, 0i, 0i, 0, 0, b)
+                cont k3
+                       (Pmakeblock,
+                        0i,
+                        0i,
+                        poison.val.variant_unboxing_field,
+                        poison.val.variant_unboxing_field,
+                        b)
               where k4 =
                 let Pmakeblock = %block.[`1`].`local`[`region`] (a, b) in
-                cont k3 (Pmakeblock, 1i, 0i, b, a, 0)))
+                cont k3
+                       (Pmakeblock,
+                        1i,
+                        0i,
+                        b,
+                        a,
+                        poison.val.variant_unboxing_field)))
     where k3
             (t : [ 0 |1 | 0 of imm tagged |1 of imm tagged * imm tagged ],
              tag : imm,
@@ -88,12 +110,17 @@ let code loopify(never) size(45) newer_version_of(f3_returning_a_2)
   (let untagged = %untag_imm (x) in
    switch untagged
      | 0 -> k4
-     | 1 -> k3 (0i, 1i, 0, 0))
+     | 1 ->
+       k3
+         (0i,
+          1i,
+          poison.val.variant_unboxing_field,
+          poison.val.variant_unboxing_field))
     where k4 =
       let untagged = %untag_imm (y) in
       switch untagged
-        | 0 -> k3 (1i, 0i, a, 0)
-        | 1 -> k3 (0i, 0i, 0, a)
+        | 0 -> k3 (1i, 0i, a, poison.val.variant_unboxing_field)
+        | 1 -> k3 (0i, 0i, poison.val.variant_unboxing_field, a)
     where k3 (tag : imm, is_int : imm, unboxed_field_1_1, unboxed_field_0_0) =
       (switch is_int
          | 0 -> k3

--- a/testsuite/tests/flambda2/examples/wrong/join_match.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/join_match.simplify.reference
@@ -31,10 +31,10 @@ let code loopify(never) size(40) newer_version_of(bar_1)
         : imm tagged =
   (let prim = %int_comp.lt (x, 0) in
    switch prim
-     | 0 -> k2 (1i, x, 0)
-     | 1 -> k2 (0i, 0, x))
+     | 0 -> k2 (1i, x, poison.val.variant_unboxing_field)
+     | 1 -> k2 (0i, poison.val.variant_unboxing_field, x))
     where k2 (tag : imm, unboxed_field_1_0, unboxed_field_0_0) =
-      let unboxed_field_2_0 = 0 in
+      let unboxed_field_2_0 = poison.val.variant_unboxing_field in
       (switch tag
          | 0 -> k2
          | 1 -> k3


### PR DESCRIPTION
Variant unboxing now produces those poison values instead of dummy values. In the types, for now poison is considered as an unknown value; there will be a future PR to handle it more precisely in the types.