### PR TITLE
Implement `split` statement in ocamltest

### DIFF
--- a/ocamltest/OCAMLTEST.org
+++ b/ocamltest/OCAMLTEST.org
@@ -611,6 +611,44 @@ For instance, given the following blocks:
 
 - The definition of =baz= is visible only in =subtest1=.
 
+*** Repeating similar tests with =split=
+
+You can concisely define several tests with differing initial setups with the
+=split= command:
+
+#+begin_src
+(* TEST
+  {
+    split [
+    | flags = "-flag1";
+    | flags = "-flag2";
+    ]
+    native;
+  }
+*)
+#+end_src
+
+is equivalent to
+
+#+begin_src
+(* TEST
+  {
+    flags = "-flag1";
+    native;
+  }
+  {
+    flags = "-flag2";
+    native;
+  }
+*)
+#+end_src
+
+Each alternative introduced by =|= is a (possibly empty) sequence of environment
+statements and tests. Everything that follows the =split= in the enclosing
+block, including sub-blocks, is run once per alternative, after the
+alternative's statements. Combining =split= statements produces a cartesian
+product.
+
 ** Other useful tests
 
 This section introduces three tests provided by =ocamltest= and that can

--- a/ocamltest/OCAMLTEST.org
+++ b/ocamltest/OCAMLTEST.org
@@ -618,13 +618,11 @@ You can concisely define several tests with differing initial setups with the
 
 #+begin_src
 (* TEST
-  {
-    split [
-    | flags = "-flag1";
-    | flags = "-flag2";
-    ]
-    native;
-  }
+  split [
+  | flags = "-flag1";
+  | flags = "-flag2";
+  ]
+  native;
 *)
 #+end_src
 

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -130,6 +130,10 @@ let string_of_test_location ~branches line =
   ^ Printf.sprintf "line %d" line
 
 let run_test_tree log add_msg behavior env summ ast =
+  (* Interpret the statements contained in [stmts] and [segments] (effectively,
+     run [stmts @ List.concat segments]), then go into each of the subtrees in
+     [subs]. [branches] is a list of indices of [split] arms that we've
+     descended into. *)
   let rec run_statements behavior env summ stmts segments subs ~branches
       ~must_do_something =
     match stmts with

--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -116,23 +116,37 @@ let join_parallel r1 r2 =
   | Pass, _ | _, Pass -> Pass
   | Skip, Skip -> Skip
 
+let join_list_parallel results = List.fold_left join_parallel Skip results
+
 let string_of_summary = function
   | Pass -> "passed"
   | Fail -> "failed"
   | Skip -> "skipped"
 
+let string_of_test_location ~branches line =
+  String.concat ""
+    (List.rev_map (fun branch -> Printf.sprintf "branch %d: " branch)
+       branches)
+  ^ Printf.sprintf "line %d" line
+
 let run_test_tree log add_msg behavior env summ ast =
-  let run_statement (behavior, env, summ, must_do_something) = function
-    | Environment_statement s ->
+  let rec run_statements behavior env summ stmts segments subs ~branches
+      ~must_do_something =
+    match stmts with
+    | Environment_statement s :: rest ->
       begin match interpret_environment_statement env s with
-      | env -> Ok (behavior, env, summ, must_do_something)
+      | env ->
+        run_statements behavior env summ rest segments subs ~branches
+          ~must_do_something
       | exception e ->
         let bt = Printexc.get_backtrace () in
         let line = s.loc.Location.loc_start.Lexing.pos_lnum in
-        Printf.ksprintf add_msg "line %d %s" line (report_error s.loc e bt);
-        Error Fail
+        Printf.ksprintf add_msg "%s %s"
+          (string_of_test_location ~branches line)
+          (report_error s.loc e bt);
+        Fail
       end
-    | Test (_, name, mods) ->
+    | Test (_, name, mods) :: rest ->
       let skip_all =
         match behavior with
         | Skip_all -> true
@@ -142,7 +156,8 @@ let run_test_tree log add_msg behavior env summ ast =
         if name.loc = Location.none then
           "default"
         else
-          Printf.sprintf "line %d" name.loc.Location.loc_start.Lexing.pos_lnum
+          string_of_test_location ~branches
+            name.loc.Location.loc_start.Lexing.pos_lnum
       in
       let test = lookup_test name in
       let (msg, behavior, env, result) =
