### PR TITLE
Type shapes for `any` fields

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -554,8 +554,9 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
                     | Some layout ->
                       type_shape_to_complex_shape ~cache ~rec_env arg layout
                     | None ->
-                      (* It's an [any] field with no fixed layout - must
-                         recompute *)
+                      (* It's an [any] field, so we must determine the layout
+                         from the shape (or fall back to [Rs.unknown Value] via
+                         the exception handler below) *)
                       type_shape_to_complex_shape_exn ~cache ~rec_env arg None ))
                 args
             in
@@ -574,9 +575,7 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
           constructors
       in
       runtime (RS.variant constructors)
-    with Layout_missing ->
-      runtime (RS.unknown Value)
-      (* should only be raised by [lay_out_into_mixed_block_exn] *))
+    with Layout_missing -> runtime (RS.unknown Value))
   | Variant _, Some ((Product _ | Base _) as ly) ->
     err_or_unknown_exn (fun f ->
         f "variant must have value layout, but got: %a" pp_layout ly)

--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -550,7 +550,13 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
                        S.field_value = arg, layout
                      } ->
                   ( field_name,
-                    type_shape_to_complex_shape ~cache ~rec_env arg layout ))
+                    match layout with
+                    | Some layout ->
+                      type_shape_to_complex_shape ~cache ~rec_env arg layout
+                    | None ->
+                      (* It's an [any] field with no fixed layout - must
+                         recompute *)
+                      type_shape_to_complex_shape_exn ~cache ~rec_env arg None ))
                 args
             in
             let constr_args =

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
@@ -14,7 +14,8 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=:: ({ key = "key1"; value = 100 }, []) : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=:: ({ key = "key2"; value = 200 }, :: ({ key = "key1"; value = 100 }, [])) : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.MakeSet.mem [inlined]
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_store_operations(store=:: ({ key = 2; value = 200 }, :: ({ key = 1; value = 100 }, [])) : IntStore.t @ value)
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Stdlib.List.length_aux [inlined]
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Stdlib.List.length_aux [inlined]
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 42; computed = 6.28; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 0; computed = 3.14; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_compute_result(x={ value = "test"; computed = 12.56; status = `Success } : StringCompute.result @ value)
@@ -23,4 +24,3 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_string_pair(x={ first = 0; second = "world"; combined = "0+world" } : IntStringAdvanced.pair_data @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_float_pair(x={ first = "test"; second = 3.14; combined = "test+3.14" } : StringFloatAdvanced.pair_data @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_comparison_result(x=Greater : IntStringAdvanced.comparison_result @ value)
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_comparison_result(x=Equal : IntStringAdvanced.comparison_result @ value)

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_simple_functor_dwarf.output
@@ -14,8 +14,7 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=:: ({ key = "key1"; value = 100 }, []) : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_store(x=:: ({ key = "key2"; value = 200 }, :: ({ key = "key1"; value = 100 }, [])) : StringStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.MakeSet.mem [inlined]
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Stdlib.List.length_aux [inlined]
-    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Stdlib.List.length_aux [inlined]
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_store_operations(store=:: ({ key = 2; value = 200 }, :: ({ key = 1; value = 100 }, [])) : IntStore.t @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 42; computed = 6.28; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_compute_result(x={ value = 0; computed = 3.14; status = `Success } : IntCompute.result @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_compute_result(x={ value = "test"; computed = 12.56; status = `Success } : StringCompute.result @ value)
@@ -24,3 +23,4 @@
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_int_string_pair(x={ first = 0; second = "world"; combined = "0+world" } : IntStringAdvanced.pair_data @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_string_float_pair(x={ first = "test"; second = 3.14; combined = "test+3.14" } : StringFloatAdvanced.pair_data @ value)
     frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_comparison_result(x=Greater : IntStringAdvanced.comparison_result @ value)
+    frame #N: <ADDRESS> test_simple_functor_dwarf.exe`Test_simple_functor_dwarf.f_comparison_result(x=Equal : IntStringAdvanced.comparison_result @ value)

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -527,7 +527,7 @@ and desc =
   | Rec_var of int
 
   (* constructors for type declarations *)
-  | Variant of (t * Layout.t) complex_constructors
+  | Variant of (t * Layout.t option) complex_constructors
   | Variant_unboxed of
     { name : string;
       variant_uid : Uid.t option;
@@ -574,7 +574,7 @@ and 'a complex_constructor_argument =
     field_value : 'a
   }
 
-and constructor_representation = mixed_product_shape
+and constructor_representation = Layout.t option array
 
 and mixed_product_shape = Layout.t array
 
@@ -604,7 +604,7 @@ let equal_complex_constructor eq
     { name = name1; kind = kind1; args = args1 }
     { name = name2; kind = kind2; args = args2 } =
   String.equal name1 name2 &&
-  Misc.Stdlib.Array.equal Layout.equal kind1 kind2 &&
+  Misc.Stdlib.Array.equal (Option.equal Layout.equal) kind1 kind2 &&
   List.equal (equal_complex_constructor_arguments eq) args1 args2
 
 let rec equal_desc0 d1 d2 =
@@ -648,7 +648,7 @@ let rec equal_desc0 d1 d2 =
   | Variant c1, Variant c2 ->
     List.equal
          (equal_complex_constructor (fun (t1, l1) (t2, l2) ->
-           equal t1 t2 && Layout.equal l1 l2))
+           equal t1 t2 && Option.equal Layout.equal l1 l2))
          c1 c2
   | Variant_unboxed c1, Variant_unboxed c2 ->
     String.equal c1.name c2.name

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -253,7 +253,9 @@ and desc =
   | Rec_var of DeBruijn_index.t
 
   (* constructors for type declarations *)
-  | Variant of (t * Layout.t) complex_constructors
+  | Variant of (t * Layout.t option) complex_constructors
+      (* An [any] field will have a layout of [None]. Each particular value of
+         that variant may have a different layout for that field. *)
       (* CR sspies: Rename this just to constructor now that simple constructors
          are no longer a thing. *)
   | Variant_unboxed of
@@ -327,8 +329,9 @@ and 'a complex_constructor_argument =
   }
 
 (* Unlike in [types.ml], we use [Layout.t] entries here, because we can
-    represent flattened floats simply as float64 in the debugger. *)
-and constructor_representation = mixed_product_shape
+    represent flattened floats simply as float64 in the debugger. [None] means
+    the field is an [any] field and thus has no fixed layout. *)
+and constructor_representation = Layout.t option array
 
 and mixed_product_shape = Layout.t array
 
