### PR TITLE
Machtype checking

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -43,6 +43,7 @@ let cmm_invariants ppf fd_cmm =
   then
     Misc.fatal_errorf "Cmm invariants failed on following fundecl:@.%a@."
       print_fundecl fd_cmm;
+  if !Clflags.check_machtypes then Cmm_invariants.check_machtypes fd_cmm;
   fd_cmm
 
 let cfg_invariants ppf cfg =

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -43,7 +43,10 @@ let cmm_invariants ppf fd_cmm =
   then
     Misc.fatal_errorf "Cmm invariants failed on following fundecl:@.%a@."
       print_fundecl fd_cmm;
-  if !Clflags.check_machtypes then Cmm_invariants.check_machtypes fd_cmm;
+  if
+    !Clflags.check_machtypes
+    && not (Flambda2_ui.Flambda_features.classic_mode ())
+  then Cmm_invariants.check_machtypes fd_cmm;
   fd_cmm
 
 let cfg_invariants ppf cfg =

--- a/backend/afl_instrument.ml
+++ b/backend/afl_instrument.ml
@@ -53,7 +53,7 @@ let rec with_afl_logging b dbg =
       Csequence(
         op (Cstore(Byte_unsigned, Assignment))
           [op Cadda [Cvar afl_area; Cvar cur_pos];
-           op Cadda [op (Cload {memory_chunk=Byte_unsigned;
+           op Caddi [op (Cload {memory_chunk=Byte_unsigned;
                                 mutability=Asttypes.Mutable;
                                 is_atomic=false})
                         [op Cadda [Cvar afl_area; Cvar cur_pos]];

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -256,7 +256,7 @@ let insert_move_extcall_arg (ty_arg : Cmm.exttype) src dst :
   let ty_arg_is_small_int =
     match ty_arg with
     | XInt32 | XInt16 | XInt8 -> true
-    | XInt | XInt64 | XFloat32 | XFloat | XVec128 -> false
+    | XInt | XInt64 | XMask | XFloat32 | XFloat | XVec128 -> false
     | XVec256 | XVec512 -> Misc.fatal_error "arm64: got 256/512 bit vector"
   in
   if macosx && ty_arg_is_small_int && is_stack_slot dst

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -193,7 +193,7 @@ let external_calling_conventions
   List.iteri (fun i (ty_arg : Cmm.exttype) ->
     let (ty : Cmm.machtype_component), registers, divisor, size =
       match ty_arg with
-      | XInt | XInt64 -> Int, int_registers, 1, size_int
+      | XInt | XInt64 | XMask -> Int, int_registers, 1, size_int
       | XInt32 -> Int, int_registers, 2, size_int
       | XInt16 -> Int, int_registers, 4, size_int
       | XInt8 -> Int, int_registers, 8, size_int

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -390,6 +390,17 @@ let size_of_memory_chunk : memory_chunk -> int = function
   | Twofiftysix_unaligned | Twofiftysix_aligned -> 32
   | Fivetwelve_unaligned | Fivetwelve_aligned -> 64
 
+let machtype_of_memory_chunk : memory_chunk -> machtype = function
+  | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+  | Thirtytwo_unsigned | Thirtytwo_signed | Word_int ->
+    typ_int
+  | Word_val -> typ_val
+  | Single { reg = Float64 } | Double -> typ_float
+  | Single { reg = Float32 } -> typ_float32
+  | Onetwentyeight_unaligned | Onetwentyeight_aligned -> typ_vec128
+  | Twofiftysix_unaligned | Twofiftysix_aligned -> typ_vec256
+  | Fivetwelve_unaligned | Fivetwelve_aligned -> typ_vec512
+
 type reinterpret_cast =
   | Int_of_value
   | Value_of_int

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -122,7 +122,9 @@ let lub_component comp1 comp2 =
   | Valx2, _ | _, Valx2 ->
     Misc.fatal_errorf "Unexpected machtype_component Valx2"
 
-let ge_component comp1 comp2 =
+exception Incomparable_components
+
+let ge_component_result comp1 comp2 =
   match comp1, comp2 with
   | Int, Int -> true
   | Int, Addr -> false
@@ -147,12 +149,20 @@ let ge_component comp1 comp2 =
   | (Float | Float32), Mask
   | Float32, Float
   | Float, Float32 ->
+    raise Incomparable_components
+  | Valx2, _ | _, Valx2 ->
+    Misc.fatal_error "Unexpected machtype_component Valx2"
+
+let ge_component comp1 comp2 =
+  try ge_component_result comp1 comp2
+  with Incomparable_components ->
     Misc.fatal_errorf
       "Cmm.ge_component: unexpected machtype_component combination (%s, %s)"
       (string_of_machtype_component comp1)
       (string_of_machtype_component comp2)
-  | Valx2, _ | _, Valx2 ->
-    Misc.fatal_error "Unexpected machtype_component Valx2"
+
+let ge_component_bool comp1 comp2 =
+  try ge_component_result comp1 comp2 with Incomparable_components -> false
 
 type exttype =
   | XInt

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -420,6 +420,18 @@ let size_of_memory_chunk : memory_chunk -> int = function
   | Twofiftysix_unaligned | Twofiftysix_aligned -> 32
   | Fivetwelve_unaligned | Fivetwelve_aligned -> 64
 
+let machtype_of_memory_chunk : memory_chunk -> machtype = function
+  | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+  | Thirtytwo_unsigned | Thirtytwo_signed | Word_int ->
+    typ_int
+  | Word_val -> typ_val
+  | Word_mask -> typ_mask
+  | Single { reg = Float64 } | Double -> typ_float
+  | Single { reg = Float32 } -> typ_float32
+  | Onetwentyeight_unaligned | Onetwentyeight_aligned -> typ_vec128
+  | Twofiftysix_unaligned | Twofiftysix_aligned -> typ_vec256
+  | Fivetwelve_unaligned | Fivetwelve_aligned -> typ_vec512
+
 type reinterpret_cast =
   | Int_of_value
   | Value_of_int

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -89,7 +89,9 @@ let string_of_machtype_component (comp : machtype_component) =
     result.) The order is used only in selection, Valx2 is generated after
     selection. *)
 
-let lub_component comp1 comp2 =
+exception Incomparable_components
+
+let lub_component_result comp1 comp2 =
   match comp1, comp2 with
   | Int, Int -> Int
   | Int, Val -> Val
@@ -114,15 +116,22 @@ let lub_component comp1 comp2 =
   | (Float | Float32), Mask
   | Float32, Float
   | Float, Float32 ->
+    raise Incomparable_components
+  | Valx2, _ | _, Valx2 ->
+    Misc.fatal_errorf "Unexpected machtype_component Valx2"
+
+let lub_component comp1 comp2 =
+  try lub_component_result comp1 comp2
+  with Incomparable_components ->
     (* Float unboxing code must be sure to avoid this case. *)
     Misc.fatal_errorf
       "Cmm.lub_component: unexpected machtype_component combination (%s, %s)"
       (string_of_machtype_component comp1)
       (string_of_machtype_component comp2)
-  | Valx2, _ | _, Valx2 ->
-    Misc.fatal_errorf "Unexpected machtype_component Valx2"
 
-exception Incomparable_components
+let lub_component_opt comp1 comp2 =
+  try Some (lub_component_result comp1 comp2)
+  with Incomparable_components -> None
 
 let ge_component_result comp1 comp2 =
   match comp1, comp2 with

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -160,6 +160,7 @@ type exttype =
   | XInt16
   | XInt32
   | XInt64
+  | XMask
   | XFloat32
   | XFloat
   | XVec128
@@ -175,6 +176,7 @@ let machtype_of_exttype = function
   | XInt16 -> typ_int
   | XInt32 -> typ_int
   | XInt64 -> typ_int
+  | XMask -> typ_mask
   | XFloat -> typ_float
   | XFloat32 -> typ_float32
   | XVec128 -> typ_vec128
@@ -952,8 +954,8 @@ let equal_machtype left right =
   Misc.Stdlib.Array.equal equal_machtype_component left right
 
 let equal_exttype
-    (( XInt | XInt8 | XInt16 | XInt32 | XInt64 | XFloat32 | XFloat | XVec128
-     | XVec256 | XVec512 ) as left) right =
+    (( XInt | XInt8 | XInt16 | XInt32 | XInt64 | XMask | XFloat32 | XFloat
+     | XVec128 | XVec256 | XVec512 ) as left) right =
   (* we can use polymorphic compare as long as exttype is all constant
      constructors *)
   Stdlib.( = ) left right

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -305,6 +305,8 @@ type memory_chunk =
 (** Size in bytes of a memory access for the given chunk type. *)
 val size_of_memory_chunk : memory_chunk -> int
 
+val machtype_of_memory_chunk : memory_chunk -> machtype
+
 (* These casts compile to a single move instruction. If the operands are
    assigned the same physical register, the move will be omitted entirely. *)
 type reinterpret_cast =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -85,8 +85,8 @@ val typ_int128 : machtype
 val lub_component :
   machtype_component -> machtype_component -> machtype_component
 
-(** Version of [lub_component] that returns [None] for uncomparable
-    components. *)
+(** Version of [lub_component] that returns [None] for uncomparable components.
+*)
 val lub_component_opt :
   machtype_component -> machtype_component -> machtype_component option
 

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -89,6 +89,9 @@ val lub_component :
     or equal to the second under the relation used by [lub_component]. *)
 val ge_component : machtype_component -> machtype_component -> bool
 
+(** Version of [ge_component] that doesn't raise for uncomparable components. *)
+val ge_component_bool : machtype_component -> machtype_component -> bool
+
 (** A variant of [machtype] used to describe arguments to external C functions
 *)
 type exttype =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -85,6 +85,11 @@ val typ_int128 : machtype
 val lub_component :
   machtype_component -> machtype_component -> machtype_component
 
+(** Version of [lub_component] that returns [None] for uncomparable
+    components. *)
+val lub_component_opt :
+  machtype_component -> machtype_component -> machtype_component option
+
 (** Returns [true] iff the first supplied [machtype_component] is greater than
     or equal to the second under the relation used by [lub_component]. *)
 val ge_component : machtype_component -> machtype_component -> bool

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -334,6 +334,8 @@ type memory_chunk =
 (** Size in bytes of a memory access for the given chunk type. *)
 val size_of_memory_chunk : memory_chunk -> int
 
+val machtype_of_memory_chunk : memory_chunk -> machtype
+
 (* These casts compile to a single move instruction. If the operands are
    assigned the same physical register, the move will be omitted entirely. *)
 type reinterpret_cast =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -97,6 +97,7 @@ type exttype =
   | XInt16  (**r 16-bit integer *)
   | XInt32  (**r 32-bit integer *)
   | XInt64  (**r 64-bit integer *)
+  | XMask  (**r mask passed as a 64-bit integer according to the C ABI *)
   | XFloat32  (**r single-precision FP number *)
   | XFloat  (**r double-precision FP number *)
   | XVec128  (**r 128-bit vector *)

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -1242,9 +1242,7 @@ let transl_builtin name args dbg typ_res =
     bigstring_cas Sixtyfour (four_args name args) dbg
   | "caml_bigstring_compare_and_swap_int32_unboxed" ->
     bigstring_cas Thirtytwo (four_args name args) dbg
-  | "caml_pause_hint" ->
-    (* The unit argument carries no effects and is dropped. *)
-    Some (return_unit dbg (Cop (Cpause, [], dbg)))
+  | "caml_pause_hint" -> Some (return_unit dbg (Cop (Cpause, [], dbg)))
   | _ -> transl_vec_builtin name args dbg typ_res
 
 let builtin_even_if_not_annotated = function

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -1242,7 +1242,9 @@ let transl_builtin name args dbg typ_res =
     bigstring_cas Sixtyfour (four_args name args) dbg
   | "caml_bigstring_compare_and_swap_int32_unboxed" ->
     bigstring_cas Thirtytwo (four_args name args) dbg
-  | "caml_pause_hint" -> Some (Cop (Cpause, args, dbg))
+  | "caml_pause_hint" ->
+    (* The unit argument carries no effects and is dropped. *)
+    Some (return_unit dbg (Cop (Cpause, [], dbg)))
   | _ -> transl_vec_builtin name args dbg typ_res
 
 let builtin_even_if_not_annotated = function

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -1229,7 +1229,7 @@ let transl_builtin name args dbg typ_res =
     bigstring_cas Sixtyfour (four_args name args) dbg
   | "caml_bigstring_compare_and_swap_int32_unboxed" ->
     bigstring_cas Thirtytwo (four_args name args) dbg
-  | "caml_pause_hint" -> Some (return_unit dbg (Cop (Cpause, [], dbg)))
+  | "caml_pause_hint" -> Some (Cop (Cpause, args, dbg))
   | _ -> transl_vec_builtin name args dbg typ_res
 
 let builtin_even_if_not_annotated = function

--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -1229,7 +1229,7 @@ let transl_builtin name args dbg typ_res =
     bigstring_cas Sixtyfour (four_args name args) dbg
   | "caml_bigstring_compare_and_swap_int32_unboxed" ->
     bigstring_cas Thirtytwo (four_args name args) dbg
-  | "caml_pause_hint" -> Some (Cop (Cpause, args, dbg))
+  | "caml_pause_hint" -> Some (return_unit dbg (Cop (Cpause, [], dbg)))
   | _ -> transl_vec_builtin name args dbg typ_res
 
 let builtin_even_if_not_annotated = function

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4043,7 +4043,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
           fun_codegen_options = [];
           fun_dbg;
           fun_poll = Default_poll;
-          fun_ret_type = result
+          fun_ret_type = typ_val
         }
       ::
       (if has_nary

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4337,7 +4337,7 @@ let intermediate_curry_functions ~nlocal ~arity result =
           fun_codegen_options = [];
           fun_dbg;
           fun_poll = Default_poll;
-          fun_ret_type = result
+          fun_ret_type = typ_val
         }
       ::
       (if has_nary

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -15,7 +15,9 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
 open! Int_replace_polymorphic_compare
-
+open Cmm
+module V = Backend_var
+module VP = Backend_var.With_provenance
 
 (* Check a number of continuation-related invariants *)
 
@@ -173,3 +175,443 @@ let run ppf (fundecl : Cmm.fundecl) =
   let env = Env.init () in
   check env fundecl.fun_body;
   Env.report ppf
+
+(* Machtype checking *)
+
+let machtype_of_float_width : float_width -> machtype = function
+  | Float64 -> typ_float
+  | Float32 -> typ_float32
+
+let machtype_of_vector_width : vector_width -> machtype = function
+  | Vec128 -> typ_vec128
+  | Vec256 -> typ_vec256
+  | Vec512 -> typ_vec512
+
+let machtype_of_vec128_scalar : vec128_type -> machtype = function
+  | Float64x2 -> typ_float
+  | Float32x4 -> typ_float32
+  | Float16x8 -> Misc.fatal_error "float16x8: scalar type not supported"
+  | Int8x16 | Int16x8 | Int32x4 | Int64x2 -> typ_int
+
+let machtype_of_vec256_scalar : vec256_type -> machtype = function
+  | Float64x4 -> typ_float
+  | Float32x8 -> typ_float32
+  | Float16x16 -> Misc.fatal_error "float16x16: scalar type not supported"
+  | Int8x32 | Int16x16 | Int32x8 | Int64x4 -> typ_int
+
+let machtype_of_vec512_scalar : vec512_type -> machtype = function
+  | Float64x8 -> typ_float
+  | Float32x16 -> typ_float32
+  | Float16x32 -> Misc.fatal_error "float16x32: scalar type not supported"
+  | Int8x64 | Int16x32 | Int32x16 | Int64x8 -> typ_int
+
+let reinterpret_cast_arg_type : reinterpret_cast -> machtype = function
+  | Int_of_value -> typ_val
+  | Value_of_int -> typ_int
+  | Float_of_float32 -> typ_float32
+  | Float32_of_float -> typ_float
+  | Float_of_int64 -> typ_int
+  | Int64_of_float -> typ_float
+  | Float32_of_int32 -> typ_int
+  | Int32_of_float32 -> typ_float32
+  | V128_of_vec width | V256_of_vec width | V512_of_vec width ->
+    machtype_of_vector_width width
+
+let static_cast_arg_type : static_cast -> machtype = function
+  | Float_of_int (_ : float_width) -> typ_int
+  | Int_of_float width -> machtype_of_float_width width
+  | Float_of_float32 -> typ_float32
+  | Float32_of_float -> typ_float
+  | V128_of_scalar ty -> machtype_of_vec128_scalar ty
+  | Scalar_of_v128 (_ : vec128_type) -> typ_vec128
+  | V256_of_scalar ty -> machtype_of_vec256_scalar ty
+  | Scalar_of_v256 (_ : vec256_type) -> typ_vec256
+  | V512_of_scalar ty -> machtype_of_vec512_scalar ty
+  | Scalar_of_v512 (_ : vec512_type) -> typ_vec512
+
+type expected_arg_type =
+  | Exactly of machtype
+  | Any_machtype
+      (** For argument slots whose machtype is not determined by the operation,
+          e.g. addresses, which may legitimately be [Val], [Addr] or naked
+          pointers outside the heap. *)
+
+type expected_arg_types =
+  | Args of expected_arg_type list
+      (** Exactly as many arguments as listed, checked slotwise. *)
+  | Any_number_of of expected_arg_type
+      (** Any number of arguments, each checked against the given
+          constraint. *)
+  | Args_then_any_number_of of expected_arg_type list * expected_arg_type
+      (** At least the listed arguments, checked slotwise, followed by any
+          number of arguments checked against the second constraint. *)
+
+(* The machtypes an operation expects for its arguments, in the style of
+   [Select_utils.oper_result_type]. *)
+let oper_arg_types : operation -> expected_arg_types = function
+  | Capply _ ->
+    Args_then_any_number_of
+      ([Any_machtype (* closure or code pointer *)], Any_machtype)
+  | Cextcall { ty_args = []; _ } ->
+    (* An empty [ty_args] means "all arguments are machine words". *)
+    Any_number_of Any_machtype
+  | Cextcall { ty_args = _ :: _ as ty_args; _ } ->
+    Args
+      (List.map
+         (fun (ty_arg : exttype) ->
+           match ty_arg with
+           | XInt ->
+             (* [XInt] is used for values as well as word-sized integers. *)
+             Any_machtype
+           | XInt8 | XInt16 | XInt32 | XInt64 | XFloat32 | XFloat | XVec128
+           | XVec256 | XVec512 ->
+             Exactly (machtype_of_exttype ty_arg))
+         ty_args)
+  | Cload _ -> Args [Any_machtype]
+  | Calloc (_, kind) ->
+    let field =
+      match kind with
+      | Alloc_block_kind_other ->
+        (* Mixed blocks are also allocated with this kind: fields after the
+           scannable prefix may be unboxed, and the prefix length is only
+           encoded in the header argument. *)
+        Any_machtype
+      | Alloc_block_kind_float | Alloc_block_kind_float_array ->
+        Exactly typ_float
+      | Alloc_block_kind_int_u_array | Alloc_block_kind_int64_u_array ->
+        Exactly typ_int
+      | Alloc_block_kind_vec128_u_array -> Exactly typ_vec128
+      | Alloc_block_kind_vec256_u_array -> Exactly typ_vec256
+      | Alloc_block_kind_vec512_u_array -> Exactly typ_vec512
+      | Alloc_block_kind_closure | Alloc_block_kind_boxed_int _
+      | Alloc_block_kind_float32 | Alloc_block_kind_vec128
+      | Alloc_block_kind_vec256 | Alloc_block_kind_vec512
+      | Alloc_block_kind_float32_u_array | Alloc_block_kind_int8_u_array
+      | Alloc_block_kind_int16_u_array | Alloc_block_kind_int32_u_array ->
+        (* Closures and custom blocks mix code pointers, raw words and
+           payloads; packed u-arrays mix packed words with a raw last
+           element. *)
+        Any_machtype
+    in
+    Args_then_any_number_of ([Any_machtype (* header *)], field)
+  | Cstore (memory_chunk, _) ->
+    Args [Any_machtype; Exactly (machtype_of_memory_chunk memory_chunk)]
+  | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor | Clsl
+  | Clsr | Casr | Ccmpi _ ->
+    (* Under [ge_component], [typ_addr] accepts any word in a general-purpose
+       register ([Int], [Val] or [Addr]): classic machtypes cannot distinguish
+       tagged values from untagged words, and word operations are applied to
+       both (e.g. physical equality on values, untagging a scrutinee). *)
+    Args [Exactly typ_addr; Exactly typ_addr]
+  | Cclz | Cctz | Cpopcnt | Cbswap _ -> Args [Exactly typ_addr]
+  | Caddi128 | Csubi128 ->
+    Args [Exactly typ_int; Exactly typ_int; Exactly typ_int; Exactly typ_int]
+  | Cmuli64 _ -> Args [Exactly typ_int; Exactly typ_int]
+  | Ccsel ty -> Args [Exactly typ_int; Exactly ty; Exactly ty]
+  | Cprefetch _ -> Args [Any_machtype]
+  | Catomic
+      { op = Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange; _ } ->
+    Args [Exactly typ_int; Any_machtype (* address *)]
+  | Catomic { op = Compare_set | Compare_exchange; _ } ->
+    Args [Exactly typ_int; Exactly typ_int; Any_machtype (* address *)]
+  | Caddv -> Args [Exactly typ_val; Exactly typ_int]
+  | Cadda -> Args [Exactly typ_addr; Exactly typ_int]
+  | Cnegf width | Cabsf width -> Args [Exactly (machtype_of_float_width width)]
+  | Caddf width | Csubf width | Cmulf width | Cdivf width ->
+    let ty = machtype_of_float_width width in
+    Args [Exactly ty; Exactly ty]
+  | Cpackf32 ->
+    (* Two float32s held in the low bits of float registers. *)
+    Args [Exactly typ_float; Exactly typ_float]
+  | Ccmpf (width, _) ->
+    let ty = machtype_of_float_width width in
+    Args [Exactly ty; Exactly ty]
+  | Creinterpret_cast cast -> Args [Exactly (reinterpret_cast_arg_type cast)]
+  | Cstatic_cast cast -> Args [Exactly (static_cast_arg_type cast)]
+  | Craise _ ->
+    (* All arguments are GC-scannable; under [ge_component], [typ_val] accepts
+       exactly [Val] and [Int]. *)
+    Any_number_of (Exactly typ_val)
+  | Cprobe _ -> Any_number_of Any_machtype
+  | Copaque -> Any_number_of Any_machtype
+  | Cprobe_is_enabled _ | Cbeginregion | Cdls_get | Ctls_get | Cdomain_index
+  | Cpoll | Cpause ->
+    Args []
+  | Cendregion -> Args [Exactly typ_int]
+  | Ctuple_field (_, fields_ty) ->
+    Args [Exactly (Array.concat (Array.to_list fields_ty))]
+
+(* [Never_returns] is for diverging expressions, which do not constrain their
+   context, in the same way as [Select_utils.Or_never_returns] in the
+   selectors. *)
+type inferred_machtype =
+  | Machtype of machtype
+  | Never_returns
+
+let dbg_suffix dbg =
+  if Debuginfo.is_none dbg
+  then ""
+  else Format.asprintf " at %a" Debuginfo.print_compact dbg
+
+(* [what] is only evaluated on error. *)
+let check_machtype ~dbg ~what ~expected (actual : inferred_machtype) =
+  match actual with
+  | Never_returns -> ()
+  | Machtype actual ->
+    let compatible =
+      Array.length expected = Array.length actual
+      && Array.for_all2
+           (fun expected_comp actual_comp ->
+             (* The compiler types statically-known tagged immediates as [Int]
+                while generic loads and calls produce them as [Val], so [Val]
+                flows into [Int] positions routinely. *)
+             (equal_machtype_component expected_comp Int
+             && equal_machtype_component actual_comp Val)
+             ||
+             (* [ge_component] is fatal on incomparable components *)
+             (try ge_component expected_comp actual_comp
+              with Misc.Fatal_error -> false))
+           expected actual
+    in
+    if not compatible
+    then
+      Misc.fatal_errorf
+        "Cmm machtype check failed%s: %s has machtype %a but %a was expected"
+        (dbg_suffix dbg) (what ()) Printcmm.machtype actual Printcmm.machtype
+        expected
+
+let join_inferred_machtypes ~dbg ty1 ty2 =
+  match ty1, ty2 with
+  | Never_returns, ty | ty, Never_returns -> ty
+  | Machtype ty1, Machtype ty2 ->
+    if Array.length ty1 <> Array.length ty2
+    then
+      Misc.fatal_errorf
+        "Cmm machtype check failed%s: join of machtype %a and machtype %a, \
+         which do not have the same number of components"
+        (dbg_suffix dbg) Printcmm.machtype ty1 Printcmm.machtype ty2
+    else Machtype (Array.map2 lub_component ty1 ty2)
+
+let join_all_inferred_machtypes ~dbg tys =
+  List.fold_left (join_inferred_machtypes ~dbg) Never_returns tys
+
+type typechecking_env =
+  { vars : machtype V.Map.t;
+    handlers : machtype list Static_label.Map.t;
+    return_type : machtype option
+  }
+
+let concat_inferred_machtypes tys =
+  List.fold_left
+    (fun acc ty ->
+      match acc, ty with
+      | Never_returns, (Machtype _ | Never_returns) | Machtype _, Never_returns
+        ->
+        Never_returns
+      | Machtype tys, Machtype ty -> Machtype (Array.append tys ty))
+    (Machtype typ_void) tys
+
+let rec infer_machtype env (expr : expression) : inferred_machtype =
+  match expr with
+  | Cconst_int _ | Cconst_natint _ | Cconst_symbol _ ->
+    (* Integer literals and statically-allocated symbols are non-heap words;
+       [Int] is below [Val], so they are also accepted where values are
+       expected. *)
+    Machtype typ_int
+  | Cconst_float _ -> Machtype typ_float
+  | Cconst_float32 _ -> Machtype typ_float32
+  | Cconst_vec128 _ -> Machtype typ_vec128
+  | Cconst_vec256 _ -> Machtype typ_vec256
+  | Cconst_vec512 _ -> Machtype typ_vec512
+  | Cvar var -> (
+    match V.Map.find_opt var env.vars with
+    | Some ty -> Machtype ty
+    | None ->
+      Misc.fatal_errorf "Cmm machtype check failed: unbound variable %a"
+        V.print var)
+  | Clet (var, defining_expr, body) -> (
+    match infer_machtype env defining_expr with
+    | Never_returns -> Never_returns
+    | Machtype ty ->
+      infer_machtype
+        { env with vars = V.Map.add (VP.var var) ty env.vars }
+        body)
+  | Cphantom_let (_, _, body) -> infer_machtype env body
+  | Ctuple exprs ->
+    concat_inferred_machtypes (List.map (infer_machtype env) exprs)
+  | Cop (op, args, dbg) -> typecheck_cop env op args dbg
+  | Csequence (expr1, expr2) -> (
+    match infer_machtype env expr1 with
+    | Never_returns -> Never_returns
+    | Machtype _ -> infer_machtype env expr2)
+  | Cifthenelse (cond, _, ifso, _, ifnot, dbg) -> (
+    let cond_ty = infer_machtype env cond in
+    check_machtype ~dbg
+      ~what:(fun () -> "if-then-else condition")
+      ~expected:typ_int cond_ty;
+    let branches_ty =
+      join_inferred_machtypes ~dbg (infer_machtype env ifso)
+        (infer_machtype env ifnot)
+    in
+    match cond_ty with
+    | Never_returns -> Never_returns
+    | Machtype _ -> branches_ty)
+  | Cswitch (scrutinee, _, cases, dbg) -> (
+    let scrutinee_ty = infer_machtype env scrutinee in
+    check_machtype ~dbg
+      ~what:(fun () -> "switch scrutinee")
+      ~expected:typ_int scrutinee_ty;
+    let cases_ty =
+      join_all_inferred_machtypes ~dbg
+        (Array.to_list
+           (Array.map
+              (fun (case, _) -> infer_machtype env case)
+              cases))
+    in
+    match scrutinee_ty with
+    | Never_returns -> Never_returns
+    | Machtype _ -> cases_ty)
+  | Ccatch (_, handlers, body) ->
+    let env =
+      { env with
+        handlers =
+          List.fold_left
+            (fun handlers handler ->
+              Static_label.Map.add handler.label
+                (List.map snd handler.params)
+                handlers)
+            env.handlers handlers
+      }
+    in
+    let body_ty = infer_machtype env body in
+    let handler_tys =
+      List.map
+        (fun (handler : static_handler) ->
+          let env =
+            { env with
+              vars =
+                List.fold_left
+                  (fun vars (var, ty) -> V.Map.add (VP.var var) ty vars)
+                  env.vars handler.params
+            }
+          in
+          infer_machtype env handler.body)
+        handlers
+    in
+    join_all_inferred_machtypes ~dbg:Debuginfo.none (body_ty :: handler_tys)
+  | Cexit (label, args, _) ->
+    (* Exit arguments are matched to handler parameters by machtype component,
+       not one-to-one: a single argument of a product machtype can fill
+       several parameters. *)
+    let args_ty =
+      concat_inferred_machtypes (List.map (infer_machtype env) args)
+    in
+    (match label with
+    | Return_lbl -> (
+      match env.return_type with
+      | None -> ()
+      | Some expected ->
+        check_machtype ~dbg:Debuginfo.none
+          ~what:(fun () -> "return")
+          ~expected args_ty)
+    | Lbl label -> (
+      match Static_label.Map.find_opt label env.handlers with
+      | None ->
+        (* Exits to out-of-scope handlers are reported by [run]. *)
+        ()
+      | Some param_tys ->
+        check_machtype ~dbg:Debuginfo.none
+          ~expected:(Array.concat param_tys)
+          args_ty
+          ~what:(fun () ->
+            Format.asprintf "arguments of exit to %a" Static_label.format
+              label)));
+    Never_returns
+  | Cinvalid _ -> Never_returns
+
+and typecheck_cop env op args dbg : inferred_machtype =
+  let arg_tys = List.map (infer_machtype env) args in
+  let check_arg arg_index expected actual =
+    match expected with
+    | Any_machtype -> ()
+    | Exactly expected ->
+      check_machtype ~dbg ~expected actual ~what:(fun () ->
+          Printf.sprintf "argument %d of operation %s" (arg_index + 1)
+            (Printcmm.operation dbg op))
+  in
+  let arity_error expected_arity =
+    Misc.fatal_errorf
+      "Cmm machtype check failed at %a: operation %s expects %s arguments but \
+       is given %d"
+      Debuginfo.print_compact dbg
+      (Printcmm.operation dbg op)
+      expected_arity (List.length args)
+  in
+  (match oper_arg_types op with
+  | Args expected_tys ->
+    if List.compare_lengths expected_tys args <> 0
+    then arity_error (string_of_int (List.length expected_tys));
+    List.iteri
+      (fun arg_index (expected, actual) -> check_arg arg_index expected actual)
+      (List.combine expected_tys arg_tys)
+  | Any_number_of expected ->
+    List.iteri (fun arg_index actual -> check_arg arg_index expected actual)
+      arg_tys
+  | Args_then_any_number_of (expected_prefix, expected_rest) ->
+    if List.compare_lengths expected_prefix args > 0
+    then
+      arity_error
+        (Printf.sprintf "at least %d" (List.length expected_prefix));
+    List.iteri
+      (fun arg_index actual ->
+        let expected =
+          match List.nth_opt expected_prefix arg_index with
+          | Some expected -> expected
+          | None -> expected_rest
+        in
+        check_arg arg_index expected actual)
+      arg_tys);
+  if
+    List.exists
+      (function Never_returns -> true | Machtype _ -> false)
+      arg_tys
+  then Never_returns
+  else
+    match op with
+    | Craise _
+    | Cextcall { returns = false; _ }
+    | Capply { returns = false; _ } ->
+      Never_returns
+    | Copaque -> (
+      (* [Copaque] is the identity whatever the machtype of its argument;
+         [oper_result_type] approximates its result as [typ_val]. *)
+      match arg_tys with
+      | [ty] -> ty
+      | [] | _ :: _ :: _ -> arity_error "1")
+    | Cextcall { returns = true; _ }
+    | Capply { returns = true; _ }
+    | Cload _ | Calloc _ | Cstore _ | Caddi | Csubi | Cmuli
+    | Cmulhi _ | Cdivi | Cmodi | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor
+    | Cxor | Clsl | Clsr | Casr | Cbswap _ | Ccsel _ | Cclz | Cctz | Cpopcnt
+    | Cprefetch _ | Catomic _ | Ccmpi _ | Caddv | Cadda | Cnegf _ | Cabsf _
+    | Caddf _ | Csubf _ | Cmulf _ | Cdivf _ | Cpackf32 | Creinterpret_cast _
+    | Cstatic_cast _ | Ccmpf _ | Cprobe _ | Cprobe_is_enabled _ | Cbeginregion
+    | Cendregion | Ctuple_field _ | Cdls_get | Ctls_get | Cdomain_index | Cpoll
+    | Cpause ->
+      Machtype (Select_utils.oper_result_type op)
+
+let check_machtypes (fundecl : fundecl) =
+  let vars =
+    List.fold_left
+      (fun vars (var, ty) -> V.Map.add (VP.var var) ty vars)
+      V.Map.empty fundecl.fun_args
+  in
+  let env =
+    { vars;
+      handlers = Static_label.Map.empty;
+      return_type = Some fundecl.fun_ret_type
+    }
+  in
+  check_machtype ~dbg:fundecl.fun_dbg ~expected:fundecl.fun_ret_type
+    ~what:(fun () -> Printf.sprintf "the body of %s" fundecl.fun_name.sym_name)
+    (infer_machtype env fundecl.fun_body)

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -592,7 +592,8 @@ and typecheck_cop env op args dbg : inferred_machtype =
   else
     match op with
     | Craise _
-    | Cextcall { returns = false; _ } ->
+    | Cextcall { returns = false; _ }
+    | Capply { returns = false; _ } ->
       Never_returns
     | Copaque -> (
       (* [Copaque] is the identity whatever the machtype of its argument;
@@ -601,7 +602,7 @@ and typecheck_cop env op args dbg : inferred_machtype =
       | [ty] -> ty
       | [] | _ :: _ :: _ -> arity_error "1")
     | Cextcall { returns = true; _ }
-    | Capply _
+    | Capply { returns = true; _ }
     | Cload _ | Calloc _ | Cstore _ | Caddi | Csubi | Cmuli
     | Cmulhi _ | Cdivi | Cmodi | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor
     | Cxor | Clsl | Clsr | Casr | Cbswap _ | Ccsel _ | Cclz | Cctz | Cpopcnt

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -295,7 +295,20 @@ let oper_arg_types : operation -> expected_arg_types = function
     in
     Args_then_any_number_of ([Any_machtype (* header *)], field)
   | Cstore (memory_chunk, _) ->
-    Args [Any_machtype; Exactly (machtype_of_memory_chunk memory_chunk)]
+    let value =
+      match memory_chunk with
+      | Word_int ->
+        (* A raw word slot is not scanned, so it accepts any word in a
+           general-purpose register, including derived pointers. *)
+        Exactly typ_addr
+      | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+      | Thirtytwo_unsigned | Thirtytwo_signed | Word_val | Single _ | Double
+      | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
+      | Fivetwelve_aligned ->
+        Exactly (machtype_of_memory_chunk memory_chunk)
+    in
+    Args [Any_machtype; value]
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi | Cmodi | Cand | Cor | Cxor | Clsl
   | Clsr | Casr | Ccmpi _ ->
     (* Under [ge_component], [typ_addr] accepts any word in a general-purpose

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -624,6 +624,11 @@ let check_machtypes (fundecl : fundecl) =
       return_type = Some fundecl.fun_ret_type
     }
   in
-  check_machtype ~dbg:fundecl.fun_dbg ~expected:fundecl.fun_ret_type
-    ~what:(fun () -> Printf.sprintf "the body of %s" fundecl.fun_name.sym_name)
-    (infer_machtype env fundecl.fun_body)
+  try
+    check_machtype ~dbg:fundecl.fun_dbg ~expected:fundecl.fun_ret_type
+      ~what:(fun () ->
+        Printf.sprintf "the body of %s" fundecl.fun_name.sym_name)
+      (infer_machtype env fundecl.fun_body)
+  with Misc.Fatal_error ->
+    Misc.fatal_errorf "Error happened while typechecking function %s; body:\n%a"
+      fundecl.fun_name.sym_name Printcmm.expression fundecl.fun_body

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -592,8 +592,7 @@ and typecheck_cop env op args dbg : inferred_machtype =
   else
     match op with
     | Craise _
-    | Cextcall { returns = false; _ }
-    | Capply { returns = false; _ } ->
+    | Cextcall { returns = false; _ } ->
       Never_returns
     | Copaque -> (
       (* [Copaque] is the identity whatever the machtype of its argument;
@@ -602,7 +601,7 @@ and typecheck_cop env op args dbg : inferred_machtype =
       | [ty] -> ty
       | [] | _ :: _ :: _ -> arity_error "1")
     | Cextcall { returns = true; _ }
-    | Capply { returns = true; _ }
+    | Capply _
     | Cload _ | Calloc _ | Cstore _ | Caddi | Csubi | Cmuli
     | Cmulhi _ | Cdivi | Cmodi | Caddi128 | Csubi128 | Cmuli64 _ | Cand | Cor
     | Cxor | Clsl | Clsr | Casr | Cbswap _ | Ccsel _ | Cclz | Cctz | Cpopcnt

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -342,9 +342,9 @@ let oper_arg_types : operation -> expected_arg_types = function
   | Creinterpret_cast cast -> Args [Exactly (reinterpret_cast_arg_type cast)]
   | Cstatic_cast cast -> Args [Exactly (static_cast_arg_type cast)]
   | Craise _ ->
-    (* All arguments are GC-scannable; under [ge_component], [typ_val] accepts
-       exactly [Val] and [Int]. *)
-    Any_number_of (Exactly typ_val)
+    (* The exception, followed by the extra args of the innermost exception
+       handler on the trap stack, whose machtypes are not known here. *)
+    Args_then_any_number_of ([Exactly typ_val], Any_machtype)
   | Cprobe _ -> Any_number_of Any_machtype
   | Copaque -> Any_number_of Any_machtype
   | Cprobe_is_enabled _ | Cbeginregion | Cdls_get | Ctls_get | Cdomain_index

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -351,7 +351,7 @@ let oper_arg_types : operation -> expected_arg_types = function
        handler on the trap stack, whose machtypes are not known here. *)
     Args_then_any_number_of ([Exactly typ_val], Any_machtype)
   | Cprobe _ -> Any_number_of Any_machtype
-  | Copaque -> Any_number_of Any_machtype
+  | Copaque -> Args [Any_machtype]
   | Cprobe_is_enabled _ | Cbeginregion | Cdls_get | Ctls_get | Cdomain_index
   | Cpoll | Cpause ->
     Args []
@@ -520,9 +520,8 @@ let rec infer_machtype env (expr : expression) : inferred_machtype =
     in
     join_all_inferred_machtypes ~dbg:Debuginfo.none (body_ty :: handler_tys)
   | Cexit (label, args, _) ->
-    (* Exit arguments are matched to handler parameters by machtype component,
-       not one-to-one: a single argument of a product machtype can fill
-       several parameters. *)
+    (* Compare exit arguments and handler parameters after flattening their
+       machtypes into components. *)
     let args_ty =
       concat_inferred_machtypes (List.map (infer_machtype env) args)
     in
@@ -534,7 +533,7 @@ let rec infer_machtype env (expr : expression) : inferred_machtype =
     | Lbl label -> (
       match Static_label.Map.find_opt label env.handlers with
       | None ->
-        (* Exits to out-of-scope handlers are reported by [run]. *)
+        (* Exits to out-of-scope handlers are reported during selection. *)
         ()
       | Some param_tys ->
         check_machtype ~dbg:Debuginfo.none

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -15,7 +15,9 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
 open! Int_replace_polymorphic_compare
-
+open Cmm
+module V = Backend_var
+module VP = Backend_var.With_provenance
 
 (* Check a number of continuation-related invariants *)
 
@@ -175,3 +177,467 @@ let run ppf (fundecl : Cmm.fundecl) =
   let env = Env.init () in
   check env fundecl.fun_body;
   Env.report ppf
+
+(* Machtype checking *)
+
+let machtype_of_float_width : float_width -> machtype = function
+  | Float64 -> typ_float
+  | Float32 -> typ_float32
+
+let machtype_of_vector_width : vector_width -> machtype = function
+  | Vec128 -> typ_vec128
+  | Vec256 -> typ_vec256
+  | Vec512 -> typ_vec512
+
+let machtype_of_vec128_scalar : vec128_type -> machtype = function
+  | Float64x2 -> typ_float
+  | Float32x4 -> typ_float32
+  | Float16x8 -> Misc.fatal_error "float16x8: scalar type not supported"
+  | Int8x16 | Int16x8 | Int32x4 | Int64x2 -> typ_int
+
+let machtype_of_vec256_scalar : vec256_type -> machtype = function
+  | Float64x4 -> typ_float
+  | Float32x8 -> typ_float32
+  | Float16x16 -> Misc.fatal_error "float16x16: scalar type not supported"
+  | Int8x32 | Int16x16 | Int32x8 | Int64x4 -> typ_int
+
+let machtype_of_vec512_scalar : vec512_type -> machtype = function
+  | Float64x8 -> typ_float
+  | Float32x16 -> typ_float32
+  | Float16x32 -> Misc.fatal_error "float16x32: scalar type not supported"
+  | Int8x64 | Int16x32 | Int32x16 | Int64x8 -> typ_int
+
+let reinterpret_cast_arg_type : reinterpret_cast -> machtype = function
+  | Int_of_value -> typ_val
+  | Value_of_int -> typ_int
+  | Float_of_float32 -> typ_float32
+  | Float32_of_float -> typ_float
+  | Float_of_int64 -> typ_int
+  | Int64_of_float -> typ_float
+  | Float32_of_int32 -> typ_int
+  | Int32_of_float32 -> typ_float32
+  | Mask_of_int64 -> typ_int
+  | Int64_of_mask -> typ_mask
+  | V128_of_vec width | V256_of_vec width | V512_of_vec width ->
+    machtype_of_vector_width width
+
+let static_cast_arg_type : static_cast -> machtype = function
+  | Float_of_int (_ : float_width) -> typ_int
+  | Int_of_float width -> machtype_of_float_width width
+  | Float_of_float32 -> typ_float32
+  | Float32_of_float -> typ_float
+  | V128_of_scalar ty -> machtype_of_vec128_scalar ty
+  | Scalar_of_v128 (_ : vec128_type) -> typ_vec128
+  | V256_of_scalar ty -> machtype_of_vec256_scalar ty
+  | Scalar_of_v256 (_ : vec256_type) -> typ_vec256
+  | V512_of_scalar ty -> machtype_of_vec512_scalar ty
+  | Scalar_of_v512 (_ : vec512_type) -> typ_vec512
+
+type expected_arg_type =
+  | Exactly of machtype
+  | Any_machtype
+      (** For argument slots whose machtype is not determined by the operation,
+          e.g. addresses, which may legitimately be [Val], [Addr] or naked
+          pointers outside the heap. *)
+
+type expected_arg_types =
+  | Args of expected_arg_type list
+      (** Exactly as many arguments as listed, checked slotwise. *)
+  | Any_number_of of expected_arg_type
+      (** Any number of arguments, each checked against the given
+          constraint. *)
+  | Args_then_any_number_of of expected_arg_type list * expected_arg_type
+      (** At least the listed arguments, checked slotwise, followed by any
+          number of arguments checked against the second constraint. *)
+
+(* The machtypes an operation expects for its arguments, in the style of
+   [Select_utils.oper_result_type]. *)
+let oper_arg_types : operation -> expected_arg_types = function
+  | Capply _ ->
+    Args_then_any_number_of
+      ([Any_machtype (* closure or code pointer *)], Any_machtype)
+  | Cextcall { ty_args = []; _ } ->
+    (* An empty [ty_args] means "all arguments are machine words". *)
+    Any_number_of Any_machtype
+  | Cextcall { ty_args = _ :: _ as ty_args; _ } ->
+    Args
+      (List.map
+         (fun (ty_arg : exttype) ->
+           match ty_arg with
+           | XInt ->
+             (* [XInt] is used for values as well as word-sized integers. *)
+             Any_machtype
+           | XInt8 | XInt16 | XInt32 | XInt64 | XFloat32 | XFloat | XVec128
+           | XVec256 | XVec512 ->
+             Exactly (machtype_of_exttype ty_arg))
+         ty_args)
+  | Cload _ -> Args [Any_machtype]
+  | Calloc (_, kind) ->
+    let field =
+      match kind with
+      | Alloc_block_kind_other ->
+        (* Mixed blocks are also allocated with this kind: fields after the
+           scannable prefix may be unboxed, and the prefix length is only
+           encoded in the header argument. *)
+        Any_machtype
+      | Alloc_block_kind_float | Alloc_block_kind_float_array ->
+        Exactly typ_float
+      | Alloc_block_kind_int_u_array | Alloc_block_kind_int64_u_array ->
+        Exactly typ_int
+      | Alloc_block_kind_mask | Alloc_block_kind_mask_u_array ->
+        Exactly typ_mask
+      | Alloc_block_kind_vec128_u_array -> Exactly typ_vec128
+      | Alloc_block_kind_vec256_u_array -> Exactly typ_vec256
+      | Alloc_block_kind_vec512_u_array -> Exactly typ_vec512
+      | Alloc_block_kind_closure | Alloc_block_kind_boxed_int _
+      | Alloc_block_kind_float32 | Alloc_block_kind_vec128
+      | Alloc_block_kind_vec256 | Alloc_block_kind_vec512
+      | Alloc_block_kind_float32_u_array | Alloc_block_kind_int8_u_array
+      | Alloc_block_kind_int16_u_array | Alloc_block_kind_int32_u_array ->
+        (* Closures and custom blocks mix code pointers, raw words and
+           payloads; packed u-arrays mix packed words with a raw last
+           element. *)
+        Any_machtype
+    in
+    Args_then_any_number_of ([Any_machtype (* header *)], field)
+  | Cstore (memory_chunk, _) ->
+    let value =
+      match memory_chunk with
+      | Word_int ->
+        (* A raw word slot is not scanned, so it accepts any word in a
+           general-purpose register, including derived pointers. *)
+        Exactly typ_addr
+      | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+      | Thirtytwo_unsigned | Thirtytwo_signed | Word_val | Word_mask | Single _
+      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
+      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
+      | Fivetwelve_aligned ->
+        Exactly (machtype_of_memory_chunk memory_chunk)
+    in
+    Args [Any_machtype; value]
+  | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor | Cxor
+  | Clsl | Clsr | Casr | Ccmpi _ ->
+    (* Under [ge_component], [typ_addr] accepts any word in a general-purpose
+       register ([Int], [Val] or [Addr]): classic machtypes cannot distinguish
+       tagged values from untagged words, and word operations are applied to
+       both (e.g. physical equality on values, untagging a scrutinee). *)
+    Args [Exactly typ_addr; Exactly typ_addr]
+  | Cclz | Cctz | Cpopcnt | Cbswap _ -> Args [Exactly typ_addr]
+  | Caddi128 | Csubi128 ->
+    Args [Exactly typ_int; Exactly typ_int; Exactly typ_int; Exactly typ_int]
+  | Cmuli64 _ -> Args [Exactly typ_int; Exactly typ_int]
+  | Ccsel ty -> Args [Exactly typ_int; Exactly ty; Exactly ty]
+  | Cprefetch _ -> Args [Any_machtype]
+  | Catomic
+      { op = Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange; _ } ->
+    Args [Exactly typ_int; Any_machtype (* address *)]
+  | Catomic { op = Compare_set | Compare_exchange; _ } ->
+    Args [Exactly typ_int; Exactly typ_int; Any_machtype (* address *)]
+  | Caddv -> Args [Exactly typ_val; Exactly typ_int]
+  | Cadda -> Args [Exactly typ_addr; Exactly typ_int]
+  | Cnegf width | Cabsf width -> Args [Exactly (machtype_of_float_width width)]
+  | Caddf width | Csubf width | Cmulf width | Cdivf width ->
+    let ty = machtype_of_float_width width in
+    Args [Exactly ty; Exactly ty]
+  | Cpackf32 ->
+    (* Two float32s held in the low bits of float registers. *)
+    Args [Exactly typ_float; Exactly typ_float]
+  | Ccmpf (width, _) ->
+    let ty = machtype_of_float_width width in
+    Args [Exactly ty; Exactly ty]
+  | Creinterpret_cast cast -> Args [Exactly (reinterpret_cast_arg_type cast)]
+  | Cstatic_cast cast -> Args [Exactly (static_cast_arg_type cast)]
+  | Craise _ ->
+    (* The exception, followed by the extra args of the innermost exception
+       handler on the trap stack, whose machtypes are not known here. *)
+    Args_then_any_number_of ([Exactly typ_val], Any_machtype)
+  | Cprobe _ -> Any_number_of Any_machtype
+  | Copaque -> Any_number_of Any_machtype
+  | Cprobe_is_enabled _ | Cbeginregion | Cdls_get | Ctls_get | Cdomain_index
+  | Cpoll | Cpause ->
+    Args []
+  | Cendregion -> Args [Exactly typ_int]
+  | Ctuple_field (_, fields_ty) ->
+    Args [Exactly (Array.concat (Array.to_list fields_ty))]
+
+(* [Never_returns] is for diverging expressions, which do not constrain their
+   context, in the same way as [Select_utils.Or_never_returns] in the
+   selectors. *)
+type inferred_machtype =
+  | Machtype of machtype
+  | Never_returns
+
+let dbg_suffix dbg =
+  if Debuginfo.is_none dbg
+  then ""
+  else Format.asprintf " at %a" Debuginfo.print_compact dbg
+
+(* [what] is only evaluated on error. *)
+let check_machtype ~dbg ~what ~expected (actual : inferred_machtype) =
+  match actual with
+  | Never_returns -> ()
+  | Machtype actual ->
+    let compatible =
+      Array.length expected = Array.length actual
+      && Array.for_all2
+           (fun expected_comp actual_comp ->
+             (* The compiler types statically-known tagged immediates as [Int]
+                while generic loads and calls produce them as [Val], so [Val]
+                flows into [Int] positions routinely. *)
+             (equal_machtype_component expected_comp Int
+             && equal_machtype_component actual_comp Val)
+             ||
+             (* [ge_component] is fatal on incomparable components *)
+             (try ge_component expected_comp actual_comp
+              with Misc.Fatal_error -> false))
+           expected actual
+    in
+    if not compatible
+    then
+      Misc.fatal_errorf
+        "Cmm machtype check failed%s: %s has machtype %a but %a was expected"
+        (dbg_suffix dbg) (what ()) Printcmm.machtype actual Printcmm.machtype
+        expected
+
+let join_inferred_machtypes ~dbg ty1 ty2 =
+  match ty1, ty2 with
+  | Never_returns, ty | ty, Never_returns -> ty
+  | Machtype ty1, Machtype ty2 ->
+    if Array.length ty1 <> Array.length ty2
+    then
+      Misc.fatal_errorf
+        "Cmm machtype check failed%s: join of machtype %a and machtype %a, \
+         which do not have the same number of components"
+        (dbg_suffix dbg) Printcmm.machtype ty1 Printcmm.machtype ty2
+    else Machtype (Array.map2 lub_component ty1 ty2)
+
+let join_all_inferred_machtypes ~dbg tys =
+  List.fold_left (join_inferred_machtypes ~dbg) Never_returns tys
+
+type typechecking_env =
+  { vars : machtype V.Map.t;
+    handlers : machtype list Static_label.Map.t;
+    return_type : machtype option
+  }
+
+let concat_inferred_machtypes tys =
+  List.fold_left
+    (fun acc ty ->
+      match acc, ty with
+      | Never_returns, (Machtype _ | Never_returns) | Machtype _, Never_returns
+        ->
+        Never_returns
+      | Machtype tys, Machtype ty -> Machtype (Array.append tys ty))
+    (Machtype typ_void) tys
+
+let rec infer_machtype env (expr : expression) : inferred_machtype =
+  match expr with
+  | Cconst_int _ | Cconst_natint _ | Cconst_symbol _ ->
+    (* Integer literals and statically-allocated symbols are non-heap words;
+       [Int] is below [Val], so they are also accepted where values are
+       expected. *)
+    Machtype typ_int
+  | Cconst_float _ -> Machtype typ_float
+  | Cconst_float32 _ -> Machtype typ_float32
+  | Cconst_vec128 _ -> Machtype typ_vec128
+  | Cconst_vec256 _ -> Machtype typ_vec256
+  | Cconst_vec512 _ -> Machtype typ_vec512
+  | Cconst_mask _ -> Machtype typ_mask
+  | Cvar var -> (
+    match V.Map.find_opt var env.vars with
+    | Some ty -> Machtype ty
+    | None ->
+      Misc.fatal_errorf "Cmm machtype check failed: unbound variable %a"
+        V.print var)
+  | Clet (var, defining_expr, body) -> (
+    match infer_machtype env defining_expr with
+    | Never_returns -> Never_returns
+    | Machtype ty ->
+      infer_machtype
+        { env with vars = V.Map.add (VP.var var) ty env.vars }
+        body)
+  | Cphantom_let (_, _, body) | Cname_for_debugger (_, body) ->
+    infer_machtype env body
+  | Ctuple exprs ->
+    concat_inferred_machtypes (List.map (infer_machtype env) exprs)
+  | Cop (op, args, dbg) -> typecheck_cop env op args dbg
+  | Csequence (expr1, expr2) -> (
+    match infer_machtype env expr1 with
+    | Never_returns -> Never_returns
+    | Machtype _ -> infer_machtype env expr2)
+  | Cifthenelse (cond, _, ifso, _, ifnot, dbg) -> (
+    let cond_ty = infer_machtype env cond in
+    check_machtype ~dbg
+      ~what:(fun () -> "if-then-else condition")
+      ~expected:typ_int cond_ty;
+    let branches_ty =
+      join_inferred_machtypes ~dbg (infer_machtype env ifso)
+        (infer_machtype env ifnot)
+    in
+    match cond_ty with
+    | Never_returns -> Never_returns
+    | Machtype _ -> branches_ty)
+  | Cswitch (scrutinee, _, cases, dbg) -> (
+    let scrutinee_ty = infer_machtype env scrutinee in
+    check_machtype ~dbg
+      ~what:(fun () -> "switch scrutinee")
+      ~expected:typ_int scrutinee_ty;
+    let cases_ty =
+      join_all_inferred_machtypes ~dbg
+        (Array.to_list
+           (Array.map
+              (fun (case, _) -> infer_machtype env case)
+              cases))
+    in
+    match scrutinee_ty with
+    | Never_returns -> Never_returns
+    | Machtype _ -> cases_ty)
+  | Ccatch (_, handlers, body) ->
+    let env =
+      { env with
+        handlers =
+          List.fold_left
+            (fun handlers handler ->
+              Static_label.Map.add handler.label
+                (List.map snd handler.params)
+                handlers)
+            env.handlers handlers
+      }
+    in
+    let body_ty = infer_machtype env body in
+    let handler_tys =
+      List.map
+        (fun (handler : static_handler) ->
+          let env =
+            { env with
+              vars =
+                List.fold_left
+                  (fun vars (var, ty) -> V.Map.add (VP.var var) ty vars)
+                  env.vars handler.params
+            }
+          in
+          infer_machtype env handler.body)
+        handlers
+    in
+    join_all_inferred_machtypes ~dbg:Debuginfo.none (body_ty :: handler_tys)
+  | Cexit (label, args, _) ->
+    (* Exit arguments are matched to handler parameters by machtype component,
+       not one-to-one: a single argument of a product machtype can fill
+       several parameters. *)
+    let args_ty =
+      concat_inferred_machtypes (List.map (infer_machtype env) args)
+    in
+    (match label with
+    | Return_lbl -> (
+      match env.return_type with
+      | None -> ()
+      | Some expected ->
+        check_machtype ~dbg:Debuginfo.none
+          ~what:(fun () -> "return")
+          ~expected args_ty)
+    | Lbl label -> (
+      match Static_label.Map.find_opt label env.handlers with
+      | None ->
+        (* Exits to out-of-scope handlers are reported by [run]. *)
+        ()
+      | Some param_tys ->
+        check_machtype ~dbg:Debuginfo.none
+          ~expected:(Array.concat param_tys)
+          args_ty
+          ~what:(fun () ->
+            Format.asprintf "arguments of exit to %a" Static_label.format
+              label)));
+    Never_returns
+  | Cinvalid _ -> Never_returns
+
+and typecheck_cop env op args dbg : inferred_machtype =
+  let arg_tys = List.map (infer_machtype env) args in
+  let check_arg arg_index expected actual =
+    match expected with
+    | Any_machtype -> ()
+    | Exactly expected ->
+      check_machtype ~dbg ~expected actual ~what:(fun () ->
+          Printf.sprintf "argument %d of operation %s" (arg_index + 1)
+            (Printcmm.operation dbg op))
+  in
+  let arity_error expected_arity =
+    Misc.fatal_errorf
+      "Cmm machtype check failed at %a: operation %s expects %s arguments but \
+       is given %d"
+      Debuginfo.print_compact dbg
+      (Printcmm.operation dbg op)
+      expected_arity (List.length args)
+  in
+  (match oper_arg_types op with
+  | Args expected_tys ->
+    if List.compare_lengths expected_tys args <> 0
+    then arity_error (string_of_int (List.length expected_tys));
+    List.iteri
+      (fun arg_index (expected, actual) -> check_arg arg_index expected actual)
+      (List.combine expected_tys arg_tys)
+  | Any_number_of expected ->
+    List.iteri (fun arg_index actual -> check_arg arg_index expected actual)
+      arg_tys
+  | Args_then_any_number_of (expected_prefix, expected_rest) ->
+    if List.compare_lengths expected_prefix args > 0
+    then
+      arity_error
+        (Printf.sprintf "at least %d" (List.length expected_prefix));
+    List.iteri
+      (fun arg_index actual ->
+        let expected =
+          match List.nth_opt expected_prefix arg_index with
+          | Some expected -> expected
+          | None -> expected_rest
+        in
+        check_arg arg_index expected actual)
+      arg_tys);
+  if
+    List.exists
+      (function Never_returns -> true | Machtype _ -> false)
+      arg_tys
+  then Never_returns
+  else
+    match op with
+    | Craise _
+    | Cextcall { returns = false; _ }
+    | Capply { returns = false; _ } ->
+      Never_returns
+    | Copaque -> (
+      (* [Copaque] is the identity whatever the machtype of its argument;
+         [oper_result_type] approximates its result as [typ_val]. *)
+      match arg_tys with
+      | [ty] -> ty
+      | [] | _ :: _ :: _ -> arity_error "1")
+    | Cextcall { returns = true; _ }
+    | Capply { returns = true; _ }
+    | Cload _ | Calloc _ | Cstore _ | Caddi | Csubi | Cmuli
+    | Cmulhi _ | Cdivi _ | Cmodi _ | Caddi128 | Csubi128 | Cmuli64 _ | Cand
+    | Cor | Cxor | Clsl | Clsr | Casr | Cbswap _ | Ccsel _ | Cclz | Cctz
+    | Cpopcnt | Cprefetch _ | Catomic _ | Ccmpi _ | Caddv | Cadda | Cnegf _
+    | Cabsf _ | Caddf _ | Csubf _ | Cmulf _ | Cdivf _ | Cpackf32
+    | Creinterpret_cast _ | Cstatic_cast _ | Ccmpf _ | Cprobe _
+    | Cprobe_is_enabled _ | Cbeginregion | Cendregion | Ctuple_field _
+    | Cdls_get | Ctls_get | Cdomain_index | Cpoll | Cpause ->
+      Machtype (Select_utils.oper_result_type op)
+
+let check_machtypes (fundecl : fundecl) =
+  let vars =
+    List.fold_left
+      (fun vars (var, ty) -> V.Map.add (VP.var var) ty vars)
+      V.Map.empty fundecl.fun_args
+  in
+  let env =
+    { vars;
+      handlers = Static_label.Map.empty;
+      return_type = Some fundecl.fun_ret_type
+    }
+  in
+  try
+    check_machtype ~dbg:fundecl.fun_dbg ~expected:fundecl.fun_ret_type
+      ~what:(fun () ->
+        Printf.sprintf "the body of %s" fundecl.fun_name.sym_name)
+      (infer_machtype env fundecl.fun_body)
+  with Misc.Fatal_error ->
+    Misc.fatal_errorf "Error happened while typechecking function %s; body:\n%a"
+      fundecl.fun_name.sym_name Printcmm.expression fundecl.fun_body

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -416,7 +416,7 @@ let join_all_inferred_machtypes ~dbg tys =
 type typechecking_env =
   { vars : machtype V.Map.t;
     handlers : machtype list Static_label.Map.t;
-    return_type : machtype option
+    return_type : machtype
   }
 
 let concat_inferred_machtypes tys =
@@ -527,13 +527,10 @@ let rec infer_machtype env (expr : expression) : inferred_machtype =
       concat_inferred_machtypes (List.map (infer_machtype env) args)
     in
     (match label with
-    | Return_lbl -> (
-      match env.return_type with
-      | None -> ()
-      | Some expected ->
-        check_machtype ~dbg:Debuginfo.none
-          ~what:(fun () -> "return")
-          ~expected args_ty)
+    | Return_lbl ->
+      check_machtype ~dbg:Debuginfo.none
+        ~what:(fun () -> "return")
+        ~expected:env.return_type args_ty
     | Lbl label -> (
       match Static_label.Map.find_opt label env.handlers with
       | None ->
@@ -629,7 +626,7 @@ let check_machtypes (fundecl : fundecl) =
   let env =
     { vars;
       handlers = Static_label.Map.empty;
-      return_type = Some fundecl.fun_ret_type
+      return_type = fundecl.fun_ret_type
     }
   in
   try

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -237,8 +237,7 @@ type expected_arg_type =
   | Exactly of machtype
   | Any_machtype
       (** For argument slots whose machtype is not determined by the operation,
-          e.g. addresses, which may legitimately be [Val], [Addr] or naked
-          pointers outside the heap. *)
+          e.g. arguments to an application whose signature is not known. *)
 
 type expected_arg_types =
   | Args of expected_arg_type list
@@ -255,10 +254,10 @@ type expected_arg_types =
 let oper_arg_types : operation -> expected_arg_types = function
   | Capply _ ->
     Args_then_any_number_of
-      ([Any_machtype (* closure or code pointer *)], Any_machtype)
+      ([Exactly typ_val (* closure or code pointer *)], Any_machtype)
   | Cextcall { ty_args = []; _ } ->
     (* An empty [ty_args] means "all arguments are machine words". *)
-    Any_number_of Any_machtype
+    Any_number_of (Exactly typ_addr)
   | Cextcall { ty_args = _ :: _ as ty_args; _ } ->
     Args
       (List.map
@@ -266,12 +265,12 @@ let oper_arg_types : operation -> expected_arg_types = function
            match ty_arg with
            | XInt ->
              (* [XInt] is used for values as well as word-sized integers. *)
-             Any_machtype
+             Exactly typ_val
            | XInt8 | XInt16 | XInt32 | XInt64 | XFloat32 | XFloat | XVec128
            | XVec256 | XVec512 ->
              Exactly (machtype_of_exttype ty_arg))
          ty_args)
-  | Cload _ -> Args [Any_machtype]
+  | Cload _ -> Args [Exactly typ_addr]
   | Calloc (_, kind) ->
     let field =
       match kind with
@@ -299,7 +298,7 @@ let oper_arg_types : operation -> expected_arg_types = function
            element. *)
         Any_machtype
     in
-    Args_then_any_number_of ([Any_machtype (* header *)], field)
+    Args_then_any_number_of ([Exactly typ_int (* header *)], field)
   | Cstore (memory_chunk, _) ->
     let value =
       match memory_chunk with
@@ -314,7 +313,7 @@ let oper_arg_types : operation -> expected_arg_types = function
       | Fivetwelve_aligned ->
         Exactly (machtype_of_memory_chunk memory_chunk)
     in
-    Args [Any_machtype; value]
+    Args [Exactly typ_addr; value]
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor | Cxor
   | Clsl | Clsr | Casr | Ccmpi _ ->
     (* Under [ge_component], [typ_addr] accepts any word in a general-purpose
@@ -327,12 +326,12 @@ let oper_arg_types : operation -> expected_arg_types = function
     Args [Exactly typ_int; Exactly typ_int; Exactly typ_int; Exactly typ_int]
   | Cmuli64 _ -> Args [Exactly typ_int; Exactly typ_int]
   | Ccsel ty -> Args [Exactly typ_int; Exactly ty; Exactly ty]
-  | Cprefetch _ -> Args [Any_machtype]
+  | Cprefetch _ -> Args [Exactly typ_addr]
   | Catomic
       { op = Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange; _ } ->
-    Args [Exactly typ_int; Any_machtype (* address *)]
+    Args [Exactly typ_int; Exactly typ_addr (* address *)]
   | Catomic { op = Compare_set | Compare_exchange; _ } ->
-    Args [Exactly typ_int; Exactly typ_int; Any_machtype (* address *)]
+    Args [Exactly typ_int; Exactly typ_int; Exactly typ_addr (* address *)]
   | Caddv -> Args [Exactly typ_val; Exactly typ_int]
   | Cadda -> Args [Exactly typ_addr; Exactly typ_int]
   | Cnegf width | Cabsf width -> Args [Exactly (machtype_of_float_width width)]

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -441,11 +441,8 @@ let concat_inferred_machtypes tys =
 
 let rec infer_machtype env (expr : expression) : inferred_machtype =
   match expr with
-  | Cconst_int _ | Cconst_natint _ | Cconst_symbol _ ->
-    (* Integer literals and statically-allocated symbols are non-heap words;
-       [Int] is below [Val], so they are also accepted where values are
-       expected. *)
-    Machtype typ_int
+  | Cconst_int _ | Cconst_natint _ -> Machtype typ_int
+  | Cconst_symbol _ -> Machtype typ_val
   | Cconst_float _ -> Machtype typ_float
   | Cconst_float32 _ -> Machtype typ_float32
   | Cconst_vec128 _ -> Machtype typ_vec128

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -384,11 +384,8 @@ let check_machtype ~dbg ~what ~expected (actual : inferred_machtype) =
                 while generic loads and calls produce them as [Val], so [Val]
                 flows into [Int] positions routinely. *)
              (equal_machtype_component expected_comp Int
-             && equal_machtype_component actual_comp Val)
-             ||
-             (* [ge_component] is fatal on incomparable components *)
-             (try ge_component expected_comp actual_comp
-              with Misc.Fatal_error -> false))
+               && equal_machtype_component actual_comp Val)
+             || ge_component_bool expected_comp actual_comp)
            expected actual
     in
     if not compatible
@@ -628,11 +625,7 @@ let check_machtypes (fundecl : fundecl) =
       return_type = fundecl.fun_ret_type
     }
   in
-  try
-    check_machtype ~dbg:fundecl.fun_dbg ~expected:fundecl.fun_ret_type
-      ~what:(fun () ->
-        Printf.sprintf "the body of %s" fundecl.fun_name.sym_name)
-      (infer_machtype env fundecl.fun_body)
-  with Misc.Fatal_error ->
-    Misc.fatal_errorf "Error happened while typechecking function %s; body:\n%a"
-      fundecl.fun_name.sym_name Printcmm.expression fundecl.fun_body
+  check_machtype ~dbg:fundecl.fun_dbg ~expected:fundecl.fun_ret_type
+    ~what:(fun () ->
+      Printf.sprintf "the body of %s" fundecl.fun_name.sym_name)
+    (infer_machtype env fundecl.fun_body)

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -180,28 +180,28 @@ let run ppf (fundecl : Cmm.fundecl) =
 
 (* Machtype checking *)
 
-let machtype_of_float_width : float_width -> machtype = function
+let machtype_of_float_width = function
   | Float64 -> typ_float
   | Float32 -> typ_float32
 
-let machtype_of_vector_width : vector_width -> machtype = function
+let machtype_of_vector_width = function
   | Vec128 -> typ_vec128
   | Vec256 -> typ_vec256
   | Vec512 -> typ_vec512
 
-let machtype_of_vec128_scalar : vec128_type -> machtype = function
+let machtype_of_vec128_scalar = function
   | Float64x2 -> typ_float
   | Float32x4 -> typ_float32
   | Float16x8 -> Misc.fatal_error "float16x8: scalar type not supported"
   | Int8x16 | Int16x8 | Int32x4 | Int64x2 -> typ_int
 
-let machtype_of_vec256_scalar : vec256_type -> machtype = function
+let machtype_of_vec256_scalar = function
   | Float64x4 -> typ_float
   | Float32x8 -> typ_float32
   | Float16x16 -> Misc.fatal_error "float16x16: scalar type not supported"
   | Int8x32 | Int16x16 | Int32x8 | Int64x4 -> typ_int
 
-let machtype_of_vec512_scalar : vec512_type -> machtype = function
+let machtype_of_vec512_scalar = function
   | Float64x8 -> typ_float
   | Float32x16 -> typ_float32
   | Float16x32 -> Misc.fatal_error "float16x32: scalar type not supported"
@@ -221,17 +221,17 @@ let reinterpret_cast_arg_type : reinterpret_cast -> machtype = function
   | V128_of_vec width | V256_of_vec width | V512_of_vec width ->
     machtype_of_vector_width width
 
-let static_cast_arg_type : static_cast -> machtype = function
-  | Float_of_int (_ : float_width) -> typ_int
+let static_cast_arg_type = function
+  | Float_of_int _ -> typ_int
   | Int_of_float width -> machtype_of_float_width width
   | Float_of_float32 -> typ_float32
   | Float32_of_float -> typ_float
   | V128_of_scalar ty -> machtype_of_vec128_scalar ty
-  | Scalar_of_v128 (_ : vec128_type) -> typ_vec128
+  | Scalar_of_v128 _ -> typ_vec128
   | V256_of_scalar ty -> machtype_of_vec256_scalar ty
-  | Scalar_of_v256 (_ : vec256_type) -> typ_vec256
+  | Scalar_of_v256 _ -> typ_vec256
   | V512_of_scalar ty -> machtype_of_vec512_scalar ty
-  | Scalar_of_v512 (_ : vec512_type) -> typ_vec512
+  | Scalar_of_v512 _ -> typ_vec512
 
 type expected_arg_type =
   | Exactly of machtype
@@ -251,7 +251,7 @@ type expected_arg_types =
 
 (* The machtypes an operation expects for its arguments, in the style of
    [Select_utils.oper_result_type]. *)
-let oper_arg_types : operation -> expected_arg_types = function
+let oper_arg_types = function
   | Capply _ ->
     Args_then_any_number_of
       ([Exactly typ_val (* closure or code pointer *)], Any_machtype)
@@ -261,7 +261,7 @@ let oper_arg_types : operation -> expected_arg_types = function
   | Cextcall { ty_args = _ :: _ as ty_args; _ } ->
     Args
       (List.map
-         (fun (ty_arg : exttype) ->
+         (fun ty_arg ->
            match ty_arg with
            | XInt ->
              (* [XInt] is used for values as well as word-sized integers. *)
@@ -376,7 +376,7 @@ let dbg_suffix dbg =
   else Format.asprintf " at %a" Debuginfo.print_compact dbg
 
 (* [what] is only evaluated on error. *)
-let check_machtype ~dbg ~what ~expected (actual : inferred_machtype) =
+let check_machtype ~dbg ~what ~expected actual =
   match actual with
   | Never_returns -> ()
   | Machtype actual ->
@@ -420,7 +420,7 @@ let join_inferred_machtypes ~dbg ty1 ty2 =
            machtype %a"
           (dbg_suffix dbg) Printcmm.machtype ty1 Printcmm.machtype ty2
 
-let join_all_inferred_machtypes ~dbg tys =
+let join_inferred_machtype_list ~dbg tys =
   List.fold_left (join_inferred_machtypes ~dbg) Never_returns tys
 
 type typechecking_env =
@@ -433,13 +433,11 @@ let concat_inferred_machtypes tys =
   List.fold_left
     (fun acc ty ->
       match acc, ty with
-      | Never_returns, (Machtype _ | Never_returns) | Machtype _, Never_returns
-        ->
-        Never_returns
-      | Machtype tys, Machtype ty -> Machtype (Array.append tys ty))
+      | Machtype tys, Machtype ty -> Machtype (Array.append tys ty)
+      | Never_returns, _ | _, Never_returns -> Never_returns)
     (Machtype typ_void) tys
 
-let rec infer_machtype env (expr : expression) : inferred_machtype =
+let rec infer_machtype env expr =
   match expr with
   | Cconst_int _ | Cconst_natint _ -> Machtype typ_int
   | Cconst_symbol _ -> Machtype typ_val
@@ -489,7 +487,7 @@ let rec infer_machtype env (expr : expression) : inferred_machtype =
       ~what:(fun () -> "switch scrutinee")
       ~expected:typ_int scrutinee_ty;
     let cases_ty =
-      join_all_inferred_machtypes ~dbg
+      join_inferred_machtype_list ~dbg
         (Array.to_list
            (Array.map
               (fun (case, _) -> infer_machtype env case)
@@ -513,7 +511,7 @@ let rec infer_machtype env (expr : expression) : inferred_machtype =
     let body_ty = infer_machtype env body in
     let handler_tys =
       List.map
-        (fun (handler : static_handler) ->
+        (fun handler ->
           let env =
             { env with
               vars =
@@ -525,7 +523,7 @@ let rec infer_machtype env (expr : expression) : inferred_machtype =
           infer_machtype env handler.body)
         handlers
     in
-    join_all_inferred_machtypes ~dbg:Debuginfo.none (body_ty :: handler_tys)
+    join_inferred_machtype_list ~dbg:Debuginfo.none (body_ty :: handler_tys)
   | Cexit (label, args, _) ->
     (* Compare exit arguments and handler parameters after flattening their
        machtypes into components. *)
@@ -552,7 +550,7 @@ let rec infer_machtype env (expr : expression) : inferred_machtype =
     Never_returns
   | Cinvalid _ -> Never_returns
 
-and typecheck_cop env op args dbg : inferred_machtype =
+and typecheck_cop env op args dbg =
   let arg_tys = List.map (infer_machtype env) args in
   let check_arg arg_index expected actual =
     match expected with
@@ -628,7 +626,7 @@ and typecheck_cop env op args dbg : inferred_machtype =
     | Cdls_get | Ctls_get | Cdomain_index | Cpoll | Cpause ->
       Machtype (Select_utils.oper_result_type op)
 
-let check_machtypes (fundecl : fundecl) =
+let check_machtypes fundecl =
   let vars =
     List.fold_left
       (fun vars (var, ty) -> V.Map.add (VP.var var) ty vars)

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -474,28 +474,24 @@ let rec infer_machtype env expr =
     check_machtype ~dbg
       ~what:(fun () -> "if-then-else condition")
       ~expected:typ_int cond_ty;
-    let branches_ty =
-      join_inferred_machtypes ~dbg (infer_machtype env ifso)
-        (infer_machtype env ifnot)
-    in
     match cond_ty with
     | Never_returns -> Never_returns
-    | Machtype _ -> branches_ty)
+    | Machtype _ ->
+      join_inferred_machtypes ~dbg (infer_machtype env ifso)
+        (infer_machtype env ifnot))
   | Cswitch (scrutinee, _, cases, dbg) -> (
     let scrutinee_ty = infer_machtype env scrutinee in
     check_machtype ~dbg
       ~what:(fun () -> "switch scrutinee")
       ~expected:typ_int scrutinee_ty;
-    let cases_ty =
+    match scrutinee_ty with
+    | Never_returns -> Never_returns
+    | Machtype _ ->
       join_inferred_machtype_list ~dbg
         (Array.to_list
            (Array.map
               (fun (case, _) -> infer_machtype env case)
-              cases))
-    in
-    match scrutinee_ty with
-    | Never_returns -> Never_returns
-    | Machtype _ -> cases_ty)
+              cases)))
   | Ccatch (_, handlers, body) ->
     let env =
       { env with

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -366,6 +366,10 @@ type inferred_machtype =
   | Machtype of machtype
   | Never_returns
 
+let print_inferred_machtype ppf = function
+  | Machtype ty -> Printcmm.machtype ppf ty
+  | Never_returns -> Format.pp_print_string ppf "never_returns"
+
 let dbg_suffix dbg =
   if Debuginfo.is_none dbg
   then ""
@@ -391,7 +395,7 @@ let check_machtype ~dbg ~what ~expected (actual : inferred_machtype) =
     if not compatible
     then
       Misc.fatal_errorf
-        "Cmm machtype check failed%s: %s has machtype %a but %a was expected"
+        "Cmm machtype check failed%s:\n  %s has machtype %a but %a was expected"
         (dbg_suffix dbg) (what ()) Printcmm.machtype actual Printcmm.machtype
         expected
 
@@ -558,8 +562,13 @@ and typecheck_cop env op args dbg : inferred_machtype =
     | Any_machtype -> ()
     | Exactly expected ->
       check_machtype ~dbg ~expected actual ~what:(fun () ->
-          Printf.sprintf "argument %d of operation %s" (arg_index + 1)
-            (Printcmm.operation dbg op))
+          Format.asprintf
+            "operation: %s\n  argument machtypes: [%a]\n  argument %d"
+            (Printcmm.operation dbg op)
+            (Format.pp_print_list
+               ~pp_sep:(fun ppf () -> Format.pp_print_string ppf "; ")
+               print_inferred_machtype)
+            arg_tys (arg_index + 1))
   in
   let arity_error expected_arity =
     Misc.fatal_errorf

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -405,7 +405,16 @@ let join_inferred_machtypes ~dbg ty1 ty2 =
         "Cmm machtype check failed%s: join of machtype %a and machtype %a, \
          which do not have the same number of components"
         (dbg_suffix dbg) Printcmm.machtype ty1 Printcmm.machtype ty2
-    else Machtype (Array.map2 lub_component ty1 ty2)
+    else
+      match
+        Misc.Stdlib.Array.all_somes (Array.map2 lub_component_opt ty1 ty2)
+      with
+      | Some lub -> Machtype lub
+      | None ->
+        Misc.fatal_errorf
+          "Cmm machtype check failed%s: join of uncomparable machtype %a and \
+           machtype %a"
+          (dbg_suffix dbg) Printcmm.machtype ty1 Printcmm.machtype ty2
 
 let join_all_inferred_machtypes ~dbg tys =
   List.fold_left (join_inferred_machtypes ~dbg) Never_returns tys

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -266,8 +266,8 @@ let oper_arg_types : operation -> expected_arg_types = function
            | XInt ->
              (* [XInt] is used for values as well as word-sized integers. *)
              Exactly typ_val
-           | XInt8 | XInt16 | XInt32 | XInt64 | XFloat32 | XFloat | XVec128
-           | XVec256 | XVec512 ->
+           | XInt8 | XInt16 | XInt32 | XInt64 | XMask | XFloat32 | XFloat
+           | XVec128 | XVec256 | XVec512 ->
              Exactly (machtype_of_exttype ty_arg))
          ty_args)
   | Cload _ -> Args [Exactly typ_addr]

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -440,7 +440,7 @@ let concat_inferred_machtypes tys =
 let rec infer_machtype env expr =
   match expr with
   | Cconst_int _ | Cconst_natint _ -> Machtype typ_int
-  | Cconst_symbol _ -> Machtype typ_val
+  | Cconst_symbol _ -> Machtype typ_int
   | Cconst_float _ -> Machtype typ_float
   | Cconst_float32 _ -> Machtype typ_float32
   | Cconst_vec128 _ -> Machtype typ_vec128

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -15,7 +15,6 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
 open! Int_replace_polymorphic_compare
-open Cmm
 module V = Backend_var
 module VP = Backend_var.With_provenance
 
@@ -180,61 +179,61 @@ let run ppf (fundecl : Cmm.fundecl) =
 
 (* Machtype checking *)
 
-let machtype_of_float_width = function
-  | Float64 -> typ_float
-  | Float32 -> typ_float32
+let machtype_of_float_width : Cmm.float_width -> Cmm.machtype = function
+  | Float64 -> Cmm.typ_float
+  | Float32 -> Cmm.typ_float32
 
-let machtype_of_vector_width = function
-  | Vec128 -> typ_vec128
-  | Vec256 -> typ_vec256
-  | Vec512 -> typ_vec512
+let machtype_of_vector_width : Cmm.vector_width -> Cmm.machtype = function
+  | Vec128 -> Cmm.typ_vec128
+  | Vec256 -> Cmm.typ_vec256
+  | Vec512 -> Cmm.typ_vec512
 
-let machtype_of_vec128_scalar = function
-  | Float64x2 -> typ_float
-  | Float32x4 -> typ_float32
+let machtype_of_vec128_scalar : Cmm.vec128_type -> Cmm.machtype = function
+  | Float64x2 -> Cmm.typ_float
+  | Float32x4 -> Cmm.typ_float32
   | Float16x8 -> Misc.fatal_error "float16x8: scalar type not supported"
-  | Int8x16 | Int16x8 | Int32x4 | Int64x2 -> typ_int
+  | Int8x16 | Int16x8 | Int32x4 | Int64x2 -> Cmm.typ_int
 
-let machtype_of_vec256_scalar = function
-  | Float64x4 -> typ_float
-  | Float32x8 -> typ_float32
+let machtype_of_vec256_scalar : Cmm.vec256_type -> Cmm.machtype = function
+  | Float64x4 -> Cmm.typ_float
+  | Float32x8 -> Cmm.typ_float32
   | Float16x16 -> Misc.fatal_error "float16x16: scalar type not supported"
-  | Int8x32 | Int16x16 | Int32x8 | Int64x4 -> typ_int
+  | Int8x32 | Int16x16 | Int32x8 | Int64x4 -> Cmm.typ_int
 
-let machtype_of_vec512_scalar = function
-  | Float64x8 -> typ_float
-  | Float32x16 -> typ_float32
+let machtype_of_vec512_scalar : Cmm.vec512_type -> Cmm.machtype = function
+  | Float64x8 -> Cmm.typ_float
+  | Float32x16 -> Cmm.typ_float32
   | Float16x32 -> Misc.fatal_error "float16x32: scalar type not supported"
-  | Int8x64 | Int16x32 | Int32x16 | Int64x8 -> typ_int
+  | Int8x64 | Int16x32 | Int32x16 | Int64x8 -> Cmm.typ_int
 
-let reinterpret_cast_arg_type : reinterpret_cast -> machtype = function
-  | Int_of_value -> typ_val
-  | Value_of_int -> typ_int
-  | Float_of_float32 -> typ_float32
-  | Float32_of_float -> typ_float
-  | Float_of_int64 -> typ_int
-  | Int64_of_float -> typ_float
-  | Float32_of_int32 -> typ_int
-  | Int32_of_float32 -> typ_float32
-  | Mask_of_int64 -> typ_int
-  | Int64_of_mask -> typ_mask
+let reinterpret_cast_arg_type : Cmm.reinterpret_cast -> Cmm.machtype = function
+  | Int_of_value -> Cmm.typ_val
+  | Value_of_int -> Cmm.typ_int
+  | Float_of_float32 -> Cmm.typ_float32
+  | Float32_of_float -> Cmm.typ_float
+  | Float_of_int64 -> Cmm.typ_int
+  | Int64_of_float -> Cmm.typ_float
+  | Float32_of_int32 -> Cmm.typ_int
+  | Int32_of_float32 -> Cmm.typ_float32
+  | Mask_of_int64 -> Cmm.typ_int
+  | Int64_of_mask -> Cmm.typ_mask
   | V128_of_vec width | V256_of_vec width | V512_of_vec width ->
     machtype_of_vector_width width
 
-let static_cast_arg_type = function
-  | Float_of_int _ -> typ_int
+let static_cast_arg_type : Cmm.static_cast -> Cmm.machtype = function
+  | Float_of_int _ -> Cmm.typ_int
   | Int_of_float width -> machtype_of_float_width width
-  | Float_of_float32 -> typ_float32
-  | Float32_of_float -> typ_float
+  | Float_of_float32 -> Cmm.typ_float32
+  | Float32_of_float -> Cmm.typ_float
   | V128_of_scalar ty -> machtype_of_vec128_scalar ty
-  | Scalar_of_v128 _ -> typ_vec128
+  | Scalar_of_v128 _ -> Cmm.typ_vec128
   | V256_of_scalar ty -> machtype_of_vec256_scalar ty
-  | Scalar_of_v256 _ -> typ_vec256
+  | Scalar_of_v256 _ -> Cmm.typ_vec256
   | V512_of_scalar ty -> machtype_of_vec512_scalar ty
-  | Scalar_of_v512 _ -> typ_vec512
+  | Scalar_of_v512 _ -> Cmm.typ_vec512
 
 type expected_arg_type =
-  | Exactly of machtype
+  | Exactly of Cmm.machtype
   | Any_machtype
       (** For argument slots whose machtype is not determined by the operation,
           e.g. arguments to an application whose signature is not known. *)
@@ -251,28 +250,28 @@ type expected_arg_types =
 
 (* The machtypes an operation expects for its arguments, in the style of
    [Select_utils.oper_result_type]. *)
-let oper_arg_types = function
+let oper_arg_types : Cmm.operation -> expected_arg_types = function
   | Capply _ ->
     Args_then_any_number_of
-      ([Exactly typ_val (* closure or code pointer *)], Any_machtype)
+      ([Exactly Cmm.typ_val (* closure or code pointer *)], Any_machtype)
   | Cextcall { ty_args = []; _ } ->
     (* An empty [ty_args] means "all arguments are machine words". *)
-    Any_number_of (Exactly typ_addr)
-  | Cextcall { ty_args = _ :: _ as ty_args; _ } ->
+    Any_number_of (Exactly Cmm.typ_addr)
+  | Cextcall { ty_args = (_ :: _) as ty_args; _ } ->
     Args
       (List.map
-         (fun ty_arg ->
+         (fun (ty_arg : Cmm.exttype) ->
            match ty_arg with
            | XInt ->
              (* [XInt] is used for values as well as word-sized integers. *)
-             Exactly typ_val
+             Exactly Cmm.typ_val
            | XInt8 | XInt16 | XInt32 | XInt64 | XMask | XFloat32 | XFloat
            | XVec128 | XVec256 | XVec512 ->
-             Exactly (machtype_of_exttype ty_arg))
+             Exactly (Cmm.machtype_of_exttype ty_arg))
          ty_args)
-  | Cload _ -> Args [Exactly typ_addr]
+  | Cload _ -> Args [Exactly Cmm.typ_addr]
   | Calloc (_, kind) ->
-    let field =
+    let machtype_for_all_fields =
       match kind with
       | Alloc_block_kind_other ->
         (* Mixed blocks are also allocated with this kind: fields after the
@@ -280,14 +279,14 @@ let oper_arg_types = function
            encoded in the header argument. *)
         Any_machtype
       | Alloc_block_kind_float | Alloc_block_kind_float_array ->
-        Exactly typ_float
+        Exactly Cmm.typ_float
       | Alloc_block_kind_int_u_array | Alloc_block_kind_int64_u_array ->
-        Exactly typ_int
+        Exactly Cmm.typ_int
       | Alloc_block_kind_mask | Alloc_block_kind_mask_u_array ->
-        Exactly typ_mask
-      | Alloc_block_kind_vec128_u_array -> Exactly typ_vec128
-      | Alloc_block_kind_vec256_u_array -> Exactly typ_vec256
-      | Alloc_block_kind_vec512_u_array -> Exactly typ_vec512
+        Exactly Cmm.typ_mask
+      | Alloc_block_kind_vec128_u_array -> Exactly Cmm.typ_vec128
+      | Alloc_block_kind_vec256_u_array -> Exactly Cmm.typ_vec256
+      | Alloc_block_kind_vec512_u_array -> Exactly Cmm.typ_vec512
       | Alloc_block_kind_closure | Alloc_block_kind_boxed_int _
       | Alloc_block_kind_float32 | Alloc_block_kind_vec128
       | Alloc_block_kind_vec256 | Alloc_block_kind_vec512
@@ -298,49 +297,54 @@ let oper_arg_types = function
            element. *)
         Any_machtype
     in
