### PR TITLE
Add `array#` and `iarray#`

### DIFF
--- a/testsuite/tests/typing-layouts/hash_types-flat-float-array.ml
+++ b/testsuite/tests/typing-layouts/hash_types-flat-float-array.ml
@@ -5,7 +5,7 @@
 *)
 
 (* See hash_types.ml for the bulk of the tests. This file collects the
-   case that depends on the flat float array optimization being enabled. *)
+   cases that depend on the flat float array optimization being enabled. *)
 
 type 'a t = { i : 'a }
 and bad = P : 'a t# -> bad [@@unboxed]
@@ -13,6 +13,22 @@ and bad = P : 'a t# -> bad [@@unboxed]
 Line 2, characters 0-38:
 2 | and bad = P : 'a t# -> bad [@@unboxed]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because
+       it might contain both float and non-float values,
+       depending on the instantiation of the existential variable "'a".
+       You should annotate it with "[@@ocaml.boxed]".
+|}]
+
+(* The negative counterpart of the [array#]/[iarray#] separability tests in
+   hash_types.ml: an abstract any-layout type's parameter gets the worst-case
+   mode, so the existential is rejected. *)
+type ('a : value) abstr : any
+type bad = B : 'a abstr -> bad [@@unboxed]
+[%%expect{|
+type 'a abstr : any
+Line 2, characters 0-42:
+2 | type bad = B : 'a abstr -> bad [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type cannot be unboxed because
        it might contain both float and non-float values,
        depending on the instantiation of the existential variable "'a".

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -1315,21 +1315,21 @@ type packed = T : (int, 'b) s# -> packed [@@unboxed]
 
 (* Unboxed arrays and iarrays, which are unrepresentable *)
 
-type 'a arr_u : any = 'a array#
+type ('a : any) arr_u : any = 'a array#
 [%%expect{|
-type 'a arr_u = 'a array#
+type ('a : any separable) arr_u = 'a array#
 |}]
 
-type 'a arr = 'a array
-type 'a arr_u_2 = 'a arr#
+type ('a : any) arr = 'a array
+type ('a : any) arr_u_2 = 'a arr#
 [%%expect{|
-type 'a arr = 'a array
-type 'a arr_u_2 = 'a arr#
+type ('a : any separable) arr = 'a array
+type ('a : any separable) arr_u_2 = 'a arr#
 |}]
 
-type 'a iarr_u : any = 'a iarray#
+type ('a : any) iarr_u : any = 'a iarray#
 [%%expect{|
-type 'a iarr_u = 'a iarray#
+type ('a : any separable) iarr_u = 'a iarray#
 |}]
 
 let bad (_ : 'a array#) = ()
@@ -1358,4 +1358,21 @@ Error: This pattern matches values of type "'a iarray#"
          because it is the unboxed version of the primitive type iarray.
        But the layout of 'a iarray# must be representable
          because we must know concretely how to pass a function argument.
+|}]
+
+(* [array#] is invariant in its parameter, like [array]. *)
+type +'a bad = 'a array#
+[%%expect{|
+Line 1, characters 0-24:
+1 | type +'a bad = 'a array#
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: In this definition, expected parameter variances are not satisfied.
+       The 1st type parameter was expected to be covariant,
+       but it is injective invariant.
+|}]
+
+(* [iarray#] is covariant in its parameter, like [iarray] (unlike [array#]). *)
+type +'a co = 'a iarray#
+[%%expect{|
+type 'a co = 'a iarray#
 |}]

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -1312,3 +1312,50 @@ type ('a, 'b) t = { a : 'a; }
 type ('a, 'b) s = ('a, 'b) t
 type packed = T : (int, 'b) s# -> packed [@@unboxed]
 |}]
+
+(* Unboxed arrays and iarrays, which are unrepresentable *)
+
+type 'a arr_u : any = 'a array#
+[%%expect{|
+type 'a arr_u = 'a array#
+|}]
+
+type 'a arr = 'a array
+type 'a arr_u_2 = 'a arr#
+[%%expect{|
+type 'a arr = 'a array
+type 'a arr_u_2 = 'a arr#
+|}]
+
+type 'a iarr_u : any = 'a iarray#
+[%%expect{|
+type 'a iarr_u = 'a iarray#
+|}]
+
+let bad (_ : 'a array#) = ()
+[%%expect{|
+Line 1, characters 8-23:
+1 | let bad (_ : 'a array#) = ()
+            ^^^^^^^^^^^^^^^
+Error: This pattern matches values of type "'a array#"
+       but a pattern was expected which matches values of type
+         "('b : '_representable_layout_1)"
+       The layout of 'a array# is any
+         because it is the unboxed version of the primitive type array.
+       But the layout of 'a array# must be representable
+         because we must know concretely how to pass a function argument.
+|}]
+
+let bad (_ : 'a iarray#) = ()
+[%%expect{|
+Line 1, characters 8-24:
+1 | let bad (_ : 'a iarray#) = ()
+            ^^^^^^^^^^^^^^^^
+Error: This pattern matches values of type "'a iarray#"
+       but a pattern was expected which matches values of type
+         "('b : '_representable_layout_2)"
+       The layout of 'a iarray# is any
+         because it is the unboxed version of the primitive type iarray.
+       But the layout of 'a iarray# must be representable
+         because we must know concretely how to pass a function argument.
+|}]

--- a/testsuite/tests/typing-layouts/hash_types.ml
+++ b/testsuite/tests/typing-layouts/hash_types.ml
@@ -1376,3 +1376,14 @@ type +'a co = 'a iarray#
 [%%expect{|
 type 'a co = 'a iarray#
 |}]
+
+(* The parameters of [array#] and [iarray#] have separability mode [Ind], like
+   [array]'s: an existential under them needn't be separable. (Cf. the abstract
+   type in hash_types-flat-float-array.ml, whose parameter gets the worst-case
+   mode.) *)
+type p = P : 'a array# -> p [@@unboxed]
+type q = Q : 'a iarray# -> q [@@unboxed]
+[%%expect{|
+type p = P : 'a array# -> p [@@unboxed]
+type q = Q : 'a iarray# -> q [@@unboxed]
+|}]

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -616,6 +616,32 @@ let or_null_kind tvar =
 let decl_of_type_constr type_constr =
   let type_ident = ident_of_type_constr type_constr in
   let type_uid = Uid.of_predef_id type_ident in
+  (* The unboxed versions explicitly added to the predef are abstract, as they
+     are special-cased; other unboxed versions are automatically derived. *)
+  let mk_unboxed_version ~params ~variance ~separability
+      (unboxed_jkind : Jkind.Const.Builtin.t) =
+    let type_jkind =
+      Jkind.of_builtin ~why:(Unboxed_primitive type_ident) unboxed_jkind
+      |> Jkind.mark_best
+    in
+    { type_params = params;
+      type_arity = List.length params;
+      type_kind = Type_abstract Definition;
+      type_jkind;
+      type_ikind = ikind_of_jkind ~params type_jkind;
+      type_loc = Location.none;
+      type_private = Asttypes.Public;
+      type_manifest = None;
+      type_variance = variance;
+      type_separability = separability;
+      type_is_newtype = false;
+      type_expansion_scope = lowest_level;
+      type_attributes = [];
+      type_unboxed_default = false;
+      type_uid = Uid.unboxed_version type_uid;
+      type_unboxed_version = None;
+    }
+  in
   let decl0
       ?(kind = Type_abstract Definition)
       ~(jkind : jkind_l)
@@ -623,36 +649,10 @@ let decl_of_type_constr type_constr =
       ?manifest
       ()
     =
-    let type_unboxed_version = match unboxed_jkind with
-      | None -> None
-      | Some unboxed_jkind ->
-        let type_jkind =
-          Jkind.of_builtin ~why:(Unboxed_primitive type_ident) unboxed_jkind
-        in
-        let type_jkind = Jkind.mark_best type_jkind in
-        let type_ikind = ikind_of_jkind ~params:[] type_jkind in
-        (* All unboxed versions of types explicitly added in the predef are
-           abstract, as they are special cased. Other unboxed versions are
-           automatically derived. *)
-        let type_kind = Type_abstract Definition in
-        Some {
-          type_params = [];
-          type_arity = 0;
-          type_kind;
-          type_jkind;
-          type_ikind;
-          type_loc = Location.none;
-          type_private = Asttypes.Public;
-          type_manifest = None;
-          type_variance = [];
-          type_separability = [];
-          type_is_newtype = false;
-          type_expansion_scope = lowest_level;
-          type_attributes = [];
-          type_unboxed_default = false;
-          type_uid = Uid.unboxed_version type_uid;
-          type_unboxed_version = None;
-        }
+    let type_unboxed_version =
+      Option.map
+        (mk_unboxed_version ~params:[] ~variance:[] ~separability:[])
+        unboxed_jkind
     in
     let type_jkind = Jkind.mark_best jkind in
     let type_ikind = ikind_of_jkind ~params:[] type_jkind in
@@ -681,11 +681,19 @@ let decl_of_type_constr type_constr =
       ?(separability = Separability.Ind)
       ?(kind = fun _ -> Type_abstract Definition)
       ?manifest
+      ?(unboxed_jkind : Jkind.Const.Builtin.t option)
       ()
     =
     let param = newgenvar param_jkind in
     let base = decl0 ~jkind:(jkind param) ~kind:(kind param) () in
     let manifest = Option.map (fun f -> f param) manifest in
+    let type_unboxed_version =
+      Option.map
+        (fun unboxed_jkind ->
+          mk_unboxed_version ~params:[param] ~variance:[variance]
+            ~separability:[separability] unboxed_jkind)
+        unboxed_jkind
+    in
     { base with
       type_params = [param];
       type_arity = 1;
@@ -693,6 +701,7 @@ let decl_of_type_constr type_constr =
       type_variance = [variance];
       type_separability = [separability];
       type_manifest = manifest;
+      type_unboxed_version;
     }
   in
   let decl2
@@ -815,6 +824,7 @@ let decl_of_type_constr type_constr =
       ~jkind:(builtin2 Jkind.Const.Builtin.value) ()
   | `Array ->
     decl1 ~variance:Variance.full ~param_jkind:Jkind.for_array_argument
+       ~unboxed_jkind:Jkind.Const.Builtin.any
        ~jkind:(fun param ->
          Jkind.Builtin.mutable_data ~why:(Primitive ident_array) |>
          Jkind.add_with_bounds
@@ -834,6 +844,7 @@ let decl_of_type_constr type_constr =
   | `Iarray ->
       decl1 ~variance:Variance.covariant
        ~param_jkind:Jkind.for_array_argument
+       ~unboxed_jkind:Jkind.Const.Builtin.any
        ~jkind:(fun param ->
          Jkind.Builtin.immutable_data ~why:(Primitive ident_iarray) |>
          Jkind.add_with_bounds

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -689,9 +689,8 @@ let decl_of_type_constr type_constr =
     let manifest = Option.map (fun f -> f param) manifest in
     let type_unboxed_version =
       Option.map
-        (fun unboxed_jkind ->
-          mk_unboxed_version ~params:[param] ~variance:[variance]
-            ~separability:[separability] unboxed_jkind)
+        (mk_unboxed_version ~params:[param] ~variance:[variance]
+           ~separability:[separability])
         unboxed_jkind
     in
     { base with


### PR DESCRIPTION
Add unboxed versions of `array` and `iarray`, with kind `any`.
```ocaml
type 'a t : any = 'a array#
```

This is a step towards changing the types of indices to use `box`.