### PR TITLE
flambda2: replace a bunch of calls to `Map.find` with `Map.find_or_null`

### DIFF
--- a/middle_end/flambda2/algorithms/container_types.ml
+++ b/middle_end/flambda2/algorithms/container_types.ml
@@ -259,6 +259,9 @@ module Make_map (T : Thing) (Set : Set_plus_stdlib with type elt = T.t) = struct
         t
     in
     if not !changed then t else t'
+
+  let find_or_null k t =
+    match find_opt k t with None -> Or_null.null | Some v -> Or_null.this v
 end
 [@@inline always]
 

--- a/middle_end/flambda2/algorithms/container_types_intf.ml
+++ b/middle_end/flambda2/algorithms/container_types_intf.ml
@@ -228,6 +228,8 @@ module type Map = sig
 
   val find_opt : key -> 'a t -> 'a option
 
+  val find_or_null : key -> 'a t -> 'a Or_null.t
+
   val map : ('a -> 'b) -> 'a t -> 'b t
 
   val mapi : (key -> 'a -> 'b) -> 'a t -> 'b t

--- a/middle_end/flambda2/algorithms/or_null.ml
+++ b/middle_end/flambda2/algorithms/or_null.ml
@@ -1,0 +1,57 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Basile Clément, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type 'a t =
+  | Null
+  | This of 'a
+[@@or_null]
+
+let equal equal x y =
+  match x, y with
+  | Null, Null -> true
+  | This x, This y -> equal x y
+  | (Null | This _), _ -> false
+
+let compare compare x y =
+  match x, y with
+  | Null, Null -> 0
+  | Null, This _ -> -1
+  | This _, Null -> 1
+  | This x, This y -> compare x y
+
+let null = Null
+
+let[@inline] this x = This x
+
+let[@inline] is_null = function Null -> true | This _ -> false
+
+let[@inline] is_this = function This _ -> true | Null -> false
+
+let to_option = function Null -> None | This x -> Some x
+
+let of_option = function None -> Null | Some x -> This x

--- a/middle_end/flambda2/algorithms/or_null.mli
+++ b/middle_end/flambda2/algorithms/or_null.mli
@@ -1,0 +1,48 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Basile Clément, OCamlPro                             *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2024 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type 'a t =
+  | Null
+  | This of 'a
+[@@or_null]
+
+val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
+
+val null : 'a t
+
+val this : 'a -> 'a t
+
+val is_null : 'a t -> bool
+
+val is_this : 'a t -> bool
+
+val to_option : 'a t -> 'a option
+
+val of_option : 'a option -> 'a t

--- a/middle_end/flambda2/algorithms/patricia_tree.ml
+++ b/middle_end/flambda2/algorithms/patricia_tree.ml
@@ -94,15 +94,6 @@ let compare_prefix prefix0 bit0 prefix1 bit1 =
   let c = compare bit0 bit1 in
   if c = 0 then compare prefix0 prefix1 else c
 
-type 'a or_null =
-  | Null
-  | This of 'a
-[@@or_null]
-
-let[@inline] option_of_or_null = function Null -> None | This x -> Some x
-
-let[@inline] _or_null_of_option = function None -> Null | Some x -> This x
-
 type empty = [`Empty]
 
 type leaf = [`Leaf]
@@ -573,6 +564,8 @@ module Tree_operations (Tree : Tree) : sig
     'c t
 
   val find_opt : key -> 'a t -> 'a option
+
+  val find_or_null : key -> 'a t -> 'a Or_null.t
 
   val get_singleton : 'a t -> 'a Binding.t option
 
@@ -1262,11 +1255,12 @@ end = struct
 
   let[@inline never] rec find_tree i t =
     match tree_descr t with
-    | Leaf l -> if leaf_key l = i then This (leaf_datum l) else Null
+    | Leaf l ->
+      if leaf_key l = i then Or_null.this (leaf_datum l) else Or_null.null
     | Branch b ->
       let prefix, bit = unpack (branch_prefix_and_bit b) in
       if not (match_prefix i prefix bit)
-      then Null
+      then Or_null.null
       else if zero_bit i bit
       then find_tree i (branch0 b)
       else find_tree i (branch1 b)
@@ -1736,10 +1730,15 @@ end = struct
     | Non_empty t0, Empty -> merge_left iv f t0
     | Non_empty t0, Non_empty t1 -> merge_tree iv f t0 t1
 
+  let find_or_null key t =
+    match descr t with
+    | Empty -> Or_null.null
+    | Non_empty tree -> find_tree key tree
+
   let find_opt key t =
     match descr t with
     | Empty -> None
-    | Non_empty tree -> option_of_or_null (find_tree key tree)
+    | Non_empty tree -> Or_null.to_option (find_tree key tree)
 
   let get_singleton t =
     match descr t with

