### PR TITLE
Add [%%expect_asm_full] codegen-test attribute & fix stack check / SIMD bug

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -55,6 +55,11 @@ let expect_asm_callbacks = ref []
 
 let asm_collected_for_expect_asm = ref []
 
+(* When set, [record_for_expect_asm] extends the captured body to include the
+   function's cold trailers (e.g. the stack-realloc handler) instead of stopping
+   at the hot body. Used by the [%%expect_asm_with_cold] variant. *)
+let expect_asm_include_cold = ref false
+
 let register_expect_asm_callback f =
   (* Reset label counter to make assembly more predictable. *)
   Label.reset ();
@@ -2715,11 +2720,18 @@ let fundecl fundecl =
   let fun_body_end = current_output_pos () in
   List.iter emit_call_gc !call_gc_sites;
   List.iter emit_local_realloc !local_realloc_sites;
-  record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
-    ~fun_body_start ~fun_body_end ~gc_jump_pads_start:fun_body_end
-    ~gc_jump_pads_end:(current_output_pos ());
+  let gc_jump_pads_end = current_output_pos () in
   emit_call_safety_errors ();
   emit_stack_realloc ();
+  (* [record_for_expect_asm] runs after the cold trailers so the
+     [%%expect_asm_with_cold] variant can include them (e.g. the stack-realloc
+     handler). For the plain variant the body still stops at [fun_body_end] and
+     the gc-pad range is unchanged, so its output is identical. *)
+  record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
+    ~fun_body_start
+    ~fun_body_end:
+      (if !expect_asm_include_cold then current_output_pos () else fun_body_end)
+    ~gc_jump_pads_start:fun_body_end ~gc_jump_pads_end;
   (if !frame_required
    then
      let n = frame_size () - 8 - if fp then 8 else 0 in

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -55,10 +55,11 @@ let expect_asm_callbacks = ref []
 
 let asm_collected_for_expect_asm = ref []
 
-(* When set, [record_for_expect_asm] extends the captured body to include the
-   function's cold trailers (e.g. the stack-realloc handler) instead of stopping
-   at the hot body. Used by the [%%expect_asm_with_cold] variant. *)
-let expect_asm_include_cold = ref false
+(* When set, [record_for_expect_asm] extends the captured body past the hot body
+   to the end of the function's emission, including the trailing out-of-line
+   code (GC jump pads, safety-error calls, the stack-realloc handler). Used by
+   the [%%expect_asm_full] variant. *)
+let expect_asm_whole_function = ref false
 
 let register_expect_asm_callback f =
   (* Reset label counter to make assembly more predictable. *)
@@ -2723,14 +2724,16 @@ let fundecl fundecl =
   let gc_jump_pads_end = current_output_pos () in
   emit_call_safety_errors ();
   emit_stack_realloc ();
-  (* [record_for_expect_asm] runs after the cold trailers so the
-     [%%expect_asm_with_cold] variant can include them (e.g. the stack-realloc
+  (* [record_for_expect_asm] runs after the trailing out-of-line code so the
+     [%%expect_asm_full] variant can include it (e.g. the stack-realloc
      handler). For the plain variant the body still stops at [fun_body_end] and
      the gc-pad range is unchanged, so its output is identical. *)
   record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
     ~fun_body_start
     ~fun_body_end:
-      (if !expect_asm_include_cold then current_output_pos () else fun_body_end)
+      (if !expect_asm_whole_function
+       then current_output_pos ()
+       else fun_body_end)
     ~gc_jump_pads_start:fun_body_end ~gc_jump_pads_end;
   (if !frame_required
    then

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2231,6 +2231,8 @@ let begin_assembly _unix =
 (* Not implemented for arm64 *)
 let register_expect_asm_callback (_ : string -> unit) = ()
 
+let expect_asm_include_cold = ref false
+
 let end_assembly () =
   let code_end = Cmm_helpers.make_symbol "code_end" in
   let code_end_sym = S.create_global code_end in

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2231,7 +2231,7 @@ let begin_assembly _unix =
 (* Not implemented for arm64 *)
 let register_expect_asm_callback (_ : string -> unit) = ()
 
-let expect_asm_include_cold = ref false
+let expect_asm_whole_function = ref false
 
 let end_assembly () =
   let code_end = Cmm_helpers.make_symbol "code_end" in

--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -161,6 +161,16 @@ let rec find_stack_check_block :
 let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
   let block = Cfg.get_block_exn cfg label in
   let stack_offset = Cfg.first_instruction_stack_offset block in
+  (* Registers live across the check are the block's live-in = the next
+     instruction's live-in. As [instr.live] is the live-across set, recover the
+     live-in by adding the next instruction's arguments. This is what the
+     emitter's [save_simd] needs to preserve SIMD registers across the realloc
+     handler (a C call that clobbers caller-save SIMD registers). *)
+  let live =
+    match DLL.hd block.body with
+    | Some hd -> Reg.add_set_array hd.live hd.arg
+    | None -> Reg.add_set_array block.terminator.live block.terminator.arg
+  in
   let check : Cfg.basic Cfg.instruction =
     (* CR xclerc for xclerc: double check `available_before` and
        `available_across`.
@@ -173,7 +183,7 @@ let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
     let id = InstructionId.get_and_incr cfg.next_instruction_id in
     Cfg.make_instruction ()
       ~desc:(Cfg.Stack_check { max_frame_size_bytes = max_frame_size })
-      ~stack_offset ~id ~available_before:Reg_availability_set.Unreachable
+      ~stack_offset ~id ~live ~available_before:Reg_availability_set.Unreachable
       ~available_across:Reg_availability_set.Unreachable
   in
   DLL.add_begin block.body check

--- a/backend/emit.mli
+++ b/backend/emit.mli
@@ -26,6 +26,8 @@ val end_assembly: unit -> unit
     tests. The callback is automatically cleared after being invoked once. *)
 val register_expect_asm_callback : (string -> unit) -> unit
 
-(** When set, the captured assembly for [%%expect_asm] includes each
-    function's cold trailers (e.g. the stack-realloc handler). *)
-val expect_asm_include_cold : bool ref
+(** When set, the captured assembly for [%%expect_asm] extends past each
+    function's hot body to the end of the function, including the trailing
+    out-of-line code (GC jump pads, safety-error calls, the stack-realloc
+    handler). *)
+val expect_asm_whole_function : bool ref

--- a/backend/emit.mli
+++ b/backend/emit.mli
@@ -25,3 +25,7 @@ val end_assembly: unit -> unit
 (** Register a callback to receive filtered and formatted asm code, for expect
     tests. The callback is automatically cleared after being invoked once. *)
 val register_expect_asm_callback : (string -> unit) -> unit
+
+(* When set, the captured assembly for [%%expect_asm] includes each
+   function's cold trailers (e.g. the stack-realloc handler). *)
+val expect_asm_include_cold : bool ref

--- a/backend/emit.mli
+++ b/backend/emit.mli
@@ -26,6 +26,6 @@ val end_assembly: unit -> unit
     tests. The callback is automatically cleared after being invoked once. *)
 val register_expect_asm_callback : (string -> unit) -> unit
 
-(* When set, the captured assembly for [%%expect_asm] includes each
-   function's cold trailers (e.g. the stack-realloc handler). *)
+(** When set, the captured assembly for [%%expect_asm] includes each
+    function's cold trailers (e.g. the stack-realloc handler). *)
 val expect_asm_include_cold : bool ref

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -1467,6 +1467,22 @@ let only_default_codegen = Actions.make
     "default codegen"
     "non-default codegen")
 
+(* Like [only_default_codegen] but requires stack checks to be enabled. Used by
+   [%%expect_asm] tests that check the code emitted for stack checks (e.g. the
+   stack-realloc handler), which only exists when stack checks are on. *)
+let only_stack_checks_codegen = Actions.make
+  ~name:"only-stack-checks-codegen"
+  ~description:"Passes if codegen options are at the default except that stack \
+                checks are enabled"
+  ~does_something:false
+  (Actions_helpers.predicate
+    (not Config.no_stack_checks
+      && not Config.poll_insertion
+      && not Config.with_address_sanitizer
+      && not Config.with_frame_pointers)
+    "stack-checks codegen"
+    "non-stack-checks codegen")
+
 let ocamldoc = Ocaml_tools.ocamldoc
 module Ocamldoc = (val ocamldoc)
 
@@ -1687,5 +1703,6 @@ let init () =
     ocamlobjinfo;
     stack_checks;
     no_stack_checks;
-    only_default_codegen
+    only_default_codegen;
+    only_stack_checks_codegen
   ]

--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -24,7 +24,7 @@ type string_constant =
 
 type expectation_filter = Principal | X86_64 | Raw | Simplify | Reaper
 
-type expectation_kind = Expect_toplevel | Expect_asm | Expect_fexpr
+type expectation_kind = Expect_toplevel | Expect_asm of bool | Expect_fexpr
 
 type expectation =
   { extid_loc       : Location.t (* Location of "expect" in "[%%expect ...]" *)
@@ -41,6 +41,10 @@ type chunk =
 
 let register_assembly_callback :
   ((string -> unit) -> unit) option ref = ref None
+
+(* Set before compiling a chunk to tell the backend whether to include the
+   functions' cold trailers in the [%%expect_asm] capture. *)
+let set_assembly_include_cold : (bool -> unit) option ref = ref None
 
 let register_compilation_unit_callback :
   ((Compilation_unit.t -> unit) -> unit) option ref = ref None
@@ -68,7 +72,9 @@ let string_of_filter = function
 let match_expect_extension (ext : Parsetree.extension) =
   let match_ext_name = function
     | "expect" | "ocaml.expect" -> Some Expect_toplevel
-    | "expect_asm" | "ocaml.expect_asm" -> Some Expect_asm
+    | "expect_asm" | "ocaml.expect_asm" -> Some (Expect_asm false)
+    | "expect_asm_with_cold" | "ocaml.expect_asm_with_cold" ->
+      Some (Expect_asm true)
     | "expect_fexpr" | "ocaml.expect_fexpr" -> Some Expect_fexpr
     | _ -> None
   in
@@ -83,7 +89,9 @@ let match_expect_extension (ext : Parsetree.extension) =
         () =
       Location.raise_errorf ~loc "%s" msg
     in
-    if Option.is_none !register_assembly_callback && kind = Expect_asm
+    if
+      Option.is_none !register_assembly_callback
+      && (match kind with Expect_asm _ -> true | _ -> false)
     then invalid_payload ~msg:"expect_asm is only supported by expect.opt" ();
     if Option.is_none !register_compilation_unit_callback && kind = Expect_fexpr
     then invalid_payload ~msg:"expect_fexpr is only supported by expect.opt" ();
@@ -197,7 +205,7 @@ let match_expect_extension (ext : Parsetree.extension) =
         let expected_output =
           match kind with
           | Expect_toplevel -> validate_expect_toplevel expected_output
-          | Expect_asm -> validate_expect_asm expected_output
+          | Expect_asm _ -> validate_expect_asm expected_output
           | Expect_fexpr -> validate_expect_fexpr expected_output
         in
         { extid_loc
@@ -214,7 +222,7 @@ let match_expect_extension (ext : Parsetree.extension) =
           ; expected_output = [([], { tag = ""; str = "" })]
           ; kind
           }
-        | Expect_asm | Expect_fexpr -> invalid_payload ())
+        | Expect_asm _ | Expect_fexpr -> invalid_payload ())
       | _ -> invalid_payload ()
     in
     Some expectation
@@ -327,7 +335,7 @@ let eval_expectation expectation ~output =
         then [([Principal], if_principal)]
         else [([], if_not_principal)]
       | _ -> Misc.fatal_error "impossible: already validated")
-  | Expect_asm ->
+  | Expect_asm _ ->
     List.filter
       ~f:(fun (f, _) ->
           match current_arch_filter () with
@@ -472,14 +480,22 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
             in
             let keep_asm = !Clflags.keep_asm_file in
             if has_fexpr then Clflags.keep_asm_file := true;
+            let include_cold =
+              List.exists ~f:(fun exp ->
+                  match exp.kind with Expect_asm true -> true | _ -> false)
+                chunk.expectations
+            in
+            Option.iter (fun set -> set include_cold)
+              !set_assembly_include_cold;
         let (success, toplevel_output, asm_output, last_unit) =
           exec_phrases chunk.phrases
         in
+        Option.iter (fun set -> set false) !set_assembly_include_cold;
         Clflags.keep_asm_file := keep_asm;
         List.filter_map chunk.expectations ~f:(fun expectation ->
           let output = match expectation.kind with
             | Expect_toplevel -> toplevel_output
-            | Expect_asm ->
+            | Expect_asm _ ->
                 if success then
                   Option.value asm_output
                     ~default:"\nNo assembly: compilation failed\n"

--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -26,7 +26,10 @@ type expectation_filter = Principal | X86_64 | Raw | Simplify | Reaper
 
 type expectation_kind =
   | Expect_toplevel
-  | Expect_asm of { include_cold : bool }
+  (* When [whole_function] is [true], the capture extends past the hot body
+     and also shows the trailing out-of-line code: GC jump pads, safety-error
+     calls and the stack-realloc handler. *)
+  | Expect_asm of { whole_function : bool }
   | Expect_fexpr
 
 type expectation =
@@ -45,9 +48,9 @@ type chunk =
 let register_assembly_callback :
   ((string -> unit) -> unit) option ref = ref None
 
-(* Set before compiling a chunk to tell the backend whether to include the
-   functions' cold trailers in the [%%expect_asm] capture. *)
-let set_assembly_include_cold : (bool -> unit) option ref = ref None
+(* Set before compiling a chunk to tell the backend whether the [%%expect_asm]
+   capture should extend to the whole function (see [Expect_asm]). *)
+let set_assembly_whole_function : (bool -> unit) option ref = ref None
 
 let register_compilation_unit_callback :
   ((Compilation_unit.t -> unit) -> unit) option ref = ref None
@@ -76,9 +79,9 @@ let match_expect_extension (ext : Parsetree.extension) =
   let match_ext_name = function
     | "expect" | "ocaml.expect" -> Some Expect_toplevel
     | "expect_asm" | "ocaml.expect_asm" ->
-      Some (Expect_asm { include_cold = false })
-    | "expect_asm_with_cold" | "ocaml.expect_asm_with_cold" ->
-      Some (Expect_asm { include_cold = true })
+      Some (Expect_asm { whole_function = false })
+    | "expect_asm_full" | "ocaml.expect_asm_full" ->
+      Some (Expect_asm { whole_function = true })
     | "expect_fexpr" | "ocaml.expect_fexpr" -> Some Expect_fexpr
     | _ -> None
   in
@@ -485,28 +488,28 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
             let asm_expectations =
               List.filter_map chunk.expectations ~f:(fun exp ->
                   match exp.kind with
-                  | Expect_asm { include_cold } -> Some (exp, include_cold)
+                  | Expect_asm { whole_function } -> Some (exp, whole_function)
                   | Expect_toplevel | Expect_fexpr -> None)
             in
-            let include_cold = List.exists ~f:snd asm_expectations in
-            (if include_cold then
+            let whole_function = List.exists ~f:snd asm_expectations in
+            (if whole_function then
                match
                  List.find_opt asm_expectations
-                   ~f:(fun (_, with_cold) -> not with_cold)
+                   ~f:(fun (_, whole_function) -> not whole_function)
                with
                | Some (exp, _) ->
                  Location.raise_errorf ~loc:exp.extid_loc
-                   "[%%%%expect_asm] and [%%%%expect_asm_with_cold] cannot be \
+                   "[%%%%expect_asm] and [%%%%expect_asm_full] cannot be \
                     attached to the same code block"
                | None -> ());
             let keep_asm = !Clflags.keep_asm_file in
             if has_fexpr then Clflags.keep_asm_file := true;
-            Option.iter (fun set -> set include_cold)
-              !set_assembly_include_cold;
+            Option.iter (fun set -> set whole_function)
+              !set_assembly_whole_function;
         let (success, toplevel_output, asm_output, last_unit) =
           Fun.protect
             ~finally:(fun () ->
-              Option.iter (fun set -> set false) !set_assembly_include_cold;
+              Option.iter (fun set -> set false) !set_assembly_whole_function;
               Clflags.keep_asm_file := keep_asm)
             (fun () -> exec_phrases chunk.phrases)
         in
@@ -540,7 +543,7 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
       List.exists chunk.expectations ~f:(fun expectation ->
         match expectation.kind with
         | Expect_toplevel -> true
-        | Expect_asm | Expect_fexpr -> false))
+        | Expect_asm _ | Expect_fexpr -> false))
   in
   { corrected_expectations; trailing_output }, ~needs_principal
 

--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -24,7 +24,10 @@ type string_constant =
 
 type expectation_filter = Principal | X86_64 | Raw | Simplify | Reaper
 
-type expectation_kind = Expect_toplevel | Expect_asm of bool | Expect_fexpr
+type expectation_kind =
+  | Expect_toplevel
+  | Expect_asm of { include_cold : bool }
+  | Expect_fexpr
 
 type expectation =
   { extid_loc       : Location.t (* Location of "expect" in "[%%expect ...]" *)
@@ -72,9 +75,10 @@ let string_of_filter = function
 let match_expect_extension (ext : Parsetree.extension) =
   let match_ext_name = function
     | "expect" | "ocaml.expect" -> Some Expect_toplevel
-    | "expect_asm" | "ocaml.expect_asm" -> Some (Expect_asm false)
+    | "expect_asm" | "ocaml.expect_asm" ->
+      Some (Expect_asm { include_cold = false })
     | "expect_asm_with_cold" | "ocaml.expect_asm_with_cold" ->
-      Some (Expect_asm true)
+      Some (Expect_asm { include_cold = true })
     | "expect_fexpr" | "ocaml.expect_fexpr" -> Some Expect_fexpr
     | _ -> None
   in
@@ -478,20 +482,34 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
                   | Expect_fexpr -> true | _ -> false)
                 chunk.expectations
             in
+            let asm_expectations =
+              List.filter_map chunk.expectations ~f:(fun exp ->
+                  match exp.kind with
+                  | Expect_asm { include_cold } -> Some (exp, include_cold)
+                  | Expect_toplevel | Expect_fexpr -> None)
+            in
+            let include_cold = List.exists ~f:snd asm_expectations in
+            (if include_cold then
+               match
+                 List.find_opt asm_expectations
+                   ~f:(fun (_, with_cold) -> not with_cold)
+               with
+               | Some (exp, _) ->
+                 Location.raise_errorf ~loc:exp.extid_loc
+                   "[%%%%expect_asm] and [%%%%expect_asm_with_cold] cannot be \
+                    attached to the same code block"
+               | None -> ());
             let keep_asm = !Clflags.keep_asm_file in
             if has_fexpr then Clflags.keep_asm_file := true;
-            let include_cold =
-              List.exists ~f:(fun exp ->
-                  match exp.kind with Expect_asm true -> true | _ -> false)
-                chunk.expectations
-            in
             Option.iter (fun set -> set include_cold)
               !set_assembly_include_cold;
         let (success, toplevel_output, asm_output, last_unit) =
-          exec_phrases chunk.phrases
+          Fun.protect
+            ~finally:(fun () ->
+              Option.iter (fun set -> set false) !set_assembly_include_cold;
+              Clflags.keep_asm_file := keep_asm)
+            (fun () -> exec_phrases chunk.phrases)
         in
-        Option.iter (fun set -> set false) !set_assembly_include_cold;
-        Clflags.keep_asm_file := keep_asm;
         List.filter_map chunk.expectations ~f:(fun expectation ->
           let output = match expectation.kind with
             | Expect_toplevel -> toplevel_output

--- a/oxcaml/testsuite/tools/expectcommon.mli
+++ b/oxcaml/testsuite/tools/expectcommon.mli
@@ -45,8 +45,9 @@ end
 val register_assembly_callback : ((string -> unit) -> unit) option ref
 
 (** Set before compiling each chunk: tells the backend whether the
-    [%%expect_asm] capture should include the cold trailers. *)
-val set_assembly_include_cold : (bool -> unit) option ref
+    [%%expect_asm] capture should extend to the whole function, including the
+    trailing out-of-line code. *)
+val set_assembly_whole_function : (bool -> unit) option ref
 
 (** Hook to capture phrase compilation unit for [%%expect_fexpr]. This
     function should be set by expectnat.ml. *)

--- a/oxcaml/testsuite/tools/expectcommon.mli
+++ b/oxcaml/testsuite/tools/expectcommon.mli
@@ -44,8 +44,8 @@ end
     set by expectnat.ml. *)
 val register_assembly_callback : ((string -> unit) -> unit) option ref
 
-(* Set before compiling each chunk: tells the backend whether the
-   [%%expect_asm] capture should include the cold trailers. *)
+(** Set before compiling each chunk: tells the backend whether the
+    [%%expect_asm] capture should include the cold trailers. *)
 val set_assembly_include_cold : (bool -> unit) option ref
 
 (** Hook to capture phrase compilation unit for [%%expect_fexpr]. This

--- a/oxcaml/testsuite/tools/expectcommon.mli
+++ b/oxcaml/testsuite/tools/expectcommon.mli
@@ -44,6 +44,10 @@ end
     set by expectnat.ml. *)
 val register_assembly_callback : ((string -> unit) -> unit) option ref
 
+(* Set before compiling each chunk: tells the backend whether the
+   [%%expect_asm] capture should include the cold trailers. *)
+val set_assembly_include_cold : (bool -> unit) option ref
+
 (** Hook to capture phrase compilation unit for [%%expect_fexpr]. This
     function should be set by expectnat.ml. *)
 val register_compilation_unit_callback :

--- a/oxcaml/testsuite/tools/expectnat.ml
+++ b/oxcaml/testsuite/tools/expectnat.ml
@@ -35,8 +35,8 @@ end);;
 let () =
   Expectcommon.register_assembly_callback :=
     Some Emit.register_expect_asm_callback;
-  Expectcommon.set_assembly_include_cold :=
-    Some (fun b -> Emit.expect_asm_include_cold := b);
+  Expectcommon.set_assembly_whole_function :=
+    Some (fun b -> Emit.expect_asm_whole_function := b);
   Expectcommon.register_compilation_unit_callback :=
     Some Flambda2.register_compilation_unit_callback;
   Expectcommon.run

--- a/oxcaml/testsuite/tools/expectnat.ml
+++ b/oxcaml/testsuite/tools/expectnat.ml
@@ -35,6 +35,8 @@ end);;
 let () =
   Expectcommon.register_assembly_callback :=
     Some Emit.register_expect_asm_callback;
+  Expectcommon.set_assembly_include_cold :=
+    Some (fun b -> Emit.expect_asm_include_cold := b);
   Expectcommon.register_compilation_unit_callback :=
     Some Flambda2.register_compilation_unit_callback;
   Expectcommon.run

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -1,0 +1,73 @@
+(* TEST
+ flags += " -O3";
+ only-stack-checks-codegen;
+ expect.opt;
+*)
+
+(* The float [x] is live (in an xmm register) across the non-tail recursive
+   call, hence across the stack check inserted at the start of the block. The
+   stack-realloc handler must therefore preserve xmm registers: it must call
+   [caml_call_realloc_stack_sse], not the plain [caml_call_realloc_stack]. This
+   is a regression test for [Cfg_stack_checks] giving the inserted [Stack_check]
+   the correct [live] set (so that [save_simd] is computed correctly).
+
+   [%%expect_asm_full] is used (rather than [%%expect_asm]) so that the
+   captured assembly includes the cold stack-realloc handler. *)
+let[@inline never] rec f (a : float array) (n : int) : float =
+  let x = Array.unsafe_get a 0 in
+  if n = 0 then x
+  else
+    let r = f a (n - 1) in
+    x +. r
+[%%expect_asm_full X86_64{|
+f:
+  subq  $8, %rsp
+  vmovsd (%rax), %xmm0
+  cmpq  $1, %rbx
+  jne   .L1
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    .L7
+.L0:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L1:
+  pushq %r10
+  leaq  -376(%rsp), %r10
+  cmpq  40(%r14), %r10
+  popq  %r10
+  jb    .L9
+.L2:
+  vmovsd %xmm0, (%rsp)
+  addq  $-2, %rbx
+  call  camlTOP1__f_0_1_code@PLT
+.L3:
+  movq  %rax, %rbx
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    .L5
+.L4:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd (%rsp), %xmm0
+  vaddsd (%rbx), %xmm0, %xmm0
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L5:
+  call  .Lcaml_call_gc_
+.L6:
+  jmp   .L4
+.L7:
+  call  .Lcaml_call_gc_sse_
+.L8:
+  jmp   .L0
+.L9:
+  push  $34
+  call  caml_call_realloc_stack_sse@PLT
+  addq  $8, %rsp
+  jmp   .L2
+|}]

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -36,7 +36,7 @@ f:
   ret
 .L1:
   pushq %r10
-  leaq  -376(%rsp), %r10
+  leaq  -384(%rsp), %r10
   cmpq  40(%r14), %r10
   popq  %r10
   jb    .L9


### PR DESCRIPTION
Add a variant of [%%expect_asm] that includes a function's cold trailers (e.g. the stack-realloc handler) in the captured assembly, instead of stopping at the hot body, so codegen tests can assert on code emitted after the hot path.

The existing machinery is reused: record_for_expect_asm now runs after the cold trailers are emitted, and a new expect_asm_include_cold flag selects whether to extend the captured range. Plain [%%expect_asm] output is unchanged.

Also add the only-stack-checks-codegen ocamltest predicate, the counterpart of only-default-codegen for builds configured with stack checks enabled.