### PR TITLE
CFG peephole bugfixes

### DIFF
--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -227,7 +227,15 @@ let remove_intop_neutral_element (cell : Cfg.basic Cfg.instruction DLL.cell) =
       in
       if to_remove
       then (
-        let continue = Some (U.prev_at_most U.go_back_const cell) in
+        (* Compute the continuation from cells that survive the deletion: if
+           [cell] were the first element of the block, [prev_at_most] would
+           return [cell] itself, and the traversal would then operate on a
+           deleted cell. *)
+        let continue =
+          match DLL.prev cell with
+          | Some _ as prev -> prev
+          | None -> DLL.next cell
+        in
         DLL.delete_curr cell;
         continue)
       else None

--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -95,19 +95,6 @@ let remove_useless_mov (cell : Cfg.basic Cfg.instruction DLL.cell) =
     can be expressed as <op2 const3> or <op2 const2> can be expressed as <op1
     const3> *)
 
-let power_of_two_immediate_for_mul shift_imm =
-  (* [shift_imm] is guaranteed to be within bounds for [Ilsl], but [1 lsl
-     shift_imm] is computed with host integers and overflows for [shift_imm >=
-     Sys.int_size - 1] (e.g. [1 lsl 63] evaluates to [0], which would
-     incorrectly fold the multiplication to [0]). The result may also not be
-     within bounds for [Imul]. *)
-  U.assert_within_range Ilsl shift_imm;
-  if shift_imm >= Sys.int_size - 1
-  then None
-  else
-    let imm = 1 lsl shift_imm in
-    if U.is_immediate_for_intop Imul imm then Some imm else None
-
 let are_compatible op1 op2 imm1 imm2 :
     (Operation.integer_operation * int) option =
   match
@@ -142,14 +129,12 @@ let are_compatible op1 op2 imm1 imm2 :
     if imm1 >= imm2
     then U.sub_immediates Isub imm1 imm2
     else U.sub_immediates Iadd imm2 imm1
-  | Ilsl, Imul -> (
-    match power_of_two_immediate_for_mul imm1 with
-    | Some imm1 -> U.mul_immediates Imul imm1 imm2
-    | None -> None)
-  | Imul, Ilsl -> (
-    match power_of_two_immediate_for_mul imm2 with
-    | Some imm2 -> U.mul_immediates Imul imm1 imm2
-    | None -> None)
+  | Ilsl, Imul ->
+    (* [(x lsl imm1) * imm2] is [x * (imm2 lsl imm1)]. *)
+    U.lsl_immediates Imul imm2 imm1
+  | Imul, Ilsl ->
+    (* [(x * imm1) lsl imm2] is [x * (imm1 lsl imm2)]. *)
+    U.lsl_immediates Imul imm1 imm2
   | Imul, Imul -> U.mul_immediates op1 imm1 imm2
   (* CR-soon gtulba-lecu: check this last case | Imod, Imod -> if imm1 mod imm2
      = 0 then Some (Imod, imm2) else None

--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -42,7 +42,13 @@ let remove_overwritten_mov (cell : Cfg.basic Cfg.instruction DLL.cell) =
       (* We only consider the removal of spill and reload instructions because a
          move from/to an arbitrary memory location could fail because of memory
          protection. *)
-      delete_fst_if_redundant ~fst ~snd ~fst_val ~snd_val
+      (* If [snd] reads the location it overwrites (i.e. is an identity move),
+         deleting [fst] would change the value [snd] reads. Such moves are
+         currently removed by [Regalloc_utils.simplify_cfg] before this pass
+         runs, but do not rely on that here. *)
+      if U.are_equal_regs snd_val.arg.(0) snd_val.res.(0)
+      then None
+      else delete_fst_if_redundant ~fst ~snd ~fst_val ~snd_val
     | _, _ -> None)
   | _ -> None
 

--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -89,6 +89,19 @@ let remove_useless_mov (cell : Cfg.basic Cfg.instruction DLL.cell) =
     can be expressed as <op2 const3> or <op2 const2> can be expressed as <op1
     const3> *)
 