-    Args_then_any_number_of ([Exactly typ_int (* header *)], field)
+    Args_then_any_number_of
+      ([Exactly Cmm.typ_int (* header *)], machtype_for_all_fields)
   | Cstore (memory_chunk, _) ->
-    let value =
+    let payload_machtype =
       match memory_chunk with
       | Word_int ->
         (* A raw word slot is not scanned, so it accepts any word in a
            general-purpose register, including derived pointers. *)
-        Exactly typ_addr
+        Exactly Cmm.typ_addr
       | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
       | Thirtytwo_unsigned | Thirtytwo_signed | Word_val | Word_mask | Single _
       | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
       | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
       | Fivetwelve_aligned ->
-        Exactly (machtype_of_memory_chunk memory_chunk)
+        Exactly (Cmm.machtype_of_memory_chunk memory_chunk)
     in
-    Args [Exactly typ_addr; value]
+    Args [Exactly Cmm.typ_addr; payload_machtype]
   | Caddi | Csubi | Cmuli | Cmulhi _ | Cdivi _ | Cmodi _ | Cand | Cor | Cxor
   | Clsl | Clsr | Casr | Ccmpi _ ->
     (* Under [ge_component], [typ_addr] accepts any word in a general-purpose
        register ([Int], [Val] or [Addr]): classic machtypes cannot distinguish
        tagged values from untagged words, and word operations are applied to
        both (e.g. physical equality on values, untagging a scrutinee). *)
