### PR TITLE
reaper: Do not produce bottom environments

### DIFF
--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -740,7 +740,19 @@ module Rewriter = struct
     | Many_sources_usages (Usages m) when Code_id_or_name.Map.is_empty m ->
       forget_type ()
     | No_source ->
-      Rule.rewrite Pattern.any (Expr.bottom (Flambda2_types.kind flambda_type))
+      (* We should be able to use [Expr.bottom] here (if we have something that
+         has no source accessible at toplevel, it means that the initialisation
+         code of the module necessarily raises).
+
+         However, we currently can't do this because there can be leftover
+         symbols in the typing env that no longer have corresponding lets in the
+         output post-simplify and returning bottom here would actually be
+         unsound in that case.
+
+         So we simply return [unknown] instead of [bottom] here because it would
+         be too easy to incorrectly conclude that the environment is
+         unsatisfiable for little actual benefit. *)
+      Rule.rewrite Pattern.any (Expr.unknown (Flambda2_types.kind flambda_type))
     | Single_source _ | Many_sources_any_usage | Many_sources_usages (Usages _)
       -> (
       match
@@ -942,8 +954,14 @@ module Rewriter = struct
             List.is_empty from_local_sets_of_closures
             && Option.is_none from_external_sources
           then
+            (* We should be able to use [Expr.bottom] here (a set of closures
+               that can't be local and also can't be external simply cannot
+               exist), but we don't because it would be too easy to be unsound
+               if there are symbols in the typing env that no longer have a
+               corresponding let symbol in the output of simplify -- see the
+               discussion for the [No_source] case in [rewrite]. *)
             Rule.rewrite Pattern.any
-              (Expr.bottom (Flambda2_types.kind flambda_type))
+              (Expr.unknown (Flambda2_types.kind flambda_type))
           else
             let from_everything =
               match from_external_sources with

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -1007,8 +1007,6 @@ module Rewriter : sig
 
     val unknown : Flambda_kind.t -> 'a t
 
-    val bottom : Flambda_kind.t -> 'a t
-
     val tag_immediate : 'a t -> 'a t
 
     val immutable_block :

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -504,7 +504,6 @@ end
 type 'a expr =
   | Identity of 'a
   | Unknown of K.With_subkind.t
-  | Bottom of K.t
   | Tag_imm of 'a expr
   | Block of
       { is_unique : bool;
@@ -530,7 +529,6 @@ module Expr = struct
     | Identity x -> pp ppf x
     | Unknown kind ->
       Format.fprintf ppf "@[<hv 1>(unknown@ %a)@]" K.With_subkind.print kind
-    | Bottom kind -> Format.fprintf ppf "@[<hv 1>(bottom@ %a)@]" K.print kind
     | Tag_imm expr ->
       Format.fprintf ppf "@[<hv 1>(tag_imm@ %a)@]" (print pp) expr
     | Block _ -> Format.fprintf ppf "@[<hv 1>(block)@]"
@@ -592,8 +590,6 @@ module Expr = struct
   let var var = Identity var
 
   let unknown kind = Unknown (K.With_subkind.anything kind)
-
-  let bottom kind = Bottom kind
 
   let unknown_with_subkind kind = Unknown kind
 
@@ -799,7 +795,6 @@ struct
       | Some ty -> ty
       | None -> Misc.fatal_errorf "Variable is not defined: %a" Var.print var)
     | Unknown kind -> MTC.unknown_with_subkind ~machine_width kind
-    | Bottom kind -> MTC.bottom kind
     | Tag_imm field ->
       TG.tag_immediate (rewrite_expr ~machine_width sigma field)
     | Block { is_unique; tag; shape; alloc_mode; fields } ->

--- a/middle_end/flambda2/types/traversals.mli
+++ b/middle_end/flambda2/types/traversals.mli
@@ -90,8 +90,6 @@ module Expr : sig
 
   val unknown : Flambda_kind.t -> 'a t
 
-  val bottom : Flambda_kind.t -> 'a t
-
   val unknown_with_subkind : Flambda_kind.With_subkind.t -> 'a t
 
   val tag_immediate : 'a t -> 'a t


### PR DESCRIPTION
This is incorrect if there are any symbols in the environment that do not have corresponding `let symbol`s in the output of simplify, which in practice is frequently the case (in particular, this is the case for the special "first const" symbol, but also for symbols of lifted constants that we discover are unused in the upward pass).

We don't expect much benefit from discovering that the environment is bottom at the compilation unit level, so we just use an unknown type instead for safety.

Note: this is currently benign because of #6347 which causes us to silently forget about the bottom equations added by the reaper, but becomes highly unsound with #6347 is fixed (so we need to fix this first).