### PR TITLE
[CI demonstration] Reduce frametable size + llvmize CI fixes (#6399 + NickBarnes#1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,12 @@ jobs:
             config: --enable-frame-pointers
             os: warp-ubuntu-latest-x64-8x
             llvmize_tests_only: true
-            oxcaml_llvm_tag: oxcaml-llvmize-16.0.6-minus3
+            # TEMPORARY: personal-fork release of llvmize-oxcaml +
+            # ocaml-flambda/llvm-project#37 (short frametables support, needed
+            # by this PR). Once #37 is merged and an official release is
+            # minted, drop oxcaml_llvm_repo and point oxcaml_llvm_tag at it.
+            oxcaml_llvm_repo: julesjacobs/llvm-project
+            oxcaml_llvm_tag: oxcaml-llvmize-16.0.6-minus3-pr37
             oxcaml_llvm_source_branch: llvmize-oxcaml
             sysdeps: gdb
 
@@ -313,9 +318,10 @@ jobs:
             exit 1
           fi
 
+          OXCAML_LLVM_REPO="${{ matrix.oxcaml_llvm_repo || 'ocaml-flambda/llvm-project' }}"
           OXCAML_LLVM_TAG="${{ matrix.oxcaml_llvm_tag }}"
           OXCAML_LLVM_SOURCE_BRANCH="${{ matrix.oxcaml_llvm_source_branch }}"
-          OXCAML_LLVM_URL="https://github.com/ocaml-flambda/llvm-project/releases/download/${OXCAML_LLVM_TAG}/${OXCAML_LLVM_TAG}-llvm-linux-${ARCH}-${OXCAML_LLVM_SOURCE_BRANCH}.tar.gz"
+          OXCAML_LLVM_URL="https://github.com/${OXCAML_LLVM_REPO}/releases/download/${OXCAML_LLVM_TAG}/${OXCAML_LLVM_TAG}-llvm-linux-${ARCH}-${OXCAML_LLVM_SOURCE_BRANCH}.tar.gz"
 
           # Download and extract custom OxCaml LLVM (includes LLDB and other LLVM tools)
           cd $GITHUB_WORKSPACE

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3107,6 +3107,16 @@ let end_assembly () =
   let frametable_section : Asm_targets.Asm_section.t =
     if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Text
   in
+  (* Mergeable string section (SHF_MERGE|SHF_STRINGS, entsize 1) for debuginfo
+     filename and defname strings (so linker will de-dupe). *)
+  let debuginfo_strings_section : Asm_targets.Asm_section.t =
+    Custom
+      { names = [".rodata.str1.1"];
+        flags = Some "aMS";
+        args = ["@progbits"; "1"];
+        is_delayed = false
+      }
+  in
   D.switch_to_section frametable_section;
   I.ud2 ();
   D.align
@@ -3142,7 +3152,15 @@ let end_assembly () =
         (fun l ->
           let lbl = label_to_asm_label ~section:frametable_section l in
           D.define_label lbl);
-      efa_string = (fun s -> D.string (s ^ "\000"))
+      efa_string = (fun s -> D.string (s ^ "\000"));
+      efa_open_string_section =
+        (fun () -> D.switch_to_section debuginfo_strings_section);
+      efa_close_string_section =
+        (fun () -> D.switch_to_section frametable_section);
+      efa_def_string_label =
+        (fun l ->
+          let lbl = label_to_asm_label ~section:debuginfo_strings_section l in
+          D.define_label lbl)
     };
   let frametable_sym = S.create_global (Cmm_helpers.make_symbol "frametable") in
   D.size frametable_sym;

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3139,14 +3139,21 @@ let end_assembly () =
     if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Text
   in
   (* Mergeable string section (SHF_MERGE|SHF_STRINGS, entsize 1) for debuginfo
-     filename and defname strings (so linker will de-dupe). *)
+     filename and defname strings (so linker will de-dupe). Mach-O relocations
+     are atom-based and cannot target the assembler-local labels that define the
+     strings, so on macOS the strings stay in the frametable section,
+     un-deduplicated; the references are then same-section label differences,
+     resolved entirely by the assembler. *)
   let debuginfo_strings_section : Asm_targets.Asm_section.t =
-    Custom
-      { names = [".rodata.str1.1"];
-        flags = Some "aMS";
-        args = ["@progbits"; "1"];
-        is_delayed = false
-      }
+    if is_macosx system
+    then frametable_section
+    else
+      Custom
+        { names = [".rodata.str1.1"];
+          flags = Some "aMS";
+          args = ["@progbits"; "1"];
+          is_delayed = false
+        }
   in
   D.switch_to_section frametable_section;
   I.ud2 ();

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -3146,6 +3146,18 @@ let end_assembly () =
     };
   let frametable_sym = S.create_global (Cmm_helpers.make_symbol "frametable") in
   D.size frametable_sym;
+  (* Experimental: emit a pointer to this unit's frametable into a
+     linker-collected section, so the runtime can enumerate the frametable of
+     *every* linked unit, including ones that are not in caml_frametable[]. The
+     linker concatenates these per-unit entries and bounds them with
+     __start_/__stop_caml_all_frametables. ELF/GAS targets only. *)
+  (match[@ocaml.warning "-4"] system with
+  | S_macosx | S_win32 | S_win64 | S_mingw | S_mingw64 | S_cygwin | S_unknown ->
+    ()
+  | _ ->
+    D.switch_to_section_raw ~names:["caml_all_frametables"] ~flags:(Some "aw")
+      ~args:["@progbits"] ~is_delayed:false;
+    D.symbol frametable_sym);
   D.data ();
   Probe_emission.emit_probe_notes ~add_def_symbol;
   emit_trap_notes ();

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -396,6 +396,8 @@ let emit_named_text_section ?(suffix = "") func_name =
     | _ ->
       D.switch_to_section_raw ~names:[".text.startup.caml"] ~flags:(Some "ax")
         ~args:["@progbits"] ~is_delayed:false;
+      (* A new text section: frame-descriptor deltas cannot cross it. *)
+      Emitaux.start_new_code_section ();
       (* Warning: We set the internal section ref to Text here, because it
          currently does not supported named text sections. In the rest of this
          file, we pretend the section is called Text rather than the function
@@ -417,13 +419,21 @@ let emit_named_text_section ?(suffix = "") func_name =
       D.switch_to_section_raw
         ~names:[Printf.sprintf ".text.caml.%s%s" (emit_symbol func_name) suffix]
         ~flags:(Some "ax") ~args:["@progbits"] ~is_delayed:false;
+      (* A new text section: frame-descriptor deltas cannot cross it. *)
+      Emitaux.start_new_code_section ();
       (* Warning: We set the internal section ref to Text here, because it
          currently does not supported named text sections. In the rest of this
          file, we pretend the section is called Text rather than the function
          specific text section. *)
       (* CR sspies: Add proper support for named text sections. *)
       D.unsafe_set_internal_section_ref Text)
-  else D.text ()
+  else (
+    D.text ();
+    (* Conservatively treat each function start as a new section boundary for
+       frame-descriptor deltas. With a single shared [.text] this only forgoes
+       cross-function deltas (safe); it avoids emitting a cross-section delta
+       should a return address ever land in a different section. *)
+    Emitaux.start_new_code_section ())
 
 let emit_function_or_basic_block_section_name () =
   let suffix =
@@ -3145,6 +3155,11 @@ let end_assembly () =
     ~bytes:8;
   (* PR#7591 *)
   emit_global_label ~section:frametable_section "frametable";
+  (* The internal-assembler / JIT binary backend cannot yet emit the short
+     format's variable-length retaddr delta, so escape every descriptor to the
+     normal format when it is active. TODO: extend internal assembler. *)
+  Emitaux.disable_short_descriptors
+    := Option.is_some !X86_proc.internal_assembler;
   (* CR sspies: Share the [emit_frames] code with the Arm backend. *)
   emit_frames
     { efa_code_label =
@@ -3169,6 +3184,12 @@ let end_assembly () =
           let ofs = Targetint.of_int32 ofs in
           D.between_this_and_label_offset_32bit_expr ~upper:lbl
             ~offset_upper:ofs);
+      efa_label_delta =
+        (fun upper lower ->
+          (* The return-address labels live in the text section. *)
+          let upper = label_to_asm_label ~section:Text upper in
+          let lower = label_to_asm_label ~section:Text lower in
+          D.frame_descr_delta ~upper ~lower);
       efa_def_label =
         (fun l ->
           let lbl = label_to_asm_label ~section:frametable_section l in

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -587,9 +587,8 @@ let must_save_simd_regs live : Regs.Save_simd_regs.t =
 (* CR sspies: Consider whether more of [record_frame_label] can be shared with
    the Arm backend. *)
 
-let record_frame_label live dbg =
+let compute_live_offset live =
   let encode_reg_offset n = (n lsl 1) + 1 in
-  let lbl = Cmm.new_label () in
   let live_offset = ref [] in
   let simd = must_save_simd_regs live in
   Reg.Set.iter
@@ -616,10 +615,14 @@ let record_frame_label live dbg =
         Misc.fatal_errorf "Unknown location %a" Printreg.reg r
       | { typ = Int | Float | Float32 | Vec128 | Vec256 | Vec512; _ } -> ())
     live;
+  !live_offset
+
+let record_frame_label live dbg =
+  let lbl = Cmm.new_label () in
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of Linear labels. *)
   record_frame_descr ~label:lbl ~frame_size:(frame_size ())
-    ~live_offset:!live_offset dbg;
+    ~live_offset:(compute_live_offset live) dbg;
   label_to_asm_label ~section:Text lbl
 
 let record_frame live dbg =
@@ -631,7 +634,14 @@ let record_frame live dbg =
 type gc_call =
   { gc_lbl : L.t; (* Entry label *)
     gc_return_lbl : L.t; (* Where to branch after GC *)
-    gc_frame : L.t; (* Label of frame descriptor *)
+    (* The frame descriptor is recorded (and its return-address label defined)
+       when the out-of-line GC stub is emitted, rather than at the allocation
+       site, so that frame descriptors are emitted in increasing return-address
+       order. *)
+    gc_frame_lbl : Label.t; (* Linear label of the frame descriptor *)
+    gc_frame_size : int;
+    gc_live_offset : int list;
+    gc_frame_dbg : frame_debuginfo; (* debuginfo for the frame descriptor *)
     gc_dbg : Debuginfo.t; (* Location of the original instruction *)
     gc_save_simd : Regs.Save_simd_regs.t
         (* What SIMD regs, if any, we need to save *)
@@ -649,7 +659,12 @@ let emit_call_gc gc =
   D.define_label gc.gc_lbl;
   emit_debug_info gc.gc_dbg;
   emit_call (call_gc_local_sym ~simd:gc.gc_save_simd);
-  D.define_label gc.gc_frame;
+  (* Record the frame descriptor here, where its return-address label is about
+     to be defined, so that frame descriptors are recorded (and hence emitted)
+     in increasing return-address order. *)
+  record_frame_descr ~label:gc.gc_frame_lbl ~frame_size:gc.gc_frame_size
+    ~live_offset:gc.gc_live_offset gc.gc_frame_dbg;
+  D.define_label (label_to_asm_label ~section:Text gc.gc_frame_lbl);
   I.jmp (emit_asm_label_arg gc.gc_return_lbl)
 
 (* Record calls to local stack reallocation *)
@@ -2191,7 +2206,7 @@ let emit_instr ~first ~last ~fallthrough i =
       I.sub (int n) r15;
       I.cmp (domain_field Domainstate.Domain_young_limit) r15;
       let lbl_call_gc = L.create Text in
-      let lbl_frame = record_frame_label i.live (Dbg_alloc dbginfo) in
+      let lbl_frame = Cmm.new_label () in
       I.jb (emit_asm_label_arg lbl_call_gc);
       let lbl_after_alloc = L.create Text in
       D.define_label lbl_after_alloc;
@@ -2200,7 +2215,10 @@ let emit_instr ~first ~last ~fallthrough i =
         := { gc_lbl = lbl_call_gc;
              gc_return_lbl = lbl_after_alloc;
              gc_dbg = i.dbg;
-             gc_frame = lbl_frame;
+             gc_frame_lbl = lbl_frame;
+             gc_frame_size = frame_size ();
+             gc_live_offset = compute_live_offset i.live;
+             gc_frame_dbg = Dbg_alloc dbginfo;
              gc_save_simd
            }
            :: !call_gc_sites)
@@ -2238,13 +2256,16 @@ let emit_instr ~first ~last ~fallthrough i =
     I.cmp (domain_field Domainstate.Domain_young_limit) r15;
     let gc_call_label = L.create Text in
     let lbl_after_poll = L.create Text in
-    let lbl_frame = record_frame_label i.live (Dbg_alloc []) in
+    let lbl_frame = Cmm.new_label () in
     I.jbe (emit_asm_label_arg gc_call_label);
     call_gc_sites
       := { gc_lbl = gc_call_label;
            gc_return_lbl = lbl_after_poll;
            gc_dbg = i.dbg;
-           gc_frame = lbl_frame;
+           gc_frame_lbl = lbl_frame;
+           gc_frame_size = frame_size ();
+           gc_live_offset = compute_live_offset i.live;
+           gc_frame_dbg = Dbg_alloc [];
            gc_save_simd = must_save_simd_regs i.live
          }
          :: !call_gc_sites;

--- a/backend/arm64/binary_emitter/binary_emitter.ml
+++ b/backend/arm64/binary_emitter/binary_emitter.ml
@@ -116,7 +116,7 @@ let compute_label_offsets emitter ~all_sections =
       | Cfi_restore_state | Cfi_def_cfa_register _ | Comment _ | Const _
       | File _ | Indirect_symbol _ | Loc _ | New_line | Private_extern _
       | Section _ | Size _ | Sleb128 _ | Space _ | Type _ | Uleb128 _
-      | Protected _ | Hidden _ | External _ | Reloc _ ->
+      | Protected _ | Hidden _ | External _ | Reloc _ | Frame_descr_delta _ ->
         ())
 
 (* Second pass: emit machine code and data *)

--- a/backend/arm64/binary_emitter/encode_directive.ml
+++ b/backend/arm64/binary_emitter/encode_directive.ml
@@ -590,6 +590,9 @@ let emit_directive state ~current_section ~all_sections
     match eval_constant state ~all_sections constant with
     | Some value -> D.Directive.emit_uleb128 buf value
     | None -> Misc.fatal_error "Cannot emit ULEB128 for external symbol")
+  | Frame_descr_delta _ ->
+    (* Small frame descriptors are not yet ported to ARM64. *)
+    Misc.fatal_error "Frame_descr_delta not supported on ARM64"
   (* Directives that don't emit data *)
   | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_endproc | Cfi_offset _
   | Cfi_startproc | Cfi_remember_state | Cfi_restore_state

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -50,7 +50,14 @@ open! Int_replace_polymorphic_compare
 type gc_call =
   { gc_lbl : L.t; (* Entry label *)
     gc_return_lbl : L.t; (* Where to branch after GC *)
-    gc_frame_lbl : L.t (* Label of frame descriptor *)
+    (* The frame descriptor is recorded (and its return-address label defined)
+       when the out-of-line GC stub is emitted, rather than at the allocation
+       site, so that frame descriptors are emitted in increasing return-address
+       order. *)
+    gc_frame_lbl : label; (* Linear label of the frame descriptor *)
+    gc_frame_size : int;
+    gc_live_offset : int list;
+    gc_frame_dbg : frame_debuginfo
   }
 
 type local_realloc_call =
@@ -717,9 +724,8 @@ let simd_instr (op : Simd.operation) (i : Linear.instruction) =
 
 (* Record live pointers at call points *)
 
-let record_frame_label env live dbg =
+let compute_live_offset env live =
   let encode_reg_offset n = (n lsl 1) + 1 in
-  let lbl = Cmm.new_label () in
   let live_offset = ref [] in
   Reg.Set.iter
     (function
@@ -740,10 +746,15 @@ let record_frame_label env live dbg =
       | { typ = Vec256 | Vec512; _ } ->
         Misc.fatal_error "arm64: got 256/512 bit vector")
     live;
+  !live_offset
+
+let record_frame_label env live dbg =
+  let lbl = Cmm.new_label () in
   (* CR sspies: Consider changing [record_frame_descr] to [Asm_label.t] instead
      of linear labels. *)
   record_frame_descr ~label:lbl ~frame_size:(Env.frame_size env)
-    ~live_offset:!live_offset dbg;
+    ~live_offset:(compute_live_offset env live)
+    dbg;
   label_to_asm_label ~section:Text lbl
 
 let record_frame env live dbg =
@@ -762,7 +773,17 @@ let emit_debug_info ?discriminator dbg =
 
 let emit_call_gc gc =
   labelled_ins1 gc.gc_lbl BL (runtime_function S.Predef.caml_call_gc);
-  labelled_ins1 gc.gc_frame_lbl B (local_label gc.gc_return_lbl)
+  (* Record the frame descriptor here, where its return-address label is
+     defined, so descriptors are recorded (and emitted) in increasing
+     return-address order. Safe across the relaxation/sizing pass: that pass
+     runs under [Emitaux.with_snapshot], which rolls back
+     [frame_descriptors]. *)
+  record_frame_descr ~label:gc.gc_frame_lbl ~frame_size:gc.gc_frame_size
+    ~live_offset:gc.gc_live_offset gc.gc_frame_dbg;
+  labelled_ins1
+    (label_to_asm_label ~section:Text gc.gc_frame_lbl)
+    B
+    (local_label gc.gc_return_lbl)
 
 (* Record calls to local stack reallocation *)
 
@@ -1117,11 +1138,20 @@ let assembly_code_for_fast_heap_allocation0 ~n ~far ~res_reg =
   gc_lbl, gc_return_lbl
 
 let assembly_code_for_fast_heap_allocation env i ~n ~far ~dbginfo =
-  let gc_frame_lbl = record_frame_label env i.live (Dbg_alloc dbginfo) in
+  let gc_frame_lbl = Cmm.new_label () in
+  let gc_frame_size = Env.frame_size env in
+  let gc_live_offset = compute_live_offset env i.live in
   let gc_lbl, gc_return_lbl =
     assembly_code_for_fast_heap_allocation0 ~n ~far ~res_reg:(H.reg_x i.res.(0))
   in
-  Env.add_call_gc_site env { gc_lbl; gc_return_lbl; gc_frame_lbl }
+  Env.add_call_gc_site env
+    { gc_lbl;
+      gc_return_lbl;
+      gc_frame_lbl;
+      gc_frame_size;
+      gc_live_offset;
+      gc_frame_dbg = Dbg_alloc dbginfo
+    }
 
 let assembly_code_for_slow_heap_allocation env i ~n ~dbginfo =
   let lbl_frame = record_frame_label env i.live (Dbg_alloc dbginfo) in
@@ -1176,9 +1206,18 @@ let assembly_code_for_poll0 ~far ~return_label =
   gc_lbl, gc_return_lbl
 
 let assembly_code_for_poll env i ~far ~return_label =
-  let gc_frame_lbl = record_frame_label env i.live (Dbg_alloc []) in
+  let gc_frame_lbl = Cmm.new_label () in
+  let gc_frame_size = Env.frame_size env in
+  let gc_live_offset = compute_live_offset env i.live in
   let gc_lbl, gc_return_lbl = assembly_code_for_poll0 ~far ~return_label in
-  Env.add_call_gc_site env { gc_lbl; gc_return_lbl; gc_frame_lbl }
+  Env.add_call_gc_site env
+    { gc_lbl;
+      gc_return_lbl;
+      gc_frame_lbl;
+      gc_frame_size;
+      gc_live_offset;
+      gc_frame_dbg = Dbg_alloc []
+    }
 
 (* Output the assembly code for a stack check. *)
 

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2294,9 +2294,13 @@ let end_assembly () =
      are atom-based and cannot target the assembler-local labels that define the
      strings, so on macOS the strings stay in the frametable section,
      un-deduplicated; the references are then same-section label differences,
-     resolved entirely by the assembler. *)
+     resolved entirely by the assembler. The binary emitter keeps them there
+     too: in JIT mode the mergeable section contains no symbol to anchor
+     cross-section relocations, and in verify mode GAS keeps local-label
+     relocations into SHF_MERGE sections (non-zero addends must not be reduced
+     to section symbols), so the two outputs would diverge. *)
   let debuginfo_strings_section : Asm_targets.Asm_section.t =
-    if macosx
+    if macosx || Binary_emitter_helpers.should_use_binary_emitter ()
     then frametable_section
     else
       Custom

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2290,14 +2290,21 @@ let end_assembly () =
     if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Data
   in
   (* Mergeable string section (SHF_MERGE|SHF_STRINGS, entsize 1) for debuginfo
-     filename and defname strings (so linker will de-dupe). *)
+     filename and defname strings (so linker will de-dupe). Mach-O relocations
+     are atom-based and cannot target the assembler-local labels that define the
+     strings, so on macOS the strings stay in the frametable section,
+     un-deduplicated; the references are then same-section label differences,
+     resolved entirely by the assembler. *)
   let debuginfo_strings_section : Asm_targets.Asm_section.t =
-    Custom
-      { names = [".rodata.str1.1"];
-        flags = Some "aMS";
-        args = ["%progbits"; "1"];
-        is_delayed = false
-      }
+    if macosx
+    then frametable_section
+    else
+      Custom
+        { names = [".rodata.str1.1"];
+          flags = Some "aMS";
+          args = ["%progbits"; "1"];
+          is_delayed = false
+        }
   in
   D.switch_to_section frametable_section;
   D.align ~fill:Zero ~bytes:8;

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2250,6 +2250,16 @@ let end_assembly () =
        unclear how much this matters. *)
     if !Oxcaml_flags.frametables_in_rodata then Read_only_data else Data
   in
