### PR TITLE
from_lambda: fix continuations being called with invalid kinds

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1823,7 +1823,7 @@ let close_exact_or_unknown_apply acc env
       ~current_region ~current_ghost_region
   in
   let dbg = Debuginfo.from_location loc in
-  let acc, call_kind, can_erase_callee =
+  let acc, call_kind, can_erase_callee, replace_by_invalid =
     match kind with
     | Function -> (
       match (callee_approx : Env.value_approximation option) with
@@ -1834,29 +1834,41 @@ let close_exact_or_unknown_apply acc env
           (* CR keryan : We could do better here since we know the arity, but we
              would have to untuple the arguments and we lack information for
              now *)
-          acc, Call_kind.indirect_function_call_unknown_arity, false
+          acc, Call_kind.indirect_function_call_unknown_arity, false, false
         else
           let result_arity_from_code = Code_metadata.result_arity meta in
           if
             (* See comment about when this check can be done, in
                simplify_apply_expr.ml *)
-            Flambda_features.kind_checks ()
-            && not
-                 (Flambda_arity.equal_ignoring_subkinds return_arity
-                    result_arity_from_code)
+            not
+              (Flambda_arity.equal_ignoring_subkinds return_arity
+                 result_arity_from_code
+              && Misc.Stdlib.List.equal
+                   (Misc.Stdlib.List.equal K.With_subkind.equal_ignoring_subkind)
+                   (Flambda_arity.unarize_per_parameter args_arity)
+                   (Flambda_arity.unarize_per_parameter
+                      (Code_metadata.params_arity meta)))
           then
-            Misc.fatal_errorf
-              "Wrong return arity for direct OCaml function call to %a@ \
-               (expected %a, found %a):@ %a@ code metadata:@ %a"
-              Ident.print func Flambda_arity.print result_arity_from_code
-              Flambda_arity.print return_arity Debuginfo.print_compact dbg
-              Code_metadata.print meta;
-          let can_erase_callee =
-            Flambda_features.classic_mode ()
-            && not (Code_metadata.is_my_closure_used meta)
-          in
-          acc, Call_kind.direct_function_call code_id, can_erase_callee
-      | None -> acc, Call_kind.indirect_function_call_unknown_arity, false
+            if Flambda_features.kind_checks ()
+            then
+              Misc.fatal_errorf
+                "Wrong arity for direct OCaml function call to %a@ (expected \
+                 parameters (%a) and result (%a),@ found arguments (%a) and \
+                 return (%a)):@ %a@ code metadata:@ %a"
+                Ident.print func Flambda_arity.print
+                (Code_metadata.params_arity meta)
+                Flambda_arity.print result_arity_from_code Flambda_arity.print
+                args_arity Flambda_arity.print return_arity
+                Debuginfo.print_compact dbg Code_metadata.print meta
+            else acc, Call_kind.direct_function_call code_id, false, true
+          else
+            let can_erase_callee =
+              Flambda_features.classic_mode ()
+              && not (Code_metadata.is_my_closure_used meta)
+            in
+            acc, Call_kind.direct_function_call code_id, can_erase_callee, false
+      | None ->
+        acc, Call_kind.indirect_function_call_unknown_arity, false, false
       | Some (Unknown _ | Value_symbol _ | Value_const _ | Block_approximation _)
         ->
         assert false (* See [close_apply] *))
@@ -1864,58 +1876,66 @@ let close_exact_or_unknown_apply acc env
       let acc, obj = find_simple acc env obj in
       ( acc,
         Call_kind.method_call (Call_kind.Method_kind.from_lambda kind) ~obj,
+        false,
         false )
   in
-  let acc, apply_exn_continuation =
-    close_exn_continuation acc env exn_continuation
-  in
-  let acc, args = find_simples acc env args in
-  let inlined_call = Inlined_attribute.from_lambda inlined in
-  let probe = Probe.from_lambda probe in
-  let position =
-    match region_close with
-    | Rc_normal | Rc_close_at_apply -> Apply.Position.Normal
-    | Rc_nontail -> Apply.Position.Nontail
-  in
-  let apply =
-    Apply.create
-      ~callee:(if can_erase_callee then None else Some callee)
-      ~continuation:(Return continuation) apply_exn_continuation ~args
-      ~args_arity ~return_arity ~call_kind ~return_mode:mode dbg
-      ~inlined:inlined_call
-      ~inlining_state:(Inlining_state.default ~round:0)
-      ~probe ~position
-      ~relative_history:(Env.relative_history_from_scoped ~loc env)
-  in
-  if Flambda_features.classic_mode ()
+  if replace_by_invalid
   then