-    Args [Exactly typ_addr; Exactly typ_addr]
-  | Cclz | Cctz | Cpopcnt | Cbswap _ -> Args [Exactly typ_addr]
+    Args [Exactly Cmm.typ_addr; Exactly Cmm.typ_addr]
+  | Cclz | Cctz | Cpopcnt | Cbswap _ -> Args [Exactly Cmm.typ_addr]
   | Caddi128 | Csubi128 ->
-    Args [Exactly typ_int; Exactly typ_int; Exactly typ_int; Exactly typ_int]
-  | Cmuli64 _ -> Args [Exactly typ_int; Exactly typ_int]
-  | Ccsel ty -> Args [Exactly typ_int; Exactly ty; Exactly ty]
-  | Cprefetch _ -> Args [Exactly typ_addr]
+    Args
+      [ Exactly Cmm.typ_int; Exactly Cmm.typ_int;
+        Exactly Cmm.typ_int; Exactly Cmm.typ_int ]
+  | Cmuli64 _ -> Args [Exactly Cmm.typ_int; Exactly Cmm.typ_int]
+  | Ccsel ty -> Args [Exactly Cmm.typ_int; Exactly ty; Exactly ty]
+  | Cprefetch _ -> Args [Exactly Cmm.typ_addr]
   | Catomic
       { op = Fetch_and_add | Add | Sub | Land | Lor | Lxor | Exchange; _ } ->
