### PR TITLE
Variable constructors recompute representations for `value_kind`

### DIFF
--- a/testsuite/tests/typing-layouts/value_kind_any_variant.ml
+++ b/testsuite/tests/typing-layouts/value_kind_any_variant.ml
@@ -1,0 +1,55 @@
+(* TEST
+ flags = "-extension layouts_alpha -dlambda -dno-unique-ids";
+ expect;
+*)
+
+(* This lambda test should show that value_kind for [opt] contains its
+   constructors (be [Pvariant _] rather than [Pgenval]) *)
+
+type ('a : any) t = A of 'a | B
+[%%expect{|
+0
+type ('a : any) t = A of 'a | B
+|}]
+
+let f (b : bool) (x : int) =
+  let opt = if b then B else A x in
+  match opt with B -> 1 | A x -> x
+[%%expect{|
+(let
+  (f =
+     (function {nlocal = 0} b[value<int>] x[value<int>] : int
+       (region
+         (let (opt = (if b 0 (makelocalblock 0 (value<int>) x)))
+           (if opt (field_imm 0 opt) 1)))))
+  (apply (field_imm 1 (global Toploop!)) "f" f))
+val f : bool -> int -> int = <fun>
+|}]
+
+external box_float : float# -> float = "%box_float"
+[%%expect{|
+0
+external box_float : float# -> float = "%box_float"
+|}]
+
+let g (b : bool) (x : float#) =
+  let opt = if b then B else A x in
+  match opt with B -> 0.0 | A x -> box_float x
+[%%expect{|
+(let
+  (g =
+     (function {nlocal = 0} b[value<int>] x[float] : float
+       (region
+         (let (opt = (if b 0 (makelocalblock 0 (float64) x)))
+           (if opt (%float_of_float# (mixedfield 0  (float64) opt)) 0.0)))))
+  (apply (field_imm 1 (global Toploop!)) "g" g))
+val g : bool -> float# -> float = <fun>
+|}]
+
+(* The field's sort is undetermined, so the value_kind stays conservative *)
+let opaque (type a : any) (r : a t) = r
+[%%expect{|
+(let (opaque = (function {nlocal = 0} r r))
+  (apply (field_imm 1 (global Toploop!)) "opaque" opaque))
+val opaque : ('a : any). 'a t -> 'a t = <fun>
+|}]

--- a/testsuite/tests/typing-layouts/value_kind_any_variant.ml
+++ b/testsuite/tests/typing-layouts/value_kind_any_variant.ml
@@ -57,3 +57,12 @@ let opaque (type a : any) (r : a t) = r
   (apply (field_imm 1 (global Toploop!)) "opaque" opaque))
 val opaque : ('a : any). 'a t -> 'a t = <fun>
 |}]
+
+(* It is important that this is NOT Pintval or Pvariant with all-"constant"
+   args, as any-refined-to-void is represented as a block rather than an
+   immediate. *)
+let containing_void (r : unit# t) = r
+[%%expect{|
+Uncaught exception: File "typing/typeopt.ml", line 1064, characters 16-22: Assertion failed
+
+|}]

--- a/testsuite/tests/typing-layouts/value_kind_any_variant.ml
+++ b/testsuite/tests/typing-layouts/value_kind_any_variant.ml
@@ -63,6 +63,11 @@ val opaque : ('a : any). 'a t -> 'a t = <fun>
    immediate. *)
 let containing_void (r : unit# t) = r
 [%%expect{|
-Uncaught exception: File "typing/typeopt.ml", line 1064, characters 16-22: Assertion failed
-
+(let
+  (containing_void =
+     (function {nlocal = 0}
+       r[value<(consts (0)) (non_consts ([0: product ]))>]
+       : (consts (0)) (non_consts ([0: product ])) r))
+  (apply (field_imm 1 (global Toploop!)) "containing_void" containing_void))
+val containing_void : unit# t -> unit# t = <fun>
 |}]

--- a/testsuite/tests/typing-layouts/value_kind_any_variant.ml
+++ b/testsuite/tests/typing-layouts/value_kind_any_variant.ml
@@ -20,7 +20,9 @@ let f (b : bool) (x : int) =
   (f =
      (function {nlocal = 0} b[value<int>] x[value<int>] : int
        (region
-         (let (opt = (if b 0 (makelocalblock 0 (value<int>) x)))
+         (let
+           (opt =[value<(consts (0)) (non_consts ([0: value<int>]))>]
+              (if b 0 (makelocalblock 0 (value<int>) x)))
            (if opt (field_imm 0 opt) 1)))))
   (apply (field_imm 1 (global Toploop!)) "f" f))
 val f : bool -> int -> int = <fun>
@@ -40,7 +42,9 @@ let g (b : bool) (x : float#) =
   (g =
      (function {nlocal = 0} b[value<int>] x[float] : float
        (region
-         (let (opt = (if b 0 (makelocalblock 0 (float64) x)))
+         (let
+           (opt =[value<(consts (0)) (non_consts ([0: float64]))>]
+              (if b 0 (makelocalblock 0 (float64) x)))
            (if opt (%float_of_float# (mixedfield 0  (float64) opt)) 0.0)))))
   (apply (field_imm 1 (global Toploop!)) "g" g))
 val g : bool -> float# -> float = <fun>

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2085,6 +2085,17 @@ let update_constructor_representation
         raise (Error (loc, Illegal_mixed_product Extension_constructor));
       Ok (Constructor_mixed shape)
 
+let update_constructor_representation_and_arg_sorts env loc args
+      ~is_extension_constructor =
+  let args, constant, jkinds, arg_sorts =
+    update_constructor_arguments_sorts env loc args
+  in
+  let constructor_shape =
+    update_constructor_representation env args jkinds ~loc
+      ~is_extension_constructor
+  in
+  args, constant, constructor_shape, arg_sorts
+
 type unrepresentable_record =
   | Unrepresentable_field of string
 
@@ -2560,28 +2571,10 @@ let rec update_decl_jkind env dpath decl =
     | cstrs, Variant_boxed cstr_layouts ->
       let cstrs =
         List.mapi (fun idx cstr ->
-          let cd_args, all_void, jkinds, arg_sorts =
-            update_constructor_arguments_sorts env cstr.Types.cd_loc
-              cstr.Types.cd_args
-          in
-          let is_nonempty_all_void =
-            all_void
-            && (match cd_args with
-                | Cstr_tuple (_ :: _) -> true
-                | Cstr_tuple [] | Cstr_record _ -> false)
-          in
-          if is_nonempty_all_void
-          && not (Builtin_attributes.has_immediate_all_void_constructor
-                    cstr.Types.cd_attributes)
-          then
-            raise
-              (Error (cstr.Types.cd_loc,
-                      Missing_immediate_all_void_constructor_attribute
-                        (Ident.name cstr.Types.cd_id)));
-          let cstr_repr =
-            update_constructor_representation env cd_args jkinds
+          let cd_args, _constant, cstr_repr, arg_sorts =
+            update_constructor_representation_and_arg_sorts env
+              cstr.Types.cd_loc cstr.Types.cd_args
               ~is_extension_constructor:false
-              ~loc:cstr.Types.cd_loc
           in
           let () =
             match cstr_repr, arg_sorts with
@@ -3859,11 +3852,8 @@ let transl_extension_constructor_decl
       ~cstr_path:(Pident id) ~type_path ~unboxed:false ~extension:true
       typext_params svars sargs sret_type
   in
-  let args, constant, jkinds, _arg_sorts =
-    update_constructor_arguments_sorts env loc args
-  in
-  let constructor_shape =
-    update_constructor_representation env args jkinds ~loc
+  let args, constant, constructor_shape, _arg_sorts =
+    update_constructor_representation_and_arg_sorts env loc args
       ~is_extension_constructor:true
   in
   let constructor_shape =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2094,7 +2094,7 @@ let update_constructor_representation_and_arg_sorts env loc args
     update_constructor_representation env args jkinds ~loc
       ~is_extension_constructor
   in
-  args, constant, constructor_shape, arg_sorts
+  args, ~constant, constructor_shape, arg_sorts
 
 type unrepresentable_record =
   | Unrepresentable_field of string
@@ -2571,7 +2571,7 @@ let rec update_decl_jkind env dpath decl =
     | cstrs, Variant_boxed cstr_layouts ->
       let cstrs =
         List.mapi (fun idx cstr ->
-          let cd_args, _constant, cstr_repr, arg_sorts =
+          let cd_args, ~constant:_, cstr_repr, arg_sorts =
             update_constructor_representation_and_arg_sorts env
               cstr.Types.cd_loc cstr.Types.cd_args
               ~is_extension_constructor:false
@@ -3852,7 +3852,7 @@ let transl_extension_constructor_decl
       ~cstr_path:(Pident id) ~type_path ~unboxed:false ~extension:true
       typext_params svars sargs sret_type
   in
-  let args, constant, constructor_shape, _arg_sorts =
+  let args, ~constant, constructor_shape, _arg_sorts =
     update_constructor_representation_and_arg_sorts env loc args
       ~is_extension_constructor:true
   in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2571,11 +2571,25 @@ let rec update_decl_jkind env dpath decl =
     | cstrs, Variant_boxed cstr_layouts ->
       let cstrs =
         List.mapi (fun idx cstr ->
-          let cd_args, ~constant:_, cstr_repr, arg_sorts =
+          let cd_args, ~constant, cstr_repr, arg_sorts =
             update_constructor_representation_and_arg_sorts env
               cstr.Types.cd_loc cstr.Types.cd_args
               ~is_extension_constructor:false
           in
+          let is_nonempty_all_void =
+            constant
+            && (match cd_args with
+                | Cstr_tuple (_ :: _) -> true
+                | Cstr_tuple [] | Cstr_record _ -> false)
+          in
+          if is_nonempty_all_void
+          && not (Builtin_attributes.has_immediate_all_void_constructor
+                    cstr.Types.cd_attributes)
+          then
+            raise
+              (Error (cstr.Types.cd_loc,
+                      Missing_immediate_all_void_constructor_attribute
+                        (Ident.name cstr.Types.cd_id)));
           let () =
             match cstr_repr, arg_sorts with
             | Ok shape, Some sorts ->

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -110,7 +110,7 @@ val update_constructor_representation:
 val update_constructor_representation_and_arg_sorts :
   Env.t -> Location.t -> Types.constructor_arguments ->
   is_extension_constructor:bool ->
-  Types.constructor_arguments * bool *
+  Types.constructor_arguments * constant:bool *
   (Types.constructor_representation, unrepresentable_constructor) Result.t *
   Jkind.Sort.Const.t array option
 

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -106,6 +106,14 @@ val update_constructor_representation:
     loc:Location.t -> is_extension_constructor:bool ->
     (Types.constructor_representation, unrepresentable_constructor) Result.t
 
+(* Same as above, but also computes sorts of arguments *)
+val update_constructor_representation_and_arg_sorts :
+  Env.t -> Location.t -> Types.constructor_arguments ->
+  is_extension_constructor:bool ->
+  Types.constructor_arguments * bool *
+  (Types.constructor_representation, unrepresentable_constructor) Result.t *
+  Jkind.Sort.Const.t array option
+
 type unrepresentable_record =
   | Unrepresentable_field of string
 
@@ -113,7 +121,7 @@ type unrepresentable_record =
    time was variable because it has a field of kind [any] *)
 val update_record_representation:
     why:Jkind_intf.History.concrete_creation_reason -> old_repres:'rep ->
-    Env.t -> Location.t -> 'rep Data_types.record_form -> 
+    Env.t -> Location.t -> 'rep Data_types.record_form ->
     (Types.label_declaration * Types.type_expr) list ->
     (Jkind.Sort.Const.t list * 'rep, unrepresentable_record) Result.t
 

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -988,7 +988,12 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
       let all_void_opt sort =
         match sort with
         | Some sort -> Jkind.Sort.Const.all_void sort
-        | None -> (* TODO Nicely handle [any] things resolving to void *) false
+        | None ->
+          (* CR rtjoa: It's important to NOT treat constructors with
+             any-args-refined-to-void as constant, as those are represented as
+             blocks rather than immediates. This footgun should no longer exist
+             once we make all-void constructors no longer immediate. *)
+          false
       in
       match cstr.cd_args with
       | Cstr_tuple [] -> true
@@ -1016,18 +1021,20 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
           | None -> None
           | Some (num_nodes_visited,
                   next_const, consts, next_tag, non_consts) ->
-            let cstr_shape_opt, constructor =
+            let ~variable_repr, cstr_shape_opt, constructor =
               match cstr_layouts.(idx) with
-              | Cstr_layout_known { shape; _ } -> Some shape, constructor
+              | Cstr_layout_known { shape; _ } ->
+                ~variable_repr:false, Some shape, constructor
               | Cstr_layout_variable ->
                 (match instantiate_cd_args constructor.cd_args with
-                 | exception Ctype.Cannot_apply -> None, constructor
+                 | exception Ctype.Cannot_apply ->
+                   ~variable_repr:true, None, constructor
                  | cd_args ->
                    let cd_args, _all_void, repr, _arg_sorts =
                      Typedecl.update_constructor_representation_and_arg_sorts
                        env loc cd_args ~is_extension_constructor:false
                    in
-                   Result.to_option repr,
+                   ~variable_repr:true, Result.to_option repr,
                    { constructor with cd_args })
             in
             match cstr_shape_opt with
@@ -1045,7 +1052,13 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
                   Some (num_nodes_visited,
                         next_const + 1, consts, next_tag, non_consts)
                 | Constructor_mixed shape
-                    when mixed_block_shape_is_empty shape ->
+                    when mixed_block_shape_is_empty shape
+                         && not variable_repr ->
+                  (* CR rtjoa: We gate on [variable_repr] because it's important
+                     to NOT treat constructors with any-args-refined-to-void as
+                     constant, as those are represented as blocks rather than
+                     immediates. This footgun should no longer exist once we
+                     make all-void constructors no longer immediate. *)
                   let consts = next_const :: consts in
                   Some (num_nodes_visited,
                         next_const + 1, consts, next_tag, non_consts)
@@ -1062,7 +1075,11 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
       | None -> (num_nodes_visited, Pgenval)
       | Some (num_nodes_visited, _, consts, _, non_consts) ->
         match non_consts with
-        | [] -> assert false  (* See [List.for_all is_constant], above *)
+        | [] ->
+          (* CR rtjoa: An refined any-constructor shouldn't become constant.
+             This footgun should no longer exist once we make all-void
+             constructors no longer immediate. *)
+          Misc.fatal_error "Typeopt.value_kind_variant: became all-constant"
         | _::_ ->
           (num_nodes_visited, Pvariant { consts; non_consts })
       end

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -710,7 +710,7 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
           || Path.same p Predef.path_iarray) ->
     let ak = array_type_kind ~elt_ty:(Some arg) env loc ty in
     num_nodes_visited, non_nullable (Parrayval ak)
-  | Tconstr(p, _, _) -> begin
+  | Tconstr(p, args, _) -> begin
       (* CR layouts v2.8: The uses of [decl.type_jkind] here are suspect:
          with with-kinds, [decl.type_jkind] will mention variables bound
          by the parameters of the declaration. The code below loses this
@@ -736,7 +736,8 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
           fallback_if_missing_cmi
             ~default:(num_nodes_visited, nullable Pgenval)
             (fun () -> value_kind_variant env ~loc ~visited ~depth
-                         ~num_nodes_visited cstrs rep)
+                         ~num_nodes_visited ~params:decl.type_params ~args
+                         cstrs rep)
         | Type_record
             (_, (Record_variable | Record_inlined (_, Constructor_variable, _)),
              _) ->
@@ -892,7 +893,7 @@ and value_kind_mixed_block
   num_nodes_visited, Constructor_mixed (Array.of_list shape)
 
 and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
-      (cstrs : Types.constructor_declaration list) rep =
+      ~params ~args (cstrs : Types.constructor_declaration list) rep =
   match rep with
   | Variant_extensible -> assert false
   | Variant_with_null -> begin
@@ -916,6 +917,18 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
     end
   | Variant_boxed cstr_layouts ->
     let depth = depth + 1 in
+    let instantiate_cd_args (cd_args : Types.constructor_arguments) =
+      let instantiate ty = Ctype.apply env params ty args in
+      match cd_args with
+      | Types.Cstr_tuple cas ->
+        Types.Cstr_tuple
+          (List.map (fun (ca : Types.constructor_argument) ->
+             { ca with ca_type = instantiate ca.ca_type }) cas)
+      | Types.Cstr_record lds ->
+        Types.Cstr_record
+          (List.map (fun (ld : Types.label_declaration) ->
+             { ld with ld_type = instantiate ld.ld_type }) lds)
+    in
     let for_one_uniform_value_constructor fields ~field_to_type ~depth
           ~num_nodes_visited =
       let num_nodes_visited, shape =
@@ -996,15 +1009,30 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
       (num_nodes_visited, Pintval)
     else
       let _idx, result =
-        List.fold_left (fun (idx, result) constructor ->
+        List.fold_left
+          (fun (idx, result) (constructor : Types.constructor_declaration) ->
           idx+1,
           match result with
           | None -> None
           | Some (num_nodes_visited,
                   next_const, consts, next_tag, non_consts) ->
-            match cstr_layouts.(idx) with
-            | Cstr_layout_variable -> None
-            | Cstr_layout_known { shape = cstr_shape; _ } ->
+            let cstr_shape_opt, constructor =
+              match cstr_layouts.(idx) with
+              | Cstr_layout_known { shape; _ } -> Some shape, constructor
+              | Cstr_layout_variable ->
+                (match instantiate_cd_args constructor.cd_args with
+                 | exception Ctype.Cannot_apply -> None, constructor
+                 | cd_args ->
+                   let cd_args, _all_void, repr, _arg_sorts =
+                     Typedecl.update_constructor_representation_and_arg_sorts
+                       env loc cd_args ~is_extension_constructor:false
+                   in
+                   Result.to_option repr,
+                   { constructor with cd_args })
+            in
+            match cstr_shape_opt with
+            | None -> None
+            | Some cstr_shape ->
                 let (is_mutable, num_nodes_visited), fields =
                   for_one_constructor constructor ~depth ~num_nodes_visited
                     ~cstr_shape

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -917,17 +917,17 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
     end
   | Variant_boxed cstr_layouts ->
     let depth = depth + 1 in
-    let instantiate_cd_args (cd_args : Types.constructor_arguments) =
-      let instantiate ty = Ctype.apply env params ty args in
+    let substitute_cd_args (cd_args : Types.constructor_arguments) =
+      let substitute ty = Ctype.apply env params ty args in
       match cd_args with
       | Types.Cstr_tuple cas ->
         Types.Cstr_tuple
           (List.map (fun (ca : Types.constructor_argument) ->
-             { ca with ca_type = instantiate ca.ca_type }) cas)
+             { ca with ca_type = substitute ca.ca_type }) cas)
       | Types.Cstr_record lds ->
         Types.Cstr_record
           (List.map (fun (ld : Types.label_declaration) ->
-             { ld with ld_type = instantiate ld.ld_type }) lds)
+             { ld with ld_type = substitute ld.ld_type }) lds)
     in
     let for_one_uniform_value_constructor fields ~field_to_type ~depth
           ~num_nodes_visited =
@@ -1026,11 +1026,11 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
               | Cstr_layout_known { shape; _ } ->
                 ~variable_repr:false, Some shape, constructor
               | Cstr_layout_variable ->
-                (match instantiate_cd_args constructor.cd_args with
+                (match substitute_cd_args constructor.cd_args with
                  | exception Ctype.Cannot_apply ->
                    ~variable_repr:true, None, constructor
                  | cd_args ->
-                   let cd_args, _all_void, repr, _arg_sorts =
+                   let cd_args, ~constant:_, repr, _arg_sorts =
                      Typedecl.update_constructor_representation_and_arg_sorts
                        env loc cd_args ~is_extension_constructor:false
                    in


### PR DESCRIPTION
Compute better `value_kinds` for variants containing `any` in `value_kind_variant`. We have to be careful to not claim an `any` refined to `void` is treated as a "constant" constructor. Review commit-by-commit.

Stacked on https://github.com/oxcaml/oxcaml/pull/6240