### PR TITLE
Fix for #6433 (mutable load CSE'd over fence)

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -37,8 +37,16 @@ let class_of_operation (op : Operation.t)
     | Ioffset_loc(_, _) -> Class (Op_store true)
     | Ifloatarithmem _ -> Class (Op_load Mutable)
     | Ibswap _ -> Use_default
-    | Irdtsc | Irdpmc
-    | Ilfence | Isfence | Imfence -> Class Op_other
+    | Irdtsc | Irdpmc -> Class Op_other
+    | Ilfence | Imfence ->
+      (* A load that follows a load fence must not be satisfied by an equation
+         over a load that precedes the fence: that would effectively hoist the
+         load above the fence. *)
+      Class Op_load_barrier
+    | Isfence ->
+      (* [sfence] only orders stores, and CSE neither eliminates nor moves
+         stores, so it does not need to be a load barrier. *)
+      Class Op_other
     | Ipackf32 -> Class Op_pure
     | Isimd op ->
       Class (of_simd_class (Simd.class_of_operation op))

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -346,7 +346,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Class op_class -> op_class
     | Use_default -> class_of_operation0 op
 
-  let is_cheap_operation : Operation.t -> bool = function
+  let is_cheap_operation0 : Operation.t -> bool = function
     | Const_int _ -> true
     | Move | Spill | Reload | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ | Opaque | Stackoffset _
@@ -356,6 +356,11 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Specific _ | Name_for_debugger _ | Probe_is_enabled _ | Begin_region
     | End_region | Dls_get | Tls_get | Domain_index ->
       false
+
+  let is_cheap_operation op =
+    match Target.is_cheap_operation op with
+    | Cheap cheap -> cheap
+    | Use_default -> is_cheap_operation0 op
 
   let kill_loads (n : numbering) : numbering = remove_mutable_load_numbering n
 

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -106,13 +106,13 @@ module Make (Op : Operation) : S with type op = Op.t = struct
         { m with
           mutable_load_equations = Rhs_map.add op v m.mutable_load_equations
         }
-      | Op_pure | Op_load Immutable | Op_store _ | Op_other ->
+      | Op_pure | Op_load Immutable | Op_store _ | Op_load_barrier | Op_other ->
         { m with other_equations = Rhs_map.add op v m.other_equations }
 
     let find (op_class : op_class) op m =
       match op_class with
       | Op_load Mutable -> Rhs_map.find op m.mutable_load_equations
-      | Op_pure | Op_load Immutable | Op_store _ | Op_other ->
+      | Op_pure | Op_load Immutable | Op_store _ | Op_load_barrier | Op_other ->
         Rhs_map.find op m.other_equations
 
     let remove_mutable_loads m =
@@ -308,14 +308,21 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
       Op_pure
-    | (Opaque | Pause) as op ->
+    | Opaque as op ->
       Misc.fatal_errorf "Cfg_cse.class_of_operation0: %a is handled specially"
         Operation.dump op
+    | Pause ->
+      (* Pause is used to spin on memory locations, so equations over mutable
+         loads must not survive it. *)
+      Op_load_barrier
     | Stackoffset _ -> Op_other
     | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