+let power_of_two_immediate_for_mul shift_imm =
+  (* [shift_imm] is guaranteed to be within bounds for [Ilsl], but [1 lsl
+     shift_imm] is computed with host integers and overflows for [shift_imm >=
+     Sys.int_size - 1] (e.g. [1 lsl 63] evaluates to [0], which would
+     incorrectly fold the multiplication to [0]). The result may also not be
+     within bounds for [Imul]. *)
+  U.assert_within_range Ilsl shift_imm;
+  if shift_imm >= Sys.int_size - 1
+  then None
+  else
+    let imm = 1 lsl shift_imm in
+    if U.is_immediate_for_intop Imul imm then Some imm else None
+
 let are_compatible op1 op2 imm1 imm2 :
     (Operation.integer_operation * int) option =
   match
@@ -123,22 +136,14 @@ let are_compatible op1 op2 imm1 imm2 :
     if imm1 >= imm2
     then U.sub_immediates Isub imm1 imm2
     else U.sub_immediates Iadd imm2 imm1
-  | Ilsl, Imul ->
-    (* [imm1] is guaranteed to be within bounds for [Ilsl], but [1 lsl imm1] may
-       not be within bounds for [Imul]. *)
-    U.assert_within_range Ilsl imm1;
-    let imm1 = 1 lsl imm1 in
-    if U.is_immediate_for_intop Imul imm1
-    then U.mul_immediates Imul imm1 imm2
-    else None
-  | Imul, Ilsl ->
-    (* [imm2] is guaranteed to be within bounds for [Ilsl], but [1 lsl imm2] may
-       not be within bounds for [Imul]. *)
-    U.assert_within_range Ilsl imm2;
-    let imm2 = 1 lsl imm2 in
-    if U.is_immediate_for_intop Imul imm2
-    then U.mul_immediates Imul imm1 imm2
-    else None
+  | Ilsl, Imul -> (
+    match power_of_two_immediate_for_mul imm1 with
+    | Some imm1 -> U.mul_immediates Imul imm1 imm2
+    | None -> None)
+  | Imul, Ilsl -> (
+    match power_of_two_immediate_for_mul imm2 with
+    | Some imm2 -> U.mul_immediates Imul imm1 imm2
+    | None -> None)
   | Imul, Imul -> U.mul_immediates op1 imm1 imm2
   (* CR-soon gtulba-lecu: check this last case | Imod, Imod -> if imm1 mod imm2
      = 0 then Some (Imod, imm2) else None

--- a/backend/peephole/peephole_utils.ml
+++ b/backend/peephole/peephole_utils.ml
@@ -63,6 +63,22 @@ let sub_immediates integer_operation imm1 imm2 =
 let mul_immediates integer_operation imm1 imm2 =
   op_immediates integer_operation imm1 imm2 Misc.no_overflow_mul ( * )
 
+let lsl_immediates integer_operation imm1 imm2 =
+  (* Unlike [op_immediates], the two immediates are validated against different
+     operations: [imm1] is a value for [integer_operation], while [imm2] is a
+     shift amount for [Ilsl]. [Misc.no_overflow_lsl] rejects any shift that
+     would overflow the host integers used to compute the folded immediate (e.g.
+     [1 lsl 63], which evaluates to [0]). *)
+  assert_within_range integer_operation imm1;
+  assert_within_range Operation.Ilsl imm2;
+  if Misc.no_overflow_lsl imm1 imm2
+  then
+    let res = imm1 lsl imm2 in
+    if is_immediate_for_intop integer_operation res
+    then Some (integer_operation, res)
+    else None
+  else None
+
 let never_overflow _ _ = true
 
 let bitwise_immediates integer_operation imm1 imm2 op =

--- a/backend/peephole/peephole_utils.mli
+++ b/backend/peephole/peephole_utils.mli
@@ -33,6 +33,15 @@ val mul_immediates :
   int ->
   (Operation.integer_operation * int) option
 
+(** [lsl_immediates op imm1 imm2] rewrites [imm1 lsl imm2] as an immediate for
+    [op]. [imm1] must be within range for [op] and [imm2] within range for
+    [Ilsl]. *)
+val lsl_immediates :
+  Operation.integer_operation ->
+  int ->
+  int ->
+  (Operation.integer_operation * int) option
+
 val bitwise_immediates :
   Operation.integer_operation ->
   int ->

--- a/backend/x86_peephole/x86_peephole_rules.ml
+++ b/backend/x86_peephole/x86_peephole_rules.ml
@@ -123,9 +123,10 @@ let remove_mov_to_dead_register stats cell =
     | _, _ -> U.No_match)
   | _ -> U.No_match
 