--- a/middle_end/flambda2/simplify/continuation_shortcut.ml
+++ b/middle_end/flambda2/simplify/continuation_shortcut.ml
@@ -49,9 +49,9 @@ let apply { params; continuation; args } shortcut_args =
       (fun arg ->
         Simple.pattern_match' arg
           ~var:(fun var ~coercion ->
-            match Variable.Map.find var subst with
-            | exception Not_found -> arg
-            | simple -> Simple.apply_coercion_exn simple coercion)
+            match Variable.Map.find_or_null var subst with
+            | Null -> arg
+            | This simple -> Simple.apply_coercion_exn simple coercion)
           ~symbol:(fun _ ~coercion:_ -> arg)
           ~const:(fun _ -> arg))
       args )

--- a/middle_end/flambda2/simplify/env/continuation_uses_env.ml
+++ b/middle_end/flambda2/simplify/env/continuation_uses_env.ml
@@ -46,19 +46,18 @@ let record_continuation_use t cont kind ~env_at_use ~arg_types =
   t, id
 
 let get_typing_env_no_more_than_one_use t k =
-  match Continuation.Map.find k t.continuation_uses with
-  | exception Not_found -> None
-  | cont_uses -> Continuation_uses.get_typing_env_no_more_than_one_use cont_uses
+  match Continuation.Map.find_or_null k t.continuation_uses with
+  | Null -> None
+  | This cont_uses ->
+    Continuation_uses.get_typing_env_no_more_than_one_use cont_uses
 
 let get_continuation_uses t cont =
-  match Continuation.Map.find cont t.continuation_uses with
-  | exception Not_found -> None
-  | uses -> Some uses
+  Continuation.Map.find_opt cont t.continuation_uses
 
 let num_continuation_uses t cont =
-  match Continuation.Map.find cont t.continuation_uses with
-  | exception Not_found -> 0
-  | uses -> Continuation_uses.number_of_uses uses
+  match Continuation.Map.find_or_null cont t.continuation_uses with
+  | Null -> 0
+  | This uses -> Continuation_uses.number_of_uses uses
 
 let all_continuations_used t = Continuation.Map.keys t.continuation_uses
 

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -522,9 +522,9 @@ let mem_code t id =
   Code_id.Map.mem id t.all_code || Exported_code.mem id (t.get_imported_code ())
 
 let find_code_exn t id =
