### PR TITLE
Basic heap-to-stack pointer invalidation in flambda2

### DIFF
--- a/middle_end/flambda2/bound_identifiers/alloc_mode.ml
+++ b/middle_end/flambda2/bound_identifiers/alloc_mode.ml
@@ -193,8 +193,7 @@ module For_allocations = struct
     then Local { region }
     else Heap
 
-  let as_type t : For_types.t =
-    match t with Heap -> Heap | Local _ -> Heap_or_local
+  let as_type t : For_types.t = match t with Heap -> Heap | Local _ -> Local
 
   let from_lambda (mode : Lambda.locality_mode) ~current_region =
     if not (Flambda_features.stack_allocation_enabled ())

--- a/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_variadic_primitive.ml
@@ -17,7 +17,8 @@
 open! Simplify_import
 
 let simplify_make_block ~original_prim ~(block_kind : P.Block_kind.t)
-    ~(mutable_or_immutable : Mutability.t) alloc_mode dacc ~original_term _dbg
+    ~(mutable_or_immutable : Mutability.t)
+    (alloc_mode : Alloc_mode.For_allocations.t) dacc ~original_term _dbg
     ~args_with_tys ~result_var =
   let typing_env = DA.typing_env dacc in
   let typing_env : _ Or_bottom.t =
@@ -32,9 +33,15 @@ let simplify_make_block ~original_prim ~(block_kind : P.Block_kind.t)
           "Shape in [Make_block] of different length from argument list:@ %a"
           Named.print original_term;
       List.fold_left2
