### PR TITLE
datalog: use Or_null to avoid allocations during rule evaluation

### DIFF
--- a/middle_end/flambda2/algorithms/channel.ml
+++ b/middle_end/flambda2/algorithms/channel.ml
@@ -38,3 +38,23 @@ let create v =
 external send : 'a sender -> 'a -> unit = "%setfield0"
 
 external recv : 'a receiver -> 'a = "%field0"
+
+(* In OxCaml ['a Or_null.t] has layout [value_or_null] but type variables by
+   default are inferred to have layout [value]. Since there is no
+   upstream-compatible syntax for annotating a type variable with layout
+   [value_or_null], we need to have a separate copy of the API for the [or_null]
+   case -- fortunately, it is tiny. *)
+
+type 'a or_null_ref = 'a Or_null.t ref
+
+type 'a or_null_sender = 'a or_null_ref
+
+type 'a or_null_receiver = 'a or_null_ref
+
+let create_or_null (v : _ Or_null.t) =
+  let r = ref v in
+  r, r
+
+external send_or_null : 'a or_null_sender -> 'a Or_null.t -> unit = "%setfield0"
+
+external recv_or_null : 'a or_null_receiver -> 'a Or_null.t = "%field0"

--- a/middle_end/flambda2/algorithms/channel.mli
+++ b/middle_end/flambda2/algorithms/channel.mli
@@ -47,3 +47,13 @@ external recv : 'a receiver -> 'a = "%field0"
     sent (using [send]) to the [sender], or the initial value provided to
     [channel]. *)
 val create : 'a -> 'a sender * 'a receiver
+
+type 'a or_null_sender
+
+external send_or_null : 'a or_null_sender -> 'a Or_null.t -> unit = "%setfield0"
+
+type 'a or_null_receiver
+
+external recv_or_null : 'a or_null_receiver -> 'a Or_null.t = "%field0"
+
+val create_or_null : 'a Or_null.t -> 'a or_null_sender * 'a or_null_receiver

--- a/middle_end/flambda2/algorithms/leapfrog.ml
+++ b/middle_end/flambda2/algorithms/leapfrog.ml
@@ -16,7 +16,7 @@
 module type Iterator = sig
   type 'a t
 
-  val current : 'a t -> 'a option
+  val current : 'a t -> 'a Or_null.t
 
   val advance : 'a t -> unit
 
@@ -44,10 +44,10 @@ module Map (T : Container_types.S_plus_iterator) = struct
 
   let compare_key (type a) (Iterator _ : a t) : a -> a -> int = T.compare
 
-  let current (type a) (Iterator i : a t) : a option =
+  let current (type a) (Iterator i : a t) : a Or_null.t =
     match T.Map.current i.iterator with
-    | Some (key, _) -> Some key
-    | None -> None
+    | Some (key, _) -> This key
+    | None -> Null
 
   let advance (type a) (Iterator i : a t) : unit =
     i.iterator <- T.Map.advance i.iterator
@@ -77,25 +77,25 @@ end = struct
       mutable at_end : bool
     }
 
-  let current (type a) ({ iterators; at_end } : a t) : a option =
+  let current (type a) ({ iterators; at_end } : a t) : a Or_null.t =
     if at_end
-    then None
+    then Null
     else Iterator.current iterators.(Array.length iterators - 1)
 
-  let rec search : type a. a Iterator.t array -> int -> a -> a option =
+  let rec search : type a. a Iterator.t array -> int -> a -> a Or_null.t =
    fun iterators index_of_lowest_key highest_key ->
     let iterator_with_lowest_key = iterators.(index_of_lowest_key) in
     let equal = Iterator.equal_key iterator_with_lowest_key in
     match Iterator.current iterator_with_lowest_key with
-    | None -> None
-    | Some lowest_key when equal lowest_key highest_key ->
+    | Null -> Null
+    | This lowest_key when equal lowest_key highest_key ->
       (* All iterators are on the same key. *)
