### PR TITLE
Add continuation specialization budget

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -855,6 +855,13 @@ let mk_flambda2_expert_cont_lifting_budget f =
       " Set the limit of extra parameters introduced\n\
       \ when lifting continuations (per function)" )
 
+let mk_flambda2_expert_cont_spec_budget f =
+  ( "-flambda2-expert-cont-spec-budget",
+    Arg.Int f,
+    Printf.sprintf
+      " Set the limit on the number of specialized continuations \n\
+      \ generated during match-in-match (per function)" )
+
 let mk_flambda2_expert_cont_spec_threshold f =
   ( "-flambda2-expert-cont-specialization-threshold",
     Arg.Float f,
@@ -1392,6 +1399,7 @@ module type Oxcaml_options = sig
   val flambda2_expert_shorten_symbol_names : unit -> unit
   val no_flambda2_expert_shorten_symbol_names : unit -> unit
   val flambda2_expert_cont_lifting_budget : int -> unit
+  val flambda2_expert_cont_spec_budget : int -> unit
   val flambda2_expert_cont_spec_threshold : float -> unit
   val flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
@@ -1598,6 +1606,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_flambda2_expert_shorten_symbol_names;
       mk_flambda2_expert_cont_lifting_budget
         F.flambda2_expert_cont_lifting_budget;
+      mk_flambda2_expert_cont_spec_budget F.flambda2_expert_cont_spec_budget;
       mk_flambda2_expert_cont_spec_threshold
         F.flambda2_expert_cont_spec_threshold;
       mk_flambda2_debug_concrete_types_only_on_canonicals
@@ -2066,6 +2075,9 @@ module Oxcaml_options_impl = struct
 
   let flambda2_expert_cont_lifting_budget budget =
     Flambda2.Expert.cont_lifting_budget := Oxcaml_flags.Set budget
+
+  let flambda2_expert_cont_spec_budget budget =
+    Flambda2.Expert.cont_spec_budget := Oxcaml_flags.Set budget
 
   let flambda2_expert_cont_spec_threshold threshold =
     Flambda2.Expert.cont_spec_threshold := Oxcaml_flags.Set threshold
@@ -2544,7 +2556,12 @@ module Extra_params = struct
         | Some i -> Flambda2.Expert.cont_lifting_budget := Oxcaml_flags.Set i
         | None -> ());
         true
-    | "flambda2-expert-cont-specialization-threshold" ->
+    | "flambda2-expert-cont-spec-budget" ->
+        (match Compenv.check_int ppf name v with
+        | Some i -> Flambda2.Expert.cont_spec_budget := Oxcaml_flags.Set i
+        | None -> ());
+        true
+    | "flambda2-expert-cont-spec-threshold" ->
         (match Compenv.check_int ppf name v with
         | Some i ->
             Flambda2.Expert.cont_spec_threshold :=

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -158,6 +158,7 @@ module type Oxcaml_options = sig
   val flambda2_expert_shorten_symbol_names : unit -> unit
   val no_flambda2_expert_shorten_symbol_names : unit -> unit
   val flambda2_expert_cont_lifting_budget : int -> unit
+  val flambda2_expert_cont_spec_budget : int -> unit
   val flambda2_expert_cont_spec_threshold : float -> unit
   val flambda2_debug_concrete_types_only_on_canonicals : unit -> unit
   val no_flambda2_debug_concrete_types_only_on_canonicals : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -298,6 +298,7 @@ module Flambda2 = struct
       let max_function_simplify_run = 2
       let shorten_symbol_names = false
       let cont_lifting_budget = 0
+      let cont_spec_budget = 0
       let cont_spec_threshold = -1.
     end
 
@@ -312,6 +313,7 @@ module Flambda2 = struct
       max_function_simplify_run : int;
       shorten_symbol_names : bool;
       cont_lifting_budget : int;
+      cont_spec_budget : int;
       cont_spec_threshold : float;
     }
 
@@ -326,6 +328,7 @@ module Flambda2 = struct
       max_function_simplify_run = Default.max_function_simplify_run;
       shorten_symbol_names = Default.shorten_symbol_names;
       cont_lifting_budget = Default.cont_lifting_budget;
