### PR TITLE
Require exclave for local tail forwards

### DIFF
--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -1,26 +1,26 @@
 let code out_0 deleted in
-let $camlEmitcode_repro__const_block32 = Block 0 (1, 1) in
-let $camlEmitcode_repro__const_block36 = Block 0 (1, 0) in
-let $camlEmitcode_repro__const_block40 = Block 0 (0, 1) in
-let $camlEmitcode_repro__const_block44 = Block 0 (0, 0) in
+let $camlEmitcode_repro__const_block23 = Block 0 (1, 1) in
+let $camlEmitcode_repro__const_block25 = Block 0 (1, 0) in
+let $camlEmitcode_repro__const_block27 = Block 0 (0, 1) in
+let $camlEmitcode_repro__const_block29 = Block 0 (0, 0) in
 let code emit_instr_1 deleted in
-let $camlEmitcode_repro__const_block70 = Block 0 (2, 2) in
-let $camlEmitcode_repro__const_block90 = Block 0 (2, 1) in
+let $camlEmitcode_repro__const_block50 = Block 0 (2, 2) in
+let $camlEmitcode_repro__const_block68 = Block 0 (2, 1) in
 let code emit_2 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(out_0)
       out_0_1 (_x)
-        my_closure my_region my_ghost_region my_depth
+        my_closure _region _ghost_region my_depth
         -> k * k1
-        : imm tagged local =
+        : imm tagged =
   let Popaque = %opaque (0) in
   cont k (Popaque)
 in
 let $camlEmitcode_repro__out_3 = closure out_0_1 @out in
 let code loopify(never) size(50) newer_version_of(emit_instr_1)
       emit_instr_1_1 (param : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
-        my_closure my_region my_ghost_region my_depth
+        my_closure _region _ghost_region my_depth
         -> k * k1
-        : imm tagged local =
+        : imm tagged =
   (let prim = %is_int (param) in
    switch prim
      | 0 -> k6
@@ -36,126 +36,110 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
         | 0 -> k4
         | 1 -> k5
     where k5 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block32)
+          ($camlEmitcode_repro__const_block23)
           -> k * k1
     where k4 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block36)
+          ($camlEmitcode_repro__const_block25)
           -> k * k1
     where k3 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block40)
+          ($camlEmitcode_repro__const_block27)
           -> k * k1
     where k2 =
-      apply direct(out_0_1 &my_region &my_ghost_region)
+      apply direct(out_0_1)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block44)
+          ($camlEmitcode_repro__const_block29)
           -> k * k1
 in
 let $camlEmitcode_repro__emit_instr_4 = closure emit_instr_1_1 @emit_instr in
