### PR TITLE
Allow void null payloads for custom or_null

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2201,7 +2201,11 @@ let get_expr_args_constr ~scopes head { arg; mut; sort; layout; _ } rem =
         @ rem
     | Variant_unboxed | Variant_with_null ->
       if cstr.cstr_constant then
-        rem (* [Null] constructor case. *)
+        List.mapi
+          (fun i ca_sort ->
+             make_field_access binding_kind ca_sort ~field:i ~pos:i)
+          arg_sorts
+        @ rem
       else
         { arg; binding_kind; mut; sort; layout } :: rem
         (* the unboxed variant constructor, or the [This] constructor

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -635,7 +635,11 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
             transl_exp ~scopes layout e) args_with_sorts
         in
         match cstr.cstr_tag, cstr.cstr_repr with
-      | Null, Variant_with_null -> Lconst Const_null
+      | Null, Variant_with_null ->
+        List.fold_left
+          (fun (acc : lambda) (e : lambda) -> Lsequence (e, acc))
+          (Lconst Const_null)
+          ll
       | Null, (Variant_boxed _ | Variant_unboxed | Variant_extensible) ->
         assert false
       | Ordinary {runtime_tag},

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -271,6 +271,50 @@ type void_null_succeeds_sep = void_null accepts_sep
 type void_null_succeeds_nonfloat = void_null accepts_nonfloat
 |}]
 
+(* A void null constructor with a [float] payload is maybe-separable (like
+   [float or_null]), unlike the [int] payload above. Separability is a jkind
+   axis computed structurally from the payload and does not depend on the
+   flat-float-array optimization, so this is rejected identically under both
+   the flat-float-array and no-flat-float-array configurations. *)
+
+type void_null_float =
+  | Null_void_float of void
+  | This_void_float of float
+[@@or_null]
+
+[%%expect{|
+type void_null_float = Null_void_float of void | This_void_float of float [@@or_null]
+|}]
+
+type void_null_float_fails_sep = void_null_float accepts_sep
+
+[%%expect{|
+Line 1, characters 33-48:
+1 | type void_null_float_fails_sep = void_null_float accepts_sep
+                                     ^^^^^^^^^^^^^^^
+Error: This type "void_null_float" should be an instance of type
+         "('a : any separable)"
+       The layout of void_null_float is value_or_null
+         because of the definition of void_null_float at lines 1-4, characters 0-11.
+       But the layout of void_null_float must be a sublayout of any separable
+         because of the definition of accepts_sep at line 2, characters 0-41.
+|}]
+
+type void_null_float_fails_nonfloat = void_null_float accepts_nonfloat
+
+[%%expect{|
+Line 1, characters 38-53:
+1 | type void_null_float_fails_nonfloat = void_null_float accepts_nonfloat
+                                          ^^^^^^^^^^^^^^^
+Error: This type "void_null_float" should be an instance of type
+         "('a : value_or_null non_float)"
+       The layout of void_null_float is value_or_null
+         because of the definition of void_null_float at lines 1-4, characters 0-11.
+       But the layout of void_null_float must be a sublayout of
+           value_or_null non_float
+         because of the definition of accepts_nonfloat at line 3, characters 0-56.
+|}]
+
 type void_alias = void
 type 'a void_param : void
 

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -166,7 +166,7 @@ Lines 1-4, characters 0-11:
 3 |   | B of int * int
 4 | [@@or_null]
 Error: Invalid [@or_null] declaration:
-       it must have exactly one nullary constructor and one unary constructor.
+       each constructor must be nullary or unary.
 |}]
 
 (* Non-parameterized custom [@@or_null] types. *)
@@ -233,6 +233,144 @@ Error: This type "float_payload" should be an instance of type
        But the layout of float_payload must be a sublayout of
            value_or_null non_float
          because of the definition of accepts_nonfloat at line 3, characters 0-56.
