### PR TITLE
Allow definition (but not use) of atomic fields in mixed records

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -234,7 +234,7 @@ let iter_on_occurrences
       | Texp_idx (ba, uas) ->
           iter_block_access exp_env ba;
           List.iter (iter_unboxed_access exp_env) uas
-      | Texp_atomic_loc (_, _, lid, label_desc, _) ->
+      | Texp_atomic_loc { lid; label = label_desc; _ } ->
           add_label ~namespace:Label exp_env lid label_desc
       | Texp_new (path, lid, _, _) ->
           f ~namespace:Class exp_env path lid

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -721,7 +721,8 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
         {fields; representation; extended_expression } ->
       transl_record_unboxed_product ~scopes e.exp_loc e.exp_env
         fields representation extended_expression
-  | Texp_atomic_loc (arg, arg_sort, _id, lbl, alloc_mode) ->
+  | Texp_atomic_loc { record = arg; record_sort = arg_sort; record_repres;
+                      lid = _; label = lbl; alloc_mode; } ->
       let shape =
         (Shape
             [| Value (Typeopt.value_kind arg.exp_env arg.exp_loc arg.exp_type);
@@ -729,12 +730,17 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
             |])
       in
       let arg_sort = Jkind.Sort.default_for_transl_and_get arg_sort in
-      let repres =
-        match lbl.lbl_repres with
-        | Record_variable | Record_inlined (_, Constructor_variable, _) ->
-            Misc.fatal_errorf "Texp_atomic_loc on record with [any] field %s"
-              lbl.lbl_name
-        | repres -> repres
+      let repres = match record_repres with
+        | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) ->
+            record_repres
+
+        (* Expect that usage of atomic.loc with mixed/variable records was
+           rejected during typechecking. *)
+        | Record_unboxed | Record_inlined (_, Constructor_variable, _)
+        | Record_inlined (_, Constructor_mixed _, _) | Record_float
+        | Record_ufloat | Record_mixed _ | Record_dummy _ | Record_variable ->
+          Misc.fatal_error
+            "transl: Texp_atomic_loc got unexpected record representation"
       in
       let arg_layout = layout_exp arg_sort arg in
       let (arg, lbl) = transl_atomic_loc ~scopes arg arg_layout lbl repres in

--- a/testsuite/tests/atomic-locs/mixed_records.ml
+++ b/testsuite/tests/atomic-locs/mixed_records.ml
@@ -215,3 +215,95 @@ Line 4, characters 4-31:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Atomic record fields must have layout value.
 |}]
