### PR TITLE
Fix leak: Tail-calling local returning function 

### DIFF
--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -14011,8 +14011,7 @@ let report_error ~loc env =
   | Tail_call_local_returning ->
       Location.errorf ~loc
         "@[This local-returning application is in a tail position that is not@ \
-          enclosed in an exclave_ expression.@ \
-          Hint: Use exclave_ to return a local value.@]"
+          enclosed in an exclave_ expression.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -638,20 +638,24 @@ let position_and_mode env (expected_mode : expected_mode) sexp
   end
 
 (* ap_mode is the return mode of the current application *)
-let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
-  match region_mode with
-  | Some region_mode -> begin
-    (* This application will be performed after the current region is closed; if
-       ap_mode is local, the application allocates in the outer
-       region, and thus [region_mode] needs to be marked local as well*)
+let check_tail_call_local_returning loc env ap_mode {apply_position; _} =
+  match apply_position with
+  | Tail -> begin
+    (* This application will be performed after the current region is closed;
+       if [ap_mode] were local, it would allocate in the outer region, which
+       would require the enclosing function's [region_mode] to be local as
+       well. Instead of inferring that, we require [ap_mode] to be global:
+       local-returning tail calls must be wrapped in [exclave_], and it is the
+       [Pexp_exclave] case of [type_expect_] that bounds [region_mode] from
+       below by local. *)
       match
         Regionality.submode ~pp:(loc, Expression)
-          (locality_as_regionality ap_mode) region_mode
+          (locality_as_regionality ap_mode) Regionality.global
       with
       | Ok () -> ()
       | Error _ -> raise (error (loc, env, Tail_call_local_returning))
     end
-  | None -> ()
+  | Nontail | Default -> ()
 
 let meet_regional ?hint:h mode =
   let mode = Value.disallow_left mode in
@@ -14006,8 +14010,9 @@ let report_error ~loc env =
         "This function is local-returning, but was expected otherwise."
   | Tail_call_local_returning ->
       Location.errorf ~loc
-        "@[This application is local-returning, but is at the tail@ \
-          position of a function that is not local-returning.@]"
+        "@[This local-returning application is in a tail position that is not@ \
+          enclosed in an exclave_ expression.@ \
+          Hint: Use exclave_ to return a local value.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -13554,8 +13554,7 @@ let report_error ~loc env =
   | Tail_call_local_returning ->
       Location.errorf ~loc
         "@[This local-returning application is in a tail position that is not@ \
-          enclosed in an exclave_ expression.@ \
-          Hint: Use exclave_ to return a local value.@]"
+          enclosed in an exclave_ expression.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -522,20 +522,24 @@ let position_and_mode env (expected_mode : expected_mode) sexp
   end
 
 (* ap_mode is the return mode of the current application *)
-let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
-  match region_mode with
-  | Some region_mode -> begin
-    (* This application will be performed after the current region is closed; if
-       ap_mode is local, the application allocates in the outer
-       region, and thus [region_mode] needs to be marked local as well*)
+let check_tail_call_local_returning loc env ap_mode {apply_position; _} =
+  match apply_position with
+  | Tail -> begin
+    (* This application will be performed after the current region is closed;
+       if [ap_mode] were local, it would allocate in the outer region, which
+       would require the enclosing function's [region_mode] to be local as
+       well. Instead of inferring that, we require [ap_mode] to be global:
+       local-returning tail calls must be wrapped in [exclave_], and it is the
+       [Pexp_exclave] case of [type_expect_] that bounds [region_mode] from
+       below by local. *)
       match
         Regionality.submode ~pp:(loc, Expression)
-          (locality_as_regionality ap_mode) region_mode
+          (locality_as_regionality ap_mode) Regionality.global
       with
       | Ok () -> ()
       | Error _ -> raise (Error (loc, env, Tail_call_local_returning))
     end
-  | None -> ()
+  | Nontail | Default -> ()
 
 let meet_regional ?hint:h mode =
   let mode = Value.disallow_left mode in
@@ -13549,8 +13553,9 @@ let report_error ~loc env =
         "This function is local-returning, but was expected otherwise."
   | Tail_call_local_returning ->
       Location.errorf ~loc
