### PR TITLE
Fix skip 80ch check in merge queue

### DIFF
--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -13,6 +13,9 @@ jobs:
   check:
     name: check (${{ matrix.system }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      pull-requests: read
     strategy:
       matrix:
         include:
@@ -42,6 +45,23 @@ jobs:
       - name: 'Check for the "skip 80ch" PR tag'
         if: ${{ contains( github.event.pull_request.labels.*.name, 'skip 80ch') }}
         run: echo SKIP_80CH=y >> "$GITHUB_ENV"
+
+      - name: 'Check for the "skip 80ch" PR tag (merge queue)'
+        if: ${{ github.event_name == 'merge_group' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          # HEAD_REF looks like refs/heads/gh-readonly-queue/main/pr-<N>-<sha>
+          if [[ "$HEAD_REF" =~ /pr-([0-9]+)- ]]; then
+            pr_number="${BASH_REMATCH[1]}"
+            if gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" \
+                 --json labels --jq '.labels[].name' | grep -qxF 'skip 80ch'; then
+              echo SKIP_80CH=y >> "$GITHUB_ENV"
+            fi
+          else
+            echo "Could not parse PR number from '$HEAD_REF'; not skipping 80ch."
+          fi
 
       - name: Check OCaml Formatting
         run: opam exec -- bash tools/ci/actions/check-fmt.sh


### PR DESCRIPTION
#6267 bounced out of the merge queue because the 80ch check failed, in spite of the fact that the PR had the skip 80ch label.

Searching around, this is a known issue, and Claude has provided the workaround mess to reverse-engineer the PR number from the ref and query the labels directly. It looks fine.

I've put 80ch on this PR so that when it goes into the merge queue we'll be able to see if it works. I'm also wondering if we should instead just not be running this workflow in the merge queue?