### PR TITLE
Replace non-obvious `assert false`s with `Misc.fatal_error`s (backend)

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -359,7 +359,9 @@ let select_floatarith commutative width (regular_op : Operation.float_operation)
     Rewritten (specific (Ifloatarithmem (width, mem_op, addr)), [arg2; arg1])
   | _, [arg1; arg2] ->
     Rewritten (Basic (Op (Floatop (width, regular_op))), [arg1; arg2])
-  | _ -> assert false
+  | _ ->
+    Misc.fatal_error
+      "Cfg_selection.select_floatarith: unexpected width/args combination"
 
 let select_operation'
     ~(generic_select_condition :

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -360,8 +360,11 @@ let select_floatarith commutative width (regular_op : Operation.float_operation)
   | _, [arg1; arg2] ->
     Rewritten (Basic (Op (Floatop (width, regular_op))), [arg1; arg2])
   | _ ->
-    Misc.fatal_error
-      "Cfg_selection.select_floatarith: unexpected width/args combination"
+    Misc.fatal_errorf
+      "Cfg_selection.select_floatarith: unexpected combination of width %s and \
+       %d argument(s)"
+      (match width with Float64 -> "Float64" | Float32 -> "Float32")
+      (List.length args)
 
 let select_operation'
     ~(generic_select_condition :

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -573,7 +573,9 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
 (* note: keep this function in sync with `is_destruction_point` below. *)
 let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with
-  | Never -> assert false
+  | Never ->
+    Misc.fatal_error
+      "Proc.destroyed_at_terminator: unexpected Never terminator"
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Return | Raise _ | Tailcall_self  _ | Tailcall_func _
   | Prim {op = Probe _; _}
@@ -600,7 +602,9 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
 (* note: keep this function in sync with `destroyed_at_terminator` above. *)
 let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_intf.S.terminator) =
   match terminator with
-  | Never -> assert false
+  | Never ->
+    Misc.fatal_error
+      "Proc.is_destruction_point: unexpected Never terminator"
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Return | Raise _ | Tailcall_self  _ | Tailcall_func _
   | Prim {op = Probe _; _} ->

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1384,7 +1384,9 @@ let emit_instr env i =
       | Reg _, Reg _ -> A.ins_mov_reg_w (H.reg_w dst) (H.reg_w src)
       | Reg _, Stack _ -> emit_stack_str env (H.reg_w src) dst
       | Stack _, Reg _ -> emit_stack_ldr env (H.reg_w dst) src
-      | Stack _, Stack _ | _, Unknown | Unknown, _ -> assert false)
+      | Stack _, Stack _ | _, Unknown | Unknown, _ ->
+        Misc.fatal_errorf "Emit.emit_instr: illegal Imove32 (%a to %a)"
+          Printreg.reg src Printreg.reg dst)
   | Lop (Const_int n) -> emit_intconst (H.reg_x i.res.(0)) n
   | Lop (Const_float32 f) ->
     if Int32.equal f 0l

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -354,7 +354,9 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
 (* note: keep this function in sync with `is_destruction_point` below. *)
 let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
   match terminator with
-  | Never -> assert false
+  | Never ->
+    Misc.fatal_error
+      "Proc.destroyed_at_terminator: unexpected Never terminator"
   | Call {op = Indirect _ | Direct _; _} ->
     all_phys_regs
   | Always _ | Parity_test _ | Truth_test _ | Float_test _
@@ -374,7 +376,9 @@ let destroyed_at_terminator (terminator : Cfg_intf.S.terminator) =
 (* note: keep this function in sync with `destroyed_at_terminator` above. *)
 let is_destruction_point ~(more_destruction_points : bool) (terminator : Cfg_intf.S.terminator) =
   match terminator with
-  | Never -> assert false
+  | Never ->
+    Misc.fatal_error
+      "Proc.is_destruction_point: unexpected Never terminator"
   | Call {op = Indirect _ | Direct _; _} ->
     true
   | Always _ | Parity_test _ | Truth_test _ | Float_test _

