### PR TITLE
Fix implicit kinds typedecl bug

### DIFF
--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -1061,3 +1061,38 @@ module type S37 =
     val f : ('t : word). 't -> 't
   end
 |}]
+
+(* Explicit [('a : any)] annotation on this GADT compiles. *)
+
+module type S38_explicit = sig
+  type ('a : any) t =
+    | F32 : float# t
+    | I32 : int# t
+end
+
+[%%expect{|
+module type S38_explicit =
+  sig type ('a : any) t = F32 : float# t | I32 : int# t end
+|}]
+
+(* CR dkalinichenko: should be equivalent to the explicit version. *)
+
+module type S38_implicit = sig
+  [@@@implicit_kind: ('a : any)]
+
+  type 'a t =
+    | F32 : float# t
+    | I32 : int# t
+end
+
+[%%expect{|
+Line 6, characters 12-16:
+6 |     | I32 : int# t
+                ^^^^
+Error: This type "int#" should be an instance of type "('a : float64)"
+       The layout of int# is untagged_immediate
+         because it is the unboxed version of the primitive type int.
+       But the layout of int# must be a sublayout of float64
+         because it instantiates an unannotated type parameter of t,
+         chosen to have layout float64.
+|}]

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -1075,7 +1075,7 @@ module type S38_explicit =
   sig type ('a : any) t = F32 : float# t | I32 : int# t end
 |}]
 
-(* CR dkalinichenko: should be equivalent to the explicit version. *)
+(* Implicit version compiles. *)
 
 module type S38_implicit = sig
   [@@@implicit_kind: ('a : any)]
@@ -1086,13 +1086,6 @@ module type S38_implicit = sig
 end
 
 [%%expect{|
-Line 6, characters 12-16:
-6 |     | I32 : int# t
-                ^^^^
-Error: This type "int#" should be an instance of type "('a : float64)"
-       The layout of int# is untagged_immediate
-         because it is the unboxed version of the primitive type int.
-       But the layout of int# must be a sublayout of float64
-         because it instantiates an unannotated type parameter of t,
-         chosen to have layout float64.
+module type S38_implicit =
+  sig type ('a : any) t = F32 : float# t | I32 : int# t end
 |}]

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -851,14 +851,22 @@ let get_type_param_jkind env path styp =
     Jkind.of_annotation env ~use_abstract_jkinds:false ~warn:false
       ~context:(Type_parameter (path, name)) jkind
   in
+  let legacy_sort () =
+    let level = get_current_level () in
+    Jkind.of_new_legacy_sort ~why:(Unannotated_type_parameter path) ~level
+  in
   match styp.ptyp_desc with
   | Ptyp_any (Some jkind) ->
       of_annotation jkind None
   | Ptyp_var (name, Some jkind) ->
       of_annotation jkind (Some name)
+  | Ptyp_var (name, None) ->
+      begin match Env.find_implicit_jkind name env with
+      | Some jkind -> jkind
+      | None -> legacy_sort ()
+      end
   | _ ->
-      let level = get_current_level () in
-      Jkind.of_new_legacy_sort ~why:(Unannotated_type_parameter path) ~level
+      legacy_sort ()
 
 let get_type_param_name styp =
   (* We don't need to check for jkinds here, just to get the name. *)


### PR DESCRIPTION
The example below compiles with explicit `type ('a : any) t = ...`. Make the implicit version compile too.

```
module type S38_implicit = sig
  [@@@implicit_kind: ('a : any)]

  type 'a t =
    | F32 : float# t
    | I32 : int# t
end
```