### PR TITLE
Use canonical ids mode throughout flambda

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -2059,6 +2059,8 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_color F._color;
     mk_error_style F._error_style;
 
+    mk_dcanonical_ids F._dcanonical_ids;
+    mk_dno_canonical_ids F._dno_canonical_ids;
     mk_dno_unique_ids F._dno_unique_ids;
     mk_dunique_ids F._dunique_ids;
     mk_dno_locations F._dno_locations;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -264,7 +264,7 @@ module Env = struct
     try Ident.Map.find id t.variables
     with Not_found ->
       Misc.fatal_errorf "Closure_conversion.Env.find_var: %s@ %s"
-        (Ident.unique_name id)
+        (Ident.canonical_name id)
         (Printexc.raw_backtrace_to_string (Printexc.get_callstack 42))
 
   let find_var_exn t id = Ident.Map.find id t.variables

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -223,7 +223,7 @@ let let_cont_nonrecursive_with_extra_params acc env ccenv ~is_exn_handler
               (fun n kind ->
                 let field =
                   Ident.create_local
-                    (Printf.sprintf "%s_unboxed%d" (Ident.unique_name id) n)
+                    (Printf.sprintf "%s_unboxed%d" (Ident.canonical_name id) n)
                 in
                 let field_uid =
                   Flambda_debug_uid.of_lambda_debug_uid_proj duid ~field:n
@@ -833,7 +833,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
                         let ident =
                           Ident.create_local
                             (Printf.sprintf "%s_unboxed%d"
-                               (Ident.unique_name arg) n)
+                               (Ident.canonical_name arg) n)
                         in
                         let duid =
                           Flambda_debug_uid.of_lambda_debug_uid_proj duid
@@ -1560,7 +1560,9 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
                 in
                 let ident =
                   Ident.create_local
-                    (Printf.sprintf "%s_unboxed%d" (Ident.unique_name name) n)
+                    (Printf.sprintf "%s_unboxed%d"
+                       (Ident.canonical_name name)
+                       n)
                 in
                 ident, duid, kind)
               kinds

--- a/middle_end/flambda2/identifiers/continuation.mli
+++ b/middle_end/flambda2/identifiers/continuation.mli
@@ -44,6 +44,8 @@ val is_renamed_version_of : t -> t -> bool
 
 val name : t -> string
 
+val name_stamp : t -> int
+
 val sort : t -> Sort.t
 
 val export : t -> exported

--- a/middle_end/flambda2/identifiers/variable.ml
+++ b/middle_end/flambda2/identifiers/variable.ml
@@ -31,3 +31,5 @@ let is_renamed_version_of t t' =
 let raw_name = name
 
 let unique_name t = name t ^ string_of_int (name_stamp t)
+
+let canonical_name t = if !Clflags.canonical_ids then name t else unique_name t

--- a/middle_end/flambda2/identifiers/variable.mli
+++ b/middle_end/flambda2/identifiers/variable.mli
@@ -30,3 +30,5 @@ val is_renamed_version_of : t -> t -> bool
 val unique_name : t -> string
 
 val raw_name : t -> string
+
+val canonical_name : t -> string

--- a/middle_end/flambda2/kinds/flambda_arity.ml
+++ b/middle_end/flambda2/kinds/flambda_arity.ml
@@ -131,7 +131,7 @@ let fresh_idents_unarized t ~id =
     (fun n kind ->
       let ident =
         Ident.create_local
-          (Printf.sprintf "%s_unboxed%d" (Ident.unique_name id) n)
+          (Printf.sprintf "%s_unboxed%d" (Ident.canonical_name id) n)
       in
       ident, kind)
     (unarize t)

--- a/middle_end/flambda2/parser/fexpr_to_flambda_commons.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda_commons.ml
@@ -115,12 +115,17 @@ let enter_code env =
     vars_within_closures = env.vars_within_closures
   }
 
+let chop_stamp name =
+  match String.split_on_char '/' name with
+  | [] | _ :: _ :: _ :: _ -> Misc.fatal_errorf "invalid id '%s'" name
+  | [name] | [name; _] -> name
+
 let fresh_cont env { Fexpr.txt = name; loc = _ } ~sort ~arity =
-  let c = Continuation.create ~sort ~name () in
+  let c = Continuation.create ~sort ~name:(chop_stamp name) () in
   c, { env with continuations = CM.add name (c, arity) env.continuations }
 
 let fresh_exn_cont env { Fexpr.txt = name; loc = _ } ~arity =