-        "@[This application is local-returning, but is at the tail@ \
-          position of a function that is not local-returning.@]"
+        "@[This local-returning application is in a tail position that is not@ \
+          enclosed in an exclave_ expression.@ \
+          Hint: Use exclave_ to return a local value.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"

--- a/testsuite/tests/effects/dynamic_stress.ml
+++ b/testsuite/tests/effects/dynamic_stress.ml
@@ -36,7 +36,7 @@ let test_stack_growth () =
   let down = Buffer.create 64 and up = Buffer.create 64 in
   let rec go i =
     if i <= depth then
-      Dynamic.with_temporarily d i ~f:(fun () ->
+      exclave_ Dynamic.with_temporarily d i ~f:(fun () ->
         Buffer.add_string down (get_int d ^ " ");
         go (i + 1);
         Buffer.add_string up (get_int d ^ " "))
@@ -67,7 +67,7 @@ let test_table_growth () =
       Printf.printf "bound %d, visible %d, all correct: %b\n" n !visible
         !correct
     end
-    else Dynamic.with_temporarily ds.(i) i ~f:(fun () -> bind (i + 1))
+    else exclave_ Dynamic.with_temporarily ds.(i) i ~f:(fun () -> exclave_ bind (i + 1))
   in
   bind 0;
   let leftover =

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -1,17 +1,17 @@
 let code out_0 deleted in
-let $camlEmitcode_repro__const_block35 = Block 0 (1, 1) in
-let $camlEmitcode_repro__const_block39 = Block 0 (1, 0) in
-let $camlEmitcode_repro__const_block43 = Block 0 (0, 1) in
-let $camlEmitcode_repro__const_block47 = Block 0 (0, 0) in
+let $camlEmitcode_repro__const_block26 = Block 0 (1, 1) in
+let $camlEmitcode_repro__const_block28 = Block 0 (1, 0) in
+let $camlEmitcode_repro__const_block30 = Block 0 (0, 1) in
+let $camlEmitcode_repro__const_block32 = Block 0 (0, 0) in
 let code emit_instr_1 deleted in
-let $camlEmitcode_repro__const_block74 = Block 0 (2, 2) in
-let $camlEmitcode_repro__const_block94 = Block 0 (2, 1) in
+let $camlEmitcode_repro__const_block54 = Block 0 (2, 2) in
+let $camlEmitcode_repro__const_block72 = Block 0 (2, 1) in
 let code emit_2 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(out_0)
       out_0_1 (_x)
-        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
-        : imm tagged stack =
+        : imm tagged =
   let Popaque = %opaque (0) in
   cont k (Popaque)
 in
@@ -19,9 +19,9 @@ let $camlEmitcode_repro__out_3 = closure out_0_1 @out &toplevel.alloc_region
 in
 let code loopify(never) size(50) newer_version_of(emit_instr_1)
       emit_instr_1_1 (param : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
-        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
-        : imm tagged stack =
+        : imm tagged =
   (let prim = %is_int (param) in
    switch prim
      | 0 -> k6
@@ -37,132 +37,112 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
         | 0 -> k4
         | 1 -> k5
     where k5 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block35)
+          ($camlEmitcode_repro__const_block26)
           -> k * k1
     where k4 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block39)
+          ($camlEmitcode_repro__const_block28)
           -> k * k1
     where k3 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block43)
+          ($camlEmitcode_repro__const_block30)
           -> k * k1
     where k2 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-          ($camlEmitcode_repro__const_block47)
+          ($camlEmitcode_repro__const_block32)
           -> k * k1
 in
 let $camlEmitcode_repro__emit_instr_4 =
   closure emit_instr_1_1 @emit_instr &toplevel.alloc_region
 in
