### PR TITLE
Measure frametables

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -636,8 +636,8 @@ type gc_call =
     gc_return_lbl : L.t; (* Where to branch after GC *)
     (* The frame descriptor is recorded (and its return-address label defined)
        when the out-of-line GC stub is emitted, rather than at the allocation
-       site, so that frame descriptors are emitted in increasing
-       return-address order. *)
+       site, so that frame descriptors are emitted in increasing return-address
+       order. *)
     gc_frame_lbl : Label.t; (* Linear label of the frame descriptor *)
     gc_frame_size : int;
     gc_live_offset : int list;
@@ -3165,11 +3165,10 @@ let end_assembly () =
   let frametable_sym = S.create_global (Cmm_helpers.make_symbol "frametable") in
   D.size frametable_sym;
   (* Experimental: emit a pointer to this unit's frametable into a
-     linker-collected section, so the runtime can enumerate the frametable
-     of *every* linked unit, including ones that are not in
-     caml_frametable[]. The linker concatenates these per-unit entries and
-     bounds them with __start_/__stop_caml_all_frametables. ELF/GAS
-     targets only. *)
+     linker-collected section, so the runtime can enumerate the frametable of
+     *every* linked unit, including ones that are not in caml_frametable[]. The
+     linker concatenates these per-unit entries and bounds them with
+     __start_/__stop_caml_all_frametables. ELF/GAS targets only. *)
   (match[@ocaml.warning "-4"] system with
   | S_macosx | S_win32 | S_win64 | S_mingw | S_mingw64 | S_cygwin | S_unknown ->
     ()

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -587,9 +587,8 @@ let must_save_simd_regs live : Regs.Save_simd_regs.t =
 (* CR sspies: Consider whether more of [record_frame_label] can be shared with
    the Arm backend. *)
 
-let record_frame_label live dbg =
+let compute_live_offset live =
   let encode_reg_offset n = (n lsl 1) + 1 in
-  let lbl = Cmm.new_label () in
   let live_offset = ref [] in
   let simd = must_save_simd_regs live in
   Reg.Set.iter
@@ -616,10 +615,14 @@ let record_frame_label live dbg =
         Misc.fatal_errorf "Unknown location %a" Printreg.reg r
       | { typ = Int | Float | Float32 | Vec128 | Vec256 | Vec512; _ } -> ())
     live;
+  !live_offset
+
+let record_frame_label live dbg =
+  let lbl = Cmm.new_label () in
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of Linear labels. *)
   record_frame_descr ~label:lbl ~frame_size:(frame_size ())
-    ~live_offset:!live_offset dbg;
+    ~live_offset:(compute_live_offset live) dbg;
   label_to_asm_label ~section:Text lbl
 
 let record_frame live dbg =
@@ -631,7 +634,14 @@ let record_frame live dbg =
 type gc_call =
   { gc_lbl : L.t; (* Entry label *)
     gc_return_lbl : L.t; (* Where to branch after GC *)
-    gc_frame : L.t; (* Label of frame descriptor *)
+    (* The frame descriptor is recorded (and its return-address label defined)
+       when the out-of-line GC stub is emitted, rather than at the allocation
+       site, so that frame descriptors are emitted in increasing
+       return-address order. *)
+    gc_frame_lbl : Label.t; (* Linear label of the frame descriptor *)
+    gc_frame_size : int;
+    gc_live_offset : int list;
+    gc_frame_dbg : frame_debuginfo; (* debuginfo for the frame descriptor *)
     gc_dbg : Debuginfo.t; (* Location of the original instruction *)
     gc_save_simd : Regs.Save_simd_regs.t
         (* What SIMD regs, if any, we need to save *)
@@ -649,7 +659,12 @@ let emit_call_gc gc =
   D.define_label gc.gc_lbl;
   emit_debug_info gc.gc_dbg;
   emit_call (call_gc_local_sym ~simd:gc.gc_save_simd);
-  D.define_label gc.gc_frame;
+  (* Record the frame descriptor here, where its return-address label is about
+     to be defined, so that frame descriptors are recorded (and hence emitted)
+     in increasing return-address order. *)
+  record_frame_descr ~label:gc.gc_frame_lbl ~frame_size:gc.gc_frame_size
+    ~live_offset:gc.gc_live_offset gc.gc_frame_dbg;
+  D.define_label (label_to_asm_label ~section:Text gc.gc_frame_lbl);
   I.jmp (emit_asm_label_arg gc.gc_return_lbl)
 
 (* Record calls to local stack reallocation *)
@@ -2189,7 +2204,7 @@ let emit_instr ~first ~last ~fallthrough i =
       I.sub (int n) r15;
       I.cmp (domain_field Domainstate.Domain_young_limit) r15;
       let lbl_call_gc = L.create Text in
-      let lbl_frame = record_frame_label i.live (Dbg_alloc dbginfo) in
+      let lbl_frame = Cmm.new_label () in
       I.jb (emit_asm_label_arg lbl_call_gc);
       let lbl_after_alloc = L.create Text in
       D.define_label lbl_after_alloc;
@@ -2198,7 +2213,10 @@ let emit_instr ~first ~last ~fallthrough i =
         := { gc_lbl = lbl_call_gc;
              gc_return_lbl = lbl_after_alloc;
              gc_dbg = i.dbg;
-             gc_frame = lbl_frame;
+             gc_frame_lbl = lbl_frame;
+             gc_frame_size = frame_size ();
+             gc_live_offset = compute_live_offset i.live;
+             gc_frame_dbg = Dbg_alloc dbginfo;
              gc_save_simd
            }
            :: !call_gc_sites)
@@ -2236,13 +2254,16 @@ let emit_instr ~first ~last ~fallthrough i =
     I.cmp (domain_field Domainstate.Domain_young_limit) r15;
     let gc_call_label = L.create Text in
     let lbl_after_poll = L.create Text in
-    let lbl_frame = record_frame_label i.live (Dbg_alloc []) in
+    let lbl_frame = Cmm.new_label () in
     I.jbe (emit_asm_label_arg gc_call_label);
     call_gc_sites
       := { gc_lbl = gc_call_label;
            gc_return_lbl = lbl_after_poll;
            gc_dbg = i.dbg;
-           gc_frame = lbl_frame;
+           gc_frame_lbl = lbl_frame;
+           gc_frame_size = frame_size ();
+           gc_live_offset = compute_live_offset i.live;
+           gc_frame_dbg = Dbg_alloc [];
            gc_save_simd = must_save_simd_regs i.live
          }
          :: !call_gc_sites;

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -396,6 +396,8 @@ let emit_named_text_section ?(suffix = "") func_name =
     | _ ->
       D.switch_to_section_raw ~names:[".text.startup.caml"] ~flags:(Some "ax")
         ~args:["@progbits"] ~is_delayed:false;
+      (* A new text section: frame-descriptor deltas cannot cross it. *)
+      Emitaux.start_new_code_section ();
       (* Warning: We set the internal section ref to Text here, because it
          currently does not supported named text sections. In the rest of this
          file, we pretend the section is called Text rather than the function
@@ -417,13 +419,21 @@ let emit_named_text_section ?(suffix = "") func_name =
       D.switch_to_section_raw
         ~names:[Printf.sprintf ".text.caml.%s%s" (emit_symbol func_name) suffix]
         ~flags:(Some "ax") ~args:["@progbits"] ~is_delayed:false;
+      (* A new text section: frame-descriptor deltas cannot cross it. *)
+      Emitaux.start_new_code_section ();
       (* Warning: We set the internal section ref to Text here, because it
          currently does not supported named text sections. In the rest of this
          file, we pretend the section is called Text rather than the function
          specific text section. *)
       (* CR sspies: Add proper support for named text sections. *)
       D.unsafe_set_internal_section_ref Text)
-  else D.text ()
+  else (
+    D.text ();
+    (* Conservatively treat each function start as a new section boundary for
+       frame-descriptor deltas. With a single shared [.text] this only forgoes
+       cross-function deltas (safe); it avoids emitting a cross-section delta
+       should a return address ever land in a different section. *)
+    Emitaux.start_new_code_section ())
 
 let emit_function_or_basic_block_section_name () =
   let suffix =
@@ -3156,6 +3166,12 @@ let end_assembly () =
           let ofs = Targetint.of_int32 ofs in
           D.between_this_and_label_offset_32bit_expr ~upper:lbl
             ~offset_upper:ofs);
+      efa_label_delta =
+        (fun upper lower ->
+          (* The return-address labels live in the text section. *)
+          let upper = label_to_asm_label ~section:Text upper in
+          let lower = label_to_asm_label ~section:Text lower in
+          D.frame_descr_delta ~upper ~lower);
       efa_def_label =
         (fun l ->
           let lbl = label_to_asm_label ~section:frametable_section l in

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3126,6 +3126,16 @@ let end_assembly () =
   let frametable_section : Asm_targets.Asm_section.t =
     if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Text
   in
+  (* Mergeable string section (SHF_MERGE|SHF_STRINGS, entsize 1) for the
+     deduplicable debuginfo filename and defname strings. *)
+  let debuginfo_strings_section : Asm_targets.Asm_section.t =
+    Custom
+      { names = [".rodata.str1.1"];
+        flags = Some "aMS";
+        args = ["@progbits"; "1"];
+        is_delayed = false
+      }
+  in
   D.switch_to_section frametable_section;
   D.align
     ~fill:(if !Oxcaml_flags.frametables_in_rodata then Zero else Nop)
@@ -3160,7 +3170,15 @@ let end_assembly () =
         (fun l ->
           let lbl = label_to_asm_label ~section:frametable_section l in
           D.define_label lbl);
-      efa_string = (fun s -> D.string (s ^ "\000"))
+      efa_string = (fun s -> D.string (s ^ "\000"));
+      efa_open_string_section =
+        (fun () -> D.switch_to_section debuginfo_strings_section);
+      efa_close_string_section =
+        (fun () -> D.switch_to_section frametable_section);
+      efa_def_string_label =
+        (fun l ->
+          let lbl = label_to_asm_label ~section:debuginfo_strings_section l in
+          D.define_label lbl)
     };
   let frametable_sym = S.create_global (Cmm_helpers.make_symbol "frametable") in
   D.size frametable_sym;

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3143,6 +3143,19 @@ let end_assembly () =
     };
   let frametable_sym = S.create_global (Cmm_helpers.make_symbol "frametable") in
   D.size frametable_sym;
+  (* Experimental: emit a pointer to this unit's frametable into a
+     linker-collected section, so the runtime can enumerate the frametable
+     of *every* linked unit, including ones that are not in
+     caml_frametable[]. The linker concatenates these per-unit entries and
+     bounds them with __start_/__stop_caml_all_frametables. ELF/GAS
+     targets only. *)
+  (match[@ocaml.warning "-4"] system with
+  | S_macosx | S_win32 | S_win64 | S_mingw | S_mingw64 | S_cygwin | S_unknown ->
+    ()
+  | _ ->
+    D.switch_to_section_raw ~names:["caml_all_frametables"] ~flags:(Some "aw")
+      ~args:["@progbits"] ~is_delayed:false;
+    D.symbol frametable_sym);
   D.data ();
   Probe_emission.emit_probe_notes ~add_def_symbol;
   emit_trap_notes ();

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3153,9 +3153,8 @@ let end_assembly () =
   (* PR#7591 *)
   emit_global_label ~section:frametable_section "frametable";
   (* The internal-assembler / JIT binary backend cannot yet emit the small
-     format's variable-length retaddr delta, so escape every descriptor to
-     the normal format when it is active. TODO: extend internal
-     assembler. *)
+     format's variable-length retaddr delta, so escape every descriptor to the
+     normal format when it is active. TODO: extend internal assembler. *)
   Emitaux.disable_small_descriptors
     := Option.is_some !X86_proc.internal_assembler;
   (* CR sspies: Share the [emit_frames] code with the Arm backend. *)

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3152,6 +3152,12 @@ let end_assembly () =
     ~bytes:8;
   (* PR#7591 *)
   emit_global_label ~section:frametable_section "frametable";
+  (* The internal-assembler / JIT binary backend cannot yet emit the small
+     format's variable-length retaddr delta, so escape every descriptor to
+     the normal format when it is active. TODO: extend internal
+     assembler. *)
+  Emitaux.disable_small_descriptors
+    := Option.is_some !X86_proc.internal_assembler;
   (* CR sspies: Share the [emit_frames] code with the Arm backend. *)
   emit_frames
     { efa_code_label =

--- a/backend/arm64/binary_emitter/binary_emitter.ml
+++ b/backend/arm64/binary_emitter/binary_emitter.ml
@@ -116,7 +116,7 @@ let compute_label_offsets emitter ~all_sections =
       | Cfi_restore_state | Cfi_def_cfa_register _ | Comment _ | Const _
       | File _ | Indirect_symbol _ | Loc _ | New_line | Private_extern _
       | Section _ | Size _ | Sleb128 _ | Space _ | Type _ | Uleb128 _
-      | Protected _ | Hidden _ | External _ | Reloc _ ->
+      | Protected _ | Hidden _ | External _ | Reloc _ | Frame_descr_delta _ ->
         ())
 
 (* Second pass: emit machine code and data *)

--- a/backend/arm64/binary_emitter/encode_directive.ml
+++ b/backend/arm64/binary_emitter/encode_directive.ml
@@ -590,6 +590,9 @@ let emit_directive state ~current_section ~all_sections
     match eval_constant state ~all_sections constant with
     | Some value -> D.Directive.emit_uleb128 buf value
     | None -> Misc.fatal_error "Cannot emit ULEB128 for external symbol")
+  | Frame_descr_delta _ ->
+    (* Small frame descriptors are not yet ported to ARM64. *)
+    Misc.fatal_error "Frame_descr_delta not supported on ARM64"
   (* Directives that don't emit data *)
   | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_endproc | Cfi_offset _
   | Cfi_startproc | Cfi_remember_state | Cfi_restore_state

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -753,7 +753,8 @@ let record_frame_label env live dbg =
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of linear labels. *)
   record_frame_descr ~label:lbl ~frame_size:(Env.frame_size env)
-    ~live_offset:(compute_live_offset env live) dbg;
+    ~live_offset:(compute_live_offset env live)
+    dbg;
   label_to_asm_label ~section:Text lbl
 
 let record_frame env live dbg =
@@ -775,11 +776,13 @@ let emit_call_gc gc =
   (* Record the frame descriptor here, where its return-address label is
      defined, so descriptors are recorded (and emitted) in increasing
      return-address order. Safe across the relaxation/sizing pass: that pass
-     runs under [Emitaux.with_snapshot], which rolls back [frame_descriptors].
-  *)
+     runs under [Emitaux.with_snapshot], which rolls back
+     [frame_descriptors]. *)
   record_frame_descr ~label:gc.gc_frame_lbl ~frame_size:gc.gc_frame_size
     ~live_offset:gc.gc_live_offset gc.gc_frame_dbg;
-  labelled_ins1 (label_to_asm_label ~section:Text gc.gc_frame_lbl) B
+  labelled_ins1
+    (label_to_asm_label ~section:Text gc.gc_frame_lbl)
+    B
     (local_label gc.gc_return_lbl)
 
 (* Record calls to local stack reallocation *)

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -50,7 +50,14 @@ open! Int_replace_polymorphic_compare
 type gc_call =
   { gc_lbl : L.t; (* Entry label *)
     gc_return_lbl : L.t; (* Where to branch after GC *)
-    gc_frame_lbl : L.t (* Label of frame descriptor *)
+    (* The frame descriptor is recorded (and its return-address label defined)
+       when the out-of-line GC stub is emitted, rather than at the allocation
+       site, so that frame descriptors are emitted in increasing return-address
+       order. *)
+    gc_frame_lbl : label; (* Linear label of the frame descriptor *)
+    gc_frame_size : int;
+    gc_live_offset : int list;
+    gc_frame_dbg : frame_debuginfo
   }
 
 type local_realloc_call =
@@ -717,9 +724,8 @@ let simd_instr (op : Simd.operation) (i : Linear.instruction) =
 
 (* Record live pointers at call points *)
 
-let record_frame_label env live dbg =
+let compute_live_offset env live =
   let encode_reg_offset n = (n lsl 1) + 1 in
-  let lbl = Cmm.new_label () in
   let live_offset = ref [] in
   Reg.Set.iter
     (function
@@ -740,10 +746,14 @@ let record_frame_label env live dbg =
       | { typ = Vec256 | Vec512; _ } ->
         Misc.fatal_error "arm64: got 256/512 bit vector")
     live;
+  !live_offset
+
+let record_frame_label env live dbg =
+  let lbl = Cmm.new_label () in
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of linear labels. *)
   record_frame_descr ~label:lbl ~frame_size:(Env.frame_size env)
-    ~live_offset:!live_offset dbg;
+    ~live_offset:(compute_live_offset env live) dbg;
   label_to_asm_label ~section:Text lbl
 
 let record_frame env live dbg =
@@ -762,7 +772,15 @@ let emit_debug_info ?discriminator dbg =
 
 let emit_call_gc gc =
   labelled_ins1 gc.gc_lbl BL (runtime_function S.Predef.caml_call_gc);
-  labelled_ins1 gc.gc_frame_lbl B (local_label gc.gc_return_lbl)
+  (* Record the frame descriptor here, where its return-address label is
+     defined, so descriptors are recorded (and emitted) in increasing
+     return-address order. Safe across the relaxation/sizing pass: that pass
+     runs under [Emitaux.with_snapshot], which rolls back [frame_descriptors].
+  *)
+  record_frame_descr ~label:gc.gc_frame_lbl ~frame_size:gc.gc_frame_size
+    ~live_offset:gc.gc_live_offset gc.gc_frame_dbg;
+  labelled_ins1 (label_to_asm_label ~section:Text gc.gc_frame_lbl) B
+    (local_label gc.gc_return_lbl)
 
 (* Record calls to local stack reallocation *)
 
@@ -1101,11 +1119,20 @@ let assembly_code_for_fast_heap_allocation0 ~n ~far ~res_reg =
   gc_lbl, gc_return_lbl
 
 let assembly_code_for_fast_heap_allocation env i ~n ~far ~dbginfo =
-  let gc_frame_lbl = record_frame_label env i.live (Dbg_alloc dbginfo) in
+  let gc_frame_lbl = Cmm.new_label () in
+  let gc_frame_size = Env.frame_size env in
+  let gc_live_offset = compute_live_offset env i.live in
   let gc_lbl, gc_return_lbl =
     assembly_code_for_fast_heap_allocation0 ~n ~far ~res_reg:(H.reg_x i.res.(0))
   in
-  Env.add_call_gc_site env { gc_lbl; gc_return_lbl; gc_frame_lbl }
+  Env.add_call_gc_site env
+    { gc_lbl;
+      gc_return_lbl;
+      gc_frame_lbl;
+      gc_frame_size;
+      gc_live_offset;
+      gc_frame_dbg = Dbg_alloc dbginfo
+    }
 
 let assembly_code_for_slow_heap_allocation env i ~n ~dbginfo =
   let lbl_frame = record_frame_label env i.live (Dbg_alloc dbginfo) in
@@ -1160,9 +1187,18 @@ let assembly_code_for_poll0 ~far ~return_label =
   gc_lbl, gc_return_lbl
 
 let assembly_code_for_poll env i ~far ~return_label =
-  let gc_frame_lbl = record_frame_label env i.live (Dbg_alloc []) in
+  let gc_frame_lbl = Cmm.new_label () in
+  let gc_frame_size = Env.frame_size env in
+  let gc_live_offset = compute_live_offset env i.live in
   let gc_lbl, gc_return_lbl = assembly_code_for_poll0 ~far ~return_label in
-  Env.add_call_gc_site env { gc_lbl; gc_return_lbl; gc_frame_lbl }
+  Env.add_call_gc_site env
+    { gc_lbl;
+      gc_return_lbl;
+      gc_frame_lbl;
+      gc_frame_size;
+      gc_live_offset;
+      gc_frame_dbg = Dbg_alloc []
+    }
 
 (* Output .text section directive, or named .text.caml.<name> if enabled. *)
 

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2242,6 +2242,9 @@ let end_assembly () =
   let frametable_sym = S.create_global frametable in
   global_maybe_protected frametable_sym;
   D.define_symbol_label ~section:frametable_section frametable_sym;
+  (* The small-format return-address delta is not yet ported to ARM64, so escape
+     every descriptor to the normal format. *)
+  Emitaux.disable_small_descriptors := true;
   (* CR sspies: Share the [emit_frames] code with the x86 backend. *)
   emit_frames
     { efa_code_label =
@@ -2269,8 +2272,8 @@ let end_assembly () =
             ~offset_upper:(Targetint.of_int32 ofs));
       efa_label_delta =
         (* The small frame-descriptor format and its runtime decoding are not
-           yet ported to ARM64; this is only reachable if [emit_frames]
-           produces a small descriptor on ARM64. *)
+           yet ported to ARM64; this is only reachable if [emit_frames] produces
+           a small descriptor on ARM64. *)
         (fun _upper _lower ->
           Misc.fatal_error "small frame descriptors not supported on ARM64");
       efa_def_label =

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2257,6 +2257,12 @@ let end_assembly () =
           let lbl = label_to_asm_label ~section:frametable_section lbl in
           D.between_this_and_label_offset_32bit_expr ~upper:lbl
             ~offset_upper:(Targetint.of_int32 ofs));
+      efa_label_delta =
+        (* The small frame-descriptor format and its runtime decoding are not
+           yet ported to ARM64; this is only reachable if [emit_frames]
+           produces a small descriptor on ARM64. *)
+        (fun _upper _lower ->
+          Misc.fatal_error "small frame descriptors not supported on ARM64");
       efa_def_label =
         (fun lbl ->
           let lbl = label_to_asm_label ~section:frametable_section lbl in

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2225,6 +2225,16 @@ let end_assembly () =
        unclear how much this matters. *)
     if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Data
   in
+  (* Mergeable string section (SHF_MERGE|SHF_STRINGS, entsize 1) for the
+     deduplicable debuginfo filename and defname strings. *)
+  let debuginfo_strings_section : Asm_targets.Asm_section.t =
+    Custom
+      { names = [".rodata.str1.1"];
+        flags = Some "aMS";
+        args = ["%progbits"; "1"];
+        is_delayed = false
+      }
+  in
   D.switch_to_section frametable_section;
   D.align ~fill:Zero ~bytes:8;
   (* #7887 *)
@@ -2261,7 +2271,15 @@ let end_assembly () =
         (fun lbl ->
           let lbl = label_to_asm_label ~section:frametable_section lbl in
           D.define_label lbl);
-      efa_string = (fun s -> D.string (s ^ "\000"))
+      efa_string = (fun s -> D.string (s ^ "\000"));
+      efa_open_string_section =
+        (fun () -> D.switch_to_section debuginfo_strings_section);
+      efa_close_string_section =
+        (fun () -> D.switch_to_section frametable_section);
+      efa_def_string_label =
+        (fun lbl ->
+          let lbl = label_to_asm_label ~section:debuginfo_strings_section lbl in
+          D.define_label lbl)
     };
   D.type_symbol ~ty:Object frametable_sym;
   D.size frametable_sym;

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -283,6 +283,12 @@ module Directive = struct
           target_symbol : Asm_symbol.t;
           addend : int64
         }
+    | Frame_descr_delta of { delta : Constant.t }
+        (* Variable-width return-address delta for a "small" frame
+           descriptor: a single byte holding [delta] when it fits 1..254,
+           otherwise a 0xFF marker byte followed by a 16-bit little-endian
+           value (255..65535). [delta] is a difference of two same-section
+           labels, so it is an assembly-time constant. *)
 
   let bprintf = Printf.bprintf
 
@@ -411,6 +417,14 @@ module Directive = struct
       | _, _ -> print_ascii_string_gas ~chunk_size:80 buf str);
       bprintf buf "%s" (gas_comment_opt comment)
     | Comment s -> if emit_comments () then bprintf buf "\t\t\t\t/* %s */" s
+    | Frame_descr_delta { delta } ->
+      (* The delta is a difference of two same-section labels. We cannot
+         pick a fixed width by inspecting its value (it is only known to
+         the assembler, and can even change under branch relaxation), so
+         we emit it as an unsigned LEB128, which the assembler computes
+         directly. The value is always >= 1, so it never starts with a 0
+         byte and stays distinct from the escape marker. *)
+      bprintf buf "\t.uleb128 (%a)" Constant.print delta
     | Global sym -> bprintf buf "\t.globl\t%s" (Asm_symbol.encode sym)
     | New_label (Label lbl, _typ) -> bprintf buf "%s:" (Asm_label.encode lbl)
     | New_label (Symbol sym, _typ) -> bprintf buf "%s:" (Asm_symbol.encode sym)
@@ -573,6 +587,7 @@ module Directive = struct
     | External sym -> bprintf buf "\tEXTRN\t%s: NEAR" (Asm_symbol.encode sym)
     (* The only supported "type" on EXTRN declarations is NEAR. *)
     | Reloc _ -> unsupported "Reloc"
+    | Frame_descr_delta _ -> unsupported "Frame_descr_delta"
 
   let print b t =
     match TS.assembler () with
@@ -663,6 +678,12 @@ module Directive = struct
       | This | Label _ | Symbol _ | Variable _ | Add _ | Sub _ ->
         Misc.fatal_error
           "increment_offset_in_bytes: uleb128 with non-integer constant")
+    | Frame_descr_delta _ ->
+      (* Variable-width (1 or 3 bytes); not supported by the offset-accounting
+         binary-emitter path. Only emitted on amd64 via the GAS text backend,
+         which does not use this function. *)
+      Misc.fatal_error
+        "increment_offset_in_bytes: Frame_descr_delta is not supported"
     (* Directives that don't contribute to section size *)
     | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_endproc
     | Cfi_offset _ | Cfi_startproc | Cfi_remember_state | Cfi_restore_state
@@ -1125,6 +1146,13 @@ let between_labels_32_bit ?comment:_comment ~upper ~lower () =
 let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () =
   (* CR poechsel: use the arguments *)
   Misc.fatal_error "between_labels_64_bit not implemented yet"
+
+let frame_descr_delta ~upper ~lower =
+  let delta =
+    Directive.Constant.Sub
+      (Directive.Constant.Label upper, Directive.Constant.Label lower)
+  in
+  emit (Frame_descr_delta { delta })
 
 let between_labels_64_bit_with_offsets ?comment:_comment ~upper ~upper_offset
     ~lower ~lower_offset () =

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -284,11 +284,7 @@ module Directive = struct
           addend : int64
         }
     | Frame_descr_delta of { delta : Constant.t }
-        (* Variable-width return-address delta for a "small" frame
-           descriptor: a single byte holding [delta] when it fits 1..254,
-           otherwise a 0xFF marker byte followed by a 16-bit little-endian
-           value (255..65535). [delta] is a difference of two same-section
-           labels, so it is an assembly-time constant. *)
+  (* Variable-width return-address delta for a "small" frame descriptor *)
 
   let bprintf = Printf.bprintf
 
@@ -418,12 +414,9 @@ module Directive = struct
       bprintf buf "%s" (gas_comment_opt comment)
     | Comment s -> if emit_comments () then bprintf buf "\t\t\t\t/* %s */" s
     | Frame_descr_delta { delta } ->
-      (* The delta is a difference of two same-section labels. We cannot
-         pick a fixed width by inspecting its value (it is only known to
-         the assembler, and can even change under branch relaxation), so
-         we emit it as an unsigned LEB128, which the assembler computes
-         directly. The value is always >= 1, so it never starts with a 0
-         byte and stays distinct from the escape marker. *)
+      (* The delta is a difference of two same-section labels. Emit as ULEB128
+         so the assembler can compute it. Always positive, so it never starts
+         with a 0 byte *)
       bprintf buf "\t.uleb128 (%a)" Constant.print delta
     | Global sym -> bprintf buf "\t.globl\t%s" (Asm_symbol.encode sym)
     | New_label (Label lbl, _typ) -> bprintf buf "%s:" (Asm_label.encode lbl)

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -287,11 +287,7 @@ val between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
 (** Emit a variable-width return-address delta for a "small" frame descriptor.
-    The difference [upper - lower] is emitted in a single byte when it is in
-    1..254, otherwise as a 0xFF marker byte followed by a 16-bit little-endian
-    value (255..65535). A difference larger than 16 bits is a (loud) error.
-    The two labels must be in the same section. Supported only on the GAS text
-    backend. *)
+    Supported only on the GAS text backend. *)
 val frame_descr_delta : upper:Asm_label.t -> lower:Asm_label.t -> unit
 
 (** Like [between_symbols], but for two labels with additional offsets, emitting
@@ -486,11 +482,7 @@ module Directive : sig
           addend : int64
         }
     | Frame_descr_delta of { delta : Constant.t }