+|}]
+
+type void : void mod everything
+external void : unit -> void = "%unbox_unit"
+
+[%%expect{|
+type void : void mod everything
+external void : unit -> void = "%unbox_unit"
+|}]
+
+type void_null =
+  | Null_void of void
+  | This_void of int
+[@@or_null]
+
+[%%expect{|
+type void_null = Null_void of void | This_void of int [@@or_null]
+|}]
+
+type void_null_flipped =
+  | This_void_flipped of int
+  | Null_void_flipped of #(void * void)
+[@@or_null]
+
+[%%expect{|
+type void_null_flipped =
+    This_void_flipped of int
+  | Null_void_flipped of #(void * void) [@@or_null]
+|}]
+
+type void_null_succeeds_sep = void_null accepts_sep
+type void_null_succeeds_nonfloat = void_null accepts_nonfloat
+
+[%%expect{|
+type void_null_succeeds_sep = void_null accepts_sep
+type void_null_succeeds_nonfloat = void_null accepts_nonfloat
+|}]
+
+type void_alias = void
+type 'a void_param : void
+
+[%%expect{|
+type void_alias = void
+type 'a void_param : void
+|}]
+
+type void_alias_null =
+  | Null_void_alias of void_alias
+  | This_void_alias of string
+[@@or_null]
+
+type 'a void_param_null =
+  | Null_void_param of 'a void_param
+  | This_void_param of int
+[@@or_null]
+
+[%%expect{|
+type void_alias_null =
+    Null_void_alias of void_alias
+  | This_void_alias of string [@@or_null]
+type 'a void_param_null =
+    Null_void_param of 'a void_param
+  | This_void_param of int [@@or_null]
+|}]
+
+type 'a constrained_void_null =
+  | Null_constrained of 'a
+  | This_constrained of int
+  constraint 'a = void
+[@@or_null]
+
+[%%expect{|
+type 'a constrained_void_null =
+    Null_constrained of 'a
+  | This_constrained of int constraint 'a = void [@@or_null]
+|}]
+
+type recursive_void_null =
+  | Null_recursive_void of recursive_void
+  | This_recursive_void of int
+[@@or_null]
+and recursive_void : void mod everything
+
+type recursive_void_alias = void
+and recursive_void_alias_null =
+  | Null_recursive_void_alias of recursive_void_alias
+  | This_recursive_void_alias of int
+[@@or_null]
+
+type recursive_payload = int
+and recursive_payload_null =
+  | Null_recursive_payload
+  | This_recursive_payload of recursive_payload
+[@@or_null]
+
+[%%expect{|
+type recursive_void_null =
+    Null_recursive_void of recursive_void
+  | This_recursive_void of int [@@or_null]
+and recursive_void : void mod everything
+type recursive_void_alias = void
+and recursive_void_alias_null =
+    Null_recursive_void_alias of recursive_void_alias
+  | This_recursive_void_alias of int [@@or_null]
+type recursive_payload = int
+and recursive_payload_null =
+    Null_recursive_payload
+  | This_recursive_payload of recursive_payload [@@or_null]
+|}]
+
+type no_nonvoid_payload =
+  | A_no_nonvoid
+  | B_no_nonvoid of void
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type no_nonvoid_payload =
+2 |   | A_no_nonvoid
+3 |   | B_no_nonvoid of void
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one null constructor and one payload constructor.
+|}]
+
+type two_nonvoid_payloads =
+  | A_nonvoid of int
+  | B_nonvoid of string
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type two_nonvoid_payloads =
+2 |   | A_nonvoid of int
+3 |   | B_nonvoid of string
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one null constructor and one payload constructor.
 |}]
 
 type portable_payload : value_or_null mod portable =

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -441,6 +441,39 @@ and both_aliased_null =
   | This_both_aliased of both_aliased_int [@@or_null]
 |}]
 
+(* Null-first declarations exercise [Ctype.contained_without_boxing] (via the
+   unboxed-recursion check and the jkind update order) before argument sorts
+   are known, when the null constructor cannot yet be told apart from the
+   payload constructor. *)
+
+type null_first_rec =
+  | Null_first of void
+  | This_first of first_wrapper
+[@@or_null]
+and first_wrapper = { fw : int } [@@unboxed]
+
+[%%expect{|
+type null_first_rec = Null_first of void | This_first of first_wrapper [@@or_null]
+and first_wrapper = { fw : int; } [@@unboxed]
+|}]
+
+type bad_rec =
+  | Null_bad of void
+  | This_bad of bad_wrapper
+[@@or_null]
+and bad_wrapper = { bw : bad_rec } [@@unboxed]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type bad_rec =
+2 |   | Null_bad of void
+3 |   | This_bad of bad_wrapper
+4 | [@@or_null]
+Error: The definition of "bad_rec" is recursive without boxing:
+         "bad_rec" contains "bad_wrapper",
+         "bad_wrapper" contains "bad_rec"
+|}]
+
 type portable_payload : value_or_null mod portable =
   | Portable_none
   | Portable_some of (unit -> unit) @@ portable

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -373,6 +373,74 @@ Error: Invalid [@or_null] declaration:
        it must have exactly one null constructor and one payload constructor.
 |}]
 
+(* The null constructor's void argument counts towards the mod-bounds of the
+   type: matching on the null constructor synthesizes a value of the argument
+   type. *)
+
+type nonportable_void : void
+
+type crossing_void_null : value_or_null mod portable =
+  | Null_crossing_void of void
+  | This_crossing_void of int
+[@@or_null]
+
+type noncrossing_void_null : value_or_null mod portable =
+  | Null_noncrossing_void of nonportable_void
+  | This_noncrossing_void of int
+[@@or_null]
+
+[%%expect{|
+type nonportable_void : void
+type crossing_void_null =
+    Null_crossing_void of void
+  | This_crossing_void of int [@@or_null]
+Lines 8-11, characters 0-11:
+ 8 | type noncrossing_void_null : value_or_null mod portable =
+ 9 |   | Null_noncrossing_void of nonportable_void
+10 |   | This_noncrossing_void of int
+11 | [@@or_null]
+Error: The kind of type "noncrossing_void_null" is
+           immediate_or_null with nonportable_void
+         because an [@@or_null] type gets the kind of or_null
+         applied to its payload type.
+       But the kind of type "noncrossing_void_null" must be a subkind of
+           value_or_null mod portable
+         because of the annotation on the declaration of the type noncrossing_void_null.
+|}]
+
+type two_nullary =
+  | A_nullary
+  | B_nullary
+[@@or_null]
+
+[%%expect{|
+Lines 1-4, characters 0-11:
+1 | type two_nullary =
+2 |   | A_nullary
+3 |   | B_nullary
+4 | [@@or_null]
+Error: Invalid [@or_null] declaration:
+       it must have exactly one null constructor and one payload constructor.
+|}]
+
+(* Both arguments are aliases from the same recursive group, so neither can
+   be classified before the whole group is translated. *)
+
+type both_aliased_void = void
+and both_aliased_int = int
+and both_aliased_null =
+  | Null_both_aliased of both_aliased_void
+  | This_both_aliased of both_aliased_int
+[@@or_null]
+
+[%%expect{|
+type both_aliased_void = void
+and both_aliased_int = int
+and both_aliased_null =
+    Null_both_aliased of both_aliased_void
+  | This_both_aliased of both_aliased_int [@@or_null]
+|}]
+
 type portable_payload : value_or_null mod portable =
   | Portable_none
   | Portable_some of (unit -> unit) @@ portable

