### PR TITLE
Force make to notice when the runtime changes

### DIFF
--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -6,6 +6,16 @@ ws_boot   = --root=. --workspace=duneconf/boot.ws
 ws_runstd = --root=. --workspace=duneconf/runtime_stdlib.ws
 ws_main   = --root=. --workspace=duneconf/main.ws
 
+# Native executables built in the main workspace link the runtime archive
+# (libasmrun.a) via Load_path from a separate workspace's install dir, so dune
+# cannot track it as a dependency and would not relink them when the runtime C
+# code changes. We pass its digest in RUNTIME_STAMP to every main-workspace
+# dune invocation below, and the affected executables depend on it via
+# (link_deps (env_var RUNTIME_STAMP)). Must be '=' (expanded at recipe time).
+runtime_stamp = RUNTIME_STAMP="$$(md5sum \
+  _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/libasmrun.a \
+  | cut -d' ' -f1)"
+
 ifeq ($(coverage),yes)
   coverage_dune_flags=--instrument-with bisect_ppx
   ocaml_subdirs_to_ignore=otherlibs
@@ -110,7 +120,8 @@ runtime-stdlib-hacking: boot-compiler
 	$(dune) build -w $(ws_runstd) --only-package=ocaml_runtime_stdlib @install
 
 compiler: runtime-stdlib
-	SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
+	$(runtime_stamp) \
+          SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
           ASPP="$(ASPP)" ASPPFLAGS="$(ASPPFLAGS)" \
           $(dune) build $(ws_main) \
           --only-package=ocaml @install \
@@ -126,7 +137,8 @@ compiler: runtime-stdlib
 
 .PHONY: minimize-failure
 minimize-failure: boot-minimizer boot-compiler runtime-stdlib
-	SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
+	$(runtime_stamp) \
+          SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
           ASPP="$(ASPP)" ASPPFLAGS="$(ASPPFLAGS)" \
           ./_build/default/chamelon/chamelon.exe dune build \
           $(ws_main) \
@@ -151,13 +163,20 @@ minimize-stdlib: boot-minimizer boot-compiler
 # and implement [runtest-upstream-boot] for testing when the final compiler
 # itself is miscompiled.
 runtest: compiler
-	OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) OXCAML_POLL_INSERTION=$(POLL_INSERTION) $(dune) runtest $(ws_main)
+	$(runtime_stamp) \
+          OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) \
+          OXCAML_POLL_INSERTION=$(POLL_INSERTION) \
+          $(dune) runtest $(ws_main)
 
 runtest-llvmize: compiler
-	OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) $(dune) build @runtest-llvmize $(ws_main)
+	$(runtime_stamp) \
+          OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) \
+          $(dune) build @runtest-llvmize $(ws_main)
 
 runtest-dwarf: compiler
-	OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) $(dune) build @runtest-dwarf $(ws_main)
+	$(runtime_stamp) \
+          OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) \
+          $(dune) build @runtest-dwarf $(ws_main)
 
 # This Makefile supports old versions that don't have $(file), so we're using
 # environment var trickery to get a multiline string into a file
@@ -487,7 +506,7 @@ hacking-emacs-builder: _build/_bootinstall
 
 .PHONY: debug-printers
 debug-printers: runtime-stdlib # required for $(ws_main) to work
-	 $(dune) build $(ws_main) $(ocamldir)/tools/debug_printers
+	 $(runtime_stamp) $(dune) build $(ws_main) $(ocamldir)/tools/debug_printers
 	@echo
 	@echo To load into ocamldebug, use:
 	@echo source \"$$(realpath _build/main/$(ocamldir)/tools/debug_printers)\"

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -6,6 +6,16 @@ ws_boot   = --root=. --workspace=duneconf/boot.ws
 ws_runstd = --root=. --workspace=duneconf/runtime_stdlib.ws
 ws_main   = --root=. --workspace=duneconf/main.ws
 
