### PR TITLE
Make expect.opt output frontend errors

### DIFF
--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -421,7 +421,7 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
         Btype.backtrack snap;
         false
     in
-    let (_ : bool) =
+    let (success : bool) =
       List.fold_left phrases ~init:true ~f:(fun acc phrase ->
           if acc then exec_one phrase else acc)
     in
@@ -432,7 +432,7 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
       Buffer.add_char buf '\n';
     let s = Buffer.contents buf in
     Buffer.clear buf;
-    (Misc.delete_eol_spaces s, !last_asm, !last_unit)
+    (success, Misc.delete_eol_spaces s, !last_asm, !last_unit)
   in
   let fexpr_outputs unit filters =
     let read_dump_file pass =
@@ -472,20 +472,25 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
             in
             let keep_asm = !Clflags.keep_asm_file in
             if has_fexpr then Clflags.keep_asm_file := true;
-        let (toplevel_output, asm_output, last_unit) =
+        let (success, toplevel_output, asm_output, last_unit) =
           exec_phrases chunk.phrases
         in
         Clflags.keep_asm_file := keep_asm;
         List.filter_map chunk.expectations ~f:(fun expectation ->
           let output = match expectation.kind with
             | Expect_toplevel -> toplevel_output
-            | Expect_asm -> Option.value asm_output
-                              ~default:"\nNo assembly: compilation failed\n"
+            | Expect_asm ->
+                if success then
+                  Option.value asm_output
+                    ~default:"\nNo assembly: compilation failed\n"
+                else toplevel_output
             | Expect_fexpr ->
-                let filters =
-                  List.concat_map ~f:fst expectation.expected_output
-                in
-                fexpr_outputs last_unit filters
+                if success then
+                  let filters =
+                    List.concat_map ~f:fst expectation.expected_output
+                  in
+                  fexpr_outputs last_unit filters
+                else toplevel_output
           in
           eval_expectation expectation ~output)))
   in
@@ -494,7 +499,7 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
     | None -> ""
     | Some phrases ->
       capture_everything buf ppf
-        ~f:(fun () -> let (r, _, _) = exec_phrases phrases in r)
+        ~f:(fun () -> let (_, r, _, _) = exec_phrases phrases in r)
   in
   { corrected_expectations; trailing_output }
 

--- a/testsuite/tests/flambda2/expectnat_failure.ml
+++ b/testsuite/tests/flambda2/expectnat_failure.ml
@@ -1,0 +1,23 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   expect.opt with dump-simplify;
+ *)
+
+(* Makes sure frontend errors are properly rendered *)
+let c = 1 + 2.
+
+[%%expect_fexpr Simplify{|
+Line 1, characters 12-14:
+1 | let c = 1 + 2.
+                ^^
+Error: The constant "2." has type "float" but an expression was expected of type
+         "int"
+|}]
+[%%expect_asm X86_64{|
+Line 1, characters 12-14:
+1 | let c = 1 + 2.
+                ^^
+Error: The constant "2." has type "float" but an expression was expected of type
+         "int"
+|}]


### PR DESCRIPTION
Typing errors, among others, were silently ignored with `expect_fexpr`, and probably `expect_asm`.

This patch fixes that by using toplevel output when phrases interpretation fails.