+      cont_spec_budget = Default.cont_spec_budget;
       cont_spec_threshold = Default.cont_spec_threshold;
     }
 
@@ -339,6 +342,11 @@ module Flambda2 = struct
       default with
       fallback_inlining_heuristic = false;
       cont_lifting_budget = 100;
+      cont_spec_budget = 100;
+      (* the cont_spec budget is here to make it possible to manually fix things
+         when compilation times grow uncontrollably. It's therefore
+         intentionally high by default, and can be lowered manually if
+         necessary *)
       cont_spec_threshold = 0.;
     }
 
@@ -346,12 +354,14 @@ module Flambda2 = struct
       default with
       cont_lifting_budget = 1_000;
       (* in the worst case : 1_000 budget -> ~+18% compilation time *)
+      cont_spec_budget = 1_000;
       cont_spec_threshold = 0.;
     }
 
     let o4 = {
       o3 with
       cont_lifting_budget = 3_000;
+      cont_spec_budget = 3_000;
       cont_spec_threshold = 0.;
     }
 
@@ -368,6 +378,7 @@ module Flambda2 = struct
     let max_function_simplify_run = ref Default
     let shorten_symbol_names = ref Default
     let cont_lifting_budget = ref Default
+    let cont_spec_budget = ref Default
     let cont_spec_threshold = ref Default
   end
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -231,6 +231,7 @@ module Flambda2 : sig
       val max_function_simplify_run : int
       val shorten_symbol_names : bool
       val cont_lifting_budget : int
+      val cont_spec_budget : int
       val cont_spec_threshold : float
     end
 
@@ -245,6 +246,7 @@ module Flambda2 : sig
       max_function_simplify_run : int;
       shorten_symbol_names : bool;
       cont_lifting_budget : int;
+      cont_spec_budget : int;
       cont_spec_threshold : float;
     }
 
@@ -260,6 +262,7 @@ module Flambda2 : sig
     val max_function_simplify_run : int or_default ref
     val shorten_symbol_names : bool or_default ref
     val cont_lifting_budget : int or_default ref
+    val cont_spec_budget : int or_default ref
     val cont_spec_threshold : float or_default ref
   end
 

--- a/middle_end/flambda2/simplify/env/downwards_acc.ml
+++ b/middle_end/flambda2/simplify/env/downwards_acc.ml
@@ -36,6 +36,7 @@ type t =
     lifted_continuations : (DE.t * Original_handlers.t) list;
     (* head of the list is the innermost continuation being lifted *)
     continuation_lifting_budget : int;
+    continuation_spec_budget : int;
     continuations_to_specialize : Continuation.Set.t;
     (* CR gbury: we could try and encode the set of continuations to specialize
        into the map below as the keys of the map *)
@@ -52,6 +53,7 @@ let [@ocamlformat "disable"] print ppf
         lifted_constants; flow_acc; demoted_exn_handlers; code_ids_to_remember;
         code_ids_to_never_delete; code_ids_never_simplified; slot_offsets; debuginfo_rewrites;
         are_lifting_conts; lifted_continuations; continuation_lifting_budget;
+        continuation_spec_budget;
         continuations_to_specialize; specialization_map; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(denv@ %a)@]@ \
@@ -69,6 +71,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>(are_lifting_conts@ %a)@]@ \
       @[<hov 1>(lifted_continuations@ %a)@]@ \
       @[<hov 1>(continuation_lifting_budget %d)@]@ \
+      @[<hov 1>(continuation_spec_budget %d)@]@ \
       @[<hov 1>(continuations_to_specialize %a)@]@ \
       @[<hov 1>(specialization_map %a)@]\
       )@]"
@@ -88,6 +91,7 @@ let [@ocamlformat "disable"] print ppf
     (Format.pp_print_list ~pp_sep:Format.pp_print_space
        print_lifted_cont) lifted_continuations
     continuation_lifting_budget
+    continuation_spec_budget
     Continuation.Set.print continuations_to_specialize
     (Continuation.Map.print (Apply_cont_rewrite_id.Map.print Continuation.print)) specialization_map
 
