### PR TITLE
atomic release-store forwarding pointers in minor GC

### DIFF
--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -312,7 +312,12 @@ Caml_inline value try_promote(value v, volatile value *p, header_t hd,
   }
 
   st->live_bytes += Bhsize_hd(hd);
-  *p = result + infix_offset;
+  /* Publish with a release store: a concurrent major-GC marker may scan
+     `p` (a remembered-set field) and dereference the promoted block's
+     header/infix-prefix relying only on an address dependency, so the
+     copy's header and unscannable-prefix writes above must be ordered
+     before this store. */
+  atomic_store_release((atomic_value *)p, result + infix_offset);
   return result;
 }
 


### PR DESCRIPTION
On the minor-GC `try_promote` winner path, the forwarding pointer was stored with a plain store; on a weakly-ordered architecture such as ARM, another domain's minor GC can observe the pointer before those header writes are visible and dereference a half-initialised block. x86/TSO architectures are unaffected.

The fix is to store with `atomic_store_release` instead of a plain store; the CAS-loser and already-promoted republication paths stay plain stores because they acquire-read `Promoted_hd` first.

Not feasible to write a regression test. Candidate for [upstreaming](https://github.com/ocaml/ocaml/blob/eef08fc14385ee1d35db03cb339328ab459dffe2/runtime/minor_gc.c#L226), but probably not until after ocaml/ocaml#14571 is [merged](https://github.com/ocaml/ocaml/blob/a93727cec2278cf2e6852d9b17b9b4c878d704b6/runtime/minor_gc.c#L282).

Bug found by Claude; this bug-fix written by Claude and reviewed by me.