@@ -167,15 +182,25 @@ let run_test_tree log add_msg behavior env summ ast =
       let must_do_something =
         must_do_something && not (Tests.does_something test)
       in
-      Ok (behavior, env, summ, must_do_something)
-  in
-  let rec run_tree behavior env summ (Ast (stmts, subs)) ~must_do_something =
-    match
-      List.fold_left_result run_statement
-        (behavior, env, summ, must_do_something) stmts
-    with
-    | Error e -> e
-    | Ok (behavior, env, summ, must_do_something) ->
+      run_statements behavior env summ rest segments subs ~branches
+        ~must_do_something
+    | Split alternatives :: rest ->
+      let count = List.length alternatives in
+      let run_alternative i alternative =
+        Printf.fprintf log "Running split branch %d of %d\n%!" (i + 1) count;
+        run_statements behavior env summ alternative (rest :: segments)
+          subs ~branches:(i + 1 :: branches) ~must_do_something
+      in
+      join_list_parallel (List.mapi run_alternative alternatives)
+    | [] ->
+      run_segments behavior env summ segments subs ~branches ~must_do_something
+  and run_segments behavior env summ segments subs ~branches
+      ~must_do_something =
+    match segments with
+    | segment :: segments ->
+        run_statements behavior env summ segment segments subs ~branches
+          ~must_do_something
+    | [] ->
         (* If [subs] is empty, there are no further test actions to
            perform: we are at the end of a test path and can report
            our current summary. Otherwise we continue with each
@@ -194,10 +219,15 @@ let run_test_tree log add_msg behavior env summ ast =
         (* CR mshinwell/xclerc: maybe sequences of actions that "do something"
            and then have further actions that do not "do something" should be
            flagged *)
-            List.fold_left join_parallel Skip
-              (List.map (run_tree behavior env summ ~must_do_something) subs)
+            join_list_parallel
+              (List.map
+                (run_tree behavior env summ ~branches ~must_do_something)
+                subs)
         end
-  in run_tree behavior env summ ast ~must_do_something:true
+  and run_tree behavior env summ (Ast (stmts, subs)) ~branches
+      ~must_do_something =
+    run_statements behavior env summ stmts [] subs ~branches ~must_do_something
+  in run_tree behavior env summ ast ~branches:[] ~must_do_something:true
 
 let get_test_source_directory test_dirname =
   if (Filename.is_relative test_dirname) then

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -32,6 +32,7 @@ type tsl_item =
     int (* test depth *) *
     string located (* test name *) *
     string located list (* environment modifiers *)
+  | Split of tsl_item list list (* alternative statement sequences *)
 
 type tsl_block = tsl_item list
 

--- a/ocamltest/tsl_ast.ml
+++ b/ocamltest/tsl_ast.ml
@@ -34,7 +34,7 @@ type tsl_item =
     string located list (* environment modifiers *)
   | Split of tsl_item list list (* alternative statement sequences *)
 
-type tsl_block = tsl_item list
+and tsl_block = tsl_item list
 
 type t = Ast of tsl_item list * t list
 

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -33,7 +33,7 @@ type tsl_item =
     int (* test depth *) *
     string located (* test name *) *
     string located list (* environment modifiers *)
-  | Split of tsl_item list list
+  | Split of tsl_block list
 
 type tsl_block = tsl_item list
 

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -33,6 +33,7 @@ type tsl_item =
     int (* test depth *) *
     string located (* test name *) *
     string located list (* environment modifiers *)
+  | Split of tsl_item list list
 
 type tsl_block = tsl_item list
 

--- a/ocamltest/tsl_ast.mli
+++ b/ocamltest/tsl_ast.mli
@@ -35,7 +35,7 @@ type tsl_item =
     string located list (* environment modifiers *)
   | Split of tsl_block list
 
-type tsl_block = tsl_item list
+and tsl_block = tsl_item list
 
 (* New syntax *)
 type t = Ast of tsl_item list * t list

--- a/ocamltest/tsl_lexer.mll
+++ b/ocamltest/tsl_lexer.mll
@@ -75,12 +75,16 @@ and token = parse
       match s with
         | "include" -> INCLUDE
         | "set" -> SET
+        | "split" -> SPLIT
         | "unset" -> UNSET
         | "with" -> WITH
         | _ -> IDENTIFIER s
     }
   | "{" { LEFT_BRACE }
   | "}" { RIGHT_BRACE }