-  let c = Continuation.create ~name () in
+  let c = Continuation.create ~name:(chop_stamp name) () in
   ( c,
     { env with
       continuations = CM.add name (c, arity) env.continuations;
@@ -128,7 +133,7 @@ let fresh_exn_cont env { Fexpr.txt = name; loc = _ } ~arity =
     } )
 
 let fresh_var env { Fexpr.txt = name; loc = _ } k =
-  let v = Variable.create name ~user_visible:() k in
+  let v = Variable.create (chop_stamp name) ~user_visible:() k in
   let v_duid = Flambda_debug_uid.none in
   (* CR sspies: In the future, try to improve the debug UID propagation here. *)
   v, v_duid, { env with variables = VM.add name v env.variables }

--- a/middle_end/flambda2/parser/flambda_lex.mll
+++ b/middle_end/flambda2/parser/flambda_lex.mll
@@ -221,7 +221,7 @@ rule token = parse
   | "~"  { TILDE }
   | "&"  { AMP }
   | "^"  { CARET }
-  | identstart identchar* as ident
+  | identstart identchar* ('/' ['0'-'9']+)? as ident
          { ident_or_keyword ident }
   | quoted_ident as ident
          { IDENT (unquote_ident ident) }

--- a/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
@@ -20,12 +20,16 @@ module type Convertible_id = sig
 
   val name : t -> string
 
+  val stamp : t -> int option
+
   val add_tag : string -> int -> string
 
   val mk_fexpr_id : string -> fexpr_id
 end
 
 let default_add_tag name tag = Printf.sprintf "%s_%d" name tag
+
+let add_stamp name stamp = Printf.sprintf "%s/%d" name stamp
 
 module Name_map (I : Convertible_id) : sig
   type t
@@ -49,6 +53,7 @@ end = struct
 
   let bind { id_map; names } id =
     let name = I.name id in
+    let stamp = I.stamp id in
     let rec try_name name names =
       match String_map.find_opt name names with
       | None ->
@@ -62,7 +67,13 @@ end = struct
          * case we'll end up with x_1_1 *)
         try_name name names
     in
-    let fexpr_id, names = try_name name names in
+    let fexpr_id, names =
+      if !Clflags.canonical_ids || Option.is_none stamp
+      then try_name name names
+      else
+        let name = add_stamp name (Option.get stamp) in
+        I.mk_fexpr_id name, names
+    in
     let id_map = I.Map.add id fexpr_id id_map in
     fexpr_id, { id_map; names }
 
@@ -170,6 +181,8 @@ end = struct
 
     let name v = raw_name v
 
+    let stamp v = Some (name_stamp v)
+
     let add_tag = default_add_tag
 
     let mk_fexpr_id name = name |> nowhere
@@ -186,6 +199,8 @@ end = struct
 
     let name v = linkage_name v |> Linkage_name.to_string
 
+    let stamp _ = None
+
     let add_tag = default_add_tag
 
     let mk_fexpr_id name = name
@@ -199,6 +214,8 @@ end = struct
     let desc = "code id"
 
     let name v = Code_id.name v
+
+    let stamp _ = None
 
     let add_tag = default_add_tag
 
@@ -214,6 +231,8 @@ end = struct
 
     let name v = Function_slot.name v
 
+    let stamp _ = None
+
     let add_tag = default_add_tag
 
     let mk_fexpr_id name = name |> nowhere
@@ -228,6 +247,8 @@ end = struct
 
     let name v = Value_slot.name v
 
+    let stamp _ = None
+
     let add_tag = default_add_tag
 
     let mk_fexpr_id name = name |> nowhere
@@ -241,6 +262,8 @@ end = struct
     let desc = "continuation"
 
     let name c = Continuation.name c
+
+    let stamp c = Some (Continuation.name_stamp c)
 
     let add_tag name tag =
       match name with

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -67,9 +67,15 @@ let is_unquoted_symbol s =
   (not (String.equal s "")) && Misc.Stdlib.String.for_all is_identchar s
 
 let is_unquoted_ident s =
+  let name, stamp =
+    match String.split_on_char '/' s with
+    | [] | [_] | _ :: _ :: _ :: _ -> s, ""
+    | [name; stamp] -> name, stamp
+  in
   (not (String.equal s ""))
   && is_identstart s.[0]
