### PR TITLE
Fix element layouts for arrays of products

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -2867,7 +2867,7 @@ let rec layout_of_scannable_kinds kinds =
   Punboxed_product (List.map layout_of_scannable_kind kinds)
 
 and layout_of_scannable_kind = function
-  | Pint_scannable -> layout_int
+  | Pint_scannable -> layout_int_or_null
   | Paddr_scannable -> layout_value_field
   | Pproduct_scannable kinds -> layout_of_scannable_kinds kinds
 
@@ -2875,7 +2875,7 @@ let rec layout_of_ignorable_kinds kinds =
   Punboxed_product (List.map layout_of_ignorable_kind kinds)
 
 and layout_of_ignorable_kind = function
-  | Pint_ignorable -> layout_int
+  | Pint_ignorable -> layout_int_or_null
   | Punboxedfloat_ignorable f -> layout_unboxed_float f
   | Punboxedvector_ignorable v -> layout_unboxed_vector v
   | Punboxedoruntaggedint_ignorable i -> layout_unboxed_int i

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -178,7 +178,7 @@ let convert_array_kind dbg (kind : L.array_kind) : converted_array_kind =
     let rec convert_kind (kind : L.scannable_product_element_kind) :
         P.Array_kind.t =
       match kind with
-      | Pint_scannable -> Values
+      | Pint_scannable -> Gc_ignorable_values
       | Paddr_scannable -> Values
       | Pproduct_scannable kinds ->
         Unboxed_product (List.map convert_kind kinds)
@@ -188,7 +188,7 @@ let convert_array_kind dbg (kind : L.array_kind) : converted_array_kind =
     let rec convert_kind (kind : L.ignorable_product_element_kind) :
         P.Array_kind.t =
       match kind with
-      | Pint_ignorable -> Values
+      | Pint_ignorable -> Gc_ignorable_values
       | Punboxedfloat_ignorable Unboxed_float32 -> Naked_float32s
       | Punboxedfloat_ignorable Unboxed_float64 -> Naked_floats
       | Punboxedvector_ignorable Unboxed_vec128 -> Naked_vec128s
@@ -279,7 +279,7 @@ let convert_array_ref_kind dbg (kind : L.array_ref_kind) :
     let rec convert_kind (kind : L.scannable_product_element_kind) :
         Array_ref_kind.no_float_array_opt =
       match kind with
-      | Pint_scannable -> Values
+      | Pint_scannable -> Gc_ignorable_values
       | Paddr_scannable -> Values
       | Pproduct_scannable kinds ->
         Unboxed_product (List.map convert_kind kinds)
@@ -290,7 +290,7 @@ let convert_array_ref_kind dbg (kind : L.array_ref_kind) :
     let rec convert_kind (kind : L.ignorable_product_element_kind) :
         Array_ref_kind.no_float_array_opt =
       match kind with
-      | Pint_ignorable -> Values
+      | Pint_ignorable -> Gc_ignorable_values
       | Punboxedfloat_ignorable Unboxed_float32 -> Naked_float32s
       | Punboxedfloat_ignorable Unboxed_float64 -> Naked_floats
       | Punboxedvector_ignorable Unboxed_vec128 -> Naked_vec128s

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -178,7 +178,7 @@ let convert_array_kind dbg (kind : L.array_kind) : converted_array_kind =
     let rec convert_kind (kind : L.scannable_product_element_kind) :
         P.Array_kind.t =
       match kind with
-      | Pint_scannable -> Immediates
+      | Pint_scannable -> Values
       | Paddr_scannable -> Values
       | Pproduct_scannable kinds ->
         Unboxed_product (List.map convert_kind kinds)
@@ -188,7 +188,7 @@ let convert_array_kind dbg (kind : L.array_kind) : converted_array_kind =
     let rec convert_kind (kind : L.ignorable_product_element_kind) :
         P.Array_kind.t =
       match kind with
-      | Pint_ignorable -> Immediates
+      | Pint_ignorable -> Values
       | Punboxedfloat_ignorable Unboxed_float32 -> Naked_float32s
       | Punboxedfloat_ignorable Unboxed_float64 -> Naked_floats
       | Punboxedvector_ignorable Unboxed_vec128 -> Naked_vec128s
@@ -279,7 +279,7 @@ let convert_array_ref_kind dbg (kind : L.array_ref_kind) :
     let rec convert_kind (kind : L.scannable_product_element_kind) :
         Array_ref_kind.no_float_array_opt =
       match kind with
