### PR TITLE
Update Merlin syntax-doc to use beta.oxcaml.org rather than oxcaml.org

### DIFF
--- a/external/merlin/src/analysis/syntax_doc.ml
+++ b/external/merlin/src/analysis/syntax_doc.ml
@@ -11,7 +11,7 @@ let syntax_doc_url (doc_website_base : Doc_website_base.t) endpoint =
   let base_url =
     match doc_website_base with
     | Ocaml -> "https://ocaml.org/manual/5.2/"
-    | Oxcaml -> "https://oxcaml.org/documentation/"
+    | Oxcaml -> "https://beta.oxcaml.org/documentation/"
   in
   Some (base_url ^ endpoint)
 

--- a/external/merlin/tests/test-dirs/syntax-document/language-extensions.t/run.t
+++ b/external/merlin/tests/test-dirs/syntax-document/language-extensions.t/run.t
@@ -907,6 +907,6 @@ Validate that docstrings, URLs, and levels are being created correctly
   {
     "name": "Kind abbreviation",
     "description": "The kind of ordinary OCaml types",
-    "url": "https://oxcaml.org/documentation/kinds/syntax/",
+    "url": "https://beta.oxcaml.org/documentation/kinds/syntax/",
     "level": "advanced"
   }


### PR DESCRIPTION
Update the Merlin `syntax-document` query to point to beta.oxcaml.org instead of oxcaml.org, as the former is more up-to-date. In the fullness of time, this is something that should be configurable, as we should probably use oxcaml.org in public releases.