--- a/testsuite/tests/typing-layouts-or-null/custom_runtime.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom_runtime.ml
@@ -33,6 +33,23 @@ type float_payload =
   | Float_payload of float
 [@@or_null]
 
+type void : void mod everything
+external void : unit -> void = "%unbox_unit"
+
+let[@inline never] use_void (v : void) =
+  let _ : void = v in
+  1
+
+type void_null =
+  | Null_void of void
+  | This_void of int
+[@@or_null]
+
+type void_product_null =
+  | This_void_product of int
+  | Null_void_product of #(void * void)
+[@@or_null]
+
 type 'a unused_param =
   | Unused_null
   | Unused_payload of int
@@ -88,6 +105,41 @@ let () =
 let () =
   match Float_payload 3.5 with
   | Float_payload x when x = 3.5 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match Null_void (void ()) with
+  | Null_void v when use_void v = 1 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  let effects = ref 0 in
+  let void_effect () =
+    incr effects;
+    void ()
+  in
+  match Null_void (void_effect ()) with
+  | Null_void _ -> assert (!effects = 1)
+  | _ -> assert false
+;;
+
+let () =
+  match This_void 17 with
+  | This_void 17 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match Null_void_product #(void (), void ()) with
+  | Null_void_product #(v1, v2) when use_void v1 = 1 && use_void v2 = 1 -> ()
+  | _ -> assert false
+;;
+
+let () =
+  match This_void_product 19 with
+  | This_void_product 19 -> ()
   | _ -> assert false
 ;;
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -2629,12 +2629,15 @@ module Jkind0 = struct
       in
       Builtin.value ~why
 
-    let for_variant_with_null_result path ~modality payload_ty =
+    let for_variant_with_null_result path args =
       let why : Jkind_intf.History.value_or_null_creation_reason =
         Or_null_payload path
       in
-      Builtin.value_or_null ~why
-      |> add_with_bounds ~modality ~type_expr:payload_ty
+      List.fold_left
+        (fun jkind (modality, type_expr) ->
+           add_with_bounds ~modality ~type_expr jkind)
+        (Builtin.value_or_null ~why)
+        args
       |> mark_best
   end
 

--- a/typing/btype.mli
+++ b/typing/btype.mli
@@ -752,7 +752,7 @@ module Jkind0 : sig
     val for_or_null_argument : Ident.t -> 'd jkind
     val for_or_null_payload : Path.t -> 'd jkind
     val for_variant_with_null_result :
-      Path.t -> modality:Mode.Modality.Const.t -> type_expr -> jkind_l
+      Path.t -> (Mode.Modality.Const.t * type_expr) list -> jkind_l
 
     val for_effect_arg : Ident.t -> 'd jkind
 

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2805,12 +2805,34 @@ let unbox_once env ty =
 
 let contained_without_boxing env ty =
   match get_desc ty with
-  | Tconstr _ ->
-    begin match unbox_once env (mk_unwrapped_type_expr ty) with
-    | Stepped { ty; modality = _; or_null = _ } -> [ty]
-    | Stepped_record_unboxed_product tys ->
-      List.map (fun { ty; _ } -> ty) tys
-    | Final_result | Missing _ -> []
+  | Tconstr (p, args, _) ->
+    begin match Env.find_type p env with
+    | { type_kind = Type_variant (cstrs, Variant_with_null, _);
+        type_params; _ } ->
+      (* Both constructors' arguments are contained without boxing. We
+         don't step to the payload with [unbox_once] here: which
+         constructor is the null constructor is only known once
+         [update_decl_jkind] has filled in the argument sorts, and the
+         callers of this function run before that on the current
+         recursive group. Returning the arguments of both constructors
+         does not depend on constructor order or sorts. *)
+      List.concat_map
+        (fun (cstr : constructor_declaration) ->
+           match cstr.cd_args with
+           | Cstr_tuple cargs ->
+             List.map
+               (fun (carg : constructor_argument) ->
+                  apply env type_params carg.ca_type args)
+               cargs
+           | Cstr_record _ -> [])
+        cstrs
+    | _ | exception Not_found ->
+      begin match unbox_once env (mk_unwrapped_type_expr ty) with
+      | Stepped { ty; modality = _; or_null = _ } -> [ty]
+      | Stepped_record_unboxed_product tys ->
+        List.map (fun { ty; _ } -> ty) tys
+      | Final_result | Missing _ -> []
+      end
     end
   | Tunboxed_tuple labeled_tys ->
     List.map snd labeled_tys

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -116,13 +116,25 @@ type variant_with_null_payload =
     payload_arg: constructor_argument;
   }
 
+type variant_with_null_null =
+  {
+    null_arg: constructor_argument option;
+  }
+
 type variant_with_null_constructor =
-  | Variant_with_null_nullary
+  | Variant_with_null_null of variant_with_null_null
   | Variant_with_null_payload of variant_with_null_payload
+
+let constructor_argument_all_void (arg : constructor_argument) =
+  match arg.ca_sort with
+  | Some sort -> Jkind_types.Sort.Const.all_void sort
+  | None -> false
 
 let classify_variant_with_null_constructor payload_cstr =
   match payload_cstr.cd_args with
-  | Cstr_tuple [] -> Variant_with_null_nullary
+  | Cstr_tuple [] -> Variant_with_null_null { null_arg = None }
+  | Cstr_tuple [payload_arg] when constructor_argument_all_void payload_arg ->
+    Variant_with_null_null { null_arg = Some payload_arg }
   | Cstr_tuple [payload_arg] ->
     Variant_with_null_payload
       { payload_cstr; payload_arg }
