### PR TITLE
Fix unsound argument value kinds in partial GADT matches

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -60,6 +60,23 @@ let pat_contains_gadt pat =
 let cases_contain_gadt cases =
   List.exists (fun { c_lhs; _ } -> pat_contains_gadt c_lhs) cases
 
+let param_is_partial_gadt_match fp =
+  match fp.fp_kind with
+  | Tparam_pat pat -> (
+      match fp.fp_partial with
+      | Total -> false
+      | Partial -> pat_contains_gadt pat)
+  | Tparam_optional_default (pat, _, _) ->
+      (* The caller can omit an optional argument, so its pattern is
+         effectively partial even when it covers the payload: the omitted
+         case carries no GADT evidence. *)
+      pat_contains_gadt pat
+
+let cases_are_partial_gadt_match cases (partial : partial) =
+  match partial with
+  | Total -> false
+  | Partial -> cases_contain_gadt cases
+
 let join_layout_of_cases sort cases =
   match cases with
   | [] -> None
@@ -75,6 +92,24 @@ let join_layout_of_cases sort cases =
                Lambda.join_layout acc (layout_pat sort c_lhs))
              first_layout rest)
       else Some first_layout
+
+(* The layout of a parameter whose pattern type may be narrowed by GADT
+   equations the caller need not satisfy is instead read from the function's
+   own type in the function's own environment: the contract the caller sees,
+   which contains no equations from the parameters' patterns.
+   [split_fun_ty] peels one parameter's type off that type. *)
+let split_fun_ty fun_ty =
+  match fun_ty with
+  | None -> (None, None)
+  | Some (env, ty) -> (
+      match Typeopt.is_function_type env ty with
+      | Some (arg_ty, res_ty) -> (Some (env, arg_ty), Some (env, res_ty))
+      | None -> (None, None))
+
+let layout_of_fun_arg_ty fun_arg_ty loc sort =
+  match fun_arg_ty with
+  | Some (env, ty) -> layout_or_sort env loc sort ty
+  | None -> layout_of_sort loc sort
 
 let field_offset_for_label lbl repres =
   match repres with
@@ -1737,7 +1772,8 @@ and transl_apply ~scopes
    [trans_curried_function]).
 *)
 and transl_function_without_attributes
-    ~scopes ~return_sort ~return_mode ~mode ~region loc repr params body =
+    ~scopes ~return_sort ~return_mode ~mode ~region ~fun_ty loc repr params
+    body =
   let return_layout =
     match body with
     | Tfunction_body exp ->
@@ -1748,15 +1784,16 @@ and transl_function_without_attributes
   in
   match
     transl_tupled_function ~scopes loc params body
-      ~return_mode ~return_layout ~mode ~region
+      ~return_mode ~return_layout ~mode ~region ~fun_ty
   with
   | Some result -> result
   | None ->
       transl_curried_function ~scopes loc repr params body
-        ~return_mode ~return_layout ~mode ~region
+        ~return_mode ~return_layout ~mode ~region ~fun_ty
 
 and transl_tupled_function
-      ~scopes ~return_mode ~return_layout ~mode ~region loc params body
+      ~scopes ~return_mode ~return_layout ~mode ~region ~fun_ty loc params
+      body
   =
   let eligible_cases =
     match params, body with
@@ -1807,15 +1844,28 @@ and transl_tupled_function
           | _ -> None
         in
         let value_kinds =
