### PR TITLE
Add `int64_u`, `int32_u`, and `nativeint_u` to predef

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2483,6 +2483,9 @@ let type_for_path loc env = function
         | "nativeint#" -> Identifier.Type.unboxed_nativeint
         | "int32#" -> Identifier.Type.unboxed_int32
         | "int64#" -> Identifier.Type.unboxed_int64
+        | "nativeint_u" -> Identifier.Type.unboxed_nativeint
+        | "int32_u" -> Identifier.Type.unboxed_int32
+        | "int64_u" -> Identifier.Type.unboxed_int64
         | "int8x16" -> Identifier.Type.int8x16
         | "int16x8" -> Identifier.Type.int16x8
         | "int32x4" -> Identifier.Type.int32x4

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -2,35 +2,35 @@
   (empty_cases_returning_string/280 =
      (function {nlocal = 0} param/282?
        (raise
-         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 28 50])))
+         (makeblock 0 (getpredef Match_failure/56!!) [0: "test.ml" 28 50])))
    empty_cases_returning_float64/283 =
      (function {nlocal = 0} param/285? : unboxed_float
        (raise
-         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 29 50])))
+         (makeblock 0 (getpredef Match_failure/56!!) [0: "test.ml" 29 50])))
    empty_cases_accepting_string/286 =
      (function {nlocal = 0} param/288?
        (raise
-         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 30 50])))
+         (makeblock 0 (getpredef Match_failure/56!!) [0: "test.ml" 30 50])))
    empty_cases_accepting_float64/289 =
      (function {nlocal = 0} param/291[float]
        (raise
-         (makeblock 0 (getpredef Match_failure/53!!) [0: "test.ml" 31 50])))
+         (makeblock 0 (getpredef Match_failure/56!!) [0: "test.ml" 31 50])))
    non_empty_cases_returning_string/292 =
      (function {nlocal = 0} param/294
        (raise
-         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 32 68])))
+         (makeblock 0 (getpredef Assert_failure/67!!) [0: "test.ml" 32 68])))
    non_empty_cases_returning_float64/295 =
      (function {nlocal = 0} param/297 : unboxed_float
        (raise
-         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 33 68])))
+         (makeblock 0 (getpredef Assert_failure/67!!) [0: "test.ml" 33 68])))
    non_empty_cases_accepting_string/298 =
      (function {nlocal = 0} param/300
        (raise
-         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 34 68])))
+         (makeblock 0 (getpredef Assert_failure/67!!) [0: "test.ml" 34 68])))
    non_empty_cases_accepting_float64/301 =
      (function {nlocal = 0} param/303[float]
        (raise
-         (makeblock 0 (getpredef Assert_failure/64!!) [0: "test.ml" 35 68]))))
+         (makeblock 0 (getpredef Assert_failure/67!!) [0: "test.ml" 35 68]))))
   (makeblock 0 empty_cases_returning_string/280
     empty_cases_returning_float64/283 empty_cases_accepting_string/286
     empty_cases_accepting_float64/289 non_empty_cases_returning_string/292

--- a/testsuite/tests/typing-layouts/renamed_unboxed_numbers.ml
+++ b/testsuite/tests/typing-layouts/renamed_unboxed_numbers.ml
@@ -1,0 +1,21 @@
+(* TEST
+ expect;
+*)
+
+let nativeint (x : nativeint_u) : nativeint# = x
+let int32 (x : int32_u) : int32# = x
+let int64 (x : int64_u) : int64# = x
+[%%expect{|
+val nativeint : nativeint_u -> nativeint# = <fun>
+val int32 : int32_u -> int32# = <fun>
+val int64 : int64_u -> int64# = <fun>
+|}]
+
+type nativeint_u_kind : word = nativeint_u
+type int32_u_kind : bits32 = int32_u
+type int64_u_kind : bits64 = int64_u
+[%%expect{|
+type nativeint_u_kind = nativeint_u
+type int32_u_kind = int32_u
+type int64_u_kind = int64_u
+|}]

--- a/testsuite/tests/typing-simd/test_disabled.ml
+++ b/testsuite/tests/typing-simd/test_disabled.ml
@@ -27,7 +27,7 @@ Line 1, characters 9-16:
 1 | type t = int32x4;;
              ^^^^^^^
 Error: Unbound type constructor "int32x4"
-Hint:              Did you mean "int32"?
+Hint:              Did you mean "int32" or "int32_u"?
 |}];;
 
 type t = int64x2;;