-let code loopify(done) size(121) newer_version_of(emit_2)
+let code loopify(done) size(115) newer_version_of(emit_2)
       emit_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
     where rec `self` (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-      let `region` = %begin_region () in
-      let ghost_region = %begin_ghost_region () in
-      ((let prim = %is_int (param_1) in
-        switch prim
-          | 0 -> k3
-          | 1 -> k2
-          where k3 =
-            let instr = %block_load.[`0`] (param_1) in
-            ((let prim_1 = %is_int (instr) in
-              switch prim_1
-                | 0 -> k6
-                | 1 -> k7)
-               where k7 =
-                 let untagged = %untag_imm (instr) in
-                 switch untagged
-                   | 0 -> k4
-                   | 1 -> k3
-               where k6 =
-                 let prim_1 = %get_tag (instr) in
-                 switch prim_1
-                   | 0 -> k3
-                   | 1 -> k5
-               where k5 =
-                 (apply direct(out_0_1 &`region` &ghost_region)
-                    ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-                      ($camlEmitcode_repro__const_block70)
-                      -> k6 * k1
-                    where k6 (param_2 : imm tagged) =
-                      cont k5
-                    where k5 =
-                      let Pfield = %block_load.[`1`] (param_1) in
-                      let `unit` = %end_region (`region`) in
-                      let unit_1 = %end_ghost_region (ghost_region) in
-                      cont `self` (Pfield))
-               where k4 =
-                 let `*match*` = %block_load.[`1`] (param_1) in
-                 let prim_1 = %is_int (`*match*`) in
-                 (switch prim_1
-                    | 0 -> k4
-                    | 1 -> k3
-                    where k4 =
-                      let Pfield = %block_load.[`0`] (`*match*`) in
-                      ((let prim_2 = %is_int (Pfield) in
-                        switch prim_2
-                          | 0 -> k5
-                          | 1 -> k3)
-                         where k5 =
-                           let prim_2 = %get_tag (Pfield) in
-                           switch prim_2
-                             | 0 -> k4
-                             | 1 -> k3
-                         where k4 =
-                           let Popaque = %opaque (0) in
-                           ((let untagged = %untag_imm (Popaque) in
-                             switch untagged
-                               | 0 -> k3
-                               | 1 -> k4)
-                              where k4 =
-                                (apply
-                                        direct(out_0_1
-                                        &`region` &ghost_region)
-                                   ($camlEmitcode_repro__out_3
-                                    : _ -> imm tagged)
-                                     ($camlEmitcode_repro__const_block90)
-                                     -> k5 * k1
-                                   where k5 (param_2 : imm tagged) =
-                                     cont k4
-                                   where k4 =
-                                     let Pfield_1 =
-                                       %block_load.[`1`] (`*match*`)
-                                     in
-                                     let `unit` = %end_region (`region`) in
-                                     let unit_1 =
-                                       %end_ghost_region (ghost_region)
-                                     in
-                                     cont `self` (Pfield_1)))))
-               where k3 =
-                 (apply direct(emit_instr_1_1 &`region` &ghost_region)
-                    ($camlEmitcode_repro__emit_instr_4 : _ -> imm tagged)
-                      (instr)
-                      -> k4 * k1
-                    where k4 (param_2 : imm tagged) =
-                      cont k3
-                    where k3 =
-                      let Pfield = %block_load.[`1`] (param_1) in
-                      let `unit` = %end_region (`region`) in
-                      let unit_1 = %end_ghost_region (ghost_region) in
-                      cont `self` (Pfield))))
+      let prim = %is_int (param_1) in
+      (switch prim
+         | 0 -> k2
+         | 1 -> k (0)
          where k2 =
-           let `unit` = %end_region (`region`) in
-           let unit_1 = %end_ghost_region (ghost_region) in
-           cont k (0))
+           let instr = %block_load.[`0`] (param_1) in
+           ((let prim_1 = %is_int (instr) in
+             switch prim_1
+               | 0 -> k5
+               | 1 -> k6)
+              where k6 =
+                let untagged = %untag_imm (instr) in
+                switch untagged
+                  | 0 -> k3
+                  | 1 -> k2
+              where k5 =
+                let prim_1 = %get_tag (instr) in
+                switch prim_1
+                  | 0 -> k2
+                  | 1 -> k4
+              where k4 =
+                (apply direct(out_0_1)
+                   ($camlEmitcode_repro__out_3 : _ -> imm tagged)
+                     ($camlEmitcode_repro__const_block50)
+                     -> k5 * k1
+                   where k5 (param_2 : imm tagged) =
+                     cont k4
+                   where k4 =
+                     let Pfield = %block_load.[`1`] (param_1) in
+                     cont `self` (Pfield))
+              where k3 =
+                let `*match*` = %block_load.[`1`] (param_1) in
+                let prim_1 = %is_int (`*match*`) in
+                (switch prim_1
+                   | 0 -> k3
+                   | 1 -> k2
+                   where k3 =
+                     let Pfield = %block_load.[`0`] (`*match*`) in
+                     ((let prim_2 = %is_int (Pfield) in
+                       switch prim_2
+                         | 0 -> k4
+                         | 1 -> k2)
+                        where k4 =
+                          let prim_2 = %get_tag (Pfield) in
+                          switch prim_2
+                            | 0 -> k3
+                            | 1 -> k2
+                        where k3 =
+                          let Popaque = %opaque (0) in
+                          ((let untagged = %untag_imm (Popaque) in
+                            switch untagged
+                              | 0 -> k2
+                              | 1 -> k3)
+                             where k3 =
+                               (apply direct(out_0_1)
+                                  ($camlEmitcode_repro__out_3
+                                   : _ -> imm tagged)
+                                    ($camlEmitcode_repro__const_block68)
+                                    -> k4 * k1
+                                  where k4 (param_2 : imm tagged) =
+                                    cont k3
+                                  where k3 =
+                                    let Pfield_1 =
+                                      %block_load.[`1`] (`*match*`)
+                                    in
+                                    cont `self` (Pfield_1)))))
+              where k2 =
+                (apply direct(emit_instr_1_1)
+                   ($camlEmitcode_repro__emit_instr_4 : _ -> imm tagged)
+                     (instr)
+                     -> k3 * k1
+                   where k3 (param_2 : imm tagged) =
+                     cont k2
+                   where k2 =
+                     let Pfield = %block_load.[`1`] (param_1) in
+                     cont `self` (Pfield))))
 in
 let $camlEmitcode_repro__emit_5 = closure emit_2_1 @emit in
 let $camlEmitcode_repro = Block 0 ($camlEmitcode_repro__emit_5) in

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1164,10 +1164,8 @@ let foo () =
 val foo : unit -> int = <fun>
 |}]
 
