### PR TITLE
Revert PR 6201

### DIFF
--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -45,31 +45,6 @@ type 'a require_nonnull
 type ('a : value mod external_) require_external
 |}]
 
-(**** Test 0: Payload alias annotations ****)
-
-module Recursive_list_alias_annotation = struct
-  type ('a : value mod contended portable) t : value mod contended portable =
-    | A of ('a t list as (_ : any mod contended portable))
-end
-(* CR layouts with-kinds: Fix the principal case for payload alias annotations.
-   Non-principal checking uses the temporary declaration ikind, but principal
-   checking still rejects the alias while looking through the temporary
-   environment. *)
-[%%expect{|
-module Recursive_list_alias_annotation :
-  sig type ('a : value mod portable contended) t = A of 'a t list end
-|}, Principal{|
-Line 3, characters 30-56:
-3 |     | A of ('a t list as (_ : any mod contended portable))
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Bad layout annotation:
-         The kind of "'a t list" is immutable_data with 'a t
-           because it's a boxed variant type.
-         But the kind of "'a t list" must be a subkind of
-             any mod portable contended
-           because of the annotation on the wildcard _ at line 3, characters 30-56.
-|}]
-
 (**** Test 1: Annotations without "with" are accepted when appropriate ****)
 
 (* immutable variants *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -372,15 +372,6 @@ in
         Btype.newgenvar ?name jkind)
       sdecl.ptype_params
   in
-  (* These temporary declarations can be consulted before the final
-     declaration exists, for example by early alias annotation checks on a
-     variant payload. Give them an ikind derived from the declaration jkind so
-     those checks see the same declaration-level bound information as jkind
-     checks. *)
-  let type_ikind =
-    Ikind.type_declaration_ikind_of_jkind ~env:(Some env) ~params:type_params
-      type_jkind
-  in
   (* In the temporary environment, all types get an unboxed version.
      See Note [Typechecking unboxed versions of types]. *)
   let type_unboxed_version =
@@ -388,7 +379,7 @@ in
       type_arity = arity;
       type_kind = Type_abstract abstract_source;
       type_jkind;
-      type_ikind;
+      type_ikind = Types.ikinds_todo "transl_declaration initial unboxed";
       type_private = sdecl.ptype_private;
       type_manifest = unboxed_type_manifest;
       type_variance = Variance.unknown_signature ~injective:false ~arity;
@@ -407,7 +398,7 @@ in
       type_arity = arity;
       type_kind = Type_abstract abstract_source;
       type_jkind;
-      type_ikind;
+      type_ikind = Types.ikinds_todo "transl_declaration initial";
       type_private = sdecl.ptype_private;
       type_manifest;
       type_variance = Variance.unknown_signature ~injective:false ~arity;


### PR DESCRIPTION
Revert 6201 because it caused a regression in the number of allocations.