-    if !Clflags.jsir
+    ( acc,
+      Expr.create_invalid
+        (Application_result_kind_mismatch_in_lambda
+           (Debuginfo.from_location loc)) )
+  else
+    let acc, apply_exn_continuation =
+      close_exn_continuation acc env exn_continuation
+    in
+    let acc, args = find_simples acc env args in
+    let inlined_call = Inlined_attribute.from_lambda inlined in
+    let probe = Probe.from_lambda probe in
+    let position =
+      match region_close with
+      | Rc_normal | Rc_close_at_apply -> Apply.Position.Normal
+      | Rc_nontail -> Apply.Position.Nontail
+    in
+    let apply =
+      Apply.create
+        ~callee:(if can_erase_callee then None else Some callee)
+        ~continuation:(Return continuation) apply_exn_continuation ~args
+        ~args_arity ~return_arity ~call_kind ~return_mode:mode dbg
+        ~inlined:inlined_call
+        ~inlining_state:(Inlining_state.default ~round:0)
+        ~probe ~position
+        ~relative_history:(Env.relative_history_from_scoped ~loc env)
+    in
+    if Flambda_features.classic_mode ()
     then
-      let apply =
-        Apply.with_inlined_attribute apply
-          (Inlined_attribute.with_use_info (Apply.inlined apply)
-             Jsir_inlining_disabled)
-      in
-      Expr_with_acc.create_apply acc apply
-    else
-      match Inlining.inlinable env apply callee_approx with
-      | Not_inlinable ->
+      if !Clflags.jsir
+      then
         let apply =
           Apply.with_inlined_attribute apply
             (Inlined_attribute.with_use_info (Apply.inlined apply)
-               Unused_because_function_unknown)
+               Jsir_inlining_disabled)
         in
         Expr_with_acc.create_apply acc apply
-      | Inlinable func_desc ->
-        let acc = Acc.mark_continuation_as_untrackable continuation acc in
-        let acc =
-          Acc.mark_continuation_as_untrackable
-            (Exn_continuation.exn_handler apply_exn_continuation)
-            acc
-        in
-        Inlining.inline acc ~apply ~apply_depth:(Env.current_depth env)
-          ~func_desc
-  else Expr_with_acc.create_apply acc apply
+      else
+        match Inlining.inlinable env apply callee_approx with
+        | Not_inlinable ->
+          let apply =
+            Apply.with_inlined_attribute apply
+              (Inlined_attribute.with_use_info (Apply.inlined apply)
+                 Unused_because_function_unknown)
+          in
+          Expr_with_acc.create_apply acc apply
+        | Inlinable func_desc ->
+          let acc = Acc.mark_continuation_as_untrackable continuation acc in
+          let acc =
+            Acc.mark_continuation_as_untrackable
+              (Exn_continuation.exn_handler apply_exn_continuation)
+              acc
+          in
+          Inlining.inline acc ~apply ~apply_depth:(Env.current_depth env)
+            ~func_desc
+    else Expr_with_acc.create_apply acc apply
 
 let close_apply_cont acc env ~dbg cont trap_action args : Expr_with_acc.t =
   let acc, args = find_simples acc env args in
@@ -3495,9 +3515,15 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     then Lambda.alloc_heap, first_complex_local_param - num_provided
     else Lambda.alloc_local, 0
   in
-  if not (Lambda.locality_return_compat closure_alloc_mode apply.IR.mode)
+  (* This can happen in a dead GADT match case. *)
+  if not (Flambda_arity.is_one_param_of_kind_value apply.IR.return_arity)
   then
