### PR TITLE
Factor shared dead-code predicate into `Cfg.is_dead_basic`

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -355,6 +355,9 @@ let is_pure_basic : basic -> bool = function
     (* May reallocate the stack. *)
     false
 
+let is_dead_basic (instr : basic instruction) ~live_after =
+  is_pure_basic instr.desc && Reg.disjoint_set_array live_after instr.res
+
 let same_location (r1 : Reg.t) (r2 : Reg.t) =
   Reg.same_loc_fatal_on_unknown
     ~fatal_message:"Cfg got unknown register location." r1 r2

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -205,6 +205,12 @@ val is_return_terminator : terminator -> bool
 
 val is_pure_basic : basic -> bool
 
+(** [is_dead_basic instr ~live_after] holds when [instr] is pure and all its
+    results are unused (disjoint from [live_after], the registers live
+    immediately after [instr]). Shared by [Cfg_liveness] (optimistic dead-code
+    case) and [Cfg_deadcode] (actual removal) so the two tests stay in sync. *)
+val is_dead_basic : basic instruction -> live_after:Reg.Set.t -> bool
+
 val is_noop_move : basic instruction -> bool
 
 val is_alloc : basic instruction -> bool

--- a/backend/cfg/cfg_deadcode.ml
+++ b/backend/cfg/cfg_deadcode.ml
@@ -18,14 +18,7 @@ let remove_deadcode (body : Cfg.basic_instruction_list) changed liveness
   let used_after = ref used_after in
   DLL.filter_right body ~f:(fun (instr : Instruction.t) ->
       let before = live_before instr liveness in
-      let is_deadcode =
-        match instr.desc with
-        | Op _ as op ->
-          Cfg.is_pure_basic op && Reg.disjoint_set_array !used_after instr.res
-        | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
-        | Stack_check _ ->
-          false
-      in
+      let is_deadcode = Cfg.is_dead_basic instr ~live_after:!used_after in
       used_after := before;
       changed := !changed || is_deadcode;
       not is_deadcode)

--- a/backend/cfg/cfg_liveness.ml
+++ b/backend/cfg/cfg_liveness.ml
@@ -57,7 +57,7 @@ module Transfer :
     match instr.desc with
     | Op _ | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
     | Stack_check _ ->
-      if Cfg.is_pure_basic instr.desc && Reg.disjoint_set_array before instr.res
+      if Cfg.is_dead_basic instr ~live_after:before
       then
         (* If the operation is without side-effects and the result is unused
            then don't mark the arguments as used because this instruction could


### PR DESCRIPTION
As per title; this is a minor refactoring suggested during
a correctness review / audit of `Cfg_deadcode`. The goal
is to ensure the liveness and dead-code elimination passes
are kept in sync by construct.