-(* tail-calling local-returning functions make the current function
-   local-returning as well; mode-crossing is irrelavent here. Whether or not the
-   function actually allocates in parent-region is also irrelavent here, but we
-   allocate just to demonstrate the potential leaking. *)
+(* Tail-calling local-returning functions must use [exclave_] to return their
+   result, even when the result type can cross modes. *)
 let foo () = exclave_
   let _ = local_ (52, 24) in
   42
@@ -1179,7 +1177,13 @@ let bar () =
   let _x = 52 in
   foo ()
 [%%expect{|
-val bar : unit -> int @ local = <fun>
+Line 3, characters 2-8:
+3 |   foo ()
+      ^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 
 (* if not at tail, then not affected *)

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1201,6 +1201,42 @@ let bar' () =
 val bar' : unit -> int = <fun>
 |}]
 
+(* A type constraint on the tail call must not re-open the areality crossing:
+   the tail forward is still rejected even though [int] crosses locality. *)
+let bar_constr () = (foo () : int)
+[%%expect{|
+Line 1, characters 21-27:
+1 | let bar_constr () = (foo () : int)
+                         ^^^^^^
+Error: This application is local-returning, but is at the tail
+       position of a function that is not local-returning.
+       Hint: Use exclave_ to return a local value.
+|}]
+
+(* Same for a return-type annotation on the enclosing function. *)
+let bar_annot () : int = foo ()
+[%%expect{|
+Line 1, characters 25-31:
+1 | let bar_annot () : int = foo ()
+                             ^^^^^^
+Error: This application is local-returning, but is at the tail
+       position of a function that is not local-returning.
+       Hint: Use exclave_ to return a local value.
+|}]
+
+(* The fix: use [exclave_] (accepted, and the function is local-returning). *)
+let bar_exclave () = exclave_ foo ()
+[%%expect{|
+val bar_exclave : unit -> int @ local = <fun>
+|}]
+
+(* Returning a local *value* whose type crosses locality is still fine: this is
+   not a tail call, so it is unaffected by the restriction. *)
+let cross_value (local_ n : int) : int = (n : int)
+[%%expect{|
+val cross_value : int @ local -> int = <fun>
+|}]
+
 (* Parameter modes must be matched by the type *)
 
 let foo : 'a -> unit = fun (local_ x) -> ()
@@ -2096,13 +2132,19 @@ Error: This value is "local"
          because it is an argument in a tail call.
 |}]
 