--- a/backend/branch_relaxation.ml
+++ b/backend/branch_relaxation.ml
@@ -196,7 +196,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
                   | Lcall_op _ | Llabel _ | Lbranch _ | Lcondbranch3 _
                   | Lswitch _ | Ladjust_stack_offset _ | Lpushtrap _ | Lraise _
                   | Lstackcheck _ ->
-                    assert false
+                    Misc.fatal_error
+                      "Branch_relaxation.measure_expanded: expected \
+                       Lcondbranch while measuring expansion"
                 in
                 let s = T.relaxed_instruction_size ri in
                 measure_expanded i.next (s :: sizes)
@@ -222,7 +224,9 @@ module Make (T : Branch_relaxation_intf.S) = struct
               | Name_for_debugger _ | Specific _ ) ->
             (* Any other instruction has already been rejected in
                [instr_overflows] above. We can *never* get here. *)
-            assert false)
+            Misc.fatal_error
+              "Branch_relaxation.fixup: instruction should have been rejected \
+               by instr_overflows")
     in
     fixup false 0 code sizes
 

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -390,7 +390,9 @@ module Transfer = struct
       | Unreachable -> unreachable, unreachable
       | Ok avail_before -> (
         match term.desc with
-        | Never -> assert false
+        | Never ->
+          Misc.fatal_error
+            "Cfg_available_regs.terminator: unexpected Never terminator"
         | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
         | Switch _ | Call _ | Prim _ | Return | Raise _ | Tailcall_func _
         | Call_no_return _ | Invalid _ | Tailcall_self _ ->
@@ -398,7 +400,9 @@ module Transfer = struct
             ~is_interesting_constructor:
               Cfg.(
                 function
-                | Never -> assert false
+                | Never ->
+                  Misc.fatal_error
+                    "Cfg_available_regs.terminator: unexpected Never terminator"
                 | Call _ | Prim { op = Probe _; label_after = _ } -> true
                 | Always _ | Parity_test _ | Truth_test _ | Float_test _
                 | Int_test _ | Switch _ | Return | Raise _ | Tailcall_self _

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -302,15 +302,15 @@ let insert_move :
 
 module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
   let class_of_operation0 : Operation.t -> op_class = function
-    | Move | Spill | Reload ->
-      Misc.fatal_error
-        "Cfg_cse.class_of_operation0: Move/Spill/Reload are handled specially"
+    | (Move | Spill | Reload) as op ->
+      Misc.fatal_errorf "Cfg_cse.class_of_operation0: %a is handled specially"
+        Operation.dump op
     | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
       Op_pure
-    | Opaque | Pause ->
-      Misc.fatal_error
-        "Cfg_cse.class_of_operation0: Opaque/Pause are handled specially"
+    | (Opaque | Pause) as op ->
+      Misc.fatal_errorf "Cfg_cse.class_of_operation0: %a is handled specially"
+        Operation.dump op
     | Stackoffset _ -> Op_other
     | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
       (* #12173: disable CSE for atomic loads. *)
@@ -320,9 +320,9 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
         Op_load
           (match mutability with Mutable -> Mutable | Immutable -> Immutable)
     | Store (_, _, asg) -> Op_store asg
-    | Alloc _ | Poll ->
-      Misc.fatal_error
-        "Cfg_cse.class_of_operation0: Alloc/Poll are handled specially"
+    | (Alloc _ | Poll) as op ->
+      Misc.fatal_errorf "Cfg_cse.class_of_operation0: %a is handled specially"
+        Operation.dump op
     | Intop _ -> Op_pure
     | Int128op _ -> Op_pure
     | Intop_imm (_, _) -> Op_pure

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -302,11 +302,15 @@ let insert_move :
 
 module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
   let class_of_operation0 : Operation.t -> op_class = function
-    | Move | Spill | Reload -> assert false (* treated specially *)
+    | Move | Spill | Reload ->
+      Misc.fatal_error
+        "Cfg_cse.class_of_operation0: Move/Spill/Reload are handled specially"
     | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
       Op_pure
-    | Opaque | Pause -> assert false (* treated specially *)
+    | Opaque | Pause ->
+      Misc.fatal_error
+        "Cfg_cse.class_of_operation0: Opaque/Pause are handled specially"
     | Stackoffset _ -> Op_other
     | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
       (* #12173: disable CSE for atomic loads. *)
@@ -316,7 +320,9 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
         Op_load
           (match mutability with Mutable -> Mutable | Immutable -> Immutable)
     | Store (_, _, asg) -> Op_store asg
-    | Alloc _ | Poll -> assert false (* treated specially *)
+    | Alloc _ | Poll ->
+      Misc.fatal_error
+        "Cfg_cse.class_of_operation0: Alloc/Poll are handled specially"
     | Intop _ -> Op_pure
     | Int128op _ -> Op_pure
     | Intop_imm (_, _) -> Op_pure
@@ -446,7 +452,8 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
       =
    fun numbering terminator ->
     match terminator.desc with
-    | Never -> assert false
+    | Never ->
+      Misc.fatal_error "Cfg_cse.cse_terminator: unexpected Never terminator"
     | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
     | Switch _ ->
       set_unknown_regs numbering (Proc.destroyed_at_terminator terminator.desc)

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -75,7 +75,8 @@ module Transfer :
     Result.ok
     @@
     match instr.desc with
-    | Never -> assert false
+    | Never ->
+      Misc.fatal_error "Cfg_liveness.terminator: unexpected Never terminator"
     | Tailcall_self _ ->
       (* CR-someday azewierzejew: If the stamps for the tail call DomainState
          argument and parameter were the same and Tailcall (Self _) had

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -127,7 +127,9 @@ let is_safe_basic : Cfg.basic Cfg.instruction -> bool =
 let is_safe_terminator : Cfg.terminator Cfg.instruction -> bool =
  fun term ->
   match term.desc with
-  | Never -> assert false
+  | Never ->
+    Misc.fatal_error
+      "Cfg_polling.is_safe_terminator: unexpected Never terminator"
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ ->
     false
@@ -215,7 +217,8 @@ module Polls_before_prtc_transfer = struct
    fun dom ~exn term
        { future_funcnames; optimistic_prologue_poll_instr_id = _ } ->
     match term.desc with
-    | Never -> assert false
+    | Never ->
+      Misc.fatal_error "Cfg_polling.terminator: unexpected Never terminator"
     | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
     | Switch _ ->
       Ok dom
@@ -374,7 +377,9 @@ let add_calls_terminator :
     Cfg.terminator Cfg.instruction -> polling_points -> polling_points =
  fun term points ->
   match term.desc with
-  | Never -> assert false
+  | Never ->
+    Misc.fatal_error
+      "Cfg_polling.add_calls_terminator: unexpected Never terminator"
   | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
   | Switch _ | Return | Raise _ ->
     points

--- a/backend/cfg/cfg_to_linear.ml
+++ b/backend/cfg/cfg_to_linear.ml
@@ -392,7 +392,10 @@ let need_starting_label (cfg_with_layout : CL.t) (block : Cfg.basic_block)
         false
       | Return | Raise _ | Tailcall_func _ | Tailcall_self _ | Call_no_return _
         ->
-        assert false)
+        Misc.fatal_errorf
+          "Cfg_to_linear.need_starting_label: block follows non-returning \
+           terminator %a"
+          Printcfg.terminator prev_block.terminator)
 
 let adjust_stack_offset body (block : Cfg.basic_block)
     ~(prev_block : Cfg.basic_block) =

--- a/backend/cfg/simplify_terminator.ml
+++ b/backend/cfg/simplify_terminator.ml
@@ -422,7 +422,9 @@ let evaluate_terminator (known_values : known_value Reg.UsingLocEquality.Tbl.t)
           then Some (Array.unsafe_get labels idx)
           else None
         else None)
-  | Never -> assert false
+  | Never ->
+    Misc.fatal_error
+      "Simplify_terminator.evaluate_terminator: unexpected Never terminator"
   | Always _ | Return | Raise _ | Tailcall_self _ | Tailcall_func _
   | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
     None

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1191,7 +1191,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         Array.iter
           (fun reg ->
             match reg.Reg.typ with
-            | Addr -> assert false
+            | Addr ->
+              Misc.fatal_error
+                "Cfg_selectgen.emit_expr_exit: unexpected machtype_component \
+                 Addr in Ccatch register"
             | Valx2 -> Misc.fatal_error "Unexpected machtype_component Valx2"
             | Val | Int | Float | Vec128 | Vec256 | Vec512 | Float32 -> ())
           src;

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -95,9 +95,10 @@ let lub_component comp1 comp2 =
   | (Vec128 | Vec256 | Vec512), (Float | Float32 | Vec256 | Vec512)
   | Float32, Float
   | Float, Float32 ->
-    Printf.eprintf "%d %d\n%!" (Obj.magic comp1) (Obj.magic comp2);
     (* Float unboxing code must be sure to avoid this case. *)
-    assert false
+    Misc.fatal_errorf
+      "Cmm.lub_component: unexpected machtype_component combination (%d, %d)"
+      (Obj.magic comp1) (Obj.magic comp2)
   | Valx2, _ | _, Valx2 ->
     Misc.fatal_errorf "Unexpected machtype_component Valx2"
 
@@ -123,8 +124,9 @@ let ge_component comp1 comp2 =
   | (Vec128 | Vec256 | Vec512), (Float | Float32 | Vec256 | Vec512)
   | Float32, Float
   | Float, Float32 ->
-    Printf.eprintf "GE: %d %d\n%!" (Obj.magic comp1) (Obj.magic comp2);
-    assert false
+    Misc.fatal_errorf
+      "Cmm.ge_component: unexpected machtype_component combination (%d, %d)"
+      (Obj.magic comp1) (Obj.magic comp2)
   | Valx2, _ | _, Valx2 ->
     Misc.fatal_error "Unexpected machtype_component Valx2"
 

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -54,6 +54,18 @@ let typ_vec512 = [| Vec512 |]
 
 let typ_int128 = [| Int; Int |]
 
+let string_of_machtype_component (comp : machtype_component) =
+  match comp with
+  | Val -> "Val"
+  | Addr -> "Addr"
+  | Int -> "Int"
+  | Float -> "Float"
+  | Vec128 -> "Vec128"
+  | Vec256 -> "Vec256"
+  | Vec512 -> "Vec512"
+  | Float32 -> "Float32"
+  | Valx2 -> "Valx2"
+
 (** [machtype_component]s are partially ordered as follows:
 
     {v
@@ -97,8 +109,9 @@ let lub_component comp1 comp2 =
   | Float, Float32 ->
     (* Float unboxing code must be sure to avoid this case. *)
     Misc.fatal_errorf
-      "Cmm.lub_component: unexpected machtype_component combination (%d, %d)"
-      (Obj.magic comp1) (Obj.magic comp2)
+      "Cmm.lub_component: unexpected machtype_component combination (%s, %s)"
+      (string_of_machtype_component comp1)
+      (string_of_machtype_component comp2)
   | Valx2, _ | _, Valx2 ->
     Misc.fatal_errorf "Unexpected machtype_component Valx2"
 
@@ -125,8 +138,9 @@ let ge_component comp1 comp2 =
   | Float32, Float
   | Float, Float32 ->
     Misc.fatal_errorf
-      "Cmm.ge_component: unexpected machtype_component combination (%d, %d)"
-      (Obj.magic comp1) (Obj.magic comp2)
+      "Cmm.ge_component: unexpected machtype_component combination (%s, %s)"
+      (string_of_machtype_component comp1)
+      (string_of_machtype_component comp2)
   | Valx2, _ | _, Valx2 ->
     Misc.fatal_error "Unexpected machtype_component Valx2"
 

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -574,7 +574,8 @@ let preproc_stack_check ~fun_body ~frame_size ~trap_size =
       loop i.next fs max_fs nontail_flag
     | Lstackcheck _ ->
       (* should not be already present *)
-      assert false
+      Misc.fatal_error
+        "Emitaux.preproc_stack_check: Lstackcheck already present"
   in
   loop fun_body frame_size frame_size false
 

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -631,8 +631,8 @@ let extcall t (i : Cfg.terminator Cfg.instruction) ~func_symbol ~alloc
           | Stack (Local _ | Incoming _ | Domainstate _) | Unknown | Reg _ ->
             Misc.fatal_errorf
               "Llvmize.extcall: unexpected non-Outgoing stack-argument \
-               location %a"
-              Printreg.reg reg)
+               location %a for call to %s"
+              Printreg.reg reg func_symbol)
         stack_arg_regs;
       (* Prepare direct args + special values for [caml_c_call_stack_args] *)
       let stack_args_begin =

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -629,7 +629,10 @@ let extcall t (i : Cfg.terminator Cfg.instruction) ~func_symbol ~alloc
             in
             emit_ins_no_res t (I.store ~ptr:slot ~to_store:temp)
           | Stack (Local _ | Incoming _ | Domainstate _) | Unknown | Reg _ ->
-            assert false)
+            Misc.fatal_errorf
+              "Llvmize.extcall: unexpected non-Outgoing stack-argument \
+               location %a"
+              Printreg.reg reg)
         stack_arg_regs;
       (* Prepare direct args + special values for [caml_c_call_stack_args] *)
       let stack_args_begin =