-        (** Variable-width return-address delta for a "small" frame
-            descriptor: a single byte holding [delta] when it fits 1..254,
-            otherwise a 0xFF marker byte followed by a 16-bit little-endian
-            value (255..65535). [delta] is a difference of two same-section
-            labels, hence an assembly-time constant. *)
+        (** Variable-width return-address delta for a small frame descriptor *)
 
   (** Translate the given directive to textual form. This produces output
       suitable for either gas or MASM as appropriate. *)

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -286,6 +286,14 @@ val between_labels_32_bit :
 val between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
+(** Emit a variable-width return-address delta for a "small" frame descriptor.
+    The difference [upper - lower] is emitted in a single byte when it is in
+    1..254, otherwise as a 0xFF marker byte followed by a 16-bit little-endian
+    value (255..65535). A difference larger than 16 bits is a (loud) error.
+    The two labels must be in the same section. Supported only on the GAS text
+    backend. *)
+val frame_descr_delta : upper:Asm_label.t -> lower:Asm_label.t -> unit
+
 (** Like [between_symbols], but for two labels with additional offsets, emitting
     a 64-bit-wide reference. The labels must be in the same section. *)
 val between_labels_64_bit_with_offsets :
@@ -477,6 +485,12 @@ module Directive : sig
           target_symbol : Asm_symbol.t;
           addend : int64
         }
+    | Frame_descr_delta of { delta : Constant.t }
+        (** Variable-width return-address delta for a "small" frame
+            descriptor: a single byte holding [delta] when it fits 1..254,
+            otherwise a 0xFF marker byte followed by a 16-bit little-endian
+            value (255..65535). [delta] is a difference of two same-section
+            labels, hence an assembly-time constant. *)
 
   (** Translate the given directive to textual form. This produces output
       suitable for either gas or MASM as appropriate. *)

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -105,7 +105,15 @@ type emit_frame_actions =
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
     efa_def_label : Label.t -> unit;
-    efa_string : string -> unit
+    efa_string : string -> unit;
+    (* Switch to / from a mergeable string section (SHF_MERGE|SHF_STRINGS), used
+       to emit the deduplicable debuginfo filename and defname strings. While it
+       is open, [efa_def_string_label] defines a label there (and [efa_string]
+       emits into it); references from the frame table section back to those
+       labels still use [efa_label_rel]. *)
+    efa_open_string_section : unit -> unit;
+    efa_close_string_section : unit -> unit;
+    efa_def_string_label : Label.t -> unit
   }
 
 let emit_frames a =
@@ -160,6 +168,17 @@ let emit_frames a =
       let def_lbl = Cmm.new_label () in
       Hashtbl.add defnames (filename, defname, loc) (file_lbl, def_lbl);
       def_lbl
+  in
+  (* The defname strings, deduplicated by content within this unit. Each is
+     emitted once into the mergeable string section and referenced from the
+     name_info / name_and_loc_info struct by [defname_offs]. *)
+  let defstrings = Hashtbl.create 7 in
+  let label_defstring defname =
+    try Hashtbl.find defstrings defname
+    with Not_found ->
+      let lbl = Cmm.new_label () in
+      Hashtbl.add defstrings defname lbl;
+      lbl
   in
   let module Label_table = Hashtbl.Make (struct
     type t = bool * Debuginfo.Dbg.t
@@ -222,9 +241,11 @@ let emit_frames a =
             else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
           dbg
   in
-  let emit_filename name lbl =
-    a.efa_def_label lbl;
-    a.efa_string name
+  (* Emit one string (filename or defname) into the open mergeable string
+     section, defining its label there. *)
+  let emit_merged_string str lbl =
+    a.efa_def_string_label lbl;
+    a.efa_string str
   in
   let emit_defname (_filename, defname, loc) (file_lbl, lbl) =
     let emit_loc (start_chr, end_chr, end_offset) =
@@ -232,16 +253,21 @@ let emit_frames a =
       emit_u16 end_chr;
       emit_i32 end_offset
     in
-    (* These must be 32-bit aligned, both because they contain a 32-bit value,
-       and because emit_debuginfo assumes the low 2 bits of their addresses are
-       0. *)
+    (* The name_info / name_and_loc_info struct. Must be 32-bit aligned, both
+       because it contains 32-bit values and because emit_debuginfo assumes the
+       low 2 bits of its address are 0. The defname string is emitted separately
+       into the mergeable string section; [defname_offs] points at it, stored
+       relative to the start of the struct (like [filename_offs]), so the
+       [efa_label_rel] addend is the field's byte offset within the struct. *)
     a.efa_align 4;
     a.efa_def_label lbl;
     a.efa_label_rel file_lbl 0l;
     (* Include the additional 64-bits of location information which didn't pack
        in the main 64-bit word *)
     Option.iter emit_loc loc;
-    a.efa_string defname
+    let defname_field_offset = match loc with None -> 4 | Some _ -> 12 in
+    a.efa_label_rel (label_defstring defname)
+      (Int32.of_int defname_field_offset)
   in
   let fully_pack_info fd_raise d has_next =
     (* See format in caml_debuginfo_location in runtime/backtrace-nat.c *)
@@ -338,9 +364,17 @@ let emit_frames a =
   a.efa_word (List.length descrs);
   List.iter emit_frame descrs;
   Label_table.iter emit_debuginfo debuginfos;
-  Hashtbl.iter emit_filename filenames;
+  (* The name structs stay in the frame table section, near the debuginfo words
+     that reference them (a 24-bit, +/-64 MB offset). Emitting them also
+     populates [defstrings]. *)
   Hashtbl.iter emit_defname defnames;
   a.efa_align Arch.size_addr;
+  (* The filename and defname strings go into a mergeable string section so the
+     linker deduplicates them across compilation units. *)
+  a.efa_open_string_section ();
+  Hashtbl.iter emit_merged_string filenames;
+  Hashtbl.iter emit_merged_string defstrings;
+  a.efa_close_string_section ();
   frame_descriptors := []
 
 (* Detection of functions that can be duplicated between a DLL and the main

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -333,8 +333,13 @@ let emit_frames a =
     in
     match rdbg with [] -> assert false | d :: rest -> emit rs d rest
   in
-  a.efa_word (List.length !frame_descriptors);
-  List.iter emit_frame !frame_descriptors;
+  (* Descriptors are recorded in increasing return-address order (calls inline
+     as they are emitted; allocations and polls when their out-of-line GC stub
+     is emitted), so the prepended list is in decreasing order. Reverse it to
+     emit the frame table in increasing return-address order. *)
+  let descrs = List.rev !frame_descriptors in
+  a.efa_word (List.length descrs);
+  List.iter emit_frame descrs;
   Label_table.iter emit_debuginfo debuginfos;
   Hashtbl.iter emit_filename filenames;
   Hashtbl.iter emit_defname defnames;

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -46,10 +46,22 @@ type frame_descr =
     fd_frame_size : int; (* Size of stack frame *)
     fd_live_offset : int list; (* Offsets/regs of live addresses *)
     fd_debuginfo : frame_debuginfo; (* Location, if any *)
-    fd_long : bool (* Use 32 instead of 16 bit format. *)
+    fd_long : bool; (* Use 32 instead of 16 bit format. *)
+    fd_section : int
+        (* Identifies the text section the return address lives in. A "small"
+           descriptor's delta is the difference between two return-address
+           labels, which is only an assembly-time constant when both labels are
+           in the same section; descriptors whose section differs from the
+           previous one escape. *)
   }
 
 let frame_descriptors = ref ([] : frame_descr list)
+
+(* Bumped by the backends whenever they switch to a different text section, so
+   [record_frame_descr] can tag each descriptor with its section. *)
+let frame_section_epoch = ref 0
+
+let start_new_code_section () = incr frame_section_epoch
 
 let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d)
 
@@ -88,7 +100,8 @@ let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
          fd_frame_size = frame_size;
          fd_live_offset = List.sort_uniq ( - ) live_offset;
          fd_debuginfo = debuginfo;
-         fd_long
+         fd_long;
+         fd_section = !frame_section_epoch
        }
        :: !frame_descriptors
 
@@ -104,6 +117,12 @@ type emit_frame_actions =
     efa_word : int -> unit;
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
+    efa_label_delta : Label.t -> Label.t -> unit;
+    (* [efa_label_delta upper lower] emits the variable-width return-address
+       delta of a "small" frame descriptor: the difference [upper - lower] in
+       a single byte when it fits 1..254, otherwise a 0xFF marker followed by
+       a 16-bit little-endian value. The two labels are return addresses in
+       the text section. *)
     efa_def_label : Label.t -> unit;
     efa_string : string -> unit
   }
@@ -179,7 +198,27 @@ let emit_frames a =
       Label_table.add debuginfos key lbl;
       lbl
   in
-  let emit_frame fd =
+  (* Emit the debuginfo words. These are identical in the normal and small
+     descriptor layouts: present iff the debug flag is set, one word per
+     allocation for an alloc descriptor, otherwise one word. *)
+  let emit_debug_words fd =
+    match fd.fd_debuginfo with
+    | _ when get_flags fd.fd_debuginfo = 0 -> ()
+    | Dbg_other dbg -> a.efa_label_rel (label_debuginfos false dbg) Int32.zero
+    | Dbg_raise dbg -> a.efa_label_rel (label_debuginfos true dbg) Int32.zero
+    | Dbg_alloc dbg ->
+      if get_flags fd.fd_debuginfo = 3
+      then
+        List.iter
+          (fun Cmm.{ alloc_dbg; _ } ->
+            if is_none_dbg alloc_dbg
+            then emit_i32 0
+            else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
+          dbg
+  in
+  (* Emit one descriptor in the existing normal/long format, with no leading
+     delta byte. Used as the body following a 0 (escape) delta byte. *)
+  let emit_escaped_frame fd =
     let flags = get_flags fd.fd_debuginfo in
     a.efa_label_rel fd.fd_lbl 0l;
     (* For short format, the size is guaranteed to be less than the constant
@@ -221,6 +260,114 @@ let emit_frames a =
             then emit_i32 0
             else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
           dbg
+  in
+  (* Partition live offsets into live registers (low bit 1, value >>1 is the
+     register number) and live stack-slot byte offsets (low bit 0). See
+     [compute_live_offset] in the backends. *)
+  let partition_live_offset live =
+    List.partition_map
+      (fun n -> if n land 1 = 1 then Either.Left (n lsr 1) else Either.Right n)
+      live
+  in
+  (* Register-number -> hot-bitmap-bit-index. This is the inverse of
+     [caml_frame_hot_regs] in runtime/caml/frame_descriptors.h; the compiler
+     and the runtime MUST agree exactly or the GC scans the wrong registers
+     (silent heap corruption). *)
+  let hot_regs = [| 0; 1; 2; 3; 4; 5; 6; 8 |] in
+  let hot_reg_bit reg =
+    let rec find i =
+      if i >= Array.length hot_regs
+      then None
+      else if hot_regs.(i) = reg
+      then Some i
+      else find (i + 1)
+    in
+    find 0
+  in
+  (* Compute the small-format encoding of a descriptor, or [None] if it must
+     escape. Result:
+     [(size_units_minus_1, num_allocs, alloc_nibbles, reg_bitmap, word_slots)] *)
+  let small_encoding fd =
+    let flags = get_flags fd.fd_debuginfo in
+    let has_alloc = flags land 2 <> 0 in
+    let size = fd.fd_frame_size in
+    if fd.fd_long || size <= 0 || size > 1024 || size land 15 <> 0
+    then None
+    else
+      let regs, slots = partition_live_offset fd.fd_live_offset in
+      let word_slots =
+        List.filter_map
+          (fun byte_ofs ->
+            if byte_ofs land (Arch.size_addr - 1) <> 0
+            then Some None
+            else
+              let w = byte_ofs / Arch.size_addr in
+              Some (if w > 255 then None else Some w))
+          slots
+      in
+      let bad_slot = List.exists Option.is_none word_slots in
+      let word_slots = List.filter_map Fun.id word_slots in
+      if bad_slot || List.length word_slots > 255
+      then None
+      else if (not has_alloc) && not (Misc.Stdlib.List.is_empty regs)
+      then None
+      else
+        let reg_bits =
+          List.fold_left
+            (fun acc reg ->
+              match acc with
+              | None -> None
+              | Some bits -> (
+                match hot_reg_bit reg with
+                | None -> None
+                | Some b -> Some (bits lor (1 lsl b))))
+            (Some 0) regs
+        in
+        match reg_bits with
+        | None -> None
+        | Some reg_bitmap -> (
+          let num_allocs, alloc_nibbles =
+            match fd.fd_debuginfo with
+            | Dbg_alloc dbg ->
+              let sizes =
+                List.map (fun Cmm.{ alloc_words; _ } -> alloc_words - 2) dbg
+              in
+              List.length sizes, sizes
+            | Dbg_other _ | Dbg_raise _ -> 0, []
+          in
+          if num_allocs > 255
+             || List.exists (fun s -> s < 0 || s > 15) alloc_nibbles
+          then None
+          else
+            Some
+              ( (size / 16) - 1,
+                num_allocs,
+                alloc_nibbles,
+                reg_bitmap,
+                word_slots ))
+  in
+  (* Emit a small descriptor body (after its leading delta byte/bytes). *)
+  let emit_small_body fd
+      (size_units_minus_1, num_allocs, alloc_nibbles, reg_bitmap, word_slots) =
+    let flags = get_flags fd.fd_debuginfo in
+    let has_alloc = flags land 2 <> 0 in
+    emit_u8 ((size_units_minus_1 lsl 2) lor flags);
+    if has_alloc
+    then (
+      emit_u8 num_allocs;
+      emit_u8 (List.length word_slots);
+      let rec emit_nibbles = function
+        | [] -> ()
+        | [a] -> emit_u8 (a land 0xf)
+        | a :: b :: rest ->
+          emit_u8 ((a land 0xf) lor ((b land 0xf) lsl 4));
+          emit_nibbles rest
+      in
+      emit_nibbles alloc_nibbles;
+      emit_u8 reg_bitmap)
+    else emit_u8 (List.length word_slots);
+    List.iter emit_u8 word_slots;
+    emit_debug_words fd
   in
   let emit_filename name lbl =
     a.efa_def_label lbl;
@@ -336,7 +483,33 @@ let emit_frames a =
      emit the frame table in increasing return-address order. *)
   let descrs = List.rev !frame_descriptors in
   a.efa_word (List.length descrs);
-  List.iter emit_frame descrs;
+  (* Emit each descriptor preceded by a delta byte. The first descriptor of
+     the frametable, and any descriptor that does not fit the small format,
+     escapes: a 0 delta byte followed by the existing normal/long descriptor
+     (which carries its own absolute return address). A small descriptor is
+     preceded by its return-address delta from the previous descriptor. *)
+  let emit_descr prev fd =
+    let escape () =
+      emit_u8 0;
+      emit_escaped_frame fd;
+      Some fd
+    in
+    match prev with
+    | Some prev_fd when prev_fd.fd_section = fd.fd_section -> (
+      (* Same text section as the previous descriptor, so the delta is an
+         assembly-time constant. *)
+      match small_encoding fd with
+      | Some enc ->
+        a.efa_label_delta fd.fd_lbl prev_fd.fd_lbl;
+        emit_small_body fd enc;
+        Some fd
+      | None -> escape ())
+    | Some _ | None ->
+      (* First descriptor of the frametable, or first of a new text section
+         (no same-section previous return address for a delta): escape. *)
+      escape ()
+  in
+  ignore (List.fold_left emit_descr None descrs);
   Label_table.iter emit_debuginfo debuginfos;
   Hashtbl.iter emit_filename filenames;
   Hashtbl.iter emit_defname defnames;

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -63,6 +63,12 @@ let frame_section_epoch = ref 0
 
 let start_new_code_section () = incr frame_section_epoch
 
+(* Set by a backend before [emit_frames] when the small descriptor format cannot be
+   emitted in the current context: internal-assembler (which cannot resolve the
+   variable-length return-address delta directive) and ARM64 (where the delta is not yet
+   ported). Every descriptor then escapes to the normal format. *)
+let disable_small_descriptors = ref false
+
 let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d)
 
 let get_flags debuginfo =
@@ -119,10 +125,7 @@ type emit_frame_actions =
     efa_label_rel : Label.t -> int32 -> unit;
     efa_label_delta : Label.t -> Label.t -> unit;
     (* [efa_label_delta upper lower] emits the variable-width return-address
-       delta of a "small" frame descriptor: the difference [upper - lower] in
-       a single byte when it fits 1..254, otherwise a 0xFF marker followed by
-       a 16-bit little-endian value. The two labels are return addresses in
-       the text section. *)
+       delta of a "small" frame descriptor, as a ULEB128 constant. *)
     efa_def_label : Label.t -> unit;
     efa_string : string -> unit;
     (* Switch to / from a mergeable string section (SHF_MERGE|SHF_STRINGS), used
@@ -295,9 +298,9 @@ let emit_frames a =
       live
   in
   (* Register-number -> hot-bitmap-bit-index. This is the inverse of
-     [caml_frame_hot_regs] in runtime/caml/frame_descriptors.h; the compiler
-     and the runtime MUST agree exactly or the GC scans the wrong registers
-     (silent heap corruption). *)
+     [caml_frame_hot_regs] in runtime/caml/frame_descriptors.h; the compiler and
+     the runtime MUST agree exactly or the GC scans the wrong registers (silent
+     heap corruption). *)
   let hot_regs = [| 0; 1; 2; 3; 4; 5; 6; 8 |] in
   let hot_reg_bit reg =
     let rec find i =
@@ -310,8 +313,8 @@ let emit_frames a =
     find 0
   in
   (* Compute the small-format encoding of a descriptor, or [None] if it must
-     escape. Result:
-     [(size_units_minus_1, num_allocs, alloc_nibbles, reg_bitmap, word_slots)] *)
+     escape. Result: [(size_units_minus_1, num_allocs, alloc_nibbles,
+     reg_bitmap, word_slots)] *)
   let small_encoding fd =
     let flags = get_flags fd.fd_debuginfo in
     let has_alloc = flags land 2 <> 0 in
@@ -350,7 +353,7 @@ let emit_frames a =
         in
         match reg_bits with
         | None -> None
-        | Some reg_bitmap -> (
+        | Some reg_bitmap ->
           let num_allocs, alloc_nibbles =
             match fd.fd_debuginfo with
             | Dbg_alloc dbg ->
@@ -360,8 +363,9 @@ let emit_frames a =
               List.length sizes, sizes
             | Dbg_other _ | Dbg_raise _ -> 0, []
           in
-          if num_allocs > 255
-             || List.exists (fun s -> s < 0 || s > 15) alloc_nibbles
+          if
+            num_allocs > 255
+            || List.exists (fun s -> s < 0 || s > 15) alloc_nibbles
           then None
           else
             Some
@@ -369,7 +373,7 @@ let emit_frames a =
                 num_allocs,
                 alloc_nibbles,
                 reg_bitmap,
-                word_slots ))
+                word_slots )
   in
   (* Emit a small descriptor body (after its leading delta byte/bytes). *)
   let emit_small_body fd
@@ -385,7 +389,7 @@ let emit_frames a =
         | [] -> ()
         | [a] -> emit_u8 (a land 0xf)
         | a :: b :: rest ->
-          emit_u8 ((a land 0xf) lor ((b land 0xf) lsl 4));
+          emit_u8 (a land 0xf lor ((b land 0xf) lsl 4));
           emit_nibbles rest
       in
       emit_nibbles alloc_nibbles;
@@ -509,31 +513,34 @@ let emit_frames a =
      emit the frame table in increasing return-address order. *)
   let descrs = List.rev !frame_descriptors in
   a.efa_word (List.length descrs);
-  (* Emit each descriptor preceded by a delta byte. The first descriptor of
-     the frametable, and any descriptor that does not fit the small format,
-     escapes: a 0 delta byte followed by the existing normal/long descriptor
-     (which carries its own absolute return address). A small descriptor is
-     preceded by its return-address delta from the previous descriptor. *)
+  (* Emit each descriptor preceded by retaddr delta. The first descriptor of the
+     frametable, and any descriptor that does not fit the small format, escapes:
+     a 0 delta byte followed by the existing normal/long descriptor (which
+     carries its own relative return address). A small descriptor is preceded by
+     its return-address delta from the previous descriptor, as ULEB128. *)
   let emit_descr prev fd =
     let escape () =
       emit_u8 0;
       emit_escaped_frame fd;
       Some fd
     in
-    match prev with
-    | Some prev_fd when prev_fd.fd_section = fd.fd_section -> (
-      (* Same text section as the previous descriptor, so the delta is an
-         assembly-time constant. *)
-      match small_encoding fd with
-      | Some enc ->
-        a.efa_label_delta fd.fd_lbl prev_fd.fd_lbl;
-        emit_small_body fd enc;
-        Some fd
-      | None -> escape ())
-    | Some _ | None ->
-      (* First descriptor of the frametable, or first of a new text section
-         (no same-section previous return address for a delta): escape. *)
-      escape ()
+    if !disable_small_descriptors
+    then escape ()
+    else
+      match prev with
+      | Some prev_fd when prev_fd.fd_section = fd.fd_section -> (
+        (* Same text section as the previous descriptor, so the delta is an
+           assembly-time constant. *)
+        match small_encoding fd with
+        | Some enc ->
+          a.efa_label_delta fd.fd_lbl prev_fd.fd_lbl;
+          emit_small_body fd enc;
+          Some fd
+        | None -> escape ())
+      | Some _ | None ->
+        (* First descriptor of the frametable, or first of a new text section
+           (no same-section previous return address for a delta): escape. *)
+        escape ()
   in
   ignore (List.fold_left emit_descr None descrs);
   Label_table.iter emit_debuginfo debuginfos;

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -187,7 +187,10 @@ let emit_frames a =
     if fd.fd_long
     then (
       emit_u16 Oxcaml_flags.max_long_frames_threshold;
-      a.efa_align 4);
+      (* Explicit 2-byte pad (formerly [efa_align 4]) keeps
+         [frame_descr_long.frame_data] at struct offset 8 now that frame
+         descriptors are no longer aligned. *)
+      emit_u16 0);
     let emit_unsigned_16_or_32 = if fd.fd_long then emit_u32 else emit_u16 in
     (* The live offsets are always unsigned. *)
     let emit_live_offset n = emit_unsigned_16_or_32 n in
@@ -197,10 +200,8 @@ let emit_frames a =
     (match fd.fd_debuginfo with
     | _ when flags = 0 -> ()
     | Dbg_other dbg ->
-      a.efa_align 4;
       a.efa_label_rel (label_debuginfos false dbg) Int32.zero
     | Dbg_raise dbg ->
-      a.efa_align 4;
       a.efa_label_rel (label_debuginfos true dbg) Int32.zero
     | Dbg_alloc dbg ->
       assert (List.length dbg < 256);
@@ -215,15 +216,13 @@ let emit_frames a =
           emit_u8 (alloc_words - 2))
         dbg;
       if flags = 3
-      then (
-        a.efa_align 4;
+      then
         List.iter
           (fun Cmm.{ alloc_dbg; _ } ->
             if is_none_dbg alloc_dbg
             then emit_i32 0
             else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
-          dbg));
-    a.efa_align Arch.size_addr
+          dbg)
   in
   let emit_filename name lbl =
     a.efa_def_label lbl;

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -197,12 +197,10 @@ let emit_frames a =
     emit_unsigned_16_or_32 (fd.fd_frame_size + flags);
     emit_unsigned_16_or_32 (List.length fd.fd_live_offset);
     List.iter emit_live_offset fd.fd_live_offset;
-    (match fd.fd_debuginfo with
+    match fd.fd_debuginfo with
     | _ when flags = 0 -> ()
-    | Dbg_other dbg ->
-      a.efa_label_rel (label_debuginfos false dbg) Int32.zero
-    | Dbg_raise dbg ->
-      a.efa_label_rel (label_debuginfos true dbg) Int32.zero
+    | Dbg_other dbg -> a.efa_label_rel (label_debuginfos false dbg) Int32.zero
+    | Dbg_raise dbg -> a.efa_label_rel (label_debuginfos true dbg) Int32.zero
     | Dbg_alloc dbg ->
       assert (List.length dbg < 256);
       emit_u8 (List.length dbg);
@@ -222,7 +220,7 @@ let emit_frames a =
             if is_none_dbg alloc_dbg
             then emit_i32 0
             else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
-          dbg)
+          dbg
   in
   let emit_filename name lbl =
     a.efa_def_label lbl;

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -63,10 +63,11 @@ let frame_section_epoch = ref 0
 
 let start_new_code_section () = incr frame_section_epoch
 
-(* Set by a backend before [emit_frames] when the small descriptor format cannot be
-   emitted in the current context: internal-assembler (which cannot resolve the
-   variable-length return-address delta directive) and ARM64 (where the delta is not yet
-   ported). Every descriptor then escapes to the normal format. *)
+(* Set by a backend before [emit_frames] when the small descriptor format cannot
+   be emitted in the current context: internal-assembler (which cannot resolve
+   the variable-length return-address delta directive) and ARM64 (where the
+   delta is not yet ported). Every descriptor then escapes to the normal
+   format. *)
 let disable_small_descriptors = ref false
 
 let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d)
@@ -381,10 +382,13 @@ let emit_frames a =
     let flags = get_flags fd.fd_debuginfo in
     let has_alloc = flags land 2 <> 0 in
     emit_u8 ((size_units_minus_1 lsl 2) lor flags);
+    (* Order: reg_bitmap, num_allocs, alloc sizes, num_live -- so num_allocs is
+       immediately followed by its alloc sizes, and num_live (here or in the
+       no-alloc branch) is immediately followed by the live stack slots. *)
     if has_alloc
     then (
+      emit_u8 reg_bitmap;
       emit_u8 num_allocs;
-      emit_u8 (List.length word_slots);
       let rec emit_nibbles = function
         | [] -> ()
         | [a] -> emit_u8 (a land 0xf)
@@ -393,7 +397,7 @@ let emit_frames a =
           emit_nibbles rest
       in
       emit_nibbles alloc_nibbles;
-      emit_u8 reg_bitmap)
+      emit_u8 (List.length word_slots))
     else emit_u8 (List.length word_slots);
     List.iter emit_u8 word_slots;
     emit_debug_words fd

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -410,19 +410,19 @@ let emit_frames a =
     in
     (* The name_info / name_and_loc_info struct. Must be 32-bit aligned, both
        because it contains 32-bit values and because emit_debuginfo assumes the
-       low 2 bits of its address are 0. The defname string is emitted separately
-       into the mergeable string section; [defname_offs] points at it, stored
-       relative to the start of the struct (like [filename_offs]), so the
-       [efa_label_rel] addend is the field's byte offset within the struct. *)
+       low 2 bits of its address are 0. *)
     a.efa_align 4;
     a.efa_def_label lbl;
     a.efa_label_rel file_lbl 0l;