-      | Pint_scannable -> Immediates
+      | Pint_scannable -> Values
       | Paddr_scannable -> Values
       | Pproduct_scannable kinds ->
         Unboxed_product (List.map convert_kind kinds)
@@ -290,7 +290,7 @@ let convert_array_ref_kind dbg (kind : L.array_ref_kind) :
     let rec convert_kind (kind : L.ignorable_product_element_kind) :
         Array_ref_kind.no_float_array_opt =
       match kind with
-      | Pint_ignorable -> Immediates
+      | Pint_ignorable -> Values
       | Punboxedfloat_ignorable Unboxed_float32 -> Naked_float32s
       | Punboxedfloat_ignorable Unboxed_float64 -> Naked_floats
       | Punboxedvector_ignorable Unboxed_vec128 -> Naked_vec128s
@@ -385,7 +385,6 @@ let convert_array_ref_kind_for_length dbg array_ref_kind :
 
 module Array_set_kind = struct
   type no_float_array_opt =
-    | Immediates
     | Values of P.Init_or_assign.t
     | Gc_ignorable_values
     | Naked_floats
@@ -422,7 +421,7 @@ let convert_array_set_kind dbg (kind : L.array_set_kind) :
          (Values (Assignment (Alloc_mode.For_assignments.from_lambda mode))))
   | Pgcignorableaddrarray_set ->
     Array_set_kind (No_float_array_opt Gc_ignorable_values)
-  | Pintarray_set -> Array_set_kind (No_float_array_opt Immediates)
+  | Pintarray_set -> Array_set_kind (No_float_array_opt Gc_ignorable_values)
   | Pfloatarray_set -> Array_set_kind Naked_floats_to_be_unboxed
   | Punboxedfloatarray_set Unboxed_float64 ->
     Array_set_kind (No_float_array_opt Naked_floats)
@@ -450,7 +449,7 @@ let convert_array_set_kind dbg (kind : L.array_set_kind) :
     let rec convert_kind (kind : L.scannable_product_element_kind) :
         Array_set_kind.no_float_array_opt =
       match kind with
-      | Pint_scannable -> Immediates
+      | Pint_scannable -> Gc_ignorable_values
       | Paddr_scannable ->
         Values (Assignment (Alloc_mode.For_assignments.from_lambda mode))
       | Pproduct_scannable kinds ->
@@ -462,7 +461,7 @@ let convert_array_set_kind dbg (kind : L.array_set_kind) :
     let rec convert_kind (kind : L.ignorable_product_element_kind) :
         Array_set_kind.no_float_array_opt =
       match kind with
-      | Pint_ignorable -> Immediates
+      | Pint_ignorable -> Gc_ignorable_values
       | Punboxedfloat_ignorable Unboxed_float32 -> Naked_float32s
       | Punboxedfloat_ignorable Unboxed_float64 -> Naked_floats
       | Punboxedvector_ignorable Unboxed_vec128 -> Naked_vec128s
@@ -487,7 +486,6 @@ let convert_array_set_kind dbg (kind : L.array_set_kind) :
 let rec convert_unboxed_product_array_set_kind
     (kind : Array_set_kind.no_float_array_opt) : P.Array_kind.t =
   match kind with
-  | Immediates -> Immediates
   | Gc_ignorable_values -> Gc_ignorable_values
   | Values _init_or_assign -> Values
   | Naked_floats -> Naked_floats
@@ -510,7 +508,6 @@ let convert_array_set_kind_to_array_kind (array_set_kind : Array_set_kind.t) :
   | Naked_floats_to_be_unboxed -> Naked_floats
   | No_float_array_opt nfo -> (
     match nfo with
-    | Immediates -> Immediates
     | Gc_ignorable_values -> Gc_ignorable_values
     | Values _ -> Values
     | Naked_floats -> Naked_floats
@@ -534,7 +531,6 @@ let convert_array_set_kind_for_length dbg array_set_kind :
   | Array_set_kind Naked_floats_to_be_unboxed -> Array_kind Naked_floats
   | Array_set_kind (No_float_array_opt nfo) -> (
     match nfo with
-    | Immediates -> Array_kind Immediates
     | Gc_ignorable_values -> Array_kind Gc_ignorable_values
     | Values _ -> Array_kind Values
     | Naked_floats -> Array_kind Naked_floats
@@ -1425,7 +1421,6 @@ let rec array_set_unsafe ~machine_width dbg ~array ~index array_kind
     let rec unarize_kind (array_set_kind : Array_set_kind.no_float_array_opt) :
         Array_set_kind.t list =
       match array_set_kind with
-      | Immediates -> [Array_set_kind.No_float_array_opt Immediates]
       | Values init_or_assign ->
         [Array_set_kind.No_float_array_opt (Values init_or_assign)]
       | Gc_ignorable_values ->
@@ -1470,12 +1465,11 @@ let rec array_set_unsafe ~machine_width dbg ~array ~index array_kind
                array_set_kind ~new_values:[new_value])
            (List.combine indexes (List.combine unarized new_values))) ]
   | No_float_array_opt
