### PR TITLE
don't set up preemption continuation in bytecode runtime

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -71,7 +71,9 @@ int caml_incoming_interrupts_queued(void);
 void caml_poll_gc_work(void);
 void caml_handle_gc_interrupt(void);
 void caml_handle_incoming_interrupts(void);
+#ifdef NATIVE_CODE
 void caml_domain_setup_preemption(void);
+#endif
 void caml_domain_reset_preemption(void);
 value caml_process_tick_exn(void);
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1929,6 +1929,7 @@ void caml_interrupt_self(void)
   is run care must be taken not to enter the GC before returning from
   caml_garbage_collection.
 */
+#ifdef NATIVE_CODE
 void caml_domain_setup_preemption(void) {
   CAMLparam0();
   CAMLlocal1(cont);
@@ -1951,6 +1952,7 @@ void caml_domain_setup_preemption(void) {
   Caml_state->preemption = cont;
   CAMLreturn0;
 }
+#endif
 
 void caml_domain_reset_preemption(void) {
   if (Is_block(Caml_state->preemption)) {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -1155,7 +1155,9 @@ void caml_alloc_small_dispatch (caml_domain_state * dom_st,
        promoted) by the GC before it is initialized. Fortunately, we do not need
        to maintain the invariant that there is enough room in the minor heap to
        re-do the allocation in this case, since we are about to preempt anyway,
-       so we can just return. */
+       so we can just return. (In the bytecode runtime [Caml_state->preemption]
+       is never set to a block, as this is only done by the native-only
+       [caml_domain_setup_preemption]). */
     if (Is_block(Caml_state->preemption)) {
       /* We should only see this case if we allocated from ocaml */
       CAMLassert(flags & CAML_FROM_CAML);

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -428,9 +428,11 @@ caml_result caml_do_pending_actions_flags_res(int flags)
      again before returning to OCaml. The continuation this allocates is
      uninitialized, and should not be promoted before being initialized.
    */
+#ifdef NATIVE_CODE
   if (flags & CAML_FROM_CAML) {
     caml_domain_setup_preemption();
   }
+#endif
 
   return Result_unit;
 


### PR DESCRIPTION
Tick preemption doesn't work in the bytecode runtime, but can corrupt the minor heap. An allocation that hits a pending tick sets up a preemption continuation, but that continuation is only ever consumed by the native asm stubs: the interpreter knows nothing about it, so it writes the new block's header at the un-reserved `young_ptr`, corrupting the minor heap. The preemption tests are native-only, so this path was untested.

Maybe in future we want tick preemption in bytecode, which may be doable by undoing this and hacking in `interp.c`.

A regression test of this is IMO not practical.

Bug found by Claude; this bug-fix written by Claude and reviewed by me.