+  (* Mergeable string section (SHF_MERGE|SHF_STRINGS, entsize 1) for debuginfo
+     filename and defname strings (so linker will de-dupe). *)
+  let debuginfo_strings_section : Asm_targets.Asm_section.t =
+    Custom
+      { names = [".rodata.str1.1"];
+        flags = Some "aMS";
+        args = ["%progbits"; "1"];
+        is_delayed = false
+      }
+  in
   D.switch_to_section frametable_section;
   D.align ~fill:Zero ~bytes:8;
   (* #7887 *)
@@ -2286,7 +2296,15 @@ let end_assembly () =
         (fun lbl ->
           let lbl = label_to_asm_label ~section:frametable_section lbl in
           D.define_label lbl);
-      efa_string = (fun s -> D.string (s ^ "\000"))
+      efa_string = (fun s -> D.string (s ^ "\000"));
+      efa_open_string_section =
+        (fun () -> D.switch_to_section debuginfo_strings_section);
+      efa_close_string_section =
+        (fun () -> D.switch_to_section frametable_section);
+      efa_def_string_label =
+        (fun lbl ->
+          let lbl = label_to_asm_label ~section:debuginfo_strings_section lbl in
+          D.define_label lbl)
     };
   D.type_symbol ~ty:Object frametable_sym;
   D.size frametable_sym;

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2306,6 +2306,9 @@ let end_assembly () =
   let frametable_sym = S.create_global frametable in
   global_maybe_protected frametable_sym;
   D.define_symbol_label ~section:frametable_section frametable_sym;
+  (* The short-format return-address delta is not yet ported to ARM64, so escape
+     every descriptor to the normal format. *)
+  Emitaux.disable_short_descriptors := true;
   (* CR sspies: Share the [emit_frames] code with the x86 backend. *)
   emit_frames
     { efa_code_label =
@@ -2331,6 +2334,12 @@ let end_assembly () =
           let lbl = label_to_asm_label ~section:frametable_section lbl in
           D.between_this_and_label_offset_32bit_expr ~upper:lbl
             ~offset_upper:(Targetint.of_int32 ofs));
+      efa_label_delta =
+        (* The short frame-descriptor format and its runtime decoding are not
+           yet ported to ARM64; this is only reachable if [emit_frames] produces
+           a short descriptor on ARM64. *)
+        (fun _upper _lower ->
+          Misc.fatal_error "short frame descriptors not supported on ARM64");
       efa_def_label =
         (fun lbl ->
           let lbl = label_to_asm_label ~section:frametable_section lbl in

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -283,6 +283,8 @@ module Directive = struct
           target_symbol : Asm_symbol.t;
           addend : int64
         }
+    | Frame_descr_delta of { delta : Constant.t }
+  (* Variable-width return-address delta for a "small" frame descriptor *)
 
   let bprintf = Printf.bprintf
 
@@ -411,6 +413,11 @@ module Directive = struct
       | _, _ -> print_ascii_string_gas ~chunk_size:80 buf str);
       bprintf buf "%s" (gas_comment_opt comment)
     | Comment s -> if emit_comments () then bprintf buf "\t\t\t\t/* %s */" s
+    | Frame_descr_delta { delta } ->
+      (* The delta is a difference of two same-section labels. Emit as ULEB128
+         so the assembler can compute it. Always positive, so it never starts
+         with a 0 byte *)
+      bprintf buf "\t.uleb128 (%a)" Constant.print delta
     | Global sym -> bprintf buf "\t.globl\t%s" (Asm_symbol.encode sym)
     | New_label (Label lbl, _typ) -> bprintf buf "%s:" (Asm_label.encode lbl)
     | New_label (Symbol sym, _typ) -> bprintf buf "%s:" (Asm_symbol.encode sym)
@@ -573,6 +580,7 @@ module Directive = struct
     | External sym -> bprintf buf "\tEXTRN\t%s: NEAR" (Asm_symbol.encode sym)
     (* The only supported "type" on EXTRN declarations is NEAR. *)
     | Reloc _ -> unsupported "Reloc"
+    | Frame_descr_delta _ -> unsupported "Frame_descr_delta"
 
   let print b t =
     match TS.assembler () with
@@ -663,6 +671,12 @@ module Directive = struct
       | This | Label _ | Symbol _ | Variable _ | Add _ | Sub _ ->
         Misc.fatal_error
           "increment_offset_in_bytes: uleb128 with non-integer constant")
+    | Frame_descr_delta _ ->
+      (* Variable-width (1 or 3 bytes); not supported by the offset-accounting
+         binary-emitter path. Only emitted on amd64 via the GAS text backend,
+         which does not use this function. *)
+      Misc.fatal_error
+        "increment_offset_in_bytes: Frame_descr_delta is not supported"
     (* Directives that don't contribute to section size *)
     | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_endproc
     | Cfi_offset _ | Cfi_startproc | Cfi_remember_state | Cfi_restore_state
@@ -1125,6 +1139,13 @@ let between_labels_32_bit ?comment:_comment ~upper ~lower () =
 let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () =
   (* CR poechsel: use the arguments *)
   Misc.fatal_error "between_labels_64_bit not implemented yet"
+
+let frame_descr_delta ~upper ~lower =
+  let delta =
+    Directive.Constant.Sub
+      (Directive.Constant.Label upper, Directive.Constant.Label lower)
+  in
+  emit (Frame_descr_delta { delta })
 
 let between_labels_64_bit_with_offsets ?comment:_comment ~upper ~upper_offset
     ~lower ~lower_offset () =

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -286,6 +286,10 @@ val between_labels_32_bit :
 val between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
+(** Emit a variable-width return-address delta for a "short" frame descriptor.
+    Supported only on the GAS text backend. *)
+val frame_descr_delta : upper:Asm_label.t -> lower:Asm_label.t -> unit
+
 (** Like [between_symbols], but for two labels with additional offsets, emitting
     a 64-bit-wide reference. The labels must be in the same section. *)
 val between_labels_64_bit_with_offsets :
@@ -477,6 +481,8 @@ module Directive : sig
           target_symbol : Asm_symbol.t;
           addend : int64
         }
+    | Frame_descr_delta of { delta : Constant.t }
+        (** Variable-width return-address delta for a short frame descriptor *)
 
   (** Translate the given directive to textual form. This produces output
       suitable for either gas or MASM as appropriate. *)

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -46,10 +46,29 @@ type frame_descr =
     fd_frame_size : int; (* Size of stack frame *)
     fd_live_offset : int list; (* Offsets/regs of live addresses *)
     fd_debuginfo : frame_debuginfo; (* Location, if any *)
-    fd_long : bool (* Use 32 instead of 16 bit format. *)
+    fd_long : bool; (* Use 32 instead of 16 bit format. *)
+    fd_section : int
+        (* Identifies the text section the return address lives in. A "short"
+           descriptor's delta is the difference between two return-address
+           labels, which is only an assembly-time constant when both labels are
+           in the same section; descriptors whose section differs from the
+           previous one escape. *)
   }
 
 let frame_descriptors = ref ([] : frame_descr list)
+
+(* Bumped by the backends whenever they switch to a different text section, so
+   [record_frame_descr] can tag each descriptor with its section. *)
+let frame_section_epoch = ref 0
+
+let start_new_code_section () = incr frame_section_epoch
+
+(* Set by a backend before [emit_frames] when the short descriptor format cannot
+   be emitted in the current context: internal-assembler (which cannot resolve
+   the variable-length return-address delta directive) and ARM64 (where the
+   delta is not yet ported). Every descriptor then escapes to the normal
+   format. *)
+let disable_short_descriptors = ref false
 
 let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d)
 
@@ -88,7 +107,8 @@ let record_frame_descr ~label ~frame_size ~live_offset debuginfo =
          fd_frame_size = frame_size;
          fd_live_offset = List.sort_uniq ( - ) live_offset;
          fd_debuginfo = debuginfo;
-         fd_long
+         fd_long;
+         fd_section = !frame_section_epoch
        }
        :: !frame_descriptors
 
@@ -104,6 +124,9 @@ type emit_frame_actions =
     efa_word : int -> unit;
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
+    efa_label_delta : Label.t -> Label.t -> unit;
+    (* [efa_label_delta upper lower] emits the variable-width return-address
+       delta of a "short" frame descriptor, as a ULEB128 constant. *)
     efa_def_label : Label.t -> unit;
     efa_string : string -> unit;
     (* Switch to / from mergeable string section, used for debuginfo filename
@@ -196,7 +219,27 @@ let emit_frames a =
       Label_table.add debuginfos key lbl;
       lbl
   in
-  let emit_frame fd =
+  (* Emit the debuginfo words. These are identical in the normal and short
+     descriptor layouts: present iff the debug flag is set, one word per
+     allocation for an alloc descriptor, otherwise one word. *)
+  let emit_debug_words fd =
+    match fd.fd_debuginfo with
+    | _ when get_flags fd.fd_debuginfo = 0 -> ()
+    | Dbg_other dbg -> a.efa_label_rel (label_debuginfos false dbg) Int32.zero
+    | Dbg_raise dbg -> a.efa_label_rel (label_debuginfos true dbg) Int32.zero
+    | Dbg_alloc dbg ->
+      if get_flags fd.fd_debuginfo = 3
+      then
+        List.iter
+          (fun Cmm.{ alloc_dbg; _ } ->
+            if is_none_dbg alloc_dbg
+            then emit_i32 0
+            else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
+          dbg
+  in
+  (* Emit one descriptor in the existing normal/long format, with no leading
+     delta byte. Used as the body following a 0 (escape) delta byte. *)
+  let emit_escaped_frame fd =
     let flags = get_flags fd.fd_debuginfo in
     a.efa_label_rel fd.fd_lbl 0l;
     (* For short format, the size is guaranteed to be less than the constant
@@ -240,6 +283,115 @@ let emit_frames a =
   let emit_merged_string str lbl =
     a.efa_def_string_label lbl;
     a.efa_string str
+  in
+  (* Partition live offsets into live registers (low bit 1, value >>1 is the
+     register number) and live stack-slot byte offsets (low bit 0). See
+     [compute_live_offset] in the backends. *)
+  let partition_live_offset live =
+    List.partition_map
+      (fun n -> if n land 1 = 1 then Either.Left (n lsr 1) else Either.Right n)
+      live
+  in
+  (* Register-number -> hot-bitmap-bit-index. This is the inverse of
+     [caml_frame_hot_regs] in runtime/caml/frame_descriptors.h; the compiler and
+     the runtime MUST agree exactly or the GC scans the wrong registers (silent
+     heap corruption). *)
+  let hot_regs = [| 0; 1; 2; 3; 4; 5; 6; 8 |] in
+  let hot_reg_bit reg =
+    let rec find i =
+      if i >= Array.length hot_regs
+      then None
+      else if hot_regs.(i) = reg
+      then Some i
+      else find (i + 1)
+    in
+    find 0
+  in
+  (* Compute the short-format encoding of a descriptor, or [None] if it must
+     escape. Result: [(size_units_minus_1, num_allocs, alloc_nibbles,
+     reg_bitmap, word_slots)] *)
+  let short_encoding fd =
+    let flags = get_flags fd.fd_debuginfo in
+    let has_alloc = flags land 2 <> 0 in
+    let size = fd.fd_frame_size in
+    if fd.fd_long || size <= 0 || size > 1024 || size land 15 <> 0
+    then None
+    else
+      let regs, slots = partition_live_offset fd.fd_live_offset in
+      let word_slots =
+        List.filter_map
+          (fun byte_ofs ->
+            if byte_ofs land (Arch.size_addr - 1) <> 0
+            then Some None
+            else
+              let w = byte_ofs / Arch.size_addr in
+              Some (if w > 255 then None else Some w))
+          slots
+      in
+      let bad_slot = List.exists Option.is_none word_slots in
+      let word_slots = List.filter_map Fun.id word_slots in
+      if bad_slot || List.length word_slots > 255
+      then None
+      else if (not has_alloc) && not (Misc.Stdlib.List.is_empty regs)
+      then None
+      else
+        let reg_bits =
+          List.fold_left
+            (fun acc reg ->
+              match acc with
+              | None -> None
+              | Some bits -> (
+                match hot_reg_bit reg with
+                | None -> None
+                | Some b -> Some (bits lor (1 lsl b))))
+            (Some 0) regs
+        in
+        match reg_bits with
+        | None -> None
+        | Some reg_bitmap ->
+          let num_allocs, alloc_nibbles =
+            match fd.fd_debuginfo with
+            | Dbg_alloc dbg ->
+              let sizes =
+                List.map (fun Cmm.{ alloc_words; _ } -> alloc_words - 2) dbg
+              in
+              List.length sizes, sizes
+            | Dbg_other _ | Dbg_raise _ -> 0, []
+          in
+          if
+            num_allocs > 255
+            || List.exists (fun s -> s < 0 || s > 15) alloc_nibbles
+          then None
+          else
+            Some
+              ( (size / 16) - 1,
+                num_allocs,
+                alloc_nibbles,
+                reg_bitmap,
+                word_slots )
+  in
+  (* Emit a short descriptor body (after its leading delta byte/bytes). *)
+  let emit_short_body fd
+      (size_units_minus_1, num_allocs, alloc_nibbles, reg_bitmap, word_slots) =
+    let flags = get_flags fd.fd_debuginfo in
+    let has_alloc = flags land 2 <> 0 in
+    emit_u8 ((size_units_minus_1 lsl 2) lor flags);
+    if has_alloc
+    then (
+      (* reg_bitmap, num_allocs, alloc sizes, num_live *)
+      emit_u8 reg_bitmap;
+      emit_u8 num_allocs;
+      let rec emit_nibbles = function
+        | [] -> ()
+        | [a] -> emit_u8 (a land 0xf)
+        | a :: b :: rest ->
+          emit_u8 (a land 0xf lor ((b land 0xf) lsl 4));
+          emit_nibbles rest
+      in
+      emit_nibbles alloc_nibbles);
+    emit_u8 (List.length word_slots);
+    List.iter emit_u8 word_slots;
+    emit_debug_words fd
   in
   let emit_defname (_filename, defname, loc) (file_lbl, lbl) =
     let emit_loc (start_chr, end_chr, end_offset) =
@@ -351,7 +503,36 @@ let emit_frames a =
      emit the frame table in increasing return-address order. *)
   let descrs = List.rev !frame_descriptors in
   a.efa_word (List.length descrs);
-  List.iter emit_frame descrs;
+  (* Emit each descriptor preceded by retaddr delta. The first descriptor of the
+     frametable, and any descriptor that does not fit the short format, escapes:
+     a 0 delta byte followed by the existing normal/long descriptor (which
+     carries its own relative return address). A short descriptor is preceded by
+     its return-address delta from the previous descriptor, as ULEB128. *)
+  let emit_descr prev fd =
+    let escape () =
+      emit_u8 0;
+      emit_escaped_frame fd;
+      Some fd
+    in
+    if !disable_short_descriptors
+    then escape ()
+    else
+      match prev with
+      | Some prev_fd when prev_fd.fd_section = fd.fd_section -> (
+        (* Same text section as the previous descriptor, so the delta is an
+           assembly-time constant. *)
+        match short_encoding fd with
+        | Some enc ->
+          a.efa_label_delta fd.fd_lbl prev_fd.fd_lbl;
+          emit_short_body fd enc;
+          Some fd
+        | None -> escape ())
+      | Some _ | None ->
+        (* First descriptor of the frametable, or first of a new text section
+           (no same-section previous return address for a delta): escape. *)
+        escape ()
+  in
+  ignore (List.fold_left emit_descr None descrs);
   Label_table.iter emit_debuginfo debuginfos;
   (* The name structs are kept near the debuginfo words that reference them (a
      24-bit, +/-64 MB offset). Emitting them also populates [defstrings]. *)

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -187,21 +187,18 @@ let emit_frames a =
     if fd.fd_long
     then (
       emit_u16 Oxcaml_flags.max_long_frames_threshold;
-      a.efa_align 4);
+      (* Keep frame_data at offset 8 *)
+      emit_u16 0);
     let emit_unsigned_16_or_32 = if fd.fd_long then emit_u32 else emit_u16 in
     (* The live offsets are always unsigned. *)
     let emit_live_offset n = emit_unsigned_16_or_32 n in
     emit_unsigned_16_or_32 (fd.fd_frame_size + flags);
     emit_unsigned_16_or_32 (List.length fd.fd_live_offset);
     List.iter emit_live_offset fd.fd_live_offset;
-    (match fd.fd_debuginfo with
+    match fd.fd_debuginfo with
     | _ when flags = 0 -> ()
-    | Dbg_other dbg ->
-      a.efa_align 4;
-      a.efa_label_rel (label_debuginfos false dbg) Int32.zero
-    | Dbg_raise dbg ->
-      a.efa_align 4;
-      a.efa_label_rel (label_debuginfos true dbg) Int32.zero
+    | Dbg_other dbg -> a.efa_label_rel (label_debuginfos false dbg) Int32.zero
+    | Dbg_raise dbg -> a.efa_label_rel (label_debuginfos true dbg) Int32.zero
     | Dbg_alloc dbg ->
       assert (List.length dbg < 256);
       emit_u8 (List.length dbg);
@@ -215,15 +212,13 @@ let emit_frames a =
           emit_u8 (alloc_words - 2))
         dbg;
       if flags = 3
-      then (
-        a.efa_align 4;
+      then
         List.iter
           (fun Cmm.{ alloc_dbg; _ } ->
             if is_none_dbg alloc_dbg
             then emit_i32 0
             else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
-          dbg));
-    a.efa_align Arch.size_addr
+          dbg
   in
   let emit_filename name lbl =
     a.efa_def_label lbl;

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -105,7 +105,14 @@ type emit_frame_actions =
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
     efa_def_label : Label.t -> unit;
-    efa_string : string -> unit
+    efa_string : string -> unit;
+    (* Switch to / from mergeable string section, used for debuginfo filename
+       and defname strings. While it is open, [efa_def_string_label] defines a
+       label and [efa_string] emits a string; references from frametables to
+       those labels use [efa_label_rel]. *)
+    efa_open_string_section : unit -> unit;
+    efa_close_string_section : unit -> unit;
+    efa_def_string_label : Label.t -> unit
   }
 
 let emit_frames a =
@@ -160,6 +167,16 @@ let emit_frames a =
       let def_lbl = Cmm.new_label () in
       Hashtbl.add defnames (filename, defname, loc) (file_lbl, def_lbl);
       def_lbl
+  in
+  (* defname strings, each emitted once into the mergeable string section and
+     referenced from the name_info / name_and_loc_info struct. *)
+  let defstrings = Hashtbl.create 7 in
+  let label_defstring defname =
+    try Hashtbl.find defstrings defname
+    with Not_found ->
+      let lbl = Cmm.new_label () in
+      Hashtbl.add defstrings defname lbl;
+      lbl
   in
   let module Label_table = Hashtbl.Make (struct
     type t = bool * Debuginfo.Dbg.t
@@ -220,9 +237,9 @@ let emit_frames a =
             else a.efa_label_rel (label_debuginfos false alloc_dbg) Int32.zero)
           dbg
   in
-  let emit_filename name lbl =
-    a.efa_def_label lbl;
-    a.efa_string name
+  let emit_merged_string str lbl =
+    a.efa_def_string_label lbl;
+    a.efa_string str
   in
   let emit_defname (_filename, defname, loc) (file_lbl, lbl) =
     let emit_loc (start_chr, end_chr, end_offset) =
@@ -230,16 +247,16 @@ let emit_frames a =
       emit_u16 end_chr;
       emit_i32 end_offset
     in
-    (* These must be 32-bit aligned, both because they contain a 32-bit value,
-       and because emit_debuginfo assumes the low 2 bits of their addresses are
-       0. *)
+    (* The name_info / name_and_loc_info struct. Must be 32-bit aligned, because
+       the low 2 bits of its address are used for flags in debuginfo *)
     a.efa_align 4;
     a.efa_def_label lbl;
     a.efa_label_rel file_lbl 0l;
-    (* Include the additional 64-bits of location information which didn't pack
-       in the main 64-bit word *)
-    Option.iter emit_loc loc;
-    a.efa_string defname
+    (* [defname_offs] relative to the start of the struct, so offset by 4 *)
+    a.efa_label_rel (label_defstring defname) 4l;
+    (* Then the extra 64 bits of location info that didn't pack into the main
+       debuginfo word (name_and_loc_info only). *)
+    Option.iter emit_loc loc
   in
   let fully_pack_info fd_raise d has_next =
     (* See format in caml_debuginfo_location in runtime/backtrace-nat.c *)
@@ -331,9 +348,15 @@ let emit_frames a =
   a.efa_word (List.length !frame_descriptors);
   List.iter emit_frame !frame_descriptors;
   Label_table.iter emit_debuginfo debuginfos;
-  Hashtbl.iter emit_filename filenames;
+  (* The name structs are kept near the debuginfo words that reference them (a
+     24-bit, +/-64 MB offset). Emitting them also populates [defstrings]. *)
   Hashtbl.iter emit_defname defnames;
   a.efa_align Arch.size_addr;
