### PR TITLE
Parse scannable axes on arbitrary kinds

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2754,7 +2754,7 @@ let assert_no_jkinds jkind =
     (fun ({ pjka_loc; pjka_desc } : Parsetree.jkind_annotation) ->
       (* Naively check if the jkind annotation is trivial *)
       match pjka_desc with
-      | Pjk_abbreviation ({ loc = _; txt = Lident "value" }, []) -> ()
+      | Pjk_abbreviation { loc = _; txt = Lident "value" } -> ()
       | _ ->
         fatal_errorf
           "Translquote [at %a]: no support for jkind annotations in this \

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -162,6 +162,8 @@ module Typ = struct
         match jkind.pjka_desc with
         | Pjk_default as x -> x
         | Pjk_abbreviation _ as x -> x
+        | Pjk_operator (jkind, sa) ->
+          Pjk_operator (loop_jkind jkind, sa)
         | Pjk_mod (jkind, modes) -> Pjk_mod (loop_jkind jkind, modes)
         | Pjk_with (jkind, typ, modalities) ->
           Pjk_with (loop_jkind jkind, loop typ, modalities)

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -887,9 +887,10 @@ let default_iterator =
          this.location this pjka_loc;
          match pjka_desc with
          | Pjk_default -> ()
-         | Pjk_abbreviation (lid, sa_annot) ->
-           iter_loc this lid;
-           List.iter (iter_loc this) sa_annot
+         | Pjk_abbreviation lid -> iter_loc this lid
+         | Pjk_operator (t, sa_annot) ->
+             this.jkind_annotation this t;
+             List.iter (iter_loc this) sa_annot
          | Pjk_mod (t, mode_list) ->
              this.jkind_annotation this t;
              this.modes this mode_list

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -1009,8 +1009,10 @@ let default_mapper =
       let pjka_desc =
         match pjka_desc with
         | Pjk_default -> Pjk_default
-        | Pjk_abbreviation (lid, sa) ->
-          Pjk_abbreviation (map_loc this lid, List.map (map_loc this) sa)
+        | Pjk_abbreviation lid -> Pjk_abbreviation (map_loc this lid)
+        | Pjk_operator (t, sa) ->
+          Pjk_operator
+            (this.jkind_annotation this t, List.map (map_loc this) sa)
         | Pjk_mod (t, mode_list) ->
           Pjk_mod (this.jkind_annotation this t, this.modes this mode_list)
         | Pjk_with (t, ty, modalities) ->

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -139,7 +139,8 @@ and add_package_type bv ptyp =
 and add_jkind bv (jkind : jkind_annotation) =
   match jkind.pjka_desc with
   | Pjk_default -> ()
-  | Pjk_abbreviation (l, _sa) -> add bv l
+  | Pjk_abbreviation l -> add bv l
+  | Pjk_operator (jkind, _sa) -> add_jkind bv jkind
   | Pjk_mod (jkind, (_ : modes)) -> add_jkind bv jkind
   | Pjk_with (jkind, typ, (_ : modalities)) ->
       add_jkind bv jkind;

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4123,8 +4123,13 @@ jkind_desc_gen(self):
       in
       Pjk_mod ($1, modes)
     }