-    (* This can happen in a dead GADT match case. *)
+    ( acc,
+      Expr.create_invalid
+        (Application_result_kind_mismatch_in_lambda
+           (Debuginfo.from_location apply.loc)) )
+  else if not (Lambda.locality_return_compat closure_alloc_mode apply.IR.mode)
+  then
     ( acc,
       Expr.create_invalid
         (Partial_application_mode_mismatch_in_lambda
@@ -3816,27 +3842,35 @@ let close_apply acc env (apply : IR.apply) : Expr_with_acc.t =
         ~arity:params_arity ~first_complex_local_param ~result_mode
     | Over_app { full; provided_arity; remaining; remaining_arity; result_mode }
       ->
-      let full_args_call apply_continuation ~region ~ghost_region acc =
-        let replace_region =
-          match region, ghost_region with
-          | None, None -> None
-          | Some region, Some ghost_region -> Some (region, ghost_region)
-          | Some _, None | None, Some _ -> Misc.fatal_error "Mismatched regions"
+      if not (Flambda_arity.is_one_param_of_kind_value result_arity)
+      then
+        ( acc,
+          Expr.create_invalid
+            (Application_result_kind_mismatch_in_lambda
+               (Debuginfo.from_location apply.loc)) )
+      else
+        let full_args_call apply_continuation ~region ~ghost_region acc =
+          let replace_region =
+            match region, ghost_region with
+            | None, None -> None
+            | Some region, Some ghost_region -> Some (region, ghost_region)
+            | Some _, None | None, Some _ ->
+              Misc.fatal_error "Mismatched regions"
+          in
+          close_exact_or_unknown_apply acc env
+            { apply with
+              args = full;
+              args_arity = provided_arity;
+              continuation = apply_continuation;
+              mode = result_mode;
+              return_arity =
+                Flambda_arity.create_singletons
+                  [Flambda_kind.With_subkind.any_value]
+            }
+            (Some approx) ~replace_region
         in
-        close_exact_or_unknown_apply acc env
-          { apply with
-            args = full;
-            args_arity = provided_arity;
-            continuation = apply_continuation;
-            mode = result_mode;
-            return_arity =
-              Flambda_arity.create_singletons
-                [Flambda_kind.With_subkind.any_value]
-          }
-          (Some approx) ~replace_region
-      in
-      wrap_over_application acc env full_args_call apply ~remaining
-        ~remaining_arity ~result_mode)
+        wrap_over_application acc env full_args_call apply ~remaining
+          ~remaining_arity ~result_mode)
 
 module CIS = Code_id_or_symbol
 module GroupMap = Numbers.Int.Map

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -1056,32 +1056,44 @@ let simplify_direct_function_call ~simplify_expr dacc apply
             (Some function_decl) ~params_arity ~result_arity ~result_types
             ~down_to_up ~coming_from_indirect ~callee's_code_metadata
       else if provided_num_args > num_params
-      then (
-        (* See comment above. *)
+      then
         if
-          Flambda_features.kind_checks ()
-          && not (Flambda_arity.is_one_param_of_kind_value result_arity)
+          (* See comment above. *)
+          not (Flambda_arity.is_one_param_of_kind_value result_arity)
         then
-          Misc.fatal_errorf
-            "Non-singleton-value return arity for overapplied OCaml function:@ \
-             %a"
-            Apply.print apply;
-        simplify_direct_over_application ~simplify_expr dacc apply ~down_to_up
-          ~coming_from_indirect ~callee's_code_id ~callee's_code_metadata)
+          if Flambda_features.kind_checks ()
+          then
+            Misc.fatal_errorf
+              "Non-singleton-value return arity for overapplied OCaml \
+               function:@ %a"
+              Apply.print apply
+          else
+            replace_apply_by_invalid dacc ~down_to_up
+              (Application_result_kind_mismatch (result_arity, apply))
+        else
+          simplify_direct_over_application ~simplify_expr dacc apply ~down_to_up
+            ~coming_from_indirect ~callee's_code_id ~callee's_code_metadata
       else if provided_num_args > 0 && provided_num_args < num_params