-  match Code_id.Map.find id t.all_code with
-  | code -> Code_or_metadata.create code
-  | exception Not_found ->
+  match Code_id.Map.find_or_null id t.all_code with
+  | This code -> Code_or_metadata.create code
+  | Null ->
     (* We might have already loaded the metadata, from another unit that
        references it. However we force loading of the corresponding .cmx to make
        sure that we will have access to the actual code (assuming the .cmx isn't

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -70,9 +70,9 @@ let check_shortcut_transitivity t cont shortcut_to =
       Continuation.print shortcut_to Continuation.print cont print t
 
 let find_continuation_shortcut t cont =
-  match Continuation.Map.find cont t.continuation_shortcuts with
-  | exception Not_found -> None
-  | shortcut_to ->
+  match Continuation.Map.find_or_null cont t.continuation_shortcuts with
+  | Null -> None
+  | This shortcut_to ->
     check_shortcut_transitivity t cont
       (Continuation_shortcut.continuation shortcut_to);
     Some shortcut_to
@@ -101,14 +101,14 @@ let add_continuation_shortcut t cont ~params ~shortcut_to ~args =
       "Cannot add continuation shortcut %a (as shortcut to %a); the target \
        continuation is itself a shortcut"
       Continuation.print cont Continuation.print shortcut_to;
-  match Continuation.Map.find cont t.continuation_shortcuts with
-  | existing_shortcut ->
+  match Continuation.Map.find_or_null cont t.continuation_shortcuts with
+  | This existing_shortcut ->
     Misc.fatal_errorf
       "Cannot add continuation shortcut %a (as shortcut to%a); the source \
        continuation is already deemed to be a shortcut (to %a)"
       Continuation.print cont Continuation.print shortcut_to Continuation.print
       (Continuation_shortcut.continuation existing_shortcut)
-  | exception Not_found ->
+  | Null ->
     let shortcut = Continuation_shortcut.create ~params shortcut_to args in
     (* For now we keep the pre-existing check for aliases, but ideally we should
        check that the arities match after applying the substitution. However it
@@ -162,6 +162,4 @@ let replace_apply_cont_rewrite t cont rewrite =
   { t with apply_cont_rewrites }
 
 let find_apply_cont_rewrite t cont =
-  match Continuation.Map.find cont t.apply_cont_rewrites with
-  | exception Not_found -> None
-  | rewrite -> Some rewrite
+  Continuation.Map.find_opt cont t.apply_cont_rewrites

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -379,9 +379,9 @@ let create_let_symbols uacc lifted_constant ~body =
               (* We're not dropping the coercion: it gets used in [stop_here] *)
               stop_here ())
             ~var:(fun var' ~coercion:coercion_from_var'_to_simple ->
-              match Variable.Map.find var' symbol_projections with
-              | exception Not_found -> stop_here ()
-              | proj' ->
+              match Variable.Map.find_or_null var' symbol_projections with
+              | Null -> stop_here ()
+              | This proj' ->
                 let coercion_from_var'_to_proj =
                   (* Since [simple] is just an evaluated form of [proj] *)
                   coercion_from_var'_to_simple

--- a/middle_end/flambda2/simplify/flow/control_flow_graph.ml
+++ b/middle_end/flambda2/simplify/flow/control_flow_graph.ml
@@ -79,9 +79,9 @@ let map_fold_on_children { children; dummy_toplevel_cont; _ } f acc =
   let rec aux k acc =
     let acc, to_add = f k acc in
     let map = Continuation.Map.singleton k to_add in
-    match Continuation.Map.find k children with
-    | exception Not_found -> map
-    | s ->
+    match Continuation.Map.find_or_null k children with
+    | Null -> map
+    | This s ->
       Continuation.Set.fold
         (fun child map -> Continuation.Map.disjoint_union map (aux child acc))
         s map
@@ -93,9 +93,9 @@ let compute_available_variables ~(source_info : T.Acc.t) t =
     (fun k acc ->
       let elt = Continuation.Map.find k source_info.map in
       let extra_vars =
-        match Continuation.Map.find k source_info.extra with
-        | exception Not_found -> Variable.Set.empty
-        | epa ->
+        match Continuation.Map.find_or_null k source_info.extra with
+        | Null -> Variable.Set.empty
+        | This epa ->
           Bound_parameters.var_set
             (Continuation_extra_params_and_args.extra_params epa)
       in
@@ -121,9 +121,9 @@ let fixpoint t ~init ~eq ~f =
       (fun res component ->
         match component with
         | G.No_loop callee -> (
-          match Continuation.Map.find callee res with
-          | exception Not_found -> res
-          | callee_set ->
+          match Continuation.Map.find_or_null callee res with
+          | Null -> res
+          | This callee_set ->
             Continuation.Set.fold
               (fun caller res ->
                 let caller_set = Continuation.Map.find caller res in
@@ -196,14 +196,14 @@ let extra_args_for_aliases_overapproximation ~required_names
         let s =
           List.fold_left
             (fun acc param ->
-              match Variable.Map.find param doms with
-              | exception Not_found ->
+              match Variable.Map.find_or_null param doms with
+              | Null ->
                 if Name.Set.mem (Name.var param) required_names
                 then
                   Misc.fatal_errorf "Dom not found for: %a@." Variable.print
                     param
                 else acc
-              | dom ->
+              | This dom ->
                 (* Parameters whose dominator/canonical alias is a symbol or a
                    constant do not require extra args to access the value of
                    that dominator. *)
@@ -259,9 +259,9 @@ let minimize_extra_args_for_one_continuation ~(source_info : T.Acc.t)
     match exception_handler_first_param with
     | None -> extra_args_for_aliases, Not_aliased
     | Some exception_param -> (
-      match Variable.Map.find exception_param doms with
-      | exception Not_found -> extra_args_for_aliases, Not_aliased
-      | alias ->
+      match Variable.Map.find_or_null exception_param doms with
+      | Null -> extra_args_for_aliases, Not_aliased
+      | This alias ->
         Simple.pattern_match' alias
           ~var:(fun alias_var ~coercion:_ ->
             if Variable.equal exception_param alias_var
@@ -297,9 +297,9 @@ let minimize_extra_args_for_one_continuation ~(source_info : T.Acc.t)
           in
           removed, lets_to_introduce
         in
-        match Variable.Map.find param doms with
-        | exception Not_found -> removed, lets_to_introduce
-        | alias -> (
+        match Variable.Map.find_or_null param doms with
+        | Null -> removed, lets_to_introduce
+        | This alias -> (
           if Simple.equal (Simple.var param) alias
           then removed, lets_to_introduce
           else
@@ -387,9 +387,9 @@ module Dot = struct
   let node ?(extra_args = Variable.Set.empty) ?(info = "") ~df ~pp_node ~ctx ()
       ppf cont =
     let params, shape =
-      match Continuation.Map.find cont df.T.Acc.map with
-      | exception Not_found -> "[ none ]", ""
-      | elt ->
+      match Continuation.Map.find_or_null cont df.T.Acc.map with
+      | Null -> "[ none ]", ""
+      | This elt ->
         let params =
           Format.asprintf "[%a]"
             (Format.pp_print_list

--- a/middle_end/flambda2/simplify/flow/dominator_graph.ml
+++ b/middle_end/flambda2/simplify/flow/dominator_graph.ml
@@ -170,7 +170,9 @@ let find_dom simple doms =
 
          - we are in the first iteration of a loop fixpoint, in which case we
          also want to initialize the dominator to the variable itself. *)
-      try Variable.Map.find var doms with Not_found -> simple)
+      match Variable.Map.find_or_null var doms with
+      | Null -> simple
+      | This dom -> dom)
 
 let update_doms_for_one_var { dominator_roots; graph; _ } doms var =
   let simple = Simple.var var in
@@ -178,9 +180,9 @@ let update_doms_for_one_var { dominator_roots; graph; _ } doms var =
     if Simple.Set.mem simple dominator_roots
     then simple
     else
-      match Simple.Map.find simple graph with
-      | exception Not_found -> simple
-      | predecessors -> (
+      match Simple.Map.find_or_null simple graph with
+      | Null -> simple
+      | This predecessors -> (
         let s =
           Simple.Set.map
             (fun predecessor -> find_dom predecessor doms)
@@ -297,9 +299,9 @@ let aliases_kind { params_kind; required_names; _ } (aliases : alias_map) =
           ~symbol:(fun _ ~coercion:_ -> acc)
           ~const:(fun _ -> acc)
           ~var:(fun v ~coercion:_ ->
-            (match Variable.Map.find v acc with
-            | exception Not_found -> ()
-            | alias_kind ->
+            (match Variable.Map.find_or_null v acc with
+            | Null -> ()
+            | This alias_kind ->
               if not (Flambda_kind.equal kind alias_kind)
               then Misc.fatal_errorf "Incoherent kinds for aliases !");
             Variable.Map.add v kind acc))

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -495,10 +495,10 @@ let record_lifted_constants lifted_constants (t : t) =
 (* ************* *)
 
 let add_extra_args_to_call ~extra_args rewrite_id original_args =
-  match Apply_cont_rewrite_id.Map.find rewrite_id extra_args with
-  | exception Not_found -> Some original_args
-  | Or_invalid.Invalid -> None
-  | Or_invalid.Ok extra_args ->
+  match Apply_cont_rewrite_id.Map.find_or_null rewrite_id extra_args with
+  | Null -> Some original_args
+  | This Or_invalid.Invalid -> None
+  | This (Or_invalid.Ok extra_args) ->
     let args_acc =
       if Numeric_types.Int.Map.is_empty original_args
       then 0, Numeric_types.Int.Map.empty
@@ -533,15 +533,16 @@ let normalize_acc ~specialization_map (t : T.Acc.t) =
         let apply_cont_args =
           Continuation.Map.fold
             (fun cont rewrite_ids acc ->
-              match Continuation.Map.find cont specialization_map with
-              | exception Not_found -> Continuation.Map.add cont rewrite_ids acc
-              | specialized_ids ->
+              match Continuation.Map.find_or_null cont specialization_map with
+              | Null -> Continuation.Map.add cont rewrite_ids acc
+              | This specialized_ids ->
                 Apply_cont_rewrite_id.Map.fold
                   (fun id args acc ->
-                    match Apply_cont_rewrite_id.Map.find id specialized_ids with
-                    | exception Not_found ->
-                      Continuation_callsite_map.add cont id args acc
-                    | specialized ->
+                    match
+                      Apply_cont_rewrite_id.Map.find_or_null id specialized_ids
+                    with
+                    | Null -> Continuation_callsite_map.add cont id args acc
+                    | This specialized ->
                       Continuation_callsite_map.add specialized id args acc)
                   rewrite_ids acc)
             elt.apply_cont_args Continuation.Map.empty
@@ -551,9 +552,9 @@ let normalize_acc ~specialization_map (t : T.Acc.t) =
           Continuation.Map.filter_map
             (fun cont rewrite_ids ->
               let rewrite_ids =
-                match Continuation.Map.find cont t.extra with
-                | exception Not_found -> rewrite_ids
-                | epa ->
+                match Continuation.Map.find_or_null cont t.extra with
+                | Null -> rewrite_ids
+                | This epa ->
                   let extra_args = EPA.extra_args epa in
                   Apply_cont_rewrite_id.Map.filter_map
                     (add_extra_args_to_call ~extra_args)
@@ -582,18 +583,18 @@ let normalize_acc ~specialization_map (t : T.Acc.t) =
         let defined =
           Continuation.Map.fold
             (fun callee_cont rewrite_ids defined ->
-              match Continuation.Map.find callee_cont t.extra with
-              | exception Not_found -> defined
-              | epa ->
+              match Continuation.Map.find_or_null callee_cont t.extra with
+              | Null -> defined
+              | This epa ->
                 Apply_cont_rewrite_id.Map.fold
                   (fun rewrite_id _args defined ->
                     match
-                      Apply_cont_rewrite_id.Map.find rewrite_id
+                      Apply_cont_rewrite_id.Map.find_or_null rewrite_id
                         (EPA.extra_args epa)
                     with
-                    | exception Not_found -> defined
-                    | Invalid -> defined
-                    | Ok extra_args ->
+                    | Null -> defined
+                    | This Invalid -> defined
+                    | This (Ok extra_args) ->
                       let defined =
                         List.fold_left
                           (fun defined -> function

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -62,9 +62,9 @@ let find_alias ~(dom : Dominator_graph.alias_map) simple =
     ~const:(fun _ -> simple)
     ~symbol:(fun _ ~coercion:_ -> simple)
     ~var:(fun var ~coercion:_ ->
-      match Variable.Map.find var dom with
-      | exception Not_found -> simple
-      | res -> res)
+      match Variable.Map.find_or_null var dom with
+      | Null -> simple
+      | This res -> res)
 
 let escaping_by_alias ~(dom : Dominator_graph.alias_map)
     ~(dom_graph : Dominator_graph.t) =
@@ -113,9 +113,9 @@ let escaping_by_use_for_one_continuation ~required_names
   let add_name_occurrences occurrences init =
     Name_occurrences.fold_variables occurrences ~init ~f:(fun escaping var ->
         let escaping =
-          match Variable.Map.find var dom with
-          | exception Not_found -> escaping
-          | simple -> Simple.Set.add simple escaping
+          match Variable.Map.find_or_null var dom with
+          | Null -> escaping
+          | This simple -> Simple.Set.add simple escaping
         in
         Simple.Set.add (Simple.var var) escaping)
   in
@@ -135,9 +135,9 @@ let escaping_by_use_for_one_continuation ~required_names
        See [flambda2/tests/ref_to_var/unboxing_cse.ml] *)
     Variable.Set.fold
       (fun var escaping ->
-        match Variable.Map.find var dom with
-        | exception Not_found -> escaping
-        | simple -> Simple.Set.add simple escaping)
+        match Variable.Map.find_or_null var dom with
+        | Null -> escaping
+        | This simple -> Simple.Set.add simple escaping)
       (names_used_in_new_let_binding elt)
       escaping
   in
@@ -177,15 +177,15 @@ let escaping_by_return ~(dom : Dominator_graph.alias_map)
   Continuation.Map.fold
     (fun _cont (elt : T.Continuation_info.t) escaping ->
       let add_escaping cont escaping =
-        match Continuation.Map.find cont elt.apply_cont_args with
-        | exception Not_found -> escaping
-        | apply_cont_args ->
+        match Continuation.Map.find_or_null cont elt.apply_cont_args with
+        | Null -> escaping
+        | This apply_cont_args ->
           Variable.Set.fold
             (fun var escaping ->
               let escaping =
-                match Variable.Map.find var dom with
-                | exception Not_found -> escaping
-                | simple -> Simple.Set.add simple escaping
+                match Variable.Map.find_or_null var dom with
+                | Null -> escaping
+                | This simple -> Simple.Set.add simple escaping
               in
               Simple.Set.add (Simple.var var) escaping)
             (free_names_of_apply_cont_args apply_cont_args)
@@ -259,9 +259,9 @@ let prims_using_block ~blocks_to_unbox ~dom prim =
   | Block_set { block; _ }
   | Block_load { block; _ } ->
     let block =
-      match Variable.Map.find block dom with
-      | exception Not_found -> Simple.var block
-      | block -> block
+      match Variable.Map.find_or_null block dom with
+      | Null -> Simple.var block
+      | This block -> block
     in
     if Simple.Map.mem block blocks_to_unbox
     then Simple.Set.singleton block
@@ -361,23 +361,23 @@ module Fold_prims = struct
 
   let with_unboxed_block ~block ~dom ~env ~blocks_to_unbox ~f =
     let block =
-      match Variable.Map.find block dom with
-      | exception Not_found -> Simple.var block
-      | block -> block
+      match Variable.Map.find_or_null block dom with
+      | Null -> Simple.var block
+      | This block -> block
     in
-    match Simple.Map.find block blocks_to_unbox with
-    | exception Not_found -> env
-    | { tag; fields_kinds; mut = _ } -> f ~block ~tag ~fields_kinds
+    match Simple.Map.find_or_null block blocks_to_unbox with
+    | Null -> env
+    | This { tag; fields_kinds; mut = _ } -> f ~block ~tag ~fields_kinds
 
   let with_unboxed_fields ~block ~dom ~env ~f =
     let block =
-      match Variable.Map.find block dom with
-      | exception Not_found -> Simple.var block
-      | block -> block
+      match Variable.Map.find_or_null block dom with
+      | Null -> Simple.var block
+      | This block -> block
     in
-    match Simple.Map.find block env.bindings with
-    | exception Not_found -> env
-    | fields -> f ~block fields
+    match Simple.Map.find_or_null block env.bindings with
+    | Null -> env
+    | This fields -> f ~block fields
 
   let apply_prim ~machine_width ~dom ~blocks_to_unbox env rewrite_id var
       (prim : T.Mutable_prim.t) =
@@ -547,10 +547,11 @@ module Fold_prims = struct
             Apply_cont_rewrite_id.Map.map
               (fun _args ->
                 match
-                  Continuation.Map.find cont continuations_with_live_block
+                  Continuation.Map.find_or_null cont
+                    continuations_with_live_block
                 with
-                | exception Not_found -> Numeric_types.Int.Map.empty
-                | blocks_needed ->
+                | Null -> Numeric_types.Int.Map.empty
+                | This blocks_needed ->
                   let extra_args =
                     Simple.Set.fold
                       (fun block_needed extra_args ->
@@ -614,9 +615,9 @@ let create ~(dom : Dominator_graph.alias_map) ~(dom_graph : Dominator_graph.t)
   }
 
 let pp_node { blocks_to_unbox = _; continuations_with_live_block; _ } ppf cont =
-  match Continuation.Map.find cont continuations_with_live_block with
-  | exception Not_found -> ()
-  | live_blocks -> Format.fprintf ppf " %a" Simple.Set.print live_blocks
+  match Continuation.Map.find_or_null cont continuations_with_live_block with
+  | Null -> ()
+  | This live_blocks -> Format.fprintf ppf " %a" Simple.Set.print live_blocks
 
 let add_to_extra_params_and_args result =
   let epa = Continuation.Map.empty in
@@ -640,11 +641,11 @@ let add_to_extra_params_and_args result =
                   match previous_extra_args with
                   | None -> (
                     match
-                      Continuation.Map.find callee_cont
+                      Continuation.Map.find_or_null callee_cont
                         result.extra_params_and_args
                     with
-                    | exception Not_found -> []
-                    | extra_params, _ ->
+                    | Null -> []
+                    | This (extra_params, _) ->
                       List.map
                         (fun _ -> Apply_cont_rewrite_id.Map.empty)
                         extra_params)
@@ -673,9 +674,11 @@ let add_to_extra_params_and_args result =
     Continuation.Map.fold
       (fun cont extra_args epa ->
         let extra_params =
-          match Continuation.Map.find cont result.extra_params_and_args with
-          | exception Not_found -> []
-          | extra_params, _ -> extra_params
+          match
+            Continuation.Map.find_or_null cont result.extra_params_and_args
+          with
+          | Null -> []
+          | This (extra_params, _) -> extra_params
         in
         Continuation.Map.update cont
           (fun epa_for_cont ->

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -332,9 +332,9 @@ let add_extra_params_for_mutable_unboxing cont uacc extra_params_and_args =
   let Flow_types.Mutable_unboxing_result.{ additional_epa; _ } =
     UA.mutable_unboxing_result uacc
   in
-  match Continuation.Map.find cont additional_epa with
-  | exception Not_found -> extra_params_and_args
-  | additional_epa ->
+  match Continuation.Map.find_or_null cont additional_epa with
+  | Null -> extra_params_and_args
+  | This additional_epa ->
     EPA.concat ~inner:extra_params_and_args ~outer:additional_epa
 
 type behaviour =
@@ -961,11 +961,11 @@ let create_handler_to_rebuild
     Apply_cont_rewrite_id.Map.of_set
       (fun rewrite_id ->
         match
-          Apply_cont_rewrite_id.Map.find rewrite_id
+          Apply_cont_rewrite_id.Map.find_or_null rewrite_id
             (EPA.extra_args data.invariant_extra_params_and_args)
         with
-        | extra_args -> extra_args
-        | exception Not_found ->
+        | This extra_args -> extra_args
+        | Null ->
           Or_invalid.Ok
             (List.map
                (fun param ->

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -411,10 +411,11 @@ let simplify_function0 context ~outer_dacc function_slot_opt code_id code
   let old_code_id = code_id in
   let code_id, newer_version_of =
     match
-      Code_id.Map.find old_code_id (C.old_to_new_code_ids_all_sets context)
+      Code_id.Map.find_or_null old_code_id
+        (C.old_to_new_code_ids_all_sets context)
     with
-    | new_code_id -> new_code_id, Some old_code_id
-    | exception Not_found -> old_code_id, None
+    | This new_code_id -> new_code_id, Some old_code_id
+    | Null -> old_code_id, None
   in
   let inlining_decision =
     let decision =
@@ -704,11 +705,13 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
           ~name:(fun name ~coercion ->
             Name.pattern_match name
               ~var:(fun var ->
-                match Variable.Map.find var closure_bound_vars_inverse with
-                | exception Not_found ->
+                match
+                  Variable.Map.find_or_null var closure_bound_vars_inverse
+                with
+                | Null ->
                   assert (DE.mem_variable (DA.denv dacc) var);
                   T.alias_type_of kind in_slot
-                | function_slot ->
+                | This function_slot ->
                   let closure_symbol =
                     Function_slot.Map.find function_slot closure_symbols_map
                   in

--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -421,15 +421,15 @@ let name_defined_earlier ~binding_time_resolver ~binding_times_and_modes alias
        However if this situation occurs they should have binding time
        [Binding_time.imported_variables] (see [Typing_env.add_equation0]). *)
     let alias_binding_time =
-      match Name.Map.find alias binding_times_and_modes with
-      | exception Not_found -> Binding_time.imported_variables
-      | _, binding_time_and_mode ->
+      match Name.Map.find_or_null alias binding_times_and_modes with
+      | Null -> Binding_time.imported_variables
+      | This (_, binding_time_and_mode) ->
         Binding_time.With_name_mode.binding_time binding_time_and_mode
     in
     let than_binding_time =
-      match Name.Map.find than binding_times_and_modes with
-      | exception Not_found -> Binding_time.imported_variables
-      | _, binding_time_and_mode ->
+      match Name.Map.find_or_null than binding_times_and_modes with
+      | Null -> Binding_time.imported_variables
+      | This (_, binding_time_and_mode) ->
         Binding_time.With_name_mode.binding_time binding_time_and_mode
     in
     if Binding_time.strictly_earlier alias_binding_time ~than:than_binding_time
@@ -471,9 +471,9 @@ let binding_time_and_name_mode ~binding_times_and_modes elt =
     ~const:(fun _ -> Binding_time.With_name_mode.consts)
     ~var:(fun var ~coercion:_ ->
       let name = Name.var var in
-      match Name.Map.find name binding_times_and_modes with
-      | _, binding_time_and_mode -> binding_time_and_mode
-      | exception Not_found ->
+      match Name.Map.find_or_null name binding_times_and_modes with
+      | This (_, binding_time_and_mode) -> binding_time_and_mode
+      | Null ->
         (* This variable must be in another compilation unit. *)
         Binding_time.With_name_mode.imported_variables)
     ~symbol:(fun _ ~coercion:_ -> Binding_time.With_name_mode.symbols)
@@ -554,9 +554,9 @@ let canonical t element : canonical =
   Simple.pattern_match element
     ~const:(fun _ -> Is_canonical)
     ~name:(fun name ~coercion:coercion_from_bare_element_to_element ->
-      match Name.Map.find name t.canonical_elements with
-      | exception Not_found -> Is_canonical
-      | canonical_element, coercion_from_bare_element_to_canonical ->
+      match Name.Map.find_or_null name t.canonical_elements with
+      | Null -> Is_canonical
+      | This (canonical_element, coercion_from_bare_element_to_canonical) ->
         let coercion_from_element_to_bare_element =
           Coercion.inverse coercion_from_bare_element_to_element
         in

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -79,9 +79,9 @@ let add_symbol_projection t var proj =
   { t with symbol_projections }
 
 let find_symbol_projection t var =
-  match Variable.Map.find var t.symbol_projections with
-  | exception Not_found -> None
-  | proj -> Some proj
+  match Variable.Map.find_or_null var t.symbol_projections with
+  | Null -> None
+  | This proj -> Some proj
 
 let clean_for_export t ~reachable_names =
   (* Names coming from other compilation units or unreachable are removed *)

--- a/middle_end/flambda2/types/env/code_age_relation.ml
+++ b/middle_end/flambda2/types/env/code_age_relation.ml
@@ -32,8 +32,8 @@ let rec has_older_version_in t ~resolver id candidates : _ Or_unknown.t =
   if Code_id.Set.mem id candidates
   then Known true
   else
-    match Code_id.Map.find id t with
-    | exception Not_found -> (
+    match Code_id.Map.find_or_null id t with
+    | Null -> (
       let comp_unit = Code_id.get_compilation_unit id in
       if Compilation_unit.equal comp_unit (Compilation_unit.get_current_exn ())
       then Known false
@@ -46,10 +46,10 @@ let rec has_older_version_in t ~resolver id candidates : _ Or_unknown.t =
         | Some t -> (
           (* Inlining the base case, so that we do not recursively loop in case
              of a code_id that is not bound in the map *)
-          match Code_id.Map.find id t with
-          | exception Not_found -> Known false
-          | older -> has_older_version_in t ~resolver older candidates))
-    | older -> has_older_version_in t ~resolver older candidates
+          match Code_id.Map.find_or_null id t with
+          | Null -> Known false
+          | This older -> has_older_version_in t ~resolver older candidates))
+    | This older -> has_older_version_in t ~resolver older candidates
 
 let meet_set t ~resolver ids1 ids2 : _ Or_bottom.t =
   if Code_id.Set.equal ids1 ids2

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -331,12 +331,13 @@ let binding_time_resolver resolver name =
   | None -> raise Binding_time_resolver_failure
   | Some t -> (
     match
-      Name.Map.find name (Cached_level.names_to_types t.just_after_level)
+      Name.Map.find_or_null name
+        (Cached_level.names_to_types t.just_after_level)
     with
-    | exception Not_found ->
+    | Null ->
       Misc.fatal_errorf "Binding time resolver cannot find name %a in:@ %a"
         Name.print name print_serializable t
-    | _, binding_time_and_mode -> binding_time_and_mode)
+    | This (_, binding_time_and_mode) -> binding_time_and_mode)
 
 let resolver t = t.resolver
 
@@ -412,8 +413,8 @@ let check_optional_kind_matches name ty kind_opt =
 let find_with_binding_time_and_mode' t name kind =
   (* Note that [Pre_serializable] (below) assumes this function only looks up
      types of names in the cache for the current level. *)
-  match Name.Map.find name (names_to_types t) with
-  | exception Not_found -> (
+  match Name.Map.find_or_null name (names_to_types t) with
+  | Null -> (
     let comp_unit = Name.compilation_unit name in
     if Compilation_unit.equal comp_unit (Compilation_unit.get_current_exn ())
     then
@@ -472,7 +473,7 @@ let find_with_binding_time_and_mode' t name kind =
           (* All variables in exported maps already have the right name mode
              (see [Cached_level.clean_for_export]) *)
           type_and_binding_time))
-  | found ->
+  | This found ->
     let ty, binding_time_and_mode = found in
     check_optional_kind_matches name ty kind;
     if t.is_bottom then MTC.bottom_like ty, binding_time_and_mode else found
@@ -532,12 +533,12 @@ let mem ?min_name_mode t name =
   Name.pattern_match name
     ~var:(fun _var ->
       let name_mode =
-        match Name.Map.find name (names_to_types t) with
-        | exception Not_found ->
+        match Name.Map.find_or_null name (names_to_types t) with
+        | Null ->
           if Compilation_unit.is_current (Name.compilation_unit name)
           then None
           else Some Name_mode.in_types
-        | _ty, binding_time_and_mode ->
+        | This (_ty, binding_time_and_mode) ->
           let scoped_name_mode =
             Binding_time.With_name_mode.scoped_name_mode binding_time_and_mode
               ~min_binding_time:t.min_binding_time

--- a/middle_end/flambda2/types/env/typing_env_level.ml
+++ b/middle_end/flambda2/types/env/typing_env_level.ml
@@ -128,9 +128,9 @@ let add_definition t var kind binding_time =
       Variable.print var print t;
   let binding_times =
     let vars =
-      match Binding_time.Map.find binding_time t.binding_times with
-      | exception Not_found -> Variable.Set.singleton var
-      | prev_vars -> Variable.Set.add var prev_vars
+      match Binding_time.Map.find_or_null binding_time t.binding_times with
+      | Null -> Variable.Set.singleton var
+      | This prev_vars -> Variable.Set.add var prev_vars
     in
     Binding_time.Map.add binding_time vars t.binding_times
   in

--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -284,9 +284,9 @@ let join ~env_at_fork envs_with_levels ~params ~extra_lifted_consts_in_use_envs
           let result =
             Name_occurrences.add_name result name Name_mode.in_types
           in
-          match Name.Map.find name joined_types with
-          | exception Not_found -> result
-          | typ -> free_names_transitive0 typ ~result)
+          match Name.Map.find_or_null name joined_types with
+          | Null -> result
+          | This typ -> free_names_transitive0 typ ~result)
     in
     free_names_transitive0 typ ~result:Name_occurrences.empty
   in


### PR DESCRIPTION
Prefer `find_or_null` in cases where failing to find in the map is not a failure case: since #6068 (commit
15cba9f34accab3de6a73eb56b6fb6a3b8ba7311) we no longer use `raise` for `Map.find`, so we should use an API that does not collect backtraces.

Also expose `Map.find_or_null` so that we don't needlessly allocate an extra option (when building with OxCaml).

Note that there may be some remaining instances where we still use `find` (either because we just re-raise an exception in that case, or because we are using maps from the stdlib), but this PR should switch the most egregious cases to `find_or_null`.