@@ -133,7 +145,7 @@ let find_variant_with_null_payload cstrs =
   List.find_map
     (fun cstr ->
       match classify_variant_with_null_constructor cstr with
-      | Variant_with_null_nullary -> None
+      | Variant_with_null_null _ -> None
       | Variant_with_null_payload payload -> Some payload)
     cstrs
 
@@ -170,9 +182,19 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
     | Variant_with_null, _ ->
       let layout cstr =
         match classify_variant_with_null_constructor cstr with
-        | Variant_with_null_nullary ->
+        | Variant_with_null_null { null_arg = None } ->
           Cstr_layout_known
             { shape = Constructor_uniform_value; sorts = [| |] }
+        | Variant_with_null_null
+            { null_arg = Some { ca_sort = Some sort; _ } } ->
+          Cstr_layout_known
+            { shape =
+                Constructor_mixed
+                  [| Types.mixed_block_element_of_const_sort sort |];
+              sorts = [| sort |] }
+        | Variant_with_null_null
+            { null_arg = Some { ca_sort = None; _ } } ->
+          Misc.fatal_error "Invalid constructor for Variant_with_null"
         | Variant_with_null_payload
             { payload_arg = { ca_sort = Some sort; _ }; _ } ->
           Cstr_layout_known
@@ -235,7 +257,7 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
         begin match classify_variant_with_null_constructor
           { cd_id; cd_args; cd_res; cd_loc; cd_attributes; cd_uid }
         with
-        | Variant_with_null_nullary -> Null
+        | Variant_with_null_null _ -> Null
         | Variant_with_null_payload _ -> Ordinary {src_index; runtime_tag}
         end
       | _ -> Ordinary {src_index; runtime_tag}

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -116,28 +116,21 @@ type variant_with_null_payload =
     payload_arg: constructor_argument;
   }
 
-type variant_with_null_null =
-  {
-    null_arg: constructor_argument option;
-  }
-
 type variant_with_null_constructor =