-      (* #12173: disable CSE for atomic loads. *)
+      (* #12173: disable CSE for atomic loads. Moreover, an atomic load is an
+         acquire: a load that follows it must not be satisfied by an equation
+         over a load that precedes it, so atomic loads are also load
+         barriers. *)
       if is_atomic
-      then Op_other
+      then Op_load_barrier
       else
         Op_load
           (match mutability with Mutable -> Mutable | Immutable -> Immutable)
@@ -368,10 +375,6 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Op Opaque ->
       (* Assume arbitrary side effects from Opaque *)
       empty_numbering
-    | Op Pause ->
-      (* We don't want to reorder loads across Pause, since it's used to spin on
-         memory locations. *)
-      kill_loads n
     | Op (Alloc _) | Op Poll ->
       (* For allocations, we must avoid extending the live range of a
          pseudoregister across the allocation if this pseudoreg is a derived
@@ -396,7 +399,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          | Intop_atomic _
          | Floatop (_, _)
          | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-         | Specific _ | Name_for_debugger _ ) as op) -> (
+         | Specific _ | Name_for_debugger _ | Pause ) as op) -> (
       match class_of_operation op with
       | (Op_pure | Op_load _) as op_class -> (
         let n1, varg = valnum_regs n i.arg in
@@ -432,9 +435,11 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
         let n1 = set_unknown_regs n (Proc.destroyed_at_basic i.desc) in
         let n2 = set_unknown_regs n1 i.res in
         n2
-      | Op_store true ->
+      | Op_store true | Op_load_barrier ->
         (* A non-initializing store can invalidate anything we know about prior
-           mutable loads. *)
+           mutable loads; a load barrier (atomic load, load fence, pause) must
+           similarly prevent a later load from reusing an equation over an
+           earlier one. *)
         let n1 = set_unknown_regs n (Proc.destroyed_at_basic i.desc) in
         let n2 = set_unknown_regs n1 i.res in
         let n3 = kill_loads n2 in

--- a/backend/cfg/cfg_cse_target_intf.ml
+++ b/backend/cfg/cfg_cse_target_intf.ml
@@ -28,6 +28,11 @@ type op_class =
   | Op_pure  (** pure arithmetic, produce one or several result *)
   | Op_load of Operation.mutable_flag  (** memory load *)
   | Op_store of bool  (** memory store, false = init, true = assign *)
+  | Op_load_barrier
+      (** operation that is never eligible for CSE itself, and across which
+          equations over mutable loads must not survive, so that a load
+          following the operation cannot reuse the result of a load preceding it
+          (e.g. atomic loads, load fences, pause) *)
   | Op_other  (** anything else that does not allocate nor store in memory *)
 
 type class_of_operation_result =

--- a/oxcaml/tests/backend/cse/dune
+++ b/oxcaml/tests/backend/cse/dune
@@ -1,0 +1,36 @@
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (= %{architecture} "amd64")))
+ (targets
+  test_cse_load_barriers.s
+  test_cse_load_barriers.cmx
+  test_cse_load_barriers.cmi
+  test_cse_load_barriers.o)
+ (deps test_cse_load_barriers.ml)
+ (action
+  (setenv
+   OCAMLPARAM
+   ""
+   (run %{bin:ocamlopt.opt} %{deps} -S -c -O3))))
+
+(rule
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (= %{architecture} "amd64")))
+ (deps filter.sh test_cse_load_barriers.s)
+ (action
+  (with-outputs-to
+   test_cse_load_barriers.output
+   (run ./filter.sh test_cse_load_barriers.s))))
+
+(rule
+ (alias runtest)
+ (enabled_if
+  (and
+   (= %{context_name} "main")
+   (= %{architecture} "amd64")))
+ (action
+  (diff test_cse_load_barriers.expected test_cse_load_barriers.output)))

--- a/oxcaml/tests/backend/cse/filter.sh
+++ b/oxcaml/tests/backend/cse/filter.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Extract the body of each OCaml function from an assembly file: print a
+# "name:" header (with the mangling stripped), then instruction lines and
+# local labels, stopping at the next symbol.
+
+awk '
+/^caml[A-Za-z0-9_]*__[A-Za-z0-9_]*_code:$/ {
+  name = $0
+  sub(/^caml[A-Za-z0-9_]*__/, "", name)
+  sub(/_[0-9]+_[0-9]+_code:$/, "", name)
+  print name ":"
+  infun = 1
+  next
+}
+infun && /^\.Lcaml[A-Za-z0-9_]*:$/ { next }
+infun && /^\t\./ { next }
+infun && /^\.L[0-9]+:$/ { print; next }
+infun && /^[^\t]/ { infun = 0; next }
+infun { print }
+' "$1"

--- a/oxcaml/tests/backend/cse/test_cse_load_barriers.expected
+++ b/oxcaml/tests/backend/cse/test_cse_load_barriers.expected
@@ -1,0 +1,22 @@
+no_barrier:
+	movq	(%rax), %rax
+	leaq	-1(%rax,%rax), %rax
+	ret
+load_across_load_fence:
+	movq	(%rax), %rax
+	movl	$1, %ebx
+	lfence
+	leaq	-1(%rax,%rax), %rax
+	ret
+load_across_memory_fence:
+	movq	(%rax), %rax
+	movl	$1, %ebx
+	mfence
+	leaq	-1(%rax,%rax), %rax
+	ret
+load_across_store_fence:
+	movq	(%rax), %rax
+	movl	$1, %ebx
+	sfence
+	leaq	-1(%rax,%rax), %rax
+	ret

