### PR TITLE
Fix kind path substitution in `Tof_kind`

### DIFF
--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1870,24 +1870,7 @@ end = struct
   type t = Rec.a
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type t = Rec.a
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = Rec.a end
-       is not included in
-         sig type t : Rec.k end
-       Type declarations do not match:
-         type t = Rec.a
-       is not included in
-         type t : Rec.k
-       The kind of the first is k
-         because of the annotation on the type at line 3, characters 11-21.
-       But the kind of the first must be a subkind of Rec.k
-         because of the definition of t at line 2, characters 2-16.
-       No .cmi file found containing k.
+module Use_rec : sig type t : Rec.k end
 |}]
 
 module Plain = struct
@@ -1904,24 +1887,7 @@ end = struct
   type t = Plain.a
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type t = Plain.a
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = Plain.a end
-       is not included in
-         sig type t : Plain.k end
-       Type declarations do not match:
-         type t = Plain.a
-       is not included in
-         type t : Plain.k
-       The kind of the first is k
-         because of the annotation on the type at line 3, characters 11-21.
-       But the kind of the first must be a subkind of Plain.k
-         because of the definition of t at line 2, characters 2-18.
-       No .cmi file found containing k.
+module Use_plain : sig type t : Plain.k end
 |}]
 
 (**************************************************************)

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1927,7 +1927,7 @@ module G2 :
 
 module AppG = G2 (struct kind_ k end)
 [%%expect{|
-module AppG : sig type t = (type : X.k) box end
+module AppG : sig type t end
 |}]
 
 type u = AppG.t

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1923,3 +1923,48 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-18.
        No .cmi file found containing k.
 |}]
+
+(**************************************************************)
+(* Test: nondep handles abstract kinds in [(type : k)] types *)
+
+module F2 (X : sig kind_ k end) = struct
+  type t = (type : X.k)
+end
+[%%expect{|
+module F2 : functor (X : sig kind_ k end) -> sig type t = (type : X.k) end
+|}]
+
+module App = F2 (struct kind_ k end)
+[%%expect{|
+Line 1, characters 13-36:
+1 | module App = F2 (struct kind_ k end)
+                 ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This functor has type
+       "functor (X : sig kind_ k end) -> sig type t = (type : X.k) end"
+       The parameter cannot be eliminated in the result type.
+       Please bind the argument to a module identifier.
+|}]
+
+(* Here the [(type : X.k)] only occurs nested inside the manifest, not in the
+   kind of [t] itself, so nondep must erase it from the manifest. *)
+
+type ('a : any) box : value
+
+module G2 (X : sig kind_ k end) = struct
+  type t = (type : X.k) box
+end
+[%%expect{|
+type ('a : any) box
+module G2 :
+  functor (X : sig kind_ k end) -> sig type t = (type : X.k) box end
+|}]
+
+module AppG = G2 (struct kind_ k end)
+[%%expect{|
+module AppG : sig type t = (type : X.k) box end
+|}]
+
+type u = AppG.t
+[%%expect{|
+type u = AppG.t
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics.ml
@@ -1852,3 +1852,74 @@ Error: This expression has type "bool id option"
        but an expression was expected of type "int id option"
        Type "bool" is not compatible with type "int"
 |}]
+
+(*****************************************************)
+(* Test: Paths are substituted in [(type : k)] types *)
+
+module rec Rec : sig
+  kind_ k
+  type a = (type : k)
+end = Rec
+[%%expect{|
+module rec Rec : sig kind_ k type a = (type : k) end
+|}]
+
+module Use_rec : sig
+  type t : Rec.k
+end = struct
+  type t = Rec.a
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = Rec.a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Rec.a end
+       is not included in
+         sig type t : Rec.k end
+       Type declarations do not match:
+         type t = Rec.a
+       is not included in
+         type t : Rec.k
+       The kind of the first is k
+         because of the annotation on the type at line 3, characters 11-21.
+       But the kind of the first must be a subkind of Rec.k
+         because of the definition of t at line 2, characters 2-16.
+       No .cmi file found containing k.
+|}]
+
+module Plain = struct
+  kind_ k
+  type a = (type : k)
+end
+[%%expect{|
+module Plain : sig kind_ k type a = (type : k) end
+|}]
+
+module Use_plain : sig
+  type t : Plain.k
+end = struct
+  type t = Plain.a
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = Plain.a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Plain.a end
+       is not included in
+         sig type t : Plain.k end
+       Type declarations do not match:
+         type t = Plain.a
+       is not included in
+         type t : Plain.k
+       The kind of the first is k
+         because of the annotation on the type at line 3, characters 11-21.
+       But the kind of the first must be a subkind of Plain.k
+         because of the definition of t at line 2, characters 2-18.
+       No .cmi file found containing k.
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1919,7 +1919,7 @@ module G2 :
 
 module AppG = G2 (struct kind_ k end)
 [%%expect{|
-module AppG : sig type t = (type : X.k) box end
+module AppG : sig type t end
 |}]
 
 type u = AppG.t

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1862,24 +1862,7 @@ end = struct
   type t = Rec.a
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type t = Rec.a
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = Rec.a end
-       is not included in
-         sig type t : Rec.k end
-       Type declarations do not match:
-         type t = Rec.a
-       is not included in
-         type t : Rec.k
-       The kind of the first is k
-         because of the annotation on the type at line 3, characters 11-21.
-       But the kind of the first must be a subkind of Rec.k
-         because of the definition of t at line 2, characters 2-16.
-       No .cmi file found containing k.
+module Use_rec : sig type t : Rec.k end
 |}]
 
 module Plain = struct