-  && Misc.Stdlib.String.for_all is_identchar s
+  && Misc.Stdlib.String.for_all is_identchar name
+  && Misc.Stdlib.String.for_all (fun c -> char_between c ('0', '9')) stamp
 
 let symbol_part ppf s =
   if is_unquoted_symbol s

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -133,7 +133,7 @@ let create_coerced_singleton_let uacc var defining_expr
         ~cost_metrics_of_defining_expr
     | Prim _ | Set_of_closures _ | Static_consts _ | Rec_info _ ->
       let uncoerced_var =
-        let name = "uncoerced_" ^ Variable.unique_name (VB.var var) in
+        let name = "uncoerced_" ^ Variable.canonical_name (VB.var var) in
         Variable.create name (Variable.kind (VB.var var))
       in
       let uncoerced_var_duid = Flambda_debug_uid.none in

--- a/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
+++ b/middle_end/flambda2/simplify/flow/mutable_unboxing.ml
@@ -476,7 +476,7 @@ module Fold_prims = struct
               (fun i kind ->
                 let name =
                   Simple.pattern_match' block_needed
-                    ~var:(fun var ~coercion:_ -> Variable.unique_name var)
+                    ~var:(fun var ~coercion:_ -> Variable.canonical_name var)
                     ~symbol:(fun _ ~coercion:_ ->
                       Misc.fatal_errorf
                         "[Mutable Unboxing] Cannot unbox mutable symbols")

--- a/ocamltest/ocaml_modifiers.ml
+++ b/ocamltest/ocaml_modifiers.ml
@@ -136,6 +136,7 @@ let extension_universe_lib name =
 
 let make_fexpr_dump pass = [
   append Ocaml_variables.fexpr_dump_files [pass ^ ".fl"];
+  append Ocaml_variables.ocamlopt_flags ["-dcanonical-ids"];
   append Ocaml_variables.ocamlopt_flags ["-dfexpr-annot-after="^pass];
 ]
 

--- a/testsuite/tests/flambda2/examples/direct_app_parameter_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/direct_app_parameter_kind_check_simplify.simplify.reference
@@ -30,8 +30,8 @@ in
 let $camlDirect_app_parameter_kind_check_simplify__create_4 =
   closure create_1_1 @create
 in
-(let Pmakeblock72_0 = 0 in
- let `*match*` = Pmakeblock72_0 in
+(let Pmakeblock_0 = 0 in
+ let `*match*` = Pmakeblock_0 in
  let prim = %is_int (`*match*`) in
  switch prim
    | 0 -> k1

--- a/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
+++ b/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
@@ -22,42 +22,41 @@ let code loopify(never) size(49) newer_version_of(ld_conf_contents_1)
      where k6 =
        (cont k6 (0)
           where rec k6
-                      (path_289_unboxed0 :
+                      (path_unboxed0 :
                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-            let path_289_unboxed0_1 = path_289_unboxed0 in
+            let path_unboxed0_1 = path_unboxed0 in
             (apply direct(input_line_0_1)
                ($camlExn_extra_args__input_line_2 : _ -> val)
                  (0)
-                 -> k7 * k5 (path_289_unboxed0 val)
+                 -> k7 * k5 (path_unboxed0 val)
                where k7 (return_val0 : val) =
-                 let Pmakeblock =
-                   %block.[`0`] (return_val0, path_289_unboxed0)
+                 let Pmakeblock = %block.[`0`] (return_val0, path_unboxed0)
                  in
                  cont k6 (Pmakeblock)))
-     where k5 exn (`exn` : val, path_289_unboxed0) =
-       let path_289_unboxed0_1 = path_289_unboxed0 in
+     where k5 exn (`exn` : val, path_unboxed0) =
+       let path_unboxed0_1 = path_unboxed0 in
        let `unit` = %end_try_region (try_region_1) in
        let unit_1 = %end_try_ghost_region (try_ghost_region_1) in
        let prim = %phys_eq (`exn`, $`*predef*`.caml_exn_End_of_file) in
        switch prim
-         | 0 -> k3 (path_289_unboxed0, `exn`)
-         | 1 -> k4 (path_289_unboxed0))
-    where k4 (path_289_unboxed0) =
-      let path_289_unboxed0_1 = path_289_unboxed0 in
-      cont k2 (path_289_unboxed0)
-    where k3 (path_289_unboxed0, `exn`) =
+         | 0 -> k3 (path_unboxed0, `exn`)
+         | 1 -> k4 (path_unboxed0))
+    where k4 (path_unboxed0) =
+      let path_unboxed0_1 = path_unboxed0 in
+      cont k2 (path_unboxed0)
+    where k3 (path_unboxed0, `exn`) =
       let exn_1 = `exn` in
-      let path_289_unboxed0_1 = path_289_unboxed0 in
+      let path_unboxed0_1 = path_unboxed0 in
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       let Pfield = %block_load.[`0`] (exn_1) in
       let prim = %phys_eq (Pfield, $`*predef*`.caml_exn_Sys_error) in
       switch prim
         | 0 -> k1 pop(reraise k1) (exn_1)
-        | 1 -> k2 (path_289_unboxed0)
-    where k2 (path_289_unboxed0) =
-      let path_289_unboxed0_1 = path_289_unboxed0 in
-      cont k (path_289_unboxed0_1)
+        | 1 -> k2 (path_unboxed0)
+    where k2 (path_unboxed0) =
+      let path_unboxed0_1 = path_unboxed0 in
+      cont k (path_unboxed0_1)
 in
 let $camlExn_extra_args__ld_conf_contents_3 =
   closure ld_conf_contents_1_1 @ld_conf_contents

--- a/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
+++ b/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
@@ -12,11 +12,10 @@ let code loopify(never) size(31) newer_version_of(f_0)
       let prim_1 = %untag_imm (x) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, init)
-         where rec k2
-                     (for_counter_naked : int64, m_290_unboxed0 : imm tagged) =
+         where rec k2 (for_counter_naked : int64, m_unboxed0 : imm tagged) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
-           let int_add = %int_barith.add (m_290_unboxed0, i) in
+           let int_add = %int_barith.add (m_unboxed0, i) in
            let for_next_naked =
              %int_barith.`int64`.add (for_counter_naked, 1L)
            in

--- a/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
@@ -30,8 +30,8 @@ let code loopify(never) size(44) newer_version_of(f_0)
              | 0 -> k2 (float_add)
              | 1 -> k3 (for_next_naked, prim_2))
     where k2 (float_add) =
-      let r_281_unboxed0 = float_add in
-      cont k (r_281_unboxed0)
+      let r_unboxed0 = float_add in
+      cont k (r_unboxed0)
 in
 let $camlFloat_unboxing__f_1 = closure f_0_1 @f in
 let $camlFloat_unboxing__Pmakeblock120 = Block 0 ($camlFloat_unboxing__f_1)

--- a/testsuite/tests/flambda2/examples/invalid.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.compilers.reference
@@ -39,35 +39,33 @@
 (data int 768 "camlInvalid__empty_array41":)
 (data int 2044 "camlInvalid__immstring17": string "lengths" skip 0 byte 0)
 (function{invalid.ml:24,25-96} camlInvalid__check_0_3_code
-     (t1/366: val t2/367: val) : int
+     (t1/0: val t2/0: val) : int
  (if
-   (!= (or (>>u (<< (load_mut int (+a t1/366 -8)) 8) 17) 1)
-     (or (>>u (<< (load_mut int (+a t2/367 -8)) 8) 17) 1))
+   (!= (or (>>u (<< (load_mut int (+a t1/0 -8)) 8) 17) 1)
+     (or (>>u (<< (load_mut int (+a t2/0 -8)) 8) 17) 1))
    (raise_notrace{invalid.ml:25,45-63;stdlib.ml:39,17-33}
      L:"camlInvalid__Pmakeblock71")
    1) )
 
 (function{invalid.ml:27,17-68} camlInvalid__bar_1_4_code
-     (t1/371: val t2/372: val) : int
+     (t1/1: val t2/1: val) : int
  (let
-   param/373
-     (app{invalid.ml:28,2-13} G:"camlInvalid__check_0_3_code" t1/371 t2/372
-       int)
-   (+ (<< (==f (load_mut float64 t2/372) 0.) 1) 1)) )
+   param/0
+     (app{invalid.ml:28,2-13} G:"camlInvalid__check_0_3_code" t1/1 t2/1 int)
+   (+ (<< (==f (load_mut float64 t2/1) 0.) 1) 1)) )
 