+
+(* Test functional updates of mixed records with atomics. *)
+
+(* We disallow functional updates that perform implicit loads of atomic fields. *)
+module Functional_update_error = struct
+  type t = { x : int64# ; mutable y : int [@atomic] }
+
+  (* The update performs an implicit atomic load of y. Not allowed! *)
+  let forbidden t = { t with x = #42L }
+end
+[%%expect{|
+Line 5, characters 22-23:
+5 |   let forbidden t = { t with x = #42L }
+                          ^
+Error: Functional updates that implicitly read atomic fields (here "y")
+       are forbidden. Hint: if you intend to copy the value
+       of an atomic field, do so explicitly: "{ t with y = t.y }"
+|}]
+
+(* Updates that overwrite all of the old record's atomic fields are allowed. *)
+
+module Functional_update_ok = struct
+  type t = { x : int64# ; mutable y : int [@atomic] }
+
+  (* The update performs no implicit atomic loads. Allowed! *)
+  let allowed t = { t with y = 42 }
+end
+[%%expect{|
+module Functional_update_ok :
+  sig
+    type t = { x : int64#; mutable y : int [@atomic]; }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_copy_ok = struct
+  type t = { x : int64# ; mutable y : int [@atomic] }
+
+  (* The update performs an explicit atomic load. Allowed! *)
+  let allowed t = { t with y = t.y }
+end
+[%%expect{|
+Line 5, characters 31-32:
+5 |   let allowed t = { t with y = t.y }
+                                   ^
+Error: Accessing atomic fields (here "y") of mixed records is not yet
+       supported.
+|}]
+
+module Functional_update_multi_error = struct
+  type t = { x : int64# ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let forbidden t = { t with y = 42 } (* implicit atomic load of z *)
+end
+[%%expect{|
+Line 4, characters 22-23:
+4 |   let forbidden t = { t with y = 42 } (* implicit atomic load of z *)
+                          ^
+Error: Functional updates that implicitly read atomic fields (here "z")
+       are forbidden. Hint: if you intend to copy the value
+       of an atomic field, do so explicitly: "{ t with z = t.z }"
+|}]
+
+module Functional_update_multi_ok = struct
+  type t = { x : int64# ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
+end
+[%%expect{|
+module Functional_update_multi_ok :
+  sig
+    type t = {
+      x : int64#;
+      mutable y : int [@atomic];
+      mutable z : int [@atomic];
+    }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_multi_copy_ok = struct
+  type t = { x : int64# ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
+end
+[%%expect{|
+Line 4, characters 31-32:
+4 |   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
+                                   ^
+Error: Accessing atomic fields (here "y") of mixed records is not yet
+       supported.
+|}]

--- a/testsuite/tests/atomic-locs/mixed_records.ml
+++ b/testsuite/tests/atomic-locs/mixed_records.ml
@@ -1,0 +1,217 @@
+(* TEST
+   flags = "-extension layouts_alpha";
+   expect;
+*)
+
+(* Atomic field test cases that use mixed records (contain both
+   values and nonvalues). *)
+
+(* Atomic fields must be mutable. *)
+module Error1_mixed = struct
+  type t = { padding: #(int * int * int); x : int [@atomic] }
+end
+[%%expect{|
+Line 2, characters 42-59:
+2 |   type t = { padding: #(int * int * int); x : int [@atomic] }
+                                              ^^^^^^^^^^^^^^^^^
+Error: The label "x" must be mutable to be declared atomic.
+|}];;
+
+
+(* [%atomic.loc _] payload must be a record field access *)
+module Error2_mixed = struct
+  type t = { padding: #(int * int * int); mutable x : int [@atomic] }
+  let f t = [%atomic.loc t]
+end
+[%%expect{|
+Line 3, characters 12-27:
+3 |   let f t = [%atomic.loc t]
+                ^^^^^^^^^^^^^^^
+Error: Invalid "[%atomic.loc]" payload, a record field access is expected.
+|}];;
+
+
+(* [%atomic.loc _] only works on atomic fields *)
+module Error3_mixed = struct
+  type t = { padding: #(int * int * int); x : int }
+  let f t = [%atomic.loc t.x]
+end
+[%%expect{|
+Line 3, characters 12-29:
+3 |   let f t = [%atomic.loc t.x]
+                ^^^^^^^^^^^^^^^^^
+Error: The record field "x" is not atomic
+|}];;
+
+
+(* Module interface checking also works for atomic fields in mixed records. *)
+
+module Wrong1 = (struct
+  type t = { mutable x : int; y: int64# }
+end : sig
+  (* adding an 'atomic' attribute missing in the implementation: invalid. *)
+  type t = { mutable x : int [@atomic]; y: int64# }
+end)
+[%%expect{|
+Lines 1-3, characters 17-3:
+1 | .................struct
+2 |   type t = { mutable x : int; y: int64# }
+3 | end......
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = { mutable x : int; y : int64#; } end
+       is not included in
+         sig type t = { mutable x : int [@atomic]; y : int64#; } end
+       Type declarations do not match:
+         type t = { mutable x : int; y : int64#; }
+       is not included in
+         type t = { mutable x : int [@atomic]; y : int64#; }
+       Fields do not match:
+         "mutable x : int;"
+       is not the same as:
+         "mutable x : int [@atomic];"
+       The second is atomic and the first is not.
+|}];;
+
+module Wrong2 = (struct
+  type t = { mutable x : int [@atomic]; y: int64# }
+end : sig
+  (* removing an 'atomic' attribute present in the implementation: invalid. *)
+  type t = { mutable x : int; y: int64# }
+end)
+[%%expect{|
+Lines 1-3, characters 17-3:
+1 | .................struct
+2 |   type t = { mutable x : int [@atomic]; y: int64# }
+3 | end......
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = { mutable x : int [@atomic]; y : int64#; } end
+       is not included in
+         sig type t = { mutable x : int; y : int64#; } end
+       Type declarations do not match:
+         type t = { mutable x : int [@atomic]; y : int64#; }
+       is not included in
+         type t = { mutable x : int; y : int64#; }
+       Fields do not match:
+         "mutable x : int [@atomic];"
+       is not the same as:
+         "mutable x : int;"
+       The first is atomic and the second is not.
+|}];;
+
+module Ok = (struct
+  type t = { mutable x : int [@atomic]; y: int64# }
+end : sig
+  type t = { mutable x : int [@atomic]; y: int64# }
+end)
+[%%expect{|
+module Ok : sig type t = { mutable x : int [@atomic]; y : int64#; } end
+|}];;
+
+(* Pattern matching on atomic fields is not permitted in mixed blocks, either. *)
+module Pattern_matching = struct
+  type t = { x : int64#; mutable y : int [@atomic] }
+
+  let forbidden { x; y } = x + y
+end
+[%%expect{|
+Line 4, characters 16-24:
+4 |   let forbidden { x; y } = x + y
+                    ^^^^^^^^
+Error: Atomic fields (here "y") are forbidden in patterns,
+       as it is difficult to reason about when the atomic read
+       will happen during pattern matching: the field may be read
+       zero, one or several times depending on the patterns around it.
+|}]
+
+(* ... except for wildcards, to allow exhaustive record patterns. *)
+module Pattern_matching_wildcard = struct
+  type t = { x : int64#; mutable y : int [@atomic] }
+
+  [@@@warning "+missing-record-field-pattern"]
+  let warning { x } = x
+
+  let allowed { x; y = _ } = x
+  let also_allowed { x; _ } = x
+end
+[%%expect{|
+Line 5, characters 14-19:
+5 |   let warning { x } = x
+                  ^^^^^
+Warning 9 [missing-record-field-pattern]: the following labels are not bound
+  in this record pattern: "y".
+  Either bind these labels explicitly or add "; _" to the pattern.
+
+module Pattern_matching_wildcard :
+  sig
+    type t = { x : int64#; mutable y : int [@atomic]; }
+    val warning : t -> int64#
+    val allowed : t -> int64#
+    val also_allowed : t -> int64#
+  end
+|}]
+
+(* Defining atomic fields in a mixed block is permitted. *)
+module Mixed_blocks_ok = struct
+  type t = {
+    padding : #(int * int * int);
+    mutable field : int [@atomic]
+  }
+end
+
+[%%expect{|
+module Mixed_blocks_ok :
+  sig
+    type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
+  end
+|}]
+
+(* Test access of nonatomic fields in mixed record with atomic fields *)
+type t = { i : int64#; mutable a : int [@atomic]; mutable b : int }
+[%%expect {|
+type t = { i : int64#; mutable a : int [@atomic]; mutable b : int; }
+|}]
+
+let ok_project (t : t) = t.b
+[%%expect {|
+val ok_project : t -> int = <fun>
+|}]
+let ok_set (t : t) = t.b <- 42
+[%%expect {|
+val ok_set : t -> unit = <fun>
+|}]
+
+(* Test mixed record atomic fields with non-value layouts *)
+
+module Non_value_atomic_mixed = struct
+  type t = {
+    padding : #(int * int * int);
+    mutable field : #(int * float#) [@atomic]
+  }
+end
+
+[%%expect{|
+Line 4, characters 4-45:
+4 |     mutable field : #(int * float#) [@atomic]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields must have layout value.
+|}]
+
+module Non_value_atomic_mixed_rec = struct
+  type t = {
+    padding : #(int * int * int);
+    mutable field : u [@atomic]
+  }
+
+  and u = #{
+    x : int#
+  }
+end
+
+[%%expect{|
+Line 4, characters 4-31:
+4 |     mutable field : u [@atomic]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields must have layout value.
+|}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -1,5 +1,5 @@
 (* TEST
-   flags = "-dlambda -dno-locations -dno-unique-ids";
+   flags = "-dlambda -dno-locations -dno-unique-ids -extension layouts_alpha";
    expect;
 *)
 
@@ -126,7 +126,6 @@ Line 3, characters 12-29:
 Error: The record field "x" is not atomic
 |}];;
 
-
 (* Check module interface checking: it is not allowed to remove or add
    atomic attributes. *)
 
@@ -194,7 +193,61 @@ end)
 module Ok : sig type t = { mutable x : int [@atomic]; } end
 |}];;
 
+(* Projecting an atomic field of a record that contains a field with layout any. *)
 
+type ('a : any) t = { a : 'a; mutable f: int [@atomic]}
+[%%expect{|
+0
+type ('a : any) t = { a : 'a; mutable f : int [@atomic]; }
+|}];;
+
+let ok_project (t: int t) = t.f
+[%%expect{|
+(let
+  (ok_project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
+  (apply (field_imm 1 (global Toploop!)) "ok_project" ok_project))
+val ok_project : int t -> int = <fun>
+|}];;
+
+let wrong_project (t: int64# t) = t.f
+[%%expect{|
+Line 1, characters 34-35:
+1 | let wrong_project (t: int64# t) = t.f
+                                      ^
+Error: Accessing atomic fields (here "f") of mixed records is not yet
+       supported.
+|}];;
+
+let ok_set (t: int t) = t.f <- 42
+[%%expect{|
+(let (ok_set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
+  (apply (field_imm 1 (global Toploop!)) "ok_set" ok_set))
+val ok_set : int t -> unit = <fun>
+|}];;
+
+let wrong_set (t: int64# t) = t.f <- 42
+[%%expect{|
+Line 1, characters 30-39:
+1 | let wrong_set (t: int64# t) = t.f <- 42
+                                  ^^^^^^^^^
+Error: Accessing atomic fields (here "f") of mixed records is not yet
+       supported.
+|}];;
+
+let ok_loc (t: int t) = [%atomic.loc t.f]
+[%%expect{|
+(let (ok_loc = (function {nlocal = 0} t (makeblock 0 (*,value<int>) t 1)))
+  (apply (field_imm 1 (global Toploop!)) "ok_loc" ok_loc))
+val ok_loc : int t -> int atomic_loc = <fun>
+|}];;
+
+let wrong_loc (t: int64# t) = [%atomic.loc t.f];
+[%%expect{|
+Line 1, characters 43-44:
+1 | let wrong_loc (t: int64# t) = [%atomic.loc t.f];
+                                               ^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "f") is forbidden.
+|}];;
 
 (* Inline records are supported, including in extensions. *)
 
@@ -204,7 +257,7 @@ module Inline_record = struct
   let test : t -> int = fun (A r) -> r.x
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record/368"
+(apply (field_imm 1 (global Toploop!)) "Inline_record/401"
   (let
     (test =
        (function {nlocal = 0} param : int (atomic_load_field_imm param 0)))
@@ -226,7 +279,7 @@ module Extension_with_inline_record = struct
   let () = assert (test (A { x = 42 }) = 42)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/376"
+(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/409"
   (let
     (A =
        (makeblock_unique 248 "Extension_with_inline_record.A"
@@ -246,6 +299,62 @@ module Extension_with_inline_record :
   end
 |}]
 
+(* Projecting an atomic field of an inline record that contains a field with layout any. *)
+
+type ('a : any) t = A of { a : 'a; mutable f: int [@atomic]}
+[%%expect{|
+0
+type ('a : any) t = A of { a : 'a; mutable f : int [@atomic]; }
+|}];;
+
+let ok_project (t: int t) = match t with A r -> r.f
+[%%expect{|
+(let
+  (ok_project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
+  (apply (field_imm 1 (global Toploop!)) "ok_project" ok_project))
+val ok_project : int t -> int = <fun>
+|}];;
+
+let wrong_project (t: int64# t) = match t with A r -> r.f
+[%%expect{|
+Line 1, characters 54-55:
+1 | let wrong_project (t: int64# t) = match t with A r -> r.f
+                                                          ^
+Error: Accessing atomic fields (here "f") of mixed records is not yet
+       supported.
+|}];;
+
+let ok_set (t: int t) = match t with A r -> r.f <- 42
+[%%expect{|
+(let (ok_set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
+  (apply (field_imm 1 (global Toploop!)) "ok_set" ok_set))
+val ok_set : int t -> unit = <fun>
+|}];;
+
+let wrong_set (t: int64# t) = match t with A r -> r.f <- 42
+[%%expect{|
+Line 1, characters 50-59:
+1 | let wrong_set (t: int64# t) = match t with A r -> r.f <- 42
+                                                      ^^^^^^^^^
+Error: Accessing atomic fields (here "f") of mixed records is not yet
+       supported.
+|}];;
+
+let ok_loc (t: int t) = match t with A r -> [%atomic.loc r.f]
+[%%expect{|
+(let (ok_loc = (function {nlocal = 0} t (makeblock 0 (*,value<int>) t 1)))
+  (apply (field_imm 1 (global Toploop!)) "ok_loc" ok_loc))
+val ok_loc : int t -> int atomic_loc = <fun>
+|}];;
+
+let wrong_loc (t: int64# t) = match t with A r -> [%atomic.loc r.f]
+[%%expect{|
+Line 1, characters 63-64:
+1 | let wrong_loc (t: int64# t) = match t with A r -> [%atomic.loc r.f]
+                                                                   ^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "f") is forbidden.
+|}];;
+
 (* Marking a field [@atomic] in a float-only record disables the unboxing optimization. *)
 module Float_records = struct
   type flat = { x : float; mutable y : float }
@@ -263,7 +372,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic float field
   which prevents the float record optimization.
   The fields of this record will be boxed instead of being
   represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/400"
+(apply (field_imm 1 (global Toploop!)) "Float_records/470"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -483,7 +592,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/463"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/533"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))
@@ -500,7 +609,7 @@ module Pattern_matching_wildcard :
 |}]
 
 (* We disallow functional updates that perform implicit loads of atomic fields. *)
-
+k
 module Functional_update_error = struct
   type t = { x : int ; mutable y : int [@atomic] }
 
@@ -620,6 +729,60 @@ module Functional_update_multi_copy_ok :
     val allowed : t -> t
   end
 |}]
+(* Pattern matching follows the same rules in mixed blocks. *)
+module Pattern_matching = struct
+  type t = { x : int64#; mutable y : int [@atomic] }
+
+  let forbidden { x; y } = x + y
+end
+[%%expect{|
+Line 4, characters 16-24:
+4 |   let forbidden { x; y } = x + y
+                    ^^^^^^^^
+Error: Atomic fields (here "y") are forbidden in patterns,
+       as it is difficult to reason about when the atomic read
+       will happen during pattern matching: the field may be read
+       zero, one or several times depending on the patterns around it.
+|}]
+
+(* ... except for wildcards, to allow exhaustive record patterns. *)
+module Pattern_matching_wildcard = struct
+  type t = { x : int64#; mutable y : int [@atomic] }
+
+  [@@@warning "+missing-record-field-pattern"]
+  let warning { x } = x
+
+  let allowed { x; y = _ } = x
+  let also_allowed { x; _ } = x
+end
+[%%expect{|
+Line 5, characters 14-19:
+5 |   let warning { x } = x
+                  ^^^^^
+Warning 9 [missing-record-field-pattern]: the following labels are not bound
+  in this record pattern: "y".
+  Either bind these labels explicitly or add "; _" to the pattern.
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/600"
+  (let
+    (warning =
+       (function {nlocal = 0} param : unboxed_int64
+         (mixedfield 0  (bits64,value_or_null<int>) param))
+     allowed =
+       (function {nlocal = 0} param : unboxed_int64
+         (mixedfield 0  (bits64,value_or_null<int>) param))
+     also_allowed =
+       (function {nlocal = 0} param : unboxed_int64
+         (mixedfield 0  (bits64,value_or_null<int>) param)))
+    (makeblock 0 warning allowed also_allowed)))
+
+module Pattern_matching_wildcard :
+  sig
+    type t = { x : int64#; mutable y : int [@atomic]; }
+    val warning : t -> int64#
+    val allowed : t -> int64#
+    val also_allowed : t -> int64#
+  end
+|}]
 
 (* Test atomic record fields in mixed blocks *)
 
@@ -630,25 +793,73 @@ module Mixed_blocks = struct
   }
 end
 
+let project (t : Mixed_blocks.t) = t.field
 [%%expect{|
-Line 4, characters 4-33:
-4 |     mutable field : int [@atomic]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Atomic record fields are not permitted in mixed blocks.
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/540" (makeblock 0))
+module Mixed_blocks :
+  sig
+    type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
+  end
+Line 8, characters 35-36:
+8 | let project (t : Mixed_blocks.t) = t.field
+                                       ^
+Error: Accessing atomic fields (here "field") of mixed records is not yet
+       supported.
+|}]
+
+let set (t: Mixed_blocks.t) = t.field <- 42
+[%%expect{|
+Line 1, characters 30-43:
+1 | let set (t: Mixed_blocks.t) = t.field <- 42
+                                  ^^^^^^^^^^^^^
+Error: Accessing atomic fields (here "field") of mixed records is not yet
+       supported.
+|}]
+
+let loc (t: Mixed_blocks.t) = [%atomic.loc t.field]
+[%%expect{|
+Line 1, characters 43-44:
+1 | let loc (t: Mixed_blocks.t) = [%atomic.loc t.field]
+                                               ^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
 module Mixed_blocks_2 = struct
   type t = {
-    mutable field : float [@atomic];
+    mutable field : int [@atomic];
     padding : #(int * int * int)
   }
 end
 
+let project (t : Mixed_blocks_2.t) = t.field
 [%%expect{|
-Line 3, characters 4-36:
-3 |     mutable field : float [@atomic];
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Atomic record fields are not permitted in mixed blocks.
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/553" (makeblock 0))
+module Mixed_blocks_2 :
+  sig
+    type t = { mutable field : int [@atomic]; padding : #(int * int * int); }
+  end
+Line 8, characters 37-38:
+8 | let project (t : Mixed_blocks_2.t) = t.field
+                                         ^
+Error: Accessing atomic fields (here "field") of mixed records is not yet
+       supported.
+|}]
+
+let set (t: Mixed_blocks_2.t) = t.field <- 42
+[%%expect{|
+Line 1, characters 32-45:
+1 | let set (t: Mixed_blocks_2.t) = t.field <- 42
+                                    ^^^^^^^^^^^^^
+Error: Accessing atomic fields (here "field") of mixed records is not yet
+       supported.
+|}]
+
+let loc (t: Mixed_blocks_2.t) = [%atomic.loc t.field]
+[%%expect{|
+Line 1, characters 45-46:
+1 | let loc (t: Mixed_blocks_2.t) = [%atomic.loc t.field]
+                                                 ^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
 module Mixed_blocks_rec = struct
@@ -664,10 +875,36 @@ module Mixed_blocks_rec = struct
 end
 
 [%%expect{|
-Line 4, characters 4-33:
-4 |     mutable field : int [@atomic]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Atomic record fields are not permitted in mixed blocks.
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/569" (makeblock 0))
+module Mixed_blocks_rec :
+  sig
+    type t = { padding : u; mutable field : int [@atomic]; }
+    and u = #{ x : int#; y : float#; }
+  end
+|}]
+
+let project (t : Mixed_blocks_rec.t) = t.field
+[%%expect{|
+Line 1, characters 39-40:
+1 | let project (t : Mixed_blocks_rec.t) = t.field
+                                           ^
+Error: Accessing atomic fields (here "field") of mixed records is not yet
+       supported.
+|}]
+let set (t: Mixed_blocks_rec.t) = t.field <- 42
+[%%expect{|
+Line 1, characters 34-47:
+1 | let set (t: Mixed_blocks_rec.t) = t.field <- 42
+                                      ^^^^^^^^^^^^^
+Error: Accessing atomic fields (here "field") of mixed records is not yet
+       supported.
+|}]
+let loc (t: Mixed_blocks_rec.t) = [%atomic.loc t.field]
+[%%expect{|
+Line 1, characters 47-48:
+1 | let loc (t: Mixed_blocks_rec.t) = [%atomic.loc t.field]
+                                                   ^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
 (* Test atomic record fields with non-value layouts *)
@@ -737,22 +974,29 @@ Error: Atomic record fields must have layout value.
 
 module Atomic_float_with_float_hash = struct
   type t = { mutable f : float [@atomic]; u : float# }
+
+  let disallowed t = t.f
 end
 
 [%%expect{|
-Line 2, characters 13-41:
-2 |   type t = { mutable f : float [@atomic]; u : float# }
-                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Atomic record fields are not permitted in mixed blocks.
+Line 4, characters 21-22:
+4 |   let disallowed t = t.f
+                         ^
+Error: Accessing atomic fields (here "f") of mixed records is not yet
+       supported.
 |}]
 
 module Inline_record_atomic_in_mixed = struct
   type t = A of { mutable f : int [@atomic]; u : int# }
+
+  let disallowed t = match t with
+  | A r -> r.f
 end
 
 [%%expect{|
-Line 2, characters 18-44:
-2 |   type t = A of { mutable f : int [@atomic]; u : int# }
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Atomic record fields are not permitted in mixed blocks.
+Line 5, characters 11-12:
+5 |   | A r -> r.f
+               ^
+Error: Accessing atomic fields (here "f") of mixed records is not yet
+       supported.
 |}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -609,7 +609,6 @@ module Pattern_matching_wildcard :
 |}]
 
 (* We disallow functional updates that perform implicit loads of atomic fields. *)
-k
 module Functional_update_error = struct
   type t = { x : int ; mutable y : int [@atomic] }
 
@@ -634,7 +633,7 @@ module Functional_update_ok = struct
   let allowed t = { t with y = 42 }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/479"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/549"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -654,7 +653,7 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/487"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/557"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -688,7 +687,7 @@ module Functional_update_multi_ok = struct
   let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/503"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/573"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -712,7 +711,7 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/512"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/582"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -762,7 +761,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/600"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/606"
   (let
     (warning =
        (function {nlocal = 0} param : unboxed_int64
@@ -795,7 +794,7 @@ end
 
 let project (t : Mixed_blocks.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/540" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/613" (makeblock 0))
 module Mixed_blocks :
   sig
     type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
@@ -833,7 +832,7 @@ end
 
 let project (t : Mixed_blocks_2.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/553" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/626" (makeblock 0))
 module Mixed_blocks_2 :
   sig
     type t = { mutable field : int [@atomic]; padding : #(int * int * int); }
@@ -875,7 +874,7 @@ module Mixed_blocks_rec = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/569" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/642" (makeblock 0))
 module Mixed_blocks_rec :
   sig
     type t = { padding : u; mutable field : int [@atomic]; }

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -770,7 +770,8 @@ and expression i ppf x =
       line i ppf "Texp_idx\n";
       block_access i ppf ba;
       List.iter (unboxed_access i ppf) uas;
-  | Texp_atomic_loc (e, sort, li, _, amode) ->
+  | Texp_atomic_loc { record = e; record_sort = sort; lid = li;
+                      alloc_mode = amode } ->
       line i ppf "Texp_atomic_loc\n";
       expression i ppf e;
       line i ppf "%a\n" fmt_sort sort;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -466,7 +466,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
           | Texp_comp_when exp ->
             sub.expr sub exp)
         comp_clauses
-  | Texp_atomic_loc (exp, _, lid, _, _) ->
+  | Texp_atomic_loc { record = exp; lid; _ } ->
       iter_loc_lid sub lid;
       sub.expr sub exp
   | Texp_ifthenelse (exp1, exp2, expo) ->

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -629,9 +629,13 @@ let expr sub x =
           newval = sub.expr sub newval;
           record_repres; record_sorts; modality; label;
         }
-    | Texp_atomic_loc (exp, sort, lid, ld, alloc_mode) ->
-        Texp_atomic_loc
-          (sub.expr sub exp, sort, map_loc_lid sub lid, ld, alloc_mode)
+    | Texp_atomic_loc { record; record_sort; record_repres; lid; label;
+                        alloc_mode; } ->
+        Texp_atomic_loc {
+          record = sub.expr sub record;
+          lid = map_loc_lid sub lid;
+          record_sort; record_repres; label; alloc_mode;
+        }
     | Texp_array (amut, sort, list, alloc_mode) ->
         Texp_array (amut, sort, List.map (sub.expr sub) list, alloc_mode)
     | Texp_idx (ba, uas) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -248,6 +248,7 @@ type error =
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
   | Mixed_record_atomic_access of Longident.t
+  | Mixed_record_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -247,6 +247,7 @@ type error =
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
+  | Mixed_record_atomic_access of Longident.t
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string
@@ -1307,6 +1308,44 @@ let mode_spliced =
 let check_project_mutability ~loc ~env mut_name mutability mode =
   if Types.is_mutable mutability then
     submode ~loc ~env mode (mode_project_mutable mut_name)
+
+(* Does this record representation permit atomic field usage? *)
+let allows_atomic_field_usage = function
+  | Record_boxed -> true
+  | Record_inlined (_tag, ctor_repres, _variant_repres) -> (
+      match ctor_repres with
+      | Constructor_uniform_value -> true
+      | Constructor_mixed _ -> false
+      (* At this point, we should know the constructor representation. *)
+      | Constructor_variable -> false)
+  (* Reads/writes of atomic record fields are currently only supported for
+     labels whose logical offset matches the physical field position. To support
+     mixed records, we will add atomic primitives to lambda that consider mixed
+     block field reordering. *)
+  | Record_mixed _ -> false
+  (* The remaining cases should be unreachable. *)
+  (* [@@unboxed] already prohibits mutable (and therefore atomic) fields. *)
+  | Record_unboxed
+  (* [@atomic] fields disable the float record optimization. *)
+  | Record_float | Record_ufloat
+  (* At this point, we should know the record representation. *)
+  | Record_dummy _ | Record_variable ->
+      false
+
+(* CR-soon jkerrigan: simplify after we allow access of atomic fields in mixed
+   records. *)
+type atomic_field_use = Access | Loc
+
+(* Raises if we try to use an atomic field from a mixed record. *)
+let check_atomic_field_usage ~usage ~loc ~env record_repres mutability lid =
+  if Types.is_atomic mutability && not (allows_atomic_field_usage record_repres)
+  then
+    let err =
+      match usage with
+      | Access -> Mixed_record_atomic_access lid
+      | Loc -> Mixed_record_atomic_loc lid
+    in
+    raise (Error (loc, env, err))
 
 (* Represents information about an array type inferred using type-directed
    disambiguation. *)
@@ -5176,7 +5215,7 @@ let rec is_nonexpansive exp =
            | Kept _ -> true)
         fields
       && is_nonexpansive_opt (Option.map fst extended_expression)
-  | Texp_atomic_loc(exp, _, _, _, _) -> is_nonexpansive exp
+  | Texp_atomic_loc { record = exp; _ } -> is_nonexpansive exp
   | Texp_field { record = exp; _ } -> is_nonexpansive exp
   | Texp_unboxed_field { record = exp; _ } -> is_nonexpansive exp
   | Texp_idx (ba, _uas) ->
@@ -7458,6 +7497,8 @@ and type_expect_
       in
       check_project_mutability ~loc:record.exp_loc ~env
         (Record_field label.lbl_name) label.lbl_mut mode;
+      check_atomic_field_usage ~usage:Access ~loc:record.exp_loc ~env
+        record_repres label.lbl_mut lid.txt;
       let is_contained_by : Mode.Hint.is_contained_by =
         { containing = Record (label.lbl_name, Modality);
           container = (record.exp_loc, Expression) }
@@ -7587,6 +7628,8 @@ and type_expect_
           ~why:Field_assignment
           ~containing_type:ty_record
       in
+      check_atomic_field_usage ~usage:Access ~loc ~env record_repres
+        label.lbl_mut lid.txt;
       rue {
         exp_desc = Texp_setfield {
           record;
@@ -8485,10 +8528,13 @@ and type_expect_
                     { pexp_desc = Pexp_field (srecord, lid); _ } as sexp, _
                   )
                } ] ->
-          let record, record_sort, _, rmode, label, ambiguity, ty_arg, _ =
+          let record, record_sort, _, rmode, label, ambiguity, ty_arg,
+              record_repres =
             solve_Pexp_field ~label_usage:Env.Mutation loc env sexp srecord
               Legacy lid
           in
+          check_atomic_field_usage ~usage:Loc ~loc:record.exp_loc ~env
+            record_repres label.lbl_mut lid.txt;
           Env.mark_label_used Env.Projection label.lbl_uid;
           if (not (Types.is_atomic label.lbl_mut))
           then raise (Error (loc, env, Label_not_atomic lid.txt));
@@ -8508,14 +8554,23 @@ and type_expect_
               (Texp_inspected_type (Label_disambiguation ambiguity), loc, [])
                 :: record.exp_extra }
           in
-          rue {
-            exp_desc =
-              Texp_atomic_loc
-                (record, record_sort, lid, label, alloc_mode);
-            exp_loc = loc; exp_extra = [];
-            exp_type = instance (Predef.type_atomic_loc ty_arg);
-            exp_attributes = sexp.pexp_attributes;
-            exp_env = env }
+          rue
+            {
+              exp_desc =
+                Texp_atomic_loc {
+                  record;
+                  record_sort;
+                  record_repres;
+                  lid;
+                  label;
+                  alloc_mode
+                };
+              exp_loc = loc;
+              exp_extra = [];
+              exp_type = instance (Predef.type_atomic_loc ty_arg);
+              exp_attributes = sexp.pexp_attributes;
+              exp_env = env;
+            }
       | _ ->
           raise (Error (loc, env, Invalid_atomic_loc_payload))
       end
@@ -12953,6 +13008,16 @@ let report_error ~loc env =
          of an atomic field, do so explicitly:@ %a"
         Style.inline_code l
         Style.inline_code ("{ t with " ^ l ^ " = t." ^ l ^ " }")
+  | Mixed_record_atomic_access lid ->
+      Location.errorf ~loc
+        "Accessing atomic fields (here %a) of mixed records is not yet@ \
+         supported."
+        quoted_longident lid
+  | Mixed_record_atomic_loc lid ->
+      Location.errorf ~loc
+        "Use of %a with mixed record fields (here %a) is forbidden."
+        Style.inline_code "[%atomic.loc]"
+        quoted_longident lid
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -297,6 +297,8 @@ type error =
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
+  | Mixed_record_atomic_access of Longident.t
+  | Mixed_record_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -152,7 +152,6 @@ type error =
   | No_unboxed_version of Path.t
   | Atomic_field_must_be_mutable of string
   | Constructor_submode_failed of Mode.Value.error
-  | Atomic_field_in_mixed_block
   | Non_value_atomic_field
   | Layout_poly_unsupported
   | Misplaced_flatten_floats
@@ -1372,12 +1371,6 @@ let gets_unboxed_version decl =
   match decl.type_kind with
   | Type_abstract _ | Type_open | Type_record_unboxed_product _
   | Type_variant _ -> false
-  | Type_record (_, Record_variable, _) ->
-    (* As of this writing (2025-11-14), it's not possible to have
-       [Record_variable] as the representation for a record that doesn't get an
-       unboxed version. Please enjoy convincing yourself that this is true
-       (you'll want to consult [update_record_kind]). *)
-    true
   | Type_record (lbls, repr, _) -> record_gets_unboxed_version lbls repr
 
 let derive_unboxed_version env path_in_group_has_unboxed_version decl =
@@ -2051,8 +2044,7 @@ let mixed_block_element env ty jkind =
   let unboxed_element = Element_repr.classify env ty jkind in
   Option.map Element_repr.to_shape_element unboxed_element
 
-(* Atomic fields must have layout value and must not appear in mixed blocks
-   (records that have any non-value field). *)
+(* Atomic fields must have layout value. *)
 let check_atomic_fields reprs lbls =
   let is_value (repr : Element_repr.t option) =
     match repr with
@@ -2063,17 +2055,7 @@ let check_atomic_fields reprs lbls =
     (fun repr (lbl : Types.label_declaration) ->
        if Types.is_atomic lbl.ld_mutable && not (is_value repr) then
          raise (Error (lbl.ld_loc, Non_value_atomic_field)))
-    reprs lbls;
-  let has_non_value = List.exists (fun r -> not (is_value r)) reprs in
-  if has_non_value then
-    match
-      List.find_opt
-        (fun (lbl : Types.label_declaration) -> Types.is_atomic lbl.ld_mutable)
-        lbls
-    with
-    | Some (lbl : Types.label_declaration) ->
-      raise (Error (lbl.ld_loc, Atomic_field_in_mixed_block))
-    | None -> ()
+    reprs lbls
 
 let update_constructor_representation
     env (cd_args : Types.constructor_arguments) arg_jkinds ~loc
@@ -2136,9 +2118,7 @@ let compute_record_repr
     ~represent_as_float_array
     ~flatten_floats
   =
-  (* Reject atomic fields with a non-value layout or in mixed blocks. After
-     this, atomic_fields:true should imply Record_boxed (value-only or
-     atomic-float) *)
+  (* Reject atomic fields with a non-value layout. *)
   check_atomic_fields (List.map fst reprs) (List.map fst lbls);
   let mixed_record () =
     let shape =
@@ -2204,12 +2184,12 @@ let compute_record_repr
   (* For other mixed blocks, float fields are stored as flat
       only when they're unboxed.
   *)
-  | ~values:true, ~voids:true, ~atomic_fields:false, ..
-  | ~floats:true, ~voids:true, ~atomic_fields:false, ..
-  | ~floats:true, ~float64s:true, ~atomic_fields:false, ..
-  | ~float64s:true, ~voids:true, ~atomic_fields:false, ..
-  | ~values:true, ~float64s:true, ~atomic_fields:false, ..
-  | ~non_float64_unboxed_fields:true, ~atomic_fields:false, .. ->
+  | ~values:true, ~voids:true, ..
+  | ~floats:true, ~voids:true, ..
+  | ~floats:true, ~float64s:true, ..
+  | ~float64s:true, ~voids:true, ..
+  | ~values:true, ~float64s:true, ..
+  | ~non_float64_unboxed_fields:true, .. ->
     mixed_record ()
   (* value-only records are stored as boxed records, including records whose
      declared types have fields of kind [any] *)
@@ -2230,12 +2210,6 @@ let compute_record_repr
     if warn && floats && not values
     then Location.prerr_warning loc Warnings.Atomic_float_record_boxed;
     Ok Record_boxed
-  (* Any remaining atomic-bearing shape should have been rejected by
-     [check_atomic_fields] above. *)
-  | ~atomic_fields:true, .. ->
-    Misc.fatal_error
-      "Typedecl.compute_record_repr: atomic field should have been \
-       rejected by check_atomic_fields"
   | ~values:false, ~floats:false, ~atomic_floats:false,
       ~float64s:false, ~non_float64_unboxed_fields:false,
       ~voids:_, ~atomic_fields:_, ~first_any:None, ..
@@ -5949,9 +5923,6 @@ let report_error ~loc = function
         (Style.as_inline_code (Mode.Value.Const.print_axis ax)) right
         ~sub:[Location.msg "@[<hv>@[@{<hint>Hint@}: all argument types must \
                             mode-cross for rebinding to succeed."]
-  | Atomic_field_in_mixed_block ->
-    Location.errorf ~loc
-      "Atomic record fields are not permitted in mixed blocks."
   | Non_value_atomic_field ->
     Location.errorf ~loc
       "Atomic record fields must have layout value."

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -250,7 +250,6 @@ type error =
   | No_unboxed_version of Path.t
   | Atomic_field_must_be_mutable of string
   | Constructor_submode_failed of Mode.Value.error
-  | Atomic_field_in_mixed_block
   | Non_value_atomic_field
   | Layout_poly_unsupported
   | Misplaced_flatten_floats

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -326,9 +326,14 @@ and expression_desc =
       representation : Types.record_unboxed_product_representation;
       extended_expression : (expression * Jkind.sort) option;
     }
-  | Texp_atomic_loc of
-      expression * Jkind.sort * Longident.t loc * label_description *
-      alloc_mode
+  | Texp_atomic_loc of {
+      record : expression;
+      record_sort : Jkind.sort;
+      record_repres : Types.record_representation;
+      lid : Longident.t loc;
+      label : Data_types.label_description;
+      alloc_mode : alloc_mode;
+    }
   | Texp_field of {
       record : expression;
       record_sort : Jkind.sort;
@@ -1613,7 +1618,7 @@ let rec fold_antiquote_exp f  acc exp =
   | Texp_letmutable (_, exp) -> fold_antiquote_exp f acc exp
   | Texp_mutvar _ -> acc
   | Texp_setmutvar (_, _, exp) -> fold_antiquote_exp f acc exp
-  | Texp_atomic_loc (exp, _, _, _, _) -> fold_antiquote_exp f acc exp
+  | Texp_atomic_loc { record = exp; _ } -> fold_antiquote_exp f acc exp
   | Texp_idx (_, _) -> acc
   | Texp_quotation exp ->
       fold_antiquote_exp (fold_antiquote_exp f) acc exp

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -623,9 +623,14 @@ and expression_desc =
               { fields = [| l1, Kept t1; l2 Override P2 |]; representation;
                 extended_expression = Some E0 }
           *)
-  | Texp_atomic_loc of
-      expression * Jkind.sort * Longident.t loc * Data_types.label_description *
-      alloc_mode
+  | Texp_atomic_loc of {
+      record : expression;
+      record_sort : Jkind.sort;
+      record_repres : Types.record_representation;
+      lid : Longident.t loc;
+      label : Data_types.label_description;
+      alloc_mode : alloc_mode;
+    }
   | Texp_field of {
       record : expression;
       record_sort : Jkind.sort;

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2547,7 +2547,7 @@ let rec check_uniqueness_exp_desc ~borrows ~overwrite (ienv : Ienv.t) ~loc :
     let uf_write = Value.mark_implicit_borrow_memory_address Write value in
     let uf_tag = Value.invalidate_tag value in
     UF.pars [uf_rcd; uf_arg; uf_write; uf_tag]
-  | Texp_atomic_loc (rcd, _, _, _, _) ->
+  | Texp_atomic_loc { record = rcd; _ } ->
     let value, uf_rcd = check_uniqueness_exp_as_value ienv rcd in
     let uf = Value.mark_consumed_memory_address value in
     UF.seq uf_rcd uf

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -703,7 +703,7 @@ let expression sub exp =
         Pexp_record_unboxed_product
           (list,
            Option.map (fun (exp, _) -> sub.expr sub exp) extended_expression)
-    | Texp_atomic_loc (exp, _, lid, _label, _) ->
+    | Texp_atomic_loc { record = exp; lid; _ } ->
         Pexp_extension ({ txt = "ocaml.atomic.loc"; loc },
                         PStr [ Str.eval ~loc
                                  (Exp.field ~loc

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -759,7 +759,7 @@ let rec expression : Typedtree.expression -> term_judg =
       list expression (List.map snd exprs) << Guard
     | Texp_unboxed_tuple exprs ->
       list expression (List.map (fun (_, e, _) -> e) exprs) << Return
-    | Texp_atomic_loc (expr, _, _, _, _) ->
+    | Texp_atomic_loc { record = expr; _ } ->
       expression expr << Guard
     | Texp_array (_, _, exprs, _) ->
       list expression exprs << array_mode exp


### PR DESCRIPTION
Reads and writes of atomic record fields are implemented using naive field offsets that do not take mixed block field reordering into account. Today, we sidestep this issue by prohibiting atomic fields within mixed records, but we want to support them.

As a preliminary step towards full support, this PR moves the check in order to allow the definition (but not the use) of atomic fields inside mixed records.

Concretely, rather than erroring on the definition of an atomic field within a mixed block, we fail when such a field is read, written, or used as the argument to an atomic.loc extension node. As a side effect, we now support atomic operations for records-containing-`any` that get narrowed to have only `value` fields.

This PR retires the existing error in favor of a new one and updates expect tests with the new expectations.