-    (* Include the additional 64-bits of location information which didn't pack
-       in the main 64-bit word *)
-    Option.iter emit_loc loc;
-    let defname_field_offset = match loc with None -> 4 | Some _ -> 12 in
-    a.efa_label_rel (label_defstring defname)
-      (Int32.of_int defname_field_offset)
+    (* [defname_offs] immediately follows [filename_offs] (offset 4) in both
+       struct formats, so it is at a fixed offset regardless of [loc]. The
+       defname string is emitted into the mergeable string section; the offset
+       is stored relative to the start of the struct, so the [efa_label_rel]
+       addend is the field's byte offset (4). *)
+    a.efa_label_rel (label_defstring defname) 4l;
+    (* Then the extra 64 bits of location info that didn't pack into the main
+       debuginfo word (name_and_loc_info only). *)
+    Option.iter emit_loc loc
   in
   let fully_pack_info fd_raise d has_next =
     (* See format in caml_debuginfo_location in runtime/backtrace-nat.c *)

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -69,7 +69,15 @@ type emit_frame_actions =
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
     efa_def_label : Label.t -> unit;
-    efa_string : string -> unit
+    efa_string : string -> unit;
+    (* Switch to / from a mergeable string section (SHF_MERGE|SHF_STRINGS), used
+       to emit the deduplicable debuginfo filename and defname strings. While it
+       is open, [efa_def_string_label] defines a label there (and [efa_string]
+       emits into it); references from the frame table section back to those
+       labels still use [efa_label_rel]. *)
+    efa_open_string_section : unit -> unit;
+    efa_close_string_section : unit -> unit;
+    efa_def_string_label : Label.t -> unit
   }
 
 val emit_frames : emit_frame_actions -> unit

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -60,6 +60,11 @@ val record_frame_descr :
     switch text section. *)
 val start_new_code_section : unit -> unit
 
+(* When set before [emit_frames], every frame descriptor escapes to the normal
+   format instead of the small encoding. Backends set this when the small format
+   cannot be emitted (the internal-assembler / JIT binary backend; ARM64). *)
+val disable_small_descriptors : bool ref
+
 (** [with_snapshot f] runs [f] and returns its result, but also ensures that the
     state of this [Emitaux] module is unchanged after [f] returns. *)
 val with_snapshot : f:(unit -> 'a) -> 'a

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -52,6 +52,14 @@ val record_frame_descr :
   (* Location, if any *)
   unit
 
+(** Signals that subsequent frame descriptors' return addresses live in a new
+    text section. A "small" frame descriptor encodes its return address as a
+    delta from the previous descriptor's; that delta is only an assembly-time
+    constant when both are in the same section, so descriptors at a section
+    boundary escape to the full format. The backends call this whenever they
+    switch text section. *)
+val start_new_code_section : unit -> unit
+
 (** [with_snapshot f] runs [f] and returns its result, but also ensures that the
     state of this [Emitaux] module is unchanged after [f] returns. *)
 val with_snapshot : f:(unit -> 'a) -> 'a
@@ -68,6 +76,7 @@ type emit_frame_actions =
     efa_word : int -> unit;
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
+    efa_label_delta : Label.t -> Label.t -> unit;
     efa_def_label : Label.t -> unit;
     efa_string : string -> unit
   }

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1635,15 +1635,16 @@ let assemble_line b loc ins =
             buf_int8 b 0
           done
     | Directive (D.Hidden _) | Directive D.New_line -> ()
-    | Directive (D.Frame_descr_delta { delta }) ->
-      (* Always use the wide encoding here (0xFF marker + 16-bit delta): the
-         runtime decodes either form, and the fixed 3-byte size keeps the
-         binary emitter's per-section layout simple. The 16-bit value is the
-         (same-section) label difference, resolved by the relocation pass
-         (mirrors the [Sixteen] case of [constant]). *)
-      buf_int8 b 0xFF;
-      record_local_reloc b (RelocConstant (delta, B16));
-      buf_int16L b 0L
+    | Directive (D.Frame_descr_delta _) ->
+      (* The internal assembler does not support the small frame-descriptor
+         format's return-address delta, so the compiler escapes every
+         descriptor when the internal-assembler backend is active (see
+         [Emitaux.disable_small_descriptors]); this directive is therefore
+         never emitted here. TODO: fix this. Claude tried and failed
+         2026-06-30. *)
+      Misc.fatal_error
+        "x86_binary_emitter: Frame_descr_delta unsupported (small descriptors \
+         must be escaped under the internal assembler)"
     | Directive
         (D.Reloc
           { name = D.R_X86_64_PLT32;

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1635,6 +1635,15 @@ let assemble_line b loc ins =
             buf_int8 b 0
           done
     | Directive (D.Hidden _) | Directive D.New_line -> ()
+    | Directive (D.Frame_descr_delta { delta }) ->
+      (* Always use the wide encoding here (0xFF marker + 16-bit delta): the
+         runtime decodes either form, and the fixed 3-byte size keeps the
+         binary emitter's per-section layout simple. The 16-bit value is the
+         (same-section) label difference, resolved by the relocation pass
+         (mirrors the [Sixteen] case of [constant]). *)
+      buf_int8 b 0xFF;
+      record_local_reloc b (RelocConstant (delta, B16));
+      buf_int16L b 0L
     | Directive
         (D.Reloc
           { name = D.R_X86_64_PLT32;

--- a/backend/x86_peephole/x86_peephole_utils.ml
+++ b/backend/x86_peephole/x86_peephole_utils.ml
@@ -29,7 +29,7 @@ let is_hard_barrier = function
     | Comment _ | Const _ | Direct_assignment _ | File _ | Global _
     | Indirect_symbol _ | Loc _ | New_line | Private_extern _ | Size _
     | Sleb128 _ | Space _ | Type _ | Uleb128 _ | Protected _ | Hidden _ | Weak _
-    | External _ | Reloc _ ->
+    | External _ | Reloc _ | Frame_descr_delta _ ->
       false)
   | Ins instr -> is_control_flow instr
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1764,6 +1764,15 @@ G(caml_system__frametable):
         .value  -1                      /* negative frame size => use callback link */
         .value  0                       /* no roots here */
 
+/* Contribute this hand-written frametable to the linker-collected
+   caml_all_frametables table, so the runtime "measure all frametables" pass
+   sees it alongside the compiler-emitted ones. ELF targets only. */
+#if !defined(SYS_macosx) && !defined(SYS_mingw64) && !defined(SYS_cygwin)
+        .section caml_all_frametables,"aw",@progbits
+        .align  EIGHT_ALIGN
+        .quad   G(caml_system__frametable)
+#endif
+
 #if defined(SYS_macosx)
         .literal16
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1756,11 +1756,18 @@ G(caml_system__code_end):
         .align  EIGHT_ALIGN
 G(caml_system__frametable):
         .quad   2            /* two descriptors */
+        /* Each descriptor is preceded by a "delta" byte. These return-to-C
+           descriptors do not fit the "small" format, so each escapes: a 0
+           delta byte followed by a descriptor in the normal format (which
+           carries its own absolute return address). See frame_descriptors.h. */
+        .byte   0            /* escape: normal descriptor follows */
         .4byte  LBL(108) - . /* return address into callback */
         .value  -1           /* negative frame size => use callback link */
         .value  0            /* no roots here */
         /* Frame descriptors are packed: no inter-descriptor alignment. The
-           two descriptors above and below are exactly 8 bytes each. */
+           two descriptors above and below are exactly 8 bytes each (plus the
+           1-byte escape prefix). */
+        .byte   0            /* escape: normal descriptor follows */
         .4byte  LBL(frame_runstack) - . /* return address into fiber_val_handler */
         .value  -1                      /* negative frame size => use callback link */
         .value  0                       /* no roots here */

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1759,7 +1759,8 @@ G(caml_system__frametable):
         .4byte  LBL(108) - . /* return address into callback */
         .value  -1           /* negative frame size => use callback link */
         .value  0            /* no roots here */
-        .align  EIGHT_ALIGN
+        /* Frame descriptors are packed: no inter-descriptor alignment. The
+           two descriptors above and below are exactly 8 bytes each. */
         .4byte  LBL(frame_runstack) - . /* return address into fiber_val_handler */
         .value  -1                      /* negative frame size => use callback link */
         .value  0                       /* no roots here */

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -609,3 +609,19 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
   /* No inlining in bytecode */
   return NULL;
 }
+
+void caml_debuginfo_reset(void)
+{
+}
+
+void caml_debuginfo_measure(debuginfo dbg)
+{
+  (void)dbg;
+}
+
+void caml_debuginfo_measurements(size_t *count_p, char **low_p, char **high_p)
+{
+  (void)count_p;
+  (void)low_p;
+  (void)high_p;
+}

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -498,16 +498,17 @@ void caml_debuginfo_measure(debuginfo dbg)
 {
   uint32_t info1, info2;
 
-  /* Control flow to match caml_debuginfo_location.
-     The defname and filename strings are no longer measured here: they live in
-     a separate mergeable string section (deduplicated across compilation units
-     by the linker), so they cannot be attributed to a single frametable. This
-     measures only the debuginfo words and the name_info/name_and_loc_info
-     structs. */
+  /* Control flow to match caml_debuginfo_location. For each debuginfo record
+     we bump the record count and bracket the referenced
+     name_info/name_and_loc_info struct into [debuginfo_low, debuginfo_high).
+     The debuginfo words themselves are accounted for by the count (each record
+     is two 32-bit words); only the structs contribute to the low/high span.
+     The defname and filename strings are not measured: they live in a separate
+     mergeable string section (deduplicated across compilation units by the
+     linker), so they cannot be attributed to a single frametable. */
   if (dbg == NULL) {
     return;
   }
-  include_low((char*)dbg);
 
   do {
     info1 = caml_read_unaligned_uint32(dbg);
@@ -527,7 +528,6 @@ void caml_debuginfo_measure(debuginfo dbg)
     }
     dbg = (debuginfo)((uint32_t*)dbg + 2);
   } while (info1 & 1);
-  include_high(dbg);
 }
 
 value caml_add_debug_info(backtrace_slot start, value size, value events)

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -311,14 +311,14 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
     /* find debug info for this allocation */
     if (alloc_idx >= 0) {
       infoptr += alloc_idx * sizeof(uint32_t);
-      if (*(uint32_t*)infoptr == 0) {
+      if (caml_read_unaligned_uint32(infoptr) == 0) {
         /* No debug info for this particular allocation */
         return NULL;
       }
     } else {
       /* we know there's at least one valid debuginfo,
          but it may not be the one for the first alloc */
-      while (*(uint32_t*)infoptr == 0) {
+      while (caml_read_unaligned_uint32(infoptr) == 0) {
         infoptr += sizeof(uint32_t);
       }
     }
@@ -328,7 +328,7 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
     CAMLassert(alloc_idx == -1);
   }
   /* read offset to debuginfo */
-  debuginfo_offset = *(uint32_t*)infoptr;
+  debuginfo_offset = caml_read_unaligned_uint32(infoptr);
   return (debuginfo)(infoptr + debuginfo_offset);
 }
 
@@ -350,7 +350,7 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
     return NULL;
 
   infoptr = dbg;
-  if ((infoptr[0] & 1) == 0)
+  if ((caml_read_unaligned_uint32(infoptr) & 1) == 0)
     /* No next debuginfo */
     return NULL;
   else
@@ -390,8 +390,8 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
     return;
   }
   /* Recover debugging info */
-  info1 = ((uint32_t *)dbg)[0];
-  info2 = ((uint32_t *)dbg)[1];
+  info1 = caml_read_unaligned_uint32(dbg);
+  info2 = caml_read_unaligned_uint32((const uint32_t *)dbg + 1);
   /* Format of the two info words:
      Two possible formats based on value of bit 63:
      Partially packed format
@@ -423,18 +423,21 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
       (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
     li->loc_defname = name_and_loc_info->name;
     li->loc_filename =
-      (char *)name_and_loc_info + name_and_loc_info->filename_offs;
+      (char *)name_and_loc_info
+      + caml_read_unaligned_int32(&name_and_loc_info->filename_offs);
     li->loc_start_lnum = li->loc_end_lnum = (info2 >> 12) & 0x7FFFF;
     li->loc_end_lnum += ((info2 & 0xFFF) << 6) | (info1 >> 26);
-    li->loc_start_chr = name_and_loc_info->start_chr;
-    li->loc_end_chr = name_and_loc_info->end_chr;
-    li->loc_end_offset = name_and_loc_info->end_offset;
+    li->loc_start_chr = caml_read_unaligned_uint16(&name_and_loc_info->start_chr);
+    li->loc_end_chr = caml_read_unaligned_uint16(&name_and_loc_info->end_chr);
+    li->loc_end_offset =
+      caml_read_unaligned_int32(&name_and_loc_info->end_offset);
   } else {
     struct name_info * name_info =
       (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
     li->loc_defname = name_info->name;
     li->loc_filename =
-      (char *)name_info + name_info->filename_offs;
+      (char *)name_info
+      + caml_read_unaligned_int32(&name_info->filename_offs);
     li->loc_start_lnum = li->loc_end_lnum = info2 >> 19; /* l */
     li->loc_end_lnum += (info2 >> 16) & 0x7;             /* m */
     li->loc_start_chr = (info2 >> 10) & 0x3F;            /* a */
@@ -494,8 +497,8 @@ void caml_debuginfo_measure(debuginfo dbg)
   include_low((char*)dbg);
 
   do {
-    info1 = ((uint32_t *)dbg)[0];
-    info2 = ((uint32_t *)dbg)[1];
+    info1 = caml_read_unaligned_uint32(dbg);
+    info2 = caml_read_unaligned_uint32((const uint32_t *)dbg + 1);
     ++debuginfo_count;
 
     if (info2 & 0x80000000) {
@@ -504,14 +507,15 @@ void caml_debuginfo_measure(debuginfo dbg)
       include_low((char*)name_and_loc_info);
       include_string(name_and_loc_info->name);
       include_string((char *)name_and_loc_info
-                     + name_and_loc_info->filename_offs);
+                     + caml_read_unaligned_int32(
+                         &name_and_loc_info->filename_offs));
     } else {
       struct name_info * name_info =
         (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
       include_low((char*)name_info);
       include_string(name_info->name);
       include_string((char *)name_info
-                     + name_info->filename_offs);
+                     + caml_read_unaligned_int32(&name_info->filename_offs));
     }
     dbg = (debuginfo)((uint32_t*)dbg + 2);
   } while (info1 & 1);

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -435,12 +435,87 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
     li->loc_defname = name_info->name;
     li->loc_filename =
       (char *)name_info + name_info->filename_offs;
-    li->loc_start_lnum = li->loc_end_lnum = info2 >> 19;
-    li->loc_end_lnum += (info2 >> 16) & 0x7;
-    li->loc_start_chr = (info2 >> 10) & 0x3F;
-    li->loc_end_chr = li->loc_end_offset = (info2 >> 3) & 0x7F;
-    li->loc_end_offset += (((info2 & 0x7) << 6) | (info1 >> 26));
+    li->loc_start_lnum = li->loc_end_lnum = info2 >> 19; /* l */
+    li->loc_end_lnum += (info2 >> 16) & 0x7;             /* m */
+    li->loc_start_chr = (info2 >> 10) & 0x3F;            /* a */
+    li->loc_end_chr = li->loc_end_offset = (info2 >> 3) & 0x7F; /* b */
+    li->loc_end_offset += (((info2 & 0x7) << 6) | (info1 >> 26)); /* o */
   }
+}
+
+/* ---- Debuginfo measurement ---- */
+
+static size_t debuginfo_count = 0; /* Number of debuginfo records seen */
+static void* debuginfo_low = NULL; /* lowest address seen */
+static void* debuginfo_high = NULL; /* highest address seen */
+
+void caml_debuginfo_reset(void)
+{
+  debuginfo_count = 0;
+  debuginfo_low = NULL;
+  debuginfo_high = NULL;
+}
+
+void caml_debuginfo_measurements(size_t *count_p, char **low_p, char **high_p)
+{
+  *count_p = debuginfo_count;
+  *low_p = debuginfo_low;
+  *high_p = debuginfo_high;
+  caml_debuginfo_reset();
+}
+
+static void include_low(char *low)
+{
+  if ((debuginfo_low == NULL) || (low < (char *)debuginfo_low))
+    debuginfo_low = low;
+}
+
+static void include_high(char *high)
+{
+  if ((debuginfo_high == NULL) || (high > (char *)debuginfo_high))
+    debuginfo_high = high;
+}
+
+
+static void include_string(char *s)
+{
+  include_low(s);
+  include_high(s + strlen(s) + 1);
+}
+
+void caml_debuginfo_measure(debuginfo dbg)
+{
+  uint32_t info1, info2;
+
+  /* Control flow to match caml_debuginfo_location */
+  if (dbg == NULL) {
+    return;
+  }
+  include_low((char*)dbg);
+
+  do {
+    info1 = ((uint32_t *)dbg)[0];
+    info2 = ((uint32_t *)dbg)[1];
+    ++debuginfo_count;
+
+    if (info2 & 0x80000000) {
+      struct name_and_loc_info * name_and_loc_info =
+        (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
+      include_low((char*)name_and_loc_info);
+      include_string(name_and_loc_info->name);
+      include_string((char *)name_and_loc_info
+                     + name_and_loc_info->filename_offs);
+    } else {
+      struct name_info * name_info =
+        (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
+      include_low((char*)name_info);
+      include_string(name_info->name);
+      include_string((char *)name_info
+                     + name_info->filename_offs);
+    }
+    dbg = (debuginfo)((uint32_t*)dbg + 2);
+  } while (info1 & 1);
+  include_high(dbg);
 }
 
 value caml_add_debug_info(backtrace_slot start, value size, value events)

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -298,6 +298,7 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
 {
   unsigned char* infoptr;
   uint32_t debuginfo_offset;
+  struct frame_descr_decoded dec;
 
   /* The special frames marking returns from Caml to C are never
      returned by caml_next_frame_descriptor, so should never reach
@@ -307,11 +308,16 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
   if (!frame_has_debug(d)) {
     return NULL;
   }
-  /* Recover debugging info */
-  infoptr = frame_end_of_live_ofs(d);
+  /* Recover debugging info. The debug words begin right after the live
+     offsets (small format) or after the alloc lengths (escaped format);
+     [caml_decode_frame_descr] gives us the precise start. */
+  caml_decode_frame_descr(d, &dec);
+  infoptr = (unsigned char *)dec.end_of_live;
   if (frame_has_allocs(d)) {
-    /* skip alloc_lengths */
-    infoptr += *infoptr + 1;
+    if (!dec.is_small) {
+      /* escaped: skip the num_allocs byte and the alloc bytes */
+      infoptr += *infoptr + 1;
+    }
     /* find debug info for this allocation */
     if (alloc_idx >= 0) {
       infoptr += alloc_idx * sizeof(uint32_t);

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -83,12 +83,18 @@ void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer) {
     caml_stat_free(backtrace_buffer);
 }
 
-/* A backtrace_slot is either a debuginfo or a frame_descr* */
+/* A backtrace_slot is either a frame_descr* or a debuginfo. Both are encoded
+   with the address shifted left two bits, leaving the low two bits free for a
+   tag: bit 1 distinguishes a debuginfo (set) from a frame_descr (clear), and
+   bit 0 is kept clear so the [>>1] in [Val_backtrace_slot] still round-trips
+   (and the bytecode backtrace encoding is unaffected). The shift means frame
+   descriptors no longer need to be aligned. 64-bit only: there are ample
+   spare high bits for the shift. */
 #define Slot_is_debuginfo(s) ((uintnat)(s) & 2)
-#define Debuginfo_slot(s) ((debuginfo)((uintnat)(s) - 2))
-#define Slot_debuginfo(d) ((backtrace_slot)((uintnat)(d) + 2))
-#define Frame_descr_slot(s) ((frame_descr*)(s))
-#define Slot_frame_descr(f) ((backtrace_slot)(f))
+#define Debuginfo_slot(s) ((debuginfo)((uintnat)(s) >> 2))
+#define Slot_debuginfo(d) ((backtrace_slot)(((uintnat)(d) << 2) | 2))
+#define Frame_descr_slot(s) ((frame_descr*)((uintnat)(s) >> 2))
+#define Slot_frame_descr(f) ((backtrace_slot)((uintnat)(f) << 2))
 
 static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx);
 
@@ -126,7 +132,7 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, const char* trapsp)
     /* store its descriptor in the backtrace buffer */
     if (domain_state->backtrace_pos >= BACKTRACE_BUFFER_SIZE) return;
     domain_state->backtrace_buffer[domain_state->backtrace_pos++] =
-      (backtrace_slot) descr;
+      Slot_frame_descr(descr);
 
     /* Stop when we reach the current exception handler */
     if (sp > trapsp) return;
@@ -306,8 +312,6 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
   if (frame_has_allocs(d)) {
     /* skip alloc_lengths */
     infoptr += *infoptr + 1;
-    /* align to 32 bits */
-    infoptr = Align_to(infoptr, uint32_t);
     /* find debug info for this allocation */
     if (alloc_idx >= 0) {
       infoptr += alloc_idx * sizeof(uint32_t);
@@ -323,8 +327,6 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
       }
     }
   } else {
-    /* align to 32 bits */
-    infoptr = Align_to(infoptr, uint32_t);
     CAMLassert(alloc_idx == -1);
   }
   /* read offset to debuginfo */

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -379,10 +379,10 @@ struct name_info {
    in the main debuginfo word. */
 struct name_and_loc_info {
   int32_t filename_offs;
+  int32_t defname_offs; /* immediately after filename_offs, as in name_info */
   uint16_t start_chr;
   uint16_t end_chr;
   int32_t end_offset; /* End character position relative to start bol */
-  int32_t defname_offs;
 };
 
 /* Extract location information for the given frame descriptor */

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -360,11 +360,13 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
     return (debuginfo*)(infoptr + 2);
 }
 
-/* Multiple names may share the same filename,
-   so it is referenced as an offset instead of stored inline */
+/* Both the filename and the defname are stored out of line, as offsets relative
+   to the struct, so that identical strings can be deduplicated across
+   compilation units by the linker (they are emitted into a mergeable string
+   section, SHF_MERGE|SHF_STRINGS). The offsets are signed 32-bit. */
 struct name_info {
   int32_t filename_offs;
-  char name[]; /* flexible array member */
+  int32_t defname_offs;
 };
 
 /* Extended version of name_info including location fields which didn't fit
@@ -374,7 +376,7 @@ struct name_and_loc_info {
   uint16_t start_chr;
   uint16_t end_chr;
   int32_t end_offset; /* End character position relative to start bol */
-  char name[]; /* flexible array member */
+  int32_t defname_offs;
 };
 
 /* Extract location information for the given frame descriptor */