+  | "[" { LEFT_BRACKET }
+  | "]" { RIGHT_BRACKET }
+  | "|" { BAR }
   | ";" { SEMI }
   | "(*"
     {

--- a/ocamltest/tsl_parser.mly
+++ b/ocamltest/tsl_parser.mly
@@ -36,10 +36,11 @@ let mkenvstmt envstmt =
 %token <[`Above | `Below]> TSL_BEGIN_OCAML_STYLE
 %token TSL_END_OCAML_STYLE
 %token COMMA LEFT_BRACE RIGHT_BRACE SEMI
+%token BAR LEFT_BRACKET RIGHT_BRACKET
 %token <int> TEST_DEPTH
 %token EQUAL PLUSEQUAL
 /* %token COLON */
-%token INCLUDE SET UNSET WITH
+%token INCLUDE SET SPLIT UNSET WITH
 %token <string> IDENTIFIER
 %token <string> STRING
 
@@ -66,6 +67,11 @@ statement_list:
 statement:
 | env_item SEMI { $1 }
 | identifier with_environment_modifiers SEMI { Test (0, $1, $2) }
+| SPLIT LEFT_BRACKET split_arms RIGHT_BRACKET { Split $3 }
+
+split_arms:
+| BAR statement_list { [$2] }
+| BAR statement_list split_arms { $2 :: $3 }
 
 tsl_script:
 | TSL_BEGIN_C_STYLE node TSL_END_C_STYLE { $2 }

--- a/ocamltest/tsl_semantics.ml
+++ b/ocamltest/tsl_semantics.ml
@@ -84,6 +84,10 @@ let unexpected_environment_statement s =
   Printf.eprintf "%s\nUnexpected environment statement\n%!" locstr;
   exit 2
 
+let split_statement_not_supported () =
+  Printf.eprintf "Split statements are not supported in old-style blocks\n%!";
+  exit 2
+
 exception No_such_test_or_action of string
 
 let lookup_test located_name =
@@ -109,6 +113,7 @@ let test_trees_of_tsl_block tsl_block =
     | line::remaining_lines as l ->
       begin match line with
         | Environment_statement s -> unexpected_environment_statement s
+        | Split _ -> split_statement_not_supported ()
         | Test (test_depth, located_name, env_modifiers) ->
           begin
             let name = located_name.node in
@@ -140,7 +145,7 @@ let test_trees_of_tsl_block tsl_block =
     | (Environment_statement s)::_ -> unexpected_environment_statement s
     | _ -> assert false
 
-let tests_in_stmt set stmt =
+let rec tests_in_stmt set stmt =
   match stmt with
   | Environment_statement _ -> set
   | Test (_, name, _) ->
@@ -148,6 +153,8 @@ let tests_in_stmt set stmt =
     | t -> Tests.TestSet.add t set
     | exception No_such_test_or_action _ -> set
     end
+  | Split alternatives ->
+    List.fold_left (List.fold_left tests_in_stmt) set alternatives
 
 let rec tests_in_tree_aux set (Tsl_ast.Ast (stmts, subs)) =
   let set1 = List.fold_left tests_in_stmt set stmts in
@@ -205,6 +212,15 @@ let print_tsl_ast ~compact oc ast =
       print_statements indent tl;
     | Environment_statement env :: tl->
       print_env indent env;
+      print_statements indent tl;
+    | Split alternatives :: tl ->
+      pr "%ssplit [\n" indent;
+      List.iter
+        (fun alternative ->
+          pr "%s|\n" indent;
+          print_statements (indent ^ "  ") alternative)
+        alternatives;
+      pr "%s]\n" indent;
       print_statements indent tl;
     | [] -> ()
 

--- a/testsuite/tests/backtrace-multifiles/main.ml
+++ b/testsuite/tests/backtrace-multifiles/main.ml
@@ -21,61 +21,32 @@ let () =
 
 (* TEST
  readonly_files = "foo.ml";
- {
-   compiler_directory_suffix = ".O3";
-   setup-ocamlopt.opt-build-env;
-   module = "foo.ml";
-   flags = "-g -O3";
-   ocamlopt.opt;
-   module = "main.ml";
-   flags = "-g -O3";
-   ocamlopt.opt;
-   module = "";
-   all_modules = "foo.cmx main.cmx";
-   ocamlopt.opt;
-   run;
-   check-program-output;
- }{
-   compiler_directory_suffix = ".Oclassic";
-   setup-ocamlopt.opt-build-env;
-   module = "foo.ml";
-   flags = "-g -Oclassic";
-   ocamlopt.opt;
-   module = "main.ml";
-   flags = "-g -Oclassic";
-   ocamlopt.opt;
-   module = "";
-   all_modules = "foo.cmx main.cmx";
-   ocamlopt.opt;
-   run;
-   check-program-output;
- }{
-   compiler_directory_suffix = ".O3-Oclassic";
-   setup-ocamlopt.opt-build-env;
-   module = "foo.ml";
-   flags = "-g -O3";
-   ocamlopt.opt;
-   module = "main.ml";
-   flags = "-g -Oclassic";
-   ocamlopt.opt;
-   module = "";
-   all_modules = "foo.cmx main.cmx";
-   ocamlopt.opt;
-   run;
-   check-program-output;
- }{
-   compiler_directory_suffix = ".Oclassic-O3";
-   setup-ocamlopt.opt-build-env;
-   module = "foo.ml";
-   flags = "-g -Oclassic";
-   ocamlopt.opt;
-   module = "main.ml";
-   flags = "-g -O3";
-   ocamlopt.opt;
-   module = "";
-   all_modules = "foo.cmx main.cmx";
-   ocamlopt.opt;
-   run;
-   check-program-output;
- }
+ set foo_flags = "";
+ set main_flags = "";
+ split [
+ | compiler_directory_suffix = ".O3";
+   foo_flags = "-O3";
+   main_flags = "-O3";
+ | compiler_directory_suffix = ".Oclassic";
+   foo_flags = "-Oclassic";
+   main_flags = "-Oclassic";
+ | compiler_directory_suffix = ".O3-Oclassic";
+   foo_flags = "-O3";
+   main_flags = "-Oclassic";
+ | compiler_directory_suffix = ".Oclassic-O3";
+   foo_flags = "-Oclassic";
+   main_flags = "-O3";
+ ]
+ setup-ocamlopt.opt-build-env;
+ module = "foo.ml";
+ flags = "-g ${foo_flags}";
+ ocamlopt.opt;
+ module = "main.ml";
+ flags = "-g ${main_flags}";
+ ocamlopt.opt;
+ module = "";
+ all_modules = "foo.cmx main.cmx";
+ ocamlopt.opt;
+ run;
+ check-program-output;
 *)

--- a/testsuite/tests/dash-Ix/test.ml
+++ b/testsuite/tests/dash-Ix/test.ml
@@ -62,35 +62,24 @@ ocamlc.byte;
    ordering of -I flags.  B was compiled against liba, so using liba_alt for A
    causes inconsistent assumptions. *)
 {
-  (* Test: -Ix liba before -I liba_alt: liba wins, compiles fine. *)
-  flags = "-Ix liba -I liba_alt -I libb -nocwd";
+  split [
+  | (* Test: -Ix liba before -I liba_alt: liba wins, compiles fine. *)
+    flags = "-Ix liba -I liba_alt -I libb -nocwd";
+  | (* Test: -I liba before -Ix liba_alt: liba wins, compiles fine. *)
+    flags = "-I liba -Ix liba_alt -I libb -nocwd";
+  ]
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
   ocamlc.byte;
 }
 {
-  (* Test: -I liba before -Ix liba_alt: liba wins, compiles fine. *)
-  flags = "-I liba -Ix liba_alt -I libb -nocwd";
-  module = "libc/c1.ml";
-  setup-ocamlc.byte-build-env;
-  ocamlc.byte;
-}
-{
-  (* Test: -Ix liba_alt before -I liba: liba_alt wins, inconsistent. *)
   not-windows;
-  flags = "-Ix liba_alt -I liba -I libb -nocwd";
-  module = "libc/c1.ml";
-  setup-ocamlc.byte-build-env;
-  ocamlc_byte_exit_status = "2";
-  ocamlc.byte;
-  compiler_reference =
-    "${test_source_directory}/wrong_include_order.ocamlc.reference";
-  check-ocamlc.byte-output;
-}
-{
-  (* Test: -I liba_alt before -Ix liba: liba_alt wins, inconsistent. *)
-  not-windows;
-  flags = "-I liba_alt -Ix liba -I libb -nocwd";
+  split [
+  | (* Test: -Ix liba_alt before -I liba: liba_alt wins, inconsistent. *)
+    flags = "-Ix liba_alt -I liba -I libb -nocwd";
+  | (* Test: -I liba_alt before -Ix liba: liba_alt wins, inconsistent. *)
+    flags = "-I liba_alt -Ix liba -I libb -nocwd";
+  ]
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
   ocamlc_byte_exit_status = "2";

--- a/testsuite/tests/hidden_includes/test.ml
+++ b/testsuite/tests/hidden_includes/test.ml
@@ -60,16 +60,12 @@ ocamlc.byte;
   compiler_reference = "${test_source_directory}/not_included.ocamlc.reference";
   check-ocamlc.byte-output;
 }