-          match
-            Option.bind (join_layout_of_cases arg_sort cases)
-              tuple_value_kinds
-          with
-          | Some kinds -> kinds
-          | None ->
-              Misc.fatal_error
-                "Translcore.transl_tupled_function: \
-                 Argument should be a tuple, but couldn't get the kinds"
+          if cases_are_partial_gadt_match cases partial
+          then
+            (* The tuple shape comes from the function's type, but the
+               components' kinds may not use the patterns' GADT equations:
+               the caller can still pass a missing constructor. Read the
+               kinds from the function's own type instead. *)
+            let fun_arg_ty, _ = split_fun_ty fun_ty in
+            (match
+               tuple_value_kinds (layout_of_fun_arg_ty fun_arg_ty loc arg_sort)
+             with
+             | Some kinds -> kinds
+             | None -> List.init size (fun _ -> Lambda.generic_value))
+          else
+            match
+              Option.bind (join_layout_of_cases arg_sort cases)
+                tuple_value_kinds
+            with
+            | Some kinds -> kinds
+            | None ->
+                Misc.fatal_error
+                  "Translcore.transl_tupled_function: \
+                   Argument should be a tuple, but couldn't get the kinds"
         in
         let kinds = List.map (fun vk -> Pvalue vk) value_kinds in
         let tparams =
@@ -1898,7 +1948,7 @@ and add_type_shapes_of_patterns patterns =
   List.iter add_case patterns
 
 and transl_curried_function ~scopes loc repr params body
-    ~return_layout ~return_mode ~region ~mode
+    ~return_layout ~return_mode ~region ~mode ~fun_ty
   =
   let { nlocal } =
     let param_curries =
@@ -1912,6 +1962,19 @@ and transl_curried_function ~scopes loc repr params body
        | Tfunction_cases fc -> param_curries @ [ Final_arg, fc.fc_arg_mode ])
   in
   add_type_shapes_of_params params;
+  (* The layout of a parameter that comes after a partial match on a GADT
+     constructor must not be narrowed by the equations introduced by that
+     constructor, as the caller can still pass a missing constructor. Such
+     layouts are read from the function's own type instead. See
+     oxcaml/oxcaml#6356 *)
+  let (any_param_is_partial_gadt_match, fc_fun_ty), param_widening_info =
+    List.fold_left_map
+      (fun (seen, fun_ty) fp ->
+        let fun_arg_ty, fun_res_ty = split_fun_ty fun_ty in
+        ( (seen || param_is_partial_gadt_match fp, fun_res_ty),
+          (seen, fun_arg_ty) ))
+      (false, fun_ty) params
+  in
   let cases_param, body =
     match body with
     | Tfunction_body body ->
@@ -1921,15 +1984,18 @@ and transl_curried_function ~scopes loc repr params body
           fc_loc; fc_arg_sort; fc_arg_mode }
       ->
         let fc_arg_sort = Jkind.Sort.default_for_transl_and_get fc_arg_sort in
+        let fc_arg_ty, _ = split_fun_ty fc_fun_ty in
         let arg_layout =
-          match join_layout_of_cases fc_arg_sort fc_cases with
-          | Some arg_layout -> arg_layout
-          | None ->
-              (* ppxes can generate empty function cases, which compiles to
-                 a function that always raises Match_failure. We try less
-                 hard to calculate a detailed layout that the middle-end can
-                 use for optimizations. *)
-              layout_of_sort fc_loc fc_arg_sort
+          if any_param_is_partial_gadt_match
+             || cases_are_partial_gadt_match fc_cases fc_partial
+          then layout_of_fun_arg_ty fc_arg_ty fc_loc fc_arg_sort
+          else
+            match join_layout_of_cases fc_arg_sort fc_cases with
+            | Some arg_layout -> arg_layout
+            | None ->
+                (* ppxes can generate empty function cases, which compiles to
+                   a function that always raises Match_failure. *)
+                layout_of_fun_arg_ty fc_arg_ty fc_loc fc_arg_sort
         in
         let arg_mode = transl_alloc_mode_l fc_arg_mode in
         add_type_shapes_of_cases fc_cases;
@@ -1955,7 +2021,7 @@ and transl_curried_function ~scopes loc repr params body
   in
   let body, params =
     List.fold_right
