### PR TITLE
Avoid adding zombie thread to ring

### DIFF
--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -831,16 +831,22 @@ static void * caml_thread_start(void * v)
 CAMLprim value caml_thread_new(value clos)
 {
   CAMLparam1(clos);
+  CAMLlocal1(descr);
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)
     caml_fatal_error("ocamldebug does not support multithreaded programs");
 #endif
 
+  /* Allocate the descriptor before adding to the ring; if
+   * [caml_thread_new_descriptor] raises then we don't want to add a
+   * zombie entry. */
+  descr = caml_thread_new_descriptor(clos);
+
   /* Create a thread info block */
   caml_thread_t th = thread_alloc_and_add();
   if (th == NULL) caml_raise_out_of_memory();
-  th->descr = caml_thread_new_descriptor(clos);
+  th->descr = descr;
 
   st_retcode err = st_thread_create(NULL, caml_thread_start, (void *) th);
 


### PR DESCRIPTION
`caml_thread_new` linked the new thread's info block into the circular thread ring before building its descriptor, but building the descriptor could raise an exception, which would then leave a zombie info block on the ring and eventually SEGV.

(`caml_thread_new_descriptor` calls `caml_threadstatus_new` calls `caml_check_error` which raises if `st_event_create` fails to create the thread's termination event).

Not feasibly testable without mocking `st_event_create`.

Not upstreamable, as OCaml already builds the descriptor first.

Bug found by Claude; this bug-fix written by Claude and reviewed by me.