+(* Test transitive use of A's cmi, both with -I and with -H. *)
 {
-  (* Test transitive use of A's cmi with -I. *)
-  flags = "-I liba -I libb -nocwd";
-  module = "libc/c1.ml";
-  setup-ocamlc.byte-build-env;
-  ocamlc.byte;
-}
-{
-  (* Test transitive use of A's cmi with -H. *)
-  flags = "-H liba -I libb -nocwd";
+  split [
+  | flags = "-I liba -I libb -nocwd";
+  | flags = "-H liba -I libb -nocwd";
+  ]
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
   ocamlc.byte;
@@ -90,31 +86,20 @@ ocamlc.byte;
    order on the command line.
 *)
 {
-  flags = "-H liba_alt -I liba -I libb -nocwd";
-  module = "libc/c1.ml";
-  setup-ocamlc.byte-build-env;
-  ocamlc.byte;
-}
-{
-  flags = "-I liba -H liba_alt -I libb -nocwd";
+  split [
+  | flags = "-H liba_alt -I liba -I libb -nocwd";
+  | flags = "-I liba -H liba_alt -I libb -nocwd";
+  ]
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
   ocamlc.byte;
 }
 {
   not-target-windows;
-  flags = "-H liba -I liba_alt -I libb -nocwd";
-  module = "libc/c1.ml";
-  setup-ocamlc.byte-build-env;
-  ocamlc_byte_exit_status = "2";
-  ocamlc.byte;
-  compiler_reference =
-    "${test_source_directory}/wrong_include_order.ocamlc.reference";
-  check-ocamlc.byte-output;
-}
-{
-  not-target-windows;
-  flags = "-I liba_alt -H liba -I libb -nocwd";
+  split [
+  | flags = "-H liba -I liba_alt -I libb -nocwd";
+  | flags = "-I liba_alt -H liba -I libb -nocwd";
+  ]
   module = "libc/c1.ml";
   setup-ocamlc.byte-build-env;
   ocamlc_byte_exit_status = "2";
@@ -178,17 +163,12 @@ ocamlc.byte;
 }
 
 (* Test that [-open-cmi] reads the cmi from the given path without
-   consulting the include path. *)
+   consulting the include path, and that it works alongside -H. *)
 {
-  flags = "-nocwd -open-cmi liba/a.cmi";
-  module = "libb/b_open.ml";
-  setup-ocamlc.byte-build-env;
-  ocamlc.byte;
-}
-
-(* Test that [-open-cmi] works alongside -H. *)
-{
-  flags = "-H liba -I libb -nocwd -open-cmi liba/a.cmi";
+  split [
+  | flags = "-nocwd -open-cmi liba/a.cmi";
+  | flags = "-H liba -I libb -nocwd -open-cmi liba/a.cmi";
+  ]
   module = "libb/b_open.ml";
   setup-ocamlc.byte-build-env;
   ocamlc.byte;

--- a/testsuite/tests/runtime-errors/syserror.ml
+++ b/testsuite/tests/runtime-errors/syserror.ml
@@ -1,35 +1,22 @@
 (* TEST
  flags = "-w -a";
- {
-   setup-ocamlc.byte-build-env;
+ split [
+ | setup-ocamlc.byte-build-env;
    ocamlc.byte;
-   exit_status = "2";
-   run;
-   hasunix;
-   {
-     not-target-windows;
-     reference = "${test_source_directory}/syserror.unix.reference";
-     check-program-output;
-   }{
-     target-windows;
-     reference = "${test_source_directory}/syserror.win32.reference";
-     check-program-output;
-   }
- }{
-   setup-ocamlopt.byte-build-env;
+ | setup-ocamlopt.byte-build-env;
    ocamlopt.byte;
-   exit_status = "2";
-   run;
-   hasunix;
-   {
-     not-target-windows;
-     reference = "${test_source_directory}/syserror.unix.reference";
-     check-program-output;
-   }{
-     target-windows;
-     reference = "${test_source_directory}/syserror.win32.reference";
-     check-program-output;
-   }
+ ]
+ exit_status = "2";
+ run;
+ hasunix;
+ {
+   not-target-windows;
+   reference = "${test_source_directory}/syserror.unix.reference";
+   check-program-output;
+ }{
+   target-windows;
+   reference = "${test_source_directory}/syserror.win32.reference";
+   check-program-output;
  }
 *)
 

--- a/testsuite/tests/tool-ocamltest/split-accum.sh
+++ b/testsuite/tests/tool-ocamltest/split-accum.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Helper for split.ml: record which split alternative is running.
+
+echo "$arm" >> arms.txt

--- a/testsuite/tests/tool-ocamltest/split-check.sh
+++ b/testsuite/tests/tool-ocamltest/split-check.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Helper for split.ml: check that every split alternative ran, in order.
+
+printf 'a\nb\nc\n' | cmp -s - arms.txt

--- a/testsuite/tests/tool-ocamltest/split.ml
+++ b/testsuite/tests/tool-ocamltest/split.ml
@@ -1,0 +1,21 @@
+(* TEST
+ set arm = "unset";
+ {
+   split [
+   | arm = "a";
+   | arm = "b";
+   | arm = "c";
+   ]
+   script = "sh ${test_source_directory}/split-accum.sh";
+   script;
+ }
+ {
+   script = "sh ${test_source_directory}/split-check.sh";
+   script;
+ }
+*)
+
+(* This file tests the "split" syntax of ocamltest. The first block should run once per
+   alternative, each run appending the value of the variable "arm" to a file in the test
+   build directory; the second block checks that all three alternatives actually ran, in
+   order. *)

--- a/testsuite/tests/tool-toplevel-invocation/test.ml
+++ b/testsuite/tests/tool-toplevel-invocation/test.ml
@@ -2,37 +2,19 @@
  readonly_files = "first_arg_fail.txt last_arg_fail.txt";
  setup-ocaml-build-env;
  {
-   flags = "-args ${test_source_directory}/first_arg_fail.txt";
-   compiler_reference = "${test_source_directory}/first_arg_fail.txt.reference";
-   compiler_output = "${test_build_directory}/first_arg_fail.output";
+   set test_case = "";
    ocaml_exit_status = "2";
-   ocaml;
-   check-ocaml-output;
- }{
-   flags = "-args ${test_source_directory}/indirect_first_arg_fail.txt";
-   compiler_reference = "${test_source_directory}/indirect_first_arg_fail.txt.reference";
-   compiler_output = "${test_build_directory}/indirect_first_arg_fail.output";
-   ocaml_exit_status = "2";
-   ocaml;
-   check-ocaml-output;
- }{
-   flags = "-args ${test_source_directory}/indirect_last_arg_fail.txt";
-   compiler_reference = "${test_source_directory}/indirect_last_arg_fail.txt.reference";
-   compiler_output = "${test_build_directory}/indirect_last_arg_fail.output";
-   ocaml_exit_status = "2";
-   ocaml;
-   check-ocaml-output;
- }{
-   flags = "-args ${test_source_directory}/last_arg_fail.txt";
-   compiler_reference = "${test_source_directory}/last_arg_fail.txt.reference";
-   compiler_output = "${test_build_directory}/last_arg_fail.output";
-   ocaml_exit_status = "2";
-   ocaml;
-   check-ocaml-output;
- }{
-   flags = "-args ${test_source_directory}/working_arg.txt";
-   compiler_reference = "${test_source_directory}/working_arg.txt.reference";
-   compiler_output = "${test_build_directory}/working_arg.output";
+   split [
+   | test_case = "first_arg_fail";
+   | test_case = "indirect_first_arg_fail";
+   | test_case = "indirect_last_arg_fail";
+   | test_case = "last_arg_fail";
+   | test_case = "working_arg";
+     ocaml_exit_status = "0";
+   ]
+   flags = "-args ${test_source_directory}/${test_case}.txt";
+   compiler_reference = "${test_source_directory}/${test_case}.txt.reference";
+   compiler_output = "${test_build_directory}/${test_case}.output";
    ocaml;
    check-ocaml-output;
  }{


### PR DESCRIPTION
Adds a new `split` statement to ocamltest:

``` 
  split [
    | flags = "-flag1";
    | flags = "-flag2";
  ]
  native;
```

This runs `native` with `-flag1` and then with `-flag2`. See testsuite refactors for examples of how much this can save.