### PR TITLE
Parse modes on binding operators

### DIFF
--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -300,10 +300,11 @@ module Exp = struct
      pc_rhs = rhs;
     }
 
-  let binding_op op pat exp loc =
+  let binding_op op pat ~modes exp loc =
     {
       pbop_op = op;
       pbop_pat = pat;
+      pbop_modes = modes;
       pbop_exp = exp;
       pbop_loc = loc;
     }

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -242,7 +242,8 @@ module Exp:
     val hole : ?loc:loc -> ?attrs:attrs -> unit -> expression
 
     val case: pattern -> ?guard:expression -> expression -> case
-    val binding_op: str -> pattern -> expression -> loc -> binding_op
+    val binding_op:
+      str -> pattern -> modes:modes -> expression -> loc -> binding_op
     val borrow : ?loc:loc -> ?attrs:attrs -> expression -> expression
   end
 

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -583,9 +583,10 @@ module E = struct
     | Pexp_hole -> ()
     | Pexp_borrow e -> sub.expr sub e
 
-  let iter_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
+  let iter_binding_op sub {pbop_op; pbop_pat; pbop_modes; pbop_exp; pbop_loc} =
     iter_loc sub pbop_op;
     sub.pat sub pbop_pat;
+    sub.modes sub pbop_modes;
     sub.expr sub pbop_exp;
     sub.location sub pbop_loc
 

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -669,13 +669,14 @@ module E = struct
     | Pexp_hole -> hole ~loc ~attrs ()
     | Pexp_borrow e -> borrow ~loc ~attrs (sub.expr sub e)
 
-  let map_binding_op sub {pbop_op; pbop_pat; pbop_exp; pbop_loc} =
+  let map_binding_op sub {pbop_op; pbop_pat; pbop_modes; pbop_exp; pbop_loc} =
     let open Exp in
     let op = map_loc sub pbop_op in
     let pat = sub.pat sub pbop_pat in
+    let modes = sub.modes sub pbop_modes in
     let exp = sub.expr sub pbop_exp in
     let loc = sub.location sub pbop_loc in
-    binding_op op pat exp loc
+    binding_op op pat ~modes exp loc
 
 end
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -2871,10 +2871,10 @@ fun_expr:
   | let_bindings(ext) IN seq_expr
       { expr_of_let_bindings ~loc:$sloc $1 $3 }
   | pbop_op = mkrhs(LETOP) bindings = letop_bindings IN body = seq_expr
