### PR TITLE
flambda2: Do not silently forget about bottom

### DIFF
--- a/middle_end/flambda2/types/meet_and_join.ml
+++ b/middle_end/flambda2/types/meet_and_join.ml
@@ -884,12 +884,12 @@ and meet_or_unknown_or_bottom : type a b.
  fun meet_elt env (input1 : a Or_unknown_or_bottom.t)
      (input2 : a Or_unknown_or_bottom.t) ->
   match input1, input2 with
-  | Unknown, Unknown -> Ok (Both_inputs, env)
-  | _, Unknown -> Ok (Left_input, env)
-  | Unknown, _ -> Ok (Right_input, env)
   | Bottom, Bottom -> Bottom Both_inputs
   | Bottom, _ -> Bottom Left_input
   | _, Bottom -> Bottom Right_input
+  | Unknown, Unknown -> Ok (Both_inputs, env)
+  | _, Unknown -> Ok (Left_input, env)
+  | Unknown, _ -> Ok (Right_input, env)
   | Ok elt1, Ok elt2 -> meet_elt env elt1 elt2
 
 and meet_expanded_head env (expanded1 : ET.t) (expanded2 : ET.t) :

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -1056,12 +1056,12 @@ and meet_or_unknown_or_bottom : type a b.
  fun meet_elt env (input1 : a Or_unknown_or_bottom.t)
      (input2 : a Or_unknown_or_bottom.t) ->
   match input1, input2 with
-  | Unknown, Unknown -> Ok (Both_inputs, env)
-  | _, Unknown -> Ok (Left_input, env)
-  | Unknown, _ -> Ok (Right_input, env)
   | Bottom, Bottom -> Bottom Both_inputs
   | Bottom, _ -> Bottom Left_input
   | _, Bottom -> Bottom Right_input
+  | Unknown, Unknown -> Ok (Both_inputs, env)
+  | _, Unknown -> Ok (Left_input, env)
+  | Unknown, _ -> Ok (Right_input, env)
   | Ok elt1, Ok elt2 -> meet_elt env elt1 elt2
 
 and meet_expanded_head env (expanded1 : ET.t) (expanded2 : ET.t) :

--- a/testsuite/tests/flambda2/examples/float_and_int_mix.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_and_int_mix.simplify.reference
@@ -1,5 +1,4 @@
 let code read_int_0 deleted in
-let $camlFloat_and_int_mix__float19 = 0x0p+0 in
 let code gasp_in_horror_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(read_int_0)
       read_int_0_1 (param : imm tagged)
@@ -11,19 +10,13 @@ in
 let $camlFloat_and_int_mix__read_int_2 =
   closure read_int_0_1 @read_int &toplevel.alloc_region
 in
-let code loopify(never) size(15) newer_version_of(gasp_in_horror_1)
+let code loopify(never) size(0) newer_version_of(gasp_in_horror_1)
       gasp_in_horror_1_1 (param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   let Popaque = %opaque (1) in
-  (let untagged = %untag_imm (Popaque) in
-   switch untagged
-     | 0 -> k ($camlFloat_and_int_mix__float19)
-     | 1 -> k2)
-    where k2 =
-      apply direct(read_int_0_1 &my_alloc_region)
-        ($camlFloat_and_int_mix__read_int_2 : _ -> imm tagged) (0) -> k * k1
+  invalid "(Defining_expr_of_let (bound_pattern untagged/54N)\n (defining_expr ((Untag_imm Popaque/53N) float_and_int_mix.ml:25,5--25)))"
 in
 let $camlFloat_and_int_mix__gasp_in_horror_3 =
   closure gasp_in_horror_1_1 @gasp_in_horror &toplevel.alloc_region


### PR DESCRIPTION
The meet of `Unknown` and `Bottom` should make the whole environment bottom (in the same way as the meet of any other type and `Bottom`), but we currently silently store a `Bottom` type instead, without making the whole environment `Bottom`.