@@ -107,6 +111,7 @@ let create denv slot_offsets continuation_uses_env =
     are_lifting_conts = Are_lifting_conts.no_lifting At_toplevel;
     lifted_continuations = [];
     continuation_lifting_budget = Flambda_features.Expert.cont_lifting_budget ();
+    continuation_spec_budget = Flambda_features.Expert.cont_spec_budget ();
     continuations_to_specialize = Continuation.Set.empty;
     specialization_map = Continuation.Map.empty
   }
@@ -305,6 +310,23 @@ let decrease_continuation_lifting_budget t cost =
   else
     with_continuation_lifting_budget t
       (max 0 (t.continuation_lifting_budget - cost))
+
+(* Invariant: budget < 0 means no limit on cont lifting *)
+let get_continuation_spec_budget t =
+  let budget = t.continuation_spec_budget in
+  if budget < 0 then max_int else budget
+
+let with_continuation_spec_budget t budget =
+  { t with continuation_spec_budget = budget }
+
+let reset_continuation_spec_budget t =
+  with_continuation_spec_budget t (Flambda_features.Expert.cont_spec_budget ())
+
+let decrease_continuation_spec_budget t cost =
+  if t.continuation_spec_budget < 0
+  then t
+  else
+    with_continuation_spec_budget t (max 0 (t.continuation_spec_budget - cost))
 
 let prepare_for_speculative_inlining dacc =
   let dacc =

--- a/middle_end/flambda2/simplify/env/downwards_acc.mli
+++ b/middle_end/flambda2/simplify/env/downwards_acc.mli
@@ -139,6 +139,14 @@ val with_continuation_lifting_budget : t -> int -> t
 
 val decrease_continuation_lifting_budget : t -> int -> t
 
+val get_continuation_spec_budget : t -> int
+
+val reset_continuation_spec_budget : t -> t
+
+val with_continuation_spec_budget : t -> int -> t
+
+val decrease_continuation_spec_budget : t -> int -> t
+
 val prepare_for_speculative_inlining : t -> t
 
 val continuations_to_specialize : t -> Continuation.Set.t

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -110,7 +110,7 @@ let dacc_inside_function context ~outer_dacc ~params ~my_closure ~my_alloc_mode
   |> DA.with_used_value_slots ~used_value_slots
   |> DA.with_shareable_constants ~shareable_constants
   |> DA.with_slot_offsets ~slot_offsets
-  |> DA.reset_continuation_lifting_budget
+  |> DA.reset_continuation_lifting_budget |> DA.reset_continuation_spec_budget
 
 let extract_accumulators_from_function outer_dacc ~dacc_after_body
     ~uacc_after_upwards_traversal =

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -1040,7 +1040,10 @@ let decide_continuation_specialization ~dacc ~switch ~scrutinee =
       | Too_many_unknown_uses ->
         Profile.Counters.incr "too_much_unknown" counters
       | Too_costly -> Profile.Counters.incr "not_beneficial" counters
-      | Specialized _ -> Profile.Counters.incr "specialized" counters)
+      | Specialized { spec_budget_cost; _ } ->
+        counters
+        |> Profile.Counters.incr "specialized"
+        |> Profile.Counters.add "generated" spec_budget_cost)
 
 let simplify_switch dacc switch ~down_to_up =
   let scrutinee = Switch.scrutinee switch in

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -875,7 +875,7 @@ type spec_decision =
   | Specialized of
       { cont : Continuation.t;
         lifting_cost : int;
-        num_specialized : int
+        spec_budget_cost : int
       }
 
 let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
@@ -985,10 +985,14 @@ let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
           | `Not_enough_join_info -> Not_enough_join_info
           | `Spec (join_analysis, specialized, generic) ->
             let spec_budget = DA.get_continuation_spec_budget dacc in
-            let num_specialized =
-              Apply_cont_rewrite_id.Set.cardinal specialized
+            let spec_budget_cost =
+              let n_spec = Apply_cont_rewrite_id.Set.cardinal specialized in
+              let n_generic =
+                if Apply_cont_rewrite_id.Set.cardinal generic > 0 then 1 else 0
+              in
+              n_spec + n_generic
             in