-(function{invalid.ml:31,8-30} camlInvalid__foo_2_5_code
-     (param/377: int) : int
+(function{invalid.ml:31,8-30} camlInvalid__foo_2_5_code (param/1: int) : int
  (let
-   (Pmakearray/378 (alloc{invalid.ml:31,17-25} 1278 1.)
-    param/379
+   (Pmakearray/0 (alloc{invalid.ml:31,17-25} 1278 1.)
+    param/2
       (app{invalid.ml:31,13-30;invalid.ml:28,2-13}
-        G:"camlInvalid__check_0_3_code" Pmakearray/378
+        G:"camlInvalid__check_0_3_code" Pmakearray/0
         L:"camlInvalid__empty_array41" int))
    (invalid
      "(Defining_expr_of_let (bound_pattern prim/110N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/106UV 0)\n   invalid.ml:29,2--23)))"
      L:"camlInvalid__invalid177")) )
 
 (function no_cse reduce_code_size linscan camlInvalid__entry () : val
- (catch (exit 7 G:"camlInvalid") with(7 *ret*/364: val) 1) )
+ (catch (exit 7 G:"camlInvalid") with(7 *ret*/0: val) 1) )
 
 (data)

--- a/testsuite/tests/flambda2/examples/invalid.no-flat-float-array.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.no-flat-float-array.compilers.reference
@@ -31,29 +31,27 @@
 (data int 768 "camlInvalid__empty_array40":)
 (data int 2044 "camlInvalid__immstring17": string "lengths" skip 0 byte 0)
 (function{invalid.ml:24,25-96} camlInvalid__check_0_3_code
-     (t1/366: val t2/367: val) : int
+     (t1/0: val t2/0: val) : int
  (if
-   (!= (or (>>u (<< (load_mut int (+a t1/366 -8)) 8) 17) 1)
-     (or (>>u (<< (load_mut int (+a t2/367 -8)) 8) 17) 1))
+   (!= (or (>>u (<< (load_mut int (+a t1/0 -8)) 8) 17) 1)
+     (or (>>u (<< (load_mut int (+a t2/0 -8)) 8) 17) 1))
    (raise_notrace{invalid.ml:25,45-63;stdlib.ml:39,17-33}
      L:"camlInvalid__Pmakeblock69")
    1) )
 
 (function{invalid.ml:27,17-68} camlInvalid__bar_1_4_code
-     (t1/371: val t2/372: val) : int
+     (t1/1: val t2/1: val) : int
  (let
-   param/373
-     (app{invalid.ml:28,2-13} G:"camlInvalid__check_0_3_code" t1/371 t2/372
-       int)
-   (+ (<< (==f (load float64 (load_mut val t2/372)) 0.) 1) 1)) )
+   param/0
+     (app{invalid.ml:28,2-13} G:"camlInvalid__check_0_3_code" t1/1 t2/1 int)
+   (+ (<< (==f (load float64 (load_mut val t2/1)) 0.) 1) 1)) )
 
