### PR TITLE
Fix stack-check SIMD save: give Stack_check the correct live set

### DIFF
--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -161,6 +161,16 @@ let rec find_stack_check_block :
 let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
   let block = Cfg.get_block_exn cfg label in
   let stack_offset = Cfg.first_instruction_stack_offset block in
+  (* Registers live across the check are the block's live-in = the next
+     instruction's live-in. As [instr.live] is the live-across set, recover the
+     live-in by adding the next instruction's arguments. This is what the
+     emitter's [save_simd] needs to preserve SIMD registers across the realloc
+     handler (a C call that clobbers caller-save SIMD registers). *)
+  let live =
+    match DLL.hd block.body with
+    | Some hd -> Reg.add_set_array hd.live hd.arg
+    | None -> Reg.add_set_array block.terminator.live block.terminator.arg
+  in
   let check : Cfg.basic Cfg.instruction =
     (* CR xclerc for xclerc: double check `available_before` and
        `available_across`.
@@ -173,7 +183,7 @@ let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
     let id = InstructionId.get_and_incr cfg.next_instruction_id in
     Cfg.make_instruction ()
       ~desc:(Cfg.Stack_check { max_frame_size_bytes = max_frame_size })
-      ~stack_offset ~id ~available_before:Reg_availability_set.Unreachable
+      ~stack_offset ~id ~live ~available_before:Reg_availability_set.Unreachable
       ~available_across:Reg_availability_set.Unreachable
   in
   DLL.add_begin block.body check

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -4,15 +4,12 @@
  expect.opt;
 *)
 
-(* Reproduction of a [Cfg_stack_checks] codegen bug.
-
-   The float [x] is live (in an xmm register) across the non-tail recursive
+(* The float [x] is live (in an xmm register) across the non-tail recursive
    call, hence across the stack check inserted at the start of the block. The
-   stack-realloc handler should therefore preserve xmm registers. But
-   [Cfg_stack_checks] gives the inserted [Stack_check] an empty [live] set, so
-   [save_simd] sees no live SIMD register and the [.L9] trailer below calls the
-   plain [caml_call_realloc_stack] (which saves no xmm/ymm/zmm) instead of
-   [caml_call_realloc_stack_sse]. The realloc handler may then clobber [x].
+   stack-realloc handler must therefore preserve xmm registers: it must call
+   [caml_call_realloc_stack_sse], not the plain [caml_call_realloc_stack]. This
+   is a regression test for [Cfg_stack_checks] giving the inserted [Stack_check]
+   the correct [live] set (so that [save_simd] is computed correctly).
 
    [%%expect_asm_full] is used (rather than [%%expect_asm]) so that the
    captured assembly includes the cold stack-realloc handler. *)
@@ -70,7 +67,7 @@ f:
   jmp   .L0
 .L9:
   push  $34
-  call  caml_call_realloc_stack@PLT
+  call  caml_call_realloc_stack_sse@PLT
   addq  $8, %rsp
   jmp   .L2
 |}]


### PR DESCRIPTION
Give the inserted Stack_check the live-in set of the following instruction instead of an empty set, so emit's must_save_simd_regs accounts for the SIMD registers live across the check. The stack-realloc trailer now uses the appropriate caml_call_realloc_stack_{sse,avx,avx512} variant instead of the plain caml_call_realloc_stack, which saved no xmm/ymm/zmm.