-      { let (pbop_pat, pbop_exp, rev_ands) = bindings in
+      { let (pbop_pat, pbop_modes, pbop_exp, rev_ands) = bindings in
         let ands = List.rev rev_ands in
         let pbop_loc = make_loc $sloc in
-        let let_ = {pbop_op; pbop_pat; pbop_exp; pbop_loc} in
+        let let_ = {pbop_op; pbop_pat; pbop_modes; pbop_exp; pbop_loc} in
         mkexp ~loc:$sloc (Pexp_letop{ let_; ands; body}) }
   | fun_expr COLONCOLON expr
       { mkexp_cons ~loc:$sloc $loc($2)
@@ -3396,27 +3396,28 @@ and_let_binding:
 ;
 letop_binding_body:
     pat = let_ident exp = strict_binding
-      { (pat, exp) }
+      { (pat, [], exp) }
   | val_ident
       (* Let-punning *)
-      { (mkpatvar ~loc:$loc $1, ghexpvar ~loc:$loc $1) }
-  (* CR zqian: support mode annotation on letop. *)
+      { (mkpatvar ~loc:$loc $1, [], ghexpvar ~loc:$loc $1) }
+  | LPAREN let_ident at_mode_expr RPAREN exp = strict_binding
+      { ($2, $3, exp) }
   | pat = simple_pattern COLON typ = core_type EQUAL exp = seq_expr
       { let loc = ($startpos(pat), $endpos(typ)) in
-        (ghpat_with_modes ~loc ~pat ~cty:(Some typ) ~modes:[], exp) }
+        (ghpat_with_modes ~loc ~pat ~cty:(Some typ) ~modes:[], [], exp) }
   | pat = pattern_no_exn EQUAL exp = seq_expr
-      { (pat, exp) }
+      { (pat, [], exp) }
 ;
 letop_bindings:
     body = letop_binding_body
-      { let let_pat, let_exp = body in
-        let_pat, let_exp, [] }
+      { let let_pat, let_modes, let_exp = body in
+        let_pat, let_modes, let_exp, [] }
   | bindings = letop_bindings pbop_op = mkrhs(ANDOP) body = letop_binding_body
-      { let let_pat, let_exp, rev_ands = bindings in
-        let pbop_pat, pbop_exp = body in
+      { let let_pat, let_modes, let_exp, rev_ands = bindings in
+        let pbop_pat, pbop_modes, pbop_exp = body in
         let pbop_loc = make_loc $sloc in
-        let and_ = {pbop_op; pbop_pat; pbop_exp; pbop_loc} in
-        let_pat, let_exp, and_ :: rev_ands }
+        let and_ = {pbop_op; pbop_pat; pbop_modes; pbop_exp; pbop_loc} in
+        let_pat, let_modes, let_exp, and_ :: rev_ands }
 ;
 strict_binding_modes:
     EQUAL seq_expr

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -582,10 +582,11 @@ and letop =
 
 and binding_op =
   {
-    pbop_op : string loc;
-    pbop_pat : pattern;
-    pbop_exp : expression;
-    pbop_loc : Location.t;
+    pbop_op    : string loc;
+    pbop_pat   : pattern;
+    pbop_modes : modes;
+    pbop_exp   : expression;
+    pbop_loc   : Location.t;
   }
 
 and function_param_desc =

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1937,14 +1937,19 @@ and bindings ctxt f (mf,rf,l) =
         (list ~sep:"@," (binding "and" Immutable Nonrecursive)) xs
 
 and binding_op ctxt f x =
-  match x.pbop_pat, x.pbop_exp with
+  match x.pbop_pat, x.pbop_exp, x.pbop_modes with
   | {ppat_desc = Ppat_var { txt=pvar; _ }; ppat_attributes = []; _},
-    {pexp_desc = Pexp_ident { txt=Lident evar; _}; pexp_attributes = []; _}
+    {pexp_desc = Pexp_ident { txt=Lident evar; _}; pexp_attributes = []; _},
+    []
        when pvar = evar ->
      pp f "@[<2>%s %s@]" x.pbop_op.txt evar
-  | pat, exp ->
+  | pat, exp, [] ->
      pp f "@[<2>%s %a@;=@;%a@]"
        x.pbop_op.txt (pattern ctxt) pat (expression ctxt) exp
+  | pat, exp, modes ->
+     pp f "@[<2>%s (%a%a)@;=@;%a@]"
+       x.pbop_op.txt (pattern ctxt) pat optional_at_modes modes
+       (expression ctxt) exp
 
 and structure_item ctxt f x =
   match x.pstr_desc with

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -1246,6 +1246,7 @@ and binding_op i ppf x =
   line i ppf "<binding_op> %a %a"
     fmt_string_loc x.pbop_op fmt_location x.pbop_loc;
   pattern (i+1) ppf x.pbop_pat;
+  modes (i+1) ppf x.pbop_modes;
   expression (i+1) ppf x.pbop_exp;
 
 and string_x_expression i ppf (s, e) =

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -1276,6 +1276,7 @@ and binding_op i ppf x =
   line i ppf "<binding_op> %a %a"
     fmt_string_loc x.pbop_op fmt_location x.pbop_loc;
   pattern (i+1) ppf x.pbop_pat;
+  modes (i+1) ppf x.pbop_modes;
   expression (i+1) ppf x.pbop_exp;
   )
 

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -895,6 +895,29 @@ Error: Stack allocating literals is not supported;
        they are not allocated at runtime.
 |}]
 
+(* Let operators *)
+
+(* Mode annotation on a binding at the operator use site. *)
+let ( let* ) (f @ local once) (x @ local) = f x [@nontail]
+let ( and* ) (a @ local once) (b @ local once) = exclave_ (a, b)
+[%%expect{|
+val ( let* ) : ('a @ local -> 'b) @ local once -> 'a @ local -> 'b = <fun>
+val ( and* ) : 'a @ local once -> 'b @ local once -> 'a * 'b @ local once =
+  <fun>
+|}]
+
+let f () =
+  let* (x @ local) = 1
+  and* (y @ local) = 2 in
+  ignore (x, y)
+(* CR aspsmith: Support modes on binding operators in typing *)
+[%%expect{|
+>> Fatal error: Not yet implemented: Modes on binding operators
+Uncaught exception: Misc.Fatal_error
+
+|}]
+
+
 (**********)
 (* unique *)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8370,6 +8370,8 @@ and type_expect_
         exp_env = env;
       }
   | Pexp_letop{ let_ = slet; ands = sands; body = sbody } ->
+      if not (List.is_empty slet.pbop_modes)
+      then Misc.fatal_error "Not yet implemented: Modes on binding operators";
       submode ~loc ~env Value.legacy expected_mode;
       let rec loop spat_acc ty_acc ty_acc_sort sands =
         match sands with

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -850,7 +850,9 @@ let binding_op sub bop pat =
   let pbop_pat = sub.pat sub pat in
   let pbop_exp = sub.expr sub bop.bop_exp in
   let pbop_loc = bop.bop_loc in
-  {pbop_op; pbop_pat; pbop_exp; pbop_loc}
+  (* CR-soon aspsmith: Fill this in once typedtree has binding op modes *)
+  let pbop_modes = [] in
+  {pbop_op; pbop_pat; pbop_exp; pbop_loc; pbop_modes}
 
 let package_type sub pack =
   { ppt_path = map_loc sub pack.tpt_txt;


### PR DESCRIPTION
Parse mode annotations on application of binding operators, threading them through a new `pbop_modes` field on `binding_op`.

Don't actually implement them in typecore yet; just fatal error if they get this far. Actually checking these modes against user annotations will come next.

nb: I reviewed this carefully and stand by it, but this was ~90% written by Fable