### PR TITLE
Compact printing of -dflambda

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -1147,6 +1147,11 @@ let mk_dreaper f =
     Arg.Unit f,
     " Dump debug info for the reaper pass (Flambda 2 only)" )
 
+let mk_dflambda_compact f =
+  ( "-dflambda-compact",
+    Arg.Unit f,
+    " Print a more compact version of Flambda 2 terms (Flambda 2 only)" )
+
 module Debugging = Dwarf_flags
 
 (* CR mshinwell: These help texts should show the default values. *)
@@ -1456,6 +1461,7 @@ module type Oxcaml_options = sig
   val dflow : unit -> unit
   val dsimplify : unit -> unit
   val dreaper : unit -> unit
+  val dflambda_compact : unit -> unit
   val use_cached_generic_functions : unit -> unit
   val cached_generic_functions_path : string -> unit
   val x : string -> unit
@@ -1677,6 +1683,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_dflow F.dflow;
       mk_dsimplify F.dsimplify;
       mk_dreaper F.dreaper;
+      mk_dflambda_compact F.dflambda_compact;
       mk_use_cached_generic_functions F.use_cached_generic_functions;
       mk_cached_generic_functions_path F.cached_generic_functions_path;
       mk_x F.x;
@@ -2245,6 +2252,7 @@ module Oxcaml_options_impl = struct
   let dflow = set' Flambda2.Dump.flow
   let dsimplify = set' Flambda2.Dump.simplify
   let dreaper = set' Flambda2.Dump.reaper
+  let dflambda_compact = set' Flambda2.Dump.compact
 
   let use_cached_generic_functions =
     set' Oxcaml_flags.use_cached_generic_functions

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -198,6 +198,7 @@ module type Oxcaml_options = sig
   val dflow : unit -> unit
   val dsimplify : unit -> unit
   val dreaper : unit -> unit
+  val dflambda_compact : unit -> unit
   val use_cached_generic_functions : unit -> unit
   val cached_generic_functions_path : string -> unit
   val x : string -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -298,6 +298,7 @@ module Flambda2 = struct
     let flow = ref false
     let simplify = ref false
     let reaper = ref false
+    let compact = ref false
   end
 
   module Expert = struct

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -220,6 +220,7 @@ module Flambda2 : sig
     val flow : bool ref
     val simplify : bool ref
     val reaper : bool ref
+    val compact : bool ref
   end
 
   module Expert : sig

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -22,7 +22,7 @@ type t =
   }
 
 let print_or_elide_debuginfo ppf dbg =
