### PR TITLE
Release Domain.Tick on normal thread termination

### DIFF
--- a/otherlibs/systhreads/thread.ml
+++ b/otherlibs/systhreads/thread.ml
@@ -55,35 +55,44 @@ let interval_usec = 50_000
 let create (fn @ once) arg =
   let tls_keys = Domain.TLS.Private.get_initial_keys () in
   let tick = Domain.Tick.acquire ~interval_usec in
-  thread_new
-    (fun () ->
-      Domain.TLS.Private.init ();
-      Domain.TLS.Private.set_initial_keys tls_keys;
-      try
-        fn arg;
-        ignore (Sys.opaque_identity (check_memprof_cb ()))
-      with
-      | Exit ->
-        Domain.Tick.release tick;
-        ignore (Sys.opaque_identity (check_memprof_cb ()))
-      | exn ->
-        let raw_backtrace = Printexc.get_raw_backtrace () in
-        Domain.Tick.release tick;
-        flush stdout; flush stderr;
+  match
+    thread_new
+      (fun () ->
+        Domain.TLS.Private.init ();
+        Domain.TLS.Private.set_initial_keys tls_keys;
         try
-          (Atomic.get uncaught_exception_handler).portable exn
+          fn arg;
+          Domain.Tick.release tick;
+          ignore (Sys.opaque_identity (check_memprof_cb ()))
         with
-        | Exit -> ()
-        | exn' ->
-          Printf.eprintf
-            "Thread %d killed on uncaught exception %s\n"
-            (id (self ())) (Printexc.to_string exn);
-          Printexc.print_raw_backtrace stderr raw_backtrace;
-          Printf.eprintf
-            "Thread %d uncaught exception handler raised %s\n"
-            (id (self ())) (Printexc.to_string exn');
-          Printexc.print_backtrace stdout;
-          flush stderr)
+        | Exit ->
+          Domain.Tick.release tick;
+          ignore (Sys.opaque_identity (check_memprof_cb ()))
+        | exn ->
+          let raw_backtrace = Printexc.get_raw_backtrace () in
+          Domain.Tick.release tick;
+          flush stdout; flush stderr;
+          try
+            (Atomic.get uncaught_exception_handler).portable exn
+          with
+          | Exit -> ()
+          | exn' ->
+            Printf.eprintf
+              "Thread %d killed on uncaught exception %s\n"
+              (id (self ())) (Printexc.to_string exn);
+            Printexc.print_raw_backtrace stderr raw_backtrace;
+            Printf.eprintf
+              "Thread %d uncaught exception handler raised %s\n"
+              (id (self ())) (Printexc.to_string exn');
+            Printexc.print_backtrace stdout;
+            flush stderr)
+  with
+  | t -> t
+  | exception exn ->
+    (* If [thread_new] itself raises (e.g. [pthread_create] fails) the thread
+       body never runs, so release the tick we acquired above. *)
+    Domain.Tick.release tick;
+    raise exn
 
 module Portable = struct
   let create (fn @ once portable) arg = create fn arg

--- a/testsuite/tests/backtrace/backtrace_systhreads.reference
+++ b/testsuite/tests/backtrace/backtrace_systhreads.reference
@@ -2,24 +2,24 @@ Thread 2 killed on uncaught exception Failure("0")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16
 Thread 3 killed on uncaught exception Failure("1")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16
 Thread 4 killed on uncaught exception Failure("2")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16
 Thread 5 killed on uncaught exception Failure("3")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 14, characters 6-37
 Re-raised at Backtrace_systhreads.thread_func in file "backtrace_systhreads.ml", line 18, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16
 Thread 1 killed on uncaught exception Failure("backtrace")
 Raised at Stdlib.failwith in file "stdlib.ml", line 39, characters 17-33
 Called from Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 22, characters 6-27
 Re-raised at Backtrace_systhreads.thread_backtrace in file "backtrace_systhreads.ml", line 26, characters 5-14
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16

--- a/testsuite/tests/lib-systhreads/tick_thread_release.ml
+++ b/testsuite/tests/lib-systhreads/tick_thread_release.ml
@@ -1,0 +1,38 @@
+(* TEST
+ include systhreads;
+ hassysthreads;
+ {
+   bytecode;
+ }{
+   native;
+ }
+*)
+
+(* Test that a thread that terminates normally releases its tick request.
+   [Thread.create] acquires a [Domain.Tick] handle for the lifetime of the
+   thread and the wrapper must release it on every exit path, including when
+   the thread body returns normally. Otherwise the effective tick interval
+   stays pinned forever, defeating the on-demand tick design.
+
+   Note: after [Thread.join] returns, the thread's wrapper closure (and hence
+   its tick release) has fully run, so this check is deterministic. *)
+
+let print_effective msg =
+  let s =
+    match Domain.Tick.effective_interval_usec () with
+    | Null -> "Null"
+    | This n -> Printf.sprintf "This %d" n
+  in
+  Printf.printf "%s: %s\n%!" msg s
+
+let () =
+  print_effective "Before Thread.create";
+  (* Body observes the tick is held, then returns normally. *)
+  let t = Thread.create (fun () -> print_effective "Inside thread body") () in
+  Thread.join t;
+  print_effective "After normal thread join";
+  (* Body exits via the Thread.Exit exception (what the deprecated
+     Thread.exit raises); avoids the deprecation alert in test output. *)
+  let t = Thread.create (fun () -> raise Thread.Exit) () in
+  Thread.join t;
+  print_effective "After Thread.exit join"

--- a/testsuite/tests/lib-systhreads/tick_thread_release.reference
+++ b/testsuite/tests/lib-systhreads/tick_thread_release.reference
@@ -1,0 +1,4 @@
+Before Thread.create: Null
+Inside thread body: This 50000
+After normal thread join: Null
+After Thread.exit join: Null

--- a/testsuite/tests/lib-threads/uncaught_exception_handler.reference
+++ b/testsuite/tests/lib-threads/uncaught_exception_handler.reference
@@ -1,15 +1,15 @@
 Thread 1 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-47
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16
 [thread 2] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-79
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16
 Thread 2 killed on uncaught exception Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-79
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16
 Thread 2 uncaught exception handler raised Uncaught_exception_handler.UncaughtHandlerExn
 Raised at Uncaught_exception_handler.handler in file "uncaught_exception_handler.ml", line 26, characters 2-17
-Called from Thread.create.(fun) in file "thread.ml", line 74, characters 10-62
+Called from Thread.create.(fun) in file "thread.ml", line 76, characters 12-64
 [thread 3] caught Uncaught_exception_handler.CallbackExn
 Raised at Uncaught_exception_handler.fn in file "uncaught_exception_handler.ml", lines 30-31, characters 2-79
-Called from Thread.create.(fun) in file "thread.ml", line 63, characters 8-14
+Called from Thread.create.(fun) in file "thread.ml", line 64, characters 10-16


### PR DESCRIPTION
`Thread.create` acquires a `Domain.Tick` handle for the thread's lifetime, but its wrapper released the tick only on the `Thread.Exit` and uncaught-exception paths, not on normal return, so a thread whose body returns normally (the common case) leaks its tick request, permanently pinning the effective tick interval and defeating the on-demand tick design.

The fix releases the tick in that case, and also if `thread_new` itself raises. Regression test (for the normal completion path) included.

Bug found by Claude; this bug-fix and test written by Claude and reviewed by me.