-            if not (spec_budget > 0 && num_specialized <= spec_budget)
+            if not (spec_budget > 0 && spec_budget_cost <= spec_budget)
             then Insufficient_spec_budget
             else
               (* Specialization benefit estimation: we use heuristics similar to
@@ -1011,7 +1015,7 @@ let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
                 Float.compare threshold 0. < 0
                 || Float.compare final_cost threshold > 0
               then Too_costly
-              else Specialized { cont; lifting_cost; num_specialized }))
+              else Specialized { cont; lifting_cost; spec_budget_cost }))
 
 let decide_continuation_specialization ~dacc ~switch ~scrutinee =
   Profile.record_with_counters ~accumulate:true "continuation_specialization"
@@ -1062,9 +1066,9 @@ let simplify_switch dacc switch ~down_to_up =
   in
   let dacc =
     match decide_continuation_specialization ~dacc ~switch ~scrutinee with
-    | Specialized { cont; lifting_cost; num_specialized } ->
+    | Specialized { cont; lifting_cost; spec_budget_cost } ->
       let dacc = DA.decrease_continuation_lifting_budget dacc lifting_cost in
-      let dacc = DA.decrease_continuation_spec_budget dacc num_specialized in
+      let dacc = DA.decrease_continuation_spec_budget dacc spec_budget_cost in
       let dacc =
         DA.with_are_lifting_conts dacc
           (Are_lifting_conts.lift_continuations_out_of cont)

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -858,6 +858,26 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
     let arms = TI.Map.add arm (action, rewrite_id, arity, env_at_use) arms in
     arms, dacc
 
+type spec_decision =
+  | Disabled
+  | Single_use
+  | Exn_handler
+  | Toplevel
+  | All_unknown
+  | No_reason_to_spec
+  | Not_lifting
+  | Cannot_specialize
+  | Insufficient_lifting_budget
+  | Insufficient_spec_budget
+  | Not_enough_join_info
+  | Too_many_unknown_uses
+  | Too_costly
+  | Specialized of
+      { cont : Continuation.t;
+        lifting_cost : int;
+        num_specialized : int
+      }
+
 let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
   match DA.are_lifting_conts dacc with
   | Lifting_out_of _ ->
@@ -865,8 +885,8 @@ let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
       "[Are_lifting_cont] values in the dacc cannot be [Lifting_out_of _] when \
        going downwards through a [Switch] expression. See the explanation in \
        [are_lifting_conts.mli]."
-  | Not_lifting _ -> `Not_lifting
-  | Analyzing { continuation; uses; is_exn_handler } -> (
+  | Not_lifting _ -> Not_lifting
+  | Analyzing { continuation = cont; uses; is_exn_handler } -> (
     (* Some preliminary requirements. We do **not** specialize continuations if
        one of the following conditions are true:
 
@@ -883,11 +903,11 @@ let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
        because partial evaluation would be better. *)
     let n_uses = Continuation_uses.number_of_uses uses in
     if n_uses <= 1
-    then `Single_use
+    then Single_use
     else if is_exn_handler
-    then `Exn_handler
+    then Exn_handler
     else if DE.at_unit_toplevel (DA.denv dacc)
-    then `Toplevel
+    then Toplevel
     else
       let denv = DA.denv dacc in
       match DE.specialization_cost denv with
@@ -895,10 +915,9 @@ let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
         (* CR gbury: we could try and emit something analog to the inlining
            report, but for other optimizations at one point ? *)
         begin match reason with