-      Some lowest_key
-    | Some _ -> (
+      This lowest_key
+    | This _ -> (
       Iterator.seek iterator_with_lowest_key highest_key;
       match Iterator.current iterator_with_lowest_key with
-      | None -> None
-      | Some new_highest_key ->
+      | Null -> Null
+      | This new_highest_key ->
         search iterators
           ((index_of_lowest_key + 1) mod Array.length iterators)
           new_highest_key)
@@ -106,11 +106,11 @@ end = struct
     then
       let iterator = iterators.(Array.length iterators - 1) in
       match Iterator.current iterator with
-      | None -> j.at_end <- true
-      | Some highest_key -> (
+      | Null -> j.at_end <- true
+      | This highest_key -> (
         match search iterators 0 highest_key with
-        | None -> j.at_end <- true
-        | Some _ -> ())
+        | Null -> j.at_end <- true
+        | This _ -> ())
 
   let advance (type a) ({ iterators; at_end } as t : a t) =
     if not at_end
@@ -135,13 +135,13 @@ end = struct
         (fun (it : a Iterator.t) ->
           Iterator.init it;
           match Iterator.current it with
-          | None -> raise Empty_iterator
-          | Some _ -> ())
+          | Null -> raise_notrace Empty_iterator
+          | This _ -> ())
         iterators;
       Array.sort
         (fun (it1 : a Iterator.t) (it2 : a Iterator.t) ->
           let compare = Iterator.compare_key it1 in
-          Option.compare compare (Iterator.current it1) (Iterator.current it2))
+          Or_null.compare compare (Iterator.current it1) (Iterator.current it2))
         iterators;
       j.at_end <- false;
       repair j

