### PR TITLE
Use %progbits not @progbits on ARM

### DIFF
--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -974,7 +974,7 @@ let emit_literals_list literals align emit_literal =
       D.switch_to_section_raw
         ~names:[".rodata.cst" ^ Int.to_string align]
         ~flags:(Some "aM")
-        ~args:["@progbits"; Int.to_string align]
+        ~args:["%progbits"; Int.to_string align]
         ~is_delayed:false;
     (* CR sspies: We set the internal section ref to Text here, because section
        ref does not support named text sections yet. Fix this when cleaning up

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -995,7 +995,7 @@ let emit_literals_list literals align emit_literal =
       D.switch_to_section_raw
         ~names:[".rodata.cst" ^ Int.to_string align]
         ~flags:(Some "aM")
-        ~args:["@progbits"; Int.to_string align]
+        ~args:["%progbits"; Int.to_string align]
         ~is_delayed:false;
     (* CR sspies: We set the internal section ref to Text here, because section
        ref does not support named text sections yet. Fix this when cleaning up


### PR DESCRIPTION
ARM assemblers like `%` sigils, as `@` (used on AMD) is a comment character. `@` does work in section-type position (which is good as it's used in the cross-platform `backend/asm_targets/asm_section.ml`), but it's good to be consistent with other sigils in our ARM64-specific code.