@@ -1896,24 +1879,7 @@ end = struct
   type t = Plain.a
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type t = Plain.a
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type t = Plain.a end
-       is not included in
-         sig type t : Plain.k end
-       Type declarations do not match:
-         type t = Plain.a
-       is not included in
-         type t : Plain.k
-       The kind of the first is k
-         because of the annotation on the type at line 3, characters 11-21.
-       But the kind of the first must be a subkind of Plain.k
-         because of the definition of t at line 2, characters 2-18.
-       No .cmi file found containing k.
+module Use_plain : sig type t : Plain.k end
 |}]
 
 (**************************************************************)

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1915,3 +1915,48 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-18.
        No .cmi file found containing k.
 |}]
+
+(**************************************************************)
+(* Test: nondep handles abstract kinds in [(type : k)] types *)
+
+module F2 (X : sig kind_ k end) = struct
+  type t = (type : X.k)
+end
+[%%expect{|
+module F2 : functor (X : sig kind_ k end) -> sig type t = (type : X.k) end
+|}]
+
+module App = F2 (struct kind_ k end)
+[%%expect{|
+Line 1, characters 13-36:
+1 | module App = F2 (struct kind_ k end)
+                 ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This functor has type
+       "functor (X : sig kind_ k end) -> sig type t = (type : X.k) end"
+       The parameter cannot be eliminated in the result type.
+       Please bind the argument to a module identifier.
+|}]
+
+(* Here the [(type : X.k)] only occurs nested inside the manifest, not in the
+   kind of [t] itself, so nondep must erase it from the manifest. *)
+
+type ('a : any) box : value
+
+module G2 (X : sig kind_ k end) = struct
+  type t = (type : X.k) box
+end
+[%%expect{|
+type ('a : any) box
+module G2 :
+  functor (X : sig kind_ k end) -> sig type t = (type : X.k) box end
+|}]
+
+module AppG = G2 (struct kind_ k end)
+[%%expect{|
+module AppG : sig type t = (type : X.k) box end
+|}]
+
+type u = AppG.t
+[%%expect{|
+type u = AppG.t
+|}]

--- a/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
+++ b/testsuite/tests/typing-abstract-kinds/basics_ikinds.ml
@@ -1844,3 +1844,74 @@ Error: This expression has type "bool id option"
        but an expression was expected of type "int id option"
        Type "bool" is not compatible with type "int"
 |}]
+
+(*****************************************************)
+(* Test: Paths are substituted in [(type : k)] types *)
+
+module rec Rec : sig
+  kind_ k
+  type a = (type : k)
+end = Rec
+[%%expect{|
+module rec Rec : sig kind_ k type a = (type : k) end
+|}]
+
+module Use_rec : sig
+  type t : Rec.k
+end = struct
+  type t = Rec.a
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = Rec.a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Rec.a end
+       is not included in
+         sig type t : Rec.k end
+       Type declarations do not match:
+         type t = Rec.a
+       is not included in
+         type t : Rec.k
+       The kind of the first is k
+         because of the annotation on the type at line 3, characters 11-21.
+       But the kind of the first must be a subkind of Rec.k
+         because of the definition of t at line 2, characters 2-16.
+       No .cmi file found containing k.
+|}]
+
+module Plain = struct
+  kind_ k
+  type a = (type : k)
+end
+[%%expect{|
+module Plain : sig kind_ k type a = (type : k) end
+|}]
+
+module Use_plain : sig
+  type t : Plain.k
+end = struct
+  type t = Plain.a
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = Plain.a
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = Plain.a end
+       is not included in
+         sig type t : Plain.k end
+       Type declarations do not match:
+         type t = Plain.a
+       is not included in
+         type t : Plain.k
+       The kind of the first is k
+         because of the annotation on the type at line 3, characters 11-21.
+       But the kind of the first must be a subkind of Plain.k
+         because of the definition of t at line 2, characters 2-18.
+       No .cmi file found containing k.
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8385,6 +8385,11 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
                 Tvariant (set_row_name row None)
             | _ -> Tvariant row
           end