+  (* Strings go into a mergeable string section to be de-duped by the linker *)
+  a.efa_open_string_section ();
+  Hashtbl.iter emit_merged_string filenames;
+  Hashtbl.iter emit_merged_string defstrings;
+  a.efa_close_string_section ();
   frame_descriptors := []
 
 (* Detection of functions that can be duplicated between a DLL and the main

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -345,8 +345,13 @@ let emit_frames a =
     in
     match rdbg with [] -> assert false | d :: rest -> emit rs d rest
   in
-  a.efa_word (List.length !frame_descriptors);
-  List.iter emit_frame !frame_descriptors;
+  (* Descriptors are recorded in increasing return-address order (calls inline
+     as they are emitted; allocations and polls when their out-of-line GC stub
+     is emitted), so the prepended list is in decreasing order. Reverse it to
+     emit the frame table in increasing return-address order. *)
+  let descrs = List.rev !frame_descriptors in
+  a.efa_word (List.length descrs);
+  List.iter emit_frame descrs;
   Label_table.iter emit_debuginfo debuginfos;
   (* The name structs are kept near the debuginfo words that reference them (a
      24-bit, +/-64 MB offset). Emitting them also populates [defstrings]. *)

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -52,6 +52,19 @@ val record_frame_descr :
   (* Location, if any *)
   unit
 
+(** Signals that subsequent frame descriptors' return addresses live in a new
+    text section. A "short" frame descriptor encodes its return address as a
+    delta from the previous descriptor's; that delta is only an assembly-time
+    constant when both are in the same section, so descriptors at a section
+    boundary escape to the full format. The backends call this whenever they
+    switch text section. *)
+val start_new_code_section : unit -> unit
+
+(* When set before [emit_frames], every frame descriptor escapes to the normal
+   format instead of the short encoding. Backends set this when the short format
+   cannot be emitted (the internal-assembler / JIT binary backend; ARM64). *)
+val disable_short_descriptors : bool ref
+
 (** [with_snapshot f] runs [f] and returns its result, but also ensures that the
     state of this [Emitaux] module is unchanged after [f] returns. *)
 val with_snapshot : f:(unit -> 'a) -> 'a
@@ -68,6 +81,7 @@ type emit_frame_actions =
     efa_word : int -> unit;
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
+    efa_label_delta : Label.t -> Label.t -> unit;
     efa_def_label : Label.t -> unit;
     efa_string : string -> unit;
     (* Switch to / from mergeable string section, used for debuginfo filename

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -69,7 +69,14 @@ type emit_frame_actions =
     efa_align : int -> unit;
     efa_label_rel : Label.t -> int32 -> unit;
     efa_def_label : Label.t -> unit;
-    efa_string : string -> unit
+    efa_string : string -> unit;
+    (* Switch to / from mergeable string section, used for debuginfo filename
+       and defname strings. While it is open, [efa_def_string_label] defines a
+       label and [efa_string] emits a string; references from frametables to
+       those labels use [efa_label_rel]. *)
+    efa_open_string_section : unit -> unit;
+    efa_close_string_section : unit -> unit;
+    efa_def_string_label : Label.t -> unit
   }
 
 val emit_frames : emit_frame_actions -> unit

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1985,7 +1985,10 @@ let write_module_metadata t =
   in
   F.pp_line t.ppf "";
   F.pp_line t.ppf {|!0 = !{ i32 1, !"oxcaml_module", !"%s" }|} module_name;
-  F.pp_line t.ppf {|!llvm.module.flags = !{ !0 }|}
+  (* Tell LLVM's frametable printer to emit the short (escape-byte, unpadded)
+     frame-descriptor format expected by this runtime. *)
+  F.pp_line t.ppf {|!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }|};
+  F.pp_line t.ppf {|!llvm.module.flags = !{ !0, !1 }|}
 
 let write_llvmir_to_file t =
   (match t.sourcefile with

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -1626,6 +1626,16 @@ let assemble_line b loc ins =
             buf_int8 b 0
           done
     | Directive (D.Hidden _) | Directive D.New_line -> ()
+    | Directive (D.Frame_descr_delta _) ->
+      (* The internal assembler does not support the short frame-descriptor
+         format's return-address delta, so the compiler escapes every
+         descriptor when the internal-assembler backend is active (see
+         [Emitaux.disable_short_descriptors]); this directive is therefore
+         never emitted here. TODO: fix this. Claude tried and failed
+         2026-06-30. *)
+      Misc.fatal_error
+        "x86_binary_emitter: Frame_descr_delta unsupported (short descriptors \
+         must be escaped under the internal assembler)"
     | Directive
         (D.Reloc
           { name = D.R_X86_64_PLT32;

--- a/backend/x86_peephole/x86_peephole_utils.ml
+++ b/backend/x86_peephole/x86_peephole_utils.ml
@@ -29,7 +29,7 @@ let is_hard_barrier = function
     | Comment _ | Const _ | Direct_assignment _ | File _ | Global _
     | Indirect_symbol _ | Loc _ | New_line | Private_extern _ | Size _
     | Sleb128 _ | Space _ | Type _ | Uleb128 _ | Protected _ | Hidden _ | Weak _
-    | External _ | Reloc _ ->
+    | External _ | Reloc _ | Frame_descr_delta _ ->
       false)
   | Ins instr -> is_control_flow instr
 

--- a/oxcaml/tests/backend/llvmize/alloc_ir.output
+++ b/oxcaml/tests/backend/llvmize/alloc_ir.output
@@ -1180,4 +1180,5 @@ declare i1 @llvm.expect.i1(i1, i1)
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Alloc" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/array_rev_ir.output
+++ b/oxcaml/tests/backend/llvmize/array_rev_ir.output
@@ -296,4 +296,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Array_rev" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/const_val_ir.output
+++ b/oxcaml/tests/backend/llvmize/const_val_ir.output
@@ -47,4 +47,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Const_val" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/csel_ir.output
+++ b/oxcaml/tests/backend/llvmize/csel_ir.output
@@ -622,4 +622,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Csel" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/data_decl_ir.output
+++ b/oxcaml/tests/backend/llvmize/data_decl_ir.output
@@ -546,4 +546,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Data_decl" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/dls_get.output
+++ b/oxcaml/tests/backend/llvmize/dls_get.output
@@ -111,4 +111,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Dls_get" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -2180,4 +2180,5 @@ module asm "  movq camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_var.L428
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Exn_part2" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/extcalls_ir.output
+++ b/oxcaml/tests/backend/llvmize/extcalls_ir.output
@@ -562,4 +562,5 @@ module asm "  movq camlExtcalls__call_too_many_with_try_HIDE_STAMP.recover_rbp_v
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Extcalls" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/float_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/float_ops_ir.output
@@ -342,4 +342,5 @@ declare double @llvm.fabs.double(double)
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Float_ops" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/gcd_ir.output
+++ b/oxcaml/tests/backend/llvmize/gcd_ir.output
@@ -236,4 +236,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Gcd" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/id_fn.output
+++ b/oxcaml/tests/backend/llvmize/id_fn.output
@@ -74,4 +74,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Id_fn" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/indirect_call_ir.output
+++ b/oxcaml/tests/backend/llvmize/indirect_call_ir.output
@@ -105,4 +105,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Indirect_call" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/int_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/int_ops_ir.output
@@ -1538,4 +1538,5 @@ declare i64 @llvm.cttz.i64(i64, i1)
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Int_ops" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/many_args_ir.output
+++ b/oxcaml/tests/backend/llvmize/many_args_ir.output
@@ -170,4 +170,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Many_args" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/multi_ret_ir.output
+++ b/oxcaml/tests/backend/llvmize/multi_ret_ir.output
@@ -104,4 +104,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Multi_ret" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/switch_ir.output
+++ b/oxcaml/tests/backend/llvmize/switch_ir.output
@@ -2132,4 +2132,5 @@ module asm "  movq camlSwitch__entry.recover_rbp_var.L367(%rip), %rbx"
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Switch" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/tailcall_ir.output
+++ b/oxcaml/tests/backend/llvmize/tailcall_ir.output
@@ -965,4 +965,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Tailcall" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 1 }
+!llvm.module.flags = !{ !0, !1 }

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1770,6 +1770,15 @@ G(caml_system__frametable):
         .value  -1                      /* negative frame size => use callback link */
         .value  0                       /* no roots here */
 
+/* Contribute this hand-written frametable to the linker-collected
+   caml_all_frametables table, so the runtime "measure all frametables" pass
+   sees it alongside the compiler-emitted ones. ELF targets only. */
+#if !defined(SYS_macosx) && !defined(SYS_mingw64) && !defined(SYS_cygwin)
+        .section caml_all_frametables,"aw",@progbits
+        .align  EIGHT_ALIGN
+        .quad   G(caml_system__frametable)
+#endif
+
 #if defined(SYS_macosx)
         .literal16
 #elif defined(SYS_mingw64) || defined(SYS_cygwin)

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1762,9 +1762,15 @@ G(caml_system__code_end):
         .align  EIGHT_ALIGN
 G(caml_system__frametable):
         .quad   2            /* two descriptors */
+        /* Each descriptor is preceded by a "delta" byte. These return-to-C
+           descriptors do not fit the "short" format, so each escapes: a 0
+           delta byte followed by a descriptor in the normal format (which
+           carries its own absolute return address). See frame_descriptors.h. */
+        .byte   0            /* escape: normal descriptor follows */
         .4byte  LBL(108) - . /* return address into callback */
         .value  -1           /* negative frame size => use callback link */
         .value  0            /* no roots here */
+        .byte   0            /* escape: normal descriptor follows */
         .4byte  LBL(frame_runstack) - . /* return address into fiber_val_handler */
         .value  -1                      /* negative frame size => use callback link */
         .value  0                       /* no roots here */

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -1765,7 +1765,6 @@ G(caml_system__frametable):
         .4byte  LBL(108) - . /* return address into callback */
         .value  -1           /* negative frame size => use callback link */
         .value  0            /* no roots here */
-        .align  EIGHT_ALIGN
         .4byte  LBL(frame_runstack) - . /* return address into fiber_val_handler */
         .value  -1                      /* negative frame size => use callback link */
         .value  0                       /* no roots here */

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -1570,9 +1570,15 @@ G(caml_system__code_end):
 /* Uses the same naming convention as ocamlopt generated modules. */
 OBJECT(CAMLSEP(system,frametable))
         .quad   2                   /* two descriptors */
+        /* Each descriptor is preceded by a "delta" byte. These return-to-C
+           descriptors do not fit the "short" format, so each escapes: a 0
+           delta byte followed by a descriptor in the normal format (which
+           carries its own absolute return address). See frame_descriptors.h. */
+        .byte   0                   /* escape: normal descriptor follows */
         .4byte  L(caml_retaddr) - . /* return address into callback */
         .short  -1                  /* negative frame size => use callback link */
         .short  0                   /* no roots */
+        .byte   0                   /* escape: normal descriptor follows */
         .4byte  L(frame_runstack) - . /* return address into fiber handler */
         .short  -1                    /* negative frame size => use callback link */
         .short  0                     /* no roots here */

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -1573,11 +1573,9 @@ OBJECT(CAMLSEP(system,frametable))
         .4byte  L(caml_retaddr) - . /* return address into callback */
         .short  -1                  /* negative frame size => use callback link */
         .short  0                   /* no roots */
-        .align  3
         .4byte  L(frame_runstack) - . /* return address into fiber handler */
         .short  -1                    /* negative frame size => use callback link */
         .short  0                     /* no roots here */
-        .align 3
         END_OBJECT(CAMLSEP(system,frametable))
 
         NONEXECSTACK_NOTE

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -609,3 +609,21 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
   /* No inlining in bytecode */
   return NULL;
 }
+
+/* In the bytecode runtime, we don't measure frametables or debuginfo */
+
+void caml_debuginfo_reset(void)
+{
+}
+
+void caml_debuginfo_measure(debuginfo dbg)
+{
+  (void)dbg;
+}
+
+void caml_debuginfo_measurements(size_t *count_p, char **low_p, char **high_p)
+{
+  (void)count_p;
+  (void)low_p;
+  (void)high_p;
+}

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -360,21 +360,23 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
     return (debuginfo*)(infoptr + 2);
 }
 
-/* Multiple names may share the same filename,
-   so it is referenced as an offset instead of stored inline */
+/* the filename and defname are stored out of line, as offsets
+   relative to the struct, so that identical strings can be
+   deduplicated across compilation units by the linker. The offsets
+   are signed 32-bit from the base of the struct.. */
 struct name_info {
   int32_t filename_offs;
-  char name[]; /* flexible array member */
+  int32_t defname_offs;
 };
 
 /* Extended version of name_info including location fields which didn't fit
    in the main debuginfo word. */
 struct name_and_loc_info {
   int32_t filename_offs;
+  int32_t defname_offs; /* immediately after filename_offs, as in name_info */
   uint16_t start_chr;
   uint16_t end_chr;
   int32_t end_offset; /* End character position relative to start bol */
-  char name[]; /* flexible array member */
 };
 
 /* Extract location information for the given frame descriptor */
@@ -423,7 +425,9 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   if (info2 & 0x80000000) {
     struct name_and_loc_info * name_and_loc_info =
       (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
-    li->loc_defname = name_and_loc_info->name;
+    li->loc_defname =
+      (char *)name_and_loc_info
+      + caml_read_unaligned_int32(&name_and_loc_info->defname_offs);
     li->loc_filename =
       (char *)name_and_loc_info
       + caml_read_unaligned_int32(&name_and_loc_info->filename_offs);
@@ -436,7 +440,9 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
   } else {
     struct name_info * name_info =
       (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
-    li->loc_defname = name_info->name;
+    li->loc_defname =
+      (char *)name_info
+      + caml_read_unaligned_int32(&name_info->defname_offs);
     li->loc_filename =
       (char *)name_info
       + caml_read_unaligned_int32(&name_info->filename_offs);
@@ -482,21 +488,20 @@ static void include_high(char *high)
 }
 
 
-static void include_string(char *s)
-{
-  include_low(s);
-  include_high(s + strlen(s) + 1);
-}
-
 void caml_debuginfo_measure(debuginfo dbg)
 {
   uint32_t info1, info2;
 
-  /* Control flow to match caml_debuginfo_location */
+  /* Control flow to match caml_debuginfo_location. For each debuginfo record
+     we bump the record count and bracket the referenced
+     name_info/name_and_loc_info struct into [debuginfo_low, debuginfo_high).
+     The debuginfo words themselves are accounted for by the count (each record
+     is two 32-bit words); only the structs contribute to the low/high span.
+     The defname and filename strings are not measured: they are de-duped by the
+     linker, so cannot be attributed to a single frametable. */
   if (dbg == NULL) {
     return;
   }
-  include_low((char*)dbg);
 
   do {
     info1 = caml_read_unaligned_uint32(dbg);
@@ -507,21 +512,15 @@ void caml_debuginfo_measure(debuginfo dbg)
       struct name_and_loc_info * name_and_loc_info =
         (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
       include_low((char*)name_and_loc_info);
-      include_string(name_and_loc_info->name);
-      include_string((char *)name_and_loc_info
-                     + caml_read_unaligned_int32(
-                         &name_and_loc_info->filename_offs));
+      include_high((char*)name_and_loc_info + sizeof(struct name_and_loc_info));
     } else {
       struct name_info * name_info =
         (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
       include_low((char*)name_info);
-      include_string(name_info->name);
-      include_string((char *)name_info
-                     + caml_read_unaligned_int32(&name_info->filename_offs));
+      include_high((char*)name_info + sizeof(struct name_info));
     }
     dbg = (debuginfo)((uint32_t*)dbg + 2);
   } while (info1 & 1);
-  include_high(dbg);
 }
 
 value caml_add_debug_info(backtrace_slot start, value size, value events)

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -311,14 +311,14 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
     /* find debug info for this allocation */
     if (alloc_idx >= 0) {
       infoptr += alloc_idx * sizeof(uint32_t);
-      if (*(uint32_t*)infoptr == 0) {
+      if (caml_read_unaligned_uint32(infoptr) == 0) {
         /* No debug info for this particular allocation */
         return NULL;
       }
     } else {
       /* we know there's at least one valid debuginfo,
          but it may not be the one for the first alloc */
-      while (*(uint32_t*)infoptr == 0) {
+      while (caml_read_unaligned_uint32(infoptr) == 0) {
         infoptr += sizeof(uint32_t);
       }
     }
@@ -328,7 +328,7 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
     CAMLassert(alloc_idx == -1);
   }
   /* read offset to debuginfo */
-  debuginfo_offset = *(uint32_t*)infoptr;
+  debuginfo_offset = caml_read_unaligned_uint32(infoptr);
   return (debuginfo)(infoptr + debuginfo_offset);
 }
 
@@ -350,7 +350,7 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
     return NULL;
 
   infoptr = dbg;
-  if ((infoptr[0] & 1) == 0)
+  if ((caml_read_unaligned_uint32(infoptr) & 1) == 0)
     /* No next debuginfo */
     return NULL;
   else
@@ -390,8 +390,8 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
     return;
   }
   /* Recover debugging info */
-  info1 = ((uint32_t *)dbg)[0];
-  info2 = ((uint32_t *)dbg)[1];
+  info1 = caml_read_unaligned_uint32(dbg);
+  info2 = caml_read_unaligned_uint32((const uint32_t *)dbg + 1);
   /* Format of the two info words:
      Two possible formats based on value of bit 63:
      Partially packed format
@@ -423,18 +423,21 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
       (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
     li->loc_defname = name_and_loc_info->name;
     li->loc_filename =
-      (char *)name_and_loc_info + name_and_loc_info->filename_offs;
+      (char *)name_and_loc_info
+      + caml_read_unaligned_int32(&name_and_loc_info->filename_offs);
     li->loc_start_lnum = li->loc_end_lnum = (info2 >> 12) & 0x7FFFF;
     li->loc_end_lnum += ((info2 & 0xFFF) << 6) | (info1 >> 26);
-    li->loc_start_chr = name_and_loc_info->start_chr;
-    li->loc_end_chr = name_and_loc_info->end_chr;
-    li->loc_end_offset = name_and_loc_info->end_offset;
+    li->loc_start_chr = caml_read_unaligned_uint16(&name_and_loc_info->start_chr);
+    li->loc_end_chr = caml_read_unaligned_uint16(&name_and_loc_info->end_chr);
+    li->loc_end_offset =
+      caml_read_unaligned_int32(&name_and_loc_info->end_offset);
   } else {
     struct name_info * name_info =
       (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
     li->loc_defname = name_info->name;
     li->loc_filename =
-      (char *)name_info + name_info->filename_offs;
+      (char *)name_info
+      + caml_read_unaligned_int32(&name_info->filename_offs);
     li->loc_start_lnum = li->loc_end_lnum = info2 >> 19;          /* l */
     li->loc_end_lnum += (info2 >> 16) & 0x7;                      /* m */
     li->loc_start_chr = (info2 >> 10) & 0x3F;                     /* a */
@@ -494,8 +497,8 @@ void caml_debuginfo_measure(debuginfo dbg)
   include_low((char*)dbg);
 
   do {
-    info1 = ((uint32_t *)dbg)[0];
-    info2 = ((uint32_t *)dbg)[1];
+    info1 = caml_read_unaligned_uint32(dbg);
+    info2 = caml_read_unaligned_uint32((const uint32_t *)dbg + 1);
     ++debuginfo_count;
 
     if (info2 & 0x80000000) {
@@ -504,14 +507,15 @@ void caml_debuginfo_measure(debuginfo dbg)
       include_low((char*)name_and_loc_info);
       include_string(name_and_loc_info->name);
       include_string((char *)name_and_loc_info
-                     + name_and_loc_info->filename_offs);
+                     + caml_read_unaligned_int32(
+                         &name_and_loc_info->filename_offs));
     } else {
       struct name_info * name_info =
         (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
       include_low((char*)name_info);
       include_string(name_info->name);
       include_string((char *)name_info
-                     + name_info->filename_offs);
+                     + caml_read_unaligned_int32(&name_info->filename_offs));
     }
     dbg = (debuginfo)((uint32_t*)dbg + 2);
   } while (info1 & 1);

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -83,12 +83,18 @@ void caml_free_backtrace_buffer(backtrace_slot *backtrace_buffer) {
     caml_stat_free(backtrace_buffer);
 }
 
-/* A backtrace_slot is either a debuginfo or a frame_descr* */
+/* A backtrace_slot is either a frame_descr* or a debuginfo. Both are encoded
+   with the address shifted left two bits, leaving the low two bits free for a
+   tag: bit 1 distinguishes a debuginfo (set) from a frame_descr (clear), and
+   bit 0 is kept clear so the [>>1] in [Val_backtrace_slot] still round-trips
+   (and the bytecode backtrace encoding is unaffected). The shift means frame
+   descriptors no longer need to be aligned. 64-bit only: there are ample
+   spare high bits for the shift. */
 #define Slot_is_debuginfo(s) ((uintnat)(s) & 2)
-#define Debuginfo_slot(s) ((debuginfo)((uintnat)(s) - 2))
-#define Slot_debuginfo(d) ((backtrace_slot)((uintnat)(d) + 2))
-#define Frame_descr_slot(s) ((frame_descr*)(s))
-#define Slot_frame_descr(f) ((backtrace_slot)(f))
+#define Debuginfo_slot(s) ((debuginfo)((uintnat)(s) >> 2))
+#define Slot_debuginfo(d) ((backtrace_slot)(((uintnat)(d) << 2) | 2))
+#define Frame_descr_slot(s) ((frame_descr*)((uintnat)(s) >> 2))
+#define Slot_frame_descr(f) ((backtrace_slot)((uintnat)(f) << 2))
 
 static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx);
 
@@ -126,7 +132,7 @@ void caml_stash_backtrace(value exn, uintnat pc, char * sp, const char* trapsp)
     /* store its descriptor in the backtrace buffer */
     if (domain_state->backtrace_pos >= BACKTRACE_BUFFER_SIZE) return;
     domain_state->backtrace_buffer[domain_state->backtrace_pos++] =
-      (backtrace_slot) descr;
+      Slot_frame_descr(descr);
 
     /* Stop when we reach the current exception handler */
     if (sp > trapsp) return;
@@ -306,8 +312,6 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
   if (frame_has_allocs(d)) {
     /* skip alloc_lengths */
     infoptr += *infoptr + 1;
-    /* align to 32 bits */
-    infoptr = Align_to(infoptr, uint32_t);
     /* find debug info for this allocation */
     if (alloc_idx >= 0) {
       infoptr += alloc_idx * sizeof(uint32_t);
@@ -323,8 +327,6 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
       }
     }
   } else {
-    /* align to 32 bits */
-    infoptr = Align_to(infoptr, uint32_t);
     CAMLassert(alloc_idx == -1);
   }
   /* read offset to debuginfo */

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -435,12 +435,87 @@ void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li)
     li->loc_defname = name_info->name;
     li->loc_filename =
       (char *)name_info + name_info->filename_offs;