@@ -374,7 +377,7 @@ val rec_var : ?uid:Uid.t -> DeBruijn_index.t -> t
 
 (* constructors for type declarations *)
 val variant :
-  ?uid:Uid.t -> (t * Layout.t) complex_constructors -> t
+  ?uid:Uid.t -> (t * Layout.t option) complex_constructors -> t
 val variant_unboxed :
   ?uid:Uid.t -> variant_uid:Uid.t option -> arg_uid:Uid.t option ->
   string -> string option -> t -> Layout.t -> t

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -151,7 +151,7 @@ end) = struct
     | NPredef of Predef.t * nf list
     | NArrow
     | NPoly_variant of nf poly_variant_constructors
-    | NVariant of  (delayed_nf * Layout.t) complex_constructors
+    | NVariant of  (delayed_nf * Layout.t option) complex_constructors
     | NVariant_unboxed of
       { name : string;
         variant_uid : Uid.t option;
@@ -252,7 +252,7 @@ end) = struct
       List.equal
         (Shape.equal_complex_constructor
           (fun (dnf1, ly1) (dnf2, ly2) ->
-            Layout.equal ly1 ly2 && equal_delayed_nf dnf1 dnf2))
+            Option.equal Layout.equal ly1 ly2 && equal_delayed_nf dnf1 dnf2))
         cc1 cc2
     | NVariant_unboxed { name = n1; variant_uid = vu1; arg_name = an1;
                          arg_uid = au1; arg_shape = as1; arg_layout = al1 },
