### PR TITLE
Quoted areality

### DIFF
--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -100,15 +100,15 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#4[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,quote_global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#4[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#a[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
-          global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          alloc_mode global,quote_global,many,portable,forkable,unyielding,stateful;id(modevar#a[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          global,quote_global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []
           Tfunction_cases (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
-            alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+            alloc_mode global,quote_global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
             value
             [
               <case>
@@ -124,7 +124,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 pattern (test_locations.ml[19,572+4]..test_locations.ml[19,572+5])
                   Tpat_var "n"
                   sort value
-                  value_mode global,many,portable,forkable,unyielding,stateless;unique,uncontended,read_write,dynamic
+                  value_mode global,quote_global,many,portable,forkable,unyielding,stateless;unique,uncontended,read_write,dynamic
                 expression (test_locations.ml[19,572+9]..test_locations.ml[19,572+34])
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dlocations.ocamlc.reference
@@ -100,10 +100,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern (test_locations.ml[17,534+8]..test_locations.ml[17,534+11])
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#4[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression (test_locations.ml[17,534+14]..test_locations.ml[19,572+34])
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#a[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
           global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -100,10 +100,10 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#3[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#4[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#9[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#a[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
           global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []

--- a/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
+++ b/testsuite/tests/formatting/test_locations.dno-locations.ocamlc.reference
@@ -100,15 +100,15 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
         pattern 
           Tpat_var "fib"
           sort value
-          value_mode global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#4[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+          value_mode global,quote_global,many,portable,forkable,unyielding,stateful;meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#4[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
         expression 
           Texp_function
-          alloc_mode global,many,portable,forkable,unyielding,stateful;id(modevar#a[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
-          global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+          alloc_mode global,quote_global,many,portable,forkable,unyielding,stateful;id(modevar#a[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static])
+          global,quote_global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
           []
           []
           Tfunction_cases 
-            alloc_mode global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
+            alloc_mode global,quote_global,many,nonportable,forkable,unyielding,stateful;aliased,uncontended,read_write,dynamic
             value
             [
               <case>
@@ -124,7 +124,7 @@ let rec fib = function | 0 | 1 -> 1 | n -> (fib (n - 1)) + (fib (n - 2))
                 pattern 
                   Tpat_var "n"
                   sort value
-                  value_mode global,many,portable,forkable,unyielding,stateless;unique,uncontended,read_write,dynamic
+                  value_mode global,quote_global,many,portable,forkable,unyielding,stateless;unique,uncontended,read_write,dynamic
                 expression 
                   Texp_apply
                   apply_mode Tail

--- a/testsuite/tests/quotation/typing/magic_staged_modes.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes.ml
@@ -71,16 +71,10 @@ Error: This value is "local" to the parent region
 [%%expect{|
 - : <[$('a) @ local -> unit]> expr = <[fun (x : _ @ local) -> ()]>
 |}];;
-(* however, the mode checks on the capture of [x] remain *)
+(* including the mode checks on the capture of [x] *)
 <[ fun (x @ local) -> $(M.of_global (<[ x ]> [@magic_staged_modes])) ]>
 [%%expect{|
-Line 1, characters 40-41:
-1 | <[ fun (x @ local) -> $(M.of_global (<[ x ]> [@magic_staged_modes])) ]>
-                                            ^
-Error: The value "x" is "local" to the parent region
-       but is expected to be "global"
-         because it is used inside the quoted expression at line 1, characters 36-67
-         which is expected to be "global".
+- : <[$('a) @ local -> unit]> expr = <[fun (x : _ @ local) -> ()]>
 |}];;
 
 (* The attribute is quoted appropriately *)

--- a/testsuite/tests/quotation/typing/magic_staged_modes.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes.ml
@@ -62,10 +62,10 @@ fun x -> <[ M.free ($x [@magic_staged_modes]) ]>
 Line 1, characters 38-39:
 1 | <[ fun (x @ local) -> $(M.of_local <[ x ]>) ]>
                                           ^
-Error: The value "x" is "local" to the parent region
-       but is expected to be "global"
+Error: The value "x" is "quote_regional"
+       but is expected to be "quote_global"
          because it is used inside the quoted expression at line 1, characters 35-42
-         which is expected to be "global".
+         which is expected to be "quote_global".
 |}];;
 (* but we can delay the mode checks on [x] until generation *)
 <[ fun (x @ local) -> $(M.of_local (<[ x ]> [@magic_staged_modes])) ]>

--- a/testsuite/tests/quotation/typing/magic_staged_modes.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes.ml
@@ -62,9 +62,10 @@ fun x -> <[ M.free ($x [@magic_staged_modes]) ]>
 Line 1, characters 38-39:
 1 | <[ fun (x @ local) -> $(M.of_local <[ x ]>) ]>
                                           ^
-Error: This value is "local" to the parent region
+Error: The value "x" is "local" to the parent region
        but is expected to be "global"
-         because it is a quoted expression's result and thus always at the legacy modes.
+         because it is used inside the quoted expression at line 1, characters 35-42
+         which is expected to be "global".
 |}];;
 (* but we can delay the mode checks on [x] until generation *)
 <[ fun (x @ local) -> $(M.of_local (<[ x ]> [@magic_staged_modes])) ]>

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -49,12 +49,24 @@ fun e -> <[ $e ]>
 (* Local spliced expression -- the result should be [local]! *)
 fun (x @ local) -> <[ $x ]>
 [%%expect{|
-- : 'a expr @ local -> 'a expr @ local once = <fun>
+Line 1, characters 23-24:
+1 | fun (x @ local) -> <[ $x ]>
+                           ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 19-27
+         which is expected to be "global".
 |}];;
 
 fun (x @ local) -> <[ Some $x ]>
 [%%expect{|
-- : 'a expr @ local -> <[$('a) option]> expr @ local once = <fun>
+Line 1, characters 28-29:
+1 | fun (x @ local) -> <[ Some $x ]>
+                                ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 19-32
+         which is expected to be "global".
 |}];;
 
 (* Unique spliced expression *)
@@ -124,7 +136,13 @@ val foo : (int -> <[int]> expr) @ local -> <[int]> expr @ once = <fun>
 
 let foo (f : (_ -> _ @ local) @ global) = exclave_ <[ $(f 42) + 1 ]>
 [%%expect{|
-val foo : (int -> <[int]> expr @ local) -> <[int]> expr @ local once = <fun>
+Line 1, characters 55-61:
+1 | let foo (f : (_ -> _ @ local) @ global) = exclave_ <[ $(f 42) + 1 ]>
+                                                           ^^^^^^
+Error: This value is "local"
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 51-68
+         which is expected to be "global".
 |}];;
 
 let foo (f : (_ -> _ @ once) @ global) = <[ fun () -> $(f 42) + 1 ]>
@@ -140,13 +158,19 @@ Line 3, characters 42-48:
 3 | fun (f : _ -> _ @ local) -> <[ fun () -> $(f ()) ]>
                                               ^^^^^^
 Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
+       but is expected to be "global"
          because it is used inside the quoted expression at line 3, characters 28-51
-         which is expected to be "local" to the parent region or "global".
+         which is expected to be "global".
 |}];;
 fun (f : _ -> _ @ local) -> exclave_ <[ fun () -> $(f ()) ]>
 [%%expect{|
-- : (unit -> 'a expr @ local) -> <[unit -> $('a)]> expr @ local = <fun>
+Line 1, characters 51-57:
+1 | fun (f : _ -> _ @ local) -> exclave_ <[ fun () -> $(f ()) ]>
+                                                       ^^^^^^
+Error: This value is "local"
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 37-60
+         which is expected to be "global".
 |}];;
 
 fun (f : _ -> _ @ local) -> <[ Some $(f ()) ]>
@@ -155,26 +179,42 @@ Line 1, characters 37-43:
 1 | fun (f : _ -> _ @ local) -> <[ Some $(f ()) ]>
                                          ^^^^^^
 Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
+       but is expected to be "global"
          because it is used inside the quoted expression at line 1, characters 28-46
-         which is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+         which is expected to be "global".
 |}];;
 fun (f : _ -> _ @ local) -> exclave_ <[ Some $(f ()) ]>
 [%%expect{|
-- : (unit -> 'a expr @ local) -> <[$('a) option]> expr @ local once = <fun>
+Line 1, characters 46-52:
+1 | fun (f : _ -> _ @ local) -> exclave_ <[ Some $(f ()) ]>
+                                                  ^^^^^^
+Error: This value is "local"
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 37-55
+         which is expected to be "global".
 |}];;
 
 (* This is not an identity, but akin to [fun (x @ local) -> Some x],
    so it should error. *)
 fun (e @ local) -> <[ fun () -> $e ]>
 [%%expect{|
-- : 'a expr @ local -> <[unit -> $('a)]> expr @ local = <fun>
+Line 1, characters 33-34:
+1 | fun (e @ local) -> <[ fun () -> $e ]>
+                                     ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 19-37
+         which is expected to be "global".
 |}];;
 fun (e @ local) -> exclave_ <[ fun () -> $e ]>
 [%%expect{|
-- : 'a expr @ local -> <[unit -> $('a)]> expr @ local = <fun>
+Line 1, characters 42-43:
+1 | fun (e @ local) -> exclave_ <[ fun () -> $e ]>
+                                              ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 28-46
+         which is expected to be "global".
 |}];;
 fun (x @ local) -> Some x
 [%%expect{|
@@ -482,7 +522,13 @@ fun e -> <[ fun () -> $e ]>
 (* This quote should be [local], as it is a syntax tree with a [local] subtree. *)
 fun (e @ local) -> <[ fun () -> $e ]>
 [%%expect{|
-- : 'a expr @ local -> <[unit -> $('a)]> expr @ local = <fun>
+Line 1, characters 33-34:
+1 | fun (e @ local) -> <[ fun () -> $e ]>
+                                     ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 19-37
+         which is expected to be "global".
 |}];;
 
 (* Quotes of syntactic values should observably cross [once]ness,

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -41,9 +41,6 @@ module M :
 
 (** Quote captures via splices **)
 
-(* CR quoted-modes jbachurski: Splicing a value should
-   bound the mode of the quote with the value's mode -- not via capture. *)
-
 fun e -> <[ $e ]>
 [%%expect{|
 - : 'a expr -> 'a expr @ once = <fun>
@@ -52,7 +49,12 @@ fun e -> <[ $e ]>
 (* Local spliced expression -- the result should be [local]! *)
 fun (x @ local) -> <[ $x ]>
 [%%expect{|
-- : 'a expr @ local -> 'a expr @ once = <fun>
+- : 'a expr @ local -> 'a expr @ local once = <fun>
+|}];;
+
+fun (x @ local) -> <[ Some $x ]>
+[%%expect{|
+- : 'a expr @ local -> <[$('a) option]> expr @ local once = <fun>
 |}];;
 
 (* Unique spliced expression *)
@@ -120,17 +122,72 @@ let foo (f : (_ -> _ @ global) @ local) = <[ $(f 42) + 1 ]>
 val foo : (int -> <[int]> expr) @ local -> <[int]> expr @ once = <fun>
 |}];;
 
-(* CR quoted-modes: Unsound -- the quote should be [local] like [f]'s return. *)
-let foo (f : (_ -> _ @ local) @ global) = <[ $(f 42) + 1 ]>
+let foo (f : (_ -> _ @ local) @ global) = exclave_ <[ $(f 42) + 1 ]>
 [%%expect{|
-val foo : (int -> <[int]> expr @ local) -> <[int]> expr @ once = <fun>
+val foo : (int -> <[int]> expr @ local) -> <[int]> expr @ local once = <fun>
 |}];;
 
-(* CR quoted-modes: Unsound -- the quote should be [once] like [f]'s return.
-   This one is a bit more annoying since that's probably not what we want with [once]. *)
 let foo (f : (_ -> _ @ once) @ global) = <[ fun () -> $(f 42) + 1 ]>
 [%%expect{|
 val foo : (int -> <[int]> expr @ once) -> <[unit -> int]> expr = <fun>
+|}];;
+
+(** Quotes and exclaves **)
+
+fun (f : _ -> _ @ local) -> <[ fun () -> $(f ()) ]>
+[%%expect{|
+Line 3, characters 42-48:
+3 | fun (f : _ -> _ @ local) -> <[ fun () -> $(f ()) ]>
+                                              ^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is used inside the quoted expression at line 3, characters 28-51
+         which is expected to be "local" to the parent region or "global".
+|}];;
+fun (f : _ -> _ @ local) -> exclave_ <[ fun () -> $(f ()) ]>
+[%%expect{|
+- : (unit -> 'a expr @ local) -> <[unit -> $('a)]> expr @ local = <fun>
+|}];;
+
+fun (f : _ -> _ @ local) -> <[ Some $(f ()) ]>
+[%%expect{|
+Line 1, characters 37-43:
+1 | fun (f : _ -> _ @ local) -> <[ Some $(f ()) ]>
+                                         ^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is used inside the quoted expression at line 1, characters 28-46
+         which is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+|}];;
+fun (f : _ -> _ @ local) -> exclave_ <[ Some $(f ()) ]>
+[%%expect{|
+- : (unit -> 'a expr @ local) -> <[$('a) option]> expr @ local once = <fun>
+|}];;
+
+(* This is not an identity, but akin to [fun (x @ local) -> Some x],
+   so it should error. *)
+fun (e @ local) -> <[ fun () -> $e ]>
+[%%expect{|
+- : 'a expr @ local -> <[unit -> $('a)]> expr @ local = <fun>
+|}];;
+fun (e @ local) -> exclave_ <[ fun () -> $e ]>
+[%%expect{|
+- : 'a expr @ local -> <[unit -> $('a)]> expr @ local = <fun>
+|}];;
+fun (x @ local) -> Some x
+[%%expect{|
+Line 1, characters 24-25:
+1 | fun (x @ local) -> Some x
+                            ^
+Error: This value is "local" to the parent region
+       but is expected to be "global"
+         because it is contained (via constructor "Some") in the value at line 1, characters 19-25
+         which is expected to be "global" because it is an allocation
+         which is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}];;
 
 (** Quoting expressions with non-legacy results **)
@@ -422,14 +479,10 @@ fun e -> <[ fun () -> $e ]>
 - : 'a expr -> <[unit -> $('a)]> expr = <fun>
 |}];;
 
-(* CR quoted-modes jbachurski: the [local] and [once] examples should be accepted.
-   The closure does not actually capture $e, as it is at a negative stage offset.
-   On the other hand, the quote does capture [e] with different results in either case. *)
-
 (* This quote should be [local], as it is a syntax tree with a [local] subtree. *)
 fun (e @ local) -> <[ fun () -> $e ]>
 [%%expect{|
-- : 'a expr @ local -> <[unit -> $('a)]> expr = <fun>
+- : 'a expr @ local -> <[unit -> $('a)]> expr @ local = <fun>
 |}];;
 
 (* Quotes of syntactic values should observably cross [once]ness,

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -5,11 +5,14 @@
 
 #syntax quotations on
 
+let ignore_quote _ = <[()]>
 module M : sig
   type t
   val x : t
   val x_unique : unit -> t @ unique
 
+  (* CR quoted-modes jbachurski: These modes should all be quoted for
+     corresponding tests to be valuable. *)
   val save : 'a @ once global -> unit
   val free : 'a @ once unique -> unit
   val send : 'a @ once portable -> unit
@@ -23,6 +26,7 @@ end = struct
   let send _ = ()
 end
 [%%expect{|
+val ignore_quote : 'a -> <[unit]> expr = <fun>
 module M :
   sig
     type t
@@ -45,10 +49,10 @@ fun e -> <[ $e ]>
 - : 'a expr -> 'a expr @ once = <fun>
 |}];;
 
-(* Local spliced expression *)
+(* Local spliced expression -- the result should be [local]! *)
 fun (x @ local) -> <[ $x ]>
 [%%expect{|
-- : 'a expr @ local -> 'a expr @ local once = <fun>
+- : 'a expr @ local -> 'a expr @ once = <fun>
 |}];;
 
 (* Unique spliced expression *)
@@ -57,7 +61,7 @@ fun (x @ unique) -> <[ $x ]>
 - : 'a expr @ unique -> 'a expr @ once = <fun>
 |}];;
 
-(* Once spliced expression *)
+(* Once spliced expression -- the result should be [once]! *)
 fun (x @ once) -> <[ $x ]>
 [%%expect{|
 - : 'a expr @ once -> 'a expr @ once = <fun>
@@ -111,11 +115,9 @@ Error: This value is "nonportable"
 
 (** Quotes capture spliced values, not computations **)
 
-(* CR quoted-modes: Incomplete -- the quote should be [global] like [f]'s return,
-   and not [local] like [f]. *)
 let foo (f : (_ -> _ @ global) @ local) = <[ $(f 42) + 1 ]>
 [%%expect{|
-val foo : (int -> <[int]> expr) @ local -> <[int]> expr @ local once = <fun>
+val foo : (int -> <[int]> expr) @ local -> <[int]> expr @ once = <fun>
 |}];;
 
 (* CR quoted-modes: Unsound -- the quote should be [local] like [f]'s return. *)
@@ -184,21 +186,23 @@ Error: This value is "contended"
 
 (** Quoting expressions with non-legacy closures **)
 
-(* All of the following examples should error.
-   Quotes in them capture values at non-legacy modes in their closure,
-   and should be given a mode accordingly. *)
+(* CR quoted-modes jbachurski: Without quoted modes, quotes can only capture
+   non-present-stage values at legacy modes.
+   These tests fail as they want to capture a non-legacy mode.
+   For axes that can be quoted the captures will be allowed,
+   and functions in [M] will be amended to include a quoted mode. *)
 
 (* Local in closure *)
 (* The quote <[f x]> is local, as it references x @ local -- should error! *)
 <[let x = stack_ (Some 42) in
   $(M.save <[let _ = x in ()]>; <[()]>)]>
 [%%expect{|
-Line 10, characters 21-22:
-10 |   $(M.save <[let _ = x in ()]>; <[()]>)]>
+Line 12, characters 21-22:
+12 |   $(M.save <[let _ = x in ()]>; <[()]>)]>
                           ^
 Error: The value "x" is "local" because it is "stack_"-allocated.
        However, the value "x" highlighted is expected to be "global"
-         because it is used inside the quoted expression at line 10, characters 11-30
+         because it is used inside the quoted expression at line 12, characters 11-30
          which is expected to be "global".
 |}];;
 
@@ -411,7 +415,7 @@ let x = <[1 + 1]> in let x, y = Quote.duplicate x in <[$x + $y]>
 - : <[int]> expr = <[(1 + 1) + (1 + 1)]>
 |}];;
 
-(** Quote captures with inner closure captures **)
+(** Quotes with inner closure captures of splices **)
 
 fun e -> <[ fun () -> $e ]>
 [%%expect{|
@@ -422,30 +426,17 @@ fun e -> <[ fun () -> $e ]>
    The closure does not actually capture $e, as it is at a negative stage offset.
    On the other hand, the quote does capture [e] with different results in either case. *)
 
-(* This quote should be [local], as it is a syntax tree pointing to a [local] syntax tree. *)
+(* This quote should be [local], as it is a syntax tree with a [local] subtree. *)
 fun (e @ local) -> <[ fun () -> $e ]>
 [%%expect{|
-Line 1, characters 33-34:
-1 | fun (e @ local) -> <[ fun () -> $e ]>
-                                     ^
-Error: The value "e" is "local" to the parent region
-       but is expected to be "global"
-         because it is used inside the function at line 1, characters 22-34
-         which is expected to be "global"
-         because it is a quoted expression's result and thus always at the legacy modes.
+- : 'a expr @ local -> <[unit -> $('a)]> expr = <fun>
 |}];;
 
-(* Quotes of syntactic values observably cross [once]ness, so this should be [many]. *)
+(* Quotes of syntactic values should observably cross [once]ness,
+   so this should be [many] even though it captures [e @ once]. *)
 fun (e @ once) -> <[ fun () -> $e ]>
 [%%expect{|
-Line 1, characters 32-33:
-1 | fun (e @ once) -> <[ fun () -> $e ]>
-                                    ^
-Error: The value "e" is "once"
-       but is expected to be "many"
-         because it is used inside the function at line 1, characters 21-33
-         which is expected to be "many"
-         because it is a quoted expression's result and thus always at the legacy modes.
+- : 'a expr @ once -> <[unit -> $('a)]> expr = <fun>
 |}];;
 
 fun (e @ unique) -> <[ fun () -> $e ]>
@@ -475,12 +466,54 @@ end = struct
   let quote_thunk (e @ once) = <[ fun () -> $e ]>
 end
 [%%expect{|
-Line 4, characters 45-46:
-4 |   let quote_thunk (e @ once) = <[ fun () -> $e ]>
-                                                 ^
+module M : sig val quote_thunk : 'a expr @ once -> <[unit -> $('a)]> expr end
+|}];;
+
+(** Splices with inner closure captures of quotes **)
+
+<[ fun e -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+[%%expect{|
+- : <[$('a) -> unit]> expr = <[fun e -> ()]>
+|}];;
+
+<[ fun (e @ local) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+[%%expect{|
+Line 1, characters 58-59:
+1 | <[ fun (e @ local) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+                                                              ^
+Error: The value "e" is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the function at line 1, characters 32-61
+         which is expected to be "global".
+|}];;
+
+<[ fun (e @ once) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+[%%expect{|
+Line 1, characters 57-58:
+1 | <[ fun (e @ once) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+                                                             ^
 Error: The value "e" is "once"
        but is expected to be "many"
-         because it is used inside the function at line 4, characters 34-46
-         which is expected to be "many"
-         because it is a quoted expression's result and thus always at the legacy modes.
+         because it is used inside the function at line 1, characters 31-60
+         which is expected to be "many".
+|}];;
+<[ fun (e @ unique) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+
+[%%expect{|
+- : <[$('a) @ unique -> unit]> expr = <[fun (e : _ @ unique) -> ()]>
+|}];;
+<[ fun (e @ portable) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+
+[%%expect{|
+- : <[$('a) @ portable -> unit]> expr = <[fun (e : _ @ portable) -> ()]>
+|}];;
+
+<[ fun (e @ shared) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+[%%expect{|
+- : <[$('a) @ shared -> unit]> expr = <[fun (e : _ @ shared) -> ()]>
+|}];;
+
+<[ fun (e @ uncontended) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
+[%%expect{|
+- : <[$('a) -> unit]> expr = <[fun (e : _ @ uncontended) -> ()]>
 |}];;

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -10,9 +10,9 @@ module M : sig
   val x : t
   val x_unique : unit -> t @ unique
 
-  val save : 'a @ global -> unit
-  val free : 'a @ unique -> unit
-  val send : 'a @ portable -> unit
+  val save : 'a @ once global -> unit
+  val free : 'a @ once unique -> unit
+  val send : 'a @ once portable -> unit
 end = struct
   type t = string
   let x = "default"
@@ -28,9 +28,9 @@ module M :
     type t
     val x : t
     val x_unique : unit -> t @ unique
-    val save : 'a -> unit
-    val free : 'a @ unique -> unit
-    val send : 'a @ portable -> unit
+    val save : 'a @ once -> unit
+    val free : 'a @ unique once -> unit
+    val send : 'a @ once portable -> unit
   end
 |}]
 #mark_toplevel_in_quotations;;
@@ -388,8 +388,9 @@ let x () = <[1 + 1]> in <[$(x ()) + $(x ())]>
 ]>
 |}];;
 
-(* We associate that quotes are [once] iff they are syntactic values.
-   Here, we can exploit this mode-based reasoning concluding the quote is once iff [e] is. *)
+(* We associate that quotes are [once] if they are syntactic computations.
+   Here, the quote is a syntactic computation if [e] is a syntactic computation,
+   so if it is a syntactic computation then [e] is [once].  *)
 
 (* CR quoted-modes jbachurski: The result should be [many] --
    the quote is a syntactic value iff [e] is. *)

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -35,14 +35,17 @@ module M :
 |}]
 #mark_toplevel_in_quotations;;
 
-(** Splicing non-legacy expressions **)
+(** Quote captures via splices **)
 
-(* We require the spliced expression to be at legacy.
-   Thus, local/once/contended fail, as they are
-   above legacy (global/many/uncontended).
-   The other cases pass. *)
+(* CR quoted-modes jbachurski: Splicing a value should
+   bound the mode of the quote with the value's mode -- not via capture. *)
 
-(* Local spliced expression -- should error! *)
+fun e -> <[ $e ]>
+[%%expect{|
+- : 'a expr -> 'a expr @ once = <fun>
+|}];;
+
+(* Local spliced expression *)
 fun (x @ local) -> <[ $x ]>
 [%%expect{|
 - : 'a expr @ local -> 'a expr @ local once = <fun>
@@ -80,6 +83,9 @@ fun x -> <[ $x ]>
 - : 'a expr -> 'a expr @ once = <fun>
 |}];;
 
+(* CR quoted-modes jbachurski: The following examples will be allowed with
+   mode-indexed [expr]. *)
+
 (* Non-unique result of splicing *)
 fun x -> <[ M.free $x ]>
 [%%expect{|
@@ -100,6 +106,29 @@ Line 1, characters 19-21:
 Error: This value is "nonportable"
          because it is a quoted expression's result and thus always at the legacy modes.
        However, the highlighted expression is expected to be "portable".
+|}];;
+
+
+(** Quotes capture spliced values, not computations **)
+
+(* CR quoted-modes: Incomplete -- the quote should be [global] like [f]'s return,
+   and not [local] like [f]. *)
+let foo (f : (_ -> _ @ global) @ local) = <[ $(f 42) + 1 ]>
+[%%expect{|
+val foo : (int -> <[int]> expr) @ local -> <[int]> expr @ local once = <fun>
+|}];;
+
+(* CR quoted-modes: Unsound -- the quote should be [local] like [f]'s return. *)
+let foo (f : (_ -> _ @ local) @ global) = <[ $(f 42) + 1 ]>
+[%%expect{|
+val foo : (int -> <[int]> expr @ local) -> <[int]> expr @ once = <fun>
+|}];;
+
+(* CR quoted-modes: Unsound -- the quote should be [once] like [f]'s return.
+   This one is a bit more annoying since that's probably not what we want with [once]. *)
+let foo (f : (_ -> _ @ once) @ global) = <[ fun () -> $(f 42) + 1 ]>
+[%%expect{|
+val foo : (int -> <[int]> expr @ once) -> <[unit -> int]> expr = <fun>
 |}];;
 
 (** Quoting expressions with non-legacy results **)
@@ -193,18 +222,17 @@ Line 3, characters 7-8:
 (* Once in closure *)
 (* The quote <[x (); 2]> is once, as it references x @ once -- should error! *)
 <[let x @ once = fun () -> () in
-  $(let y = <[x (); 2]> in
-    <[$y + $y]>)]>
+  $(let y = <[fun () -> x (); 2]> in
+    <[$(y ()) + $(y ())]>)]>
 [%%expect{|
-Line 3, characters 12-13:
-3 |     <[$y + $y]>)]>
-                ^
-Error: This value is used here,
-       but it is defined as once and is also being used at:
-Line 3, characters 7-8:
-3 |     <[$y + $y]>)]>
-           ^
-
+Line 2, characters 24-25:
+2 |   $(let y = <[fun () -> x (); 2]> in
+                            ^
+Error: The value "x" is "once"
+       but is expected to be "many"
+         because it is used inside the function at line 2, characters 14-31
+         which is expected to be "many"
+         because it is a quoted expression's result and thus always at the legacy modes.
 |}];;
 
 (* Uncontended in closure *)
@@ -360,9 +388,98 @@ let x () = <[1 + 1]> in <[$(x ()) + $(x ())]>
 ]>
 |}];;
 
+(* We associate that quotes are [once] iff they are syntactic values.
+   Here, we can exploit this mode-based reasoning concluding the quote is once iff [e] is. *)
+
+(* CR quoted-modes jbachurski: The result should be [many] --
+   the quote is a syntactic value iff [e] is. *)
+fun (e @ many) -> <[ Some $e ]>
+[%%expect{|
+- : 'a expr -> <[$('a) option]> expr @ once = <fun>
+|}];;
+
+fun (e @ once) -> <[ Some $e ]>
+[%%expect{|
+- : 'a expr @ once -> <[$('a) option]> expr @ once = <fun>
+|}];;
+
 (** Duplication of [once] quotes *)
 
 let x = <[1 + 1]> in let x, y = Quote.duplicate x in <[$x + $y]>
 [%%expect{|
 - : <[int]> expr = <[(1 + 1) + (1 + 1)]>
+|}];;
+
+(** Quote captures with inner closure captures **)
+
+fun e -> <[ fun () -> $e ]>
+[%%expect{|
+- : 'a expr -> <[unit -> $('a)]> expr = <fun>
+|}];;
+
+(* CR quoted-modes jbachurski: the [local] and [once] examples should be accepted.
+   The closure does not actually capture $e, as it is at a negative stage offset.
+   On the other hand, the quote does capture [e] with different results in either case. *)
+
+(* This quote should be [local], as it is a syntax tree pointing to a [local] syntax tree. *)
+fun (e @ local) -> <[ fun () -> $e ]>
+[%%expect{|
+Line 1, characters 33-34:
+1 | fun (e @ local) -> <[ fun () -> $e ]>
+                                     ^
+Error: The value "e" is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the function at line 1, characters 22-34
+         which is expected to be "global"
+         because it is a quoted expression's result and thus always at the legacy modes.
+|}];;
+
+(* Quotes of syntactic values observably cross [once]ness, so this should be [many]. *)
+fun (e @ once) -> <[ fun () -> $e ]>
+[%%expect{|
+Line 1, characters 32-33:
+1 | fun (e @ once) -> <[ fun () -> $e ]>
+                                    ^
+Error: The value "e" is "once"
+       but is expected to be "many"
+         because it is used inside the function at line 1, characters 21-33
+         which is expected to be "many"
+         because it is a quoted expression's result and thus always at the legacy modes.
+|}];;
+
+fun (e @ unique) -> <[ fun () -> $e ]>
+[%%expect{|
+- : 'a expr @ unique -> <[unit -> $('a)]> expr = <fun>
+|}];;
+
+fun (e @ portable) -> <[ fun () -> $e ]>
+[%%expect{|
+- : 'a expr @ portable -> <[unit -> $('a)]> expr = <fun>
+|}];;
+
+fun (e @ shared) -> <[ fun () -> $e ]>
+[%%expect{|
+- : 'a expr @ shared -> <[unit -> $('a)]> expr = <fun>
+|}];;
+
+fun (e @ uncontended) -> <[ fun () -> $e ]>
+[%%expect{|
+- : 'a expr -> <[unit -> $('a)]> expr = <fun>
+|}];;
+
+(* CR quoted-modes jbachurski: This should be accepted. *)
+module M : sig
+  val quote_thunk : 'a expr @ once -> <[unit -> $'a]> expr
+end = struct
+  let quote_thunk (e @ once) = <[ fun () -> $e ]>
+end
+[%%expect{|
+Line 4, characters 45-46:
+4 |   let quote_thunk (e @ once) = <[ fun () -> $e ]>
+                                                 ^
+Error: The value "e" is "once"
+       but is expected to be "many"
+         because it is used inside the function at line 4, characters 34-46
+         which is expected to be "many"
+         because it is a quoted expression's result and thus always at the legacy modes.
 |}];;

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -52,7 +52,7 @@ fun (x @ local) -> <[ $x ]>
 Line 1, characters 23-24:
 1 | fun (x @ local) -> <[ $x ]>
                            ^
-Error: This value is "local" to the parent region
+Error: The value "x" is "local" to the parent region
        but is expected to be "global"
          because it is used inside the quoted expression at line 1, characters 19-27
          which is expected to be "global".
@@ -63,7 +63,7 @@ fun (x @ local) -> <[ Some $x ]>
 Line 1, characters 28-29:
 1 | fun (x @ local) -> <[ Some $x ]>
                                 ^
-Error: This value is "local" to the parent region
+Error: The value "x" is "local" to the parent region
        but is expected to be "global"
          because it is used inside the quoted expression at line 1, characters 19-32
          which is expected to be "global".
@@ -131,7 +131,13 @@ Error: This value is "nonportable"
 
 let foo (f : (_ -> _ @ global) @ local) = <[ $(f 42) + 1 ]>
 [%%expect{|
-val foo : (int -> <[int]> expr) @ local -> <[int]> expr @ once = <fun>
+Line 3, characters 47-48:
+3 | let foo (f : (_ -> _ @ global) @ local) = <[ $(f 42) + 1 ]>
+                                                   ^
+Error: The value "f" is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 3, characters 42-59
+         which is expected to be "global".
 |}];;
 
 let foo (f : (_ -> _ @ local) @ global) = exclave_ <[ $(f 42) + 1 ]>
@@ -201,7 +207,7 @@ fun (e @ local) -> <[ fun () -> $e ]>
 Line 1, characters 33-34:
 1 | fun (e @ local) -> <[ fun () -> $e ]>
                                      ^
-Error: This value is "local" to the parent region
+Error: The value "e" is "local" to the parent region
        but is expected to be "global"
          because it is used inside the quoted expression at line 1, characters 19-37
          which is expected to be "global".
@@ -211,7 +217,7 @@ fun (e @ local) -> exclave_ <[ fun () -> $e ]>
 Line 1, characters 42-43:
 1 | fun (e @ local) -> exclave_ <[ fun () -> $e ]>
                                               ^
-Error: This value is "local" to the parent region
+Error: The value "e" is "local"
        but is expected to be "global"
          because it is used inside the quoted expression at line 1, characters 28-46
          which is expected to be "global".
@@ -297,10 +303,10 @@ Error: This value is "contended"
 Line 12, characters 21-22:
 12 |   $(M.save <[let _ = x in ()]>; <[()]>)]>
                           ^
-Error: The value "x" is "local" because it is "stack_"-allocated.
-       However, the value "x" highlighted is expected to be "global"
+Error: The value "x" is "quote_local"
+       but is expected to be "quote_global"
          because it is used inside the quoted expression at line 12, characters 11-30
-         which is expected to be "global".
+         which is expected to be "quote_global".
 |}];;
 
 (* Unique in closure *)
@@ -344,10 +350,10 @@ Error: The value "x" is "once"
 Line 2, characters 13-14:
 2 |   $(M.send <[x := 0]>; <[!x]>)]>
                  ^
-Error: This value is "contended"
+Error: The value "x" is "nonportable"
+       but is expected to be "portable"
          because it is used inside the quoted expression at line 2, characters 11-21
          which is expected to be "portable".
-       However, the highlighted expression is expected to be "uncontended".
 |}];;
 
 (* Nonportable in closure *)
@@ -360,9 +366,7 @@ Line 3, characters 13-14:
 3 |   $(M.send <[f ()]>; <[()]>)]>
                  ^
 Error: The value "f" is "nonportable"
-         because it contains a usage (of the value "x" at line 2, characters 20-21)
-         which is expected to be "uncontended".
-       However, the value "f" highlighted is expected to be "portable"
+       but is expected to be "portable"
          because it is used inside the quoted expression at line 3, characters 11-19
          which is expected to be "portable".
 |}];;
@@ -525,7 +529,7 @@ fun (e @ local) -> <[ fun () -> $e ]>
 Line 1, characters 33-34:
 1 | fun (e @ local) -> <[ fun () -> $e ]>
                                      ^
-Error: This value is "local" to the parent region
+Error: The value "e" is "local" to the parent region
        but is expected to be "global"
          because it is used inside the quoted expression at line 1, characters 19-37
          which is expected to be "global".