-        | Specialization_disabled -> `Disabled
-        | At_toplevel -> `Toplevel
-        | Contains_static_consts | Contains_set_of_closures ->
-          `Cannot_specialize
+        | Specialization_disabled -> Disabled
+        | At_toplevel -> Toplevel
+        | Contains_static_consts | Contains_set_of_closures -> Cannot_specialize
         end
       | Can_specialize spec_cost -> (
         (* We should never reach here if specialization is disabled, since we
@@ -919,7 +938,7 @@ let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
         in
         (* is_lifting_allowed_by_budget ? *)
         if not (lifting_budget > 0 && lifting_cost <= lifting_budget)
-        then `Insufficient_lifting_budget
+        then Insufficient_lifting_budget
         else
           (* Main Criterion: whether all callsites (but one) of the continuation
              determine the value of the scrutinee (and therefore the specialized
@@ -960,31 +979,39 @@ let decide_continuation_specialization0 ~dacc ~switch ~scrutinee =
                   else `Too_many_unknown_uses))
           in
           match join_analysis_result with
-          | ( `No_reason_to_spec | `Too_many_unknown_uses | `All_unknown
-            | `Not_enough_join_info ) as res ->
-            res
+          | `No_reason_to_spec -> No_reason_to_spec
+          | `Too_many_unknown_uses -> Too_many_unknown_uses
+          | `All_unknown -> All_unknown
+          | `Not_enough_join_info -> Not_enough_join_info
           | `Spec (join_analysis, specialized, generic) ->
-            (* Specialization benefit estimation: we use heuristics similar to
-               that of inlining to estimate the benefit based on code size and
-               removed operations (note that we use the join info in the typing
-               env to estimate which operations will be removed during
-               specialization, rather that computing it speculatively like is
-               done for inlining). *)
-            let cost_metrics =
-              Specialization_cost.cost_metrics (DE.typing_env denv) spec_cost
-                ~switch ~join_analysis ~specialized ~generic
+            let spec_budget = DA.get_continuation_spec_budget dacc in
+            let num_specialized =
+              Apply_cont_rewrite_id.Set.cardinal specialized
             in
-            let final_cost =
-              Cost_metrics.evaluate
-                ~args:(DE.inlining_arguments denv)
-                cost_metrics
-            in
-            let threshold = Flambda_features.Expert.cont_spec_threshold () in
-            if
-              Float.compare threshold 0. < 0
-              || Float.compare final_cost threshold > 0
-            then `Too_costly
-            else `Specialized (continuation, lifting_cost)))
+            if not (spec_budget > 0 && num_specialized <= spec_budget)
+            then Insufficient_spec_budget
+            else
+              (* Specialization benefit estimation: we use heuristics similar to
+                 that of inlining to estimate the benefit based on code size and
+                 removed operations (note that we use the join info in the
+                 typing env to estimate which operations will be removed during
+                 specialization, rather that computing it speculatively like is
+                 done for inlining). *)
+              let cost_metrics =
+                Specialization_cost.cost_metrics (DE.typing_env denv) spec_cost
+                  ~switch ~join_analysis ~specialized ~generic
+              in
+              let final_cost =
+                Cost_metrics.evaluate
+                  ~args:(DE.inlining_arguments denv)
+                  cost_metrics
+              in
+              let threshold = Flambda_features.Expert.cont_spec_threshold () in
+              if
+                Float.compare threshold 0. < 0
+                || Float.compare final_cost threshold > 0
+              then Too_costly
+              else Specialized { cont; lifting_cost; num_specialized }))
 
 let decide_continuation_specialization ~dacc ~switch ~scrutinee =
   Profile.record_with_counters ~accumulate:true "continuation_specialization"