-let code loopify(done) size(121) newer_version_of(emit_2)
+let code loopify(done) size(115) newer_version_of(emit_2)
       emit_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
     where rec `self` (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-      let `region` = %begin_region () in
-      let ghost_region = %begin_ghost_region () in
-      ((let prim = %is_int (param_1) in
-        switch prim
-          | 0 -> k3
-          | 1 -> k2
-          where k3 =
-            let instr = %block_load.[`0`] (param_1) in
-            ((let prim_1 = %is_int (instr) in
-              switch prim_1
-                | 0 -> k6
-                | 1 -> k7)
-               where k7 =
-                 let untagged = %untag_imm (instr) in
-                 switch untagged
-                   | 0 -> k4
-                   | 1 -> k3
-               where k6 =
-                 let prim_1 = %get_tag (instr) in
-                 switch prim_1
-                   | 0 -> k3
-                   | 1 -> k5
-               where k5 =
-                 (apply
-                         direct(out_0_1
-                         &my_alloc_region &`region` &ghost_region)
-                    ($camlEmitcode_repro__out_3 : _ -> imm tagged)
-                      ($camlEmitcode_repro__const_block74)
-                      -> k6 * k1
-                    where k6 (param_2 : imm tagged) =
-                      cont k5
-                    where k5 =
-                      let Pfield = %block_load.[`1`] (param_1) in
-                      let `unit` = %end_region (`region`) in
-                      let unit_1 = %end_ghost_region (ghost_region) in
-                      cont `self` (Pfield))
-               where k4 =
-                 let `*match*` = %block_load.[`1`] (param_1) in
-                 let prim_1 = %is_int (`*match*`) in
-                 (switch prim_1
-                    | 0 -> k4
-                    | 1 -> k3
-                    where k4 =
-                      let Pfield = %block_load.[`0`] (`*match*`) in
-                      ((let prim_2 = %is_int (Pfield) in
-                        switch prim_2
-                          | 0 -> k5
-                          | 1 -> k3)
-                         where k5 =
-                           let prim_2 = %get_tag (Pfield) in
-                           switch prim_2
-                             | 0 -> k4
-                             | 1 -> k3
-                         where k4 =
-                           let Popaque = %opaque (0) in
-                           ((let untagged = %untag_imm (Popaque) in
-                             switch untagged
-                               | 0 -> k3
-                               | 1 -> k4)
-                              where k4 =
-                                (apply
-                                        direct(out_0_1
-                                        &my_alloc_region &`region` &ghost_region)
-                                   ($camlEmitcode_repro__out_3
-                                    : _ -> imm tagged)
-                                     ($camlEmitcode_repro__const_block94)
-                                     -> k5 * k1
-                                   where k5 (param_2 : imm tagged) =
-                                     cont k4
-                                   where k4 =
-                                     let Pfield_1 =
-                                       %block_load.[`1`] (`*match*`)
-                                     in
-                                     let `unit` = %end_region (`region`) in
-                                     let unit_1 =
-                                       %end_ghost_region (ghost_region)
-                                     in
-                                     cont `self` (Pfield_1)))))
-               where k3 =
-                 (apply
-                         direct(emit_instr_1_1
-                         &my_alloc_region &`region` &ghost_region)
-                    ($camlEmitcode_repro__emit_instr_4 : _ -> imm tagged)
-                      (instr)
-                      -> k4 * k1
-                    where k4 (param_2 : imm tagged) =
-                      cont k3
-                    where k3 =
-                      let Pfield = %block_load.[`1`] (param_1) in
-                      let `unit` = %end_region (`region`) in
-                      let unit_1 = %end_ghost_region (ghost_region) in
-                      cont `self` (Pfield))))
+      let prim = %is_int (param_1) in
+      (switch prim
+         | 0 -> k2
+         | 1 -> k (0)
          where k2 =
-           let `unit` = %end_region (`region`) in
-           let unit_1 = %end_ghost_region (ghost_region) in
-           cont k (0))
+           let instr = %block_load.[`0`] (param_1) in
+           ((let prim_1 = %is_int (instr) in
+             switch prim_1
+               | 0 -> k5
+               | 1 -> k6)
+              where k6 =
+                let untagged = %untag_imm (instr) in
+                switch untagged
+                  | 0 -> k3
+                  | 1 -> k2
+              where k5 =
+                let prim_1 = %get_tag (instr) in
+                switch prim_1
+                  | 0 -> k2
+                  | 1 -> k4
+              where k4 =
+                (apply direct(out_0_1 &my_alloc_region)
+                   ($camlEmitcode_repro__out_3 : _ -> imm tagged)
+                     ($camlEmitcode_repro__const_block54)
+                     -> k5 * k1
+                   where k5 (param_2 : imm tagged) =
+                     cont k4
+                   where k4 =
+                     let Pfield = %block_load.[`1`] (param_1) in
+                     cont `self` (Pfield))
+              where k3 =
+                let `*match*` = %block_load.[`1`] (param_1) in
+                let prim_1 = %is_int (`*match*`) in
+                (switch prim_1
+                   | 0 -> k3
+                   | 1 -> k2
+                   where k3 =
+                     let Pfield = %block_load.[`0`] (`*match*`) in
+                     ((let prim_2 = %is_int (Pfield) in
+                       switch prim_2
+                         | 0 -> k4
+                         | 1 -> k2)
+                        where k4 =
+                          let prim_2 = %get_tag (Pfield) in
+                          switch prim_2
+                            | 0 -> k3
+                            | 1 -> k2
+                        where k3 =
+                          let Popaque = %opaque (0) in
+                          ((let untagged = %untag_imm (Popaque) in
+                            switch untagged
+                              | 0 -> k2
+                              | 1 -> k3)
+                             where k3 =
+                               (apply direct(out_0_1 &my_alloc_region)
+                                  ($camlEmitcode_repro__out_3
+                                   : _ -> imm tagged)
+                                    ($camlEmitcode_repro__const_block72)
+                                    -> k4 * k1
+                                  where k4 (param_2 : imm tagged) =
+                                    cont k3
+                                  where k3 =
+                                    let Pfield_1 =
+                                      %block_load.[`1`] (`*match*`)
+                                    in
+                                    cont `self` (Pfield_1)))))
+              where k2 =
+                (apply direct(emit_instr_1_1 &my_alloc_region)
+                   ($camlEmitcode_repro__emit_instr_4 : _ -> imm tagged)
+                     (instr)
+                     -> k3 * k1
+                   where k3 (param_2 : imm tagged) =
+                     cont k2
+                   where k2 =
+                     let Pfield = %block_load.[`1`] (param_1) in
+                     cont `self` (Pfield))))
 in
 let $camlEmitcode_repro__emit_5 =
   closure emit_2_1 @emit &toplevel.alloc_region

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -9,9 +9,9 @@ let $camlEmitcode_repro__const_block_5 = Block 0 (2, 1) in
 let code emit_2 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(out_0)
       out_0_1 (_x)
-        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
-        : imm tagged stack =
+        : imm tagged =
   let Popaque = %opaque (0) in
   cont k (Popaque)
 in
@@ -19,9 +19,9 @@ let $camlEmitcode_repro__out_6 = closure out_0_1 @out &toplevel.alloc_region
 in
 let code loopify(never) size(50) newer_version_of(emit_instr_1)
       emit_instr_1_1 (param : [ 0 |1 | 0 of imm tagged |1 of imm tagged ])
-        my_closure &my_alloc_region &my_region &my_ghost_region my_depth
+        my_closure &my_alloc_region my_depth
         -> k * k1
-        : imm tagged stack =
+        : imm tagged =
   (let prim = %is_int (param) in
    switch prim
      | 0 -> k6
@@ -37,22 +37,22 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
         | 0 -> k4
         | 1 -> k5
     where k5 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_0)
           -> k * k1
     where k4 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_1)
           -> k * k1
     where k3 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_2)
           -> k * k1
     where k2 =