--- a/oxcaml/tests/backend/cse/test_cse_load_barriers.expected
+++ b/oxcaml/tests/backend/cse/test_cse_load_barriers.expected
@@ -3,16 +3,18 @@ no_barrier:
 	leaq	-1(%rax,%rax), %rax
 	ret
 load_across_load_fence:
-	movq	(%rax), %rax
-	movl	$1, %ebx
+	movq	(%rax), %rbx
+	movl	$1, %edi
 	lfence
-	leaq	-1(%rax,%rax), %rax
+	movq	(%rax), %rax
+	leaq	-1(%rbx,%rax), %rax
 	ret
 load_across_memory_fence:
-	movq	(%rax), %rax
-	movl	$1, %ebx
+	movq	(%rax), %rbx
+	movl	$1, %edi
 	mfence
-	leaq	-1(%rax,%rax), %rax
+	movq	(%rax), %rax
+	leaq	-1(%rbx,%rax), %rax
 	ret
 load_across_store_fence:
 	movq	(%rax), %rax

--- a/oxcaml/tests/backend/cse/test_cse_load_barriers.ml
+++ b/oxcaml/tests/backend/cse/test_cse_load_barriers.ml
@@ -1,0 +1,38 @@
+(* Regression test for CSE across memory fences. CSE must not merge a mutable
+   load across [lfence] or [mfence] — the merge would effectively hoist the load
+   above the fence. The expected output currently captures the incorrect
+   behaviour: the loads following [load_fence] and [memory_fence] are merged
+   with the loads preceding them.
+
+   These externals are rewritten to fence instructions at direct call sites (see
+   [backend/amd64/cfg_selection.ml]); this file is only compiled, never linked
+   or executed, so the absence of C implementations does not matter. *)
+
+external load_fence : unit -> unit = "caml_load_fence" [@@noalloc] [@@builtin]
+
+external store_fence : unit -> unit = "caml_store_fence" [@@noalloc] [@@builtin]
+
+external memory_fence : unit -> unit = "caml_memory_fence"
+[@@noalloc] [@@builtin]
+
+(* Baseline: without a barrier, the second load is CSE'd. *)
+let[@inline never] no_barrier (r : int ref) = !r + !r
+
+(* The load after [load_fence] must not be merged with the one before. *)
+let[@inline never] load_across_load_fence (r : int ref) =
+  let a = !r in
+  load_fence ();
+  a + !r
+
+(* Same for [memory_fence]. *)
+let[@inline never] load_across_memory_fence (r : int ref) =
+  let a = !r in
+  memory_fence ();
+  a + !r
+
+(* [store_fence] only orders stores, which CSE neither eliminates nor moves, so
+   merging the two loads is allowed. *)
+let[@inline never] load_across_store_fence (r : int ref) =
+  let a = !r in
+  store_fence ();
+  a + !r

--- a/oxcaml/tests/backend/cse/test_cse_load_barriers.ml
+++ b/oxcaml/tests/backend/cse/test_cse_load_barriers.ml
@@ -1,8 +1,6 @@
 (* Regression test for CSE across memory fences. CSE must not merge a mutable
    load across [lfence] or [mfence] — the merge would effectively hoist the load
-   above the fence. The expected output currently captures the incorrect
-   behaviour: the loads following [load_fence] and [memory_fence] are merged
-   with the loads preceding them.
+   above the fence.
 
    These externals are rewritten to fence instructions at direct call sites (see
    [backend/amd64/cfg_selection.ml]); this file is only compiled, never linked

--- a/testsuite/tests/codegen/cse_load_barriers.ml
+++ b/testsuite/tests/codegen/cse_load_barriers.ml
@@ -1,0 +1,69 @@
+(* TEST
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Regression tests for CSE across load barriers: a mutable load must not be
+   satisfied by an equation over a load that precedes an atomic load
+   (acquire) or a cpu-relax hint, since that would effectively hoist the load
+   above the barrier.
+
+   The expected output for [load_across_atomic_get] below captures the
+   current, incorrect behaviour: the load following [Atomic.get] is merged
+   with the load preceding it.
+
+   The fence intrinsics ("caml_load_fence" etc.) cannot be tested here: this
+   machinery executes each phrase in a native toplevel, and those externals
+   have no C implementation in the process (they are only rewritten to fence
+   instructions at direct call sites). See oxcaml/tests/backend/cse for the
+   corresponding assembly tests. *)
+
+external cpu_relax : unit -> unit = "%cpu_relax"
+
+(* Baseline: without a barrier, the second load is CSE'd. *)
+let no_barrier r = !r + !r
+[%%expect_asm X86_64{|
+no_barrier:
+  movq  (%rax), %rax
+  leaq  -1(%rax,%rax), %rax
+  ret
+|}]
+
+(* The load after [Atomic.get] must not be merged with the one before. The
+   expected output below shows the current, incorrect behaviour: there is a
+   single load, and the sum is computed as [a + a]
+   ([leaq -1(%rax,%rax)]). *)
+let load_across_atomic_get (r : int ref) (flag : int Atomic.t) =
+  let a = !r in
+  if Atomic.get flag = 1 then a + !r else a
+[%%expect_asm X86_64{|
+load_across_atomic_get:
+  movq  (%rax), %rax
+  movq  (%rbx), %rbx
+  cmpq  $3, %rbx
+  jne   .L0
+  leaq  -1(%rax,%rax), %rax
+  ret
+.L0:
+  ret
+|}]
+
+(* [cpu_relax] is used to spin on a memory location, so the load after it
+   must not be merged with the one before (which is already the case). *)
+let load_across_cpu_relax (r : int ref) =
+  let a = !r in
+  cpu_relax ();
+  a + !r
+[%%expect_asm X86_64{|
+load_across_cpu_relax:
+  subq  $8, %rsp
+  movq  (%rax), %rbx
+  pause
+  cmpq  (%r14), %r15
+  jbe   <hidden GC jump pad>
+.L0:
+  movq  (%rax), %rax
+  leaq  -1(%rbx,%rax), %rax
+  addq  $8, %rsp
+  ret
+|}]

--- a/testsuite/tests/codegen/cse_load_barriers.ml
+++ b/testsuite/tests/codegen/cse_load_barriers.ml
@@ -8,10 +8,6 @@
    (acquire) or a cpu-relax hint, since that would effectively hoist the load
    above the barrier.
 
-   The expected output for [load_across_atomic_get] below captures the
-   current, incorrect behaviour: the load following [Atomic.get] is merged
-   with the load preceding it.
-
    The fence intrinsics ("caml_load_fence" etc.) cannot be tested here: this
    machinery executes each phrase in a native toplevel, and those externals
    have no C implementation in the process (they are only rewritten to fence
@@ -29,27 +25,26 @@ no_barrier:
   ret
 |}]
 
-(* The load after [Atomic.get] must not be merged with the one before. The
-   expected output below shows the current, incorrect behaviour: there is a
-   single load, and the sum is computed as [a + a]
-   ([leaq -1(%rax,%rax)]). *)
+(* The load after [Atomic.get] must not be merged with the one before. *)
 let load_across_atomic_get (r : int ref) (flag : int Atomic.t) =
   let a = !r in
   if Atomic.get flag = 1 then a + !r else a
 [%%expect_asm X86_64{|
 load_across_atomic_get:
-  movq  (%rax), %rax
+  movq  %rax, %rdi
+  movq  (%rdi), %rax
   movq  (%rbx), %rbx
   cmpq  $3, %rbx
   jne   .L0
-  leaq  -1(%rax,%rax), %rax
+  movq  (%rdi), %rbx
+  leaq  -1(%rax,%rbx), %rax
   ret
 .L0:
   ret
 |}]
 
 (* [cpu_relax] is used to spin on a memory location, so the load after it
-   must not be merged with the one before (which is already the case). *)
+   must not be merged with the one before. *)
 let load_across_cpu_relax (r : int ref) =
   let a = !r in
   cpu_relax ();


### PR DESCRIPTION
(https://github.com/oxcaml/oxcaml/pull/6434/commits/de4db893d1997acbe873f585e960c7079d99f0f5 is not part of the fix; `is_cheap_operation` was not properly used.)