-        (fun typing_env arg_kind (arg, _arg_ty) : _ Or_bottom.t ->
+        (fun typing_env arg_kind (arg, arg_ty) : _ Or_bottom.t ->
           let open Or_bottom.Let_syntax in
           let<* typing_env = typing_env in
+          let<* typing_env =
+            match alloc_mode, T.prove_alloc_mode typing_env arg_ty with
+            | Heap, Proved Local -> Bottom
+            | Heap, (Proved (Heap | Heap_or_local) | Unknown) | Local _, _ ->
+              Ok typing_env
+          in
           Simple.pattern_match' arg
             ~var:(fun _ ~coercion:_ : _ Or_bottom.t ->
               let<+ _ty, typing_env =

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -882,6 +882,9 @@ val meet_rec_info : Typing_env.t -> t -> Rec_info_expr.t meet_shortcut
 val prove_alloc_mode_of_boxed_number :
   Typing_env.t -> t -> Alloc_mode.For_types.t proof_of_property
 
+val prove_alloc_mode :
+  Typing_env.t -> t -> Alloc_mode.For_types.t proof_of_property
+
 val prove_physical_equality : Typing_env.t -> t -> t -> bool proof_of_property
 
 type to_lift = private

--- a/middle_end/flambda2/types/provers.ml
+++ b/middle_end/flambda2/types/provers.ml
@@ -1149,6 +1149,41 @@ let prove_alloc_mode_of_boxed_number_value _env
 let prove_alloc_mode_of_boxed_number env t =
   gen_value_to_proof prove_alloc_mode_of_boxed_number_value env t
 
+let prove_alloc_mode env (value : TG.t) :
+    Alloc_mode.For_types.t proof_of_property =
+  match expand_head env value with
+  | Value
+      (Ok
+         { is_null = _;
+           non_null =
+             Ok
+               ( Boxed_float32 (_, alloc_mode)
+               | Boxed_float (_, alloc_mode)
+               | Boxed_int32 (_, alloc_mode)
+               | Boxed_int64 (_, alloc_mode)
+               | Boxed_nativeint (_, alloc_mode)
+               | Boxed_vec128 (_, alloc_mode)
+               | Boxed_vec256 (_, alloc_mode)
+               | Boxed_vec512 (_, alloc_mode)
+               | Variant { blocks = Known { alloc_mode; _ }; _ }
+               | Mutable_block { alloc_mode }
+               | Array { alloc_mode; _ }
+               | Closures { alloc_mode; _ } )
+         }) ->
+    Proved alloc_mode
+  | Value
+      ( Ok
+          { is_null = _;
+            non_null =
+              Ok (Variant { blocks = Unknown; _ } | String _) | Unknown | Bottom
+          }
+      | Unknown | Bottom )
+  | Naked_immediate _ | Naked_float _ | Naked_float32 _ | Naked_int8 _
+  | Naked_int16 _ | Naked_int32 _ | Naked_int64 _ | Naked_vec128 _
+  | Naked_vec256 _ | Naked_vec512 _ | Naked_nativeint _ | Rec_info _ | Region _
+    ->
+    Unknown
+
 let never_holds_locally_allocated_values env var : _ proof_of_property =
   let ty = TE.find env (Name.var var) None in
   match expand_head env ty with

--- a/middle_end/flambda2/types/provers.mli
+++ b/middle_end/flambda2/types/provers.mli
@@ -304,6 +304,9 @@ val meet_rec_info :
 val prove_alloc_mode_of_boxed_number :
   Typing_env.t -> Type_grammar.t -> Alloc_mode.For_types.t proof_of_property
 
+val prove_alloc_mode :
+  Typing_env.t -> Type_grammar.t -> Alloc_mode.For_types.t proof_of_property
+
 val never_holds_locally_allocated_values :
   Typing_env.t -> Variable.t -> unit proof_of_property
 

--- a/testsuite/tests/typing-local/heap_to_stack/make_block.ml
+++ b/testsuite/tests/typing-local/heap_to_stack/make_block.ml
@@ -1,0 +1,14 @@
+(* TEST
+   flags += "-O3";
+   exit_status = "-6";
+   native;
+*)
+
+external magic_local : 'a @ local -> 'a = "%identity"
+
+let f x = exclave_ stack_ Some x
+
+let[@inline never] bad z =
+   let x = magic_local ((f [@inlined]) z) in x, x
+
+let () = ignore (Sys.opaque_identity (bad 0))

--- a/testsuite/tests/typing-local/heap_to_stack/make_block.reference
+++ b/testsuite/tests/typing-local/heap_to_stack/make_block.reference
@@ -1,0 +1,14 @@
+[ocaml] [flambda2] Invalid code:
+(Defining_expr_of_let (bound_pattern Pmakeblock/60N)
+ (defining_expr
+  (((Make_block
+     (Values (tag 0)
+      (shape
+       (𝕍=Variant((consts ({ 0 })) (non_consts ({(0 [𝕍?])})))
+        𝕍=Variant((consts ({ 0 })) (non_consts ({(0 [𝕍?])})))))) Immutable
+     Heap) x/50UV x/50UV) make_block.ml:12,45--49)))
+
+This might have arisen from a wrong use of [%identity],
+for example confusing arrays and records, or non-mixed and
+mixed blocks.
+Consider using [Obj.magic], [Obj.repr] and/or [Obj.obj].


### PR DESCRIPTION
It is possible to accidentally make the compiler emit Lambda that results in heap-to-stack pointers, which are not handled gracefully by the garbage collector and often lead to difficult-to-debug memory corruption bugs. 
One example is in metaprogramming, where we had this bug persist undetected for a while – see #6316 for a bug we investigated with @Skepfyr. Recent work refactoring the mode-checker by @ageorg29 could also benefit from a check like this.

Flambda2 already has analysis and validation facilities and some information about `Alloc_mode`s. We can use these to detect when we are definitely constructing a heap-to-stack pointer. In this situation, we can emit `invalid` (since sometimes such code is unreachable, so we cannot always crash at compile-time).

This PR is a draft that implements this check for make-blocks as part of `simplify_make_block`. There is a simple example test with an invalid allocation.

- [ ] Skip the test for Oclassic and ASan builds.
- [ ] Move `Alloc_mode.For_allocation.as_type` change to separate PR.
- [ ] Refactor `Simplify_primitive_result.invalid` to accept a reason, and add a reason specific to heap-to-stack pointers to `Invalid.t`.
- [ ] Add invalidation for heap-allocated closures capturing stack-allocated variables (as in the metaprogramming bug).