-      then (
-        (* See comment above. *)
+      then
         if
-          Flambda_features.kind_checks ()
-          && not
-               (Flambda_arity.is_one_param_of_kind_value
-                  result_arity_of_application)
+          (* See comment above. *)
+          not
+            (Flambda_arity.is_one_param_of_kind_value
+               result_arity_of_application)
         then
-          Misc.fatal_errorf
-            "Non-singleton-value return arity for partially-applied OCaml \
-             function:@ %a"
-            Apply.print apply;
-        if DE.disable_partial_application_stub_generation (DA.denv dacc)
+          if Flambda_features.kind_checks ()
+          then
+            Misc.fatal_errorf
+              "Non-singleton-value return arity for partially-applied OCaml \
+               function:@ %a"
+              Apply.print apply
+          else
+            replace_apply_by_invalid dacc ~down_to_up
+              (Application_result_kind_mismatch
+                 ( Flambda_arity.create_singletons
+                     [Flambda_kind.With_subkind.any_value],
+                   apply ))
+        else if DE.disable_partial_application_stub_generation (DA.denv dacc)
         then
           simplify_function_call_where_callee's_type_unavailable dacc apply
             (call : Call_kind.Function_call.t)
@@ -1094,7 +1106,7 @@ let simplify_direct_function_call ~simplify_expr dacc apply
             ~args_arity ~result_arity ~recursive ~down_to_up
             ~coming_from_indirect ~closure_alloc_mode_from_type
             ~first_complex_local_param:
-              (Code_metadata.first_complex_local_param callee's_code_metadata))
+              (Code_metadata.first_complex_local_param callee's_code_metadata)
       else
         Misc.fatal_errorf
           "Function with %d params when simplifying direct OCaml function call \

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1531,6 +1531,7 @@ module Invalid = struct
         [`Unarized] Flambda_arity.t * Apply_expr.t
     | Application_result_kind_mismatch of
         [`Unarized] Flambda_arity.t * Apply_expr.t
+    | Application_result_kind_mismatch_in_lambda of Debuginfo.t
     | Partial_application_mode_mismatch of Apply_expr.t * Code_metadata.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t
@@ -1575,6 +1576,11 @@ module Invalid = struct
         "@[<hov 1>(Application_result_kind_mismatch@ @[<hov 1>(result_arity@ \
          %a)@ (apply_expr@ %a)@])@]"
         Flambda_arity.print result_arity Apply_expr.print apply_expr
+    | Application_result_kind_mismatch_in_lambda dbg ->
+      Format.asprintf
+        "@[<hov 1>(Application_result_kind_mismatch_in_lambda@ @[<hov 1>(dbg@ \
+         %a)@])@]"
+        Debuginfo.print_compact dbg
     | Partial_application_mode_mismatch (apply_expr, code_metadata) ->
       Format.asprintf
         "@[<hov 1>(Partial_application_mode_mismatch@ @[<hov 1>(apply_expr@ \

--- a/middle_end/flambda2/terms/flambda.mli
+++ b/middle_end/flambda2/terms/flambda.mli
@@ -121,6 +121,7 @@ module Invalid : sig
         [`Unarized] Flambda_arity.t * Apply_expr.t
     | Application_result_kind_mismatch of
         [`Unarized] Flambda_arity.t * Apply_expr.t
+    | Application_result_kind_mismatch_in_lambda of Debuginfo.t
     | Partial_application_mode_mismatch of Apply_expr.t * Code_metadata.t
     | Partial_application_mode_mismatch_in_lambda of Debuginfo.t
     | Calling_local_returning_closure_with_normal_apply of Apply_expr.t

--- a/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.ml
+++ b/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.ml
@@ -1,0 +1,17 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte with dump-raw, dump-simplify;
+ check-fexpr-dump;
+*)
+
+(* The #(int * unit#) type needs to be correctly considered, as it unarizes to a single kind,
+   even though it is an unboxed product. *)
+
+let f (x : #(int * unit#)) =
+  let #(a, _) = x in a
+
+let[@local never] g (f : #(int * unit#) -> int) x = f x
+
+let h x = g f x

--- a/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.raw.reference
+++ b/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.raw.reference
@@ -1,0 +1,34 @@
+let $camlApp_unarized_to_single_kind__first_const_0 = Block 0 () in
+(let code size(1)
+       f_0 (x) my_closure &my_alloc_region my_depth -> k1 * k2 : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   cont k1 (x)
+ in
+ let code size(6)
+       g_1 (f : val, x)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   apply &my_alloc_region f (x) -> k1 * k2
+ in
+ let code size(6)
+       h_2 (x) my_closure &my_alloc_region my_depth -> k1 * k2 : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   let f = %project_value_slot.[h].[f] (my_closure) in
+   let g = %project_value_slot.[h].[g] (my_closure) in
+   apply direct(g_1 &my_alloc_region) (g : _ -> imm tagged) (f, x) -> k1 * k2
+ in
+ let f = closure f_0 @f &toplevel.alloc_region in
+ let g = closure g_1 @g &toplevel.alloc_region in
+ let h = closure h_2 @h &toplevel.alloc_region with { f = f; g = g } in
+ let Pmakeblock = %block.[`0`].`toplevel` (f, g, h) in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (module_block) in
+    let field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (module_block) in
+    let $camlApp_unarized_to_single_kind =
+      Block 0 (field_0, field_1, field_2)
+    in
+    cont done ($camlApp_unarized_to_single_kind)

--- a/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.simplify.reference
+++ b/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.simplify.reference
@@ -1,0 +1,33 @@
+let code f_0 deleted in
+let code g_1 deleted in
+let code h_2 deleted in
+let code loopify(never) size(1) newer_version_of(f_0)
+      f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
+  cont k (x)
+in
+let $camlApp_unarized_to_single_kind__f_1 =
+  closure f_0_1 @f &toplevel.alloc_region
+in
+let code loopify(never) size(6) newer_version_of(g_1)
+      g_1_1 (f : val, x)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  apply &my_alloc_region f (x) -> k * k1
+in
+let $camlApp_unarized_to_single_kind__g_2 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
+let code loopify(never) size(1) newer_version_of(h_2)
+      h_2_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
+  cont k (x)
+in
+let $camlApp_unarized_to_single_kind__h_3 =
+  closure h_2_1 @h &toplevel.alloc_region
+in
+let $camlApp_unarized_to_single_kind =
+  Block 0 ($camlApp_unarized_to_single_kind__f_1,
+           $camlApp_unarized_to_single_kind__g_2,
+           $camlApp_unarized_to_single_kind__h_3)
+in
+cont done ($camlApp_unarized_to_single_kind)

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_classic.raw.reference
@@ -2,14 +2,12 @@
        f_1 (param) my_closure &my_alloc_region my_depth -> k1 * k2 : int64 =
    cont k1 (0L)
  in
- let code inline(never) size(10)
+ let code inline(never) size(0)
        test_0 (u : imm tagged, a, b)
          my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
-   apply direct(f_1 &my_alloc_region)  (0) -> k3 * k2
-     where k3 (func) =
-       apply &my_alloc_region func (0) -> k1 * k2
+   invalid "(Application_result_kind_mismatch_in_lambda\n (dbg over_app_kind_check_classic.ml:16,2--16))"
  in
  let $camlOver_app_kind_check_classic__s0 =
    closure test_0 @test &toplevel.alloc_region

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.ml
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.ml
@@ -2,7 +2,7 @@
  compile_only = "true";
  flambda2;
  setup-ocamlopt.byte-build-env;
- ocamlopt.byte with dump-simplify;
+ ocamlopt.byte with dump-raw, dump-simplify;
  check-fexpr-dump;
 *)
 
@@ -11,6 +11,6 @@
 type (_,_) eq = Eq : ('a,'a) eq
 
 let test (u : (int -> int64#, int -> int -> int) eq) a b =
-  let[@local always] cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x in
+  let[@inline always][@local never] cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x in
   let[@inline never][@local never] f _ = #0L in
   (cast u f) 0 0

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.raw.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.raw.reference
@@ -1,0 +1,33 @@
+let $camlOver_app_kind_check_simplify__first_const_0 = Block 0 () in
+(let code inline(always) size(1)
+       cast_1 (param : imm tagged, x : val)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : val =
+   let next_depth = rec_info (succ my_depth) in
+   cont k1 (x)
+ in
+ let code inline(never) size(1)
+       f_2 (param) my_closure &my_alloc_region my_depth -> k1 * k2 : int64 =
+   let next_depth = rec_info (succ my_depth) in
+   cont k1 (0L)
+ in
+ let code size(27)
+       test_0 (u : imm tagged, a, b)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   let cast = closure cast_1 @cast &my_alloc_region in
+   let f = closure f_2 @f &my_alloc_region in
+   apply direct(cast_1 &my_alloc_region) (cast : _ -> val) (u, f) -> k3 * k2
+     where k3 (apply_result : val) =
+       apply &my_alloc_region apply_result (0, 0) -> k1 * k2
+ in
+ let test = closure test_0 @test &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (test) in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
+    let $camlOver_app_kind_check_simplify = Block 0 (field_0) in
+    cont done ($camlOver_app_kind_check_simplify)

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.simplify.reference
@@ -4,7 +4,7 @@ let code loopify(never) size(0) newer_version_of(test_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  invalid "(Application_result_kind_mismatch\n (result_arity \226\132\149\240\157\159\158\240\157\159\156) (apply_expr\n  (((Some Over_app_kind_check_simplify.camlOver_app_kind_check_simplify__f_2)\227\128\136k21\227\128\137\227\128\138k13\227\128\139(0))\n   (args_arity \240\157\149\141?) (return_arity \240\157\149\141?)\n   (call_kind\n    (Function\n     (function_call (Direct camlOver_app_kind_check_simplify__f_1_3_code))))\n   (return_mode (Not_alloc_stack (alloc my_alloc_region/25N)))\n   (dbg over_app_kind_check_simplify.ml:16,2--16) (inline Default_inlined)\n   (inlining_state (depth 0, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))"
+  invalid "(Application_result_kind_mismatch\n (result_arity \226\132\149\240\157\159\158\240\157\159\156) (apply_expr\n  (((Some Over_app_kind_check_simplify.camlOver_app_kind_check_simplify__f_3)\227\128\136k32\227\128\137\227\128\138k31\227\128\139(0\n    0)) (args_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154 \226\168\175 \240\157\149\141=tagged_\226\132\149\240\157\149\154) (return_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154)\n   (call_kind\n    (Function\n     (function_call (Direct camlOver_app_kind_check_simplify__f_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc my_alloc_region/82N)))\n   (dbg over_app_kind_check_simplify.ml:16,2--16) (inline Default_inlined)\n   (inlining_state (depth 0, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))"
 in
 let $camlOver_app_kind_check_simplify__test_1 =
   closure test_0_1 @test &toplevel.alloc_region

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_classic.raw.reference
@@ -5,33 +5,23 @@
          : imm tagged =
    cont k1 (0)
  in
- let code size(4) stub
-       partial_f_2 (param1)
-         my_closure &my_alloc_region my_depth
-         -> k1 * k2
-         : imm tagged =
-   apply direct(f_1 &my_alloc_region)  (0, param1) -> k1 * k2
- in
- let $camlPartial_app_kind_check_classic__s2 =
-   closure partial_f_2 @partial_f &toplevel.alloc_region
- in
- let code inline(never) size(1)
+ let code inline(never) size(0)
        test_0 (u : imm tagged, a, b)
          my_closure &my_alloc_region my_depth
          -> k1 * k2
          : int64 =
-   cont k1 ($camlPartial_app_kind_check_classic__s2)
+   invalid "(Application_result_kind_mismatch_in_lambda\n (dbg partial_app_kind_check_classic.ml:16,2--14))"
  in
  let $camlPartial_app_kind_check_classic__s0 =
    closure test_0 @test &toplevel.alloc_region
  in
- let $camlPartial_app_kind_check_classic__s3 =
+ let $camlPartial_app_kind_check_classic__s2 =
    Block 0 ($camlPartial_app_kind_check_classic__s0)
  in
  let $camlPartial_app_kind_check_classic__s1 =
    closure f_1 @f &toplevel.alloc_region
  in
- cont k ($camlPartial_app_kind_check_classic__s3))
+ cont k ($camlPartial_app_kind_check_classic__s2))
   where k define_root_symbol (module_block) =
     let field_0 = $camlPartial_app_kind_check_classic__s0 in
     let $camlPartial_app_kind_check_classic = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.ml
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.ml
@@ -2,7 +2,7 @@
  compile_only = "true";
  flambda2;
  setup-ocamlopt.byte-build-env;
- ocamlopt.byte with dump-simplify;
+ ocamlopt.byte with dump-raw, dump-simplify;
  check-fexpr-dump;
 *)
 
@@ -11,6 +11,6 @@
 type (_,_) eq = Eq : ('a,'a) eq
 
 let test (u : (int -> int -> int, int -> int64#) eq) a b =
-  let[@local always] cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x in
+  let[@inline always][@local never] cast : type a b. (a,b) eq -> a -> b = fun Eq x -> x in
   let[@inline never][@local never] f _ _ = 0 in
   (cast u f) 0

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.raw.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.raw.reference
@@ -1,0 +1,36 @@
+let $camlPartial_app_kind_check_simplify__first_const_0 = Block 0 () in
+(let code inline(always) size(1)
+       cast_1 (param : imm tagged, x : val)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : val =
+   let next_depth = rec_info (succ my_depth) in
+   cont k1 (x)
+ in
+ let code inline(never) size(1)
+       f_2 (param, param_1)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let next_depth = rec_info (succ my_depth) in
+   cont k1 (0)
+ in
+ let code size(28)
+       test_0 (u : imm tagged, a, b)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : int64 =
+   let next_depth = rec_info (succ my_depth) in
+   let cast = closure cast_1 @cast &my_alloc_region in
+   let f = closure f_2 @f &my_alloc_region in
+   apply direct(cast_1 &my_alloc_region) (cast : _ -> val) (u, f) -> k3 * k2
+     where k3 (apply_result : val) =
+       apply &my_alloc_region apply_result (0) -> k1 * k2
+ in
+ let test = closure test_0 @test &toplevel.alloc_region in
+ let Pmakeblock = %block.[`0`].`toplevel` (test) in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
+    let $camlPartial_app_kind_check_simplify = Block 0 (field_0) in
+    cont done ($camlPartial_app_kind_check_simplify)

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
@@ -1,33 +1,10 @@
-let code f_1 deleted in
-let code loopify(never) size(7) stub
-      partial_f_2 (param1)
-        my_closure &my_alloc_region my_depth
-        -> k * k1
-        : imm tagged =
-  let f = %project_value_slot.[partial_f].[f] (my_closure) in
-  apply &my_alloc_region (f : val * val -> imm tagged) (0, param1) -> k * k1
-in
 let code test_0 deleted in
-let code inline(never) loopify(never) size(1) newer_version_of(f_1)
-      f_1_1 (param, param_1)
-        my_closure &my_alloc_region my_depth
-        -> k * k1
-        : imm tagged =
-  cont k (0)
-in
-let $camlPartial_app_kind_check_simplify__f_2 =
-  closure f_1_1 @f &toplevel.alloc_region
-in
-let $camlPartial_app_kind_check_simplify__partial_f_3 =
-  closure partial_f_2 @partial_f &toplevel.alloc_region
-  with { f = $camlPartial_app_kind_check_simplify__f_2 }
-in
-let code loopify(never) size(1) newer_version_of(test_0)
+let code loopify(never) size(0) newer_version_of(test_0)
       test_0_1 (u : imm tagged, a, b)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 =
-  cont k ($camlPartial_app_kind_check_simplify__partial_f_3)
+  invalid "(Application_result_kind_mismatch\n (result_arity \240\157\149\141?) (apply_expr\n  (((Some\n    Partial_app_kind_check_simplify.camlPartial_app_kind_check_simplify__f_3)\227\128\136k32\227\128\137\227\128\138k31\227\128\139(0))\n   (args_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154) (return_arity \226\132\149\240\157\159\158\240\157\159\156)\n   (call_kind\n    (Function\n     (function_call (Direct camlPartial_app_kind_check_simplify__f_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc my_alloc_region/85N)))\n   (dbg partial_app_kind_check_simplify.ml:16,2--14) (inline Default_inlined)\n   (inlining_state (depth 0, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))"
 in
 let $camlPartial_app_kind_check_simplify__test_1 =
   closure test_0_1 @test &toplevel.alloc_region


### PR DESCRIPTION
This was causing partial applications with mismatched result continuations to produce code with invalid kinds in the raw flambda.