-  | mkrhs(type_longident) mkrhs(LIDENT)* {
-      Pjk_abbreviation ($1, $2)
+  | name = mkrhs(type_longident) axes = mkrhs(LIDENT)* {
+      match axes with
+      | [] -> Pjk_abbreviation name
+      | _ :: _ ->
+        Pjk_operator
+          ({ pjka_loc = make_loc $loc(name);
+             pjka_desc = Pjk_abbreviation name }, axes)
     }
   | KIND_OF ty=core_type %prec below_LBRACKETAT {
       Pjk_kind_of ty
@@ -4135,8 +4140,12 @@ jkind_desc_gen(self):
   | reverse_product_jkind_gen(self) %prec below_AMPERSAND {
       Pjk_product (List.rev $1)
     }
-  | LPAREN self RPAREN {
-      $2
+  | LPAREN inner = self RPAREN axes = mkrhs(LIDENT)* {
+      match axes with
+      | [] -> inner
+      | _ :: _ ->
+        Pjk_operator
+          ({ pjka_loc = make_loc $loc(inner); pjka_desc = inner }, axes)
     }
 ;
 

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -1376,15 +1376,12 @@ and module_binding =
 
 and jkind_annotation_desc =
   | Pjk_default
-  (* CR layouts-scannable: Scannable axes annotations only currently parse on
-     abbreviations, not on products/etc. It could be desirable for these
-     annotations to parse in more places with a warning (ex: for generated
-     code). This change should only be made if necessary (and after the
-     ignored-kind-modifier warning is enabled), since it adds confusion. *)
-  | Pjk_abbreviation of Longident.t loc * string loc list
-  (** [Pjk_abbreviation(A, [SA1; ...; SAn])] represents the layout
-      [A SA1 ... SAn] where [A] is some abbreviation (like [value])
-      and each [SAi] is a scannable axis annotation (like [non_pointer]) *)
+  | Pjk_abbreviation of Longident.t loc
+  (** [Pjk_abbreviation A] represents an abbreviation [A] (like [value]) *)
+  | Pjk_operator of jkind_annotation * string loc list
+  (** [Pjk_operator(K, [SA1; ...; SAn])] represents the layout
+      [K SA1 ... SAn] where [K] is an arbitrary kind and each [SAi] is a
+      scannable axis annotation (like [non_pointer]). *)
   (* CR layouts v2.8: [mod] can have only layouts on the left, not
      full kind annotations. We may want to narrow this type some.
      Internal ticket 5085. *)

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -503,8 +503,9 @@ and type_with_label ctxt f (label, c, mode) =
 
 and jkind_annotation ?(nested = false) ctxt f k = match k.pjka_desc with
   | Pjk_default -> pp f "_"
-  | Pjk_abbreviation (s, sa) ->
-    value_longident_loc f s;
+  | Pjk_abbreviation s -> value_longident_loc f s
+  | Pjk_operator (t, sa) ->
+    jkind_annotation ~nested:true ctxt f t;
     List.iter (fun a -> pp f " %s" a.Location.txt) sa
   | Pjk_mod (t, modes) ->
     begin match modes with

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -577,8 +577,11 @@ and jkind_annotation i ppf (jkind : jkind_annotation) =
   line i ppf "jkind %a\n" fmt_location jkind.pjka_loc;
   match jkind.pjka_desc with
   | Pjk_default -> line i ppf "Pjk_default\n"
-  | Pjk_abbreviation (abbrev, sa) ->
-      line i ppf "Pjk_abbreviation %a\n" fmt_longident_loc abbrev;
+  | Pjk_abbreviation abbrev ->
+      line i ppf "Pjk_abbreviation %a\n" fmt_longident_loc abbrev
+  | Pjk_operator (jkind, sa) ->
+      line i ppf "Pjk_operator\n";
+      jkind_annotation (i+1) ppf jkind;
       List.iter
         (fun a -> line (i+1) ppf "scannable_axis %a\n" fmt_string_loc a) sa
   | Pjk_mod (jkind, m) ->

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -597,8 +597,11 @@ and jkind_annotation i ppf (jkind : jkind_annotation) =
   line i ppf "jkind %a\n" fmt_location jkind.pjka_loc;
   match jkind.pjka_desc with
   | Pjk_default -> line i ppf "Pjk_default\n"
-  | Pjk_abbreviation (abbrev, sa) ->
-      line i ppf "Pjk_abbreviation %a\n" fmt_longident_loc abbrev;
+  | Pjk_abbreviation abbrev ->
+      line i ppf "Pjk_abbreviation %a\n" fmt_longident_loc abbrev
+  | Pjk_operator (jkind, sa) ->
+      line i ppf "Pjk_operator\n";
+      jkind_annotation (i+1) ppf jkind;
       List.iter
         (fun a -> line (i+1) ppf "scannable_axis %a\n" fmt_string_loc a) sa
   | Pjk_mod (jkind, m) ->

--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -103,7 +103,7 @@ module Example = struct
       pjka_desc =
         Pjk_with
           ( { pjka_loc = loc;
-              pjka_desc = Pjk_abbreviation ({ loc; txt = (Lident "value") }, []);
+              pjka_desc = Pjk_abbreviation { loc; txt = (Lident "value") };
             }
           , core_type
           , modalities

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -156,10 +156,12 @@ type ('a, 'b : float64, 'c : any, 'd, 'e, 'f, 'g, 'h, 'i, 'j : bits64, 'k,
 type t15 : any non_pointer
 type t16 : value non_pointer
 type t17 : value & value non_pointer
+type t17b : (value & value) non_pointer
 [%%expect{|
 type t15 : any non_pointer
 type t16 : value non_pointer
 type t17 : value & value non_pointer
+type t17b : value & value
 |}]
 
 type ('a : value mod external_ stateless many unyielding non_float) t18 =

--- a/testsuite/tests/parsetree/test_ppx.compilers.reference
+++ b/testsuite/tests/parsetree/test_ppx.compilers.reference
@@ -1,5 +1,5 @@
-File "source_jane_street.ml", line 171, characters 0-24:
-171 | type t = #(int * float#)
+File "source_jane_street.ml", line 173, characters 0-24:
+173 | type t = #(int * float#)
       ^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Multiple definition of the type name t.
        Names must be unique in a given structure or signature.

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
@@ -89,5 +89,56 @@
               ]
               mode "global" (parsing_ambiguous_product.ml[16,429+41]..[16,429+47])
     ]
+  structure_item (parsing_ambiguous_product.ml[20,561+0]..[20,561+37])
+    Pstr_type Rec
+    [
+      type_declaration "t4" (parsing_ambiguous_product.ml[20,561+5]..[20,561+7]) (parsing_ambiguous_product.ml[20,561+0]..[20,561+37])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          None
+        ptype_jkind_annotation =
+          Some
+            jkind (parsing_ambiguous_product.ml[20,561+10]..[20,561+37])
+            Pjk_operator
+              jkind (parsing_ambiguous_product.ml[20,561+11]..[20,561+24])
+              Pjk_product
+              [
+                jkind (parsing_ambiguous_product.ml[20,561+11]..[20,561+16])
+                Pjk_abbreviation "value" (parsing_ambiguous_product.ml[20,561+11]..[20,561+16])
+                jkind (parsing_ambiguous_product.ml[20,561+19]..[20,561+24])
+                Pjk_abbreviation "value" (parsing_ambiguous_product.ml[20,561+19]..[20,561+24])
+              ]
+              scannable_axis "non_pointer" (parsing_ambiguous_product.ml[20,561+26]..[20,561+37])
+    ]
+  structure_item (parsing_ambiguous_product.ml[22,602+0]..[22,602+40])
+    Pstr_type Rec
+    [
+      type_declaration "t5" (parsing_ambiguous_product.ml[22,602+5]..[22,602+7]) (parsing_ambiguous_product.ml[22,602+0]..[22,602+40])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          None
+        ptype_jkind_annotation =
+          Some
+            jkind (parsing_ambiguous_product.ml[22,602+10]..[22,602+40])
+            Pjk_operator
+              jkind (parsing_ambiguous_product.ml[22,602+11]..[22,602+27])
+              Pjk_mod
+                jkind (parsing_ambiguous_product.ml[22,602+11]..[22,602+16])
+                Pjk_abbreviation "value" (parsing_ambiguous_product.ml[22,602+11]..[22,602+16])
+                mode "global" (parsing_ambiguous_product.ml[22,602+21]..[22,602+27])
+              scannable_axis "non_pointer" (parsing_ambiguous_product.ml[22,602+29]..[22,602+40])
+    ]
 ]
 

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
@@ -140,5 +140,31 @@
                 mode "global" (parsing_ambiguous_product.ml[22,602+21]..[22,602+27])
               scannable_axis "non_pointer" (parsing_ambiguous_product.ml[22,602+29]..[22,602+40])
     ]
+  structure_item (parsing_ambiguous_product.ml[24,646+0]..[24,646+38])
+    Pstr_type Rec
+    [
+      type_declaration "t6" (parsing_ambiguous_product.ml[24,646+5]..[24,646+7]) (parsing_ambiguous_product.ml[24,646+0]..[24,646+38])
+        ptype_params =
+          []
+        ptype_cstrs =
+          []
+        ptype_kind =
+          Ptype_abstract
+        ptype_private = Public
+        ptype_manifest =
+          None
+        ptype_jkind_annotation =
+          Some
+            jkind (parsing_ambiguous_product.ml[24,646+10]..[24,646+38])
+            Pjk_operator
+              jkind (parsing_ambiguous_product.ml[24,646+11]..[24,646+25])
+              Pjk_with
+                jkind (parsing_ambiguous_product.ml[24,646+11]..[24,646+16])
+                Pjk_abbreviation "value" (parsing_ambiguous_product.ml[24,646+11]..[24,646+16])
+                core_type (parsing_ambiguous_product.ml[24,646+22]..[24,646+25])
+                  Ptyp_constr "int" (parsing_ambiguous_product.ml[24,646+22]..[24,646+25])
+                  []
+              scannable_axis "non_pointer" (parsing_ambiguous_product.ml[24,646+27]..[24,646+38])
+    ]
 ]
 

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.ml
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.ml
@@ -19,4 +19,6 @@ type t3 : (value mod global & value) mod global;;
 
 type t4 : (value & value) non_pointer;;
 
-type t5 : (value mod global) non_pointer
+type t5 : (value mod global) non_pointer;;
+
+type t6 : (value with int) non_pointer

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.ml
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.ml
@@ -13,4 +13,10 @@ type t1 : (value mod global) & (value mod global);;
 
 type t2 : value mod global & value mod global;;
 
-type t3 : (value mod global & value) mod global
+type t3 : (value mod global & value) mod global;;
+
+(* Scannable axes parse on products and other kinds, not just abbreviations. *)
+
+type t4 : (value & value) non_pointer;;
+
+type t5 : (value mod global) non_pointer

--- a/testsuite/tests/typing-layouts-scannable/warnings.ml
+++ b/testsuite/tests/typing-layouts-scannable/warnings.ml
@@ -13,9 +13,9 @@ Error: Unknown kind modifier non_pointerrrrr
 
 type t : non_pointer value
 [%%expect{|
-Line 1, characters 9-26:
+Line 1, characters 9-20:
 1 | type t : non_pointer value
-             ^^^^^^^^^^^^^^^^^
+             ^^^^^^^^^^^
 Error: Unbound kind "non_pointer"
 |}]
 
@@ -403,4 +403,66 @@ Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
   is already implied by the kind "value non_pointer".
 
 type t : void mod global & value non_pointer mod global
+|}]
+
+(* Scannable axes can be written on arbitrary kinds, not just abbreviations.
+   Products are not scannable, so they get the ignored-kind-modifier warning. *)
+
+type t : (value & value) non_pointer
+[%%expect{|
+Line 1, characters 9-36:
+1 | type t : (value & value) non_pointer
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "value & value".
+
+Line 1, characters 9-36:
+1 | type t : (value & value) non_pointer
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "value & value".
+
+Line 1, characters 9-36:
+1 | type t : (value & value) non_pointer
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 184 [ignored-kind-modifier]: The kind modifier(s) "non_pointer" have no effect on the kind "value & value".
+
+type t : value & value
+|}]
+
+(* On a scannable kind the axis applies, with no warning. *)
+
+type t : (value) non_pointer
+[%%expect{|
+type t : value non_pointer
+|}]
+
+(* Redundant axes still warn. *)
+
+type t : (value) non_pointer non_pointer
+[%%expect{|
+Line 1, characters 29-40:
+1 | type t : (value) non_pointer non_pointer
+                                 ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "value non_pointer".
+
+Line 1, characters 29-40:
+1 | type t : (value) non_pointer non_pointer
+                                 ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "value non_pointer".
+
+Line 1, characters 29-40:
+1 | type t : (value) non_pointer non_pointer
+                                 ^^^^^^^^^^^
+Warning 183 [redundant-kind-modifier]: This kind modifier, or a stronger one,
+  is already implied by the kind "value non_pointer".
+
+type t : value non_pointer
+|}]
+
+(* Axes compose with [mod]. *)
+
+type t : (value mod global) non_pointer
+[%%expect{|
+type t : value non_pointer mod global
 |}]

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2079,8 +2079,8 @@ module Jkind0 = struct
       Some
         Parsetree.{
           pjka_loc = Location.none;
-          pjka_desc = Pjk_abbreviation ({ loc = Location.none;
-                                          txt = (Lident name) }, [])
+          pjka_desc = Pjk_abbreviation { loc = Location.none;
+                                         txt = (Lident name) }
         }
 
     let mark_best (type l r) (t : (l * r) jkind) =

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2011,6 +2011,19 @@ module Const = struct
                 (Layout.Const.set_root_scannable_axes layout (update_sa sa))
           }))
 