-    Args [Exactly typ_int; Exactly typ_addr (* address *)]
+    Args [Exactly Cmm.typ_int; Exactly Cmm.typ_addr (* address *)]
   | Catomic { op = Compare_set | Compare_exchange; _ } ->
-    Args [Exactly typ_int; Exactly typ_int; Exactly typ_addr (* address *)]
-  | Caddv -> Args [Exactly typ_val; Exactly typ_int]
-  | Cadda -> Args [Exactly typ_addr; Exactly typ_int]
+    Args
+      [ Exactly Cmm.typ_int; Exactly Cmm.typ_int;
+        Exactly Cmm.typ_addr (* address *) ]
+  | Caddv -> Args [Exactly Cmm.typ_val; Exactly Cmm.typ_int]
+  | Cadda -> Args [Exactly Cmm.typ_addr; Exactly Cmm.typ_int]
   | Cnegf width | Cabsf width -> Args [Exactly (machtype_of_float_width width)]
   | Caddf width | Csubf width | Cmulf width | Cdivf width ->
     let ty = machtype_of_float_width width in
     Args [Exactly ty; Exactly ty]
   | Cpackf32 ->
     (* Two float32s held in the low bits of float registers. *)
-    Args [Exactly typ_float; Exactly typ_float]
+    Args [Exactly Cmm.typ_float; Exactly Cmm.typ_float]
   | Ccmpf (width, _) ->
     let ty = machtype_of_float_width width in
     Args [Exactly ty; Exactly ty]