-(* Find a redundant CMP instruction with the same operands. Returns Some cell if
-   found, None otherwise. *)
-let find_redundant_cmp src dst start_cell =
+(* Find a redundant CMP instruction with the same operands. [src_reg] and
+   [dst_reg] are the underlying 64-bit registers of [src] and [dst]. Returns
+   Some cell if found, None otherwise. *)
+let find_redundant_cmp src dst src_reg dst_reg start_cell =
   let rec loop cell_opt =
     match cell_opt with
     | None -> None
@@ -143,8 +144,7 @@ let find_redundant_cmp src dst start_cell =
             if U.maybe_writes_flags instr
             then None
             else if
-              U.writes_to_reg64 (U.underlying_reg64 src |> Option.get) instr
-              || U.writes_to_reg64 (U.underlying_reg64 dst |> Option.get) instr
+              U.writes_to_reg64 src_reg instr || U.writes_to_reg64 dst_reg instr
             then None
             else loop (DLL.next cell))
         | Directive _ -> loop (DLL.next cell))
@@ -161,18 +161,22 @@ let find_redundant_cmp src dst start_cell =
    control flow between the CMPs *)
 let remove_redundant_cmp stats cell =
   match DLL.value cell with
-  (* Only optimize register-register comparisons to avoid issues with mutable
-     memory *)
-  | Ins (CMP (src, dst)) when U.is_register src && U.is_register dst -> (
-    (* Search for a redundant CMP *)
-    match find_redundant_cmp src dst cell with
-    | Some redundant_cell ->
-      (* Delete the redundant CMP *)
-      DLL.delete_curr redundant_cell;
-      stats.remove_redundant_cmp <- stats.remove_redundant_cmp + 1;
-      (* Return the first CMP cell to allow iterative removal *)
-      U.Matched (Some cell)
-    | None -> U.No_match)
+  (* Only optimize comparisons between general-purpose registers, to avoid
+     issues with mutable memory. [underlying_reg64] returns None for the other
+     kinds of arguments, including float registers. *)
+  | Ins (CMP (src, dst)) -> (
+    match U.underlying_reg64 src, U.underlying_reg64 dst with
+    | Some src_reg, Some dst_reg -> (
+      (* Search for a redundant CMP *)
+      match find_redundant_cmp src dst src_reg dst_reg cell with
+      | Some redundant_cell ->
+        (* Delete the redundant CMP *)
+        DLL.delete_curr redundant_cell;
+        stats.remove_redundant_cmp <- stats.remove_redundant_cmp + 1;
+        (* Return the first CMP cell to allow iterative removal *)
+        U.Matched (Some cell)
+      | None -> U.No_match)
+    | (Some _ | None), _ -> U.No_match)
   | _ -> U.No_match
 
 (* Apply all rewrite rules in sequence using a pipeline. *)

--- a/testsuite/tests/basic/lsl_mul.ml
+++ b/testsuite/tests/basic/lsl_mul.ml
@@ -1,0 +1,16 @@
+(* TEST *)
+
+(* Regression test for a CFG peephole bug: when folding [lsl] followed by
+   [mul] (or the converse), a shift amount of 63 made the computation of the
+   combined immediate overflow on the host ([1 lsl 63] evaluates to [0]),
+   incorrectly folding the multiplication to [0]. *)
+
+let[@inline never] shift_then_mul (x : int64) =
+  Int64.mul (Int64.shift_left x 63) 3L
+
+let[@inline never] mul_then_shift (x : int64) =
+  Int64.shift_left (Int64.mul x 3L) 63
+
+let () =
+  assert (Int64.equal (shift_then_mul 1L) Int64.min_int);
+  assert (Int64.equal (mul_then_shift 1L) Int64.min_int)


### PR DESCRIPTION
This pull request fixes 3 CFG peephole bugs:

- a potential miscompilation because of overflow, when simplifying a mul/lsl sequence (ab39972f7e26538803c2b19c2ee3d618c0811fd1);
- a (currently unreachable) invalid simplification, that would remove a meaningful instruction in presence of a noop-move, such moves being currently filtered before peephole rules are applies (c1c694c5b2bca70ce0e8dec4619f16742f48acbc);
- a missed opportunity, when the wrong list cell is returned after a rule has been applied (49aab01daa132257eb910ec90afa6d83738c50f4).