-  if Debuginfo.is_none dbg
+  if Flambda_features.dump_compact () || Debuginfo.is_none dbg
   then Format.pp_print_string ppf ""
   else (
     Format.pp_print_string ppf " ";

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -167,9 +167,9 @@ let [@ocamlformat "disable"] print_effect ppf
 let print ppf t =
   match t.call_kind with
   | Function _ | Method _ | C_call _ ->
-      if Flambda_features.dump_compact ()
-      then print_compact ppf t
-      else print_normal ppf t
+    if Flambda_features.dump_compact ()
+    then print_compact ppf t
+    else print_normal ppf t
   | Effect _ -> print_effect ppf t
 
 let invariant

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -90,6 +90,17 @@ let [@ocamlformat "disable"] print_inlining_paths ppf relative_history =
     Format.fprintf ppf "@[<hov 1>(relative_history@ %a)@]@ "
       Inlining_history.Relative.print relative_history
 
+let [@ocamlformat "disable"] print_compact ppf
+    { callee; continuation; exn_continuation; args; _ } =
+  Format.fprintf ppf "@[<hov 1>(\
+      @[<hov 1>(%a\u{3008}%a\u{3009}\u{300a}%a\u{300b}\
+      (%a))@]\
+      )@]"
+    (Misc.Stdlib.Option.print Simple.print) callee
+    Result_continuation.print continuation
+    Exn_continuation.print exn_continuation
+    Simple.List.print args
+
 let [@ocamlformat "disable"] print_normal ppf
     { callee; continuation; exn_continuation; args; args_arity;
       return_arity; call_kind; alloc_mode; dbg; inlined; inlining_state; probe;
@@ -155,7 +166,10 @@ let [@ocamlformat "disable"] print_effect ppf
 
 let print ppf t =
   match t.call_kind with
-  | Function _ | Method _ | C_call _ -> print_normal ppf t
+  | Function _ | Method _ | C_call _ ->
+      if Flambda_features.dump_compact ()
+      then print_compact ppf t
+      else print_normal ppf t
   | Effect _ -> print_effect ppf t
 
 let invariant

--- a/middle_end/flambda2/terms/code0.ml
+++ b/middle_end/flambda2/terms/code0.ml
@@ -77,9 +77,14 @@ let with_newer_version_of newer_version_of t =
 
 let print ~print_function_params_and_body ppf
     { params_and_body; code_metadata; free_names_of_params_and_body = _ } =
-  Format.fprintf ppf "@[<hov 1>(@[<hov 1>(code_metadata@ %a)@]@ %a)@]"
-    Code_metadata.print code_metadata print_function_params_and_body
-    params_and_body
+  if Flambda_features.dump_compact ()
+  then
+    Format.fprintf ppf "@[<hov 1>(%a)@]" print_function_params_and_body
+      params_and_body
+  else
+    Format.fprintf ppf "@[<hov 1>(@[<hov 1>(code_metadata@ %a)@]@ %a)@]"
+      Code_metadata.print code_metadata print_function_params_and_body
+      params_and_body
 
 let compare t1 t2 = Code_id.compare (code_id t1) (code_id t2)
 

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -890,7 +890,7 @@ and print_let_expr ppf ({ let_abst = _; defining_expr } as t) : unit =
 
 and print_named ppf (t : named) =
   let print_or_elide_debuginfo ppf dbg =
-    if Debuginfo.is_none dbg
+    if Flambda_features.dump_compact () || Debuginfo.is_none dbg
     then Format.pp_print_string ppf ""
     else Format.fprintf ppf "@ %a" Debuginfo.print_compact dbg
   in

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -61,13 +61,18 @@ module Block_kind = struct
   let [@ocamlformat "disable"] print ppf t =
    match t with
    | Values (tag, shape) ->
-     Format.fprintf ppf
-       "@[<hov 1>(Values@ \
-         @[<hov 1>(tag %a)@]@ \
-         @[<hov 1>(shape@ @[<hov 1>(%a)@])@])@]"
-       Tag.Scannable.print tag
-       (Format.pp_print_list ~pp_sep:Format.pp_print_space
-      K.With_subkind.print) shape
+     if Flambda_features.dump_compact ()
+     then
+       Format.fprintf ppf "@[<hov 1>(tag %a)@]"
+         Tag.Scannable.print tag
+     else
+       Format.fprintf ppf
+         "@[<hov 1>(Values@ \
+           @[<hov 1>(tag %a)@]@ \
+           @[<hov 1>(shape@ @[<hov 1>(%a)@])@])@]"
+         Tag.Scannable.print tag
+         (Format.pp_print_list ~pp_sep:Format.pp_print_space
+        K.With_subkind.print) shape
    | Naked_floats ->
      Format.pp_print_string ppf "Naked_floats"
    | Mixed (tag, shape) ->

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -189,6 +189,8 @@ let dump_simplify () = !Oxcaml_flags.Flambda2.Dump.simplify
 
 let dump_reaper () = !Oxcaml_flags.Flambda2.Dump.reaper
 
+let dump_compact () = !Oxcaml_flags.Flambda2.Dump.compact
+
 let freshen_when_printing () = !Oxcaml_flags.Flambda2.Dump.freshen
 
 let erase_in_types_depth_variables =

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -123,6 +123,8 @@ val dump_simplify : unit -> bool
 
 val dump_reaper : unit -> bool
 
+val dump_compact : unit -> bool
+
 val freshen_when_printing : unit -> bool
 
 val erase_in_types_depth_variables : unit -> bool


### PR DESCRIPTION
This adds the '-dflambda-compact' argument to reduce the verbosity of printing of flambda terms. This mostly removes code_metadata, apply annotations and shapes on makeblocks

For instance:
```ocaml
type t = { a : int; b : float }

let f a b =
  { a; b }

let v = (f[@inlined never]) 1 1.
```

Without
```
After simplify:
((module_symbol Plop.camlPlop) (return_continuation k3) (exn_continuation k2)
 (toplevel_my_region toplevel_my_region/0N)
 (toplevel_my_ghost_region toplevel_my_ghost_region/1N) (used_value_slots ⊤)
 camlPlop__f_0_0_code = (Deleted)
 Plop.camlPlop__float12 = (Boxed_float 1.)
 camlPlop__f_0_1_code =
  ((code_metadata
    ((newer_version_of camlPlop__f_0_0_code) (stub false)
     (inline Default_inline) () (poll_attribute Default)
     (regalloc_attribute default) (regalloc_param_attribute []) (cold false)
     (is_a_functor false) (is_opaque false)
     (params_arity 𝕍=tagged_ℕ𝕚 ⨯ 𝕍=boxed_ℕ𝕗) (param_modes (Heap Heap))
     (first_complex_local_param 2)
     (result_arity
      𝕍=Variant((consts ({ })) (non_consts ({(0 [𝕍=tagged_ℕ𝕚 𝕍=boxed_ℕ𝕗])}))))
     (result_types (⊤)) (result_mode Heap) (recursive Non_recursive)
     (cost_metrics
      size: 8 removed: {call: 0 alloc: 0 prim: 0 branch: 0 direct: 0
                        poly_cmp: 0 requested: 0})
     (inlining_arguments
      ((max_inlining_depth 19) (max_rec_depth 0) (call_cost 0.625000)
       (alloc_cost 0.875000) (prim_cost 0.375000) (branch_cost 0.625000)
       (indirect_call_cost 0.500000) (poly_compare_cost 1.250000)
       (small_function_size 10) (large_function_size 10)
       (small_functor_size 10) (large_functor_size 2000000)
       (threshold 10.000000))) (dbg /tmp/plop.ml:4,6--22) (is_tupled false)
     (is_my_closure_used false)
     (inlining_decision (Small_function (size 8) (small_function_size 10)))
     (loopify Never_loopify)))
   (λ〈k12〉《k11》⟅⟆ ⟅⟆
      (a/21UV ∷ 𝕍=tagged_ℕ𝕚) (b/22UV ∷ 𝕍=boxed_ℕ𝕗) (my_closure/20N ∷ 𝕍) my_depth/19N .
    Pmakeblock/24N =
     (((Make_block (Values (tag 0) (shape (𝕍=tagged_ℕ𝕚 𝕍=boxed_ℕ𝕗)))
        Immutable Heap) a/21UV b/22UV) /tmp/plop.ml:5,2--10)
    return k12 Pmakeblock/24N)))
 Plop.camlPlop__f_1 ↤ (f/0 ∷ 𝕍) =
  (set_of_closures ({((f/0 ∷ 𝕍) camlPlop__f_0_1_code)}))
 ((apply
   (((Some Plop.camlPlop__f_1)〈k15〉《k2》(1 Plop.camlPlop__float12))
    (args_arity 𝕍=tagged_ℕ𝕚 ⨯ 𝕍=boxed_ℕ𝕗)
    (return_arity
     𝕍=Variant((consts ({ })) (non_consts ({(0 [𝕍=tagged_ℕ𝕚 𝕍=boxed_ℕ𝕗])}))))
    (call_kind (Function (function_call (Direct camlPlop__f_0_1_code))))
    (alloc_mode Heap) (dbg /tmp/plop.ml:7,8--32) (inline Never_inlined)
    (inlining_state
     (depth 0, arguments
      ((max_inlining_depth 19) (max_rec_depth 0) (call_cost 0.625000)
       (alloc_cost 0.875000) (prim_cost 0.375000) (branch_cost 0.625000)
       (indirect_call_cost 0.500000) (poly_compare_cost 1.250000)
       (small_function_size 10) (large_function_size 10)
       (small_functor_size 10) (large_functor_size 2000000)
       (threshold 10.000000)))) (probe ()) (position Normal)))
  k15 (v/25UV ∷ 𝕍=Variant((consts ({ }))
               (non_consts ({(0 [𝕍=tagged_ℕ𝕚 𝕍=boxed_ℕ𝕗])})))) #One:
  Plop.camlPlop =
   (Immutable_block (tag 0) (shape Value_only) (Plop.camlPlop__f_1 v/25UV))
  module_init_end k3 Plop.camlPlop))
```

With
```
After simplify:
((module_symbol Plop.camlPlop) (return_continuation k3) (exn_continuation k2)
 (toplevel_my_region toplevel_my_region/0N)
 (toplevel_my_ghost_region toplevel_my_ghost_region/1N) (used_value_slots ⊤)
 camlPlop__f_0_0_code = (Deleted)
 Plop.camlPlop__float12 = (Boxed_float 1.)
 camlPlop__f_0_1_code =
  ((λ〈k12〉《k11》⟅⟆ ⟅⟆
      (a/21UV ∷ 𝕍=tagged_ℕ𝕚) (b/22UV ∷ 𝕍=boxed_ℕ𝕗) (my_closure/20N ∷ 𝕍) my_depth/19N .
    Pmakeblock/24N = (((Make_block (tag 0) Immutable Heap) a/21UV b/22UV))
    return k12 Pmakeblock/24N)))
 Plop.camlPlop__f_1 ↤ (f/0 ∷ 𝕍) =
  (set_of_closures ({((f/0 ∷ 𝕍) camlPlop__f_0_1_code)}))
 ((apply (((Some Plop.camlPlop__f_1)〈k15〉《k2》(1 Plop.camlPlop__float12))))
  k15 (v/25UV ∷ 𝕍=Variant((consts ({ }))
               (non_consts ({(0 [𝕍=tagged_ℕ𝕚 𝕍=boxed_ℕ𝕗])})))) #One:
  Plop.camlPlop =
   (Immutable_block (tag 0) (shape Value_only) (Plop.camlPlop__f_1 v/25UV))
  module_init_end k3 Plop.camlPlop))
```