### PR TITLE
Minor CFG fixes to align with SSA

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -160,7 +160,8 @@ let pseudoregs_for_operation op arg res =
   (* One-address unary operations: arg.(0) and res.(0) must be the same *)
   | Intop_imm ((Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)
   | Floatop ((Float64 | Float32), (Iabsf | Inegf))
-  | Specific (Ibswap { bitwidth = Thirtytwo | Sixtyfour }) ->
+  | Specific (Ibswap { bitwidth = Thirtytwo | Sixtyfour })
+  | Opaque ->
     res, res
   (* For xchg, args must be a register allowing access to high 8 bit register
      (rax, rbx, rcx or rdx). Keep it simple, just force the argument in rax. *)
@@ -230,8 +231,8 @@ let pseudoregs_for_operation op arg res =
   | Const_float32 _ | Const_float _ | Const_vec128 _ | Const_vec256 _
   | Const_vec512 _ | Const_symbol _ | Stackoffset _ | Load _
   | Store (_, _, _)
-  | Alloc _ | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
-  | Begin_region | End_region | Poll | Dls_get | Tls_get | Domain_index ->
+  | Alloc _ | Name_for_debugger _ | Probe_is_enabled _ | Pause | Begin_region
+  | End_region | Poll | Dls_get | Tls_get | Domain_index ->
     raise Use_default_exn
   | Specific (Illvm_intrinsic intr) ->
     Misc.fatal_errorf "Unexpected llvm_intrinsic %s: not using LLVM backend"

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2368,7 +2368,8 @@ let emit_instr ~first ~last ~fallthrough i =
       (res i 0)
   | Lop (Floatop (width, ((Iaddf | Isubf | Imulf | Idivf) as floatop))) ->
     instr_for_floatop width floatop (arg i 0) (arg i 1) (res i 0)
-  | Lop Opaque -> assert (Reg.equal_location i.arg.(0).loc i.res.(0).loc)
+  | Lop Opaque ->
+    assert (Array.equal (fun a b -> Reg.equal_location a.loc b.loc) i.arg i.res)
   | Lop (Specific (Ilea addr)) -> I.lea (addressing addr NONE i 0) (res i 0)
   | Lop (Specific (Ioffset_loc (n, addr))) ->
     I.add (int n) (addressing addr QWORD i 0)

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -268,12 +268,13 @@ let pseudoregs_for_operation op arg res =
   match (op : Operation.t) with
   | Specific (Isimd simd_op) ->
     Simd_selection.pseudoregs_for_operation simd_op arg res
+  | Opaque -> res, res
   | Specific
       ( Ifar_poll | Imuladd | Imulsub | Inegmulf | Imuladdf | Inegmuladdf
       | Imulsubf | Inegmulsubf | Isqrtf | Imove32 | Ifar_alloc _
       | Ishiftarith (_, _)
       | Ibswap _ | Isignext _ )
-  | Move | Spill | Reload | Opaque | Pause | Begin_region | End_region | Dls_get
+  | Move | Spill | Reload | Pause | Begin_region | End_region | Dls_get
   | Tls_get | Domain_index | Poll | Const_int _ | Const_float32 _
   | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
   | Const_vec512 _ | Stackoffset _ | Load _

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1739,7 +1739,8 @@ let emit_instr env i =
     match H.reg_fp_operand_4 i.res.(0) i.arg.(1) i.arg.(2) i.arg.(0) with
     | S_regs (rd, rn, rm, ra) -> A.ins4 FNMSUB rd rn rm ra
     | D_regs (rd, rn, rm, ra) -> A.ins4 FNMSUB rd rn rm ra)
-  | Lop Opaque -> assert (Reg.equal_location i.arg.(0).loc i.res.(0).loc)
+  | Lop Opaque ->
+    assert (Array.equal (fun a b -> Reg.equal_location a.loc b.loc) i.arg i.res)
   | Lop (Specific (Ishiftarith (op, shift))) ->
     let rd, rn, rm = H.reg_x i.res.(0), H.reg_x i.arg.(0), H.reg_x i.arg.(1) in
     let emit_shift_arith instr kind amount =

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -339,8 +339,7 @@ let check_basic_arity t label (instr : Cfg.basic Cfg.instruction) =
     | Begin_region -> check ~expected_args:[0] ~expected_res:[1]
     | End_region -> check ~expected_args:[1] ~expected_res:[0]
     | Specific _ -> ()
-    | Name_for_debugger { regs; _ } ->
-      check ~expected_args:[0; Array.length regs] ~expected_res:[0]
+    | Name_for_debugger _ -> check ~expected_args:[0] ~expected_res:[0]
     | Dls_get | Tls_get | Domain_index ->
       check ~expected_args:[0] ~expected_res:[1]
     | Poll | Pause -> check ~expected_args:[0] ~expected_res:[0]

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -768,7 +768,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | Never_returns -> Never_returns
       | Ok (simple_args, env) ->
         let* rs = emit_tuple env sub_cfg simple_args in
-        Ok (insert_op_debug env sub_cfg (SU.make_opaque ()) dbg rs rs))
+        let rd = Reg.createv_with_typs rs in
+        Ok (insert_op_debug env sub_cfg (SU.make_opaque ()) dbg rs rd))
     | Cop (Ctuple_field (field, fields_layout), [arg], _dbg) -> (
       match emit_expr env sub_cfg arg ~bound_name:None with
       | Never_returns -> Never_returns
@@ -1476,8 +1477,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
               }
           in
           DLL.add_end block.Cfg.body
-            (Sub_cfg.make_instr (Cfg.Op naming_op) hard_regs_for_arg [||]
-               Debuginfo.none))
+            (Sub_cfg.make_instr (Cfg.Op naming_op) [||] [||] Debuginfo.none))
       fun_args
 
   (* Sequentialization of a function definition *)


### PR DESCRIPTION
While validating the new SSA pipeline against the existing one, two CFG issues came up:

1. **Non-lexical effect of opaque** `opaque(x)` is meant to produce an opaque *alias* of `x` — a separate value the optimizer cannot see through — while leaving direct uses of `x` unaffected. However, it was emitted reusing its input array as its result (`rs rs`), so the input and output were the same register: any use of `x` after the `opaque` would automatically read the opaque output instead, so the opacity barrier silently applied to all later uses of `x`, not just those going through the opaque result. Fix: allocate a fresh result register (`Reg.createv_with_typs`) so it's a genuine distinct alias, and add the `Opaque -> res, res` one-address constraint in `pseudoregs_for_operation` (amd64 + arm64) so it stays a zero-cost identity after regalloc.

2. **Uniformly no args for `Name_for_debugger`.** `insert_param_name_for_debugger` was the only site passing the named registers as the instruction's `arg`; every other `Name_for_debugger` uses `[||]`. The `arg` was redundant — the registers live in the op's `regs` field. In principle, using `arg` makes a difference in extending live ranges up to the `Name_for_debugger`, which we generally avoid. But since the code using `arg` was only used at the function start, it did not meaningfully extend the live ranges of the function parameters either. So handling this uniformly makes no observable difference.