--- a/backend/regalloc/regalloc_irc_state.ml
+++ b/backend/regalloc/regalloc_irc_state.ml
@@ -161,8 +161,11 @@ let[@inline] reset state ~new_inst_temporaries ~new_block_temporaries =
           RegWorkList.Precolored);
       (match reg.Reg.loc, Reg.Tbl.find state.reg_color reg with
       | Reg color, Some color' -> assert (Regs.Phys_reg.equal color color')
-      | Reg _, None -> assert false
-      | (Unknown | Stack _), _ -> assert false);
+      | Reg _, None | (Unknown | Stack _), _ ->
+        fatal
+          "Regalloc_irc_state.reset: precolored register %a has unexpected \
+           location/color"
+          Printreg.reg reg);
       Reg.Tbl.replace state.reg_alias reg None;
       Regalloc_interf_graph.init_register_with_infinite_degree state.graph reg;
       assert (Regalloc_interf_graph.degree state.graph reg = Degree.infinite))

--- a/backend/regalloc/regalloc_ls.ml
+++ b/backend/regalloc/regalloc_ls.ml
@@ -209,7 +209,13 @@ let allocate_blocked_register : State.t -> Interval.t -> spilling_reg =
            (DLL.exists ~f:chk intervals.fixed_dll
            || DLL.exists ~f:chk intervals.inactive_dll)
     then (
-      (match hd.reg.loc with Reg _ -> () | Stack _ | Unknown -> assert false);
+      (match hd.reg.loc with
+      | Reg _ -> ()
+      | Stack _ | Unknown ->
+        fatal
+          "Regalloc_ls.allocate_blocked_register: active interval %a has no \
+           physical register"
+          Printreg.reg hd.reg);
       Reg.set_loc interval.reg hd.reg.loc;
       DLL.delete_curr hd_cell;
       Interval.DLL.insert_sorted intervals.active_dll interval;

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -424,7 +424,10 @@ let insert_phi_moves :
           in
           match predecessor_block.terminator.desc with
           | Return | Raise _ | Tailcall_func _ | Call_no_return _ | Never ->
-            assert false
+            fatal
+              "Regalloc_split.insert_phi_moves: phi block %a has predecessor \
+               %a with unexpected terminator"
+              Label.format label Label.format predecessor_label
           | Tailcall_self _ -> ()
           | Always _ ->
             add_phi_moves_to_instr_list ~phi_moves ~instr_id

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -1216,9 +1216,10 @@ module Transfer (Desc_val : Description_value) :
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
       | _ ->
-        Misc.fatal_error
-          "Regalloc_validate.basic: added instruction must be Spill, Reload, \
-           or Move")
+        Regalloc_utils.fatal
+          "Regalloc_validate.basic: added instruction no. %a must be Spill, \
+           Reload, or Move: %a"
+          InstructionId.format instr.id Printcfg.basic instr)
     | Some instr_before -> (
       match instr.desc with
       | Op Move

--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -1140,7 +1140,10 @@ module Transfer (Desc_val : Description_value) :
     let loc =
       match reg.reg_id with
       | Preassigned { location } -> location
-      | Named _ -> assert false
+      | Named _ ->
+        Misc.fatal_error
+          "Regalloc_validate.remove_exn_bucket: exception bucket register must \
+           be preassigned"
     in
     Equation_set.remove_result equations ~reg_res:[| reg |] ~loc_res:[| loc |]
     |> Result.map_error (fun message ->
@@ -1212,7 +1215,10 @@ module Transfer (Desc_val : Description_value) :
       match instr.desc with
       | Op (Spill | Reload | Move) ->
         Result.ok @@ rename_location t ~loc_instr:instr
-      | _ -> assert false)
+      | _ ->
+        Misc.fatal_error
+          "Regalloc_validate.basic: added instruction must be Spill, Reload, \
+           or Move")
     | Some instr_before -> (
       match instr.desc with
       | Op Move

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -83,7 +83,7 @@ let suf arg =
   | QWORD -> "q"
   | REAL4 -> "s"
   | VEC128 | VEC256 | VEC512 | NONE -> ""
-  | NEAR | PROC -> assert false
+  | NEAR | PROC -> Misc.fatal_error "X86_gas.suf: unexpected datatype NEAR/PROC"
 
 let i0 b s = bprintf b "\t%s" s
 
@@ -110,7 +110,8 @@ let i1_call_jmp b s = function
   | (Reg32 _ | Reg64 _ | Mem { arch = X64 | X86; _ } | Mem64_RIP _) as x ->
     bprintf b "\t%s\t*%a" s arg x
   | Sym x -> bprintf b "\t%s\t%s" s x
-  | Imm _ | Reg8L _ | Reg8H _ | Reg16 _ | Regf _ -> assert false
+  | Imm _ | Reg8L _ | Reg8H _ | Reg16 _ | Regf _ ->
+    Misc.fatal_error "X86_gas.i1_call_jmp: invalid operand"
 
 let print_instr b = function
   | ADD (arg1, arg2) -> i2_s b "add" arg1 arg2

--- a/backend/x86_gas.ml
+++ b/backend/x86_gas.ml
@@ -83,7 +83,8 @@ let suf arg =
   | QWORD -> "q"
   | REAL4 -> "s"
   | VEC128 | VEC256 | VEC512 | NONE -> ""
-  | NEAR | PROC -> Misc.fatal_error "X86_gas.suf: unexpected datatype NEAR/PROC"
+  | NEAR -> Misc.fatal_error "X86_gas.suf: unexpected datatype NEAR"
+  | PROC -> Misc.fatal_error "X86_gas.suf: unexpected datatype PROC"
 
 let i0 b s = bprintf b "\t%s" s
 
@@ -110,8 +111,11 @@ let i1_call_jmp b s = function
   | (Reg32 _ | Reg64 _ | Mem { arch = X64 | X86; _ } | Mem64_RIP _) as x ->
     bprintf b "\t%s\t*%a" s arg x
   | Sym x -> bprintf b "\t%s\t%s" s x
-  | Imm _ | Reg8L _ | Reg8H _ | Reg16 _ | Regf _ ->
-    Misc.fatal_error "X86_gas.i1_call_jmp: invalid operand"
+  | (Imm _ | Reg8L _ | Reg8H _ | Reg16 _ | Regf _) as x ->
+    let buf = Buffer.create 16 in
+    arg buf x;
+    Misc.fatal_errorf "X86_gas.i1_call_jmp: invalid operand %s"
+      (Buffer.contents buf)
 
 let print_instr b = function
   | ADD (arg1, arg2) -> i2_s b "add" arg1 arg2

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1117,7 +1117,10 @@ end = struct
     match t with
     | Top w -> w
     | Bot | Safe -> Witnesses.empty
-    | Var _ | Transform _ | Join _ -> assert false
+    | Var _ | Transform _ | Join _ ->
+      Misc.fatal_error
+        "Zero_alloc_checker.get_witnesses: unresolved value \
+         (Var/Transform/Join)"
 
   (* structural *)
   let compare t1 t2 =
@@ -1291,7 +1294,9 @@ end = struct
     | Safe, Bot -> Witnesses.empty
     | Top w, (Bot | Safe) -> w
     | (Var _ | Join _ | Transform _), _ | _, (Var _ | Join _ | Transform _) ->
-      assert false
+      Misc.fatal_error
+        "Zero_alloc_checker.diff_witnesses: unresolved value \
+         (Var/Transform/Join)"
 
   let meet t1 t2 =
     match t1, t2 with
@@ -2055,7 +2060,9 @@ end = struct
     V.match_with v
       ~top:(fun _ -> 0)
       ~safe:1 ~bot:2
-      ~unresolved:(fun () -> assert false)
+      ~unresolved:(fun () ->
+        Misc.fatal_error
+          "Zero_alloc_checker.encode: unexpected unresolved value")
 
   (* Witnesses are not used across functions and not stored in cmx. Witnesses
      that appear in a function's summary are only used for error messages about
@@ -2667,7 +2674,9 @@ end = struct
       let terminator next ~exn (i : Cfg.terminator Cfg.instruction) t =
         let dbg = i.dbg in
         match i.desc with
-        | Never -> assert false
+        | Never ->
+          Misc.fatal_error
+            "Zero_alloc_checker.terminator: unexpected Never terminator"
         | Return -> Value.normal_return
         | Raise Raise_notrace ->
           (* [raise_notrace] is typically used for control flow, not for

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -1118,9 +1118,8 @@ end = struct
     | Top w -> w
     | Bot | Safe -> Witnesses.empty
     | Var _ | Transform _ | Join _ ->
-      Misc.fatal_error
-        "Zero_alloc_checker.get_witnesses: unresolved value \
-         (Var/Transform/Join)"
+      Misc.fatal_errorf "Zero_alloc_checker.get_witnesses: unresolved value %a"
+        (print ~witnesses:false) t
 
   (* structural *)
   let compare t1 t2 =
@@ -1294,9 +1293,10 @@ end = struct
     | Safe, Bot -> Witnesses.empty
     | Top w, (Bot | Safe) -> w
     | (Var _ | Join _ | Transform _), _ | _, (Var _ | Join _ | Transform _) ->
-      Misc.fatal_error
-        "Zero_alloc_checker.diff_witnesses: unresolved value \
-         (Var/Transform/Join)"
+      Misc.fatal_errorf
+        "Zero_alloc_checker.diff_witnesses: unresolved value (actual %a, \
+         expected %a)"
+        (print ~witnesses:false) actual (print ~witnesses:false) expected
 
   let meet t1 t2 =
     match t1, t2 with
@@ -2061,8 +2061,9 @@ end = struct
       ~top:(fun _ -> 0)
       ~safe:1 ~bot:2
       ~unresolved:(fun () ->
-        Misc.fatal_error
-          "Zero_alloc_checker.encode: unexpected unresolved value")
+        Misc.fatal_errorf
+          "Zero_alloc_checker.encode: unexpected unresolved value %a"
+          (V.print ~witnesses:false) v)
 
   (* Witnesses are not used across functions and not stored in cmx. Witnesses
      that appear in a function's summary are only used for error messages about


### PR DESCRIPTION
Convert 37 `assert false` occurrences under `backend/` (excluding amd64/emit.ml, amd64/simd_selection.ml, and x86_binary_emitter.ml) into `Misc.fatal_error`/`Misc.fatal_errorf` calls carrying a descriptive message, so a violated invariant surfaces meaningful context instead of a bare Assert_failure when triaging compiler bugs.

Only sites whose unreachability rests on a non-local invariant were converted: Never terminators across the CFG passes, allocator/ISA register and operand invariants, caller-precondition catch-alls, and a few internal abstract-value states. Locally-obvious dead branches (tautological matches, locally-guarded lookups, exhaustive type matches) are left as `assert false`.

In cmm.ml, the two `Printf.eprintf` + `assert false` debugging combinations in `lub_component`/`ge_component` are folded into a single `Misc.fatal_errorf` that preserves the printed component tags.

All messages follow a uniform "Module.function: description" format. In regalloc files the local `fatal` helper (which also runs the state-dump callback) is used instead of `Misc.fatal_error` directly.