-      (( Immediates | Gc_ignorable_values | Values _ | Naked_floats
-       | Naked_float32s | Naked_ints | Naked_int8s | Naked_int16s | Naked_int32s
-       | Naked_int64s | Naked_nativeints | Naked_vec128s | Naked_vec256s
-       | Naked_vec512s ) as nfo) -> (
+      (( Gc_ignorable_values | Values _ | Naked_floats | Naked_float32s
+       | Naked_ints | Naked_int8s | Naked_int16s | Naked_int32s | Naked_int64s
+       | Naked_nativeints | Naked_vec128s | Naked_vec256s | Naked_vec512s ) as
+       nfo) -> (
     match nfo with
-    | Immediates -> normal_case Immediates new_values
     | Values init_or_assign -> normal_case (Values init_or_assign) new_values
     | Gc_ignorable_values -> normal_case Gc_ignorable_values new_values
     | Naked_floats -> normal_case Naked_floats new_values

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -209,7 +209,8 @@ let make_non_scannable_unboxed_product_array ~dbg kind mode args =
     P.Array_kind.element_kinds kind
   in
   let mem_chunks_per_non_unarized_element =
-    List.map C.memory_chunk_of_kind element_kinds_per_non_unarized_element
+    List.map C.memory_chunk_of_non_scannable_kind
+      element_kinds_per_non_unarized_element
   in
   let num_mem_chunks_per_non_unarized_element =
     List.length mem_chunks_per_non_unarized_element

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -145,6 +145,16 @@ let memory_chunk_of_kind (kind : Flambda_kind.With_subkind.t) : Cmm.memory_chunk
     Misc.fatal_errorf "Bad kind %a for [memory_chunk_of_kind]"
       Flambda_kind.With_subkind.print kind
 
+let memory_chunk_of_non_scannable_kind kind : Cmm.memory_chunk =
+  match memory_chunk_of_kind kind with
+  | Word_val -> Word_int
+  | ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+    | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Single _ | Double
+    | Onetwentyeight_unaligned | Onetwentyeight_aligned | Twofiftysix_unaligned
+    | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) as mem
+    ->
+    mem
+
 let machtype_of_kinded_parameter p = Bound_parameter.kind p |> machtype_of_kind
 
 let param_machtype_of_kinded_parameter bp : _ To_cmm_env.param_type =

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.mli
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.mli
@@ -51,6 +51,10 @@ val param_machtype_of_kinded_parameter :
 
 val memory_chunk_of_kind : Flambda_kind.With_subkind.t -> Cmm.memory_chunk
 
+(** Same as [memory_chunk_of_kind], but assumes that values are not scannable *)
+val memory_chunk_of_non_scannable_kind :
+  Flambda_kind.With_subkind.t -> Cmm.memory_chunk
+
 (** Create a constant int expression from a targetint. *)
 val targetint : dbg:Debuginfo.t -> Targetint_32_64.t -> Cmm.expression
 

--- a/testsuite/tests/flambda2/examples/int_array_modify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/int_array_modify.simplify.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(12) newer_version_of(f_0)
   apply ccall
     ($`*extern*`.caml_array_make : val * val -> val) (42, 0) -> k2 * k1
     where k2 (a) =
-      let Parraysetu = %array_set.`imm` (a, 0, x) in
+      let Parraysetu = %array_set.gc_ign (a, 0, x) in
       cont k (a)
 in
 let $camlInt_array_modify__f_1 = closure f_0_1 @f in


### PR DESCRIPTION
In `Typeopt`, when computing the layout of an array, the `Pint_scannable` and `Pint_ignorable` layouts are given to all immediate types, regardless of nullability. So when extracting layouts for the elements of such arrays, we need to reflect this possible nullability.

This should fix some of the errors seen on #6347.