### PR TITLE
Allow coercion for modes on function return values for non-local axes

### DIFF
--- a/testsuite/tests/typing-modes/coerce.ml
+++ b/testsuite/tests/typing-modes/coerce.ml
@@ -44,11 +44,8 @@ let cross_ret :
   type a (b : value mod portable). (a -> b) -> (a -> b @ portable) =
   fun f -> (f :> _ -> b @ portable)
 [%%expect{|
-Line 3, characters 12-13:
-3 |   fun f -> (f :> _ -> b @ portable)
-                ^
-Error: This expression cannot be coerced to type ""'c -> b @ portable"";
-       it has type "a -> b" but is here used with type "'a -> b @ portable"
+val cross_ret :
+  'a ('b : value mod portable). ('a -> 'b) -> 'a -> 'b @ portable = <fun>
 |}]
 
 (* Same, with a closed coercion (exercises the ground subtyping path rather
@@ -57,10 +54,8 @@ let cross_ret_closed :
   type a (b : value mod portable). (a -> b) -> (a -> b @ portable) =
   fun f -> (f : a -> b :> a -> b @ portable)
 [%%expect{|
-Line 3, characters 11-44:
-3 |   fun f -> (f : a -> b :> a -> b @ portable)
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "a -> b" is not a subtype of "a -> b @ portable"
+val cross_ret_closed :
+  'a ('b : value mod portable). ('a -> 'b) -> 'a -> 'b @ portable = <fun>
 |}]
 
 (* Locality on the return position must not cross, even for immediates: the
@@ -90,13 +85,10 @@ let cross_ret_nested :
     ((a -> b @ portable) -> c) -> ((a -> b) -> c) =
   fun f -> (f :> (_ -> b) -> _)
 [%%expect{|
-Line 4, characters 12-13:
-4 |   fun f -> (f :> (_ -> b) -> _)
-                ^
-Error: This expression cannot be coerced to type ""('b -> b) -> 'c""; it has type
-         "(a -> b @ portable) -> c"
-       but is here used with type "('a -> b) -> 'b"
-       Type "a -> b @ portable" is not compatible with type "'a -> b"
+val cross_ret_nested :
+  'a ('b : value mod portable) 'c.
+    (('a -> 'b @ portable) -> 'c) -> ('a -> 'b) -> 'c =
+  <fun>
 |}]
 
 let cross_ret_nested_closed :
@@ -104,11 +96,10 @@ let cross_ret_nested_closed :
     ((a -> b @ portable) -> c) -> ((a -> b) -> c) =
   fun f -> (f : (a -> b @ portable) -> c :> (a -> b) -> c)
 [%%expect{|
-Line 4, characters 11-58:
-4 |   fun f -> (f : (a -> b @ portable) -> c :> (a -> b) -> c)
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Type "(a -> b @ portable) -> c" is not a subtype of "(a -> b) -> c"
-       Type "a -> b" is not a subtype of "a -> b @ portable"
+val cross_ret_nested_closed :
+  'a ('b : value mod portable) 'c.
+    (('a -> 'b @ portable) -> 'c) -> ('a -> 'b) -> 'c =
+  <fun>
 |}]
 
 (* Locality on the nested return position must still not cross. *)

--- a/testsuite/tests/typing-modes/coerce.ml
+++ b/testsuite/tests/typing-modes/coerce.ml
@@ -16,3 +16,121 @@ end
 [%%expect{|
 module M : sig val f : 'a @ local -> unit end
 |}]
+
+(* Mode crossing in coercions should treat argument and return positions
+   uniformly on all axes except locality. *)
+
+let subtype_arg : 'a 'b. ('a -> 'b) -> ('a @ portable -> 'b) =
+  fun f -> (f : _ @ portable -> _)
+[%%expect{|
+val subtype_arg : ('a -> 'b) -> 'a @ portable -> 'b = <fun>
+|}]
+
+let cross_arg :
+  type (a : value mod portable) b. (a @ portable -> b) -> (a -> b) =
+  fun f -> (f :> a -> _)
+[%%expect{|
+val cross_arg :
+  ('a : value mod portable) 'b. ('a @ portable -> 'b) -> 'a -> 'b = <fun>
+|}]
+
+let subtype_ret : 'a 'b. ('a -> 'b @ portable) -> ('a -> 'b) =
+  fun f -> (f : _ -> _)
+[%%expect{|
+val subtype_ret : ('a -> 'b @ portable) -> 'a -> 'b = <fun>
+|}]
+
+let cross_ret :
+  type a (b : value mod portable). (a -> b) -> (a -> b @ portable) =
+  fun f -> (f :> _ -> b @ portable)
+[%%expect{|
+Line 3, characters 12-13:
+3 |   fun f -> (f :> _ -> b @ portable)
+                ^
+Error: This expression cannot be coerced to type ""'c -> b @ portable"";
+       it has type "a -> b" but is here used with type "'a -> b @ portable"
+|}]
+
+(* Same, with a closed coercion (exercises the ground subtyping path rather
+   than [enlarge_type]) *)
+let cross_ret_closed :
+  type a (b : value mod portable). (a -> b) -> (a -> b @ portable) =
+  fun f -> (f : a -> b :> a -> b @ portable)
+[%%expect{|
+Line 3, characters 11-44:
+3 |   fun f -> (f : a -> b :> a -> b @ portable)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "a -> b" is not a subtype of "a -> b @ portable"
+|}]
+
+(* Locality on the return position must not cross, even for immediates: the
+   function might allocate in the caller's region. *)
+let cross_ret_local (f : int -> int @ local) = (f :> int -> int)
+[%%expect{|
+Line 1, characters 47-64:
+1 | let cross_ret_local (f : int -> int @ local) = (f :> int -> int)
+                                                   ^^^^^^^^^^^^^^^^^
+Error: Type "int -> int @ local" is not a subtype of "int -> int"
+|}]
+
+let cross_ret_local' (f : int -> int @ local) = (f :> _ -> int)
+[%%expect{|
+Line 1, characters 49-50:
+1 | let cross_ret_local' (f : int -> int @ local) = (f :> _ -> int)
+                                                     ^
+Error: This expression cannot be coerced to type ""'a -> int""; it has type
+         "int -> int @ local"
+       but is here used with type "'a -> int"
+|}]
+
+(* The same coercions with the arrow nested in a contravariant position. *)
+
+let cross_ret_nested :
+  type a (b : value mod portable) c.
+    ((a -> b @ portable) -> c) -> ((a -> b) -> c) =
+  fun f -> (f :> (_ -> b) -> _)
+[%%expect{|
+Line 4, characters 12-13:
+4 |   fun f -> (f :> (_ -> b) -> _)
+                ^
+Error: This expression cannot be coerced to type ""('b -> b) -> 'c""; it has type
+         "(a -> b @ portable) -> c"
+       but is here used with type "('a -> b) -> 'b"
+       Type "a -> b @ portable" is not compatible with type "'a -> b"
+|}]
+
+let cross_ret_nested_closed :
+  type a (b : value mod portable) c.
+    ((a -> b @ portable) -> c) -> ((a -> b) -> c) =
+  fun f -> (f : (a -> b @ portable) -> c :> (a -> b) -> c)
+[%%expect{|
+Line 4, characters 11-58:
+4 |   fun f -> (f : (a -> b @ portable) -> c :> (a -> b) -> c)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(a -> b @ portable) -> c" is not a subtype of "(a -> b) -> c"
+       Type "a -> b" is not a subtype of "a -> b @ portable"
+|}]
+
+(* Locality on the nested return position must still not cross. *)
+let cross_ret_nested_local (f : (int -> int) -> int) =
+  (f :> (int -> int @ local) -> int)
+[%%expect{|
+Line 2, characters 2-36:
+2 |   (f :> (int -> int @ local) -> int)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(int -> int) -> int" is not a subtype of
+         "(int -> int @ local) -> int"
+       Type "int -> int @ local" is not a subtype of "int -> int"
+|}]
+
+let cross_ret_nested_local' (f : (int -> int) -> int) =
+  (f :> (_ -> int @ local) -> _)
+[%%expect{|
+Line 2, characters 3-4:
+2 |   (f :> (_ -> int @ local) -> _)
+       ^
+Error: This expression cannot be coerced to type ""('a -> int @ local) -> 'b"";
+       it has type "(int -> int) -> int" but is here used with type
+         "('a -> int @ local) -> 'b"
+       Type "int -> int" is not compatible with type "'a -> int @ local"
+|}]

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6287,18 +6287,27 @@ let cross_right_alloc env ?modalities ty mode =
   let crossing = crossing_of_ty env ?modalities ty in
   mode |> Alloc.disallow_left |> Crossing.apply_right_alloc crossing
 
+(* The locality axis of the return mode of an arrow cannot cross modes,
+   because a local-returning function might allocate in the caller's region,
+   and this info must be preserved. The [_ret] variants below cross modes on
+   all axes except locality and are to be used on return modes. *)
+
+let cross_left_alloc_ret env ?modalities ty mode =
+  let mode' = cross_left_alloc env ?modalities ty mode in
+  Alloc.join
+    [mode';
+     Alloc.min_with_comonadic Areality (Alloc.proj_comonadic Areality mode)]
+
+let cross_right_alloc_ret env ?modalities ty mode =
+  let mode' = cross_right_alloc env ?modalities ty mode in
+  Alloc.meet
+    [mode';
+     Alloc.max_with_comonadic Areality (Alloc.proj_comonadic Areality mode)]
+
 let submode_with_cross env ~is_ret ty l r =
-  let r' = cross_right_alloc env ty r in
   let r' =
-    if is_ret then
-      (* the locality axis of the return mode cannot cross modes, because a
-         local-returning function might allocate in the caller's region, and
-         this info must be preserved. *)
-      Alloc.meet
-        [r';
-         Alloc.max_with_comonadic Areality (Alloc.proj_comonadic Areality r)]
-    else
-      r'
+    if is_ret then cross_right_alloc_ret env ty r
+    else cross_right_alloc env ty r
   in
   Alloc.submode l r'
 
@@ -7472,10 +7481,6 @@ let build_submode_neg m =
   let c = if changed then Changed else Unchanged in
   m', c
 
-let build_submode posi m =
-  if posi then build_submode_pos (Alloc.allow_left m)
-  else build_submode_neg (Alloc.allow_right m)
-
 let rec build_subtype env (visited : transient_expr list)
     (loops : (int * type_expr) list) posi level t =
   match get_desc t with
@@ -7513,7 +7518,16 @@ let rec build_subtype env (visited : transient_expr list)
         end else a, Unchanged
       in
       let (r', c4) =
-        if level > 2 then build_submode posi r else r, Unchanged
+        if level > 2 then begin
+          (* As for the argument mode above, pick the smaller type. *)
+          if posi then begin
+            let r = cross_right_alloc_ret env t2' r in
+            build_submode_pos r
+          end else begin
+            let r = cross_left_alloc_ret env t2 r in
+            build_submode_neg r
+          end
+        end else r, Unchanged
       in
       let c = max_change c1 (max_change c2 (max_change c3 c4)) in
       if c > Unchanged
@@ -7763,9 +7777,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
             cstrs
         in
         let a2 = cross_left_alloc env t2 a2 in
-         subtype_alloc_mode env trace a2 a1;
-        (* RHS mode of arrow types indicates allocation in the parent region
-           and is not subject to mode crossing *)
+        subtype_alloc_mode env trace a2 a1;
+        let r2 = cross_right_alloc_ret env u2 r2 in
         subtype_alloc_mode env trace r1 r2;
         subtype_rec
           env


### PR DESCRIPTION
For example, allow `int -> int :> int -> int @ portable`. This was previously forbidden since functions ending with `@ local` have a different calling conventions. 