@@ -423,7 +425,9 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   if (info2 & 0x80000000) {
     struct name_and_loc_info * name_and_loc_info =
       (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
-    li->loc_defname = name_and_loc_info->name;
+    li->loc_defname =
+      (char *)name_and_loc_info
+      + caml_read_unaligned_int32(&name_and_loc_info->defname_offs);
     li->loc_filename =
       (char *)name_and_loc_info
       + caml_read_unaligned_int32(&name_and_loc_info->filename_offs);
@@ -436,7 +440,9 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   } else {
     struct name_info * name_info =
       (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
-    li->loc_defname = name_info->name;
+    li->loc_defname =
+      (char *)name_info
+      + caml_read_unaligned_int32(&name_info->defname_offs);
     li->loc_filename =
       (char *)name_info
       + caml_read_unaligned_int32(&name_info->filename_offs);
@@ -482,17 +488,16 @@ static void include_high(char *high)
 }
 
 
-static void include_string(char *s)
-{
-  include_low(s);
-  include_high(s + strlen(s) + 1);
-}
-
 void caml_debuginfo_measure(debuginfo dbg)
 {
   uint32_t info1, info2;
 
-  /* Control flow to match caml_debuginfo_location */
+  /* Control flow to match caml_debuginfo_location.
+     The defname and filename strings are no longer measured here: they live in
+     a separate mergeable string section (deduplicated across compilation units
+     by the linker), so they cannot be attributed to a single frametable. This
+     measures only the debuginfo words and the name_info/name_and_loc_info
+     structs. */
   if (dbg == NULL) {
     return;
   }
@@ -507,17 +512,12 @@ void caml_debuginfo_measure(debuginfo dbg)
       struct name_and_loc_info * name_and_loc_info =
         (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
       include_low((char*)name_and_loc_info);
-      include_string(name_and_loc_info->name);
-      include_string((char *)name_and_loc_info
-                     + caml_read_unaligned_int32(
-                         &name_and_loc_info->filename_offs));
+      include_high((char*)name_and_loc_info + sizeof(struct name_and_loc_info));
     } else {
       struct name_info * name_info =
         (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
       include_low((char*)name_info);
-      include_string(name_info->name);
-      include_string((char *)name_info
-                     + caml_read_unaligned_int32(&name_info->filename_offs));
+      include_high((char*)name_info + sizeof(struct name_info));
     }
     dbg = (debuginfo)((uint32_t*)dbg + 2);
   } while (info1 & 1);

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -69,6 +69,13 @@ debuginfo caml_debuginfo_next(debuginfo dbg);
 /* Extract locations from backtrace_slot */
 void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li);
 
+/* Measuring debuginfo, when Xmeasure_frametables=1 */
+void caml_debuginfo_reset(void);
+void caml_debuginfo_measure(debuginfo dbg);
+/* Return the number of debuginfos measured, and the lowest and
+ * highest addresses seen */
+void caml_debuginfo_measurements(size_t *count_p, char **low_p, char **high_p);
+
 /* In order to prevent the GC from walking through the debug
    information (which have no headers), we transform slots to 31/63 bits
    ocaml integers by shifting them by 1 to the right. We do not lose

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -70,7 +70,7 @@
  *
  *  - a leading 0 byte (FRAME_DELTA_ESCAPE) is an ESCAPE: the bytes that
  *    follow are a descriptor in the existing normal-or-long format (the
- *    [frame_descr] / [frame_descr_long] structs below). Used for the
+ *    wire layout documented at [frame_descr] below). Used for the
  *    first descriptor of each frametable (no previous return address),
  *    for the first descriptor of each new text section (the delta would
  *    span sections), and for any descriptor that does not fit the small
@@ -91,14 +91,17 @@
  *       two bits are the flags (FRAME_DESCRIPTOR_ALLOC | _DEBUG).
  *
  *   (2a) if alloc:
+ *          uint8_t reg_bitmap;  bit i set => register HOT_REGS[i] is live
  *          uint8_t num_allocs;
- *          uint8_t num_live;  (live scannable STACK slots, not registers)
  *          uint8_t alloc_sizes[ceil(num_allocs/2)];  4 bits each,
  *                                                     low nibble first
- *          uint8_t reg_bitmap;  bit i set => register HOT_REGS[i] is live
+ *          uint8_t num_live;  (live scannable STACK slots, not registers)
  *   (2b) if no alloc:
  *          uint8_t num_live;  (no register byte: non-alloc descriptors
  *                              never keep GC roots in registers)
+ *
+ *   (num_allocs is always immediately followed by its alloc sizes, and
+ *    num_live -- in either branch -- by the live stack slots.)
  *
  *   (3) uint8_t stack_word_ofs[num_live]; each a live stack-slot WORD
  *       offset (byte offset / word size) into the frame.
@@ -117,48 +120,40 @@
 CAMLunused static const unsigned char
   caml_frame_hot_regs[FRAME_NUM_HOT_REGS] = { 0, 1, 2, 3, 4, 5, 6, 8 };
 
-typedef struct {
-  int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
-  uint16_t frame_data; /* frame size and various flags */
-  uint16_t num_live;
-  uint16_t live_ofs[/* num_live */]; /* flexible array member */
-  /*
-    If frame_has_allocs(), alloc lengths follow:
-        uint8_t num_allocs;
-        uint8_t alloc[num_allocs];
-
-    If frame_has_debug(), debug info follows (32-bit aligned):
-        uint32_t debug_info[frame_has_allocs() ? num_allocs : 1];
-
-    Debug info is stored as a relative offset, in bytes, from the
-    debug_info itself to a debuginfo structure. */
-} frame_descr;
-
-typedef struct {
-  int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
-  uint16_t marker;     /* FRAME_LONG_MARKER */
-  uint16_t _pad;       /* Ensure frame_data is 4-byte aligned */
-  uint32_t frame_data; /* frame size and various flags */
-  uint32_t num_live;
-  uint32_t live_ofs[1 /* num_live */];
-  /*
-    If frame_has_allocs(), alloc lengths follow:
-        uint8_t num_allocs;
-        uint8_t alloc[num_allocs];
-
-    If frame_has_debug(), debug info follows (32-bit aligned):
-        uint32_t debug_info[frame_has_allocs() ? num_allocs : 1];
-
-    Debug info is stored as a relative offset, in bytes, from the
-    debug_info itself to a debuginfo structure. */
-} frame_descr_long;
-
-/* A [frame_descr *] points at a descriptor BODY, i.e. the byte that
- * follows the delta byte. For an escaped descriptor that body is exactly
- * the [frame_descr] / [frame_descr_long] struct, so the legacy accessors
- * below work unchanged. For a small descriptor it is the size+flags byte.
+/* A frame descriptor is a packed, unaligned byte sequence: since the alignment
+ * relaxation the data is no longer C-struct-aligned, so we treat a
+ * [frame_descr *] as an opaque byte pointer and read its fields at explicit
+ * offsets via [caml_read_unaligned_*] (forming an aligned-typed pointer to the
+ * unaligned data would be undefined behaviour).
  *
- * The descriptor's preceding delta byte tells the two apart. */
+ * A [frame_descr *] points at a descriptor BODY, i.e. the byte after the delta
+ * field. For a small descriptor that is the size+flags byte (see above). For an
+ * escaped descriptor it is the normal-or-long wire layout below; the preceding
+ * delta byte (== FRAME_DELTA_ESCAPE) and frame_data tell the formats apart:
+ *
+ *   normal:                          long (frame_data @4 == FRAME_LONG_MARKER):
+ *     int32_t  retaddr_rel  @ 0        int32_t  retaddr_rel  @ 0
+ *     uint16_t frame_data   @ 4        uint16_t marker       @ 4
+ *     uint16_t num_live     @ 6        uint16_t _pad         @ 6
+ *     uint16_t live_ofs[]   @ 8        uint32_t frame_data   @ 8
+ *                                      uint32_t num_live     @ 12
+ *                                      uint32_t live_ofs[]   @ 16
+ *
+ * After live_ofs[]: if frame_has_allocs(), { uint8_t num_allocs; uint8_t
+ * alloc[num_allocs] }; if frame_has_debug(), 32-bit-aligned uint32_t
+ * debug_info[frame_has_allocs() ? num_allocs : 1] (each a byte offset from
+ * itself to a debuginfo structure). retaddr_rel is the byte offset from the
+ * descriptor body to the return address. */
+typedef unsigned char frame_descr;
+
+/* Field byte offsets within an escaped descriptor body (normal and long). */
+#define Frame_retaddr_rel_ofs   0
+#define Frame_data_ofs          4
+#define Frame_num_live_ofs      6
+#define Frame_live_ofs          8
+#define Frame_long_data_ofs     8
+#define Frame_long_num_live_ofs 12
+#define Frame_long_live_ofs     16
 
 Caml_inline bool frame_is_small(frame_descr *d) {
   return ((const unsigned char *)d)[-1] != FRAME_DELTA_ESCAPE;
@@ -197,18 +192,13 @@ void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out);
 
 Caml_inline bool frame_return_to_C(frame_descr *d) {
   if (frame_is_small(d)) return false;
-  return caml_read_unaligned_uint16(&d->frame_data) == FRAME_RETURN_TO_C;
+  return caml_read_unaligned_uint16(d + Frame_data_ofs) == FRAME_RETURN_TO_C;
 }
 
 Caml_inline bool frame_is_long(frame_descr *d) {
   CAMLassert(d && !frame_return_to_C(d));
   if (frame_is_small(d)) return false;
-  return (caml_read_unaligned_uint16(&d->frame_data) == FRAME_LONG_MARKER);
-}
-
-Caml_inline frame_descr_long *frame_as_long(frame_descr *d) {
-  frame_descr_long *dl = (frame_descr_long *) d;
-  return dl;
+  return (caml_read_unaligned_uint16(d + Frame_data_ofs) == FRAME_LONG_MARKER);
 }
 
 /* Frame size in bytes of a small descriptor, from its size+flags byte:
@@ -223,10 +213,9 @@ Caml_inline uint32_t frame_data(frame_descr *d) {
     return frame_small_size(d) | (frame_small_sizeflags(d) & FRAME_DESCRIPTOR_FLAGS);
   }
   if (frame_is_long(d)) {
-    frame_descr_long *dl = frame_as_long(d);
-    return caml_read_unaligned_uint32(&dl->frame_data);
+    return caml_read_unaligned_uint32(d + Frame_long_data_ofs);
   } else {
-    return caml_read_unaligned_uint16(&d->frame_data);
+    return caml_read_unaligned_uint16(d + Frame_data_ofs);
   }
 }
 
@@ -257,12 +246,11 @@ Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
     return (unsigned char *)dec.end_of_live;
   }
   if (frame_is_long(d)) {
-    frame_descr_long *dl = frame_as_long(d);
-    uint32_t num_live = caml_read_unaligned_uint32(&dl->num_live);
-    return ((unsigned char *)&dl->live_ofs[num_live]);
+    uint32_t num_live = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
+    return d + Frame_long_live_ofs + (uintnat)num_live * sizeof(uint32_t);
   } else {
-    uint16_t num_live = caml_read_unaligned_uint16(&d->num_live);
-    return ((unsigned char *)&d->live_ofs[num_live]);
+    uint16_t num_live = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
+    return d + Frame_live_ofs + (uintnat)num_live * sizeof(uint16_t);
   }
 }
 
@@ -280,8 +268,7 @@ Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
   ((((uintnat)(addr) * 52437813) >> 5) & (mask))
 
 #define Retaddr_frame(d) \
-  ((uintnat)&(d)->retaddr_rel + \
-   (uintnat)(intnat)caml_read_unaligned_int32(&(d)->retaddr_rel))
+  ((uintnat)(d) + (uintnat)(intnat)caml_read_unaligned_int32(d))
 
 void caml_init_frame_descriptors(void);
 

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -61,6 +61,62 @@
 #define FRAME_RETURN_TO_C 0xFFFF
 #define FRAME_LONG_MARKER 0x7FFF
 
+/* "Small" (compact) frame-descriptor format.
+ *
+ * Within a frametable, descriptors are concatenated in increasing
+ * return-address order, and every descriptor is preceded by a "delta"
+ * field encoding the difference between this descriptor's return address
+ * and the previous one's:
+ *
+ *  - a leading 0 byte (FRAME_DELTA_ESCAPE) is an ESCAPE: the bytes that
+ *    follow are a descriptor in the existing normal-or-long format (the
+ *    [frame_descr] / [frame_descr_long] structs below). Used for the
+ *    first descriptor of each frametable (no previous return address),
+ *    for the first descriptor of each new text section (the delta would
+ *    span sections), and for any descriptor that does not fit the small
+ *    format.
+ *
+ *  - otherwise the delta is an unsigned LEB128 value (always >= 1, so it
+ *    never starts with a 0 byte and so is unambiguous with the escape).
+ *    The return address is the previous descriptor's plus the delta. We
+ *    use LEB128 rather than a fixed width because the compiler emits the
+ *    delta as a label difference resolved by the assembler, which cannot
+ *    choose a width by inspecting the value but emits LEB128 of a label
+ *    difference directly (even across relaxable branches).
+ *
+ * A small-descriptor body (after the delta field) is:
+ *
+ *   (1) size+flags byte: top 6 bits = (frame_size_in_16-byte_units - 1),
+ *       i.e. value 0..63 means 1..64 units, i.e. 16..1024 bytes. Bottom
+ *       two bits are the flags (FRAME_DESCRIPTOR_ALLOC | _DEBUG).
+ *
+ *   (2a) if alloc:
+ *          uint8_t num_allocs;
+ *          uint8_t num_live;  (live scannable STACK slots, not registers)
+ *          uint8_t alloc_sizes[ceil(num_allocs/2)];  4 bits each,
+ *                                                     low nibble first
+ *          uint8_t reg_bitmap;  bit i set => register HOT_REGS[i] is live
+ *   (2b) if no alloc:
+ *          uint8_t num_live;  (no register byte: non-alloc descriptors
+ *                              never keep GC roots in registers)
+ *
+ *   (3) uint8_t stack_word_ofs[num_live]; each a live stack-slot WORD
+ *       offset (byte offset / word size) into the frame.
+ *
+ *   (4) if debug: uint32_t debug_info[alloc ? num_allocs : 1]; identical
+ *       layout to the normal format. */
+
+#define FRAME_DELTA_ESCAPE 0
+
+/* The eight most common GC-root registers, by measurement. The compiler
+ * (backend/emitaux.ml, [hot_regs]) and the runtime MUST agree on this
+ * table exactly: a mismatch causes SILENT GC HEAP CORRUPTION. The runtime
+ * maps bit-index -> register-number (this forward table); the compiler
+ * maps register-number -> bit-index. */
+#define FRAME_NUM_HOT_REGS 8
+CAMLunused static const unsigned char
+  caml_frame_hot_regs[FRAME_NUM_HOT_REGS] = { 0, 1, 2, 3, 4, 5, 6, 8 };
+
 typedef struct {
   int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
   uint16_t frame_data; /* frame size and various flags */
@@ -97,12 +153,56 @@ typedef struct {
     debug_info itself to a debuginfo structure. */
 } frame_descr_long;
 
+/* A [frame_descr *] points at a descriptor BODY, i.e. the byte that
+ * follows the delta byte. For an escaped descriptor that body is exactly
+ * the [frame_descr] / [frame_descr_long] struct, so the legacy accessors
+ * below work unchanged. For a small descriptor it is the size+flags byte.
+ *
+ * The descriptor's preceding delta byte tells the two apart. */
+
+Caml_inline bool frame_is_small(frame_descr *d) {
+  return ((const unsigned char *)d)[-1] != FRAME_DELTA_ESCAPE;
+}
+
+/* The size+flags byte of a small descriptor. */
+Caml_inline unsigned char frame_small_sizeflags(frame_descr *d) {
+  return ((const unsigned char *)d)[0];
+}
+
+/* Decoded form of one descriptor (small or escaped). [body] points at
+ * the size+flags byte (small) or the [frame_descr] struct (escaped). */
+struct frame_descr_decoded {
+  bool is_small;
+  bool return_to_C;
+  bool is_long;
+  bool has_allocs;
+  bool has_debug;
+  uint32_t frame_size;   /* in bytes */
+  uint32_t num_live;     /* small: live stack slots; escaped: live_ofs[] */
+  /* For small descriptors only: */
+  const unsigned char *small_allocs;  /* alloc_sizes[] (4-bit nibbles) */
+  uint8_t small_num_allocs;
+  uint8_t small_reg_bitmap;
+  const unsigned char *small_live;    /* stack_word_ofs[num_live] */
+  /* The byte just past the live_ofs / stack offsets, i.e. where the
+   * alloc-count (escaped) or the debug words begin. */
+  const unsigned char *end_of_live;
+  /* For escaped descriptors: num debuginfo words (= num_allocs or 1). */
+  uint32_t num_debuginfo;
+  /* One past the whole descriptor body (start of the next delta byte). */
+  const unsigned char *end;
+};
+
+void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out);
+
 Caml_inline bool frame_return_to_C(frame_descr *d) {
+  if (frame_is_small(d)) return false;
   return caml_read_unaligned_uint16(&d->frame_data) == FRAME_RETURN_TO_C;
 }
 
 Caml_inline bool frame_is_long(frame_descr *d) {
   CAMLassert(d && !frame_return_to_C(d));
+  if (frame_is_small(d)) return false;
   return (caml_read_unaligned_uint16(&d->frame_data) == FRAME_LONG_MARKER);
 }
 
@@ -111,7 +211,17 @@ Caml_inline frame_descr_long *frame_as_long(frame_descr *d) {
   return dl;
 }
 
+/* Frame size in bytes of a small descriptor, from its size+flags byte:
+   top 6 bits hold (size_in_16-byte_units - 1). */
+Caml_inline uint32_t frame_small_size(frame_descr *d) {
+  return (((uint32_t)(frame_small_sizeflags(d) >> 2)) + 1) * 16;
+}
+
 Caml_inline uint32_t frame_data(frame_descr *d) {
+  if (frame_is_small(d)) {
+    /* Reconstruct an equivalent normal frame_data: size | flags. */
+    return frame_small_size(d) | (frame_small_sizeflags(d) & FRAME_DESCRIPTOR_FLAGS);
+  }
   if (frame_is_long(d)) {
     frame_descr_long *dl = frame_as_long(d);
     return caml_read_unaligned_uint32(&dl->frame_data);
@@ -120,7 +230,32 @@ Caml_inline uint32_t frame_data(frame_descr *d) {
   }
 }
 
+Caml_inline uint32_t frame_size(frame_descr *d) {
+  if (frame_is_small(d)) return frame_small_size(d);
+  return frame_data(d) &~ FRAME_DESCRIPTOR_FLAGS;
+}
+
+Caml_inline bool frame_has_allocs(frame_descr *d) {
+  if (frame_is_small(d))
+    return (frame_small_sizeflags(d) & FRAME_DESCRIPTOR_ALLOC) != 0;
+  return (frame_data(d) & FRAME_DESCRIPTOR_ALLOC) != 0;
+}
+
+Caml_inline bool frame_has_debug(frame_descr *d) {
+  if (frame_is_small(d))
+    return (frame_small_sizeflags(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
+  return (frame_data(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
+}
+
+/* End of the live-offset region: where alloc lengths / debug words begin.
+ * For small descriptors this is past the stack-slot offset bytes; for
+ * escaped descriptors it is past live_ofs[]. */
 Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
+  if (frame_is_small(d)) {
+    struct frame_descr_decoded dec;
+    caml_decode_frame_descr(d, &dec);
+    return (unsigned char *)dec.end_of_live;
+  }
   if (frame_is_long(d)) {
     frame_descr_long *dl = frame_as_long(d);
     uint32_t num_live = caml_read_unaligned_uint32(&dl->num_live);
@@ -129,18 +264,6 @@ Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
     uint16_t num_live = caml_read_unaligned_uint16(&d->num_live);
     return ((unsigned char *)&d->live_ofs[num_live]);
   }
-}
-
-Caml_inline uint32_t frame_size(frame_descr *d) {
-  return frame_data(d) &~ FRAME_DESCRIPTOR_FLAGS;
-}
-
-Caml_inline bool frame_has_allocs(frame_descr *d) {
-  return (frame_data(d) & FRAME_DESCRIPTOR_ALLOC) != 0;
-}
-
-Caml_inline bool frame_has_debug(frame_descr *d) {
-  return (frame_data(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
 }
 
 /* Allocation lengths are encoded reduced by one, so values 0-255 mean

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 #include "config.h"
+#include "misc.h"
 
 /* The compiler generates a "frame descriptor" for every potential
  * return address. Each loaded module has a block of memory, the
@@ -97,12 +98,12 @@ typedef struct {
 } frame_descr_long;
 
 Caml_inline bool frame_return_to_C(frame_descr *d) {
-  return d->frame_data == FRAME_RETURN_TO_C;
+  return caml_read_unaligned_uint16(&d->frame_data) == FRAME_RETURN_TO_C;
 }
 
 Caml_inline bool frame_is_long(frame_descr *d) {
   CAMLassert(d && !frame_return_to_C(d));
-  return (d -> frame_data == FRAME_LONG_MARKER);
+  return (caml_read_unaligned_uint16(&d->frame_data) == FRAME_LONG_MARKER);
 }
 
 Caml_inline frame_descr_long *frame_as_long(frame_descr *d) {
@@ -113,18 +114,20 @@ Caml_inline frame_descr_long *frame_as_long(frame_descr *d) {
 Caml_inline uint32_t frame_data(frame_descr *d) {
   if (frame_is_long(d)) {
     frame_descr_long *dl = frame_as_long(d);
-    return (dl -> frame_data);
+    return caml_read_unaligned_uint32(&dl->frame_data);
   } else {
-    return (d -> frame_data);
+    return caml_read_unaligned_uint16(&d->frame_data);
   }
 }
 
 Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
   if (frame_is_long(d)) {
     frame_descr_long *dl = frame_as_long(d);
-    return ((unsigned char *)&dl->live_ofs[dl->num_live]);
+    uint32_t num_live = caml_read_unaligned_uint32(&dl->num_live);
+    return ((unsigned char *)&dl->live_ofs[num_live]);
   } else {
-    return ((unsigned char *)&d->live_ofs[d->num_live]);
+    uint16_t num_live = caml_read_unaligned_uint16(&d->num_live);
+    return ((unsigned char *)&d->live_ofs[num_live]);
   }
 }
 
@@ -155,7 +158,7 @@ Caml_inline bool frame_has_debug(frame_descr *d) {
 
 #define Retaddr_frame(d) \
   ((uintnat)&(d)->retaddr_rel + \
-   (uintnat)(intnat)((d)->retaddr_rel))
+   (uintnat)(intnat)caml_read_unaligned_int32(&(d)->retaddr_rel))
 
 void caml_init_frame_descriptors(void);
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <limits.h>
+#include <string.h>
 
 /* Detection of available C attributes and compiler extensions */
 
@@ -529,6 +530,39 @@ extern int caml_umul_overflow(uintnat a, uintnat b, uintnat * res);
 Caml_inline uintnat caml_round_up(uintnat value, uintnat align) {
   CAMLassert(Is_power_of_2(align));
   return (value + align - 1) & ~(align - 1);
+}
+
+/* Unaligned reads.
+
+   Frame descriptors and debuginfo are not guaranteed to be aligned, so
+   reads from them must not assume alignment. These helpers read a value
+   of the given width from a possibly-unaligned address. Every C compiler
+   we use compiles the [memcpy] to a single (unaligned) load instruction
+   at the optimisation levels used to build the runtime, and the idiom is
+   portable to architectures that fault on unaligned accesses. */
+
+Caml_inline uint16_t caml_read_unaligned_uint16(const void *p) {
+  uint16_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+Caml_inline uint32_t caml_read_unaligned_uint32(const void *p) {
+  uint32_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+Caml_inline int32_t caml_read_unaligned_int32(const void *p) {
+  int32_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+Caml_inline uintnat caml_read_unaligned_uintnat(const void *p) {
+  uintnat v;
+  memcpy(&v, p, sizeof(v));
+  return v;
 }
 
 #endif

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -44,6 +44,8 @@ void caml_init_codefrag(void) {
   caml_lf_skiplist_init(&code_fragments_by_num);
 }
 
+extern uintnat caml_measure_frametables;
+
 int caml_register_code_fragment(char *start, char *end,
                                 enum digest_status digest_kind,
                                 unsigned char *opt_digest) {
@@ -72,6 +74,9 @@ int caml_register_code_fragment(char *start, char *end,
   caml_lf_skiplist_insert(&code_fragments_by_pc, (uintnat)start, (uintnat)cf);
   caml_lf_skiplist_insert(&code_fragments_by_num, (uintnat)cf->fragnum,
                           (uintnat)cf);
+  if (caml_measure_frametables) {
+    printf("Code fragment %p-%p\n", start, end);
+  }
   return cf->fragnum;
 }
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -629,8 +629,9 @@ next_chunk:
         frame_descr_long *dl = frame_as_long(d);
         uint32_t *p;
         uint32_t n;
-        for (p = dl->live_ofs, n = dl->num_live; n > 0; n--, p++) {
-          uint32_t ofs = *p;
+        for (p = dl->live_ofs, n = caml_read_unaligned_uint32(&dl->num_live);
+             n > 0; n--, p++) {
+          uint32_t ofs = caml_read_unaligned_uint32(p);
           if (ofs & 1) {
             root = regs + (ofs >> 1);
           } else {
@@ -641,8 +642,9 @@ next_chunk:
       } else {
         uint16_t *p;
         uint16_t n;
-        for (p = d->live_ofs, n = d->num_live; n > 0; n--, p++) {
-          uint16_t ofs = *p;
+        for (p = d->live_ofs, n = caml_read_unaligned_uint16(&d->num_live);
+             n > 0; n--, p++) {
+          uint16_t ofs = caml_read_unaligned_uint16(p);
           if (ofs & 1) {
             root = regs + (ofs >> 1);
           } else {

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -644,11 +644,9 @@ next_chunk:
           visit (f, fdata, locals, colors, root);
         }
       } else if (frame_is_long(d)) {
-        frame_descr_long *dl = frame_as_long(d);
-        uint32_t *p;
-        uint32_t n;
-        for (p = dl->live_ofs, n = caml_read_unaligned_uint32(&dl->num_live);
-             n > 0; n--, p++) {
+        const unsigned char *p = d + Frame_long_live_ofs;
+        uint32_t n = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
+        for (; n > 0; n--, p += sizeof(uint32_t)) {
           uint32_t ofs = caml_read_unaligned_uint32(p);
           if (ofs & 1) {
             root = regs + (ofs >> 1);
@@ -658,10 +656,9 @@ next_chunk:
           visit (f, fdata, locals, colors, root);
         }
       } else {
-        uint16_t *p;
-        uint16_t n;
-        for (p = d->live_ofs, n = caml_read_unaligned_uint16(&d->num_live);
-             n > 0; n--, p++) {
+        const unsigned char *p = d + Frame_live_ofs;
+        uint16_t n = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
+        for (; n > 0; n--, p += sizeof(uint16_t)) {
           uint16_t ofs = caml_read_unaligned_uint16(p);
           if (ofs & 1) {
             root = regs + (ofs >> 1);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -625,7 +625,25 @@ next_chunk:
     CAMLassert(d);
     if (!frame_return_to_C(d)) {
       /* Scan the roots in this frame */
-      if (frame_is_long(d)) {
+      if (frame_is_small(d)) {
+        /* Small descriptor: live registers come from the hot-register
+         * bitmap, live stack slots from word offsets. */
+        struct frame_descr_decoded dec;
+        caml_decode_frame_descr(d, &dec);
+        if (dec.has_allocs) {
+          unsigned char bitmap = dec.small_reg_bitmap;
+          for (int i = 0; bitmap; i++, bitmap >>= 1) {
+            if (bitmap & 1) {
+              root = regs + caml_frame_hot_regs[i];
+              visit (f, fdata, locals, colors, root);
+            }
+          }
+        }
+        for (uint32_t k = 0; k < dec.num_live; k++) {
+          root = (value *)(sp + (uintnat)dec.small_live[k] * sizeof(value));
+          visit (f, fdata, locals, colors, root);
+        }
+      } else if (frame_is_long(d)) {
         frame_descr_long *dl = frame_as_long(d);
         uint32_t *p;
         uint32_t n;

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -93,7 +93,7 @@ static frame_descr * next_frame_descr(frame_descr * d) {
     /* This marks the top of an ML stack chunk. Skip over empty
      * frame descriptor */
     /* Skip to address of zero-sized live_ofs */
-    CAMLassert(d->num_live == 0);
+    CAMLassert(caml_read_unaligned_uint16(&d->num_live) == 0);
     p = (unsigned char*)&d->live_ofs[0];
     /* Align to word size */
     p = Align_to(p, void*);
@@ -104,7 +104,7 @@ static frame_descr * next_frame_descr(frame_descr * d) {
 static intnat count_descriptors(caml_frametable_list *list) {
   intnat num_descr = 0;
   iter_list(list,cur) {
-    num_descr += *((intnat*) cur->frametable);
+    num_descr += (intnat)caml_read_unaligned_uintnat(cur->frametable);
   }
   return num_descr;
 }
@@ -128,7 +128,7 @@ static void fill_hashtable(
 {
   iter_list(new_frametables,cur) {
     intnat * tbl = (intnat*) cur->frametable;
-    intnat len = *tbl;
+    intnat len = (intnat)caml_read_unaligned_uintnat(tbl);
     frame_descr * d = (frame_descr *)(tbl + 1);
     for (intnat j = 0; j < len; j++) {
       uintnat h = Hash_retaddr(Retaddr_frame(d), table->mask);
@@ -588,7 +588,7 @@ static void add_descriptor_to_stats(frame_descr *d,
     stats->min_descr = (unsigned char*)d;
   }
 
-  intnat retaddr_rel = d->retaddr_rel;
+  intnat retaddr_rel = caml_read_unaligned_int32(&d->retaddr_rel);
   if (retaddr_rel < 0) {
     count_item(-retaddr_rel, &stats->max_neg_retaddr_rel, NULL,
                stats->log_neg_retaddr_rel);
@@ -639,18 +639,18 @@ static void add_descriptor_to_stats(frame_descr *d,
     if (frame_is_long(d)) {
       ++stats->long_descrs;
       frame_descr_long *dl = frame_as_long(d);
-      num_live = dl->num_live;
+      num_live = caml_read_unaligned_uint32(&dl->num_live);
       uint32_t n = num_live;
       for (uint32_t *ofp = dl->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(*ofp, &regs, &max_reg, &reg_map, &has_big_reg,
-                     &slots, &max_slot, stats);
+        add_live_ofs(caml_read_unaligned_uint32(ofp), &regs, &max_reg,
+                     &reg_map, &has_big_reg, &slots, &max_slot, stats);
       }
     } else {
-      num_live = d->num_live;
+      num_live = caml_read_unaligned_uint16(&d->num_live);
       uint16_t n = num_live;
       for (uint16_t *ofp = d->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(*ofp, &regs, &max_reg, &reg_map, &has_big_reg,
-                     &slots, &max_slot, stats);
+        add_live_ofs(caml_read_unaligned_uint16(ofp), &regs, &max_reg,
+                     &reg_map, &has_big_reg, &slots, &max_slot, stats);
       }
     }
 
@@ -712,7 +712,7 @@ static void add_descriptor_to_stats(frame_descr *d,
       /* Align to 32 bits */
       p = Align_to(p, uint32_t);
       for (size_t i = 0; i <  num_debuginfo; ++i) {
-        uint32_t offset = *(uint32_t*)p;
+        uint32_t offset = caml_read_unaligned_uint32(p);
         if (offset) { /* there may be invalid debuginfo slots */
           caml_debuginfo_measure((debuginfo)(p + offset));
         }

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -24,6 +24,7 @@
 #include "caml/memory.h"
 #include "caml/fail.h"
 #include "caml/shared_heap.h"
+#include "caml/backtrace_prim.h"
 #include <stddef.h>
 
 struct caml_frame_descrs {
@@ -192,6 +193,573 @@ static void clean_frame_descriptors(caml_frame_descrs *table)
   table->zombies = NULL;
 }
 
+/* ---- Frametable measurement ---- */
+
+/* As preparation for designing a more memory-efficient frametable
+ * format, this code measures various things about the frametables of
+ * an executable. */
+
+/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_frametables */
+extern uintnat caml_measure_frametables;
+
+#define MAX_LOG 32
+#define SMALL_FRAMES 32
+#define REGS 64
+#define MAX_REG (REGS - 1) /* Largest register index recorded in reg tables */
+#define MAX_REG_IN_SMALL_MAP 12
+#define REG_MAPS (1<<(MAX_REG_IN_SMALL_MAP + 1))
+#define REGMAP_REPORT_THRESHOLD 1000
+
+struct frametable_stats {
+  /* A few per-frametable items */
+  unsigned char *last_retaddr;
+  unsigned char *min_retaddr;
+  unsigned char *max_retaddr;
+  unsigned char *min_descr;
+  unsigned char *max_descr;
+  size_t descrs;
+
+  /* Everything else is accumulated over all frametables */
+  size_t frametables;
+  size_t total_codesize;
+  size_t total_ft_size;
+  size_t total_debuginfo_size;
+  size_t total_descrs;
+  size_t total_debuginfo;
+
+  /* Are frametables in memory before or after the code they describe? */
+  size_t ft_before_code;
+  size_t ft_after_code;
+
+  /* Descriptor kinds */
+  size_t return_to_C;
+  size_t with_debug;
+  size_t with_alloc;
+  size_t long_descrs;
+
+  /* Frame sizes */
+  size_t small_frames[SMALL_FRAMES];
+  size_t log_framesize[MAX_LOG];
+  size_t max_framesize;
+
+  /* Relative return addresses */
+  size_t log_pos_retaddr_rel[MAX_LOG];
+  size_t max_pos_retaddr_rel;
+  size_t log_neg_retaddr_rel[MAX_LOG];
+  size_t max_neg_retaddr_rel;
+
+  /* Delta from one retaddr to the next */
+  size_t log_pos_delta[MAX_LOG];
+  size_t max_pos_delta;
+  size_t log_neg_delta[MAX_LOG];
+  size_t max_neg_delta;
+
+  /* Counts of "live offset" slots (GC regs + slots) */
+  size_t small_lives[SMALL_FRAMES];
+  size_t log_lives[MAX_LOG];
+  size_t max_lives; /* Overall maximum count of lives */
+
+  /* GCable registers */
+  size_t reg_count[REGS]; /* Count GCable registers */
+  size_t max_regs;
+  size_t max_reg[REGS];  /* Count max GCable register index */
+  size_t reg_maps[REG_MAPS]; /* Count reg maps up to REG_MAPS */
+  size_t big_reg_descrs; /* Descrs with a register > MAX_REG_IN_SMALL_MAP */
+  size_t big_reg_entries; /* live_ofs register entries with number > MAX_REG */
+  size_t noalloc_with_regs; /* Non-alloc descrs that have registers (anomaly) */
+
+  /* Count of GCable stack slots */
+  size_t small_slots[SMALL_FRAMES];
+  size_t log_slots[MAX_LOG];
+  size_t max_slots;
+
+  /* maximum GCable stack slot offset */
+  size_t small_max_slot[SMALL_FRAMES];
+  size_t log_max_slot[MAX_LOG];
+  size_t max_slot;
+
+  /* Comballoc allocation counts */
+  size_t log_comballocs[MAX_LOG];
+  size_t small_comballocs[SMALL_FRAMES];
+  size_t max_comballocs;
+
+  /* allocation sizes */
+  size_t alloc_sizes;
+  size_t log_alloc_sizes[MAX_LOG];
+  size_t small_alloc_sizes[SMALL_FRAMES];
+  size_t max_alloc_size;
+};
+
+static void clear_stats(struct frametable_stats *stats)
+{
+  caml_debuginfo_reset();
+  memset(stats, 0, sizeof(*stats));
+}
+
+static void clear_per_frametable_stats(struct frametable_stats *stats)
+{
+  stats->min_retaddr = stats->max_retaddr = stats->last_retaddr =
+    stats->min_descr = stats->max_descr = NULL;
+  stats->descrs = 0;
+  caml_debuginfo_reset();
+}
+
+/* Turn `val` into a string representing that number of bytes */
+
+static void report_bytes(char *buf, size_t space, size_t val)
+{
+  if (val < 1024) {
+    snprintf(buf, space, "%zu", val);
+  } else {
+    char suffix[] = " kMGTE";
+    double scaled = val;
+    char *p = suffix;
+    while(scaled > 1000 && *p) {
+      scaled /= 1024.0;
+      ++p;
+    }
+    snprintf(buf, space, "%.2f %ciB", scaled, *p);
+  }
+}
+
+/* Write text showing an array `vals` of `count` size_t values,
+ * without trailing zero values, into `buf` (size `space` bytes). */
+
+/* This works for regs and logs and smalls */
+#define TABLE_BUF_SIZE (REGS * 16)
+
+static void report_table(char *fmt, size_t *vals, size_t count)
+{
+  char buf[TABLE_BUF_SIZE];
+  size_t space = TABLE_BUF_SIZE;
+
+  size_t max = count - 1;
+  while(max && vals[max] == 0) {
+    --max;
+  }
+  char *p = buf;
+  for (size_t i = 0; i <= max; ++i) {
+    int len = snprintf(p, space, "%zu ", vals[i]);
+    if (len > space) { /* truncated, replace with ... */
+      p[space-4] = p[space-3] = p[space-2] = '.';
+      p[space-1] = '\0';
+      return;
+    }
+    space -= len;
+    p += len;
+  }
+  printf(fmt, buf);
+}
+
+/* At the end of a single frametable, deduce per-frametable sizes and
+ * add them to global stats. */
+
+static void accumulate_frametable_stats(intnat *frametable,
+                                        struct frametable_stats *stats)
+{
+  char *debuginfo_low, *debuginfo_high;
+  size_t debuginfo_count;
+  caml_debuginfo_measurements(&debuginfo_count,
+                              &debuginfo_low,
+                              &debuginfo_high);
+  /* round debuginfo_high up to word boundary */
+  debuginfo_high = Align_to(debuginfo_high, uintnat);
+/*
+  printf("Frametable at %p: return addresses %p-%p(0x%zx), "
+        "descriptors %p-%p(0x%zx, %zu), "
+        "debuginfo %p-%p(0x%zx, %zu)\n",
+        (void*)frametable,
+        (void*)stats->min_retaddr,
+        (void*)stats->max_retaddr,
+        (size_t)(stats->max_retaddr - stats->min_retaddr),
+        (void*)stats->min_descr,
+        (void*)stats->max_descr,
+        (size_t)(stats->max_descr - stats->min_descr),
+        stats->descrs,
+        (void*)debuginfo_low,
+        (void*)debuginfo_high,
+        (size_t)(debuginfo_high - debuginfo_low),
+        debuginfo_count);
+*/
+  stats->total_codesize += (stats->max_retaddr - stats->min_retaddr);
+  stats->total_ft_size += (stats->max_descr - stats->min_descr);
+  stats->total_debuginfo_size += (debuginfo_high - debuginfo_low);
+  stats->total_descrs += stats->descrs;
+  stats->total_debuginfo += debuginfo_count;
+  if (stats->min_retaddr) {
+    if (stats->min_retaddr > stats->min_descr)
+      ++ stats->ft_before_code;
+    else
+      ++ stats->ft_after_code;
+  }
+}
+
+/* Report all accumulated frametable stats to stdout. */
+
+static void report_stats(struct frametable_stats *stats)
+{
+  char table_buf[TABLE_BUF_SIZE];
+
+  size_t total_size =
+    stats->total_codesize
+    + stats->total_ft_size
+    + stats->total_debuginfo_size;
+  printf("Summary of %zu frametables.\n", stats->frametables);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_codesize);
+  printf("%s code (%5.2f%%)\n", table_buf,
+         (double)stats->total_codesize/total_size * 100.0);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_ft_size);
+  printf("%s descriptors (%5.2f%%; %zu descrs, %f bytes each)\n",
+         table_buf,
+         (double)stats->total_ft_size/total_size * 100.0,
+         stats->total_descrs,
+         (double)stats->total_ft_size / stats->total_descrs);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_debuginfo_size);
+  printf("%s Debuginfo (%5.2f%% %zu entries)\n",
+         table_buf,
+         (double)stats->total_debuginfo_size/total_size * 100.0,
+         stats->total_debuginfo);
+  printf("%zu frametables before code, %zu after code.\n",
+         stats->ft_before_code, stats->ft_after_code);
+  printf("long %zu return to C %zu alloc %zu debug %zu\n",
+         stats->long_descrs, stats->return_to_C,
+         stats->with_alloc, stats->with_debug);
+
+  printf("Max pos retaddr offset %zu\n", stats->max_pos_retaddr_rel);
+  report_table("  (logs %s)\n", stats->log_pos_retaddr_rel, MAX_LOG);
+  printf("Max neg retaddr offset %zu\n", stats->max_neg_retaddr_rel);
+  report_table("  (logs %s)\n", stats->log_neg_retaddr_rel, MAX_LOG);
+  printf("Max retaddr pos delta %zu\n", stats->max_pos_delta);
+  report_table("  (logs %s)\n", stats->log_pos_delta, MAX_LOG);
+  printf("Max retaddr neg delta %zu\n", stats->max_neg_delta);
+  report_table("  (logs %s)\n", stats->log_neg_delta, MAX_LOG);
+
+  printf("Frame sizes (max %zu)\n", stats->max_framesize);
+  report_table("  (small %s)\n", stats->small_frames, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_framesize, MAX_LOG);
+
+  printf("Comballoc entries (max %zu)\n",
+         stats->max_comballocs);
+  report_table("  (small %s)\n", stats->small_comballocs, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_comballocs, MAX_LOG);
+
+  printf("Allocation sizes (wosize-1) (%zu allocs, max %zu)\n",
+         stats->alloc_sizes, stats->max_alloc_size);
+  report_table("  (small %s)\n", stats->small_alloc_sizes, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_alloc_sizes, MAX_LOG);
+
+  printf("GC live values (max %zu)\n", stats->max_lives);
+  report_table("  (small %s)\n", stats->small_lives, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_lives, MAX_LOG);
+
+  printf("GCable stack slots (max %zu)\n", stats->max_slots);
+  report_table("  (small %s)\n", stats->small_slots, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_slots, MAX_LOG);
+
+  printf("Max GCable stack slot (max %zu)\n", stats->max_slot);
+  report_table("  (small %s)\n", stats->small_max_slot, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_max_slot, MAX_LOG);
+
+  printf("GCable registers (max %zu)\n", stats->max_regs);
+  report_table("  (counts %s)\n", stats->reg_count, REGS);
+  report_table("  (max %s)\n", stats->max_reg, REGS);
+
+  /* report all register maps which are more than 1/128 of the total
+   * (apart from the empty reg map */
+  size_t others = 0;
+  size_t regmaps = 0;
+  for (size_t i = 1; i < REG_MAPS; ++i) {
+    regmaps += stats->reg_maps[i];
+  }
+
+  printf("Register map frequencies (of %zu allocation descriptors):\n",
+         stats->with_alloc);
+  for (size_t i = 0; i < REG_MAPS; ++i) {
+    if (stats->reg_maps[i] > regmaps/REGMAP_REPORT_THRESHOLD) {
+      for (size_t j = 0; j <= MAX_REG_IN_SMALL_MAP; ++j) {
+        table_buf[MAX_REG_IN_SMALL_MAP - j] = (i & (1 << j)) ? '1' : '0';
+      }
+      table_buf[MAX_REG_IN_SMALL_MAP+1] = '\0';
+      printf("  %s %zu\n", table_buf, stats->reg_maps[i]);
+    } else {
+      others += stats->reg_maps[i];
+    }
+  }
+  printf("  others (<= %zu) %zu\n", regmaps/REGMAP_REPORT_THRESHOLD, others);
+  printf("Descriptors with a register > %d: %zu\n",
+         MAX_REG_IN_SMALL_MAP, stats->big_reg_descrs);
+  printf("live_ofs register entries with number > %d: %zu\n",
+         MAX_REG, stats->big_reg_entries);
+  printf("Non-allocation descriptors with registers: %zu\n",
+         stats->noalloc_with_regs);
+}
+
+/* Actually log+1.
+   mylog(0) = 0
+   mylog(1) = 1
+   mylog(2) = 2
+   mylog(3) = 2
+   mylog(4) = 3
+   ...
+   mylog(255) = 8
+   mylog(256) = 9
+   etc
+  */
+Caml_inline size_t mylog(size_t v)
+{
+  size_t log = 0;
+  while(v) {
+    v /= 2;
+    ++ log;
+  }
+  /* Clamp so the result is always a valid index into a MAX_LOG table */
+  if (log >= MAX_LOG) {
+    log = MAX_LOG - 1;
+  }
+  return log;
+}
+
+/* Common code for recording an item in:
+   - an optional max value;
+   - an optional table of small values (less than SMALL_FRAMES)
+   - an optional table of log values.
+ */
+
+Caml_inline void count_item(size_t item, size_t *max, size_t *smalls,
+                            size_t *logs)
+{
+  if (max && item > *max) {
+    *max = item;
+  }
+  if (smalls && item < SMALL_FRAMES) {
+    ++ smalls[item];
+  }
+  if (logs) {
+    ++ logs[mylog(item)];
+  }
+}
+
+/* Record a single live_ofs entry: either a GCable register or a GCable
+   stack slot.  Register numbers are normally small (we have never
+   observed one larger than MAX_REG_IN_SMALL_MAP), but the format
+   permits large ones (e.g. Valx2 values held in SIMD registers), so we
+   guard the fixed-size tables and count the outliers separately. */
+
+static void add_live_ofs(uint32_t ofs,
+                         size_t *regs, size_t *max_reg, uint64_t *reg_map,
+                         bool *has_big_reg,
+                         size_t *slots, size_t *max_slot,
+                         struct frametable_stats *stats)
+{
+  if (ofs & 1) {
+    size_t reg = ofs >> 1;
+    ++ *regs;
+    if (reg > *max_reg) {
+      *max_reg = reg;
+    }
+    if (reg <= MAX_REG_IN_SMALL_MAP) {
+      *reg_map |= (uint64_t)1 << reg;
+    } else {
+      *has_big_reg = true;
+    }
+    if (reg > MAX_REG) {
+      ++ stats->big_reg_entries;
+    }
+  } else {
+    size_t slot = ofs / sizeof(value);
+    ++ *slots;
+    if (slot > *max_slot) {
+      *max_slot = slot;
+    }
+  }
+}
+
+/* Record stats for a single descriptor */
+
+static void add_descriptor_to_stats(frame_descr *d,
+                                    struct frametable_stats *stats)
+{
+  unsigned char *p;
+  ++ stats->descrs;
+  if (!stats->min_descr || ((unsigned char*)d < stats->min_descr)) {
+    stats->min_descr = (unsigned char*)d;
+  }
+
+  intnat retaddr_rel = d->retaddr_rel;
+  if (retaddr_rel < 0) {
+    count_item(-retaddr_rel, &stats->max_neg_retaddr_rel, NULL,
+               stats->log_neg_retaddr_rel);
+  } else {
+    count_item(retaddr_rel, &stats->max_pos_retaddr_rel, NULL,
+               stats->log_pos_retaddr_rel);
+  }
+
+  unsigned char *retaddr = (unsigned char *)Retaddr_frame(d);
+  if (stats->last_retaddr) {
+    if (retaddr < stats->min_retaddr) {
+      stats->min_retaddr = retaddr;
+    }
+    if (retaddr > stats->max_retaddr) {
+      stats->max_retaddr = retaddr;
+    }
+    intnat delta = (uintnat)retaddr - (uintnat)stats->last_retaddr;
+    if (delta < 0) {
+      count_item(-delta, &stats->max_neg_delta, NULL, stats->log_neg_delta);
+    } else {
+      count_item(delta, &stats->max_pos_delta, NULL, stats->log_pos_delta);
+    }
+  } else {
+    stats->min_retaddr = stats->max_retaddr = retaddr;
+  }
+  stats->last_retaddr = retaddr;
+
+  if (frame_return_to_C(d)) {
+    ++ stats->return_to_C;
+    /* Top of an ML stack chunk. Skip over empty frame descriptor */
+    p = (unsigned char*)&d->live_ofs[0];
+    /* Align to word size */
+    p = Align_to(p, void*);
+  } else {
+    uint32_t sz = frame_size(d); /* in bytes */
+    sz /= sizeof(uintnat);
+    count_item(sz, &stats->max_framesize, stats->small_frames,
+               stats->log_framesize);
+
+    uint64_t reg_map = 0; /* bitmap of live registers */
+    size_t regs = 0; /* number of live registers */
+    size_t max_reg = 0; /* max live register number */
+    size_t slots = 0; /* number of live stack slots */
+    size_t max_slot = 0; /* max live stack slot offset */
+    bool has_big_reg = false; /* saw a register too big for the small map */
+
+    uint32_t num_live;
+    if (frame_is_long(d)) {
+      ++stats->long_descrs;
+      frame_descr_long *dl = frame_as_long(d);
+      num_live = dl->num_live;
+      uint32_t n = num_live;
+      for (uint32_t *ofp = dl->live_ofs; n > 0; n--, ofp++) {
+        add_live_ofs(*ofp, &regs, &max_reg, &reg_map, &has_big_reg,
+                     &slots, &max_slot, stats);
+      }
+    } else {
+      num_live = d->num_live;
+      uint16_t n = num_live;
+      for (uint16_t *ofp = d->live_ofs; n > 0; n--, ofp++) {
+        add_live_ofs(*ofp, &regs, &max_reg, &reg_map, &has_big_reg,
+                     &slots, &max_slot, stats);
+      }
+    }
+
+    /* Record size of GC "offset" table */
+    count_item(num_live, &stats->max_lives, stats->small_lives,
+               stats->log_lives);
+
+    /* Register counts and maps, recorded only for allocation descriptors.
+       Non-allocation descriptors are not expected to keep GC roots in
+       registers, so count any that do as an anomaly rather than folding
+       them into the register statistics. */
+    if (frame_has_allocs(d)) {
+      if (regs < REGS) {
+        ++ stats->reg_count[regs];
+      }
+      if (max_reg < REGS) {
+        ++ stats->max_reg[max_reg];
+      }
+      if (regs > stats->max_regs) {
+        stats->max_regs = regs;
+      }
+      if (reg_map < REG_MAPS) {
+        ++ stats->reg_maps[reg_map];
+      }
+      if (has_big_reg) {
+        ++ stats->big_reg_descrs;
+      }
+    } else if (regs > 0) {
+      ++ stats->noalloc_with_regs;
+    }
+
+    /* Slot counts */
+    count_item(slots, &stats->max_slots, stats->small_slots,
+               stats->log_slots);
+
+    /* Maximum slot offset */
+    count_item(max_slot, &stats->max_slot, stats->small_max_slot,
+               stats->log_max_slot);
+
+    p = (unsigned char*)frame_end_of_live_ofs(d);
+    size_t num_debuginfo = 1;
+    if (frame_has_allocs(d)) {
+      ++ stats->with_alloc;
+      size_t num_allocs = *(uint8_t *)p;
+      stats->alloc_sizes += num_allocs;
+      num_debuginfo = num_allocs;
+      count_item(num_allocs, &stats->max_comballocs, stats->small_comballocs,
+                 stats->log_comballocs);
+      ++ p;
+      for (size_t idx = 0; idx < num_allocs; ++idx) {
+        count_item(p[idx], &stats->max_alloc_size, stats->small_alloc_sizes,
+                   stats->log_alloc_sizes);
+      }
+      p += num_allocs;
+    }
+    /* Count debug info if present */
+    if (frame_has_debug(d)) {
+      ++ stats->with_debug;
+      /* Align to 32 bits */
+      p = Align_to(p, uint32_t);
+      for (size_t i = 0; i <  num_debuginfo; ++i) {
+        uint32_t offset = *(uint32_t*)p;
+        if (offset) { /* there may be invalid debuginfo slots */
+          caml_debuginfo_measure((debuginfo)(p + offset));
+        }
+        p += sizeof(uint32_t);
+      }
+    }
+    /* Align to word size */
+    p = Align_to(p, void*);
+  }
+  if (!stats->max_descr || (p > stats->max_descr)) {
+    stats->max_descr = p;
+  }
+}
+
+/* Record stats for all descriptors from a frametable */
+
+static void add_frametable_to_stats(intnat *frametable,
+                                    struct frametable_stats *stats)
+{
+  ++ stats->frametables;
+  if (!stats->min_descr ||
+      ((unsigned char*)frametable < stats->min_descr)) {
+    stats->min_descr = (unsigned char*)frametable;
+  }
+  if (!stats->max_descr ||
+      ((unsigned char*)frametable > stats->max_descr)) {
+    stats->max_descr = (unsigned char*)(frametable+1);
+  }
+  intnat len = *frametable;
+  frame_descr * d = (frame_descr *)(frametable + 1);
+  for (intnat j = 0; j < len; j++) {
+    add_descriptor_to_stats(d, stats);
+    d = next_frame_descr(d);
+  }
+}
+
+/* Record and report stats for all frametables on a list */
+
+static void report_frametables_stats(caml_frametable_list *new_frametables)
+{
+  struct frametable_stats stats;
+  clear_stats(&stats);
+  iter_list(new_frametables, cur) {
+    add_frametable_to_stats(cur->frametable, &stats);
+    accumulate_frametable_stats(cur->frametable, &stats);
+    clear_per_frametable_stats(&stats);
+  }
+  report_stats(&stats);
+}
+
 static void add_frame_descriptors(
   caml_frame_descrs *table,
   caml_frametable_list *new_frametables)
@@ -226,9 +794,15 @@ static void add_frame_descriptors(
     if (table->descriptors == NULL) caml_raise_out_of_memory();
 
     fill_hashtable(table, new_frametables);
+    if (caml_measure_frametables) {
+      report_frametables_stats(new_frametables);
+    }
   } else {
     table->num_descr += increase;
     fill_hashtable(table, new_frametables);
+    if (caml_measure_frametables) {
+      report_frametables_stats(new_frametables);
+    }
     tail->next = table->frametables;
   }
 

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -202,6 +202,9 @@ static void clean_frame_descriptors(caml_frame_descrs *table)
 /* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_frametables */
 extern uintnat caml_measure_frametables;
 
+/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_all_frametables. */
+extern uintnat caml_measure_all_frametables;
+
 #define MAX_LOG 32
 #define SMALL_FRAMES 32
 #define REGS 64
@@ -760,6 +763,28 @@ static void report_frametables_stats(caml_frametable_list *new_frametables)
   report_stats(&stats);
 }
 
+/* The backend emits one pointer per linked unit into the caml_all_frametables
+ * section; the linker concatenates them and provides these bounds. Weak so the
+ * runtime still links where no such section exists (both NULL). */
+extern intnat *__start_caml_all_frametables[] __attribute__((weak));
+extern intnat *__stop_caml_all_frametables[] __attribute__((weak));
+
+/* Measure every frametable in the executable - including dynlink-available
+ * units that are never registered in caml_frametable[]. Reads only static data
+ * and read-only frame descriptors; runs no module initializers. */
+static void report_all_frametables_stats(void)
+{
+  struct frametable_stats stats;
+  clear_stats(&stats);
+  for (intnat **p = __start_caml_all_frametables;
+       p < __stop_caml_all_frametables; p++) {
+    add_frametable_to_stats(*p, &stats);
+    accumulate_frametable_stats(*p, &stats);
+    clear_per_frametable_stats(&stats);
+  }
+  report_stats(&stats);
+}
+
 static void add_frame_descriptors(
   caml_frame_descrs *table,
   caml_frametable_list *new_frametables)
@@ -853,6 +878,10 @@ void caml_init_frame_descriptors(void)
      any mutator can run. We can mutate [current_frame_descrs]
      at will. */
   add_frame_descriptors(&current_frame_descrs, frametables);
+
+  if (caml_measure_all_frametables) {
+    report_all_frametables_stats();
+  }
 }
 
 static void register_frametables_from_stw_single(

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -27,10 +27,20 @@
 #include "caml/backtrace_prim.h"
 #include <stddef.h>
 
+/* A small descriptor does not carry its own return address (it is
+   reconstructed by walking the delta chain when a frametable is
+   registered), so each hash-table slot stores the absolute return
+   address alongside the descriptor-body pointer. An empty slot has
+   [fd == NULL]. */
+typedef struct {
+  uintnat retaddr;
+  frame_descr *fd;
+} frame_descr_entry;
+
 struct caml_frame_descrs {
   int num_descr;
   int mask;
-  frame_descr** descriptors;
+  frame_descr_entry *descriptors;
   caml_frametable_list *frametables;
   caml_frametable_list *zombies;
   caml_plat_mutex mutex;
@@ -69,31 +79,118 @@ extern intnat * caml_frametable[];
 #define iter_list(list,cur) \
   for (caml_frametable_list *cur = list; cur != NULL; cur = cur->next)
 
-static frame_descr * next_frame_descr(frame_descr * d) {
-  unsigned char num_allocs = 0, *p;
-  CAMLassert(Retaddr_frame(d) >= 4096);
-  if (!frame_return_to_C(d)) {
-    /* Skip to end of live_ofs */
-    p = frame_end_of_live_ofs(d);
-    /* Skip alloc_lengths if present */
-    if (frame_has_allocs(d)) {
-      num_allocs = *p;
-      p += num_allocs + 1;
+/* Decode one descriptor (small or escaped) into [out], filling in its
+   flags, sizes, and the pointers needed to locate its live offsets,
+   allocation sizes, and debug words. [d] points at the descriptor body
+   (the byte after its LEB128 delta / escape byte). */
+void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out)
+{
+  memset(out, 0, sizeof(*out));
+  if (frame_is_small(d)) {
+    const unsigned char *p = (const unsigned char *)d;
+    unsigned char sf = *p++; /* size+flags byte */
+    out->is_small = true;
+    out->has_allocs = (sf & FRAME_DESCRIPTOR_ALLOC) != 0;
+    out->has_debug = (sf & FRAME_DESCRIPTOR_DEBUG) != 0;
+    out->frame_size = (((uint32_t)(sf >> 2)) + 1) * 16;
+    if (out->has_allocs) {
+      out->small_num_allocs = *p++;
+      out->num_live = *p++;
+      out->small_allocs = p;
+      p += (out->small_num_allocs + 1) / 2; /* 4-bit alloc sizes */
+      out->small_reg_bitmap = *p++;
+    } else {
+      out->num_live = *p++;
     }
-    /* Skip debug info if present */
-    if (frame_has_debug(d)) {
-      p += sizeof(uint32_t) * (frame_has_allocs(d) ? num_allocs : 1);
+    out->small_live = p;
+    p += out->num_live; /* one byte per live stack slot (word offset) */
+    out->end_of_live = p;
+    out->num_debuginfo = out->has_allocs ? out->small_num_allocs : 1;
+    if (out->has_debug) {
+      p += sizeof(uint32_t) * out->num_debuginfo;
     }
-    /* Frame descriptors are not aligned: the next one follows immediately. */
-    return ((frame_descr*) p);
-  } else {
-    /* This marks the top of an ML stack chunk. Skip over empty
-     * frame descriptor */
-    /* Skip to address of zero-sized live_ofs */
-    CAMLassert(caml_read_unaligned_uint16(&d->num_live) == 0);
-    p = (unsigned char*)&d->live_ofs[0];
-    return ((frame_descr*) p);
+    out->end = p;
+    return;
   }
+
+  /* Escaped descriptor: normal or long format. */
+  if (frame_return_to_C(d)) {
+    out->return_to_C = true;
+    /* Top of an ML stack chunk: an empty descriptor. */
+    CAMLassert(caml_read_unaligned_uint16(&d->num_live) == 0);
+    out->end_of_live = out->end = (const unsigned char *)&d->live_ofs[0];
+    return;
+  }
+  out->is_long = frame_is_long(d);
+  out->has_allocs = frame_has_allocs(d);
+  out->has_debug = frame_has_debug(d);
+  out->frame_size = frame_size(d);
+  if (out->is_long) {
+    out->num_live = caml_read_unaligned_uint32(&frame_as_long(d)->num_live);
+  } else {
+    out->num_live = caml_read_unaligned_uint16(&d->num_live);
+  }
+  const unsigned char *p = frame_end_of_live_ofs(d);
+  out->end_of_live = p;
+  out->num_debuginfo = 1;
+  if (out->has_allocs) {
+    out->small_num_allocs = *p;
+    out->num_debuginfo = *p;
+    p += (uintnat)(*p) + 1; /* num_allocs byte + one byte per alloc */
+  }
+  if (out->has_debug) {
+    p += sizeof(uint32_t) * out->num_debuginfo;
+  }
+  out->end = p;
+}
+
+/* Iterate over the descriptors of one frametable, reconstructing the
+   absolute return address of each descriptor by walking the delta chain.
+   An escaped descriptor carries an absolute return address (retaddr_rel);
+   a small descriptor's address is the running address plus its delta. */
+typedef struct {
+  const unsigned char *next; /* points at the next descriptor's delta byte */
+  uintnat retaddr;           /* running absolute return address */
+  intnat remaining;          /* descriptors left to yield */
+} frametable_iter;
+
+static void frametable_iter_start(frametable_iter *it, intnat *tbl)
+{
+  it->remaining = (intnat)caml_read_unaligned_uintnat(tbl);
+  it->next = (const unsigned char *)(tbl + 1);
+  it->retaddr = 0;
+}
+
+/* Yield the next descriptor body and its absolute return address. Must
+   only be called while [it->remaining > 0]. */
+static frame_descr *frametable_iter_next(frametable_iter *it,
+                                         uintnat *retaddr_out)
+{
+  const unsigned char *p = it->next;
+  frame_descr *d;
+  if (*p == FRAME_DELTA_ESCAPE) {
+    p++;
+    d = (frame_descr *)p;
+    it->retaddr = Retaddr_frame(d);
+  } else {
+    /* Unsigned LEB128 delta (>= 1, so it never starts with a 0 byte). */
+    uintnat delta = 0;
+    int shift = 0;
+    unsigned char byte;
+    do {
+      byte = *p++;
+      delta |= (uintnat)(byte & 0x7f) << shift;
+      shift += 7;
+    } while (byte & 0x80);
+    it->retaddr += delta;
+    d = (frame_descr *)p;
+  }
+  struct frame_descr_decoded dec;
+  caml_decode_frame_descr(d, &dec);
+  it->next = dec.end;
+  it->remaining--;
+  *retaddr_out = it->retaddr;
+  return d;
 }
 
 static intnat count_descriptors(caml_frametable_list *list) {
@@ -122,38 +219,40 @@ static void fill_hashtable(
   caml_frame_descrs *table, caml_frametable_list *new_frametables)
 {
   iter_list(new_frametables,cur) {
-    intnat * tbl = (intnat*) cur->frametable;
-    intnat len = (intnat)caml_read_unaligned_uintnat(tbl);
-    frame_descr * d = (frame_descr *)(tbl + 1);
-    for (intnat j = 0; j < len; j++) {
-      uintnat h = Hash_retaddr(Retaddr_frame(d), table->mask);
-      while (table->descriptors[h] != NULL) {
+    frametable_iter it;
+    frametable_iter_start(&it, (intnat *) cur->frametable);
+    while (it.remaining > 0) {
+      uintnat retaddr;
+      frame_descr *d = frametable_iter_next(&it, &retaddr);
+      uintnat h = Hash_retaddr(retaddr, table->mask);
+      while (table->descriptors[h].fd != NULL) {
         h = (h+1) & table->mask;
       }
-      table->descriptors[h] = d;
-      d = next_frame_descr(d);
+      table->descriptors[h].retaddr = retaddr;
+      table->descriptors[h].fd = d;
     }
   }
 }
 
-static void remove_entry(caml_frame_descrs *table, frame_descr * d) {
+static void remove_entry(caml_frame_descrs *table, uintnat retaddr,
+                         frame_descr * d) {
   uintnat i;
   uintnat r;
   uintnat j;
 
-  i = Hash_retaddr(Retaddr_frame(d), table->mask);
-  while (table->descriptors[i] != d) {
+  i = Hash_retaddr(retaddr, table->mask);
+  while (table->descriptors[i].fd != d) {
     i = (i+1) & table->mask;
   }
 
  r1:
   j = i;
-  table->descriptors[i] = NULL;
+  table->descriptors[i].fd = NULL;
  r2:
   i = (i+1) & table->mask;
   // r3
-  if(table->descriptors[i] == NULL) return;
-  r = Hash_retaddr(Retaddr_frame(table->descriptors[i]), table->mask);
+  if(table->descriptors[i].fd == NULL) return;
+  r = Hash_retaddr(table->descriptors[i].retaddr, table->mask);
   /* If r is between i and j (cyclically), i.e. if
      table->descriptors[i]->retaddr don't need to be moved */
   if(( ( j < r )  && ( r <= i ) ) ||
@@ -168,16 +267,16 @@ static void remove_entry(caml_frame_descrs *table, frame_descr * d) {
 
 static void clean_frame_descriptors(caml_frame_descrs *table)
 {
-  intnat *tbl, len, decrease = 0;
-  frame_descr * d;
+  intnat decrease = 0;
   caml_frametable_list *cur = table->zombies, *rem;
   while (cur != NULL) {
-    tbl = (intnat*) cur->frametable;
-    len = *tbl;
-    d = (frame_descr *)(tbl + 1);
-    for (intnat j = 0; j < len; j++) {
-      remove_entry(table, d);
-      d = next_frame_descr(d);
+    frametable_iter it;
+    frametable_iter_start(&it, (intnat *) cur->frametable);
+    intnat len = it.remaining;
+    while (it.remaining > 0) {
+      uintnat retaddr;
+      frame_descr *d = frametable_iter_next(&it, &retaddr);
+      remove_entry(table, retaddr, d);
     }
     decrease += len;
     rem = cur;
@@ -190,144 +289,30 @@ static void clean_frame_descriptors(caml_frame_descrs *table)
 
 /* ---- Frametable measurement ---- */
 
-/* As preparation for designing a more memory-efficient frametable
- * format, this code measures various things about the frametables of
- * an executable. */
+/* Walks the frametables in the new ("small") on-disk format and reports
+ * their real sizes, so we can track how much the compact encoding saves.
+ * Settable via GC tweaks OCAMLRUNPARAM=Xmeasure_frametables (the
+ * frametables registered in this batch) and Xmeasure_all_frametables (all
+ * units linked into the executable, via the caml_all_frametables set). */
 
-/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_frametables */
 extern uintnat caml_measure_frametables;
-
-/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_all_frametables. */
 extern uintnat caml_measure_all_frametables;
 
-#define MAX_LOG 32
-#define SMALL_FRAMES 32
-#define REGS 64
-#define MAX_REG (REGS - 1) /* Largest register index recorded in reg tables */
-#define MAX_REG_IN_SMALL_MAP 12
-#define REG_MAPS (1<<(MAX_REG_IN_SMALL_MAP + 1))
-#define REGMAP_REPORT_THRESHOLD 1000
-
-/* Step 2 of the small-frame-descriptor design: simulate, without changing the
-   format, how big each descriptor would be in the proposed "small" format, and
-   how much we'd save. */
-#define SIM_MAXK 8  /* ALLOC_BITS swept 0..SIM_MAXK in the combined na/nl byte */
-/* The 8 hottest GC registers, from the measured (each reg) histogram on
-   ocamlopt.opt: 0,1,2,3,4,5,6,8. A small alloc descriptor's live registers
-   must all be in this set (others escape to the normal format). */
-#define SIM_HOT_REGS \
-  ((1ULL<<0)|(1ULL<<1)|(1ULL<<2)|(1ULL<<3)|(1ULL<<4)|(1ULL<<5)|(1ULL<<6)|(1ULL<<8))
-
 struct frametable_stats {
-  /* A few per-frametable items */
-  unsigned char *last_retaddr;
-  unsigned char *min_retaddr;
-  unsigned char *max_retaddr;
-  unsigned char *min_descr;
-  unsigned char *max_descr;
-  size_t descrs;
-
-  /* Everything else is accumulated over all frametables */
   size_t frametables;
-  size_t total_codesize;
-  size_t total_ft_size;
-  size_t total_debuginfo_size;
-  size_t total_descrs;
-  size_t total_debuginfo;
-
-  /* Are frametables in memory before or after the code they describe? */
-  size_t ft_before_code;
-  size_t ft_after_code;
-
-  /* Descriptor kinds */
+  size_t descrs;         /* total descriptors */
+  size_t small_descrs;   /* small-format descriptors */
+  size_t escaped_descrs; /* escaped (normal/long) descriptors */
+  size_t wide_deltas;    /* small descrs whose LEB128 delta needs >1 byte */
   size_t return_to_C;
-  size_t with_debug;
   size_t with_alloc;
-  size_t long_descrs;
+  size_t with_debug;
 
-  /* Frame sizes */
-  size_t small_frames[SMALL_FRAMES];
-  size_t log_framesize[MAX_LOG];
-  size_t max_framesize;
-
-  /* Relative return addresses */
-  size_t log_pos_retaddr_rel[MAX_LOG];
-  size_t max_pos_retaddr_rel;
-  size_t log_neg_retaddr_rel[MAX_LOG];
-  size_t max_neg_retaddr_rel;
-
-  /* Delta from one retaddr to the next */
-  size_t log_pos_delta[MAX_LOG];
-  size_t max_pos_delta;
-  size_t log_neg_delta[MAX_LOG];
-  size_t max_neg_delta;
-
-  /* Counts of "live offset" slots (GC regs + slots) */
-  size_t small_lives[SMALL_FRAMES];
-  size_t log_lives[MAX_LOG];
-  size_t max_lives; /* Overall maximum count of lives */
-
-  /* GCable registers */
-  size_t reg[REGS]; /* # descriptors using each register */
-  size_t reg_count[REGS]; /* Count GCable registers */
-  size_t max_regs;
-  size_t max_reg[REGS];  /* Count max GCable register index */
-  size_t reg_maps[REG_MAPS]; /* Count reg maps up to REG_MAPS */
-  size_t big_reg_descrs; /* Descrs with a register > MAX_REG_IN_SMALL_MAP */
-  size_t big_reg_entries; /* live_ofs register entries with number > MAX_REG */
-  size_t noalloc_with_regs; /* Non-alloc descrs that have registers (anomaly) */
-
-  /* Count of GCable stack slots */
-  size_t small_slots[SMALL_FRAMES];
-  size_t log_slots[MAX_LOG];
-  size_t max_slots;
-
-  /* maximum GCable stack slot offset */
-  size_t small_max_slot[SMALL_FRAMES];
-  size_t log_max_slot[MAX_LOG];
-  size_t max_slot;
-
-  /* Comballoc allocation counts */
-  size_t log_comballocs[MAX_LOG];
-  size_t small_comballocs[SMALL_FRAMES];
-  size_t max_comballocs;
-
-  /* allocation sizes */
-  size_t alloc_sizes;
-  size_t log_alloc_sizes[MAX_LOG];
-  size_t small_alloc_sizes[SMALL_FRAMES];
-  size_t max_alloc_size;
-
-  /* Small-descriptor format simulation (step 2) */
-  size_t sim_descrs;                       /* descriptors simulated */
-  size_t sim_current_total;                /* bytes in the current packed format */
-  size_t sim_aligned_total;                /* bytes in the old (pre-relaxation) aligned format */
-  /* [varint delta?][16-bit register bitmap?][ALLOC_BITS] */
-  size_t sim_total[2][2][SIM_MAXK + 1];    /* total bytes, combined na/nl byte */
-  size_t sim_small[2][2][SIM_MAXK + 1];    /* # small descriptors */
-  /* [varint?][16-bit bitmap?]: separate full bytes for num_allocs & num_live */
-  size_t sim_sep_total[2][2];
-  size_t sim_sep_small[2][2];
-  /* base-ineligibility causes (independent of ALLOC_BITS) */
-  size_t sim_esc_first, sim_esc_rettoc, sim_esc_delta, sim_esc_size,
-         sim_esc_reg, sim_esc_allocsize;
+  size_t descr_bytes;    /* bytes of frame descriptors (incl. delta bytes) */
+  size_t header_bytes;   /* per-frametable count words */
+  size_t debuginfo_bytes;
+  size_t debuginfo_count;
 };
-
-static void clear_stats(struct frametable_stats *stats)
-{
-  caml_debuginfo_reset();
-  memset(stats, 0, sizeof(*stats));
-}
-
-static void clear_per_frametable_stats(struct frametable_stats *stats)
-{
-  stats->min_retaddr = stats->max_retaddr = stats->last_retaddr =
-    stats->min_descr = stats->max_descr = NULL;
-  stats->descrs = 0;
-  caml_debuginfo_reset();
-}
-
-/* Turn `val` into a string representing that number of bytes */
 
 static void report_bytes(char *buf, size_t space, size_t val)
 {
@@ -337,7 +322,7 @@ static void report_bytes(char *buf, size_t space, size_t val)
     char suffix[] = " kMGTE";
     double scaled = val;
     char *p = suffix;
-    while(scaled > 1000 && *p) {
+    while (scaled > 1000 && *p) {
       scaled /= 1024.0;
       ++p;
     }
@@ -345,620 +330,94 @@ static void report_bytes(char *buf, size_t space, size_t val)
   }
 }
 
-/* Write text showing an array `vals` of `count` size_t values,
- * without trailing zero values, into `buf` (size `space` bytes). */
-
-/* This works for regs and logs and smalls */
-#define TABLE_BUF_SIZE (REGS * 16)
-
-static void report_table(char *fmt, size_t *vals, size_t count)
-{
-  char buf[TABLE_BUF_SIZE];
-  size_t space = TABLE_BUF_SIZE;
-
-  size_t max = count - 1;
-  while(max && vals[max] == 0) {
-    --max;
-  }
-  char *p = buf;
-  for (size_t i = 0; i <= max; ++i) {
-    int len = snprintf(p, space, "%zu ", vals[i]);
-    if (len > space) { /* truncated, replace with ... */
-      p[space-4] = p[space-3] = p[space-2] = '.';
-      p[space-1] = '\0';
-      return;
-    }
-    space -= len;
-    p += len;
-  }
-  printf(fmt, buf);
-}
-
-/* At the end of a single frametable, deduce per-frametable sizes and
- * add them to global stats. */
-
-static void accumulate_frametable_stats(intnat *frametable,
-                                        struct frametable_stats *stats)
-{
-  char *debuginfo_low, *debuginfo_high;
-  size_t debuginfo_count;
-  caml_debuginfo_measurements(&debuginfo_count,
-                              &debuginfo_low,
-                              &debuginfo_high);
-  /* round debuginfo_high up to word boundary */
-  debuginfo_high = Align_to(debuginfo_high, uintnat);
-/*
-  printf("Frametable at %p: return addresses %p-%p(0x%zx), "
-        "descriptors %p-%p(0x%zx, %zu), "
-        "debuginfo %p-%p(0x%zx, %zu)\n",
-        (void*)frametable,
-        (void*)stats->min_retaddr,
-        (void*)stats->max_retaddr,
-        (size_t)(stats->max_retaddr - stats->min_retaddr),
-        (void*)stats->min_descr,
-        (void*)stats->max_descr,
-        (size_t)(stats->max_descr - stats->min_descr),
-        stats->descrs,
-        (void*)debuginfo_low,
-        (void*)debuginfo_high,
-        (size_t)(debuginfo_high - debuginfo_low),
-        debuginfo_count);
-*/
-  stats->total_codesize += (stats->max_retaddr - stats->min_retaddr);
-  stats->total_ft_size += (stats->max_descr - stats->min_descr);
-  stats->total_debuginfo_size += (debuginfo_high - debuginfo_low);
-  stats->total_descrs += stats->descrs;
-  stats->total_debuginfo += debuginfo_count;
-  if (stats->min_retaddr) {
-    if (stats->min_retaddr > stats->min_descr)
-      ++ stats->ft_before_code;
-    else
-      ++ stats->ft_after_code;
-  }
-}
-
-/* Report all accumulated frametable stats to stdout. */
-
-static void report_stats(struct frametable_stats *stats)
-{
-  char table_buf[TABLE_BUF_SIZE];
-
-  size_t total_size =
-    stats->total_codesize
-    + stats->total_ft_size
-    + stats->total_debuginfo_size;
-  printf("Summary of %zu frametables.\n", stats->frametables);
-  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_codesize);
-  printf("%s code (%5.2f%%)\n", table_buf,
-         (double)stats->total_codesize/total_size * 100.0);
-  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_ft_size);
-  printf("%s descriptors (%5.2f%%; %zu descrs, %f bytes each)\n",
-         table_buf,
-         (double)stats->total_ft_size/total_size * 100.0,
-         stats->total_descrs,
-         (double)stats->total_ft_size / stats->total_descrs);
-  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_debuginfo_size);
-  printf("%s Debuginfo (%5.2f%% %zu entries)\n",
-         table_buf,
-         (double)stats->total_debuginfo_size/total_size * 100.0,
-         stats->total_debuginfo);
-  printf("%zu frametables before code, %zu after code.\n",
-         stats->ft_before_code, stats->ft_after_code);
-  printf("long %zu return to C %zu alloc %zu debug %zu\n",
-         stats->long_descrs, stats->return_to_C,
-         stats->with_alloc, stats->with_debug);
-
-  printf("Max pos retaddr offset %zu\n", stats->max_pos_retaddr_rel);
-  report_table("  (logs %s)\n", stats->log_pos_retaddr_rel, MAX_LOG);
-  printf("Max neg retaddr offset %zu\n", stats->max_neg_retaddr_rel);
-  report_table("  (logs %s)\n", stats->log_neg_retaddr_rel, MAX_LOG);
-  printf("Max retaddr pos delta %zu\n", stats->max_pos_delta);
-  report_table("  (logs %s)\n", stats->log_pos_delta, MAX_LOG);
-  printf("Max retaddr neg delta %zu\n", stats->max_neg_delta);
-  report_table("  (logs %s)\n", stats->log_neg_delta, MAX_LOG);
-
-  printf("Frame sizes (max %zu)\n", stats->max_framesize);
-  report_table("  (small %s)\n", stats->small_frames, SMALL_FRAMES);
-  report_table("  (logs %s)\n", stats->log_framesize, MAX_LOG);
-
-  printf("Comballoc entries (max %zu)\n",
-         stats->max_comballocs);
-  report_table("  (small %s)\n", stats->small_comballocs, SMALL_FRAMES);
-  report_table("  (logs %s)\n", stats->log_comballocs, MAX_LOG);
-
-  printf("Allocation sizes (wosize-1) (%zu allocs, max %zu)\n",
-         stats->alloc_sizes, stats->max_alloc_size);
-  report_table("  (small %s)\n", stats->small_alloc_sizes, SMALL_FRAMES);
-  report_table("  (logs %s)\n", stats->log_alloc_sizes, MAX_LOG);
-
-  printf("GC live values (max %zu)\n", stats->max_lives);
-  report_table("  (small %s)\n", stats->small_lives, SMALL_FRAMES);
-  report_table("  (logs %s)\n", stats->log_lives, MAX_LOG);
-
-  printf("GCable stack slots (max %zu)\n", stats->max_slots);
-  report_table("  (small %s)\n", stats->small_slots, SMALL_FRAMES);
-  report_table("  (logs %s)\n", stats->log_slots, MAX_LOG);
-
-  printf("Max GCable stack slot (max %zu)\n", stats->max_slot);
-  report_table("  (small %s)\n", stats->small_max_slot, SMALL_FRAMES);
-  report_table("  (logs %s)\n", stats->log_max_slot, MAX_LOG);
-
-  printf("GCable registers (max %zu)\n", stats->max_regs);
-  report_table("  (counts %s)\n", stats->reg_count, REGS);
-  report_table("  (each reg %s)\n", stats->reg, REGS);
-  report_table("  (max %s)\n", stats->max_reg, REGS);
-
-  /* report all register maps which are more than 1/128 of the total
-   * (apart from the empty reg map */
-  size_t others = 0;
-  size_t regmaps = 0;
-  for (size_t i = 1; i < REG_MAPS; ++i) {
-    regmaps += stats->reg_maps[i];
-  }
-
-  printf("Register map frequencies (of %zu allocation descriptors):\n",
-         stats->with_alloc);
-  for (size_t i = 0; i < REG_MAPS; ++i) {
-    if (stats->reg_maps[i] > regmaps/REGMAP_REPORT_THRESHOLD) {
-      for (size_t j = 0; j <= MAX_REG_IN_SMALL_MAP; ++j) {
-        table_buf[MAX_REG_IN_SMALL_MAP - j] = (i & (1 << j)) ? '1' : '0';
-      }
-      table_buf[MAX_REG_IN_SMALL_MAP+1] = '\0';
-      printf("  %s %zu\n", table_buf, stats->reg_maps[i]);
-    } else {
-      others += stats->reg_maps[i];
-    }
-  }
-  printf("  others (<= %zu) %zu\n", regmaps/REGMAP_REPORT_THRESHOLD, others);
-  printf("Descriptors with a register > %d: %zu\n",
-         MAX_REG_IN_SMALL_MAP, stats->big_reg_descrs);
-  printf("live_ofs register entries with number > %d: %zu\n",
-         MAX_REG, stats->big_reg_entries);
-  printf("Non-allocation descriptors with registers: %zu\n",
-         stats->noalloc_with_regs);
-
-  /* --- Small-descriptor format simulation (step 2) --- */
-  printf("\nSmall-descriptor simulation: %zu descriptors\n", stats->sim_descrs);
-  report_bytes(table_buf, TABLE_BUF_SIZE, stats->sim_aligned_total);
-  printf("  baseline aligned: %s\n", table_buf);
-  report_bytes(table_buf, TABLE_BUF_SIZE, stats->sim_current_total);
-  printf("  baseline packed:  %s\n", table_buf);
-  printf("  base-escape causes: first=%zu retC=%zu delta>255=%zu size=%zu "
-         "reg=%zu allocsz=%zu\n",
-         stats->sim_esc_first, stats->sim_esc_rettoc, stats->sim_esc_delta,
-         stats->sim_esc_size, stats->sim_esc_reg, stats->sim_esc_allocsize);
-  printf("  base format (8-reg bitmap, 1-byte delta), by ALLOC_BITS:\n");
-  printf("  %-10s %14s %10s %10s %9s %9s\n",
-         "ALLOC_BITS", "total", "small", "escaped", "vs_packed", "vs_aligned");
-  for (int k = 0; k <= SIM_MAXK; k++) {
-    size_t esc = stats->sim_descrs - stats->sim_small[0][0][k];
-    double pk = stats->sim_current_total
-      ? 100.0 * ((double)stats->sim_current_total
-                 - (double)stats->sim_total[0][0][k])
-        / (double)stats->sim_current_total : 0.0;
-    double al = stats->sim_aligned_total
-      ? 100.0 * ((double)stats->sim_aligned_total
-                 - (double)stats->sim_total[0][0][k])
-        / (double)stats->sim_aligned_total : 0.0;
-    printf("  %-10d %14zu %10zu %10zu %8.1f%% %8.1f%%\n",
-           k, stats->sim_total[0][0][k], stats->sim_small[0][0][k], esc, pk, al);
-  }
-  {
-    static const char *nm[2][2] =
-      { { "base", "+16b-bitmap" }, { "+varint", "+varint+16b" } };
-    printf("  refinements (each at its best ALLOC_BITS):\n");
-    for (int v = 0; v < 2; v++) for (int b = 0; b < 2; b++) {
-      int bk = 0;
-      for (int k = 1; k <= SIM_MAXK; k++)
-        if (stats->sim_total[v][b][k] < stats->sim_total[v][b][bk]) bk = k;
-      size_t tot = stats->sim_total[v][b][bk];
-      double pk = stats->sim_current_total
-        ? 100.0 * ((double)stats->sim_current_total - (double)tot)
-          / (double)stats->sim_current_total : 0.0;
-      double al = stats->sim_aligned_total
-        ? 100.0 * ((double)stats->sim_aligned_total - (double)tot)
-          / (double)stats->sim_aligned_total : 0.0;
-      printf("  %-12s k=%d  %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
-             nm[v][b], bk, tot, pk, al);
-    }
-    printf("  separate na/nl bytes (no ALLOC_BITS split):\n");
-    for (int v = 0; v < 2; v++) for (int b = 0; b < 2; b++) {
-      size_t tot = stats->sim_sep_total[v][b];
-      double pk = stats->sim_current_total
-        ? 100.0 * ((double)stats->sim_current_total - (double)tot)
-          / (double)stats->sim_current_total : 0.0;
-      double al = stats->sim_aligned_total
-        ? 100.0 * ((double)stats->sim_aligned_total - (double)tot)
-          / (double)stats->sim_aligned_total : 0.0;
-      printf("  %-12s      %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
-             nm[v][b], tot, pk, al);
-    }
-  }
-}
-
-/* Actually floor(log_2(x))+1, clamped at MAX_LOG-1.
-   mylog(0) = 0
-   mylog(1) = 1
-   mylog(2) = 2
-   mylog(3) = 2
-   mylog(4) = 3
-   ...
-   mylog(255) = 8
-   mylog(256) = 9
-   etc
-  */
-Caml_inline size_t mylog(size_t v)
-{
-  size_t log = 0;
-  while(v) {
-    v /= 2;
-    ++ log;
-  }
-  /* Clamp so the result is always a valid index into a MAX_LOG table */
-  if (log >= MAX_LOG) {
-    log = MAX_LOG - 1;
-  }
-  return log;
-}
-
-/* Common code for recording an item in:
-   - an optional max value;
-   - an optional table of small values (less than SMALL_FRAMES)
-   - an optional table of log values.
- */
-
-Caml_inline void count_item(size_t item, size_t *max, size_t *smalls,
-                            size_t *logs)
-{
-  if (max && item > *max) {
-    *max = item;
-  }
-  if (smalls && item < SMALL_FRAMES) {
-    ++ smalls[item];
-  }
-  if (logs) {
-    ++ logs[mylog(item)];
-  }
-}
-
-/* Record a single live_ofs entry: either a GCable register or a GCable
-   stack slot.  Register numbers are normally small (we have never
-   observed one larger than MAX_REG_IN_SMALL_MAP), but the format
-   permits large ones (e.g. Valx2 values held in SIMD registers), so we
-   guard the fixed-size tables and count the outliers separately. */
-
-static void add_live_ofs(uint32_t ofs, size_t *reg_p,
-                         size_t *regs, size_t *max_reg, uint64_t *reg_map,
-                         bool *has_big_reg,
-                         size_t *slots, size_t *max_slot,
-                         struct frametable_stats *stats)
-{
-  if (ofs & 1) {
-    size_t reg = ofs >> 1;
-    ++ *regs;
-    if (reg < REGS) {
-      ++ reg_p[reg];
-    }
-    if (reg > *max_reg) {
-      *max_reg = reg;
-    }
-    if (reg <= MAX_REG_IN_SMALL_MAP) {
-      *reg_map |= (uint64_t)1 << reg;
-    } else {
-      *has_big_reg = true;
-    }
-    if (reg > MAX_REG) {
-      ++ stats->big_reg_entries;
-    }
-  } else {
-    size_t slot = ofs / sizeof(value);
-    ++ *slots;
-    if (slot > *max_slot) {
-      *max_slot = slot;
-    }
-  }
-}
-
-/* Record stats for a single descriptor */
-
-static void add_descriptor_to_stats(frame_descr *d,
+/* Record stats for the descriptors of one frametable. */
+static void add_frametable_to_stats(intnat *frametable,
                                     struct frametable_stats *stats)
 {
-  unsigned char *p;
-  /* Facts gathered for the small-descriptor simulation at the end. */
-  bool sim_is_first = false, sim_rettoc = false, sim_is_long = false;
-  bool sim_has_alloc = false, sim_has_debug = false, sim_bigreg = false;
-  bool sim_allocs4 = true;
-  intnat sim_delta = 0;
-  uint32_t sim_fsize = 0;
-  uint64_t sim_regmap = 0;
-  size_t sim_nlive = 0, sim_slots = 0, sim_regs = 0, sim_nalloc = 0,
-         sim_ndbg = 0;
-  ++ stats->descrs;
-  if (!stats->min_descr || ((unsigned char*)d < stats->min_descr)) {
-    stats->min_descr = (unsigned char*)d;
-  }
+  ++stats->frametables;
+  stats->header_bytes += sizeof(intnat);
+  caml_debuginfo_reset();
 
-  intnat retaddr_rel = caml_read_unaligned_int32(&d->retaddr_rel);
-  if (retaddr_rel < 0) {
-    count_item(-retaddr_rel, &stats->max_neg_retaddr_rel, NULL,
-               stats->log_neg_retaddr_rel);
-  } else {
-    count_item(retaddr_rel, &stats->max_pos_retaddr_rel, NULL,
-               stats->log_pos_retaddr_rel);
-  }
-
-  unsigned char *retaddr = (unsigned char *)Retaddr_frame(d);
-  sim_is_first = (stats->last_retaddr == NULL);
-  if (!sim_is_first)
-    sim_delta = (intnat)((uintnat)retaddr - (uintnat)stats->last_retaddr);
-  if (stats->last_retaddr) {
-    if (retaddr < stats->min_retaddr) {
-      stats->min_retaddr = retaddr;
-    }
-    if (retaddr > stats->max_retaddr) {
-      stats->max_retaddr = retaddr;
-    }
-    intnat delta = (uintnat)retaddr - (uintnat)stats->last_retaddr;
-    if (delta < 0) {
-      count_item(-delta, &stats->max_neg_delta, NULL, stats->log_neg_delta);
+  frametable_iter it;
+  frametable_iter_start(&it, frametable);
+  const unsigned char *start = it.next;
+  while (it.remaining > 0) {
+    const unsigned char *delta_at = it.next;
+    unsigned char delta0 = *delta_at;
+    uintnat retaddr;
+    frame_descr *d = frametable_iter_next(&it, &retaddr);
+    ++stats->descrs;
+    if (delta0 == FRAME_DELTA_ESCAPE) {
+      ++stats->escaped_descrs;
     } else {
-      count_item(delta, &stats->max_pos_delta, NULL, stats->log_pos_delta);
-    }
-  } else {
-    stats->min_retaddr = stats->max_retaddr = retaddr;
-  }
-  stats->last_retaddr = retaddr;
-
-  if (frame_return_to_C(d)) {
-    ++ stats->return_to_C;
-    sim_rettoc = true;
-    /* Top of an ML stack chunk. Skip over empty frame descriptor */
-    p = (unsigned char*)&d->live_ofs[0];
-  } else {
-    uint32_t sz = frame_size(d); /* in bytes */
-    sz /= sizeof(uintnat);
-    count_item(sz, &stats->max_framesize, stats->small_frames,
-               stats->log_framesize);
-
-    uint64_t reg_map = 0; /* bitmap of live registers */
-    size_t regs = 0; /* number of live registers */
-    size_t max_reg = 0; /* max live register number */
-    size_t slots = 0; /* number of live stack slots */
-    size_t max_slot = 0; /* max live stack slot offset */
-    bool has_big_reg = false; /* saw a register too big for the small map */
-
-    uint32_t num_live;
-    if (frame_is_long(d)) {
-      ++stats->long_descrs;
-      frame_descr_long *dl = frame_as_long(d);
-      num_live = caml_read_unaligned_uint32(&dl->num_live);
-      uint32_t n = num_live;
-      for (uint32_t *ofp = dl->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(caml_read_unaligned_uint32(ofp), stats->reg, &regs,
-                     &max_reg, &reg_map, &has_big_reg, &slots, &max_slot,
-                     stats);
-      }
-    } else {
-      num_live = caml_read_unaligned_uint16(&d->num_live);
-      uint16_t n = num_live;
-      for (uint16_t *ofp = d->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(caml_read_unaligned_uint16(ofp), stats->reg,
-                     &regs, &max_reg, &reg_map, &has_big_reg, &slots,
-                     &max_slot, stats);
-      }
+      ++stats->small_descrs;
+      /* Count small descriptors whose LEB128 delta needed more than one
+         byte (the high bit of the first byte is set). */
+      if (delta0 & 0x80) ++stats->wide_deltas;
     }
 
-    /* Record size of GC "offset" table */
-    count_item(num_live, &stats->max_lives, stats->small_lives,
-               stats->log_lives);
-
-    /* Register counts and maps, recorded only for allocation descriptors.
-       Non-allocation descriptors are not expected to keep GC roots in
-       registers, so count any that do as an anomaly rather than folding
-       them into the register statistics. */
-    if (frame_has_allocs(d)) {
-      if (regs < REGS) {
-        ++ stats->reg_count[regs];
+    struct frame_descr_decoded dec;
+    caml_decode_frame_descr(d, &dec);
+    if (dec.return_to_C) ++stats->return_to_C;
+    if (dec.has_allocs) ++stats->with_alloc;
+    if (dec.has_debug) {
+      ++stats->with_debug;
+      const unsigned char *p = dec.end_of_live;
+      if (!dec.is_small && dec.has_allocs) {
+        /* escaped: skip num_allocs byte + alloc bytes */
+        p += (uintnat)(*p) + 1;
       }
-      if (max_reg < REGS) {
-        ++ stats->max_reg[max_reg];
-      }
-      if (regs > stats->max_regs) {
-        stats->max_regs = regs;
-      }
-      if (reg_map < REG_MAPS) {
-        ++ stats->reg_maps[reg_map];
-      }
-      if (has_big_reg) {
-        ++ stats->big_reg_descrs;
-      }
-    } else if (regs > 0) {
-      ++ stats->noalloc_with_regs;
-    }
-
-    /* Slot counts */
-    count_item(slots, &stats->max_slots, stats->small_slots,
-               stats->log_slots);
-
-    /* Maximum slot offset */
-    count_item(max_slot, &stats->max_slot, stats->small_max_slot,
-               stats->log_max_slot);
-
-    p = (unsigned char*)frame_end_of_live_ofs(d);
-    size_t num_debuginfo = 1;
-    size_t num_allocs = 0;
-    bool all_allocs_4bit = true; /* do all alloc sizes fit in 4 bits? */
-    if (frame_has_allocs(d)) {
-      ++ stats->with_alloc;
-      num_allocs = *(uint8_t *)p;
-      stats->alloc_sizes += num_allocs;
-      num_debuginfo = num_allocs;
-      count_item(num_allocs, &stats->max_comballocs, stats->small_comballocs,
-                 stats->log_comballocs);
-      ++ p;
-      for (size_t idx = 0; idx < num_allocs; ++idx) {
-        if (p[idx] > 15) all_allocs_4bit = false;
-        count_item(p[idx], &stats->max_alloc_size, stats->small_alloc_sizes,
-                   stats->log_alloc_sizes);
-      }
-      p += num_allocs;
-    }
-    /* Count debug info if present */
-    if (frame_has_debug(d)) {
-      ++ stats->with_debug;
-      for (size_t i = 0; i <  num_debuginfo; ++i) {
+      for (uint32_t i = 0; i < dec.num_debuginfo; ++i) {
         uint32_t offset = caml_read_unaligned_uint32(p);
-        if (offset) { /* there may be invalid debuginfo slots */
+        if (offset) {
           caml_debuginfo_measure((debuginfo)(p + offset));
         }
         p += sizeof(uint32_t);
       }
     }
-    /* Capture facts for the small-descriptor simulation. */
-    sim_is_long = frame_is_long(d);
-    sim_fsize = frame_size(d);
-    sim_has_alloc = frame_has_allocs(d);
-    sim_has_debug = frame_has_debug(d);
-    sim_nlive = num_live;
-    sim_slots = slots;
-    sim_regs = regs;
-    sim_regmap = reg_map;
-    sim_bigreg = has_big_reg;
-    sim_nalloc = num_allocs;
-    sim_ndbg = num_debuginfo;
-    sim_allocs4 = all_allocs_4bit;
   }
-  if (!stats->max_descr || (p > stats->max_descr)) {
-    stats->max_descr = p;
-  }
+  /* it.next now points just past the last descriptor. */
+  stats->descr_bytes += (size_t)(it.next - start);
 
-  /* --- Small-descriptor format simulation (step 2) --- */
-  {
-    /* Current (packed) size of this descriptor. */
-    size_t cur;
-    if (sim_rettoc) {
-      cur = 8; /* retaddr(4) + frame_data(2) + num_live(2), no body */
-    } else {
-      size_t hdr = sim_is_long ? 16 : 8;
-      size_t live = sim_nlive * (sim_is_long ? 4 : 2);
-      size_t a = sim_has_alloc ? (1 + sim_nalloc) : 0;
-      size_t db = sim_has_debug ? (sim_ndbg * 4) : 0;
-      cur = hdr + live + a + db;
-    }
-    ++ stats->sim_descrs;
-    stats->sim_current_total += cur;
-    size_t escape = 1 + cur; /* leading zero byte + the normal/large descriptor */
-
-    /* Old aligned size: each descriptor was 8-byte aligned, debug_info[] 4. */
-    size_t aligned;
-    if (sim_rettoc) {
-      aligned = 8;
-    } else {
-      size_t off = (sim_is_long ? 16 : 8) + sim_nlive * (sim_is_long ? 4 : 2)
-                 + (sim_has_alloc ? (1 + sim_nalloc) : 0);
-      if (sim_has_debug) {
-        off = (off + 3) & ~(size_t)3;
-        off += sim_ndbg * 4;
-      }
-      aligned = (off + 7) & ~(size_t)7;
-    }
-    stats->sim_aligned_total += aligned;
-
-    /* Base-format escape causes (diagnostic: 8-reg bitmap, 1-byte delta). */
-    bool fits_size = !sim_rettoc && (sim_fsize % 16 == 0)
-                     && (sim_fsize / 16 >= 1) && (sim_fsize / 16 <= 64);
-    bool reg_ok = sim_has_alloc
-      ? (((sim_regmap & ~(uint64_t)SIM_HOT_REGS) == 0) && !sim_bigreg)
-      : (sim_regs == 0);
-    if (sim_is_first)        ++stats->sim_esc_first;
-    else if (sim_rettoc)     ++stats->sim_esc_rettoc;
-    else if (sim_delta < 1 || sim_delta > 255) ++stats->sim_esc_delta;
-    else if (!fits_size)     ++stats->sim_esc_size;
-    else if (!reg_ok)        ++stats->sim_esc_reg;
-    else if (!sim_allocs4)   ++stats->sim_esc_allocsize;
-
-    /* Small size = delta field + size+flags(1) + (alloc ? na/nl(1) + 4-bit
-       alloc sizes + register bitmap : num_live(1)) + live slots(1 each)
-       + debug(4 each). Refinements: v=1 varint delta (255 -> +16 bits),
-       b=1 a 16-bit (2-byte) register bitmap covering regs 0..15. */
-    size_t asz = sim_has_alloc ? ((sim_nalloc + 1) / 2) : 0;
-    size_t dbz = sim_has_debug ? (sim_ndbg * 4) : 0;
-    bool dok[2] = { (sim_delta >= 1 && sim_delta <= 255),
-                    (sim_delta >= 1 && sim_delta <= 65535) };
-    size_t dfield[2] = { 1, (sim_delta <= 254 ? 1 : 3) };
-    bool rok[2];
-    rok[0] = reg_ok;                                       /* 8-reg hot-set bitmap */
-    rok[1] = sim_has_alloc ? !sim_bigreg : (sim_regs == 0);/* 16-bit bitmap 0..15 */
-    size_t rfield[2] = { 1, 2 };
-    for (int v = 0; v < 2; v++) {
-      for (int b = 0; b < 2; b++) {
-        bool be = !sim_is_first && !sim_rettoc && fits_size && sim_allocs4
-                  && dok[v] && rok[b];
-        size_t sbase = dfield[v] + 1 + sim_slots + dbz
-          + (sim_has_alloc ? (asz + rfield[b]) : 0);
-        for (int k = 0; k <= SIM_MAXK; k++) {
-          bool small = be;
-          if (small && sim_has_alloc) {
-            if (!(sim_nalloc < ((size_t)1 << k)
-                  && sim_slots < ((size_t)1 << (8 - k))))
-              small = false;
-          } else if (small && sim_slots > 255) {
-            small = false;
-          }
-          if (small) {
-            stats->sim_total[v][b][k] += sbase + 1; /* na/nl or num_live byte */
-            ++ stats->sim_small[v][b][k];
-          } else {
-            stats->sim_total[v][b][k] += escape;
-          }
-        }
-        /* Separate full bytes for num_allocs and num_live (no ALLOC_BITS
-           split). num_allocs is a byte already; this fits whenever the
-           descriptor is base-eligible and num_live fits a byte. */
-        if (be && sim_slots <= 255) {
-          stats->sim_sep_total[v][b] += sbase + (sim_has_alloc ? 2 : 1);
-          ++ stats->sim_sep_small[v][b];
-        } else {
-          stats->sim_sep_total[v][b] += escape;
-        }
-      }
-    }
+  char *dbg_low, *dbg_high;
+  size_t dbg_count;
+  caml_debuginfo_measurements(&dbg_count, &dbg_low, &dbg_high);
+  dbg_high = Align_to(dbg_high, uintnat);
+  if (dbg_count) {
+    stats->debuginfo_bytes += (size_t)(dbg_high - dbg_low);
+    stats->debuginfo_count += dbg_count;
   }
 }
 
-/* Record stats for all descriptors from a frametable */
-
-static void add_frametable_to_stats(intnat *frametable,
-                                    struct frametable_stats *stats)
+static void report_stats(struct frametable_stats *stats)
 {
-  ++ stats->frametables;
-  if (!stats->min_descr ||
-      ((unsigned char*)frametable < stats->min_descr)) {
-    stats->min_descr = (unsigned char*)frametable;
-  }
-  if (!stats->max_descr ||
-      ((unsigned char*)frametable > stats->max_descr)) {
-    stats->max_descr = (unsigned char*)(frametable+1);
-  }
-  intnat len = *frametable;
-  frame_descr * d = (frame_descr *)(frametable + 1);
-  for (intnat j = 0; j < len; j++) {
-    add_descriptor_to_stats(d, stats);
-    d = next_frame_descr(d);
-  }
+  char buf[64];
+  size_t total = stats->header_bytes + stats->descr_bytes
+                 + stats->debuginfo_bytes;
+  printf("Summary of %zu frametables, %zu descriptors "
+         "(%zu small, %zu escaped, %zu multi-byte-delta).\n",
+         stats->frametables, stats->descrs, stats->small_descrs,
+         stats->escaped_descrs, stats->wide_deltas);
+  printf("return-to-C %zu  alloc %zu  debug %zu\n",
+         stats->return_to_C, stats->with_alloc, stats->with_debug);
+  report_bytes(buf, sizeof(buf), stats->descr_bytes);
+  printf("%s descriptors (%5.2f%%; %f bytes each)\n", buf,
+         total ? (double)stats->descr_bytes / total * 100.0 : 0.0,
+         stats->descrs ? (double)stats->descr_bytes / stats->descrs : 0.0);
+  report_bytes(buf, sizeof(buf), stats->header_bytes);
+  printf("%s frametable headers\n", buf);
+  report_bytes(buf, sizeof(buf), stats->debuginfo_bytes);
+  printf("%s Debuginfo (%5.2f%%; %zu entries)\n", buf,
+         total ? (double)stats->debuginfo_bytes / total * 100.0 : 0.0,
+         stats->debuginfo_count);
 }
-
-/* Record and report stats for all frametables on a list */
 
 static void report_frametables_stats(caml_frametable_list *new_frametables)
 {
   struct frametable_stats stats;
-  clear_stats(&stats);
+  memset(&stats, 0, sizeof(stats));
   iter_list(new_frametables, cur) {
     add_frametable_to_stats(cur->frametable, &stats);
-    accumulate_frametable_stats(cur->frametable, &stats);
-    clear_per_frametable_stats(&stats);
   }
   report_stats(&stats);
 }
@@ -975,12 +434,10 @@ extern intnat *__stop_caml_all_frametables[] __attribute__((weak));
 static void report_all_frametables_stats(void)
 {
   struct frametable_stats stats;
-  clear_stats(&stats);
+  memset(&stats, 0, sizeof(stats));
   for (intnat **p = __start_caml_all_frametables;
        p < __stop_caml_all_frametables; p++) {
     add_frametable_to_stats(*p, &stats);
-    accumulate_frametable_stats(*p, &stats);
-    clear_per_frametable_stats(&stats);
   }
   report_stats(&stats);
 }
@@ -1015,7 +472,8 @@ static void add_frame_descriptors(
 
     if (table->descriptors != NULL) caml_stat_free(table->descriptors);
     table->descriptors =
-      (frame_descr **) caml_stat_calloc_noexc(tblsize, sizeof(frame_descr *));
+      (frame_descr_entry *) caml_stat_calloc_noexc(tblsize,
+                                                   sizeof(frame_descr_entry));
     if (table->descriptors == NULL) caml_raise_out_of_memory();
 
     fill_hashtable(table, new_frametables);
@@ -1185,15 +643,14 @@ caml_frame_descrs* caml_get_frame_descrs(void)
 
 frame_descr* caml_find_frame_descr(caml_frame_descrs *fds, uintnat pc)
 {
-  frame_descr * d;
   uintnat h;
 
   h = Hash_retaddr(pc, fds->mask);
   while (1) {
-    d = fds->descriptors[h];
-    if (d == 0) return NULL; /* can happen if some code compiled without -g */
-    if (Retaddr_frame(d) == pc) break;
+    frame_descr_entry e = fds->descriptors[h];
+    if (e.fd == NULL)
+      return NULL; /* can happen if some code compiled without -g */
+    if (e.retaddr == pc) return e.fd;
     h = (h+1) & fds->mask;
   }
-  return d;
 }

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -82,12 +82,9 @@ static frame_descr * next_frame_descr(frame_descr * d) {
     }
     /* Skip debug info if present */
     if (frame_has_debug(d)) {
-      /* Align to 32 bits */
-      p = Align_to(p, uint32_t);
       p += sizeof(uint32_t) * (frame_has_allocs(d) ? num_allocs : 1);
     }
-    /* Align to word size */
-    p = Align_to(p, void*);
+    /* Frame descriptors are not aligned: the next one follows immediately. */
     return ((frame_descr*) p);
   } else {
     /* This marks the top of an ML stack chunk. Skip over empty
@@ -95,8 +92,6 @@ static frame_descr * next_frame_descr(frame_descr * d) {
     /* Skip to address of zero-sized live_ofs */
     CAMLassert(caml_read_unaligned_uint16(&d->num_live) == 0);
     p = (unsigned char*)&d->live_ofs[0];
-    /* Align to word size */
-    p = Align_to(p, void*);
     return ((frame_descr*) p);
   }
 }
@@ -263,6 +258,7 @@ struct frametable_stats {
   size_t max_lives; /* Overall maximum count of lives */
 
   /* GCable registers */
+  size_t reg[REGS]; /* # descriptors using each register */
   size_t reg_count[REGS]; /* Count GCable registers */
   size_t max_regs;
   size_t max_reg[REGS];  /* Count max GCable register index */
@@ -465,6 +461,7 @@ static void report_stats(struct frametable_stats *stats)
 
   printf("GCable registers (max %zu)\n", stats->max_regs);
   report_table("  (counts %s)\n", stats->reg_count, REGS);
+  report_table("  (each reg %s)\n", stats->reg, REGS);
   report_table("  (max %s)\n", stats->max_reg, REGS);
 
   /* report all register maps which are more than 1/128 of the total
@@ -548,7 +545,7 @@ Caml_inline void count_item(size_t item, size_t *max, size_t *smalls,
    permits large ones (e.g. Valx2 values held in SIMD registers), so we
    guard the fixed-size tables and count the outliers separately. */
 
-static void add_live_ofs(uint32_t ofs,
+static void add_live_ofs(uint32_t ofs, size_t *reg_p,
                          size_t *regs, size_t *max_reg, uint64_t *reg_map,
                          bool *has_big_reg,
                          size_t *slots, size_t *max_slot,
@@ -557,6 +554,9 @@ static void add_live_ofs(uint32_t ofs,
   if (ofs & 1) {
     size_t reg = ofs >> 1;
     ++ *regs;
+    if (reg < REGS) {
+      ++ reg_p[reg];
+    }
     if (reg > *max_reg) {
       *max_reg = reg;
     }
@@ -620,8 +620,6 @@ static void add_descriptor_to_stats(frame_descr *d,
     ++ stats->return_to_C;
     /* Top of an ML stack chunk. Skip over empty frame descriptor */
     p = (unsigned char*)&d->live_ofs[0];
-    /* Align to word size */
-    p = Align_to(p, void*);
   } else {
     uint32_t sz = frame_size(d); /* in bytes */
     sz /= sizeof(uintnat);
@@ -642,15 +640,17 @@ static void add_descriptor_to_stats(frame_descr *d,
       num_live = caml_read_unaligned_uint32(&dl->num_live);
       uint32_t n = num_live;
       for (uint32_t *ofp = dl->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(caml_read_unaligned_uint32(ofp), &regs, &max_reg,
-                     &reg_map, &has_big_reg, &slots, &max_slot, stats);
+        add_live_ofs(caml_read_unaligned_uint32(ofp), stats->reg, &regs,
+                     &max_reg, &reg_map, &has_big_reg, &slots, &max_slot,
+                     stats);
       }
     } else {
       num_live = caml_read_unaligned_uint16(&d->num_live);
       uint16_t n = num_live;
       for (uint16_t *ofp = d->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(caml_read_unaligned_uint16(ofp), &regs, &max_reg,
-                     &reg_map, &has_big_reg, &slots, &max_slot, stats);
+        add_live_ofs(caml_read_unaligned_uint16(ofp), stats->reg,
+                     &regs, &max_reg, &reg_map, &has_big_reg, &slots,
+                     &max_slot, stats);
       }
     }
 
@@ -709,8 +709,6 @@ static void add_descriptor_to_stats(frame_descr *d,
     /* Count debug info if present */
     if (frame_has_debug(d)) {
       ++ stats->with_debug;
-      /* Align to 32 bits */
-      p = Align_to(p, uint32_t);
       for (size_t i = 0; i <  num_debuginfo; ++i) {
         uint32_t offset = caml_read_unaligned_uint32(p);
         if (offset) { /* there may be invalid debuginfo slots */
@@ -719,8 +717,6 @@ static void add_descriptor_to_stats(frame_descr *d,
         p += sizeof(uint32_t);
       }
     }
-    /* Align to word size */
-    p = Align_to(p, void*);
   }
   if (!stats->max_descr || (p > stats->max_descr)) {
     stats->max_descr = p;

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -208,6 +208,16 @@ extern uintnat caml_measure_all_frametables;
 #define REG_MAPS (1<<(MAX_REG_IN_SMALL_MAP + 1))
 #define REGMAP_REPORT_THRESHOLD 1000
 
+/* Step 2 of the small-frame-descriptor design: simulate, without changing the
+   format, how big each descriptor would be in the proposed "small" format, and
+   how much we'd save. */
+#define SIM_MAXK 8  /* ALLOC_BITS swept 0..SIM_MAXK in the combined na/nl byte */
+/* The 8 hottest GC registers, from the measured (each reg) histogram on
+   ocamlopt.opt: 0,1,2,3,4,5,6,8. A small alloc descriptor's live registers
+   must all be in this set (others escape to the normal format). */
+#define SIM_HOT_REGS \
+  ((1ULL<<0)|(1ULL<<1)|(1ULL<<2)|(1ULL<<3)|(1ULL<<4)|(1ULL<<5)|(1ULL<<6)|(1ULL<<8))
+
 struct frametable_stats {
   /* A few per-frametable items */
   unsigned char *last_retaddr;
@@ -287,6 +297,20 @@ struct frametable_stats {
   size_t log_alloc_sizes[MAX_LOG];
   size_t small_alloc_sizes[SMALL_FRAMES];
   size_t max_alloc_size;
+
+  /* Small-descriptor format simulation (step 2) */
+  size_t sim_descrs;                       /* descriptors simulated */
+  size_t sim_current_total;                /* bytes in the current packed format */
+  size_t sim_aligned_total;                /* bytes in the old (pre-relaxation) aligned format */
+  /* [varint delta?][16-bit register bitmap?][ALLOC_BITS] */
+  size_t sim_total[2][2][SIM_MAXK + 1];    /* total bytes, combined na/nl byte */
+  size_t sim_small[2][2][SIM_MAXK + 1];    /* # small descriptors */
+  /* [varint?][16-bit bitmap?]: separate full bytes for num_allocs & num_live */
+  size_t sim_sep_total[2][2];
+  size_t sim_sep_small[2][2];
+  /* base-ineligibility causes (independent of ALLOC_BITS) */
+  size_t sim_esc_first, sim_esc_rettoc, sim_esc_delta, sim_esc_size,
+         sim_esc_reg, sim_esc_allocsize;
 };
 
 static void clear_stats(struct frametable_stats *stats)
@@ -492,9 +516,67 @@ static void report_stats(struct frametable_stats *stats)
          MAX_REG, stats->big_reg_entries);
   printf("Non-allocation descriptors with registers: %zu\n",
          stats->noalloc_with_regs);
+
+  /* --- Small-descriptor format simulation (step 2) --- */
+  printf("\nSmall-descriptor simulation: %zu descriptors\n", stats->sim_descrs);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->sim_aligned_total);
+  printf("  baseline aligned: %s\n", table_buf);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->sim_current_total);
+  printf("  baseline packed:  %s\n", table_buf);
+  printf("  base-escape causes: first=%zu retC=%zu delta>255=%zu size=%zu "
+         "reg=%zu allocsz=%zu\n",
+         stats->sim_esc_first, stats->sim_esc_rettoc, stats->sim_esc_delta,
+         stats->sim_esc_size, stats->sim_esc_reg, stats->sim_esc_allocsize);
+  printf("  base format (8-reg bitmap, 1-byte delta), by ALLOC_BITS:\n");
+  printf("  %-10s %14s %10s %10s %9s %9s\n",
+         "ALLOC_BITS", "total", "small", "escaped", "vs_packed", "vs_aligned");
+  for (int k = 0; k <= SIM_MAXK; k++) {
+    size_t esc = stats->sim_descrs - stats->sim_small[0][0][k];
+    double pk = stats->sim_current_total
+      ? 100.0 * ((double)stats->sim_current_total
+                 - (double)stats->sim_total[0][0][k])
+        / (double)stats->sim_current_total : 0.0;
+    double al = stats->sim_aligned_total
+      ? 100.0 * ((double)stats->sim_aligned_total
+                 - (double)stats->sim_total[0][0][k])
+        / (double)stats->sim_aligned_total : 0.0;
+    printf("  %-10d %14zu %10zu %10zu %8.1f%% %8.1f%%\n",
+           k, stats->sim_total[0][0][k], stats->sim_small[0][0][k], esc, pk, al);
+  }
+  {
+    static const char *nm[2][2] =
+      { { "base", "+16b-bitmap" }, { "+varint", "+varint+16b" } };
+    printf("  refinements (each at its best ALLOC_BITS):\n");
+    for (int v = 0; v < 2; v++) for (int b = 0; b < 2; b++) {
+      int bk = 0;
+      for (int k = 1; k <= SIM_MAXK; k++)
+        if (stats->sim_total[v][b][k] < stats->sim_total[v][b][bk]) bk = k;
+      size_t tot = stats->sim_total[v][b][bk];
+      double pk = stats->sim_current_total
+        ? 100.0 * ((double)stats->sim_current_total - (double)tot)
+          / (double)stats->sim_current_total : 0.0;
+      double al = stats->sim_aligned_total
+        ? 100.0 * ((double)stats->sim_aligned_total - (double)tot)
+          / (double)stats->sim_aligned_total : 0.0;
+      printf("  %-12s k=%d  %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
+             nm[v][b], bk, tot, pk, al);
+    }
+    printf("  separate na/nl bytes (no ALLOC_BITS split):\n");
+    for (int v = 0; v < 2; v++) for (int b = 0; b < 2; b++) {
+      size_t tot = stats->sim_sep_total[v][b];
+      double pk = stats->sim_current_total
+        ? 100.0 * ((double)stats->sim_current_total - (double)tot)
+          / (double)stats->sim_current_total : 0.0;
+      double al = stats->sim_aligned_total
+        ? 100.0 * ((double)stats->sim_aligned_total - (double)tot)
+          / (double)stats->sim_aligned_total : 0.0;
+      printf("  %-12s      %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
+             nm[v][b], tot, pk, al);
+    }
+  }
 }
 
-/* Actually log+1.
+/* Actually floor(log_2(x))+1, clamped at MAX_LOG-1.
    mylog(0) = 0
    mylog(1) = 1
    mylog(2) = 2
@@ -583,6 +665,15 @@ static void add_descriptor_to_stats(frame_descr *d,
                                     struct frametable_stats *stats)
 {
   unsigned char *p;
+  /* Facts gathered for the small-descriptor simulation at the end. */
+  bool sim_is_first = false, sim_rettoc = false, sim_is_long = false;
+  bool sim_has_alloc = false, sim_has_debug = false, sim_bigreg = false;
+  bool sim_allocs4 = true;
+  intnat sim_delta = 0;
+  uint32_t sim_fsize = 0;
+  uint64_t sim_regmap = 0;
+  size_t sim_nlive = 0, sim_slots = 0, sim_regs = 0, sim_nalloc = 0,
+         sim_ndbg = 0;
   ++ stats->descrs;
   if (!stats->min_descr || ((unsigned char*)d < stats->min_descr)) {
     stats->min_descr = (unsigned char*)d;
@@ -598,6 +689,9 @@ static void add_descriptor_to_stats(frame_descr *d,
   }
 
   unsigned char *retaddr = (unsigned char *)Retaddr_frame(d);
+  sim_is_first = (stats->last_retaddr == NULL);
+  if (!sim_is_first)
+    sim_delta = (intnat)((uintnat)retaddr - (uintnat)stats->last_retaddr);
   if (stats->last_retaddr) {
     if (retaddr < stats->min_retaddr) {
       stats->min_retaddr = retaddr;
@@ -618,6 +712,7 @@ static void add_descriptor_to_stats(frame_descr *d,
 
   if (frame_return_to_C(d)) {
     ++ stats->return_to_C;
+    sim_rettoc = true;
     /* Top of an ML stack chunk. Skip over empty frame descriptor */
     p = (unsigned char*)&d->live_ofs[0];
   } else {
@@ -692,15 +787,18 @@ static void add_descriptor_to_stats(frame_descr *d,
 
     p = (unsigned char*)frame_end_of_live_ofs(d);
     size_t num_debuginfo = 1;
+    size_t num_allocs = 0;
+    bool all_allocs_4bit = true; /* do all alloc sizes fit in 4 bits? */
     if (frame_has_allocs(d)) {
       ++ stats->with_alloc;
-      size_t num_allocs = *(uint8_t *)p;
+      num_allocs = *(uint8_t *)p;
       stats->alloc_sizes += num_allocs;
       num_debuginfo = num_allocs;
       count_item(num_allocs, &stats->max_comballocs, stats->small_comballocs,
                  stats->log_comballocs);
       ++ p;
       for (size_t idx = 0; idx < num_allocs; ++idx) {
+        if (p[idx] > 15) all_allocs_4bit = false;
         count_item(p[idx], &stats->max_alloc_size, stats->small_alloc_sizes,
                    stats->log_alloc_sizes);
       }
@@ -717,9 +815,115 @@ static void add_descriptor_to_stats(frame_descr *d,
         p += sizeof(uint32_t);
       }
     }
+    /* Capture facts for the small-descriptor simulation. */
+    sim_is_long = frame_is_long(d);
+    sim_fsize = frame_size(d);
+    sim_has_alloc = frame_has_allocs(d);
+    sim_has_debug = frame_has_debug(d);
+    sim_nlive = num_live;
+    sim_slots = slots;
+    sim_regs = regs;
+    sim_regmap = reg_map;
+    sim_bigreg = has_big_reg;
+    sim_nalloc = num_allocs;
+    sim_ndbg = num_debuginfo;
+    sim_allocs4 = all_allocs_4bit;
   }
   if (!stats->max_descr || (p > stats->max_descr)) {
     stats->max_descr = p;
+  }
+
+  /* --- Small-descriptor format simulation (step 2) --- */
+  {
+    /* Current (packed) size of this descriptor. */
+    size_t cur;
+    if (sim_rettoc) {
+      cur = 8; /* retaddr(4) + frame_data(2) + num_live(2), no body */
+    } else {
+      size_t hdr = sim_is_long ? 16 : 8;
+      size_t live = sim_nlive * (sim_is_long ? 4 : 2);
+      size_t a = sim_has_alloc ? (1 + sim_nalloc) : 0;
+      size_t db = sim_has_debug ? (sim_ndbg * 4) : 0;
+      cur = hdr + live + a + db;
+    }
+    ++ stats->sim_descrs;
+    stats->sim_current_total += cur;
+    size_t escape = 1 + cur; /* leading zero byte + the normal/large descriptor */
+
+    /* Old aligned size: each descriptor was 8-byte aligned, debug_info[] 4. */
+    size_t aligned;
+    if (sim_rettoc) {
+      aligned = 8;
+    } else {
+      size_t off = (sim_is_long ? 16 : 8) + sim_nlive * (sim_is_long ? 4 : 2)
+                 + (sim_has_alloc ? (1 + sim_nalloc) : 0);
+      if (sim_has_debug) {
+        off = (off + 3) & ~(size_t)3;
+        off += sim_ndbg * 4;
+      }
+      aligned = (off + 7) & ~(size_t)7;
+    }
+    stats->sim_aligned_total += aligned;
+
+    /* Base-format escape causes (diagnostic: 8-reg bitmap, 1-byte delta). */
+    bool fits_size = !sim_rettoc && (sim_fsize % 16 == 0)
+                     && (sim_fsize / 16 >= 1) && (sim_fsize / 16 <= 64);
+    bool reg_ok = sim_has_alloc
+      ? (((sim_regmap & ~(uint64_t)SIM_HOT_REGS) == 0) && !sim_bigreg)
+      : (sim_regs == 0);
+    if (sim_is_first)        ++stats->sim_esc_first;
+    else if (sim_rettoc)     ++stats->sim_esc_rettoc;
+    else if (sim_delta < 1 || sim_delta > 255) ++stats->sim_esc_delta;
+    else if (!fits_size)     ++stats->sim_esc_size;
+    else if (!reg_ok)        ++stats->sim_esc_reg;
+    else if (!sim_allocs4)   ++stats->sim_esc_allocsize;
+
+    /* Small size = delta field + size+flags(1) + (alloc ? na/nl(1) + 4-bit
+       alloc sizes + register bitmap : num_live(1)) + live slots(1 each)
+       + debug(4 each). Refinements: v=1 varint delta (255 -> +16 bits),
+       b=1 a 16-bit (2-byte) register bitmap covering regs 0..15. */
+    size_t asz = sim_has_alloc ? ((sim_nalloc + 1) / 2) : 0;
+    size_t dbz = sim_has_debug ? (sim_ndbg * 4) : 0;
+    bool dok[2] = { (sim_delta >= 1 && sim_delta <= 255),
+                    (sim_delta >= 1 && sim_delta <= 65535) };
+    size_t dfield[2] = { 1, (sim_delta <= 254 ? 1 : 3) };
+    bool rok[2];
+    rok[0] = reg_ok;                                       /* 8-reg hot-set bitmap */
+    rok[1] = sim_has_alloc ? !sim_bigreg : (sim_regs == 0);/* 16-bit bitmap 0..15 */
+    size_t rfield[2] = { 1, 2 };
+    for (int v = 0; v < 2; v++) {
+      for (int b = 0; b < 2; b++) {
+        bool be = !sim_is_first && !sim_rettoc && fits_size && sim_allocs4
+                  && dok[v] && rok[b];
+        size_t sbase = dfield[v] + 1 + sim_slots + dbz
+          + (sim_has_alloc ? (asz + rfield[b]) : 0);
+        for (int k = 0; k <= SIM_MAXK; k++) {
+          bool small = be;
+          if (small && sim_has_alloc) {
+            if (!(sim_nalloc < ((size_t)1 << k)
+                  && sim_slots < ((size_t)1 << (8 - k))))
+              small = false;
+          } else if (small && sim_slots > 255) {
+            small = false;
+          }
+          if (small) {
+            stats->sim_total[v][b][k] += sbase + 1; /* na/nl or num_live byte */
+            ++ stats->sim_small[v][b][k];
+          } else {
+            stats->sim_total[v][b][k] += escape;
+          }
+        }
+        /* Separate full bytes for num_allocs and num_live (no ALLOC_BITS
+           split). num_allocs is a byte already; this fits whenever the
+           descriptor is base-eligible and num_live fits a byte. */
+        if (be && sim_slots <= 255) {
+          stats->sim_sep_total[v][b] += sbase + (sim_has_alloc ? 2 : 1);
+          ++ stats->sim_sep_small[v][b];
+        } else {
+          stats->sim_sep_total[v][b] += escape;
+        }
+      }
+    }
   }
 }
 

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -382,10 +382,14 @@ static void add_frametable_to_stats(intnat *frametable,
   char *dbg_low, *dbg_high;
   size_t dbg_count;
   caml_debuginfo_measurements(&dbg_count, &dbg_low, &dbg_high);
-  dbg_high = Align_to(dbg_high, uintnat);
   if (dbg_count) {
-    stats->debuginfo_bytes += (size_t)(dbg_high - dbg_low);
+    /* Each debuginfo record is two 32-bit words; the referenced
+       name_info/name_and_loc_info structs occupy [dbg_low, dbg_high). The
+       deduplicated filename/defname strings live in a separate section and are
+       not counted here. */
     stats->debuginfo_count += dbg_count;
+    stats->debuginfo_bytes += dbg_count * 2 * sizeof(uint32_t)
+                              + (size_t)(dbg_high - dbg_low);
   }
 }
 

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -212,11 +212,19 @@ extern uintnat caml_measure_all_frametables;
    format, how big each descriptor would be in the proposed "small" format, and
    how much we'd save. */
 #define SIM_MAXK 8  /* ALLOC_BITS swept 0..SIM_MAXK in the combined na/nl byte */
-/* The 8 hottest GC registers, from the measured (each reg) histogram on
-   ocamlopt.opt: 0,1,2,3,4,5,6,8. A small alloc descriptor's live registers
-   must all be in this set (others escape to the normal format). */
-#define SIM_HOT_REGS \
-  ((1ULL<<0)|(1ULL<<1)|(1ULL<<2)|(1ULL<<3)|(1ULL<<4)|(1ULL<<5)|(1ULL<<6)|(1ULL<<8))
+
+/* Return addresses are byte-aligned on amd64 but 4-byte aligned on AArch64, so
+   a small descriptor stores delta/DELTA_SCALE -- one delta byte reaches 4x
+   further on AArch64, with correspondingly fewer escapes. */
+#if defined(__aarch64__)
+#define DELTA_SCALE 4
+#else
+#define DELTA_SCALE 1
+#endif
+
+/* The register map is direct-indexed (bit N = register N; no hot-set lookup):
+   a descriptor fits a width-W map iff its highest live register is < W. The
+   simulation sweeps W in {16, 32} -- the [b] axis below (b=0 -> 16, b=1 -> 32). */
 
 struct frametable_stats {
   /* A few per-frametable items */
@@ -523,11 +531,11 @@ static void report_stats(struct frametable_stats *stats)
   printf("  baseline aligned: %s\n", table_buf);
   report_bytes(table_buf, TABLE_BUF_SIZE, stats->sim_current_total);
   printf("  baseline packed:  %s\n", table_buf);
-  printf("  base-escape causes: first=%zu retC=%zu delta>255=%zu size=%zu "
-         "reg=%zu allocsz=%zu\n",
+  printf("  base-escape causes: first=%zu retC=%zu delta_ovf=%zu size=%zu "
+         "reg>=16=%zu allocsz=%zu\n",
          stats->sim_esc_first, stats->sim_esc_rettoc, stats->sim_esc_delta,
          stats->sim_esc_size, stats->sim_esc_reg, stats->sim_esc_allocsize);
-  printf("  base format (8-reg bitmap, 1-byte delta), by ALLOC_BITS:\n");
+  printf("  base format (16-bit direct map, 1-byte delta), by ALLOC_BITS:\n");
   printf("  %-10s %14s %10s %10s %9s %9s\n",
          "ALLOC_BITS", "total", "small", "escaped", "vs_packed", "vs_aligned");
   for (int k = 0; k <= SIM_MAXK; k++) {
@@ -545,7 +553,7 @@ static void report_stats(struct frametable_stats *stats)
   }
   {
     static const char *nm[2][2] =
-      { { "base", "+16b-bitmap" }, { "+varint", "+varint+16b" } };
+      { { "16-bit", "32-bit" }, { "16-bit+varint", "32-bit+varint" } };
     printf("  refinements (each at its best ALLOC_BITS):\n");
     for (int v = 0; v < 2; v++) for (int b = 0; b < 2; b++) {
       int bk = 0;
@@ -558,7 +566,7 @@ static void report_stats(struct frametable_stats *stats)
       double al = stats->sim_aligned_total
         ? 100.0 * ((double)stats->sim_aligned_total - (double)tot)
           / (double)stats->sim_aligned_total : 0.0;
-      printf("  %-12s k=%d  %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
+      printf("  %-14s k=%d  %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
              nm[v][b], bk, tot, pk, al);
     }
     printf("  separate na/nl bytes (no ALLOC_BITS split):\n");
@@ -570,7 +578,7 @@ static void report_stats(struct frametable_stats *stats)
       double al = stats->sim_aligned_total
         ? 100.0 * ((double)stats->sim_aligned_total - (double)tot)
           / (double)stats->sim_aligned_total : 0.0;
-      printf("  %-12s      %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
+      printf("  %-14s      %14zu  vs_packed %5.1f%%  vs_aligned %5.1f%%\n",
              nm[v][b], tot, pk, al);
     }
   }
@@ -667,13 +675,12 @@ static void add_descriptor_to_stats(frame_descr *d,
   unsigned char *p;
   /* Facts gathered for the small-descriptor simulation at the end. */
   bool sim_is_first = false, sim_rettoc = false, sim_is_long = false;
-  bool sim_has_alloc = false, sim_has_debug = false, sim_bigreg = false;
+  bool sim_has_alloc = false, sim_has_debug = false;
   bool sim_allocs4 = true;
   intnat sim_delta = 0;
   uint32_t sim_fsize = 0;
-  uint64_t sim_regmap = 0;
   size_t sim_nlive = 0, sim_slots = 0, sim_regs = 0, sim_nalloc = 0,
-         sim_ndbg = 0;
+         sim_ndbg = 0, sim_maxreg = 0;
   ++ stats->descrs;
   if (!stats->min_descr || ((unsigned char*)d < stats->min_descr)) {
     stats->min_descr = (unsigned char*)d;
@@ -823,8 +830,7 @@ static void add_descriptor_to_stats(frame_descr *d,
     sim_nlive = num_live;
     sim_slots = slots;
     sim_regs = regs;
-    sim_regmap = reg_map;
-    sim_bigreg = has_big_reg;
+    sim_maxreg = max_reg;
     sim_nalloc = num_allocs;
     sim_ndbg = num_debuginfo;
     sim_allocs4 = all_allocs_4bit;
@@ -865,32 +871,32 @@ static void add_descriptor_to_stats(frame_descr *d,
     }
     stats->sim_aligned_total += aligned;
 
-    /* Base-format escape causes (diagnostic: 8-reg bitmap, 1-byte delta). */
+    /* Base-format escape causes (diagnostic: 16-bit direct map, 1-byte delta).
+       delta is stored scaled by DELTA_SCALE. */
+    size_t dscaled = (size_t)(sim_delta / DELTA_SCALE);
     bool fits_size = !sim_rettoc && (sim_fsize % 16 == 0)
                      && (sim_fsize / 16 >= 1) && (sim_fsize / 16 <= 64);
-    bool reg_ok = sim_has_alloc
-      ? (((sim_regmap & ~(uint64_t)SIM_HOT_REGS) == 0) && !sim_bigreg)
-      : (sim_regs == 0);
+    bool reg_ok = sim_has_alloc ? (sim_maxreg < 16) : (sim_regs == 0);
     if (sim_is_first)        ++stats->sim_esc_first;
     else if (sim_rettoc)     ++stats->sim_esc_rettoc;
-    else if (sim_delta < 1 || sim_delta > 255) ++stats->sim_esc_delta;
+    else if (sim_delta < 1 || dscaled > 255) ++stats->sim_esc_delta;
     else if (!fits_size)     ++stats->sim_esc_size;
     else if (!reg_ok)        ++stats->sim_esc_reg;
     else if (!sim_allocs4)   ++stats->sim_esc_allocsize;
 
     /* Small size = delta field + size+flags(1) + (alloc ? na/nl(1) + 4-bit
-       alloc sizes + register bitmap : num_live(1)) + live slots(1 each)
-       + debug(4 each). Refinements: v=1 varint delta (255 -> +16 bits),
-       b=1 a 16-bit (2-byte) register bitmap covering regs 0..15. */
+       alloc sizes + register map : num_live(1)) + live slots(1 each)
+       + debug(4 each). Axes: v=1 varint delta (255 -> +16 bits); b selects the
+       direct register-map width, 16 bits (2 B) or 32 bits (4 B). */
     size_t asz = sim_has_alloc ? ((sim_nalloc + 1) / 2) : 0;
     size_t dbz = sim_has_debug ? (sim_ndbg * 4) : 0;
-    bool dok[2] = { (sim_delta >= 1 && sim_delta <= 255),
-                    (sim_delta >= 1 && sim_delta <= 65535) };
-    size_t dfield[2] = { 1, (sim_delta <= 254 ? 1 : 3) };
+    bool dok[2] = { (sim_delta >= 1 && dscaled <= 255),
+                    (sim_delta >= 1 && dscaled <= 65535) };
+    size_t dfield[2] = { 1, (dscaled <= 254 ? 1 : 3) };
     bool rok[2];
-    rok[0] = reg_ok;                                       /* 8-reg hot-set bitmap */
-    rok[1] = sim_has_alloc ? !sim_bigreg : (sim_regs == 0);/* 16-bit bitmap 0..15 */
-    size_t rfield[2] = { 1, 2 };
+    rok[0] = sim_has_alloc ? (sim_maxreg < 16) : (sim_regs == 0); /* 16-bit map */
+    rok[1] = sim_has_alloc ? (sim_maxreg < 32) : (sim_regs == 0); /* 32-bit map */
+    size_t rfield[2] = { 2, 4 };
     for (int v = 0; v < 2; v++) {
       for (int b = 0; b < 2; b++) {
         bool be = !sim_is_first && !sim_rettoc && fits_size && sim_allocs4
@@ -964,8 +970,12 @@ static void report_frametables_stats(caml_frametable_list *new_frametables)
 }
 
 /* The backend emits one pointer per linked unit into the caml_all_frametables
- * section; the linker concatenates them and provides these bounds. Weak so the
- * runtime still links where no such section exists (both NULL). */
+ * section; the linker concatenates them and bounds them with these
+ * __start_/__stop_ symbols. That linker-set mechanism is ELF-only -- on
+ * Mach-O (macOS) and PE (Windows) the symbols don't exist (and the backend
+ * doesn't emit the section there), so the all-frametables measurement is
+ * available on ELF targets only. */
+#if defined(__ELF__)
 extern intnat *__start_caml_all_frametables[] __attribute__((weak));
 extern intnat *__stop_caml_all_frametables[] __attribute__((weak));
 
@@ -984,6 +994,12 @@ static void report_all_frametables_stats(void)
   }
   report_stats(&stats);
 }
+#else
+static void report_all_frametables_stats(void)
+{
+  printf("Xmeasure_all_frametables is only supported on ELF targets.\n");
+}
+#endif
 
 static void add_frame_descriptors(
   caml_frame_descrs *table,

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -94,11 +94,11 @@ void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out)
     out->has_debug = (sf & FRAME_DESCRIPTOR_DEBUG) != 0;
     out->frame_size = (((uint32_t)(sf >> 2)) + 1) * 16;
     if (out->has_allocs) {
+      out->small_reg_bitmap = *p++;
       out->small_num_allocs = *p++;
-      out->num_live = *p++;
       out->small_allocs = p;
       p += (out->small_num_allocs + 1) / 2; /* 4-bit alloc sizes */
-      out->small_reg_bitmap = *p++;
+      out->num_live = *p++;
     } else {
       out->num_live = *p++;
     }
@@ -117,8 +117,8 @@ void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out)
   if (frame_return_to_C(d)) {
     out->return_to_C = true;
     /* Top of an ML stack chunk: an empty descriptor. */
-    CAMLassert(caml_read_unaligned_uint16(&d->num_live) == 0);
-    out->end_of_live = out->end = (const unsigned char *)&d->live_ofs[0];
+    CAMLassert(caml_read_unaligned_uint16(d + Frame_num_live_ofs) == 0);
+    out->end_of_live = out->end = d + Frame_live_ofs;
     return;
   }
   out->is_long = frame_is_long(d);
@@ -126,9 +126,9 @@ void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out)
   out->has_debug = frame_has_debug(d);
   out->frame_size = frame_size(d);
   if (out->is_long) {
-    out->num_live = caml_read_unaligned_uint32(&frame_as_long(d)->num_live);
+    out->num_live = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
   } else {
-    out->num_live = caml_read_unaligned_uint16(&d->num_live);
+    out->num_live = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
   }
   const unsigned char *p = frame_end_of_live_ofs(d);
   out->end_of_live = p;

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -57,6 +57,7 @@ extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
 extern uintnat caml_nohugepage_stacks;    /* see fiber.c */
 extern uintnat caml_enable_segv_handler;  /* see signals.c / signals_nat.c */
 uintnat caml_measure_frametables = 0; /* see frame_descriptors.c */
+uintnat caml_measure_all_frametables = 0; /* see frame_descriptors.c */
 
 /* runtime config parameters set with caml_gc_set */
 extern atomic_uintnat caml_major_heap_increment; /* percent or words; see shared_heap.c */
@@ -463,6 +464,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "cache_stacks_per_class", &caml_cache_stacks_per_class, 0 },
   { "tick_use_usleep", &caml_tick_use_usleep, 0 },
   { "measure_frametables", &caml_measure_frametables, 0 },
+  { "measure_all_frametables", &caml_measure_all_frametables, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -56,6 +56,7 @@ extern uintnat caml_percent_sweep_per_mark; /* see major_gc.c */
 extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
 extern uintnat caml_nohugepage_stacks;    /* see fiber.c */
 extern uintnat caml_enable_segv_handler;  /* see signals.c / signals_nat.c */
+uintnat caml_measure_frametables = 0; /* see frame_descriptors.c */
 
 /* runtime config parameters set with caml_gc_set */
 extern atomic_uintnat caml_major_heap_increment; /* percent or words; see shared_heap.c */
@@ -461,6 +462,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "enable_segv_handler", &caml_enable_segv_handler, 0 },
   { "cache_stacks_per_class", &caml_cache_stacks_per_class, 0 },
   { "tick_use_usleep", &caml_tick_use_usleep, 0 },
+  { "measure_frametables", &caml_measure_frametables, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -58,13 +58,31 @@ Caml_inline intnat current_frame_alloc_wosize(unsigned char** alloc_len_out,
   d = caml_find_frame_descr(fds, retaddr);
   CAMLassert(d && !frame_return_to_C(d) && frame_has_allocs(d));
 
-  /* Compute the total allocation size at this point,
-     including allocations combined by Comballoc */
-  unsigned char* alloc_len = frame_end_of_live_ofs(d);
-  int nallocs = *alloc_len++;
-
-  if (nallocs == 0) {
-    return 0; /* This is a poll */
+  /* Compute the total allocation size at this point, including allocations
+     combined by Comballoc. The encoded allocation lengths are returned as a
+     byte-per-allocation array. In the small descriptor format they are stored
+     as 4-bit nibbles, so we unpack them into a thread-local buffer. */
+  unsigned char* alloc_len;
+  int nallocs;
+  if (frame_is_small(d)) {
+    struct frame_descr_decoded dec;
+    caml_decode_frame_descr(d, &dec);
+    nallocs = dec.small_num_allocs;
+    if (nallocs == 0) {
+      return 0; /* This is a poll */
+    }
+    static CAMLthread_local unsigned char unpacked[256];
+    for (int i = 0; i < nallocs; i++) {
+      unsigned char byte = dec.small_allocs[i / 2];
+      unpacked[i] = (i & 1) ? (byte >> 4) : (byte & 0xf);
+    }
+    alloc_len = unpacked;
+  } else {
+    alloc_len = frame_end_of_live_ofs(d);
+    nallocs = *alloc_len++;
+    if (nallocs == 0) {
+      return 0; /* This is a poll */
+    }
   }
 
   intnat allocsz = 0;


### PR DESCRIPTION
To inform the design of more compact frametable data structures, this PR adds code that records and reports a lot of measurements about all the frametables in an executable. Turn it on with `OCAMLRUNPARAM=Xmeasure_frametables=1`.

Kept in draft as we may well not want to merge this at all.

The output looks like this (this is for `ocamlopt.opt` built from the current tree).

For some figures it records and reports an array of frequencies for small values (0 to 31). For other figures it records and reports frequencies of value logarithms, with an initial bucket for value 0 (so the buckets are {0}, {1}, {2, 3}, {4, 5, 6, 7}, {8, 9, ..., 15}, {16 ... 31}, etc).

"retaddr offset" is the numeric value of `retaddr_rel`: the displacement from the entry to the return address. "delta" is the difference between consecutive descriptor retaddrs (one design idea is to record these deltas in most frametable entries, rather than the 32-bit `retaddr_rel`): obviously these deltas would be more reliably small if frametable entries were in address order of retaddr.
```
Summary of 728 frametables.
13.88 MiB code (57.53%)
4.40 MiB descriptors (18.23%; 215420 descrs, 21.418141 bytes each)
5.85 MiB Debuginfo (24.24% 429862 entries)
681 frametables before code, 19 after code.
long 0 return to C 2 alloc 88254 debug 192812
Max pos retaddr offset 991641
  (logs 0 0 0 0 0 0 0 0 17 106 404 1186 3895 9878 20211 33200 43385 39576 32042 19873 8760 )
Max neg retaddr offset 8008464
  (logs 0 0 0 0 0 0 8 14 32 59 97 185 289 400 461 558 146 445 191 0 0 0 0 2 )
Max retaddr pos delta 117481
  (logs 0 0 0 7161 10026 2417 4025 5539 5979 5762 4011 3193 2647 1481 734 265 190 32 )
Max retaddr neg delta 117587
  (logs 0 0 0 1588 8042 26252 35989 39255 21743 12364 6351 3876 2959 1593 754 269 190 33 )
Frame sizes (max 90)
  (small 0 0 55176 0 45961 0 39727 0 29376 0 12030 0 12546 0 6635 0 3638 0 3272 0 2086 0 1168 0 766 0 368 0 528 0 69 )
  (logs 0 0 55176 85688 60587 11895 1981 91 )
Comballoc entries (max 40)
  (small 20307 51144 10958 3540 1270 409 198 135 78 26 64 20 23 17 5 7 10 8 8 5 0 4 2 0 6 3 0 1 0 1 1 )
  (logs 20307 51144 14498 2012 240 49 4 )
Allocation sizes (96442 allocs, max 197)
  (small 28219 31671 10324 13878 7085 1723 766 505 287 583 189 58 78 121 32 177 52 470 1 1 6 6 2 0 3 105 19 3 3 2 0 2 )
  (logs 28219 31671 24202 10079 1525 675 55 13 3 )
GC live values (max 79)
  (small 41678 40164 44885 31845 18032 13030 7980 5291 3433 2425 1694 1205 859 558 411 316 253 225 184 178 138 104 57 81 51 36 28 32 22 28 22 23 )
  (logs 41678 40164 76730 44333 10901 1462 134 16 )
GCable stack slots (max 79)
  (small 83385 38005 31237 21190 11980 9861 6240 3989 2662 1995 1288 824 533 332 234 259 225 203 157 151 121 80 58 66 37 32 22 28 21 23 23 18 )
  (logs 83385 38005 52427 32070 8127 1265 123 16 )
Max GCable stack slot (max 78)
  (small 108295 23460 19999 13770 11714 8995 7347 4037 2827 3627 2596 2039 1168 839 628 521 498 446 388 406 280 136 291 117 145 106 83 39 88 38 18 54 )
  (logs 108295 23460 33769 32093 14245 3133 344 79 )
GCable registers (max 11)
  (counts 139480 36924 18845 10886 4955 2120 1023 439 259 156 148 183 )
  (max 152060 19555 13749 10933 5536 4615 2208 1332 2601 747 0 0 2082 )
Register maps frequencies:
  0000000000000 139480
  0000000000001 12580
  0000000000010 16552
  0000000000011 3003
  0000000000100 4718
  0000000000101 2179
  0000000000110 5127
  0000000000111 1725
  0000000001000 1316
  0000000001001 1295
  0000000001010 2174
  0000000001011 923
  0000000001100 1537
  0000000001101 721
  0000000001110 2045
  0000000001111 922
  0000000010000 453
  0000000010001 255
  0000000010010 360
  0000000010011 179
  0000000010100 197
  0000000010101 169
  0000000010110 300
  0000000010111 166
  0000000011000 308
  0000000011001 436
  0000000011010 499
  0000000011011 290
  0000000011100 467
  0000000011101 245
  0000000011110 917
  0000000011111 295
  0000000100000 290
  0000000100001 103
  0000000100010 294
  0000000100100 95
  0000000100110 124
  0000000101000 135
  0000000101010 77
  0000000101100 212
  0000000101110 104
  0000000101111 77
  0000000110001 91
  0000000110010 84
  0000000110100 959
  0000000110110 144
  0000000110111 105
  0000000111000 129
  0000000111001 96
  0000000111010 253
  0000000111011 239
  0000000111101 100
  0000000111110 222
  0000000111111 150
  0000001000000 108
  0000001100010 83
  0000001111000 212
  0000001111011 177
  0000001111110 108
  0000011101000 80
  0000100000000 690
  0000100000001 79
  0000100000010 660
  0000100000110 84
  1000000000000 134
  1000000000010 167
  1000100000000 207
  1000100000010 263
  1001111111111 183
  others (<= 75) 6267
Code fragment 0xd0c2f0-0x2589868
Code fragment 0x25ce291-0x25d0121
```