### PR TITLE
Control PR for compiler perf CI

### DIFF
--- a/tools/ci/compiler_perf/control-pr.md
+++ b/tools/ci/compiler_perf/control-pr.md
@@ -1,0 +1,3 @@
+This file exists only to create a compiler-perf control PR.
+
+It does not affect compiler sources or the compiler-perf workflow.


### PR DESCRIPTION
Control PR for compiler-perf CI calibration.

This changes only a marker document under tools/ci/compiler_perf. It should exercise the perf workflow without changing the compiler.