@@ -489,6 +489,12 @@ end) = struct
                                            field_value = sh, layout } ->
                   let name = Option.get field_name in
                   let sh = delayed_nf_set_uid sh field_uid in
+                  (* This projection exists only for Merlin, which does not
+                     consume the layouts, so default any layouts that were
+                     unknown at declaration time. *)
+                  let layout =
+                    Option.value layout ~default:(Layout.Base Scannable)
+                  in
                   (name, field_uid, sh, layout)
                 ) args in
                 { desc = NRecord { fields; kind = Record_boxed };

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -489,9 +489,8 @@ end) = struct
                                            field_value = sh, layout } ->
                   let name = Option.get field_name in
                   let sh = delayed_nf_set_uid sh field_uid in
-                  (* This projection exists only for Merlin, which does not
-                     consume the layouts, so default any layouts that were
-                     unknown at declaration time. *)
+                  (* Since this projection only exists for Merlin (see comment above), we
+                     can choose any layout here. Merlin does not consume the layout. *)
                   let layout =
                     Option.value layout ~default:(Layout.Base Scannable)
                   in

--- a/typing/shape_reduce.ml
+++ b/typing/shape_reduce.ml
@@ -489,8 +489,9 @@ end) = struct
                                            field_value = sh, layout } ->
                   let name = Option.get field_name in
                   let sh = delayed_nf_set_uid sh field_uid in
-                  (* Since this projection only exists for Merlin (see comment above), we
-                     can choose any layout here. Merlin does not consume the layout. *)
+                  (* Since this projection only exists for Merlin (see comment
+                     above), we can choose any layout here. Merlin does not
+                     consume the layout. *)
                   let layout =
                     Option.value layout ~default:(Layout.Base Scannable)
                   in

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -414,85 +414,86 @@ module Type_decl_shape = struct
     let args =
       match cstr_args.cd_args with
       | Cstr_tuple list ->
-        Misc.Stdlib.List.map_option
+        List.map
           (fun ({ ca_type = type_expr; ca_sort = type_layout; _ } :
                  Types.constructor_argument) ->
-            Option.map
-              (fun type_layout ->
-                { Shape.field_name = None;
-                  field_uid = None;
-                  field_value =
-                    ( Type_shape.of_type_expr_with_type_subst type_expr
-                        shape_for_constr type_subst,
-                      type_layout )
-                })
-              type_layout)
+            { Shape.field_name = None;
+              field_uid = None;
+              field_value =
+                ( Type_shape.of_type_expr_with_type_subst type_expr
+                    shape_for_constr type_subst,
+                  type_layout )
+            })
           list
       | Cstr_record list ->
-        Misc.Stdlib.List.map_option
+        List.map
           (fun (lbl : Types.label_declaration) ->
-            Option.map
-              (fun sort ->
-                { Shape.field_name = Some (Ident.name lbl.ld_id);
-                  field_uid = Some lbl.ld_uid;
-                  field_value =
-                    ( Type_shape.of_type_expr_with_type_subst lbl.ld_type
-                        shape_for_constr type_subst,
-                      sort )
-                })
-              lbl.ld_sort)
+            { Shape.field_name = Some (Ident.name lbl.ld_id);
+              field_uid = Some lbl.ld_uid;
+              field_value =
+                ( Type_shape.of_type_expr_with_type_subst lbl.ld_type
+                    shape_for_constr type_subst,
+                  lbl.ld_sort )
+            })
           list
     in
