### PR TITLE
Detect heap allocation to constrain Allocation mode

### DIFF
--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -171,7 +171,7 @@ Error: Signature mismatch:
              sig
                val pack :
                  ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array
-                 @@ stateless noalloc_strict
+                 @@ stateless
              end
          end
        is not included in
@@ -186,7 +186,7 @@ Error: Signature mismatch:
            sig
              val pack :
                ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array
-               @@ stateless noalloc_strict
+               @@ stateless
            end
        does not match
          module type T =
@@ -198,7 +198,7 @@ Error: Signature mismatch:
          sig
            val pack :
              ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array @@
-             stateless noalloc_strict
+             stateless
          end
        is not equal to
          sig
@@ -208,7 +208,7 @@ Error: Signature mismatch:
        Values do not match:
          val pack :
            ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array @@
-           stateless noalloc_strict
+           stateless
        is not included in
          val pack : ('from_sig : bits64). 'from_sig -> 'from_sig array
        The type "'a -> 'a array" is not compatible with the type "'b -> 'b array"
@@ -236,7 +236,7 @@ module type Sig_default_defines_struct =
         val pack :
           ('from_defined_sig : bits64).
             'from_defined_sig -> 'from_defined_sig array
-          @@ stateless noalloc_strict
+          @@ stateless
       end
   end
 |}]

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -674,13 +674,13 @@ module M : sig end @@ stateless noalloc_strict
 module F (X : S @ portable) = struct
 end
 [%%expect{|
-module F : functor (X : S @ portable) -> sig end @@ stateless noalloc_strict
+module F : functor (X : S @ portable) -> sig end @@ stateless
 |}]
 
 module F (_ : S @ portable) = struct
 end
 [%%expect{|
-module F : S @ portable -> sig end @@ stateless noalloc_strict
+module F : S @ portable -> sig end @@ stateless
 |}]
 
 module M' = (M : S @ portable)
@@ -691,13 +691,13 @@ module M' : S @@ stateless noalloc_strict
 module F (M : S @ portable) : S @ portable = struct
 end
 [%%expect{|
-module F : functor (M : S @ portable) -> S @@ stateless noalloc_strict
+module F : functor (M : S @ portable) -> S @@ stateless
 |}]
 
 module F (M : S @ portable) @ portable = struct
 end
 [%%expect{|
-module F : functor (M : S @ portable) -> sig end @@ stateless noalloc_strict
+module F : functor (M : S @ portable) -> sig end @@ stateless
 |}]
 
 
