### PR TITLE
Mop up _exn functions from the 5.4 merge and convert to _res

### DIFF
--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -75,7 +75,7 @@ void caml_handle_incoming_interrupts(void);
 void caml_domain_setup_preemption(void);
 #endif
 void caml_domain_reset_preemption(void);
-value caml_process_tick_exn(void);
+caml_result caml_process_tick_res(void);
 
 CAMLextern void caml_interrupt_self(void);
 void caml_interrupt_all_signal_safe(void);

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -382,7 +382,7 @@ bool caml_continuation_is_preemption(value cont);
    its [gc_regs] struct, or NULL otherwise */
 value* caml_continuation_gc_regs(value cont);
 
-value caml_tick_fiber_exn(struct stack_info* stack);
+caml_result caml_tick_fiber_res(struct stack_info* stack);
 
 CAMLnoret CAMLextern void caml_raise_continuation_already_resumed (void);
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -2290,24 +2290,22 @@ static void tick_thread_wake(void) {}
 
 #endif
 
-value caml_process_tick_exn(void)
+caml_result caml_process_tick_res(void)
 {
-  CAMLparam0();
-  CAMLlocal1(res);
   if (atomic_exchange_explicit(&Caml_state->requested_tick, false,
                                memory_order_acquire)) {
     caml_domain_tick_hook();
 
-    res = caml_tick_fiber_exn(Caml_state->current_stack);
-    if (Is_exception_result(res)) {
-      CAMLreturn(res);
+    caml_result res = caml_tick_fiber_res(Caml_state->current_stack);
+    if (caml_result_is_exception(res)) {
+      return res;
     }
 
-    if (res == Val_true) {
+    if (res.data == Val_true) {
       Caml_state->preemption = Val_long(1);
     }
   }
-  CAMLreturn(Val_unit);
+  return Result_unit;
 }
 
 CAMLextern void caml_stop_tick_thread(void)

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -1376,39 +1376,39 @@ CAMLexport value caml_get_preemption_effect(void) {
 /* Call the tick handler for each running fiber *in reverse order*, stopping as
    soon as one preempts
 
-   Returns Val_true if a preemption occurred, Val_false if one did not, or an
-   encoded exception result if any of the callbacks raised an exception.
+   Returns Result_value(Val_true) if a preemption occurred,
+   Result_value(Val_false) if one did not, or a Result_exception
+   result if any of the callbacks raised an exception.
 */
-value caml_tick_fiber_exn(struct stack_info *stack) {
-  CAMLparam0();
-  CAMLlocal1(res);
+caml_result caml_tick_fiber_res(struct stack_info *stack) {
+  caml_result res;
 
   if (Stack_parent(stack)) {
-    res = caml_tick_fiber_exn(Stack_parent(stack));
-    if (Is_exception_result(res) || res == Val_true) {
-      CAMLreturn(res);
+    res = caml_tick_fiber_res(Stack_parent(stack));
+    if (caml_result_is_exception(res) || res.data == Val_true) {
+      return res;
     }
   }
 
   if (Stack_is_preemptible(stack)) {
-    res = caml_callback_exn(Stack_handle_tick(stack), Val_unit);
-    if (Is_exception_result(res)) {
-      CAMLreturn(res);
+    res = caml_callback_res(Stack_handle_tick(stack), Val_unit);
+    if (caml_result_is_exception(res)) {
+      return res;
     }
 
-    switch (Long_val(res)) {
+    switch (Long_val(res.data)) {
     case TICK_RESULT_PREEMPT:
-      CAMLreturn(Val_true);
+      return Result_value(Val_true);
     case TICK_RESULT_CONTINUE:
       break;
     default: {
       value exn =
         caml_exception_failure_value(caml_copy_string(
           "caml_tick_fiber: tick_handler returned invalid result"));
-      CAMLreturn(Make_exception_result(exn));
+      return Result_exception(exn);
     }
     }
   }
 
-  CAMLreturn(Val_false);
+  return Result_value(Val_false);
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -409,12 +409,7 @@ caml_result caml_do_pending_actions_flags_res(int flags)
      this after all other possibly exception-returning actions, we do not need
      to set the action pending flag in case a context switch happens: all
      actions have been processed at this point. */
-  {
-    value tick_exn = caml_process_tick_exn();
-    res = Is_exception_result(tick_exn)
-      ? Result_exception(Extract_exception(tick_exn))
-      : Result_unit;
-  }
+  res = caml_process_tick_res();
   caml_check_async(res, "tick handler");
   if (caml_result_is_exception(res)) goto exception;
 


### PR DESCRIPTION
A loose end from our 5.4 merge: 5.4 introduces the new safer `caml_result` type in the runtime for capturing value-or-exception results, and renames functions from `_exn` to `_res` to reflect the change. OxCaml work from before the 5.4 merge introduced a couple of old-style `_exn` functions. This PR converts them to `_res` names and semantics.