### PR TITLE
Add more bounds checks to arm64 AST constructors

### DIFF
--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -2957,11 +2957,26 @@ module DSL = struct
 
   let reg_op reg = Operand.Reg reg
 
-  let imm n : _ Operand.t = Imm (Twelve n)
+  let imm n : _ Operand.t =
+    (* An ADD/SUB/CMP 12-bit immediate, optionally shifted left by 12 (the shift
+       is inferred from the value). *)
+    if n < 0 || n > 0xFFF_000 || (n > 0xFFF && n land 0xFFF <> 0)
+    then
+      Misc.fatal_errorf
+        "imm: value %d not encodable as a 12-bit immediate, optionally shifted \
+         left by 12"
+        n;
+    Imm (Twelve n)
 
-  let imm_six n : _ Operand.t = Imm (Six n)
+  let imm_six n : _ Operand.t =
+    if n < 0 || n > 0x3F
+    then Misc.fatal_errorf "imm_six: value %d out of range [0, 63]" n;
+    Imm (Six n)
 
-  let imm_sixteen n : _ Operand.t = Imm (Sixteen_unsigned n)
+  let imm_sixteen n : _ Operand.t =
+    if n < 0 || n > 0xFFFF
+    then Misc.fatal_errorf "imm_sixteen: value %d out of range [0, 65535]" n;
+    Imm (Sixteen_unsigned n)
 
   let imm_sixteen_of_nativeint n : _ Operand.t =
     if Nativeint.compare n 0n < 0 || Nativeint.compare n 0xFFFFn > 0


### PR DESCRIPTION
This adds range checks to the previously-unchecked fixed-width immediate constructors in `backend/arm64/ast/ast.ml`, matching the existing `imm_sixteen_of_nativeint` / bitmask style:

  - `imm_sixteen` (16-bit) — rejects outside [0, 65535].
  - `imm_six` (6-bit: `TBNZ`/`TBZ` bit positions, `UBFM`/`SBFM`, `EXT` index) — rejects outside [0, 63].
  - `imm` (12-bit `ADD`/`SUB`/`CMP` immediate) — rejects anything not encodable as a 12-bit immediate optionally
  shifted left by 12: `n < 0 || n > 0xFFF_000 || (n > 0xFFF && n land 0xFFF <> 0)`.

The `imm` bound needed the shift nuance because the backend legitimately passes pre-shifted values up to `0xFFF000` (e.g. `emit_addimm` passes `n land 0xFFF_000` with no explicit shift, letting the assembler infer `LSL #12`). This bound is exactly the range already accepted by the binary emitter's `encode_add_sub_imm_auto_shift`.

Left deliberately unchecked: `imm_float` and `imm_nativeint` (no simple integer range; `FMOV` float-immediate validity is checked separately, `nativeint` is full 64-bit), and the local `imm` helper at `ast.ml:2107` (only ever called with 0).
