### PR TITLE
Fix and enable scannable axis warnings

### DIFF
--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -161,6 +161,11 @@ type t17b : (value & value) non_pointer
 type t15 : any non_pointer
 type t16 : value non_pointer
 type t17 : value & value non_pointer
+Line 4, characters 12-39:
+4 | type t17b : (value & value) non_pointer
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "value & value".
+
 type t17b : value & value
 |}]
 

--- a/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,5 +1,10 @@
-File "source_jane_street.ml", line 173, characters 0-24:
-173 | type t = #(int * float#)
+File "source_jane_street.ml", line 159, characters 12-39:
+159 | type t17b : (value & value) non_pointer
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 184 [ignored-kind-modifier]: The kind modifier(s) non_pointer have no effect on the kind value & value.
+
+File "source_jane_street.ml", line 178, characters 0-24:
+178 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name t.
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/typing-layouts-scannable/non_pointer.ml
+++ b/testsuite/tests/typing-layouts-scannable/non_pointer.ml
@@ -17,6 +17,12 @@ type t : immutable_data non_pointer
 
 type ('a : any non_pointer, 'b : any maybe_separable, 'c : any) t;;
 [%%expect{|
+Line 1, characters 37-52:
+1 | type ('a : any non_pointer, 'b : any maybe_separable, 'c : any) t;;
+                                         ^^^^^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "any".
+
 type ('a : any non_pointer, 'b : any, 'c : any) t
 |}]
 
@@ -34,6 +40,12 @@ type t : value non_pointer & value_maybe_separable & float64
 type t_maybeptr : any maybe_separable
 type t_nonptr : any non_pointer
 [%%expect{|
+Line 1, characters 22-37:
+1 | type t_maybeptr : any maybe_separable
+                          ^^^^^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "any".
+
 type t_maybeptr : any
 type t_nonptr : any non_pointer
 |}]
@@ -48,6 +60,12 @@ type t_nonptr_val : value non_pointer
 type ('a : any maybe_separable) accepts_maybeptr
 type ('a : any non_pointer) accepts_nonptr
 [%%expect{|
+Line 1, characters 15-30:
+1 | type ('a : any maybe_separable) accepts_maybeptr
+                   ^^^^^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "any".
+
 type ('a : any) accepts_maybeptr
 type ('a : any non_pointer) accepts_nonptr
 |}]
@@ -283,6 +301,12 @@ let f (a : (_ : any non_pointer)) (b : (_ : any maybe_separable)) =
   let _unify_them = [ a; b ] in
   ()
 [%%expect{|
+Line 1, characters 48-63:
+1 | let f (a : (_ : any non_pointer)) (b : (_ : any maybe_separable)) =
+                                                    ^^^^^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "any".
+
 val f : ('a : value_or_null non_pointer). 'a -> 'a -> unit = <fun>
 |}]
 
@@ -307,6 +331,16 @@ let f (type a : float64 maybe_separable) (x : a) =
   let g (x : (_ : float64 non_pointer)) = () in
   g x
 [%%expect{|
+Line 1, characters 16-39:
+1 | let f (type a : float64 maybe_separable) (x : a) =
+                    ^^^^^^^^^^^^^^^^^^^^^^^
+Warning 184 [ignored-kind-modifier]: The kind modifier(s) "maybe_separable" have no effect on the kind "float64".
+
+Line 2, characters 18-37:
+2 |   let g (x : (_ : float64 non_pointer)) = () in
+                      ^^^^^^^^^^^^^^^^^^^
+Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "float64".
+
 val f : ('a : float64). 'a -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-layouts-scannable/warnings.ml
+++ b/testsuite/tests/typing-layouts-scannable/warnings.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension layouts_alpha -w +183..184";
+ flags = "-extension layouts_alpha";
  expect;
 *)
 
@@ -27,9 +27,6 @@ Line 1, characters 0-46:
 Error: A type declaration's layout can be given at most once.
        This declaration has an layout annotation (value non_pointer) and a layout attribute ([@@immediate]).
 |}]
-
-(* These warnings are disabled by default but enabled locally in this test file
-   (see the [-w +183..184] flag above). *)
 
 type t : value separable
 [%%expect{|

--- a/testsuite/tests/typing-layouts-scannable/warnings.ml
+++ b/testsuite/tests/typing-layouts-scannable/warnings.ml
@@ -213,16 +213,6 @@ Line 1, characters 9-36:
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "value & value".
 
-Line 1, characters 9-36:
-1 | type t : (value & value) non_pointer
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "value & value".
-
-Line 1, characters 9-36:
-1 | type t : (value & value) non_pointer
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "value & value".
-
 type t : value & value
 |}]
 
@@ -237,18 +227,6 @@ type t : value non_pointer
 
 type t : (value) non_pointer non_pointer
 [%%expect{|
-Line 1, characters 29-40:
-1 | type t : (value) non_pointer non_pointer
-                                 ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
-Line 1, characters 29-40:
-1 | type t : (value) non_pointer non_pointer
-                                 ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
 Line 1, characters 29-40:
 1 | type t : (value) non_pointer non_pointer
                                  ^^^^^^^^^^^

--- a/testsuite/tests/typing-layouts-scannable/warnings.ml
+++ b/testsuite/tests/typing-layouts-scannable/warnings.ml
@@ -28,24 +28,11 @@ Error: A type declaration's layout can be given at most once.
        This declaration has an layout annotation (value non_pointer) and a layout attribute ([@@immediate]).
 |}]
 
-(* CR layouts-scannable: The following errors should only print ONCE.
-   They are disabled by default because of the triple printing
-   but enabled locally in this test file. Once this is fixed, adjust this! *)
+(* These warnings are disabled by default but enabled locally in this test file
+   (see the [-w +183..184] flag above). *)
 
 type t : value separable
 [%%expect{|
-Line 1, characters 15-24:
-1 | type t : value separable
-                   ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value".
-
-Line 1, characters 15-24:
-1 | type t : value separable
-                   ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value".
-
 Line 1, characters 15-24:
 1 | type t : value separable
                    ^^^^^^^^^
@@ -69,47 +56,11 @@ Line 1, characters 34-49:
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
   is already implied by the kind "value_or_null maybe_null".
 
-Line 1, characters 23-33:
-1 | type t : value_or_null maybe_null maybe_separable
-                           ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value_or_null".
-
-Line 1, characters 34-49:
-1 | type t : value_or_null maybe_null maybe_separable
-                                      ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value_or_null maybe_null".
-
-Line 1, characters 23-33:
-1 | type t : value_or_null maybe_null maybe_separable
-                           ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value_or_null".
-
-Line 1, characters 34-49:
-1 | type t : value_or_null maybe_null maybe_separable
-                                      ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value_or_null maybe_null".
-
 type t : value_or_null
 |}]
 
 type t : immediate non_pointer
 [%%expect{|
-Line 1, characters 19-30:
-1 | type t : immediate non_pointer
-                       ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "immediate".
-
-Line 1, characters 19-30:
-1 | type t : immediate non_pointer
-                       ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "immediate".
-
 Line 1, characters 19-30:
 1 | type t : immediate non_pointer
                        ^^^^^^^^^^^
@@ -133,47 +84,11 @@ Line 1, characters 24-34:
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
   is already implied by the kind "value non_null".
 
-Line 1, characters 15-23:
-1 | type t : value non_null maybe_null
-                   ^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value".
-
-Line 1, characters 24-34:
-1 | type t : value non_null maybe_null
-                            ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_null".
-
-Line 1, characters 15-23:
-1 | type t : value non_null maybe_null
-                   ^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value".
-
-Line 1, characters 24-34:
-1 | type t : value non_null maybe_null
-                            ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_null".
-
 type t
 |}]
 
 type t : value maybe_separable non_pointer
 [%%expect{|
-Line 1, characters 15-30:
-1 | type t : value maybe_separable non_pointer
-                   ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value".
-
-Line 1, characters 15-30:
-1 | type t : value maybe_separable non_pointer
-                   ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value".
-
 Line 1, characters 15-30:
 1 | type t : value maybe_separable non_pointer
                    ^^^^^^^^^^^^^^^
@@ -191,18 +106,6 @@ Line 1, characters 27-36:
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
   is already implied by the kind "value non_pointer".
 
-Line 1, characters 27-36:
-1 | type t : value non_pointer separable
-                               ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
-Line 1, characters 27-36:
-1 | type t : value non_pointer separable
-                               ^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
 type t : value non_pointer
 |}]
 
@@ -214,47 +117,11 @@ Line 1, characters 27-38:
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
   is already implied by the kind "value non_pointer".
 
-Line 1, characters 27-38:
-1 | type t : value non_pointer non_pointer
-                               ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
-Line 1, characters 27-38:
-1 | type t : value non_pointer non_pointer
-                               ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
 type t : value non_pointer
 |}]
 
 type t : value non_pointer maybe_separable non_pointer
 [%%expect{|
-Line 1, characters 27-42:
-1 | type t : value non_pointer maybe_separable non_pointer
-                               ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
-Line 1, characters 43-54:
-1 | type t : value non_pointer maybe_separable non_pointer
-                                               ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer maybe_separable".
-
-Line 1, characters 27-42:
-1 | type t : value non_pointer maybe_separable non_pointer
-                               ^^^^^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
-Line 1, characters 43-54:
-1 | type t : value non_pointer maybe_separable non_pointer
-                                               ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer maybe_separable".
-
 Line 1, characters 27-42:
 1 | type t : value non_pointer maybe_separable non_pointer
                                ^^^^^^^^^^^^^^^
@@ -290,57 +157,11 @@ Line 1, characters 50-60:
 Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
   is already implied by the kind "value non_pointer maybe_null non_pointer".
 
-Line 1, characters 27-37:
-1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                               ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
-Line 1, characters 38-49:
-1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                                          ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer maybe_null".
-
-Line 1, characters 50-60:
-1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                                                      ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer maybe_null non_pointer".
-
-Line 1, characters 27-37:
-1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                               ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer".
-
-Line 1, characters 38-49:
-1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                                          ^^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer maybe_null".
-
-Line 1, characters 50-60:
-1 | type t : value non_pointer maybe_null non_pointer maybe_null
-                                                      ^^^^^^^^^^
-Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
-  is already implied by the kind "value non_pointer maybe_null non_pointer".
-
 type t : value non_pointer
 |}]
 
 type t : void non_pointer
 [%%expect{|
-Line 1, characters 9-25:
-1 | type t : void non_pointer
-             ^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "void".
-
-Line 1, characters 9-25:
-1 | type t : void non_pointer
-             ^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "void".
-
 Line 1, characters 9-25:
 1 | type t : void non_pointer
              ^^^^^^^^^^^^^^^^
@@ -356,31 +177,11 @@ Line 1, characters 9-34:
              ^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer non_null" have no effect on the kind "void".
 
-Line 1, characters 9-34:
-1 | type t : void non_pointer non_null
-             ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer non_null" have no effect on the kind "void".
-
-Line 1, characters 9-34:
-1 | type t : void non_pointer non_null
-             ^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer non_null" have no effect on the kind "void".
-
 type t : void
 |}]
 
 type t : void non_pointer maybe_separable
 [%%expect{|
-Line 1, characters 9-41:
-1 | type t : void non_pointer maybe_separable
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer maybe_separable" have no effect on the kind "void".
-
-Line 1, characters 9-41:
-1 | type t : void non_pointer maybe_separable
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer maybe_separable" have no effect on the kind "void".
-
 Line 1, characters 9-41:
 1 | type t : void non_pointer maybe_separable
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2097,14 +2097,14 @@ module Const = struct
            (Scannable_axis.annot_of_separability_annot separability)
     | Pjk_operator (base, sa_annot) ->
       let base_jkind =
-        of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
-          context base
+        of_user_written_annotation_unchecked_level ~use_abstract_jkinds ~warn
+          env context base
       in
       if warn then warn_ignored_kind_modifier ~loc env base base_jkind sa_annot;
       let jkind, _ =
         List.fold_left
           (fun (jkind, rev_axes) axis ->
-            ( apply_scannable_axis ~prior_annot:(base, rev_axes) env
+            ( apply_scannable_axis ~prior_annot:(base, rev_axes) ~warn env
                 (Some (transl_scannable_axis axis))
                 jkind,
               axis.Location.txt :: rev_axes ))

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1981,7 +1981,7 @@ module Const = struct
       Option.map (Location.map (fun x -> Separability x))
   end
 
-  let apply_scannable_axis ?prior_annot env
+  let apply_scannable_axis ?prior_annot ~warn env
       (axis : Scannable_axis.t Location.loc option) t =
     match axis with
     | None -> t
@@ -1989,7 +1989,7 @@ module Const = struct
       let update_sa sa =
         let sa' = Scannable_axis.lower_axes sa axis in
         (match prior_annot with
-        | Some (base, rev_axes) when Scannable_axes.equal sa sa' ->
+        | Some (base, rev_axes) when warn && Scannable_axes.equal sa sa' ->
           Location.prerr_warning loc
             (Warnings.Redundant_kind_modifier
                (Format.asprintf "%a%s" Pprintast.jkind_annotation base
@@ -2066,11 +2066,12 @@ module Const = struct
 
   let rec of_user_written_annotation_unchecked_level : type l r.
       use_abstract_jkinds:bool ->
+      warn:bool ->
       _ ->
       (l * r) Context_with_transl.t ->
       Parsetree.jkind_annotation ->
       (l * r) t =
-   fun ~use_abstract_jkinds env context jkind ->
+   fun ~use_abstract_jkinds ~warn env context jkind ->
     let loc = jkind.pjka_loc in
     match jkind.pjka_desc with
     | Pjk_abbreviation name ->
@@ -2078,8 +2079,8 @@ module Const = struct
       allow_left (of_path p) |> allow_right
     | Pjk_mod (base, modifiers) ->
       let base =
-        of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
-          context base
+        of_user_written_annotation_unchecked_level ~use_abstract_jkinds ~warn
+          env context base
       in
       (* for each mode, lower the corresponding modal bound to be that
          mode *)
@@ -2090,16 +2091,16 @@ module Const = struct
       { base = base.base; mod_bounds; with_bounds = No_with_bounds }
       (* For scannable axes in mod bounds, we do not print redundancy warnings,
          as scannable axes in mod bounds will be deprecated anyway *)
-      |> apply_scannable_axis env
+      |> apply_scannable_axis ~warn env
            (Scannable_axis.annot_of_nullability_annot nullability)
-      |> apply_scannable_axis env
+      |> apply_scannable_axis ~warn env
            (Scannable_axis.annot_of_separability_annot separability)
     | Pjk_operator (base, sa_annot) ->
       let base_jkind =
         of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
           context base
       in
-      warn_ignored_kind_modifier ~loc env base base_jkind sa_annot;
+      if warn then warn_ignored_kind_modifier ~loc env base base_jkind sa_annot;
       let jkind, _ =
         List.fold_left
           (fun (jkind, rev_axes) axis ->
@@ -2113,15 +2114,15 @@ module Const = struct
     | Pjk_product ts ->
       let jkinds =
         List.map
-          (of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
-             context)
+          (of_user_written_annotation_unchecked_level ~use_abstract_jkinds ~warn
+             env context)
           ts
       in
       jkind_of_product_annotations ~loc env jkinds
     | Pjk_with (base, type_, modalities) -> (
       let base =
-        of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
-          context base
+        of_user_written_annotation_unchecked_level ~use_abstract_jkinds ~warn
+          env context base
       in
       match context with
       | Right_jkind c -> raise ~loc:type_.ptyp_loc (With_on_right c)
@@ -2177,11 +2178,11 @@ module Const = struct
        that needs a different extension level. *)
     | Layout l -> scan_layout l
 
-  let of_user_written_annotation ~use_abstract_jkinds env ~context
+  let of_user_written_annotation ~use_abstract_jkinds ~warn env ~context
       (annot : Parsetree.jkind_annotation) =
     Env.check_no_open_quotations annot.pjka_loc env Jkind_annotation_qt;
     let const =
-      of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
+      of_user_written_annotation_unchecked_level ~use_abstract_jkinds ~warn env
         context annot
     in
     let required_layouts_level = get_required_layouts_level context const in
@@ -2191,8 +2192,9 @@ module Const = struct
         (Insufficient_level { jkind = annot; required_layouts_level });
     const
 
-  let of_annotation ?(use_abstract_jkinds = true) ~context env annot =
-    of_user_written_annotation env ~use_abstract_jkinds
+  let of_annotation ?(use_abstract_jkinds = true) ?(warn = true) ~context env
+      annot =
+    of_user_written_annotation env ~use_abstract_jkinds ~warn
       ~context:(Right_jkind context) annot
 end
 
@@ -2287,16 +2289,19 @@ let of_annotated_const ~context ~annotation ~const ~const_loc =
     ~why:(Annotated (context, const_loc))
     const ~quality:Not_best ~ran_out_of_fuel_during_normalize:false
 
-let of_annotation_lr ~use_abstract_jkinds ~context env
+let of_annotation_lr ~use_abstract_jkinds ~warn ~context env
     (annot : Parsetree.jkind_annotation) =
   let const =
-    Const.of_user_written_annotation ~use_abstract_jkinds ~context env annot
+    Const.of_user_written_annotation ~use_abstract_jkinds ~warn ~context env
+      annot
   in
   of_annotated_const ~annotation:(Some annot) ~const ~const_loc:annot.pjka_loc
     ~context
 
-let of_annotation ?(use_abstract_jkinds = true) ~context env annot =
-  of_annotation_lr ~use_abstract_jkinds ~context:(Right_jkind context) env annot
+let of_annotation ?(use_abstract_jkinds = true) ?(warn = true) ~context env
+    annot =
+  of_annotation_lr ~use_abstract_jkinds ~warn ~context:(Right_jkind context) env
+    annot
 
 let of_annotation_option_default ?use_abstract_jkinds ~default ~context env =
   function
@@ -2311,13 +2316,13 @@ let of_attribute ~context
   of_annotated_const ~context ~annotation:(mk_annot name) ~const
     ~const_loc:attribute.loc
 
-let of_type_decl ?(use_abstract_jkinds = true) ~context ~transl_type env
-    (decl : Parsetree.type_declaration) =
+let of_type_decl ?(use_abstract_jkinds = true) ?(warn = true) ~context
+    ~transl_type env (decl : Parsetree.type_declaration) =
   let context = Context_with_transl.Left_jkind (transl_type, context) in
   let jkind_of_annotation =
     decl.ptype_jkind_annotation
     |> Option.map (fun annot ->
-        of_annotation_lr ~use_abstract_jkinds ~context env annot, annot)
+        of_annotation_lr ~use_abstract_jkinds ~warn ~context env annot, annot)
   in
   let jkind_of_attribute =
     Builtin_attributes.jkind decl.ptype_attributes
@@ -2360,7 +2365,9 @@ let of_type_decl_overapproximate_unknown ~context env
     (* CR with-kinds: we could still compute the layout here. *)
     Some (Builtin.any ~why:Overapproximation_of_with_bounds)
   | _ ->
-    of_type_decl ~use_abstract_jkinds:false ~context ~transl_type env decl
+    (* Warnings are emitted in [of_type_decl] rather than here *)
+    of_type_decl ~use_abstract_jkinds:false ~warn:false ~context ~transl_type
+      env decl
     |> Option.map fst
 
 let for_unboxed_record_with_updates lbls =

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -299,6 +299,7 @@ module Const : sig
      as uses of them for unused abstract kind warnings. *)
   val of_annotation :
     ?use_abstract_jkinds:bool ->
+    ?warn:bool ->
     context:('l * allowed) History.annotation_context ->
     Env.t ->
     Parsetree.jkind_annotation ->
@@ -429,9 +430,13 @@ val of_sort_univar :
   'd Types.jkind
 
 (* [use_abstract_jkinds] controls whether references to other kinds here count
-   as uses of them for unused abstract kind warnings. *)
+   as uses of them for unused abstract kind warnings.
+
+   [warn] (default: true) controls whether redundant/ignored kind modifier
+   warnings are emitted. *)
 val of_annotation :
   ?use_abstract_jkinds:bool ->
+  ?warn:bool ->
   context:('l * allowed) History.annotation_context ->
   Env.t ->
   Parsetree.jkind_annotation ->
@@ -461,6 +466,7 @@ val of_annotation_option_default :
     as uses of them for unused abstract kind warnings. *)
 val of_type_decl :
   ?use_abstract_jkinds:bool ->
+  ?warn:bool ->
   context:History.annotation_context_l ->
   transl_type:(Parsetree.core_type -> Types.type_expr) ->
   Env.t ->

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -762,11 +762,9 @@ let transl_type_param env path jkind_default styp =
 
 let get_type_param_jkind env path styp =
   let of_annotation jkind name =
-    let jkind =
-      Jkind.of_annotation env ~use_abstract_jkinds:false
-        ~context:(Type_parameter (path, name)) jkind
-    in
-    jkind
+    (* Warnings are emitted in [transl_type_param] rather than here *)
+    Jkind.of_annotation env ~use_abstract_jkinds:false ~warn:false
+      ~context:(Type_parameter (path, name)) jkind
   in
   match styp.ptyp_desc with
   | Ptyp_any (Some jkind) ->

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -1022,7 +1022,7 @@ let parse_options errflag s =
   alerts
 
 (* If you change these, don't forget to change them in man/ocamlc.m *)
-let defaults_w = "+a-4-7-9-27-29-30-32..42-44-45-48-50-60-66..70-74-183..184"
+let defaults_w = "+a-4-7-9-27-29-30-32..42-44-45-48-50-60-66..70-74"
 let defaults_warn_error = "-a"
 let default_disabled_alerts = [ "unstable"; "unsynchronized_access" ]
 


### PR DESCRIPTION
"Redundant/ignored scannable axis" warnings were disabled because they printed thrice. This PR fixes that and enables the warnings. 