### PR TITLE
flambda2: Skip bottom environments during join

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1897,13 +1897,20 @@ let cut_and_n_way_join ~n_way_join_type ~meet_expanded_head ~cut_after
   let joined_envs, equations_to_join, symbol_projections_to_join =
     Index.fold_list
       (fun index typing_env
-           (joined_envs, equations_to_join, symbol_projections_to_join) ->
-        let equations, symbol_projections =
-          cut_for_join typing_env ~cut_after
-        in
-        ( Index.Map.add index typing_env joined_envs,
-          Index.Map.add index (typing_env, equations) equations_to_join,
-          Index.Map.add index symbol_projections symbol_projections_to_join ))
+           ((joined_envs, equations_to_join, symbol_projections_to_join) as acc)
+         ->
+        (* Skip bottom environments -- we should have detected the impossibility
+           and replaced them with an invalid earlier, but if we did not, they
+           won't bring anything but subtleties to the join. *)
+        if TE.is_bottom typing_env
+        then acc
+        else
+          let equations, symbol_projections =
+            cut_for_join typing_env ~cut_after
+          in
+          ( Index.Map.add index typing_env joined_envs,
+            Index.Map.add index (typing_env, equations) equations_to_join,
+            Index.Map.add index symbol_projections symbol_projections_to_join ))
       joined_envs
       (Index.Map.empty, Index.Map.empty, Index.Map.empty)
   in
@@ -1918,17 +1925,23 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
   let external_ids, joined_envs, equations_to_join, symbol_projections_to_join =
     Index.fold_list
       (fun index (external_id, typing_env)
-           ( external_ids,
-             joined_envs,
-             equations_to_join,
-             symbol_projections_to_join ) ->
-        let equations, symbol_projections =
-          cut_for_join typing_env ~cut_after
-        in
-        ( Index.Map.add index external_id external_ids,
-          Index.Map.add index typing_env joined_envs,
-          Index.Map.add index (typing_env, equations) equations_to_join,
-          Index.Map.add index symbol_projections symbol_projections_to_join ))
+           (( external_ids,
+              joined_envs,
+              equations_to_join,
+              symbol_projections_to_join ) as acc) ->
+        (* Skip bottom environments -- we should have detected the impossibility
+           and replaced them with an invalid earlier, but if we did not, they
+           won't bring anything but subtleties to the join. *)
+        if TE.is_bottom typing_env
+        then acc
+        else
+          let equations, symbol_projections =
+            cut_for_join typing_env ~cut_after
+          in
+          ( Index.Map.add index external_id external_ids,
+            Index.Map.add index typing_env joined_envs,
+            Index.Map.add index (typing_env, equations) equations_to_join,
+            Index.Map.add index symbol_projections symbol_projections_to_join ))
       joined_envs
       (Index.Map.empty, Index.Map.empty, Index.Map.empty, Index.Map.empty)
   in


### PR DESCRIPTION
Otherwise, we can sometimes hit the assertion
`not (TE.is_bottom parent_env)` in the join of env extensions. We prevent this by ensuring that we skip bottom environment at the start of the join (i.e. we don't create `Joined_envs.t` with bottom environments in the first place) .

Note that this is currently unlikely (but possible) to happen without #6347 .