### PR TITLE
Flush dynamic-binding cache on async unwind across fibers

### DIFF
--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -87,6 +87,9 @@ CAMLexport void caml_raise_async(value v)
   Caml_state->local_top = Caml_state->current_stack->local_top;
   Caml_state->local_limit = Caml_state->current_stack->local_limit;
 
+  /* Fiber switch: flush dynamic binding cache */
+  caml_dynamic_flush_thread(Caml_state->dynamic_bindings);
+
   *Caml_state->external_raise_async->exn_bucket = v;
 
   Caml_state->local_roots = Caml_state->external_raise_async->local_roots;

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -144,6 +144,9 @@ CAMLno_asan void caml_raise_async(value v)
   Caml_state->local_top = Caml_state->current_stack->local_top;
   Caml_state->local_limit = Caml_state->current_stack->local_limit;
 
+  /* Fiber switch: flush dynamic binding cache */
+  caml_dynamic_flush_thread(Caml_state->dynamic_bindings);
+
   /* Do not run callbacks here: we are already raising an async exn,
      so no need to check for another one, and avoiding polling here
      removes the risk of recursion in caml_raise */

--- a/testsuite/tests/effects/dynamic_async_exn.ml
+++ b/testsuite/tests/effects/dynamic_async_exn.ml
@@ -1,0 +1,88 @@
+(* TEST
+   { bytecode; }
+   { native; }
+*)
+
+(* Regression test for the dynamic-binding cache not being flushed when an
+   asynchronous exception unwinds across fibers.
+
+   A child fiber binds [d] to a child value (via [with_temporarily], which uses
+   the [%with_stack_bind] primitive) and reads it, so the per-thread direct
+   mapped cache holds [d -> child].  An async exception (here [Sys.Break],
+   raised from a finaliser) then fires inside that fiber and unwinds, via
+   [caml_raise_async], back to an ancestor [Sys.with_async_exns] handler,
+   freeing the bound fiber's stack.  After unwinding, [Dynamic.get d] must
+   return the root value again; if the cache is not flushed it wrongly returns
+   the now-out-of-scope child value. *)
+
+(* Dynamic.t isn't yet implemented in the OxCaml stdlib, only the runtime
+   support for it, so testing requires faking the infrastructure here. *)
+
+module Dynamic : sig
+  type 'a t
+
+  val make : 'a -> 'a t
+  val get : 'a t -> 'a
+
+  val with_temporarily : 'a t -> 'a -> f: (unit -> 'b) -> 'b
+
+end = struct
+  type last_fiber : immediate
+  type (-'a, +'b) cont
+  type 'a t
+
+  external reperform :
+    'a Effect.t -> ('a, 'b) cont -> last_fiber -> 'b = "%reperform"
+
+  external with_stack_bind :
+    ('a -> 'b) ->
+    (exn -> 'b) ->
+    ('c Effect.t -> ('c, 'b) cont -> last_fiber -> 'b) ->
+    'd t ->
+    'd ->
+    ('e -> 'a) ->
+    'e ->
+    'b = "%with_stack_bind"
+
+  external make : 'a -> 'a t = "caml_dynamic_make"
+  external get : 'a t -> 'a = "caml_dynamic_get"
+
+  let with_temporarily d v ~f =
+    let effc eff k last_fiber = reperform eff k last_fiber in
+    with_stack_bind (fun x -> x) (fun e -> raise e) effc d v f ()
+end
+
+let () = Sys.catch_break true
+
+let[@inline never] allocate_bytes finished =
+  let b = Bytes.create 42 in
+  Gc.finalise_last (fun () ->
+      finished := true;
+      raise Sys.Break)
+    b;
+  ref (Some b)
+
+let root = 100
+let child = 200
+
+let () =
+  let d = Dynamic.make root in
+  let finished = ref false in
+  let r = allocate_bytes finished in
+  (try
+    Sys.with_async_exns (fun () ->
+      r := None;
+      (* Bind [d] to [child] in a fiber and read it so the cache holds
+         [d -> child], then allocate until the finaliser raises [Sys.Break]
+         asynchronously, unwinding out of this fiber. *)
+      Dynamic.with_temporarily d child ~f:(fun () ->
+        Printf.printf "in fiber [expect %d]: %d\n%!" child (Dynamic.get d);
+        while true do
+          let _ @ global = Sys.opaque_identity (42, Random.int 42) in
+          ()
+        done))
+  with
+  | Sys.Break -> assert !finished
+  | _ -> assert false);
+  (* The bound fiber is gone; [d] must read as [root] again. *)
+  Printf.printf "after async unwind [expect %d]: %d\n%!" root (Dynamic.get d)

--- a/testsuite/tests/effects/dynamic_async_exn.reference
+++ b/testsuite/tests/effects/dynamic_async_exn.reference
@@ -1,0 +1,2 @@
+in fiber [expect 200]: 200
+after async unwind [expect 100]: 100


### PR DESCRIPTION
`caml_raise_async` crosses fibers so must flush the per-thread dynamic-binding cache (as all other fiber-crossings already do).

Includes a regression test.

Bug found by Claude; this bug-fix and test written by Claude and reviewed by me.