-      apply direct(out_0_1 &my_alloc_region &my_region &my_ghost_region)
+      apply direct(out_0_1 &my_alloc_region)
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_3)
           -> k * k1
@@ -60,109 +60,89 @@ in
 let $camlEmitcode_repro__emit_instr_7 =
   closure emit_instr_1_1 @emit_instr &toplevel.alloc_region
 in
-let code loopify(done) size(121) newer_version_of(emit_2)
+let code loopify(done) size(115) newer_version_of(emit_2)
       emit_2_1 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
   cont `self` (param)
     where rec `self` (param_1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
-      let `region` = %begin_region () in
-      let ghost_region = %begin_ghost_region () in
-      ((let prim = %is_int (param_1) in
-        switch prim
-          | 0 -> k3
-          | 1 -> k2
-          where k3 =
-            let instr = %block_load.[`0`] (param_1) in
-            ((let prim_1 = %is_int (instr) in
-              switch prim_1
-                | 0 -> k6
-                | 1 -> k7)
-               where k7 =
-                 let untagged = %untag_imm (instr) in
-                 switch untagged
-                   | 0 -> k4
-                   | 1 -> k3
-               where k6 =
-                 let prim_1 = %get_tag (instr) in
-                 switch prim_1
-                   | 0 -> k3
-                   | 1 -> k5
-               where k5 =
-                 (apply
-                         direct(out_0_1
-                         &my_alloc_region &`region` &ghost_region)
-                    ($camlEmitcode_repro__out_6 : _ -> imm tagged)
-                      ($camlEmitcode_repro__const_block_4)
-                      -> k6 * k1
-                    where k6 (param_2 : imm tagged) =
-                      cont k5
-                    where k5 =
-                      let Pfield = %block_load.[`1`] (param_1) in
-                      let `unit` = %end_region (`region`) in
-                      let unit_1 = %end_ghost_region (ghost_region) in
-                      cont `self` (Pfield))
-               where k4 =
-                 let `*match*` = %block_load.[`1`] (param_1) in
-                 let prim_1 = %is_int (`*match*`) in
-                 (switch prim_1
-                    | 0 -> k4
-                    | 1 -> k3
-                    where k4 =
-                      let Pfield = %block_load.[`0`] (`*match*`) in
-                      ((let prim_2 = %is_int (Pfield) in
-                        switch prim_2
-                          | 0 -> k5
-                          | 1 -> k3)
-                         where k5 =
-                           let prim_2 = %get_tag (Pfield) in
-                           switch prim_2
-                             | 0 -> k4
-                             | 1 -> k3
-                         where k4 =
-                           let Popaque = %opaque (0) in
-                           ((let untagged = %untag_imm (Popaque) in
-                             switch untagged
-                               | 0 -> k3
-                               | 1 -> k4)
-                              where k4 =
-                                (apply
-                                        direct(out_0_1
-                                        &my_alloc_region &`region` &ghost_region)
-                                   ($camlEmitcode_repro__out_6
-                                    : _ -> imm tagged)
-                                     ($camlEmitcode_repro__const_block_5)
-                                     -> k5 * k1
-                                   where k5 (param_2 : imm tagged) =
-                                     cont k4
-                                   where k4 =
-                                     let Pfield_1 =
-                                       %block_load.[`1`] (`*match*`)
-                                     in
-                                     let `unit` = %end_region (`region`) in
-                                     let unit_1 =
-                                       %end_ghost_region (ghost_region)
-                                     in
-                                     cont `self` (Pfield_1)))))
-               where k3 =
-                 (apply
-                         direct(emit_instr_1_1
-                         &my_alloc_region &`region` &ghost_region)
-                    ($camlEmitcode_repro__emit_instr_7 : _ -> imm tagged)
-                      (instr)
-                      -> k4 * k1
-                    where k4 (param_2 : imm tagged) =
-                      cont k3
-                    where k3 =
-                      let Pfield = %block_load.[`1`] (param_1) in
-                      let `unit` = %end_region (`region`) in
-                      let unit_1 = %end_ghost_region (ghost_region) in
-                      cont `self` (Pfield))))
+      let prim = %is_int (param_1) in
+      (switch prim
+         | 0 -> k2
+         | 1 -> k (0)
          where k2 =
-           let `unit` = %end_region (`region`) in
-           let unit_1 = %end_ghost_region (ghost_region) in
-           cont k (0))
+           let instr = %block_load.[`0`] (param_1) in
+           ((let prim_1 = %is_int (instr) in
+             switch prim_1
+               | 0 -> k5
+               | 1 -> k6)
+              where k6 =
+                let untagged = %untag_imm (instr) in
+                switch untagged
+                  | 0 -> k3
+                  | 1 -> k2
+              where k5 =
+                let prim_1 = %get_tag (instr) in
+                switch prim_1
+                  | 0 -> k2
+                  | 1 -> k4
+              where k4 =
+                (apply direct(out_0_1 &my_alloc_region)
+                   ($camlEmitcode_repro__out_6 : _ -> imm tagged)
+                     ($camlEmitcode_repro__const_block_4)
+                     -> k5 * k1
+                   where k5 (param_2 : imm tagged) =
+                     cont k4
+                   where k4 =
+                     let Pfield = %block_load.[`1`] (param_1) in
+                     cont `self` (Pfield))
+              where k3 =
+                let `*match*` = %block_load.[`1`] (param_1) in
+                let prim_1 = %is_int (`*match*`) in
+                (switch prim_1
+                   | 0 -> k3
+                   | 1 -> k2
+                   where k3 =
+                     let Pfield = %block_load.[`0`] (`*match*`) in
+                     ((let prim_2 = %is_int (Pfield) in
+                       switch prim_2
+                         | 0 -> k4
+                         | 1 -> k2)
+                        where k4 =
+                          let prim_2 = %get_tag (Pfield) in
+                          switch prim_2
+                            | 0 -> k3
+                            | 1 -> k2
+                        where k3 =
+                          let Popaque = %opaque (0) in
+                          ((let untagged = %untag_imm (Popaque) in
+                            switch untagged
+                              | 0 -> k2
+                              | 1 -> k3)
+                             where k3 =
+                               (apply direct(out_0_1 &my_alloc_region)
+                                  ($camlEmitcode_repro__out_6
+                                   : _ -> imm tagged)
+                                    ($camlEmitcode_repro__const_block_5)
+                                    -> k4 * k1
+                                  where k4 (param_2 : imm tagged) =
+                                    cont k3
+                                  where k3 =
+                                    let Pfield_1 =
+                                      %block_load.[`1`] (`*match*`)
+                                    in
+                                    cont `self` (Pfield_1)))))
+              where k2 =
+                (apply direct(emit_instr_1_1 &my_alloc_region)
+                   ($camlEmitcode_repro__emit_instr_7 : _ -> imm tagged)
+                     (instr)
+                     -> k3 * k1
+                   where k3 (param_2 : imm tagged) =
+                     cont k2
+                   where k2 =
+                     let Pfield = %block_load.[`1`] (param_1) in
+                     cont `self` (Pfield))))
 in
 let $camlEmitcode_repro__emit_8 =
   closure emit_2_1 @emit &toplevel.alloc_region

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1165,9 +1165,9 @@ val foo : unit -> int = <fun>
 |}]
 
 (* tail-calling local-returning functions make the current function
-   local-returning as well; mode-crossing is irrelavent here. Whether or not the
-   function actually allocates in parent-region is also irrelavent here, but we
-   allocate just to demonstrate the potential leaking. *)
+   local-returning as well, and must therefore use [exclave_] even if
+   the callee does not return an allocation. We allocate to demonstrate
+   the potential leaking.  *)
 let foo () = exclave_
   let _ = local_ (52, 24) in
   42