@@ -36,7 +36,7 @@ Line 1, characters 9-16:
 1 | type t = int64x2;;
              ^^^^^^^
 Error: Unbound type constructor "int64x2"
-Hint:              Did you mean "int64"?
+Hint:              Did you mean "int64" or "int64_u"?
 |}];;
 
 type t = float32x4;;

--- a/testsuite/tests/typing-simd/test_upstream_compatible.ml
+++ b/testsuite/tests/typing-simd/test_upstream_compatible.ml
@@ -26,7 +26,7 @@ Line 1, characters 9-16:
 1 | type t = int32x4;;
              ^^^^^^^
 Error: Unbound type constructor "int32x4"
-Hint:              Did you mean "int32"?
+Hint:              Did you mean "int32" or "int32_u"?
 |}];;
 
 type t = int64x2;;
@@ -35,7 +35,7 @@ Line 1, characters 9-16:
 1 | type t = int64x2;;
              ^^^^^^^
 Error: Unbound type constructor "int64x2"
-Hint:              Did you mean "int64"?
+Hint:              Did you mean "int64" or "int64_u"?
 |}];;
 
 type t = float32x4;;

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -58,6 +58,9 @@ type abstract_type_constr = [
   | `Int16
 ]
 type abstract_non_value_type_constr = [
+  | `Nativeint_u
+  | `Int32_u
+  | `Int64_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -121,6 +124,9 @@ let base_type_constrs : type_constr list = [
   `Atomic_loc;
   `Lexing_position;
   `Box;
+  `Nativeint_u;
+  `Int32_u;
+  `Int64_u;
   `Idx_imm;
   `Idx_mut;
 ]
@@ -210,6 +216,9 @@ and ident_code = ident_create "expr"
 and ident_eval = ident_create "eval"
 and ident_box = ident_create "box"
 
+and ident_nativeint_u = ident_create "nativeint_u"
+and ident_int32_u = ident_create "int32_u"
+and ident_int64_u = ident_create "int64_u"
 and ident_or_null = ident_create "or_null"
 and ident_idx_imm = ident_create "idx_imm"
 and ident_idx_mut = ident_create "idx_mut"
@@ -265,6 +274,9 @@ let ident_of_type_constr : type_constr -> Ident.t = function
   | `Float32 -> ident_float32
   | `Int8 -> ident_int8
   | `Int16 -> ident_int16
+  | `Nativeint_u -> ident_nativeint_u
+  | `Int32_u -> ident_int32_u
+  | `Int64_u -> ident_int64_u
   | `Idx_imm -> ident_idx_imm
   | `Idx_mut -> ident_idx_mut
   | `Int8x16 -> ident_int8x16
@@ -315,6 +327,9 @@ and path_floatarray = Pident ident_floatarray
 and path_iarray = Pident ident_iarray
 and path_atomic_loc = Pident ident_atomic_loc
 and path_lexing_position = Pident ident_lexing_position
+and path_nativeint_u = Pident ident_nativeint_u
+and path_int32_u = Pident ident_int32_u
+and path_int64_u = Pident ident_int64_u
 and path_idx_imm = Pident ident_idx_imm
 and path_idx_mut = Pident ident_idx_mut
 and path_code = Pident ident_code
@@ -421,6 +436,9 @@ and type_unboxed_char = tconstr path_unboxed_char []
 and type_unboxed_int = tconstr path_unboxed_int []
 and type_unboxed_int8 = tconstr path_unboxed_int8 []
 and type_unboxed_int16 = tconstr path_unboxed_int16 []
+and type_nativeint_u = tconstr path_nativeint_u []
+and type_int32_u = tconstr path_int32_u []
+and type_int64_u = tconstr path_int64_u []
 and type_or_null t = tconstr path_or_null [t]
 and type_idx_imm t1 t2 = tconstr path_idx_imm [t1; t2]
 and type_idx_mut t1 t2 = tconstr path_idx_mut [t1; t2]
@@ -595,13 +613,14 @@ let or_null_kind tvar =
       cstr ident_this [unrestricted tvar or_null_argument_sort]] in
   Type_variant (cstrs, Variant_with_null, None)
 
-let decl_of_type_constr tconstr =
-  let type_ident = ident_of_type_constr tconstr in
+let decl_of_type_constr type_constr =
+  let type_ident = ident_of_type_constr type_constr in
   let type_uid = Uid.of_predef_id type_ident in
   let decl0
       ?(kind = Type_abstract Definition)
       ~(jkind : jkind_l)
       ?(unboxed_jkind : Jkind.Const.Builtin.t option)
+      ?manifest
       ()
     =
     let type_unboxed_version = match unboxed_jkind with
@@ -644,7 +663,7 @@ let decl_of_type_constr tconstr =
      type_ikind;
      type_loc = Location.none;
      type_private = Asttypes.Public;
-     type_manifest = None;
+     type_manifest = manifest;
      type_variance = [];
      type_separability = [];
      type_is_newtype = false;
@@ -735,7 +754,7 @@ let decl_of_type_constr tconstr =
       ~why:(Type_argument {parent_path = Path.Pident type_ident;
                            position = 2; arity = 2}))
   in
-  match tconstr with
+  match type_constr with
   | `Int ->
     decl0 ~jkind:(builtin Jkind.Const.Builtin.immediate)
        ~unboxed_jkind:Jkind.Const.Builtin.kind_of_untagged_int ()
@@ -852,6 +871,15 @@ let decl_of_type_constr tconstr =
       ~param_jkind:value_param_jkind
       ~jkind:(fun _ -> Jkind.for_non_float ~why:(Primitive ident_lazy_t))
       ()
+  | `Nativeint_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_nativeint)
+      ~manifest:(tconstr (Path.unboxed_version path_nativeint) []) ()
+  | `Int32_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int32)
+      ~manifest:(tconstr (Path.unboxed_version path_int32) []) ()
+  | `Int64_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int64)
+      ~manifest:(tconstr (Path.unboxed_version path_int64) []) ()
   | `Idx_imm ->
     decl2 ~variance:(Variance.full, Variance.covariant)
        ~param_jkinds:(

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -42,6 +42,9 @@ type abstract_type_constr = [
   | `Int16
 ]
 type abstract_non_value_type_constr = [
+  | `Nativeint_u
+  | `Int32_u
+  | `Int64_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -120,6 +123,9 @@ val type_unboxed_int8: type_expr
 val type_unboxed_int16: type_expr
 val type_unboxed_int32:type_expr
 val type_unboxed_int64:type_expr
+val type_nativeint_u: type_expr
+val type_int32_u: type_expr
+val type_int64_u: type_expr
 val type_or_null: type_expr -> type_expr
 val type_idx_imm : type_expr -> type_expr -> type_expr
 val type_idx_mut : type_expr -> type_expr -> type_expr
@@ -208,6 +214,9 @@ val path_unboxed_int8: Path.t
 val path_unboxed_int16: Path.t
 val path_unboxed_int32: Path.t
 val path_unboxed_int64: Path.t
+val path_nativeint_u: Path.t
+val path_int32_u: Path.t
+val path_int64_u: Path.t
 val path_or_null: Path.t
 val path_idx_imm: Path.t
 val path_idx_mut: Path.t


### PR DESCRIPTION
Add the following types to the predef.
```ocaml
type int64_u = int64#
type int32_u = int32#
type nativeint_u = nativeint#
```

In the future, these types will be abstract, and we will delete `int64#`, `int32#`, and `nativeint#`, as they are not "truly" unboxed versions of `int64`, `int32`, and `nativeint` (which are custom blocks and thus should not have unboxed versions).

**For review.** In `predef.ml`, we rename the parameter `tconstr` so it doesn't shadow the top-level function of the same name.