-  | Variant_with_null_null of variant_with_null_null
+  | Variant_with_null_null of Jkind_types.Sort.Const.t option
+      (* The sort of the null constructor's all-void argument, if any. *)
   | Variant_with_null_payload of variant_with_null_payload
-
-let constructor_argument_all_void (arg : constructor_argument) =
-  match arg.ca_sort with
-  | Some sort -> Jkind_types.Sort.Const.all_void sort
-  | None -> false
 
 let classify_variant_with_null_constructor payload_cstr =
   match payload_cstr.cd_args with
-  | Cstr_tuple [] -> Variant_with_null_null { null_arg = None }
-  | Cstr_tuple [payload_arg] when constructor_argument_all_void payload_arg ->
-    Variant_with_null_null { null_arg = Some payload_arg }
+  | Cstr_tuple [] -> Variant_with_null_null None
   | Cstr_tuple [payload_arg] ->
-    Variant_with_null_payload
-      { payload_cstr; payload_arg }
+    begin match payload_arg.ca_sort with
+    | Some sort when Jkind_types.Sort.Const.all_void sort ->
+      Variant_with_null_null (Some sort)
+    | Some _ | None ->
+      Variant_with_null_payload { payload_cstr; payload_arg }
+    end
   | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
     Misc.fatal_error "Invalid constructor for Variant_with_null"
 
@@ -182,19 +175,15 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
     | Variant_with_null, _ ->
       let layout cstr =
         match classify_variant_with_null_constructor cstr with
-        | Variant_with_null_null { null_arg = None } ->
+        | Variant_with_null_null None ->
           Cstr_layout_known
             { shape = Constructor_uniform_value; sorts = [| |] }
-        | Variant_with_null_null
-            { null_arg = Some { ca_sort = Some sort; _ } } ->
+        | Variant_with_null_null (Some sort) ->
           Cstr_layout_known
             { shape =
                 Constructor_mixed
                   [| Types.mixed_block_element_of_const_sort sort |];
               sorts = [| sort |] }
-        | Variant_with_null_null
-            { null_arg = Some { ca_sort = None; _ } } ->
-          Misc.fatal_error "Invalid constructor for Variant_with_null"
         | Variant_with_null_payload
             { payload_arg = { ca_sort = Some sort; _ }; _ } ->
           Cstr_layout_known

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -134,6 +134,11 @@ let classify_variant_with_null_constructor payload_cstr =
   | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
     Misc.fatal_error "Invalid constructor for Variant_with_null"
 
+(* Note: before [update_decl_jkind] has filled in the argument sorts, a
+   unary null constructor is indistinguishable from the payload constructor
+   (its [ca_sort] is still [None]), so this function can return the wrong
+   constructor. Callers must run after sorts are filled in, or tolerate
+   misclassification. *)
 let find_variant_with_null_payload cstrs =
   List.find_map
     (fun cstr ->

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -223,62 +223,9 @@ let check_or_null_variant_shape sdecl scstrs =
   check_or_null_decl bad sdecl;
   check_or_null_constructors bad scstrs
 
-type or_null_constructor =
-  | Or_null_null
-  | Or_null_payload of Types.constructor_argument
-  | Or_null_unresolved of Types.constructor_argument
-
-type or_null_payload_arg =
-  | Or_null_known_payload of Types.constructor_argument
-  | Or_null_unresolved_payload of Types.constructor_argument
-  | Or_null_deferred_payload
-
-let invalid_or_null_payload_message =
-  "it must have exactly one null constructor and one payload constructor"
-
 let bad_or_null_payload_count loc =
-  raise (Error (loc, Bad_or_null_attribute invalid_or_null_payload_message))
-
-let classify_or_null_payload env (arg : Types.constructor_argument) =
-  let sort =
-    arg.ca_type
-    |> Ctype.type_jkind env
-    |> Jkind.sort_option_of_jkind env
-  in
-  match sort with
-  | Some sort ->
-    let all_void =
-      sort
-      |> Jkind.Sort.default_to_scannable_and_get
-      |> Jkind.Sort.Const.all_void
-    in
-    if all_void then Or_null_null else Or_null_payload arg
-  | None -> Or_null_unresolved arg
-
-let classify_or_null_constructor env (cstr : Types.constructor_declaration) =
-  match cstr.cd_args with
-  | Cstr_tuple [] -> Or_null_null
-  | Cstr_tuple [arg] -> classify_or_null_payload env arg
-  | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
-    Misc.fatal_error "Invalid constructor for Variant_with_null"
-
-let get_or_null_payload_arg env sdecl cstrs : or_null_payload_arg =
-  let num_nulls, payloads, unresolved =
-    List.fold_left
-      (fun (num_nulls, payloads, unresolved) cstr ->
-         match classify_or_null_constructor env cstr with
-         | Or_null_null -> num_nulls + 1, payloads, unresolved
-         | Or_null_payload payload -> num_nulls, payload :: payloads, unresolved
-         | Or_null_unresolved payload ->
-           num_nulls, payloads, payload :: unresolved)
-      (0, [], []) cstrs
-  in
-  match num_nulls, payloads, unresolved with
-  | 1, [payload_arg], [] -> Or_null_known_payload payload_arg
-  | 1, [], [payload_arg] -> Or_null_unresolved_payload payload_arg
-  | _, [payload_arg], _ -> Or_null_known_payload payload_arg
-  | 0, [], [_; _] -> Or_null_deferred_payload
-  | _ -> bad_or_null_payload_count sdecl.ptype_loc
+  raise (Error (loc, Bad_or_null_attribute
+    "it must have exactly one null constructor and one payload constructor"))
 
 let constrain_or_null_payload ~env ~path payload_ty payload_loc =
   let required = Btype.Jkind0.for_or_null_payload path in
@@ -1021,19 +968,6 @@ let transl_declaration env sdecl (id, uid) =
       transl_simple_type ~new_var_jkind:Sort env ~closed:false Mode.Alloc.Const.legacy sty', loc)
     sdecl.ptype_cstrs
   in
-  let constraints_checked = ref false in
-  let check_constraints () =
-    if not !constraints_checked then begin
-      List.iter
-        (fun (cty, cty', loc) ->
-           let ty = cty.ctyp_type in
-           let ty' = cty'.ctyp_type in
-           try Ctype.unify env ty ty' with Ctype.Unify err ->
-             raise(Error(loc, Inconsistent_constraint (env, err))))
-        cstrs;
-      constraints_checked := true
-    end
-  in
   let unboxed_attr = get_unboxed_from_attributes sdecl in
   let represent_as_float_array =
     Builtin_attributes.has_represent_as_float_array sdecl.ptype_attributes
@@ -1182,56 +1116,66 @@ let transl_declaration env sdecl (id, uid) =
             (fun () -> make_cstr scstr)
         in
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
-        let or_null_payload_arg =
-          if or_null then begin
-            check_constraints ();
-            let payload_arg = get_or_null_payload_arg env sdecl cstrs in
-            begin match payload_arg with
-            | Or_null_known_payload payload_arg ->
-              let payload_ty = payload_arg.Types.ca_type in
-              let payload_loc = payload_arg.Types.ca_loc in
-              constrain_or_null_payload ~env ~path payload_ty payload_loc
-            | Or_null_unresolved_payload _ | Or_null_deferred_payload -> ()
-            end;
-            Some payload_arg
-          end else
-            None
-        in
         let rep, jkind =
-          match or_null_payload_arg with
-          | Some
-              (Or_null_known_payload payload_arg
-              | Or_null_unresolved_payload payload_arg) ->
-            let payload_ty = payload_arg.Types.ca_type in
-            let modality = payload_arg.Types.ca_modalities in
+          if or_null then begin
+            (* Which constructor is the null constructor and which is the
+               payload constructor is determined by which one has an
+               all-void argument. Jkinds are not reliably available here
+               (types in the same recursive group still have temporary
+               jkinds), so the constructors are classified - and the
+               payload constrained - in [update_decl_jkind], where the
+               argument sorts of ordinary variants are computed too. Here
+               we only need a jkind for the temporary environment:
+               [value_or_null], bounded by the arguments of both
+               constructors, is correct whichever way the classification
+               goes. *)
+            let unary_args =
+              List.filter_map
+                (fun (cstr : Types.constructor_declaration) ->
+                   match cstr.cd_args with
+                   | Cstr_tuple [] -> None
+                   | Cstr_tuple [arg] -> Some arg
+                   | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
+                     Misc.fatal_error
+                       "Invalid constructor for Variant_with_null")
+                cstrs
+            in
+            begin match unary_args with
+            | [] ->
+              (* Two nullary constructors: no payload constructor. *)
+              bad_or_null_payload_count sdecl.ptype_loc
+            | _ :: _ -> ()
+            end;
             Variant_with_null,
-            Btype.Jkind0.for_variant_with_null_result path ~modality payload_ty
-          | Some Or_null_deferred_payload ->
-            Variant_with_null, Jkind.Builtin.any ~why:Initial_typedecl_env
-          | None ->
-            if unbox then
-              Variant_unboxed,
-              Jkind.Builtin.any ~why:Old_style_unboxed_type
-            else
-              (* We mark all arg sorts "void" here.  They are updated later,
-                 after the circular type checks make it safe to check sorts.
-                 Likewise, [Constructor_uniform_value] is potentially wrong
-                 and will be updated later.
-              *)
-              Variant_boxed (
-                Array.map
-                  (fun cstr ->
-                     let sorts =
-                       match Types.(cstr.cd_args) with
-                        | Cstr_tuple args ->
-                          Array.make (List.length args) Jkind.Sort.Const.void
-                        | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
-                      in
-                      Cstr_layout_known
-                        { shape = Constructor_uniform_value; sorts })
-                   (Array.of_list cstrs)
-               ),
-               Jkind.for_non_float ~why:Boxed_variant
+            Btype.Jkind0.for_variant_with_null_result path
+              (List.map
+                 (fun (arg : Types.constructor_argument) ->
+                    arg.ca_modalities, arg.ca_type)
+                 unary_args)
+          end
+          else if unbox then
+            Variant_unboxed,
+            Jkind.Builtin.any ~why:Old_style_unboxed_type
+          else
+            (* We mark all arg sorts "void" here.  They are updated later,
+               after the circular type checks make it safe to check sorts.
+               Likewise, [Constructor_uniform_value] is potentially wrong
+               and will be updated later.
+            *)
+            Variant_boxed (
+              Array.map
+                (fun cstr ->
+                   let sorts =
+                     match Types.(cstr.cd_args) with
+                      | Cstr_tuple args ->
+                        Array.make (List.length args) Jkind.Sort.Const.void
+                      | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
+                    in
+                    Cstr_layout_known
+                      { shape = Constructor_uniform_value; sorts })
+                 (Array.of_list cstrs)
+             ),
+             Jkind.for_non_float ~why:Boxed_variant
         in
           Ttype_variant tcstrs, Type_variant (cstrs, rep, None), jkind
       | Ptype_record lbls ->
@@ -1336,7 +1280,13 @@ let transl_declaration env sdecl (id, uid) =
            translated, in [derive_unboxed_versions] *)
       } in
   (* Check constraints *)
-    check_constraints ();
+    List.iter
+      (fun (cty, cty', loc) ->
+        let ty = cty.ctyp_type in
+        let ty' = cty'.ctyp_type in
+        try Ctype.unify env ty ty' with Ctype.Unify err ->
+          raise(Error(loc, Inconsistent_constraint (env, err))))
+      cstrs;
   (* Check for imprecise type parameter annotations *)
     List.iter2 (check_imprecise_type_param_annotation env)
       tparams param_annotated_jkinds;
@@ -2567,43 +2517,46 @@ let rec update_decl_jkind env dpath decl =
     (* CR layouts: factor out duplication *)
     match cstrs, rep with
     | _, Variant_with_null ->
+      (* The null constructor is the one with an all-void argument (or no
+         argument); the payload constructor is the other one. We classify
+         the constructors here, rather than in [transl_declaration],
+         because the jkinds of the arguments are only known once the whole
+         recursive group has been translated, just like the argument sorts
+         of ordinary variants. *)
       let payload = ref None in
+      let null_payload = ref None in
+      let sort_of_jkind jkind =
+        Option.bind
+          (Jkind.sort_option_of_jkind env jkind)
+          Jkind.Sort.default_to_scannable_and_get_some
+      in
       let cstrs =
         List.map
           (fun (cstr : Types.constructor_declaration) ->
              match cstr.cd_args with
              | Cstr_tuple [] -> cstr
-             | Cstr_tuple [{ ca_type; ca_modalities; ca_loc; _ }] ->
+             | Cstr_tuple [({ ca_type; ca_modalities; ca_loc; _ } as arg)] ->
                let jkind = Ctype.type_jkind env ca_type in
                let ca_sort =
-                 let sort = Jkind.sort_option_of_jkind env jkind in
-                 Option.bind sort Jkind.Sort.default_to_scannable_and_get_some
-               in
-               let ca_sort =
-                 if match ca_sort with
-                   | Some sort -> Jkind.Sort.Const.all_void sort
-                   | None -> false
-                 then
-                   ca_sort
-                 else begin
+                 match sort_of_jkind jkind with
+                 | Some sort when Jkind.Sort.Const.all_void sort ->
+                   (* The null constructor. *)
+                   begin match !null_payload with
+                   | None -> null_payload := Some (ca_modalities, ca_type)
+                   | Some _ -> bad_or_null_payload_count loc
+                   end;
+                   Some sort
+                 | _ ->
+                   (* The payload constructor. *)
                    constrain_or_null_payload ~env ~path:dpath ca_type ca_loc;
                    let jkind = Ctype.type_jkind env ca_type in
-                   let ca_sort =
-                     let sort = Jkind.sort_option_of_jkind env jkind in
-                     Option.bind sort
-                       Jkind.Sort.default_to_scannable_and_get_some
-                   in
                    begin match !payload with
                    | None -> payload := Some (jkind, ca_modalities, ca_type)
                    | Some _ -> bad_or_null_payload_count loc
                    end;
-                   ca_sort
-                 end
+                   sort_of_jkind jkind
                in
-               { cstr with
-                 cd_args =
-                   Cstr_tuple
-                     [{ ca_type; ca_sort; ca_modalities; ca_loc }] }
+               { cstr with cd_args = Cstr_tuple [{ arg with ca_sort }] }
              | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
                Misc.fatal_error "Invalid constructor for Variant_with_null")
           cstrs
@@ -2615,6 +2568,15 @@ let rec update_decl_jkind env dpath decl =
             ~payload_jkind:jkind
         with
         | Ok type_jkind ->
+          let type_jkind =
+            (* A void argument of the null constructor still counts
+               towards the bounds of the declaration: matching on the null
+               constructor synthesizes a value of that type. *)
+            match !null_payload with
+            | None -> type_jkind
+            | Some (modality, type_expr) ->
+              Btype.Jkind0.add_with_bounds ~modality ~type_expr type_jkind
+          in
           let type_jkind =
             Jkind.History.update_reason type_jkind
               (Value_or_null_creation (Or_null_payload dpath))

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -205,19 +205,14 @@ let check_or_null_constructors bad = function
     in
     check_no_gadt c1;
     check_no_gadt c2;
-    begin match c1.pcd_args, c2.pcd_args with
-    | Pcstr_tuple [],
-      Pcstr_tuple
-        [_]
-    | Pcstr_tuple
-        [_],
-      Pcstr_tuple [] ->
-      ()
-    | _ ->
-      bad
-        "it must have exactly one nullary constructor and one unary \
-         constructor"
-    end
+    let check_args ({ pcd_args; _ } : Parsetree.constructor_declaration) =
+      match pcd_args with
+      | Pcstr_tuple [] | Pcstr_tuple [_] -> ()
+      | Pcstr_tuple (_ :: _ :: _) | Pcstr_record _ ->
+        bad "each constructor must be nullary or unary"
+    in
+    check_args c1;
+    check_args c2
   | _ ->
     bad "it must have exactly two constructors"
 
@@ -228,10 +223,62 @@ let check_or_null_variant_shape sdecl scstrs =
   check_or_null_decl bad sdecl;
   check_or_null_constructors bad scstrs
 
-let get_or_null_payload_arg cstrs : Types.constructor_argument =
-  match Datarepr.find_variant_with_null_payload cstrs with
-  | Some { payload_arg; _ } -> payload_arg
-  | None -> Misc.fatal_error "Invalid constructor for Variant_with_null"
+type or_null_constructor =
+  | Or_null_null
+  | Or_null_payload of Types.constructor_argument
+  | Or_null_unresolved of Types.constructor_argument
+
+type or_null_payload_arg =
+  | Or_null_known_payload of Types.constructor_argument
+  | Or_null_unresolved_payload of Types.constructor_argument
+  | Or_null_deferred_payload
+
+let invalid_or_null_payload_message =
+  "it must have exactly one null constructor and one payload constructor"
+
+let bad_or_null_payload_count loc =
+  raise (Error (loc, Bad_or_null_attribute invalid_or_null_payload_message))
+
+let classify_or_null_payload env (arg : Types.constructor_argument) =
+  let sort =
+    arg.ca_type
+    |> Ctype.type_jkind env
+    |> Jkind.sort_option_of_jkind env
+  in
+  match sort with
+  | Some sort ->
+    let all_void =
+      sort
+      |> Jkind.Sort.default_to_scannable_and_get
+      |> Jkind.Sort.Const.all_void
+    in
+    if all_void then Or_null_null else Or_null_payload arg
+  | None -> Or_null_unresolved arg
+
+let classify_or_null_constructor env (cstr : Types.constructor_declaration) =
+  match cstr.cd_args with
+  | Cstr_tuple [] -> Or_null_null
+  | Cstr_tuple [arg] -> classify_or_null_payload env arg
+  | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
+    Misc.fatal_error "Invalid constructor for Variant_with_null"
+
+let get_or_null_payload_arg env sdecl cstrs : or_null_payload_arg =
+  let num_nulls, payloads, unresolved =
+    List.fold_left
+      (fun (num_nulls, payloads, unresolved) cstr ->
+         match classify_or_null_constructor env cstr with
+         | Or_null_null -> num_nulls + 1, payloads, unresolved
+         | Or_null_payload payload -> num_nulls, payload :: payloads, unresolved
+         | Or_null_unresolved payload ->
+           num_nulls, payloads, payload :: unresolved)
+      (0, [], []) cstrs
+  in
+  match num_nulls, payloads, unresolved with
+  | 1, [payload_arg], [] -> Or_null_known_payload payload_arg
+  | 1, [], [payload_arg] -> Or_null_unresolved_payload payload_arg
+  | _, [payload_arg], _ -> Or_null_known_payload payload_arg
+  | 0, [], [_; _] -> Or_null_deferred_payload
+  | _ -> bad_or_null_payload_count sdecl.ptype_loc
 
 let constrain_or_null_payload ~env ~path payload_ty payload_loc =
   let required = Btype.Jkind0.for_or_null_payload path in
@@ -974,6 +1021,19 @@ let transl_declaration env sdecl (id, uid) =
       transl_simple_type ~new_var_jkind:Sort env ~closed:false Mode.Alloc.Const.legacy sty', loc)
     sdecl.ptype_cstrs
   in
+  let constraints_checked = ref false in
+  let check_constraints () =
+    if not !constraints_checked then begin
+      List.iter
+        (fun (cty, cty', loc) ->
+           let ty = cty.ctyp_type in
+           let ty' = cty'.ctyp_type in
+           try Ctype.unify env ty ty' with Ctype.Unify err ->
+             raise(Error(loc, Inconsistent_constraint (env, err))))
+        cstrs;
+      constraints_checked := true
+    end
+  in
   let unboxed_attr = get_unboxed_from_attributes sdecl in
   let represent_as_float_array =
     Builtin_attributes.has_represent_as_float_array sdecl.ptype_attributes
@@ -1124,21 +1184,30 @@ let transl_declaration env sdecl (id, uid) =
         let tcstrs, cstrs = List.split (List.map make_cstr scstrs) in
         let or_null_payload_arg =
           if or_null then begin
-            let payload_arg = get_or_null_payload_arg cstrs in
-            let payload_ty = payload_arg.Types.ca_type in
-            let payload_loc = payload_arg.Types.ca_loc in
-            constrain_or_null_payload ~env ~path payload_ty payload_loc;
+            check_constraints ();
+            let payload_arg = get_or_null_payload_arg env sdecl cstrs in
+            begin match payload_arg with
+            | Or_null_known_payload payload_arg ->
+              let payload_ty = payload_arg.Types.ca_type in
+              let payload_loc = payload_arg.Types.ca_loc in
+              constrain_or_null_payload ~env ~path payload_ty payload_loc
+            | Or_null_unresolved_payload _ | Or_null_deferred_payload -> ()
+            end;
             Some payload_arg
           end else
             None
         in
         let rep, jkind =
           match or_null_payload_arg with
-          | Some payload_arg ->
+          | Some
+              (Or_null_known_payload payload_arg
+              | Or_null_unresolved_payload payload_arg) ->
             let payload_ty = payload_arg.Types.ca_type in
             let modality = payload_arg.Types.ca_modalities in
             Variant_with_null,
             Btype.Jkind0.for_variant_with_null_result path ~modality payload_ty
+          | Some Or_null_deferred_payload ->
+            Variant_with_null, Jkind.Builtin.any ~why:Initial_typedecl_env
           | None ->
             if unbox then
               Variant_unboxed,
@@ -1267,13 +1336,7 @@ let transl_declaration env sdecl (id, uid) =
            translated, in [derive_unboxed_versions] *)
       } in
   (* Check constraints *)
-    List.iter
-      (fun (cty, cty', loc) ->
-        let ty = cty.ctyp_type in
-        let ty' = cty'.ctyp_type in
-        try Ctype.unify env ty ty' with Ctype.Unify err ->
-          raise(Error(loc, Inconsistent_constraint (env, err))))
-      cstrs;
+    check_constraints ();
   (* Check for imprecise type parameter annotations *)
     List.iter2 (check_imprecise_type_param_annotation env)
       tparams param_annotated_jkinds;
@@ -2504,31 +2567,51 @@ let rec update_decl_jkind env dpath decl =
     (* CR layouts: factor out duplication *)
     match cstrs, rep with
     | _, Variant_with_null ->
-      begin match Datarepr.find_variant_with_null_payload cstrs with
-      | Some
-          { payload_cstr = { Types.cd_uid; _ };
-            payload_arg = { ca_type = ty; ca_modalities = modality; _ } } ->
-        let jkind = Ctype.type_jkind env ty in
-        let sort = Jkind.sort_of_jkind env jkind in
-        let ca_sort = Jkind.Sort.default_to_scannable_and_get_some sort in
-        let cstrs =
-          List.map
-            (fun (cstr : Types.constructor_declaration) ->
-               if Uid.equal cstr.cd_uid cd_uid then
-                 match cstr.cd_args with
-                 | Cstr_tuple [{ ca_type; ca_modalities; ca_loc; _ }] ->
-                   { cstr with
-                     cd_args =
-                       Cstr_tuple
-                         [{ ca_type; ca_sort; ca_modalities;
-                            ca_loc }] }
-                 | Cstr_tuple [] | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
-                   Misc.fatal_error "Invalid constructor for Variant_with_null"
-               else cstr)
-            cstrs
-        in
+      let payload = ref None in
+      let cstrs =
+        List.map
+          (fun (cstr : Types.constructor_declaration) ->
+             match cstr.cd_args with
+             | Cstr_tuple [] -> cstr
+             | Cstr_tuple [{ ca_type; ca_modalities; ca_loc; _ }] ->
+               let jkind = Ctype.type_jkind env ca_type in
+               let ca_sort =
+                 let sort = Jkind.sort_option_of_jkind env jkind in
+                 Option.bind sort Jkind.Sort.default_to_scannable_and_get_some
+               in
+               let ca_sort =
+                 if match ca_sort with
+                   | Some sort -> Jkind.Sort.Const.all_void sort
+                   | None -> false
+                 then
+                   ca_sort
+                 else begin
+                   constrain_or_null_payload ~env ~path:dpath ca_type ca_loc;
+                   let jkind = Ctype.type_jkind env ca_type in
+                   let ca_sort =
+                     let sort = Jkind.sort_option_of_jkind env jkind in
+                     Option.bind sort
+                       Jkind.Sort.default_to_scannable_and_get_some
+                   in
+                   begin match !payload with
+                   | None -> payload := Some (jkind, ca_modalities, ca_type)
+                   | Some _ -> bad_or_null_payload_count loc
+                   end;
+                   ca_sort
+                 end
+               in
+               { cstr with
+                 cd_args =
+                   Cstr_tuple
+                     [{ ca_type; ca_sort; ca_modalities; ca_loc }] }
+             | Cstr_tuple (_ :: _ :: _) | Cstr_record _ ->
+               Misc.fatal_error "Invalid constructor for Variant_with_null")
+          cstrs
+      in
+      begin match !payload with
+      | Some (jkind, modality, payload_type) ->
         begin match
-          Jkind.for_or_null_variant env ~payload_type:ty ~modality
+          Jkind.for_or_null_variant env ~payload_type ~modality
             ~payload_jkind:jkind
         with
         | Ok type_jkind ->
@@ -2542,8 +2625,7 @@ let rec update_decl_jkind env dpath decl =
             "Typedecl.update_variant_kind: Variant_with_null payload is \
              already maybe-null"
         end
-      | None ->
-        Misc.fatal_error "Invalid constructor for Variant_with_null"
+      | None -> bad_or_null_payload_count loc
       end
     | [{Types.cd_args} as cstr], Variant_unboxed -> begin
         match cd_args with


### PR DESCRIPTION
This allows the null constructor of a custom `[@@or_null]` type to be unary when its payload has kind `void`.

The compiler now classifies all-void unary constructors as the null case, still preserves evaluation of erased void payload expressions (in case they have effects), and synthesizes void payload bindings when matching on the null case.

The implementation also handles same-recursive-group void aliases/types by deferring ambiguous null-vs-payload classification until final jkind information is available.