+      | Tof_kind jk ->
+          let jk = nondep_jkind_base env ids jk in
+          (* CR layouts v2.8: This should be done with a proper nondep_jkind.
+             Internal ticket 5113. *)
+          Tof_kind (Jkind.map_type_expr (nondep_type_rec env ids) jk)
       | desc -> copy_type_desc (nondep_type_rec env ids) desc
     with
     | desc ->

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -655,10 +655,11 @@ let rec typexp copy_scope s ty =
     let has_fixed_row =
       not (is_Tconstr ty) && is_constr_row ~allow_ident:false tm in
     (* Make a stub *)
-    let jkind = Jkind.Builtin.any ~why:Dummy_jkind in
+    let stub_jkind = Jkind.Builtin.any ~why:Dummy_jkind in
     let ty' =
-      if should_duplicate_vars then newpersty (Tvar {name = None; jkind})
-      else newgenstub ~scope:(get_scope ty) jkind
+      if should_duplicate_vars
+      then newpersty (Tvar {name = None; jkind = stub_jkind})
+      else newgenstub ~scope:(get_scope ty) stub_jkind
     in
     For_copy.redirect_desc copy_scope ty (Tsubst (ty', None));
     let desc =
@@ -751,6 +752,7 @@ let rec typexp copy_scope s ty =
           let ret = typexp copy_scope s ret in
           let comm = copy_commu comm in
           Tarrow ((label, marg, mret), arg, ret, comm)
+      | Tof_kind jk -> Tof_kind (jkind copy_scope s jk)
       | _ -> copy_type_desc (typexp copy_scope s) desc
     in
     Transient_expr.set_stub_desc ty' desc;

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -482,7 +482,7 @@ let apply_type_function params args body =
                     Tsubst (ty, None) -> ty
                     (* TODO: is this case possible?
                        possibly an interaction with (copy more) below? *)
-                  | Tconstr _ | Tnil ->
+                  | Tconstr _ | Tnil | Tof_kind _ ->
                       copy more
                   | Tvar _ | Tunivar _ ->
                       newgenty mored


### PR DESCRIPTION
`(type : k)` types (`Tof_kind`) carry a kind that can reference an abstract kind by path, but type substitution ignored it, so accessing such a type through a module path left the kind path dangling. For example:

```ocaml
module M = struct
  kind_ k
  type a = (type : k)
end

module S : sig
  type t : M.k
end = struct
  type t = M.a
end
```
```
Error: Signature mismatch:
       ...
       The kind of the first is k
         because of the annotation on the type at line 3, characters 11-21.
       But the kind of the first must be a subkind of M.k
         because of the definition of t at line 2, characters 2-14.
       No .cmi file found containing k.
```

The root cause is that the type-traversal functions had no case for `Tof_kind`, so it hit their catch-all, `copy_type_desc`, which leaves the carried kind untouched. The same gap existed in two places, both fixed here:

**1. `Subst.typexp` now substitutes the kind inside `Tof_kind`**, prefixing abstract kind paths when a module's components are accessed through a path. The example above now typechecks.

**2. `Ctype.nondep_type_rec` now erases `Tof_kind` kinds that mention an eliminated module.** When the `(type : X.k)` occurs nested inside a manifest, the dangling path used to leak into the resulting signature:

```ocaml
type ('a : any) box : value

module G (X : sig kind_ k end) = struct
  type t = (type : X.k) box
end

module App = G (struct kind_ k end)
(* was: module App : sig type t = (type : X.k) box end, with X unbound *)
```

Now `t` is correctly abstracted: `module App : sig type t end`. (When the `(type : X.k)` is the entire manifest, the declaration's own kind already caught this with "the parameter cannot be eliminated", so the leak only showed up nested.)

**Review.** Review commit-by-commit.