-      (fun fp (body, params) ->
+      (fun (fp, (follows_partial_gadt, fun_arg_ty)) (body, params) ->
         let { fp_param; fp_param_debug_uid; fp_kind; fp_mode; fp_sort;
               fp_partial; fp_loc } = fp in
         let arg_env, arg_type, attributes =
@@ -1966,7 +2032,11 @@ and transl_curried_function ~scopes loc repr params body
               expr.exp_env, Predef.type_option expr.exp_type, Translattribute.transl_param_attributes pat
         in
         let fp_sort = Jkind.Sort.default_for_transl_and_get fp_sort in
-        let arg_layout = layout arg_env fp_loc fp_sort arg_type in
+        let arg_layout =
+          if follows_partial_gadt || param_is_partial_gadt_match fp
+          then layout_of_fun_arg_ty fun_arg_ty fp_loc fp_sort
+          else layout arg_env fp_loc fp_sort arg_type
+        in
         let arg_mode = transl_alloc_mode_l fp_mode.mode_modes in
         let param =
           { name = fp_param;
@@ -1998,7 +2068,7 @@ and transl_curried_function ~scopes loc repr params body
                 ~param:fp_param
         in
         body, param :: params)
-      params
+      (List.combine params param_widening_info)
       (body, Option.to_list cases_param)
     in
     (* chunk params according to Lambda.max_arity. If Lambda.max_arity = n and
@@ -2117,6 +2187,7 @@ and transl_function ~in_new_scope ~scopes e params body
       (function repr ->
          transl_function_without_attributes
            ~mode ~return_sort ~return_mode
+           ~fun_ty:(Some (e.exp_env, e.exp_type))
            ~scopes e.exp_loc repr ~region params body)
   in
   let zero_alloc : Lambda.zero_alloc_attribute =
@@ -2982,7 +3053,7 @@ and transl_letop ~scopes loc env let_ ands param param_debug_uid param_sort case
            let ghost_loc = { loc with loc_ghost = true } in
            transl_function_without_attributes ~scopes ~region:true
              ~return_sort:case_sort ~mode:alloc_heap ~return_mode
-             loc repr []
+             ~fun_ty:None loc repr []
              (Tfunction_cases
                 { fc_cases = [case]; fc_param = param;
                   fc_param_debug_uid = param_debug_uid; fc_partial = partial;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -68,8 +68,7 @@ let param_is_partial_gadt_match fp =
       | Partial -> pat_contains_gadt pat)
   | Tparam_optional_default (pat, _, _) ->
       (* The caller can omit an optional argument, so its pattern is
-         effectively partial even when it covers the payload: the omitted
-         case carries no GADT evidence. *)
+         effectively partial *)
       pat_contains_gadt pat
 
 let cases_are_partial_gadt_match cases (partial : partial) =
@@ -93,11 +92,6 @@ let join_layout_of_cases sort cases =
              first_layout rest)
       else Some first_layout
 
-(* The layout of a parameter whose pattern type may be narrowed by GADT
-   equations the caller need not satisfy is instead read from the function's
-   own type in the function's own environment: the contract the caller sees,
-   which contains no equations from the parameters' patterns.
-   [split_fun_ty] peels one parameter's type off that type. *)
 let split_fun_ty fun_ty =
   match fun_ty with
   | None -> (None, None)
@@ -1846,10 +1840,9 @@ and transl_tupled_function
         let value_kinds =
           if cases_are_partial_gadt_match cases partial
           then
-            (* The tuple shape comes from the function's type, but the
-               components' kinds may not use the patterns' GADT equations:
-               the caller can still pass a missing constructor. Read the
-               kinds from the function's own type instead. *)
+            (* Under a partial GADT match, we can't rely on the pattern's
+               types as the caller can still pass a missing constructor, so we
+               compute kinds from the function's own type instead. *)
             let fun_arg_ty, _ = split_fun_ty fun_ty in
             (match
                tuple_value_kinds (layout_of_fun_arg_ty fun_arg_ty loc arg_sort)

--- a/testsuite/tests/ppx-empty-cases/test.compilers.reference
+++ b/testsuite/tests/ppx-empty-cases/test.compilers.reference
@@ -1,14 +1,14 @@
 (let
   (empty_cases_returning_string/0 =
-     (function {nlocal = 0} param/0?
+     (function {nlocal = 0} param/0
        (raise
          (makeblock 0 (getpredef Match_failure/0!!) [0: "test.ml" 28 50])))
    empty_cases_returning_float64/0 =
-     (function {nlocal = 0} param/1? : unboxed_float
+     (function {nlocal = 0} param/1 : unboxed_float
        (raise
          (makeblock 0 (getpredef Match_failure/0!!) [0: "test.ml" 29 50])))
    empty_cases_accepting_string/0 =
-     (function {nlocal = 0} param/2?
+     (function {nlocal = 0} param/2
        (raise
          (makeblock 0 (getpredef Match_failure/0!!) [0: "test.ml" 30 50])))
    empty_cases_accepting_float64/0 =

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_widening.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_widening.ml
@@ -7,9 +7,86 @@
  }
 *)
 
-(* Regression tests: an argument matched by a multi-case GADT match used to
-   get its value kind from the first branch's equations, miscompiling callers
-   that pick another constructor. *)
+(* Regression tests: an argument that follows a non-exhaustive GADT
+   constructor match used to get its value kind from the matched branch's
+   equations, miscompiling callers that pick a missing constructor. *)
+
+(* The matched branch says [f]'s second argument is a tuple, but a caller can
+   reach it with an immediate. This used to segfault. *)
+type 'a rep = Block : (int * int) rep | Int : int rep
+
+let[@inline never] g b =
+  let[@local] f : type a. a rep -> a -> int = fun Block (a, _b) -> a in
+  if b then f Block (1, 2) else f Int (Sys.opaque_identity 0)
+
+let () =
+  assert (g true = 1);
+  match g false with
+  | _ -> assert false
+  | exception Match_failure _ -> ()
+
+(* The matched branch says [f2]'s second argument is immediate, but a partial
+   application can store a string there; it must be scanned by the GC while it
+   lives in the wrapper's closure. *)
+type 'a rep2 = Int2 : int rep2 | String2 : string rep2
+
+let f2 : type a. a rep2 -> a -> unit -> a = fun Int2 x () -> x
+let[@inline always] g2 x = x
+
+let p =
+  (Sys.opaque_identity (g2 f2)) String2
+    (Sys.opaque_identity (String.make 4 'h'))
+
+let () = Gc.compact ()
+
+let () =
+  match p () with
+  | _ -> assert false
+  | exception Match_failure _ -> ()
+
+(* The matched branch says [f]'s second argument is a tagged immediate, but a
+   caller can reach it with a boxed float. *)
+type 'a rep3 = Int3 : int rep3 | Float3 : float rep3
+
+let g3 b =
+  let[@local] f : type a. a rep3 -> a -> int = fun Int3 z -> z in
+  if b then f Int3 0 else f Float3 (Sys.opaque_identity 0.)
+
+let () =
+  assert (g3 true = 0);
+  match g3 false with
+  | _ -> assert false
+  | exception Match_failure _ -> ()
+
+(* The pattern on the optional argument covers its payload, but a caller can
+   omit the argument, so [y]'s slot must not be marked immediate. This used to
+   segfault. *)
+type 'a rep4 = Int4 : int rep4
+
+let f4 : type a. ?x:(a rep4) -> a -> unit -> a =
+  fun ?x:(Int4 = assert false) y () -> y
+
+let p4 = (Sys.opaque_identity f4) (Sys.opaque_identity (String.make 4 'h'))
+
+let () = Gc.compact ()
+
+let () =
+  match p4 () with
+  | _ -> assert false
+  | exception Assert_failure _ -> ()
+
+(* Regression test: partial match unpacking, unarized. *)
+type 'a rep5 = Block5 : (int * int) rep5 | Int5 : int rep5
+
+let[@inline never] g5 b =
+  let[@local] f : type a. a rep5 * a -> int = fun (Block5, (a, _b)) -> a in
+  if b then f (Block5, (1, 2)) else f (Int5, Sys.opaque_identity 0)
+
+let () =
+  assert (g5 true = 1);
+  match g5 false with
+  | _ -> assert false
+  | exception Match_failure _ -> ()
 
 (* Regression test: total match unpacking a tuple, unarized *)
 type 'a rep6 = Block6 : (int * int) rep6 | Int6 : int rep6
@@ -24,6 +101,38 @@ let[@inline never] g6 b =
 let () =
   assert (g6 true = 1);
   assert (g6 false = 0)
+
+(* Regression test: partial match unpacking a tuple,
+   not unarized due to the extra argument. *)
+type 'a rep7 = Block7 : (int * int) rep7 | Int7 : int rep7
+
+let[@inline never] g7 b =
+  let[@local] f : type a. a rep7 * a -> unit -> int =
+    fun (Block7, (a, _b)) () -> a
+  in
+  if b then f (Block7, (1, 2)) () else f (Int7, Sys.opaque_identity 0) ()
+
+let () =
+  assert (g7 true = 1);
+  match g7 false with
+  | _ -> assert false
+  | exception Match_failure _ -> ()
+
+(* Regression test: partial match unpacking a tuple,
+   not unarized due to [as _p]. *)
+type 'a rep8 = Block8 : (int * int) rep8 | Int8 : int rep8
+
+let[@inline never] g8 b =
+  let[@local] f : type a. a rep8 * a -> int =
+    fun ((Block8, (a, _b)) as _p) -> a
+  in
+  if b then f (Block8, (1, 2)) else f (Int8, Sys.opaque_identity 0)
+
+let () =
+  assert (g8 true = 1);
+  match g8 false with
+  | _ -> assert false
+  | exception Match_failure _ -> ()
 
 (* Regression test: total match unpacking a tuple,
    not unarized due to the extra argument. *)
@@ -55,6 +164,19 @@ let[@inline never] g10 b =
 let () =
   assert (g10 true = 4.5);
   assert (g10 false = 7.0)
+
+(* Regression test: partial match unpacking a tuple, compiled with the
+   tupled calling convention. *)
+type 'a rep11 = Block11 : (int * int) rep11 | Int11 : int rep11
+
+let[@inline never] f11 : type a. a rep11 * a -> int =
+  fun (Block11, (a, _b)) -> a
+
+let () =
+  assert (f11 (Block11, (1, 2)) = 1);
+  match f11 (Int11, Sys.opaque_identity 0) with
+  | _ -> assert false
+  | exception Match_failure _ -> ()
 
 (* Regression test: total match unpacking a tuple whose branch kinds
    disagree, compiled with the tupled calling convention. *)

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
@@ -18,9 +18,7 @@ let f : type a. a rep -> a -> int = fun Block (a, _b) -> a
 [%%expect{|
 (let
   (f =
-     (function {nlocal = 0} param[value<int>]
-       param[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
-       : int
+     (function {nlocal = 0} param[value<int>] param : int
        (if param
          (raise (makeblock 0 (getpredef Match_failure!!) [0: "" 1 40]))
          (field_imm 0 param))))
@@ -48,10 +46,7 @@ let h b =
   (h =
      (function {nlocal = 0} b[value<int>] : int
        (catch (if b (exit 9 0 [0: 1 2]) (exit 9 1 0))
-        with (9 param[value<int>] param[value<
-                                         (consts ())
-                                          (non_consts ([0: value<int>,
-                                                        value<int>]))>])
+        with (9 param[value<int>] param)
          (if param
            (raise (makeblock 0 (getpredef Match_failure!!) [0: "" 2 50]))
            (field_imm 0 param)))))

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
@@ -12,6 +12,53 @@ type 'a rep = Block : (int * int) rep | Int : int rep
 type 'a rep = Block : (int * int) rep | Int : int rep
 |}]
 
+(* The second parameter's kind must not be the (int * int) tuple kind from
+   the [Block] equation. *)
+let f : type a. a rep -> a -> int = fun Block (a, _b) -> a
+[%%expect{|
+(let
+  (f =
+     (function {nlocal = 0} param[value<int>]
+       param[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+       : int
+       (if param
+         (raise (makeblock 0 (getpredef Match_failure!!) [0: "" 1 40]))
+         (field_imm 0 param))))
+  (apply (field_imm 1 (global Toploop!)) "f" f))
+val f : 'a rep -> 'a -> int = <fun>
+|}]
+
+(* Same for a total match: the kind of [x] must not come from the [Block]
+   branch's pattern type. *)
+let g : type a. a rep -> a -> int = fun r x ->
+  match r, x with Block, (a, _b) -> a | Int, y -> y
+[%%expect{|
+(let
+  (g = (function {nlocal = 0} r[value<int>] x : int (if r x (field_imm 0 x))))
+  (apply (field_imm 1 (global Toploop!)) "g" g))
+val g : 'a rep -> 'a -> int = <fun>
+|}]
+
+(* [@local] functions: the same applies to the catch parameters' kinds. *)
+let h b =
+  let[@local] f : type a. a rep -> a -> int = fun Block (a, _b) -> a in
+  if b then f Block (1, 2) else f Int 0
+[%%expect{|
+(let
+  (h =
+     (function {nlocal = 0} b[value<int>] : int
+       (catch (if b (exit 9 0 [0: 1 2]) (exit 9 1 0))
+        with (9 param[value<int>] param[value<
+                                         (consts ())
+                                          (non_consts ([0: value<int>,
+                                                        value<int>]))>])
+         (if param
+           (raise (makeblock 0 (getpredef Match_failure!!) [0: "" 2 50]))
+           (field_imm 0 param)))))
+  (apply (field_imm 1 (global Toploop!)) "h" h))
+val h : bool -> int = <fun>
+|}]
+
 (* Control: no GADT narrowing involved. The parameter's kind must stay
    precise. *)
 let fst2 (p : int * int) = match p with a, _b -> a
@@ -35,6 +82,56 @@ let get (o : int option) = match o with Some x -> x | None -> 0
        : int (if o (field_imm 0 o) 0)))
   (apply (field_imm 1 (global Toploop!)) "get" get))
 val get : int option -> int = <fun>
+|}]
+
+(* Sound cases: the refinement below is implied by more than the matched
+   pattern. *)
+
+(* Sound: the function's own type already determines the argument type; no
+   GADT equation is needed for precision. *)
+let i : (int * int) rep -> int * int -> int = fun Block (a, _b) -> a
+[%%expect{|
+(let
+  (i =
+     (function {nlocal = 0} param[value<int>]
+       param[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+       : int (field_imm 0 param)))
+  (apply (field_imm 1 (global Toploop!)) "i" i))
+val i : (int * int) rep -> int * int -> int = <fun>
+|}]
+
+(* Sound: the equation from matching [r] is established before the inner
+   closures are built, so it holds for every call of those closures. *)
+let j (type a) (r : a rep) : a -> int =
+  match r with Block -> (fun (a, _b) -> a) | Int -> fun x -> x
+[%%expect{|
+(let
+  (j =
+     (function {nlocal = 0} r[value<int>]
+       (if r (function {nlocal = 0} x[value<int>] : int x)
+         (function {nlocal = 0}
+           param[value<
+                  (consts ()) (non_consts ([0: value<int>, value<int>]))>]
+           : int (field_imm 0 param)))))
+  (apply (field_imm 1 (global Toploop!)) "j" j))
+val j : 'a rep -> 'a -> int = <fun>
+|}]
+
+(* Sound: a single-constructor GADT; every caller's instantiation satisfies
+   the equation, and the total match lets the kind stay precise. *)
+type _ only = Only : (int * int) only
+
+let k : type a. a only -> a -> int = fun Only (a, _b) -> a
+[%%expect{|
+0
+type _ only = Only : (int * int) only
+(let
+  (k =
+     (function {nlocal = 0} param[value<int>]
+       param[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+       : int (field_imm 0 param)))
+  (apply (field_imm 1 (global Toploop!)) "k" k))
+val k : 'a only -> 'a -> int = <fun>
 |}]
 
 (* Sound: a total multi-case GADT match; the parameter's kind is the join of
@@ -135,4 +232,21 @@ type _ rep3 = RF : fa rep3 | RG : fb rep3
          (mixedfield 0  (value<int>,float64) (field_imm 1 param)))))
   (apply (field_imm 1 (global Toploop!)) "mixed_flat" mixed_flat))
 val mixed_flat : 'a rep3 * 'a -> int = <fun>
+|}]
+
+(* A parameter following a partial GADT match gets its kind from the
+   function's own type, which the caller must satisfy, rather than from the
+   pattern's environment, which contains the equations. *)
+let p : type a. a rep -> int * int -> int = fun Block (x, _y) -> x
+[%%expect{|
+(let
+  (p =
+     (function {nlocal = 0} param[value<int>]
+       param[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+       : int
+       (if param
+         (raise (makeblock 0 (getpredef Match_failure!!) [0: "" 1 48]))
+         (field_imm 0 param))))
+  (apply (field_imm 1 (global Toploop!)) "p" p))
+val p : 'a rep -> int * int -> int = <fun>
 |}]

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1323,10 +1323,6 @@ let layout_of_non_void_sort c =
       Misc.fatal_errorf_doc "layout_of_const_sort: %a encountered"
         Jkind.Sort.Const.format const)
 
-(* Like [layout], but falls back to the sort's layout when the type's jkind
-   does not determine a kind (e.g. jkind [any], where GADT equations in scope
-   at the type's uses, rather than the type itself, determine the
-   representation). *)
 let layout_or_sort env loc sort ty =
   try layout env loc sort ty
   with Error (_, Non_value_layout _) -> layout_of_sort loc sort

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -1323,6 +1323,14 @@ let layout_of_non_void_sort c =
       Misc.fatal_errorf_doc "layout_of_const_sort: %a encountered"
         Jkind.Sort.Const.format const)
 
+(* Like [layout], but falls back to the sort's layout when the type's jkind
+   does not determine a kind (e.g. jkind [any], where GADT equations in scope
+   at the type's uses, rather than the type itself, determine the
+   representation). *)
+let layout_or_sort env loc sort ty =
+  try layout env loc sort ty
+  with Error (_, Non_value_layout _) -> layout_of_sort loc sort
+
 let function_return_layout env loc sort ty =
   match is_function_type env ty with
   | Some (_lhs, rhs) -> layout env loc sort rhs

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -64,9 +64,8 @@ val layout_of_ident : Env.t -> Ident.t -> Lambda.layout option
 val layout_of_sort : Location.t -> Jkind.Sort.Const.t -> Lambda.layout
 val layout_of_non_void_sort : Jkind.Sort.Const.t -> Lambda.layout
 
-(* Like [layout], but falls back to [layout_of_sort] when the type's jkind
-   does not determine a kind (e.g. jkind [any], when only GADT equations in
-   scope at the type's uses determine the representation). *)
+(* Like [layout], but falls back to the sort when the type does not determine a
+   value kind (e.g. has jkind [any]) *)
 val layout_or_sort :
   Env.t -> Location.t -> Jkind.Sort.Const.t -> Types.type_expr -> Lambda.layout
 

--- a/typing/typeopt.mli
+++ b/typing/typeopt.mli
@@ -64,6 +64,12 @@ val layout_of_ident : Env.t -> Ident.t -> Lambda.layout option
 val layout_of_sort : Location.t -> Jkind.Sort.Const.t -> Lambda.layout
 val layout_of_non_void_sort : Jkind.Sort.Const.t -> Lambda.layout
 
+(* Like [layout], but falls back to [layout_of_sort] when the type's jkind
+   does not determine a kind (e.g. jkind [any], when only GADT equations in
+   scope at the type's uses determine the representation). *)
+val layout_or_sort :
+  Env.t -> Location.t -> Jkind.Sort.Const.t -> Types.type_expr -> Lambda.layout
+
 (* Given a function type and the sort of its return type, compute the layout of
    its return type. *)
 val function_return_layout :


### PR DESCRIPTION
When a parameter pattern of a function matches a GADT constructor, the parameters after it get their value kinds from the first constructor's equations, yet a caller might pick another constructor. These kinds are part of the function's calling convention (flambda2 bakes them into arities and partial-application wrappers), so simply calling such a function could segfault. The below program segfaults because `f`'s second parameter has the tuple kind from the `Block` branch, but `g false` reaches it with an immediate.
```ocaml
type 'a rep = Block : (int * int) rep | Int : int rep
external opaque : 'a -> 'a = "%opaque"

let[@inline never] g b =
  let[@local] f : type a. a rep -> a -> int = fun Block (a, _) -> a in
  if b then f Block (1, 2) else f Int (opaque 0)
let _ = g false
```

Now, such arguments get their `value_kind` computed from the *function*'s type.

An optional argument's pattern counts as non-exhaustive here even when it covers the payload, since a caller omitting the argument bypasses the constructor entirely. Return layouts keep the narrowing since returned values only flow out of matched branches.

H/t @Ekdohibs for the report. See also https://github.com/ocaml/ocaml/issues/14898.

Depends on https://github.com/oxcaml/oxcaml/pull/6533.