### PR TITLE
Fix: Types that depend on GADT equation information can escape through functor applications

### DIFF
--- a/testsuite/tests/typing-gadts/equation_escape_functor.ml
+++ b/testsuite/tests/typing-gadts/equation_escape_functor.ml
@@ -1,0 +1,156 @@
+(* TEST
+ expect;
+*)
+
+(* Matching a GADT witness can refine an abstract type's jkind (here [M.t : any]
+   becomes [bits64] under [T]). A type relying on that narrowing must not escape
+   the match.
+
+   These tests check that such a type cannot be laundered out through
+   a module type produced by a functor application *)
+
+type ('a : any) is_bits64 = T : ('a : bits64). 'a is_bits64
+
+module M : sig
+  type t : any
+  val witness : t is_bits64
+end = struct
+  type t = int64#
+  let witness = T
+end
+
+type ('a : bits64) foo
+[%%expect {|
+type ('a : any) is_bits64 = T : ('a : bits64). 'a is_bits64
+module M : sig type t : any val witness : t is_bits64 end
+type ('a : bits64) foo
+|}]
+
+(* For reference: directly writing [M.t foo] is rejected. *)
+let direct =
+  let T = M.witness in
+  (fun (x : M.t foo) -> x)
+[%%expect {|
+Line 3, characters 7-20:
+3 |   (fun (x : M.t foo) -> x)
+           ^^^^^^^^^^^^^
+Error: This pattern matches values of type "M.t foo"
+       but a pattern was expected which matches values of type "'a"
+       This instance of "$0" is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+(* Regression test: Laundering it through a functor application is rejected too
+*)
+module F_c (X : sig type t : bits64 end) = struct
+  let f (x : X.t foo) = x
+end
+
+let via_functor_application =
+  let T = M.witness in
+  let module N = F_c(M) in
+  N.f
+[%%expect {|
+module F_c :
+  functor (X : sig type t : bits64 end) -> sig val f : X.t foo -> X.t foo end
+val via_functor_application : M.t foo -> M.t foo = <fun>
+|}]
+
+
+(* We also reject a module with a module type produced by a functor application
+*)
+module Mk_S (X : sig type t : bits64 end) = struct
+  module type S = sig val f : X.t foo -> X.t foo end
+end
+
+let via_modtype_path =
+  let T = M.witness in
+  let module N : Mk_S(M).S = struct let f x = x end in
+  N.f
+[%%expect {|
+module Mk_S :
+  functor (X : sig type t : bits64 end) ->
+    sig module type S = sig val f : X.t foo -> X.t foo end end
+val via_modtype_path : M.t foo -> M.t foo = <fun>
+|}]
+
+(* Similar test, but we match on the witness inside of the module *)
+module F_b (X : sig type t : bits64 end) = struct
+  let f (x : X.t foo) = x
+end
+
+module Mk_S_b (X : sig type t : bits64 end) = struct
+  module type S = sig val f : X.t foo -> X.t foo end
+end
+
+let via_first_class_module =
+  let module N =
+    (val
+      let T = M.witness in
+      (module F_b(M) : Mk_S_b(M).S))
+  in
+  N.f
+[%%expect {|
+module F_b :
+  functor (X : sig type t : bits64 end) -> sig val f : X.t foo -> X.t foo end
+module Mk_S_b :
+  functor (X : sig type t : bits64 end) ->
+    sig module type S = sig val f : X.t foo -> X.t foo end end
+val via_first_class_module : M.t foo -> M.t foo = <fun>
+|}]
+
+(* CR layouts: Once we support [any] in tuples, the below will and should
+   compile and can be deleted. *)
+
+type ('a : any) is_value = V : ('a : value). 'a is_value
+
+module Mv : sig
+  type t : any
+  val v : unit -> t
+  val witness : t is_value
+end = struct
+  type t = string
+  let v () = ""
+  let witness = V
+end
+
+module Mk_St (X : sig type t val v : unit -> t end) = struct
+  module type S = sig val x : X.t * X.t end
+end
+[%%expect {|
+type ('a : any) is_value = V : 'a is_value
+module Mv : sig type t : any val v : unit -> t val witness : t is_value end
+module Mk_St :
+  functor (X : sig type t val v : unit -> t end) ->
+    sig module type S = sig val x : X.t * X.t end end
+|}]
+
+let tuple_direct =
+  let V = Mv.witness in
+  (Mv.v (), Mv.v ())
+[%%expect {|
+Line 3, characters 3-10:
+3 |   (Mv.v (), Mv.v ())
+       ^^^^^^^
+Error: This expression has type "Mv.t" = "$0"
+       but an expression was expected of type "'a"
+       This instance of "$0" is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+let tuple_via_modtype_path =
+  let V = Mv.witness in
+  let module N : Mk_St(Mv).S = struct let x = Mv.v (), Mv.v () end in
+  N.x
+[%%expect {|
+Lines 2-4, characters 2-5:
+2 | ..let V = Mv.witness in
+3 |   let module N : Mk_St(Mv).S = struct let x = Mv.v (), Mv.v () end in
+4 |   N.x
+Error: Non-value detected in [value_kind].
+       Please report this error to the Jane Street compilers team.
+       The layout of Mv.t is any
+         because of the definition of t at line 4, characters 2-14.
+       But the layout of Mv.t must be a value layout
+         because it has to be value for the V1 safety check.
+|}]

--- a/testsuite/tests/typing-gadts/equation_escape_functor.ml
+++ b/testsuite/tests/typing-gadts/equation_escape_functor.ml
@@ -53,7 +53,13 @@ let via_functor_application =
 [%%expect {|
 module F_c :
   functor (X : sig type t : bits64 end) -> sig val f : X.t foo -> X.t foo end
-val via_functor_application : M.t foo -> M.t foo = <fun>
+Line 8, characters 2-5:
+8 |   N.f
+      ^^^
+Error: The value "N.f" has type "M.t foo -> M.t foo"
+       but an expression was expected of type "'a"
+       This instance of "$0" is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 
@@ -71,7 +77,13 @@ let via_modtype_path =
 module Mk_S :
   functor (X : sig type t : bits64 end) ->
     sig module type S = sig val f : X.t foo -> X.t foo end end
-val via_modtype_path : M.t foo -> M.t foo = <fun>
+Line 8, characters 2-5:
+8 |   N.f
+      ^^^
+Error: The value "N.f" has type "M.t foo -> M.t foo"
+       but an expression was expected of type "'a"
+       This instance of "$0" is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 (* Similar test, but we match on the witness inside of the module *)
@@ -96,7 +108,13 @@ module F_b :
 module Mk_S_b :
   functor (X : sig type t : bits64 end) ->
     sig module type S = sig val f : X.t foo -> X.t foo end end
-val via_first_class_module : M.t foo -> M.t foo = <fun>
+Line 15, characters 2-5:
+15 |   N.f
+       ^^^
+Error: The value "N.f" has type "M.t foo -> M.t foo"
+       but an expression was expected of type "'a"
+       This instance of "M.t" is ambiguous:
+       it would escape the scope of its equation
 |}]
 
 (* CR layouts: Once we support [any] in tuples, the below will and should
@@ -143,14 +161,11 @@ let tuple_via_modtype_path =
   let module N : Mk_St(Mv).S = struct let x = Mv.v (), Mv.v () end in
   N.x
 [%%expect {|
-Lines 2-4, characters 2-5:
-2 | ..let V = Mv.witness in
-3 |   let module N : Mk_St(Mv).S = struct let x = Mv.v (), Mv.v () end in
+Line 4, characters 2-5:
 4 |   N.x
-Error: Non-value detected in [value_kind].
-       Please report this error to the Jane Street compilers team.
-       The layout of Mv.t is any
-         because of the definition of t at line 4, characters 2-14.
-       But the layout of Mv.t must be a value layout
-         because it has to be value for the V1 safety check.
+      ^^^
+Error: The value "N.x" has type "Mv.t * Mv.t"
+       but an expression was expected of type "'a"
+       This instance of "$0" is ambiguous:
+       it would escape the scope of its equation
 |}]

--- a/testsuite/tests/typing-gadts/equation_escape_functor.ml
+++ b/testsuite/tests/typing-gadts/equation_escape_functor.ml
@@ -2,13 +2,45 @@
  expect;
 *)
 
-(* Matching a GADT witness can refine an abstract type's jkind (here [M.t : any]
-   becomes [bits64] under [T]). A type relying on that narrowing must not escape
-   the match.
+(* Matching a GADT witness can refine an abstract type. A type relying on that
+   narrowing (via a kind annotation or constraint) must not escape the match.
 
    These tests check that such a type cannot be laundered out through
    a module type produced by a functor application *)
 
+module M : sig
+  type t
+  val witness : (t, string) Type.eq
+end = struct
+  type t = string
+  let witness = Type.Equal
+end
+
+type 'a foo constraint 'a = string
+
+module F_c (X : sig type t = string end) = struct
+  let f (x : X.t foo) = x
+end
+
+let f =
+  let Equal = M.witness in
+  let module N = F_c(M) in
+  N.f
+[%%expect{|
+module M : sig type t val witness : (t, string) Type.eq end
+type 'a foo constraint 'a = string
+module F_c :
+  functor (X : sig type t = string end) -> sig val f : X.t foo -> X.t foo end
+Line 18, characters 2-5:
+18 |   N.f
+       ^^^
+Error: The value "N.f" has type "M.t foo -> M.t foo"
+       but an expression was expected of type "'a"
+       This instance of "string" is ambiguous:
+       it would escape the scope of its equation
+|}]
+
+(* In this test, [M.t]'s kind narrows from [any] to [bits64] under [T] *)
 type ('a : any) is_bits64 = T : ('a : bits64). 'a is_bits64
 
 module M : sig

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -4181,6 +4181,17 @@ let find_expansion_scope env path =
   | { type_manifest = None ; _ } | exception Not_found -> generic_level
   | decl -> decl.type_expansion_scope
 
+let iterator_scope_local_equations env super =
+  let it_do_type_expr it ty =
+    begin match get_desc ty with
+    | Tconstr (path, _, _) when Env.is_local_type_constraint path env ->
+      update_scope (find_expansion_scope env path) ty
+    | _ -> ()
+    end;
+    super.it_do_type_expr it ty
+  in
+  { super with it_do_type_expr }
+
 let non_aliasable p decl =
   (* in_pervasives p ||  (subsumed by in_current_module) *)
   in_current_module p && not decl.type_is_newtype

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -303,6 +303,12 @@ val expand_head_opt: Env.t -> type_expr -> type_expr
 (** The compiler's own version of [expand_head] necessary for type-based
     optimisations. *)
 
+val iterator_scope_local_equations:
+  Env.t -> Btype.type_iterators_full -> Btype.type_iterators_full
+(** Extend an iterator to update scopes to reflect a potential dependence on
+    local equations on any [Tconstr]s; these scopes can be stale after a
+    signature substitution. *)
+
 (** Expansion of types for error traces; lives here instead of in [Errortrace]
     because the expansion machinery lives here. *)
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -939,6 +939,8 @@ let constrain_type_jkind = ref (fun _ _ _ -> assert false)
 
 let check_well_formed_module = ref (fun _ -> assert false)
 
+let scope_local_equations = ref (fun _ _ -> assert false)
+
 (* Helper to decide whether to report an identifier shadowing
    by some 'open'. For labels and constructors, we do not report
    if the two elements are from the same re-exported declaration.
@@ -1001,6 +1003,9 @@ let is_in_signature env = env.flags land in_signature_flag <> 0
 
 let has_local_constraints env =
   not (StagedPath.Map.is_empty env.local_constraints)
+
+let is_local_type_constraint path env =
+  StagedPath.Map.mem (path_at_current_stage env path) env.local_constraints
 
 let is_ext cda =
   match cda.cda_description with
@@ -2934,6 +2939,7 @@ let components_of_functor_appl ~loc ~f_path ~f_comp ~arg env =
        because of the call to [check_well_formed_module]. *)
     let mty = Subst.modtype (Rescope (Path.scope p)) sub f_comp.fcomp_res in
     let addr = Lazy_backtrack.create_failed Not_found in
+    !scope_local_equations env mty;
     !check_well_formed_module env loc
       ("the signature of " ^ Path.name p) mty;
     let shape_arg =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -196,6 +196,9 @@ val has_probe: string -> bool
 
 val has_local_constraints: t -> bool
 
+(* Whether [path] denotes a local type equation (e.g. a GADT equation). *)
+val is_local_type_constraint: Path.t -> t -> bool
+
 (* Mark definitions as used *)
 val mark_value_used: Uid.t -> unit
 val mark_module_used: Uid.t -> unit
@@ -722,6 +725,8 @@ val check_functor_application:
 (* Forward declaration to break mutual recursion with Typemod. *)
 val check_well_formed_module:
     (t -> Location.t -> string -> module_type -> unit) ref
+(* Forward declaration to break mutual recursion with Mtype. *)
+val scope_local_equations: (t -> module_type -> unit) ref
 (* Forward declaration to break mutual recursion with Typecore. *)
 val add_delayed_check_forward: ((unit -> unit) -> unit) ref
 (* Forward declaration to break mutual recursion with Mtype. *)

--- a/typing/mtype.ml
+++ b/typing/mtype.ml
@@ -457,9 +457,21 @@ let scrape env mty =
       Subst.Lazy.force_modtype (scrape_lazy env (Subst.Lazy.of_modtype mty))
   | _ -> mty
 
+let scope_local_equations env mty =
+  if Env.has_local_constraints env then begin
+    let open Btype in
+    with_type_mark begin fun mark ->
+      let it =
+        Ctype.iterator_scope_local_equations env (type_iterators mark)
+      in
+      it.it_module_type it mty
+    end
+  end
+
 let () =
   Out_type.expand_module_type := expand ;
-  Env.scrape_alias := scrape_alias_lazy
+  Env.scrape_alias := scrape_alias_lazy;
+  Env.scope_local_equations := scope_local_equations
 
 let find_type_of_module ~strengthen ~aliasable env path =
   if strengthen then

--- a/typing/mtype.mli
+++ b/typing/mtype.mli
@@ -98,3 +98,8 @@ module Contains_type_or_jkind : sig
 end
 
 val lower_nongen: int -> module_type -> unit
+
+(* Correct a signature's scopes, as a signature built by substitution could
+   have incorrect scopes if a constructor being substituted in depended on
+   local equations. *)
+val scope_local_equations: Env.t -> module_type -> unit

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -887,9 +887,11 @@ module Merge = struct
       else sg
     in
     (* check that the resulting signature is still wellformed *)
-    let () = if not approx then
+    let () = if not approx then begin
+               Mtype.scope_local_equations env (Mty_signature sg);
                check_well_formed_module env loc "this instantiated signature"
-                 (Mty_signature sg) in
+                 (Mty_signature sg)
+             end in
     sg
 
   (* Main recursive knot to handle deep merges *)
@@ -3551,6 +3553,7 @@ and type_one_application ~ctx:(apply_loc,sfunct,md_f,args)
             end;
             nondep_mty
       in
+      Mtype.scope_local_equations env mty_appl;
       check_well_formed_module env apply_loc
         "the signature of this functor application" mty_appl;
       check_curried_application_complete


### PR DESCRIPTION
A signature built by substitution can have an incorrect scope when a constructor being substituted in depended on local equations, in particular, when the equations refine it in a way that makes it meet a kind annotation or type equality in a functor argument signature.

To fix this, we correct scopes after functor applications, by raising the scopes of constructors with local equations to their equations' scope as if they were expanded.

### Example with `constraint` (also exists upstream)
```ocaml
module M : sig
  type t
  val witness : (t, string) Type.eq
end = struct
  type t = string
  let witness = Type.Equal
end

type 'a foo constraint 'a = string

module F_c (X : sig type t = string end) = struct
  let f (x : X.t foo) = x
end

let f =
  let Equal = M.witness in
  let module N = F_c(M) in
  N.f
```

Writing `M.t foo` should be a type error outside of a match on `M.witness`, as `foo`'s type argument must be `string` via the constraint, yet the above program typechecks with `val f : M.t foo -> M.t foo`.

### Example with kinds
```ocaml
type ('a : any) is_bits64 = T : ('a : bits64). 'a is_bits64

module M : sig
  type t : any
  val witness : t is_bits64
end = struct
  type t = int64#
  let witness = T
end

type ('a : bits64) foo

module F_c (X : sig type t : bits64 end) = struct
  let f (x : X.t foo) = x
end

let f =
  let T = M.witness in
  let module N = F_c(M) in
  N.f
```

Writing `M.t foo` should be a type error outside of a match on `M.witness`, as `foo`'s type argument must be `bits64` while `M.t` appears to be `any`, yet the above program typechecks with `val f : M.t foo -> M.t foo`.

This can also be used to produce a tuple containing a type with kind `any`, hitting the `value_kind` safety check (see regression test).

### Review
Commit structure should be useful.