@@ -577,32 +581,20 @@ module M : sig val quote_thunk : 'a expr @ once -> <[unit -> $('a)]> expr end
 
 <[ fun (e @ local) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
 [%%expect{|
-Line 1, characters 58-59:
-1 | <[ fun (e @ local) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
-                                                              ^
-Error: The value "e" is "local" to the parent region
-       but is expected to be "global"
-         because it is used inside the function at line 1, characters 32-61
-         which is expected to be "global".
+- : <[$('a) @ local -> unit]> expr = <[fun (e : _ @ local) -> ()]>
 |}];;
 
 <[ fun (e @ once) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
 [%%expect{|
-Line 1, characters 57-58:
-1 | <[ fun (e @ once) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
-                                                             ^
-Error: The value "e" is "once"
-       but is expected to be "many"
-         because it is used inside the function at line 1, characters 31-60
-         which is expected to be "many".
+- : <[$('a) @ once -> unit]> expr = <[fun (e : _ @ once) -> ()]>
 |}];;
-<[ fun (e @ unique) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
 
+<[ fun (e @ unique) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
 [%%expect{|
 - : <[$('a) @ unique -> unit]> expr = <[fun (e : _ @ unique) -> ()]>
 |}];;
-<[ fun (e @ portable) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
 
+<[ fun (e @ portable) -> $(let _ = fun () -> <[(fun _ -> ()) e]> in <[()]>) ]>
 [%%expect{|
 - : <[$('a) @ portable -> unit]> expr = <[fun (e : _ @ portable) -> ()]>
 |}];;

--- a/testsuite/tests/quotation/typing/moding_quote_local.ml
+++ b/testsuite/tests/quotation/typing/moding_quote_local.ml
@@ -15,16 +15,23 @@ val f : 'a @ local quote_local -> 'a @ local quote_local = <fun>
 
 let set r (x @ quote_local) = r := x
 [%%expect{|
-val set : 'a ref @ quote_local -> 'a @ quote_local -> unit @ quote_local =
-  <fun>
+Line 1, characters 35-36:
+1 | let set r (x @ quote_local) = r := x
+                                       ^
+Error: This value is "quote_local" but is expected to be "quote_global".
 |}];;
 
 exception Extrusion of <[int]> expr
 let extrude (x @ quote_local) = try raise (Extrusion x) with Extrusion x -> x
 [%%expect{|
 exception Extrusion of <[int]> expr
-val extrude : <[int]> expr @ quote_local -> <[int]> expr @ quote_local =
-  <fun>
+Line 2, characters 53-54:
+2 | let extrude (x @ quote_local) = try raise (Extrusion x) with Extrusion x -> x
+                                                         ^
+Error: This value is "quote_local"
+       but is expected to be "quote_global"
+         because it is contained (via constructor "Extrusion") in the value at line 2, characters 42-55
+         which is expected to be "quote_global".
 |}];;
 
 (* Lower-stage local captures are <[local]> *)
@@ -44,8 +51,13 @@ Error: The value "x" is "local" to the parent region
 (* infers that [g] accepts a <[local]> *)
 let f g = <[ fun (x @ local) -> $(g <[ x ]>) ]>
 [%%expect{|
-Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
-
+Line 1, characters 39-40:
+1 | let f g = <[ fun (x @ local) -> $(g <[ x ]>) ]>
+                                           ^
+Error: The value "x" is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 36-43
+         which is expected to be "global".
 |}];;
 
 (* Higher-stage <[local]> captures are local *)
@@ -53,8 +65,7 @@ Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality
 (* error: <[x]> is quote_local *)
 let f (x @ quote_local) = <[ fun () -> $x ]>
 [%%expect{|
-Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
-
+val f : 'a expr @ quote_local -> <[unit -> $('a)]> expr @ quote_local = <fun>
 |}];;
 
 (* Splice captures cross quoted modes like <[local]> *)
@@ -62,13 +73,14 @@ Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality
 (* <[local]> crossed, only [g] is captured by the quote *)
 let f (g : unit -> 'a expr @ quote_local) = <[ $(g ()) ]>
 [%%expect{|
-Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
-
+val f :
+  ('a : any). (unit -> 'a expr @ quote_local) -> 'a expr @ quote_local once =
+  <fun>
 |}];;
 
 (* [x] is captured by the quote and its mode is taken *)
 let f (x @ quote_local) = <[ $x ]>
 [%%expect{|
-Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
-
+val f : ('a : any). 'a expr @ quote_local -> 'a expr @ quote_local once =
+  <fun>
 |}];;

--- a/testsuite/tests/quotation/typing/moding_quote_local.ml
+++ b/testsuite/tests/quotation/typing/moding_quote_local.ml
@@ -1,0 +1,74 @@
+(* TEST
+ flags = "-extension runtime_metaprogramming";
+ expect;
+*)
+
+#syntax quotations on
+
+(* local is different from <[local]> *)
+let f (x @ local quote_local) = x
+[%%expect{|
+val f : 'a @ local quote_local -> 'a @ local quote_local = <fun>
+|}];;
+
+(* The ambient state monad requires <[global]> *)
+
+let set r (x @ quote_local) = r := x
+[%%expect{|
+val set : 'a ref @ quote_local -> 'a @ quote_local -> unit @ quote_local =
+  <fun>
+|}];;
+
+exception Extrusion of <[int]> expr
+let extrude (x @ quote_local) = try raise (Extrusion x) with Extrusion x -> x
+[%%expect{|
+exception Extrusion of <[int]> expr
+val extrude : <[int]> expr @ quote_local -> <[int]> expr @ quote_local =
+  <fun>
+|}];;
+
+(* Lower-stage local captures are <[local]> *)
+
+(* error: <[x]> is quote_local *)
+let e = <[ fun (x @ local) -> $((<[ x ]> :@ quote_global)) ]>
+[%%expect{|
+Line 1, characters 36-37:
+1 | let e = <[ fun (x @ local) -> $((<[ x ]> :@ quote_global)) ]>
+                                        ^
+Error: The value "x" is "local" to the parent region
+       but is expected to be "global"
+         because it is used inside the quoted expression at line 1, characters 33-40
+         which is expected to be "global".
+|}];;
+
+(* infers that [g] accepts a <[local]> *)
+let f g = <[ fun (x @ local) -> $(g <[ x ]>) ]>
+[%%expect{|
+Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
+
+|}];;
+
+(* Higher-stage <[local]> captures are local *)
+
+(* error: <[x]> is quote_local *)
+let f (x @ quote_local) = <[ fun () -> $x ]>
+[%%expect{|
+Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
+
+|}];;
+
+(* Splice captures cross quoted modes like <[local]> *)
+
+(* <[local]> crossed, only [g] is captured by the quote *)
+let f (g : unit -> 'a expr @ quote_local) = <[ $(g ()) ]>
+[%%expect{|
+Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
+
+|}];;
+
+(* [x] is captured by the quote and its mode is taken *)
+let f (x @ quote_local) = <[ $x ]>
+[%%expect{|
+Uncaught exception: Failure("CR quoted-modes jbachurski: Locality_full; Locality_splice_and_full")
+
+|}];;

--- a/testsuite/tests/quotation/typing/moding_quote_local.ml
+++ b/testsuite/tests/quotation/typing/moding_quote_local.ml
@@ -5,6 +5,22 @@
 
 #syntax quotations on
 
+(* Main example: cross-stage accesses and [local]/[quote_local] matter *)
+(* CR quoted-modes jbachurski: Splices should constrain  modulo quoted modes. *)
+(* CR quoted-modes jbachurski: [Region_lock]/[Exclave_lock] should be staged. *)
+let ignore = <[ fun (_ @ local) -> () ]>
+let foo f = <[ fun (x @ local) -> $(f (<[$ignore x]>)) ]>
+let bar f (x @ quote_local) = <[$f (fun () -> $x)]>
+[%%expect{|
+val ignore : <[$('a) @ local -> unit]> expr = <[fun (_ : _ @ local) -> ()]>
+val foo :
+  (<[unit]> expr @ quote_regional once -> 'a expr) ->
+  <[$('b) @ local -> $('a)]> expr = <fun>
+val bar :
+  <[(unit -> $('a)) @ local -> $('b)]> expr ->
+  'a expr @ quote_local -> 'b expr @ quote_local once = <fun>
+|}];;
+
 (* local is different from <[local]> *)
 let f (x @ local quote_local) = x
 [%%expect{|

--- a/testsuite/tests/quotation/typing/moding_quote_local.ml
+++ b/testsuite/tests/quotation/typing/moding_quote_local.ml
@@ -36,36 +36,46 @@ Error: This value is "quote_local"
 
 (* Lower-stage local captures are <[local]> *)
 
-(* error: <[x]> is quote_local *)
-let e = <[ fun (x @ local) -> $((<[ x ]> :@ quote_global)) ]>
+let ignore = <[ fun (_ @ local) -> () ]>
 [%%expect{|
-Line 1, characters 36-37:
-1 | let e = <[ fun (x @ local) -> $((<[ x ]> :@ quote_global)) ]>
-                                        ^
-Error: The value "x" is "local" to the parent region
-       but is expected to be "global"
-         because it is used inside the quoted expression at line 1, characters 33-40
-         which is expected to be "global".
+val ignore : <[$('a) @ local -> unit]> expr = <[fun (_ : _ @ local) -> ()]>
+|}];;
+
+(* error: <[x]> is quote_local *)
+let e = <[ fun (x @ local) -> $((<[ $ignore x ]> :@ quote_global)) ]>
+[%%expect{|
+Line 1, characters 44-45:
+1 | let e = <[ fun (x @ local) -> $((<[ $ignore x ]> :@ quote_global)) ]>
+                                                ^
+Error: The value "x" is "quote_regional"
+       but is expected to be "quote_global"
+         because it is used inside the quoted expression at line 1, characters 33-48
+         which is expected to be "quote_global"
+         because it is used inside the quoted expression at line 1, characters 8-69
+         which is expected to be "quote_global".
 |}];;
 
 (* infers that [g] accepts a <[local]> *)
-let f g = <[ fun (x @ local) -> $(g <[ x ]>) ]>
+let f g = <[ fun (x @ local) -> $(g <[ $ignore x ]>) ]>
 [%%expect{|
-Line 1, characters 39-40:
-1 | let f g = <[ fun (x @ local) -> $(g <[ x ]>) ]>
-                                           ^
-Error: The value "x" is "local" to the parent region
-       but is expected to be "global"
-         because it is used inside the quoted expression at line 1, characters 36-43
-         which is expected to be "global".
+val f :
+  (<[unit]> expr @ quote_regional once -> 'a expr) ->
+  <[$('b) @ local -> $('a)]> expr = <fun>
 |}];;
 
 (* Higher-stage <[local]> captures are local *)
 
-(* error: <[x]> is quote_local *)
+(* <[x]> is quote_local, so the quoted closure is local *)
 let f (x @ quote_local) = <[ fun () -> $x ]>
 [%%expect{|
-val f : 'a expr @ quote_local -> <[unit -> $('a)]> expr @ quote_local = <fun>
+Line 1, characters 40-41:
+1 | let f (x @ quote_local) = <[ fun () -> $x ]>
+                                            ^
+Error: The value "x" is "local"
+       but is expected to be "global"
+         because it is used inside the function at line 1, characters 29-41
+         which is expected to be "global"
+         because it is a quoted expression's result and thus always at the legacy modes.
 |}];;
 
 (* Splice captures cross quoted modes like <[local]> *)

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_typing_impl.compilers.reference
@@ -8,17 +8,17 @@
         core_type (stop_after_typing_impl.ml[13,365+16]..stop_after_typing_impl.ml[13,365+19])
           Ttyp_constr "int!"
           []
-        global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
+        global,quote_global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
         []
         core_type (stop_after_typing_impl.ml[13,365+23]..stop_after_typing_impl.ml[13,365+26])
           Ttyp_constr "int!"
           []
-        global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
+        global,quote_global,many,nonportable,forkable,unyielding,stateful,aliased,uncontended,read_write,dynamic
         []
       [
         "%apply"
       ]
-      None,None,None,None,None,None,None,None,None,None
+      None,None,None,None,None,None,None,None,None,None,None
       []
 ]
 

--- a/testsuite/tests/typedtree/module_presence.ml
+++ b/testsuite/tests/typedtree/module_presence.ml
@@ -60,7 +60,7 @@ module type T = sig module Y = X end
               module_type
                 Tmty_alias "X/290"
         ]
-        join_const(unique,uncontended,read_write,static);meet_const(local,once,nonportable,unforkable,yielding,stateful)
+        join_const(unique,uncontended,read_write,static);meet_const(local,quote_local,once,nonportable,unforkable,yielding,stateful)
         []
 ]
 

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -1441,7 +1441,7 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod portable)"
-       The kind of <  > is value non_float mod global many
+       The kind of <  > is value non_float mod global quote_global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod portable
          because of the annotation on the wildcard _ at line 1, characters 19-37.
@@ -1454,7 +1454,7 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod contended)"
-       The kind of <  > is value non_float mod global many
+       The kind of <  > is value non_float mod global quote_global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod contended
          because of the annotation on the wildcard _ at line 1, characters 19-38.
@@ -1467,7 +1467,7 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod external_)"
-       The kind of <  > is value non_float mod global many
+       The kind of <  > is value non_float mod global quote_global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod external_
          because of the annotation on the wildcard _ at line 1, characters 19-38.

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -1441,7 +1441,7 @@ Line 1, characters 42-52:
                                               ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod portable)"
-       The kind of <  > is value non_float mod global many
+       The kind of <  > is value non_float mod global quote_global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod portable
          because of the annotation on the wildcard _ at line 1, characters 19-37.
@@ -1454,7 +1454,7 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod contended)"
-       The kind of <  > is value non_float mod global many
+       The kind of <  > is value non_float mod global quote_global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod contended
          because of the annotation on the wildcard _ at line 1, characters 19-38.
@@ -1467,7 +1467,7 @@ Line 1, characters 43-53:
                                                ^^^^^^^^^^
 Error: This expression has type "<  >" but an expression was expected of type
          "('a : value mod external_)"
-       The kind of <  > is value non_float mod global many
+       The kind of <  > is value non_float mod global quote_global many
          because it's the type of an object.
        But the kind of <  > must be a subkind of value mod external_
          because of the annotation on the wildcard _ at line 1, characters 19-38.

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
@@ -15,7 +15,9 @@ type t : value non_float mod forkable unyielding many stateless immutable
 
 type t : immediate
 [%%expect {|
-type t : value non_pointer mod global many stateless immutable external_
+type t
+  : value non_pointer
+      mod global quote_global many stateless immutable external_
 |}]
 
 type t : float64

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity2.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity2.ml
@@ -24,6 +24,7 @@ type t
           portable
           contended
           local
+          quote_local
           unique
           static
           internal
@@ -34,6 +35,7 @@ type t : immediate
 type t
   : value non_pointer non_null
       mod global
+          quote_global
           many
           stateless
           immutable
@@ -52,6 +54,7 @@ type t
   : float64
       mod external_
           local
+          quote_local
           unforkable
           yielding
           once
@@ -68,6 +71,7 @@ type t : any
 type t
   : any
       mod local
+          quote_local
           unforkable
           yielding
           once
@@ -86,6 +90,7 @@ type t
   : value separable non_null
       mod portable
           local
+          quote_local
           unforkable
           yielding
           once
@@ -104,6 +109,7 @@ type t
       mod stateless
           portable
           local
+          quote_local
           unforkable
           yielding
           once
@@ -126,6 +132,7 @@ type 'a t
           portable
           contended
           local
+          quote_local
           unique
           static
           internal
@@ -144,6 +151,7 @@ type ('a
              portable
              contended
              local
+             quote_local
              unique
              static
              internal)
@@ -157,6 +165,7 @@ type ('a
          mod stateless
              portable
              local
+             quote_local
              unforkable
              yielding
              once
@@ -175,6 +184,7 @@ type 'a t
       mod portable
           external_
           local
+          quote_local
           unforkable
           yielding
           once
@@ -192,6 +202,7 @@ type 'a t
   : value separable non_null
       mod external_
           local
+          quote_local
           unforkable
           yielding
           once
@@ -215,6 +226,7 @@ type 'a t
           portable
           contended
           local
+          quote_local
           unique
           static
           internal

--- a/testsuite/tests/typing-modes/test_morph_compose.ml
+++ b/testsuite/tests/typing-modes/test_morph_compose.ml
@@ -4,7 +4,7 @@
 *)
 
 let () =
-  Mode.For_testing.check_composition_jobs ~full:true ()
+  Mode.For_testing.check_composition_jobs ~full:false ()
   |> List.iter (fun job ->
     match job () with
     | Ok () -> ()

--- a/testsuite/tests/typing-modes/test_morph_compose.ml
+++ b/testsuite/tests/typing-modes/test_morph_compose.ml
@@ -4,7 +4,7 @@
 *)
 
 let () =
-  Mode.For_testing.check_composition_jobs ~full:false ()
+  Mode.For_testing.check_composition_jobs ~full:true ()
   |> List.iter (fun job ->
     match job () with
     | Ok () -> ()

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -63,6 +63,7 @@ let axis_shapes =
     (fun (Pack axis) ->
       match axis with
       | Modal (Comonadic Areality) -> Chain3
+      | Modal (Comonadic ArealityQuoted) -> Chain3
       | Modal (Monadic Uniqueness) -> Chain2
       | Modal (Comonadic Linearity) -> Chain2
       | Modal (Monadic Contention) -> Diamond4

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -190,7 +190,7 @@ let partition_locks locks =
     (function | Stage_lock lock -> Left lock | Nonstage_lock lock -> Right lock)
     locks
 
-type locks = lock list
+type locks = lock_or_stage list
 
 type summary =
     Env_empty
@@ -3547,9 +3547,8 @@ let assert_does_not_cross_quotation ~loc_use ~loc_def env path locks =
         (Location.Doc.loc ~capitalize_first:false) loc_use
 
 let locks_for_pers_mod ~loc_use ~loc_def env path =
-  let stage_locks, locks =
-    partition_locks (IdTbl.get_all_locks env.modules)
-  in
+  let locks = IdTbl.get_all_locks env.modules in
+  let stage_locks, _nonstage_locks = partition_locks locks in
   (* Tripwire: persistent paths are toplevel-scoped, so this should never
      fire. *)
   assert_does_not_cross_quotation env ~loc_use ~loc_def path stage_locks;
@@ -3693,7 +3692,7 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
   let path, locks, data =
     match find_name_module ~mark:use ~stage:env.stage s env.modules with
     | path, locks, data -> begin
-        let stage_locks, locks = partition_locks locks in
+        let stage_locks, _nonstage_locks = partition_locks locks in
         check_cross_quotation ~errors ~loc_use:loc ~loc_def:Location.none env
           path (Lident s) stage_locks;
         path, locks, data
@@ -3804,19 +3803,39 @@ let unboxed_type ~errors ~env ~loc ty_and_lid =
     [pp] is the pinpoint used in errors. *)
 let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
   List.fold_left
-    (fun vmode lock ->
-      match lock with
-      | Region_lock -> region_mode vmode
-      | Const_closure_lock (_, closure_context, comonadic) ->
-          const_closure_mode pp vmode closure_context comonadic
-      | Closure_lock (closure_context, comonadic) ->
-          closure_mode pp vmode closure_context comonadic
-      | Exclave_lock ->
-          exclave_mode ~errors ~env ~pp vmode
-      | Unboxed_lock ->
-          unboxed_type ~errors ~env ~loc:(fst pp) ty_and_lid;
-          vmode
-    ) mode locks
+    (fun (vmode, stage_offset) -> function
+    (* We walk in direction from the introduction of a value towards its use.
+       Since the introduction and use are at the same stage, we know both the
+       stage offset from the current lock to the introduction ([stage_offset])
+       and to the use ([-stage_offset]). *)
+    | Stage_lock Quotation_lock ->
+      vmode, stage_offset + 1
+    | Stage_lock Splice_lock ->
+      vmode, stage_offset - 1
+    | Nonstage_lock lock ->
+      let vmode =
+        match lock with
+        | Region_lock ->
+            region_mode vmode
+        (* We want to offset the stage of [vmode] by [-stage_offset].
+           It's easier to apply the right-adjoint to the [comonadic] bound,
+           which is [offset_stage_r stage_offset]. *)
+        | Const_closure_lock (_, closure_context, comonadic) ->
+            const_closure_mode pp vmode closure_context
+              (Mode.Value.Comonadic.const_offset_stage_r
+                stage_offset comonadic)
+        | Closure_lock (closure_context, comonadic) ->
+            closure_mode pp vmode closure_context
+              (Mode.Value.Comonadic.offset_stage_r
+                stage_offset comonadic)
+        | Exclave_lock ->
+            exclave_mode ~errors ~env ~pp vmode
+        | Unboxed_lock ->
+            unboxed_type ~errors ~env ~loc:(fst pp) ty_and_lid;
+            vmode
+        in
+      vmode, stage_offset
+    ) (mode, 0) locks |> fst
 
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
@@ -3825,7 +3844,6 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
     stateful. *)
 let walk_locks_for_legacy_construct ~env pp =
   let locks = IdTbl.get_all_locks env.values in
-  let _stage_locks, locks = partition_locks locks in
   ignore
     (walk_locks ~errors:true ~env ~pp
        (Mode.Value.disallow_right Mode.Value.legacy) None locks
@@ -3871,13 +3889,15 @@ let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
 let lookup_ident_value ~errors ~use ~loc name env =
   match IdTbl.find_name_and_locks wrap_value ~mark:use name env.values with
   | Ok (path, locks, Val_bound vda) ->
-      let stage_locks, locks = partition_locks locks in
+      let stage_locks, nonstage_locks = partition_locks locks in
       begin match vda with
       | {vda_description={val_kind=Val_mut (m0, _); _}; _} ->
           m0
-          |> walk_locks_for_mutable_mode ~errors ~loc ~env locks
+          |> walk_locks_for_mutable_mode ~errors ~loc ~env nonstage_locks
           |> ignore
       | _ -> () end;
+      (* CR quoted-modes jbachurski: It might be worth to get rid of
+         [partition_locks] and to move this check to [walk_locks]. *)
       check_cross_quotation ~errors ~loc_use:loc
         ~loc_def:vda.vda_description.val_loc env path (Lident name) stage_locks;
       use_value ~use ~loc path vda;
@@ -3910,7 +3930,7 @@ let lookup_ident_modtype ~errors ~use ~loc s env =
 let lookup_ident_class ~errors ~use ~loc s env =
   match IdTbl.find_name_and_locks wrap_identity ~mark:use s env.classes with
   | Ok (path, locks, clda) ->
-      let stage_locks, locks = partition_locks locks in
+      let stage_locks, _nonstage_locks = partition_locks locks in
       check_cross_quotation ~errors ~loc_def:loc
         ~loc_use:clda.clda_declaration.cty_loc env path (Lident s) stage_locks;
       use_class ~use ~loc path clda;
@@ -3978,7 +3998,7 @@ let lookup_all_ident_constructors ~errors ~use ~loc usage s env =
   let cstrs_filtered =
     List.filter_map
       (fun (path, cda, (locks, use_fn)) ->
-         let stage_locks, locks = partition_locks locks in
+         let stage_locks, _nonstage_locks = partition_locks locks in
          does_not_cross_quotation env path stage_locks
          |> Result.map (fun () -> (path, cda, (locks, use_fn)))
          |> Result.to_option)
@@ -4246,15 +4266,14 @@ let lookup_all_dot_constructors ~errors ~use ~loc usage l s env =
 (* Open a signature path *)
 
 let add_components slot root env0 comps (locks : locks) =
-  let locks' = List.map (fun lock -> Nonstage_lock lock) locks in
   let add_l w comps env0 =
     TycompTbl.add_open slot w root comps ([] : stage_lock list) env0
   in
   let add_c w comps env0 =
-    TycompTbl.add_open slot w root comps locks' env0
+    TycompTbl.add_open slot w root comps locks env0
   in
   let add_v w comps env0 =
-    IdTbl.add_open slot w root comps locks' env0
+    IdTbl.add_open slot w root comps locks env0
   in
   let add_s w comps env0 =
     IdTbl.add_open slot w root comps ([] : stage_lock list) env0

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -680,6 +680,7 @@ type t = {
   implicit_jkinds: jkind_lr loc String.Map.t;
   flags: int;
   stage: stage;
+  last_quote_lock : Location.t * Mode.Value.Comonadic.r;
   toplevel_scope: int
 }
 
@@ -985,6 +986,7 @@ let empty = {
   functor_args = Ident.empty;
   jkinds = IdTbl.empty;
   stage = 0;
+  last_quote_lock = Location.none, Mode.Value.Comonadic.newvar ();
   toplevel_scope = Ident.lowest_scope
  }
 
@@ -3154,6 +3156,26 @@ let enter_splice ~loc env =
   if env.stage = 0 then
     raise (Error (Toplevel_splice loc));
   add_stage_lock Splice_lock {env with stage = env.stage - 1}
+
+let add_quotation_lock ~loc comonadic env =
+  let comonadic = Mode.Value.Comonadic.disallow_left comonadic in
+  let env =
+    enter_quotation env
+    |> add_lock (Closure_lock ((loc, Quote), comonadic))
+  in
+  { env with last_quote_lock = (loc, comonadic) }
+
+let splice_closure_mode comonadic env =
+  (* This logic mimics [closure_mode], pretending [last_quote_lock] is the
+     containing closure.
+     Monadic modes are ignored here, as expressions cross monadic modes
+     (like functions). *)
+  let (loc, comonadic0) = env.last_quote_lock in
+  let hint_comonadic : _ Mode.Hint.morph =
+    Is_closed_by (Comonadic, {closure = (loc, Quote); closed = (loc, Splice)})
+  in
+  Mode.Value.Comonadic.submode_err (loc, Splice)
+    comonadic (Mode.Value.Comonadic.apply_hint hint_comonadic comonadic0)
 
 let enter_future env =
   (* Reuse a very large number *)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3161,8 +3161,9 @@ let enter_splice ~loc env =
 let add_quotation_lock ~loc comonadic env =
   let comonadic = Mode.Value.Comonadic.disallow_left comonadic in
   let env =
-    enter_quotation env
+    env
     |> add_lock (Closure_lock ((loc, Quote), comonadic))
+    |> enter_quotation
   in
   { env with last_quote_lock = (loc, comonadic) }
 
@@ -3755,12 +3756,14 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
       path, (mode, locks), a
     end
 
-let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
+let closure_mode pp {Mode.monadic; comonadic}
+  closure_context comonadic0 stage_offset =
   let hint_comonadic : _ Mode.Hint.morph =
     Is_closed_by (Comonadic, {closure = closure_context; closed = pp})
   in
   Mode.Value.Comonadic.submode_err pp
-    comonadic (Mode.Value.Comonadic.apply_hint hint_comonadic comonadic0);
+    (Mode.offset_stage_l (-stage_offset) comonadic)
+    (Mode.Value.Comonadic.apply_hint hint_comonadic comonadic0);
   let hint_monadic : _ Mode.Hint.morph =
     Is_closed_by (Monadic, {closure = closure_context; closed = pp})
   in
@@ -3772,8 +3775,9 @@ let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
   {Mode.monadic; comonadic}
 
 let const_closure_mode pp {Mode.monadic; comonadic}
-  closure_context comonadic0 =
-  Mode.Value.Comonadic.(submode_err pp comonadic
+  closure_context comonadic0 stage_offset =
+  Mode.Value.Comonadic.(submode_err pp
+    (Mode.offset_stage_l (-stage_offset) comonadic)
     (of_const ~hint:(Is_used_in closure_context) comonadic0));
   let monadic =
     Mode.Value.(Monadic.join
@@ -3825,6 +3829,7 @@ let unboxed_type ~errors ~env ~loc ty_and_lid =
 
     [pp] is the pinpoint used in errors. *)
 let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
+  (* Format.printf "@.walk@."; *)
   List.fold_left
     (fun (vmode, stage_offset) -> function
     (* We walk in direction from the introduction of a value towards its use.
@@ -3832,25 +3837,25 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
        stage offset from the current lock to the introduction ([stage_offset])
        and to the use ([-stage_offset]). *)
     | Stage_lock Quotation_lock ->
+      (* Format.printf "quote@."; *)
       vmode, stage_offset + 1
     | Stage_lock Splice_lock ->
+      (* Format.printf "splice@."; *)
       vmode, stage_offset - 1
     | Nonstage_lock lock ->
       let vmode =
+      (* Format.printf "lock stage_offset=%d@." stage_offset; *)
         match lock with
         | Region_lock ->
             region_mode vmode
         (* We want to offset the stage of [vmode] by [-stage_offset].
            It's easier to apply the right-adjoint to the [comonadic] bound,
-           which is [offset_stage_r stage_offset]. *)
+           which is [offset_stage_l stage_offset]. *)
         | Const_closure_lock (_, closure_context, comonadic) ->
-            const_closure_mode pp vmode closure_context
-              (Mode.const_offset_stage_r
-                stage_offset comonadic)
+            const_closure_mode pp vmode closure_context comonadic stage_offset
         | Closure_lock (closure_context, comonadic) ->
-            closure_mode pp vmode closure_context
-              (Mode.offset_stage_r
-                stage_offset comonadic)
+            (* Format.printf "offset(%d)(%a) <= %a@." stage_offset (Format_doc.compat (Mode.Value.Comonadic.print ())) vmode.Mode.comonadic (Format_doc.compat (Mode.Value.Comonadic.print ())) comonadic; *)
+            closure_mode pp vmode closure_context comonadic stage_offset
         | Exclave_lock ->
             exclave_mode ~errors ~env ~pp vmode
         | Unboxed_lock ->

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3845,11 +3845,11 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
            which is [offset_stage_r stage_offset]. *)
         | Const_closure_lock (_, closure_context, comonadic) ->
             const_closure_mode pp vmode closure_context
-              (Mode.Value.Comonadic.const_offset_stage_r
+              (Mode.const_offset_stage_r
                 stage_offset comonadic)
         | Closure_lock (closure_context, comonadic) ->
             closure_mode pp vmode closure_context
-              (Mode.Value.Comonadic.offset_stage_r
+              (Mode.offset_stage_r
                 stage_offset comonadic)
         | Exclave_lock ->
             exclave_mode ~errors ~env ~pp vmode

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1237,6 +1237,7 @@ let mode_unit ~staticity =
   let hint : _ Mode.Hint.const = Legacy Compilation_unit in
   Mode.Value.of_const
     { areality = Global;
+      areality_quoted = Quote Global;
       linearity = Many;
       uniqueness = Aliased;
       portability = Nonportable;
@@ -4350,6 +4351,7 @@ let add_components slot root env0 comps (locks : locks) =
     implicit_jkinds = env0.implicit_jkinds;
     flags = env0.flags;
     stage = env0.stage;
+    last_quote_lock = env0.last_quote_lock;
     toplevel_scope = env0.toplevel_scope;
   }
 

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -592,6 +592,10 @@ val add_exclave_lock : t -> t
 val add_unboxed_lock : t -> t
 val enter_quotation : t -> t
 val enter_splice : loc:Location.t -> t -> t
+val add_quotation_lock : loc:Location.t ->
+  ('l * Mode.allowed) Mode.Value.Comonadic.t -> t -> t
+val splice_closure_mode :
+  (Mode.allowed * 'r) Mode.Value.Comonadic.t -> t -> unit
 
 (** Set the environment's stage to a fixed one in the far future.
     Should only be used in cases where the stage is unknown. *)

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -135,6 +135,7 @@ module Axis = struct
 
   type packed = Pack : 'a t -> packed [@@unboxed]
 
+  (* CR quoted-modes jbachurski: Should [ArealityQuoted] be here? *)
   let all =
     [ Pack (Modal (Comonadic Areality));
       Pack (Modal (Monadic Uniqueness));
@@ -255,6 +256,7 @@ module Axis_set = struct
 
   let[@inline] axis_index (type a) : a Axis.t -> _ = function
     | Modal (Comonadic Areality) -> 0
+    | Modal (Comonadic ArealityQuoted) -> failwith "ArealityQuoted"
     | Modal (Monadic Uniqueness) -> 1
     | Modal (Comonadic Linearity) -> 2
     | Modal (Monadic Contention) -> 3

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -2589,7 +2589,7 @@ module Lattices_mono = struct
 
            Without this condition, [commute_meet_const_from_right] may no longer be
            implementable, and we will need to change the implementation of
-           [Simple_morph.compose], as well as add the missing cases in [Simple_morph.t].
+           [Meta_morph.compose], as well as add the missing cases in [Meta_morph.t].
 
            If all morphisms preserve binary meets, the correctness argument
            goes as follows:
@@ -3045,7 +3045,7 @@ module Lattices_mono = struct
 
   let max_with dst ax a = Axis.set ax a (max dst)
 
-  module Simple_morph = struct
+  module Meta_morph = struct
     (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Id : ('a, 'a, 'd) t  (** identity morphism *)
@@ -3654,7 +3654,50 @@ module Lattices_mono = struct
       (To Id :: core_morphs) @ constants @ core_imply_consts
   end
 
-  module Meta_morph = struct
+  module Simple_morph = struct
+    type ('a, 'b, 'd) t = Meta : ('a, 'b, 'd) Meta_morph.t -> ('a, 'b, 'd) t
+
+    let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+     fun (Meta m) -> Meta (Meta_morph.allow_left m)
+
+    let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+     fun (Meta m) -> Meta (Meta_morph.allow_right m)
+
+    let disallow_left : type a b l r.
+        (a, b, l * r) t -> (a, b, disallowed * r) t =
+     fun (Meta m) -> Meta (Meta_morph.disallow_left m)
+
+    let disallow_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * disallowed) t =
+     fun (Meta m) -> Meta (Meta_morph.disallow_right m)
+
+    let src : type a b d. b obj -> (a, b, d) t -> a obj =
+     fun dst (Meta m) -> Meta_morph.src dst m
+
+    let compare_total : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
+     fun dst (Meta m1) (Meta m2) -> Meta_morph.compare_total dst m1 m2
+
+    let equal : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> (a1, a2) Misc.is_eq =
+     fun dst (Meta m1) (Meta m2) -> Meta_morph.equal dst m1 m2
+
+    let print : type a b d. b obj -> Fmt.formatter -> (a, b, d) t -> unit =
+     fun dst ppf (Meta m) -> Meta_morph.print dst ppf m
+
+    let apply : type a b d. b obj -> (a, b, d) t -> a -> b =
+     fun dst (Meta m) a -> Meta_morph.apply dst m a
+
+    let right_adjoint : type a b r.
+        b obj -> (a, b, allowed * r) t -> (b, a, disallowed * allowed) t =
+     fun dst (Meta m) -> Meta (Meta_morph.right_adjoint dst m)
+
+    let left_adjoint : type a b l.
+        b obj -> (a, b, l * allowed) t -> (b, a, allowed * disallowed) t =
+     fun dst (Meta m) -> Meta (Meta_morph.left_adjoint dst m)
+  end
+
+  module Final_morph = struct
     (* New morphisms must be added to [left_to] and [right_to]. *)
     type ('a, 'b, 'd) t =
       | Simple : ('a, 'b, 'd) Simple_morph.t -> ('a, 'b, 'd) t
@@ -3860,18 +3903,18 @@ module Lattices_mono = struct
         b obj -> Fmt.formatter -> (a, b, d) t -> unit =
      fun dst ppf -> function
       | Simple m -> Simple_morph.print dst ppf m
-      | Simple_proj (Id, ax, src) ->
+      | Simple_proj (Meta Id, ax, src) ->
         Fmt.fprintf ppf "proj_%a" print_obj (proj_obj ax src)
       | Simple_proj (m, ax, src) ->
         Fmt.fprintf ppf "%a . proj_%a" (Simple_morph.print dst) m print_obj
           (proj_obj ax src)
-      | Max_with_simple (ax, Id) ->
+      | Max_with_simple (ax, Meta Id) ->
         Fmt.fprintf ppf "max_with_%a" print_obj (proj_obj ax dst)
       | Max_with_simple (ax, m) ->
         let mid = proj_obj ax dst in
         Fmt.fprintf ppf "max_with_%a . %a" print_obj mid
           (Simple_morph.print mid) m
-      | Min_with_simple (ax, Id) ->
+      | Min_with_simple (ax, Meta Id) ->
         Fmt.fprintf ppf "min_with_%a" print_obj (proj_obj ax dst)
       | Min_with_simple (ax, m) ->
         let mid = proj_obj ax dst in
@@ -3885,7 +3928,7 @@ module Lattices_mono = struct
         Fmt.fprintf ppf "%a . %a" (print_morph dst) mb (print_morph mid) ma
     [@@warning "-4"]
 
-    let id = Simple Id
+    let id = Simple (Meta Id)
 
     let rec apply : type a b d. b obj -> (a, b, d) t -> a -> b =
      fun dst f a ->
@@ -3931,44 +3974,44 @@ module Lattices_mono = struct
 
     let const_max_or_apply : type a c p r.
         c obj ->
-        (p, c, disallowed * r) Simple_morph.t ->
+        (p, c, disallowed * r) Meta_morph.t ->
         a obj ->
         (a, c, disallowed * r) t =
      fun dst m obj ->
-      match Simple_morph.maybe_allowed_right m with
+      match Meta_morph.maybe_allowed_right m with
       | Allowed_right _ -> Const_max obj
       | Not_allowed_right ->
-        let src = Simple_morph.src dst m in
-        Const (obj, Simple_morph.apply dst m (max src))
+        let src = Meta_morph.src dst m in
+        Const (obj, Meta_morph.apply dst m (max src))
 
     let const_min_or_apply : type a c p l.
         c obj ->
-        (p, c, l * disallowed) Simple_morph.t ->
+        (p, c, l * disallowed) Meta_morph.t ->
         a obj ->
         (a, c, l * disallowed) t =
      fun dst m obj ->
-      match Simple_morph.maybe_allowed_left m with
+      match Meta_morph.maybe_allowed_left m with
       | Allowed_left _ -> Const_min obj
       | Not_allowed_left ->
-        let src = Simple_morph.src dst m in
-        Const (obj, Simple_morph.apply dst m (min src))
+        let src = Meta_morph.src dst m in
+        Const (obj, Meta_morph.apply dst m (min src))
 
     let compose_simple_proj_core : type a c p d.
         c obj ->
-        (p, c, d) Simple_morph.t ->
+        (p, c, d) Meta_morph.t ->
         (a, p, d) Core_morph.compose_proj_result ->
         (a, c, d) t =
      fun dst m0 pm1 ->
       match pm1 with
       | Proj_core (m1, ax1, obj1) ->
-        Simple_proj (Simple_morph.compose dst m0 (Core m1), ax1, obj1)
-      | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
+        Simple_proj (Meta (Meta_morph.compose dst m0 (Core m1)), ax1, obj1)
+      | Proj_id (ax1, obj1) -> Simple_proj (Meta m0, ax1, obj1)
       | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
       | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
     let compose_simple_proj_meet_const_core : type a c p l.
         c obj ->
-        (p, c, l * disallowed) Simple_morph.t ->
+        (p, c, l * disallowed) Meta_morph.t ->
         p ->
         (a, p, l * disallowed) Core_morph.compose_proj_result ->
         (a, c, l * disallowed) t =
@@ -3976,15 +4019,17 @@ module Lattices_mono = struct
       match pm1 with
       | Proj_core (m1, ax1, obj1) ->
         Simple_proj
-          (Simple_morph.compose dst m0 (Meet_const_core (c1, m1)), ax1, obj1)
+          ( Meta (Meta_morph.compose dst m0 (Meet_const_core (c1, m1))),
+            ax1,
+            obj1 )
       | Proj_id (ax1, obj1) ->
-        Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax1, obj1)
-      | Proj_const_max obj1 -> Const (obj1, Simple_morph.apply dst m0 c1)
+        Simple_proj (Meta (Meta_morph.compose dst m0 (Meet_const c1)), ax1, obj1)
+      | Proj_const_max obj1 -> Const (obj1, Meta_morph.apply dst m0 c1)
       | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
     let compose_simple_proj_core_imply_const : type a c p r.
         c obj ->
-        (p, c, disallowed * r) Simple_morph.t ->
+        (p, c, disallowed * r) Meta_morph.t ->
         a ->
         (a, p, disallowed * r) Core_morph.compose_proj_result ->
         (a, c, disallowed * r) t =
@@ -3993,32 +4038,36 @@ module Lattices_mono = struct
       | Proj_core (m1, ax1, obj1) ->
         let c1 = Axis.proj ax1 c1 in
         Simple_proj
-          (Simple_morph.compose dst m0 (Core_imply_const (m1, c1)), ax1, obj1)
+          ( Meta (Meta_morph.compose dst m0 (Core_imply_const (m1, c1))),
+            ax1,
+            obj1 )
       | Proj_id (ax1, obj1) ->
         let c1 = Axis.proj ax1 c1 in
-        Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax1, obj1)
+        Simple_proj
+          (Meta (Meta_morph.compose dst m0 (Imply_const c1)), ax1, obj1)
       | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
       | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
     let compose_simple_proj_with_simple : type a b c p d.
         c obj ->
-        (p, c, d) Simple_morph.t ->
+        (p, c, d) Meta_morph.t ->
         (b, p) Axis.t ->
         b obj ->
-        (a, b, d) Simple_morph.t ->
+        (a, b, d) Meta_morph.t ->
         (a, c, d) t =
      fun dst m0 ax0 obj0 m1 ->
       match m1 with
-      | Id -> Simple_proj (m0, ax0, obj0)
+      | Id -> Simple_proj (Meta m0, ax0, obj0)
       | Core m1 ->
         let pm1 = Core_morph.compose_projection_core ax0 m1 in
         compose_simple_proj_core dst m0 pm1
       | Meet_const c1 ->
         let c1 = Axis.proj ax0 c1 in
-        Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax0, obj0)
+        Simple_proj (Meta (Meta_morph.compose dst m0 (Meet_const c1)), ax0, obj0)
       | Imply_const c1 ->
         let c1 = Axis.proj ax0 c1 in
-        Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax0, obj0)
+        Simple_proj
+          (Meta (Meta_morph.compose dst m0 (Imply_const c1)), ax0, obj0)
       | Meet_const_core (c1, m1) ->
         let c1 = Axis.proj ax0 c1 in
         let pm1 = Core_morph.compose_projection_core ax0 m1 in
@@ -4026,95 +4075,105 @@ module Lattices_mono = struct
       | Core_imply_const (m1, c1) ->
         let pm1 = Core_morph.compose_projection_core ax0 m1 in
         compose_simple_proj_core_imply_const dst m0 c1 pm1
-      | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple m1)
+      | Compose _ -> Compose (Simple_proj (Meta m0, ax0, obj0), Simple (Meta m1))
 
     let compose_simple_max_with_simple : type a b c q r.
         c obj ->
-        (b, c, disallowed * r) Simple_morph.t ->
+        (b, c, disallowed * r) Meta_morph.t ->
         (b, q) Axis.t ->
-        (a, q, disallowed * r) Simple_morph.t ->
+        (a, q, disallowed * r) Meta_morph.t ->
         (a, c, disallowed * r) t =
      fun dst sm0 ax1 m1 ->
-      let b_obj = Simple_morph.src dst sm0 in
-      let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+      let b_obj = Meta_morph.src dst sm0 in
+      let a_obj = src b_obj (Max_with_simple (ax1, Meta m1)) in
       match sm0 with
-      | Id -> Max_with_simple (ax1, m1)
+      | Id -> Max_with_simple (ax1, Meta m1)
       | Core m0 ->
         begin match Core_morph.compose_core_max_with m0 ax1 with
         | And_max_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
-          Max_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+          Max_with_simple (ax1, Meta (Meta_morph.compose obj0 (Core m0) m1))
         | Const_max_core -> Const_max a_obj
-        | And_max_id ax1 -> Max_with_simple (ax1, m1)
-        | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+        | And_max_id ax1 -> Max_with_simple (ax1, Meta m1)
+        | Disallowed ->
+          Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
         end
       | Imply_const c0 ->
         let c0 = Axis.proj ax1 c0 in
         let obj0 = proj_obj ax1 dst in
-        Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
+        Max_with_simple (ax1, Meta (Meta_morph.compose obj0 (Imply_const c0) m1))
       | Core_imply_const (m0, c0) -> begin
         let c0 = Axis.proj ax1 c0 in
         match Core_morph.compose_core_max_with m0 ax1 with
         | And_max_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
           Max_with_simple
-            (ax1, Simple_morph.compose obj0 (Core_imply_const (m0, c0)) m1)
+            (ax1, Meta (Meta_morph.compose obj0 (Core_imply_const (m0, c0)) m1))
         | Const_max_core -> Const_max a_obj
         | And_max_id ax1 ->
           let obj0 = proj_obj ax1 dst in
-          Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
-        | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+          Max_with_simple
+            (ax1, Meta (Meta_morph.compose obj0 (Imply_const c0) m1))
+        | Disallowed ->
+          Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
         end
-      | Meet_const_core _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
-      | Meet_const _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
-      | Compose _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      | Meet_const_core _ ->
+        Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
+      | Meet_const _ ->
+        Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
+      | Compose _ -> Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
 
     let compose_simple_min_with_simple : type a b c q l.
         c obj ->
-        (b, c, l * disallowed) Simple_morph.t ->
+        (b, c, l * disallowed) Meta_morph.t ->
         (b, q) Axis.t ->
-        (a, q, l * disallowed) Simple_morph.t ->
+        (a, q, l * disallowed) Meta_morph.t ->
         (a, c, l * disallowed) t =
      fun dst sm0 ax1 m1 ->
-      let b_obj = Simple_morph.src dst sm0 in
-      let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+      let b_obj = Meta_morph.src dst sm0 in
+      let a_obj = src b_obj (Min_with_simple (ax1, Meta m1)) in
       match sm0 with
-      | Id -> Min_with_simple (ax1, m1)
+      | Id -> Min_with_simple (ax1, Meta m1)
       | Core m0 ->
         begin match Core_morph.compose_core_min_with m0 ax1 with
         | And_min_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
-          Min_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+          Min_with_simple (ax1, Meta (Meta_morph.compose obj0 (Core m0) m1))
         | Const_min_core -> Const_min a_obj
-        | And_min_id ax1 -> Min_with_simple (ax1, m1)
-        | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+        | And_min_id ax1 -> Min_with_simple (ax1, Meta m1)
+        | Disallowed ->
+          Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
         end
       | Meet_const c0 ->
         let c0 = Axis.proj ax1 c0 in
         let obj0 = proj_obj ax1 dst in
-        Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
+        Min_with_simple (ax1, Meta (Meta_morph.compose obj0 (Meet_const c0) m1))
       | Meet_const_core (c0, m0) ->
         begin match Core_morph.compose_core_min_with m0 ax1 with
         | And_min_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
           let c0 = Axis.proj ax1 c0 in
           Min_with_simple
-            (ax1, Simple_morph.compose obj0 (Meet_const_core (c0, m0)) m1)
+            (ax1, Meta (Meta_morph.compose obj0 (Meet_const_core (c0, m0)) m1))
         | Const_min_core -> Const_min a_obj
         | And_min_id ax1 ->
           let obj0 = proj_obj ax1 dst in
           let c0 = Axis.proj ax1 c0 in
-          Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
-        | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+          Min_with_simple
+            (ax1, Meta (Meta_morph.compose obj0 (Meet_const c0) m1))
+        | Disallowed ->
+          Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
         end
-      | Imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
-      | Core_imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
-      | Compose _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      | Imply_const _ ->
+        Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
+      | Core_imply_const _ ->
+        Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
+      | Compose _ -> Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
 
     let refute_compose_and_with : type a b c q0 q1 d.
         c obj ->
         (c, q0) Axis.t ->
-        (b, q0, d) Simple_morph.t ->
+        (b, q0, d) Meta_morph.t ->
         (b, q1) Axis.t ->
         (b, c, d) t ->
         (a, b, d) t ->
@@ -4132,109 +4191,114 @@ module Lattices_mono = struct
         c obj -> (b, c, d) t -> (a, b, d) t -> (a, c, d) t =
      fun dst m0 m1 ->
       match m0, m1 with
-      | Simple m0, Simple m1 -> Simple (Simple_morph.compose dst m0 m1)
+      | Simple (Meta m0), Simple (Meta m1) ->
+        Simple (Meta (Meta_morph.compose dst m0 m1))
       | Const_max b_obj, _ -> Const_max (src b_obj m1)
       | Const_min b_obj, _ -> Const_min (src b_obj m1)
       | Const (b_obj, c), _ -> Const (src b_obj m1, c)
-      | Simple m0, Simple_proj (m1, ax1, obj1) ->
-        Simple_proj (Simple_morph.compose dst m0 m1, ax1, obj1)
-      | Simple_proj (m0, ax0, obj0), Simple m1 ->
+      | Simple (Meta m0), Simple_proj (Meta m1, ax1, obj1) ->
+        Simple_proj (Meta (Meta_morph.compose dst m0 m1), ax1, obj1)
+      | Simple_proj (Meta m0, ax0, obj0), Simple (Meta m1) ->
         compose_simple_proj_with_simple dst m0 ax0 obj0 m1
-      | Max_with_simple (ax0, m0), Simple m1 ->
+      | Max_with_simple (ax0, Meta m0), Simple (Meta m1) ->
         let dst = proj_obj ax0 dst in
-        Max_with_simple (ax0, Simple_morph.compose dst m0 m1)
-      | Simple m0, Max_with_simple (ax1, m1) ->
+        Max_with_simple (ax0, Meta (Meta_morph.compose dst m0 m1))
+      | Simple (Meta m0), Max_with_simple (ax1, Meta m1) ->
         compose_simple_max_with_simple dst m0 ax1 m1
-      | Min_with_simple (ax0, m0), Simple m1 ->
+      | Min_with_simple (ax0, Meta m0), Simple (Meta m1) ->
         let dst = proj_obj ax0 dst in
-        Min_with_simple (ax0, Simple_morph.compose dst m0 m1)
-      | Simple m0, Min_with_simple (ax1, m1) ->
+        Min_with_simple (ax0, Meta (Meta_morph.compose dst m0 m1))
+      | Simple (Meta m0), Min_with_simple (ax1, Meta m1) ->
         compose_simple_min_with_simple dst m0 ax1 m1
-      | Simple_proj (m0, ax0, obj1), Max_with_simple (ax1, m1) ->
+      | Simple_proj (Meta m0, ax0, obj1), Max_with_simple (ax1, Meta m1) ->
         begin match Axis.equal ax0 ax1 with
-        | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+        | Misc.Is_eq -> Simple (Meta (Meta_morph.compose dst m0 m1))
         | Misc.Is_not_eq ->
-          let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
-          let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+          let b_obj = src dst (Simple_proj (Meta m0, ax0, obj1)) in
+          let a_obj = src b_obj (Max_with_simple (ax1, Meta m1)) in
           const_max_or_apply dst m0 a_obj
         end
-      | Simple_proj (m0, ax0, obj1), Min_with_simple (ax1, m1) ->
+      | Simple_proj (Meta m0, ax0, obj1), Min_with_simple (ax1, Meta m1) ->
         begin match Axis.equal ax0 ax1 with
-        | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+        | Misc.Is_eq -> Simple (Meta (Meta_morph.compose dst m0 m1))
         | Misc.Is_not_eq ->
-          let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
-          let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+          let b_obj = src dst (Simple_proj (Meta m0, ax0, obj1)) in
+          let a_obj = src b_obj (Min_with_simple (ax1, Meta m1)) in
           const_min_or_apply dst m0 a_obj
         end
-      | (Max_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
-        ->
+      | ( (Max_with_simple (ax0, Meta m0) as m0'),
+          (Simple_proj (Meta m1, ax1, obj1) as m1') ) ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = src dst (Max_with_simple (ax0, m0)) in
-        let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
-        let m0m1 = Simple_morph.compose q_obj m0 m1 in
-        begin match Simple_morph.maybe_allowed_right m0m1 with
+        let b_obj = src dst (Max_with_simple (ax0, Meta m0)) in
+        let a_obj = src b_obj (Simple_proj (Meta m1, ax1, obj1)) in
+        let m0m1 = Meta_morph.compose q_obj m0 m1 in
+        begin match Meta_morph.maybe_allowed_right m0m1 with
         | Allowed_right m0m1 ->
-          allow_right (Simple (Simple_morph.lift_max a_obj dst m0m1 ax1 ax0))
+          allow_right
+            (Simple (Meta (Meta_morph.lift_max a_obj dst m0m1 ax1 ax0)))
         | Not_allowed_right -> Compose (m0', m1')
         end
-      | (Min_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
-        ->
+      | ( (Min_with_simple (ax0, Meta m0) as m0'),
+          (Simple_proj (Meta m1, ax1, obj1) as m1') ) ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = src dst (Min_with_simple (ax0, m0)) in
-        let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
-        let m0m1 = Simple_morph.compose q_obj m0 m1 in
-        begin match Simple_morph.maybe_allowed_left m0m1 with
+        let b_obj = src dst (Min_with_simple (ax0, Meta m0)) in
+        let a_obj = src b_obj (Simple_proj (Meta m1, ax1, obj1)) in
+        let m0m1 = Meta_morph.compose q_obj m0 m1 in
+        begin match Meta_morph.maybe_allowed_left m0m1 with
         | Allowed_left m0m1 ->
-          allow_left (Simple (Simple_morph.lift_min a_obj dst m0m1 ax1 ax0))
+          allow_left
+            (Simple (Meta (Meta_morph.lift_min a_obj dst m0m1 ax1 ax0)))
         | Not_allowed_left -> Compose (m0', m1')
         end
-      | Simple m0, Const_max a_obj -> const_max_or_apply dst m0 a_obj
-      | Simple m0, Const_min a_obj -> const_min_or_apply dst m0 a_obj
-      | Simple_proj (m0, _ax0, _obj0), Const_max obj1 ->
+      | Simple (Meta m0), Const_max a_obj -> const_max_or_apply dst m0 a_obj
+      | Simple (Meta m0), Const_min a_obj -> const_min_or_apply dst m0 a_obj
+      | Simple_proj (Meta m0, _ax0, _obj0), Const_max obj1 ->
         const_max_or_apply dst m0 obj1
-      | Simple_proj (m0, _ax0, _obj0), Const_min obj1 ->
+      | Simple_proj (Meta m0, _ax0, _obj0), Const_min obj1 ->
         const_min_or_apply dst m0 obj1
-      | Min_with_simple (ax0, m0), Const_max obj1 ->
+      | Min_with_simple (ax0, Meta m0), Const_max obj1 ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = Simple_morph.src q_obj m0 in
-        Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
-      | Min_with_simple (ax0, m0), Const_min obj1 ->
-        begin match Simple_morph.maybe_allowed_left m0 with
+        let b_obj = Meta_morph.src q_obj m0 in
+        Const (obj1, min_with dst ax0 (Meta_morph.apply q_obj m0 (max b_obj)))
+      | Min_with_simple (ax0, Meta m0), Const_min obj1 ->
+        begin match Meta_morph.maybe_allowed_left m0 with
         | Allowed_left _ -> Const_min obj1
         | Not_allowed_left ->
           let q_obj = proj_obj ax0 dst in
-          let b_obj = Simple_morph.src q_obj m0 in
-          Const
-            (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+          let b_obj = Meta_morph.src q_obj m0 in
+          Const (obj1, min_with dst ax0 (Meta_morph.apply q_obj m0 (min b_obj)))
         end
-      | Max_with_simple (ax0, m0), Const_max obj1 ->
-        begin match Simple_morph.maybe_allowed_right m0 with
+      | Max_with_simple (ax0, Meta m0), Const_max obj1 ->
+        begin match Meta_morph.maybe_allowed_right m0 with
         | Allowed_right _ -> Const_max obj1
         | Not_allowed_right ->
           let q_obj = proj_obj ax0 dst in
-          let b_obj = Simple_morph.src q_obj m0 in
-          Const
-            (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
+          let b_obj = Meta_morph.src q_obj m0 in
+          Const (obj1, max_with dst ax0 (Meta_morph.apply q_obj m0 (max b_obj)))
         end
-      | Max_with_simple (ax0, m0), Const_min obj1 ->
+      | Max_with_simple (ax0, Meta m0), Const_min obj1 ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = Simple_morph.src q_obj m0 in
-        Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+        let b_obj = Meta_morph.src q_obj m0 in
+        Const (obj1, max_with dst ax0 (Meta_morph.apply q_obj m0 (min b_obj)))
       | (_ as m0), Const (obj1, c1) -> Const (obj1, apply dst m0 c1)
       | (_ as m0), Compose (m1, m2) -> Compose (Compose (m0, m1), m2)
       | Compose (m0, m1), (_ as m2) -> Compose (Compose (m0, m1), m2)
       (* The remaining cases are unreachable by looking at the axes and objects *)
-      | _, Simple_proj (Core (Locality_restricted _), _, _) -> .
-      | _, Simple_proj (Meet_const_core (_, Locality_restricted _), _, _) -> .
-      | _, Simple_proj (Core_imply_const (Locality_restricted _, _), _, _) -> .
-      | _, Simple_proj (Compose _, _, _) -> Compose (m0, m1)
-      | Max_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+      | _, Simple_proj (Meta (Core (Locality_restricted _)), _, _) -> .
+      | _, Simple_proj (Meta (Meet_const_core (_, Locality_restricted _)), _, _)
+        ->
+        .
+      | _, Simple_proj (Meta (Core_imply_const (Locality_restricted _, _)), _, _)
+        ->
+        .
+      | _, Simple_proj (Meta (Compose _), _, _) -> Compose (m0, m1)
+      | Max_with_simple (ax0, Meta m0'), Max_with_simple (ax1, _) ->
         refute_compose_and_with dst ax0 m0' ax1 m0 m1
-      | Max_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+      | Max_with_simple (ax0, Meta m0'), Min_with_simple (ax1, _) ->
         refute_compose_and_with dst ax0 m0' ax1 m0 m1
-      | Min_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+      | Min_with_simple (ax0, Meta m0'), Max_with_simple (ax1, _) ->
         refute_compose_and_with dst ax0 m0' ax1 m0 m1
-      | Min_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+      | Min_with_simple (ax0, Meta m0'), Min_with_simple (ax1, _) ->
         refute_compose_and_with dst ax0 m0' ax1 m0 m1
       | _, _ -> .
     [@@warning "-4"]
@@ -4247,23 +4311,23 @@ module Lattices_mono = struct
 
     let left_to : type b. full:bool -> b obj -> b to_ list =
      fun ~full dst ->
-      let simple_morphs = Simple_morph.left_to ~full dst in
+      let simple_morphs = Meta_morph.left_to ~full dst in
       let simple =
         List.map
-          (fun (Simple_morph.To m) -> To (disallow_left (Simple m)))
+          (fun (Meta_morph.To m) -> To (disallow_left (Simple (Meta m))))
           simple_morphs
       in
       let projections =
-        let* (Simple_morph.To m) = simple_morphs in
-        let src = Simple_morph.src dst m in
+        let* (Meta_morph.To m) = simple_morphs in
+        let src = Meta_morph.src dst m in
         let+ (Axis.To (src, ax)) = Axis.to_ src in
-        To (disallow_left (Simple_proj (m, ax, src)))
+        To (disallow_left (Simple_proj (Meta m, ax, src)))
       in
       let min_with =
         let* (Axis.From ax) = Axis.from dst in
         let projected = proj_obj ax dst in
-        let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
-        To (disallow_left (Min_with_simple (ax, m)))
+        let+ (Meta_morph.To m) = Meta_morph.left_to ~full projected in
+        To (disallow_left (Min_with_simple (ax, Meta m)))
       in
       let const_min =
         List.map (fun (Obj src) -> To (disallow_left (Const_min src))) all_objs
@@ -4272,23 +4336,23 @@ module Lattices_mono = struct
 
     let right_to : type b. full:bool -> b obj -> b to_ list =
      fun ~full dst ->
-      let simple_morphs = Simple_morph.right_to ~full dst in
+      let simple_morphs = Meta_morph.right_to ~full dst in
       let simple =
         List.map
-          (fun (Simple_morph.To m) -> To (disallow_right (Simple m)))
+          (fun (Meta_morph.To m) -> To (disallow_right (Simple (Meta m))))
           simple_morphs
       in
       let projections =
-        let* (Simple_morph.To m) = simple_morphs in
-        let projected = Simple_morph.src dst m in
+        let* (Meta_morph.To m) = simple_morphs in
+        let projected = Meta_morph.src dst m in
         let+ (Axis.To (src, ax)) = Axis.to_ projected in
-        To (disallow_right (Simple_proj (m, ax, src)))
+        To (disallow_right (Simple_proj (Meta m, ax, src)))
       in
       let max_with =
         let* (Axis.From ax) = Axis.from dst in
         let projected = proj_obj ax dst in
-        let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
-        To (disallow_right (Max_with_simple (ax, m)))
+        let+ (Meta_morph.To m) = Meta_morph.right_to ~full projected in
+        To (disallow_right (Max_with_simple (ax, Meta m)))
       in
       let const_max =
         List.map (fun (Obj src) -> To (disallow_right (Const_max src))) all_objs
@@ -4365,7 +4429,7 @@ module Lattices_mono = struct
 
   (* Finally, morphisms in the solver *)
 
-  module Morph = Meta_morph
+  module Morph = Final_morph
 
   type ('a, 'b, 'd) morph = ('a, 'b, 'd) Morph.t
 
@@ -4470,7 +4534,7 @@ module Lattices_mono = struct
       | Comonadic_to_monadic_op_max _, Staticity -> None_responsible
 
     let rec find_responsible_axis_proj_simple : type a b b_ax l r.
-        (a, b, l * r) Simple_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
+        (a, b, l * r) Meta_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
      fun m ax ->
       match m with
       | Id -> Axis ax
@@ -4490,10 +4554,10 @@ module Lattices_mono = struct
     (** Given a morphism and an axis, return the portion of the input that's
         responsible for the specified axis of the output. *)
     let rec find_responsible_axis_proj : type a b b_ax l r.
-        (a, b, l * r) Meta_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
+        (a, b, l * r) Final_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
      fun m ax ->
       match m with
-      | Simple m -> find_responsible_axis_proj_simple m ax
+      | Simple (Meta m) -> find_responsible_axis_proj_simple m ax
       | Simple_proj (_, ax, _) -> Axis ax
       | Max_with_simple (m_ax, _) ->
         begin match Axis.equal m_ax ax with
@@ -4516,7 +4580,7 @@ module Lattices_mono = struct
     (** Given a morphism return the portion of the input that's responsible for
         all of the output. *)
     let rec find_responsible_axis_all : type a b l r.
-        (a, b, l * r) Meta_morph.t -> a responsible_axis = function
+        (a, b, l * r) Final_morph.t -> a responsible_axis = function
       | Simple _ -> All_responsible
       | Simple_proj (_, ax, _) -> Axis ax
       | Max_with_simple _ | Min_with_simple _ -> All_responsible
@@ -5300,7 +5364,7 @@ module Report = struct
   let implements_identity : type a b. a C.obj -> b C.obj -> a -> b -> bool =
    fun src obj a b ->
     match C.equal_obj src obj with
-    | Misc.Is_eq -> implements_morph obj (Simple Id) a b
+    | Misc.Is_eq -> implements_morph obj (Simple (Meta Id)) a b
     | Misc.Is_not_eq -> false
 
   let implements_value_to_alloc : type l r a b.
@@ -5313,10 +5377,11 @@ module Report = struct
    fun locality_morph src obj a b ->
     match src, obj with
     | Regionality, Locality ->
-      implements_morph obj (Simple (Core (Locality_restricted locality_morph)))
-        a b
+      implements_morph obj
+        (Simple (Meta (Core (Locality_restricted locality_morph)))) a b
     | Comonadic_with_regionality, Comonadic_with_locality ->
-      implements_morph obj (Simple (Core (Locality_full locality_morph))) a b
+      implements_morph obj (Simple (Meta (Core (Locality_full locality_morph))))
+        a b
     | _, _ -> implements_identity src obj a b
 
   let implements_alloc_to_value : type l r a b.
@@ -5329,10 +5394,11 @@ module Report = struct
    fun locality_morph src obj a b ->
     match src, obj with
     | Locality, Regionality ->
-      implements_morph obj (Simple (Core (Locality_restricted locality_morph)))
-        a b
+      implements_morph obj
+        (Simple (Meta (Core (Locality_restricted locality_morph)))) a b
     | Comonadic_with_locality, Comonadic_with_regionality ->
-      implements_morph obj (Simple (Core (Locality_full locality_morph))) a b
+      implements_morph obj (Simple (Meta (Core (Locality_full locality_morph))))
+        a b
     | _, _ -> implements_identity src obj a b
 
   let equal_mode : type a b. a C.obj -> b C.obj -> a -> b -> bool =
@@ -5717,11 +5783,13 @@ module Comonadic_gen (Obj : Obj) = struct
 
   let apply_hint hint m = wrap ~hint Fun.id m
 
-  let meet_const_unhint c m = S.Unhint.apply obj (Simple (Meet_const c)) m
+  let meet_const_unhint c m =
+    S.Unhint.apply obj (Simple (Meta (Meet_const c))) m
 
   let meet_const ?hint c m = wrap ?hint (meet_const_unhint c) (disallow_right m)
 
-  let imply_const_unhint c m = S.Unhint.apply obj (Simple (Imply_const c)) m
+  let imply_const_unhint c m =
+    S.Unhint.apply obj (Simple (Meta (Imply_const c))) m
 
   let imply_const c m = m |> disallow_left |> wrap (imply_const_unhint c)
 
@@ -5819,11 +5887,13 @@ module Monadic_gen (Obj : Obj) = struct
 
   let apply_hint hint m = wrap ~hint Fun.id m
 
-  let join_const_unhint c m = S.Unhint.apply Obj.obj (Simple (Meet_const c)) m
+  let join_const_unhint c m =
+    S.Unhint.apply Obj.obj (Simple (Meta (Meet_const c))) m
 
   let join_const ?hint c m = wrap ?hint (join_const_unhint c) (disallow_left m)
 
-  let subtract_const_unhint c m = S.Unhint.apply obj (Simple (Imply_const c)) m
+  let subtract_const_unhint c m =
+    S.Unhint.apply obj (Simple (Meta (Imply_const c))) m
 
   let subtract_const c m = m |> disallow_right |> wrap (subtract_const_unhint c)
 
@@ -6204,7 +6274,7 @@ module Comonadic_with (Areality : Areality) = struct
   end
 
   let proj ax m =
-    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Id, ax, Obj.obj)) m
+    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Meta Id, ax, Obj.obj)) m
 
   module Per_axis = struct
     let zap_to_floor ax m =
@@ -6217,10 +6287,12 @@ module Comonadic_with (Areality : Areality) = struct
   end
 
   let min_with ax m =
-    S.apply ~hint:Skip Obj.obj (Min_with_simple (ax, Id)) (disallow_right m)
+    S.apply ~hint:Skip Obj.obj
+      (Min_with_simple (ax, Meta Id))
+      (disallow_right m)
 
   let max_with ax m =
-    S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (disallow_left m)
+    S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Meta Id)) (disallow_left m)
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
@@ -6371,7 +6443,7 @@ module Monadic = struct
   end
 
   let proj ax m =
-    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Id, ax, Obj.obj)) m
+    S.apply ~hint:Skip (proj_obj ax) (Simple_proj (Meta Id, ax, Obj.obj)) m
 
   module Per_axis = struct
     let zap_to_floor ax m =
@@ -6388,7 +6460,9 @@ module Monadic = struct
   let join_const_with ax c m = join_const (C.min_with Obj.obj ax c) m
 
   let min_with ax m =
-    S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
+    S.apply ~hint:Skip Obj.obj
+      (Max_with_simple (ax, Meta Id))
+      (S.disallow_left m)
 
   let zap_to_legacy m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
@@ -7030,15 +7104,16 @@ module Value_with (Areality : Areality) = struct
 
   let comonadic_to_monadic_min ?hint m =
     S.apply ?hint Monadic.Obj.obj
-      (Simple (Core (Comonadic_to_monadic_op_max Areality.Const.areality)))
+      (Simple
+         (Meta (Core (Comonadic_to_monadic_op_max Areality.Const.areality))))
       (Comonadic.disallow_left m)
 
   let monadic_to_comonadic_min m =
-    S.apply Comonadic.Obj.obj (Simple (Core Monadic_op_to_comonadic_min))
+    S.apply Comonadic.Obj.obj (Simple (Meta (Core Monadic_op_to_comonadic_min)))
       (Monadic.disallow_left m)
 
   let monadic_to_comonadic_max m =
-    S.apply Comonadic.Obj.obj (Simple (Core Monadic_op_to_comonadic_max))
+    S.apply Comonadic.Obj.obj (Simple (Meta (Core Monadic_op_to_comonadic_max)))
       (Monadic.disallow_right m)
 
   let meet_const c { comonadic; monadic } =
@@ -7168,13 +7243,13 @@ end
 
 let locality_as_regionality m =
   S.apply C.Regionality
-    (Simple (Core (Locality_restricted Locality_as_regionality))) m
+    (Simple (Meta (Core (Locality_restricted Locality_as_regionality)))) m
 
 let alloc_as_value ?allocation { comonadic; monadic } =
   let hint = Option.map (fun a -> Hint.Allocation a) allocation in
   { comonadic =
       S.apply Value.Comonadic.Obj.obj ?hint
-        (Simple (Core (Locality_full Locality_as_regionality))) comonadic;
+        (Simple (Meta (Core (Locality_full Locality_as_regionality)))) comonadic;
     monadic = Value.Monadic.apply_hint Skip monadic
   }
 
@@ -7182,7 +7257,7 @@ let alloc_to_value_l2r m =
   let { comonadic; monadic } = Alloc.disallow_right m in
   { comonadic =
       S.apply Value.Comonadic.Obj.obj
-        (Simple (Core (Locality_full Local_to_regional))) comonadic;
+        (Simple (Meta (Core (Locality_full Local_to_regional)))) comonadic;
     monadic = Value.Monadic.apply_hint Skip monadic
   }
 
@@ -7191,14 +7266,14 @@ let value_to_alloc_r2g ?allocation m =
   let { comonadic; monadic } = Value.disallow_left m in
   { comonadic =
       S.apply Alloc.Comonadic.Obj.obj ?hint
-        (Simple (Core (Locality_full Regional_to_global))) comonadic;
+        (Simple (Meta (Core (Locality_full Regional_to_global)))) comonadic;
     monadic = Alloc.Monadic.apply_hint Skip monadic
   }
 
 let value_to_alloc_r2l { comonadic; monadic } =
   { comonadic =
       S.apply Alloc.Comonadic.Obj.obj
-        (Simple (Core (Locality_full Regional_to_local))) comonadic;
+        (Simple (Meta (Core (Locality_full Regional_to_local)))) comonadic;
     monadic = Alloc.Monadic.apply_hint Skip monadic
   }
 
@@ -8173,7 +8248,7 @@ module Crossing = struct
     let { comonadic; monadic } = m in
     let comonadic =
       S.Unhint.apply Alloc.Comonadic.Obj.obj
-        (Simple (Core (Locality_full Regional_to_local))) comonadic
+        (Simple (Meta (Core (Locality_full Regional_to_local)))) comonadic
     in
     { comonadic; monadic }
 
@@ -8181,17 +8256,17 @@ module Crossing = struct
     let { comonadic; monadic } = m in
     let comonadic =
       S.Unhint.apply Alloc.Comonadic.Obj.obj
-        (Simple (Core (Locality_full Regional_to_global))) comonadic
+        (Simple (Meta (Core (Locality_full Regional_to_global)))) comonadic
     in
     { comonadic; monadic }
 
   let comonadic_locality_as_regionality comonadic =
     S.Unhint.apply Value.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
+      (Simple (Meta (Core (Locality_full Locality_as_regionality)))) comonadic
 
   let comonadic_regional_to_local comonadic =
     S.Unhint.apply Alloc.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Regional_to_local))) comonadic
+      (Simple (Meta (Core (Locality_full Regional_to_local)))) comonadic
 
   let apply_left_alloc t m =
     m |> alloc_as_value |> apply_left_unhint t |> value_to_alloc_r2l_unhint

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -902,8 +902,6 @@ module Lattices = struct
        that this type cannot be equal to other datatypes. *)
     type 'a t = 'a quoted = Quote of 'a [@@unboxed]
 
-    val return : 'a -> 'a t
-
     module Make (L : sig
       include Const
 
@@ -915,8 +913,6 @@ module Lattices = struct
     end
   end = struct
     type 'a t = 'a quoted = Quote of 'a [@@unboxed]
-
-    let[@inline] return x = Quote x
 
     let[@inline] lift f (Quote x) (Quote y) = Quote (f x y)
 
@@ -7952,11 +7948,11 @@ module Crossing = struct
         ~forkable:(Atom.Modality (Meet_const forkable))
         ~yielding:(Atom.Modality (Meet_const yielding))
         ~statefulness:(Atom.Modality (Meet_const statefulness)) =
-      let areality_quoted = C.Quote.return areality in
+      (* CR quoted-modes jbachurski: We never cross quoted-areality. *)
       Modality
         (Meet_const
            { areality;
-             areality_quoted;
+             areality_quoted = C.ArealityQuoted.max;
              linearity;
              portability;
              statefulness;

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7151,6 +7151,10 @@ let value_to_alloc_r2l { comonadic; monadic } =
     monadic = Alloc.Monadic.apply_hint Skip monadic
   }
 
+let offset_stage_r = Value.Comonadic.offset_stage_r
+
+let const_offset_stage_r = Value.Comonadic.const_offset_stage_r
+
 module Modality = struct
   (* Inferred modalities
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1825,7 +1825,7 @@ module Lattices_mono = struct
       (* Versions of the above morphisms operating on regionality. *)
       | Local_to_regional_regionality :
           (Regionality.t, Regionality.t, 'l * disallowed) t
-          (** Maps regional to local, identity otherwise. *)
+          (** Maps local to regional, identity otherwise. *)
       | Regional_to_local_regionality :
           (Regionality.t, Regionality.t, 'l * 'r) t
           (** Maps regional to local, identity otherwise. *)
@@ -3067,7 +3067,7 @@ module Lattices_mono = struct
       | Compose :
           ('b, 'c, neither) t * ('a, 'b, neither) t
           -> ('a, 'c, neither) t
-          (** Compoistion of two morphisms. We don't allow compositions to
+          (** Composition of two morphisms. We don't allow compositions to
               appear on either side to ensure that there are a finite number of
               morphisms we can encounter in practice. *)
 
@@ -3681,7 +3681,7 @@ module Lattices_mono = struct
     | Compose :
         ('b, 'c, neither) morph * ('a, 'b, neither) morph
         -> ('a, 'c, neither) morph
-        (** Compoistion of two morphisms. We don't allow compositions to appear
+        (** Composition of two morphisms. We don't allow compositions to appear
             on either side to ensure that there are a finite number of morphisms
             we can encounter in practice. *)
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -930,9 +930,9 @@ module Lattices = struct
     struct
       type nonrec t = L.t t
 
-      let min = Quote L.max
+      let min = Quote L.min
 
-      let max = Quote L.min
+      let max = Quote L.max
 
       let legacy = Quote L.legacy
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -1026,6 +1026,40 @@ module Lattices = struct
         statefulness
       }
 
+    let unquoted_legacy_and_quoted_min =
+      let areality = Areality.legacy in
+      let areality_quoted = ArealityQuoted.min in
+      let linearity = Linearity.legacy in
+      let portability = Portability.legacy in
+      let forkable = Forkable.legacy in
+      let yielding = Yielding.legacy in
+      let statefulness = Statefulness.legacy in
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
+
+    let unquoted_max_and_quoted_min =
+      let areality = Areality.max in
+      let areality_quoted = ArealityQuoted.min in
+      let linearity = Linearity.max in
+      let portability = Portability.max in
+      let forkable = Forkable.max in
+      let yielding = Yielding.max in
+      let statefulness = Statefulness.max in
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
+
     (** All product values, including every combination of axis values. *)
     let all =
       lazy
@@ -6792,8 +6826,6 @@ module Comonadic_with (Areality : Areality) = struct
 
     let proj = Axis.proj
 
-    let offset_stage_r k c = if k < 0 then legacy else if k > 0 then max else c
-
     module Per_axis = struct
       let print ax ppf a =
         let obj = proj_obj ax in
@@ -6888,14 +6920,8 @@ module Comonadic_with (Areality : Areality) = struct
 
   let legacy = of_const Const.legacy
 
-  let offset_stage_r k m =
-    if k < 0
-    then of_const Const.legacy
-    else if k > 0
-    then of_const Const.max
-    else m
-
-  let const_offset_stage_r = Const.offset_stage_r
+  let unquoted_legacy_and_quoted_min =
+    of_const Const.unquoted_legacy_and_quoted_min
 
   type simple_error =
     | Error : 'a Axis.t * 'a Mode_intf.simple_error -> simple_error
@@ -7749,7 +7775,49 @@ module Value_with (Areality : Areality) = struct
 end
 [@@inline]
 
-module Value = Value_with (Regionality)
+module Value = struct
+  include Value_with (Regionality)
+
+  module Comonadic = struct
+    include Comonadic
+
+    let areality_quote_morph : _ C.morph =
+      Min_with_simple_proj
+        (ArealityQuoted, Quote_meta Id, Areality, Comonadic_with_regionality)
+
+    let areality_splice_morph : _ C.morph =
+      Min_with_simple_proj
+        (Areality, Meta_splice Id, ArealityQuoted, Comonadic_with_regionality)
+
+    let quote m =
+      join
+        [S.apply Obj.obj areality_quote_morph m; unquoted_legacy_and_quoted_min]
+
+    let splice m = S.apply Obj.obj areality_splice_morph m
+
+    let rec offset_stage_l k m =
+      if k < 0
+      then offset_stage_l (k + 1) (splice m)
+      else if k > 0
+      then offset_stage_l (k - 1) (quote m)
+      else m
+
+    let const_quote c =
+      C.meet Obj.obj
+        (C.apply Obj.obj areality_quote_morph c)
+        Const.unquoted_legacy_and_quoted_min
+
+    let const_splice c = C.apply Obj.obj areality_splice_morph c
+
+    let rec const_offset_stage_l k c =
+      if k < 0
+      then const_offset_stage_l (k + 1) (const_splice c)
+      else if k > 0
+      then const_offset_stage_l (k - 1) (const_quote c)
+      else c
+  end
+end
+
 module Alloc = Value_with (Locality)
 
 module Const = struct
@@ -7843,9 +7911,15 @@ let value_to_alloc_r2l { comonadic; monadic } =
     monadic = Alloc.Monadic.apply_hint Skip monadic
   }
 
-let offset_stage_r = Value.Comonadic.offset_stage_r
+let quoted_floor comonadic =
+  S.apply Value.Comonadic.Obj.obj
+    (Simple
+       (Meta (Meet_const Value.Comonadic.Const.unquoted_max_and_quoted_min)))
+    comonadic
 
-let const_offset_stage_r = Value.Comonadic.const_offset_stage_r
+let offset_stage_l = Value.Comonadic.offset_stage_l
+
+let const_offset_stage_l = Value.Comonadic.const_offset_stage_l
 
 module Modality = struct
   (* Inferred modalities

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -13,7 +13,7 @@
 (**************************************************************************)
 
 (* warn on fragile matches *)
-[@@@warning "+4"]
+[@@@warning "+4+9"]
 
 open Allowance
 open Solver_intf
@@ -1070,6 +1070,7 @@ module Lattices = struct
 
     let le m1 m2 =
       let { areality = areality1;
+            areality_quoted = areality_quoted1;
             linearity = linearity1;
             portability = portability1;
             forkable = forkable1;
@@ -1079,6 +1080,7 @@ module Lattices = struct
         m1
       in
       let { areality = areality2;
+            areality_quoted = areality_quoted2;
             linearity = linearity2;
             portability = portability2;
             forkable = forkable2;
@@ -1088,6 +1090,7 @@ module Lattices = struct
         m2
       in
       Areality.le areality1 areality2
+      && ArealityQuoted.le areality_quoted1 areality_quoted2
       && Linearity.le linearity1 linearity2
       && Portability.le portability1 portability2
       && Forkable.le forkable1 forkable2
@@ -1096,6 +1099,7 @@ module Lattices = struct
 
     let equal m1 m2 =
       let { areality = areality1;
+            areality_quoted = areality_quoted1;
             linearity = linearity1;
             portability = portability1;
             forkable = forkable1;
@@ -1105,6 +1109,7 @@ module Lattices = struct
         m1
       in
       let { areality = areality2;
+            areality_quoted = areality_quoted2;
             linearity = linearity2;
             portability = portability2;
             forkable = forkable2;
@@ -1114,6 +1119,7 @@ module Lattices = struct
         m2
       in
       Areality.equal areality1 areality2
+      && ArealityQuoted.equal areality_quoted1 areality_quoted2
       && Linearity.equal linearity1 linearity2
       && Portability.equal portability1 portability2
       && Forkable.equal forkable1 forkable2
@@ -1200,10 +1206,10 @@ module Lattices = struct
       }
 
     let print ppf m =
-      Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a" Areality.print m.areality
-        Linearity.print m.linearity Portability.print m.portability
-        Forkable.print m.forkable Yielding.print m.yielding Statefulness.print
-        m.statefulness
+      Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a,%a" Areality.print m.areality
+        ArealityQuoted.print m.areality_quoted Linearity.print m.linearity
+        Portability.print m.portability Forkable.print m.forkable Yielding.print
+        m.yielding Statefulness.print m.statefulness
   end
   [@@inline]
 
@@ -6705,6 +6711,7 @@ module Value_with (Areality : Areality) = struct
 
       let print ppf
           { areality;
+            areality_quoted;
             uniqueness;
             linearity;
             portability;
@@ -6719,9 +6726,11 @@ module Value_with (Areality : Areality) = struct
           | None -> Fmt.fprintf ppf "None"
           | Some a -> Fmt.fprintf ppf "Some %a" print a
         in
-        Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a,%a,%a,%a,%a"
+        Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a"
           (option_print Areality.Const.print)
           areality
+          (option_print ArealityQuoted.Const.print)
+          areality_quoted
           (option_print Linearity.Const.print)
           linearity
           (option_print Uniqueness.Const.print)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -895,8 +895,72 @@ module Lattices = struct
         Staticity.print m.staticity
   end
 
+  type 'a quoted = Quote of 'a [@@unboxed]
+
+  module Quote : sig
+    (* Exposing this is a datatype lets the type checker reason
+       that this type cannot be equal to other datatypes. *)
+    type 'a t = 'a quoted = Quote of 'a [@@unboxed]
+
+    val return : 'a -> 'a t
+
+    module Make (L : sig
+      include Const
+
+      include Heyting with type t := t
+    end) : sig
+      include Const with type t = L.t t
+
+      include Heyting with type t = t
+    end
+  end = struct
+    type 'a t = 'a quoted = Quote of 'a [@@unboxed]
+
+    let[@inline] return x = Quote x
+
+    let[@inline] lift f (Quote x) (Quote y) = Quote (f x y)
+
+    let[@inline] lift' f (Quote x) (Quote y) = f x y
+
+    module Make (L : sig
+      include Const
+
+      include Heyting with type t := t
+    end) =
+    struct
+      type nonrec t = L.t t
+
+      let min = Quote L.max
+
+      let max = Quote L.min
+
+      let legacy = Quote L.legacy
+
+      let all = lazy (List.map (fun x -> Quote x) (Lazy.force L.all))
+
+      let le = lift' L.le
+
+      let equal = lift' L.equal
+
+      let compare_total = lift' L.compare_total
+
+      let join = lift L.join
+
+      let meet = lift L.meet
+
+      (* CR quoted-modes jbachurski: Parsing has to be updated to allow <[%a]> here. *)
+      let print ppf (Quote t) = Fmt.fprintf ppf "quote_%a" L.print t
+
+      let imply = lift L.imply
+    end
+    [@@inline]
+  end
+
+  module ArealityQuoted = Quote.Make (Regionality)
+
   type 'areality comonadic_with =
     { areality : 'areality;
+      areality_quoted : ArealityQuoted.t;
       linearity : Linearity.t;
       portability : Portability.t;
       forkable : Forkable.t;
@@ -909,30 +973,54 @@ module Lattices = struct
 
     let min =
       let areality = Areality.min in
+      let areality_quoted = ArealityQuoted.min in
       let linearity = Linearity.min in
       let portability = Portability.min in
       let forkable = Forkable.min in
       let yielding = Yielding.min in
       let statefulness = Statefulness.min in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let max =
       let areality = Areality.max in
+      let areality_quoted = ArealityQuoted.max in
       let linearity = Linearity.max in
       let portability = Portability.max in
       let forkable = Forkable.max in
       let yielding = Yielding.max in
       let statefulness = Statefulness.max in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let legacy =
       let areality = Areality.legacy in
+      let areality_quoted = ArealityQuoted.legacy in
       let linearity = Linearity.legacy in
       let portability = Portability.legacy in
       let forkable = Forkable.legacy in
       let yielding = Yielding.legacy in
       let statefulness = Statefulness.legacy in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     (** All product values, including every combination of axis values. *)
     let all =
@@ -940,12 +1028,20 @@ module Lattices = struct
         (let ( let* ) xs f = List.concat_map f xs in
          let ( let+ ) xs f = List.map f xs in
          let* areality = Lazy.force Areality.all in
+         let* areality_quoted = Lazy.force ArealityQuoted.all in
          let* linearity = Lazy.force Linearity.all in
          let* portability = Lazy.force Portability.all in
          let* forkable = Lazy.force Forkable.all in
          let* yielding = Lazy.force Yielding.all in
          let+ statefulness = Lazy.force Statefulness.all in
-         { areality; linearity; portability; forkable; yielding; statefulness })
+         { areality;
+           areality_quoted;
+           linearity;
+           portability;
+           forkable;
+           yielding;
+           statefulness
+         })
 
     (* CR-someday ageorges: the following code manually enumerates axes. It would be nice
        to use the later definition of Lattices.Comonadic_with.Axis.all *)
@@ -1048,30 +1144,60 @@ module Lattices = struct
 
     let join m1 m2 =
       let areality = Areality.join m1.areality m2.areality in
+      let areality_quoted =
+        ArealityQuoted.join m1.areality_quoted m2.areality_quoted
+      in
       let linearity = Linearity.join m1.linearity m2.linearity in
       let portability = Portability.join m1.portability m2.portability in
       let forkable = Forkable.join m1.forkable m2.forkable in
       let yielding = Yielding.join m1.yielding m2.yielding in
       let statefulness = Statefulness.join m1.statefulness m2.statefulness in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let meet m1 m2 =
       let areality = Areality.meet m1.areality m2.areality in
+      let areality_quoted =
+        ArealityQuoted.meet m1.areality_quoted m2.areality_quoted
+      in
       let linearity = Linearity.meet m1.linearity m2.linearity in
       let portability = Portability.meet m1.portability m2.portability in
       let forkable = Forkable.meet m1.forkable m2.forkable in
       let yielding = Yielding.meet m1.yielding m2.yielding in
       let statefulness = Statefulness.meet m1.statefulness m2.statefulness in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let imply m1 m2 =
       let areality = Areality.imply m1.areality m2.areality in
+      let areality_quoted =
+        ArealityQuoted.imply m1.areality_quoted m2.areality_quoted
+      in
       let linearity = Linearity.imply m1.linearity m2.linearity in
       let portability = Portability.imply m1.portability m2.portability in
       let forkable = Forkable.imply m1.forkable m2.forkable in
       let yielding = Yielding.imply m1.yielding m2.yielding in
       let statefulness = Statefulness.imply m1.statefulness m2.statefulness in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let print ppf m =
       Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a" Areality.print m.areality
@@ -1132,6 +1258,7 @@ module Lattices = struct
   type 'a obj =
     | Locality : Locality.t obj
     | Regionality : Regionality.t obj
+    | ArealityQuoted : ArealityQuoted.t obj
     | Uniqueness_op : Uniqueness_op.t obj
     | Linearity : Linearity.t obj
     | Portability : Portability.t obj
@@ -1158,9 +1285,10 @@ module Lattices = struct
   let to_areality : type a. a obj -> a areality = function
     | Locality -> Locality
     | Regionality -> Regionality
-    | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
-    | Comonadic_with_locality | Contention_op | Visibility_op | Portability
-    | Forkable | Yielding | Statefulness | Staticity_op ->
+    | ArealityQuoted | Uniqueness_op | Linearity | Monadic_op
+    | Comonadic_with_regionality | Comonadic_with_locality | Contention_op
+    | Visibility_op | Portability | Forkable | Yielding | Statefulness
+    | Staticity_op ->
       assert false
 
   let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
@@ -1169,6 +1297,7 @@ module Lattices = struct
   let is_opposite : type a. a obj -> bool = function
     | Locality -> false
     | Regionality -> false
+    | ArealityQuoted -> false
     | Uniqueness_op -> true
     | Linearity -> false
     | Portability -> false
@@ -1186,6 +1315,7 @@ module Lattices = struct
    fun ppf -> function
     | Locality -> Fmt.fprintf ppf "Locality"
     | Regionality -> Fmt.fprintf ppf "Regionality"
+    | ArealityQuoted -> Fmt.fprintf ppf "ArealityQuoted"
     | Uniqueness_op -> Fmt.fprintf ppf "Uniqueness_op"
     | Linearity -> Fmt.fprintf ppf "Linearity"
     | Portability -> Fmt.fprintf ppf "Portability"
@@ -1202,6 +1332,7 @@ module Lattices = struct
   let min : type a. a obj -> a = function
     | Locality -> Locality.min
     | Regionality -> Regionality.min
+    | ArealityQuoted -> ArealityQuoted.min
     | Uniqueness_op -> Uniqueness_op.min
     | Contention_op -> Contention_op.min
     | Visibility_op -> Visibility_op.min
@@ -1218,6 +1349,7 @@ module Lattices = struct
   let max : type a. a obj -> a = function
     | Locality -> Locality.max
     | Regionality -> Regionality.max
+    | ArealityQuoted -> ArealityQuoted.max
     | Uniqueness_op -> Uniqueness_op.max
     | Contention_op -> Contention_op.max
     | Visibility_op -> Visibility_op.max
@@ -1236,6 +1368,7 @@ module Lattices = struct
     match obj with
     | Locality -> Locality.le a b
     | Regionality -> Regionality.le a b
+    | ArealityQuoted -> ArealityQuoted.le a b
     | Uniqueness_op -> Uniqueness_op.le a b
     | Contention_op -> Contention_op.le a b
     | Visibility_op -> Visibility_op.le a b
@@ -1254,6 +1387,7 @@ module Lattices = struct
     match obj with
     | Locality -> Locality.compare_total a b
     | Regionality -> Regionality.compare_total a b
+    | ArealityQuoted -> ArealityQuoted.compare_total a b
     | Uniqueness_op -> Uniqueness_op.compare_total a b
     | Contention_op -> Contention_op.compare_total a b
     | Visibility_op -> Visibility_op.compare_total a b
@@ -1272,6 +1406,7 @@ module Lattices = struct
     match obj with
     | Locality -> Locality.equal a b
     | Regionality -> Regionality.equal a b
+    | ArealityQuoted -> ArealityQuoted.equal a b
     | Uniqueness_op -> Uniqueness_op.equal a b
     | Contention_op -> Contention_op.equal a b
     | Visibility_op -> Visibility_op.equal a b
@@ -1290,6 +1425,7 @@ module Lattices = struct
     match obj with
     | Locality -> Locality.join a b
     | Regionality -> Regionality.join a b
+    | ArealityQuoted -> ArealityQuoted.join a b
     | Uniqueness_op -> Uniqueness_op.join a b
     | Contention_op -> Contention_op.join a b
     | Visibility_op -> Visibility_op.join a b
@@ -1308,6 +1444,7 @@ module Lattices = struct
     match obj with
     | Locality -> Locality.meet a b
     | Regionality -> Regionality.meet a b
+    | ArealityQuoted -> ArealityQuoted.meet a b
     | Uniqueness_op -> Uniqueness_op.meet a b
     | Contention_op -> Contention_op.meet a b
     | Visibility_op -> Visibility_op.meet a b
@@ -1326,6 +1463,7 @@ module Lattices = struct
     match obj with
     | Locality -> Locality.imply a b
     | Regionality -> Regionality.imply a b
+    | ArealityQuoted -> ArealityQuoted.imply a b
     | Uniqueness_op -> Uniqueness_op.imply a b
     | Contention_op -> Contention_op.imply a b
     | Visibility_op -> Visibility_op.imply a b
@@ -1343,6 +1481,7 @@ module Lattices = struct
   let print : type a. a obj -> _ -> a -> unit = function
     | Locality -> Locality.print
     | Regionality -> Regionality.print
+    | ArealityQuoted -> ArealityQuoted.print
     | Uniqueness_op -> Uniqueness_op.print
     | Contention_op -> Contention_op.print
     | Visibility_op -> Visibility_op.print
@@ -1360,6 +1499,7 @@ module Lattices = struct
   let arbitrary : type a. a obj -> a = function
     | Locality -> Locality.min
     | Regionality -> Regionality.min
+    | ArealityQuoted -> ArealityQuoted.min
     | Uniqueness_op -> Uniqueness_op.min
     | Contention_op -> Contention_op.min
     | Visibility_op -> Visibility_op.min
@@ -1382,6 +1522,9 @@ module Lattices = struct
     | Regionality, Regionality -> 0
     | Regionality, _ -> -1
     | _, Regionality -> 1
+    | ArealityQuoted, ArealityQuoted -> 0
+    | ArealityQuoted, _ -> -1
+    | _, ArealityQuoted -> 1
     | Uniqueness_op, Uniqueness_op -> 0
     | Uniqueness_op, _ -> -1
     | _, Uniqueness_op -> 1
@@ -1422,6 +1565,7 @@ module Lattices = struct
     match a, b with
     | Locality, Locality -> Misc.Is_eq
     | Regionality, Regionality -> Misc.Is_eq
+    | ArealityQuoted, ArealityQuoted -> Misc.Is_eq
     | Uniqueness_op, Uniqueness_op -> Misc.Is_eq
     | Linearity, Linearity -> Misc.Is_eq
     | Portability, Portability -> Misc.Is_eq
@@ -1434,9 +1578,9 @@ module Lattices = struct
     | Monadic_op, Monadic_op -> Misc.Is_eq
     | Comonadic_with_regionality, Comonadic_with_regionality -> Misc.Is_eq
     | Comonadic_with_locality, Comonadic_with_locality -> Misc.Is_eq
-    | ( ( Locality | Regionality | Uniqueness_op | Linearity | Portability
-        | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
-        | Staticity_op | Monadic_op | Comonadic_with_regionality
+    | ( ( Locality | Regionality | ArealityQuoted | Uniqueness_op | Linearity
+        | Portability | Forkable | Yielding | Statefulness | Contention_op
+        | Visibility_op | Staticity_op | Monadic_op | Comonadic_with_regionality
         | Comonadic_with_locality ),
         _ ) ->
       Misc.Is_not_eq
@@ -1448,6 +1592,7 @@ module Lattices_mono = struct
   module Axis = struct
     type ('t, 'r) t =
       | Areality : ('a comonadic_with, 'a) t
+      | ArealityQuoted : ('a comonadic_with, ArealityQuoted.t) t
       | Forkable : ('areality comonadic_with, Forkable.t) t
       | Yielding : ('areality comonadic_with, Yielding.t) t
       | Linearity : ('areality comonadic_with, Linearity.t) t
@@ -1461,6 +1606,7 @@ module Lattices_mono = struct
     let print : type p r. _ -> (p, r) t -> unit =
      fun ppf -> function
       | Areality -> Fmt.fprintf ppf "locality"
+      | ArealityQuoted -> Fmt.fprintf ppf "<[locality]>"
       | Linearity -> Fmt.fprintf ppf "linearity"
       | Portability -> Fmt.fprintf ppf "portability"
       | Uniqueness -> Fmt.fprintf ppf "uniqueness"
@@ -1475,6 +1621,7 @@ module Lattices_mono = struct
      fun ax1 ax2 ->
       match ax1, ax2 with
       | Areality, Areality -> Is_eq
+      | ArealityQuoted, ArealityQuoted -> Is_eq
       | Linearity, Linearity -> Is_eq
       | Portability, Portability -> Is_eq
       | Uniqueness, Uniqueness -> Is_eq
@@ -1484,22 +1631,24 @@ module Lattices_mono = struct
       | Statefulness, Statefulness -> Is_eq
       | Visibility, Visibility -> Is_eq
       | Staticity, Staticity -> Is_eq
-      | ( ( Areality | Linearity | Uniqueness | Portability | Contention
-          | Forkable | Yielding | Statefulness | Visibility | Staticity ),
+      | ( ( Areality | Linearity | ArealityQuoted | Uniqueness | Portability
+          | Contention | Forkable | Yielding | Statefulness | Visibility
+          | Staticity ),
           _ ) ->
         Is_not_eq
 
     let ord : type p r. (p, r) t -> int = function
       | Areality -> 0
-      | Forkable -> 1
-      | Yielding -> 2
-      | Linearity -> 3
-      | Statefulness -> 4
-      | Portability -> 5
-      | Uniqueness -> 6
-      | Visibility -> 7
-      | Contention -> 8
-      | Staticity -> 9
+      | ArealityQuoted -> 1
+      | Forkable -> 2
+      | Yielding -> 3
+      | Linearity -> 4
+      | Statefulness -> 5
+      | Portability -> 6
+      | Uniqueness -> 7
+      | Visibility -> 8
+      | Contention -> 9
+      | Staticity -> 10
 
     let compare : type p r1 r2. (p, r1) t -> (p, r2) t -> int =
      fun ax1 ax2 -> Int.compare (ord ax1) (ord ax2)
@@ -1508,6 +1657,7 @@ module Lattices_mono = struct
      fun ax t ->
       match ax with
       | Areality -> t.areality
+      | ArealityQuoted -> t.areality_quoted
       | Linearity -> t.linearity
       | Portability -> t.portability
       | Forkable -> t.forkable
@@ -1522,6 +1672,7 @@ module Lattices_mono = struct
      fun ax r t ->
       match ax with
       | Areality -> { t with areality = r }
+      | ArealityQuoted -> { t with areality_quoted = r }
       | Linearity -> { t with linearity = r }
       | Portability -> { t with portability = r }
       | Forkable -> { t with forkable = r }
@@ -1537,6 +1688,7 @@ module Lattices_mono = struct
     let from : type a. a obj -> a from list = function
       | Comonadic_with_locality ->
         [ From Areality;
+          From ArealityQuoted;
           From Forkable;
           From Yielding;
           From Linearity;
@@ -1544,6 +1696,7 @@ module Lattices_mono = struct
           From Portability ]
       | Comonadic_with_regionality ->
         [ From Areality;
+          From ArealityQuoted;
           From Forkable;
           From Yielding;
           From Linearity;
@@ -1551,9 +1704,9 @@ module Lattices_mono = struct
           From Portability ]
       | Monadic_op ->
         [From Uniqueness; From Visibility; From Contention; From Staticity]
-      | Locality | Regionality | Uniqueness_op | Linearity | Portability
-      | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
-      | Staticity_op ->
+      | Locality | Regionality | ArealityQuoted | Uniqueness_op | Linearity
+      | Portability | Forkable | Yielding | Statefulness | Contention_op
+      | Visibility_op | Staticity_op ->
         []
 
     type 'b to_ = To : 'a obj * ('a, 'b) t -> 'b to_
@@ -1564,6 +1717,9 @@ module Lattices_mono = struct
       | Monadic_op -> []
       | Locality -> [To (Comonadic_with_locality, Areality)]
       | Regionality -> [To (Comonadic_with_regionality, Areality)]
+      | ArealityQuoted ->
+        [ To (Comonadic_with_locality, ArealityQuoted);
+          To (Comonadic_with_regionality, ArealityQuoted) ]
       | Uniqueness_op -> [To (Monadic_op, Uniqueness)]
       | Linearity ->
         [ To (Comonadic_with_locality, Linearity);
@@ -1594,6 +1750,7 @@ module Lattices_mono = struct
      fun obj ax ->
       match ax with
       | Areality -> Comonadic (obj, ax)
+      | ArealityQuoted -> Comonadic (obj, ax)
       | Forkable -> Comonadic (obj, ax)
       | Yielding -> Comonadic (obj, ax)
       | Linearity -> Comonadic (obj, ax)
@@ -1610,6 +1767,7 @@ module Lattices_mono = struct
   let all_objs =
     [ Obj Locality;
       Obj Regionality;
+      Obj ArealityQuoted;
       Obj Uniqueness_op;
       Obj Linearity;
       Obj Portability;
@@ -1629,6 +1787,7 @@ module Lattices_mono = struct
       match obj with
       | Locality -> Locality.all
       | Regionality -> Regionality.all
+      | ArealityQuoted -> ArealityQuoted.all
       | Uniqueness_op -> Uniqueness.all
       | Linearity -> Linearity.all
       | Portability -> Portability.all
@@ -2234,12 +2393,20 @@ module Lattices_mono = struct
         | Comonadic_with_locality -> Locality.min
         | Comonadic_with_regionality -> Regionality.min
       in
+      let areality_quoted = ArealityQuoted.min in
       let linearity = uniqueness_op_to_linearity m.uniqueness in
       let portability = contention_op_to_portability m.contention in
       let forkable = Forkable.min in
       let yielding = Yielding.min in
       let statefulness = visibility_op_to_statefulness m.visibility in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let comonadic_to_monadic_op_min : type a.
         a areality -> a comonadic_with -> Monadic_op.t =
@@ -2258,12 +2425,20 @@ module Lattices_mono = struct
         | Comonadic_with_locality -> Locality.max
         | Comonadic_with_regionality -> Regionality.max
       in
+      let areality_quoted = ArealityQuoted.max in
       let linearity = uniqueness_op_to_linearity m.uniqueness in
       let portability = contention_op_to_portability m.contention in
       let forkable = Forkable.max in
       let yielding = Yielding.max in
       let statefulness = visibility_op_to_statefulness m.visibility in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let comonadic_to_monadic_op_max : type a.
         a areality -> a comonadic_with -> Monadic_op.t =
@@ -2474,6 +2649,7 @@ module Lattices_mono = struct
      fun ax0 lm1 ->
       let src = Locality_morph.src_full lm1 in
       match ax0 with
+      | ArealityQuoted -> Proj_id (ArealityQuoted, src)
       | Forkable -> Proj_id (Forkable, src)
       | Yielding -> Proj_id (Yielding, src)
       | Linearity -> Proj_id (Linearity, src)
@@ -2486,6 +2662,7 @@ module Lattices_mono = struct
      fun ax0 m1 ->
       match (m1 : (a, b, d) t), (ax0 : (b, p) Axis.t) with
       | Monadic_op_to_comonadic_min, Areality -> Proj_const_min Monadic_op
+      | Monadic_op_to_comonadic_min, ArealityQuoted -> Proj_const_min Monadic_op
       | Monadic_op_to_comonadic_min, Forkable -> Proj_const_min Monadic_op
       | Monadic_op_to_comonadic_min, Yielding -> Proj_const_min Monadic_op
       | Monadic_op_to_comonadic_min, Linearity ->
@@ -2512,6 +2689,7 @@ module Lattices_mono = struct
       | Comonadic_to_monadic_op_min areality, Staticity ->
         Proj_const_min (areality_comonadic_obj areality)
       | Monadic_op_to_comonadic_max, Areality -> Proj_const_max Monadic_op
+      | Monadic_op_to_comonadic_max, ArealityQuoted -> Proj_const_max Monadic_op
       | Monadic_op_to_comonadic_max, Forkable -> Proj_const_max Monadic_op
       | Monadic_op_to_comonadic_max, Yielding -> Proj_const_max Monadic_op
       | Monadic_op_to_comonadic_max, Linearity ->
@@ -2557,6 +2735,13 @@ module Lattices_mono = struct
         (q, c comonadic_with, disallowed * r) compose_and_max_result =
      fun lm1 ax0 ->
       match ax0 with
+      | ArealityQuoted -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id ArealityQuoted)
       | Forkable -> (
         match lm1 with
         | Local_to_regional -> Disallowed
@@ -2609,6 +2794,7 @@ module Lattices_mono = struct
       | Comonadic_to_monadic_op_max _, Yielding -> Const_max_core
       | Comonadic_to_monadic_op_max _, Forkable -> Const_max_core
       | Comonadic_to_monadic_op_max _, Areality -> Const_max_core
+      | Comonadic_to_monadic_op_max _, ArealityQuoted -> Const_max_core
       | Monadic_op_to_comonadic_max, Staticity -> Const_max_core
       | Monadic_op_to_comonadic_max, Contention ->
         And_max_core (Portability, Contention_op_to_portability)
@@ -2638,6 +2824,7 @@ module Lattices_mono = struct
         (q, c comonadic_with, l * disallowed) compose_and_min_result =
      fun lm1 ax0 ->
       match ax0 with
+      | ArealityQuoted -> And_min_id ArealityQuoted
       | Forkable -> And_min_id Forkable
       | Yielding -> And_min_id Yielding
       | Linearity -> And_min_id Linearity
@@ -2660,6 +2847,7 @@ module Lattices_mono = struct
       | Comonadic_to_monadic_op_min _, Yielding -> Const_min_core
       | Comonadic_to_monadic_op_min _, Forkable -> Const_min_core
       | Comonadic_to_monadic_op_min _, Areality -> Const_min_core
+      | Comonadic_to_monadic_op_min _, ArealityQuoted -> Const_min_core
       | Monadic_op_to_comonadic_min, Staticity -> Const_min_core
       | Monadic_op_to_comonadic_min, Contention ->
         And_min_core (Portability, Contention_op_to_portability)
@@ -2773,6 +2961,9 @@ module Lattices_mono = struct
       | Regionality ->
         let+ (Locality_morph.To lm) = Locality_morph.left_to Regionality in
         To (Locality_restricted lm)
+      | ArealityQuoted ->
+        (* CR quoted-modes jbachurski: update *)
+        []
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -2801,6 +2992,9 @@ module Lattices_mono = struct
       | Regionality ->
         let+ (Locality_morph.To lm) = Locality_morph.right_to Regionality in
         To (Locality_restricted lm)
+      | ArealityQuoted ->
+        (* CR quoted-modes jbachurski: update *)
+        []
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -2828,6 +3022,8 @@ module Lattices_mono = struct
     match ax, obj with
     | Areality, Comonadic_with_locality -> Locality
     | Areality, Comonadic_with_regionality -> Regionality
+    | ArealityQuoted, Comonadic_with_locality -> ArealityQuoted
+    | ArealityQuoted, Comonadic_with_regionality -> ArealityQuoted
     | Linearity, Comonadic_with_locality -> Linearity
     | Linearity, Comonadic_with_regionality -> Linearity
     | Portability, Comonadic_with_locality -> Portability
@@ -4113,6 +4309,8 @@ module Lattices_mono = struct
 
   let morphs_to_regionality = morphs_to_obj Regionality
 
+  let morphs_to_areality_quoted = morphs_to_obj ArealityQuoted
+
   let morphs_to_uniqueness_op = morphs_to_obj Uniqueness_op
 
   let morphs_to_linearity = morphs_to_obj Linearity
@@ -4142,6 +4340,7 @@ module Lattices_mono = struct
    fun ~full -> function
     | Locality -> force_by_coverage ~full morphs_to_locality
     | Regionality -> force_by_coverage ~full morphs_to_regionality
+    | ArealityQuoted -> force_by_coverage ~full morphs_to_areality_quoted
     | Uniqueness_op -> force_by_coverage ~full morphs_to_uniqueness_op
     | Linearity -> force_by_coverage ~full morphs_to_linearity
     | Portability -> force_by_coverage ~full morphs_to_portability
@@ -4192,6 +4391,7 @@ module Lattices_mono = struct
       | Visibility_op_to_statefulness, _ -> .
       | Statefulness_to_visibility_op, _ -> .
       | Locality_full _, (Areality as ax) -> Axis ax
+      | Locality_full _, (ArealityQuoted as ax) -> Axis ax
       | Locality_full _, (Forkable as ax) -> Axis ax
       | Locality_full _, (Yielding as ax) -> Axis ax
       | Locality_full _, (Linearity as ax) -> Axis ax
@@ -4199,6 +4399,7 @@ module Lattices_mono = struct
       | Locality_full _, (Portability as ax) -> Axis ax
       | Locality_full _, _ -> .
       | Monadic_op_to_comonadic_min, Areality -> None_responsible
+      | Monadic_op_to_comonadic_min, ArealityQuoted -> None_responsible
       | Monadic_op_to_comonadic_min, Forkable -> None_responsible
       | Monadic_op_to_comonadic_min, Yielding -> None_responsible
       | Monadic_op_to_comonadic_min, Linearity -> Axis Uniqueness
@@ -4209,6 +4410,7 @@ module Lattices_mono = struct
       | Comonadic_to_monadic_op_min _, Contention -> Axis Portability
       | Comonadic_to_monadic_op_min _, Staticity -> None_responsible
       | Monadic_op_to_comonadic_max, Areality -> None_responsible
+      | Monadic_op_to_comonadic_max, ArealityQuoted -> None_responsible
       | Monadic_op_to_comonadic_max, Forkable -> None_responsible
       | Monadic_op_to_comonadic_max, Yielding -> None_responsible
       | Monadic_op_to_comonadic_max, Linearity -> Axis Uniqueness
@@ -4383,6 +4585,7 @@ type monadic = C.monadic =
 
 type 'a comonadic_with = 'a C.comonadic_with =
   { areality : 'a;
+    areality_quoted : C.ArealityQuoted.t;
     linearity : C.Linearity.t;
     portability : C.Portability.t;
     forkable : C.Forkable.t;
@@ -5338,6 +5541,8 @@ module type Common_axis_neg = sig
        and type 'd hint_const := 'd neg_hint_const
 end
 
+type 'a quoted = 'a C.quoted = Quote of 'a [@@unboxed]
+
 (** Representing a single object *)
 module type Obj = sig
   type const
@@ -5634,6 +5839,22 @@ module Regionality = struct
   let zap_to_legacy = zap_to_floor
 end
 
+module ArealityQuoted = struct
+  module Const = C.ArealityQuoted
+
+  module Obj = struct
+    type const = Const.t
+
+    let obj : _ C.obj = C.ArealityQuoted
+  end
+
+  include Comonadic_gen (Obj)
+
+  let legacy = of_const Const.legacy
+
+  let zap_to_legacy = zap_to_floor
+end
+
 module Linearity = struct
   module Const = C.Linearity
 
@@ -5870,6 +6091,7 @@ module Comonadic_with (Areality : Areality) = struct
 
     let all =
       [ P Areality;
+        P ArealityQuoted;
         P Linearity;
         P Portability;
         P Forkable;
@@ -5886,10 +6108,7 @@ module Comonadic_with (Areality : Areality) = struct
 
     let proj = Axis.proj
 
-    let offset_stage_r k c =
-      if k < 0 then legacy
-      else if k > 0 then max
-      else c
+    let offset_stage_r k c = if k < 0 then legacy else if k > 0 then max else c
 
     module Per_axis = struct
       let print ax ppf a =
@@ -5961,6 +6180,9 @@ module Comonadic_with (Areality : Areality) = struct
 
   let zap_to_legacy m : Const.t =
     let areality = proj Areality m |> Areality.zap_to_legacy in
+    let areality_quoted =
+      proj ArealityQuoted m |> ArealityQuoted.zap_to_legacy
+    in
     let linearity = proj Linearity m |> Linearity.zap_to_legacy in
     let statefulness = proj Statefulness m |> Statefulness.zap_to_legacy in
     let portability =
@@ -5969,13 +6191,22 @@ module Comonadic_with (Areality : Areality) = struct
     let global = Areality.Const.equal areality Areality.Const.legacy in
     let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
     let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
-    { areality; linearity; portability; forkable; yielding; statefulness }
+    { areality;
+      areality_quoted;
+      linearity;
+      portability;
+      forkable;
+      yielding;
+      statefulness
+    }
 
   let legacy = of_const Const.legacy
 
   let offset_stage_r k m =
-    if k < 0 then of_const Const.legacy
-    else if k > 0 then of_const Const.max
+    if k < 0
+    then of_const Const.legacy
+    else if k > 0
+    then of_const Const.max
     else m
 
   let const_offset_stage_r = Const.offset_stage_r
@@ -6203,8 +6434,9 @@ module Value_with (Areality : Areality) = struct
 
   (* CR-soon zqian: make a functor [Mode.Value.Const.Make] to generalize over any type
      operator applied on each mode constants. *)
-  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
+  type ('a, 'aq, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
     { areality : 'a;
+      areality_quoted : 'aq;
       linearity : 'b;
       uniqueness : 'c;
       portability : 'd;
@@ -6218,6 +6450,7 @@ module Value_with (Areality : Areality) = struct
 
   let split
       { areality;
+        areality_quoted;
         linearity;
         portability;
         forkable;
@@ -6232,12 +6465,26 @@ module Value_with (Areality : Areality) = struct
       { uniqueness; contention; visibility; staticity }
     in
     let comonadic : Comonadic.Const.t =
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        areality_quoted;
+        linearity;
+        portability;
+        forkable;
+        yielding;
+        statefulness
+      }
     in
     { comonadic; monadic }
 
   let merge { comonadic; monadic } =
-    let ({ areality; linearity; portability; forkable; yielding; statefulness }
+    let ({ areality;
+           areality_quoted;
+           linearity;
+           portability;
+           forkable;
+           yielding;
+           statefulness
+         }
           : Comonadic.Const.t) =
       comonadic
     in
@@ -6245,6 +6492,7 @@ module Value_with (Areality : Areality) = struct
       monadic
     in
     { areality;
+      areality_quoted;
       linearity;
       portability;
       forkable;
@@ -6290,6 +6538,7 @@ module Value_with (Areality : Areality) = struct
        operator applied on each mode constants. *)
     type t =
       ( Areality.Const.t,
+        ArealityQuoted.Const.t,
         Linearity.Const.t,
         Uniqueness.Const.t,
         Portability.Const.t,
@@ -6355,6 +6604,7 @@ module Value_with (Areality : Areality) = struct
 
       type t =
         ( Areality.Const.t option,
+          ArealityQuoted.Const.t option,
           Linearity.Const.t option,
           Uniqueness.Const.t option,
           Portability.Const.t option,
@@ -6368,6 +6618,7 @@ module Value_with (Areality : Areality) = struct
 
       let none =
         { areality = None;
+          areality_quoted = None;
           uniqueness = None;
           linearity = None;
           portability = None;
@@ -6381,6 +6632,9 @@ module Value_with (Areality : Areality) = struct
 
       let value opt ~default =
         let areality = Option.value opt.areality ~default:default.areality in
+        let areality_quoted =
+          Option.value opt.areality_quoted ~default:default.areality_quoted
+        in
         let uniqueness =
           Option.value opt.uniqueness ~default:default.uniqueness
         in
@@ -6401,6 +6655,7 @@ module Value_with (Areality : Areality) = struct
         in
         let staticity = Option.value opt.staticity ~default:default.staticity in
         { areality;
+          areality_quoted;
           uniqueness;
           linearity;
           portability;
@@ -6423,6 +6678,7 @@ module Value_with (Areality : Areality) = struct
         | Comonadic ax -> (
           match ax with
           | Areality -> t.areality
+          | ArealityQuoted -> t.areality_quoted
           | Linearity -> t.linearity
           | Portability -> t.portability
           | Forkable -> t.forkable
@@ -6440,6 +6696,7 @@ module Value_with (Areality : Areality) = struct
         | Comonadic ax -> (
           match ax with
           | Areality -> { t with areality = a }
+          | ArealityQuoted -> { t with areality_quoted = a }
           | Linearity -> { t with linearity = a }
           | Portability -> { t with portability = a }
           | Yielding -> { t with yielding = a }
@@ -6488,6 +6745,9 @@ module Value_with (Areality : Areality) = struct
     let diff m1 m2 =
       let diff le a1 a2 = if le a1 a2 && le a2 a1 then None else Some a1 in
       let areality = diff Areality.Const.le m1.areality m2.areality in
+      let areality_quoted =
+        diff ArealityQuoted.Const.le m1.areality_quoted m2.areality_quoted
+      in
       let linearity = diff Linearity.Const.le m1.linearity m2.linearity in
       let uniqueness = diff Uniqueness.Const.le m1.uniqueness m2.uniqueness in
       let portability =
@@ -6502,6 +6762,7 @@ module Value_with (Areality : Areality) = struct
       let visibility = diff Visibility.Const.le m1.visibility m2.visibility in
       let staticity = diff Staticity.Const.le m1.staticity m2.staticity in
       { areality;
+        areality_quoted;
         linearity;
         uniqueness;
         portability;
@@ -6804,6 +7065,7 @@ module Const = struct
 
   let alloc_as_value
       ({ areality;
+         areality_quoted;
          linearity;
          portability;
          uniqueness;
@@ -6817,6 +7079,7 @@ module Const = struct
         Alloc.Const.t) : Value.Const.t =
     let areality = locality_as_regionality areality in
     { areality;
+      areality_quoted;
       linearity;
       portability;
       uniqueness;
@@ -6833,6 +7096,7 @@ module Const = struct
         a Alloc.Axis.t ->
         ((a, Locality.Const.t) Misc.eq, a Value.Axis.t) Either.t = function
       | Comonadic Areality -> Left Refl
+      | Comonadic ArealityQuoted -> Right (Comonadic ArealityQuoted)
       | Comonadic Linearity -> Right (Comonadic Linearity)
       | Comonadic Portability -> Right (Comonadic Portability)
       | Comonadic Forkable -> Right (Comonadic Forkable)
@@ -7675,9 +7939,11 @@ module Crossing = struct
         ~forkable:(Atom.Modality (Meet_const forkable))
         ~yielding:(Atom.Modality (Meet_const yielding))
         ~statefulness:(Atom.Modality (Meet_const statefulness)) =
+      let areality_quoted = C.Quote.return areality in
       Modality
         (Meet_const
            { areality;
+             areality_quoted;
              linearity;
              portability;
              statefulness;

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5879,6 +5879,11 @@ module Comonadic_with (Areality : Areality) = struct
 
     let proj = Axis.proj
 
+    let offset_stage_r k c =
+      if k < 0 then legacy
+      else if k > 0 then max
+      else c
+
     module Per_axis = struct
       let print ax ppf a =
         let obj = proj_obj ax in
@@ -5960,6 +5965,13 @@ module Comonadic_with (Areality : Areality) = struct
     { areality; linearity; portability; forkable; yielding; statefulness }
 
   let legacy = of_const Const.legacy
+
+  let offset_stage_r k m =
+    if k < 0 then of_const Const.legacy
+    else if k > 0 then of_const Const.max
+    else m
+
+  let const_offset_stage_r = Const.offset_stage_r
 
   type simple_error =
     | Error : 'a Axis.t * 'a Mode_intf.simple_error -> simple_error

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5945,6 +5945,8 @@ module Comonadic_with (Areality : Areality) = struct
 
   let meet_const_with ax c m = meet_const (C.max_with Obj.obj ax c) m
 
+  let imply_const_with ax c m = imply_const (C.max_with Obj.obj ax c) m
+
   let zap_to_legacy m : Const.t =
     let areality = proj Areality m |> Areality.zap_to_legacy in
     let linearity = proj Linearity m |> Linearity.zap_to_legacy in
@@ -6666,6 +6668,11 @@ module Value_with (Areality : Areality) = struct
   let meet_const_with ax c { monadic; comonadic } =
     let monadic = Monadic.disallow_right monadic in
     let comonadic = Comonadic.meet_const_with ax c comonadic in
+    { comonadic; monadic }
+
+  let imply_const_with ax c { monadic; comonadic } =
+    let monadic = Monadic.disallow_left monadic in
+    let comonadic = Comonadic.imply_const_with ax c comonadic in
     { comonadic; monadic }
 
   let join l =

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -902,6 +902,10 @@ module Lattices = struct
        that this type cannot be equal to other datatypes. *)
     type 'a t = 'a quoted = Quote of 'a [@@unboxed]
 
+    val return : 'a -> 'a t
+
+    val extract : 'a t -> 'a
+
     module Make (L : sig
       include Const
 
@@ -913,6 +917,10 @@ module Lattices = struct
     end
   end = struct
     type 'a t = 'a quoted = Quote of 'a [@@unboxed]
+
+    let return x = Quote x
+
+    let extract (Quote x) = x
 
     let[@inline] lift f (Quote x) (Quote y) = Quote (f x y)
 
@@ -1288,6 +1296,17 @@ module Lattices = struct
     | Locality -> Locality
     | Regionality -> Regionality
     | ArealityQuoted | Uniqueness_op | Linearity | Monadic_op
+    | Comonadic_with_regionality | Comonadic_with_locality | Contention_op
+    | Visibility_op | Portability | Forkable | Yielding | Statefulness
+    | Staticity_op ->
+      assert false
+
+  let to_splice : type a. a quoted obj -> a obj = function
+    | ArealityQuoted -> Regionality
+
+  let to_quote : type a. a obj -> a quoted obj = function
+    | Regionality -> ArealityQuoted
+    | Locality | ArealityQuoted | Uniqueness_op | Linearity | Monadic_op
     | Comonadic_with_regionality | Comonadic_with_locality | Contention_op
     | Visibility_op | Portability | Forkable | Yielding | Statefulness
     | Staticity_op ->
@@ -2963,9 +2982,7 @@ module Lattices_mono = struct
       | Regionality ->
         let+ (Locality_morph.To lm) = Locality_morph.left_to Regionality in
         To (Locality_restricted lm)
-      | ArealityQuoted ->
-        (* CR quoted-modes jbachurski: update *)
-        []
+      | ArealityQuoted -> []
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -2994,9 +3011,7 @@ module Lattices_mono = struct
       | Regionality ->
         let+ (Locality_morph.To lm) = Locality_morph.right_to Regionality in
         To (Locality_restricted lm)
-      | ArealityQuoted ->
-        (* CR quoted-modes jbachurski: update *)
-        []
+      | ArealityQuoted -> []
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
@@ -3655,46 +3670,325 @@ module Lattices_mono = struct
   end
 
   module Simple_morph = struct
-    type ('a, 'b, 'd) t = Meta : ('a, 'b, 'd) Meta_morph.t -> ('a, 'b, 'd) t
+    type ('a, 'b, 'd) t =
+      | Meta : ('a, 'b, 'd) Meta_morph.t -> ('a, 'b, 'd) t
+      | Quote_meta : ('a, 'b, 'd) Meta_morph.t -> ('a, 'b quoted, 'd) t
+      | Meta_splice : ('a, 'b, 'd) Meta_morph.t -> ('a quoted, 'b, 'd) t
+      | Quote_meta_splice :
+          ('a, 'b, 'd) Meta_morph.t
+          -> ('a quoted, 'b quoted, 'd) t
 
     let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
-     fun (Meta m) -> Meta (Meta_morph.allow_left m)
+      function
+      | Meta m -> Meta (Meta_morph.allow_left m)
+      | Quote_meta m -> Quote_meta (Meta_morph.allow_left m)
+      | Meta_splice m -> Meta_splice (Meta_morph.allow_left m)
+      | Quote_meta_splice m -> Quote_meta_splice (Meta_morph.allow_left m)
 
     let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
-     fun (Meta m) -> Meta (Meta_morph.allow_right m)
+      function
+      | Meta m -> Meta (Meta_morph.allow_right m)
+      | Quote_meta m -> Quote_meta (Meta_morph.allow_right m)
+      | Meta_splice m -> Meta_splice (Meta_morph.allow_right m)
+      | Quote_meta_splice m -> Quote_meta_splice (Meta_morph.allow_right m)
 
     let disallow_left : type a b l r.
-        (a, b, l * r) t -> (a, b, disallowed * r) t =
-     fun (Meta m) -> Meta (Meta_morph.disallow_left m)
+        (a, b, l * r) t -> (a, b, disallowed * r) t = function
+      | Meta m -> Meta (Meta_morph.disallow_left m)
+      | Quote_meta m -> Quote_meta (Meta_morph.disallow_left m)
+      | Meta_splice m -> Meta_splice (Meta_morph.disallow_left m)
+      | Quote_meta_splice m -> Quote_meta_splice (Meta_morph.disallow_left m)
 
     let disallow_right : type a b l r.
-        (a, b, l * r) t -> (a, b, l * disallowed) t =
-     fun (Meta m) -> Meta (Meta_morph.disallow_right m)
+        (a, b, l * r) t -> (a, b, l * disallowed) t = function
+      | Meta m -> Meta (Meta_morph.disallow_right m)
+      | Quote_meta m -> Quote_meta (Meta_morph.disallow_right m)
+      | Meta_splice m -> Meta_splice (Meta_morph.disallow_right m)
+      | Quote_meta_splice m -> Quote_meta_splice (Meta_morph.disallow_right m)
 
     let src : type a b d. b obj -> (a, b, d) t -> a obj =
-     fun dst (Meta m) -> Meta_morph.src dst m
+     fun dst f ->
+      match f with
+      | Meta m -> Meta_morph.src dst m
+      | Quote_meta m -> Meta_morph.src (to_splice dst) m
+      | Meta_splice m -> to_quote (Meta_morph.src dst m)
+      | Quote_meta_splice m -> to_quote (Meta_morph.src (to_splice dst) m)
 
     let compare_total : type a1 d1 a2 b d2.
         b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
-     fun dst (Meta m1) (Meta m2) -> Meta_morph.compare_total dst m1 m2
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Meta m1, Meta m2 -> Meta_morph.compare_total dst m1 m2
+      | Meta _, _ -> -1
+      | _, Meta _ -> 1
+      | Quote_meta m1, Quote_meta m2 ->
+        Meta_morph.compare_total (to_splice dst) m1 m2
+      | Quote_meta _, _ -> -1
+      | _, Quote_meta _ -> 1
+      | Meta_splice m1, Meta_splice m2 -> Meta_morph.compare_total dst m1 m2
+      | Meta_splice _, _ -> -1
+      | _, Meta_splice _ -> 1
+      | Quote_meta_splice m1, Quote_meta_splice m2 ->
+        Meta_morph.compare_total (to_splice dst) m1 m2
 
     let equal : type a1 d1 a2 b d2.
         b obj -> (a1, b, d1) t -> (a2, b, d2) t -> (a1, a2) Misc.is_eq =
-     fun dst (Meta m1) (Meta m2) -> Meta_morph.equal dst m1 m2
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Meta m1, Meta m2 -> Meta_morph.equal dst m1 m2
+      | Quote_meta m1, Quote_meta m2 -> Meta_morph.equal (to_splice dst) m1 m2
+      | Meta_splice m1, Meta_splice m2 -> (
+        match Meta_morph.equal dst m1 m2 with
+        | Is_eq -> Is_eq
+        | Is_not_eq -> Is_not_eq)
+      | Quote_meta_splice m1, Quote_meta_splice m2 -> (
+        match Meta_morph.equal (to_splice dst) m1 m2 with
+        | Is_eq -> Is_eq
+        | Is_not_eq -> Is_not_eq)
+      | (Meta _ | Quote_meta _ | Meta_splice _ | Quote_meta_splice _), _ ->
+        Is_not_eq
 
     let print : type a b d. b obj -> Fmt.formatter -> (a, b, d) t -> unit =
-     fun dst ppf (Meta m) -> Meta_morph.print dst ppf m
+     fun dst ppf -> function
+      | Meta m -> Meta_morph.print dst ppf m
+      | Quote_meta Id -> Fmt.fprintf ppf "quote"
+      | Quote_meta m ->
+        Fmt.fprintf ppf "quote . %a" (Meta_morph.print (to_splice dst)) m
+      | Meta_splice Id -> Fmt.fprintf ppf "splice"
+      | Meta_splice m -> Fmt.fprintf ppf "%a . splice" (Meta_morph.print dst) m
+      | Quote_meta_splice Id -> Fmt.fprintf ppf "id"
+      | Quote_meta_splice m ->
+        Fmt.fprintf ppf "splice . %a . quote"
+          (Meta_morph.print (to_splice dst))
+          m
+    [@@warning "-4"]
 
     let apply : type a b d. b obj -> (a, b, d) t -> a -> b =
-     fun dst (Meta m) a -> Meta_morph.apply dst m a
+     fun dst f a ->
+      match f with
+      | Meta m -> Meta_morph.apply dst m a
+      | Quote_meta m -> Quote.return (Meta_morph.apply (to_splice dst) m a)
+      | Meta_splice m -> Meta_morph.apply dst m (Quote.extract a)
+      | Quote_meta_splice m ->
+        Quote.return (Meta_morph.apply (to_splice dst) m (Quote.extract a))
 
     let right_adjoint : type a b r.
         b obj -> (a, b, allowed * r) t -> (b, a, disallowed * allowed) t =
-     fun dst (Meta m) -> Meta (Meta_morph.right_adjoint dst m)
+     fun dst f ->
+      match f with
+      | Meta m -> Meta (Meta_morph.right_adjoint dst m)
+      | Quote_meta m -> Meta_splice (Meta_morph.right_adjoint (to_splice dst) m)
+      | Meta_splice m -> Quote_meta (Meta_morph.right_adjoint dst m)
+      | Quote_meta_splice m ->
+        Quote_meta_splice (Meta_morph.right_adjoint (to_splice dst) m)
 
     let left_adjoint : type a b l.
         b obj -> (a, b, l * allowed) t -> (b, a, allowed * disallowed) t =
-     fun dst (Meta m) -> Meta (Meta_morph.left_adjoint dst m)
+     fun dst f ->
+      match f with
+      | Meta m -> Meta (Meta_morph.left_adjoint dst m)
+      | Quote_meta m -> Meta_splice (Meta_morph.left_adjoint (to_splice dst) m)
+      | Meta_splice m -> Quote_meta (Meta_morph.left_adjoint dst m)
+      | Quote_meta_splice m ->
+        Quote_meta_splice (Meta_morph.left_adjoint (to_splice dst) m)
+
+    type ('a, 'b, 'd) maybe_allowed_right =
+      | Allowed_right :
+          ('a, 'b, 'l * allowed) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_right
+      | Not_allowed_right : ('a, 'b, 'l * disallowed) maybe_allowed_right
+
+    let maybe_allowed_right : type a b l r.
+        (a, b, l * r) t -> (a, b, l * r) maybe_allowed_right = function
+      | Meta m -> (
+        match Meta_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Meta m)
+        | Not_allowed_right -> Not_allowed_right)
+      | Quote_meta m -> (
+        match Meta_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Quote_meta m)
+        | Not_allowed_right -> Not_allowed_right)
+      | Meta_splice m -> (
+        match Meta_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Meta_splice m)
+        | Not_allowed_right -> Not_allowed_right)
+      | Quote_meta_splice m -> (
+        match Meta_morph.maybe_allowed_right m with
+        | Allowed_right m -> Allowed_right (Quote_meta_splice m)
+        | Not_allowed_right -> Not_allowed_right)
+
+    type ('a, 'b, 'd) maybe_allowed_left =
+      | Allowed_left :
+          ('a, 'b, allowed * 'r) t
+          -> ('a, 'b, 'l * 'r) maybe_allowed_left
+      | Not_allowed_left : ('a, 'b, disallowed * 'r) maybe_allowed_left
+
+    let maybe_allowed_left : type a b l r.
+        (a, b, l * r) t -> (a, b, l * r) maybe_allowed_left = function
+      | Meta m -> (
+        match Meta_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Meta m)
+        | Not_allowed_left -> Not_allowed_left)
+      | Quote_meta m -> (
+        match Meta_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Quote_meta m)
+        | Not_allowed_left -> Not_allowed_left)
+      | Meta_splice m -> (
+        match Meta_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Meta_splice m)
+        | Not_allowed_left -> Not_allowed_left)
+      | Quote_meta_splice m -> (
+        match Meta_morph.maybe_allowed_left m with
+        | Allowed_left m -> Allowed_left (Quote_meta_splice m)
+        | Not_allowed_left -> Not_allowed_left)
+
+    let quote_morph : type a b d.
+        b quoted obj -> (a, b, d) t -> (a, b quoted, d) t =
+     fun dst m ->
+      match m with
+      | Meta m -> Quote_meta m
+      | Meta_splice m -> Quote_meta_splice m
+      | Quote_meta _ -> ( match dst with _ -> .)
+      | Quote_meta_splice _ -> ( match dst with _ -> .)
+
+    let morph_splice : type a b d.
+        a quoted obj -> (a, b, d) t -> (a quoted, b, d) t =
+     fun src m ->
+      match m with
+      | Meta m -> Meta_splice m
+      | Quote_meta m -> Quote_meta_splice m
+      | Meta_splice _ -> ( match src with _ -> .)
+      | Quote_meta_splice _ -> ( match src with _ -> .)
+
+    let refute_core_src_quoted : type a b d void.
+        (a quoted, b, d) Core_morph.t -> void =
+     fun cm ->
+      match cm with
+      | Locality_restricted lm -> ( match lm with _ -> .)
+      | _ -> .
+    [@@warning "-4"]
+
+    let refute_core_dst_quoted : type a b d void.
+        (a, b quoted, d) Core_morph.t -> void =
+     fun cm ->
+      match cm with
+      | Locality_restricted lm -> ( match lm with _ -> .)
+      | _ -> .
+    [@@warning "-4"]
+
+    let rec compose : type a b c d.
+        c obj -> (b, c, d) t -> (a, b, d) t -> (a, c, d) t =
+     fun dst m0 m1 ->
+      let src = src (src dst m0) m1 in
+      match m0, m1 with
+      | Meta m0, Meta m1 -> Meta (Meta_morph.compose dst m0 m1)
+      | Meta m0, Quote_meta m1 -> compose dst (meta_quote dst m0) (Meta m1)
+      | Meta m0, Meta_splice m1 -> Meta_splice (Meta_morph.compose dst m0 m1)
+      | Meta m0, Quote_meta_splice m1 ->
+        compose dst (meta_quote dst m0) (Meta_splice m1)
+      | Quote_meta m0, Meta m1 ->
+        Quote_meta (Meta_morph.compose (to_splice dst) m0 m1)
+      | Quote_meta m0, Quote_meta m1 ->
+        quote_morph dst
+          (compose (to_splice dst) (meta_quote (to_splice dst) m0) (Meta m1))
+      | Quote_meta m0, Meta_splice m1 ->
+        Quote_meta_splice (Meta_morph.compose (to_splice dst) m0 m1)
+      | Quote_meta m0, Quote_meta_splice m1 ->
+        quote_morph dst
+          (compose (to_splice dst)
+             (meta_quote (to_splice dst) m0)
+             (Meta_splice m1))
+      | Meta_splice m0, Meta m1 ->
+        compose dst (Meta m0) (splice_meta (Meta_morph.src dst m0) m1)
+      | Meta_splice m0, Quote_meta m1 -> Meta (Meta_morph.compose dst m0 m1)
+      | Meta_splice m0, Meta_splice m1 ->
+        morph_splice src
+          (compose dst (Meta m0) (splice_meta (Meta_morph.src dst m0) m1))
+      | Meta_splice m0, Quote_meta_splice m1 ->
+        Meta_splice (Meta_morph.compose dst m0 m1)
+      | Quote_meta_splice m0, Meta m1 ->
+        quote_morph dst
+          (compose (to_splice dst) (Meta m0)
+             (splice_meta (Meta_morph.src (to_splice dst) m0) m1))
+      | Quote_meta_splice m0, Quote_meta m1 ->
+        Quote_meta (Meta_morph.compose (to_splice dst) m0 m1)
+      | Quote_meta_splice m0, Meta_splice m1 ->
+        let dst' = to_splice dst in
+        quote_morph dst
+          (morph_splice src
+             (compose dst' (Meta m0) (splice_meta (Meta_morph.src dst' m0) m1)))
+      | Quote_meta_splice m0, Quote_meta_splice m1 ->
+        Quote_meta_splice (Meta_morph.compose (to_splice dst) m0 m1)
+
+    and meta_quote : type a b d.
+        b obj -> (a quoted, b, d) Meta_morph.t -> (a, b, d) t =
+     fun dst -> function
+      | Id -> Quote_meta Id
+      | Meet_const cst -> Quote_meta (Meet_const (Quote.extract cst))
+      | Imply_const cst -> Quote_meta (Imply_const (Quote.extract cst))
+      | Core cm -> refute_core_src_quoted cm
+      | Meet_const_core (_, cm) -> refute_core_src_quoted cm
+      | Core_imply_const (cm, _) -> refute_core_src_quoted cm
+      | Compose (m0, m1) ->
+        let mid = Meta_morph.src dst m0 in
+        compose dst (Meta m0) (meta_quote mid m1)
+
+    and splice_meta : type a b d.
+        b obj -> (a, b quoted, d) Meta_morph.t -> (a, b, d) t =
+     fun dst -> function
+      | Id -> Meta_splice Id
+      | Meet_const cst -> Meta_splice (Meet_const (Quote.extract cst))
+      | Imply_const cst -> Meta_splice (Imply_const (Quote.extract cst))
+      | Core cm -> refute_core_dst_quoted cm
+      | Meet_const_core (_, cm) -> refute_core_dst_quoted cm
+      | Core_imply_const (cm, _) -> refute_core_dst_quoted cm
+      | Compose (m0, m1) -> compose dst (splice_meta dst m0) (Meta m1)
+
+    let ( let* ) xs f = List.concat_map f xs
+
+    type ('b, 'd) to_ = To : ('a, 'b, 'd) t -> ('b, 'd) to_ [@@unboxed]
+
+    let left_to : type b. full:bool -> b obj -> (b, left_only) to_ list =
+     fun ~full dst ->
+      let unquoted : (b, left_only) to_ list =
+        let* (Meta_morph.To m) = Meta_morph.left_to ~full dst in
+        match Meta_morph.src dst m with
+        | Regionality -> [To (Meta m); To (Meta_splice m)]
+        | _ -> [To (Meta m)]
+      in
+      let quoted : (b, left_only) to_ list =
+        match dst with
+        | ArealityQuoted ->
+          let* (Meta_morph.To m) = Meta_morph.left_to ~full (to_splice dst) in
+          begin match Meta_morph.src (to_splice dst) m with
+          | Regionality -> [To (Quote_meta m); To (Quote_meta_splice m)]
+          | _ -> [To (Quote_meta m)]
+          end
+        | _ -> []
+      in
+      unquoted @ quoted
+    [@@warning "-4"]
+
+    let right_to : type b. full:bool -> b obj -> (b, right_only) to_ list =
+     fun ~full dst ->
+      let unquoted : (b, right_only) to_ list =
+        let* (Meta_morph.To m) = Meta_morph.right_to ~full dst in
+        match Meta_morph.src dst m with
+        | Regionality -> [To (Meta m); To (Meta_splice m)]
+        | _ -> [To (Meta m)]
+      in
+      let quoted : (b, right_only) to_ list =
+        match dst with
+        | ArealityQuoted ->
+          let* (Meta_morph.To m) = Meta_morph.right_to ~full (to_splice dst) in
+          begin match Meta_morph.src (to_splice dst) m with
+          | Regionality -> [To (Quote_meta m); To (Quote_meta_splice m)]
+          | _ -> [To (Quote_meta m)]
+          end
+        | _ -> []
+      in
+      unquoted @ quoted
+    [@@warning "-4"]
   end
 
   module Final_morph = struct
@@ -3724,6 +4018,22 @@ module Lattices_mono = struct
           -> ('p, 's, 'l * disallowed) t
           (** Composition of a morphism and combining an axis with the minima
               along other axes. *)
+      | Max_with_simple_proj :
+          ('c, 'q) Axis.t
+          * ('p, 'q, disallowed * 'r) Simple_morph.t
+          * ('a, 'p) Axis.t
+          * 'a obj
+          -> ('a, 'c, disallowed * 'r) t
+          (** [Max_with_simple (ax0, s) . Simple_proj (Id, ax1, obj)]. Used when
+              [s] quotes/splices so we cannot [Meta_morph.lift_max]. *)
+      | Min_with_simple_proj :
+          ('c, 'q) Axis.t
+          * ('p, 'q, 'l * disallowed) Simple_morph.t
+          * ('a, 'p) Axis.t
+          * 'a obj
+          -> ('a, 'c, 'l * disallowed) t
+          (** [Min_with_simple (ax0, s) . Simple_proj (Id, ax1, obj)]. Used when
+              [s] quotes/splices so we cannot [Meta_morph.lift_min]. *)
       | Compose :
           ('b, 'c, neither) t * ('a, 'b, neither) t
           -> ('a, 'c, neither) t
@@ -3741,6 +4051,8 @@ module Lattices_mono = struct
           Simple_proj (Simple_morph.allow_left m, ax, src)
         | Min_with_simple (ax, m) ->
           Min_with_simple (ax, Simple_morph.allow_left m)
+        | Min_with_simple_proj (ax, m, ax1, obj) ->
+          Min_with_simple_proj (ax, Simple_morph.allow_left m, ax1, obj)
         | Const_min src -> Const_min src
 
       let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
@@ -3750,6 +4062,8 @@ module Lattices_mono = struct
           Simple_proj (Simple_morph.allow_right m, ax, src)
         | Max_with_simple (ax, m) ->
           Max_with_simple (ax, Simple_morph.allow_right m)
+        | Max_with_simple_proj (ax, m, ax1, obj) ->
+          Max_with_simple_proj (ax, Simple_morph.allow_right m, ax1, obj)
         | Const_max src -> Const_max src
 
       let rec disallow_left : type a b l r.
@@ -3761,6 +4075,10 @@ module Lattices_mono = struct
           Max_with_simple (ax, Simple_morph.disallow_left m)
         | Min_with_simple (ax, m) ->
           Min_with_simple (ax, Simple_morph.disallow_left m)
+        | Max_with_simple_proj (ax, m, ax1, obj) ->
+          Max_with_simple_proj (ax, Simple_morph.disallow_left m, ax1, obj)
+        | Min_with_simple_proj (ax, m, ax1, obj) ->
+          Min_with_simple_proj (ax, Simple_morph.disallow_left m, ax1, obj)
         | Const_max src -> Const_max src
         | Const_min src -> Const_min src
         | Const (src, c) -> Const (src, c)
@@ -3778,6 +4096,10 @@ module Lattices_mono = struct
           Max_with_simple (ax, Simple_morph.disallow_right m)
         | Min_with_simple (ax, m) ->
           Min_with_simple (ax, Simple_morph.disallow_right m)
+        | Max_with_simple_proj (ax, m, ax1, obj) ->
+          Max_with_simple_proj (ax, Simple_morph.disallow_right m, ax1, obj)
+        | Min_with_simple_proj (ax, m, ax1, obj) ->
+          Min_with_simple_proj (ax, Simple_morph.disallow_right m, ax1, obj)
         | Const_max src -> Const_max src
         | Const_min src -> Const_min src
         | Const (src, c) -> Const (src, c)
@@ -3794,12 +4116,68 @@ module Lattices_mono = struct
       | Simple_proj (_, _, src) -> src
       | Max_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
       | Min_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
+      | Max_with_simple_proj (_, _, _, obj) -> obj
+      | Min_with_simple_proj (_, _, _, obj) -> obj
       | Const_min src -> src
       | Const_max src -> src
       | Const (src, _) -> src
       | Compose (mb, ma) ->
         let mid = src dst mb in
         src mid ma
+
+    let compare_simple_proj_key : type c q1 p1 a1 d1 q2 p2 a2 d2.
+        c obj ->
+        (c, q1) Axis.t ->
+        (p1, q1, d1) Simple_morph.t ->
+        (a1, p1) Axis.t ->
+        a1 obj ->
+        (c, q2) Axis.t ->
+        (p2, q2, d2) Simple_morph.t ->
+        (a2, p2) Axis.t ->
+        a2 obj ->
+        int =
+     fun dst ax0_1 s1 ax1_1 obj1 ax0_2 s2 ax1_2 obj2 ->
+      let c = compare_obj obj1 obj2 in
+      if c <> 0
+      then c
+      else
+        let Refl = equal_obj obj1 obj2 |> Misc.get_eq_exn in
+        let c = Axis.compare ax1_1 ax1_2 in
+        if c <> 0
+        then c
+        else
+          let Refl = Axis.equal ax1_1 ax1_2 |> Misc.get_eq_exn in
+          let c = Axis.compare ax0_1 ax0_2 in
+          if c <> 0
+          then c
+          else
+            let Refl = Axis.equal ax0_1 ax0_2 |> Misc.get_eq_exn in
+            Simple_morph.compare_total (proj_obj ax0_1 dst) s1 s2
+
+    let equal_simple_proj_key : type c q1 p1 a1 d1 q2 p2 a2 d2.
+        c obj ->
+        (c, q1) Axis.t ->
+        (p1, q1, d1) Simple_morph.t ->
+        (a1, p1) Axis.t ->
+        a1 obj ->
+        (c, q2) Axis.t ->
+        (p2, q2, d2) Simple_morph.t ->
+        (a2, p2) Axis.t ->
+        a2 obj ->
+        (a1, a2) Misc.is_eq =
+     fun dst ax0_1 s1 ax1_1 obj1 ax0_2 s2 ax1_2 obj2 ->
+      match equal_obj obj1 obj2 with
+      | Misc.Is_not_eq -> Misc.Is_not_eq
+      | Misc.Is_eq -> (
+        match Axis.equal ax1_1 ax1_2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> (
+          match Axis.equal ax0_1 ax0_2 with
+          | Misc.Is_not_eq -> Misc.Is_not_eq
+          | Misc.Is_eq -> (
+            match Simple_morph.equal (proj_obj ax0_1 dst) s1 s2 with
+            | Misc.Is_eq -> Misc.Is_eq
+            | Misc.Is_not_eq -> Misc.Is_not_eq)))
 
     let rec compare_morph : type a1 d1 a2 b d2.
         b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
@@ -3851,6 +4229,16 @@ module Lattices_mono = struct
           Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
       | Min_with_simple _, _ -> -1
       | _, Min_with_simple _ -> 1
+      | ( Max_with_simple_proj (ax0_1, s1, ax1_1, obj1),
+          Max_with_simple_proj (ax0_2, s2, ax1_2, obj2) ) ->
+        compare_simple_proj_key dst ax0_1 s1 ax1_1 obj1 ax0_2 s2 ax1_2 obj2
+      | Max_with_simple_proj _, _ -> -1
+      | _, Max_with_simple_proj _ -> 1
+      | ( Min_with_simple_proj (ax0_1, s1, ax1_1, obj1),
+          Min_with_simple_proj (ax0_2, s2, ax1_2, obj2) ) ->
+        compare_simple_proj_key dst ax0_1 s1 ax1_1 obj1 ax0_2 s2 ax1_2 obj2
+      | Min_with_simple_proj _, _ -> -1
+      | _, Min_with_simple_proj _ -> 1
       | Compose (mb1, ma1), Compose (mb2, ma2) ->
         let c = compare_morph dst mb1 mb2 in
         if c <> 0
@@ -3890,12 +4278,19 @@ module Lattices_mono = struct
         match Axis.equal ax1 ax2 with
         | Misc.Is_not_eq -> Misc.Is_not_eq
         | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
+      | ( Max_with_simple_proj (ax0_1, s1, ax1_1, obj1),
+          Max_with_simple_proj (ax0_2, s2, ax1_2, obj2) ) ->
+        equal_simple_proj_key dst ax0_1 s1 ax1_1 obj1 ax0_2 s2 ax1_2 obj2
+      | ( Min_with_simple_proj (ax0_1, s1, ax1_1, obj1),
+          Min_with_simple_proj (ax0_2, s2, ax1_2, obj2) ) ->
+        equal_simple_proj_key dst ax0_1 s1 ax1_1 obj1 ax0_2 s2 ax1_2 obj2
       | Compose (mb1, ma1), Compose (mb2, ma2) -> (
         match equal_morph dst mb1 mb2 with
         | Misc.Is_not_eq -> Misc.Is_not_eq
         | Misc.Is_eq -> equal_morph (src dst mb1) ma1 ma2)
       | ( ( Simple _ | Const_max _ | Const_min _ | Const _ | Simple_proj _
-          | Max_with_simple _ | Min_with_simple _ | Compose _ ),
+          | Max_with_simple _ | Min_with_simple _ | Max_with_simple_proj _
+          | Min_with_simple_proj _ | Compose _ ),
           _ ) ->
         Misc.Is_not_eq
 
@@ -3920,6 +4315,14 @@ module Lattices_mono = struct
         let mid = proj_obj ax dst in
         Fmt.fprintf ppf "min_with_%a . %a" print_obj mid
           (Simple_morph.print mid) m
+      | Max_with_simple_proj (ax0, s, ax1, obj) ->
+        let mid = proj_obj ax0 dst in
+        Fmt.fprintf ppf "max_with_%a . %a . proj_%a" print_obj mid
+          (Simple_morph.print mid) s print_obj (proj_obj ax1 obj)
+      | Min_with_simple_proj (ax0, s, ax1, obj) ->
+        let mid = proj_obj ax0 dst in
+        Fmt.fprintf ppf "min_with_%a . %a . proj_%a" print_obj mid
+          (Simple_morph.print mid) s print_obj (proj_obj ax1 obj)
       | Const_max _ -> Fmt.fprintf ppf "const_%a" (print dst) (max dst)
       | Const_min _ -> Fmt.fprintf ppf "const_%a" (print dst) (min dst)
       | Const (_, c) -> Fmt.fprintf ppf "const_%a" (print dst) c
@@ -3941,6 +4344,12 @@ module Lattices_mono = struct
       | Min_with_simple (ax, m) ->
         let mid = proj_obj ax dst in
         min_with dst ax (Simple_morph.apply mid m a)
+      | Max_with_simple_proj (ax0, s, ax1, _) ->
+        let mid = proj_obj ax0 dst in
+        max_with dst ax0 (Simple_morph.apply mid s (Axis.proj ax1 a))
+      | Min_with_simple_proj (ax0, s, ax1, _) ->
+        let mid = proj_obj ax0 dst in
+        min_with dst ax0 (Simple_morph.apply mid s (Axis.proj ax1 a))
       | Const_max _ -> max dst
       | Const_min _ -> min dst
       | Const (_, c) -> c
@@ -3958,6 +4367,9 @@ module Lattices_mono = struct
       | Min_with_simple (ax, m) ->
         let mid = proj_obj ax dst in
         Simple_proj (Simple_morph.right_adjoint mid m, ax, dst)
+      | Min_with_simple_proj (ax0, s, ax1, _) ->
+        let mid = proj_obj ax0 dst in
+        Max_with_simple_proj (ax1, Simple_morph.right_adjoint mid s, ax0, dst)
       | Const_min _ -> Const_max dst
 
     let left_adjoint : type a b l.
@@ -3970,48 +4382,91 @@ module Lattices_mono = struct
       | Max_with_simple (ax, m) ->
         let mid = proj_obj ax dst in
         Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
+      | Max_with_simple_proj (ax0, s, ax1, _) ->
+        let mid = proj_obj ax0 dst in
+        Min_with_simple_proj (ax1, Simple_morph.left_adjoint mid s, ax0, dst)
       | Const_max _ -> Const_min dst
+
+    let rec quote_morph : type a c d.
+        c quoted obj -> (a, c, d) t -> (a, c quoted, d) t =
+     fun dst -> function
+      | Simple m -> Simple (Simple_morph.quote_morph dst m)
+      | Const_max obj -> Const_max obj
+      | Const_min obj -> Const_min obj
+      | Const (obj, c) -> Const (obj, Quote.return c)
+      | Simple_proj (m, ax, sobj) ->
+        Simple_proj (Simple_morph.quote_morph dst m, ax, sobj)
+      | Compose (m0, m1) -> Compose (quote_morph dst m0, m1)
+      | Max_with_simple (ax, _) -> (
+        match dst with ArealityQuoted -> ( match ax with _ -> .))
+      | Min_with_simple (ax, _) -> (
+        match dst with ArealityQuoted -> ( match ax with _ -> .))
+      | Max_with_simple_proj (ax, _, _, _) -> (
+        match dst with ArealityQuoted -> ( match ax with _ -> .))
+      | Min_with_simple_proj (ax, _, _, _) -> (
+        match dst with ArealityQuoted -> ( match ax with _ -> .))
+    [@@warning "-4"]
+
+    let rec morph_splice : type a b d.
+        a quoted obj -> (a, b, d) t -> (a quoted, b, d) t =
+     fun src -> function
+      | Simple m -> Simple (Simple_morph.morph_splice src m)
+      | Const_max _ -> Const_max src
+      | Const_min _ -> Const_min src
+      | Const (_, c) -> Const (src, c)
+      | Max_with_simple (ax, m) ->
+        Max_with_simple (ax, Simple_morph.morph_splice src m)
+      | Min_with_simple (ax, m) ->
+        Min_with_simple (ax, Simple_morph.morph_splice src m)
+      | Compose (m0, m1) -> Compose (m0, morph_splice src m1)
+      | Simple_proj (_, ax, _) -> (
+        match src with ArealityQuoted -> ( match ax with _ -> .))
+      | Max_with_simple_proj (_, _, ax1, _) -> (
+        match src with ArealityQuoted -> ( match ax1 with _ -> .))
+      | Min_with_simple_proj (_, _, ax1, _) -> (
+        match src with ArealityQuoted -> ( match ax1 with _ -> .))
+    [@@warning "-4"]
 
     let const_max_or_apply : type a c p r.
         c obj ->
-        (p, c, disallowed * r) Meta_morph.t ->
+        (p, c, disallowed * r) Simple_morph.t ->
         a obj ->
         (a, c, disallowed * r) t =
      fun dst m obj ->
-      match Meta_morph.maybe_allowed_right m with
+      match Simple_morph.maybe_allowed_right m with
       | Allowed_right _ -> Const_max obj
       | Not_allowed_right ->
-        let src = Meta_morph.src dst m in
-        Const (obj, Meta_morph.apply dst m (max src))
+        let src = Simple_morph.src dst m in
+        Const (obj, Simple_morph.apply dst m (max src))
 
     let const_min_or_apply : type a c p l.
         c obj ->
-        (p, c, l * disallowed) Meta_morph.t ->
+        (p, c, l * disallowed) Simple_morph.t ->
         a obj ->
         (a, c, l * disallowed) t =
      fun dst m obj ->
-      match Meta_morph.maybe_allowed_left m with
+      match Simple_morph.maybe_allowed_left m with
       | Allowed_left _ -> Const_min obj
       | Not_allowed_left ->
-        let src = Meta_morph.src dst m in
-        Const (obj, Meta_morph.apply dst m (min src))
+        let src = Simple_morph.src dst m in
+        Const (obj, Simple_morph.apply dst m (min src))
 
     let compose_simple_proj_core : type a c p d.
         c obj ->
-        (p, c, d) Meta_morph.t ->
+        (p, c, d) Simple_morph.t ->
         (a, p, d) Core_morph.compose_proj_result ->
         (a, c, d) t =
      fun dst m0 pm1 ->
       match pm1 with
       | Proj_core (m1, ax1, obj1) ->
-        Simple_proj (Meta (Meta_morph.compose dst m0 (Core m1)), ax1, obj1)
-      | Proj_id (ax1, obj1) -> Simple_proj (Meta m0, ax1, obj1)
+        Simple_proj (Simple_morph.compose dst m0 (Meta (Core m1)), ax1, obj1)
+      | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
       | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
       | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
     let compose_simple_proj_meet_const_core : type a c p l.
         c obj ->
-        (p, c, l * disallowed) Meta_morph.t ->
+        (p, c, l * disallowed) Simple_morph.t ->
         p ->
         (a, p, l * disallowed) Core_morph.compose_proj_result ->
         (a, c, l * disallowed) t =
@@ -4019,17 +4474,18 @@ module Lattices_mono = struct
       match pm1 with
       | Proj_core (m1, ax1, obj1) ->
         Simple_proj
-          ( Meta (Meta_morph.compose dst m0 (Meet_const_core (c1, m1))),
+          ( Simple_morph.compose dst m0 (Meta (Meet_const_core (c1, m1))),
             ax1,
             obj1 )
       | Proj_id (ax1, obj1) ->
-        Simple_proj (Meta (Meta_morph.compose dst m0 (Meet_const c1)), ax1, obj1)
-      | Proj_const_max obj1 -> Const (obj1, Meta_morph.apply dst m0 c1)
+        Simple_proj
+          (Simple_morph.compose dst m0 (Meta (Meet_const c1)), ax1, obj1)
+      | Proj_const_max obj1 -> Const (obj1, Simple_morph.apply dst m0 c1)
       | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
     let compose_simple_proj_core_imply_const : type a c p r.
         c obj ->
-        (p, c, disallowed * r) Meta_morph.t ->
+        (p, c, disallowed * r) Simple_morph.t ->
         a ->
         (a, p, disallowed * r) Core_morph.compose_proj_result ->
         (a, c, disallowed * r) t =
@@ -4038,36 +4494,37 @@ module Lattices_mono = struct
       | Proj_core (m1, ax1, obj1) ->
         let c1 = Axis.proj ax1 c1 in
         Simple_proj
-          ( Meta (Meta_morph.compose dst m0 (Core_imply_const (m1, c1))),
+          ( Simple_morph.compose dst m0 (Meta (Core_imply_const (m1, c1))),
             ax1,
             obj1 )
       | Proj_id (ax1, obj1) ->
         let c1 = Axis.proj ax1 c1 in
         Simple_proj
-          (Meta (Meta_morph.compose dst m0 (Imply_const c1)), ax1, obj1)
+          (Simple_morph.compose dst m0 (Meta (Imply_const c1)), ax1, obj1)
       | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
       | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
     let compose_simple_proj_with_simple : type a b c p d.
         c obj ->
-        (p, c, d) Meta_morph.t ->
+        (p, c, d) Simple_morph.t ->
         (b, p) Axis.t ->
         b obj ->
         (a, b, d) Meta_morph.t ->
         (a, c, d) t =
      fun dst m0 ax0 obj0 m1 ->
       match m1 with
-      | Id -> Simple_proj (Meta m0, ax0, obj0)
+      | Id -> Simple_proj (m0, ax0, obj0)
       | Core m1 ->
         let pm1 = Core_morph.compose_projection_core ax0 m1 in
         compose_simple_proj_core dst m0 pm1
       | Meet_const c1 ->
         let c1 = Axis.proj ax0 c1 in
-        Simple_proj (Meta (Meta_morph.compose dst m0 (Meet_const c1)), ax0, obj0)
+        Simple_proj
+          (Simple_morph.compose dst m0 (Meta (Meet_const c1)), ax0, obj0)
       | Imply_const c1 ->
         let c1 = Axis.proj ax0 c1 in
         Simple_proj
-          (Meta (Meta_morph.compose dst m0 (Imply_const c1)), ax0, obj0)
+          (Simple_morph.compose dst m0 (Meta (Imply_const c1)), ax0, obj0)
       | Meet_const_core (c1, m1) ->
         let c1 = Axis.proj ax0 c1 in
         let pm1 = Core_morph.compose_projection_core ax0 m1 in
@@ -4075,211 +4532,288 @@ module Lattices_mono = struct
       | Core_imply_const (m1, c1) ->
         let pm1 = Core_morph.compose_projection_core ax0 m1 in
         compose_simple_proj_core_imply_const dst m0 c1 pm1
-      | Compose _ -> Compose (Simple_proj (Meta m0, ax0, obj0), Simple (Meta m1))
+      | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple (Meta m1))
 
     let compose_simple_max_with_simple : type a b c q r.
         c obj ->
         (b, c, disallowed * r) Meta_morph.t ->
         (b, q) Axis.t ->
-        (a, q, disallowed * r) Meta_morph.t ->
+        (a, q, disallowed * r) Simple_morph.t ->
         (a, c, disallowed * r) t =
      fun dst sm0 ax1 m1 ->
       let b_obj = Meta_morph.src dst sm0 in
-      let a_obj = src b_obj (Max_with_simple (ax1, Meta m1)) in
+      let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
       match sm0 with
-      | Id -> Max_with_simple (ax1, Meta m1)
+      | Id -> Max_with_simple (ax1, m1)
       | Core m0 ->
         begin match Core_morph.compose_core_max_with m0 ax1 with
         | And_max_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
-          Max_with_simple (ax1, Meta (Meta_morph.compose obj0 (Core m0) m1))
+          Max_with_simple (ax1, Simple_morph.compose obj0 (Meta (Core m0)) m1)
         | Const_max_core -> Const_max a_obj
-        | And_max_id ax1 -> Max_with_simple (ax1, Meta m1)
-        | Disallowed ->
-          Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
+        | And_max_id ax1 -> Max_with_simple (ax1, m1)
+        | Disallowed -> Compose (Simple (Meta sm0), Max_with_simple (ax1, m1))
         end
       | Imply_const c0 ->
         let c0 = Axis.proj ax1 c0 in
         let obj0 = proj_obj ax1 dst in
-        Max_with_simple (ax1, Meta (Meta_morph.compose obj0 (Imply_const c0) m1))
+        Max_with_simple
+          (ax1, Simple_morph.compose obj0 (Meta (Imply_const c0)) m1)
       | Core_imply_const (m0, c0) -> begin
         let c0 = Axis.proj ax1 c0 in
         match Core_morph.compose_core_max_with m0 ax1 with
         | And_max_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
           Max_with_simple
-            (ax1, Meta (Meta_morph.compose obj0 (Core_imply_const (m0, c0)) m1))
+            ( ax1,
+              Simple_morph.compose obj0 (Meta (Core_imply_const (m0, c0))) m1 )
         | Const_max_core -> Const_max a_obj
         | And_max_id ax1 ->
           let obj0 = proj_obj ax1 dst in
           Max_with_simple
-            (ax1, Meta (Meta_morph.compose obj0 (Imply_const c0) m1))
-        | Disallowed ->
-          Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
+            (ax1, Simple_morph.compose obj0 (Meta (Imply_const c0)) m1)
+        | Disallowed -> Compose (Simple (Meta sm0), Max_with_simple (ax1, m1))
         end
       | Meet_const_core _ ->
-        Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
-      | Meet_const _ ->
-        Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
-      | Compose _ -> Compose (Simple (Meta sm0), Max_with_simple (ax1, Meta m1))
+        Compose (Simple (Meta sm0), Max_with_simple (ax1, m1))
+      | Meet_const _ -> Compose (Simple (Meta sm0), Max_with_simple (ax1, m1))
+      | Compose _ -> Compose (Simple (Meta sm0), Max_with_simple (ax1, m1))
 
     let compose_simple_min_with_simple : type a b c q l.
         c obj ->
         (b, c, l * disallowed) Meta_morph.t ->
         (b, q) Axis.t ->
-        (a, q, l * disallowed) Meta_morph.t ->
+        (a, q, l * disallowed) Simple_morph.t ->
         (a, c, l * disallowed) t =
      fun dst sm0 ax1 m1 ->
       let b_obj = Meta_morph.src dst sm0 in
-      let a_obj = src b_obj (Min_with_simple (ax1, Meta m1)) in
+      let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
       match sm0 with
-      | Id -> Min_with_simple (ax1, Meta m1)
+      | Id -> Min_with_simple (ax1, m1)
       | Core m0 ->
         begin match Core_morph.compose_core_min_with m0 ax1 with
         | And_min_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
-          Min_with_simple (ax1, Meta (Meta_morph.compose obj0 (Core m0) m1))
+          Min_with_simple (ax1, Simple_morph.compose obj0 (Meta (Core m0)) m1)
         | Const_min_core -> Const_min a_obj
-        | And_min_id ax1 -> Min_with_simple (ax1, Meta m1)
-        | Disallowed ->
-          Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
+        | And_min_id ax1 -> Min_with_simple (ax1, m1)
+        | Disallowed -> Compose (Simple (Meta sm0), Min_with_simple (ax1, m1))
         end
       | Meet_const c0 ->
         let c0 = Axis.proj ax1 c0 in
         let obj0 = proj_obj ax1 dst in
-        Min_with_simple (ax1, Meta (Meta_morph.compose obj0 (Meet_const c0) m1))
+        Min_with_simple
+          (ax1, Simple_morph.compose obj0 (Meta (Meet_const c0)) m1)
       | Meet_const_core (c0, m0) ->
         begin match Core_morph.compose_core_min_with m0 ax1 with
         | And_min_core (ax1, m0) ->
           let obj0 = proj_obj ax1 dst in
           let c0 = Axis.proj ax1 c0 in
           Min_with_simple
-            (ax1, Meta (Meta_morph.compose obj0 (Meet_const_core (c0, m0)) m1))
+            (ax1, Simple_morph.compose obj0 (Meta (Meet_const_core (c0, m0))) m1)
         | Const_min_core -> Const_min a_obj
         | And_min_id ax1 ->
           let obj0 = proj_obj ax1 dst in
           let c0 = Axis.proj ax1 c0 in
           Min_with_simple
-            (ax1, Meta (Meta_morph.compose obj0 (Meet_const c0) m1))
-        | Disallowed ->
-          Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
+            (ax1, Simple_morph.compose obj0 (Meta (Meet_const c0)) m1)
+        | Disallowed -> Compose (Simple (Meta sm0), Min_with_simple (ax1, m1))
         end
-      | Imply_const _ ->
-        Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
+      | Imply_const _ -> Compose (Simple (Meta sm0), Min_with_simple (ax1, m1))
       | Core_imply_const _ ->
-        Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
-      | Compose _ -> Compose (Simple (Meta sm0), Min_with_simple (ax1, Meta m1))
+        Compose (Simple (Meta sm0), Min_with_simple (ax1, m1))
+      | Compose _ -> Compose (Simple (Meta sm0), Min_with_simple (ax1, m1))
 
     let refute_compose_and_with : type a b c q0 q1 d.
         c obj ->
         (c, q0) Axis.t ->
-        (b, q0, d) Meta_morph.t ->
+        (b, q0, d) Simple_morph.t ->
         (b, q1) Axis.t ->
         (b, c, d) t ->
         (a, b, d) t ->
         (a, c, d) t =
-     fun dst ax0 m0' ax1 m0 m1 ->
-      match ax0, m0', ax1, dst with
-      | _, Core (Locality_restricted _), _, _ -> .
-      | _, Meet_const_core (_, Locality_restricted _), _, _ -> .
-      | _, Core_imply_const (Locality_restricted _, _), _, _ -> .
-      | _, Compose _, _, _ -> Compose (m0, m1)
+     fun dst ax0 s0 ax1 m0 m1 ->
+      match ax0, s0, ax1, dst with
+      | _, Meta (Core (Locality_restricted _)), _, _ -> .
+      | _, Meta (Meet_const_core (_, Locality_restricted _)), _, _ -> .
+      | _, Meta (Core_imply_const (Locality_restricted _, _)), _, _ -> .
+      | _, Meta (Compose _), _, _ -> Compose (m0, m1)
+      | _, Quote_meta (Core (Locality_restricted _)), _, _ -> .
+      | _, Quote_meta (Meet_const_core (_, Locality_restricted _)), _, _ -> .
+      | _, Quote_meta (Core_imply_const (Locality_restricted _, _)), _, _ -> .
+      | _, Quote_meta (Compose _), _, _ -> Compose (m0, m1)
       | _, _, _, _ -> .
     [@@warning "-4"]
 
-    let compose : type a b c d.
+    let rec compose : type a b c d.
         c obj -> (b, c, d) t -> (a, b, d) t -> (a, c, d) t =
      fun dst m0 m1 ->
       match m0, m1 with
-      | Simple (Meta m0), Simple (Meta m1) ->
-        Simple (Meta (Meta_morph.compose dst m0 m1))
+      | Simple s0, Simple s1 -> Simple (Simple_morph.compose dst s0 s1)
+      | Simple s0, Simple_proj (s1, ax1, obj1) ->
+        Simple_proj (Simple_morph.compose dst s0 s1, ax1, obj1)
       | Const_max b_obj, _ -> Const_max (src b_obj m1)
       | Const_min b_obj, _ -> Const_min (src b_obj m1)
       | Const (b_obj, c), _ -> Const (src b_obj m1, c)
-      | Simple (Meta m0), Simple_proj (Meta m1, ax1, obj1) ->
-        Simple_proj (Meta (Meta_morph.compose dst m0 m1), ax1, obj1)
-      | Simple_proj (Meta m0, ax0, obj0), Simple (Meta m1) ->
-        compose_simple_proj_with_simple dst m0 ax0 obj0 m1
-      | Max_with_simple (ax0, Meta m0), Simple (Meta m1) ->
-        let dst = proj_obj ax0 dst in
-        Max_with_simple (ax0, Meta (Meta_morph.compose dst m0 m1))
-      | Simple (Meta m0), Max_with_simple (ax1, Meta m1) ->
-        compose_simple_max_with_simple dst m0 ax1 m1
-      | Min_with_simple (ax0, Meta m0), Simple (Meta m1) ->
-        let dst = proj_obj ax0 dst in
-        Min_with_simple (ax0, Meta (Meta_morph.compose dst m0 m1))
-      | Simple (Meta m0), Min_with_simple (ax1, Meta m1) ->
-        compose_simple_min_with_simple dst m0 ax1 m1
-      | Simple_proj (Meta m0, ax0, obj1), Max_with_simple (ax1, Meta m1) ->
+      (* Re-expand the un-reduced lift. *)
+      | Max_with_simple_proj (ax0, s, ax1, obj), _ ->
+        compose dst
+          (Max_with_simple (ax0, s))
+          (compose (proj_obj ax1 obj) (Simple_proj (Meta Id, ax1, obj)) m1)
+      | Min_with_simple_proj (ax0, s, ax1, obj), _ ->
+        compose dst
+          (Min_with_simple (ax0, s))
+          (compose (proj_obj ax1 obj) (Simple_proj (Meta Id, ax1, obj)) m1)
+      | _, Max_with_simple_proj (ax0, s, ax1, obj) ->
+        compose dst
+          (compose dst m0 (Max_with_simple (ax0, s)))
+          (Simple_proj (Meta Id, ax1, obj))
+      | _, Min_with_simple_proj (ax0, s, ax1, obj) ->
+        compose dst
+          (compose dst m0 (Min_with_simple (ax0, s)))
+          (Simple_proj (Meta Id, ax1, obj))
+      (* Factor a quote on the destination out of [m0]. *)
+      | Simple (Quote_meta m0), _ ->
+        quote_morph dst (compose (to_splice dst) (Simple (Meta m0)) m1)
+      | Simple (Quote_meta_splice m0), _ ->
+        quote_morph dst (compose (to_splice dst) (Simple (Meta_splice m0)) m1)
+      | Simple_proj (Quote_meta m0, ax0, obj0), _ ->
+        quote_morph dst
+          (compose (to_splice dst) (Simple_proj (Meta m0, ax0, obj0)) m1)
+      | Simple_proj (Quote_meta_splice m0, ax0, obj0), _ ->
+        quote_morph dst
+          (compose (to_splice dst) (Simple_proj (Meta_splice m0, ax0, obj0)) m1)
+      (* Factor a splice on the source out of [m1]. *)
+      | _, Simple (Meta_splice m1) ->
+        let a_obj = src (src dst m0) (Simple (Meta_splice m1)) in
+        morph_splice a_obj (compose dst m0 (Simple (Meta m1)))
+      | _, Simple (Quote_meta_splice m1) ->
+        let a_obj = src (src dst m0) (Simple (Quote_meta_splice m1)) in
+        morph_splice a_obj (compose dst m0 (Simple (Quote_meta m1)))
+      | _, Max_with_simple (ax1, Meta_splice m1) ->
+        let a_obj = src (src dst m0) (Max_with_simple (ax1, Meta_splice m1)) in
+        morph_splice a_obj (compose dst m0 (Max_with_simple (ax1, Meta m1)))
+      | _, Max_with_simple (ax1, Quote_meta_splice m1) ->
+        let a_obj =
+          src (src dst m0) (Max_with_simple (ax1, Quote_meta_splice m1))
+        in
+        morph_splice a_obj
+          (compose dst m0 (Max_with_simple (ax1, Quote_meta m1)))
+      | _, Min_with_simple (ax1, Meta_splice m1) ->
+        let a_obj = src (src dst m0) (Min_with_simple (ax1, Meta_splice m1)) in
+        morph_splice a_obj (compose dst m0 (Min_with_simple (ax1, Meta m1)))
+      | _, Min_with_simple (ax1, Quote_meta_splice m1) ->
+        let a_obj =
+          src (src dst m0) (Min_with_simple (ax1, Quote_meta_splice m1))
+        in
+        morph_splice a_obj
+          (compose dst m0 (Min_with_simple (ax1, Quote_meta m1)))
+      (* Lifts and projections *)
+      | Simple_proj (s0, ax0, obj0), Simple (Meta m1) ->
+        compose_simple_proj_with_simple dst s0 ax0 obj0 m1
+      | Simple_proj (_, _, _), Simple (Quote_meta _) -> .
+      | Max_with_simple (ax0, s0), Simple s1 ->
+        Max_with_simple (ax0, Simple_morph.compose (proj_obj ax0 dst) s0 s1)
+      | Simple (Meta m0), Max_with_simple (ax1, s1) ->
+        compose_simple_max_with_simple dst m0 ax1 s1
+      | Simple (Meta_splice _), Max_with_simple (_, _) -> .
+      | Min_with_simple (ax0, s0), Simple s1 ->
+        Min_with_simple (ax0, Simple_morph.compose (proj_obj ax0 dst) s0 s1)
+      | Simple (Meta m0), Min_with_simple (ax1, s1) ->
+        compose_simple_min_with_simple dst m0 ax1 s1
+      | Simple (Meta_splice _), Min_with_simple (_, _) -> .
+      | Simple_proj (s0, ax0, obj1), Max_with_simple (ax1, s1) ->
         begin match Axis.equal ax0 ax1 with
-        | Misc.Is_eq -> Simple (Meta (Meta_morph.compose dst m0 m1))
+        | Misc.Is_eq -> Simple (Simple_morph.compose dst s0 s1)
         | Misc.Is_not_eq ->
-          let b_obj = src dst (Simple_proj (Meta m0, ax0, obj1)) in
-          let a_obj = src b_obj (Max_with_simple (ax1, Meta m1)) in
-          const_max_or_apply dst m0 a_obj
+          let b_obj = src dst (Simple_proj (s0, ax0, obj1)) in
+          let a_obj = src b_obj (Max_with_simple (ax1, s1)) in
+          const_max_or_apply dst s0 a_obj
         end
-      | Simple_proj (Meta m0, ax0, obj1), Min_with_simple (ax1, Meta m1) ->
+      | Simple_proj (s0, ax0, obj1), Min_with_simple (ax1, s1) ->
         begin match Axis.equal ax0 ax1 with
-        | Misc.Is_eq -> Simple (Meta (Meta_morph.compose dst m0 m1))
+        | Misc.Is_eq -> Simple (Simple_morph.compose dst s0 s1)
         | Misc.Is_not_eq ->
-          let b_obj = src dst (Simple_proj (Meta m0, ax0, obj1)) in
-          let a_obj = src b_obj (Min_with_simple (ax1, Meta m1)) in
-          const_min_or_apply dst m0 a_obj
+          let b_obj = src dst (Simple_proj (s0, ax0, obj1)) in
+          let a_obj = src b_obj (Min_with_simple (ax1, s1)) in
+          const_min_or_apply dst s0 a_obj
         end
-      | ( (Max_with_simple (ax0, Meta m0) as m0'),
-          (Simple_proj (Meta m1, ax1, obj1) as m1') ) ->
+      | Max_with_simple (ax0, s0), Simple_proj (s1, ax1, obj1) ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = src dst (Max_with_simple (ax0, Meta m0)) in
-        let a_obj = src b_obj (Simple_proj (Meta m1, ax1, obj1)) in
-        let m0m1 = Meta_morph.compose q_obj m0 m1 in
-        begin match Meta_morph.maybe_allowed_right m0m1 with
-        | Allowed_right m0m1 ->
-          allow_right
-            (Simple (Meta (Meta_morph.lift_max a_obj dst m0m1 ax1 ax0)))
-        | Not_allowed_right -> Compose (m0', m1')
+        let b_obj = src dst (Max_with_simple (ax0, s0)) in
+        let a_obj = src b_obj (Simple_proj (s1, ax1, obj1)) in
+        let m0m1 = Simple_morph.compose q_obj s0 s1 in
+        begin match m0m1 with
+        | Meta m0m1 ->
+          begin match Meta_morph.maybe_allowed_right m0m1 with
+          | Allowed_right m0m1 ->
+            allow_right
+              (Simple (Meta (Meta_morph.lift_max a_obj dst m0m1 ax1 ax0)))
+          | Not_allowed_right ->
+            Compose (Max_with_simple (ax0, s0), Simple_proj (s1, ax1, obj1))
+          end
+        | Quote_meta _ | Meta_splice _ | Quote_meta_splice _ ->
+          begin match Simple_morph.maybe_allowed_right m0m1 with
+          | Allowed_right m0m1 ->
+            allow_right (Max_with_simple_proj (ax0, m0m1, ax1, a_obj))
+          | Not_allowed_right ->
+            Compose (Max_with_simple (ax0, s0), Simple_proj (s1, ax1, obj1))
+          end
         end
-      | ( (Min_with_simple (ax0, Meta m0) as m0'),
-          (Simple_proj (Meta m1, ax1, obj1) as m1') ) ->
+      | Min_with_simple (ax0, s0), Simple_proj (s1, ax1, obj1) ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = src dst (Min_with_simple (ax0, Meta m0)) in
-        let a_obj = src b_obj (Simple_proj (Meta m1, ax1, obj1)) in
-        let m0m1 = Meta_morph.compose q_obj m0 m1 in
-        begin match Meta_morph.maybe_allowed_left m0m1 with
-        | Allowed_left m0m1 ->
-          allow_left
-            (Simple (Meta (Meta_morph.lift_min a_obj dst m0m1 ax1 ax0)))
-        | Not_allowed_left -> Compose (m0', m1')
+        let b_obj = src dst (Min_with_simple (ax0, s0)) in
+        let a_obj = src b_obj (Simple_proj (s1, ax1, obj1)) in
+        let m0m1 = Simple_morph.compose q_obj s0 s1 in
+        begin match m0m1 with
+        | Meta m0m1 ->
+          begin match Meta_morph.maybe_allowed_left m0m1 with
+          | Allowed_left m0m1 ->
+            allow_left
+              (Simple (Meta (Meta_morph.lift_min a_obj dst m0m1 ax1 ax0)))
+          | Not_allowed_left ->
+            Compose (Min_with_simple (ax0, s0), Simple_proj (s1, ax1, obj1))
+          end
+        | Quote_meta _ | Meta_splice _ | Quote_meta_splice _ ->
+          begin match Simple_morph.maybe_allowed_left m0m1 with
+          | Allowed_left m0m1 ->
+            allow_left (Min_with_simple_proj (ax0, m0m1, ax1, a_obj))
+          | Not_allowed_left ->
+            Compose (Min_with_simple (ax0, s0), Simple_proj (s1, ax1, obj1))
+          end
         end
-      | Simple (Meta m0), Const_max a_obj -> const_max_or_apply dst m0 a_obj
-      | Simple (Meta m0), Const_min a_obj -> const_min_or_apply dst m0 a_obj
-      | Simple_proj (Meta m0, _ax0, _obj0), Const_max obj1 ->
-        const_max_or_apply dst m0 obj1
-      | Simple_proj (Meta m0, _ax0, _obj0), Const_min obj1 ->
-        const_min_or_apply dst m0 obj1
-      | Min_with_simple (ax0, Meta m0), Const_max obj1 ->
+      | Simple s0, Const_max a_obj -> const_max_or_apply dst s0 a_obj
+      | Simple s0, Const_min a_obj -> const_min_or_apply dst s0 a_obj
+      | Simple_proj (s0, _ax0, _obj0), Const_max obj1 ->
+        const_max_or_apply dst s0 obj1
+      | Simple_proj (s0, _ax0, _obj0), Const_min obj1 ->
+        const_min_or_apply dst s0 obj1
+      | Min_with_simple (ax0, s0), Const_max obj1 ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = Meta_morph.src q_obj m0 in
-        Const (obj1, min_with dst ax0 (Meta_morph.apply q_obj m0 (max b_obj)))
-      | Min_with_simple (ax0, Meta m0), Const_min obj1 ->
-        begin match Meta_morph.maybe_allowed_left m0 with
+        let b_obj = Simple_morph.src q_obj s0 in
+        Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj s0 (max b_obj)))
+      | Min_with_simple (ax0, s0), Const_min obj1 ->
+        begin match Simple_morph.maybe_allowed_left s0 with
         | Allowed_left _ -> Const_min obj1
         | Not_allowed_left ->
           let q_obj = proj_obj ax0 dst in
-          let b_obj = Meta_morph.src q_obj m0 in
-          Const (obj1, min_with dst ax0 (Meta_morph.apply q_obj m0 (min b_obj)))
+          let b_obj = Simple_morph.src q_obj s0 in
+          Const
+            (obj1, min_with dst ax0 (Simple_morph.apply q_obj s0 (min b_obj)))
         end
-      | Max_with_simple (ax0, Meta m0), Const_max obj1 ->
-        begin match Meta_morph.maybe_allowed_right m0 with
+      | Max_with_simple (ax0, s0), Const_max obj1 ->
+        begin match Simple_morph.maybe_allowed_right s0 with
         | Allowed_right _ -> Const_max obj1
         | Not_allowed_right ->
           let q_obj = proj_obj ax0 dst in
-          let b_obj = Meta_morph.src q_obj m0 in
-          Const (obj1, max_with dst ax0 (Meta_morph.apply q_obj m0 (max b_obj)))
+          let b_obj = Simple_morph.src q_obj s0 in
+          Const
+            (obj1, max_with dst ax0 (Simple_morph.apply q_obj s0 (max b_obj)))
         end
-      | Max_with_simple (ax0, Meta m0), Const_min obj1 ->
+      | Max_with_simple (ax0, s0), Const_min obj1 ->
         let q_obj = proj_obj ax0 dst in
-        let b_obj = Meta_morph.src q_obj m0 in
-        Const (obj1, max_with dst ax0 (Meta_morph.apply q_obj m0 (min b_obj)))
+        let b_obj = Simple_morph.src q_obj s0 in
+        Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj s0 (min b_obj)))
       | (_ as m0), Const (obj1, c1) -> Const (obj1, apply dst m0 c1)
       | (_ as m0), Compose (m1, m2) -> Compose (Compose (m0, m1), m2)
       | Compose (m0, m1), (_ as m2) -> Compose (Compose (m0, m1), m2)
@@ -4292,14 +4826,26 @@ module Lattices_mono = struct
         ->
         .
       | _, Simple_proj (Meta (Compose _), _, _) -> Compose (m0, m1)
-      | Max_with_simple (ax0, Meta m0'), Max_with_simple (ax1, _) ->
-        refute_compose_and_with dst ax0 m0' ax1 m0 m1
-      | Max_with_simple (ax0, Meta m0'), Min_with_simple (ax1, _) ->
-        refute_compose_and_with dst ax0 m0' ax1 m0 m1
-      | Min_with_simple (ax0, Meta m0'), Max_with_simple (ax1, _) ->
-        refute_compose_and_with dst ax0 m0' ax1 m0 m1
-      | Min_with_simple (ax0, Meta m0'), Min_with_simple (ax1, _) ->
-        refute_compose_and_with dst ax0 m0' ax1 m0 m1
+      | _, Simple_proj (Meta_splice (Core (Locality_restricted _)), _, _) -> .
+      | ( _,
+          Simple_proj
+            (Meta_splice (Meet_const_core (_, Locality_restricted _)), _, _) )
+        ->
+        .
+      | ( _,
+          Simple_proj
+            (Meta_splice (Core_imply_const (Locality_restricted _, _)), _, _) )
+        ->
+        .
+      | _, Simple_proj (Meta_splice (Compose _), _, _) -> Compose (m0, m1)
+      | Max_with_simple (ax0, s0), Max_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 s0 ax1 m0 m1
+      | Max_with_simple (ax0, s0), Min_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 s0 ax1 m0 m1
+      | Min_with_simple (ax0, s0), Max_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 s0 ax1 m0 m1
+      | Min_with_simple (ax0, s0), Min_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 s0 ax1 m0 m1
       | _, _ -> .
     [@@warning "-4"]
 
@@ -4311,23 +4857,23 @@ module Lattices_mono = struct
 
     let left_to : type b. full:bool -> b obj -> b to_ list =
      fun ~full dst ->
-      let simple_morphs = Meta_morph.left_to ~full dst in
+      let simple_morphs = Simple_morph.left_to ~full dst in
       let simple =
         List.map
-          (fun (Meta_morph.To m) -> To (disallow_left (Simple (Meta m))))
+          (fun (Simple_morph.To m) -> To (disallow_left (Simple m)))
           simple_morphs
       in
       let projections =
-        let* (Meta_morph.To m) = simple_morphs in
-        let src = Meta_morph.src dst m in
+        let* (Simple_morph.To m) = simple_morphs in
+        let src = Simple_morph.src dst m in
         let+ (Axis.To (src, ax)) = Axis.to_ src in
-        To (disallow_left (Simple_proj (Meta m, ax, src)))
+        To (disallow_left (Simple_proj (m, ax, src)))
       in
       let min_with =
         let* (Axis.From ax) = Axis.from dst in
         let projected = proj_obj ax dst in
-        let+ (Meta_morph.To m) = Meta_morph.left_to ~full projected in
-        To (disallow_left (Min_with_simple (ax, Meta m)))
+        let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
+        To (disallow_left (Min_with_simple (ax, m)))
       in
       let const_min =
         List.map (fun (Obj src) -> To (disallow_left (Const_min src))) all_objs
@@ -4336,23 +4882,23 @@ module Lattices_mono = struct
 
     let right_to : type b. full:bool -> b obj -> b to_ list =
      fun ~full dst ->
-      let simple_morphs = Meta_morph.right_to ~full dst in
+      let simple_morphs = Simple_morph.right_to ~full dst in
       let simple =
         List.map
-          (fun (Meta_morph.To m) -> To (disallow_right (Simple (Meta m))))
+          (fun (Simple_morph.To m) -> To (disallow_right (Simple m)))
           simple_morphs
       in
       let projections =
-        let* (Meta_morph.To m) = simple_morphs in
-        let projected = Meta_morph.src dst m in
+        let* (Simple_morph.To m) = simple_morphs in
+        let projected = Simple_morph.src dst m in
         let+ (Axis.To (src, ax)) = Axis.to_ projected in
-        To (disallow_right (Simple_proj (Meta m, ax, src)))
+        To (disallow_right (Simple_proj (m, ax, src)))
       in
       let max_with =
         let* (Axis.From ax) = Axis.from dst in
         let projected = proj_obj ax dst in
-        let+ (Meta_morph.To m) = Meta_morph.right_to ~full projected in
-        To (disallow_right (Max_with_simple (ax, Meta m)))
+        let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
+        To (disallow_right (Max_with_simple (ax, m)))
       in
       let const_max =
         List.map (fun (Obj src) -> To (disallow_right (Const_max src))) all_objs
@@ -4558,6 +5104,14 @@ module Lattices_mono = struct
      fun m ax ->
       match m with
       | Simple (Meta m) -> find_responsible_axis_proj_simple m ax
+      | Simple (Meta_splice m) ->
+        begin match find_responsible_axis_proj_simple m ax with
+        | None_responsible -> None_responsible
+        | All_responsible -> All_responsible
+        | Axis _ -> All_responsible
+        end
+      | Simple (Quote_meta _) -> ( match ax with _ -> .)
+      | Simple (Quote_meta_splice _) -> ( match ax with _ -> .)
       | Simple_proj (_, ax, _) -> Axis ax
       | Max_with_simple (m_ax, _) ->
         begin match Axis.equal m_ax ax with
@@ -4568,6 +5122,16 @@ module Lattices_mono = struct
         begin match Axis.equal m_ax ax with
         | Misc.Is_not_eq -> None_responsible
         | Misc.Is_eq -> All_responsible
+        end
+      | Max_with_simple_proj (ax0, _, ax1, _) ->
+        begin match Axis.equal ax0 ax with
+        | Misc.Is_not_eq -> None_responsible
+        | Misc.Is_eq -> Axis ax1
+        end
+      | Min_with_simple_proj (ax0, _, ax1, _) ->
+        begin match Axis.equal ax0 ax with
+        | Misc.Is_not_eq -> None_responsible
+        | Misc.Is_eq -> Axis ax1
         end
       | Const_max _ | Const_min _ | Const _ -> None_responsible
       | Compose (mb, ma) ->
@@ -4584,6 +5148,8 @@ module Lattices_mono = struct
       | Simple _ -> All_responsible
       | Simple_proj (_, ax, _) -> Axis ax
       | Max_with_simple _ | Min_with_simple _ -> All_responsible
+      | Max_with_simple_proj (_, _, ax1, _) -> Axis ax1
+      | Min_with_simple_proj (_, _, ax1, _) -> Axis ax1
       | Const_max _ | Const_min _ | Const _ -> None_responsible
       | Compose (mb, ma) -> (
         match find_responsible_axis_all mb with

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4664,6 +4664,7 @@ module Report = struct
     | Functor -> Some (print_article_noun Consonant "functor")
     | Lazy -> Some (print_article_noun Consonant "lazy expression")
     | Quote -> Some (print_article_noun Consonant "quoted expression")
+    | Splice -> Some (print_article_noun Consonant "splice")
     | Expression -> Some (print_article_noun Vowel "expression")
     | Effect_match ->
       Some (print_article_noun Consonant "pattern match with effect cases")
@@ -4822,6 +4823,8 @@ module Report = struct
             Fmt.dprintf "contains %t%a defined as %t"
               (print_structure_item ~capitalize:false x)
               maybe_modality moda print_pp
+          | Quote ->
+            Fmt.dprintf "is a quoted expression that contains %t" print_pp
         in
         pr, contained)
 
@@ -4850,6 +4853,10 @@ module Report = struct
       Fmt.dprintf "is %t%a in the structure at %a"
         (print_structure_item ~capitalize:false x)
         maybe_modality moda
+        (Location.Doc.loc ~capitalize_first:false)
+        container
+    | Quote ->
+      Fmt.dprintf "is part of the quoted expression at %a"
         (Location.Doc.loc ~capitalize_first:false)
         container
 

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -3654,709 +3654,755 @@ module Lattices_mono = struct
       (To Id :: core_morphs) @ constants @ core_imply_consts
   end
 
-  (* New morphisms must be added to [left_to] and [right_to]. *)
-  type ('a, 'b, 'd) morph =
-    | Simple : ('a, 'b, 'd) Simple_morph.t -> ('a, 'b, 'd) morph
-    | Const_max : 'a obj -> ('a, 'c, disallowed * 'r) morph
-        (** Discards an arbitrary input and apply a simple morphism to the
-            maximum of a lattice *)
-    | Const_min : 'a obj -> ('a, 'c, 'l * disallowed) morph
-        (** Discards an arbitrary input and apply a simple morphism to the
-            minimum of a lattice *)
-    | Const : 'a obj * 'c -> ('a, 'c, neither) morph
-        (** A constant function on any constant: we don't allow arbitrary
-            constant functions to appear on either side *)
-    | Simple_proj :
-        ('p, 'q, 'd) Simple_morph.t * ('s, 'p) Axis.t * 's obj
-        -> ('s, 'q, 'd) morph
-        (** Composition of projecting out an axis and a simple morphism. *)
-    | Max_with_simple :
-        ('s, 'q) Axis.t * ('p, 'q, disallowed * 'r) Simple_morph.t
-        -> ('p, 's, disallowed * 'r) morph
-        (** Composition of a morphism and combining an axis with the maxima
-            along other axes. *)
-    | Min_with_simple :
-        ('s, 'q) Axis.t * ('p, 'q, 'l * disallowed) Simple_morph.t
-        -> ('p, 's, 'l * disallowed) morph
-        (** Composition of a morphism and combining an axis with the minima
-            along other axes. *)
-    | Compose :
-        ('b, 'c, neither) morph * ('a, 'b, neither) morph
-        -> ('a, 'c, neither) morph
-        (** Composition of two morphisms. We don't allow compositions to appear
-            on either side to ensure that there are a finite number of morphisms
-            we can encounter in practice. *)
+  module Meta_morph = struct
+    (* New morphisms must be added to [left_to] and [right_to]. *)
+    type ('a, 'b, 'd) t =
+      | Simple : ('a, 'b, 'd) Simple_morph.t -> ('a, 'b, 'd) t
+      | Const_max : 'a obj -> ('a, 'c, disallowed * 'r) t
+          (** Discards an arbitrary input and apply a simple morphism to the
+              maximum of a lattice *)
+      | Const_min : 'a obj -> ('a, 'c, 'l * disallowed) t
+          (** Discards an arbitrary input and apply a simple morphism to the
+              minimum of a lattice *)
+      | Const : 'a obj * 'c -> ('a, 'c, neither) t
+          (** A constant function on any constant: we don't allow arbitrary
+              constant functions to appear on either side *)
+      | Simple_proj :
+          ('p, 'q, 'd) Simple_morph.t * ('s, 'p) Axis.t * 's obj
+          -> ('s, 'q, 'd) t
+          (** Composition of projecting out an axis and a simple morphism. *)
+      | Max_with_simple :
+          ('s, 'q) Axis.t * ('p, 'q, disallowed * 'r) Simple_morph.t
+          -> ('p, 's, disallowed * 'r) t
+          (** Composition of a morphism and combining an axis with the maxima
+              along other axes. *)
+      | Min_with_simple :
+          ('s, 'q) Axis.t * ('p, 'q, 'l * disallowed) Simple_morph.t
+          -> ('p, 's, 'l * disallowed) t
+          (** Composition of a morphism and combining an axis with the minima
+              along other axes. *)
+      | Compose :
+          ('b, 'c, neither) t * ('a, 'b, neither) t
+          -> ('a, 'c, neither) t
+          (** Composition of two morphisms. We don't allow compositions to
+              appear on either side to ensure that there are a finite number of
+              morphisms we can encounter in practice. *)
 
-  include Magic_allow_disallow (struct
-    type ('a, 'b, 'd) sided = ('a, 'b, 'd) morph constraint 'd = _ * _
+    include Magic_allow_disallow (struct
+      type ('a, 'b, 'd) sided = ('a, 'b, 'd) t constraint 'd = _ * _
 
-    let allow_left : type a b l r.
-        (a, b, allowed * r) morph -> (a, b, l * r) morph = function
-      | Simple m -> Simple (Simple_morph.allow_left m)
-      | Simple_proj (m, ax, src) ->
-        Simple_proj (Simple_morph.allow_left m, ax, src)
-      | Min_with_simple (ax, m) ->
-        Min_with_simple (ax, Simple_morph.allow_left m)
-      | Const_min src -> Const_min src
+      let allow_left : type a b l r. (a, b, allowed * r) t -> (a, b, l * r) t =
+        function
+        | Simple m -> Simple (Simple_morph.allow_left m)
+        | Simple_proj (m, ax, src) ->
+          Simple_proj (Simple_morph.allow_left m, ax, src)
+        | Min_with_simple (ax, m) ->
+          Min_with_simple (ax, Simple_morph.allow_left m)
+        | Const_min src -> Const_min src
 
-    let allow_right : type a b l r.
-        (a, b, l * allowed) morph -> (a, b, l * r) morph = function
-      | Simple m -> Simple (Simple_morph.allow_right m)
-      | Simple_proj (m, ax, src) ->
-        Simple_proj (Simple_morph.allow_right m, ax, src)
-      | Max_with_simple (ax, m) ->
-        Max_with_simple (ax, Simple_morph.allow_right m)
-      | Const_max src -> Const_max src
+      let allow_right : type a b l r. (a, b, l * allowed) t -> (a, b, l * r) t =
+        function
+        | Simple m -> Simple (Simple_morph.allow_right m)
+        | Simple_proj (m, ax, src) ->
+          Simple_proj (Simple_morph.allow_right m, ax, src)
+        | Max_with_simple (ax, m) ->
+          Max_with_simple (ax, Simple_morph.allow_right m)
+        | Const_max src -> Const_max src
 
-    let rec disallow_left : type a b l r.
-        (a, b, l * r) morph -> (a, b, disallowed * r) morph = function
-      | Simple m -> Simple (Simple_morph.disallow_left m)
-      | Simple_proj (m, ax, src) ->
-        Simple_proj (Simple_morph.disallow_left m, ax, src)
-      | Max_with_simple (ax, m) ->
-        Max_with_simple (ax, Simple_morph.disallow_left m)
-      | Min_with_simple (ax, m) ->
-        Min_with_simple (ax, Simple_morph.disallow_left m)
-      | Const_max src -> Const_max src
-      | Const_min src -> Const_min src
-      | Const (src, c) -> Const (src, c)
+      let rec disallow_left : type a b l r.
+          (a, b, l * r) t -> (a, b, disallowed * r) t = function
+        | Simple m -> Simple (Simple_morph.disallow_left m)
+        | Simple_proj (m, ax, src) ->
+          Simple_proj (Simple_morph.disallow_left m, ax, src)
+        | Max_with_simple (ax, m) ->
+          Max_with_simple (ax, Simple_morph.disallow_left m)
+        | Min_with_simple (ax, m) ->
+          Min_with_simple (ax, Simple_morph.disallow_left m)
+        | Const_max src -> Const_max src
+        | Const_min src -> Const_min src
+        | Const (src, c) -> Const (src, c)
+        | Compose (mb, ma) ->
+          let mb = disallow_left mb in
+          let ma = disallow_left ma in
+          Compose (mb, ma)
+
+      let rec disallow_right : type a b l r.
+          (a, b, l * r) t -> (a, b, l * disallowed) t = function
+        | Simple m -> Simple (Simple_morph.disallow_right m)
+        | Simple_proj (m, ax, src) ->
+          Simple_proj (Simple_morph.disallow_right m, ax, src)
+        | Max_with_simple (ax, m) ->
+          Max_with_simple (ax, Simple_morph.disallow_right m)
+        | Min_with_simple (ax, m) ->
+          Min_with_simple (ax, Simple_morph.disallow_right m)
+        | Const_max src -> Const_max src
+        | Const_min src -> Const_min src
+        | Const (src, c) -> Const (src, c)
+        | Compose (mb, ma) ->
+          let mb = disallow_right mb in
+          let ma = disallow_right ma in
+          Compose (mb, ma)
+    end)
+
+    let rec src : type a b d. b obj -> (a, b, d) t -> a obj =
+     fun dst f ->
+      match f with
+      | Simple m -> Simple_morph.src dst m
+      | Simple_proj (_, _, src) -> src
+      | Max_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
+      | Min_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
+      | Const_min src -> src
+      | Const_max src -> src
+      | Const (src, _) -> src
       | Compose (mb, ma) ->
-        let mb = disallow_left mb in
-        let ma = disallow_left ma in
-        Compose (mb, ma)
+        let mid = src dst mb in
+        src mid ma
 
-    let rec disallow_right : type a b l r.
-        (a, b, l * r) morph -> (a, b, l * disallowed) morph = function
-      | Simple m -> Simple (Simple_morph.disallow_right m)
-      | Simple_proj (m, ax, src) ->
-        Simple_proj (Simple_morph.disallow_right m, ax, src)
-      | Max_with_simple (ax, m) ->
-        Max_with_simple (ax, Simple_morph.disallow_right m)
-      | Min_with_simple (ax, m) ->
-        Min_with_simple (ax, Simple_morph.disallow_right m)
-      | Const_max src -> Const_max src
-      | Const_min src -> Const_min src
-      | Const (src, c) -> Const (src, c)
-      | Compose (mb, ma) ->
-        let mb = disallow_right mb in
-        let ma = disallow_right ma in
-        Compose (mb, ma)
-  end)
-
-  let rec src : type a b d. b obj -> (a, b, d) morph -> a obj =
-   fun dst f ->
-    match f with
-    | Simple m -> Simple_morph.src dst m
-    | Simple_proj (_, _, src) -> src
-    | Max_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
-    | Min_with_simple (ax, m) -> Simple_morph.src (proj_obj ax dst) m
-    | Const_min src -> src
-    | Const_max src -> src
-    | Const (src, _) -> src
-    | Compose (mb, ma) ->
-      let mid = src dst mb in
-      src mid ma
-
-  let rec compare_morph : type a1 d1 a2 b d2.
-      b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> int =
-   fun dst m1 m2 ->
-    match m1, m2 with
-    | Simple m1, Simple m2 -> Simple_morph.compare_total dst m1 m2
-    | Simple _, _ -> -1
-    | _, Simple _ -> 1
-    | Const_max obj1, Const_max obj2 -> compare_obj obj1 obj2
-    | Const_max _, _ -> -1
-    | _, Const_max _ -> 1
-    | Const_min obj1, Const_min obj2 -> compare_obj obj1 obj2
-    | Const_min _, _ -> -1
-    | _, Const_min _ -> 1
-    | Const (obj1, c1), Const (obj2, c2) ->
-      let c = compare_obj obj1 obj2 in
-      if c <> 0 then c else compare_total dst c1 c2
-    | Const _, _ -> -1
-    | _, Const _ -> 1
-    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) ->
-      let c = compare_obj src1 src2 in
-      if c <> 0
-      then c
-      else
-        let Refl = equal_obj src1 src2 |> Misc.get_eq_exn in
+    let rec compare_morph : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> int =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Simple m1, Simple m2 -> Simple_morph.compare_total dst m1 m2
+      | Simple _, _ -> -1
+      | _, Simple _ -> 1
+      | Const_max obj1, Const_max obj2 -> compare_obj obj1 obj2
+      | Const_max _, _ -> -1
+      | _, Const_max _ -> 1
+      | Const_min obj1, Const_min obj2 -> compare_obj obj1 obj2
+      | Const_min _, _ -> -1
+      | _, Const_min _ -> 1
+      | Const (obj1, c1), Const (obj2, c2) ->
+        let c = compare_obj obj1 obj2 in
+        if c <> 0 then c else compare_total dst c1 c2
+      | Const _, _ -> -1
+      | _, Const _ -> 1
+      | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) ->
+        let c = compare_obj src1 src2 in
+        if c <> 0
+        then c
+        else
+          let Refl = equal_obj src1 src2 |> Misc.get_eq_exn in
+          let c = Axis.compare ax1 ax2 in
+          if c <> 0
+          then c
+          else
+            let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+            Simple_morph.compare_total dst m1 m2
+      | Simple_proj _, _ -> -1
+      | _, Simple_proj _ -> 1
+      | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) ->
         let c = Axis.compare ax1 ax2 in
         if c <> 0
         then c
         else
           let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-          Simple_morph.compare_total dst m1 m2
-    | Simple_proj _, _ -> -1
-    | _, Simple_proj _ -> 1
-    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) ->
-      let c = Axis.compare ax1 ax2 in
-      if c <> 0
-      then c
-      else
-        let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-        Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
-    | Max_with_simple _, _ -> -1
-    | _, Max_with_simple _ -> 1
-    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) ->
-      let c = Axis.compare ax1 ax2 in
-      if c <> 0
-      then c
-      else
-        let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
-        Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
-    | Min_with_simple _, _ -> -1
-    | _, Min_with_simple _ -> 1
-    | Compose (mb1, ma1), Compose (mb2, ma2) ->
-      let c = compare_morph dst mb1 mb2 in
-      if c <> 0
-      then c
-      else
-        let Refl = equal_morph dst mb1 mb2 |> Misc.get_eq_exn in
-        compare_morph (src dst mb1) ma1 ma2
-    | Compose _, _ -> .
-    | _, Compose _ -> .
+          Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
+      | Max_with_simple _, _ -> -1
+      | _, Max_with_simple _ -> 1
+      | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) ->
+        let c = Axis.compare ax1 ax2 in
+        if c <> 0
+        then c
+        else
+          let Refl = Axis.equal ax1 ax2 |> Misc.get_eq_exn in
+          Simple_morph.compare_total (proj_obj ax1 dst) m1 m2
+      | Min_with_simple _, _ -> -1
+      | _, Min_with_simple _ -> 1
+      | Compose (mb1, ma1), Compose (mb2, ma2) ->
+        let c = compare_morph dst mb1 mb2 in
+        if c <> 0
+        then c
+        else
+          let Refl = equal_morph dst mb1 mb2 |> Misc.get_eq_exn in
+          compare_morph (src dst mb1) ma1 ma2
+      | Compose _, _ -> .
+      | _, Compose _ -> .
 
-  and equal_morph : type a1 d1 a2 b d2.
-      b obj -> (a1, b, d1) morph -> (a2, b, d2) morph -> (a1, a2) Misc.is_eq =
-   fun dst m1 m2 ->
-    match m1, m2 with
-    | Simple m1, Simple m2 -> Simple_morph.equal dst m1 m2
-    | Const_max obj1, Const_max obj2 -> equal_obj obj1 obj2
-    | Const_min obj1, Const_min obj2 -> equal_obj obj1 obj2
-    | Const (obj1, c1), Const (obj2, c2) -> (
-      match equal_obj obj1 obj2 with
-      | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq)
-    | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
-      match equal_obj src1 src2 with
-      | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> (
-        match Axis.equal ax1 ax2 with
+    and equal_morph : type a1 d1 a2 b d2.
+        b obj -> (a1, b, d1) t -> (a2, b, d2) t -> (a1, a2) Misc.is_eq =
+     fun dst m1 m2 ->
+      match m1, m2 with
+      | Simple m1, Simple m2 -> Simple_morph.equal dst m1 m2
+      | Const_max obj1, Const_max obj2 -> equal_obj obj1 obj2
+      | Const_min obj1, Const_min obj2 -> equal_obj obj1 obj2
+      | Const (obj1, c1), Const (obj2, c2) -> (
+        match equal_obj obj1 obj2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> if equal dst c1 c2 then Misc.Is_eq else Misc.Is_not_eq)
+      | Simple_proj (m1, ax1, src1), Simple_proj (m2, ax2, src2) -> (
+        match equal_obj src1 src2 with
         | Misc.Is_not_eq -> Misc.Is_not_eq
         | Misc.Is_eq -> (
-          match Simple_morph.equal dst m1 m2 with
-          | Misc.Is_eq -> Misc.Is_eq
-          | Misc.Is_not_eq -> Misc.Is_not_eq)))
-    | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
-      match Axis.equal ax1 ax2 with
-      | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
-    | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
-      match Axis.equal ax1 ax2 with
-      | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
-    | Compose (mb1, ma1), Compose (mb2, ma2) -> (
-      match equal_morph dst mb1 mb2 with
-      | Misc.Is_not_eq -> Misc.Is_not_eq
-      | Misc.Is_eq -> equal_morph (src dst mb1) ma1 ma2)
-    | ( ( Simple _ | Const_max _ | Const_min _ | Const _ | Simple_proj _
-        | Max_with_simple _ | Min_with_simple _ | Compose _ ),
-        _ ) ->
-      Misc.Is_not_eq
+          match Axis.equal ax1 ax2 with
+          | Misc.Is_not_eq -> Misc.Is_not_eq
+          | Misc.Is_eq -> (
+            match Simple_morph.equal dst m1 m2 with
+            | Misc.Is_eq -> Misc.Is_eq
+            | Misc.Is_not_eq -> Misc.Is_not_eq)))
+      | Max_with_simple (ax1, m1), Max_with_simple (ax2, m2) -> (
+        match Axis.equal ax1 ax2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
+      | Min_with_simple (ax1, m1), Min_with_simple (ax2, m2) -> (
+        match Axis.equal ax1 ax2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> Simple_morph.equal (proj_obj ax1 dst) m1 m2)
+      | Compose (mb1, ma1), Compose (mb2, ma2) -> (
+        match equal_morph dst mb1 mb2 with
+        | Misc.Is_not_eq -> Misc.Is_not_eq
+        | Misc.Is_eq -> equal_morph (src dst mb1) ma1 ma2)
+      | ( ( Simple _ | Const_max _ | Const_min _ | Const _ | Simple_proj _
+          | Max_with_simple _ | Min_with_simple _ | Compose _ ),
+          _ ) ->
+        Misc.Is_not_eq
 
-  let rec print_morph : type a b d.
-      b obj -> Fmt.formatter -> (a, b, d) morph -> unit =
-   fun dst ppf -> function
-    | Simple m -> Simple_morph.print dst ppf m
-    | Simple_proj (Id, ax, src) ->
-      Fmt.fprintf ppf "proj_%a" print_obj (proj_obj ax src)
-    | Simple_proj (m, ax, src) ->
-      Fmt.fprintf ppf "%a . proj_%a" (Simple_morph.print dst) m print_obj
-        (proj_obj ax src)
-    | Max_with_simple (ax, Id) ->
-      Fmt.fprintf ppf "max_with_%a" print_obj (proj_obj ax dst)
-    | Max_with_simple (ax, m) ->
-      let mid = proj_obj ax dst in
-      Fmt.fprintf ppf "max_with_%a . %a" print_obj mid (Simple_morph.print mid)
-        m
-    | Min_with_simple (ax, Id) ->
-      Fmt.fprintf ppf "min_with_%a" print_obj (proj_obj ax dst)
-    | Min_with_simple (ax, m) ->
-      let mid = proj_obj ax dst in
-      Fmt.fprintf ppf "min_with_%a . %a" print_obj mid (Simple_morph.print mid)
-        m
-    | Const_max _ -> Fmt.fprintf ppf "const_%a" (print dst) (max dst)
-    | Const_min _ -> Fmt.fprintf ppf "const_%a" (print dst) (min dst)
-    | Const (_, c) -> Fmt.fprintf ppf "const_%a" (print dst) c
-    | Compose (mb, ma) ->
-      let mid = src dst mb in
-      Fmt.fprintf ppf "%a . %a" (print_morph dst) mb (print_morph mid) ma
-  [@@warning "-4"]
+    let rec print_morph : type a b d.
+        b obj -> Fmt.formatter -> (a, b, d) t -> unit =
+     fun dst ppf -> function
+      | Simple m -> Simple_morph.print dst ppf m
+      | Simple_proj (Id, ax, src) ->
+        Fmt.fprintf ppf "proj_%a" print_obj (proj_obj ax src)
+      | Simple_proj (m, ax, src) ->
+        Fmt.fprintf ppf "%a . proj_%a" (Simple_morph.print dst) m print_obj
+          (proj_obj ax src)
+      | Max_with_simple (ax, Id) ->
+        Fmt.fprintf ppf "max_with_%a" print_obj (proj_obj ax dst)
+      | Max_with_simple (ax, m) ->
+        let mid = proj_obj ax dst in
+        Fmt.fprintf ppf "max_with_%a . %a" print_obj mid
+          (Simple_morph.print mid) m
+      | Min_with_simple (ax, Id) ->
+        Fmt.fprintf ppf "min_with_%a" print_obj (proj_obj ax dst)
+      | Min_with_simple (ax, m) ->
+        let mid = proj_obj ax dst in
+        Fmt.fprintf ppf "min_with_%a . %a" print_obj mid
+          (Simple_morph.print mid) m
+      | Const_max _ -> Fmt.fprintf ppf "const_%a" (print dst) (max dst)
+      | Const_min _ -> Fmt.fprintf ppf "const_%a" (print dst) (min dst)
+      | Const (_, c) -> Fmt.fprintf ppf "const_%a" (print dst) c
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        Fmt.fprintf ppf "%a . %a" (print_morph dst) mb (print_morph mid) ma
+    [@@warning "-4"]
 
-  let id = Simple Id
+    let id = Simple Id
 
-  let rec apply : type a b d. b obj -> (a, b, d) morph -> a -> b =
-   fun dst f a ->
-    match f with
-    | Simple m -> Simple_morph.apply dst m a
-    | Simple_proj (m, ax, _) -> Simple_morph.apply dst m (Axis.proj ax a)
-    | Max_with_simple (ax, m) ->
-      let mid = proj_obj ax dst in
-      max_with dst ax (Simple_morph.apply mid m a)
-    | Min_with_simple (ax, m) ->
-      let mid = proj_obj ax dst in
-      min_with dst ax (Simple_morph.apply mid m a)
-    | Const_max _ -> max dst
-    | Const_min _ -> min dst
-    | Const (_, c) -> c
-    | Compose (mb, ma) ->
-      let mid = src dst mb in
-      apply dst mb (apply mid ma a)
+    let rec apply : type a b d. b obj -> (a, b, d) t -> a -> b =
+     fun dst f a ->
+      match f with
+      | Simple m -> Simple_morph.apply dst m a
+      | Simple_proj (m, ax, _) -> Simple_morph.apply dst m (Axis.proj ax a)
+      | Max_with_simple (ax, m) ->
+        let mid = proj_obj ax dst in
+        max_with dst ax (Simple_morph.apply mid m a)
+      | Min_with_simple (ax, m) ->
+        let mid = proj_obj ax dst in
+        min_with dst ax (Simple_morph.apply mid m a)
+      | Const_max _ -> max dst
+      | Const_min _ -> min dst
+      | Const (_, c) -> c
+      | Compose (mb, ma) ->
+        let mid = src dst mb in
+        apply dst mb (apply mid ma a)
 
-  let right_adjoint : type a b r.
-      b obj -> (a, b, allowed * r) morph -> (b, a, disallowed * allowed) morph =
-   fun dst f ->
-    match f with
-    | Simple m -> Simple (Simple_morph.right_adjoint dst m)
-    | Simple_proj (m, ax, _) ->
-      Max_with_simple (ax, Simple_morph.right_adjoint dst m)
-    | Min_with_simple (ax, m) ->
-      let mid = proj_obj ax dst in
-      Simple_proj (Simple_morph.right_adjoint mid m, ax, dst)
-    | Const_min _ -> Const_max dst
+    let right_adjoint : type a b r.
+        b obj -> (a, b, allowed * r) t -> (b, a, disallowed * allowed) t =
+     fun dst f ->
+      match f with
+      | Simple m -> Simple (Simple_morph.right_adjoint dst m)
+      | Simple_proj (m, ax, _) ->
+        Max_with_simple (ax, Simple_morph.right_adjoint dst m)
+      | Min_with_simple (ax, m) ->
+        let mid = proj_obj ax dst in
+        Simple_proj (Simple_morph.right_adjoint mid m, ax, dst)
+      | Const_min _ -> Const_max dst
 
-  let left_adjoint : type a b l.
-      b obj -> (a, b, l * allowed) morph -> (b, a, allowed * disallowed) morph =
-   fun dst f ->
-    match f with
-    | Simple m -> Simple (Simple_morph.left_adjoint dst m)
-    | Simple_proj (m, ax, _) ->
-      Min_with_simple (ax, Simple_morph.left_adjoint dst m)
-    | Max_with_simple (ax, m) ->
-      let mid = proj_obj ax dst in
-      Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
-    | Const_max _ -> Const_min dst
+    let left_adjoint : type a b l.
+        b obj -> (a, b, l * allowed) t -> (b, a, allowed * disallowed) t =
+     fun dst f ->
+      match f with
+      | Simple m -> Simple (Simple_morph.left_adjoint dst m)
+      | Simple_proj (m, ax, _) ->
+        Min_with_simple (ax, Simple_morph.left_adjoint dst m)
+      | Max_with_simple (ax, m) ->
+        let mid = proj_obj ax dst in
+        Simple_proj (Simple_morph.left_adjoint mid m, ax, dst)
+      | Const_max _ -> Const_min dst
 
-  let const_max_or_apply : type a c p r.
-      c obj ->
-      (p, c, disallowed * r) Simple_morph.t ->
-      a obj ->
-      (a, c, disallowed * r) morph =
-   fun dst m obj ->
-    match Simple_morph.maybe_allowed_right m with
-    | Allowed_right _ -> Const_max obj
-    | Not_allowed_right ->
-      let src = Simple_morph.src dst m in
-      Const (obj, Simple_morph.apply dst m (max src))
+    let const_max_or_apply : type a c p r.
+        c obj ->
+        (p, c, disallowed * r) Simple_morph.t ->
+        a obj ->
+        (a, c, disallowed * r) t =
+     fun dst m obj ->
+      match Simple_morph.maybe_allowed_right m with
+      | Allowed_right _ -> Const_max obj
+      | Not_allowed_right ->
+        let src = Simple_morph.src dst m in
+        Const (obj, Simple_morph.apply dst m (max src))
 
-  let const_min_or_apply : type a c p l.
-      c obj ->
-      (p, c, l * disallowed) Simple_morph.t ->
-      a obj ->
-      (a, c, l * disallowed) morph =
-   fun dst m obj ->
-    match Simple_morph.maybe_allowed_left m with
-    | Allowed_left _ -> Const_min obj
-    | Not_allowed_left ->
-      let src = Simple_morph.src dst m in
-      Const (obj, Simple_morph.apply dst m (min src))
+    let const_min_or_apply : type a c p l.
+        c obj ->
+        (p, c, l * disallowed) Simple_morph.t ->
+        a obj ->
+        (a, c, l * disallowed) t =
+     fun dst m obj ->
+      match Simple_morph.maybe_allowed_left m with
+      | Allowed_left _ -> Const_min obj
+      | Not_allowed_left ->
+        let src = Simple_morph.src dst m in
+        Const (obj, Simple_morph.apply dst m (min src))
 
-  let compose_simple_proj_core : type a c p d.
-      c obj ->
-      (p, c, d) Simple_morph.t ->
-      (a, p, d) Core_morph.compose_proj_result ->
-      (a, c, d) morph =
-   fun dst m0 pm1 ->
-    match pm1 with
-    | Proj_core (m1, ax1, obj1) ->
-      Simple_proj (Simple_morph.compose dst m0 (Core m1), ax1, obj1)
-    | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
-    | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
-    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
+    let compose_simple_proj_core : type a c p d.
+        c obj ->
+        (p, c, d) Simple_morph.t ->
+        (a, p, d) Core_morph.compose_proj_result ->
+        (a, c, d) t =
+     fun dst m0 pm1 ->
+      match pm1 with
+      | Proj_core (m1, ax1, obj1) ->
+        Simple_proj (Simple_morph.compose dst m0 (Core m1), ax1, obj1)
+      | Proj_id (ax1, obj1) -> Simple_proj (m0, ax1, obj1)
+      | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
+      | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
-  let compose_simple_proj_meet_const_core : type a c p l.
-      c obj ->
-      (p, c, l * disallowed) Simple_morph.t ->
-      p ->
-      (a, p, l * disallowed) Core_morph.compose_proj_result ->
-      (a, c, l * disallowed) morph =
-   fun dst m0 c1 pm1 ->
-    match pm1 with
-    | Proj_core (m1, ax1, obj1) ->
-      Simple_proj
-        (Simple_morph.compose dst m0 (Meet_const_core (c1, m1)), ax1, obj1)
-    | Proj_id (ax1, obj1) ->
-      Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax1, obj1)
-    | Proj_const_max obj1 -> Const (obj1, Simple_morph.apply dst m0 c1)
-    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
+    let compose_simple_proj_meet_const_core : type a c p l.
+        c obj ->
+        (p, c, l * disallowed) Simple_morph.t ->
+        p ->
+        (a, p, l * disallowed) Core_morph.compose_proj_result ->
+        (a, c, l * disallowed) t =
+     fun dst m0 c1 pm1 ->
+      match pm1 with
+      | Proj_core (m1, ax1, obj1) ->
+        Simple_proj
+          (Simple_morph.compose dst m0 (Meet_const_core (c1, m1)), ax1, obj1)
+      | Proj_id (ax1, obj1) ->
+        Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax1, obj1)
+      | Proj_const_max obj1 -> Const (obj1, Simple_morph.apply dst m0 c1)
+      | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
-  let compose_simple_proj_core_imply_const : type a c p r.
-      c obj ->
-      (p, c, disallowed * r) Simple_morph.t ->
-      a ->
-      (a, p, disallowed * r) Core_morph.compose_proj_result ->
-      (a, c, disallowed * r) morph =
-   fun dst m0 c1 pm1 ->
-    match pm1 with
-    | Proj_core (m1, ax1, obj1) ->
-      let c1 = Axis.proj ax1 c1 in
-      Simple_proj
-        (Simple_morph.compose dst m0 (Core_imply_const (m1, c1)), ax1, obj1)
-    | Proj_id (ax1, obj1) ->
-      let c1 = Axis.proj ax1 c1 in
-      Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax1, obj1)
-    | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
-    | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
+    let compose_simple_proj_core_imply_const : type a c p r.
+        c obj ->
+        (p, c, disallowed * r) Simple_morph.t ->
+        a ->
+        (a, p, disallowed * r) Core_morph.compose_proj_result ->
+        (a, c, disallowed * r) t =
+     fun dst m0 c1 pm1 ->
+      match pm1 with
+      | Proj_core (m1, ax1, obj1) ->
+        let c1 = Axis.proj ax1 c1 in
+        Simple_proj
+          (Simple_morph.compose dst m0 (Core_imply_const (m1, c1)), ax1, obj1)
+      | Proj_id (ax1, obj1) ->
+        let c1 = Axis.proj ax1 c1 in
+        Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax1, obj1)
+      | Proj_const_max obj1 -> const_max_or_apply dst m0 obj1
+      | Proj_const_min obj1 -> const_min_or_apply dst m0 obj1
 
-  let compose_simple_proj_with_simple : type a b c p d.
-      c obj ->
-      (p, c, d) Simple_morph.t ->
-      (b, p) Axis.t ->
-      b obj ->
-      (a, b, d) Simple_morph.t ->
-      (a, c, d) morph =
-   fun dst m0 ax0 obj0 m1 ->
-    match m1 with
-    | Id -> Simple_proj (m0, ax0, obj0)
-    | Core m1 ->
-      let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_proj_core dst m0 pm1
-    | Meet_const c1 ->
-      let c1 = Axis.proj ax0 c1 in
-      Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax0, obj0)
-    | Imply_const c1 ->
-      let c1 = Axis.proj ax0 c1 in
-      Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax0, obj0)
-    | Meet_const_core (c1, m1) ->
-      let c1 = Axis.proj ax0 c1 in
-      let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_proj_meet_const_core dst m0 c1 pm1
-    | Core_imply_const (m1, c1) ->
-      let pm1 = Core_morph.compose_projection_core ax0 m1 in
-      compose_simple_proj_core_imply_const dst m0 c1 pm1
-    | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple m1)
+    let compose_simple_proj_with_simple : type a b c p d.
+        c obj ->
+        (p, c, d) Simple_morph.t ->
+        (b, p) Axis.t ->
+        b obj ->
+        (a, b, d) Simple_morph.t ->
+        (a, c, d) t =
+     fun dst m0 ax0 obj0 m1 ->
+      match m1 with
+      | Id -> Simple_proj (m0, ax0, obj0)
+      | Core m1 ->
+        let pm1 = Core_morph.compose_projection_core ax0 m1 in
+        compose_simple_proj_core dst m0 pm1
+      | Meet_const c1 ->
+        let c1 = Axis.proj ax0 c1 in
+        Simple_proj (Simple_morph.compose dst m0 (Meet_const c1), ax0, obj0)
+      | Imply_const c1 ->
+        let c1 = Axis.proj ax0 c1 in
+        Simple_proj (Simple_morph.compose dst m0 (Imply_const c1), ax0, obj0)
+      | Meet_const_core (c1, m1) ->
+        let c1 = Axis.proj ax0 c1 in
+        let pm1 = Core_morph.compose_projection_core ax0 m1 in
+        compose_simple_proj_meet_const_core dst m0 c1 pm1
+      | Core_imply_const (m1, c1) ->
+        let pm1 = Core_morph.compose_projection_core ax0 m1 in
+        compose_simple_proj_core_imply_const dst m0 c1 pm1
+      | Compose _ -> Compose (Simple_proj (m0, ax0, obj0), Simple m1)
 
-  let compose_simple_max_with_simple : type a b c q r.
-      c obj ->
-      (b, c, disallowed * r) Simple_morph.t ->
-      (b, q) Axis.t ->
-      (a, q, disallowed * r) Simple_morph.t ->
-      (a, c, disallowed * r) morph =
-   fun dst sm0 ax1 m1 ->
-    let b_obj = Simple_morph.src dst sm0 in
-    let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
-    match sm0 with
-    | Id -> Max_with_simple (ax1, m1)
-    | Core m0 ->
-      begin match Core_morph.compose_core_max_with m0 ax1 with
-      | And_max_core (ax1, m0) ->
-        let obj0 = proj_obj ax1 dst in
-        Max_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
-      | Const_max_core -> Const_max a_obj
-      | And_max_id ax1 -> Max_with_simple (ax1, m1)
-      | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
-      end
-    | Imply_const c0 ->
-      let c0 = Axis.proj ax1 c0 in
-      let obj0 = proj_obj ax1 dst in
-      Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
-    | Core_imply_const (m0, c0) -> begin
-      let c0 = Axis.proj ax1 c0 in
-      match Core_morph.compose_core_max_with m0 ax1 with
-      | And_max_core (ax1, m0) ->
-        let obj0 = proj_obj ax1 dst in
-        Max_with_simple
-          (ax1, Simple_morph.compose obj0 (Core_imply_const (m0, c0)) m1)
-      | Const_max_core -> Const_max a_obj
-      | And_max_id ax1 ->
+    let compose_simple_max_with_simple : type a b c q r.
+        c obj ->
+        (b, c, disallowed * r) Simple_morph.t ->
+        (b, q) Axis.t ->
+        (a, q, disallowed * r) Simple_morph.t ->
+        (a, c, disallowed * r) t =
+     fun dst sm0 ax1 m1 ->
+      let b_obj = Simple_morph.src dst sm0 in
+      let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+      match sm0 with
+      | Id -> Max_with_simple (ax1, m1)
+      | Core m0 ->
+        begin match Core_morph.compose_core_max_with m0 ax1 with
+        | And_max_core (ax1, m0) ->
+          let obj0 = proj_obj ax1 dst in
+          Max_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+        | Const_max_core -> Const_max a_obj
+        | And_max_id ax1 -> Max_with_simple (ax1, m1)
+        | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+        end
+      | Imply_const c0 ->
+        let c0 = Axis.proj ax1 c0 in
         let obj0 = proj_obj ax1 dst in
         Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
-      | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
-      end
-    | Meet_const_core _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
-    | Meet_const _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
-    | Compose _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      | Core_imply_const (m0, c0) -> begin
+        let c0 = Axis.proj ax1 c0 in
+        match Core_morph.compose_core_max_with m0 ax1 with
+        | And_max_core (ax1, m0) ->
+          let obj0 = proj_obj ax1 dst in
+          Max_with_simple
+            (ax1, Simple_morph.compose obj0 (Core_imply_const (m0, c0)) m1)
+        | Const_max_core -> Const_max a_obj
+        | And_max_id ax1 ->
+          let obj0 = proj_obj ax1 dst in
+          Max_with_simple (ax1, Simple_morph.compose obj0 (Imply_const c0) m1)
+        | Disallowed -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+        end
+      | Meet_const_core _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      | Meet_const _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
+      | Compose _ -> Compose (Simple sm0, Max_with_simple (ax1, m1))
 
-  let compose_simple_min_with_simple : type a b c q l.
-      c obj ->
-      (b, c, l * disallowed) Simple_morph.t ->
-      (b, q) Axis.t ->
-      (a, q, l * disallowed) Simple_morph.t ->
-      (a, c, l * disallowed) morph =
-   fun dst sm0 ax1 m1 ->
-    let b_obj = Simple_morph.src dst sm0 in
-    let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
-    match sm0 with
-    | Id -> Min_with_simple (ax1, m1)
-    | Core m0 ->
-      begin match Core_morph.compose_core_min_with m0 ax1 with
-      | And_min_core (ax1, m0) ->
-        let obj0 = proj_obj ax1 dst in
-        Min_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
-      | Const_min_core -> Const_min a_obj
-      | And_min_id ax1 -> Min_with_simple (ax1, m1)
-      | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
-      end
-    | Meet_const c0 ->
-      let c0 = Axis.proj ax1 c0 in
-      let obj0 = proj_obj ax1 dst in
-      Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
-    | Meet_const_core (c0, m0) ->
-      begin match Core_morph.compose_core_min_with m0 ax1 with
-      | And_min_core (ax1, m0) ->
-        let obj0 = proj_obj ax1 dst in
+    let compose_simple_min_with_simple : type a b c q l.
+        c obj ->
+        (b, c, l * disallowed) Simple_morph.t ->
+        (b, q) Axis.t ->
+        (a, q, l * disallowed) Simple_morph.t ->
+        (a, c, l * disallowed) t =
+     fun dst sm0 ax1 m1 ->
+      let b_obj = Simple_morph.src dst sm0 in
+      let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+      match sm0 with
+      | Id -> Min_with_simple (ax1, m1)
+      | Core m0 ->
+        begin match Core_morph.compose_core_min_with m0 ax1 with
+        | And_min_core (ax1, m0) ->
+          let obj0 = proj_obj ax1 dst in
+          Min_with_simple (ax1, Simple_morph.compose obj0 (Core m0) m1)
+        | Const_min_core -> Const_min a_obj
+        | And_min_id ax1 -> Min_with_simple (ax1, m1)
+        | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+        end
+      | Meet_const c0 ->
         let c0 = Axis.proj ax1 c0 in
-        Min_with_simple
-          (ax1, Simple_morph.compose obj0 (Meet_const_core (c0, m0)) m1)
-      | Const_min_core -> Const_min a_obj
-      | And_min_id ax1 ->
         let obj0 = proj_obj ax1 dst in
-        let c0 = Axis.proj ax1 c0 in
         Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
-      | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
-      end
-    | Imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
-    | Core_imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
-    | Compose _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      | Meet_const_core (c0, m0) ->
+        begin match Core_morph.compose_core_min_with m0 ax1 with
+        | And_min_core (ax1, m0) ->
+          let obj0 = proj_obj ax1 dst in
+          let c0 = Axis.proj ax1 c0 in
+          Min_with_simple
+            (ax1, Simple_morph.compose obj0 (Meet_const_core (c0, m0)) m1)
+        | Const_min_core -> Const_min a_obj
+        | And_min_id ax1 ->
+          let obj0 = proj_obj ax1 dst in
+          let c0 = Axis.proj ax1 c0 in
+          Min_with_simple (ax1, Simple_morph.compose obj0 (Meet_const c0) m1)
+        | Disallowed -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+        end
+      | Imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      | Core_imply_const _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
+      | Compose _ -> Compose (Simple sm0, Min_with_simple (ax1, m1))
 
-  let refute_compose_and_with : type a b c q0 q1 d.
-      c obj ->
-      (c, q0) Axis.t ->
-      (b, q0, d) Simple_morph.t ->
-      (b, q1) Axis.t ->
-      (b, c, d) morph ->
-      (a, b, d) morph ->
-      (a, c, d) morph =
-   fun dst ax0 m0' ax1 m0 m1 ->
-    match ax0, m0', ax1, dst with
-    | _, Core (Locality_restricted _), _, _ -> .
-    | _, Meet_const_core (_, Locality_restricted _), _, _ -> .
-    | _, Core_imply_const (Locality_restricted _, _), _, _ -> .
-    | _, Compose _, _, _ -> Compose (m0, m1)
-    | _, _, _, _ -> .
-  [@@warning "-4"]
+    let refute_compose_and_with : type a b c q0 q1 d.
+        c obj ->
+        (c, q0) Axis.t ->
+        (b, q0, d) Simple_morph.t ->
+        (b, q1) Axis.t ->
+        (b, c, d) t ->
+        (a, b, d) t ->
+        (a, c, d) t =
+     fun dst ax0 m0' ax1 m0 m1 ->
+      match ax0, m0', ax1, dst with
+      | _, Core (Locality_restricted _), _, _ -> .
+      | _, Meet_const_core (_, Locality_restricted _), _, _ -> .
+      | _, Core_imply_const (Locality_restricted _, _), _, _ -> .
+      | _, Compose _, _, _ -> Compose (m0, m1)
+      | _, _, _, _ -> .
+    [@@warning "-4"]
 
-  let compose : type a b c d.
-      c obj -> (b, c, d) morph -> (a, b, d) morph -> (a, c, d) morph =
-   fun dst m0 m1 ->
-    match m0, m1 with
-    | Simple m0, Simple m1 -> Simple (Simple_morph.compose dst m0 m1)
-    | Const_max b_obj, _ -> Const_max (src b_obj m1)
-    | Const_min b_obj, _ -> Const_min (src b_obj m1)
-    | Const (b_obj, c), _ -> Const (src b_obj m1, c)
-    | Simple m0, Simple_proj (m1, ax1, obj1) ->
-      Simple_proj (Simple_morph.compose dst m0 m1, ax1, obj1)
-    | Simple_proj (m0, ax0, obj0), Simple m1 ->
-      compose_simple_proj_with_simple dst m0 ax0 obj0 m1
-    | Max_with_simple (ax0, m0), Simple m1 ->
-      let dst = proj_obj ax0 dst in
-      Max_with_simple (ax0, Simple_morph.compose dst m0 m1)
-    | Simple m0, Max_with_simple (ax1, m1) ->
-      compose_simple_max_with_simple dst m0 ax1 m1
-    | Min_with_simple (ax0, m0), Simple m1 ->
-      let dst = proj_obj ax0 dst in
-      Min_with_simple (ax0, Simple_morph.compose dst m0 m1)
-    | Simple m0, Min_with_simple (ax1, m1) ->
-      compose_simple_min_with_simple dst m0 ax1 m1
-    | Simple_proj (m0, ax0, obj1), Max_with_simple (ax1, m1) ->
-      begin match Axis.equal ax0 ax1 with
-      | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
-      | Misc.Is_not_eq ->
-        let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
-        let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
-        const_max_or_apply dst m0 a_obj
-      end
-    | Simple_proj (m0, ax0, obj1), Min_with_simple (ax1, m1) ->
-      begin match Axis.equal ax0 ax1 with
-      | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
-      | Misc.Is_not_eq ->
-        let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
-        let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
-        const_min_or_apply dst m0 a_obj
-      end
-    | (Max_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
-      ->
-      let q_obj = proj_obj ax0 dst in
-      let b_obj = src dst (Max_with_simple (ax0, m0)) in
-      let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
-      let m0m1 = Simple_morph.compose q_obj m0 m1 in
-      begin match Simple_morph.maybe_allowed_right m0m1 with
-      | Allowed_right m0m1 ->
-        allow_right (Simple (Simple_morph.lift_max a_obj dst m0m1 ax1 ax0))
-      | Not_allowed_right -> Compose (m0', m1')
-      end
-    | (Min_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
-      ->
-      let q_obj = proj_obj ax0 dst in
-      let b_obj = src dst (Min_with_simple (ax0, m0)) in
-      let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
-      let m0m1 = Simple_morph.compose q_obj m0 m1 in
-      begin match Simple_morph.maybe_allowed_left m0m1 with
-      | Allowed_left m0m1 ->
-        allow_left (Simple (Simple_morph.lift_min a_obj dst m0m1 ax1 ax0))
-      | Not_allowed_left -> Compose (m0', m1')
-      end
-    | Simple m0, Const_max a_obj -> const_max_or_apply dst m0 a_obj
-    | Simple m0, Const_min a_obj -> const_min_or_apply dst m0 a_obj
-    | Simple_proj (m0, _ax0, _obj0), Const_max obj1 ->
-      const_max_or_apply dst m0 obj1
-    | Simple_proj (m0, _ax0, _obj0), Const_min obj1 ->
-      const_min_or_apply dst m0 obj1
-    | Min_with_simple (ax0, m0), Const_max obj1 ->
-      let q_obj = proj_obj ax0 dst in
-      let b_obj = Simple_morph.src q_obj m0 in
-      Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
-    | Min_with_simple (ax0, m0), Const_min obj1 ->
-      begin match Simple_morph.maybe_allowed_left m0 with
-      | Allowed_left _ -> Const_min obj1
-      | Not_allowed_left ->
+    let compose : type a b c d.
+        c obj -> (b, c, d) t -> (a, b, d) t -> (a, c, d) t =
+     fun dst m0 m1 ->
+      match m0, m1 with
+      | Simple m0, Simple m1 -> Simple (Simple_morph.compose dst m0 m1)
+      | Const_max b_obj, _ -> Const_max (src b_obj m1)
+      | Const_min b_obj, _ -> Const_min (src b_obj m1)
+      | Const (b_obj, c), _ -> Const (src b_obj m1, c)
+      | Simple m0, Simple_proj (m1, ax1, obj1) ->
+        Simple_proj (Simple_morph.compose dst m0 m1, ax1, obj1)
+      | Simple_proj (m0, ax0, obj0), Simple m1 ->
+        compose_simple_proj_with_simple dst m0 ax0 obj0 m1
+      | Max_with_simple (ax0, m0), Simple m1 ->
+        let dst = proj_obj ax0 dst in
+        Max_with_simple (ax0, Simple_morph.compose dst m0 m1)
+      | Simple m0, Max_with_simple (ax1, m1) ->
+        compose_simple_max_with_simple dst m0 ax1 m1
+      | Min_with_simple (ax0, m0), Simple m1 ->
+        let dst = proj_obj ax0 dst in
+        Min_with_simple (ax0, Simple_morph.compose dst m0 m1)
+      | Simple m0, Min_with_simple (ax1, m1) ->
+        compose_simple_min_with_simple dst m0 ax1 m1
+      | Simple_proj (m0, ax0, obj1), Max_with_simple (ax1, m1) ->
+        begin match Axis.equal ax0 ax1 with
+        | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+        | Misc.Is_not_eq ->
+          let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
+          let a_obj = src b_obj (Max_with_simple (ax1, m1)) in
+          const_max_or_apply dst m0 a_obj
+        end
+      | Simple_proj (m0, ax0, obj1), Min_with_simple (ax1, m1) ->
+        begin match Axis.equal ax0 ax1 with
+        | Misc.Is_eq -> Simple (Simple_morph.compose dst m0 m1)
+        | Misc.Is_not_eq ->
+          let b_obj = src dst (Simple_proj (m0, ax0, obj1)) in
+          let a_obj = src b_obj (Min_with_simple (ax1, m1)) in
+          const_min_or_apply dst m0 a_obj
+        end
+      | (Max_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
+        ->
+        let q_obj = proj_obj ax0 dst in
+        let b_obj = src dst (Max_with_simple (ax0, m0)) in
+        let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
+        let m0m1 = Simple_morph.compose q_obj m0 m1 in
+        begin match Simple_morph.maybe_allowed_right m0m1 with
+        | Allowed_right m0m1 ->
+          allow_right (Simple (Simple_morph.lift_max a_obj dst m0m1 ax1 ax0))
+        | Not_allowed_right -> Compose (m0', m1')
+        end
+      | (Min_with_simple (ax0, m0) as m0'), (Simple_proj (m1, ax1, obj1) as m1')
+        ->
+        let q_obj = proj_obj ax0 dst in
+        let b_obj = src dst (Min_with_simple (ax0, m0)) in
+        let a_obj = src b_obj (Simple_proj (m1, ax1, obj1)) in
+        let m0m1 = Simple_morph.compose q_obj m0 m1 in
+        begin match Simple_morph.maybe_allowed_left m0m1 with
+        | Allowed_left m0m1 ->
+          allow_left (Simple (Simple_morph.lift_min a_obj dst m0m1 ax1 ax0))
+        | Not_allowed_left -> Compose (m0', m1')
+        end
+      | Simple m0, Const_max a_obj -> const_max_or_apply dst m0 a_obj
+      | Simple m0, Const_min a_obj -> const_min_or_apply dst m0 a_obj
+      | Simple_proj (m0, _ax0, _obj0), Const_max obj1 ->
+        const_max_or_apply dst m0 obj1
+      | Simple_proj (m0, _ax0, _obj0), Const_min obj1 ->
+        const_min_or_apply dst m0 obj1
+      | Min_with_simple (ax0, m0), Const_max obj1 ->
         let q_obj = proj_obj ax0 dst in
         let b_obj = Simple_morph.src q_obj m0 in
-        Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
-      end
-    | Max_with_simple (ax0, m0), Const_max obj1 ->
-      begin match Simple_morph.maybe_allowed_right m0 with
-      | Allowed_right _ -> Const_max obj1
-      | Not_allowed_right ->
+        Const (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
+      | Min_with_simple (ax0, m0), Const_min obj1 ->
+        begin match Simple_morph.maybe_allowed_left m0 with
+        | Allowed_left _ -> Const_min obj1
+        | Not_allowed_left ->
+          let q_obj = proj_obj ax0 dst in
+          let b_obj = Simple_morph.src q_obj m0 in
+          Const
+            (obj1, min_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+        end
+      | Max_with_simple (ax0, m0), Const_max obj1 ->
+        begin match Simple_morph.maybe_allowed_right m0 with
+        | Allowed_right _ -> Const_max obj1
+        | Not_allowed_right ->
+          let q_obj = proj_obj ax0 dst in
+          let b_obj = Simple_morph.src q_obj m0 in
+          Const
+            (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
+        end
+      | Max_with_simple (ax0, m0), Const_min obj1 ->
         let q_obj = proj_obj ax0 dst in
         let b_obj = Simple_morph.src q_obj m0 in
-        Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (max b_obj)))
-      end
-    | Max_with_simple (ax0, m0), Const_min obj1 ->
-      let q_obj = proj_obj ax0 dst in
-      let b_obj = Simple_morph.src q_obj m0 in
-      Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
-    | (_ as m0), Const (obj1, c1) -> Const (obj1, apply dst m0 c1)
-    | (_ as m0), Compose (m1, m2) -> Compose (Compose (m0, m1), m2)
-    | Compose (m0, m1), (_ as m2) -> Compose (Compose (m0, m1), m2)
-    (* The remaining cases are unreachable by looking at the axes and objects *)
-    | _, Simple_proj (Core (Locality_restricted _), _, _) -> .
-    | _, Simple_proj (Meet_const_core (_, Locality_restricted _), _, _) -> .
-    | _, Simple_proj (Core_imply_const (Locality_restricted _, _), _, _) -> .
-    | _, Simple_proj (Compose _, _, _) -> Compose (m0, m1)
-    | Max_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
-      refute_compose_and_with dst ax0 m0' ax1 m0 m1
-    | Max_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
-      refute_compose_and_with dst ax0 m0' ax1 m0 m1
-    | Min_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
-      refute_compose_and_with dst ax0 m0' ax1 m0 m1
-    | Min_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
-      refute_compose_and_with dst ax0 m0' ax1 m0 m1
-    | _, _ -> .
-  [@@warning "-4"]
+        Const (obj1, max_with dst ax0 (Simple_morph.apply q_obj m0 (min b_obj)))
+      | (_ as m0), Const (obj1, c1) -> Const (obj1, apply dst m0 c1)
+      | (_ as m0), Compose (m1, m2) -> Compose (Compose (m0, m1), m2)
+      | Compose (m0, m1), (_ as m2) -> Compose (Compose (m0, m1), m2)
+      (* The remaining cases are unreachable by looking at the axes and objects *)
+      | _, Simple_proj (Core (Locality_restricted _), _, _) -> .
+      | _, Simple_proj (Meet_const_core (_, Locality_restricted _), _, _) -> .
+      | _, Simple_proj (Core_imply_const (Locality_restricted _, _), _, _) -> .
+      | _, Simple_proj (Compose _, _, _) -> Compose (m0, m1)
+      | Max_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 m0' ax1 m0 m1
+      | Max_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 m0' ax1 m0 m1
+      | Min_with_simple (ax0, m0'), Max_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 m0' ax1 m0 m1
+      | Min_with_simple (ax0, m0'), Min_with_simple (ax1, _) ->
+        refute_compose_and_with dst ax0 m0' ax1 m0 m1
+      | _, _ -> .
+    [@@warning "-4"]
 
-  let ( let* ) xs f = List.concat_map f xs
+    let ( let* ) xs f = List.concat_map f xs
 
-  let ( let+ ) xs f = List.map f xs
+    let ( let+ ) xs f = List.map f xs
 
-  type 'b to_ = To : ('a, 'b, neither) morph -> 'b to_ [@@unboxed]
+    type 'b to_ = To : ('a, 'b, neither) t -> 'b to_ [@@unboxed]
 
-  let left_to : type b. full:bool -> b obj -> b to_ list =
-   fun ~full dst ->
-    let simple_morphs = Simple_morph.left_to ~full dst in
-    let simple =
-      List.map
-        (fun (Simple_morph.To m) -> To (disallow_left (Simple m)))
-        simple_morphs
-    in
-    let projections =
-      let* (Simple_morph.To m) = simple_morphs in
-      let src = Simple_morph.src dst m in
-      let+ (Axis.To (src, ax)) = Axis.to_ src in
-      To (disallow_left (Simple_proj (m, ax, src)))
-    in
-    let min_with =
-      let* (Axis.From ax) = Axis.from dst in
-      let projected = proj_obj ax dst in
-      let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
-      To (disallow_left (Min_with_simple (ax, m)))
-    in
-    let const_min =
-      List.map (fun (Obj src) -> To (disallow_left (Const_min src))) all_objs
-    in
-    simple @ projections @ min_with @ const_min
+    let left_to : type b. full:bool -> b obj -> b to_ list =
+     fun ~full dst ->
+      let simple_morphs = Simple_morph.left_to ~full dst in
+      let simple =
+        List.map
+          (fun (Simple_morph.To m) -> To (disallow_left (Simple m)))
+          simple_morphs
+      in
+      let projections =
+        let* (Simple_morph.To m) = simple_morphs in
+        let src = Simple_morph.src dst m in
+        let+ (Axis.To (src, ax)) = Axis.to_ src in
+        To (disallow_left (Simple_proj (m, ax, src)))
+      in
+      let min_with =
+        let* (Axis.From ax) = Axis.from dst in
+        let projected = proj_obj ax dst in
+        let+ (Simple_morph.To m) = Simple_morph.left_to ~full projected in
+        To (disallow_left (Min_with_simple (ax, m)))
+      in
+      let const_min =
+        List.map (fun (Obj src) -> To (disallow_left (Const_min src))) all_objs
+      in
+      simple @ projections @ min_with @ const_min
 
-  let right_to : type b. full:bool -> b obj -> b to_ list =
-   fun ~full dst ->
-    let simple_morphs = Simple_morph.right_to ~full dst in
-    let simple =
-      List.map
-        (fun (Simple_morph.To m) -> To (disallow_right (Simple m)))
-        simple_morphs
-    in
-    let projections =
-      let* (Simple_morph.To m) = simple_morphs in
-      let projected = Simple_morph.src dst m in
-      let+ (Axis.To (src, ax)) = Axis.to_ projected in
-      To (disallow_right (Simple_proj (m, ax, src)))
-    in
-    let max_with =
-      let* (Axis.From ax) = Axis.from dst in
-      let projected = proj_obj ax dst in
-      let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
-      To (disallow_right (Max_with_simple (ax, m)))
-    in
-    let const_max =
-      List.map (fun (Obj src) -> To (disallow_right (Const_max src))) all_objs
-    in
-    simple @ projections @ max_with @ const_max
+    let right_to : type b. full:bool -> b obj -> b to_ list =
+     fun ~full dst ->
+      let simple_morphs = Simple_morph.right_to ~full dst in
+      let simple =
+        List.map
+          (fun (Simple_morph.To m) -> To (disallow_right (Simple m)))
+          simple_morphs
+      in
+      let projections =
+        let* (Simple_morph.To m) = simple_morphs in
+        let projected = Simple_morph.src dst m in
+        let+ (Axis.To (src, ax)) = Axis.to_ projected in
+        To (disallow_right (Simple_proj (m, ax, src)))
+      in
+      let max_with =
+        let* (Axis.From ax) = Axis.from dst in
+        let projected = proj_obj ax dst in
+        let+ (Simple_morph.To m) = Simple_morph.right_to ~full projected in
+        To (disallow_right (Max_with_simple (ax, m)))
+      in
+      let const_max =
+        List.map (fun (Obj src) -> To (disallow_right (Const_max src))) all_objs
+      in
+      simple @ projections @ max_with @ const_max
 
-  let generate_morphs_to ~full dst = left_to ~full dst @ right_to ~full dst
+    let generate_morphs_to ~full dst = left_to ~full dst @ right_to ~full dst
 
-  type 'a covered =
-    { full_coverage : 'a;
-      partial_coverage : 'a
-    }
+    type 'a covered =
+      { full_coverage : 'a;
+        partial_coverage : 'a
+      }
 
-  let force_by_coverage ~full { full_coverage; partial_coverage } =
-    Lazy.force (if full then full_coverage else partial_coverage)
+    let force_by_coverage ~full { full_coverage; partial_coverage } =
+      Lazy.force (if full then full_coverage else partial_coverage)
 
-  let morphs_to_obj obj =
-    let full_coverage = lazy (generate_morphs_to ~full:true obj) in
-    let partial_coverage = lazy (generate_morphs_to ~full:false obj) in
-    { full_coverage; partial_coverage }
+    let morphs_to_obj obj =
+      let full_coverage = lazy (generate_morphs_to ~full:true obj) in
+      let partial_coverage = lazy (generate_morphs_to ~full:false obj) in
+      { full_coverage; partial_coverage }
 
-  let morphs_to_locality = morphs_to_obj Locality
+    let morphs_to_locality = morphs_to_obj Locality
 
-  let morphs_to_regionality = morphs_to_obj Regionality
+    let morphs_to_regionality = morphs_to_obj Regionality
 
-  let morphs_to_areality_quoted = morphs_to_obj ArealityQuoted
+    let morphs_to_areality_quoted = morphs_to_obj ArealityQuoted
 
-  let morphs_to_uniqueness_op = morphs_to_obj Uniqueness_op
+    let morphs_to_uniqueness_op = morphs_to_obj Uniqueness_op
 
-  let morphs_to_linearity = morphs_to_obj Linearity
+    let morphs_to_linearity = morphs_to_obj Linearity
 
-  let morphs_to_portability = morphs_to_obj Portability
+    let morphs_to_portability = morphs_to_obj Portability
 
-  let morphs_to_forkable = morphs_to_obj Forkable
+    let morphs_to_forkable = morphs_to_obj Forkable
 
-  let morphs_to_yielding = morphs_to_obj Yielding
+    let morphs_to_yielding = morphs_to_obj Yielding
 
-  let morphs_to_statefulness = morphs_to_obj Statefulness
+    let morphs_to_statefulness = morphs_to_obj Statefulness
 
-  let morphs_to_contention_op = morphs_to_obj Contention_op
+    let morphs_to_contention_op = morphs_to_obj Contention_op
 
-  let morphs_to_visibility_op = morphs_to_obj Visibility_op
+    let morphs_to_visibility_op = morphs_to_obj Visibility_op
 
-  let morphs_to_staticity_op = morphs_to_obj Staticity_op
+    let morphs_to_staticity_op = morphs_to_obj Staticity_op
 
-  let morphs_to_monadic_op = morphs_to_obj Monadic_op
+    let morphs_to_monadic_op = morphs_to_obj Monadic_op
 
-  let morphs_to_comonadic_with_locality = morphs_to_obj Comonadic_with_locality
+    let morphs_to_comonadic_with_locality =
+      morphs_to_obj Comonadic_with_locality
 
-  let morphs_to_comonadic_with_regionality =
-    morphs_to_obj Comonadic_with_regionality
+    let morphs_to_comonadic_with_regionality =
+      morphs_to_obj Comonadic_with_regionality
 
-  let morphs_to : type b. full:bool -> b obj -> b to_ list =
-   fun ~full -> function
-    | Locality -> force_by_coverage ~full morphs_to_locality
-    | Regionality -> force_by_coverage ~full morphs_to_regionality
-    | ArealityQuoted -> force_by_coverage ~full morphs_to_areality_quoted
-    | Uniqueness_op -> force_by_coverage ~full morphs_to_uniqueness_op
-    | Linearity -> force_by_coverage ~full morphs_to_linearity
-    | Portability -> force_by_coverage ~full morphs_to_portability
-    | Forkable -> force_by_coverage ~full morphs_to_forkable
-    | Yielding -> force_by_coverage ~full morphs_to_yielding
-    | Statefulness -> force_by_coverage ~full morphs_to_statefulness
-    | Contention_op -> force_by_coverage ~full morphs_to_contention_op
-    | Visibility_op -> force_by_coverage ~full morphs_to_visibility_op
-    | Staticity_op -> force_by_coverage ~full morphs_to_staticity_op
-    | Monadic_op -> force_by_coverage ~full morphs_to_monadic_op
-    | Comonadic_with_locality ->
-      force_by_coverage ~full morphs_to_comonadic_with_locality
-    | Comonadic_with_regionality ->
-      force_by_coverage ~full morphs_to_comonadic_with_regionality
+    let morphs_to : type b. full:bool -> b obj -> b to_ list =
+     fun ~full -> function
+      | Locality -> force_by_coverage ~full morphs_to_locality
+      | Regionality -> force_by_coverage ~full morphs_to_regionality
+      | ArealityQuoted -> force_by_coverage ~full morphs_to_areality_quoted
+      | Uniqueness_op -> force_by_coverage ~full morphs_to_uniqueness_op
+      | Linearity -> force_by_coverage ~full morphs_to_linearity
+      | Portability -> force_by_coverage ~full morphs_to_portability
+      | Forkable -> force_by_coverage ~full morphs_to_forkable
+      | Yielding -> force_by_coverage ~full morphs_to_yielding
+      | Statefulness -> force_by_coverage ~full morphs_to_statefulness
+      | Contention_op -> force_by_coverage ~full morphs_to_contention_op
+      | Visibility_op -> force_by_coverage ~full morphs_to_visibility_op
+      | Staticity_op -> force_by_coverage ~full morphs_to_staticity_op
+      | Monadic_op -> force_by_coverage ~full morphs_to_monadic_op
+      | Comonadic_with_locality ->
+        force_by_coverage ~full morphs_to_comonadic_with_locality
+      | Comonadic_with_regionality ->
+        force_by_coverage ~full morphs_to_comonadic_with_regionality
+  end
+
+  (* Finally, morphisms in the solver *)
+
+  module Morph = Meta_morph
+
+  type ('a, 'b, 'd) morph = ('a, 'b, 'd) Morph.t
+
+  type ('a, 'b, 'd) sided = ('a, 'b, 'd) Morph.t constraint 'd = 'l * 'r
+
+  let src = Morph.src
+
+  let id = Morph.id
+
+  let compose = Morph.compose
+
+  let left_adjoint = Morph.left_adjoint
+
+  let right_adjoint = Morph.right_adjoint
+
+  let allow_left = Morph.allow_left
+
+  let allow_right = Morph.allow_right
+
+  let disallow_left = Morph.disallow_left
+
+  let disallow_right = Morph.disallow_right
+
+  let apply = Morph.apply
+
+  let compare_morph = Morph.compare_morph
+
+  let equal_morph = Morph.equal_morph
+
+  let print_morph = Morph.print_morph
+
+  (* Extras *)
+
+  type 'b to_ = 'b Morph.to_ = To : ('a, 'b, neither) morph -> 'b to_
+  [@@unboxed]
+
+  let morphs_to = Morph.morphs_to
 
   module For_hint = struct
     (** Describes the portion of the input that's responsible for a portion of
@@ -4444,7 +4490,7 @@ module Lattices_mono = struct
     (** Given a morphism and an axis, return the portion of the input that's
         responsible for the specified axis of the output. *)
     let rec find_responsible_axis_proj : type a b b_ax l r.
-        (a, b, l * r) morph -> (b, b_ax) Axis.t -> a responsible_axis =
+        (a, b, l * r) Meta_morph.t -> (b, b_ax) Axis.t -> a responsible_axis =
      fun m ax ->
       match m with
       | Simple m -> find_responsible_axis_proj_simple m ax
@@ -4470,7 +4516,7 @@ module Lattices_mono = struct
     (** Given a morphism return the portion of the input that's responsible for
         all of the output. *)
     let rec find_responsible_axis_all : type a b l r.
-        (a, b, l * r) morph -> a responsible_axis = function
+        (a, b, l * r) Meta_morph.t -> a responsible_axis = function
       | Simple _ -> All_responsible
       | Simple_proj (_, ax, _) -> Axis ax
       | Max_with_simple _ | Min_with_simple _ -> All_responsible

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -34,6 +34,7 @@ type pinpoint_desc =
   | Structure  (** A structure definition *)
   | Lazy  (** A lazy expression *)
   | Quote  (** A quoted expression *)
+  | Splice  (** A splice *)
   | Allocation  (** An allocation *)
   | Expression  (** An arbitrary expression *)
   | Effect_match  (** A pattern match with effect cases *)
@@ -87,8 +88,9 @@ type containing =
   | Array of modality
   | Constructor of string * modality
   | Structure of structure_item * modality
-(* Some structure items (such as classes) don't have modalities. We gloss over
+  (* Some structure items (such as classes) don't have modalities. We gloss over
      for simplicity. *)
+  | Quote
 
 type contains =
   { containing : containing;

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -372,6 +372,8 @@ module type S = sig
          and type 'd hint_const := 'd neg_hint_const
   end
 
+  type 'a quoted = Quote of 'a [@@unboxed]
+
   module Locality : sig
     module Const : sig
       type t =
@@ -421,6 +423,16 @@ module type S = sig
     val regional : lr
 
     val local : lr
+  end
+
+  module ArealityQuoted : sig
+    module Const : sig
+      type t = Regionality.Const.t quoted
+
+      include Const with type t := t
+    end
+
+    include Common_axis_pos with module Const := Const
   end
 
   module Linearity : sig
@@ -570,6 +582,7 @@ module type S = sig
 
   type 'a comonadic_with =
     { areality : 'a;
+      areality_quoted : ArealityQuoted.Const.t;
       linearity : Linearity.Const.t;
       portability : Portability.Const.t;
       forkable : Forkable.Const.t;
@@ -591,6 +604,7 @@ module type S = sig
         NB: must listed in the order of axis implication. See [typemode.ml]. *)
     type ('p, 'r) t =
       | Areality : ('a comonadic_with, 'a) t
+      | ArealityQuoted : ('a comonadic_with, ArealityQuoted.Const.t) t
       | Forkable : ('areality comonadic_with, Forkable.Const.t) t
       | Yielding : ('areality comonadic_with, Yielding.Const.t) t
       | Linearity : ('areality comonadic_with, Linearity.Const.t) t
@@ -663,8 +677,9 @@ module type S = sig
       include Axis with type 'a t := 'a t
     end
 
-    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
+    type ('a, 'aq, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
       { areality : 'a;
+        areality_quoted : 'aq;
         linearity : 'b;
         uniqueness : 'c;
         portability : 'd;
@@ -681,6 +696,7 @@ module type S = sig
         Const
           with type t =
             ( Areality.Const.t,
+              ArealityQuoted.Const.t,
               Linearity.Const.t,
               Uniqueness.Const.t,
               Portability.Const.t,
@@ -697,6 +713,7 @@ module type S = sig
 
         type t =
           ( Areality.Const.t option,
+            ArealityQuoted.Const.t option,
             Linearity.Const.t option,
             Uniqueness.Const.t option,
             Portability.Const.t option,

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -786,6 +786,9 @@ module type S = sig
     val meet_const_with :
       'a Comonadic.Axis.t -> 'a -> ('l * 'r) t -> ('l * disallowed) t
 
+    val imply_const_with :
+      'a Comonadic.Axis.t -> 'a -> ('l * 'r) t -> (disallowed * 'r) t
+
     val join_const_with :
       'a Monadic.Axis.t -> 'a -> ('l * 'r) t -> (disallowed * 'r) t
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -647,6 +647,10 @@ module type S = sig
       end
 
       val max_with : 'a Axis.t -> ('a, 'l * 'r) mode -> (disallowed * 'r) t
+
+      val offset_stage_r : int -> r -> r
+
+      val const_offset_stage_r : int -> Const.t -> Const.t
     end
 
     module Axis : sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -887,9 +887,11 @@ module type S = sig
     ('l * 'r) Value.t ->
     (disallowed * 'r) Alloc.t
 
-  val offset_stage_r : int -> Value.Comonadic.r -> Value.Comonadic.r
+  val quoted_floor : Value.Comonadic.l -> Value.Comonadic.l
 
-  val const_offset_stage_r :
+  val offset_stage_l : int -> Value.Comonadic.l -> Value.Comonadic.l
+
+  val const_offset_stage_l :
     int -> Value.Comonadic.Const.t -> Value.Comonadic.Const.t
 
   module Modality : sig

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -661,10 +661,6 @@ module type S = sig
       end
 
       val max_with : 'a Axis.t -> ('a, 'l * 'r) mode -> (disallowed * 'r) t
-
-      val offset_stage_r : int -> r -> r
-
-      val const_offset_stage_r : int -> Const.t -> Const.t
     end
 
     module Axis : sig
@@ -890,6 +886,11 @@ module type S = sig
     ?allocation:Hint.allocation ->
     ('l * 'r) Value.t ->
     (disallowed * 'r) Alloc.t
+
+  val offset_stage_r : int -> Value.Comonadic.r -> Value.Comonadic.r
+
+  val const_offset_stage_r :
+    int -> Value.Comonadic.Const.t -> Value.Comonadic.Const.t
 
   module Modality : sig
     module Comonadic : sig

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1356,6 +1356,7 @@ let tree_of_modes (modes : Mode.Alloc.Const.t) =
   let print_to_string_opt print a = Option.map (Fmt.asprintf "%a" print) a in
   let modes =
     [ print_to_string_opt Mode.Locality.Const.print diff.areality
+    ; print_to_string_opt Mode.ArealityQuoted.Const.print diff.areality_quoted
     ; print_to_string_opt Mode.Uniqueness.Const.print diff.uniqueness
     ; print_to_string_opt Mode.Linearity.Const.print diff.linearity
     ; print_to_string_opt Mode.Portability.Const.print diff.portability

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1297,6 +1297,14 @@ let mode_computation_quote : Value.l =
   { Value.Const.min with linearity = Once }
   |> Value.of_const ~hint_comonadic:Quoted_computation
 
+(** Upper bound for the mode of values captured by a quote.
+    Quotes are always heap-allocated, so they must only capture globals. **)
+(* CR quoted-modes jbachurski: If we are confident, we can make quotes cross
+   locality. Since quotes ([expr]s) can only same-stage-capture other quotes,
+   this would mean this upper bound never really matters. *)
+let mode_quote_max : Value.r =
+  { Value.Const.max with areality = Global } |> Value.of_const
+
 (** The [expected_mode] of a quoted expression value when it is spliced. *)
 let mode_spliced =
   let open Mode_hint in
@@ -8692,6 +8700,11 @@ and type_expect_
             (fun mode ->
               Value.imply_const_with Linearity Linearity.Const.Many mode)
             expected_mode
+      in
+      let expected_mode =
+        mode_morph
+          (fun mode -> Mode.Value.meet [mode; mode_quote_max])
+          expected_mode
       in
       let ty = newgenvar (Jkind.Builtin.any ~why:Inside_quote) in
       let expr_ty = Predef.type_code (newgenty (Tquote ty)) in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8689,7 +8689,6 @@ and type_expect_
         else
           expected_mode
       in
-      let expected_comonadic_mode = (as_single_mode expected_mode).comonadic in
       let ty = newgenvar (Jkind.Builtin.any ~why:Inside_quote) in
       let expr_ty = Predef.type_code (newgenty (Tquote ty)) in
       with_explanation (fun () ->
@@ -8707,7 +8706,9 @@ and type_expect_
       let quote_env = begin
           if Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes
           then quote_env
-          else Env.add_closure_lock (loc, Quote) expected_comonadic_mode quote_env
+          else
+            let { comonadic; _ } = as_single_mode expected_mode in
+            Env.add_closure_lock (loc, Quote) comonadic quote_env
         end
       in
       let arg = type_expect quote_env mode_quoted exp (mk_expected ty) in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1288,8 +1288,7 @@ let mode_quoted : expected_mode = mode_default mode_in_quotes
     Note: we must have that [mode_quoted <= mode_splice] for soundness. *)
 and mode_splice : Value.l = Value.disallow_right mode_in_quotes
 
-(** Lower bound for the mode of a quoted expression that
-    might have side-effects. *)
+(** Lower bound for the mode of a quoted expression that is a computation. *)
 let mode_computation_quoted : Value.l =
   let open Mode_hint in
   { Value.Const.min with linearity = Once }
@@ -8681,6 +8680,15 @@ and type_expect_
       if not (Language_extension.is_enabled Runtime_metaprogramming) then
         raise (Typetexp.Error (loc, env,
                                Unsupported_extension Runtime_metaprogramming));
+      let expected_mode =
+        if not (maybe_computation exp) then
+          mode_morph
+            (fun mode ->
+              Value.imply_const_with Linearity Linearity.Const.Many mode)
+            expected_mode
+        else
+          expected_mode
+      in
       let expected_comonadic_mode = (as_single_mode expected_mode).comonadic in
       let new_env =
         env

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5358,95 +5358,76 @@ let maybe_expansive e = not (is_nonexpansive e)
     Potentially expensive or side-effectful computations should return [true],
     and only syntactic values should return [false]. **)
 let rec maybe_computation exp =
-  match exp.exp_desc with
+  match exp.pexp_desc with
   (* Return [false] for syntactic values *)
-  | Texp_ident _ ->
+  | Pexp_ident _ ->
     false
-  | Texp_constant _ ->
+  | Pexp_constant _ ->
     false
-  | Texp_function _ ->
+  | Pexp_function _ ->
     false
-  | Texp_unboxed_unit ->
+  | Pexp_unboxed_unit ->
     false
-  | Texp_unboxed_bool _ ->
+  | Pexp_unboxed_bool _ ->
     false
-  | Texp_tuple (exps, _) ->
+  | Pexp_tuple exps ->
     List.exists (fun (_, exp) -> maybe_computation exp) exps
-  | Texp_unboxed_tuple exps ->
-    List.exists (fun (_, exp, _) -> maybe_computation exp) exps
-  | Texp_construct (_, _, _, exps, _) ->
+  | Pexp_unboxed_tuple exps ->
     List.exists (fun (_, exp) -> maybe_computation exp) exps
-  | Texp_variant (_, Some (exp, _)) ->
+  | Pexp_construct (_, Some exp) | Pexp_variant (_, Some exp) ->
     maybe_computation exp
-  | Texp_variant (_, None) ->
+  | Pexp_construct (_, None) | Pexp_variant (_, None) ->
     false
-  | Texp_record { fields; extended_expression = None; _ } ->
-    Array.exists
-      (function
-      | (_, _, Overridden (_, exp)) -> maybe_computation exp
-      | (_, _, Kept _) -> false)
-      fields
-  | Texp_record { extended_expression = Some _; _ } ->
+  | Pexp_record (fields, None) | Pexp_record_unboxed_product (fields, None) ->
+    List.exists (fun (_, exp) -> maybe_computation exp) fields
+  | Pexp_record (_, Some _) | Pexp_record_unboxed_product (_, Some _) ->
     true
-  | Texp_record_unboxed_product { fields; extended_expression = None; _ } ->
-    Array.exists
-      (function
-      | (_, _, Overridden (_, exp)) -> maybe_computation exp
-      | (_, _, Kept _) -> false)
-      fields
-  | Texp_record_unboxed_product { extended_expression = Some _; _ } ->
-    true
-  | Texp_field { record = exp; _ } ->
+  | Pexp_field (exp, _) ->
     maybe_computation exp
-  | Texp_unboxed_field { record = exp; _ } ->
+  | Pexp_unboxed_field (exp, _) ->
     maybe_computation exp
-  | Texp_array (_, _, exps, _) ->
+  | Pexp_array (_, exps) ->
     List.exists maybe_computation exps
-  | Texp_hole _ ->
+  | Pexp_hole ->
     false
-  | Texp_quotation exp ->
+  | Pexp_constraint (e, _, _) | Pexp_coerce (e, _, _) ->
+    maybe_computation e
+  | Pexp_quote exp ->
     (* Approximate quote values as quotes of values.
        Note that splices are always considered computations. *)
     maybe_computation exp
   (* it is always safe to approximate [maybe_computation] as [true]. *)
-  | Texp_let _
-  | Texp_letmutable _
-  | Texp_apply _
-  | Texp_match _
-  | Texp_try _
-  | Texp_atomic_loc _
-  | Texp_setfield _
-  | Texp_idx _
-  | Texp_list_comprehension _
-  | Texp_array_comprehension _
-  | Texp_ifthenelse _
-  | Texp_sequence _
-  | Texp_while _
-  | Texp_for _
-  | Texp_send _
-  | Texp_new _
-  | Texp_instvar _
-  | Texp_mutvar _
-  | Texp_setinstvar _
-  | Texp_setmutvar _
-  | Texp_override _
-  | Texp_letmodule _
-  | Texp_letexception _
-  | Texp_assert _
-  | Texp_lazy _
-  | Texp_object _
-  | Texp_pack _
-  | Texp_letop _
-  | Texp_unreachable
-  | Texp_extension_constructor _
-  | Texp_open _
-  | Texp_probe _
-  | Texp_probe_is_enabled _
-  | Texp_exclave _
-  | Texp_src_pos
-  | Texp_overwrite _
-  | Texp_antiquotation _
-  | Texp_apply_layout _
+  | Pexp_let _
+  | Pexp_apply _
+  | Pexp_match _
+  | Pexp_try _
+  | Pexp_setfield _
+  | Pexp_idx _
+  | Pexp_comprehension _
+  | Pexp_ifthenelse _
+  | Pexp_sequence _
+  | Pexp_while _
+  | Pexp_for _
+  | Pexp_send _
+  | Pexp_new _
+  | Pexp_setvar _
+  | Pexp_override _
+  | Pexp_letmodule _
+  | Pexp_letexception _
+  | Pexp_assert _
+  | Pexp_lazy _
+  | Pexp_object _
+  | Pexp_pack _
+  | Pexp_letop _
+  | Pexp_unreachable
+  | Pexp_extension _
+  | Pexp_open _
+  | Pexp_overwrite _
+  | Pexp_newtype _
+  | Pexp_poly _
+  | Pexp_stack _
+  | Pexp_borrow _
+  | Pexp_splice _
     -> true
 
 (* Returns true if, for every [Texp_ident x] occurring in the expression,
@@ -8720,7 +8701,7 @@ and type_expect_
         else mode_quoted
       in
       let arg = type_expect new_env mode_quoted exp (mk_expected ty) in
-      if maybe_computation arg then
+      if maybe_computation exp then
         submode ~loc ~env ~reason:Other mode_computation_quoted expected_mode;
       re {
         exp_desc = Texp_quotation arg;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1288,8 +1288,11 @@ let mode_quoted : expected_mode = mode_default mode_in_quotes
     Note: we must have that [mode_quoted <= mode_splice] for soundness. *)
 and mode_splice : Value.l = Value.disallow_right mode_in_quotes
 
-(** Lower bound for the mode of a quoted expression that is a computation. *)
-let mode_computation_quoted : Value.l =
+(** Lower bound for the mode of a quoted value. *)
+let mode_value_quote : Value.l = Value.of_const Value.Const.min
+
+(** Lower bound for the mode of a quoted computation. *)
+let mode_computation_quote : Value.l =
   let open Mode_hint in
   { Value.Const.min with linearity = Once }
   |> Value.of_const ~hint_comonadic:Quoted_computation
@@ -8680,14 +8683,15 @@ and type_expect_
       if not (Language_extension.is_enabled Runtime_metaprogramming) then
         raise (Typetexp.Error (loc, env,
                                Unsupported_extension Runtime_metaprogramming));
-      let expected_mode =
-        if not (maybe_computation exp) then
+      let mode_quote, expected_mode =
+        if maybe_computation exp then
+          mode_computation_quote, expected_mode
+        else
+          mode_value_quote,
           mode_morph
             (fun mode ->
               Value.imply_const_with Linearity Linearity.Const.Many mode)
             expected_mode
-        else
-          expected_mode
       in
       let ty = newgenvar (Jkind.Builtin.any ~why:Inside_quote) in
       let expr_ty = Predef.type_code (newgenty (Tquote ty)) in
@@ -8702,18 +8706,16 @@ and type_expect_
         then mode_default Value.max
         else mode_quoted
       in
-      let quote_env = Env.enter_quotation env in
       let quote_env = begin
           if Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes
-          then quote_env
+          then Env.enter_quotation env
           else
             let { comonadic; _ } = as_single_mode expected_mode in
-            Env.add_closure_lock (loc, Quote) comonadic quote_env
+            Env.add_quotation_lock ~loc comonadic env
         end
       in
       let arg = type_expect quote_env mode_quoted exp (mk_expected ty) in
-      if maybe_computation exp then
-        submode ~loc ~env ~reason:Other mode_computation_quoted expected_mode;
+      submode ~loc ~env mode_quote expected_mode;
       re {
         exp_desc = Texp_quotation arg;
         exp_loc = loc; exp_extra = [];
@@ -8731,11 +8733,14 @@ and type_expect_
       let magic_staged_modes =
         Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes
       in
-      if not magic_staged_modes then
+      let mode, _ = Value.newvar_below (as_single_mode mode_spliced) in
+      if not magic_staged_modes then begin
         submode ~loc ~env ~reason:Other mode_splice expected_mode;
+        Env.splice_closure_mode mode.comonadic env
+      end;
       let new_env = Env.enter_splice ~loc env in
       let ty = Predef.type_code (newgenty (Tquote ty_expected)) in
-      let arg = type_expect new_env mode_spliced exp (mk_expected ty) in
+      let arg = type_expect new_env (mode_default mode) exp (mk_expected ty) in
       re {
         exp_desc = Texp_antiquotation arg;
         exp_loc = loc; exp_extra = [];

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8690,11 +8690,6 @@ and type_expect_
           expected_mode
       in
       let expected_comonadic_mode = (as_single_mode expected_mode).comonadic in
-      let new_env =
-        env
-        |> Env.enter_quotation
-        |> Env.add_closure_lock (loc, Quote) expected_comonadic_mode
-      in
       let ty = newgenvar (Jkind.Builtin.any ~why:Inside_quote) in
       let expr_ty = Predef.type_code (newgenty (Tquote ty)) in
       with_explanation (fun () ->
@@ -8708,7 +8703,14 @@ and type_expect_
         then mode_default Value.max
         else mode_quoted
       in
-      let arg = type_expect new_env mode_quoted exp (mk_expected ty) in
+      let quote_env = Env.enter_quotation env in
+      let quote_env = begin
+          if Builtin_attributes.has_magic_staged_modes sexp.pexp_attributes
+          then quote_env
+          else Env.add_closure_lock (loc, Quote) expected_comonadic_mode quote_env
+        end
+      in
+      let arg = type_expect quote_env mode_quoted exp (mk_expected ty) in
       if maybe_computation exp then
         submode ~loc ~env ~reason:Other mode_computation_quoted expected_mode;
       re {

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -72,6 +72,8 @@ module Mode_axis_pair = struct
     | "local" -> comonadic Areality Local
     (* "regional" is not supported *)
     | "global" -> comonadic Areality Global
+    | "quote_local" -> comonadic ArealityQuoted (Quote Local)
+    | "quote_global" -> comonadic ArealityQuoted (Quote Global)
     | "unique" -> monadic Uniqueness Unique
     | "aliased" -> monadic Uniqueness Aliased
     | "once" -> comonadic Linearity Once
@@ -136,6 +138,8 @@ module Transled_modifiers = struct
 
   type t =
     { areality : Mode.Regionality.Const.t Comonadic.Atom.t Location.loc option;
+      areality_quoted :
+        Mode.ArealityQuoted.Const.t Comonadic.Atom.t Location.loc option;
       linearity : Mode.Linearity.Const.t Comonadic.Atom.t Location.loc option;
       uniqueness : Mode.Uniqueness.Const.t Monadic.Atom.t Location.loc option;
       portability :
@@ -158,6 +162,7 @@ module Transled_modifiers = struct
 
   let empty =
     { areality = None;
+      areality_quoted = None;
       linearity = None;
       uniqueness = None;
       portability = None;
@@ -175,6 +180,7 @@ module Transled_modifiers = struct
   let get (type a) ~(axis : a Axis.t) (t : t) : a Location.loc option =
     match axis with
     | Modal (Comonadic Areality) -> t.areality
+    | Modal (Comonadic ArealityQuoted) -> t.areality_quoted
     | Modal (Comonadic Linearity) -> t.linearity
     | Modal (Monadic Uniqueness) -> t.uniqueness
     | Modal (Comonadic Portability) -> t.portability
@@ -190,6 +196,7 @@ module Transled_modifiers = struct
       t =
     match axis with
     | Modal (Comonadic Areality) -> { t with areality = value }
+    | Modal (Comonadic ArealityQuoted) -> { t with areality_quoted = value }
     | Modal (Comonadic Linearity) -> { t with linearity = value }
     | Modal (Monadic Uniqueness) -> { t with uniqueness = value }
     | Modal (Comonadic Portability) -> { t with portability = value }
@@ -316,6 +323,9 @@ let transl_mod_bounds annots =
         Transled_modifiers.
           { areality =
               Some { txt = Per_axis.min (Modal (Comonadic Areality)); loc };
+            areality_quoted =
+              Some
+                { txt = Per_axis.min (Modal (Comonadic ArealityQuoted)); loc };
             linearity =
               Some { txt = Per_axis.min (Modal (Comonadic Linearity)); loc };
             uniqueness =

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -72,6 +72,7 @@ module Mode_axis_pair = struct
     | "local" -> comonadic Areality Local
     (* "regional" is not supported *)
     | "global" -> comonadic Areality Global
+    (* CR quoted-modes jbachurski: Guard behind the [Runtime_metaprogramming] extension. *)
     | "quote_local" -> comonadic ArealityQuoted (Quote Local)
     | "quote_global" -> comonadic ArealityQuoted (Quote Global)
     | "unique" -> monadic Uniqueness Unique


### PR DESCRIPTION
This is a draft of the implementation of the quoted areality axis. It tracks _quoted_ captures of locals, e.g. for `x @ local` available at stage 1 we'll have `<[x]> @ <[local]>` in stage 0.

There's several other completeness/soundness changes to mode checking here currently that I'll probably move to other PRs. Commit structure should be useful.

There's now a draft of the quoted areality axis and staging morphisms.