-(function{invalid.ml:31,8-30} camlInvalid__foo_2_5_code
-     (param/378: int) : int
+(function{invalid.ml:31,8-30} camlInvalid__foo_2_5_code (param/1: int) : int
  (let
-   (Pmakearray/379 (alloc{invalid.ml:31,17-25} 1024 L:"camlInvalid__float43")
-    param/380
+   (Pmakearray/0 (alloc{invalid.ml:31,17-25} 1024 L:"camlInvalid__float43")
+    param/2
       (app{invalid.ml:31,13-30;invalid.ml:28,2-13}
-        G:"camlInvalid__check_0_3_code" Pmakearray/379
+        G:"camlInvalid__check_0_3_code" Pmakearray/0
         L:"camlInvalid__empty_array40" int))
    (+
      (<<
@@ -62,6 +60,6 @@
      1)) )
 
 (function no_cse reduce_code_size linscan camlInvalid__entry () : val
- (catch (exit 7 G:"camlInvalid") with(7 *ret*/364: val) 1) )
+ (catch (exit 7 G:"camlInvalid") with(7 *ret*/0: val) 1) )
 
 (data)

--- a/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
+++ b/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
@@ -13,8 +13,7 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
     where k2 =
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim) in
       (cont k2 (0L, 0)
-         where rec k2
-                     (for_counter_naked : int64, n_293_unboxed0 : imm tagged) =
+         where rec k2 (for_counter_naked : int64, n_unboxed0 : imm tagged) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let prim_3 = %num_conv.[tagged_imm].[`nativeint`] (i) in
@@ -27,17 +26,17 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
                where k5 =
                  let prim_6 = %num_conv.[tagged_imm].[int8] (c) in
                  let prim_7 =
-                   %num_conv.[tagged_imm].[`nativeint`] (n_293_unboxed0)
+                   %num_conv.[tagged_imm].[`nativeint`] (n_unboxed0)
                  in
                  let Pbytessetu =
                    %bytes_or_bigstring_set.bytes.[`8`] (s', prim_7, prim_6)
                  in
-                 cont k3 (n_293_unboxed0)
+                 cont k3 (n_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (n_293_unboxed0, 1) in
+                 let int_add = %int_barith.add (n_unboxed0, 1) in
                  cont k3 (int_add))
-              where k3 (n_293_unboxed0_1 : imm tagged) =
-                let int_add = %int_barith.add (n_293_unboxed0_1, 1) in
+              where k3 (n_unboxed0_1 : imm tagged) =
+                let int_add = %int_barith.add (n_unboxed0_1, 1) in
                 let for_next_naked =
                   %int_barith.`int64`.add (for_counter_naked, 1L)
                 in

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
@@ -26,16 +26,16 @@ let code loopify(never) size(20) newer_version_of(stuff_1)
    let try_ghost_region = %begin_try_ghost_region (ghost_region) in
    cont k4 push(k3)
      where k4 =
-       let r_285_unboxed0 = 0 in
+       let r_unboxed0 = 0 in
        let Popaque = %opaque ($camlData_flow_exception_bug__do_stuff_2) in
        (apply Popaque (env) -> k4 * k3
           where k4 (return_val0 : [ 0 | 0 of val ]) =
             cont k2 pop(k3) (return_val0))
      where k3 exn (`exn` : val) =
-       let r_285_unboxed0 = 0 in
+       let r_unboxed0 = 0 in
        let `unit` = %end_try_region (try_region) in
        let unit_1 = %end_try_ghost_region (try_ghost_region) in
-       let Popaque = %opaque (r_285_unboxed0) in
+       let Popaque = %opaque (r_unboxed0) in
        cont k2 (Popaque))
     where k2 (region_return : [ 0 | 0 of val ]) =
       let `unit` = %end_region (`region`) in

--- a/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
@@ -27,7 +27,7 @@
    cont k1 (Pmakeblock)
  in
  let code size(1)
-       fn_2 (param_302_unboxed0, param_302_unboxed1)
+       fn_2 (param_unboxed0, param_unboxed1)
          my_closure _region _ghost_region my_depth
          -> k1 * k2
          : imm tagged =

--- a/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
@@ -45,28 +45,28 @@ let code loopify(never) size(18) newer_version_of(f_3)
   let try_region = %begin_try_region () in
   let try_ghost_region = %begin_try_ghost_region () in
   cont k3 (x)
-    where rec k3 (c_299_unboxed0 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+    where rec k3 (c_unboxed0 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
       (cont k6 push(k5)
          where k6 =
            (apply direct(p_2_1) inlining_state(depth(10))
               ($camlTest_exn_handler_inlining__p_6
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
-                (c_299_unboxed0)
+                (c_unboxed0)
                 -> k6 * k5
               where k6
                       (wrapper_return :
                          [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                 cont k4 pop(k5) (wrapper_return))
          where k5 exn (`exn`) =
-           cont k2 (c_299_unboxed0)
+           cont k2 (c_unboxed0)
          where k4 (wrapper_return) =
            let return_val0 = wrapper_return in
            cont k3 (return_val0))
-    where k2 (c_299_unboxed0) =
-      let c_299_unboxed0_1 = c_299_unboxed0 in
+    where k2 (c_unboxed0) =
+      let c_unboxed0_1 = c_unboxed0 in
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
-      cont k (c_299_unboxed0_1)
+      cont k (c_unboxed0_1)
 in
 let $camlTest_exn_handler_inlining__f_7 = closure f_3_1 @f in
 let $camlTest_exn_handler_inlining =

--- a/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
@@ -21,13 +21,13 @@ apply ccall noalloc
       cont k3 push(k2)
         where k3 =
           (cont k3 (x)
-             where rec k3 (r_294_unboxed0 : imm tagged) =
-               let prim = %int_comp.lt (r_294_unboxed0, 42) in
+             where rec k3 (r_unboxed0 : imm tagged) =
+               let prim = %int_comp.lt (r_unboxed0, 42) in
                (switch prim
                   | 0 -> k pop(k2) (0)
                   | 1 -> k4
                   where k4 =
-                    (apply g (r_294_unboxed0) -> k6 * k2
+                    (apply g (r_unboxed0) -> k6 * k2
                        where k6 (param : [ 0 |1 ]) =
                          let unboxed_field = %untag_imm (param) in
                          cont k5 (unboxed_field)
@@ -40,7 +40,7 @@ apply ccall noalloc
                                pop(regular k2)
                                ($camlLocal_exns_to_jumps__Exit209)
                        where k4 =
-                         let int_add = %int_barith.add (r_294_unboxed0, 1) in
+                         let int_add = %int_barith.add (r_unboxed0, 1) in
                          cont k3 (int_add))))
         where k2 exn (`exn` : val) =
           let `unit` = %end_try_region (try_region) in
@@ -59,8 +59,8 @@ apply ccall noalloc
       let try_region = %begin_try_region () in
       let try_ghost_region = %begin_try_ghost_region () in
       cont k3 (x)
-        where rec k3 (r_299_unboxed0 : imm tagged) =
-          let prim = %int_comp.lt (r_299_unboxed0, 42) in
+        where rec k3 (r_unboxed0 : imm tagged) =
+          let prim = %int_comp.lt (r_unboxed0, 42) in
           (switch prim
              | 0 -> k (0)
              | 1 -> k4
@@ -69,8 +69,8 @@ apply ccall noalloc
                  let try_ghost_region_1 = %begin_try_ghost_region () in
                  cont k7 push(k6)
                    where k7 =
-                     let r_299_unboxed0_1 = r_299_unboxed0 in
-                     (apply g (r_299_unboxed0) -> k8 * k6
+                     let r_unboxed0_1 = r_unboxed0 in
+                     (apply g (r_unboxed0) -> k8 * k6
                         where k8 (param : [ 0 |1 ]) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
@@ -78,19 +78,19 @@ apply ccall noalloc
                           let naked_immediate = unboxed_field in
                           cont k5 pop(k6) (naked_immediate))
                    where k6 exn (`exn` : val) =
-                     let r_299_unboxed0_1 = r_299_unboxed0 in
+                     let r_unboxed0_1 = r_unboxed0 in
                      let `unit` = %end_try_region (try_region_1) in
                      let unit_1 = %end_try_ghost_region (try_ghost_region_1)
                      in
                      cont k5 (0i)
                    where k5 (naked_immediate : imm) =
-                     let r_299_unboxed0_1 = r_299_unboxed0 in
+                     let r_unboxed0_1 = r_unboxed0 in
                      switch naked_immediate
                        | 0 -> k4
                        | 1 -> k2)
                   where k4 =
-                    let r_299_unboxed0_1 = r_299_unboxed0 in
-                    let int_add = %int_barith.add (r_299_unboxed0_1, 1) in
+                    let r_unboxed0_1 = r_unboxed0 in
+                    let int_add = %int_barith.add (r_unboxed0_1, 1) in
                     cont k3 (int_add)))
         where k2 =
           let `unit` = %end_try_region (try_region) in
@@ -106,8 +106,8 @@ apply ccall noalloc
       let try_region = %begin_try_region () in
       let try_ghost_region = %begin_try_ghost_region () in
       cont k3 (x)
-        where rec k3 (r_304_unboxed0 : imm tagged) =
-          let prim = %int_comp.lt (r_304_unboxed0, 42) in
+        where rec k3 (r_unboxed0 : imm tagged) =
+          let prim = %int_comp.lt (r_unboxed0, 42) in
           (switch prim
              | 0 -> k (0)
              | 1 -> k4
@@ -116,8 +116,8 @@ apply ccall noalloc
                  let try_ghost_region_1 = %begin_try_ghost_region () in
                  cont k7 push(k6)
                    where k7 =
-                     let r_304_unboxed0_1 = r_304_unboxed0 in
-                     (apply g (r_304_unboxed0) -> k8 * k6
+                     let r_unboxed0_1 = r_unboxed0 in
+                     (apply g (r_unboxed0) -> k8 * k6
                         where k8 (param : [ 0 |1 ]) =
                           let unboxed_field = %untag_imm (param) in
                           cont k7 (unboxed_field)
@@ -125,19 +125,19 @@ apply ccall noalloc
                           let naked_immediate = unboxed_field in
                           cont k5 pop(k6) (naked_immediate))
                    where k6 exn (`exn` : val) =
-                     let r_304_unboxed0_1 = r_304_unboxed0 in
+                     let r_unboxed0_1 = r_unboxed0 in
                      let `unit` = %end_try_region (try_region_1) in
                      let unit_1 = %end_try_ghost_region (try_ghost_region_1)
                      in
                      cont k5 (0i)
                    where k5 (naked_immediate : imm) =
-                     let r_304_unboxed0_1 = r_304_unboxed0 in
+                     let r_unboxed0_1 = r_unboxed0 in
                      switch naked_immediate
                        | 0 -> k4
                        | 1 -> k2)
                   where k4 =
-                    let r_304_unboxed0_1 = r_304_unboxed0 in
-                    let int_add = %int_barith.add (r_304_unboxed0_1, 1) in
+                    let r_unboxed0_1 = r_unboxed0 in
+                    let int_add = %int_barith.add (r_unboxed0_1, 1) in
                     cont k3 (int_add)))
         where k2 =
           let `unit` = %end_try_region (try_region) in
@@ -160,8 +160,8 @@ apply ccall noalloc
            let try_region = %begin_try_region () in
            let try_ghost_region = %begin_try_ghost_region () in
            cont k3 (x)
-             where rec k3 (r_310_unboxed0 : imm tagged) =
-               let prim = %int_comp.lt (r_310_unboxed0, 42) in
+             where rec k3 (r_unboxed0 : imm tagged) =
+               let prim = %int_comp.lt (r_unboxed0, 42) in
                (switch prim
                   | 0 -> k (0)
                   | 1 -> k4
@@ -170,8 +170,8 @@ apply ccall noalloc
                       let try_ghost_region_1 = %begin_try_ghost_region () in
                       cont k7 push(k6)
                         where k7 =
-                          let r_310_unboxed0_1 = r_310_unboxed0 in
-                          (apply g (r_310_unboxed0) -> k8 * k6
+                          let r_unboxed0_1 = r_unboxed0 in
+                          (apply g (r_unboxed0) -> k8 * k6
                              where k8 (param : [ 0 |1 ]) =
                                let unboxed_field = %untag_imm (param) in
                                cont k7 (unboxed_field)
@@ -179,29 +179,28 @@ apply ccall noalloc
                                let naked_immediate = unboxed_field in
                                cont k5 pop(k6) (naked_immediate))
                         where k6 exn (`exn` : val) =
-                          let r_310_unboxed0_1 = r_310_unboxed0 in
+                          let r_unboxed0_1 = r_unboxed0 in
                           let `unit` = %end_try_region (try_region_1) in
                           let unit_1 =
                             %end_try_ghost_region (try_ghost_region_1)
                           in
                           cont k5 (0i)
                         where k5 (naked_immediate : imm) =
-                          let r_310_unboxed0_1 = r_310_unboxed0 in
+                          let r_unboxed0_1 = r_unboxed0 in
                           (switch naked_immediate
                              | 0 -> k4
                              | 1 -> k5
                              where k5 =
                                let int_add =
-                                 %int_barith.add (r_310_unboxed0_1, 3)
+                                 %int_barith.add (r_unboxed0_1, 3)
                                in
                                let int_add_1 =
-                                 %int_barith.add (r_310_unboxed0_1, 2)
+                                 %int_barith.add (r_unboxed0_1, 2)
                                in
                                cont k2 (int_add_1, int_add)))
                        where k4 =
-                         let r_310_unboxed0_1 = r_310_unboxed0 in
-                         let int_add = %int_barith.add (r_310_unboxed0_1, 1)
-                         in
+                         let r_unboxed0_1 = r_unboxed0 in
+                         let int_add = %int_barith.add (r_unboxed0_1, 1) in
                          cont k3 (int_add)))
              where k2 (int_add, int_add_1) =
                let cse_param = int_add_1 in

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -94,6 +94,8 @@ let unique_name = function
       name
   | Global_with_args g -> global_name g
 
+let canonical_name i = if !Clflags.canonical_ids then name i else unique_name i
+
 let unique_toplevel_name = function
   | Local { name; stamp }
   | Scoped { name; stamp } -> name ^ "/" ^ Int.to_string stamp

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -51,6 +51,9 @@ val rename: t -> t
 
 val name: t -> string
 val unique_name: t -> string
+val canonical_name: t -> string
+        (** [name] or [unique_name] following [-d(no)canonical-ids] flag *)
+
 val unique_toplevel_name: t -> string
 val same: t -> t -> bool
         (** Compare identifiers by binding location.


### PR DESCRIPTION
This patch makes flambda2 consider the `-d(no)canonical-ids` flag to its generated ids for better test stability.

It also makes fexpr dumps in ocamltest implicitely use canonical mode.