+# Native executables built in the main workspace link the runtime archive
+# (libasmrun.a) via Load_path from a separate workspace's install dir, so dune
+# cannot track it as a dependency and would not relink them when the runtime C
+# code changes. We pass its digest in RUNTIME_STAMP to every main-workspace
+# dune invocation below, and the affected executables depend on it via
+# (link_deps (env_var RUNTIME_STAMP)). Must be '=' (expanded at recipe time).
+runtime_stamp = RUNTIME_STAMP="$$(md5sum \
+  _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/libasmrun.a \
+  | cut -d' ' -f1)"
+
 ifeq ($(coverage),yes)
   coverage_dune_flags=--instrument-with bisect_ppx
   ocaml_subdirs_to_ignore=otherlibs
@@ -115,7 +125,8 @@ runtime-stdlib-hacking: boot-compiler
 	$(dune) build -w $(ws_runstd) --only-package=ocaml_runtime_stdlib @install
 
 compiler: runtime-stdlib
-	SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
+	$(runtime_stamp) \
+          SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
           ASPP="$(ASPP)" ASPPFLAGS="$(ASPPFLAGS)" \
           $(dune) build $(ws_main) \
           --only-package=ocaml @install \
@@ -131,7 +142,8 @@ compiler: runtime-stdlib
 
 .PHONY: minimize-failure
 minimize-failure: boot-minimizer boot-compiler runtime-stdlib
-	SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
+	$(runtime_stamp) \
+          SYSTEM=$(SYSTEM) MODEL=$(MODEL) \
           ASPP="$(ASPP)" ASPPFLAGS="$(ASPPFLAGS)" \
           ./_build/default/chamelon/chamelon.exe dune build \
           $(ws_main) \
@@ -164,13 +176,20 @@ runtest_targets := $(sort $(addprefix @, $(addsuffix runtest, $(filter-out autom
 # and implement [runtest-upstream-boot] for testing when the final compiler
 # itself is miscompiled.
 runtest: compiler
-	OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) OXCAML_POLL_INSERTION=$(POLL_INSERTION) $(dune) build $(ws_main) $(runtest_targets)
+	$(runtime_stamp) \
+          OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) \
+          OXCAML_POLL_INSERTION=$(POLL_INSERTION) \
+          $(dune) build $(ws_main) $(runtest_targets)
 
 runtest-llvmize: compiler
-	OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) $(dune) build @runtest-llvmize $(ws_main)
+	$(runtime_stamp) \
+          OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) \
+          $(dune) build @runtest-llvmize $(ws_main)
 
 runtest-dwarf: compiler
-	OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) $(dune) build @runtest-dwarf $(ws_main)
+	$(runtime_stamp) \
+          OXCAML_NAME_MANGLING=$(NAME_MANGLING_SCHEME) \
+          $(dune) build @runtest-dwarf $(ws_main)
 
 # This Makefile supports old versions that don't have $(file), so we're using
 # environment var trickery to get a multiline string into a file
@@ -497,7 +516,7 @@ hacking-emacs-builder: _build/_bootinstall
 
 .PHONY: debug-printers
 debug-printers: runtime-stdlib # required for $(ws_main) to work
-	 $(dune) build $(ws_main) $(ocamldir)/tools/debug_printers
+	 $(runtime_stamp) $(dune) build $(ws_main) $(ocamldir)/tools/debug_printers
 	@echo
 	@echo To load into ocamldebug, use:
 	@echo source \"$$(realpath _build/main/$(ocamldir)/tools/debug_printers)\"

--- a/dune
+++ b/dune
@@ -404,6 +404,8 @@
  (flags
   (:standard -strict-sequence -w +67 -bin-annot -safe-string -strict-formats))
  (libraries ocamlbytecomp ocamlcommon)
+ ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+ (link_deps (env_var RUNTIME_STAMP))
  (modules main_native))
 
 (library
@@ -805,6 +807,12 @@
   (backend bisect_ppx))
  (ocamlopt_flags
   (:standard -runtime-variant nnp))
