### PR TITLE
Add codegen test exhibiting the stack-check SIMD-save bug

### DIFF
--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -161,6 +161,16 @@ let rec find_stack_check_block :
 let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
   let block = Cfg.get_block_exn cfg label in
   let stack_offset = Cfg.first_instruction_stack_offset block in
+  (* Registers live across the check are the block's live-in = the next
+     instruction's live-in. As [instr.live] is the live-across set, recover the
+     live-in by adding the next instruction's arguments. This is what the
+     emitter's [save_simd] needs to preserve SIMD registers across the realloc
+     handler (a C call that clobbers caller-save SIMD registers). *)
+  let live =
+    match DLL.hd block.body with
+    | Some hd -> Reg.add_set_array hd.live hd.arg
+    | None -> Reg.add_set_array block.terminator.live block.terminator.arg
+  in
   let check : Cfg.basic Cfg.instruction =
     (* CR xclerc for xclerc: double check `available_before` and
        `available_across`.
@@ -173,7 +183,7 @@ let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
     let id = InstructionId.get_and_incr cfg.next_instruction_id in
     Cfg.make_instruction ()
       ~desc:(Cfg.Stack_check { max_frame_size_bytes = max_frame_size })
-      ~stack_offset ~id ~available_before:Reg_availability_set.Unreachable
+      ~stack_offset ~id ~live ~available_before:Reg_availability_set.Unreachable
       ~available_across:Reg_availability_set.Unreachable
   in
   DLL.add_begin block.body check

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -1,0 +1,76 @@
+(* TEST
+ flags += " -O3";
+ only-stack-checks-codegen;
+ expect.opt;
+*)
+
+(* Reproduction of a [Cfg_stack_checks] codegen bug.
+
+   The float [x] is live (in an xmm register) across the non-tail recursive
+   call, hence across the stack check inserted at the start of the block. The
+   stack-realloc handler should therefore preserve xmm registers. But
+   [Cfg_stack_checks] gives the inserted [Stack_check] an empty [live] set, so
+   [save_simd] sees no live SIMD register and the [.L9] trailer below calls the
+   plain [caml_call_realloc_stack] (which saves no xmm/ymm/zmm) instead of
+   [caml_call_realloc_stack_sse]. The realloc handler may then clobber [x].
+
+   [%%expect_asm_full] is used (rather than [%%expect_asm]) so that the
+   captured assembly includes the cold stack-realloc handler. *)
+let[@inline never] rec f (a : float array) (n : int) : float =
+  let x = Array.unsafe_get a 0 in
+  if n = 0 then x
+  else
+    let r = f a (n - 1) in
+    x +. r
+[%%expect_asm_full X86_64{|
+f:
+  subq  $8, %rsp
+  vmovsd (%rax), %xmm0
+  cmpq  $1, %rbx
+  jne   .L1
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    .L7
+.L0:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L1:
+  pushq %r10
+  leaq  -376(%rsp), %r10
+  cmpq  40(%r14), %r10
+  popq  %r10
+  jb    .L9
+.L2:
+  vmovsd %xmm0, (%rsp)
+  addq  $-2, %rbx
+  call  camlTOP1__f_0_1_code@PLT
+.L3:
+  movq  %rax, %rbx
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    .L5
+.L4:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd (%rsp), %xmm0
+  vaddsd (%rbx), %xmm0, %xmm0
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L5:
+  call  .Lcaml_call_gc_
+.L6:
+  jmp   .L4
+.L7:
+  call  .Lcaml_call_gc_sse_
+.L8:
+  jmp   .L0
+.L9:
+  push  $34
+  call  caml_call_realloc_stack@PLT
+  addq  $8, %rsp
+  jmp   .L2
+|}]

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -4,15 +4,12 @@
  expect.opt;
 *)
 
-(* Reproduction of a [Cfg_stack_checks] codegen bug.
-
-   The float [x] is live (in an xmm register) across the non-tail recursive
+(* The float [x] is live (in an xmm register) across the non-tail recursive
    call, hence across the stack check inserted at the start of the block. The
-   stack-realloc handler should therefore preserve xmm registers. But
-   [Cfg_stack_checks] gives the inserted [Stack_check] an empty [live] set, so
-   [save_simd] sees no live SIMD register and the [.L9] trailer below calls the
-   plain [caml_call_realloc_stack] (which saves no xmm/ymm/zmm) instead of
-   [caml_call_realloc_stack_sse]. The realloc handler may then clobber [x].
+   stack-realloc handler must therefore preserve xmm registers: it must call
+   [caml_call_realloc_stack_sse], not the plain [caml_call_realloc_stack]. This
+   is a regression test for [Cfg_stack_checks] giving the inserted [Stack_check]
+   the correct [live] set (so that [save_simd] is computed correctly).
 
    [%%expect_asm_full] is used (rather than [%%expect_asm]) so that the
    captured assembly includes the cold stack-realloc handler. *)
@@ -70,7 +67,7 @@ f:
   jmp   .L0
 .L9:
   push  $34
-  call  caml_call_realloc_stack@PLT
+  call  caml_call_realloc_stack_sse@PLT
   addq  $8, %rsp
   jmp   .L2
 |}]


### PR DESCRIPTION
Cfg_stack_checks inserts the Stack_check instruction with an empty live set. As a result emit's must_save_simd_regs sees no SIMD register live across the inserted check, and a stack reallocation that fires there is emitted as the plain caml_call_realloc_stack (which saves no xmm/ymm/zmm) instead of the _sse/_avx/_avx512 variant, so the realloc handler can clobber a live SIMD value.

The bug is latent, so this test asserts on the generated assembly rather than on program output:
it is not observable at runtime in practice. It affects only an unboxed-float/SIMD value kept live
across a stack check; the realloc trailer is cold (entered only when the OCaml stack actually
grows); and even then caml_try_realloc_stack grows the stack mainly via a memcpy whose large-copy
rep movsb path leaves the vector registers untouched, so the live value usually survives. This is
not guaranteed — a different copy size, libc, or CPU could pick the SSE/AVX memcpy path and
corrupt the value — which is what makes the codegen assertion the right regression guard.