@@ -747,26 +747,25 @@ module type S'' = S @ local -> S -> S
 
 module (F @ portable) () = struct end
 [%%expect{|
-module F : functor () -> sig end @@ stateless noalloc_strict
+module F : functor () -> sig end @@ stateless
 |}]
 
 module (G @ portable) () = F
 
 [%%expect{|
 module G : functor () -> (functor () -> sig end) @ contended @@ portable
-  noalloc_strict
 |}]
 
 module (G @ portable) (F : (S @ unique -> S @ once) @ local) @ contended = struct end
 [%%expect{|
 module G :
   functor (F : (S @ unique -> S @ once) @ local) -> sig end @ contended @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 module (G' @ portable) = F
 [%%expect{|
-module G' = F @@ stateless noalloc_strict
+module G' = F @@ stateless
 |}]
 
 module rec (F @ portable) () = struct end
@@ -911,7 +910,7 @@ module type S = sig
 end;;
 
 [%%expect{|
-module F_struct : sig end -> sig end @@ stateless noalloc_strict
+module F_struct : sig end -> sig end @@ stateless
 module type F_sig = sig end -> sig end
 module T : sig end @@ stateless noalloc_strict
 module type S = sig end
@@ -982,7 +981,7 @@ module M :
   sig
     val f : (x:int * string) -> x:int * string
     val mk : unit -> x:bool * y:string
-  end @@ stateless noalloc_strict
+  end @@ stateless
 module X_int_int : sig type t = x:int * int end @@ stateless noalloc_strict
 |}]
 
@@ -1530,11 +1529,11 @@ module _ = Base(Name1)(Value1)(Name2)(Value2(Name2_1)(Value2_1)) [@jane.non_eras
 
 [%%expect{|
 module Base : sig end -> sig end -> sig end -> sig end -> sig end @@
-  stateless noalloc_strict
+  stateless
 module Name1 : sig end @@ stateless noalloc_strict
 module Name2 : sig end @@ stateless noalloc_strict
 module Value1 : sig end @@ stateless noalloc_strict
-module Value2 : sig end -> sig end -> sig end @@ stateless noalloc_strict
+module Value2 : sig end -> sig end -> sig end @@ stateless
 module Name2_1 : sig end @@ stateless noalloc_strict
 module Name2_1 : sig end @@ stateless noalloc_strict
 Line 9, characters 11-95:

--- a/testsuite/tests/templates/basic/bad_arg_impl.reference
+++ b/testsuite/tests/templates/basic/bad_arg_impl.reference
@@ -3,7 +3,6 @@ Error: The argument module bad_arg_impl.ml
        does not match the parameter signature monoid.cmi: 
        Values do not match:
          val append : unit -> unit -> [> `Banana ] @@ stateless
-           noalloc_strict
        is not included in
          val append : t -> t -> t
        The type unit -> unit -> [> `Banana ] is not compatible with the type

--- a/testsuite/tests/typing-modes/functor.ml
+++ b/testsuite/tests/typing-modes/functor.ml
@@ -70,21 +70,19 @@ module F : S -> T = functor (M : S) -> struct
   let g = M.f
 end
 [%%expect{|
-module F : S -> T @@ stateless noalloc_strict
+module F : S -> T @@ stateless
 |}]
 
 module F (M : S @ portable) (M' : S) = struct
 end
 [%%expect{|
 module F : functor (M : S @ portable) (M' : S) -> sig end @@ stateless
-  noalloc_strict
 |}]
 
 module F (M : S) (M' : S @ portable) @ portable = struct
 end
 [%%expect{|
 module F : functor (M : S) (M' : S @ portable) -> sig end @@ stateless
-  noalloc_strict
 |}]
 
 module F (M : S @ portable) (M' : S @ portable) : T @ portable = struct
@@ -92,7 +90,6 @@ module F (M : S @ portable) (M' : S @ portable) : T @ portable = struct
 end
 [%%expect{|
 module F : functor (M : S @ portable) (M' : S @ portable) -> T @@ stateless
-  noalloc_strict
 |}]
 
 (* In REPL (called "toplevel" in the compiler source code), functors, just like
@@ -152,7 +149,7 @@ module Workaround :
   sig
     module F :
       functor (M : S @ portable) -> sig val g : unit -> unit end @ portable
-      @@ stateless nonportable noalloc_strict
+      @@ stateless nonportable
     module M' : sig val g : unit -> unit end
   end @@ portable
 |}]
@@ -419,7 +416,7 @@ val f_local : 'a @ local -> unit -> unit = <fun>
 module F (M : S @ local) () = struct end
 [%%expect{|
 module F : functor (M : S @ local) -> (functor () -> sig end) @ local @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 (* Demonstration. *)
@@ -428,7 +425,7 @@ let f_stateful (x @ stateful) () = ()
 module F (M : S @ stateful) () = struct end
 [%%expect{|
 val f_stateful : 'a -> unit -> unit = <fun>
-module F : functor (M : S) () -> sig end @@ stateless noalloc_strict
+module F : functor (M : S) () -> sig end @@ stateless
 |}]
 
 let f_stateful_app (x @ stateful) =
@@ -510,7 +507,7 @@ val f_read_write : 'a -> unit -> unit = <fun>
 
 module F (M : S @ read_write) () = struct end
 [%%expect{|
-module F : functor (M : S) () -> sig end @@ stateless noalloc_strict
+module F : functor (M : S) () -> sig end @@ stateless
 |}]
 
 let f_read_write_app (x @ read_write) =
@@ -595,7 +592,7 @@ val f_read_write_ret : 'a -> unit -> unit = <fun>
 module F (M : S @ read_write) =
   ((functor () -> struct end) : (functor () -> sig end) @ stateless)
 [%%expect{|
-module F : functor (M : S) () -> sig end @@ stateless noalloc_strict
+module F : functor (M : S) () -> sig end @@ stateless
 |}]
 
 let f1 (x1 @ stateful) (x2 @ stateless) (x3 @ stateless) =
@@ -614,7 +611,7 @@ end
 [%%expect{|
 module F1 :
   functor (M1 : S) (M2 : S @ stateless) (M3 : S @ stateless) -> sig end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 let f1_flip (x2 @ stateless) (x1 @ stateful) = f1 x1 x2
@@ -628,7 +625,7 @@ module F1_flip (M2 : S @ stateless) (M1 : S @ read_write) = F1 (M1) (M2)
 [%%expect{|
 module F1_flip :
   functor (M2 : S @ stateless) (M1 : S) (M3 : S @ stateless) -> sig end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 (* This example explains why we need the stricter partial application
@@ -673,7 +670,7 @@ end
 [%%expect{|
 module F2 :
   functor (M1 : S @ stateless) (M2 : S) (M3 : S @ stateless) -> sig end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 let f3 (x1 @ stateless) (x2 @ stateless) (x3 @ stateful) =
@@ -692,7 +689,7 @@ end
 [%%expect{|
 module F3 :
   functor (M1 : S @ stateless) (M2 : S @ stateless) (M3 : S) -> sig end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 let test1 (_x @ stateful) : (unit -> unit) @ stateless = fun () -> ()
@@ -703,7 +700,7 @@ val test1 : 'a -> (unit -> unit) @ stateless = <fun>
 module F1 (M1 : S @ stateful) : (functor () -> sig end) @ stateless =
   functor () -> struct end
 [%%expect{|
-module F1 : functor (M1 : S) () -> sig end @@ stateless noalloc_strict
+module F1 : functor (M1 : S) () -> sig end @@ stateless
 |}]
 
 let test2 (x @ stateful) : (unit -> unit) @ stateless =
@@ -954,7 +951,6 @@ end
 type t' = F(M).t
 [%%expect{|
 module F : functor (X : S @ portable) -> sig type t = int end @@ stateless
-  noalloc_strict
 module M : sig val f : unit -> unit end
 type t' = F(M).t
 |}]
@@ -967,7 +963,7 @@ let (foo @ portable) () =
   let _ : F(M).t = 42 in
   ()
 [%%expect{|
-module F = F @@ stateless nonportable noalloc_strict
+module F = F @@ stateless nonportable
 module M = M
 val foo : unit -> unit = <fun>
 |}]
@@ -995,7 +991,7 @@ end
 [%%expect{|
 module F :
   functor (G : S -> S @ portable) -> sig module H : S -> S @ portable end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 module F(G : S -> S) = struct
@@ -1049,7 +1045,7 @@ module F(G : S -> S) = struct
 end
 [%%expect{|
 module F : functor (G : S -> S) -> sig module H : S @ portable -> S end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 module F (M : (S @ portable -> S) -> S) = (M : (S -> S) -> S)

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -244,7 +244,7 @@ Error: The module "M" is "nonportable"
 module F (X : S @ portable) = struct
 end
 [%%expect{|
-module F : functor (X : S @ portable) -> sig end @@ stateless noalloc_strict
+module F : functor (X : S @ portable) -> sig end @@ stateless
 |}]
 
 module type S = functor () (M : S @ portable) (_ : S @ portable) -> S
@@ -264,7 +264,7 @@ end
 module F :
   functor () ->
     sig val foo : unit -> unit @@ stateless noalloc_strict end @ once
-  @@ stateless noalloc_strict
+  @@ stateless
 |}]
 
 module type Empty = sig end
@@ -398,7 +398,7 @@ end
 [%%expect{|
 module F :
   functor (X : sig val x : int -> int end) -> sig val bar : int -> int end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -742,7 +742,7 @@ end
 module F :
   functor (M : sig val foo : 'a -> 'a end) ->
     sig module M' : sig val foo : 'a -> 'a @@ global many end end
-  @@ stateless noalloc_strict
+  @@ stateless
 |}]
 
 (* Similiar for recursive modules *)
@@ -762,13 +762,12 @@ module F (M : sig val f : 'a -> 'a @@ global many end) = struct
 end
 [%%expect{|
 module F : functor (M : sig val f : 'a -> 'a @@ global many end) -> sig end
-  @@ stateless noalloc_strict
+  @@ stateless
 |}]
 
 module G (M : sig val f : 'a -> 'a end) = F(M)
 [%%expect{|
 module G : functor (M : sig val f : 'a -> 'a end) -> sig end @@ stateless
-  noalloc_strict
 |}]
 
 (* Similiar for [include_functor] *)
@@ -778,7 +777,7 @@ module G (M : sig val f : 'a -> 'a end) = struct
 end
 [%%expect{|
 module G : functor (M : sig val f : 'a -> 'a end) -> sig val f : 'a -> 'a end
-  @@ stateless noalloc_strict
+  @@ stateless
 |}]
 
 (* functor declaration inclusion check  looks at the modes of parameter and
@@ -788,7 +787,7 @@ functor (M : sig val foo : 'a -> 'a @@ global many end) -> struct let bar = M.fo
 [%%expect{|
 module F :
   sig val foo : 'a -> 'a end -> sig val bar : 'a -> 'a @@ global many end @@
-  stateless noalloc_strict
+  stateless
 |}]
 
 (* CR zqian: package subtyping doesn't look at the package mode for simplicity.
@@ -1387,7 +1386,6 @@ let (bar @ portable) () =
 [%%expect{|
 module type F = sig end -> sig end
 module F : functor (X : sig end) -> sig end @@ stateless nonportable
-  noalloc_strict
 Line 4, characters 18-19:
 4 |   let k = (module F : F) in
                       ^
@@ -1405,7 +1403,7 @@ let (bar @ portable) () =
   k
 [%%expect{|
 module type F = sig end -> sig end
-module F : functor (X : sig end) -> sig end @@ stateless noalloc_strict
+module F : functor (X : sig end) -> sig end @@ stateless
 val bar : unit -> (module F) = <fun>
 |}]
 
@@ -1471,7 +1469,6 @@ let (f @ portable) () =
   ()
 [%%expect{|
 module F : functor (X : sig end) -> sig type t = string end @@ stateless
-  noalloc_strict
 module X : sig end @@ stateless noalloc_strict
 val f : unit -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1605,6 +1605,66 @@ Error: This value is "local" because it is "stack_"-allocated.
 |}]
 
 
+(** Test 5i: annotating the codomain of the arrow with [@ noalloc_strict]
+    constrains the mode of the application result. With
+    [foo : int -> t @ noalloc_strict], applying [M.foo 1] yields a
+    [noalloc_strict] value (and likewise [M.foo_int 1]). Note the codomain mode
+    [@ noalloc_strict] must precede the [@@ noalloc_strict] modality; writing it
+    as [(t @ noalloc_strict) @@ ...] is a syntax error. *)
+
+module M : sig
+  type t
+  val foo : int -> t @ noalloc_strict @@ noalloc_strict
+
+  type int_t
+  val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
+  val foo_int_default : int -> int_t @@ noalloc_strict
+end = struct
+  type t = (int -> unit) -> unit
+  let g0 : t = fun g -> g 0
+  let foo (_ : int) = g0
+
+  type int_t = int
+  let foo_int x = x
+  let foo_int_default x = x
+end
+[%%expect{|
+module M :
+  sig
+    type t
+    val foo : int -> t @ noalloc_strict @@ noalloc_strict
+    type int_t
+    val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
+    val foo_int_default : int -> int_t @@ noalloc_strict
+  end @@ stateless noalloc_strict
+|}]
+
+(* CR shsong: Error expected -- [M.foo 1] is a partial application,
+    which causes allocation. The current partial application detection
+    cannot detect whether an abstract type is an arrow type. *)
+let apply_one () = (M.foo 1 : _ @ noalloc_strict)
+[%%expect{|
+val apply_one : unit -> M.t = <fun>
+|}]
+
+let apply_zero () = (M.foo : _ @ noalloc_strict)
+[%%expect{|
+val apply_zero : unit -> int -> M.t @ noalloc_strict = <fun>
+|}]
+
+let apply_foo_int () = (M.foo_int 1 : _ @ noalloc_strict)
+[%%expect{|
+val apply_foo_int : unit -> M.int_t = <fun>
+|}]
+
+let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
+[%%expect{|
+Line 1, characters 32-51:
+1 | let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
+                                    ^^^^^^^^^^^^^^^^^^^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
+|}]
+
 (** Test 6: Misc *)
 
 type record_t = { x : float; y : float }

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -585,6 +585,8 @@ let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
 val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
 |}]
 
+(* CR shsong: Currently it may also because multi-argument function
+    always allocates. Revisit this in the next PR. *)
 (* A function that takes an optional argument allocates (to handle the
    optional-argument wrapping). *)
 let (alloc_optional_arg @ noalloc_strict) ?a () = a
@@ -892,8 +894,7 @@ Error: The allocation is "alloc"
 |}]
 
 (* An object with no allocating method (here only a value field) still
-   allocates the object block itself, which the [Pexp_object] walk detects,
-   so it is rejected even though [get] does not allocate. *)
+   allocates the object block itself. *)
 let (obj_no_alloc_method @ noalloc_strict) () = object val x = 0 end
 [%%expect{|
 Line 1, characters 48-68:
@@ -1160,14 +1161,16 @@ Error: The allocation is "alloc"
    [register_allocation_mode], which now walks locks, so it is wrongly rejected
    -- note the error is "The allocation is alloc". It should be accepted once the
    Prim_poly site is exempted from walking. *)
-let (array_get_prim_poly @ noalloc_strict) (a : int array) (i : int) = a.(i)
+let array_get_prim_poly (a : int array) (i : int) =
+  let (f @ noalloc_strict) () = a.(i) in
+  f ()
 [%%expect{|
-Line 1, characters 59-76:
-1 | let (array_get_prim_poly @ noalloc_strict) (a : int array) (i : int) = a.(i)
-                                                               ^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
+Line 2, characters 32-37:
+2 |   let (f @ noalloc_strict) () = a.(i) in
+                                    ^^^^^
+Error: The value "Array.get" is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 43-76
+         because it is used inside the function at line 2, characters 27-37
          which is expected to be "noalloc_strict".
 |}]
 
@@ -1481,30 +1484,36 @@ Error: This expression is not an allocation site.
     components, record fields, function bodies) or because [mode_morph] resets
     [strictly_stack] for children (lazy thunk body, partial-application args). *)
 
-(* lazy thunk body holds a new allocation *)
-let (stack_inner_lazy @ noalloc_strict) (a : int) =
-  exclave_ stack_ (lazy (Just a))
+(* a new allocation captured as an argument of a function application *)
+let stack_inner_function_application
+      (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
+  let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2 3) in
+  ()
 [%%expect{|
-Line 12, characters 18-33:
-12 |   exclave_ stack_ (lazy (Just a))
-                       ^^^^^^^^^^^^^^^
+Line 3, characters 51-59:
+3 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2 3) in
+                                                       ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 11-12, characters 40-33
+         because it is used inside the function at line 3, characters 27-64
          which is expected to be "noalloc_strict".
 |}]
 
+(* CR shsong: function partial application triggers allocation, and is not
+    considered to be on the stack even though it is annotated with [stack_].
+    Revisit this in the next PR. *)
 (* a new allocation captured as an argument of a partial application *)
-let (stack_inner_partial @ noalloc_strict)
+let stack_inner_partial_application
       (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
-  exclave_ stack_ (g (Just a) 2)
+  let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
+  ()
 [%%expect{|
-Lines 2-3, characters 67-32:
-2 | ...................................................................(a : int) =
-3 |   exclave_ stack_ (g (Just a) 2)
+Line 3, characters 48-62:
+3 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
+                                                    ^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-3, characters 6-32
+         because it is used inside the function at line 3, characters 27-62
          which is expected to be "noalloc_strict".
 |}]
 
@@ -1829,7 +1838,8 @@ Line 1, characters 27-52:
 Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
-(* CR-soon shsong: error expected -- cannot call [whitewashed ()] *)
+(** CR-soon shsong: revisit the following tests after supporting
+    using zero_alloc backend for our analysis. *)
 let (secretly_allocates @ noalloc) () =
   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
   whitewashed ()
@@ -1843,7 +1853,6 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc".
 |}]
 
-(* CR-soon shsong: error expected -- cannot assign alloc func to escape_hatch ref *)
 let (secretly_allocates' @ noalloc) () = exclave_
  let mutable escape_hatch = None in
  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
@@ -1860,7 +1869,6 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc".
 |}]
 
-(* CR-soon shsong: error expected -- cannot call [f ()] because it is alloc *)
 let (secretly_allocates @ noalloc) () = exclave_
  let mutable (escape_hatch @ alloc) = None in
  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1665,6 +1665,66 @@ Line 1, characters 32-51:
 Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
+(** Test 5.10:
+
+    CR shsong: a curried multi-argument function cannot be [noalloc]/
+    [noalloc_strict].
+
+    Writing [let f x y = x] desugars to [fun x -> (fun y -> x)]. Applying [f] to
+    one argument builds the inner closure [fun y -> x], preventing [f] from
+    begin [noalloc]/[noalloc_strict]. *)
+
+let (f @ noalloc_strict) x y = x
+[%%expect{|
+Line 10, characters 27-32:
+10 | let (f @ noalloc_strict) x y = x
+                                ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 10, characters 25-32
+         which is expected to be "noalloc_strict".
+|}]
+
+let (f_explicit @ noalloc_strict) x = fun y -> x
+[%%expect{|
+Line 1, characters 38-48:
+1 | let (f_explicit @ noalloc_strict) x = fun y -> x
+                                          ^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 34-48
+         which is expected to be "noalloc_strict".
+|}]
+
+let (f_n @ noalloc) x y = x
+[%%expect{|
+Line 1, characters 22-27:
+1 | let (f_n @ noalloc) x y = x
+                          ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 20-27
+         which is expected to be "noalloc".
+|}]
+
+(* Contrast: a single-argument function builds no inner closure and so is
+   accepted at [noalloc_strict]. *)
+let (g @ noalloc_strict) x = x
+[%%expect{|
+val g : 'a -> 'a = <fun>
+|}]
+
+let (f_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
+[%%expect{|
+Line 1, characters 46-58:
+1 | let (f_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
+                                                  ^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 33-58
+         which is expected to be "noalloc_strict".
+|}]
+
 (** Test 6: Misc *)
 
 type record_t = { x : float; y : float }

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags+="-extension mode_alpha";
+ flags+="-extension mode_alpha -extension comprehensions";
  expect;
 *)
 
@@ -383,7 +383,735 @@ Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
 
-(* Test 5: Other tests *)
+(** Test 5: Allocation mode identifies all allocations and forces the proper
+    mode. For each kind of allocation the typechecker can see, we test a
+    [noalloc_strict] and a [noalloc] enclosing function side by side, and -- for
+    the allocations that [stack_] supports -- a [stack_]-marked pair as well. An
+    allocation currently forces the enclosing function to [alloc], which is
+    above both [noalloc] and [noalloc_strict], so the detected cases error for
+    both; the gaps (marked [CR shsong]) are accepted for both.
+
+    CR shsong: [stack_] handling for the allocation axis is not yet implemented,
+    so a [stack_]-marked allocation still forces [alloc] and errors just like a
+    heap allocation. Once [stack_] is recognized, the [stack_]-marked cases
+    below should be accepted -- a stack allocation does not count towards the
+    allocation axis. (Allocations that [stack_] does not support, and [stack_]
+    on non-allocations, are covered in the negative tests after this section.) *)
+
+type record_t5 = { x : float; y : float }
+type 'a variant_t5 = Nothing | Just of 'a
+[%%expect{|
+type record_t5 = { x : float; y : float; }
+type 'a variant_t5 = Nothing | Just of 'a
+|}]
+
+(* Record construction allocates. *)
+let (alloc_record @ noalloc_strict) () = { x = 1.; y = 2. }
+[%%expect{|
+Line 1, characters 41-59:
+1 | let (alloc_record @ noalloc_strict) () = { x = 1.; y = 2. }
+                                             ^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-59
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_record @ noalloc) () = { x = 1.; y = 2. }
+[%%expect{|
+Line 1, characters 34-52:
+1 | let (alloc_record @ noalloc) () = { x = 1.; y = 2. }
+                                      ^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 29-52
+         which is expected to be "noalloc".
+|}]
+
+(* The same record allocation, but [stack_]-marked. *)
+let (alloc_record @ noalloc_strict) () = stack_ { x = 1.; y = 2. }
+[%%expect{|
+Line 1, characters 48-66:
+1 | let (alloc_record @ noalloc_strict) () = stack_ { x = 1.; y = 2. }
+                                                    ^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-66
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_record @ noalloc) () = stack_ { x = 1.; y = 2. }
+[%%expect{|
+Line 1, characters 41-59:
+1 | let (alloc_record @ noalloc) () = stack_ { x = 1.; y = 2. }
+                                             ^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 29-59
+         which is expected to be "noalloc".
+|}]
+
+(* A variant constructor with arguments allocates (constant constructors do
+   not). *)
+let (alloc_variant @ noalloc_strict) (a : int) = Just a
+[%%expect{|
+Line 1, characters 49-55:
+1 | let (alloc_variant @ noalloc_strict) (a : int) = Just a
+                                                     ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 37-55
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_variant @ noalloc) (a : int) = Just a
+[%%expect{|
+Line 1, characters 42-48:
+1 | let (alloc_variant @ noalloc) (a : int) = Just a
+                                              ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 30-48
+         which is expected to be "noalloc".
+|}]
+
+(* The same variant allocation, but [stack_]-marked. *)
+let (alloc_variant @ noalloc_strict) (a : int) = stack_ (Just a)
+[%%expect{|
+Line 1, characters 56-64:
+1 | let (alloc_variant @ noalloc_strict) (a : int) = stack_ (Just a)
+                                                            ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 37-64
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_variant @ noalloc) (a : int) = stack_ (Just a)
+[%%expect{|
+Line 1, characters 49-57:
+1 | let (alloc_variant @ noalloc) (a : int) = stack_ (Just a)
+                                                     ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 30-57
+         which is expected to be "noalloc".
+|}]
+
+(* A cons cell of a list allocates. *)
+let (alloc_list @ noalloc_strict) (a : int) = [a]
+[%%expect{|
+Line 1, characters 46-49:
+1 | let (alloc_list @ noalloc_strict) (a : int) = [a]
+                                                  ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 34-49
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_list @ noalloc) (a : int) = [a]
+[%%expect{|
+Line 1, characters 39-42:
+1 | let (alloc_list @ noalloc) (a : int) = [a]
+                                           ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 27-42
+         which is expected to be "noalloc".
+|}]
+
+(* The same list cell, but [stack_]-marked. *)
+let (alloc_list @ noalloc_strict) (a : int) = stack_ [a]
+[%%expect{|
+Line 1, characters 53-56:
+1 | let (alloc_list @ noalloc_strict) (a : int) = stack_ [a]
+                                                         ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 34-56
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_list @ noalloc) (a : int) = stack_ [a]
+[%%expect{|
+Line 1, characters 46-49:
+1 | let (alloc_list @ noalloc) (a : int) = stack_ [a]
+                                                  ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 27-49
+         which is expected to be "noalloc".
+|}]
+
+(* An array literal allocates. *)
+let (alloc_array @ noalloc_strict) (a : int) = [| a |]
+[%%expect{|
+Line 1, characters 47-54:
+1 | let (alloc_array @ noalloc_strict) (a : int) = [| a |]
+                                                   ^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 35-54
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_array @ noalloc) (a : int) = [| a |]
+[%%expect{|
+Line 1, characters 40-47:
+1 | let (alloc_array @ noalloc) (a : int) = [| a |]
+                                            ^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 28-47
+         which is expected to be "noalloc".
+|}]
+
+(* The same array, but [stack_]-marked. *)
+let (alloc_array @ noalloc_strict) (a : int) = stack_ [| a |]
+[%%expect{|
+Line 1, characters 54-61:
+1 | let (alloc_array @ noalloc_strict) (a : int) = stack_ [| a |]
+                                                          ^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 35-61
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_array @ noalloc) (a : int) = stack_ [| a |]
+[%%expect{|
+Line 1, characters 47-54:
+1 | let (alloc_array @ noalloc) (a : int) = stack_ [| a |]
+                                                   ^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 28-54
+         which is expected to be "noalloc".
+|}]
+
+(* A polymorphic variant with an argument allocates. *)
+let (alloc_polyvariant @ noalloc_strict) (a : int) = `Tag a
+[%%expect{|
+Line 1, characters 53-59:
+1 | let (alloc_polyvariant @ noalloc_strict) (a : int) = `Tag a
+                                                         ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 41-59
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_polyvariant @ noalloc) (a : int) = `Tag a
+[%%expect{|
+Line 1, characters 46-52:
+1 | let (alloc_polyvariant @ noalloc) (a : int) = `Tag a
+                                                  ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 34-52
+         which is expected to be "noalloc".
+|}]
+
+(* The same polymorphic variant, but [stack_]-marked. *)
+let (alloc_polyvariant @ noalloc_strict) (a : int) = stack_ (`Tag a)
+[%%expect{|
+Line 1, characters 60-68:
+1 | let (alloc_polyvariant @ noalloc_strict) (a : int) = stack_ (`Tag a)
+                                                                ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 41-68
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_polyvariant @ noalloc) (a : int) = stack_ (`Tag a)
+[%%expect{|
+Line 1, characters 53-61:
+1 | let (alloc_polyvariant @ noalloc) (a : int) = stack_ (`Tag a)
+                                                         ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 34-61
+         which is expected to be "noalloc".
+|}]
+
+(* A function that takes an optional argument allocates (to handle the
+   optional-argument wrapping). *)
+let (alloc_optional_arg @ noalloc_strict) ?a () = a
+[%%expect{|
+Line 1, characters 45-51:
+1 | let (alloc_optional_arg @ noalloc_strict) ?a () = a
+                                                 ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 42-51
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_optional_arg @ noalloc) ?a () = a
+[%%expect{|
+Line 1, characters 38-44:
+1 | let (alloc_optional_arg @ noalloc) ?a () = a
+                                          ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 35-44
+         which is expected to be "noalloc".
+|}]
+
+(* Building a closure that captures a variable allocates. *)
+let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
+[%%expect{|
+Line 1, characters 49-60:
+1 | let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
+                                                     ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 37-60
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_closure @ noalloc) (a : int) = fun () -> a
+[%%expect{|
+Line 1, characters 42-53:
+1 | let (alloc_closure @ noalloc) (a : int) = fun () -> a
+                                              ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 30-53
+         which is expected to be "noalloc".
+|}]
+
+(* The same closure, but [stack_]-marked. *)
+let (alloc_closure @ noalloc_strict) (a : int) = stack_ (fun () -> a)
+[%%expect{|
+Line 1, characters 56-69:
+1 | let (alloc_closure @ noalloc_strict) (a : int) = stack_ (fun () -> a)
+                                                            ^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 37-69
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_closure @ noalloc) (a : int) = stack_ (fun () -> a)
+[%%expect{|
+Line 1, characters 49-62:
+1 | let (alloc_closure @ noalloc) (a : int) = stack_ (fun () -> a)
+                                                     ^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 30-62
+         which is expected to be "noalloc".
+|}]
+
+(* Boxing a float read out of a flat float record allocates. *)
+let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = r.x
+[%%expect{|
+Line 1, characters 60-63:
+1 | let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = r.x
+                                                                ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 42-63
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_float_boxing @ noalloc) (r : record_t5) = r.x
+[%%expect{|
+Line 1, characters 53-56:
+1 | let (alloc_float_boxing @ noalloc) (r : record_t5) = r.x
+                                                         ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 35-56
+         which is expected to be "noalloc".
+|}]
+
+(* The same float boxing, but [stack_]-marked. *)
+let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = stack_ r.x
+[%%expect{|
+Line 1, characters 67-70:
+1 | let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = stack_ r.x
+                                                                       ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 42-70
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_float_boxing @ noalloc) (r : record_t5) = stack_ r.x
+[%%expect{|
+Line 1, characters 60-63:
+1 | let (alloc_float_boxing @ noalloc) (r : record_t5) = stack_ r.x
+                                                                ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 35-63
+         which is expected to be "noalloc".
+|}]
+
+(* CR shsong: tuple construction allocates a boxed block, but the allocation
+   is registered via [register_allocation_value_mode], which does not walk
+   locks, so this is wrongly accepted. (We use a unit argument and constant
+   elements to avoid an inner currying closure, which would otherwise be the
+   real cause of an error.) *)
+let (alloc_tuple @ noalloc_strict) () = (1, 2)
+[%%expect{|
+val alloc_tuple : unit -> int * int = <fun>
+|}]
+let (alloc_tuple @ noalloc) () = (1, 2)
+[%%expect{|
+val alloc_tuple : unit -> int * int = <fun>
+|}]
+
+(* CR shsong: the same tuple, but [stack_]-marked. Tuples are a gap, so this
+   is accepted regardless of [stack_]. *)
+let (alloc_tuple @ noalloc_strict) () = exclave_ stack_ (1, 2)
+[%%expect{|
+val alloc_tuple : unit -> int * int @ local = <fun>
+|}]
+let (alloc_tuple @ noalloc) () = exclave_ stack_ (1, 2)
+[%%expect{|
+val alloc_tuple : unit -> int * int @ local = <fun>
+|}]
+
+(* CR shsong: partial application allocates a closure, but it is registered
+   via [register_allocation_mode], which does not walk locks, so this is
+   wrongly accepted. We receive [f] as a parameter (rather than defining a
+   multi-argument function, whose curried closures would themselves be flagged)
+   so the only allocation here is the partial-application closure. *)
+let (alloc_partial_app @ noalloc_strict)
+      (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
+[%%expect{|
+val alloc_partial_app :
+  (int -> int -> int -> int) @ noalloc_strict -> int -> int = <fun>
+|}]
+let (alloc_partial_app @ noalloc)
+      (f : (int -> int -> int -> int) @ noalloc) = f 1 2
+[%%expect{|
+val alloc_partial_app : (int -> int -> int -> int) @ noalloc -> int -> int =
+  <fun>
+|}]
+
+(* CR shsong: a lazy block allocates on the heap, but no allocation is
+   registered for it, so this is wrongly accepted. We use [lazy a] with
+   [a : int] so the thunk body has no [alloc] reference. *)
+let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
+[%%expect{|
+val alloc_lazy : int -> int lazy_t = <fun>
+|}]
+let (alloc_lazy @ noalloc) (a : int) = lazy a
+[%%expect{|
+val alloc_lazy : int -> int lazy_t = <fun>
+|}]
+
+(* An object allocates. *)
+let (alloc_object @ noalloc_strict) () = object method m = 1 end
+[%%expect{|
+Line 1, characters 59-60:
+1 | let (alloc_object @ noalloc_strict) () = object method m = 1 end
+                                                               ^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-64
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_object @ noalloc) () = object method m = 1 end
+[%%expect{|
+Line 1, characters 52-53:
+1 | let (alloc_object @ noalloc) () = object method m = 1 end
+                                                        ^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 29-57
+         which is expected to be "noalloc".
+|}]
+
+(* CR shsong: packing a first-class module [(module M)] allocates, but no
+   allocation is registered for it ([Pexp_pack] in [type_expect] only submodes;
+   the module-level [register_allocation] in [typemod.ml] does not walk locks),
+   so this is wrongly accepted. *)
+module type S = sig end
+module Empty : S = struct end
+[%%expect{|
+module type S = sig end
+module Empty : S @@ stateless noalloc_strict
+|}]
+let (alloc_first_class_module @ noalloc_strict) () = (module Empty : S)
+[%%expect{|
+val alloc_first_class_module : unit -> (module S) = <fun>
+|}]
+let (alloc_first_class_module @ noalloc) () = (module Empty : S)
+[%%expect{|
+val alloc_first_class_module : unit -> (module S) = <fun>
+|}]
+
+(* An external/primitive is [alloc] by default, so referencing one is rejected:
+   primitives are treated as allocating conservatively. *)
+external my_extern : int -> int = "some_c_stub"
+[%%expect{|
+external my_extern : int -> int = "some_c_stub"
+|}]
+let (alloc_external @ noalloc_strict) (a : int) = my_extern a
+[%%expect{|
+Line 1, characters 50-59:
+1 | let (alloc_external @ noalloc_strict) (a : int) = my_extern a
+                                                      ^^^^^^^^^
+Error: The value "my_extern" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 38-61
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_external @ noalloc) (a : int) = my_extern a
+[%%expect{|
+Line 1, characters 43-52:
+1 | let (alloc_external @ noalloc) (a : int) = my_extern a
+                                               ^^^^^^^^^
+Error: The value "my_extern" is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 31-54
+         which is expected to be "noalloc".
+|}]
+
+(* Arithmetic boxing is handled conservatively: the arithmetic operators are
+   themselves [alloc] values, so using one is rejected even though the box is
+   created in the backend. No allocation is missed. *)
+let (alloc_float_arith @ noalloc_strict) (a : float) = a +. a
+[%%expect{|
+Line 1, characters 57-59:
+1 | let (alloc_float_arith @ noalloc_strict) (a : float) = a +. a
+                                                             ^^
+Error: The value "(+.)" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 41-61
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_float_arith @ noalloc) (a : float) = a +. a
+[%%expect{|
+Line 1, characters 50-52:
+1 | let (alloc_float_arith @ noalloc) (a : float) = a +. a
+                                                      ^^
+Error: The value "(+.)" is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 34-54
+         which is expected to be "noalloc".
+|}]
+
+(* Likewise for boxed-integer arithmetic via a [Stdlib] primitive. *)
+let (alloc_int64_arith @ noalloc_strict) (a : int64) = Int64.add a a
+[%%expect{|
+Line 1, characters 55-64:
+1 | let (alloc_int64_arith @ noalloc_strict) (a : int64) = Int64.add a a
+                                                           ^^^^^^^^^
+Error: The value "Int64.add" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 41-68
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_int64_arith @ noalloc) (a : int64) = Int64.add a a
+[%%expect{|
+Line 1, characters 48-57:
+1 | let (alloc_int64_arith @ noalloc) (a : int64) = Int64.add a a
+                                                    ^^^^^^^^^
+Error: The value "Int64.add" is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 34-61
+         which is expected to be "noalloc".
+|}]
+
+(* CR-soon shsong: revisit exception handling after implementing the
+    part that distinguishes noalloc_strict and noalloc *)
+(* Constructing an exception (an extensible variant) with an argument
+   allocates. *)
+let (alloc_exception @ noalloc_strict) (a : string) = Failure a
+[%%expect{|
+Line 1, characters 54-63:
+1 | let (alloc_exception @ noalloc_strict) (a : string) = Failure a
+                                                          ^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 39-63
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_exception @ noalloc) (a : string) = Failure a
+[%%expect{|
+Line 1, characters 47-56:
+1 | let (alloc_exception @ noalloc) (a : string) = Failure a
+                                                   ^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 32-56
+         which is expected to be "noalloc".
+|}]
+
+(* The same exception construction, but [stack_]-marked. *)
+let (alloc_exception @ noalloc_strict) (a : string) = stack_ (Failure a)
+[%%expect{|
+Line 1, characters 61-72:
+1 | let (alloc_exception @ noalloc_strict) (a : string) = stack_ (Failure a)
+                                                                 ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 39-72
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_exception @ noalloc) (a : string) = stack_ (Failure a)
+[%%expect{|
+Line 1, characters 54-65:
+1 | let (alloc_exception @ noalloc) (a : string) = stack_ (Failure a)
+                                                          ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 32-65
+         which is expected to be "noalloc".
+|}]
+
+(* Reading an atomic record field via [%atomic.loc] allocates an atomic
+   location. *)
+type atomic_record = { mutable af : string [@atomic] }
+[%%expect{|
+type atomic_record = { mutable af : string [@atomic]; }
+|}]
+let (alloc_atomic_loc @ noalloc_strict) (r : atomic_record) =
+  [%atomic.loc r.af]
+[%%expect{|
+Line 2, characters 2-20:
+2 |   [%atomic.loc r.af]
+      ^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-2, characters 40-20
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_atomic_loc @ noalloc) (r : atomic_record) =
+  [%atomic.loc r.af]
+[%%expect{|
+Line 2, characters 2-20:
+2 |   [%atomic.loc r.af]
+      ^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at lines 1-2, characters 33-20
+         which is expected to be "noalloc".
+|}]
+
+(* CR-soon shsong: check currying-related behavior later *)
+(* Coercing a function with an optional argument to a plain arrow eta-expands
+   it, allocating a closure. We receive both functions as parameters (in a
+   tuple to avoid currying closures) so the only allocation is the coercion
+   closure. *)
+let (alloc_fun_coerce @ noalloc_strict)
+      ((apply, opt) :
+         (((unit -> int) -> int) * (?x:int -> unit -> int)) @ noalloc_strict) =
+  apply opt
+[%%expect{|
+Line 4, characters 8-11:
+4 |   apply opt
+            ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 2-4, characters 6-11
+         which is expected to be "noalloc_strict".
+|}]
+let (alloc_fun_coerce @ noalloc)
+      ((apply, opt) :
+         (((unit -> int) -> int) * (?x:int -> unit -> int)) @ noalloc) =
+  apply opt
+[%%expect{|
+Line 4, characters 8-11:
+4 |   apply opt
+            ^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at lines 2-4, characters 6-11
+         which is expected to be "noalloc".
+|}]
+
+(* CR shsong: a list/array comprehension allocates its result, but no
+   allocation is registered for it (the comprehension result block is built
+   directly at [Value.legacy]), so this is wrongly accepted. *)
+let (alloc_list_comprehension @ noalloc_strict) () = [ x for x = 1 to 10 ]
+[%%expect{|
+val alloc_list_comprehension : unit -> int list = <fun>
+|}]
+let (alloc_list_comprehension @ noalloc) () = [ x for x = 1 to 10 ]
+[%%expect{|
+val alloc_list_comprehension : unit -> int list = <fun>
+|}]
+
+
+(** Test 5b: [stack_] negative cases *)
+
+(* [stack_] on a non-allocation (a plain value) is rejected: it is not an
+   allocation. *)
+let (stack_non_alloc @ noalloc_strict) (a : int) = stack_ a
+[%%expect{|
+Line 6, characters 58-59:
+6 | let (stack_non_alloc @ noalloc_strict) (a : int) = stack_ a
+                                                              ^
+Error: This expression is not an allocation site.
+|}]
+
+(* [stack_] on a partial application is rejected: it is an application, not a
+   recognized allocation form. [f] is received as a parameter to avoid the
+   currying closures of a multi-argument definition. *)
+let (stack_partial_app @ noalloc_strict)
+      (f : (int -> int -> int -> int) @ noalloc_strict) = stack_ (f 1 2)
+[%%expect{|
+Line 2, characters 65-72:
+2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = stack_ (f 1 2)
+                                                                     ^^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+(* [stack_] does not support lazy expressions. *)
+let (stack_lazy @ noalloc_strict) (a : int) = stack_ (lazy a)
+[%%expect{|
+Line 1, characters 53-61:
+1 | let (stack_lazy @ noalloc_strict) (a : int) = stack_ (lazy a)
+                                                         ^^^^^^^^
+Error: Stack allocating lazy expressions is unsupported yet.
+|}]
+
+(* [stack_] does not support objects; here the object's method closure is
+   itself a detected allocation, so the allocation-axis error fires on the
+   method body before the unsupported-[stack_] check is reached. *)
+let (stack_object @ noalloc_strict) () = stack_ (object method m = 1 end)
+[%%expect{|
+Line 1, characters 67-68:
+1 | let (stack_object @ noalloc_strict) () = stack_ (object method m = 1 end)
+                                                                       ^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-73
+         which is expected to be "noalloc_strict".
+|}]
+
+(* [stack_] does not support first-class modules ([Empty]/[S] from Test 5). *)
+let (stack_first_class_module @ noalloc_strict) () = stack_ (module Empty : S)
+[%%expect{|
+Line 1, characters 60-78:
+1 | let (stack_first_class_module @ noalloc_strict) () = stack_ (module Empty : S)
+                                                                ^^^^^^^^^^^^^^^^^^
+Error: Stack allocating modules is unsupported yet.
+|}]
+
+(* [stack_] does not support comprehensions. *)
+let (stack_comprehension @ noalloc_strict) () = stack_ [ x for x = 1 to 10 ]
+[%%expect{|
+Line 1, characters 55-76:
+1 | let (stack_comprehension @ noalloc_strict) () = stack_ [ x for x = 1 to 10 ]
+                                                           ^^^^^^^^^^^^^^^^^^^^^
+Error: Stack allocating list comprehensions is unsupported yet.
+|}]
+
+
+(** Test 5b: [stack_] nested cases. *)
+(* Nested: an inner allocation that is not itself [stack_]-marked still
+   allocates on the heap, even when an enclosing allocation is [stack_]-marked.
+   (Currently the outer [stack_] is not recognized either, so both contribute;
+   once [stack_] is recognized, only the inner allocation should remain and the
+   function should still be rejected.) *)
+let (stack_nested @ noalloc_strict) (a : int) = stack_ (Just (Just a))
+[%%expect{|
+Line 1, characters 55-70:
+1 | let (stack_nested @ noalloc_strict) (a : int) = stack_ (Just (Just a))
+                                                           ^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-70
+         which is expected to be "noalloc_strict".
+|}]
+
+
+(** Test 6: Other tests *)
 
 type record_t = { x : float; y : float }
 [%%expect{|
@@ -399,15 +1127,18 @@ let (new_record @ alloc) () =
 val new_record : unit -> record_t = <fun>
 |}]
 
-(* CR-soon shsong: error expected -- f should not be accepted as
-    [@ noalloc_strict] *)
-(* The allocation mode shows up in a [val] signature's function type. *)
+(* f triggers allocation, so it cannot be accepted as [@ noalloc_strict] *)
 module M : sig val f : unit -> record_t @ noalloc_strict end = struct
     let (f @ noalloc_strict) () = { x = 3.0; y = 4.0 }
 end
 [%%expect{|
-module M : sig val f : unit -> record_t @ noalloc_strict end @@ stateless
-  noalloc_strict
+Line 2, characters 34-54:
+2 |     let (f @ noalloc_strict) () = { x = 3.0; y = 4.0 }
+                                      ^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 29-54
+         which is expected to be "noalloc_strict".
 |}]
 
 (* Parameter is not captured *)
@@ -478,7 +1209,13 @@ let (secretly_allocates @ noalloc) () =
   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
   whitewashed ()
 [%%expect{|
-val secretly_allocates : unit -> record_t = <fun>
+Line 2, characters 30-58:
+2 |   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at lines 1-3, characters 35-16
+         which is expected to be "noalloc".
 |}]
 
 (* CR-soon shsong: error expected -- cannot assign alloc func to escape_hatch ref *)
@@ -489,7 +1226,13 @@ let (secretly_allocates' @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-val secretly_allocates' : unit -> record_t @ local = <fun>
+Line 3, characters 25-60:
+3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at lines 1-6, characters 36-17
+         which is expected to be "noalloc".
 |}]
 
 (* CR-soon shsong: error expected -- cannot call [f ()] because it is alloc *)
@@ -500,5 +1243,11 @@ let (secretly_allocates @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-val secretly_allocates : unit -> record_t @ local = <fun>
+Line 3, characters 25-60:
+3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at lines 1-6, characters 35-17
+         which is expected to be "noalloc".
 |}]

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -695,14 +695,39 @@ val alloc_tuple : unit -> int * int @ local = <fun>
 let (alloc_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
 [%%expect{|
-val alloc_partial_app :
-  (int -> int -> int -> int) @ noalloc_strict -> int -> int = <fun>
+Line 2, characters 58-63:
+2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
+                                                              ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 6-63
+         which is expected to be "noalloc_strict".
 |}]
 let (alloc_partial_app @ noalloc)
       (f : (int -> int -> int -> int) @ noalloc) = f 1 2
 [%%expect{|
-val alloc_partial_app : (int -> int -> int -> int) @ noalloc -> int -> int =
-  <fun>
+Line 2, characters 51-56:
+2 |       (f : (int -> int -> int -> int) @ noalloc) = f 1 2
+                                                       ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 2, characters 6-56
+         which is expected to be "noalloc".
+|}]
+
+(* [stack_] on a partial application is rejected: it is an application, not a
+   recognized allocation form. [f] is received as a parameter to avoid the
+   currying closures of a multi-argument definition. *)
+let (stack_partial_app @ noalloc_strict)
+      (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
+[%%expect{|
+Line 2, characters 74-81:
+2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
+                                                                              ^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 6-81
+         which is expected to be "noalloc_strict".
 |}]
 
 (* CR shsong: a lazy block allocates on the heap, but no allocation is
@@ -949,18 +974,6 @@ let (stack_non_alloc @ noalloc_strict) (a : int) = exclave_ stack_ a
 Line 5, characters 67-68:
 5 | let (stack_non_alloc @ noalloc_strict) (a : int) = exclave_ stack_ a
                                                                        ^
-Error: This expression is not an allocation site.
-|}]
-
-(* [stack_] on a partial application is rejected: it is an application, not a
-   recognized allocation form. [f] is received as a parameter to avoid the
-   currying closures of a multi-argument definition. *)
-let (stack_partial_app @ noalloc_strict)
-      (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
-[%%expect{|
-Line 2, characters 74-81:
-2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
-                                                                              ^^^^^^^
 Error: This expression is not an allocation site.
 |}]
 

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1490,12 +1490,12 @@ let stack_inner_function_application
   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2 3) in
   ()
 [%%expect{|
-Line 3, characters 51-59:
-3 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2 3) in
-                                                       ^^^^^^^^
+Line 13, characters 51-59:
+13 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2 3) in
+                                                        ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 27-64
+         because it is used inside the function at line 13, characters 27-64
          which is expected to be "noalloc_strict".
 |}]
 

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -430,23 +430,11 @@ Error: The allocation is "alloc"
 (* The same record allocation, but [stack_]-marked. *)
 let (alloc_record @ noalloc_strict) () = exclave_ stack_ { x = 1.; y = 2. }
 [%%expect{|
-Line 1, characters 57-75:
-1 | let (alloc_record @ noalloc_strict) () = exclave_ stack_ { x = 1.; y = 2. }
-                                                             ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-75
-         which is expected to be "noalloc_strict".
+val alloc_record : unit -> record_t5 @ local = <fun>
 |}]
 let (alloc_record @ noalloc) () = exclave_ stack_ { x = 1.; y = 2. }
 [%%expect{|
-Line 1, characters 50-68:
-1 | let (alloc_record @ noalloc) () = exclave_ stack_ { x = 1.; y = 2. }
-                                                      ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 29-68
-         which is expected to be "noalloc".
+val alloc_record : unit -> record_t5 @ local = <fun>
 |}]
 
 (* A variant constructor with arguments allocates (constant constructors do
@@ -475,23 +463,11 @@ Error: The allocation is "alloc"
 (* The same variant allocation, but [stack_]-marked. *)
 let (alloc_variant @ noalloc_strict) (a : int) = exclave_ stack_ (Just a)
 [%%expect{|
-Line 1, characters 65-73:
-1 | let (alloc_variant @ noalloc_strict) (a : int) = exclave_ stack_ (Just a)
-                                                                     ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-73
-         which is expected to be "noalloc_strict".
+val alloc_variant : int -> int variant_t5 @ local = <fun>
 |}]
 let (alloc_variant @ noalloc) (a : int) = exclave_ stack_ (Just a)
 [%%expect{|
-Line 1, characters 58-66:
-1 | let (alloc_variant @ noalloc) (a : int) = exclave_ stack_ (Just a)
-                                                              ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 30-66
-         which is expected to be "noalloc".
+val alloc_variant : int -> int variant_t5 @ local = <fun>
 |}]
 
 (* A cons cell of a list allocates. *)
@@ -519,23 +495,11 @@ Error: The allocation is "alloc"
 (* The same list cell, but [stack_]-marked. *)
 let (alloc_list @ noalloc_strict) (a : int) = exclave_ stack_ [a]
 [%%expect{|
-Line 1, characters 62-65:
-1 | let (alloc_list @ noalloc_strict) (a : int) = exclave_ stack_ [a]
-                                                                  ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-65
-         which is expected to be "noalloc_strict".
+val alloc_list : int -> int list @ local = <fun>
 |}]
 let (alloc_list @ noalloc) (a : int) = exclave_ stack_ [a]
 [%%expect{|
-Line 1, characters 55-58:
-1 | let (alloc_list @ noalloc) (a : int) = exclave_ stack_ [a]
-                                                           ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 27-58
-         which is expected to be "noalloc".
+val alloc_list : int -> int list @ local = <fun>
 |}]
 
 (* An array literal allocates. *)
@@ -563,23 +527,11 @@ Error: The allocation is "alloc"
 (* The same array, but [stack_]-marked. *)
 let (alloc_array @ noalloc_strict) (a : int) = exclave_ stack_ [| a |]
 [%%expect{|
-Line 1, characters 63-70:
-1 | let (alloc_array @ noalloc_strict) (a : int) = exclave_ stack_ [| a |]
-                                                                   ^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 35-70
-         which is expected to be "noalloc_strict".
+val alloc_array : int -> int array @ local = <fun>
 |}]
 let (alloc_array @ noalloc) (a : int) = exclave_ stack_ [| a |]
 [%%expect{|
-Line 1, characters 56-63:
-1 | let (alloc_array @ noalloc) (a : int) = exclave_ stack_ [| a |]
-                                                            ^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 28-63
-         which is expected to be "noalloc".
+val alloc_array : int -> int array @ local = <fun>
 |}]
 
 (* A polymorphic variant with an argument allocates. *)
@@ -607,23 +559,11 @@ Error: The allocation is "alloc"
 (* The same polymorphic variant, but [stack_]-marked. *)
 let (alloc_polyvariant @ noalloc_strict) (a : int) = exclave_ stack_ (`Tag a)
 [%%expect{|
-Line 1, characters 69-77:
-1 | let (alloc_polyvariant @ noalloc_strict) (a : int) = exclave_ stack_ (`Tag a)
-                                                                         ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 41-77
-         which is expected to be "noalloc_strict".
+val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
 |}]
 let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
 [%%expect{|
-Line 1, characters 62-70:
-1 | let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
-                                                                  ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 34-70
-         which is expected to be "noalloc".
+val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
 |}]
 
 (* A function that takes an optional argument allocates (to handle the
@@ -674,23 +614,11 @@ Error: The allocation is "alloc"
 (* The same closure, but [stack_]-marked. *)
 let (alloc_closure @ noalloc_strict) (a : int) = exclave_ stack_ (fun () -> a)
 [%%expect{|
-Line 1, characters 65-78:
-1 | let (alloc_closure @ noalloc_strict) (a : int) = exclave_ stack_ (fun () -> a)
-                                                                     ^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-78
-         which is expected to be "noalloc_strict".
+val alloc_closure : int -> (unit -> int) @ local = <fun>
 |}]
 let (alloc_closure @ noalloc) (a : int) = exclave_ stack_ (fun () -> a)
 [%%expect{|
-Line 1, characters 58-71:
-1 | let (alloc_closure @ noalloc) (a : int) = exclave_ stack_ (fun () -> a)
-                                                              ^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 30-71
-         which is expected to be "noalloc".
+val alloc_closure : int -> (unit -> int) @ local = <fun>
 |}]
 
 (* Boxing a float read out of a flat float record allocates. *)
@@ -718,23 +646,11 @@ Error: The allocation is "alloc"
 (* The same float boxing, but [stack_]-marked. *)
 let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = exclave_ stack_ r.x
 [%%expect{|
-Line 1, characters 76-79:
-1 | let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = exclave_ stack_ r.x
-                                                                                ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 42-79
-         which is expected to be "noalloc_strict".
+val alloc_float_boxing : record_t5 -> float @ local = <fun>
 |}]
 let (alloc_float_boxing @ noalloc) (r : record_t5) = exclave_ stack_ r.x
 [%%expect{|
-Line 1, characters 69-72:
-1 | let (alloc_float_boxing @ noalloc) (r : record_t5) = exclave_ stack_ r.x
-                                                                         ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 35-72
-         which is expected to be "noalloc".
+val alloc_float_boxing : record_t5 -> float @ local = <fun>
 |}]
 
 (* CR shsong: tuple construction allocates a boxed block, but the allocation
@@ -744,11 +660,23 @@ Error: The allocation is "alloc"
    real cause of an error.) *)
 let (alloc_tuple @ noalloc_strict) () = (1, 2)
 [%%expect{|
-val alloc_tuple : unit -> int * int = <fun>
+Line 1, characters 40-46:
+1 | let (alloc_tuple @ noalloc_strict) () = (1, 2)
+                                            ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 35-46
+         which is expected to be "noalloc_strict".
 |}]
 let (alloc_tuple @ noalloc) () = (1, 2)
 [%%expect{|
-val alloc_tuple : unit -> int * int = <fun>
+Line 1, characters 33-39:
+1 | let (alloc_tuple @ noalloc) () = (1, 2)
+                                     ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 28-39
+         which is expected to be "noalloc".
 |}]
 
 (* CR shsong: the same tuple, but [stack_]-marked. Tuples are a gap, so this
@@ -934,23 +862,11 @@ Error: The allocation is "alloc"
 (* The same exception construction, but [stack_]-marked. *)
 let (alloc_exception @ noalloc_strict) (a : string) = exclave_ stack_ (Failure a)
 [%%expect{|
-Line 1, characters 70-81:
-1 | let (alloc_exception @ noalloc_strict) (a : string) = exclave_ stack_ (Failure a)
-                                                                          ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 39-81
-         which is expected to be "noalloc_strict".
+val alloc_exception : string -> exn @ local = <fun>
 |}]
 let (alloc_exception @ noalloc) (a : string) = exclave_ stack_ (Failure a)
 [%%expect{|
-Line 1, characters 63-74:
-1 | let (alloc_exception @ noalloc) (a : string) = exclave_ stack_ (Failure a)
-                                                                   ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 32-74
-         which is expected to be "noalloc".
+val alloc_exception : string -> exn @ local = <fun>
 |}]
 
 (* Reading an atomic record field via [%atomic.loc] allocates an atomic
@@ -1101,9 +1017,9 @@ Error: Stack allocating list comprehensions is unsupported yet.
    function should still be rejected.) *)
 let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
 [%%expect{|
-Line 1, characters 64-79:
+Line 1, characters 70-78:
 1 | let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
-                                                                    ^^^^^^^^^^^^^^^
+                                                                          ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at line 1, characters 36-79
@@ -1226,9 +1142,9 @@ let (secretly_allocates' @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-Line 3, characters 25-60:
+Line 3, characters 30-60:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 36-17
@@ -1243,9 +1159,9 @@ let (secretly_allocates @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-Line 3, characters 25-60:
+Line 3, characters 30-60:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 35-17

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -552,6 +552,13 @@ let (alloc_array @ noalloc) (a : int) = exclave_ stack_ [| a |]
 val alloc_array : int -> int array @ local = <fun>
 |}]
 
+
+(* A polymorphic variant with no argument does not allocate. *)
+let (noalloc_polyvariant @ noalloc_strict) () = `Tag
+[%%expect{|
+val noalloc_polyvariant : unit -> [> `Tag ] = <fun>
+|}]
+
 (* A polymorphic variant with an argument allocates. *)
 let (alloc_polyvariant @ noalloc_strict) (a : int) = `Tag a
 [%%expect{|
@@ -747,6 +754,30 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
+(* CR shsong: rare partial application whose result is a function hidden behind a
+   type abbreviation ([myfun = int -> int]). Here [f 1 2] is a partial
+   application returning [myfun], so it allocates a closure. The detection uses
+   [get_desc (expand_head env ty_ret)]: [expand_head] unfolds [myfun] to
+   [int -> int] and the [Tarrow] is seen, so the allocation IS currently caught.
+
+   This case is exactly the one that the simpler [get_desc ty_ret] (without
+   [expand_head], proposed to avoid the GADT scope-escape side effect) would
+   MISS: [get_desc myfun] is a [Tconstr], not a [Tarrow], so the partial
+   application would be wrongly accepted as [noalloc_strict]. *)
+type myfun = int -> int
+let (alloc_partial_app_abbrev @ noalloc_strict)
+      (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
+[%%expect{|
+type myfun = int -> int
+Line 3, characters 53-58:
+3 |       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
+                                                         ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 6-58
+         which is expected to be "noalloc_strict".
+|}]
+
 (* A function [f] with mixed arguments: optional [a], mandatory [b], optional
    [c], mandatory [d], optional [e], mandatory [g]. It ends in a mandatory
    argument [g], so it can be fully applied. It is received as a parameter so
@@ -781,6 +812,23 @@ Error: The allocation is "alloc"
          because it is used inside the function at lines 2-3, characters 6-10
          which is expected to be "noalloc_strict".
 |}]
+
+(* Case 3: call a function whose last agument is optional argument and
+   all mandatory arguments are applied. Since the last argument is optional
+   the result still allocates. *)
+let (call_one_opt_one_mand @ noalloc_strict)
+      (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int)) =
+  f ~a:1 2
+[%%expect{|
+Line 3, characters 2-10:
+3 |   f ~a:1 2
+      ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 2-3, characters 6-10
+         which is expected to be "noalloc_strict".
+|}]
+
 
 (* A lazy block allocates on the heap *)
 let (alloc_lazy @ noalloc_strict) (a : int) = lazy a

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -382,6 +382,24 @@ Line 1, characters 66-67:
 Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
+(* Does an object type cross the Allocation axis? I.e. can an [alloc] object be
+   used where [noalloc] / [noalloc_strict] is expected? (cf. Test 4: functions do
+   NOT cross, immediates and records of immediates do.) *)
+let cross_object (x : < get : int > @ alloc) : _ @ noalloc = x
+[%%expect{|
+Line 1, characters 61-62:
+1 | let cross_object (x : < get : int > @ alloc) : _ @ noalloc = x
+                                                                 ^
+Error: This value is "alloc" but is expected to be "noalloc".
+|}]
+let cross_object_ss (x : < get : int > @ alloc) : _ @ noalloc_strict = x
+[%%expect{|
+Line 1, characters 71-72:
+1 | let cross_object_ss (x : < get : int > @ alloc) : _ @ noalloc_strict = x
+                                                                           ^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
+|}]
+
 
 (** Test 5: Allocation mode identifies all allocations and forces the proper
     mode. For each kind of allocation the typechecker can see, we test a
@@ -687,10 +705,9 @@ let (alloc_tuple @ noalloc) () = exclave_ stack_ (1, 2)
 val alloc_tuple : unit -> int * int @ local = <fun>
 |}]
 
-(* CR shsong: partial application allocates a closure, but it is registered
-   via [register_allocation_mode], which does not walk locks, so this is
-   wrongly accepted. We receive [f] as a parameter (rather than defining a
-   multi-argument function, whose curried closures would themselves be flagged)
+(* Partial application allocates a closure.
+   We receive [f] as a parameter (rather than defining a multi-argument
+   function, whose curried closures would themselves be flagged)
    so the only allocation here is the partial-application closure. *)
 let (alloc_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
@@ -730,24 +747,82 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
-(* CR shsong: a lazy block allocates on the heap, but no allocation is
-   registered for it, so this is wrongly accepted. We use [lazy a] with
-   [a : int] so the thunk body has no [alloc] reference. *)
+(* A function [f] with mixed arguments: optional [a], mandatory [b], optional
+   [c], mandatory [d], optional [e], mandatory [g]. It ends in a mandatory
+   argument [g], so it can be fully applied. It is received as a parameter so
+   referencing it (in function position) does not itself trigger the capture
+   rule; the only allocations come from how it is called. *)
+
+(* Case 1: call with all mandatory args ([b], [d], [g]); all optionals are
+   omitted, so they default to [None] (constant constructors, no [Some]
+   wrapping). The call is fully applied (not partial), so it allocates nothing
+   and is accepted. *)
+let (call_all_mandatory @ noalloc_strict)
+      (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
+  f 1 2 3
+[%%expect{|
+val call_all_mandatory :
+  (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int) -> int = <fun>
+|}]
+
+(* Case 2: call with one optional ([~a:1]) and one mandatory ([b]). The mandatory
+   args [d] and [g] are still missing, so this is a partial application, which
+   allocates a closure and is rejected. (The provided [~a:1] would additionally
+   be wrapped in [Some], but the partial-application check fires first.) *)
+let (call_one_opt_one_mand @ noalloc_strict)
+      (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
+  f ~a:1 2
+[%%expect{|
+Line 3, characters 2-10:
+3 |   f ~a:1 2
+      ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 2-3, characters 6-10
+         which is expected to be "noalloc_strict".
+|}]
+
+(* A lazy block allocates on the heap *)
 let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
 [%%expect{|
-val alloc_lazy : int -> int lazy_t = <fun>
+Line 1, characters 46-52:
+1 | let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
+                                                  ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 34-52
+         which is expected to be "noalloc_strict".
 |}]
 let (alloc_lazy @ noalloc) (a : int) = lazy a
 [%%expect{|
-val alloc_lazy : int -> int lazy_t = <fun>
+Line 1, characters 39-45:
+1 | let (alloc_lazy @ noalloc) (a : int) = lazy a
+                                           ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 27-45
+         which is expected to be "noalloc".
 |}]
+
+(* [stack_] does not support lazy expressions. *)
+let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
+[%%expect{|
+Line 1, characters 62-70:
+1 | let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
+                                                                  ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 34-70
+         which is expected to be "noalloc_strict".
+|}]
+
 
 (* An object allocates. *)
 let (alloc_object @ noalloc_strict) () = object method m = 1 end
 [%%expect{|
-Line 1, characters 59-60:
+Line 1, characters 41-64:
 1 | let (alloc_object @ noalloc_strict) () = object method m = 1 end
-                                                               ^
+                                             ^^^^^^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at line 1, characters 36-64
@@ -755,19 +830,45 @@ Error: The allocation is "alloc"
 |}]
 let (alloc_object @ noalloc) () = object method m = 1 end
 [%%expect{|
-Line 1, characters 52-53:
+Line 1, characters 34-57:
 1 | let (alloc_object @ noalloc) () = object method m = 1 end
-                                                        ^
+                                      ^^^^^^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at line 1, characters 29-57
          which is expected to be "noalloc".
 |}]
 
-(* CR shsong: packing a first-class module [(module M)] allocates, but no
-   allocation is registered for it ([Pexp_pack] in [type_expect] only submodes;
-   the module-level [register_allocation] in [typemod.ml] does not walk locks),
-   so this is wrongly accepted. *)
+(* [stack_] does not support objects; here the object's method closure is
+   itself a detected allocation, so the allocation-axis error fires on the
+   method body before the unsupported-[stack_] check is reached. *)
+let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
+[%%expect{|
+Line 1, characters 57-82:
+1 | let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
+                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-82
+         which is expected to be "noalloc_strict".
+|}]
+
+(* An object with no allocating method (here only a value field) still
+   allocates the object block itself, which the [Pexp_object] walk detects,
+   so it is rejected even though [get] does not allocate. *)
+let (obj_no_alloc_method @ noalloc_strict) () = object val x = 0 end
+[%%expect{|
+Line 1, characters 48-68:
+1 | let (obj_no_alloc_method @ noalloc_strict) () = object val x = 0 end
+                                                    ^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 43-68
+         which is expected to be "noalloc_strict".
+|}]
+
+
+(* Packing a first-class module [(module M)] allocates *)
 module type S = sig end
 module Empty : S = struct end
 [%%expect{|
@@ -776,12 +877,37 @@ module Empty : S @@ stateless noalloc_strict
 |}]
 let (alloc_first_class_module @ noalloc_strict) () = (module Empty : S)
 [%%expect{|
-val alloc_first_class_module : unit -> (module S) = <fun>
+Line 1, characters 61-66:
+1 | let (alloc_first_class_module @ noalloc_strict) () = (module Empty : S)
+                                                                 ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 48-71
+         which is expected to be "noalloc_strict".
 |}]
 let (alloc_first_class_module @ noalloc) () = (module Empty : S)
 [%%expect{|
-val alloc_first_class_module : unit -> (module S) = <fun>
+Line 1, characters 54-59:
+1 | let (alloc_first_class_module @ noalloc) () = (module Empty : S)
+                                                          ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 41-64
+         which is expected to be "noalloc".
 |}]
+
+(* [stack_] does not support first-class modules. *)
+let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
+[%%expect{|
+Line 1, characters 77-82:
+1 | let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
+                                                                                 ^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 48-87
+         which is expected to be "noalloc_strict".
+|}]
+
 
 (* An external/primitive is [alloc] by default, so referencing one is rejected:
    primitives are treated as allocating conservatively. *)
@@ -952,16 +1078,119 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc".
 |}]
 
-(* CR shsong: a list/array comprehension allocates its result, but no
-   allocation is registered for it (the comprehension result block is built
-   directly at [Value.legacy]), so this is wrongly accepted. *)
+(* A list/array comprehension allocates its result *)
 let (alloc_list_comprehension @ noalloc_strict) () = [ x for x = 1 to 10 ]
 [%%expect{|
-val alloc_list_comprehension : unit -> int list = <fun>
+Line 1, characters 53-74:
+1 | let (alloc_list_comprehension @ noalloc_strict) () = [ x for x = 1 to 10 ]
+                                                         ^^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 48-74
+         which is expected to be "noalloc_strict".
 |}]
 let (alloc_list_comprehension @ noalloc) () = [ x for x = 1 to 10 ]
 [%%expect{|
-val alloc_list_comprehension : unit -> int list = <fun>
+Line 1, characters 46-67:
+1 | let (alloc_list_comprehension @ noalloc) () = [ x for x = 1 to 10 ]
+                                                  ^^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at line 1, characters 41-67
+         which is expected to be "noalloc".
+|}]
+
+(* [stack_] does not support comprehensions. *)
+let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
+[%%expect{|
+Line 1, characters 64-85:
+1 | let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
+                                                                    ^^^^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 43-85
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Only the first case below is a genuine bug introduced by routing the
+   lock-walk through [register_allocation_mode]. The others turned out NOT to be
+   problems and are kept for contrast. *)
+
+(* CR shsong (false positive): array indexing uses the [%array_safe_get]
+   primitive, whose result is [@local_opt] (Prim_poly). It does NOT allocate, but
+   the Prim_poly registration in [type_ident] goes through
+   [register_allocation_mode], which now walks locks, so it is wrongly rejected
+   -- note the error is "The allocation is alloc". It should be accepted once the
+   Prim_poly site is exempted from walking. *)
+let (array_get_prim_poly @ noalloc_strict) (a : int array) (i : int) = a.(i)
+[%%expect{|
+Line 1, characters 59-76:
+1 | let (array_get_prim_poly @ noalloc_strict) (a : int array) (i : int) = a.(i)
+                                                               ^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 43-76
+         which is expected to be "noalloc_strict".
+|}]
+
+(* NOT the Prim_poly bug: referencing a primitive/operator as a value is rejected
+   by the pre-existing capture rule (primitives are [alloc] by default) -- note
+   "The value ... is alloc", not "The allocation is alloc". Same conservative
+   behavior as the external/arithmetic tests above; independent of Prim_poly.
+   ([my_id]/[!] do not allocate, but referencing the value is conservatively
+   treated as [alloc].) *)
+external my_id : ('a[@local_opt]) -> ('a[@local_opt]) = "%identity"
+let (prim_value_captured @ noalloc_strict) (x : int) = my_id x
+[%%expect{|
+external my_id : ('a [@local_opt]) -> ('a [@local_opt]) = "%identity"
+Line 2, characters 55-60:
+2 | let (prim_value_captured @ noalloc_strict) (x : int) = my_id x
+                                                           ^^^^^
+Error: The value "my_id" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 43-62
+         which is expected to be "noalloc_strict".
+|}]
+let (deref_value_captured @ noalloc_strict) (r : int ref) = !r
+[%%expect{|
+Line 1, characters 60-61:
+1 | let (deref_value_captured @ noalloc_strict) (r : int ref) = !r
+                                                                ^
+Error: The value "(!)" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 44-62
+         which is expected to be "noalloc_strict".
+|}]
+
+(* NOT a gap: [new] does not register the object allocation, but a class is
+   always at the legacy ([alloc]) mode and the lock walk propagates that, so the
+   instantiation is still (conservatively) rejected. *)
+class cls = object method m = 1 end
+let (alloc_new @ noalloc_strict) () = new cls
+[%%expect{|
+class cls : object method m : int end
+Line 2, characters 42-45:
+2 | let (alloc_new @ noalloc_strict) () = new cls
+                                              ^^^
+Error: The class "cls" is "alloc" because classes are always at the legacy modes.
+       However, the class "cls" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 33-45
+         which is expected to be "noalloc_strict".
+|}]
+
+(* A format string literal used at [format] type is built into a
+   [CamlinternalFormatBasics] value, which allocates. This IS detected (the
+   format is built as a constructor application that registers an allocation),
+   so the enclosing function is correctly rejected. *)
+let (use_format @ noalloc_strict) () : (_, _, _) format = "%d"
+[%%expect{|
+Line 1, characters 58-62:
+1 | let (use_format @ noalloc_strict) () : (_, _, _) format = "%d"
+                                                              ^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 34-62
+         which is expected to be "noalloc_strict".
 |}]
 
 
@@ -977,49 +1206,7 @@ Line 5, characters 67-68:
 Error: This expression is not an allocation site.
 |}]
 
-(* [stack_] does not support lazy expressions. *)
-let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
-[%%expect{|
-Line 1, characters 62-70:
-1 | let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
-                                                                  ^^^^^^^^
-Error: Stack allocating lazy expressions is unsupported yet.
-|}]
-
-(* [stack_] does not support objects; here the object's method closure is
-   itself a detected allocation, so the allocation-axis error fires on the
-   method body before the unsupported-[stack_] check is reached. *)
-let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
-[%%expect{|
-Line 1, characters 76-77:
-1 | let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
-                                                                                ^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-82
-         which is expected to be "noalloc_strict".
-|}]
-
-(* [stack_] does not support first-class modules ([Empty]/[S] from Test 5). *)
-let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
-[%%expect{|
-Line 1, characters 69-87:
-1 | let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
-                                                                         ^^^^^^^^^^^^^^^^^^
-Error: Stack allocating modules is unsupported yet.
-|}]
-
-(* [stack_] does not support comprehensions. *)
-let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
-[%%expect{|
-Line 1, characters 64-85:
-1 | let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
-                                                                    ^^^^^^^^^^^^^^^^^^^^^
-Error: Stack allocating list comprehensions is unsupported yet.
-|}]
-
-
-(** Test 5b: [stack_] nested cases. *)
+(** Test 5c: [stack_] nested cases. *)
 (* Nested: an inner allocation that is not itself [stack_]-marked still
    allocates on the heap, even when an enclosing allocation is [stack_]-marked. *)
 let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
@@ -1034,7 +1221,7 @@ Error: The allocation is "alloc"
 |}]
 
 
-(** Test 6: Other tests *)
+(** Test 6: Misc *)
 
 type record_t = { x : float; y : float }
 [%%expect{|
@@ -1127,6 +1314,17 @@ Error: The module is "alloc"
        However, the module highlighted is expected to be "noalloc".
 |}]
 
+(* An object is always constructed at the legacy ([alloc]) mode, so it cannot be
+   created at [noalloc_strict]: the binding annotation requires the object value
+   to be [noalloc_strict], but its construction forces it to [alloc]. *)
+let (o @ noalloc_strict) = object method get = 0 end
+[%%expect{|
+Line 1, characters 27-52:
+1 | let (o @ noalloc_strict) = object method get = 0 end
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
+|}]
+
 (* CR-soon shsong: error expected -- cannot call [whitewashed ()] *)
 let (secretly_allocates @ noalloc) () =
   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
@@ -1173,4 +1371,38 @@ Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 35-17
          which is expected to be "noalloc".
+|}]
+
+(* [Pexp_lazy] (typecore.ml) must call [walk_locks_for_allocation] for the lazy
+   *cell* BEFORE adding the [Lazy] closure lock for the thunk:
+
+     Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);       (* correct *)
+     let env = Env.add_closure_lock (loc, Lazy) ... env in
+
+   The cell is allocated in the *enclosing* scope, not inside the thunk, so the
+   walk must use the enclosing env. If the walk is placed AFTER [add_closure_lock]
+   (using the env that already contains the thunk's own [Lazy] lock), the cell
+   allocation is wrongly attributed to the thunk.
+
+   This top-level binding distinguishes the two placements:
+   - correct placement: there is no enclosing closure to force, so it is
+     accepted;
+   - wrong placement: the walk traverses the thunk's [Lazy] lock and reports
+     "...because it is used inside the lazy expression...". *)
+let (lz_toplevel @ noalloc_strict) = lazy 1
+[%%expect{|
+val lz_toplevel : int lazy_t = lazy 1
+|}]
+
+(* For contrast: inside a function the two placements agree, because the cell
+   walk reaches the enclosing function either way. *)
+let (lz_in_fn @ noalloc_strict) (x : int) = lazy x
+[%%expect{|
+Line 1, characters 44-50:
+1 | let (lz_in_fn @ noalloc_strict) (x : int) = lazy x
+                                                ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 32-50
+         which is expected to be "noalloc_strict".
 |}]

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1232,7 +1232,88 @@ Error: The allocation is "alloc"
 |}]
 
 
-(** Test 5b: [stack_] negative cases *)
+(** Test 5b: an allocation nested inside several enclosing functions forces
+    every enclosing layer. The functions [g] and [h] each capture the parameter
+    [a], so building each inner closure is itself an allocation in its parent;
+    together with the innermost [Just a] this makes every one of the three nested
+    functions an allocation site, so each is forced to [alloc]. *)
+
+(* All three layers annotated [noalloc_strict]: the capture chain reaches the
+   outermost function, so building the closure [g] (which transitively captures
+   [a]) is an allocation inside the outermost function and is reported there --
+   demonstrating that the deepest allocation forces every enclosing layer, not
+   just the immediately enclosing one. *)
+let (layers3_ss @ noalloc_strict) (a : int) =
+  let (g @ noalloc_strict) () =
+    let (h @ noalloc_strict) () = Just a in
+    h
+  in
+  g
+[%%expect{|
+Lines 13-15, characters 27-5:
+13 | ...........................() =
+14 |     let (h @ noalloc_strict) () = Just a in
+15 |     h
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 12-17, characters 34-3
+         which is expected to be "noalloc_strict".
+|}]
+
+(* The same nesting, all layers [noalloc]. *)
+let (layers3_n @ noalloc) (a : int) =
+  let (g @ noalloc) () =
+    let (h @ noalloc) () = Just a in
+    h
+  in
+  g
+[%%expect{|
+Lines 2-4, characters 20-5:
+2 | ....................() =
+3 |     let (h @ noalloc) () = Just a in
+4 |     h
+Error: The allocation is "alloc"
+       but is expected to be "noalloc"
+         because it is used inside the function at lines 1-6, characters 26-3
+         which is expected to be "noalloc".
+|}]
+
+(* Annotating only the middle layer still errors: building the closure [h]
+   inside [g] is an allocation that forces [g]. *)
+let layers_middle (a : int) =
+  let (g @ noalloc_strict) () =
+    let h () = Just a in
+    h
+  in
+  g
+[%%expect{|
+Line 3, characters 10-21:
+3 |     let h () = Just a in
+              ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 2-4, characters 27-5
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Annotating only the innermost layer still errors: [Just a] forces [h]. *)
+let layers_inner (a : int) =
+  let g () =
+    let (h @ noalloc_strict) () = Just a in
+    h
+  in
+  g
+[%%expect{|
+Line 3, characters 34-40:
+3 |     let (h @ noalloc_strict) () = Just a in
+                                      ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 29-40
+         which is expected to be "noalloc_strict".
+|}]
+
+(** Test 5c: [stack_] negative cases *)
 
 (* [stack_] on a non-allocation (a plain value) is rejected: it is not an
    allocation. *)
@@ -1244,7 +1325,7 @@ Line 5, characters 67-68:
 Error: This expression is not an allocation site.
 |}]
 
-(** Test 5c: [stack_] nested cases. *)
+(** Test 5d: [stack_] nested cases. *)
 (* Nested: an inner allocation that is not itself [stack_]-marked still
    allocates on the heap, even when an enclosing allocation is [stack_]-marked. *)
 let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
@@ -1255,6 +1336,237 @@ Line 1, characters 70-78:
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at line 1, characters 36-79
+         which is expected to be "noalloc_strict".
+|}]
+
+(* A [@@ global] field forces its value onto the heap even when the enclosing
+   record is [stack_]-allocated: the record block is exempt, but the global
+   field value [Just a] is a genuine heap allocation and is still rejected. This
+   is another way (besides plain nesting above) for a heap allocation to sit
+   inside a [stack_] one. *)
+type 'a global_field_rec = { gf : 'a @@ global; rest : int }
+let (stack_global_field @ noalloc_strict) (a : int) =
+  exclave_ stack_ { gf = Just a; rest = a }
+[%%expect{|
+type 'a global_field_rec = { gf : 'a @@ global; rest : int; }
+Line 3, characters 25-31:
+3 |   exclave_ stack_ { gf = Just a; rest = a }
+                             ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 2-3, characters 42-43
+         which is expected to be "noalloc_strict".
+|}]
+
+
+(** Test 5e: the allocation axis is exempted only by [stack_]
+    ([expected_mode.strictly_stack]), not by [local_]/[exclave_]
+    ([expected_mode.strictly_local]). The two flags are independent, so they are
+    NOT interchangeable:
+
+    - [strictly_stack] is set ONLY by the direct operand of [stack_], the
+      explicit, checked stack-allocation form. It can be [true] while
+      [strictly_local] is [false] -- e.g. a [stack_] in a plain [let] binding,
+      not under any [exclave_]/[local_]. Gating the walk on [strictly_local]
+      would WRONGLY REJECT such a legitimate [stack_] (see [stack_in_let]).
+    - [strictly_local] is set by [local_]/[exclave_], which only constrain the
+      *mode* to [local]. The current implementation does not treat them as
+      exempt (it conservatively requires the explicit, checked [stack_] marker),
+      so these still error (see [exclave_not_exempt]/[local_not_exempt]). *)
+
+(* [exclave_] alone (no [stack_]) does not exempt the allocation. *)
+let (exclave_not_exempt @ noalloc_strict) (a : int) = exclave_ (Just a)
+[%%expect{|
+Line 17, characters 63-71:
+17 | let (exclave_not_exempt @ noalloc_strict) (a : int) = exclave_ (Just a)
+                                                                    ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 17, characters 42-71
+         which is expected to be "noalloc_strict".
+|}]
+
+(* [local_] alone (no [stack_]) does not exempt the allocation. *)
+let (local_not_exempt @ noalloc_strict) (a : int) =
+  let _x = local_ (Just a) in
+  ()
+[%%expect{|
+Line 2, characters 18-26:
+2 |   let _x = local_ (Just a) in
+                      ^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-3, characters 40-4
+         which is expected to be "noalloc_strict".
+|}]
+
+(* For contrast, the same allocation wrapped in [stack_] (sets [strictly_stack])
+   is exempt and accepted. *)
+let (stack_is_exempt @ noalloc_strict) (a : int) = exclave_ stack_ (Just a)
+[%%expect{|
+val stack_is_exempt : int -> int variant_t5 @ local = <fun>
+|}]
+
+(* The decisive case: a [stack_] in a plain [let] binding (no [exclave_]/[local_]
+   around it) has [strictly_stack = true] but [strictly_local = false]. It is
+   correctly accepted. Gating the walk on [strictly_local] would reject it, which
+   is why [strictly_stack] is required rather than reusing [strictly_local]. *)
+let (stack_in_let @ noalloc_strict) (a : int) =
+  let _x = stack_ (Just a) in
+  ()
+[%%expect{|
+val stack_in_let : int -> unit = <fun>
+|}]
+
+
+(** Test 5f: a transparent wrapper around the [stack_] operand can defeat the
+    [stack_] exemption.
+
+    [stack_] sets [strictly_stack] on its operand, but [mode_morph]/[mode_coerce]
+    reset [strictly_stack] for children (while keeping [strictly_local]). A
+    transparent re-typing layer -- one that wraps the SAME allocation rather than
+    introducing a new inner one -- therefore loses [strictly_stack], so the
+    underlying allocation is registered as if un-marked. The allocation is still
+    genuinely stack-allocated (the inferred result is [@ local]), so these are
+    conservative FALSE POSITIVES of the current implementation. *)
+
+(* CR shsong (false positive): a type annotation goes through [Pexp_constraint]
+   -> [type_expect_mode] -> [mode_coerce], which resets [strictly_stack] on the
+   inner allocation, so it is wrongly rejected. *)
+let (stack_through_type_annot @ noalloc_strict) (a : int) =
+  exclave_ stack_ ((Just a : int variant_t5))
+[%%expect{|
+Line 16, characters 20-26:
+16 |   exclave_ stack_ ((Just a : int variant_t5))
+                         ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 15-16, characters 48-45
+         which is expected to be "noalloc_strict".
+|}]
+
+(* CR shsong (false positive): same via a mode annotation. *)
+let (stack_through_mode_annot @ noalloc_strict) (a : int) =
+  exclave_ stack_ ((Just a : _ @ local))
+[%%expect{|
+Line 2, characters 20-26:
+2 |   exclave_ stack_ ((Just a : _ @ local))
+                        ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-2, characters 48-40
+         which is expected to be "noalloc_strict".
+|}]
+
+(* For contrast, a coercion [:>] does NOT reset [strictly_stack]: the [stack_]
+   operand stays exempt and is correctly accepted. *)
+let (stack_through_coercion @ noalloc_strict) (a : int) =
+  exclave_ stack_ ((Just a :> int variant_t5))
+[%%expect{|
+val stack_through_coercion : int -> int variant_t5 @ local = <fun>
+|}]
+
+(* For contrast, an attribute on the allocation is also fine. *)
+let (stack_through_attribute @ noalloc_strict) (a : int) =
+  exclave_ stack_ ((Just a)[@inline])
+[%%expect{|
+val stack_through_attribute : int -> int variant_t5 @ local = <fun>
+|}]
+
+(* CR shsong (different symptom): [let open ... in] is also transparent, but here
+   [stack_] fails to even recognize the allocation site -- the [Pexp_stack]
+   allocation-site detection does not see through [Pexp_open] (this is a
+   detection gap, not the [strictly_stack] reset above). *)
+let (stack_through_open @ noalloc_strict) (a : int) =
+  exclave_ stack_ (let open Stdlib in Just a)
+[%%expect{|
+Line 2, characters 18-45:
+2 |   exclave_ stack_ (let open Stdlib in Just a)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression is not an allocation site.
+|}]
+
+
+(** Test 5g: a genuinely NEW inner allocation under a [stack_] outer is still
+    flagged. Unlike a transparent wrapper (Test 5f), these inner expressions
+    introduce their own allocation, so the [stack_] exemption must NOT reach
+    them. It does not: [stack_] only marks its top operand, and every inner
+    allocation below is registered with [strictly_stack = false] -- either
+    because its mode is built by [mode_default] (constructor args, tuple
+    components, record fields, function bodies) or because [mode_morph] resets
+    [strictly_stack] for children (lazy thunk body, partial-application args).
+
+    NOTE (verified by experiment): deleting the [strictly_stack = false] line in
+    [mode_morph] does NOT change any case below -- they all still error -- so
+    that line is not what protects these. Its only observed effect across the
+    whole [typing-modes] suite is on the transparent constraint cases of Test 5f
+    (whose false positives it causes). *)
+
+(* lazy thunk body holds a new allocation *)
+let (stack_inner_lazy @ noalloc_strict) (a : int) =
+  exclave_ stack_ (lazy (Just a))
+[%%expect{|
+Line 18, characters 18-33:
+18 |   exclave_ stack_ (lazy (Just a))
+                       ^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 17-18, characters 40-33
+         which is expected to be "noalloc_strict".
+|}]
+
+(* a new allocation captured as an argument of a partial application *)
+let (stack_inner_partial @ noalloc_strict)
+      (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
+  exclave_ stack_ (g (Just a) 2)
+[%%expect{|
+Lines 2-3, characters 67-32:
+2 | ...................................................................(a : int) =
+3 |   exclave_ stack_ (g (Just a) 2)
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 2-3, characters 6-32
+         which is expected to be "noalloc_strict".
+|}]
+
+(* a tuple component is a new allocation *)
+let (stack_inner_tuple @ noalloc_strict) (a : int) =
+  exclave_ stack_ (Just a, Just a)
+[%%expect{|
+Line 2, characters 19-25:
+2 |   exclave_ stack_ (Just a, Just a)
+                       ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-2, characters 41-34
+         which is expected to be "noalloc_strict".
+|}]
+
+(* a record field is a new allocation *)
+type stack_inner_rec = { sf1 : int variant_t5; sf2 : int }
+let (stack_inner_field @ noalloc_strict) (a : int) =
+  exclave_ stack_ { sf1 = Just a; sf2 = a }
+[%%expect{|
+type stack_inner_rec = { sf1 : int variant_t5; sf2 : int; }
+Line 3, characters 26-32:
+3 |   exclave_ stack_ { sf1 = Just a; sf2 = a }
+                              ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 2-3, characters 41-43
+         which is expected to be "noalloc_strict".
+|}]
+
+(* a function body has a new allocation *)
+let (stack_inner_funbody @ noalloc_strict) (a : int) =
+  exclave_ stack_ (fun () -> Just a)
+[%%expect{|
+Line 2, characters 29-35:
+2 |   exclave_ stack_ (fun () -> Just a)
+                                 ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-2, characters 43-36
          which is expected to be "noalloc_strict".
 |}]
 

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1485,12 +1485,12 @@ Error: This expression is not an allocation site.
 let (stack_inner_lazy @ noalloc_strict) (a : int) =
   exclave_ stack_ (lazy (Just a))
 [%%expect{|
-Line 18, characters 18-33:
-18 |   exclave_ stack_ (lazy (Just a))
+Line 12, characters 18-33:
+12 |   exclave_ stack_ (lazy (Just a))
                        ^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 17-18, characters 40-33
+         because it is used inside the function at lines 11-12, characters 40-33
          which is expected to be "noalloc_strict".
 |}]
 

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -407,14 +407,8 @@ Error: This value is "alloc" but is expected to be "noalloc_strict".
     the allocations that [stack_] supports -- a [stack_]-marked pair as well. An
     allocation currently forces the enclosing function to [alloc], which is
     above both [noalloc] and [noalloc_strict], so the detected cases error for
-    both; the gaps (marked [CR shsong]) are accepted for both.
-
-    CR shsong: [stack_] handling for the allocation axis is not yet implemented,
-    so a [stack_]-marked allocation still forces [alloc] and errors just like a
-    heap allocation. Once [stack_] is recognized, the [stack_]-marked cases
-    below should be accepted -- a stack allocation does not count towards the
-    allocation axis. (Allocations that [stack_] does not support, and [stack_]
-    on non-allocations, are covered in the negative tests after this section.) *)
+    both. For allocations that are moved to the stack by [stack_], no error
+    is expected. *)
 
 type record_t5 = { x : float; y : float }
 type 'a variant_t5 = Nothing | Just of 'a
@@ -754,16 +748,12 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
-(* CR shsong: rare partial application whose result is a function hidden behind a
+(* Partial application whose result is a function hidden behind a
    type abbreviation ([myfun = int -> int]). Here [f 1 2] is a partial
    application returning [myfun], so it allocates a closure. The detection uses
    [get_desc (expand_head env ty_ret)]: [expand_head] unfolds [myfun] to
-   [int -> int] and the [Tarrow] is seen, so the allocation IS currently caught.
-
-   This case is exactly the one that the simpler [get_desc ty_ret] (without
-   [expand_head], proposed to avoid the GADT scope-escape side effect) would
-   MISS: [get_desc myfun] is a [Tconstr], not a [Tarrow], so the partial
-   application would be wrongly accepted as [noalloc_strict]. *)
+   [int -> int] and the [Tarrow] is seen, so the allocation IS currently
+   caught. *)
 type myfun = int -> int
 let (alloc_partial_app_abbrev @ noalloc_strict)
       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -428,24 +428,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same record allocation, but [stack_]-marked. *)
-let (alloc_record @ noalloc_strict) () = stack_ { x = 1.; y = 2. }
+let (alloc_record @ noalloc_strict) () = exclave_ stack_ { x = 1.; y = 2. }
 [%%expect{|
-Line 1, characters 48-66:
-1 | let (alloc_record @ noalloc_strict) () = stack_ { x = 1.; y = 2. }
-                                                    ^^^^^^^^^^^^^^^^^^
+Line 1, characters 57-75:
+1 | let (alloc_record @ noalloc_strict) () = exclave_ stack_ { x = 1.; y = 2. }
+                                                             ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-66
+         because it is used inside the function at line 1, characters 36-75
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_record @ noalloc) () = stack_ { x = 1.; y = 2. }
+let (alloc_record @ noalloc) () = exclave_ stack_ { x = 1.; y = 2. }
 [%%expect{|
-Line 1, characters 41-59:
-1 | let (alloc_record @ noalloc) () = stack_ { x = 1.; y = 2. }
-                                             ^^^^^^^^^^^^^^^^^^
+Line 1, characters 50-68:
+1 | let (alloc_record @ noalloc) () = exclave_ stack_ { x = 1.; y = 2. }
+                                                      ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 29-59
+         because it is used inside the function at line 1, characters 29-68
          which is expected to be "noalloc".
 |}]
 
@@ -473,24 +473,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same variant allocation, but [stack_]-marked. *)
-let (alloc_variant @ noalloc_strict) (a : int) = stack_ (Just a)
+let (alloc_variant @ noalloc_strict) (a : int) = exclave_ stack_ (Just a)
 [%%expect{|
-Line 1, characters 56-64:
-1 | let (alloc_variant @ noalloc_strict) (a : int) = stack_ (Just a)
-                                                            ^^^^^^^^
+Line 1, characters 65-73:
+1 | let (alloc_variant @ noalloc_strict) (a : int) = exclave_ stack_ (Just a)
+                                                                     ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-64
+         because it is used inside the function at line 1, characters 37-73
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_variant @ noalloc) (a : int) = stack_ (Just a)
+let (alloc_variant @ noalloc) (a : int) = exclave_ stack_ (Just a)
 [%%expect{|
-Line 1, characters 49-57:
-1 | let (alloc_variant @ noalloc) (a : int) = stack_ (Just a)
-                                                     ^^^^^^^^
+Line 1, characters 58-66:
+1 | let (alloc_variant @ noalloc) (a : int) = exclave_ stack_ (Just a)
+                                                              ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 30-57
+         because it is used inside the function at line 1, characters 30-66
          which is expected to be "noalloc".
 |}]
 
@@ -517,24 +517,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same list cell, but [stack_]-marked. *)
-let (alloc_list @ noalloc_strict) (a : int) = stack_ [a]
+let (alloc_list @ noalloc_strict) (a : int) = exclave_ stack_ [a]
 [%%expect{|
-Line 1, characters 53-56:
-1 | let (alloc_list @ noalloc_strict) (a : int) = stack_ [a]
-                                                         ^^^
+Line 1, characters 62-65:
+1 | let (alloc_list @ noalloc_strict) (a : int) = exclave_ stack_ [a]
+                                                                  ^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-56
+         because it is used inside the function at line 1, characters 34-65
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_list @ noalloc) (a : int) = stack_ [a]
+let (alloc_list @ noalloc) (a : int) = exclave_ stack_ [a]
 [%%expect{|
-Line 1, characters 46-49:
-1 | let (alloc_list @ noalloc) (a : int) = stack_ [a]
-                                                  ^^^
+Line 1, characters 55-58:
+1 | let (alloc_list @ noalloc) (a : int) = exclave_ stack_ [a]
+                                                           ^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 27-49
+         because it is used inside the function at line 1, characters 27-58
          which is expected to be "noalloc".
 |}]
 
@@ -561,24 +561,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same array, but [stack_]-marked. *)
-let (alloc_array @ noalloc_strict) (a : int) = stack_ [| a |]
+let (alloc_array @ noalloc_strict) (a : int) = exclave_ stack_ [| a |]
 [%%expect{|
-Line 1, characters 54-61:
-1 | let (alloc_array @ noalloc_strict) (a : int) = stack_ [| a |]
-                                                          ^^^^^^^
+Line 1, characters 63-70:
+1 | let (alloc_array @ noalloc_strict) (a : int) = exclave_ stack_ [| a |]
+                                                                   ^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 35-61
+         because it is used inside the function at line 1, characters 35-70
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_array @ noalloc) (a : int) = stack_ [| a |]
+let (alloc_array @ noalloc) (a : int) = exclave_ stack_ [| a |]
 [%%expect{|
-Line 1, characters 47-54:
-1 | let (alloc_array @ noalloc) (a : int) = stack_ [| a |]
-                                                   ^^^^^^^
+Line 1, characters 56-63:
+1 | let (alloc_array @ noalloc) (a : int) = exclave_ stack_ [| a |]
+                                                            ^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 28-54
+         because it is used inside the function at line 1, characters 28-63
          which is expected to be "noalloc".
 |}]
 
@@ -605,24 +605,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same polymorphic variant, but [stack_]-marked. *)
-let (alloc_polyvariant @ noalloc_strict) (a : int) = stack_ (`Tag a)
+let (alloc_polyvariant @ noalloc_strict) (a : int) = exclave_ stack_ (`Tag a)
 [%%expect{|
-Line 1, characters 60-68:
-1 | let (alloc_polyvariant @ noalloc_strict) (a : int) = stack_ (`Tag a)
-                                                                ^^^^^^^^
+Line 1, characters 69-77:
+1 | let (alloc_polyvariant @ noalloc_strict) (a : int) = exclave_ stack_ (`Tag a)
+                                                                         ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 41-68
+         because it is used inside the function at line 1, characters 41-77
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_polyvariant @ noalloc) (a : int) = stack_ (`Tag a)
+let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
 [%%expect{|
-Line 1, characters 53-61:
-1 | let (alloc_polyvariant @ noalloc) (a : int) = stack_ (`Tag a)
-                                                         ^^^^^^^^
+Line 1, characters 62-70:
+1 | let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
+                                                                  ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 34-61
+         because it is used inside the function at line 1, characters 34-70
          which is expected to be "noalloc".
 |}]
 
@@ -672,24 +672,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same closure, but [stack_]-marked. *)
-let (alloc_closure @ noalloc_strict) (a : int) = stack_ (fun () -> a)
+let (alloc_closure @ noalloc_strict) (a : int) = exclave_ stack_ (fun () -> a)
 [%%expect{|
-Line 1, characters 56-69:
-1 | let (alloc_closure @ noalloc_strict) (a : int) = stack_ (fun () -> a)
-                                                            ^^^^^^^^^^^^^
+Line 1, characters 65-78:
+1 | let (alloc_closure @ noalloc_strict) (a : int) = exclave_ stack_ (fun () -> a)
+                                                                     ^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-69
+         because it is used inside the function at line 1, characters 37-78
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_closure @ noalloc) (a : int) = stack_ (fun () -> a)
+let (alloc_closure @ noalloc) (a : int) = exclave_ stack_ (fun () -> a)
 [%%expect{|
-Line 1, characters 49-62:
-1 | let (alloc_closure @ noalloc) (a : int) = stack_ (fun () -> a)
-                                                     ^^^^^^^^^^^^^
+Line 1, characters 58-71:
+1 | let (alloc_closure @ noalloc) (a : int) = exclave_ stack_ (fun () -> a)
+                                                              ^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 30-62
+         because it is used inside the function at line 1, characters 30-71
          which is expected to be "noalloc".
 |}]
 
@@ -716,24 +716,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same float boxing, but [stack_]-marked. *)
-let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = stack_ r.x
+let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = exclave_ stack_ r.x
 [%%expect{|
-Line 1, characters 67-70:
-1 | let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = stack_ r.x
-                                                                       ^^^
+Line 1, characters 76-79:
+1 | let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = exclave_ stack_ r.x
+                                                                                ^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 42-70
+         because it is used inside the function at line 1, characters 42-79
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_float_boxing @ noalloc) (r : record_t5) = stack_ r.x
+let (alloc_float_boxing @ noalloc) (r : record_t5) = exclave_ stack_ r.x
 [%%expect{|
-Line 1, characters 60-63:
-1 | let (alloc_float_boxing @ noalloc) (r : record_t5) = stack_ r.x
-                                                                ^^^
+Line 1, characters 69-72:
+1 | let (alloc_float_boxing @ noalloc) (r : record_t5) = exclave_ stack_ r.x
+                                                                         ^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 35-63
+         because it is used inside the function at line 1, characters 35-72
          which is expected to be "noalloc".
 |}]
 
@@ -932,24 +932,24 @@ Error: The allocation is "alloc"
 |}]
 
 (* The same exception construction, but [stack_]-marked. *)
-let (alloc_exception @ noalloc_strict) (a : string) = stack_ (Failure a)
+let (alloc_exception @ noalloc_strict) (a : string) = exclave_ stack_ (Failure a)
 [%%expect{|
-Line 1, characters 61-72:
-1 | let (alloc_exception @ noalloc_strict) (a : string) = stack_ (Failure a)
-                                                                 ^^^^^^^^^^^
+Line 1, characters 70-81:
+1 | let (alloc_exception @ noalloc_strict) (a : string) = exclave_ stack_ (Failure a)
+                                                                          ^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 39-72
+         because it is used inside the function at line 1, characters 39-81
          which is expected to be "noalloc_strict".
 |}]
-let (alloc_exception @ noalloc) (a : string) = stack_ (Failure a)
+let (alloc_exception @ noalloc) (a : string) = exclave_ stack_ (Failure a)
 [%%expect{|
-Line 1, characters 54-65:
-1 | let (alloc_exception @ noalloc) (a : string) = stack_ (Failure a)
-                                                          ^^^^^^^^^^^
+Line 1, characters 63-74:
+1 | let (alloc_exception @ noalloc) (a : string) = exclave_ stack_ (Failure a)
+                                                                   ^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 32-65
+         because it is used inside the function at line 1, characters 32-74
          which is expected to be "noalloc".
 |}]
 
@@ -1031,11 +1031,11 @@ val alloc_list_comprehension : unit -> int list = <fun>
 
 (* [stack_] on a non-allocation (a plain value) is rejected: it is not an
    allocation. *)
-let (stack_non_alloc @ noalloc_strict) (a : int) = stack_ a
+let (stack_non_alloc @ noalloc_strict) (a : int) = exclave_ stack_ a
 [%%expect{|
-Line 6, characters 58-59:
-6 | let (stack_non_alloc @ noalloc_strict) (a : int) = stack_ a
-                                                              ^
+Line 5, characters 67-68:
+5 | let (stack_non_alloc @ noalloc_strict) (a : int) = exclave_ stack_ a
+                                                                       ^
 Error: This expression is not an allocation site.
 |}]
 
@@ -1043,52 +1043,52 @@ Error: This expression is not an allocation site.
    recognized allocation form. [f] is received as a parameter to avoid the
    currying closures of a multi-argument definition. *)
 let (stack_partial_app @ noalloc_strict)
-      (f : (int -> int -> int -> int) @ noalloc_strict) = stack_ (f 1 2)
+      (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
 [%%expect{|
-Line 2, characters 65-72:
-2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = stack_ (f 1 2)
-                                                                     ^^^^^^^
+Line 2, characters 74-81:
+2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
+                                                                              ^^^^^^^
 Error: This expression is not an allocation site.
 |}]
 
 (* [stack_] does not support lazy expressions. *)
-let (stack_lazy @ noalloc_strict) (a : int) = stack_ (lazy a)
+let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
 [%%expect{|
-Line 1, characters 53-61:
-1 | let (stack_lazy @ noalloc_strict) (a : int) = stack_ (lazy a)
-                                                         ^^^^^^^^
+Line 1, characters 62-70:
+1 | let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
+                                                                  ^^^^^^^^
 Error: Stack allocating lazy expressions is unsupported yet.
 |}]
 
 (* [stack_] does not support objects; here the object's method closure is
    itself a detected allocation, so the allocation-axis error fires on the
    method body before the unsupported-[stack_] check is reached. *)
-let (stack_object @ noalloc_strict) () = stack_ (object method m = 1 end)
+let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
 [%%expect{|
-Line 1, characters 67-68:
-1 | let (stack_object @ noalloc_strict) () = stack_ (object method m = 1 end)
-                                                                       ^
+Line 1, characters 76-77:
+1 | let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
+                                                                                ^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-73
+         because it is used inside the function at line 1, characters 36-82
          which is expected to be "noalloc_strict".
 |}]
 
 (* [stack_] does not support first-class modules ([Empty]/[S] from Test 5). *)
-let (stack_first_class_module @ noalloc_strict) () = stack_ (module Empty : S)
+let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
 [%%expect{|
-Line 1, characters 60-78:
-1 | let (stack_first_class_module @ noalloc_strict) () = stack_ (module Empty : S)
-                                                                ^^^^^^^^^^^^^^^^^^
+Line 1, characters 69-87:
+1 | let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
+                                                                         ^^^^^^^^^^^^^^^^^^
 Error: Stack allocating modules is unsupported yet.
 |}]
 
 (* [stack_] does not support comprehensions. *)
-let (stack_comprehension @ noalloc_strict) () = stack_ [ x for x = 1 to 10 ]
+let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
 [%%expect{|
-Line 1, characters 55-76:
-1 | let (stack_comprehension @ noalloc_strict) () = stack_ [ x for x = 1 to 10 ]
-                                                           ^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 64-85:
+1 | let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
+                                                                    ^^^^^^^^^^^^^^^^^^^^^
 Error: Stack allocating list comprehensions is unsupported yet.
 |}]
 
@@ -1099,14 +1099,14 @@ Error: Stack allocating list comprehensions is unsupported yet.
    (Currently the outer [stack_] is not recognized either, so both contribute;
    once [stack_] is recognized, only the inner allocation should remain and the
    function should still be rejected.) *)
-let (stack_nested @ noalloc_strict) (a : int) = stack_ (Just (Just a))
+let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
 [%%expect{|
-Line 1, characters 55-70:
-1 | let (stack_nested @ noalloc_strict) (a : int) = stack_ (Just (Just a))
-                                                           ^^^^^^^^^^^^^^^
+Line 1, characters 64-79:
+1 | let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
+                                                                    ^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-70
+         because it is used inside the function at line 1, characters 36-79
          which is expected to be "noalloc_strict".
 |}]
 

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -401,7 +401,7 @@ Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
 
-(** Test 5: Allocation mode identifies all allocations and forces the proper
+(** Test 5.1: Allocation mode identifies all allocations and forces the proper
     mode. For each kind of allocation the typechecker can see, we test a
     [noalloc_strict] and a [noalloc] enclosing function side by side, and -- for
     the allocations that [stack_] supports -- a [stack_]-marked pair as well. An
@@ -1232,7 +1232,7 @@ Error: The allocation is "alloc"
 |}]
 
 
-(** Test 5b: an allocation nested inside several enclosing functions forces
+(** Test 5.2: an allocation nested inside several enclosing functions forces
     every enclosing layer. The functions [g] and [h] each capture the parameter
     [a], so building each inner closure is itself an allocation in its parent;
     together with the innermost [Just a] this makes every one of the three nested
@@ -1313,7 +1313,7 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
-(** Test 5c: [stack_] negative cases *)
+(** Test 5.3: [stack_] negative cases *)
 
 (* [stack_] on a non-allocation (a plain value) is rejected: it is not an
    allocation. *)
@@ -1325,7 +1325,7 @@ Line 5, characters 67-68:
 Error: This expression is not an allocation site.
 |}]
 
-(** Test 5d: [stack_] nested cases. *)
+(** Test 5.4: [stack_] nested cases. *)
 (* Nested: an inner allocation that is not itself [stack_]-marked still
    allocates on the heap, even when an enclosing allocation is [stack_]-marked. *)
 let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
@@ -1359,7 +1359,7 @@ Error: The allocation is "alloc"
 |}]
 
 
-(** Test 5e: the allocation axis is exempted only by [stack_]
+(** Test 5.5: the allocation axis is exempted only by [stack_]
     ([expected_mode.strictly_stack]), not by [local_]/[exclave_]
     ([expected_mode.strictly_local]). The two flags are independent, so they are
     NOT interchangeable:
@@ -1419,7 +1419,7 @@ val stack_in_let : int -> unit = <fun>
 |}]
 
 
-(** Test 5f: a transparent wrapper around the [stack_] operand should not defeat
+(** Test 5.6: a transparent wrapper around the [stack_] operand should not defeat
     the [stack_] exemption.
 
     [stack_] sets [strictly_stack] on its operand.
@@ -1472,8 +1472,8 @@ Error: This expression is not an allocation site.
 |}]
 
 
-(** Test 5g: a genuinely NEW inner allocation under a [stack_] outer is still
-    flagged. Unlike a transparent wrapper (Test 5f), these inner expressions
+(** Test 5.7: a genuinely NEW inner allocation under a [stack_] outer is still
+    flagged. Unlike a transparent wrapper (Test 5.6), these inner expressions
     introduce their own allocation, so the [stack_] exemption must NOT reach
     them. It does not: [stack_] only marks its top operand, and every inner
     allocation below is registered with [strictly_stack = false] -- either
@@ -1550,7 +1550,7 @@ Error: The allocation is "alloc"
 |}]
 
 
-(** Test 5h: regression guard for making [stack_] set [strictly_local].
+(** Test 5.8: regression guard for making [stack_] set [strictly_local].
 
     A [stack_] closure placed where a [global] value is required must report a
     clean locality error, NOT crash. If the [Pexp_stack] handler is changed to
@@ -1605,7 +1605,7 @@ Error: This value is "local" because it is "stack_"-allocated.
 |}]
 
 
-(** Test 5i: annotating the codomain of the arrow with [@ noalloc_strict]
+(** Test 5.9: annotating the codomain of the arrow with [@ noalloc_strict]
     constrains the mode of the application result. With
     [foo : int -> t @ noalloc_strict], applying [M.foo 1] yields a
     [noalloc_strict] value (and likewise [M.foo_int 1]). Note the codomain mode

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -653,9 +653,7 @@ let (alloc_float_boxing @ noalloc) (r : record_t5) = exclave_ stack_ r.x
 val alloc_float_boxing : record_t5 -> float @ local = <fun>
 |}]
 
-(* CR shsong: tuple construction allocates a boxed block, but the allocation
-   is registered via [register_allocation_value_mode], which does not walk
-   locks, so this is wrongly accepted. (We use a unit argument and constant
+(* Tuple construction allocates a boxed block. (We use a unit argument and constant
    elements to avoid an inner currying closure, which would otherwise be the
    real cause of an error.) *)
 let (alloc_tuple @ noalloc_strict) () = (1, 2)
@@ -679,8 +677,7 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc".
 |}]
 
-(* CR shsong: the same tuple, but [stack_]-marked. Tuples are a gap, so this
-   is accepted regardless of [stack_]. *)
+(* The same tuple, but [stack_]-marked. *)
 let (alloc_tuple @ noalloc_strict) () = exclave_ stack_ (1, 2)
 [%%expect{|
 val alloc_tuple : unit -> int * int @ local = <fun>
@@ -1011,10 +1008,7 @@ Error: Stack allocating list comprehensions is unsupported yet.
 
 (** Test 5b: [stack_] nested cases. *)
 (* Nested: an inner allocation that is not itself [stack_]-marked still
-   allocates on the heap, even when an enclosing allocation is [stack_]-marked.
-   (Currently the outer [stack_] is not recognized either, so both contribute;
-   once [stack_] is recognized, only the inner allocation should remain and the
-   function should still be rejected.) *)
+   allocates on the heap, even when an enclosing allocation is [stack_]-marked. *)
 let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
 [%%expect{|
 Line 1, characters 70-78:

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1419,46 +1419,31 @@ val stack_in_let : int -> unit = <fun>
 |}]
 
 
-(** Test 5f: a transparent wrapper around the [stack_] operand can defeat the
-    [stack_] exemption.
+(** Test 5f: a transparent wrapper around the [stack_] operand should not defeat
+    the [stack_] exemption.
 
-    [stack_] sets [strictly_stack] on its operand, but [mode_morph]/[mode_coerce]
-    reset [strictly_stack] for children (while keeping [strictly_local]). A
-    transparent re-typing layer -- one that wraps the SAME allocation rather than
-    introducing a new inner one -- therefore loses [strictly_stack], so the
-    underlying allocation is registered as if un-marked. The allocation is still
-    genuinely stack-allocated (the inferred result is [@ local]), so these are
-    conservative FALSE POSITIVES of the current implementation. *)
+    [stack_] sets [strictly_stack] on its operand.
+    Although we do not want [strictly_stack = true] for children allocations,
+    we should not use [mode_morph]/[mode_coerce] to reset [strictly_stack] for
+    children (while keeping [strictly_local]). *)
 
-(* CR shsong (false positive): a type annotation goes through [Pexp_constraint]
-   -> [type_expect_mode] -> [mode_coerce], which resets [strictly_stack] on the
-   inner allocation, so it is wrongly rejected. *)
+(* A type annotation goes through [Pexp_constraint] -> [type_expect_mode]
+   -> [mode_coerce], which should not resets [strictly_stack] on the
+   inner allocation, i.e., the inner allocation is still on stack. *)
 let (stack_through_type_annot @ noalloc_strict) (a : int) =
   exclave_ stack_ ((Just a : int variant_t5))
 [%%expect{|
-Line 16, characters 20-26:
-16 |   exclave_ stack_ ((Just a : int variant_t5))
-                         ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 15-16, characters 48-45
-         which is expected to be "noalloc_strict".
+val stack_through_type_annot : int -> int variant_t5 @ local = <fun>
 |}]
 
-(* CR shsong (false positive): same via a mode annotation. *)
+(* Same via a mode annotation. *)
 let (stack_through_mode_annot @ noalloc_strict) (a : int) =
   exclave_ stack_ ((Just a : _ @ local))
 [%%expect{|
-Line 2, characters 20-26:
-2 |   exclave_ stack_ ((Just a : _ @ local))
-                        ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-2, characters 48-40
-         which is expected to be "noalloc_strict".
+val stack_through_mode_annot : int -> int variant_t5 @ local = <fun>
 |}]
 
-(* For contrast, a coercion [:>] does NOT reset [strictly_stack]: the [stack_]
+(* A coercion [:>] does NOT reset [strictly_stack]: the [stack_]
    operand stays exempt and is correctly accepted. *)
 let (stack_through_coercion @ noalloc_strict) (a : int) =
   exclave_ stack_ ((Just a :> int variant_t5))
@@ -1466,17 +1451,17 @@ let (stack_through_coercion @ noalloc_strict) (a : int) =
 val stack_through_coercion : int -> int variant_t5 @ local = <fun>
 |}]
 
-(* For contrast, an attribute on the allocation is also fine. *)
+(* An attribute on the allocation is also fine. *)
 let (stack_through_attribute @ noalloc_strict) (a : int) =
   exclave_ stack_ ((Just a)[@inline])
 [%%expect{|
 val stack_through_attribute : int -> int variant_t5 @ local = <fun>
 |}]
 
-(* CR shsong (different symptom): [let open ... in] is also transparent, but here
-   [stack_] fails to even recognize the allocation site -- the [Pexp_stack]
+(* [let open ... in] is also transparent, but here [stack_]
+   fails to even recognize the allocation site -- the [Pexp_stack]
    allocation-site detection does not see through [Pexp_open] (this is a
-   detection gap, not the [strictly_stack] reset above). *)
+   detection gap, not the [strictly_stack] reset issue). *)
 let (stack_through_open @ noalloc_strict) (a : int) =
   exclave_ stack_ (let open Stdlib in Just a)
 [%%expect{|
@@ -1494,13 +1479,7 @@ Error: This expression is not an allocation site.
     allocation below is registered with [strictly_stack = false] -- either
     because its mode is built by [mode_default] (constructor args, tuple
     components, record fields, function bodies) or because [mode_morph] resets
-    [strictly_stack] for children (lazy thunk body, partial-application args).
-
-    NOTE (verified by experiment): deleting the [strictly_stack = false] line in
-    [mode_morph] does NOT change any case below -- they all still error -- so
-    that line is not what protects these. Its only observed effect across the
-    whole [typing-modes] suite is on the transparent constraint cases of Test 5f
-    (whose false positives it causes). *)
+    [strictly_stack] for children (lazy thunk body, partial-application args). *)
 
 (* lazy thunk body holds a new allocation *)
 let (stack_inner_lazy @ noalloc_strict) (a : int) =
@@ -1568,6 +1547,61 @@ Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 1-2, characters 43-36
          which is expected to be "noalloc_strict".
+|}]
+
+
+(** Test 5h: regression guard for making [stack_] set [strictly_local].
+
+    A [stack_] closure placed where a [global] value is required must report a
+    clean locality error, NOT crash. If the [Pexp_stack] handler is changed to
+    [mode_strictly_stack expected_mode |> mode_strictly_local], then
+    [split_function_ty] forces the closure areality with [Locality.submode_exn]
+    (line ~6237). That submode genuinely fails here (the closure must be global),
+    and the [_exn] form raises [Invalid_argument "result is Error _"] -- a
+    compiler crash -- instead of the graceful error below. With the handler left
+    as [mode_strictly_stack] only, all four error cleanly. *)
+
+(* stack_ closure stored in a ref (ref contents must be global) *)
+let stack_clo_in_ref = ref (stack_ (fun x -> x))
+[%%expect{|
+Line 13, characters 27-48:
+13 | let stack_clo_in_ref = ref (stack_ (fun x -> x))
+                                ^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
+|}]
+
+(* stack_ closure as the function in a tail call *)
+let stack_clo_tailcall () = (stack_ (fun x -> x)) 42
+[%%expect{|
+Line 1, characters 28-49:
+1 | let stack_clo_tailcall () = (stack_ (fun x -> x)) 42
+                                ^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
+         because it is the function in a tail call.
+|}]
+
+(* stack_ multi-argument closure stored in a ref *)
+let stack_clo_multiarg () = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a))
+[%%expect{|
+Line 1, characters 32-72:
+1 | let stack_clo_multiarg () = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a))
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "global".
+|}]
+
+(* stack_ closure returned where a global function is expected *)
+let stack_clo_global_return () : int -> int = stack_ (fun x -> x)
+[%%expect{|
+Line 1, characters 46-65:
+1 | let stack_clo_global_return () : int -> int = stack_ (fun x -> x)
+                                                  ^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" because it is "stack_"-allocated.
+       However, the highlighted expression is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 
 

--- a/testsuite/tests/typing-unique/rbtree.ml
+++ b/testsuite/tests/typing-unique/rbtree.ml
@@ -502,12 +502,9 @@ module Make_Okasaki :
       type 'a t = (Ord.t, 'a) tree
       val fold : ('a -> 'b -> 'c -> 'c) -> 'c -> ('a, 'b) tree -> 'c
       val balance_left : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
-        noalloc_strict
       val balance_right : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
-        noalloc_strict
       val ins : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
       val set_black : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
-        noalloc_strict
       val insert : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
     end
 Line 110, characters 16-52:

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -1133,7 +1133,7 @@ module M_explicit_arity_2 : sig type t = int -> int val f : int -> t end
 module type S =
   sig
     type t = int -> int
-    val f : int -> t @@ stateless noalloc_strict [@@zero_alloc arity 2]
+    val f : int -> t @@ stateless [@@zero_alloc arity 2]
   end
 |}]
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3801,18 +3801,22 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
           vmode
     ) mode locks
 
+(** Constrains every enclosing closure lock with the given minimum mode. *)
+let walk_locks_with_mode_constraint ~env pp ~mode =
+  let locks = IdTbl.get_all_locks env.values in
+  let _stage_locks, locks = partition_locks locks in
+  ignore
+    (walk_locks ~errors:true ~env ~pp
+       (Mode.Value.disallow_right mode) None locks
+      : Mode.Value.l)
+
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
     toplevel were used at the pinpoint's location. Used for constructs (e.g.
     effect handlers) that force enclosing functions to be nonportable and
     stateful. *)
 let walk_locks_for_legacy_construct ~env pp =
-  let locks = IdTbl.get_all_locks env.values in
-  let _stage_locks, locks = partition_locks locks in
-  ignore
-    (walk_locks ~errors:true ~env ~pp
-       (Mode.Value.disallow_right Mode.Value.legacy) None locks
-      : Mode.Value.l)
+  walk_locks_with_mode_constraint ~env pp ~mode:Mode.Value.legacy
 
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
@@ -3820,14 +3824,8 @@ let walk_locks_for_legacy_construct ~env pp =
 (* CR shsong: currently it only considers noalloc_strict and alloc,
     need to customize this to support noalloc later *)
 let walk_locks_for_allocation ~env pp =
-  let locks = IdTbl.get_all_locks env.values in
-  let _stage_locks, locks = partition_locks locks in
-  ignore
-    (walk_locks ~errors:true ~env ~pp
-      (Mode.Value.disallow_right
-        (Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc))
-      None locks
-      : Mode.Value.l)
+  walk_locks_with_mode_constraint ~env pp
+    ~mode:(Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc)
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
   and [locks] which is the locks between the declaration and the usage (either

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3732,6 +3732,7 @@ let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
   in
   {Mode.monadic; comonadic}
 
+(* CR shsong: rebase conflict was formatting-only here; kept main's wrapping. *)
 let const_closure_mode pp {Mode.monadic; comonadic}
   closure_context comonadic0 =
   Mode.Value.Comonadic.(submode_err pp comonadic
@@ -3801,6 +3802,8 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
           vmode
     ) mode locks
 
+(* CR shsong: rebase conflict - main added [walk_locks_for_legacy_construct] at
+   the same spot this commit added [walk_locks_for_allocation]; kept both. *)
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
     toplevel were used at the pinpoint's location. Used for constructs (e.g.
@@ -3812,6 +3815,20 @@ let walk_locks_for_legacy_construct ~env pp =
   ignore
     (walk_locks ~errors:true ~env ~pp
        (Mode.Value.disallow_right Mode.Value.legacy) None locks
+      : Mode.Value.l)
+
+(** Registers a use of an allocation, constraining every enclosing closure lock.
+    Used for constructs with allocations that force enclosing functions to be
+    alloc (rather than noalloc_strict) *)
+(* CR shsong: currently it only considers noalloc_strict and alloc,
+    need to customize this to support noalloc later *)
+let walk_locks_for_allocation ~env pp =
+  let locks = IdTbl.get_all_locks env.values in
+  let _stage_locks, locks = partition_locks locks in
+  ignore
+    (walk_locks ~errors:true ~env ~pp
+      (Mode.Value.disallow_right
+        (Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc)) None locks
       : Mode.Value.l)
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
@@ -5107,6 +5124,8 @@ let extract_settable_variables env =
 let print_pinpoint_desc ppf desc =
   (Mode.print_pinpoint_desc desc |> Option.get)
     ~definite:true ~capitalize:true ppf
+(* CR shsong: rebase conflict - dropped this commit's [module Style = Misc.Style]
+   as main already binds [Style] (used below); verify no shadowing was intended. *)
 
 let print_stage ppf stage =
   if stage = 0 then fprintf ppf "outside any quotations"
@@ -5388,6 +5407,9 @@ let report_lookup_error_doc loc env = function
         "The module %a is an alias for module %a, which %s"
         quoted_longident lid
         (Style.as_inline_code pp_path) p cause
+  (* CR shsong: rebase conflict - adopted main's new error API
+     ([Location.errorf]/[pp_path]); this commit's [print_pinpoint_desc] change is
+     preserved below. *)
   | Local_value_used_in_exclave desc ->
       Location.errorf ~loc
         "%a is local, so it cannot be used inside an exclave_"

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3828,7 +3828,8 @@ let walk_locks_for_allocation ~env pp =
   ignore
     (walk_locks ~errors:true ~env ~pp
       (Mode.Value.disallow_right
-        (Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc)) None locks
+        (Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc))
+      None locks
       : Mode.Value.l)
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3732,7 +3732,6 @@ let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
   in
   {Mode.monadic; comonadic}
 
-(* CR shsong: rebase conflict was formatting-only here; kept main's wrapping. *)
 let const_closure_mode pp {Mode.monadic; comonadic}
   closure_context comonadic0 =
   Mode.Value.Comonadic.(submode_err pp comonadic
@@ -3802,8 +3801,6 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
           vmode
     ) mode locks
 
-(* CR shsong: rebase conflict - main added [walk_locks_for_legacy_construct] at
-   the same spot this commit added [walk_locks_for_allocation]; kept both. *)
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
     toplevel were used at the pinpoint's location. Used for constructs (e.g.
@@ -5125,8 +5122,6 @@ let extract_settable_variables env =
 let print_pinpoint_desc ppf desc =
   (Mode.print_pinpoint_desc desc |> Option.get)
     ~definite:true ~capitalize:true ppf
-(* CR shsong: rebase conflict - dropped this commit's [module Style = Misc.Style]
-   as main already binds [Style] (used below); verify no shadowing was intended. *)
 
 let print_stage ppf stage =
   if stage = 0 then fprintf ppf "outside any quotations"
@@ -5408,9 +5403,6 @@ let report_lookup_error_doc loc env = function
         "The module %a is an alias for module %a, which %s"
         quoted_longident lid
         (Style.as_inline_code pp_path) p cause
-  (* CR shsong: rebase conflict - adopted main's new error API
-     ([Location.errorf]/[pp_path]); this commit's [print_pinpoint_desc] change is
-     preserved below. *)
   | Local_value_used_in_exclave desc ->
       Location.errorf ~loc
         "%a is local, so it cannot be used inside an exclave_"

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -319,12 +319,19 @@ val walk_locks : env:t -> loc:Location.t -> Longident.t ->
   item:Mode.Hint.lock_item ->
   type_expr option -> mode_with_locks -> Mode.Value.l
 
+(* CR shsong: rebase conflict - kept both main's [walk_locks_for_legacy_construct]
+   and this commit's [walk_locks_for_allocation]. *)
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
     toplevel were used at the pinpoint's location. Used for constructs (e.g.
     effect handlers) that force enclosing functions to be nonportable and
     stateful. *)
 val walk_locks_for_legacy_construct : env:t -> Mode.Hint.pinpoint -> unit
+
+(** Registers a use of an allocation, constraining every enclosing closure lock.
+    Used for constructs with allocations that force enclosing functions to be
+    alloc (rather than noalloc_strict) *)
+val walk_locks_for_allocation : env:t -> Mode.Hint.pinpoint -> unit
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -319,8 +319,6 @@ val walk_locks : env:t -> loc:Location.t -> Longident.t ->
   item:Mode.Hint.lock_item ->
   type_expr option -> mode_with_locks -> Mode.Value.l
 
-(* CR shsong: rebase conflict - kept both main's [walk_locks_for_legacy_construct]
-   and this commit's [walk_locks_for_allocation]. *)
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
     toplevel were used at the pinpoint's location. Used for constructs (e.g.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -446,6 +446,10 @@ type expected_mode =
     field and [mode]: this field being [true] while [mode] being [global] is
     sensible, but not very useful as it will fail all expressions. *)
 
+    strictly_stack : bool;
+    (** True iff this expression is the direct operand of [stack_].
+    Suppresses the allocation-axis lock-walk for its top allocation. *)
+
     tuple_modes : (Value.r * Location.t) list option;
     (** No invariant between this and [mode]. It is UNSOUND to ignore this
         field. If this is [Some [x0; x1; ..]]:
@@ -528,6 +532,7 @@ let mode_default mode =
   { position = RNontail;
     mode = Value.disallow_left mode;
     strictly_local = false;
+    strictly_stack = false;
     tuple_modes = None }
 
 let mode_legacy = mode_default Value.legacy
@@ -573,7 +578,8 @@ let mode_morph f expected_mode =
   let mode = as_single_mode expected_mode in
   let mode = f mode |> Mode.Value.disallow_left in
   let tuple_modes = None in
-  {expected_mode with mode; tuple_modes}
+  { expected_mode with mode; tuple_modes;
+    strictly_stack = false (* strictly_stack does not affect children *) }
 
 (** Similiar to [apply_left_is_contained_by] but for [expected_mode]. *)
 let mode_is_contained_by is_contained_by ?modalities expected_mode =
@@ -644,6 +650,11 @@ let mode_exclave expected_mode =
 let mode_strictly_local expected_mode =
   { expected_mode
     with strictly_local = true
+  }
+
+let mode_strictly_stack expected_mode =
+  { expected_mode
+    with strictly_stack = true
   }
 
 let mode_coerce mode expected_mode =
@@ -799,14 +810,20 @@ let allocations : Alloc.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
-let register_allocation_mode alloc_mode =
+let register_allocation_mode ~env ~loc ?(stack = false) alloc_mode =
+  (* [stack_]-marked allocations are stack-allocated and so do not count
+     towards the allocation axis; only heap allocations walk the locks. *)
+  if not stack then
+    Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
   let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
-let register_allocation_value_mode ~loc
+let register_allocation_value_mode ~env ~loc ?(stack = false)
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
   let alloc_mode = value_to_alloc_r2g mode in
-  register_allocation_mode alloc_mode;
+  (* CR shsong: rebase conflict - took this commit's [~env ~loc ~stack] call;
+     kept main's morphism comment below. *)
+  register_allocation_mode ~env ~loc ~stack alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
   let mode =
@@ -821,15 +838,17 @@ let register_allocation_value_mode ~loc
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-(* CR shsong: rebase conflict - kept main's [Hint.allocation] naming and added
-   this commit's [~env] param + [walk_locks_for_allocation] call. *)
-let register_closure_allocation ~env (mode : Value.r) ~loc : Alloc.lr * Value.r =
-  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+(* CR shsong: rebase conflict - this commit centralized the lock-walk into
+   [register_allocation_mode], so dropped the [walk_locks_for_allocation] call
+   the earlier commit had added here; kept main's [let allocation] naming (used
+   below) and added this commit's [?(stack = false)]. *)
+let register_closure_allocation ~env ?(stack = false) (mode : Value.r) ~loc
+    : Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
   let (alloc_mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode (Alloc.disallow_left alloc_mode);
+  register_allocation_mode ~env ~loc ~stack (Alloc.disallow_left alloc_mode);
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
   in
@@ -839,9 +858,9 @@ let register_closure_allocation ~env (mode : Value.r) ~loc : Alloc.lr * Value.r 
     [expected_mode]. Returns the mode of the allocation, and the expected mode
     of potential subcomponents. *)
 let register_allocation ~env ~loc ?desc (expected_mode : expected_mode) =
-  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
   let alloc_mode, mode =
-    register_allocation_value_mode ~loc ?desc (as_single_mode expected_mode)
+    register_allocation_value_mode ~env ~loc ~stack:expected_mode.strictly_stack
+      ?desc (as_single_mode expected_mode)
   in
   alloc_mode, mode_default mode
 
@@ -5086,7 +5105,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
                Alloc.newvar_above (Alloc.join
                 (mode_partial_fun:: mode_closed_args))
              in
-             register_allocation_mode mode_closure;
+             register_allocation_mode ~env ~loc mode_closure;
              let arg =
               Omitted {
                 mode_closure = Alloc.disallow_left mode_closure;
@@ -6205,7 +6224,8 @@ let split_function_ty
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
   let alloc_mode, closed_over_mode =
-    register_closure_allocation ~env ~loc (as_single_mode expected_mode)
+    register_closure_allocation ~env ~stack:expected_mode.strictly_stack ~loc
+      (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
@@ -8513,7 +8533,9 @@ and type_expect_
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
   | Pexp_stack e ->
-      let exp = type_expect env expected_mode e ty_expected_explained in
+      (* Allocation axis: suppress the axis lock-walk at the registration site *)
+      let expected_stack_mode = mode_strictly_stack expected_mode in
+      let exp = type_expect env expected_stack_mode e ty_expected_explained in
       let unsupported category =
         raise (Error (exp.exp_loc, env, Unsupported_stack_allocation category))
       in
@@ -9061,7 +9083,8 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
-           register_allocation_mode (Alloc.max_with_comonadic Areality mode)
+           register_allocation_mode ~env ~loc:lid.loc
+             (Alloc.max_with_comonadic Areality mode)
        | _ -> ()
        end;
        [], ty, Id_prim (Option.map Locality.disallow_right mode, sort)
@@ -10320,7 +10343,8 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
     (fun l -> raise (Error (loc, env, Repeated_tuple_exp_label l)))
     (Misc.repeated_label sexpl);
   let alloc_mode, value_mode =
-    register_allocation_value_mode ~loc expected_mode.mode
+    register_allocation_value_mode ~env ~loc
+      ~stack:expected_mode.strictly_stack expected_mode.mode
   in
   let argument_mode =
     value_mode
@@ -10351,7 +10375,8 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
           should be an type error. Here, we give the sound mode anyway. *)
         let tuple_modes =
           List.map (fun (mode, _) ->
-            snd (register_allocation_value_mode ~loc mode)) tuple_modes
+            snd (register_allocation_value_mode ~env ~loc
+                   ~stack:expected_mode.strictly_stack mode)) tuple_modes
         in
         let argument_mode = Value.meet (argument_mode :: tuple_modes) in
         List.init arity (fun _ -> argument_mode)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4954,7 +4954,7 @@ let collect_apply_args env loc funct ignore_labels ty_fun ty_fun0 mode_fun sargs
           are in the return value) is false, since if partial_app is true,
           there are Omitted args and the code walks the locks already *)
       if ty_fun_is_arrow then
-        Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+        register_allocation_mode ~env ~loc Alloc.legacy;
       collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
         ret_tvar
     end
@@ -8180,10 +8180,8 @@ and type_expect_
       let to_unify = Predef.type_lazy_t ty in
       with_explanation (fun () ->
         unify_exp_types loc env to_unify (generic_instance ty_expected));
-      (* Allocation axis check: constructing a lazy block allocates, but
-         register_allocation_mode is not called, so we manually
-         walk locks here *)
-      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+      (* Allocation axis check: constructing a lazy block allocates *)
+      register_allocation_mode ~env ~loc Alloc.legacy;
       let env = Env.add_closure_lock (loc, Lazy) closure_mode.comonadic env in
       let arg = type_expect env expected_mode e (mk_expected ty) in
       re {
@@ -8196,10 +8194,8 @@ and type_expect_
   | Pexp_object s ->
       Env.check_no_open_quotations loc env Object_qt;
       submode ~loc ~env Value.legacy expected_mode;
-      (* Allocation axis check: constructing an object block allocates,
-         but register_allocation_mode is not called, so we manually
-         walk locks here *)
-      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+      (* Allocation axis check: constructing an object block allocates *)
+      register_allocation_mode ~env ~loc Alloc.legacy;
       let desc, meths = !type_object env loc s in
       rue {
         exp_desc = Texp_object (desc, meths);
@@ -11923,10 +11919,8 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
        "What modes should comprehensions use?", above *)
     type_expect new_env mode_legacy sbody (mk_expected element_ty)
   in
-  (* Allocation axis check: comprehension expr allocates, but
-    register_allocation_mode is not called, so we manually
-    walk locks here *)
-  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+  (* Allocation axis check: comprehension expr allocates *)
+  register_allocation_mode ~env ~loc Alloc.legacy;
   re { exp_desc       = make_texp { comp_body ; comp_clauses }
      ; exp_loc        = loc
      ; exp_extra      = []

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4949,6 +4949,10 @@ let collect_apply_args env loc funct ignore_labels ty_fun ty_fun0 mode_fun sargs
       let ty_fun_is_arrow =
         match get_desc ty_fun' with Tarrow _ -> true | _ -> false
       in
+      (* CR shsong: this check for partial application is not strong enough
+          to guarantee soundness. Especially for the case where the partial
+          application's return type is an abstract type and is actually a
+          function. *)
       (* CR shsong: Alternative design: only register_allocation_mode if
           partial_app = is_partial_apply untyped_args (where untyped_args
           are in the return value) is false, since if partial_app is true,

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -821,7 +821,10 @@ let register_allocation_value_mode ~loc
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
+(* CR shsong: rebase conflict - kept main's [Hint.allocation] naming and added
+   this commit's [~env] param + [walk_locks_for_allocation] call. *)
+let register_closure_allocation ~env (mode : Value.r) ~loc : Alloc.lr * Value.r =
+  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
   let allocation : Hint.allocation = {loc; txt = Unknown} in
   let (alloc_mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
@@ -835,7 +838,8 @@ let register_closure_allocation (mode : Value.r) ~loc : Alloc.lr * Value.r =
 (** Register as allocation the expression constrained by the given
     [expected_mode]. Returns the mode of the allocation, and the expected mode
     of potential subcomponents. *)
-let register_allocation ~loc ?desc (expected_mode : expected_mode) =
+let register_allocation ~env ~loc ?desc (expected_mode : expected_mode) =
+  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
   let alloc_mode, mode =
     register_allocation_value_mode ~loc ?desc (as_single_mode expected_mode)
   in
@@ -6201,7 +6205,7 @@ let split_function_ty
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
   let alloc_mode, closed_over_mode =
-    register_closure_allocation ~loc (as_single_mode expected_mode)
+    register_closure_allocation ~env ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
@@ -6383,7 +6387,7 @@ let vb_pat_constraint
   in
   vb.pvb_attributes, spat
 
-let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
+let pat_modes ~env ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
   let pat_mode, exp_mode =
     if force_toplevel
     then simple_pat_mode Value.legacy, mode_legacy
@@ -6408,7 +6412,7 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
          can conservatively use the RHS's comonadic mode as the captured
          environment's mode. *)
       let env_alloc_mode, env_mode =
-        register_allocation ~loc:spat.ppat_loc
+        register_allocation ~env ~loc:spat.ppat_loc
           ~desc:Lpoly_captured_environment exp_mode
       in
       let exp_mode =
@@ -6609,7 +6613,7 @@ and type_expect_
       let alloc_mode, record_mode =
         if is_boxed then
           let alloc_mode, record_mode =
-            register_allocation ~loc expected_mode
+            register_allocation ~env ~loc expected_mode
           in
           Some alloc_mode, record_mode
         else
@@ -7384,7 +7388,7 @@ and type_expect_
           with
             Rpresent (Some ty), Rpresent (Some ty0) ->
               let alloc_mode, argument_mode =
-                register_allocation ~loc expected_mode
+                register_allocation ~env ~loc expected_mode
               in
               let arg =
                 type_argument ~overwrite:No_overwrite env argument_mode sarg ty ty0
@@ -7405,7 +7409,7 @@ and type_expect_
               newvar (Jkind.Builtin.value_or_null ~why:Polymorphic_variant_field)
             in
             let alloc_mode, argument_mode =
-              register_allocation ~loc expected_mode
+              register_allocation ~env ~loc expected_mode
             in
             let arg =
               type_expect env argument_mode sarg (mk_expected ty_expected)
@@ -7466,7 +7470,7 @@ and type_expect_
         match is_float_boxing with
         | true ->
           let alloc_mode, argument_mode =
-            register_allocation ~loc ~desc:Float_projection expected_mode
+            register_allocation ~env ~loc ~desc:Float_projection expected_mode
           in
           let mode = cross_left env Predef.type_unboxed_float mode in
           submode ~loc ~env mode argument_mode;
@@ -7631,7 +7635,9 @@ and type_expect_
         }
         | Immutable -> Immutable
       in
-      let alloc_mode, array_mode = register_allocation ~loc expected_mode in
+      (* CR shsong: rebase - threading [~env] into [register_allocation] here, the
+         site main inlined from the deleted [type_generic_array]. *)
+      let alloc_mode, array_mode = register_allocation ~env ~loc expected_mode in
       let modalities = Typemode.mutable_modalities mutability in
       let is_contained_by : Mode.Hint.is_contained_by =
         {containing = Array Modality; container = (loc, Expression)}
@@ -8471,7 +8477,7 @@ and type_expect_
           if (not (Types.is_atomic label.lbl_mut))
           then raise (Error (loc, env, Label_not_atomic lid.txt));
           let alloc_mode, argument_mode =
-            register_allocation ~loc expected_mode
+            register_allocation ~env ~loc expected_mode
           in
           begin match Mode.Modality.Const.equate label.lbl_modalities
                         (Typemode.atomic_mutable_modalities)
@@ -9828,7 +9834,7 @@ and type_option_some env expected_mode sarg ty ty0 =
   let ty' = extract_option_type env ty in
   let ty0' = extract_option_type env ty0 in
   let alloc_mode, argument_mode =
-    register_allocation ~loc:sarg.pexp_loc ~desc:Optional_argument expected_mode
+    register_allocation ~env ~loc:sarg.pexp_loc ~desc:Optional_argument expected_mode
   in
   let arg = type_argument ~overwrite:No_overwrite env argument_mode sarg ty' ty0' in
   let lid = Longident.Lident "Some" in
@@ -10006,7 +10012,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       unify_exp ~sexp:sarg env {texp with exp_type = ty_fun} ty_expected;
       if args = [] then texp else begin
       let alloc_mode, mode_subcomponent =
-        register_allocation ~loc:sarg.pexp_loc ~desc:Function_coercion mode
+        register_allocation ~env ~loc:sarg.pexp_loc ~desc:Function_coercion mode
       in
       submode ~loc:sarg.pexp_loc ~env ~reason:Other
         exp_mode mode_subcomponent;
@@ -10557,8 +10563,10 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
     | Variant_unboxed | Variant_with_null -> expected_mode, None
     | Variant_boxed _ when constr.cstr_constant -> expected_mode, None
     | Variant_boxed _ | Variant_extensible ->
+       (* CR shsong: rebase conflict - kept main's [~loc:sexp.pexp_loc] and added
+          this commit's [~env]. *)
        let alloc_mode, argument_mode =
-         register_allocation ~loc:sexp.pexp_loc expected_mode
+         register_allocation ~env ~loc:sexp.pexp_loc expected_mode
        in
        argument_mode, Some alloc_mode
   in
@@ -11146,7 +11154,7 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
   in
   let spatl = List.map vb_pat_constraint spat_sexp_list in
   let spatl =
-    List.map (pat_modes ~force_toplevel rec_mode_var ~is_lpoly) spatl
+    List.map (pat_modes ~env ~force_toplevel rec_mode_var ~is_lpoly) spatl
   in
   let attrs_list = List.map (fun (attrs, _, _, _, _) -> attrs) spatl in
   let is_recursive = (rec_flag = Recursive) in
@@ -11584,6 +11592,10 @@ and type_andops env sarg sands expected_sort expected_ty =
   in
   let_arg, sort_let_arg, List.rev rev_ands
 
+(* CR shsong: rebase conflict - main deleted [type_generic_array] (inlined into
+   the [Pexp_array] case in [type_expect_]). Dropped this commit's copy here; this
+   commit's only change to it was threading [~env] into [register_allocation],
+   which is now applied at that inlined call site instead. *)
 and type_expect_mode ~loc ~env ~(modes : Alloc.Const.Option.t) expected_mode =
     let min = Alloc.Const.Option.value ~default:Alloc.Const.min modes |> Const.alloc_as_value in
     let max = Alloc.Const.Option.value ~default:Alloc.Const.max modes |> Const.alloc_as_value in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -821,8 +821,6 @@ let register_allocation_mode ~env ~loc ?(stack = false) alloc_mode =
 let register_allocation_value_mode ~env ~loc ?(stack = false)
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
   let alloc_mode = value_to_alloc_r2g mode in
-  (* CR shsong: rebase conflict - took this commit's [~env ~loc ~stack] call;
-     kept main's morphism comment below. *)
   register_allocation_mode ~env ~loc ~stack alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
@@ -838,10 +836,6 @@ let register_allocation_value_mode ~env ~loc ?(stack = false)
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-(* CR shsong: rebase conflict - this commit centralized the lock-walk into
-   [register_allocation_mode], so dropped the [walk_locks_for_allocation] call
-   the earlier commit had added here; kept main's [let allocation] naming (used
-   below) and added this commit's [?(stack = false)]. *)
 let register_closure_allocation ~env ?(stack = false) (mode : Value.r) ~loc
     : Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
@@ -4939,10 +4933,6 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
   loop ty_fun0 mode_fun rev_args sargs
 
 (* See Note [Type-checking applications] for an overview *)
-(* CR shsong: rebase conflict - main refactored [collect_apply_args] to the
-   [lopt]/[arrow_kind]/[may_warn] structure; kept that and re-applied this
-   commit's [loc] param plus the partial-application allocation check in the
-   [sargs = []] branch. *)
 let collect_apply_args env loc funct ignore_labels ty_fun ty_fun0 mode_fun sargs
       ret_tvar =
   let warned = ref false in
@@ -7672,8 +7662,6 @@ and type_expect_
         }
         | Immutable -> Immutable
       in
-      (* CR shsong: rebase - threading [~env] into [register_allocation] here, the
-         site main inlined from the deleted [type_generic_array]. *)
       let alloc_mode, array_mode = register_allocation ~env ~loc expected_mode in
       let modalities = Typemode.mutable_modalities mutability in
       let is_contained_by : Mode.Hint.is_contained_by =
@@ -8275,8 +8263,6 @@ and type_expect_
              loc, sexp.pexp_attributes) :: body.exp_extra
           }
   | Pexp_pack (m, optyp) ->
-      (* CR shsong: rebase conflict - main rewrote this [Pexp_pack] case; took
-         main's version and preserved the design note below. *)
       (* CR shsong: Design choice: I do not walk locks here but in
          the module-level [register_allocation] in [typemod.ml] *)
       begin match optyp with
@@ -10330,9 +10316,6 @@ and type_application env app_loc expected_mode position_and_mode
             collect_apply_args env app_loc funct ignore_labels ty (instance ty)
               (value_to_alloc_r2l funct_mode) sargs ret_tvar
           in
-          (* CR shsong: rebase conflict - this commit moved the partial-app
-             allocation check into [collect_apply_args]; removed the duplicate
-             here and kept main's example comment. *)
           (* example: [collect_apply_args] returns
              [ty_ret = unit] and
              [args = [(Label "a", Omitted bar);
@@ -10622,9 +10605,6 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
     | Variant_unboxed | Variant_with_null -> expected_mode, None
     | Variant_boxed _ when constr.cstr_constant -> expected_mode, None
     | Variant_boxed _ | Variant_extensible ->
-       (* CR shsong: rebase conflict - kept [~loc:sexp.pexp_loc]; main removed the
-          [loc] param from [type_construct] (now takes [~sexp]), so this commit's
-          plain [~loc] would be unbound. This commit only reformatted here. *)
        let alloc_mode, argument_mode =
          register_allocation ~env ~loc:sexp.pexp_loc expected_mode
        in
@@ -11652,10 +11632,6 @@ and type_andops env sarg sands expected_sort expected_ty =
   in
   let_arg, sort_let_arg, List.rev rev_ands
 
-(* CR shsong: rebase conflict - main deleted [type_generic_array] (inlined into
-   the [Pexp_array] case in [type_expect_]). Dropped this commit's copy here; this
-   commit's only change to it was threading [~env] into [register_allocation],
-   which is now applied at that inlined call site instead. *)
 and type_expect_mode ~loc ~env ~(modes : Alloc.Const.Option.t) expected_mode =
     let min = Alloc.Const.Option.value ~default:Alloc.Const.min modes |> Const.alloc_as_value in
     let max = Alloc.Const.Option.value ~default:Alloc.Const.max modes |> Const.alloc_as_value in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7662,7 +7662,9 @@ and type_expect_
         }
         | Immutable -> Immutable
       in
-      let alloc_mode, array_mode = register_allocation ~env ~loc expected_mode in
+      let alloc_mode, array_mode =
+        register_allocation ~env ~loc expected_mode
+      in
       let modalities = Typemode.mutable_modalities mutability in
       let is_contained_by : Mode.Hint.is_contained_by =
         {containing = Array Modality; container = (loc, Expression)}

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4939,13 +4939,30 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
   loop ty_fun0 mode_fun rev_args sargs
 
 (* See Note [Type-checking applications] for an overview *)
-let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs
+(* CR shsong: rebase conflict - main refactored [collect_apply_args] to the
+   [lopt]/[arrow_kind]/[may_warn] structure; kept that and re-applied this
+   commit's [loc] param plus the partial-application allocation check in the
+   [sargs = []] branch. *)
+let collect_apply_args env loc funct ignore_labels ty_fun ty_fun0 mode_fun sargs
       ret_tvar =
   let warned = ref false in
   let rec loop ty_fun ty_fun0 mode_fun rev_args sargs =
-    if sargs = [] then
+    if sargs = [] then begin
+      (* Allocation axis check: partial application of a function returns
+         an arrow type and allocates *)
+      let ty_fun' = expand_head env ty_fun in
+      let ty_fun_is_arrow =
+        match get_desc ty_fun' with Tarrow _ -> true | _ -> false
+      in
+      (* CR shsong: Alternative design: only register_allocation_mode if
+          partial_app = is_partial_apply untyped_args (where untyped_args
+          are in the return value) is false, since if partial_app is true,
+          there are Omitted args and the code walks the locks already *)
+      if ty_fun_is_arrow then
+        Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
       collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
         ret_tvar
+    end
     else
     let ty_fun' = expand_head env ty_fun in
     let lv = get_level ty_fun' in
@@ -8545,7 +8562,8 @@ and type_expect_
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
   | Pexp_stack e ->
-      (* Allocation axis: suppress the axis lock-walk at the registration site *)
+      (* Allocation axis: suppress the axis lock-walk at the registration
+          site *)
       let expected_stack_mode = mode_strictly_stack expected_mode in
       let exp = type_expect env expected_stack_mode e ty_expected_explained in
       let unsupported category =
@@ -9869,7 +9887,8 @@ and type_option_some env expected_mode sarg ty ty0 =
   let ty' = extract_option_type env ty in
   let ty0' = extract_option_type env ty0 in
   let alloc_mode, argument_mode =
-    register_allocation ~env ~loc:sarg.pexp_loc ~desc:Optional_argument expected_mode
+    register_allocation ~env ~loc:sarg.pexp_loc ~desc:Optional_argument
+      expected_mode
   in
   let arg = type_argument ~overwrite:No_overwrite env argument_mode sarg ty' ty0' in
   let lid = Longident.Lident "Some" in
@@ -10308,26 +10327,17 @@ and type_application env app_loc expected_mode position_and_mode
             (fun (label, e) -> Typetexp.transl_label_from_expr label e) sargs
           in
           let ty_ret, mode_ret, untyped_args =
-            collect_apply_args env funct ignore_labels ty (instance ty)
+            collect_apply_args env app_loc funct ignore_labels ty (instance ty)
               (value_to_alloc_r2l funct_mode) sargs ret_tvar
           in
-          (* CR shsong: rebase conflict - kept both main's example comment and
-             this commit's arrow-check allocation registration. *)
+          (* CR shsong: rebase conflict - this commit moved the partial-app
+             allocation check into [collect_apply_args]; removed the duplicate
+             here and kept main's example comment. *)
           (* example: [collect_apply_args] returns
              [ty_ret = unit] and
              [args = [(Label "a", Omitted bar);
                       (Optional "opt", Arg (Eliminated_optional_arg baz));
                       (Nolabel, Arg (Known_arg n))]] *)
-          let ty_ret_is_arrow =
-            match get_desc (expand_head env ty_ret) with
-            | Tarrow _ -> true
-            | _ -> false
-          in
-          (* CR shsong: Alternative design: only register_allocation_mode if
-              partial_app is false, since if partial_app is true, there are
-              Omitted args and the code walks the locks already *)
-          if ty_ret_is_arrow then
-            Env.walk_locks_for_allocation ~env (app_loc, Hint.Allocation);
           let partial_app = is_partial_apply untyped_args in
           let position_and_mode =
             if partial_app then position_and_mode_default else position_and_mode
@@ -10612,8 +10622,9 @@ and type_construct ~overwrite ~sexp env (expected_mode : expected_mode) lid sarg
     | Variant_unboxed | Variant_with_null -> expected_mode, None
     | Variant_boxed _ when constr.cstr_constant -> expected_mode, None
     | Variant_boxed _ | Variant_extensible ->
-       (* CR shsong: rebase conflict - kept main's [~loc:sexp.pexp_loc] and added
-          this commit's [~env]. *)
+       (* CR shsong: rebase conflict - kept [~loc:sexp.pexp_loc]; main removed the
+          [loc] param from [type_construct] (now takes [~sexp]), so this commit's
+          plain [~loc] would be unbound. This commit only reformatted here. *)
        let alloc_mode, argument_mode =
          register_allocation ~env ~loc:sexp.pexp_loc expected_mode
        in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -10299,11 +10299,22 @@ and type_application env app_loc expected_mode position_and_mode
             collect_apply_args env funct ignore_labels ty (instance ty)
               (value_to_alloc_r2l funct_mode) sargs ret_tvar
           in
+          (* CR shsong: rebase conflict - kept both main's example comment and
+             this commit's arrow-check allocation registration. *)
           (* example: [collect_apply_args] returns
              [ty_ret = unit] and
              [args = [(Label "a", Omitted bar);
                       (Optional "opt", Arg (Eliminated_optional_arg baz));
                       (Nolabel, Arg (Known_arg n))]] *)
+          let ty_ret_is_arrow =
+            match get_desc (expand_head env ty_ret) with
+            | Tarrow _ -> true
+            | _ -> false
+          in
+          (* CR shsong: Alternative design: only register_allocation_mode if
+              partial_app is false, since if partial_app is true, there are
+              Omitted args and the code walks the locks already *)
+          if ty_ret_is_arrow then register_allocation_mode ~env ~loc:app_loc mode_ret;
           let partial_app = is_partial_apply untyped_args in
           let position_and_mode =
             if partial_app then position_and_mode_default else position_and_mode

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -450,6 +450,12 @@ type expected_mode =
     (** True iff this expression is the direct operand of [stack_].
     Suppresses the allocation-axis lock-walk for its top allocation. *)
 
+    (* CR shsong: An alternative design is to unify strictly_local and
+    strictly_stack. Specifically, we want to set strictly_local when
+    [stack_] keyword is used, so that we can use strictly_local and remove
+    strictly_stack. However, if we do that, there would be uncaught exception
+    in Test 5h in test typing-modes/zero_alloc.ml. We will review this later. *)
+
     tuple_modes : (Value.r * Location.t) list option;
     (** No invariant between this and [mode]. It is UNSOUND to ignore this
         field. If this is [Some [x0; x1; ..]]:
@@ -578,8 +584,7 @@ let mode_morph f expected_mode =
   let mode = as_single_mode expected_mode in
   let mode = f mode |> Mode.Value.disallow_left in
   let tuple_modes = None in
-  { expected_mode with mode; tuple_modes;
-    strictly_stack = false (* strictly_stack does not affect children *) }
+  { expected_mode with mode; tuple_modes }
 
 (** Similiar to [apply_left_is_contained_by] but for [expected_mode]. *)
 let mode_is_contained_by is_contained_by ?modalities expected_mode =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8168,6 +8168,10 @@ and type_expect_
       let to_unify = Predef.type_lazy_t ty in
       with_explanation (fun () ->
         unify_exp_types loc env to_unify (generic_instance ty_expected));
+      (* Allocation axis check: constructing a lazy block allocates, but
+         register_allocation_mode is not called, so we manually
+         walk locks here *)
+      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
       let env = Env.add_closure_lock (loc, Lazy) closure_mode.comonadic env in
       let arg = type_expect env expected_mode e (mk_expected ty) in
       re {
@@ -8180,6 +8184,10 @@ and type_expect_
   | Pexp_object s ->
       Env.check_no_open_quotations loc env Object_qt;
       submode ~loc ~env Value.legacy expected_mode;
+      (* Allocation axis check: constructing an object block allocates,
+         but register_allocation_mode is not called, so we manually
+         walk locks here *)
+      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
       let desc, meths = !type_object env loc s in
       rue {
         exp_desc = Texp_object (desc, meths);
@@ -8250,6 +8258,10 @@ and type_expect_
              loc, sexp.pexp_attributes) :: body.exp_extra
           }
   | Pexp_pack (m, optyp) ->
+      (* CR shsong: rebase conflict - main rewrote this [Pexp_pack] case; took
+         main's version and preserved the design note below. *)
+      (* CR shsong: Design choice: I do not walk locks here but in
+         the module-level [register_allocation] in [typemod.ml] *)
       begin match optyp with
       | Some ptyp ->
         let t = Ast_helper.Typ.package ~loc:ptyp.ppt_loc ptyp in
@@ -10314,7 +10326,8 @@ and type_application env app_loc expected_mode position_and_mode
           (* CR shsong: Alternative design: only register_allocation_mode if
               partial_app is false, since if partial_app is true, there are
               Omitted args and the code walks the locks already *)
-          if ty_ret_is_arrow then register_allocation_mode ~env ~loc:app_loc mode_ret;
+          if ty_ret_is_arrow then
+            Env.walk_locks_for_allocation ~env (app_loc, Hint.Allocation);
           let partial_app = is_partial_apply untyped_args in
           let position_and_mode =
             if partial_app then position_and_mode_default else position_and_mode
@@ -11916,6 +11929,10 @@ and type_comprehension_expr ~loc ~env ~ty_expected ~attributes cexpr =
        "What modes should comprehensions use?", above *)
     type_expect new_env mode_legacy sbody (mk_expected element_ty)
   in
+  (* Allocation axis check: comprehension expr allocates, but
+    register_allocation_mode is not called, so we manually
+    walk locks here *)
+  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
   re { exp_desc       = make_texp { comp_body ; comp_clauses }
      ; exp_loc        = loc
      ; exp_extra      = []

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -115,7 +115,11 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value);
   mode
 
-let register_allocation loc : Alloc.lr * Value.lr =
+(* CR shsong: rebase conflict - main also added a [loc] param here; took this
+   commit's labeled [~env ~loc] signature plus the lock-walk (a superset of
+   main's), and used labeled callers below. *)
+let register_allocation ~env ~loc : Alloc.lr * Value.lr =
+  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
   let upper_bound =
     Alloc.of_const
       ~hint_comonadic:Module_allocated_on_heap
@@ -3184,7 +3188,9 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
       md, shape
   | Pmod_functor(arg_opt, sbody) ->
       let alloc_mode, closed_over_mode =
-        register_allocation sbody.pmod_loc
+        (* CR shsong: rebase conflict - used this commit's [~env ~loc:smod.pmod_loc];
+           main passed [sbody.pmod_loc] instead - confirm which loc is wanted. *)
+        register_allocation ~env ~loc:smod.pmod_loc
       in
       let newenv =
         Env.add_closure_lock
@@ -3645,7 +3651,8 @@ and type_open_decl_aux ?used_slot ?toplevel ~funct_body names env od =
 and type_structure ?(toplevel = None) ~funct_body anchor env sstr =
   let names = Signature_names.create () in
   let loc_md = location_of_structure sstr in
-  let _, md_mode = register_allocation loc_md in
+  (* CR shsong: rebase conflict - same [loc_md]; took this commit's [~env ~loc]. *)
+  let _, md_mode = register_allocation ~env ~loc:loc_md in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
     let smodl = sincl.pincl_mod in
@@ -4311,7 +4318,8 @@ let type_package env m pack =
         let lid = Longident.unflatten n |> Option.get in
         raise (Error(modl.mod_loc, env, Scoping_pack (lid,ty))))
     fl';
-  let _, mode = register_allocation modl.mod_loc in
+  (* CR shsong: rebase conflict - same [modl.mod_loc]; took this commit's [~env ~loc]. *)
+  let _, mode = register_allocation ~env ~loc:modl.mod_loc in
   let modl =
     wrap_constraint_package env true modl mty mode Tmodtype_implicit
   in

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -115,9 +115,6 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   Value.submode_exn mode (max |> Alloc.of_const |> alloc_as_value);
   mode
 
-(* CR shsong: rebase conflict - main also added a [loc] param here; took this
-   commit's labeled [~env ~loc] signature plus the lock-walk (a superset of
-   main's), and used labeled callers below. *)
 let register_allocation ~env ~loc : Alloc.lr * Value.lr =
   Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
   let upper_bound =
@@ -3188,9 +3185,7 @@ and type_module_aux ~alias ~hold_locks ~strengthen ~funct_body anchor env
       md, shape
   | Pmod_functor(arg_opt, sbody) ->
       let alloc_mode, closed_over_mode =
-        (* CR shsong: rebase conflict - used this commit's [~env ~loc:smod.pmod_loc];
-           main passed [sbody.pmod_loc] instead - confirm which loc is wanted. *)
-        register_allocation ~env ~loc:smod.pmod_loc
+        register_allocation ~env ~loc:sbody.pmod_loc
       in
       let newenv =
         Env.add_closure_lock
@@ -3651,7 +3646,6 @@ and type_open_decl_aux ?used_slot ?toplevel ~funct_body names env od =
 and type_structure ?(toplevel = None) ~funct_body anchor env sstr =
   let names = Signature_names.create () in
   let loc_md = location_of_structure sstr in
-  (* CR shsong: rebase conflict - same [loc_md]; took this commit's [~env ~loc]. *)
   let _, md_mode = register_allocation ~env ~loc:loc_md in
 
   let type_str_include ~loc env shape_map sincl sig_acc =
@@ -4318,7 +4312,6 @@ let type_package env m pack =
         let lid = Longident.unflatten n |> Option.get in
         raise (Error(modl.mod_loc, env, Scoping_pack (lid,ty))))
     fl';
-  (* CR shsong: rebase conflict - same [modl.mod_loc]; took this commit's [~env ~loc]. *)
   let _, mode = register_allocation ~env ~loc:modl.mod_loc in
   let modl =
     wrap_constraint_package env true modl mty mode Tmodtype_implicit


### PR DESCRIPTION
- Detect all kinds of possible heap allocation to determine mode for the Allocation mode axis
- Distinguish stack allocations marked by `stack_` from others - these stack allocations do not force the closure's mode to be alloc
- Handle corner cases conservatively: (1) `Prim_poly` primitives; (2) multi-argument (curried) function definitions; (3) empty/non-capturing functors


Testing
-------
Add more tests in `testsuite/tests/typing-modes/zero_alloc.ml`
- If a closure contains any kind of allocation, the closure is forced to be alloc
- Allocation mode axis check skips stack allocations (marked by `stack_`)
- Test several special cases that are handled conservatively