### PR TITLE
Tweaks to the OxCaml DWARF tests

### DIFF
--- a/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
@@ -566,7 +566,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
    (= %{context_name} "main")
    (<> %{env:OXCAML_LLDB=} "")))
  (targets test_ocaml_and_c_dwarf.output.corrected)
- (deps test_ocaml_and_c_dwarf.exe test_ocaml_and_c_dwarf.lldb filter_for_function_call_only.sh)
+ (deps test_ocaml_and_c_dwarf.exe test_ocaml_and_c_dwarf.lldb filter_for_function_call_only.sh frames.py)
  (action
   (progn
    (bash

--- a/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
+++ b/oxcaml/tests/backend/oxcaml_dwarf/dune.inc
@@ -7,7 +7,7 @@
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -57,7 +57,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -107,7 +107,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -157,7 +157,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -207,7 +207,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -257,7 +257,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -307,7 +307,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -357,7 +357,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -407,7 +407,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -457,7 +457,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -507,7 +507,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule
@@ -557,7 +557,7 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule

--- a/oxcaml/tests/backend/oxcaml_dwarf/frames.py
+++ b/oxcaml/tests/backend/oxcaml_dwarf/frames.py
@@ -1,0 +1,54 @@
+"""LLDB helper for the OCaml/C boundary DWARF test.
+
+Defines a `frames` command that prints only the backtrace frames whose
+function (or symbol) name contains one of the given names, in stack order,
+using LLDB's native frame formatting.
+"""
+
+import lldb
+
+_default_frame_format = ""
+
+
+def _get_frame_format(debugger):
+    vals = lldb.SBDebugger.GetInternalVariableValue(
+        "frame-format", debugger.GetInstanceName())
+    return vals.GetStringAtIndex(0) if vals and vals.GetSize() else ""
+
+
+def _set_frame_format(debugger, value):
+    lldb.SBDebugger.SetInternalVariable(
+        "frame-format", value, debugger.GetInstanceName())
+
+
+def _frame_name(frame):
+    name = frame.GetFunctionName()
+    if name:
+        return name
+    symbol = frame.GetSymbol()
+    if symbol and symbol.GetName():
+        return symbol.GetName()
+    return frame.GetDisplayFunctionName() or ""
+
+
+def frames(debugger, command, result, internal_dict):
+    # Restore the real frame format so GetDescription produces the full frame
+    # line (with formatted arguments), then blank it again so the next
+    # breakpoint stop prints no frame line of its own.
+    _set_frame_format(debugger, _default_frame_format)
+    wanted = command.split()
+    thread = debugger.GetSelectedTarget().GetProcess().GetSelectedThread()
+    for frame in thread.frames:
+        name = _frame_name(frame)
+        if any(keyword in name for keyword in wanted):
+            stream = lldb.SBStream()
+            frame.GetDescription(stream)
+            result.AppendMessage("    " + stream.GetData().rstrip("\n"))
+    _set_frame_format(debugger, "")
+
+
+def __lldb_init_module(debugger, internal_dict):
+    global _default_frame_format
+    _default_frame_format = _get_frame_format(debugger)
+    _set_frame_format(debugger, "")
+    debugger.HandleCommand("command script add -f frames.frames frames")

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -14,13 +14,16 @@ let () =
   in
   let buf = Buffer.create 1000 in
   (* Function to generate rules for executable tests that produce output *)
-  let print_dwarf_test name =
+  let print_dwarf_test ?(extra_deps = []) name =
+    (* Leading "" yields a space after [${filter}], or "" when empty. *)
+    let extra_deps = String.concat " " ("" :: extra_deps) in
     let subst = function
       | "enabled_if" -> enabled_if
       | "enabled_if_with_lldb" -> enabled_if_with_lldb
       | "enabled_if_without_lldb" -> enabled_if_without_lldb
       | "name" -> name
       | "filter" -> "filter_for_function_call_only.sh"
+      | "extra_deps" -> extra_deps
       | _ -> assert false
     in
     Buffer.clear buf;
@@ -42,7 +45,7 @@ let () =
 (rule
  ${enabled_if_with_lldb}
  (targets ${name}.output.corrected)
- (deps ${name}.exe ${name}.lldb ${filter})
+ (deps ${name}.exe ${name}.lldb ${filter}${extra_deps})
  (action
   (progn
    (bash
@@ -86,5 +89,5 @@ Example: export OXCAML_LLDB=/path/to/custom/lldb")
   print_dwarf_test "test_closures_dwarf";
   print_dwarf_test "test_large_data_dwarf";
   print_dwarf_test "test_tailrec_dwarf";
-  print_dwarf_test "test_ocaml_and_c_dwarf";
+  print_dwarf_test "test_ocaml_and_c_dwarf" ~extra_deps:["frames.py"];
   ()

--- a/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/gen/gen_dune.ml
@@ -24,6 +24,8 @@ let () =
       | _ -> assert false
     in
     Buffer.clear buf;
+    (* Pin the optimization level to [-O3] so the DWARF output is stable
+       regardless of the dune build profile. *)
     Buffer.add_substitute buf subst
       {|
 (executable
@@ -34,7 +36,7 @@ let () =
  (ocamlopt_flags
   (:standard -g -gno-upstream-dwarf -bin-annot-cms -gdwarf-fidelity high
    -shape-format debugging-shapes -extension simd_beta -gdwarf-pedantic
-   -function-sections))
+   -function-sections -O3))
  (foreign_archives simd_stubs))
 
 (rule

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.lldb
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.lldb
@@ -1,3 +1,4 @@
+(lldb) command script import frames.py
 (lldb) settings set stop-line-count-before 0
 (lldb) settings set stop-line-count-after 0
 (lldb) settings set stop-disassembly-display never
@@ -6,57 +7,29 @@
 (lldb) script print("=== Testing OCaml/C boundary - string allocation ===")
 (lldb) br set -o true -n caml_alloc_string
 (lldb) c
-(lldb) bt 5
+(lldb) frames caml_alloc_string Stdlib.String.make f_allocate_string
 (lldb) script print("=== Testing OCaml/C boundary - array allocation ===")
 (lldb) br set -o true -n caml_array_make
 (lldb) c
-(lldb) bt 4
+(lldb) frames caml_array_make f_inner
 (lldb) script print("=== Testing OCaml/C boundary - bytes blit ===")
 (lldb) br set -o true -n caml_blit_bytes
 (lldb) c
-(lldb) bt 4
-(lldb) script print("=== Testing OCaml/C boundary - GC minor ===")
-(lldb) br set -o true -n caml_gc_minor
-(lldb) c
-(lldb) bt 3
+(lldb) frames caml_blit_bytes Stdlib.Bytes.blit f_bytes_blit
 (lldb) script print("=== Testing OCaml/C boundary - polymorphic hash ===")
 (lldb) br set -o true -n caml_hash_exn
 (lldb) c
-(lldb) bt 5
-(lldb) script print("=== Testing OCaml/C boundary - polymorphic compare ===")
-(lldb) br set -o true -n caml_compare
-(lldb) c
-(lldb) bt 4
-(lldb) script print("=== Testing OCaml/C boundary - marshal output ===")
-(lldb) br set -o true -n caml_output_value_to_buffer
-(lldb) c
-(lldb) bt 4
-(lldb) script print("=== Testing OCaml/C boundary - unmarshal input ===")
-(lldb) br set -o true -n caml_input_value_from_bytes
-(lldb) c
-(lldb) bt 4
+(lldb) frames caml_hash_exn f_hash add
 (lldb) script print("=== Testing OCaml/C boundary - MD5 hash ===")
 (lldb) br set -o true -n caml_md5_string
 (lldb) c
-(lldb) bt 4
-(lldb) script print("=== Testing OCaml/C boundary - getenv ===")
-(lldb) br set -o true -n caml_sys_getenv
-(lldb) c
-(lldb) bt 4
-(lldb) script print("=== Testing OCaml/C boundary - bigarray create ===")
-(lldb) br set -o true -n caml_ba_create
-(lldb) c
-(lldb) bt 4
+(lldb) frames caml_md5_string f_md5
 (lldb) script print("=== Testing OCaml/C boundary - large tuple (caml_alloc_shr_check_gc) ===")
 (lldb) br set -o true -n caml_alloc_shr_check_gc
 (lldb) c
-(lldb) bt 3
+(lldb) frames caml_alloc_shr_check_gc f_large_tuple
 (lldb) script print("=== Testing OCaml/C boundary - callback (C calls OCaml) ===")
 (lldb) br set -o true -n Test_ocaml_and_c_dwarf.f_callback_inner
 (lldb) c
-(lldb) bt 6
-(lldb) script print("=== Testing OCaml/C boundary - finalizer (C calls OCaml during GC) ===")
-(lldb) br set -o true -n Test_ocaml_and_c_dwarf.f_my_finalizer
-(lldb) c
-(lldb) bt 6
+(lldb) frames f_callback_inner caml_start_program f_callback
 (lldb) quit

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.ml
@@ -41,14 +41,7 @@ let[@inline never] [@local never] f_bytes_blit (src : bytes) (dst : bytes)
 
 let _ = f_bytes_blit src_bytes dst_bytes 10 [@nontail]
 
-(* Test case 4: GC minor collection *)
-let[@inline never] [@local never] f_gc_minor () =
-  Gc.minor ();
-  42
-
-let _ = f_gc_minor ()
-
-(* Test case 5: Polymorphic hashing via Hashtbl *)
+(* Test case 4: Polymorphic hashing via Hashtbl *)
 let[@inline never] [@local never] f_hash ((key, value) : string * int) =
   let tbl = Hashtbl.create 10 in
   Hashtbl.add tbl key value;
@@ -56,55 +49,16 @@ let[@inline never] [@local never] f_hash ((key, value) : string * int) =
 
 let _ = f_hash ("key", 42)
 
-(* Test case 6: Polymorphic comparison *)
-let[@inline never] [@local never] f_compare (a : int array) (b : int array) =
-  compare a b
-
-let _ = f_compare [| 1; 2; 3 |] [| 1; 2; 4 |]
-
-(* Test case 7: Marshalling *)
-let[@inline never] [@local never] f_marshal () =
-  let buf = Bytes.create 64 in
-  let _ = Marshal.to_buffer buf 0 64 [1; 2; 3] [] in
-  42
-
-let _ = f_marshal ()
-
-(* Test case 8: Unmarshalling *)
-let[@inline never] [@local never] f_unmarshal () =
-  let data = Marshal.to_bytes [1; 2; 3] [] in
-  let (_ : int list) = Marshal.from_bytes data 0 in
-  42
-
-let _ = f_unmarshal ()
-
-(* Test case 9: MD5 hashing *)
+(* Test case 5: MD5 hashing *)
 let[@inline never] [@local never] f_md5 (s : string) =
   let hash = Digest.string s in
   String.length hash
 
 let _ = f_md5 "Hello, World!"
 
-(* Test case 10: Environment variable access *)
-let[@inline never] [@local never] f_getenv (var : string) =
-  try
-    let _ = Sys.getenv var in
-    42
-  with Not_found -> 0
-
-let _ = f_getenv "PATH"
-
-(* Test case 11: Bigarray creation *)
-let[@inline never] [@local never] f_bigarray () =
-  let arr = Bigarray.Array1.create Bigarray.Float64 Bigarray.C_layout 100 in
-  Bigarray.Array1.set arr 0 3.14;
-  int_of_float (Bigarray.Array1.get arr 0)
-
-let _ = f_bigarray ()
-
-(* Test case 12: Large tuple allocation - 500 components exceeds
-   Max_young_wosize (256 words), so this should go through caml_alloc_shr for
-   shared heap allocation. *)
+(* Test case 6: Large tuple allocation - 500 components exceeds Max_young_wosize
+   (256 words), so this should go through caml_alloc_shr for shared heap
+   allocation. *)
 let[@inline never] [@local never] f_large_tuple (n : int) =
   Sys.opaque_identity
     ( n,
@@ -610,7 +564,7 @@ let[@inline never] [@local never] f_large_tuple (n : int) =
 
 let _ = ignore (f_large_tuple 42)
 
-(* Test case 13: C-to-OCaml callback via Sys.with_async_exns. The stack trace
+(* Test case 7: C-to-OCaml callback via Sys.with_async_exns. The stack trace
    will show OCaml -> C -> OCaml. *)
 let[@inline never] [@local never] f_callback_inner () = 42
 
@@ -618,18 +572,3 @@ let[@inline never] [@local never] f_callback () =
   Sys.with_async_exns f_callback_inner
 
 let _ = f_callback ()
-
-(* Test case 14: Finalization callback - C calls OCaml during GC. The stack
-   trace will show OCaml finalizer called from C GC code. *)
-let[@inline never] [@local never] f_my_finalizer (_ : int ref) = ()
-
-let[@inline never] [@local never] f_trigger_finalizer (value : int) =
-  let r = ref value in
-  Gc.finalise f_my_finalizer r;
-  (* Make r unreachable by not returning it, then force GC *)
-  ignore (Sys.opaque_identity r);
-  Gc.full_major ();
-  Gc.full_major ();
-  value
-
-let _ = f_trigger_finalizer 42

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
@@ -1,89 +1,26 @@
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_start(param=0 : ocaml_value)
 === Testing OCaml/C boundary - string allocation ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_string(len=100)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_string(len=100)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Bytes.make [inlined]
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.String.make [inlined]
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_allocate_string(param=[100, 120] : ocaml_value)
 === Testing OCaml/C boundary - array allocation ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_array_make(len=101, init=201)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_array_make(len=101, init=201)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_inner(x=50 : int @ value, y=100 : int @ value)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_outer(n=<unavailable>)
 === Testing OCaml/C boundary - bytes blit ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_blit_bytes(s1=<PTR>, ofs1=1, s2=<PTR>, ofs2=1, n=21)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_blit_bytes(s1=<PTR>, ofs1=1, s2=<PTR>, ofs2=1, n=21)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Bytes.blit [inlined]
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_bytes_blit(src=<unavailable>, dst=<unavailable>, len=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`camlTest_ocaml_and_c_dwarf__entry
-=== Testing OCaml/C boundary - GC minor ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_gc_minor(v=1)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_gc_minor(v=1)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_gc_minor(param=<unavailable>)
 === Testing OCaml/C boundary - polymorphic hash ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_hash_exn(count=21, limit=201, seed=1, obj=<PTR>)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_hash_exn(count=21, limit=201, seed=1, obj=<PTR>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Hashtbl.add
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_hash(param="key" : ocaml_value, param=42 : ocaml_value)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`camlTest_ocaml_and_c_dwarf__entry
-=== Testing OCaml/C boundary - polymorphic compare ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_compare(v1=<PTR>, v2=<PTR>)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_compare(v1=<PTR>, v2=<PTR>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Hashtbl.find
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`camlTest_ocaml_and_c_dwarf__entry
-=== Testing OCaml/C boundary - marshal output ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_output_value_to_buffer(buf=<PTR>, ofs=1, len=129, v=<PTR>, flags=1)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_output_value_to_buffer(buf=<PTR>, ofs=1, len=129, v=<PTR>, flags=1)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Marshal.to_buffer [inlined]
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_marshal(param=<unavailable>)
-=== Testing OCaml/C boundary - unmarshal input ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_input_value_from_bytes(str=<PTR>, ofs=1)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_input_value_from_bytes(str=<PTR>, ofs=1)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Marshal.from_bytes [inlined]
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_unmarshal(param=<unavailable>)
 === Testing OCaml/C boundary - MD5 hash ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_md5_string(str=<PTR>, ofs=1, len=27)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_md5_string(str=<PTR>, ofs=1, len=27)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_md5(s=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`camlTest_ocaml_and_c_dwarf__entry
-=== Testing OCaml/C boundary - getenv ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_sys_getenv(var=<PTR>)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_sys_getenv(var=<PTR>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_getenv(var=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`camlTest_ocaml_and_c_dwarf__entry
-=== Testing OCaml/C boundary - bigarray create ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_ba_create(vkind=3, vlayout=1, vdim=<PTR>)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_ba_create(vkind=3, vlayout=1, vdim=<PTR>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_bigarray(param=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`camlTest_ocaml_and_c_dwarf__entry
 === Testing OCaml/C boundary - large tuple (caml_alloc_shr_check_gc) ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_shr_check_gc(wosize=500, tag=0)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_shr_check_gc(wosize=500, tag=0)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_large_tuple(n=42 : int @ value)
 === Testing OCaml/C boundary - callback (C calls OCaml) ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_callback_inner(param=0 : ocaml_value)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_callback_inner(param=0 : ocaml_value)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_start_program
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`callback(closure=<unavailable>, arg=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_callback_exn(arg=1, closure=<PTR>) [inlined]
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_with_async_exns(body_callback=<PTR>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
-=== Testing OCaml/C boundary - finalizer (C calls OCaml during GC) ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_my_finalizer(param=[42] : ocaml_value)
-  * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_my_finalizer(param=[42] : ocaml_value)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_callback(param=<unavailable>)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_start_program
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`callback(closure=<unavailable>, arg=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_callback_exn(arg=<unavailable>, closure=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_callback_res(closure=<unavailable>, arg=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_final_do_calls_res

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.ml
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.ml
@@ -2,6 +2,10 @@ let[@inline never] [@local never] f_start () = ()
 
 let _ = f_start ()
 
+(* Utility to ensure a breakpoint on a function lands on the first
+   instruction. *)
+let[@inline never] [@local never] keep x = x
+
 module type OrderedType = sig
   type t
 
@@ -234,6 +238,7 @@ let string_store3 =
 let _ = f_string_store string_store3
 
 let[@inline never] [@local never] f_set_operations (set : IntSet.t) =
+  let set = keep set in
   let size = IntSet.size set in
   let has_10 = IntSet.mem 10 set in
   let sum = IntSet.fold ( + ) set 0 in
@@ -242,6 +247,7 @@ let[@inline never] [@local never] f_set_operations (set : IntSet.t) =
 let _ = f_set_operations int_set3
 
 let[@inline never] [@local never] f_store_operations (store : IntStore.t) =
+  let store = keep store in
   let size = IntStore.size store in
   let lookup_result = IntStore.find 1 store in
   size, lookup_result

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
@@ -13,9 +13,8 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=[] : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=:: ({ key = "key1"; value = 100 }, []) : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=:: ({ key = "key2"; value = 200 }, :: ({ key = "key1"; value = 100 }, [])) : StringStore.t @ value)
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.MakeSet.mem [inlined]
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Stdlib.List.length_aux [inlined]
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Stdlib.List.length_aux [inlined]
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_set_operations(set={ root = Node { value = 30; left = Node { value = 20; left = Node { value = 10; left = Empty; right = Empty; height = 1 }; right = Empty; height = 2 }; right = Empty; height = 3 }; count = 3 } : IntSet.t @ value)
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_store_operations(store=:: ({ key = 2; value = 200 }, :: ({ key = 1; value = 100 }, [])) : IntStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 42; computed = 6.28; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 0; computed = 3.14; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_compute_result(x={ value = "test"; computed = 12.56; status = `Success } : StringCompute.result @ value)
@@ -24,3 +23,4 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_string_pair(x={ first = 0; second = "world"; combined = "0+world" } : IntStringAdvanced.pair_data @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_float_pair(x={ first = "test"; second = 3.14; combined = "test+3.14" } : StringFloatAdvanced.pair_data @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_comparison_result(x=Greater : IntStringAdvanced.comparison_result @ value)
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_comparison_result(x=Equal : IntStringAdvanced.comparison_result @ value)


### PR DESCRIPTION
This PR make two changes to the DWARF tests:

1. It corrects an unintended change in #5778, which changed where breakpoints land in one of the tests.
2. It stabilizes the tests for the interaction between C and OCaml such that they are not sensitive to the choice of C compiler.