-    match (arg_layout : Types.cstr_layout), args with
-    | Cstr_layout_known { shape = constructor_repr; _ }, Some args ->
-      let constructor_repr =
+    let constructor_repr =
+      match (arg_layout : Types.cstr_layout) with
+      | Cstr_layout_known { shape = constructor_repr; _ } -> (
         match (constructor_repr : Types.constructor_representation) with
         | Constructor_mixed shapes ->
           List.iter2
             (fun mix_shape { Shape.field_name = _; field_value = _, ly } ->
               let ly2 = mixed_block_shape_to_layout mix_shape in
-              if not (Layout.equal ly ly2)
-              then
+              match ly with
+              | Some ly when not (Layout.equal ly ly2) ->
                 if !Clflags.dwarf_pedantic
                 then
                   Misc.fatal_errorf_doc
                     "Type_shape: variant constructor with mismatched layout, \
                      has %a but expected %a"
                     Layout.format ly Layout.format ly2
-                else ())
+                else ()
+              | _ -> ())
             (Array.to_list shapes) args;
-          Array.map mixed_block_shape_to_layout shapes
+          Array.map
+            (fun mix_shape ->
+              Layout.some (mixed_block_shape_to_layout mix_shape))
+            shapes
         | Constructor_uniform_value ->
           let lys =
             List.map
               (fun { Shape.field_name = _; field_value = _, ly } ->
-                if
-                  not
-                    (Layout.equal ly (Layout.Base Scannable)
-                    || Layout.equal ly (Layout.Base Void))
-                then
+                match ly with
+                | Some ly
+                  when not
+                         (Layout.equal ly (Base Scannable)
+                         || Layout.equal ly (Base Void)) ->
                   if !Clflags.dwarf_pedantic
                   then
                     Misc.fatal_errorf_doc
                       "Type_shape: variant constructor with mismatched layout, \
                        has %a but expected value or void."
                       Layout.format ly
-                  else Layout.Base Scannable
-                else ly)
+                  else Layout.some (Base Scannable)
+                | _ -> ly)
               args
           in
           Array.of_list lys
         | Constructor_variable ->
           Misc.fatal_error
-            "Type_shape: unexpected variable constructor representation"
-      in
-      Some
-        { Shape.name;
-          constr_uid = Some cstr_args.cd_uid;
-          kind = constructor_repr;
+            "Type_shape: unexpected variable constructor representation")
+      | Cstr_layout_variable ->
+        Misc.Stdlib.Array.of_list_map
+          (fun { Shape.field_name = _; field_uid = _; field_value = _, ly } ->
+            ly)
           args
-        }
-    | Cstr_layout_known _, None | Cstr_layout_variable, _ -> None
+    in
+    { Shape.name;
+      constr_uid = Some cstr_args.cd_uid;
+      kind = constructor_repr;
+      args
+    }
 
   let is_empty_constructor_list (cstr_args : Types.constructor_declaration) =
     match cstr_args.cd_args with
@@ -546,17 +547,14 @@ module Type_decl_shape = struct
             List.combine cstr_list (Array.to_list layouts)
           in
           let constructors =
-            Misc.Stdlib.List.map_option
+            List.map
               (fun ((cstr, arg_layouts) : Types.constructor_declaration * _) ->
                 let name = Ident.name cstr.cd_id in
                 of_complex_constructor type_subst name cstr arg_layouts
                   shape_for_constr)
               cstrs_with_layouts
           in
-          begin match constructors with
-          | Some constructors -> Shape.variant constructors
-          | None -> Shape.unknown_type ()
-          end
+          Shape.variant constructors
         | Type_variant ([cstr], Variant_unboxed, _unsafe_mode_crossing)
           when not (is_empty_constructor_list cstr) ->
           let name = Ident.name cstr.cd_id in


### PR DESCRIPTION
A type declaration with an `any` field cannot be given a complete type shape because the field layouts are unknown. This lets a type shape have a layout of `None` for a field, deferring the computation until the shape of an actual value is needed.