### PR TITLE
Implement interior pointer access primitives (`%unsafe_ptr_{get,set}`) on bytecode

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -558,6 +558,8 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       | [] | _ :: _ :: _ -> wrong_arity ~expected:1)
     | Pget_idx _ -> binary (Ccall "caml_get_idx_bytecode")
     | Pset_idx _ -> ternary (Ccall "caml_set_idx_bytecode")
+    | Pget_ptr _ -> unary (Ccall "caml_get_ptr_bytecode")
+    | Pset_ptr _ -> binary (Ccall "caml_set_ptr_bytecode")
     | Pmake_idx_field pos ->
       Const (Const_block (0, [Const_base (Const_int pos)]))
     | Pmake_idx_mixed_field (_, pos, path) ->
@@ -908,7 +910,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
       | Punspecializedarray_set _ ->
         Misc.fatal_error "Blambda_of_lambda: Parrayblit Punspecializedarray_set"
       )
-    | Pprobe_is_enabled _ | Ppeek _ | Ppoke _ | Pget_ptr _ | Pset_ptr _ ->
+    | Pprobe_is_enabled _ | Ppeek _ | Ppoke _ ->
       Misc.fatal_errorf "Blambda_of_lambda: %a is not supported in bytecode"
         Printlambda.primitive primitive
     | Pmakelazyblock Lazy_tag ->

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -1143,6 +1143,22 @@ CAMLprim value caml_set_idx_bytecode(value base, value idx, value v)
   CAMLreturn (Val_unit);
 }
 
+CAMLprim value caml_get_ptr_bytecode(value ptr)
+{
+  value base = Field(ptr, 0);
+  if (Is_null(base))
+    caml_failwith("External ptrs are unimplemented on bytecode");
+  return caml_get_idx_bytecode(base, Field(ptr, 1));
+}
+
+CAMLprim value caml_set_ptr_bytecode(value ptr, value v)
+{
+  value base = Field(ptr, 0);
+  if (Is_null(base))
+    caml_failwith("External ptrs are unimplemented on bytecode");
+  return caml_set_idx_bytecode(base, Field(ptr, 1), v);
+}
+
 /* Concatenates idx_prefix and idx_suffix */
 CAMLprim value caml_deepen_idx_bytecode(value idx_prefix, value idx_suffix) {
   mlsize_t prefix_depth = Wosize_val(idx_prefix);

--- a/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.disabled.compilers.reference
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.disabled.compilers.reference
@@ -1,4 +1,4 @@
-File "block_indices_using_ptr_primitives.ml", line 28, characters 34-45:
-28 | let _fail_when_no_extensions () = (.contents)
+File "block_indices_using_ptr_primitives.ml", line 30, characters 34-45:
+30 | let _fail_when_no_extensions () = (.contents)
                                        ^^^^^^^^^^^
 Error: This construct requires the stable version of the extension "layouts", which is disabled and cannot be used

--- a/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.ml
+++ b/testsuite/tests/typing-layouts-block-indices/block_indices_using_ptr_primitives.ml
@@ -11,6 +11,8 @@
    ocamlc.byte;
    check-ocamlc.byte-output;
  } {
+   bytecode;
+ } {
    native;
  } {
    flags = "-Oclassic";


### PR DESCRIPTION
These differ from the index primitives in that they take the base and offset an as unboxed product, and will (eventually) support external pointers (with a null base, and an index into a bigsting or external memory). See also https://github.com/oxcaml/oxcaml/pull/5087.

## Context

The below tables show how updating `#(b, o)` (standing for "base" and "offset") with the value `x` will be handled on various platforms.

Code is written in C-style pseudocode where the offset is a single word in native, an array of logical offsets in bytecode (in these examples, we arbitrarily always assume they're length 2), and a block containing some extra information in JSOO. (Some context on JSOO is missing in this PR description. For the purposes of reviewing this PR, it should be fine to disregard JSOO.)

### Before this PR

<table>
<tr>
<td></td>
<td><strong>Bytecode</strong></td>
<td><strong>Native</strong></td>
<td><strong>JSOO</strong></td>
</tr>
<tr>
<td>

`%unsafe_set_idx`

</td>
<td>

```c

caml_modify(b[o[0]][o[1]], x);

```

</td>
<td>

```c

caml_modify(b + o, x);

```

</td>
<td>

```c
if (o.tag == ERR)
  raise();
else
  b[o[0]][o[1]] = x;
```

</td>
</tr>
<tr>
<td>

`%unsafe_set_ptr`

</td>
<td>

Unimplemented

</td>
<td>

```c
if (b == NULL)
  *(b + o) = x;
else
  caml_modify(b + o, x);
```

</td>
<td>

Unimplemented

</td>
</tr>
</table>

### Future

(This PR implements only ptr on bytecode.)

<table>
<tr>
<td></td>
<td><strong>Bytecode</strong></td>
<td><strong>Native</strong></td>
<td><strong>JSOO</strong></td>
</tr>
<tr>
<td>


`%unsafe_set_idx`

</td>
<td>

```c

caml_modify(&b[o[0]][o[1]], x);

```

</td>
<td>

```c

caml_modify(b + o, x);

```

</td>
<td>

```c

b[o[0]][o[1]] = x;

```

</td>
</tr>
<tr>
<td>

`%unsafe_set_ptr`

</td><td>

_This PR._ The `NULL`-base case is unimplemented because we have not yet decided on the bytecode representation of external offsets.

```c
if (b == NULL)
  raise("unimplemented");
else
  caml_modify(&b[o[0]][o[1]], x);
```

</td>
<td>

```c
if (b == NULL)
  *(b + o) = x;
else
  caml_modify(b + o, x);
```

</td>
<td>

```c
if (o.tag == ERR)
  raise();
else if (o.tag == BA_CHAR || o.tag == BA_F64 || ...)
  bigstring_set(b, o[0], x);
else
  caml_modify(&b[o[0]][o[1]], x);
```

</td>
</tr>
</table>