+ ; The native runtime archive (libasmrun.a) is built in a separate dune
+ ; workspace and supplied to the linker via Load_path/OCAMLLIB, so dune cannot
+ ; see it as a dependency and would not relink the compiler when the runtime C
+ ; changes. The Makefile's `compiler` target passes the archive's digest in
+ ; RUNTIME_STAMP; depending on that env var forces a relink when it changes.
+ (link_deps (env_var RUNTIME_STAMP))
  (libraries
   memtrace
   flambda2

--- a/dune
+++ b/dune
@@ -408,6 +408,8 @@
  (flags
   (:standard -strict-sequence -w +67 -bin-annot -safe-string -strict-formats))
  (libraries ocamlbytecomp ocamlfrontend)
+ ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+ (link_deps (env_var RUNTIME_STAMP))
  (modules main_native))
 
 (library
@@ -819,6 +821,12 @@
   (backend bisect_ppx))
  (ocamlopt_flags
   (:standard -runtime-variant nnp))
+ ; The native runtime archive (libasmrun.a) is built in a separate dune
+ ; workspace and supplied to the linker via Load_path/OCAMLLIB, so dune cannot
+ ; see it as a dependency and would not relink the compiler when the runtime C
+ ; changes. The Makefile's `compiler` target passes the archive's digest in
+ ; RUNTIME_STAMP; depending on that env var forces a relink when it changes.
+ (link_deps (env_var RUNTIME_STAMP))
  (libraries
   memtrace
   flambda2

--- a/middle_end/flambda2/tests/tools/dune
+++ b/middle_end/flambda2/tests/tools/dune
@@ -1,6 +1,8 @@
 (executables
   (names fldiff fexprc roundtrip)
   (modes native)
+  ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+  (link_deps (env_var RUNTIME_STAMP))
   (libraries
    ocamlcommon ocamloptcomp
    flambda2 flambda2_compare flambda2_parser flambda2_terms flambda2_cmx))

--- a/middle_end/flambda2/tests/tools/dune
+++ b/middle_end/flambda2/tests/tools/dune
@@ -1,6 +1,8 @@
 (executables
   (names fldiff fexprc roundtrip)
   (modes native)
+  ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+  (link_deps (env_var RUNTIME_STAMP))
   (libraries
    ocamlfrontend ocamloptcomp
    flambda2 flambda2_compare flambda2_parser flambda2_terms flambda2_cmx))

--- a/oxcaml/testsuite/tools/dune
+++ b/oxcaml/testsuite/tools/dune
@@ -16,6 +16,8 @@
  (modes native)
  (libraries expectcommon ocamlopttoplevel)
  (flags (:standard -linkall))
+ ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+ (link_deps (env_var RUNTIME_STAMP))
  (modules expectnat))
 
 (ocamllex
@@ -28,6 +30,8 @@
  (name codegen_main)
  (modes native)
  (libraries ocamlcommon ocamloptcomp unix)
+ ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+ (link_deps (env_var RUNTIME_STAMP))
  (modules codegen_main lexcmm parsecmm parsecmmaux))
 
 (rule

--- a/oxcaml/testsuite/tools/dune
+++ b/oxcaml/testsuite/tools/dune
@@ -16,6 +16,8 @@
  (modes native)
  (libraries expectcommon ocamlopttoplevel)
  (flags (:standard -linkall))
+ ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+ (link_deps (env_var RUNTIME_STAMP))
  (modules expectnat))
 
 (ocamllex
@@ -28,6 +30,8 @@
  (name codegen_main)
  (modes native)
  (libraries ocamlfrontend ocamloptcomp unix)
+ ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+ (link_deps (env_var RUNTIME_STAMP))
  (modules codegen_main lexcmm parsecmm parsecmmaux))
 
 (rule

--- a/tools/regalloc/dune
+++ b/tools/regalloc/dune
@@ -3,4 +3,6 @@
  (modes native)
  (flags
   (:standard -w +a-30-40-41-42))
+ ; Relink on native-runtime change (RUNTIME_STAMP; see Makefile.common-ox).
+ (link_deps (env_var RUNTIME_STAMP))
  (libraries ocamloptcomp))


### PR DESCRIPTION
At present, if I change a runtime file and then `make install` (or whatever) then the runtime changes don't make it into the rebuild. I complained to Claude and it made this plausible fix, which needs review from someone who understands the history of the Dune/Make interactions.