-    li->loc_start_lnum = li->loc_end_lnum = info2 >> 19;
-    li->loc_end_lnum += (info2 >> 16) & 0x7;
-    li->loc_start_chr = (info2 >> 10) & 0x3F;
-    li->loc_end_chr = li->loc_end_offset = (info2 >> 3) & 0x7F;
-    li->loc_end_offset += (((info2 & 0x7) << 6) | (info1 >> 26));
+    li->loc_start_lnum = li->loc_end_lnum = info2 >> 19;          /* l */
+    li->loc_end_lnum += (info2 >> 16) & 0x7;                      /* m */
+    li->loc_start_chr = (info2 >> 10) & 0x3F;                     /* a */
+    li->loc_end_chr = li->loc_end_offset = (info2 >> 3) & 0x7F;   /* b */
+    li->loc_end_offset += (((info2 & 0x7) << 6) | (info1 >> 26)); /* o */
   }
+}
+
+/* ---- Debuginfo measurement ---- */
+
+static size_t debuginfo_count = 0; /* Number of debuginfo records seen */
+static void* debuginfo_low = NULL; /* lowest address seen */
+static void* debuginfo_high = NULL; /* highest address seen */
+
+void caml_debuginfo_reset(void)
+{
+  debuginfo_count = 0;
+  debuginfo_low = NULL;
+  debuginfo_high = NULL;
+}
+
+void caml_debuginfo_measurements(size_t *count_p, char **low_p, char **high_p)
+{
+  *count_p = debuginfo_count;
+  *low_p = debuginfo_low;
+  *high_p = debuginfo_high;
+  caml_debuginfo_reset();
+}
+
+static void include_low(char *low)
+{
+  if ((debuginfo_low == NULL) || (low < (char *)debuginfo_low))
+    debuginfo_low = low;
+}
+
+static void include_high(char *high)
+{
+  if ((debuginfo_high == NULL) || (high > (char *)debuginfo_high))
+    debuginfo_high = high;
+}
+
+
+static void include_string(char *s)
+{
+  include_low(s);
+  include_high(s + strlen(s) + 1);
+}
+
+void caml_debuginfo_measure(debuginfo dbg)
+{
+  uint32_t info1, info2;
+
+  /* Control flow to match caml_debuginfo_location */
+  if (dbg == NULL) {
+    return;
+  }
+  include_low((char*)dbg);
+
+  do {
+    info1 = ((uint32_t *)dbg)[0];
+    info2 = ((uint32_t *)dbg)[1];
+    ++debuginfo_count;
+
+    if (info2 & 0x80000000) {
+      struct name_and_loc_info * name_and_loc_info =
+        (struct name_and_loc_info*)((char *) dbg + (info1 & 0x3FFFFFC));
+      include_low((char*)name_and_loc_info);
+      include_string(name_and_loc_info->name);
+      include_string((char *)name_and_loc_info
+                     + name_and_loc_info->filename_offs);
+    } else {
+      struct name_info * name_info =
+        (struct name_info*)((char *) dbg + (info1 & 0x3FFFFFC));
+      include_low((char*)name_info);
+      include_string(name_info->name);
+      include_string((char *)name_info
+                     + name_info->filename_offs);
+    }
+    dbg = (debuginfo)((uint32_t*)dbg + 2);
+  } while (info1 & 1);
+  include_high(dbg);
 }
 
 value caml_add_debug_info(backtrace_slot start, value size, value events)

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -298,6 +298,7 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
 {
   unsigned char* infoptr;
   uint32_t debuginfo_offset;
+  struct frame_descr_decoded dec;
 
   /* The special frames marking returns from Caml to C are never
      returned by caml_next_frame_descriptor, so should never reach
@@ -307,11 +308,16 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx)
   if (!frame_has_debug(d)) {
     return NULL;
   }
-  /* Recover debugging info */
-  infoptr = frame_end_of_live_ofs(d);
+  /* Recover debugging info. The debug words begin right after the live
+     offsets (short format) or after the alloc lengths (escaped format);
+     [caml_decode_frame_descr] gives us the precise start. */
+  caml_decode_frame_descr(d, &dec);
+  infoptr = (unsigned char *)dec.end_of_live;
   if (frame_has_allocs(d)) {
-    /* skip alloc_lengths */
-    infoptr += *infoptr + 1;
+    if (!dec.is_short) {
+      /* escaped: skip the num_allocs byte and the alloc bytes */
+      infoptr += *infoptr + 1;
+    }
     /* find debug info for this allocation */
     if (alloc_idx >= 0) {
       infoptr += alloc_idx * sizeof(uint32_t);

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -69,6 +69,13 @@ debuginfo caml_debuginfo_next(debuginfo dbg);
 /* Extract locations from backtrace_slot */
 void caml_debuginfo_location(debuginfo dbg, /*out*/ struct caml_loc_info * li);
 
+/* Measuring debuginfo, when Xmeasure_frametables=1 */
+void caml_debuginfo_reset(void);
+void caml_debuginfo_measure(debuginfo dbg);
+/* Return the number of debuginfos measured, and the lowest and
+ * highest addresses seen */
+void caml_debuginfo_measurements(size_t *count_p, char **low_p, char **high_p);
+
 /* In order to prevent the GC from walking through the debug
    information (which have no headers), we transform slots to 31/63 bits
    ocaml integers by shifting them by 1 to the right. We do not lose

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -59,10 +59,56 @@
  * [caml_read_unaligned_*]. This allows all alignment restrictions to
  * be relaxed.
  *
- * There are two layouts; the field at offset 4 tells them apart (a uint16
- * equal to FRAME_LONG_MARKER means long):
+ * Within a frametable, descriptors are concatenated in increasing
+ * return-address order.
  *
- *  normal:                      long:
+ * There are three descriptor layouts: "short", "medium", and "long".
+ *
+ * A short descriptor is preceded by a "delta" field encoding the
+ * difference between this descriptor's return address and the
+ * previous one's. The delta is an unsigned LEB128 value, >= 1.  The
+ * return address is the previous descriptor's plus the delta. We use
+ * LEB128 as it is efficient and supported by the assembler.
+ *
+ * Any descriptor not fitting the constraints of the "short" layout
+ * begins with a zero byte (FRAME_DELTA_ESCAPE). Since a zero "delta"
+ * is impossible, this marks it as non-short ("medium" or "long", see
+ * below). This includes the first descriptor of any frametable (no
+ * previous return address), and the first descriptor in any section.
+ *
+ * "Short" layout:
+ *
+ * A [frame_descr *] for a short descriptor points to the byte _after_
+ * the delta. It can be distinguished by the _preceding_ byte being
+ * non-zero (the last byte of an ULEB128 value cannot be zero). A
+ * short-descriptor body is:
+ *
+ *   (1) size+flags byte: top 6 bits = (frame_size_in_16-byte_units - 1):
+ *       value 0..63 means 1..64 units, i.e. 16..1024 bytes. Bottom
+ *       two bits are the flags (FRAME_DESCRIPTOR_ALLOC | _DEBUG).
+ *
+ *   (2) if alloc:
+ *          uint8  reg_bitmap;  bit i set => register HOT_REGS[i] is live
+ *          uint8  num_allocs;
+ *          uint8  alloc_sizes[ceil(num_allocs/2)];  4 bits each,
+ *                                                     low nibble first
+ *
+ *   (3) uint8 num_live;  (live scannable STACK slots)
+ *
+ *   (4) uint8 stack_word_ofs[num_live]; each a live stack-slot WORD
+ *       offset (byte offset / word size) into the frame.
+ *
+ *   (5) if debug: uint32_t debug_info[alloc ? num_allocs : 1]; as for
+ *       the medium/long layouts.
+ *
+ * "Medium" and "Long" layouts:
+ *
+ * A [frame_descr *] byte points to the byte following the ESCAPE
+ * byte, from which the descriptor is laid out as either "medium" or
+ * "long" as follows; the field at offset 4 tells them apart (a
+ * uint16 equal to FRAME_LONG_MARKER means long):
+ *
+ *  medium:                      long:
  *    int32  retaddr_rel  @ 0      int32  retaddr_rel  @ 0
  *    uint16 frame_data   @ 4      uint16 marker       @ 4: FRAME_LONG_MARKER
  *    uint16 num_live     @ 6      uint16 _pad         @ 6
@@ -92,7 +138,23 @@ typedef unsigned char frame_descr;
 #define FRAME_RETURN_TO_C 0xFFFF
 #define FRAME_LONG_MARKER 0x7FFF
 
-/* Field byte offsets within a descriptor (normal and long). */
+#define FRAME_DELTA_ESCAPE 0
+
+/* The eight most common GC-root registers, by measurement. The
+ * compiler (hot_regs in backend/emitaux.ml) and the runtime must
+ * agree on this table: a mismatch causes heap corruption. The GC maps
+ * bit-index -> register-number (this forward table); the compiler
+ * maps register-number -> bit-index.
+ *
+ * TODO: when short descriptors are ported to ARM64, measure there to
+ * choose the hot register numbers, and make this
+ * architcture-specific */
+
+#define FRAME_NUM_HOT_REGS 8
+CAMLunused static const unsigned char
+  caml_frame_hot_regs[FRAME_NUM_HOT_REGS] = { 0, 1, 2, 3, 4, 5, 6, 8 };
+
+/* Field byte offsets within an escaped descriptor body (medium and long). */
 #define Frame_retaddr_rel_ofs   0
 #define Frame_data_ofs          4
 #define Frame_num_live_ofs      6
@@ -101,16 +163,63 @@ typedef unsigned char frame_descr;
 #define Frame_long_num_live_ofs 12
 #define Frame_long_live_ofs     16
 
+Caml_inline bool frame_is_short(frame_descr *d) {
+  return ((const unsigned char *)d)[-1] != FRAME_DELTA_ESCAPE;
+}
+
+/* The size+flags byte of a short descriptor. */
+Caml_inline unsigned char frame_short_sizeflags(frame_descr *d) {
+  return ((const unsigned char *)d)[0];
+}
+
+/* Decoded form of one descriptor (short or escaped). [body] points at
+ * the size+flags byte (short) or the [frame_descr] struct (escaped). */
+struct frame_descr_decoded {
+  bool is_short;
+  bool return_to_C;
+  bool is_long;
+  bool has_allocs;
+  bool has_debug;
+  uint32_t frame_size;   /* in bytes */
+  uint32_t num_live;     /* short: live stack slots; escaped: live_ofs[] */
+  /* For short descriptors only: */
+  const unsigned char *short_allocs;  /* alloc_sizes[] (4-bit nibbles) */
+  uint8_t short_num_allocs;
+  uint8_t short_reg_bitmap;
+  const unsigned char *short_live;    /* stack_word_ofs[num_live] */
+  /* The byte just past the live_ofs / stack offsets, i.e. where the
+   * alloc-count (escaped) or the debug words begin. */
+  const unsigned char *end_of_live;
+  /* For escaped descriptors: num debuginfo words (= num_allocs or 1). */
+  uint32_t num_debuginfo;
+  /* One past the whole descriptor body (start of the next delta byte). */
+  const unsigned char *end;
+};
+
+void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out);
+
 Caml_inline bool frame_return_to_C(frame_descr *d) {
+  if (frame_is_short(d)) return false;
   return caml_read_unaligned_uint16(d + Frame_data_ofs) == FRAME_RETURN_TO_C;
 }
 
 Caml_inline bool frame_is_long(frame_descr *d) {
   CAMLassert(d && !frame_return_to_C(d));
+  if (frame_is_short(d)) return false;
   return (caml_read_unaligned_uint16(d + Frame_data_ofs) == FRAME_LONG_MARKER);
 }
 
+/* Frame size in bytes of a short descriptor, from its size+flags byte:
+   top 6 bits hold (size_in_16-byte_units - 1). */
+Caml_inline uint32_t frame_short_size(frame_descr *d) {
+  return (((uint32_t)(frame_short_sizeflags(d) >> 2)) + 1) * 16;
+}
+
 Caml_inline uint32_t frame_data(frame_descr *d) {
+  if (frame_is_short(d)) {
+    /* Reconstruct an equivalent normal frame_data: size | flags. */
+    return frame_short_size(d) | (frame_short_sizeflags(d) & FRAME_DESCRIPTOR_FLAGS);
+  }
   if (frame_is_long(d)) {
     return caml_read_unaligned_uint32(d + Frame_long_data_ofs);
   } else {
@@ -118,7 +227,32 @@ Caml_inline uint32_t frame_data(frame_descr *d) {
   }
 }
 
+Caml_inline uint32_t frame_size(frame_descr *d) {
+  if (frame_is_short(d)) return frame_short_size(d);
+  return frame_data(d) &~ FRAME_DESCRIPTOR_FLAGS;
+}
+
+Caml_inline bool frame_has_allocs(frame_descr *d) {
+  if (frame_is_short(d))
+    return (frame_short_sizeflags(d) & FRAME_DESCRIPTOR_ALLOC) != 0;
+  return (frame_data(d) & FRAME_DESCRIPTOR_ALLOC) != 0;
+}
+
+Caml_inline bool frame_has_debug(frame_descr *d) {
+  if (frame_is_short(d))
+    return (frame_short_sizeflags(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
+  return (frame_data(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
+}
+
+/* End of the live-offset region: where alloc lengths / debug words begin.
+ * For short descriptors this is past the stack-slot offset bytes; for
+ * escaped descriptors it is past live_ofs[]. */
 Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
+  if (frame_is_short(d)) {
+    struct frame_descr_decoded dec;
+    caml_decode_frame_descr(d, &dec);
+    return (unsigned char *)dec.end_of_live;
+  }
   if (frame_is_long(d)) {
     uint32_t num_live = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
     return d + Frame_long_live_ofs + (uintnat)num_live * sizeof(uint32_t);
@@ -126,18 +260,6 @@ Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
     uint16_t num_live = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
     return d + Frame_live_ofs + (uintnat)num_live * sizeof(uint16_t);
   }
-}
-
-Caml_inline uint32_t frame_size(frame_descr *d) {
-  return frame_data(d) &~ FRAME_DESCRIPTOR_FLAGS;
-}
-
-Caml_inline bool frame_has_allocs(frame_descr *d) {
-  return (frame_data(d) & FRAME_DESCRIPTOR_ALLOC) != 0;
-}
-
-Caml_inline bool frame_has_debug(frame_descr *d) {
-  return (frame_data(d) & FRAME_DESCRIPTOR_DEBUG) != 0;
 }
 
 /* Allocation lengths are encoded reduced by one, so values 0-255 mean
@@ -154,8 +276,7 @@ Caml_inline bool frame_has_debug(frame_descr *d) {
   ((((uintnat)(addr) * 52437813) >> 5) & (mask))
 
 #define Retaddr_frame(d) \
-  ((uintnat)(d) + \
-   (uintnat)(intnat)caml_read_unaligned_int32(d))
+  ((uintnat)(d) + (uintnat)(intnat)caml_read_unaligned_int32(d))
 
 void caml_init_frame_descriptors(void);
 

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -23,6 +23,7 @@
 
 #include <stdbool.h>
 #include "config.h"
+#include "misc.h"
 
 /* The compiler generates a "frame descriptor" for every potential
  * return address. Each loaded module has a block of memory, the
@@ -43,16 +44,47 @@
  *   be allocated by this call. Each size is stored reduced by 1, so
  *   that a single byte can record sizes (wosize) from 1 to 256 words.
  *
- * - frame_has_debug(): Whether we have debug information for this
- *   stack frame, and if so the "debuginfo" (source location) of this
- *   return address. (If frame_has_allocs(), this is an array of
- *   debuginfo, one for each of the set of allocations performed by
- *   this GC entry).
+ * - frame_has_debug(): Whether the frame descriptor has debug
+ *   information. (The debug info is one or more 32-bit relative
+ *   pointers: if frame_has_allocs(), there is one for each of the set
+ *   of allocations performed by this GC entry).
  *
  * - the register or stack frame offset of every "live" value,
  *   which should be scanned by the garbage collector if a GC is
  *   performed at this point.
- */
+ *
+ * A frame descriptor is read as a packed byte sequence rather than
+ * through a C struct: we treat a [frame_descr *] as an opaque byte
+ * pointer and read its fields at explicit byte offsets via
+ * [caml_read_unaligned_*]. This allows all alignment restrictions to
+ * be relaxed.
+ *
+ * There are two layouts; the field at offset 4 tells them apart (a uint16
+ * equal to FRAME_LONG_MARKER means long):
+ *
+ *  normal:                      long:
+ *    int32  retaddr_rel  @ 0      int32  retaddr_rel  @ 0
+ *    uint16 frame_data   @ 4      uint16 marker       @ 4: FRAME_LONG_MARKER
+ *    uint16 num_live     @ 6      uint16 _pad         @ 6
+ *    uint16 live_ofs[]   @ 8      uint32 frame_data   @ 8
+ *                                 uint32 num_live     @ 12
+ *                                 uint32 live_ofs[]   @ 16
+ *
+ * retaddr_rel is the byte offset from the descriptor to the return address.
+ *
+ * After live_ofs[]:
+ *
+ *   If frame_has_allocs(), allocation sizes follow:
+ *       uint8 num_allocs;
+ *       uint8 alloc[num_allocs];
+ *
+ *   If frame_has_debug(), debug info follows (32-bit aligned):
+ *       int32 debug_info[frame_has_allocs() ? num_allocs : 1];
+ *
+ * Each debug info is a signed relative offset, in bytes, from its own
+ * address to a debuginfo structure. */
+
+typedef unsigned char frame_descr;
 
 #define FRAME_DESCRIPTOR_DEBUG 1
 #define FRAME_DESCRIPTOR_ALLOC 2
@@ -60,71 +92,39 @@
 #define FRAME_RETURN_TO_C 0xFFFF
 #define FRAME_LONG_MARKER 0x7FFF
 
-typedef struct {
-  int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
-  uint16_t frame_data; /* frame size and various flags */
-  uint16_t num_live;
-  uint16_t live_ofs[/* num_live */]; /* flexible array member */
-  /*
-    If frame_has_allocs(), alloc lengths follow:
-        uint8_t num_allocs;
-        uint8_t alloc[num_allocs];
-
-    If frame_has_debug(), debug info follows (32-bit aligned):
-        uint32_t debug_info[frame_has_allocs() ? num_allocs : 1];
-
-    Debug info is stored as a relative offset, in bytes, from the
-    debug_info itself to a debuginfo structure. */
-} frame_descr;
-
-typedef struct {
-  int32_t retaddr_rel; /* offset of return address from &retaddr_rel */
-  uint16_t marker;     /* FRAME_LONG_MARKER */
-  uint16_t _pad;       /* Ensure frame_data is 4-byte aligned */
-  uint32_t frame_data; /* frame size and various flags */
-  uint32_t num_live;
-  uint32_t live_ofs[1 /* num_live */];
-  /*
-    If frame_has_allocs(), alloc lengths follow:
-        uint8_t num_allocs;
-        uint8_t alloc[num_allocs];
-
-    If frame_has_debug(), debug info follows (32-bit aligned):
-        uint32_t debug_info[frame_has_allocs() ? num_allocs : 1];
-
-    Debug info is stored as a relative offset, in bytes, from the
-    debug_info itself to a debuginfo structure. */
-} frame_descr_long;
+/* Field byte offsets within a descriptor (normal and long). */
+#define Frame_retaddr_rel_ofs   0
+#define Frame_data_ofs          4
+#define Frame_num_live_ofs      6
+#define Frame_live_ofs          8
+#define Frame_long_data_ofs     8
+#define Frame_long_num_live_ofs 12
+#define Frame_long_live_ofs     16
 
 Caml_inline bool frame_return_to_C(frame_descr *d) {
-  return d->frame_data == FRAME_RETURN_TO_C;
+  return caml_read_unaligned_uint16(d + Frame_data_ofs) == FRAME_RETURN_TO_C;
 }
 
 Caml_inline bool frame_is_long(frame_descr *d) {
   CAMLassert(d && !frame_return_to_C(d));
-  return (d -> frame_data == FRAME_LONG_MARKER);
-}
-
-Caml_inline frame_descr_long *frame_as_long(frame_descr *d) {
-  frame_descr_long *dl = (frame_descr_long *) d;
-  return dl;
+  return (caml_read_unaligned_uint16(d + Frame_data_ofs) == FRAME_LONG_MARKER);
 }
 
 Caml_inline uint32_t frame_data(frame_descr *d) {
   if (frame_is_long(d)) {
-    frame_descr_long *dl = frame_as_long(d);
-    return (dl -> frame_data);
+    return caml_read_unaligned_uint32(d + Frame_long_data_ofs);
   } else {
-    return (d -> frame_data);
+    return caml_read_unaligned_uint16(d + Frame_data_ofs);
   }
 }
 
 Caml_inline unsigned char *frame_end_of_live_ofs(frame_descr *d) {
   if (frame_is_long(d)) {
-    frame_descr_long *dl = frame_as_long(d);
-    return ((unsigned char *)&dl->live_ofs[dl->num_live]);
+    uint32_t num_live = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
+    return d + Frame_long_live_ofs + (uintnat)num_live * sizeof(uint32_t);
   } else {
-    return ((unsigned char *)&d->live_ofs[d->num_live]);
+    uint16_t num_live = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
+    return d + Frame_live_ofs + (uintnat)num_live * sizeof(uint16_t);
   }
 }
 
@@ -154,8 +154,8 @@ Caml_inline bool frame_has_debug(frame_descr *d) {
   ((((uintnat)(addr) * 52437813) >> 5) & (mask))
 
 #define Retaddr_frame(d) \
-  ((uintnat)&(d)->retaddr_rel + \
-   (uintnat)(intnat)((d)->retaddr_rel))
+  ((uintnat)(d) + \
+   (uintnat)(intnat)caml_read_unaligned_int32(d))
 
 void caml_init_frame_descriptors(void);
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <limits.h>
+#include <string.h>
 
 /* Detection of available C attributes and compiler extensions */
 
@@ -529,6 +530,39 @@ extern int caml_umul_overflow(uintnat a, uintnat b, uintnat * res);
 Caml_inline uintnat caml_round_up(uintnat value, uintnat align) {
   CAMLassert(Is_power_of_2(align));
   return (value + align - 1) & ~(align - 1);
+}
+
+/* Unaligned reads.
+
+   Frame descriptors are not guaranteed to be aligned, so reads from
+   them must not assume alignment. These helpers read a value of the
+   given type from a possibly-unaligned address. Every C compiler we
+   use compiles the [memcpy] to a single (unaligned) load instruction
+   at the optimisation levels used to build the runtime, and the idiom
+   is portable to architectures that fault on unaligned accesses. */
+
+Caml_inline uint16_t caml_read_unaligned_uint16(const void *p) {
+  uint16_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+Caml_inline uint32_t caml_read_unaligned_uint32(const void *p) {
+  uint32_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+Caml_inline int32_t caml_read_unaligned_int32(const void *p) {
+  int32_t v;
+  memcpy(&v, p, sizeof(v));
+  return v;
+}
+
+Caml_inline uintnat caml_read_unaligned_uintnat(const void *p) {
+  uintnat v;
+  memcpy(&v, p, sizeof(v));
+  return v;
 }
 
 #endif

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -44,6 +44,8 @@ void caml_init_codefrag(void) {
   caml_lf_skiplist_init(&code_fragments_by_num);
 }
 
+extern uintnat caml_measure_frametables;
+
 int caml_register_code_fragment(char *start, char *end,
                                 enum digest_status digest_kind,
                                 unsigned char *opt_digest) {
@@ -72,6 +74,9 @@ int caml_register_code_fragment(char *start, char *end,
   caml_lf_skiplist_insert(&code_fragments_by_pc, (uintnat)start, (uintnat)cf);
   caml_lf_skiplist_insert(&code_fragments_by_num, (uintnat)cf->fragnum,
                           (uintnat)cf);
+  if (caml_measure_frametables) {
+    printf("Code fragment %p-%p\n", start, end);
+  }
   return cf->fragnum;
 }
 

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -626,7 +626,25 @@ next_chunk:
     CAMLassert(d);
     if (!frame_return_to_C(d)) {
       /* Scan the roots in this frame */
-      if (frame_is_long(d)) {
+      if (frame_is_short(d)) {
+        /* Short descriptor: live registers come from the hot-register
+         * bitmap, live stack slots from word offsets. */
+        struct frame_descr_decoded dec;
+        caml_decode_frame_descr(d, &dec);
+        if (dec.has_allocs) {
+          unsigned char bitmap = dec.short_reg_bitmap;
+          for (int i = 0; bitmap; i++, bitmap >>= 1) {
+            if (bitmap & 1) {
+              root = regs + caml_frame_hot_regs[i];
+              visit (f, fdata, locals, colors, root);
+            }
+          }
+        }
+        for (uint32_t k = 0; k < dec.num_live; k++) {
+          root = (value *)(sp + (uintnat)dec.short_live[k] * sizeof(value));
+          visit (f, fdata, locals, colors, root);
+        }
+      } else if (frame_is_long(d)) {
         const unsigned char *p = d + Frame_long_live_ofs;
         uint32_t n = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
         for (; n > 0; n--, p += sizeof(uint32_t)) {

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -627,11 +627,10 @@ next_chunk:
     if (!frame_return_to_C(d)) {
       /* Scan the roots in this frame */
       if (frame_is_long(d)) {
-        frame_descr_long *dl = frame_as_long(d);
-        uint32_t *p;
-        uint32_t n;
-        for (p = dl->live_ofs, n = dl->num_live; n > 0; n--, p++) {
-          uint32_t ofs = *p;
+        const unsigned char *p = d + Frame_long_live_ofs;
+        uint32_t n = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
+        for (; n > 0; n--, p += sizeof(uint32_t)) {
+          uint32_t ofs = caml_read_unaligned_uint32(p);
           if (ofs & 1) {
             root = regs + (ofs >> 1);
           } else {
@@ -640,10 +639,10 @@ next_chunk:
           visit (f, fdata, locals, colors, root);
         }
       } else {
-        uint16_t *p;
-        uint16_t n;
-        for (p = d->live_ofs, n = d->num_live; n > 0; n--, p++) {
-          uint16_t ofs = *p;
+        const unsigned char *p = d + Frame_live_ofs;
+        uint16_t n = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
+        for (; n > 0; n--, p += sizeof(uint16_t)) {
+          uint16_t ofs = caml_read_unaligned_uint16(p);
           if (ofs & 1) {
             root = regs + (ofs >> 1);
           } else {

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -82,12 +82,9 @@ static frame_descr * next_frame_descr(frame_descr * d) {
     }
     /* Skip debug info if present */
     if (frame_has_debug(d)) {
-      /* Align to 32 bits */
-      p = Align_to(p, uint32_t);
       p += sizeof(uint32_t) * (frame_has_allocs(d) ? num_allocs : 1);
     }
-    /* Align to word size */
-    p = Align_to(p, void*);
+    /* Frame descriptors are not aligned: the next one follows immediately. */
     return ((frame_descr*) p);
   } else {
     /* This marks the top of an ML stack chunk. Skip over empty
@@ -95,8 +92,6 @@ static frame_descr * next_frame_descr(frame_descr * d) {
     /* Skip to address of zero-sized live_ofs */
     CAMLassert(caml_read_unaligned_uint16(d + Frame_num_live_ofs) == 0);
     p = d + Frame_live_ofs;
-    /* Align to word size */
-    p = Align_to(p, void*);
     return ((frame_descr*) p);
   }
 }
@@ -625,8 +620,6 @@ static void add_descriptor_to_stats(frame_descr *d,
     ++ stats->return_to_C;
     /* Top of an ML stack chunk. Skip over empty frame descriptor */
     p = d + Frame_live_ofs;
-    /* Align to word size */
-    p = Align_to(p, void*);
   } else {
     uint32_t sz = frame_size(d); /* in bytes */
     sz /= sizeof(uintnat);
@@ -717,8 +710,6 @@ static void add_descriptor_to_stats(frame_descr *d,
     /* Count debug info if present */
     if (frame_has_debug(d)) {
       ++ stats->with_debug;
-      /* Align to 32 bits */
-      p = Align_to(p, uint32_t);
       for (size_t i = 0; i <  num_debuginfo; ++i) {
         uint32_t offset = caml_read_unaligned_uint32(p);
         if (offset) { /* there may be invalid debuginfo slots */
@@ -727,8 +718,6 @@ static void add_descriptor_to_stats(frame_descr *d,
         p += sizeof(uint32_t);
       }
     }
-    /* Align to word size */
-    p = Align_to(p, void*);
   }
   if (!stats->max_descr || (p > stats->max_descr)) {
     stats->max_descr = p;

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -307,6 +307,23 @@ extern uintnat caml_measure_all_frametables;
 #define MAX_REG (REGS - 1) /* Largest register index recorded in reg tables */
 #define MAX_REG_IN_SMALL_MAP 12
 
+/* Why an escaped descriptor could not use the short format. [ESC_FITS] means
+   its content is short-compatible, so it escaped only for a positional reason
+   (a function / text-section boundary). Mirrors [short_encoding] in
+   backend/emitaux.ml; the enum order follows that function's checks. */
+enum escape_reason {
+  ESC_FITS = 0,     /* short-compatible: escaped only for a boundary */
+  ESC_LONG,         /* long (32-bit) descriptor */
+  ESC_BADSIZE,      /* frame size 0, > 1024, or not a multiple of 16 */
+  ESC_BADSLOT,      /* a live stack slot is unaligned or > 255 words in */
+  ESC_MANYSLOTS,    /* more than 255 live stack slots */
+  ESC_NOALLOC_REGS, /* non-allocation descriptor with live registers */
+  ESC_COLDREG,      /* a live register outside the 8 hot registers */
+  ESC_MANYALLOCS,   /* more than 255 allocations (comballoc) */
+  ESC_BIGALLOC,     /* an allocation size that does not fit a 4-bit nibble */
+  NUM_ESCAPE_REASONS
+};
+
 struct frametable_stats {
   /* A few per-frametable items */
   unsigned char *last_retaddr;
@@ -335,6 +352,14 @@ struct frametable_stats {
   size_t short_descrs;
   size_t medium_descrs;
   size_t long_descrs;
+
+  /* Why escaped (non-short) descriptors could not use the short format.
+     [escape_ft_first] is the first descriptor of a frametable, which always
+     escapes. Of the remaining escapes, [escape_reason[ESC_FITS]] are
+     short-compatible and so escaped only for a function / text-section
+     boundary -- the descriptors a cross-function delta chain could reclaim. */
+  size_t escape_ft_first;
+  size_t escape_reason[NUM_ESCAPE_REASONS];
 
   /* Frame sizes */
   size_t small_frames[SMALL_FRAMES];
@@ -512,6 +537,29 @@ static void report_stats(struct frametable_stats *stats)
          stats->short_descrs, stats->medium_descrs, stats->long_descrs,
          stats->return_to_C, stats->with_alloc, stats->with_debug);
 
+  {
+    static const char *const escape_names[NUM_ESCAPE_REASONS] = {
+      "fits (reclaimable boundary escape)",
+      "long",
+      "bad frame size",
+      "bad stack slot",
+      "> 255 stack slots",
+      "non-alloc with registers",
+      "cold register",
+      "> 255 allocations",
+      "alloc size > nibble"
+    };
+    size_t total_escapes = stats->escape_ft_first;
+    for (int i = 0; i < NUM_ESCAPE_REASONS; ++i) {
+      total_escapes += stats->escape_reason[i];
+    }
+    printf("Escaped descriptors: %zu (frametable-first %zu)\n",
+           total_escapes, stats->escape_ft_first);
+    for (int i = 0; i < NUM_ESCAPE_REASONS; ++i) {
+      printf("  %-36s %zu\n", escape_names[i], stats->escape_reason[i]);
+    }
+  }
+
   printf("Max pos retaddr offset %zu\n", stats->max_pos_retaddr_rel);
   report_table("  (logs %s)\n", stats->log_pos_retaddr_rel, MAX_LOG);
   printf("Max neg retaddr offset %zu\n", stats->max_neg_retaddr_rel);
@@ -639,6 +687,63 @@ static void add_slot(size_t byte_ofs, size_t *slots, size_t *max_slot)
   }
 }
 
+/* Is [reg] one of the eight hot registers the short format can encode? */
+
+static bool reg_is_hot(size_t reg)
+{
+  for (int i = 0; i < FRAME_NUM_HOT_REGS; ++i) {
+    if (caml_frame_hot_regs[i] == reg) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/* For an escaped (non-short, non-return-to-C) descriptor, determine why it
+   could not be encoded in the short format, mirroring [short_encoding] in
+   backend/emitaux.ml (same checks, same order). Returns [ESC_FITS] if the
+   content is short-compatible, meaning the descriptor escaped only for a
+   positional reason (first-in-frametable or a function/text-section
+   boundary). */
+
+static enum escape_reason classify_escape(frame_descr *d,
+                                          struct frame_descr_decoded *dec)
+{
+  if (dec->is_long) return ESC_LONG;
+  uint32_t size = dec->frame_size; /* in bytes, flag bits already masked off */
+  if (size == 0 || size > 1024 || (size & 15) != 0) return ESC_BADSIZE;
+
+  size_t nregs = 0, nslots = 0;
+  bool cold_reg = false;
+  const uint16_t *ofp = (const uint16_t *)(d + Frame_live_ofs);
+  for (uint32_t n = dec->num_live; n > 0; n--, ofp++) {
+    uint16_t v = caml_read_unaligned_uint16(ofp);
+    if (v & 1) {
+      ++ nregs;
+      if (!reg_is_hot(v >> 1)) cold_reg = true;
+    } else {
+      ++ nslots;
+      if ((v & (sizeof(value) - 1)) != 0) return ESC_BADSLOT; /* unaligned */
+      if ((size_t)(v / sizeof(value)) > 255) return ESC_BADSLOT;
+    }
+  }
+  if (nslots > 255) return ESC_MANYSLOTS;
+  if (!dec->has_allocs && nregs > 0) return ESC_NOALLOC_REGS;
+  if (cold_reg) return ESC_COLDREG;
+
+  if (dec->has_allocs) {
+    size_t num_allocs = dec->short_num_allocs;
+    if (num_allocs > 255) return ESC_MANYALLOCS;
+    /* Escaped alloc sizes are one byte each (same wosize-1 value the short
+       format would store in a nibble), just past the num_allocs byte. */
+    const unsigned char *sizes = dec->end_of_live + 1;
+    for (size_t i = 0; i < num_allocs; ++i) {
+      if (sizes[i] > 15) return ESC_BIGALLOC;
+    }
+  }
+  return ESC_FITS;
+}
+
 /* Record stats for a single descriptor, given its decoded form, its
    descriptor body pointer, and its absolute return address (as
    reconstructed by the frametable iterator). */
@@ -648,6 +753,7 @@ static void add_descriptor_to_stats(frame_descr *d,
                                     uintnat retaddr,
                                     struct frametable_stats *stats)
 {
+  bool first_in_ft = (stats->descrs == 0);
   ++ stats->descrs;
   if (!stats->min_descr || ((unsigned char*)d < stats->min_descr)) {
     stats->min_descr = (unsigned char*)d;
@@ -691,6 +797,17 @@ static void add_descriptor_to_stats(frame_descr *d,
     if (dec->is_short) ++ stats->short_descrs;
     else if (dec->is_long) ++ stats->long_descrs;
     else ++ stats->medium_descrs;
+
+    /* For escaped descriptors, record why they could not go short. The first
+       descriptor of a frametable always escapes; the rest are classified by
+       whether their content fits (a reclaimable boundary escape) or not. */
+    if (!dec->is_short) {
+      if (first_in_ft) {
+        ++ stats->escape_ft_first;
+      } else {
+        ++ stats->escape_reason[classify_escape(d, dec)];
+      }
+    }
 
     uint32_t sz = dec->frame_size; /* in bytes */
     sz /= sizeof(uintnat);

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -93,8 +93,8 @@ static frame_descr * next_frame_descr(frame_descr * d) {
     /* This marks the top of an ML stack chunk. Skip over empty
      * frame descriptor */
     /* Skip to address of zero-sized live_ofs */
-    CAMLassert(d->num_live == 0);
-    p = (unsigned char*)&d->live_ofs[0];
+    CAMLassert(caml_read_unaligned_uint16(d + Frame_num_live_ofs) == 0);
+    p = d + Frame_live_ofs;
     /* Align to word size */
     p = Align_to(p, void*);
     return ((frame_descr*) p);
@@ -104,7 +104,7 @@ static frame_descr * next_frame_descr(frame_descr * d) {
 static intnat count_descriptors(caml_frametable_list *list) {
   intnat num_descr = 0;
   iter_list(list,cur) {
-    num_descr += *((intnat*) cur->frametable);
+    num_descr += (intnat)caml_read_unaligned_uintnat(cur->frametable);
   }
   return num_descr;
 }
@@ -128,7 +128,7 @@ static void fill_hashtable(
 {
   iter_list(new_frametables,cur) {
     intnat * tbl = (intnat*) cur->frametable;
-    intnat len = *tbl;
+    intnat len = (intnat)caml_read_unaligned_uintnat(tbl);
     frame_descr * d = (frame_descr *)(tbl + 1);
     for (intnat j = 0; j < len; j++) {
       uintnat h = Hash_retaddr(Retaddr_frame(d), table->mask);
@@ -593,7 +593,7 @@ static void add_descriptor_to_stats(frame_descr *d,
     stats->min_descr = (unsigned char*)d;
   }
 
-  intnat retaddr_rel = d->retaddr_rel;
+  intnat retaddr_rel = caml_read_unaligned_int32(d + Frame_retaddr_rel_ofs);
   if (retaddr_rel < 0) {
     count_item(-retaddr_rel, &stats->max_neg_retaddr_rel, NULL,
                stats->log_neg_retaddr_rel);
@@ -624,7 +624,7 @@ static void add_descriptor_to_stats(frame_descr *d,
   if (frame_return_to_C(d)) {
     ++ stats->return_to_C;
     /* Top of an ML stack chunk. Skip over empty frame descriptor */
-    p = (unsigned char*)&d->live_ofs[0];
+    p = d + Frame_live_ofs;
     /* Align to word size */
     p = Align_to(p, void*);
   } else {
@@ -643,19 +643,22 @@ static void add_descriptor_to_stats(frame_descr *d,
     uint32_t num_live;
     if (frame_is_long(d)) {
       ++stats->long_descrs;
-      frame_descr_long *dl = frame_as_long(d);
-      num_live = dl->num_live;
+      num_live = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
       uint32_t n = num_live;
-      for (uint32_t *ofp = dl->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(*ofp, stats->reg, &regs, &max_reg, &reg_map,
-                     &has_big_reg, &slots, &max_slot, stats);
+      const unsigned char *lp = d + Frame_long_live_ofs;
+      for (; n > 0; n--, lp += sizeof(uint32_t)) {
+        add_live_ofs(caml_read_unaligned_uint32(lp), stats->reg, &regs,
+                     &max_reg, &reg_map, &has_big_reg, &slots, &max_slot,
+                     stats);
       }
     } else {
-      num_live = d->num_live;
+      num_live = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
       uint16_t n = num_live;
-      for (uint16_t *ofp = d->live_ofs; n > 0; n--, ofp++) {
-        add_live_ofs(*ofp, stats->reg, &regs, &max_reg, &reg_map,
-                     &has_big_reg, &slots, &max_slot, stats);
+      const unsigned char *lp = d + Frame_live_ofs;
+      for (; n > 0; n--, lp += sizeof(uint16_t)) {
+        add_live_ofs(caml_read_unaligned_uint16(lp), stats->reg, &regs,
+                     &max_reg, &reg_map, &has_big_reg, &slots, &max_slot,
+                     stats);
       }
     }
 
@@ -717,7 +720,7 @@ static void add_descriptor_to_stats(frame_descr *d,
       /* Align to 32 bits */
       p = Align_to(p, uint32_t);
       for (size_t i = 0; i <  num_debuginfo; ++i) {
-        uint32_t offset = *(uint32_t*)p;
+        uint32_t offset = caml_read_unaligned_uint32(p);
         if (offset) { /* there may be invalid debuginfo slots */
           caml_debuginfo_measure((debuginfo)(p + offset));
         }

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -27,10 +27,20 @@
 #include "caml/backtrace_prim.h"
 #include <stddef.h>
 
+/* A short descriptor does not carry its own return address (it is
+   reconstructed by walking the delta chain when a frametable is
+   registered), so each hash-table slot stores the absolute return
+   address alongside the descriptor-body pointer. An empty slot has
+   [fd == NULL]. */
+typedef struct {
+  uintnat retaddr;
+  frame_descr *fd;
+} frame_descr_entry;
+
 struct caml_frame_descrs {
   int num_descr;
   int mask;
-  frame_descr** descriptors;
+  frame_descr_entry *descriptors;
   caml_frametable_list *frametables;
   caml_frametable_list *zombies;
   caml_plat_mutex mutex;
@@ -69,31 +79,118 @@ extern intnat * caml_frametable[];
 #define iter_list(list,cur) \
   for (caml_frametable_list *cur = list; cur != NULL; cur = cur->next)
 
-static frame_descr * next_frame_descr(frame_descr * d) {
-  unsigned char num_allocs = 0, *p;
-  CAMLassert(Retaddr_frame(d) >= 4096);
-  if (!frame_return_to_C(d)) {
-    /* Skip to end of live_ofs */
-    p = frame_end_of_live_ofs(d);
-    /* Skip alloc_lengths if present */
-    if (frame_has_allocs(d)) {
-      num_allocs = *p;
-      p += num_allocs + 1;
+/* Decode one descriptor (short or escaped) into [out], filling in its
+   flags, sizes, and the pointers needed to locate its live offsets,
+   allocation sizes, and debug words. [d] points at the descriptor body
+   (the byte after its LEB128 delta / escape byte). */
+void caml_decode_frame_descr(frame_descr *d, struct frame_descr_decoded *out)
+{
+  memset(out, 0, sizeof(*out));
+  if (frame_is_short(d)) {
+    const unsigned char *p = (const unsigned char *)d;
+    unsigned char sf = *p++; /* size+flags byte */
+    out->is_short = true;
+    out->has_allocs = (sf & FRAME_DESCRIPTOR_ALLOC) != 0;
+    out->has_debug = (sf & FRAME_DESCRIPTOR_DEBUG) != 0;
+    out->frame_size = (((uint32_t)(sf >> 2)) + 1) * 16;
+    if (out->has_allocs) {
+      out->short_reg_bitmap = *p++;
+      out->short_num_allocs = *p++;
+      out->short_allocs = p;
+      p += (out->short_num_allocs + 1) / 2; /* 4-bit alloc sizes */
+      out->num_live = *p++;
+    } else {
+      out->num_live = *p++;
     }
-    /* Skip debug info if present */
-    if (frame_has_debug(d)) {
-      p += sizeof(uint32_t) * (frame_has_allocs(d) ? num_allocs : 1);
+    out->short_live = p;
+    p += out->num_live; /* one byte per live stack slot (word offset) */
+    out->end_of_live = p;
+    out->num_debuginfo = out->has_allocs ? out->short_num_allocs : 1;
+    if (out->has_debug) {
+      p += sizeof(uint32_t) * out->num_debuginfo;
     }
-    /* Frame descriptors are not aligned: the next one follows immediately. */
-    return ((frame_descr*) p);
-  } else {
-    /* This marks the top of an ML stack chunk. Skip over empty
-     * frame descriptor */
-    /* Skip to address of zero-sized live_ofs */
-    CAMLassert(caml_read_unaligned_uint16(d + Frame_num_live_ofs) == 0);
-    p = d + Frame_live_ofs;
-    return ((frame_descr*) p);
+    out->end = p;
+    return;
   }
+
+  /* Escaped descriptor: normal or long format. */
+  if (frame_return_to_C(d)) {
+    out->return_to_C = true;
+    /* Top of an ML stack chunk: an empty descriptor. */
+    CAMLassert(caml_read_unaligned_uint16(d + Frame_num_live_ofs) == 0);
+    out->end_of_live = out->end = d + Frame_live_ofs;
+    return;
+  }
+  out->is_long = frame_is_long(d);
+  out->has_allocs = frame_has_allocs(d);
+  out->has_debug = frame_has_debug(d);
+  out->frame_size = frame_size(d);
+  if (out->is_long) {
+    out->num_live = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
+  } else {
+    out->num_live = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
+  }
+  const unsigned char *p = frame_end_of_live_ofs(d);
+  out->end_of_live = p;
+  out->num_debuginfo = 1;
+  if (out->has_allocs) {
+    out->short_num_allocs = *p;
+    out->num_debuginfo = *p;
+    p += (uintnat)(*p) + 1; /* num_allocs byte + one byte per alloc */
+  }
+  if (out->has_debug) {
+    p += sizeof(uint32_t) * out->num_debuginfo;
+  }
+  out->end = p;
+}
+
+/* Iterate over the descriptors of one frametable, reconstructing the
+   absolute return address of each descriptor by walking the delta chain.
+   An escaped descriptor carries an absolute return address (retaddr_rel);
+   a short descriptor's address is the running address plus its delta. */
+typedef struct {
+  const unsigned char *next; /* points at the next descriptor's delta byte */
+  uintnat retaddr;           /* running absolute return address */
+  intnat remaining;          /* descriptors left to yield */
+} frametable_iter;
+
+static void frametable_iter_start(frametable_iter *it, intnat *tbl)
+{
+  it->remaining = (intnat)caml_read_unaligned_uintnat(tbl);
+  it->next = (const unsigned char *)(tbl + 1);
+  it->retaddr = 0;
+}
+
+/* Yield the next descriptor body and its absolute return address. Must
+   only be called while [it->remaining > 0]. */
+static frame_descr *frametable_iter_next(frametable_iter *it,
+                                         uintnat *retaddr_out)
+{
+  const unsigned char *p = it->next;
+  frame_descr *d;
+  if (*p == FRAME_DELTA_ESCAPE) {
+    p++;
+    d = (frame_descr *)p;
+    it->retaddr = Retaddr_frame(d);
+  } else {
+    /* Unsigned LEB128 delta (>= 1, so it never starts with a 0 byte). */
+    uintnat delta = 0;
+    int shift = 0;
+    unsigned char byte;
+    do {
+      byte = *p++;
+      delta |= (uintnat)(byte & 0x7f) << shift;
+      shift += 7;
+    } while (byte & 0x80);
+    it->retaddr += delta;
+    d = (frame_descr *)p;
+  }
+  struct frame_descr_decoded dec;
+  caml_decode_frame_descr(d, &dec);
+  it->next = dec.end;
+  it->remaining--;
+  *retaddr_out = it->retaddr;
+  return d;
 }
 
 static intnat count_descriptors(caml_frametable_list *list) {
@@ -122,38 +219,40 @@ static void fill_hashtable(
   caml_frame_descrs *table, caml_frametable_list *new_frametables)
 {
   iter_list(new_frametables,cur) {
-    intnat * tbl = (intnat*) cur->frametable;
-    intnat len = (intnat)caml_read_unaligned_uintnat(tbl);
-    frame_descr * d = (frame_descr *)(tbl + 1);
-    for (intnat j = 0; j < len; j++) {
-      uintnat h = Hash_retaddr(Retaddr_frame(d), table->mask);
-      while (table->descriptors[h] != NULL) {
+    frametable_iter it;
+    frametable_iter_start(&it, (intnat *) cur->frametable);
+    while (it.remaining > 0) {
+      uintnat retaddr;
+      frame_descr *d = frametable_iter_next(&it, &retaddr);
+      uintnat h = Hash_retaddr(retaddr, table->mask);
+      while (table->descriptors[h].fd != NULL) {
         h = (h+1) & table->mask;
       }
-      table->descriptors[h] = d;
-      d = next_frame_descr(d);
+      table->descriptors[h].retaddr = retaddr;
+      table->descriptors[h].fd = d;
     }
   }
 }
 
-static void remove_entry(caml_frame_descrs *table, frame_descr * d) {
+static void remove_entry(caml_frame_descrs *table, uintnat retaddr,
+                         frame_descr * d) {
   uintnat i;
   uintnat r;
   uintnat j;
 
-  i = Hash_retaddr(Retaddr_frame(d), table->mask);
-  while (table->descriptors[i] != d) {
+  i = Hash_retaddr(retaddr, table->mask);
+  while (table->descriptors[i].fd != d) {
     i = (i+1) & table->mask;
   }
 
  r1:
   j = i;
-  table->descriptors[i] = NULL;
+  table->descriptors[i].fd = NULL;
  r2:
   i = (i+1) & table->mask;
   // r3
-  if(table->descriptors[i] == NULL) return;
-  r = Hash_retaddr(Retaddr_frame(table->descriptors[i]), table->mask);
+  if(table->descriptors[i].fd == NULL) return;
+  r = Hash_retaddr(table->descriptors[i].retaddr, table->mask);
   /* If r is between i and j (cyclically), i.e. if
      table->descriptors[i]->retaddr don't need to be moved */
   if(( ( j < r )  && ( r <= i ) ) ||
@@ -168,16 +267,16 @@ static void remove_entry(caml_frame_descrs *table, frame_descr * d) {
 
 static void clean_frame_descriptors(caml_frame_descrs *table)
 {
-  intnat *tbl, len, decrease = 0;
-  frame_descr * d;
+  intnat decrease = 0;
   caml_frametable_list *cur = table->zombies, *rem;
   while (cur != NULL) {
-    tbl = (intnat*) cur->frametable;
-    len = *tbl;
-    d = (frame_descr *)(tbl + 1);
-    for (intnat j = 0; j < len; j++) {
-      remove_entry(table, d);
-      d = next_frame_descr(d);
+    frametable_iter it;
+    frametable_iter_start(&it, (intnat *) cur->frametable);
+    intnat len = it.remaining;
+    while (it.remaining > 0) {
+      uintnat retaddr;
+      frame_descr *d = frametable_iter_next(&it, &retaddr);
+      remove_entry(table, retaddr, d);
     }
     decrease += len;
     rem = cur;
@@ -192,12 +291,14 @@ static void clean_frame_descriptors(caml_frame_descrs *table)
 
 /* As preparation for designing a more memory-efficient frametable
  * format, this code measures various things about the frametables of
- * an executable. */
+ * an executable. It decodes both short and escaped ("medium"/"long")
+ * descriptors compatibly, via caml_decode_frame_descr.
+ *
+ * Settable via GC tweaks OCAMLRUNPARAM=Xmeasure_frametables (the
+ * frametables registered in this batch) and Xmeasure_all_frametables (all
+ * units linked into the executable, via the caml_all_frametables set). */
 
-/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_frametables */
 extern uintnat caml_measure_frametables;
-
-/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_all_frametables. */
 extern uintnat caml_measure_all_frametables;
 
 #define MAX_LOG 32
@@ -205,8 +306,6 @@ extern uintnat caml_measure_all_frametables;
 #define REGS 64
 #define MAX_REG (REGS - 1) /* Largest register index recorded in reg tables */
 #define MAX_REG_IN_SMALL_MAP 12
-#define REG_MAPS (1<<(MAX_REG_IN_SMALL_MAP + 1))
-#define REGMAP_REPORT_THRESHOLD 1000
 
 struct frametable_stats {
   /* A few per-frametable items */
@@ -233,6 +332,8 @@ struct frametable_stats {
   size_t return_to_C;
   size_t with_debug;
   size_t with_alloc;
+  size_t short_descrs;
+  size_t medium_descrs;
   size_t long_descrs;
 
   /* Frame sizes */
@@ -252,7 +353,7 @@ struct frametable_stats {
   size_t log_neg_delta[MAX_LOG];
   size_t max_neg_delta;
 
-  /* Counts of "live offset" slots (GC regs + slots) */
+  /* Counts of "live" values (GC regs + slots) */
   size_t small_lives[SMALL_FRAMES];
   size_t log_lives[MAX_LOG];
   size_t max_lives; /* Overall maximum count of lives */
@@ -262,9 +363,8 @@ struct frametable_stats {
   size_t reg_count[REGS]; /* Count GCable registers */
   size_t max_regs;
   size_t max_reg[REGS];  /* Count max GCable register index */
-  size_t reg_maps[REG_MAPS]; /* Count reg maps up to REG_MAPS */
   size_t big_reg_descrs; /* Descrs with a register > MAX_REG_IN_SMALL_MAP */
-  size_t big_reg_entries; /* live_ofs register entries with number > MAX_REG */
+  size_t big_reg_entries; /* live register entries with number > MAX_REG */
   size_t noalloc_with_regs; /* Non-alloc descrs that have registers (anomaly) */
 
   /* Count of GCable stack slots */
@@ -361,29 +461,14 @@ static void accumulate_frametable_stats(intnat *frametable,
   caml_debuginfo_measurements(&debuginfo_count,
                               &debuginfo_low,
                               &debuginfo_high);
-/*
-  printf("Frametable at %p: return addresses %p-%p(0x%zx), "
-        "descriptors %p-%p(0x%zx, %zu), "
-        "debuginfo %p-%p(0x%zx, %zu)\n",
-        (void*)frametable,
-        (void*)stats->min_retaddr,
-        (void*)stats->max_retaddr,
-        (size_t)(stats->max_retaddr - stats->min_retaddr),
-        (void*)stats->min_descr,
-        (void*)stats->max_descr,
-        (size_t)(stats->max_descr - stats->min_descr),
-        stats->descrs,
-        (void*)debuginfo_low,
-        (void*)debuginfo_high,
-        (size_t)(debuginfo_high - debuginfo_low),
-        debuginfo_count);
-*/
+  /* round debuginfo_high up to word boundary */
+  debuginfo_high = Align_to(debuginfo_high, uintnat);
   stats->total_codesize += (stats->max_retaddr - stats->min_retaddr);
   stats->total_ft_size += (stats->max_descr - stats->min_descr);
-  /* Each debuginfo record is two 32-bit words; the name_info /
-     name_and_loc_info structs occupy [debuginfo_low, debuginfo_high). The
-     deduplicated filename/defname strings live in a separate section and are
-     not counted here. */
+  /* Debuginfo bytes = the record words (each record is two uint32, counted
+     by debuginfo_count) plus the name_info/name_and_loc_info struct span.
+     The deduped filename/defname strings live in a separate section and are
+     not attributed to a frametable here. */
   stats->total_debuginfo_size += debuginfo_count * 2 * sizeof(uint32_t)
                                  + (debuginfo_high - debuginfo_low);
   stats->total_descrs += stats->descrs;
@@ -423,9 +508,9 @@ static void report_stats(struct frametable_stats *stats)
          stats->total_debuginfo);
   printf("%zu frametables before code, %zu after code.\n",
          stats->ft_before_code, stats->ft_after_code);
-  printf("long %zu return to C %zu alloc %zu debug %zu\n",
-         stats->long_descrs, stats->return_to_C,
-         stats->with_alloc, stats->with_debug);
+  printf("short %zu medium %zu long %zu return to C %zu alloc %zu debug %zu\n",
+         stats->short_descrs, stats->medium_descrs, stats->long_descrs,
+         stats->return_to_C, stats->with_alloc, stats->with_debug);
 
   printf("Max pos retaddr offset %zu\n", stats->max_pos_retaddr_rel);
   report_table("  (logs %s)\n", stats->log_pos_retaddr_rel, MAX_LOG);
@@ -467,37 +552,15 @@ static void report_stats(struct frametable_stats *stats)
   report_table("  (each reg %s)\n", stats->reg, REGS);
   report_table("  (max %s)\n", stats->max_reg, REGS);
 
-  /* report all register maps which are more than 1/128 of the total
-   * (apart from the empty reg map */
-  size_t others = 0;
-  size_t regmaps = 0;
-  for (size_t i = 1; i < REG_MAPS; ++i) {
-    regmaps += stats->reg_maps[i];
-  }
-
-  printf("Register map frequencies (of %zu allocation descriptors):\n",
-         stats->with_alloc);
-  for (size_t i = 0; i < REG_MAPS; ++i) {
-    if (stats->reg_maps[i] > regmaps/REGMAP_REPORT_THRESHOLD) {
-      for (size_t j = 0; j <= MAX_REG_IN_SMALL_MAP; ++j) {
-        table_buf[MAX_REG_IN_SMALL_MAP - j] = (i & (1 << j)) ? '1' : '0';
-      }
-      table_buf[MAX_REG_IN_SMALL_MAP+1] = '\0';
-      printf("  %s %zu\n", table_buf, stats->reg_maps[i]);
-    } else {
-      others += stats->reg_maps[i];
-    }
-  }
-  printf("  others (<= %zu) %zu\n", regmaps/REGMAP_REPORT_THRESHOLD, others);
   printf("Descriptors with a register > %d: %zu\n",
          MAX_REG_IN_SMALL_MAP, stats->big_reg_descrs);
-  printf("live_ofs register entries with number > %d: %zu\n",
+  printf("live register entries with number > %d: %zu\n",
          MAX_REG, stats->big_reg_entries);
   printf("Non-allocation descriptors with registers: %zu\n",
          stats->noalloc_with_regs);
 }
 
-/* Actually log+1.
+/* Actually floor(log_2(x))+1, clamped at MAX_LOG-1.
    mylog(0) = 0
    mylog(1) = 1
    mylog(2) = 2
@@ -542,56 +605,59 @@ Caml_inline void count_item(size_t item, size_t *max, size_t *smalls,
   }
 }
 
-/* Record a single live_ofs entry: either a GCable register or a GCable
-   stack slot.  Register numbers are normally small (we have never
-   observed one larger than MAX_REG_IN_SMALL_MAP), but the format
-   permits large ones (e.g. Valx2 values held in SIMD registers), so we
-   guard the fixed-size tables and count the outliers separately. */
+/* Record a single GCable register: register numbers are normally small
+   (we have never observed one larger than MAX_REG_IN_SMALL_MAP), but the
+   format permits large ones (e.g. Valx2 values held in SIMD registers),
+   so we guard the fixed-size tables and count the outliers separately. */
 
-static void add_live_ofs(uint32_t ofs, size_t *reg_p,
-                         size_t *regs, size_t *max_reg, uint64_t *reg_map,
-                         bool *has_big_reg,
-                         size_t *slots, size_t *max_slot,
-                         struct frametable_stats *stats)
+static void add_reg(size_t reg, size_t *regs, size_t *max_reg,
+                    bool *has_big_reg, struct frametable_stats *stats)
 {
-  if (ofs & 1) {
-    size_t reg = ofs >> 1;
-    ++ *regs;
-    if (reg < REGS) {
-      ++ reg_p[reg];
-    }
-    if (reg > *max_reg) {
-      *max_reg = reg;
-    }
-    if (reg <= MAX_REG_IN_SMALL_MAP) {
-      *reg_map |= (uint64_t)1 << reg;
-    } else {
-      *has_big_reg = true;
-    }
-    if (reg > MAX_REG) {
-      ++ stats->big_reg_entries;
-    }
-  } else {
-    size_t slot = ofs / sizeof(value);
-    ++ *slots;
-    if (slot > *max_slot) {
-      *max_slot = slot;
-    }
+  ++ *regs;
+  if (reg < REGS) {
+    ++ stats->reg[reg];
+  }
+  if (reg > *max_reg) {
+    *max_reg = reg;
+  }
+  if (reg > MAX_REG_IN_SMALL_MAP) {
+    *has_big_reg = true;
+  }
+  if (reg > MAX_REG) {
+    ++ stats->big_reg_entries;
   }
 }
 
-/* Record stats for a single descriptor */
+/* Record a single GCable stack slot, given its byte offset. */
+
+static void add_slot(size_t byte_ofs, size_t *slots, size_t *max_slot)
+{
+  size_t slot = byte_ofs / sizeof(value);
+  ++ *slots;
+  if (slot > *max_slot) {
+    *max_slot = slot;
+  }
+}
+
+/* Record stats for a single descriptor, given its decoded form, its
+   descriptor body pointer, and its absolute return address (as
+   reconstructed by the frametable iterator). */
 
 static void add_descriptor_to_stats(frame_descr *d,
+                                    struct frame_descr_decoded *dec,
+                                    uintnat retaddr,
                                     struct frametable_stats *stats)
 {
-  unsigned char *p;
   ++ stats->descrs;
   if (!stats->min_descr || ((unsigned char*)d < stats->min_descr)) {
     stats->min_descr = (unsigned char*)d;
   }
 
-  intnat retaddr_rel = caml_read_unaligned_int32(d + Frame_retaddr_rel_ofs);
+  /* Relative return address: the (signed) byte offset from the
+     descriptor to its return address. For short descriptors this is
+     implicit (encoded as a delta); we compute it from the
+     reconstructed absolute address. */
+  intnat retaddr_rel = (intnat)((uintnat)retaddr - (uintnat)d);
   if (retaddr_rel < 0) {
     count_item(-retaddr_rel, &stats->max_neg_retaddr_rel, NULL,
                stats->log_neg_retaddr_rel);
@@ -600,73 +666,90 @@ static void add_descriptor_to_stats(frame_descr *d,
                stats->log_pos_retaddr_rel);
   }
 
-  unsigned char *retaddr = (unsigned char *)Retaddr_frame(d);
+  unsigned char *retaddr_p = (unsigned char *)retaddr;
   if (stats->last_retaddr) {
-    if (retaddr < stats->min_retaddr) {
-      stats->min_retaddr = retaddr;
+    if (retaddr_p < stats->min_retaddr) {
+      stats->min_retaddr = retaddr_p;
     }
-    if (retaddr > stats->max_retaddr) {
-      stats->max_retaddr = retaddr;
+    if (retaddr_p > stats->max_retaddr) {
+      stats->max_retaddr = retaddr_p;
     }
-    intnat delta = (uintnat)retaddr - (uintnat)stats->last_retaddr;
+    intnat delta = (uintnat)retaddr_p - (uintnat)stats->last_retaddr;
     if (delta < 0) {
       count_item(-delta, &stats->max_neg_delta, NULL, stats->log_neg_delta);
     } else {
       count_item(delta, &stats->max_pos_delta, NULL, stats->log_pos_delta);
     }
   } else {
-    stats->min_retaddr = stats->max_retaddr = retaddr;
+    stats->min_retaddr = stats->max_retaddr = retaddr_p;
   }
-  stats->last_retaddr = retaddr;
+  stats->last_retaddr = retaddr_p;
 
-  if (frame_return_to_C(d)) {
+  if (dec->return_to_C) {
     ++ stats->return_to_C;
-    /* Top of an ML stack chunk. Skip over empty frame descriptor */
-    p = d + Frame_live_ofs;
   } else {
-    uint32_t sz = frame_size(d); /* in bytes */
+    if (dec->is_short) ++ stats->short_descrs;
+    else if (dec->is_long) ++ stats->long_descrs;
+    else ++ stats->medium_descrs;
+
+    uint32_t sz = dec->frame_size; /* in bytes */
     sz /= sizeof(uintnat);
     count_item(sz, &stats->max_framesize, stats->small_frames,
                stats->log_framesize);
 
-    uint64_t reg_map = 0; /* bitmap of live registers */
     size_t regs = 0; /* number of live registers */
     size_t max_reg = 0; /* max live register number */
     size_t slots = 0; /* number of live stack slots */
     size_t max_slot = 0; /* max live stack slot offset */
     bool has_big_reg = false; /* saw a register too big for the small map */
 
-    uint32_t num_live;
-    if (frame_is_long(d)) {
-      ++stats->long_descrs;
-      num_live = caml_read_unaligned_uint32(d + Frame_long_num_live_ofs);
-      uint32_t n = num_live;
-      const unsigned char *lp = d + Frame_long_live_ofs;
-      for (; n > 0; n--, lp += sizeof(uint32_t)) {
-        add_live_ofs(caml_read_unaligned_uint32(lp), stats->reg, &regs,
-                     &max_reg, &reg_map, &has_big_reg, &slots, &max_slot,
-                     stats);
+    /* Extract the normalized (registers, stack slots) live set,
+       decoding short and escaped descriptors compatibly. */
+    if (dec->is_short) {
+      /* Short: live registers come from the hot-register bitmap (set
+         only for allocation descriptors); live stack slots are word
+         offsets, one byte each. */
+      for (int i = 0; i < FRAME_NUM_HOT_REGS; ++i) {
+        if (dec->short_reg_bitmap & (1u << i)) {
+          add_reg(caml_frame_hot_regs[i], &regs, &max_reg, &has_big_reg,
+                  stats);
+        }
+      }
+      for (uint32_t k = 0; k < dec->num_live; ++k) {
+        size_t byte_ofs = (size_t)dec->short_live[k] * sizeof(value);
+        add_slot(byte_ofs, &slots, &max_slot);
+      }
+    } else if (dec->is_long) {
+      const uint32_t *ofp = (const uint32_t *)(d + Frame_long_live_ofs);
+      for (uint32_t n = dec->num_live; n > 0; n--, ofp++) {
+        uint32_t v = caml_read_unaligned_uint32(ofp);
+        if (v & 1) {
+          add_reg(v >> 1, &regs, &max_reg, &has_big_reg, stats);
+        } else {
+          add_slot(v, &slots, &max_slot);
+        }
       }
     } else {
-      num_live = caml_read_unaligned_uint16(d + Frame_num_live_ofs);
-      uint16_t n = num_live;
-      const unsigned char *lp = d + Frame_live_ofs;
-      for (; n > 0; n--, lp += sizeof(uint16_t)) {
-        add_live_ofs(caml_read_unaligned_uint16(lp), stats->reg, &regs,
-                     &max_reg, &reg_map, &has_big_reg, &slots, &max_slot,
-                     stats);
+      const uint16_t *ofp = (const uint16_t *)(d + Frame_live_ofs);
+      for (uint32_t n = dec->num_live; n > 0; n--, ofp++) {
+        uint16_t v = caml_read_unaligned_uint16(ofp);
+        if (v & 1) {
+          add_reg(v >> 1, &regs, &max_reg, &has_big_reg, stats);
+        } else {
+          add_slot(v, &slots, &max_slot);
+        }
       }
     }
 
-    /* Record size of GC "offset" table */
-    count_item(num_live, &stats->max_lives, stats->small_lives,
+    /* GC live values = live registers + live stack slots. */
+    count_item(regs + slots, &stats->max_lives, stats->small_lives,
                stats->log_lives);
 
-    /* Register counts and maps, recorded only for allocation descriptors.
+    /* Register counts, recorded only for allocation descriptors.
        Non-allocation descriptors are not expected to keep GC roots in
        registers, so count any that do as an anomaly rather than folding
        them into the register statistics. */
-    if (frame_has_allocs(d)) {
+    if (dec->has_allocs) {
       if (regs < REGS) {
         ++ stats->reg_count[regs];
       }
@@ -675,9 +758,6 @@ static void add_descriptor_to_stats(frame_descr *d,
       }
       if (regs > stats->max_regs) {
         stats->max_regs = regs;
-      }
-      if (reg_map < REG_MAPS) {
-        ++ stats->reg_maps[reg_map];
       }
       if (has_big_reg) {
         ++ stats->big_reg_descrs;
@@ -694,26 +774,41 @@ static void add_descriptor_to_stats(frame_descr *d,
     count_item(max_slot, &stats->max_slot, stats->small_max_slot,
                stats->log_max_slot);
 
-    p = (unsigned char*)frame_end_of_live_ofs(d);
-    size_t num_debuginfo = 1;
-    if (frame_has_allocs(d)) {
+    /* Allocation sizes and comballoc counts. The alloc sizes store
+       wosize-1 in both encodings (short: 4-bit nibbles; escaped: whole
+       bytes after end_of_live), so they are directly comparable. */
+    if (dec->has_allocs) {
       ++ stats->with_alloc;
-      size_t num_allocs = *(uint8_t *)p;
+      size_t num_allocs = dec->short_num_allocs;
       stats->alloc_sizes += num_allocs;
-      num_debuginfo = num_allocs;
       count_item(num_allocs, &stats->max_comballocs, stats->small_comballocs,
                  stats->log_comballocs);
-      ++ p;
-      for (size_t idx = 0; idx < num_allocs; ++idx) {
-        count_item(p[idx], &stats->max_alloc_size, stats->small_alloc_sizes,
-                   stats->log_alloc_sizes);
+      if (dec->is_short) {
+        for (size_t idx = 0; idx < num_allocs; ++idx) {
+          unsigned char byte = dec->short_allocs[idx / 2];
+          unsigned char sz = (idx & 1) ? (byte >> 4) : (byte & 0x0f);
+          count_item(sz, &stats->max_alloc_size, stats->small_alloc_sizes,
+                     stats->log_alloc_sizes);
+        }
+      } else {
+        /* escaped: [num_allocs byte][num_allocs size bytes] */
+        const unsigned char *sizes = dec->end_of_live + 1;
+        for (size_t idx = 0; idx < num_allocs; ++idx) {
+          count_item(sizes[idx], &stats->max_alloc_size,
+                     stats->small_alloc_sizes, stats->log_alloc_sizes);
+        }
       }
-      p += num_allocs;
     }
+
     /* Count debug info if present */
-    if (frame_has_debug(d)) {
+    if (dec->has_debug) {
       ++ stats->with_debug;
-      for (size_t i = 0; i <  num_debuginfo; ++i) {
+      const unsigned char *p = dec->end_of_live;
+      if (!dec->is_short && dec->has_allocs) {
+        /* escaped: skip num_allocs byte + alloc bytes */
+        p += (uintnat)(*p) + 1;
+      }
+      for (uint32_t i = 0; i < dec->num_debuginfo; ++i) {
         uint32_t offset = caml_read_unaligned_uint32(p);
         if (offset) { /* there may be invalid debuginfo slots */
           caml_debuginfo_measure((debuginfo)(p + offset));
@@ -722,8 +817,9 @@ static void add_descriptor_to_stats(frame_descr *d,
       }
     }
   }
-  if (!stats->max_descr || (p > stats->max_descr)) {
-    stats->max_descr = p;
+
+  if (!stats->max_descr || (dec->end > stats->max_descr)) {
+    stats->max_descr = (unsigned char *)dec->end;
   }
 }
 
@@ -741,11 +837,14 @@ static void add_frametable_to_stats(intnat *frametable,
       ((unsigned char*)frametable > stats->max_descr)) {
     stats->max_descr = (unsigned char*)(frametable+1);
   }
-  intnat len = *frametable;
-  frame_descr * d = (frame_descr *)(frametable + 1);
-  for (intnat j = 0; j < len; j++) {
-    add_descriptor_to_stats(d, stats);
-    d = next_frame_descr(d);
+  frametable_iter it;
+  frametable_iter_start(&it, frametable);
+  while (it.remaining > 0) {
+    uintnat retaddr;
+    frame_descr *d = frametable_iter_next(&it, &retaddr);
+    struct frame_descr_decoded dec;
+    caml_decode_frame_descr(d, &dec);
+    add_descriptor_to_stats(d, &dec, retaddr, stats);
   }
 }
 
@@ -815,7 +914,8 @@ static void add_frame_descriptors(
 
     if (table->descriptors != NULL) caml_stat_free(table->descriptors);
     table->descriptors =
-      (frame_descr **) caml_stat_calloc_noexc(tblsize, sizeof(frame_descr *));
+      (frame_descr_entry *) caml_stat_calloc_noexc(tblsize,
+                                                   sizeof(frame_descr_entry));
     if (table->descriptors == NULL) caml_raise_out_of_memory();
 
     fill_hashtable(table, new_frametables);
@@ -985,15 +1085,14 @@ caml_frame_descrs* caml_get_frame_descrs(void)
 
 frame_descr* caml_find_frame_descr(caml_frame_descrs *fds, uintnat pc)
 {
-  frame_descr * d;
   uintnat h;
 
   h = Hash_retaddr(pc, fds->mask);
   while (1) {
-    d = fds->descriptors[h];
-    if (d == 0) return NULL; /* can happen if some code compiled without -g */
-    if (Retaddr_frame(d) == pc) break;
+    frame_descr_entry e = fds->descriptors[h];
+    if (e.fd == NULL)
+      return NULL; /* can happen if some code compiled without -g */
+    if (e.retaddr == pc) return e.fd;
     h = (h+1) & fds->mask;
   }
-  return d;
 }

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -202,6 +202,9 @@ static void clean_frame_descriptors(caml_frame_descrs *table)
 /* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_frametables */
 extern uintnat caml_measure_frametables;
 
+/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_all_frametables. */
+extern uintnat caml_measure_all_frametables;
+
 #define MAX_LOG 32
 #define SMALL_FRAMES 32
 #define REGS 64
@@ -765,6 +768,28 @@ static void report_frametables_stats(caml_frametable_list *new_frametables)
   report_stats(&stats);
 }
 
+/* The backend emits one pointer per linked unit into the caml_all_frametables
+ * section; the linker concatenates them and provides these bounds. Weak so the
+ * runtime still links where no such section exists (both NULL). */
+extern intnat *__start_caml_all_frametables[] __attribute__((weak));
+extern intnat *__stop_caml_all_frametables[] __attribute__((weak));
+
+/* Measure every frametable in the executable - including dynlink-available
+ * units that are never registered in caml_frametable[]. Reads only static data
+ * and read-only frame descriptors; runs no module initializers. */
+static void report_all_frametables_stats(void)
+{
+  struct frametable_stats stats;
+  clear_stats(&stats);
+  for (intnat **p = __start_caml_all_frametables;
+       p < __stop_caml_all_frametables; p++) {
+    add_frametable_to_stats(*p, &stats);
+    accumulate_frametable_stats(*p, &stats);
+    clear_per_frametable_stats(&stats);
+  }
+  report_stats(&stats);
+}
+
 static void add_frame_descriptors(
   caml_frame_descrs *table,
   caml_frametable_list *new_frametables)
@@ -858,6 +883,10 @@ void caml_init_frame_descriptors(void)
      any mutator can run. We can mutate [current_frame_descrs]
      at will. */
   add_frame_descriptors(&current_frame_descrs, frametables);
+
+  if (caml_measure_all_frametables) {
+    report_all_frametables_stats();
+  }
 }
 
 static void register_frametables_from_stw_single(

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -24,6 +24,7 @@
 #include "caml/memory.h"
 #include "caml/fail.h"
 #include "caml/shared_heap.h"
+#include "caml/backtrace_prim.h"
 #include <stddef.h>
 
 struct caml_frame_descrs {
@@ -192,6 +193,578 @@ static void clean_frame_descriptors(caml_frame_descrs *table)
   table->zombies = NULL;
 }
 
+/* ---- Frametable measurement ---- */
+
+/* As preparation for designing a more memory-efficient frametable
+ * format, this code measures various things about the frametables of
+ * an executable. */
+
+/* Settable via GC tweak OCAMLRUNPARAM=Xmeasure_frametables */
+extern uintnat caml_measure_frametables;
+
+#define MAX_LOG 32
+#define SMALL_FRAMES 32
+#define REGS 64
+#define MAX_REG (REGS - 1) /* Largest register index recorded in reg tables */
+#define MAX_REG_IN_SMALL_MAP 12
+#define REG_MAPS (1<<(MAX_REG_IN_SMALL_MAP + 1))
+#define REGMAP_REPORT_THRESHOLD 1000
+
+struct frametable_stats {
+  /* A few per-frametable items */
+  unsigned char *last_retaddr;
+  unsigned char *min_retaddr;
+  unsigned char *max_retaddr;
+  unsigned char *min_descr;
+  unsigned char *max_descr;
+  size_t descrs;
+
+  /* Everything else is accumulated over all frametables */
+  size_t frametables;
+  size_t total_codesize;
+  size_t total_ft_size;
+  size_t total_debuginfo_size;
+  size_t total_descrs;
+  size_t total_debuginfo;
+
+  /* Are frametables in memory before or after the code they describe? */
+  size_t ft_before_code;
+  size_t ft_after_code;
+
+  /* Descriptor kinds */
+  size_t return_to_C;
+  size_t with_debug;
+  size_t with_alloc;
+  size_t long_descrs;
+
+  /* Frame sizes */
+  size_t small_frames[SMALL_FRAMES];
+  size_t log_framesize[MAX_LOG];
+  size_t max_framesize;
+
+  /* Relative return addresses */
+  size_t log_pos_retaddr_rel[MAX_LOG];
+  size_t max_pos_retaddr_rel;
+  size_t log_neg_retaddr_rel[MAX_LOG];
+  size_t max_neg_retaddr_rel;
+
+  /* Delta from one retaddr to the next */
+  size_t log_pos_delta[MAX_LOG];
+  size_t max_pos_delta;
+  size_t log_neg_delta[MAX_LOG];
+  size_t max_neg_delta;
+
+  /* Counts of "live offset" slots (GC regs + slots) */
+  size_t small_lives[SMALL_FRAMES];
+  size_t log_lives[MAX_LOG];
+  size_t max_lives; /* Overall maximum count of lives */
+
+  /* GCable registers */
+  size_t reg[REGS]; /* # descriptors using each register */
+  size_t reg_count[REGS]; /* Count GCable registers */
+  size_t max_regs;
+  size_t max_reg[REGS];  /* Count max GCable register index */
+  size_t reg_maps[REG_MAPS]; /* Count reg maps up to REG_MAPS */
+  size_t big_reg_descrs; /* Descrs with a register > MAX_REG_IN_SMALL_MAP */
+  size_t big_reg_entries; /* live_ofs register entries with number > MAX_REG */
+  size_t noalloc_with_regs; /* Non-alloc descrs that have registers (anomaly) */
+
+  /* Count of GCable stack slots */
+  size_t small_slots[SMALL_FRAMES];
+  size_t log_slots[MAX_LOG];
+  size_t max_slots;
+
+  /* maximum GCable stack slot offset */
+  size_t small_max_slot[SMALL_FRAMES];
+  size_t log_max_slot[MAX_LOG];
+  size_t max_slot;
+
+  /* Comballoc allocation counts */
+  size_t log_comballocs[MAX_LOG];
+  size_t small_comballocs[SMALL_FRAMES];
+  size_t max_comballocs;
+
+  /* allocation sizes */
+  size_t alloc_sizes;
+  size_t log_alloc_sizes[MAX_LOG];
+  size_t small_alloc_sizes[SMALL_FRAMES];
+  size_t max_alloc_size;
+};
+
+static void clear_stats(struct frametable_stats *stats)
+{
+  caml_debuginfo_reset();
+  memset(stats, 0, sizeof(*stats));
+}
+
+static void clear_per_frametable_stats(struct frametable_stats *stats)
+{
+  stats->min_retaddr = stats->max_retaddr = stats->last_retaddr =
+    stats->min_descr = stats->max_descr = NULL;
+  stats->descrs = 0;
+  caml_debuginfo_reset();
+}
+
+/* Turn `val` into a string representing that number of bytes */
+
+static void report_bytes(char *buf, size_t space, size_t val)
+{
+  if (val < 1024) {
+    snprintf(buf, space, "%zu", val);
+  } else {
+    char suffix[] = " kMGTE";
+    double scaled = val;
+    char *p = suffix;
+    while(scaled > 1000 && *p) {
+      scaled /= 1024.0;
+      ++p;
+    }
+    snprintf(buf, space, "%.2f %ciB", scaled, *p);
+  }
+}
+
+/* Write text showing an array `vals` of `count` size_t values,
+ * without trailing zero values, into `buf` (size `space` bytes). */
+
+/* This works for regs and logs and smalls */
+#define TABLE_BUF_SIZE (REGS * 16)
+
+static void report_table(char *fmt, size_t *vals, size_t count)
+{
+  char buf[TABLE_BUF_SIZE];
+  size_t space = TABLE_BUF_SIZE;
+
+  size_t max = count - 1;
+  while(max && vals[max] == 0) {
+    --max;
+  }
+  char *p = buf;
+  for (size_t i = 0; i <= max; ++i) {
+    int len = snprintf(p, space, "%zu ", vals[i]);
+    if (len > space) { /* truncated, replace with ... */
+      p[space-4] = p[space-3] = p[space-2] = '.';
+      p[space-1] = '\0';
+      return;
+    }
+    space -= len;
+    p += len;
+  }
+  printf(fmt, buf);
+}
+
+/* At the end of a single frametable, deduce per-frametable sizes and
+ * add them to global stats. */
+
+static void accumulate_frametable_stats(intnat *frametable,
+                                        struct frametable_stats *stats)
+{
+  char *debuginfo_low, *debuginfo_high;
+  size_t debuginfo_count;
+  caml_debuginfo_measurements(&debuginfo_count,
+                              &debuginfo_low,
+                              &debuginfo_high);
+  /* round debuginfo_high up to word boundary */
+  debuginfo_high = Align_to(debuginfo_high, uintnat);
+/*
+  printf("Frametable at %p: return addresses %p-%p(0x%zx), "
+        "descriptors %p-%p(0x%zx, %zu), "
+        "debuginfo %p-%p(0x%zx, %zu)\n",
+        (void*)frametable,
+        (void*)stats->min_retaddr,
+        (void*)stats->max_retaddr,
+        (size_t)(stats->max_retaddr - stats->min_retaddr),
+        (void*)stats->min_descr,
+        (void*)stats->max_descr,
+        (size_t)(stats->max_descr - stats->min_descr),
+        stats->descrs,
+        (void*)debuginfo_low,
+        (void*)debuginfo_high,
+        (size_t)(debuginfo_high - debuginfo_low),
+        debuginfo_count);
+*/
+  stats->total_codesize += (stats->max_retaddr - stats->min_retaddr);
+  stats->total_ft_size += (stats->max_descr - stats->min_descr);
+  stats->total_debuginfo_size += (debuginfo_high - debuginfo_low);
+  stats->total_descrs += stats->descrs;
+  stats->total_debuginfo += debuginfo_count;
+  if (stats->min_retaddr) {
+    if (stats->min_retaddr > stats->min_descr)
+      ++ stats->ft_before_code;
+    else
+      ++ stats->ft_after_code;
+  }
+}
+
+/* Report all accumulated frametable stats to stdout. */
+
+static void report_stats(struct frametable_stats *stats)
+{
+  char table_buf[TABLE_BUF_SIZE];
+
+  size_t total_size =
+    stats->total_codesize
+    + stats->total_ft_size
+    + stats->total_debuginfo_size;
+  printf("Summary of %zu frametables.\n", stats->frametables);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_codesize);
+  printf("%s code (%5.2f%%)\n", table_buf,
+         (double)stats->total_codesize/total_size * 100.0);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_ft_size);
+  printf("%s descriptors (%5.2f%%; %zu descrs, %f bytes each)\n",
+         table_buf,
+         (double)stats->total_ft_size/total_size * 100.0,
+         stats->total_descrs,
+         (double)stats->total_ft_size / stats->total_descrs);
+  report_bytes(table_buf, TABLE_BUF_SIZE, stats->total_debuginfo_size);
+  printf("%s Debuginfo (%5.2f%% %zu entries)\n",
+         table_buf,
+         (double)stats->total_debuginfo_size/total_size * 100.0,
+         stats->total_debuginfo);
+  printf("%zu frametables before code, %zu after code.\n",
+         stats->ft_before_code, stats->ft_after_code);
+  printf("long %zu return to C %zu alloc %zu debug %zu\n",
+         stats->long_descrs, stats->return_to_C,
+         stats->with_alloc, stats->with_debug);
+
+  printf("Max pos retaddr offset %zu\n", stats->max_pos_retaddr_rel);
+  report_table("  (logs %s)\n", stats->log_pos_retaddr_rel, MAX_LOG);
+  printf("Max neg retaddr offset %zu\n", stats->max_neg_retaddr_rel);
+  report_table("  (logs %s)\n", stats->log_neg_retaddr_rel, MAX_LOG);
+  printf("Max retaddr pos delta %zu\n", stats->max_pos_delta);
+  report_table("  (logs %s)\n", stats->log_pos_delta, MAX_LOG);
+  printf("Max retaddr neg delta %zu\n", stats->max_neg_delta);
+  report_table("  (logs %s)\n", stats->log_neg_delta, MAX_LOG);
+
+  printf("Frame sizes (max %zu)\n", stats->max_framesize);
+  report_table("  (small %s)\n", stats->small_frames, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_framesize, MAX_LOG);
+
+  printf("Comballoc entries (max %zu)\n",
+         stats->max_comballocs);
+  report_table("  (small %s)\n", stats->small_comballocs, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_comballocs, MAX_LOG);
+
+  printf("Allocation sizes (wosize-1) (%zu allocs, max %zu)\n",
+         stats->alloc_sizes, stats->max_alloc_size);
+  report_table("  (small %s)\n", stats->small_alloc_sizes, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_alloc_sizes, MAX_LOG);
+
+  printf("GC live values (max %zu)\n", stats->max_lives);
+  report_table("  (small %s)\n", stats->small_lives, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_lives, MAX_LOG);
+
+  printf("GCable stack slots (max %zu)\n", stats->max_slots);
+  report_table("  (small %s)\n", stats->small_slots, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_slots, MAX_LOG);
+
+  printf("Max GCable stack slot (max %zu)\n", stats->max_slot);
+  report_table("  (small %s)\n", stats->small_max_slot, SMALL_FRAMES);
+  report_table("  (logs %s)\n", stats->log_max_slot, MAX_LOG);
+
+  printf("GCable registers (max %zu)\n", stats->max_regs);
+  report_table("  (counts %s)\n", stats->reg_count, REGS);
+  report_table("  (each reg %s)\n", stats->reg, REGS);
+  report_table("  (max %s)\n", stats->max_reg, REGS);
+
+  /* report all register maps which are more than 1/128 of the total
+   * (apart from the empty reg map */
+  size_t others = 0;
+  size_t regmaps = 0;
+  for (size_t i = 1; i < REG_MAPS; ++i) {
+    regmaps += stats->reg_maps[i];
+  }
+
+  printf("Register map frequencies (of %zu allocation descriptors):\n",
+         stats->with_alloc);
+  for (size_t i = 0; i < REG_MAPS; ++i) {
+    if (stats->reg_maps[i] > regmaps/REGMAP_REPORT_THRESHOLD) {
+      for (size_t j = 0; j <= MAX_REG_IN_SMALL_MAP; ++j) {
+        table_buf[MAX_REG_IN_SMALL_MAP - j] = (i & (1 << j)) ? '1' : '0';
+      }
+      table_buf[MAX_REG_IN_SMALL_MAP+1] = '\0';
+      printf("  %s %zu\n", table_buf, stats->reg_maps[i]);
+    } else {
+      others += stats->reg_maps[i];
+    }
+  }
+  printf("  others (<= %zu) %zu\n", regmaps/REGMAP_REPORT_THRESHOLD, others);
+  printf("Descriptors with a register > %d: %zu\n",
+         MAX_REG_IN_SMALL_MAP, stats->big_reg_descrs);
+  printf("live_ofs register entries with number > %d: %zu\n",
+         MAX_REG, stats->big_reg_entries);
+  printf("Non-allocation descriptors with registers: %zu\n",
+         stats->noalloc_with_regs);
+}
+
+/* Actually log+1.
+   mylog(0) = 0
+   mylog(1) = 1
+   mylog(2) = 2
+   mylog(3) = 2
+   mylog(4) = 3
+   ...
+   mylog(255) = 8
+   mylog(256) = 9
+   etc
+  */
+Caml_inline size_t mylog(size_t v)
+{
+  size_t log = 0;
+  while(v) {
+    v /= 2;
+    ++ log;
+  }
+  /* Clamp so the result is always a valid index into a MAX_LOG table */
+  if (log >= MAX_LOG) {
+    log = MAX_LOG - 1;
+  }
+  return log;
+}
+
+/* Common code for recording an item in:
+   - an optional max value;
+   - an optional table of small values (less than SMALL_FRAMES)
+   - an optional table of log values.
+ */
+
+Caml_inline void count_item(size_t item, size_t *max, size_t *smalls,
+                            size_t *logs)
+{
+  if (max && item > *max) {
+    *max = item;
+  }
+  if (smalls && item < SMALL_FRAMES) {
+    ++ smalls[item];
+  }
+  if (logs) {
+    ++ logs[mylog(item)];
+  }
+}
+
+/* Record a single live_ofs entry: either a GCable register or a GCable
+   stack slot.  Register numbers are normally small (we have never
+   observed one larger than MAX_REG_IN_SMALL_MAP), but the format
+   permits large ones (e.g. Valx2 values held in SIMD registers), so we
+   guard the fixed-size tables and count the outliers separately. */
+
+static void add_live_ofs(uint32_t ofs, size_t *reg_p,
+                         size_t *regs, size_t *max_reg, uint64_t *reg_map,
+                         bool *has_big_reg,
+                         size_t *slots, size_t *max_slot,
+                         struct frametable_stats *stats)
+{
+  if (ofs & 1) {
+    size_t reg = ofs >> 1;
+    ++ *regs;
+    if (reg < REGS) {
+      ++ reg_p[reg];
+    }
+    if (reg > *max_reg) {
+      *max_reg = reg;
+    }
+    if (reg <= MAX_REG_IN_SMALL_MAP) {
+      *reg_map |= (uint64_t)1 << reg;
+    } else {
+      *has_big_reg = true;
+    }
+    if (reg > MAX_REG) {
+      ++ stats->big_reg_entries;
+    }
+  } else {
+    size_t slot = ofs / sizeof(value);
+    ++ *slots;
+    if (slot > *max_slot) {
+      *max_slot = slot;
+    }
+  }
+}
+
+/* Record stats for a single descriptor */
+
+static void add_descriptor_to_stats(frame_descr *d,
+                                    struct frametable_stats *stats)
+{
+  unsigned char *p;
+  ++ stats->descrs;
+  if (!stats->min_descr || ((unsigned char*)d < stats->min_descr)) {
+    stats->min_descr = (unsigned char*)d;
+  }
+
+  intnat retaddr_rel = d->retaddr_rel;
+  if (retaddr_rel < 0) {
+    count_item(-retaddr_rel, &stats->max_neg_retaddr_rel, NULL,
+               stats->log_neg_retaddr_rel);
+  } else {
+    count_item(retaddr_rel, &stats->max_pos_retaddr_rel, NULL,
+               stats->log_pos_retaddr_rel);
+  }
+
+  unsigned char *retaddr = (unsigned char *)Retaddr_frame(d);
+  if (stats->last_retaddr) {
+    if (retaddr < stats->min_retaddr) {
+      stats->min_retaddr = retaddr;
+    }
+    if (retaddr > stats->max_retaddr) {
+      stats->max_retaddr = retaddr;
+    }
+    intnat delta = (uintnat)retaddr - (uintnat)stats->last_retaddr;
+    if (delta < 0) {
+      count_item(-delta, &stats->max_neg_delta, NULL, stats->log_neg_delta);
+    } else {
+      count_item(delta, &stats->max_pos_delta, NULL, stats->log_pos_delta);
+    }
+  } else {
+    stats->min_retaddr = stats->max_retaddr = retaddr;
+  }
+  stats->last_retaddr = retaddr;
+
+  if (frame_return_to_C(d)) {
+    ++ stats->return_to_C;
+    /* Top of an ML stack chunk. Skip over empty frame descriptor */
+    p = (unsigned char*)&d->live_ofs[0];
+    /* Align to word size */
+    p = Align_to(p, void*);
+  } else {
+    uint32_t sz = frame_size(d); /* in bytes */
+    sz /= sizeof(uintnat);
+    count_item(sz, &stats->max_framesize, stats->small_frames,
+               stats->log_framesize);
+
+    uint64_t reg_map = 0; /* bitmap of live registers */
+    size_t regs = 0; /* number of live registers */
+    size_t max_reg = 0; /* max live register number */
+    size_t slots = 0; /* number of live stack slots */
+    size_t max_slot = 0; /* max live stack slot offset */
+    bool has_big_reg = false; /* saw a register too big for the small map */
+
+    uint32_t num_live;
+    if (frame_is_long(d)) {
+      ++stats->long_descrs;
+      frame_descr_long *dl = frame_as_long(d);
+      num_live = dl->num_live;
+      uint32_t n = num_live;
+      for (uint32_t *ofp = dl->live_ofs; n > 0; n--, ofp++) {
+        add_live_ofs(*ofp, stats->reg, &regs, &max_reg, &reg_map,
+                     &has_big_reg, &slots, &max_slot, stats);
+      }
+    } else {
+      num_live = d->num_live;
+      uint16_t n = num_live;
+      for (uint16_t *ofp = d->live_ofs; n > 0; n--, ofp++) {
+        add_live_ofs(*ofp, stats->reg, &regs, &max_reg, &reg_map,
+                     &has_big_reg, &slots, &max_slot, stats);
+      }
+    }
+
+    /* Record size of GC "offset" table */
+    count_item(num_live, &stats->max_lives, stats->small_lives,
+               stats->log_lives);
+
+    /* Register counts and maps, recorded only for allocation descriptors.
+       Non-allocation descriptors are not expected to keep GC roots in
+       registers, so count any that do as an anomaly rather than folding
+       them into the register statistics. */
+    if (frame_has_allocs(d)) {
+      if (regs < REGS) {
+        ++ stats->reg_count[regs];
+      }
+      if (max_reg < REGS) {
+        ++ stats->max_reg[max_reg];
+      }
+      if (regs > stats->max_regs) {
+        stats->max_regs = regs;
+      }
+      if (reg_map < REG_MAPS) {
+        ++ stats->reg_maps[reg_map];
+      }
+      if (has_big_reg) {
+        ++ stats->big_reg_descrs;
+      }
+    } else if (regs > 0) {
+      ++ stats->noalloc_with_regs;
+    }
+
+    /* Slot counts */
+    count_item(slots, &stats->max_slots, stats->small_slots,
+               stats->log_slots);
+
+    /* Maximum slot offset */
+    count_item(max_slot, &stats->max_slot, stats->small_max_slot,
+               stats->log_max_slot);
+
+    p = (unsigned char*)frame_end_of_live_ofs(d);
+    size_t num_debuginfo = 1;
+    if (frame_has_allocs(d)) {
+      ++ stats->with_alloc;
+      size_t num_allocs = *(uint8_t *)p;
+      stats->alloc_sizes += num_allocs;
+      num_debuginfo = num_allocs;
+      count_item(num_allocs, &stats->max_comballocs, stats->small_comballocs,
+                 stats->log_comballocs);
+      ++ p;
+      for (size_t idx = 0; idx < num_allocs; ++idx) {
+        count_item(p[idx], &stats->max_alloc_size, stats->small_alloc_sizes,
+                   stats->log_alloc_sizes);
+      }
+      p += num_allocs;
+    }
+    /* Count debug info if present */
+    if (frame_has_debug(d)) {
+      ++ stats->with_debug;
+      /* Align to 32 bits */
+      p = Align_to(p, uint32_t);
+      for (size_t i = 0; i <  num_debuginfo; ++i) {
+        uint32_t offset = *(uint32_t*)p;
+        if (offset) { /* there may be invalid debuginfo slots */
+          caml_debuginfo_measure((debuginfo)(p + offset));
+        }
+        p += sizeof(uint32_t);
+      }
+    }
+    /* Align to word size */
+    p = Align_to(p, void*);
+  }
+  if (!stats->max_descr || (p > stats->max_descr)) {
+    stats->max_descr = p;
+  }
+}
+
+/* Record stats for all descriptors from a frametable */
+
+static void add_frametable_to_stats(intnat *frametable,
+                                    struct frametable_stats *stats)
+{
+  ++ stats->frametables;
+  if (!stats->min_descr ||
+      ((unsigned char*)frametable < stats->min_descr)) {
+    stats->min_descr = (unsigned char*)frametable;
+  }
+  if (!stats->max_descr ||
+      ((unsigned char*)frametable > stats->max_descr)) {
+    stats->max_descr = (unsigned char*)(frametable+1);
+  }
+  intnat len = *frametable;
+  frame_descr * d = (frame_descr *)(frametable + 1);
+  for (intnat j = 0; j < len; j++) {
+    add_descriptor_to_stats(d, stats);
+    d = next_frame_descr(d);
+  }
+}
+
+/* Record and report stats for all frametables on a list */
+
+static void report_frametables_stats(caml_frametable_list *new_frametables)
+{
+  struct frametable_stats stats;
+  clear_stats(&stats);
+  iter_list(new_frametables, cur) {
+    add_frametable_to_stats(cur->frametable, &stats);
+    accumulate_frametable_stats(cur->frametable, &stats);
+    clear_per_frametable_stats(&stats);
+  }
+  report_stats(&stats);
+}
+
 static void add_frame_descriptors(
   caml_frame_descrs *table,
   caml_frametable_list *new_frametables)
@@ -226,9 +799,15 @@ static void add_frame_descriptors(
     if (table->descriptors == NULL) caml_raise_out_of_memory();
 
     fill_hashtable(table, new_frametables);
+    if (caml_measure_frametables) {
+      report_frametables_stats(new_frametables);
+    }
   } else {
     table->num_descr += increase;
     fill_hashtable(table, new_frametables);
+    if (caml_measure_frametables) {
+      report_frametables_stats(new_frametables);
+    }
     tail->next = table->frametables;
   }
 

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -981,9 +981,18 @@ static void report_frametables_stats(caml_frametable_list *new_frametables)
 
 /* The backend emits one pointer per linked unit into the caml_all_frametables
  * section; the linker concatenates them and provides these bounds. Weak so the
- * runtime still links where no such section exists (both NULL). */
+ * runtime still links where no such section exists (both NULL). The
+ * __start_/__stop_ encapsulation symbols are an ELF linker feature; on other
+ * platforms (e.g. Mach-O) the measurement covers no frametables. */
+#ifdef __ELF__
 extern intnat *__start_caml_all_frametables[] __attribute__((weak));
 extern intnat *__stop_caml_all_frametables[] __attribute__((weak));
+#define ALL_FRAMETABLES_START __start_caml_all_frametables
+#define ALL_FRAMETABLES_STOP __stop_caml_all_frametables
+#else
+#define ALL_FRAMETABLES_START ((intnat **)NULL)
+#define ALL_FRAMETABLES_STOP ((intnat **)NULL)
+#endif
 
 /* Measure every frametable in the executable - including dynlink-available
  * units that are never registered in caml_frametable[]. Reads only static data
@@ -992,8 +1001,8 @@ static void report_all_frametables_stats(void)
 {
   struct frametable_stats stats;
   clear_stats(&stats);
-  for (intnat **p = __start_caml_all_frametables;
-       p < __stop_caml_all_frametables; p++) {
+  for (intnat **p = ALL_FRAMETABLES_START;
+       p < ALL_FRAMETABLES_STOP; p++) {
     add_frametable_to_stats(*p, &stats);
     accumulate_frametable_stats(*p, &stats);
     clear_per_frametable_stats(&stats);

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -361,8 +361,6 @@ static void accumulate_frametable_stats(intnat *frametable,
   caml_debuginfo_measurements(&debuginfo_count,
                               &debuginfo_low,
                               &debuginfo_high);
-  /* round debuginfo_high up to word boundary */
-  debuginfo_high = Align_to(debuginfo_high, uintnat);
 /*
   printf("Frametable at %p: return addresses %p-%p(0x%zx), "
         "descriptors %p-%p(0x%zx, %zu), "
@@ -382,7 +380,12 @@ static void accumulate_frametable_stats(intnat *frametable,
 */
   stats->total_codesize += (stats->max_retaddr - stats->min_retaddr);
   stats->total_ft_size += (stats->max_descr - stats->min_descr);
-  stats->total_debuginfo_size += (debuginfo_high - debuginfo_low);
+  /* Each debuginfo record is two 32-bit words; the name_info /
+     name_and_loc_info structs occupy [debuginfo_low, debuginfo_high). The
+     deduplicated filename/defname strings live in a separate section and are
+     not counted here. */
+  stats->total_debuginfo_size += debuginfo_count * 2 * sizeof(uint32_t)
+                                 + (debuginfo_high - debuginfo_low);
   stats->total_descrs += stats->descrs;
   stats->total_debuginfo += debuginfo_count;
   if (stats->min_retaddr) {

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -57,6 +57,7 @@ extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
 extern uintnat caml_nohugepage_stacks;    /* see fiber.c */
 extern uintnat caml_enable_segv_handler;  /* see signals.c / signals_nat.c */
 uintnat caml_measure_frametables = 0; /* see frame_descriptors.c */
+uintnat caml_measure_all_frametables = 0; /* see frame_descriptors.c */
 
 /* runtime config parameters set with caml_gc_set */
 extern atomic_uintnat caml_major_heap_increment; /* percent or words; see shared_heap.c */
@@ -463,6 +464,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "cache_stacks_per_class", &caml_cache_stacks_per_class, 0 },
   { "tick_use_usleep", &caml_tick_use_usleep, 0 },
   { "measure_frametables", &caml_measure_frametables, 0 },
+  { "measure_all_frametables", &caml_measure_all_frametables, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -56,6 +56,7 @@ extern uintnat caml_percent_sweep_per_mark; /* see major_gc.c */
 extern uintnat caml_gc_overhead_adjustment; /* see major_gc.c */
 extern uintnat caml_nohugepage_stacks;    /* see fiber.c */
 extern uintnat caml_enable_segv_handler;  /* see signals.c / signals_nat.c */
+uintnat caml_measure_frametables = 0; /* see frame_descriptors.c */
 
 /* runtime config parameters set with caml_gc_set */
 extern atomic_uintnat caml_major_heap_increment; /* percent or words; see shared_heap.c */
@@ -461,6 +462,7 @@ static struct gc_tweak gc_tweaks[] = {
   { "enable_segv_handler", &caml_enable_segv_handler, 0 },
   { "cache_stacks_per_class", &caml_cache_stacks_per_class, 0 },
   { "tick_use_usleep", &caml_tick_use_usleep, 0 },
+  { "measure_frametables", &caml_measure_frametables, 0 },
 };
 
 enum {N_GC_TWEAKS = sizeof(gc_tweaks)/sizeof(gc_tweaks[0])};

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -37,12 +37,25 @@
 #include "caml/signals.h"
 #include "caml/stack.h"
 
+/* The number of allocations in a frame descriptor fits in a byte. */
+#define Alloc_len_bufsize 256
+
 /* Get allocation info for the current frame, for re-doing allocations after GC
    or resuming preemption.
 
    Returns the allocation size in words (wosize, without header).
-   Sets *alloc_len_out and *nallocs_out if they are non-NULL. */
-Caml_inline intnat current_frame_alloc_wosize(unsigned char** alloc_len_out,
+   Sets *alloc_len_out and *nallocs_out if they are non-NULL.
+
+   [unpacked] is caller-owned scratch space of at least
+   [Alloc_len_bufsize] bytes; *alloc_len_out may point into it. It
+   must not be shared (static or thread-local): the result is
+   consumed across operations which can re-enter this function on the
+   same thread (memprof sampling captures callstacks, which can
+   allocate, run pending memprof callbacks, and so trigger a nested
+   caml_garbage_collection), and a shared buffer would be overwritten
+   while still in use. */
+Caml_inline intnat current_frame_alloc_wosize(unsigned char* unpacked,
+                                              unsigned char** alloc_len_out,
                                               int* nallocs_out)
 {
   frame_descr* d;
@@ -58,13 +71,30 @@ Caml_inline intnat current_frame_alloc_wosize(unsigned char** alloc_len_out,
   d = caml_find_frame_descr(fds, retaddr);
   CAMLassert(d && !frame_return_to_C(d) && frame_has_allocs(d));
 
-  /* Compute the total allocation size at this point,
-     including allocations combined by Comballoc */
-  unsigned char* alloc_len = frame_end_of_live_ofs(d);
-  int nallocs = *alloc_len++;
-
-  if (nallocs == 0) {
-    return 0; /* This is a poll */
+  /* Compute the total allocation size at this point, including allocations
+     combined by Comballoc. The encoded allocation lengths are returned as a
+     byte-per-allocation array. In the short descriptor format they are stored
+     as 4-bit nibbles, so we unpack them into the caller's buffer. */
+  unsigned char* alloc_len;
+  int nallocs;
+  if (frame_is_short(d)) {
+    struct frame_descr_decoded dec;
+    caml_decode_frame_descr(d, &dec);
+    nallocs = dec.short_num_allocs;
+    if (nallocs == 0) {
+      return 0; /* This is a poll */
+    }
+    for (int i = 0; i < nallocs; i++) {
+      unsigned char byte = dec.short_allocs[i / 2];
+      unpacked[i] = (i & 1) ? (byte >> 4) : (byte & 0xf);
+    }
+    alloc_len = unpacked;
+  } else {
+    alloc_len = frame_end_of_live_ofs(d);
+    nallocs = *alloc_len++;
+    if (nallocs == 0) {
+      return 0; /* This is a poll */
+    }
   }
 
   intnat allocsz = 0;
@@ -97,9 +127,11 @@ void caml_garbage_collection(void)
      us. */
   atomic_thread_fence(memory_order_acquire);
 
+  unsigned char alloc_len_buf[Alloc_len_bufsize];
   unsigned char* alloc_len = NULL;
   int nallocs = 0;
-  intnat allocsz = current_frame_alloc_wosize(&alloc_len, &nallocs);
+  intnat allocsz =
+    current_frame_alloc_wosize(alloc_len_buf, &alloc_len, &nallocs);
 
   if (nallocs == 0) {
     /* This is a poll */
@@ -116,7 +148,8 @@ void caml_redo_preempted_allocation(void)
 {
   caml_domain_state * dom_st = Caml_state;
 
-  intnat allocsz = current_frame_alloc_wosize(NULL, NULL);
+  unsigned char alloc_len_buf[Alloc_len_bufsize];
+  intnat allocsz = current_frame_alloc_wosize(alloc_len_buf, NULL, NULL);
 
   if (allocsz == 0) {
     /* This is a poll - no allocation to redo */


### PR DESCRIPTION
**Not for merging** — this is #6399 (NickBarnes:frametable-rearrange) plus the two CI fixes proposed in NickBarnes/oxcaml#1, opened as a draft solely to demonstrate the `frame-pointers llvmize-tests` job going green, since fork PRs get no CI runners.

The two extra commits on top of #6399:
1. Promote `id_fn.output` / `dls_get.output` for the new `oxcaml_short_frametables` module flag.
2. Point the llvmize CI job at an LLVM release that includes ocaml-flambda/llvm-project#37 (temporary personal-fork release [`oxcaml-llvmize-16.0.6-minus3-pr37`](https://github.com/julesjacobs/llvm-project/releases/tag/oxcaml-llvmize-16.0.6-minus3-pr37) built from #37's head, until #37 is merged and an official release is minted).

Will be closed once NickBarnes/oxcaml#1 is merged into #6399 (which makes #6399's own CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)