@@ -1176,6 +1176,18 @@ val foo : unit -> int @ local = <fun>
 |}]
 
 let bar () =
+  let _x = 52 in
+  foo ()
+[%%expect{|
+Line 3, characters 2-8:
+3 |   foo ()
+      ^^^^^^
+Error: This application is local-returning, but is at the tail
+       position of a function that is not local-returning.
+       Hint: Use exclave_ to return a local value.
+|}]
+
+let bar () = exclave_
   let _x = 52 in
   foo ()
 [%%expect{|
@@ -1195,6 +1207,23 @@ let bar' () =
   foo () [@nontail]
 [%%expect{|
 val bar' : unit -> int = <fun>
+|}]
+
+(* variant of above where f is an argument that is local-returning, but does not
+   return an allocation *)
+let foo g = let () = g () in ()
+[%%expect{|
+val foo : (unit -> unit) -> unit = <fun>
+|}]
+
+let bar (f : _ -> _ @ local) = foo (fun () -> f ())
+[%%expect{|
+Line 1, characters 46-50:
+1 | let bar (f : _ -> _ @ local) = foo (fun () -> f ())
+                                                  ^^^^
+Error: This application is local-returning, but is at the tail
+       position of a function that is not local-returning.
+       Hint: Use exclave_ to return a local value.
 |}]
 
 (* Parameter modes must be matched by the type *)
@@ -2098,6 +2127,17 @@ let foo () = exclave_ let local_ _x = "hello" in true
 let testboo3 () =  true && (foo ())
 [%%expect{|
 val foo : unit -> bool @ local = <fun>
+Line 2, characters 27-35:
+2 | let testboo3 () =  true && (foo ())
+                               ^^^^^^^^
+Error: This application is local-returning, but is at the tail
+       position of a function that is not local-returning.
+       Hint: Use exclave_ to return a local value.
+|}]
+(* since the tailcall calls a local-returning function, it will only type-check
+   under an exclave_ *)
+let testboo3 () = exclave_ true && (foo ())
+[%%expect{|
 val testboo3 : unit -> bool @ local = <fun>
 |}]
 

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1184,7 +1184,6 @@ Line 3, characters 2-8:
       ^^^^^^
 Error: This local-returning application is in a tail position that is not
        enclosed in an exclave_ expression.
-       Hint: Use exclave_ to return a local value.
 |}]
 
 let bar () : int @ local = foo ()