-(* boolean operator when at tail of function makes the function local-returning
-   if its RHS is local-returning *)
+(* boolean operator at tail of a function is a tail forward: if its RHS is
+   local-returning it must use [exclave_], even though [bool] crosses locality
+   (the crossing must not silently re-open the areality of the tail forward) *)
 let foo () = exclave_ let local_ _x = "hello" in true
 let testboo3 () =  true && (foo ())
 [%%expect{|
 val foo : unit -> bool @ local = <fun>
-val testboo3 : unit -> bool @ local = <fun>
+Line 2, characters 27-35:
+2 | let testboo3 () =  true && (foo ())
+                               ^^^^^^^^
+Error: This application is local-returning, but is at the tail
+       position of a function that is not local-returning.
+       Hint: Use exclave_ to return a local value.
 |}]
 
 (* Test from Nathanaëlle Courant.

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7219,7 +7219,18 @@ and type_expect_
       in
       let mode_ret = Alloc.disallow_right mode_ret in
       let ap_mode = Alloc.proj_comonadic Areality mode_ret in
-      let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
+      let mode_ret_uncrossed = alloc_as_value mode_ret in
+      let mode_ret_crossed = cross_left env ty_ret mode_ret_uncrossed in
+      let mode_ret =
+        match pm.region_mode with
+        | None -> mode_ret_crossed
+        | Some _ ->
+          Value.join
+            [ mode_ret_crossed;
+              Value.min_with_comonadic Areality
+                (Value.proj_comonadic Areality mode_ret_uncrossed)
+            ]
+      in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
           ~on_application:true

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7219,18 +7219,22 @@ and type_expect_
       in
       let mode_ret = Alloc.disallow_right mode_ret in
       let ap_mode = Alloc.proj_comonadic Areality mode_ret in
-      let mode_ret_uncrossed = alloc_as_value mode_ret in
-      let mode_ret_crossed = cross_left env ty_ret mode_ret_uncrossed in
-      let mode_ret =
+      let crossing = crossing_of_ty env ty_ret in
+      let crossing =
         match pm.region_mode with
-        | None -> mode_ret_crossed
+        | None -> crossing
         | Some _ ->
-          Value.join
-            [ mode_ret_crossed;
-              Value.min_with_comonadic Areality
-                (Value.proj_comonadic Areality mode_ret_uncrossed)
-            ]
+          (* The application is in tail position, so if it returns local, it
+             allocates in the caller's region, and this info must be preserved
+             even if [ty_ret] crosses locality: forwarding the region to the
+             callee requires an explicit [exclave_]. Hence, we prevent mode
+             crossing on the areality axis. *)
+          Crossing.set
+            (Crossing.Axis.Comonadic Areality)
+            (Crossing.Per_axis.max (Crossing.Axis.Comonadic Areality))
+            crossing
       in
+      let mode_ret = Crossing.apply_left crossing (alloc_as_value mode_ret) in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
           ~on_application:true

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -504,13 +504,19 @@ let position_and_mode env (expected_mode : expected_mode) sexp
 (* ap_mode is the return mode of the current application *)
 let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
   match region_mode with
-  | Some region_mode -> begin
-    (* This application will be performed after the current region is closed; if
-       ap_mode is local, the application allocates in the outer
-       region, and thus [region_mode] needs to be marked local as well*)
+  | Some _ -> begin
+    (* This application is in tail position, so if it is local-returning it
+       allocates in the caller's region and makes the caller local-returning
+       too. We require that to be requested explicitly with [exclave_] (which
+       puts the application in non-tail position, i.e. [region_mode = None]),
+       so reject a local-returning tail call here. This check keys on [ap_mode]
+       and [region_mode], neither of which is affected by an enclosing type
+       constraint or return annotation: those only relax the return submode's
+       expected side (see [expect_mode_cross]), which would otherwise mask a
+       local tail forward even when the result type crosses locality. *)
       match
         Regionality.submode ~pp:(loc, Expression)
-          (locality_as_regionality ap_mode) region_mode
+          (locality_as_regionality ap_mode) Regionality.global
       with
       | Ok () -> ()
       | Error _ -> raise (Error (loc, env, Tail_call_local_returning))
@@ -13240,7 +13246,8 @@ let report_error ~loc env =
   | Tail_call_local_returning ->
       Location.errorf ~loc
         "@[This application is local-returning, but is at the tail@ \
-          position of a function that is not local-returning.@]"
+          position of a function that is not local-returning.@ \
+          Hint: Use exclave_ to return a local value.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"


### PR DESCRIPTION
Preserve the uncrossed areality of local-returning applications in function-return tail position, so implicit tail forwarding requires an explicit exclave_ even when the result type can cross modes. This is in preparation for mode poly, especially to see if jane still builds.

Longer explanation:
* Generally, exclave is mandatory for tail calls that return `@ local`
* However, if the type mode crosses, that isn't needed
* But the function's return still gets inferred as `@ local` in the end, because the situation is actually more complex with regionality than the surface syntax suggests
* For mode poly, we want to change some internal rule about which functions get region parameters to say that they get it if their body contains an exclave, not when its result is `@ local`
* This breaks with mode crossing tail calls not requiring exclave, because then the parent function may not have a region parameter to pass down to the child tail call
* This makes it so that the type checker rejects that even for mode crossed types, so exclave is always forced, and the above rule becomes viable