### PR TITLE
Untag max_frames in caml_get_continuation_callstack

### DIFF
--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -280,7 +280,7 @@ CAMLprim value caml_get_continuation_callstack (value cont, value max_frames)
   stack = Ptr_val(caml_continuation_use(cont));
   {
     CAMLnoalloc;
-    slots = get_callstack(stack, max_frames, -1,
+    slots = get_callstack(stack, Long_val(max_frames), -1,
                           &trace, &trace_size);
     caml_continuation_replace(cont, stack);
   }


### PR DESCRIPTION
`Effect.Deep.get_callstack k n` (and the `Shallow` variant) is documented to return at most `n` frames. `caml_get_continuation_callstack` passed the OCaml `max_frames` argument to `get_callstack` without `Long_val`, so the runtime saw the tagged value `2n+1` instead of `n` and could return up to `2n+1` frames. The sibling `caml_get_current_callstack` applies `Long_val`; this restores parity.

Includes a regression test.

Candidate for [upstreaming](https://github.com/ocaml/ocaml/blob/9945953832465d3355ccfc908edffe3d323e4f8e/runtime/backtrace_nat.c#L259).

Bug found by Claude; this bug-fix and test written by Claude and reviewed by me.