--- a/middle_end/flambda2/algorithms/leapfrog.mli
+++ b/middle_end/flambda2/algorithms/leapfrog.mli
@@ -64,8 +64,8 @@ module type Iterator = sig
   type 'a t
 
   (** [current it] is the key at the current position of the iterator [it], or
-      [None] if the iterator is exhausted. *)
-  val current : 'a t -> 'a option
+      [Null] if the iterator is exhausted. *)
+  val current : 'a t -> 'a Or_null.t
 
   (** [advance it] advances the iterator to the next key.
 

--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -21,24 +21,24 @@ type vm_action =
   | Unless :
       ('t, 'k, 'v) Trie.is_trie
       * 't Channel.receiver
-      * 'k Option_receiver.hlist
+      * 'k Or_null_receiver.hlist
       * string
       * string list
       -> vm_action
   | Unless_eq :
-      'k option Channel.receiver
-      * 'k option Channel.receiver
+      'k Or_null_receiver.t
+      * 'k Or_null_receiver.t
       * string
       * string
       * 'k Value.repr
       -> vm_action
   | Filter :
-      ('k Constant.hlist -> bool) * 'k Option_receiver.hlist * string list
+      ('k Constant.hlist -> bool) * 'k Or_null_receiver.hlist * string list
       -> vm_action
 
 type action =
   | Bind_iterator :
-      'a option Channel.receiver with_name * 'a Trie.Iterator.t with_name
+      'a Or_null_receiver.t with_name * 'a Trie.Iterator.t with_name
       -> action
   | VM_action : vm_action -> action
 
@@ -118,7 +118,7 @@ module Level = struct
       actions : actions;
       mutable iterators : 'a Trie.Iterator.t with_name list;
       mutable output :
-        ('a option Channel.sender * 'a option Channel.receiver) with_name option;
+        ('a Or_null_sender.t * 'a Or_null_receiver.t) with_name option;
       mutable output_cardinality : cardinality
     }
 
@@ -139,7 +139,7 @@ module Level = struct
       <- max_cardinality level.output_cardinality cardinality;
     match level.output with
     | None ->
-      let channel = Channel.create None in
+      let channel = Channel.create_or_null Null in
       let output = { value = channel; name = level.name } in
       level.output <- Some output;
       { output with value = snd output.value }
@@ -278,7 +278,7 @@ let rec open_rev_vars : type a s.
         match var.output with
         | Some output -> { output with value = fst output.value }
         | None ->
-          let send, _recv = Channel.create None in
+          let send, _recv = Channel.create_or_null Null in
           { value = send; name = "_" }
       in
       let iterators = List.map (fun it -> it.value) var.iterators in
@@ -312,7 +312,7 @@ type call =
       { func : 'c -> 'a Constant.hlist -> unit;
         name : string;
         context : 'c;
-        args : 'a Option_receiver.hlist with_names
+        args : 'a Or_null_receiver.hlist with_names
       }
       -> call
 
@@ -380,18 +380,20 @@ let evaluate = function
   | Unless (is_trie, cell, args, _cell_name, _args_names) ->
     if
       Option.is_some
-        (Trie.find_opt is_trie (Option_receiver.recv args) (Channel.recv cell))
+        (Trie.find_opt is_trie
+           (Or_null_receiver.recv_hlist args)
+           (Channel.recv cell))
     then Virtual_machine.Skip
     else Virtual_machine.Accept
   | Unless_eq (cell1, cell2, _cell1_name, _cell2_name, repr) ->
     if
       Value.equal_repr repr
-        (Option.get (Channel.recv cell1))
-        (Option.get (Channel.recv cell2))
+        (Or_null_receiver.recv cell1)
+        (Or_null_receiver.recv cell2)
     then Virtual_machine.Skip
     else Virtual_machine.Accept
   | Filter (f, args, _args_names) ->
-    if f (Option_receiver.recv args)
+    if f (Or_null_receiver.recv_hlist args)
     then Virtual_machine.Accept
     else Virtual_machine.Skip
 
@@ -422,7 +424,7 @@ let[@inline] seminaive_run cursor ~previous ~diff ~current =
 
 module With_parameters = struct
   type nonrec ('p, !'v) t =
-    { parameters : 'p Option_sender.hlist;
+    { parameters : 'p Or_null_sender.hlist;
       cursor : 'v t
     }
 
@@ -434,14 +436,14 @@ module With_parameters = struct
     { cursor = create ?calls ?output context; parameters }
 
   let naive_fold { parameters; cursor } ps db f acc =
-    Option_sender.send parameters ps;
+    Or_null_sender.send_hlist parameters ps;
     naive_fold cursor db f acc
 
   let naive_iter { parameters; cursor } ps db f =
-    Option_sender.send parameters ps;
+    Or_null_sender.send_hlist parameters ps;
     naive_iter cursor db f
 
   let seminaive_run { parameters; cursor } ps ~previous ~diff ~current =
-    Option_sender.send parameters ps;
+    Or_null_sender.send_hlist parameters ps;
     seminaive_run ~previous ~diff ~current cursor
 end

--- a/middle_end/flambda2/datalog/cursor.ml
+++ b/middle_end/flambda2/datalog/cursor.ml
@@ -379,8 +379,8 @@ let with_bound_cursor ?callback cursor db f =
 let evaluate = function
   | Unless (is_trie, cell, args, _cell_name, _args_names) ->
     if
-      Option.is_some
-        (Trie.find_opt is_trie
+      Or_null.is_this
+        (Trie.find_or_null is_trie
            (Or_null_receiver.recv_hlist args)
            (Channel.recv cell))
     then Virtual_machine.Skip

--- a/middle_end/flambda2/datalog/cursor.mli
+++ b/middle_end/flambda2/datalog/cursor.mli
@@ -18,22 +18,22 @@ open Datalog_imports
 type action
 
 val bind_iterator :
-  'a option Channel.receiver with_name -> 'a Trie.Iterator.t with_name -> action
+  'a Or_null_receiver.t with_name -> 'a Trie.Iterator.t with_name -> action
 
 val unless :
   ('t, 'k, 'v) Table.Id.t ->
   't Channel.receiver ->
-  'k Option_receiver.hlist with_names ->
+  'k Or_null_receiver.hlist with_names ->
   action
 
 val unless_eq :
   'k Value.repr ->
-  'k option Channel.receiver with_name ->
-  'k option Channel.receiver with_name ->
+  'k Or_null_receiver.t with_name ->
+  'k Or_null_receiver.t with_name ->
   action
 
 val filter :
-  ('k Constant.hlist -> bool) -> 'k Option_receiver.hlist with_names -> action
+  ('k Constant.hlist -> bool) -> 'k Or_null_receiver.hlist with_names -> action
 
 type actions
 
@@ -72,7 +72,7 @@ module Level : sig
       the associated actions, if any, and can thus be used in actions for this
       level or levels of later orders. *)
   val use_output :
-    ?cardinality:cardinality -> 'a t -> 'a option Channel.receiver with_name
+    ?cardinality:cardinality -> 'a t -> 'a Or_null_receiver.t with_name
 
   (** Actions to execute immediately after a value is found at this level. *)
   val actions : 'a t -> actions
@@ -112,12 +112,12 @@ val create_call :
   ('c -> 'a Constant.hlist -> unit) ->
   name:string ->
   context:'c ->
-  'a Option_receiver.hlist with_names ->
+  'a Or_null_receiver.hlist with_names ->
   call
 
 val create :
   ?calls:call list ->
-  ?output:'v Option_receiver.hlist with_names ->
+  ?output:'v Or_null_receiver.hlist with_names ->
   context ->
   'v t
 
@@ -169,9 +169,9 @@ module With_parameters : sig
   val without_parameters : (nil, 'v) t -> 'v cursor
 
   val create :
-    parameters:'p Option_sender.hlist ->
+    parameters:'p Or_null_sender.hlist ->
     ?calls:call list ->
-    ?output:'v Option_receiver.hlist with_names ->
+    ?output:'v Or_null_receiver.hlist with_names ->
     context ->
     ('p, 'v) t
 

--- a/middle_end/flambda2/datalog/datalog.ml
+++ b/middle_end/flambda2/datalog/datalog.ml
@@ -27,8 +27,8 @@ module Parameter = struct
   module T0 = struct
     type 'a t =
       { name : string;
-        sender : 'a option Channel.sender;
-        receiver : 'a option Channel.receiver
+        sender : 'a Or_null_sender.t;
+        receiver : 'a Or_null_receiver.t
       }
   end
 
@@ -36,7 +36,7 @@ module Parameter = struct
   include Heterogenous_list.Make (T0)
 
   let create name =
-    let sender, receiver = Channel.create None in
+    let sender, receiver = Channel.create_or_null Null in
     { name; sender; receiver }
 
   let rec list : type a. a String.hlist -> a hlist = function
@@ -47,7 +47,7 @@ module Parameter = struct
 
   let get_receiver { receiver; _ } = receiver
 
-  let rec to_senders : type a. a hlist -> a Option_sender.hlist = function
+  let rec to_senders : type a. a hlist -> a Or_null_sender.hlist = function
     | [] -> []
     | p :: ps -> get_sender p :: to_senders ps
 end
@@ -142,12 +142,12 @@ type filter =
   | User : ('k Constant.hlist -> bool) * 'k Term.hlist -> filter
 
 type bindings_ref =
-  | Bindings_ref : 'a Variable.hlist * 'a Option_receiver.hlist -> bindings_ref
+  | Bindings_ref : 'a Variable.hlist * 'a Or_null_receiver.hlist -> bindings_ref
 
 type bindings = Bindings : 'a Variable.hlist * 'a Constant.hlist -> bindings
 
 let get_bindings (Bindings_ref (vars, receivers)) =
-  Bindings (vars, Option_receiver.recv receivers)
+  Bindings (vars, Or_null_receiver.recv_hlist receivers)
 
 let print_bindings ppf (Bindings (vars, values)) =
   let rec loop : type a.
@@ -263,7 +263,7 @@ let rec bind_atom : type a.
     let this_iterator = { value = this_iterator; name = this_iterator_name } in
     match this_arg with
     | Constant cte ->
-      let _send, recv = Channel.create (Some cte) in
+      let _send, recv = Channel.create_or_null (Or_null.this cte) in
       bind_iterator post_level
         { value = recv; name = "<constant>" }
         this_iterator;
@@ -311,10 +311,10 @@ let find_last_binding post_level args =
   find_last_binding0 ~order:Cursor.Order.parameters post_level args
 
 let compile_term :
-    ?cardinality:_ -> 'a Term.t -> 'a option Channel.receiver with_name =
+    ?cardinality:_ -> 'a Term.t -> 'a Or_null_receiver.t with_name =
  fun ?cardinality -> function
   | Constant cte ->
-    let _send, recv = Channel.create (Some cte) in
+    let _send, recv = Channel.create_or_null (Or_null.this cte) in
     { value = recv; name = "<constant>" }
   | Parameter param ->
     { value = Parameter.get_receiver param; name = param.name }
@@ -323,7 +323,7 @@ let compile_term :
     Cursor.Level.use_output ?cardinality var
 
 let rec compile_terms : type a.
-    ?cardinality:_ -> a Term.hlist -> a Option_receiver.hlist with_names =
+    ?cardinality:_ -> a Term.hlist -> a Or_null_receiver.hlist with_names =
  fun ?cardinality vars ->
   match vars with
   | [] -> { values = []; names = [] }

--- a/middle_end/flambda2/datalog/datalog_imports.ml
+++ b/middle_end/flambda2/datalog/datalog_imports.ml
@@ -25,26 +25,39 @@ type 'a with_names =
 
 include Heterogenous_list
 
-module Option_sender = struct
-  include Make (struct
-    type 'a t = 'a option Channel.sender
-  end)
+module Or_null_sender = struct
+  module T0 = struct
+    type 'a t = 'a Channel.or_null_sender
+  end
 
-  let rec send : type s. s hlist -> s Constant.hlist -> unit =
+  include T0
+  include Make (T0)
+
+  let[@inline] send s v = Channel.send_or_null s (Or_null.this v)
+
+  let rec send_hlist : type s. s hlist -> s Constant.hlist -> unit =
    fun refs values ->
     match refs, values with
     | [], [] -> ()
     | r :: rs, v :: vs ->
-      Channel.send r (Some v);
-      send rs vs
+      send r v;
+      send_hlist rs vs
 end
 
-module Option_receiver = struct
-  include Make (struct
-    type 'a t = 'a option Channel.receiver
-  end)
+module Or_null_receiver = struct
+  module T0 = struct
+    type 'a t = 'a Channel.or_null_receiver
+  end
 
-  let rec recv : type s. s hlist -> s Constant.hlist = function
+  include T0
+  include Make (T0)
+
+  let[@inline] recv r =
+    match Channel.recv_or_null r with
+    | Null -> Misc.fatal_error "Or_null_receiver: empty receiver"
+    | This r -> r
+
+  let rec recv_hlist : type s. s hlist -> s Constant.hlist = function
     | [] -> []
-    | r :: rs -> Option.get (Channel.recv r) :: recv rs
+    | r :: rs -> recv r :: recv_hlist rs
 end

--- a/middle_end/flambda2/datalog/schedule.ml
+++ b/middle_end/flambda2/datalog/schedule.ml
@@ -159,9 +159,9 @@ let deduce (atoms : deduction) =
         let table_ref = find_or_create_ref binders tid in
         let callback_fn bindings keys =
           let incremental_table = !table_ref in
-          match Trie.find_opt is_trie keys incremental_table.current with
-          | Some _ -> ()
-          | None ->
+          match Trie.find_or_null is_trie keys incremental_table.current with
+          | This _ -> ()
+          | Null ->
             if !enable_provenance
             then
               provenance_table_ref

--- a/middle_end/flambda2/datalog/trie.ml
+++ b/middle_end/flambda2/datalog/trie.ml
@@ -42,18 +42,21 @@ let is_empty : type t k v. (t, k, v) is_trie -> t -> bool = function
   | Nested_trie _ -> Int.Map.is_empty
 
 let rec find0 : type t k r v.
-    (t, k -> r, v) is_trie -> k -> r Constant.hlist -> t -> v =
+    (t, k -> r, v) is_trie -> k -> r Constant.hlist -> t -> v Or_null.t =
  fun w k ks t ->
   match ks, w with
   | [], Nested_trie _ -> .
-  | [], Map_is_trie -> Int.Map.find k t
-  | k' :: ks', Nested_trie w' -> find0 w' k' ks' (Int.Map.find k t)
+  | [], Map_is_trie -> Int.Map.find_or_null k t
+  | k' :: ks', Nested_trie w' -> (
+    match Int.Map.find_or_null k t with
+    | Null -> Or_null.null
+    | This datum -> find0 w' k' ks' datum)
 
-let find : type t k v. (t, k, v) is_trie -> k Constant.hlist -> t -> v =
+let find_or_null : type t k v.
+    (t, k, v) is_trie -> k Constant.hlist -> t -> v Or_null.t =
  fun w k t -> match k, w with [], _ -> . | k :: ks, _ -> find0 w k ks t
 
-let find_opt w k t =
-  match find w k t with exception Not_found -> None | datum -> Some datum
+let find_opt w k t = Or_null.to_option (find_or_null w k t)
 
 let rec singleton0 : type t k r v.
     (t, k -> r, v) is_trie -> k -> r Constant.hlist -> v -> t =
@@ -73,9 +76,9 @@ let rec add0 : type t k r v.
   | [], Nested_trie _ -> .
   | [], Map_is_trie -> Int.Map.add k v t
   | k' :: ks', Nested_trie w' -> (
-    match Int.Map.find_opt k t with
-    | Some m -> Int.Map.add k (add0 w' k' ks' v m) t
-    | None -> Int.Map.add k (singleton0 w' k' ks' v) t)
+    match Int.Map.find_or_null k t with
+    | This m -> Int.Map.add k (add0 w' k' ks' v m) t
+    | Null -> Int.Map.add k (singleton0 w' k' ks' v) t)
 
 let add_or_replace : type t k v.
     (t, k, v) is_trie -> k Constant.hlist -> v -> t -> t =
@@ -88,9 +91,9 @@ let rec remove0 : type t k r v.
   | [], Nested_trie _ -> .
   | [], Map_is_trie -> Int.Map.remove k t
   | k' :: ks', Nested_trie w' -> (
-    match Int.Map.find_opt k t with
-    | None -> t
-    | Some m ->
+    match Int.Map.find_or_null k t with
+    | Null -> t
+    | This m ->
       let m' = remove0 w' k' ks' m in
       if is_empty w' m' then Int.Map.remove k t else Int.Map.add k m' t)
 

--- a/middle_end/flambda2/datalog/trie.mli
+++ b/middle_end/flambda2/datalog/trie.mli
@@ -44,6 +44,9 @@ val remove : ('t, 'k, 'v) is_trie -> 'k Constant.hlist -> 't -> 't
 
 val union : ('t, 'k, 'v) is_trie -> ('v -> 'v -> 'v option) -> 't -> 't -> 't
 
+val find_or_null :
+  ('t, 'k, 'v) is_trie -> 'k Constant.hlist -> 't -> 'v Or_null.t
+
 val find_opt : ('t, 'k, 'v) is_trie -> 'k Constant.hlist -> 't -> 'v option
 
 val iter :

--- a/middle_end/flambda2/datalog/virtual_machine.ml
+++ b/middle_end/flambda2/datalog/virtual_machine.ml
@@ -29,7 +29,7 @@ struct
     | Stack_nil : nil stack
     | Stack_cons :
         'a Iterator.t
-        * 'a option Channel.sender
+        * 'a Channel.or_null_sender
         * ('a -> 's) continuation
         * 's stack
         -> ('a -> 's) stack
@@ -41,7 +41,7 @@ struct
     | Up : ('x, 's) instruction -> ('x, 'a -> 's) instruction
     | Dispatch : ('a, 'b -> 's) instruction
     | Seek :
-        'b option Channel.receiver
+        'b Channel.or_null_receiver
         * 'b Iterator.t
         * ('a, 's) instruction
         * string
@@ -49,7 +49,7 @@ struct
         -> ('a, 's) instruction
     | Open :
         'b Iterator.t
-        * 'b option Channel.sender
+        * 'b Channel.or_null_sender
         * ('a, 'b -> 's) instruction
         * ('a, 'b -> 's) instruction
         * string
@@ -59,7 +59,7 @@ struct
     | Call :
         ('c -> 'b Constant.hlist -> unit)
         * 'c
-        * 'b Option_receiver.hlist
+        * 'b Or_null_receiver.hlist
         * ('a, 's) instruction
         * string
         * string list
@@ -129,11 +129,11 @@ struct
   let[@inline always] dispatch ~advance (stack : (_ -> _) stack) =
     let (Stack_cons (iterator, cell, level, next_stack)) = stack in
     match Iterator.current iterator with
-    | Some current_key ->
+    | This _ as current_key ->
       Iterator.accept iterator;
-      Channel.send cell (Some current_key);
+      Channel.send_or_null cell current_key;
       level stack
-    | None -> advance next_stack
+    | Null -> advance next_stack
 
   let[@loop] rec advance : type s. s continuation =
    fun stack ->
@@ -157,21 +157,23 @@ struct
         Iterator.init iterator;
         execute k (Stack_cons (iterator, cell, execute for_each, stack))
       | Seek (key_ref, iterator, k, _key_ref_name, _iterator_name) -> (
-        let key = Option.get (Channel.recv key_ref) in
-        Iterator.init iterator;
-        Iterator.seek iterator key;
-        match Iterator.current iterator with
-        | Some current_key when Iterator.equal_key iterator current_key key ->
-          Iterator.accept iterator;
-          execute k stack
-        | None | Some _ -> advance stack)
+        match Channel.recv_or_null key_ref with
+        | Null -> Misc.fatal_error "datalog: seek key must be bound"
+        | This key -> (
+          Iterator.init iterator;
+          Iterator.seek iterator key;
+          match Iterator.current iterator with
+          | This current_key when Iterator.equal_key iterator current_key key ->
+            Iterator.accept iterator;
+            execute k stack
+          | Null | This _ -> advance stack))
       | Dispatch -> dispatch ~advance stack
       | Action (op, k) -> (
         match (evaluate [@inlined hint]) op with
         | Accept -> execute k stack
         | Skip -> advance stack)
       | Call (f, ctx, rs, k, _name, _names) ->
-        f ctx (Option_receiver.recv rs);
+        f ctx (Or_null_receiver.recv_hlist rs);
         execute k stack
     in
     execute instruction

--- a/middle_end/flambda2/datalog/virtual_machine.mli
+++ b/middle_end/flambda2/datalog/virtual_machine.mli
@@ -85,7 +85,7 @@ end) : sig
   val dispatch : ('a, _ -> 's) instruction
 
   val seek :
-    'a option Channel.receiver with_name ->
+    'a Channel.or_null_receiver with_name ->
     'a Iterator.t with_name ->
     ('b, 's) instruction ->
     ('b, 's) instruction
@@ -101,7 +101,7 @@ end) : sig
       [k]. *)
   val open_ :
     'i Iterator.t with_name ->
-    'i option Channel.sender with_name ->
+    'i Channel.or_null_sender with_name ->
     ('a, 'i -> 's) instruction ->
     ('a, 'i -> 's) instruction ->
     ('a, 's) instruction
@@ -123,7 +123,7 @@ end) : sig
     ('c -> 'a Constant.hlist -> unit) ->
     name:string ->
     context:'c ->
-    'a Option_receiver.hlist with_names ->
+    'a Or_null_receiver.hlist with_names ->
     ('x, 's) instruction ->
     ('x, 's) instruction
 

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -162,8 +162,8 @@ end = struct
   let[@inline] fold_iterator ~f ~init iterator =
     let rec loop iterator acc =
       match Name_map_join_iterator.current iterator with
-      | None -> acc
-      | Some name ->
+      | Null -> acc
+      | This name ->
         Name_map_join_iterator.accept iterator;
         let acc = (f [@inlined hint]) name acc in
         Name_map_join_iterator.advance iterator;


### PR DESCRIPTION
This does not do anything when running with the boot compiler but can't hurt the performance of the reaper.

The allocations from `Iterator.current` don't really matter because we likely inline these anyway, but avoiding allocations in the cells used to communicate between different levels of the iterators is nice — further, this means that we no longer have to worry about the write barrier, because we only write immediates into these cells now.