@@ -993,21 +1020,23 @@ let decide_continuation_specialization ~dacc ~switch ~scrutinee =
     ~counter_f:(fun result ->
       let counters = Profile.Counters.create () in
       match result with
-      | `Disabled -> counters
-      | `Single_use -> counters
-      | `Exn_handler -> counters
-      | `Toplevel -> counters
-      | `All_unknown -> Profile.Counters.incr "all_unknown" counters
-      | `No_reason_to_spec -> Profile.Counters.incr "no_reason" counters
-      | `Not_lifting -> Profile.Counters.incr "not_lifting" counters
-      | `Cannot_specialize -> Profile.Counters.incr "cannot_spec" counters
-      | `Insufficient_lifting_budget ->
+      | Disabled -> counters
+      | Single_use -> counters
+      | Exn_handler -> counters
+      | Toplevel -> counters
+      | All_unknown -> Profile.Counters.incr "all_unknown" counters
+      | No_reason_to_spec -> Profile.Counters.incr "no_reason" counters
+      | Not_lifting -> Profile.Counters.incr "not_lifting" counters
+      | Cannot_specialize -> Profile.Counters.incr "cannot_spec" counters
+      | Insufficient_lifting_budget ->
         Profile.Counters.incr "no_lifting_budget" counters
-      | `Not_enough_join_info -> Profile.Counters.incr "no_join_info" counters
-      | `Too_many_unknown_uses ->
+      | Insufficient_spec_budget ->
+        Profile.Counters.incr "no_spec_budget" counters
+      | Not_enough_join_info -> Profile.Counters.incr "no_join_info" counters
+      | Too_many_unknown_uses ->
         Profile.Counters.incr "too_much_unknown" counters
-      | `Too_costly -> Profile.Counters.incr "not_beneficial" counters
-      | `Specialized _ -> Profile.Counters.incr "specialized" counters)
+      | Too_costly -> Profile.Counters.incr "not_beneficial" counters
+      | Specialized _ -> Profile.Counters.incr "specialized" counters)
 
 let simplify_switch dacc switch ~down_to_up =
   let scrutinee = Switch.scrutinee switch in
@@ -1033,15 +1062,20 @@ let simplify_switch dacc switch ~down_to_up =
   in
   let dacc =
     match decide_continuation_specialization ~dacc ~switch ~scrutinee with
-    | `Specialized (continuation, lifting_cost) ->
+    | Specialized { cont; lifting_cost; num_specialized } ->
       let dacc = DA.decrease_continuation_lifting_budget dacc lifting_cost in
+      let dacc = DA.decrease_continuation_spec_budget dacc num_specialized in
       let dacc =
         DA.with_are_lifting_conts dacc
-          (Are_lifting_conts.lift_continuations_out_of continuation)
+          (Are_lifting_conts.lift_continuations_out_of cont)
       in
-      let dacc = DA.add_continuation_to_specialize dacc continuation in
+      let dacc = DA.add_continuation_to_specialize dacc cont in
       dacc
-    | _ -> dacc
+    | Disabled | Single_use | Exn_handler | Toplevel | All_unknown
+    | No_reason_to_spec | Not_lifting | Cannot_specialize
+    | Insufficient_lifting_budget | Insufficient_spec_budget
+    | Not_enough_join_info | Too_many_unknown_uses | Too_costly ->
+      dacc
   in
   down_to_up dacc
     ~rebuild:

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -350,6 +350,10 @@ module Expert = struct
     !Oxcaml_flags.Flambda2.Expert.cont_lifting_budget
     |> with_default ~f:(fun d -> d.cont_lifting_budget)
 
+  let cont_spec_budget () =
+    !Oxcaml_flags.Flambda2.Expert.cont_spec_budget
+    |> with_default ~f:(fun d -> d.cont_spec_budget)
+
   let cont_spec_threshold () =
     !Oxcaml_flags.Flambda2.Expert.cont_spec_threshold
     |> with_default ~f:(fun d -> d.cont_spec_threshold)

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -194,6 +194,8 @@ module Expert : sig
 
   val cont_lifting_budget : unit -> int
 
+  val cont_spec_budget : unit -> int
+
   val cont_spec_threshold : unit -> float
 end
 

--- a/utils/profile.ml
+++ b/utils/profile.ml
@@ -26,12 +26,13 @@ module Counters = struct
   let create () = String.Map.empty
   let get name t = String.Map.find_opt name t |> Option.value ~default:0
   let set name count t = String.Map.add name count t
-  let incr name t =
+  let add name n t =
     String.Map.update name
       (fun count_opt ->
         let count = Option.value ~default:0 count_opt in
-        Some (succ count))
+        Some (count + n))
       t
+  let incr name t = add name 1 t
   let is_empty = String.Map.is_empty
   let union = String.Map.union (fun _ count1 count2 -> Some (count1 + count2))
   let to_string t =

--- a/utils/profile.mli
+++ b/utils/profile.mli
@@ -30,6 +30,7 @@ module Counters : sig
   val get : string -> t -> int
   val set : string -> int -> t -> t
   val incr : string -> t -> t
+  val add : string -> int -> t -> t
   val union : t -> t -> t
   val to_string : t -> string
 end


### PR DESCRIPTION
This will provide an escape hatch for situations where enabling match-in-match makes the compilation time explode.

And also replace polymorphic variants by a regular variants for the specialization decision in simplify_switch.