@@ -349,13 +353,13 @@ let oper_arg_types = function
   | Craise _ ->
     (* The exception, followed by the extra args of the innermost exception
        handler on the trap stack, whose machtypes are not known here. *)
-    Args_then_any_number_of ([Exactly typ_val], Any_machtype)
+    Args_then_any_number_of ([Exactly Cmm.typ_val], Any_machtype)
   | Cprobe _ -> Any_number_of Any_machtype
   | Copaque -> Args [Any_machtype]
   | Cprobe_is_enabled _ | Cbeginregion | Cdls_get | Ctls_get | Cdomain_index
   | Cpoll | Cpause ->
     Args []
-  | Cendregion -> Args [Exactly typ_int]
+  | Cendregion -> Args [Exactly Cmm.typ_int]
   | Ctuple_field (_, fields_ty) ->
     Args [Exactly (Array.concat (Array.to_list fields_ty))]
 
@@ -363,7 +367,7 @@ let oper_arg_types = function
    context, in the same way as [Select_utils.Or_never_returns] in the
    selectors. *)
 type inferred_machtype =
-  | Machtype of machtype
+  | Machtype of Cmm.machtype
   | Never_returns
 
 let print_inferred_machtype ppf = function
@@ -376,7 +380,8 @@ let dbg_suffix dbg =
   else Format.asprintf " at %a" Debuginfo.print_compact dbg
 
 (* [what] is only evaluated on error. *)