@@ -1194,7 +1193,6 @@ Line 1, characters 27-33:
                                ^^^^^^
 Error: This local-returning application is in a tail position that is not
        enclosed in an exclave_ expression.
-       Hint: Use exclave_ to return a local value.
 |}]
 
 let bar () = exclave_
@@ -1233,7 +1231,6 @@ Line 1, characters 46-50:
                                                   ^^^^
 Error: This local-returning application is in a tail position that is not
        enclosed in an exclave_ expression.
-       Hint: Use exclave_ to return a local value.
 |}]
 
 (* Parameter modes must be matched by the type *)
@@ -2142,7 +2139,6 @@ Line 2, characters 27-35:
                                ^^^^^^^^
 Error: This local-returning application is in a tail position that is not
        enclosed in an exclave_ expression.
-       Hint: Use exclave_ to return a local value.
 |}]
 (* since the tailcall calls a local-returning function, it will only type-check
    under an exclave_ *)

--- a/testsuite/tests/typing-local/local.ml
+++ b/testsuite/tests/typing-local/local.ml
@@ -1182,8 +1182,18 @@ let bar () =
 Line 3, characters 2-8:
 3 |   foo ()
       ^^^^^^
-Error: This application is local-returning, but is at the tail
-       position of a function that is not local-returning.
+Error: This local-returning application is in a tail position that is not
+       enclosed in an exclave_ expression.
+       Hint: Use exclave_ to return a local value.
+|}]
+
+let bar () : int @ local = foo ()
+[%%expect{|
+Line 1, characters 27-33:
+1 | let bar () : int @ local = foo ()
+                               ^^^^^^
+Error: This local-returning application is in a tail position that is not
+       enclosed in an exclave_ expression.
        Hint: Use exclave_ to return a local value.
 |}]
 