+  let warn_ignored_kind_modifier ~loc env base base_jkind sa_annot =
+    if
+      sa_annot <> []
+      &&
+      match get_layout_result env base_jkind with
+      | Ok layout -> not (Layout.Const.is_scannable_or_any layout)
+      | Error _ -> false
+    then
+      Location.prerr_warning loc
+        (Warnings.Ignored_kind_modifier
+           ( Format.asprintf "%a" Pprintast.jkind_annotation base,
+             List.map Location.get_txt sa_annot ))
+
   let jkind_of_product_annotations (type l r) ~loc env (jkinds : (l * r) t list)
       =
     let folder (type l r) (layouts_acc, mod_bounds_acc, with_bounds_acc)
@@ -2086,17 +2099,7 @@ module Const = struct
         of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
           context base
       in
-      if
-        sa_annot <> []
-        &&
-        match get_layout_result env base_jkind with
-        | Ok layout -> not (Layout.Const.is_scannable_or_any layout)
-        | Error _ -> false
-      then
-        Location.prerr_warning loc
-          (Warnings.Ignored_kind_modifier
-             ( Format.asprintf "%a" Pprintast.jkind_annotation base,
-               List.map Location.get_txt sa_annot ));
+      warn_ignored_kind_modifier ~loc env base base_jkind sa_annot;
       let jkind, _ =
         List.fold_left
           (fun (jkind, rev_axes) axis ->

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1989,10 +1989,10 @@ module Const = struct
       let update_sa sa =
         let sa' = Scannable_axis.lower_axes sa axis in
         (match prior_annot with
-        | Some (abbrev, rev_axes) when Scannable_axes.equal sa sa' ->
+        | Some (base, rev_axes) when Scannable_axes.equal sa sa' ->
           Location.prerr_warning loc
             (Warnings.Redundant_kind_modifier
-               (Format.asprintf "%a%s" Pprintast.longident abbrev
+               (Format.asprintf "%a%s" Pprintast.jkind_annotation base
                   (String.concat ""
                      (List.rev_map (fun axis -> " " ^ axis) rev_axes))))
         | _ -> ());
@@ -2060,30 +2060,9 @@ module Const = struct
    fun ~use_abstract_jkinds env context jkind ->
     let loc = jkind.pjka_loc in
     match jkind.pjka_desc with
-    | Pjk_abbreviation (name, sa_annot) ->
+    | Pjk_abbreviation name ->
       let p, _ = Env.lookup_jkind ~use:use_abstract_jkinds ~loc name.txt env in
-      let jkind_without_sa = of_path p in
-      if
-        sa_annot <> []
-        &&
-        match get_layout_result env jkind_without_sa with
-        | Ok layout -> not (Layout.Const.is_scannable_or_any layout)
-        | Error _ -> false
-      then
-        Location.prerr_warning jkind.pjka_loc
-          (Warnings.Ignored_kind_modifier
-             ( Format.asprintf "%a" Pprintast.longident name.txt,
-               List.map Location.get_txt sa_annot ));
-      let jkind, _abbrev =
-        List.fold_left
-          (fun (jkind, rev_axes) axis ->
-            ( apply_scannable_axis ~prior_annot:(name.txt, rev_axes) env
-                (Some (transl_scannable_axis axis))
-                jkind,
-              axis.Location.txt :: rev_axes ))
-          (jkind_without_sa, []) sa_annot
-      in
-      allow_left jkind |> allow_right
+      allow_left (of_path p) |> allow_right
     | Pjk_mod (base, modifiers) ->
       let base =
         of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
@@ -2102,6 +2081,32 @@ module Const = struct
            (Scannable_axis.annot_of_nullability_annot nullability)
       |> apply_scannable_axis env
            (Scannable_axis.annot_of_separability_annot separability)
+    | Pjk_operator (base, sa_annot) ->
+      let base_jkind =
+        of_user_written_annotation_unchecked_level ~use_abstract_jkinds env
+          context base
+      in
+      if
+        sa_annot <> []
+        &&
+        match get_layout_result env base_jkind with
+        | Ok layout -> not (Layout.Const.is_scannable_or_any layout)
+        | Error _ -> false
+      then
+        Location.prerr_warning loc
+          (Warnings.Ignored_kind_modifier
+             ( Format.asprintf "%a" Pprintast.jkind_annotation base,
+               List.map Location.get_txt sa_annot ));
+      let jkind, _ =
+        List.fold_left
+          (fun (jkind, rev_axes) axis ->
+            ( apply_scannable_axis ~prior_annot:(base, rev_axes) env
+                (Some (transl_scannable_axis axis))
+                jkind,
+              axis.Location.txt :: rev_axes ))
+          (base_jkind, []) sa_annot
+      in
+      jkind
     | Pjk_product ts ->
       let jkinds =
         List.map
@@ -2334,6 +2339,7 @@ let of_type_decl_overapproximate_unknown ~context env
     match jkind.pjka_desc with
     | Pjk_with _ -> true
     | Pjk_mod (base, _) -> has_with_bounds base
+    | Pjk_operator (base, _) -> has_with_bounds base
     | Pjk_product jkinds -> List.exists has_with_bounds jkinds
     | Pjk_abbreviation _ -> false
     | Pjk_default | Pjk_kind_of _ ->

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -206,8 +206,8 @@ end = struct
         ~ran_out_of_fuel_during_normalize
         ~annotation:
           (Some { pjka_loc = Location.none;
-                  pjka_desc = Pjk_abbreviation ({ loc = Location.none;
-                                                  txt = name }, []) })
+                  pjka_desc = Pjk_abbreviation { loc = Location.none;
+                                                 txt = name } })
         ~why:Jkind_intf.History.Imported)
       (const_builtins @ const_predefs)
 

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -716,11 +716,11 @@ let type_decl_is_alias sdecl = (* assuming no explicit constraint *)
 
 let kind_decl_is_alias sdecl =
   match sdecl.pjkind_manifest with
-  | Some { pjka_desc = Pjk_abbreviation (lid, []); _ } -> Some lid
+  | Some { pjka_desc = Pjk_abbreviation lid; _ } -> Some lid
   | None
   | Some { pjka_desc =
-             ( Pjk_abbreviation (_, _ :: _) | Pjk_default | Pjk_mod _
-             | Pjk_with _ | Pjk_kind_of _ | Pjk_product _ ); _ }
+             ( Pjk_operator _ | Pjk_default | Pjk_mod _ | Pjk_with _
+             | Pjk_kind_of _ | Pjk_product _ ); _ }
     -> None
 
 let params_are_constrained =


### PR DESCRIPTION
Parse scannable axes on arbitrary kinds, such as in `(value & value) non_pointer`. (They have no effect on product kinds; we'll give a warning with https://github.com/oxcaml/oxcaml/pull/6360.)

The purpose of this change is to increase uniformity and make way for parsing other kind modifiers such as `box`.