-let check_machtype ~dbg ~what ~expected actual =
+let check_machtype ~dbg ~(what : unit -> string) ~(expected : Cmm.machtype)
+      (actual : inferred_machtype) =
   match actual with
   | Never_returns -> ()
   | Machtype actual ->
@@ -387,9 +392,9 @@ let check_machtype ~dbg ~what ~expected actual =
              (* The compiler types statically-known tagged immediates as [Int]
                 while generic loads and calls produce them as [Val], so [Val]
                 flows into [Int] positions routinely. *)
-             (equal_machtype_component expected_comp Int
-               && equal_machtype_component actual_comp Val)
-             || ge_component_bool expected_comp actual_comp)
+             (Cmm.equal_machtype_component expected_comp Int
+               && Cmm.equal_machtype_component actual_comp Val)
+             || Cmm.ge_component_bool expected_comp actual_comp)
            expected actual
     in
     if not compatible
@@ -399,7 +404,7 @@ let check_machtype ~dbg ~what ~expected actual =
         (dbg_suffix dbg) (what ()) Printcmm.machtype actual Printcmm.machtype
         expected
 
-let join_inferred_machtypes ~dbg ty1 ty2 =
+let join_inferred_machtypes ~dbg ty1 ty2 : inferred_machtype =
   match ty1, ty2 with
   | Never_returns, ty | ty, Never_returns -> ty
   | Machtype ty1, Machtype ty2 ->