@@ -1221,8 +1231,8 @@ let bar (f : _ -> _ @ local) = foo (fun () -> f ())
 Line 1, characters 46-50:
 1 | let bar (f : _ -> _ @ local) = foo (fun () -> f ())
                                                   ^^^^
-Error: This application is local-returning, but is at the tail
-       position of a function that is not local-returning.
+Error: This local-returning application is in a tail position that is not
+       enclosed in an exclave_ expression.
        Hint: Use exclave_ to return a local value.
 |}]
 
@@ -2130,8 +2140,8 @@ val foo : unit -> bool @ local = <fun>
 Line 2, characters 27-35:
 2 | let testboo3 () =  true && (foo ())
                                ^^^^^^^^
-Error: This application is local-returning, but is at the tail
-       position of a function that is not local-returning.
+Error: This local-returning application is in a tail position that is not
+       enclosed in an exclave_ expression.
        Hint: Use exclave_ to return a local value.
 |}]
 (* since the tailcall calls a local-returning function, it will only type-check

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -13554,8 +13554,7 @@ let report_error ~loc env =
   | Tail_call_local_returning ->
       Location.errorf ~loc
         "@[This local-returning application is in a tail position that is not@ \
-          enclosed in an exclave_ expression.@ \
-          Hint: Use exclave_ to return a local value.@]"
+          enclosed in an exclave_ expression.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -522,20 +522,24 @@ let position_and_mode env (expected_mode : expected_mode) sexp
   end
 
 (* ap_mode is the return mode of the current application *)
-let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
-  match region_mode with
-  | Some region_mode -> begin
-    (* This application will be performed after the current region is closed; if
-       ap_mode is local, the application allocates in the outer
-       region, and thus [region_mode] needs to be marked local as well*)
+let check_tail_call_local_returning loc env ap_mode {apply_position; _} =
+  match apply_position with
+  | Tail -> begin
+    (* This application will be performed after the current region is closed;
+       if [ap_mode] were local, it would allocate in the outer region, which
+       would require the enclosing function's [region_mode] to be local as
+       well. Instead of inferring that, we require [ap_mode] to be global:
+       local-returning tail calls must be wrapped in [exclave_], and it is the
+       [Pexp_exclave] case of [type_expect_] that bounds [region_mode] from
+       below by local. *)
       match
         Regionality.submode ~pp:(loc, Expression)
-          (locality_as_regionality ap_mode) region_mode
+          (locality_as_regionality ap_mode) Regionality.global
       with
       | Ok () -> ()
       | Error _ -> raise (Error (loc, env, Tail_call_local_returning))
     end
-  | None -> ()
+  | Nontail | Default -> ()
 
 let meet_regional ?hint:h mode =
   let mode = Value.disallow_left mode in
@@ -13550,7 +13554,8 @@ let report_error ~loc env =
   | Tail_call_local_returning ->
       Location.errorf ~loc
         "@[This application is local-returning, but is at the tail@ \
-          position of a function that is not local-returning.@]"
+          position of a function that is not local-returning.@ \
+          Hint: Use exclave_ to return a local value.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -13553,8 +13553,8 @@ let report_error ~loc env =
         "This function is local-returning, but was expected otherwise."
   | Tail_call_local_returning ->
       Location.errorf ~loc
-        "@[This application is local-returning, but is at the tail@ \
-          position of a function that is not local-returning.@ \
+        "@[This local-returning application is in a tail position that is not@ \
+          enclosed in an exclave_ expression.@ \
           Hint: Use exclave_ to return a local value.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -517,20 +517,24 @@ let position_and_mode env (expected_mode : expected_mode) sexp
   end
 
 (* ap_mode is the return mode of the current application *)
-let check_tail_call_local_returning loc env ap_mode {region_mode; _} =
-  match region_mode with
-  | Some region_mode -> begin
-    (* This application will be performed after the current region is closed; if
-       ap_mode is local, the application allocates in the outer
-       region, and thus [region_mode] needs to be marked local as well*)
+let check_tail_call_local_returning loc env ap_mode {apply_position; _} =
+  match apply_position with
+  | Tail -> begin
+    (* This application will be performed after the current region is closed;
+       if [ap_mode] were local, it would allocate in the outer region, which
+       would require the enclosing function's [region_mode] to be local as
+       well. Instead of inferring that, we require [ap_mode] to be global:
+       local-returning tail calls must be wrapped in [exclave_], and it is the
+       [Pexp_exclave] case of [type_expect_] that bounds [region_mode] from
+       below by local. *)
       match
         Regionality.submode ~pp:(loc, Expression)
-          (locality_as_regionality ap_mode) region_mode
+          (locality_as_regionality ap_mode) Regionality.global
       with
       | Ok () -> ()
       | Error _ -> raise (Error (loc, env, Tail_call_local_returning))
     end
-  | None -> ()
+  | Nontail | Default -> ()
 
 let meet_regional ?hint:h mode =
   let mode = Value.disallow_left mode in
@@ -13368,7 +13372,8 @@ let report_error ~loc env =
   | Tail_call_local_returning ->
       Location.errorf ~loc
         "@[This application is local-returning, but is at the tail@ \
-          position of a function that is not local-returning.@]"
+          position of a function that is not local-returning.@ \
+          Hint: Use exclave_ to return a local value.@]"
   | Unboxed_int_literals_not_supported ->
       Location.errorf ~loc
         "@[Unboxed int literals aren't supported yet.@]"


### PR DESCRIPTION
Currently, mode-crossing is applied when enforcing a lower bound on the result of an application. As a result, the following program is allowed: 
```
let foo () = exclave_
  let p = local_ (52, 24) in
  (* use p *)
  42

let bar () =
  let _x = 52 in
  foo ()
```
Even though `bar` makes a tail-call to a locally returning function without wrapping the call in an `exclave_`. This breaks an assumption made by the compiler, that all tail-calls to local returning functions must be exclaved. 

This in turn hides a leak.
```
let main () = 
  let a = bar () in
  let b = bar () in 
  a + b
```
Although the tail-call to `foo` is not exclaved, it behaves as though it was: `bar`'s region is collapsed into `main`'s at the call: the pair allocated by `foo`, which is dead by the time `foo` returns, is placed in `main`'s region rather than freed when `bar` returns.

This PR makes such leaks explicit by enforcing a hard `global` boundary on the application mode when checking function calls of local returning functions in tail position.