### PR TITLE
Use denv with extra equations in switch args

### DIFF
--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -833,7 +833,7 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
       Simplify_common.apply_cont_use_kind ~context:Switch_branch action
     in
     let { S.simples = args; simple_tys = arg_types } =
-      S.simplify_simples dacc args
+      S.simplify_simples (DA.with_denv dacc denv_at_use) args
     in
     let dacc, rewrite_id =
       DA.record_continuation_use dacc (AC.continuation action) use_kind

--- a/testsuite/tests/codegen/check_elimination.ml
+++ b/testsuite/tests/codegen/check_elimination.ml
@@ -94,7 +94,7 @@ search:
   je    .L1
 .L0:
   xorl  %esi, %esi
-  movq  %rbx, %rax
+  movl  $1, %eax
   jmp   .L4
 .L1:
   movq  (%rbx), %rax


### PR DESCRIPTION
This does not matter much at the moment, since we rarely have equations that will impact the continuation arms of the switch, but this is clearly the right environment to use and will matter if we start recording equations on boolean primitives (e.g. the output of `%eq`).