@@ -411,7 +416,7 @@ let join_inferred_machtypes ~dbg ty1 ty2 =
         (dbg_suffix dbg) Printcmm.machtype ty1 Printcmm.machtype ty2
     else
       match
-        Misc.Stdlib.Array.all_somes (Array.map2 lub_component_opt ty1 ty2)
+        Misc.Stdlib.Array.all_somes (Array.map2 Cmm.lub_component_opt ty1 ty2)
       with
       | Some lub -> Machtype lub
       | None ->
@@ -420,33 +425,33 @@ let join_inferred_machtypes ~dbg ty1 ty2 =
            machtype %a"
           (dbg_suffix dbg) Printcmm.machtype ty1 Printcmm.machtype ty2
 
-let join_inferred_machtype_list ~dbg tys =
+let join_inferred_machtype_list ~dbg tys : inferred_machtype =
   List.fold_left (join_inferred_machtypes ~dbg) Never_returns tys
 
 type typechecking_env =
-  { vars : machtype V.Map.t;
-    handlers : machtype list Static_label.Map.t;
-    return_type : machtype
+  { vars : Cmm.machtype V.Map.t;
+    handlers : Cmm.machtype list Static_label.Map.t;
+    return_type : Cmm.machtype
   }
 
-let concat_inferred_machtypes tys =
+let concat_inferred_machtypes tys : inferred_machtype =
   List.fold_left
     (fun acc ty ->
       match acc, ty with
       | Machtype tys, Machtype ty -> Machtype (Array.append tys ty)
       | Never_returns, _ | _, Never_returns -> Never_returns)
-    (Machtype typ_void) tys
+    (Machtype Cmm.typ_void) tys
 
-let rec infer_machtype env expr =
+let rec infer_machtype env (expr : Cmm.expression) : inferred_machtype =
   match expr with
-  | Cconst_int _ | Cconst_natint _ -> Machtype typ_int
-  | Cconst_symbol _ -> Machtype typ_int
-  | Cconst_float _ -> Machtype typ_float
-  | Cconst_float32 _ -> Machtype typ_float32
-  | Cconst_vec128 _ -> Machtype typ_vec128
-  | Cconst_vec256 _ -> Machtype typ_vec256
-  | Cconst_vec512 _ -> Machtype typ_vec512
-  | Cconst_mask _ -> Machtype typ_mask
+  | Cconst_int _ | Cconst_natint _ -> Machtype Cmm.typ_int
+  | Cconst_symbol _ -> Machtype Cmm.typ_int
+  | Cconst_float _ -> Machtype Cmm.typ_float
+  | Cconst_float32 _ -> Machtype Cmm.typ_float32
+  | Cconst_vec128 _ -> Machtype Cmm.typ_vec128
+  | Cconst_vec256 _ -> Machtype Cmm.typ_vec256
+  | Cconst_vec512 _ -> Machtype Cmm.typ_vec512
+  | Cconst_mask _ -> Machtype Cmm.typ_mask
   | Cvar var -> (
     match V.Map.find_opt var env.vars with
     | Some ty -> Machtype ty
@@ -473,7 +478,7 @@ let rec infer_machtype env expr =
     let cond_ty = infer_machtype env cond in
     check_machtype ~dbg
       ~what:(fun () -> "if-then-else condition")
-      ~expected:typ_int cond_ty;
+      ~expected:Cmm.typ_int cond_ty;
     match cond_ty with
     | Never_returns -> Never_returns
     | Machtype _ ->
@@ -483,7 +488,7 @@ let rec infer_machtype env expr =
     let scrutinee_ty = infer_machtype env scrutinee in
     check_machtype ~dbg
       ~what:(fun () -> "switch scrutinee")
-      ~expected:typ_int scrutinee_ty;
+      ~expected:Cmm.typ_int scrutinee_ty;
     match scrutinee_ty with
     | Never_returns -> Never_returns
     | Machtype _ ->
@@ -497,7 +502,7 @@ let rec infer_machtype env expr =
       { env with
         handlers =
           List.fold_left
-            (fun handlers handler ->
+            (fun handlers (handler : Cmm.static_handler) ->
               Static_label.Map.add handler.label
                 (List.map snd handler.params)
                 handlers)
@@ -507,7 +512,7 @@ let rec infer_machtype env expr =
     let body_ty = infer_machtype env body in
     let handler_tys =
       List.map
-        (fun handler ->
+        (fun (handler : Cmm.static_handler) ->
           let env =
             { env with
               vars =
@@ -546,7 +551,8 @@ let rec infer_machtype env expr =
     Never_returns
   | Cinvalid _ -> Never_returns
 
-and typecheck_cop env op args dbg =
+and typecheck_cop env (op : Cmm.operation) (args : Cmm.expression list) dbg
+    : inferred_machtype =
   let arg_tys = List.map (infer_machtype env) args in
   let check_arg arg_index expected actual =
     match expected with
@@ -622,7 +628,7 @@ and typecheck_cop env op args dbg =
     | Cdls_get | Ctls_get | Cdomain_index | Cpoll | Cpause ->
       Machtype (Select_utils.oper_result_type op)
 
-let check_machtypes fundecl =
+let check_machtypes (fundecl : Cmm.fundecl) =
   let vars =
     List.fold_left
       (fun vars (var, ty) -> V.Map.add (VP.var var) ty vars)

--- a/backend/cmm_invariants.mli
+++ b/backend/cmm_invariants.mli
@@ -35,3 +35,16 @@
     any errors were encountered (with corresponding error messages printed
     on the given formatter). *)
 val run : Format.formatter -> Cmm.fundecl -> bool
+
+(** Checks that machtypes are used consistently within the given function's
+    body: the machtype inferred for each subexpression is compared against the
+    machtype its context expects, componentwise under the partial order of
+    [Cmm.ge_component]. In particular, the arguments of each [Cop] are checked
+    against the machtypes the operation expects (whose results are given by
+    [Select_utils.oper_result_type]), and the machtype of the body against
+    [fun_ret_type]. Calls [Misc.fatal_error] on the first violation.
+
+    Some argument slots (e.g. addresses, which may be [Val], [Addr] or naked
+    pointers) are not determined by the operation; checks on them are
+    skipped. *)
+val check_machtypes : Cmm.fundecl -> unit

--- a/backend/cmm_invariants.mli
+++ b/backend/cmm_invariants.mli
@@ -44,7 +44,8 @@ val run : Format.formatter -> Cmm.fundecl -> bool
     [Select_utils.oper_result_type]), and the machtype of the body against
     [fun_ret_type]. Calls [Misc.fatal_error] on the first violation.
 
-    Some argument slots (e.g. addresses, which may be [Val], [Addr] or naked
-    pointers) are not determined by the operation; checks on them are
-    skipped. *)
+    Argument slots whose machtypes are not determined by the operation (e.g.
+    arguments to an application whose signature is unavailable) are not
+    checked. Address operands are checked against [Cmm.typ_addr], which accepts
+    [Int], [Val] and [Addr] under the partial order. *)
 val check_machtypes : Cmm.fundecl -> unit

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -59,6 +59,7 @@ let exttype ppf = function
   | XInt16 -> fprintf ppf "int16"
   | XInt32 -> fprintf ppf "int32"
   | XInt64 -> fprintf ppf "int64"
+  | XMask -> fprintf ppf "mask"
   | XFloat -> fprintf ppf "float"
   | XFloat32 -> fprintf ppf "float32"
   | XVec128 -> fprintf ppf "vec128"

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -172,15 +172,7 @@ let select_mutable_flag : Asttypes.mutable_flag -> Operation.mutable_flag =
 let oper_result_type = function
   | Capply { result_type = ty; _ } -> ty
   | Cextcall { ty; ty_args = _; alloc = _; func = _; _ } -> ty
-  | Cload { memory_chunk; _ } -> (
-    match memory_chunk with
-    | Word_val -> typ_val
-    | Single { reg = Float64 } | Double -> typ_float
-    | Single { reg = Float32 } -> typ_float32
-    | Onetwentyeight_aligned | Onetwentyeight_unaligned -> typ_vec128
-    | Twofiftysix_aligned | Twofiftysix_unaligned -> typ_vec256
-    | Fivetwelve_aligned | Fivetwelve_unaligned -> typ_vec512
-    | _ -> typ_int)
+  | Cload { memory_chunk; _ } -> machtype_of_memory_chunk memory_chunk
   | Calloc _ -> typ_val
   | Cstore (_c, _) -> typ_void
   | Cdls_get -> typ_val

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -172,16 +172,7 @@ let select_mutable_flag : Asttypes.mutable_flag -> Operation.mutable_flag =
 let oper_result_type = function
   | Capply { result_type = ty; _ } -> ty
   | Cextcall { ty; ty_args = _; alloc = _; func = _; _ } -> ty
-  | Cload { memory_chunk; _ } -> (
-    match memory_chunk with
-    | Word_val -> typ_val
-    | Word_mask -> typ_mask
-    | Single { reg = Float64 } | Double -> typ_float
-    | Single { reg = Float32 } -> typ_float32
-    | Onetwentyeight_aligned | Onetwentyeight_unaligned -> typ_vec128
-    | Twofiftysix_aligned | Twofiftysix_unaligned -> typ_vec256
-    | Fivetwelve_aligned | Fivetwelve_unaligned -> typ_vec512
-    | _ -> typ_int)
+  | Cload { memory_chunk; _ } -> machtype_of_memory_chunk memory_chunk
   | Calloc _ -> typ_val
   | Cstore (_c, _) -> typ_void
   | Cdls_get -> typ_val

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -460,6 +460,10 @@ let read_one_param ppf position name v =
       set "linscan" [ use_linscan ] v
   | "insn-sched" -> set "insn-sched" [ insn_sched ] v
   | "no-insn-sched" -> clear "insn-sched" [ insn_sched ] v
+  | "cmm-check-machtypes" ->
+      set "cmm-check-machtypes" [ check_machtypes ] v
+  | "no-cmm-check-machtypes" ->
+      clear "cmm-check-machtypes" [ check_machtypes ] v
 
   (* color output *)
   | "color" ->

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -456,14 +456,11 @@ let read_one_param ppf position name v =
     set_flambda_invariants ppf ~name v flambda_invariant_checks
   | "cmm-invariants" ->
       set "cmm-invariants" [ cmm_invariants ] v
+  | "cmm-check-machtypes" -> set "cmm-check-machtypes" [ check_machtypes ] v
   | "linscan" ->
       set "linscan" [ use_linscan ] v
   | "insn-sched" -> set "insn-sched" [ insn_sched ] v
   | "no-insn-sched" -> clear "insn-sched" [ insn_sched ] v
-  | "cmm-check-machtypes" ->
-      set "cmm-check-machtypes" [ check_machtypes ] v
-  | "no-cmm-check-machtypes" ->
-      clear "cmm-check-machtypes" [ check_machtypes ] v
 
   (* color output *)
   | "color" ->

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -461,6 +461,7 @@ let read_one_param ppf position name v =
     set_flambda_invariants ppf ~name v flambda_invariant_checks
   | "cmm-invariants" ->
       set "cmm-invariants" [ cmm_invariants ] v
+  | "cmm-check-machtypes" -> set "cmm-check-machtypes" [ check_machtypes ] v
   | "linscan" ->
       set "linscan" [ use_linscan ] v
   | "insn-sched" -> set "insn-sched" [ insn_sched ] v

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -329,14 +329,6 @@ let mk_no_insn_sched f =
   Printf.sprintf " Do not run the instruction scheduling pass%s"
     (if not Clflags.insn_sched_default then " (default)" else "")
 
-let mk_dcmm_check_machtypes f =
-  "-dcmm-check-machtypes", Arg.Unit f,
-  " Check that machtypes are used consistently in Cmm (default)"
-
-let mk_dcmm_no_check_machtypes f =
-  "-dcmm-no-check-machtypes", Arg.Unit f,
-  " Do not check that machtypes are used consistently in Cmm"
-
 let mk_keep_docs f =
   "-keep-docs", Arg.Unit f, " Keep documentation strings in .cmi files"
 
@@ -998,6 +990,14 @@ let mk_dcamlprimc f =
 let mk_dcmm_invariants f =
   "-dcmm-invariants", Arg.Unit f, " Extra sanity checks on Cmm"
 
+let mk_dcmm_check_machtypes f =
+  "-dcmm-check-machtypes", Arg.Unit f,
+  " Check that machtypes are used consistently in Cmm (default)"
+
+let mk_dcmm_no_check_machtypes f =
+  "-dcmm-no-check-machtypes", Arg.Unit f,
+  " Do not check that machtypes are used consistently in Cmm"
+
 let mk_dcmm f =
   "-dcmm", Arg.Unit f, " (undocumented)"
 
@@ -1372,8 +1372,6 @@ module type Optcommon_options = sig
   val _o4 : unit -> unit
   val _insn_sched : unit -> unit
   val _no_insn_sched : unit -> unit
-  val _dcmm_check_machtypes : unit -> unit
-  val _dcmm_no_check_machtypes : unit -> unit
   val _linscan : unit -> unit
   val _no_float_const_prop : unit -> unit
 
@@ -1388,6 +1386,8 @@ module type Optcommon_options = sig
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
   val _dcmm_invariants : unit -> unit
+  val _dcmm_check_machtypes : unit -> unit
+  val _dcmm_no_check_machtypes : unit -> unit
   val _dcmm : unit -> unit
   val _dcse : unit -> unit
   val _dlinear :  unit -> unit
@@ -1814,7 +1814,6 @@ struct
     mk_inline_lifting_benefit F._inline_lifting_benefit;
     mk_inlining_report F._inlining_report;
     mk_insn_sched F._insn_sched;
-    mk_dcmm_check_machtypes F._dcmm_check_machtypes;
     mk_instantiate_opt F._instantiate;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
@@ -1840,7 +1839,6 @@ struct
     mk_noautolink_opt F._noautolink;
     mk_nodynlink F._nodynlink;
     mk_no_insn_sched F._no_insn_sched;
-    mk_dcmm_no_check_machtypes F._dcmm_no_check_machtypes;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
     mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
@@ -1927,6 +1925,8 @@ struct
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
     mk_dcmm_invariants F._dcmm_invariants;
+    mk_dcmm_check_machtypes F._dcmm_check_machtypes;
+    mk_dcmm_no_check_machtypes F._dcmm_no_check_machtypes;
     mk_dflambda F._dflambda;
     mk_drawflambda F._drawflambda;
     mk_dflambda_invariants F._dflambda_invariants;
@@ -2092,6 +2092,8 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
     mk_dcmm_invariants F._dcmm_invariants;
+    mk_dcmm_check_machtypes F._dcmm_check_machtypes;
+    mk_dcmm_no_check_machtypes F._dcmm_no_check_machtypes;
     mk_drawflambda F._drawflambda;
     mk_dflambda F._dflambda;
     mk_dcmm F._dcmm;
@@ -2499,6 +2501,8 @@ module Default = struct
     let _dcmm = set dump_cmm
     let _dcse = set dump_cse
     let _dcmm_invariants = set cmm_invariants
+    let _dcmm_check_machtypes = set check_machtypes
+    let _dcmm_no_check_machtypes = clear check_machtypes
     let _dcse = set dump_cse
     let _dflambda = set dump_flambda
     let _dflambda_heavy_invariants () =
@@ -2558,8 +2562,6 @@ module Default = struct
     let _inlining_report () = inlining_report := true
     let _insn_sched = set insn_sched
     let _no_insn_sched = clear insn_sched
-    let _dcmm_check_machtypes = set check_machtypes
-    let _dcmm_no_check_machtypes = clear check_machtypes
     let _linscan = set use_linscan
     let _no_float_const_prop = clear float_const_prop
     let _no_unbox_free_vars_of_closures = clear unbox_free_vars_of_closures

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -329,6 +329,14 @@ let mk_no_insn_sched f =
   Printf.sprintf " Do not run the instruction scheduling pass%s"
     (if not Clflags.insn_sched_default then " (default)" else "")
 
+let mk_dcmm_check_machtypes f =
+  "-dcmm-check-machtypes", Arg.Unit f,
+  " Check that machtypes are used consistently in Cmm (default)"
+
+let mk_dcmm_no_check_machtypes f =
+  "-dcmm-no-check-machtypes", Arg.Unit f,
+  " Do not check that machtypes are used consistently in Cmm"
+
 let mk_keep_docs f =
   "-keep-docs", Arg.Unit f, " Keep documentation strings in .cmi files"
 
@@ -1364,6 +1372,8 @@ module type Optcommon_options = sig
   val _o4 : unit -> unit
   val _insn_sched : unit -> unit
   val _no_insn_sched : unit -> unit
+  val _dcmm_check_machtypes : unit -> unit
+  val _dcmm_no_check_machtypes : unit -> unit
   val _linscan : unit -> unit
   val _no_float_const_prop : unit -> unit
 
@@ -1804,6 +1814,7 @@ struct
     mk_inline_lifting_benefit F._inline_lifting_benefit;
     mk_inlining_report F._inlining_report;
     mk_insn_sched F._insn_sched;
+    mk_dcmm_check_machtypes F._dcmm_check_machtypes;
     mk_instantiate_opt F._instantiate;
     mk_intf F._intf;
     mk_intf_suffix F._intf_suffix;
@@ -1829,6 +1840,7 @@ struct
     mk_noautolink_opt F._noautolink;
     mk_nodynlink F._nodynlink;
     mk_no_insn_sched F._no_insn_sched;
+    mk_dcmm_no_check_machtypes F._dcmm_no_check_machtypes;
     mk_nolabels F._nolabels;
     mk_nostdlib F._nostdlib;
     mk_no_auto_include_otherlibs F._no_auto_include_otherlibs;
@@ -2546,6 +2558,8 @@ module Default = struct
     let _inlining_report () = inlining_report := true
     let _insn_sched = set insn_sched
     let _no_insn_sched = clear insn_sched
+    let _dcmm_check_machtypes = set check_machtypes
+    let _dcmm_no_check_machtypes = clear check_machtypes
     let _linscan = set use_linscan
     let _no_float_const_prop = clear float_const_prop
     let _no_unbox_free_vars_of_closures = clear unbox_free_vars_of_closures

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1005,7 +1005,8 @@ let mk_dcmm_invariants f =
 
 let mk_dcmm_check_machtypes f =
   "-dcmm-check-machtypes", Arg.Unit f,
-  " Check that machtypes are used consistently in Cmm (default)"
+  " Check that machtypes are used consistently in Cmm. Machtypes are never \
+      checked with -Oclassic (default)"
 
 let mk_dcmm_no_check_machtypes f =
   "-dcmm-no-check-machtypes", Arg.Unit f,

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1003,6 +1003,14 @@ let mk_dcamlprimc f =
 let mk_dcmm_invariants f =
   "-dcmm-invariants", Arg.Unit f, " Extra sanity checks on Cmm"
 
+let mk_dcmm_check_machtypes f =
+  "-dcmm-check-machtypes", Arg.Unit f,
+  " Check that machtypes are used consistently in Cmm (default)"
+
+let mk_dcmm_no_check_machtypes f =
+  "-dcmm-no-check-machtypes", Arg.Unit f,
+  " Do not check that machtypes are used consistently in Cmm"
+
 let mk_dcmm f =
   "-dcmm", Arg.Unit f, " (undocumented)"
 
@@ -1403,6 +1411,8 @@ module type Optcommon_options = sig
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
   val _dcmm_invariants : unit -> unit
+  val _dcmm_check_machtypes : unit -> unit
+  val _dcmm_no_check_machtypes : unit -> unit
   val _dcmm : unit -> unit
   val _dcse : unit -> unit
   val _dlinear :  unit -> unit
@@ -1945,6 +1955,8 @@ struct
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
     mk_dcmm_invariants F._dcmm_invariants;
+    mk_dcmm_check_machtypes F._dcmm_check_machtypes;
+    mk_dcmm_no_check_machtypes F._dcmm_no_check_machtypes;
     mk_dflambda F._dflambda;
     mk_drawflambda F._drawflambda;
     mk_dflambda_invariants F._dflambda_invariants;
@@ -2111,6 +2123,8 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_drawclambda F._drawclambda;
     mk_dclambda F._dclambda;
     mk_dcmm_invariants F._dcmm_invariants;
+    mk_dcmm_check_machtypes F._dcmm_check_machtypes;
+    mk_dcmm_no_check_machtypes F._dcmm_no_check_machtypes;
     mk_drawflambda F._drawflambda;
     mk_dflambda F._dflambda;
     mk_dcmm F._dcmm;
@@ -2521,6 +2535,8 @@ module Default = struct
     let _dcmm = set dump_cmm
     let _dcse = set dump_cse
     let _dcmm_invariants = set cmm_invariants
+    let _dcmm_check_machtypes = set check_machtypes
+    let _dcmm_no_check_machtypes = clear check_machtypes
     let _dcse = set dump_cse
     let _dflambda = set dump_flambda
     let _dflambda_heavy_invariants () =

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -246,6 +246,8 @@ module type Optcommon_options = sig
   val _o4 : unit -> unit
   val _insn_sched : unit -> unit
   val _no_insn_sched : unit -> unit
+  val _dcmm_check_machtypes : unit -> unit
+  val _dcmm_no_check_machtypes : unit -> unit
   val _linscan : unit -> unit
   val _no_float_const_prop : unit -> unit
 

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -246,8 +246,6 @@ module type Optcommon_options = sig
   val _o4 : unit -> unit
   val _insn_sched : unit -> unit
   val _no_insn_sched : unit -> unit
-  val _dcmm_check_machtypes : unit -> unit
-  val _dcmm_no_check_machtypes : unit -> unit
   val _linscan : unit -> unit
   val _no_float_const_prop : unit -> unit
 
@@ -262,6 +260,8 @@ module type Optcommon_options = sig
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
   val _dcmm_invariants : unit -> unit
+  val _dcmm_check_machtypes : unit -> unit
+  val _dcmm_no_check_machtypes : unit -> unit
   val _dcmm : unit -> unit
   val _dcse : unit -> unit
   val _dlinear :  unit -> unit

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -263,6 +263,8 @@ module type Optcommon_options = sig
   val _drawclambda : unit -> unit
   val _dclambda : unit -> unit
   val _dcmm_invariants : unit -> unit
+  val _dcmm_check_machtypes : unit -> unit
+  val _dcmm_no_check_machtypes : unit -> unit
   val _dcmm : unit -> unit
   val _dcse : unit -> unit
   val _dlinear :  unit -> unit

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -741,6 +741,8 @@ let ocaml_ignored_flags =
     "-dcfg";
     "-dcfg-invariants";
     "-dcmm-invariants";
+    "-dcmm-check-machtypes";
+    "-dcmm-no-check-machtypes";
     "-ddebug-avail-sets";
     "-ddebug-available-regs";
     "-dfexpr";

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -61,7 +61,7 @@ let exttype_of_kind (k : Flambda_kind.t) : Cmm.exttype =
   | Naked_number Naked_vec128 -> XVec128
   | Naked_number Naked_vec256 -> XVec256
   | Naked_number Naked_vec512 -> XVec512
-  | Naked_number Naked_mask -> XInt64
+  | Naked_number Naked_mask -> XMask
   | Region -> Misc.fatal_error "[Region] kind not expected here"
   | Rec_info -> Misc.fatal_error "[Rec_info] kind not expected here"
 

--- a/oxcaml/testsuite/tests/asmgen/arith.cmm
+++ b/oxcaml/testsuite/tests/asmgen/arith.cmm
@@ -1,6 +1,7 @@
 (* TEST
  readonly_files = "mainarith.c asan_report_wrappers.c";
  arguments = "mainarith.c asan_report_wrappers.c";
+ flags = "-dcmm-no-check-machtypes";
  asmgen;
 *)
 

--- a/oxcaml/testsuite/tests/asmgen/catch-float.cmm
+++ b/oxcaml/testsuite/tests/asmgen/catch-float.cmm
@@ -1,6 +1,7 @@
 (* TEST
  readonly_files = "main.c";
  arguments = "-DFLOAT_CATCH -DFUN=catch_float main.c";
+ flags = "-dcmm-no-check-machtypes";
  asmgen;
 *)
 

--- a/oxcaml/testsuite/tests/asmgen/catch-try-float.cmm
+++ b/oxcaml/testsuite/tests/asmgen/catch-try-float.cmm
@@ -1,6 +1,7 @@
 (* TEST
  readonly_files = "main.c";
  arguments = "-DFLOAT_CATCH -DFUN=catch_try_float main.c";
+ flags = "-dcmm-no-check-machtypes";
  asmgen;
 *)
 

--- a/oxcaml/testsuite/tests/asmgen/even-odd-spill-float.cmm
+++ b/oxcaml/testsuite/tests/asmgen/even-odd-spill-float.cmm
@@ -1,6 +1,7 @@
 (* TEST
  readonly_files = "main.c";
  arguments = "-DINT_FLOAT -DFUN=is_even main.c";
+ flags = "-dcmm-no-check-machtypes";
  asmgen;
 *)
 

--- a/oxcaml/testsuite/tests/asmgen/immediates.cmm
+++ b/oxcaml/testsuite/tests/asmgen/immediates.cmm
@@ -1,6 +1,7 @@
 (* TEST
  readonly_files = "mainimmed.c asan_report_wrappers.c";
  arguments = "-I ${test_source_directory} mainimmed.c asan_report_wrappers.c";
+ flags = "-dcmm-no-check-machtypes";
  asmgen;
 *)
 (* Regenerate with cpp -P immediates.cmmpp > immediates.cmm *)

--- a/oxcaml/testsuite/tools/codegen_main.ml
+++ b/oxcaml/testsuite/tools/codegen_main.ml
@@ -60,6 +60,7 @@ let main() =
   Arg.parse [
      "-S", Arg.Set write_asm_file,
        " Output file to filename.s (default is stdout)";
+     "-dcmm-no-check-machtypes", Arg.Clear Clflags.check_machtypes, "";
      "-g", Arg.Set Clflags.debug, "";
      "-dcfg", Arg.Set Oxcaml_flags.dump_cfg, "";
      "-dcmm", Arg.Set dump_cmm, "";

--- a/oxcaml/testsuite/tools/codegen_main.ml
+++ b/oxcaml/testsuite/tools/codegen_main.ml
@@ -72,6 +72,7 @@ let main() =
   Arg.parse [
      "-S", Arg.Set write_asm_file,
        " Output file to filename.s (default is stdout)";
+     "-dcmm-no-check-machtypes", Arg.Clear Clflags.check_machtypes, "";
      "-g", Arg.Set Clflags.debug, "";
      "-dcfg", Arg.Set Oxcaml_flags.dump_cfg, "";
      "-dcmm", Arg.Set dump_cmm, "";

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -580,8 +580,8 @@ do_prefetch_write_low:
 let do_pause () = Builtins.pause_hint ()
 [%%expect_asm X86_64{|
 do_pause:
-  movl  $1, %eax
   pause
+  movl  $1, %eax
   ret
 |}]
 

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -572,11 +572,10 @@ do_prefetch_write_low:
 
 (* Pause *)
 
-let do_pause () = Builtins.pause_hint ()
+let do_pause () = Builtins.pause_hint #()
 [%%expect_asm X86_64{|
 do_pause:
   pause
-  movl  $1, %eax
   ret
 |}]
 

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -575,8 +575,8 @@ do_prefetch_write_low:
 let do_pause () = Builtins.pause_hint ()
 [%%expect_asm X86_64{|
 do_pause:
-  movl  $1, %eax
   pause
+  movl  $1, %eax
   ret
 |}]
 

--- a/testsuite/tests/codegen/intrinsics.ml
+++ b/testsuite/tests/codegen/intrinsics.ml
@@ -1201,7 +1201,7 @@ module Builtins = struct
 
   (* Pause *)
 
-  external pause_hint : unit -> unit
+  external pause_hint : unit# -> unit#
     = "" "caml_pause_hint"
     [@@noalloc] [@@builtin]
 

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -241,6 +241,7 @@ let force_slash = ref false             (* for ocamldep *)
 let clambda_checks = ref false          (* -clambda-checks *)
 let cmm_invariants =
   ref Config.with_cmm_invariants        (* -dcmm-invariants *)
+let check_machtypes = ref true          (* -dcmm-[no-]check-machtypes *)
 
 let parsetree_ghost_loc_invariant = ref false
   (* -dparsetree-ghost-loc-invariant *)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -246,6 +246,7 @@ let force_slash = ref false             (* for ocamldep *)
 let clambda_checks = ref false          (* -clambda-checks *)
 let cmm_invariants =
   ref Config.with_cmm_invariants        (* -dcmm-invariants *)
+let check_machtypes = ref true          (* -dcmm-[no-]check-machtypes *)
 
 let parsetree_ghost_loc_invariant = ref false
   (* -dparsetree-ghost-loc-invariant *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -251,6 +251,7 @@ val unbox_free_vars_of_closures : bool ref
 val unbox_specialised_args : bool ref
 val clambda_checks : bool ref
 val cmm_invariants : bool ref
+val check_machtypes : bool ref
 val parsetree_ghost_loc_invariant : bool ref
 val default_inline_max_depth : int
 val inline_max_depth : Int_arg_helper.parsed ref

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -254,6 +254,7 @@ val unbox_free_vars_of_closures : bool ref
 val unbox_specialised_args : bool ref
 val clambda_checks : bool ref
 val cmm_invariants : bool ref
+val check_machtypes : bool ref
 val parsetree_ghost_loc_invariant : bool ref
 val default_inline_max_depth : int
 val inline_max_depth : Int_arg_helper.parsed ref


### PR DESCRIPTION
Adds another pass during `cmm_invariants` that traverses Cmm expressions and makes sure the machtypes of inputs and outputs of each operation are consistent with eachother. For now, this machtype-checking pass is toggled with a separate flag (`-dcmm-check-machtypes`, default enabled), but it can be folded into `-dcmm-invariants` when we consider the machtype checker stable.

Most of the interesting changes are in `cmm_invariants.ml`, where the checker is actually implemented. The core of the algorithm is `infer_machtypes : typechecking_env -> Cmm.expression -> [ Machtype of machtype | Never_returns ]`, which implements standard bottom-up type inference.

An internal deployment of this compiler did not error on an optimized build.