### PR TITLE
Add Dynamics to Stdlib

### DIFF
--- a/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
@@ -76,8 +76,8 @@
   * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_callback_inner(param=0 : ocaml_value)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_start_program
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`callback(closure=<unavailable>, arg=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_callback_exn(arg=1, closure=93824994011000) [inlined]
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_with_async_exns(body_callback=93824994011000)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_callback_exn(arg=1, closure=93824994011040) [inlined]
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_with_async_exns(body_callback=93824994011040)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
 === Testing OCaml/C boundary - finalizer (C calls OCaml during GC) ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_my_finalizer(param=[42] : ocaml_value)

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -43,6 +43,8 @@ STDLIB_MODULE_BASENAMES = \
   type \
   atomic \
   camlinternalLazy \
+  context \
+  dynamic \
   lazy \
   seq \
   option \

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -43,7 +43,6 @@ STDLIB_MODULE_BASENAMES = \
   type \
   atomic \
   camlinternalLazy \
-  context \
   dynamic \
   lazy \
   seq \

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -64,6 +64,8 @@
   atomic.mli
   backoff.ml
   backoff.mli
+  dynamic.ml
+  dynamic.mli
   effect.ml
   effect.mli
   bigarray.ml
@@ -237,6 +239,9 @@
   .stdlib.objs/byte/stdlib__Backoff.cmsi
   .stdlib.objs/byte/stdlib__Backoff.cmt
   .stdlib.objs/byte/stdlib__Backoff.cmti
+  .stdlib.objs/byte/stdlib__Dynamic.cmi
+  .stdlib.objs/byte/stdlib__Dynamic.cmt
+  .stdlib.objs/byte/stdlib__Dynamic.cmti
   .stdlib.objs/byte/stdlib__Effect.cmi
   .stdlib.objs/byte/stdlib__Effect.cms
   .stdlib.objs/byte/stdlib__Effect.cmsi
@@ -666,6 +671,7 @@
   .stdlib.objs/native/stdlib__Dynarray.cmx
   .stdlib.objs/native/stdlib__Atomic.cmx
   .stdlib.objs/native/stdlib__Backoff.cmx
+  .stdlib.objs/native/stdlib__Dynamic.cmx
   .stdlib.objs/native/stdlib__Effect.cmx
   .stdlib.objs/native/stdlib__Either.cmx
   .stdlib.objs/native/stdlib__In_channel.cmx

--- a/stdlib/dynamic.ml
+++ b/stdlib/dynamic.ml
@@ -14,14 +14,12 @@
 
 type 'a t : value mod everything with 'a @@ contended portable
 
-external make' : inherit_:bool -> 'a t @@ portable = "caml_dynamic_make"
+external make : unit -> 'a t @@ portable = "caml_dynamic_make"
 external get : 'a t -> 'a or_null @ contended portable @@ portable =
   "caml_dynamic_get" [@@noalloc]
 external push : 'a t -> 'a @ contended portable -> unit @@ portable =
   "caml_dynamic_push"
 external pop : 'a t -> unit @@ portable = "caml_dynamic_pop" [@@noalloc]
-
-let[@inline] make () = make' ~inherit_:false
 
 let[@inline] with_temporarily t v ~f = exclave_
   push t v;
@@ -31,12 +29,3 @@ let[@inline] with_temporarily t v ~f = exclave_
     let bt = Printexc.get_raw_backtrace () in
     pop t;
     Printexc.raise_with_backtrace exn bt
-
-module Context = struct
-  type nonrec 'a t = 'a t
-
-  let[@inline] make () = make' ~inherit_:true
-
-  let get = get
-  let with_temporarily = with_temporarily
-end

--- a/stdlib/dynamic.ml
+++ b/stdlib/dynamic.ml
@@ -1,0 +1,42 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Aspen Smith, Jane Street                         *)
+(*                                                                        *)
+(*   Copyright 2025 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a t : value mod everything with 'a @@ contended portable
+
+external make' : inherit_:bool -> 'a t @@ portable = "caml_dynamic_make"
+external get : 'a t -> 'a or_null @ contended portable @@ portable =
+  "caml_dynamic_get" [@@noalloc]
+external push : 'a t -> 'a @ contended portable -> unit @@ portable =
+  "caml_dynamic_push"
+external pop : 'a t -> unit @@ portable = "caml_dynamic_pop" [@@noalloc]
+
+let[@inline] make () = make' ~inherit_:false
+
+let[@inline] with_temporarily t v ~f = exclave_
+  push t v;
+  match f () with
+  | res -> pop t; res
+  | exception exn ->
+    let bt = Printexc.get_raw_backtrace () in
+    pop t;
+    Printexc.raise_with_backtrace exn bt
+
+module Context = struct
+  type nonrec 'a t = 'a t
+
+  let[@inline] make () = make' ~inherit_:true
+
+  let get = get
+  let with_temporarily = with_temporarily
+end

--- a/stdlib/dynamic.mli
+++ b/stdlib/dynamic.mli
@@ -47,34 +47,3 @@ val with_temporarily : ('b : value_or_null).
   'a @ contended portable ->
   f:(unit -> 'b @ local unique once) @ local once ->
   'b @ local unique once
-
-module Context : sig
-  (** ['a Context.t] is like ['a Dynamic.t], but fibers permanently inherit the
-      value bound at the time of their creation. *)
-  type 'a t : value mod everything with 'a @@ contended portable
-
-  (** [make ()] creates a new contextual variable. *)
-  val make : unit -> 'a t
-
-  (** [get t] retrieves the current value of the contextual variable [t] in the
-      current fiber.
-
-      Within a call to [with_temporarily], this returns the {i local} value
-      of the contextual variable. Outside of a call to [with_temporarily], this
-      returns [Null].
-
-      Because the contextual binding may be accessed concurrently, its contents
-      are contended. *)
-  val get : 'a t -> 'a or_null @ contended portable
-
-  (** [with_temporarily t v ~f] invokes [f] in a context where [t] is bound to
-      [v], then restores [t] to its previous state.
-
-      Because the contextual binding may be accessed concurrently, the new value
-      must be portable. *)
-  val with_temporarily : ('b : value_or_null).
-    'a t ->
-    'a @ contended portable ->
-    f:(unit -> 'b @ local unique once) @ local once ->
-    'b @ local unique once
-end

--- a/stdlib/dynamic.mli
+++ b/stdlib/dynamic.mli
@@ -1,0 +1,80 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                       Aspen Smith, Jane Street                         *)
+(*                                                                        *)
+(*   Copyright 2025 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+@@ portable
+
+(** A value of type ['a Dynamic.t] is a dynamically scoped variable of type
+    ['a].
+
+    A fiber can temporarily change the locally visible value of a dynamic
+    variable by calling [with_temporarily]. Child fibers executing within
+    [with_temporarily] will see the local value, but escaped fibers will
+    read the value bound by their future parent. *)
+type 'a t : value mod everything with 'a @@ contended portable
+
+(** [make ()] creates a new dynamic variable. *)
+val make : unit -> 'a t
+
+(** [get t] retrieves the current value of the dynamic variable [t] in the
+    current fiber.
+
+    Within a call to [with_temporarily], this returns the {i local} value
+    of the dynamic variable. Outside of a call to [with_temporarily], this
+    returns [Null].
+
+    Because the dynamic binding may be accessed concurrently, its contents
+    are contended. *)
+val get : 'a t -> 'a or_null @ contended portable
+
+(** [with_temporarily t v ~f] invokes [f] in a context where [t] is bound to
+    [v], then restores [t] to its previous state.
+
+    Because the dynamic binding may be accessed concurrently, the new value
+    must be portable. *)
+val with_temporarily : ('b : value_or_null).
+  'a t ->
+  'a @ contended portable ->
+  f:(unit -> 'b @ local unique once) @ local once ->
+  'b @ local unique once
+
+module Context : sig
+  (** ['a Context.t] is like ['a Dynamic.t], but fibers permanently inherit the
+      value bound at the time of their creation. *)
+  type 'a t : value mod everything with 'a @@ contended portable
+
+  (** [make ()] creates a new contextual variable. *)
+  val make : unit -> 'a t
+
+  (** [get t] retrieves the current value of the contextual variable [t] in the
+      current fiber.
+
+      Within a call to [with_temporarily], this returns the {i local} value
+      of the contextual variable. Outside of a call to [with_temporarily], this
+      returns [Null].
+
+      Because the contextual binding may be accessed concurrently, its contents
+      are contended. *)
+  val get : 'a t -> 'a or_null @ contended portable
+
+  (** [with_temporarily t v ~f] invokes [f] in a context where [t] is bound to
+      [v], then restores [t] to its previous state.
+
+      Because the contextual binding may be accessed concurrently, the new value
+      must be portable. *)
+  val with_temporarily : ('b : value_or_null).
+    'a t ->
+    'a @ contended portable ->
+    f:(unit -> 'b @ local unique once) @ local once ->
+    'b @ local unique once
+end

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -632,6 +632,7 @@ module Complex        = Complex
 module Condition      = Condition
 module Digest         = Digest
 module Domain         = Domain
+module Dynamic        = Dynamic
 module Dynarray       = Dynarray
 module Pqueue         = Pqueue
 module Effect         = Effect

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1404,6 +1404,7 @@ module Domain         = Domain
 [@@alert unstable
     "The Domain interface may change in incompatible ways in the future."
 ]
+module Dynamic        = Dynamic
 module Dynarray       = Dynarray
 module Pqueue         = Pqueue
 module Effect         = Effect

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -525,7 +525,7 @@ module Functional_update_ok = struct
   let allowed t = { t with y = 42 }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/479"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/480"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -545,7 +545,7 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/487"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/488"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -579,7 +579,7 @@ module Functional_update_multi_ok = struct
   let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/503"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/504"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -603,7 +603,7 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/512"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/513"
   (let
     (allowed =
        (function {nlocal = 0} t

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -17,7 +17,7 @@ module Atomic = struct
   end
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Atomic/292"
+(apply (field_imm 1 (global Toploop!)) "Atomic/293"
   (let (Loc = (makeblock 0)) (makeblock 0 Loc)))
 module Atomic :
   sig
@@ -55,7 +55,7 @@ module Basic = struct
     Atomic.Loc.compare_and_set (get_loc r) oldv newv
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Basic/330"
+(apply (field_imm 1 (global Toploop!)) "Basic/331"
   (let
     (get = (function {nlocal = 0} r (atomic_load_field_ptr r 1))
      get_imm = (function {nlocal = 0} r : int (atomic_load_field_imm r 1))
@@ -190,7 +190,7 @@ end : sig
   type t = { mutable x : int [@atomic] }
 end)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Ok/360" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Ok/361" (makeblock 0))
 module Ok : sig type t = { mutable x : int [@atomic]; } end
 |}];;
 
@@ -204,7 +204,7 @@ module Inline_record = struct
   let test : t -> int = fun (A r) -> r.x
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record/368"
+(apply (field_imm 1 (global Toploop!)) "Inline_record/369"
   (let
     (test =
        (function {nlocal = 0} param : int (atomic_load_field_imm param 0)))
@@ -226,7 +226,7 @@ module Extension_with_inline_record = struct
   let () = assert (test (A { x = 42 }) = 42)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/376"
+(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/377"
   (let
     (A =
        (makeblock_unique 248 "Extension_with_inline_record.A"
@@ -263,7 +263,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic float field
   which prevents the float record optimization.
   The fields of this record will be boxed instead of being
   represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/400"
+(apply (field_imm 1 (global Toploop!)) "Float_records/401"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -483,7 +483,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/463"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/464"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))

--- a/testsuite/tests/callback/dynamic_callback.ml
+++ b/testsuite/tests/callback/dynamic_callback.ml
@@ -7,19 +7,6 @@
  }
 *)
 
-module Dynamic = struct
-  type 'a t
-
-  external make : unit -> 'a t = "caml_dynamic_make"
-  external get : 'a t -> 'a or_null = "caml_dynamic_get"
-  external push : 'a t -> 'a -> unit = "caml_dynamic_push"
-  external pop : 'a t -> unit = "caml_dynamic_pop"
-
-  let with_temporarily d v ~f =
-    push d v;
-    Fun.protect f ~finally:(fun () -> pop d)
-end
-
 (* Runs [f] on a fresh stack, so that the dynamic bindings of the caller are
    only reachable through the parent stack, which callbacks from C do not
    see. *)

--- a/testsuite/tests/effects/dynamic.ml
+++ b/testsuite/tests/effects/dynamic.ml
@@ -4,66 +4,46 @@
    { native; }
 *)
 
-(* Tests the runtime support for dynamic bindings. Dynamic.t isn't yet implemented in the
-   OxCaml stdlib, only the runtime support for it, so testing that requires faking a bit
-   more infrastructure here in the test case. *)
+open Modes
 
 module type Dynamic_S = sig
   type 'a t
 
   val make : unit -> 'a t
-  val get : 'a t -> 'a or_null
+  val get : 'a t -> 'a or_null @ portable contended
 
-  val with_temporarily : 'a t -> 'a -> f: (unit -> 'b) -> 'b
-end
+  val with_temporarily : 'a t -> 'a @ portable -> f:(unit -> 'b) -> 'b
+ end
 
-module Dynamic : Dynamic_S = struct
-  type 'a t
-
-  external make : unit -> 'a t = "caml_dynamic_make"
-  external get : 'a t -> 'a or_null = "caml_dynamic_get"
-  external push : 'a t -> 'a -> unit  = "caml_dynamic_push"
-  external pop : 'a t -> unit = "caml_dynamic_pop"
+ module Dynamic : Dynamic_S = struct
+  include Dynamic
 
   let with_temporarily d v ~f =
-    push d v;
-    Fun.protect f ~finally:(fun () -> pop d)
-end
+    (with_temporarily d v ~f:(fun () ->
+      { Many.many = { Aliased.aliased = { Global.global = f () }}})).many.aliased.global
+ end
 
-module Dynamic_inside_fiber : Dynamic_S = struct
-  type 'a t
-
-  external make : unit -> 'a t = "caml_dynamic_make"
-  external get : 'a t -> 'a or_null = "caml_dynamic_get"
-  external push : 'a t -> 'a -> unit  = "caml_dynamic_push"
-  external pop : 'a t -> unit = "caml_dynamic_pop"
+ module Dynamic_inside_fiber : Dynamic_S = struct
+  include Dynamic
 
   let with_temporarily d v ~f =
     Effect.Deep.match_with
-      (fun () ->
-        push d v;
-        Fun.protect f ~finally:(fun () -> pop d)) ()
+      (fun () -> with_temporarily d v ~f)
+      ()
       { retc = (fun v -> v);
         exnc = (fun e -> raise e);
         effc = (fun (type a) (_ : a Effect.t) -> None) }
-end
+ end
 
-module Dynamic_outside_fiber : Dynamic_S = struct
-  type 'a t
-
-  external make : unit -> 'a t = "caml_dynamic_make"
-  external get : 'a t -> 'a or_null = "caml_dynamic_get"
-  external push : 'a t -> 'a -> unit  = "caml_dynamic_push"
-  external pop : 'a t -> unit = "caml_dynamic_pop"
+ module Dynamic_outside_fiber : Dynamic_S = struct
+  include Dynamic
 
   let with_temporarily d v ~f =
-    push d v;
-    Fun.protect (fun () ->
-      Effect.Deep.match_with f ()
-        { retc = (fun v -> v);
-          exnc = (fun e -> raise e);
-          effc = (fun (type a) (_ : a Effect.t) -> None) })
-      ~finally:(fun () -> pop d)
+    with_temporarily d v ~f:(fun () ->
+        Effect.Deep.match_with f ()
+          { retc = (fun v -> v);
+            exnc = (fun e -> raise e);
+            effc = (fun (type a) (_ : a Effect.t) -> None) })
 end
 
 type _ Effect.t += E : unit -> unit Effect.t

--- a/testsuite/tests/effects/dynamic_async_exn.ml
+++ b/testsuite/tests/effects/dynamic_async_exn.ml
@@ -34,7 +34,7 @@ let print_dyn d = print_null (Dynamic.get d)
 let () =
   let d = Dynamic.make () in
   let parent = (Bytes.unsafe_to_string (Bytes.make 4 'x')) in
-  Dynamic.with_temporarily d parent ~f:(fun () ->
+  Dynamic.with_temporarily d parent ~f:(fun () -> exclave_
     let finished = ref false in
     let r = allocate_bytes finished in
     (try
@@ -44,12 +44,13 @@ let () =
           [d -> child], then allocate until the finaliser raises [Sys.Break]
           asynchronously, unwinding out of this async exn handler. *)
         let child = (Bytes.unsafe_to_string (Bytes.make 4 'y')) in
-        Dynamic.with_temporarily d child ~f:(fun () ->
+        Dynamic.with_temporarily d child ~f:(fun () -> exclave_
           Printf.printf "in fiber [expect %s]: %s\n%!" child (print_dyn d);
           while true do
             let _ @ global = Sys.opaque_identity (42, Random.int 42) in
             ()
-          done))
+          done;
+          ()) [@nontail])
     with
     | Sys.Break -> assert !finished
     | _ -> assert false);

--- a/testsuite/tests/effects/dynamic_async_exn.ml
+++ b/testsuite/tests/effects/dynamic_async_exn.ml
@@ -15,22 +15,6 @@
    return the root value again; if the cache is not flushed it wrongly returns
    the now-out-of-scope child value. *)
 
-(* Dynamic.t isn't yet implemented in the OxCaml stdlib, only the runtime
-   support for it, so testing requires faking the infrastructure here. *)
-
-module Dynamic = struct
-  type 'a t
-
-  external make : unit -> 'a t = "caml_dynamic_make"
-  external get : 'a t -> 'a or_null = "caml_dynamic_get"
-  external push : 'a t -> 'a -> unit  = "caml_dynamic_push"
-  external pop : 'a t -> unit = "caml_dynamic_pop"
-
-  let with_temporarily d v ~f =
-    push d v;
-    Fun.protect f ~finally:(fun () -> pop d)
-end
-
 let () = Sys.catch_break true
 
 let[@inline never] allocate_bytes finished =
@@ -50,24 +34,24 @@ let print_dyn d = print_null (Dynamic.get d)
 let () =
   let d = Dynamic.make () in
   let parent = (Bytes.unsafe_to_string (Bytes.make 4 'x')) in
-  Dynamic.push d parent;
-  let finished = ref false in
-  let r = allocate_bytes finished in
-  (try
-    Sys.with_async_exns (fun () ->
-      r := None;
-      (* Bind [d] to [child] and read it so the cache holds
-         [d -> child], then allocate until the finaliser raises [Sys.Break]
-         asynchronously, unwinding out of this async exn handler. *)
-      let child = (Bytes.unsafe_to_string (Bytes.make 4 'y')) in
-      Dynamic.with_temporarily d child ~f:(fun () ->
-        Printf.printf "in fiber [expect %s]: %s\n%!" child (print_dyn d);
-        while true do
-          let _ @ global = Sys.opaque_identity (42, Random.int 42) in
-          ()
-        done))
-  with
-  | Sys.Break -> assert !finished
-  | _ -> assert false);
-  (* The bound fiber is gone; [d] must read as [parent] again. *)
-  Printf.printf "after async unwind [expect %s]: %s\n%!" parent (print_dyn d)
+  Dynamic.with_temporarily d parent ~f:(fun () ->
+    let finished = ref false in
+    let r = allocate_bytes finished in
+    (try
+      Sys.with_async_exns (fun () ->
+        r := None;
+        (* Bind [d] to [child] and read it so the cache holds
+          [d -> child], then allocate until the finaliser raises [Sys.Break]
+          asynchronously, unwinding out of this async exn handler. *)
+        let child = (Bytes.unsafe_to_string (Bytes.make 4 'y')) in
+        Dynamic.with_temporarily d child ~f:(fun () ->
+          Printf.printf "in fiber [expect %s]: %s\n%!" child (print_dyn d);
+          while true do
+            let _ @ global = Sys.opaque_identity (42, Random.int 42) in
+            ()
+          done))
+    with
+    | Sys.Break -> assert !finished
+    | _ -> assert false);
+    (* The bound fiber is gone; [d] must read as [parent] again. *)
+    Printf.printf "after async unwind [expect %s]: %s\n%!" parent (print_dyn d))

--- a/testsuite/tests/effects/dynamic_stress.ml
+++ b/testsuite/tests/effects/dynamic_stress.ml
@@ -4,21 +4,12 @@
 *)
 
 module Dynamic = struct
-  type 'a t
+  include Dynamic
 
-  external make : unit -> 'a t = "caml_dynamic_make"
-  external get : 'a t -> 'a or_null = "caml_dynamic_get"
-  external push : 'a t -> 'a -> unit = "caml_dynamic_push"
+  (* Expose the implementation of dynamic for testing. *)
+  external push : 'a t -> 'a @ contended portable -> unit = "caml_dynamic_push"
   external pop : 'a t -> unit = "caml_dynamic_pop"
-
-  (* A Dynamic.t is represented at runtime as the immediate OO-id that is also
-     used as its hash (Hash_dyn = Long_val). Exposing it lets us construct
-     deterministic hash collisions from OCaml. *)
   external hash : 'a t -> int = "%identity"
-
-  let with_temporarily d v ~f =
-    push d v;
-    Fun.protect f ~finally:(fun () -> pop d)
 end
 
 let str_or_null = function This s -> s | Null -> "null"
@@ -66,7 +57,7 @@ let test_table_growth () =
     if i = n then begin
       let visible = ref 0 and correct = ref true in
       Array.iteri
-        (fun j d ->
+        (fun j (d : int Dynamic.t) ->
           match Dynamic.get d with
           | This v ->
             incr visible;
@@ -132,7 +123,8 @@ let test_gc () =
   print_endline "\n# GC root scanning of live bindings";
   let flush_gc () =
     for _ = 1 to 64 do
-      ignore (Dynamic.get (Dynamic.make ()))
+      let _ = Dynamic.get (Dynamic.make ()) in
+      ()
     done;
     Gc.full_major ();
     Gc.compact ()

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
@@ -15,16 +15,16 @@ let code loopify(never) size(49) newer_version_of(sum_0)
       let prim_1 = %untag_imm (for_stop) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, 0)
-         where rec k2 (for_counter_naked : int64, r_441_unboxed0) =
+         where rec k2 (for_counter_naked : int64, r_442_unboxed0) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let Parrayrefu = %array_load.mut (Pfield, i) in
            ((let prim_3 = %is_int (Parrayrefu) in
              switch prim_3
                | 0 -> k4
-               | 1 -> k3 (r_441_unboxed0)
+               | 1 -> k3 (r_442_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (r_441_unboxed0, 1) in
+                 let int_add = %int_barith.add (r_442_unboxed0, 1) in
                  cont k3 (int_add))
               where k3 (return_val0) =
                 let for_next_naked =

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -15,16 +15,16 @@ let code loopify(never) size(52) newer_version_of(sum_0)
       let prim_1 = %untag_imm (for_stop) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, 0)
-         where rec k2 (for_counter_naked : int64, r_441_unboxed0) =
+         where rec k2 (for_counter_naked : int64, r_442_unboxed0) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let ifnot_result = %array_load.mut (Pfield, i) in
            ((let prim_3 = %is_int (ifnot_result) in
              switch prim_3
                | 0 -> k4
-               | 1 -> k3 (r_441_unboxed0)
+               | 1 -> k3 (r_442_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (r_441_unboxed0, 1) in
+                 let int_add = %int_barith.add (r_442_unboxed0, 1) in
                  cont k3 (int_add))
               where k3 (return_val0) =
                 let for_next_naked =

--- a/testsuite/tests/typedtree/module_presence.ml
+++ b/testsuite/tests/typedtree/module_presence.ml
@@ -8,7 +8,7 @@ module X = struct end
 [
   structure_item
     Tstr_module (Present)
-    X/289
+    X/290
       module_expr
         Tmod_structure
         []
@@ -22,7 +22,7 @@ module X = struct end [@foo]
 [
   structure_item
     Tstr_module (Present)
-    X/290
+    X/291
       module_expr
         attribute "foo"
           []
@@ -38,9 +38,9 @@ module Y = X
 [
   structure_item
     Tstr_module (Absent)
-    Y/291
+    Y/292
       module_expr
-        Tmod_ident "X/290"
+        Tmod_ident "X/291"
 ]
 
 module Y = X
@@ -50,15 +50,15 @@ module type T = sig module Y = X end
 [%%expect{|
 [
   structure_item
-    Tstr_modtype "T/293"
+    Tstr_modtype "T/294"
       module_type
         Tmty_signature
         [
           signature_item
             Tsig_module (Absent)
-            Y/292
+            Y/293
               module_type
-                Tmty_alias "X/290"
+                Tmty_alias "X/291"
         ]
         join_const(unique,uncontended,read_write,static);meet_const(local,once,nonportable,unforkable,yielding,stateful)
         []

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -57,7 +57,7 @@ end = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "X/366"
+(apply (field_imm 1 (global Toploop!)) "X/367"
   (let
     (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
        [0: "first" 1]
@@ -80,7 +80,7 @@ let () =
 
 [%%expect{|
 (let
-  (X =? (apply (field_imm 0 (global Toploop!)) "X/366")
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/367")
    *match* =[value<int>]
      (let (xs =[value<addrarray>] (caml_array_make 4 (field_imm 0 X)))
        (seq (array.set[addr indexed by int] xs 1 (field_imm 1 X))


### PR DESCRIPTION
Exposes dynamics in the stdlib as `Dynamic`. Updates the tests to use the stdlib implementations.