### PR TITLE
Don't rerun `expect_asm/fexpr` tests with `-principal`

### DIFF
--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -901,22 +901,30 @@ let run_expect_once input_file principal log env ~backend =
   let exit_status =
     Actions_helpers.run_cmd ~environment:default_ocaml_env log env commandline
   in
-  if exit_status=0 then (Result.pass, env)
+  if exit_status=0 then (Result.pass, env, ~needs_principal:false)
+  else if exit_status=3 then (Result.pass, env, ~needs_principal:true)
   else begin
     let reason = (Actions_helpers.mkreason
       "expect" (String.concat " " commandline) exit_status) in
-    (Result.fail_with_reason reason, env)
+    (Result.fail_with_reason reason, env, ~needs_principal:false)
   end
 
 let run_expect_twice input_file log env ~backend =
   let corrected filename = Filename.make_filename filename "corrected" in
-  let (result1, env1) = run_expect_once input_file false log env ~backend in
+  let (result1, env1, ~needs_principal) =
+    run_expect_once input_file false log env ~backend
+  in
   if Result.is_pass result1 then begin
     let intermediate_file = corrected input_file in
-    let (result2, env2) =
-      run_expect_once intermediate_file true log env1 ~backend in
+    let (result2, env2, output_file) =
+      if needs_principal then
+        let (result2, env2, ..) =
+          run_expect_once intermediate_file true log env1 ~backend
+        in
+        (result2, env2, corrected intermediate_file)
+      else (result1, env1, intermediate_file)
+    in
     if Result.is_pass result2 then begin
-      let output_file = corrected intermediate_file in
       let output_env = Environments.add_bindings
       [
         Builtin_variables.reference, input_file;

--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -501,7 +501,14 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
       capture_everything buf ppf
         ~f:(fun () -> let (_, r, _, _) = exec_phrases phrases in r)
   in
-  { corrected_expectations; trailing_output }
+  let needs_principal =
+    List.exists chunks ~f:(fun chunk ->
+      List.exists chunk.expectations ~f:(fun expectation ->
+        match expectation.kind with
+        | Expect_toplevel -> true
+        | Expect_asm | Expect_fexpr -> false))
+  in
+  { corrected_expectations; trailing_output }, ~needs_principal
 
 let output_slice oc s a b =
   output_string oc (String.sub s ~pos:a ~len:(b - a))
@@ -546,8 +553,11 @@ let process_expect_file fname ~execute_phrase =
     | s           -> close_in ic; Misc.normalise_eol s
     | exception e -> close_in ic; raise e
   in
-  let correction = eval_expect_file fname ~file_contents ~execute_phrase in
-  write_corrected ~file:corrected_fname ~file_contents correction
+  let correction, ~needs_principal =
+    eval_expect_file fname ~file_contents ~execute_phrase
+  in
+  write_corrected ~file:corrected_fname ~file_contents correction;
+  needs_principal
 
 let repo_root = ref None
 let keep_original_error_size = ref false
@@ -607,8 +617,10 @@ let main (module Toplevel : Toplevel) fname =
       exit 2);
   (* We are in interactive mode and should record directive error on stdout *)
   Sys.interactive := true;
-  process_expect_file fname ~execute_phrase:Toplevel.execute_phrase;
-  exit 0
+  let needs_principal =
+    process_expect_file fname ~execute_phrase:Toplevel.execute_phrase
+  in
+  exit (if needs_principal then 3 else 0)
 
 let run ~read_anonymous_arg ~extra_args ~extra_init toplevel =
   let args =


### PR DESCRIPTION
Previously, every expect test was rerun with `-principal`, but this is only necessary for reporting typing errors with toplevel expect tests. Tests that contain only `expect_asm` or `expect_fexpr` can safely be run only once[^1].

This doesn't have a large impact on running the entire test suite, but it does noticeably speed up running individual expect_asm/fexpr tests.

Exit codes are the most convenient way to report whether or not an expect test needs to be rerun with `-principal`.

[^1]: Actually, all tests without `Principal{||}` tags can safely only be run once. However, easing the restriction for toplevel expect tests is more work, and those tests are fast anyway.