### PR TITLE
Fix crash when an `any` type variable resolves to unboxed product

### DIFF
--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2574,7 +2574,7 @@ let get_expr_args_record ~scopes head { arg; mut; sort; layout; _ } rem =
       let ptr, _ = Typeopt.maybe_pointer_type head.pat_env lbl.lbl_arg in
       let lbl_sort =
         match label_sort Legacy lbl all_sorts with
-        | `Sort s -> s
+        | `Sort s -> Jkind.Sort.default_for_transl_and_get s
         | `Same_as_record_sort -> sort
       in
       let lbl_layout = Typeopt.layout_of_sort lbl.lbl_loc lbl_sort in
@@ -2655,7 +2655,9 @@ let get_expr_args_record_unboxed_product ~scopes head { arg; mut; _ } rem =
   in
   let lbl_layouts =
     Array.map (fun lbl ->
-      Typeopt.layout_of_sort lbl.lbl_loc (unboxed_label_sort lbl all_sorts)
+      Typeopt.layout_of_sort lbl.lbl_loc
+        (Jkind.Sort.default_for_transl_and_get
+           (unboxed_label_sort lbl all_sorts))
     ) all_labels
     |> Array.to_list
   in
@@ -2677,7 +2679,10 @@ let get_expr_args_record_unboxed_product ~scopes head { arg; mut; _ } rem =
         else
           Alias, compose_mut mut Immutable
       in
-      let lbl_sort = unboxed_label_sort lbl all_sorts in
+      let lbl_sort =
+        Jkind.Sort.default_for_transl_and_get
+          (unboxed_label_sort lbl all_sorts)
+      in
       let layout = Typeopt.layout_of_sort lbl.lbl_loc lbl_sort in
       {
         arg = access;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -834,7 +834,10 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
       fatal_error "transl_exp0: variable unboxed-product record representation"
     | Record_unboxed_product ->
       let lbl_layout l =
-        let sort = unboxed_label_sort l record_sorts in
+        let sort =
+          Jkind.Sort.default_for_transl_and_get
+            (unboxed_label_sort l record_sorts)
+        in
         if l.lbl_pos = lbl.lbl_pos then
           (* This is the field being projected, so give it a precise value kind
              (by using the known type of the expression) *)
@@ -873,7 +876,7 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
       in
       let sort_newval =
         match label_sort Legacy lbl record_sorts with
-        | `Sort s -> s
+        | `Sort s -> Jkind.Sort.default_for_transl_and_get s
         | `Same_as_record_sort -> sort_arg
       in
       let arg_layout = layout_exp sort_arg arg in
@@ -2534,7 +2537,10 @@ and transl_idx ~scopes loc _env ba uas =
     begin match uas with
     | [] -> idx
     | Uaccess_unboxed_field (_, lbl, sorts) :: _ ->
-      let sorts = unboxed_label_all_sorts lbl sorts in
+      let sorts =
+        Array.map Jkind.Sort.default_for_transl_and_get
+          (unboxed_label_all_sorts lbl sorts)
+      in
       (* Preserve the invariant that products have at least two elements *)
       let base_sort =
         if Int.equal (Array.length sorts) 1 then

--- a/testsuite/tests/typing-layouts-products/inline_record_any_field_inference.ml
+++ b/testsuite/tests/typing-layouts-products/inline_record_any_field_inference.ml
@@ -1,0 +1,40 @@
+(* TEST
+ flags = "-extension layouts_beta";
+ flambda2;
+ compile_only = "true";
+ ocamlopt_opt_exit_status = "2";
+ setup-ocamlopt.opt-build-env;
+ ocamlopt.opt;
+*)
+
+(* CR-soon lmaurer from Claude: this is a KNOWN BUG, recorded here as a failing
+   test (the compiler currently crashes with [Invalid_argument "Array.sub"] in
+   flambda2's [Lambda_to_flambda_primitives], so this test expects exit code 2).
+   It is the inline-record sibling of the bug fixed by keeping live sorts in
+   [Typedtree.record_sorts] (see unboxed_record_any_field_inference.ml): when a
+   constructor's inline-record field has kind [any] and its instantiation is
+   only discovered from the function body by inference, the field's sort and the
+   mixed-block shape are computed during pattern typing, before the [any] field
+   is resolved. The field read is then compiled as a plain value load
+   ([field_imm]) while the projections downstream use the resolved
+   unboxed-product sort. The concrete-annotation control [g] below compiles
+   fine, which shows the staleness is introduced at use-site typing time, not at
+   declaration time. When this is fixed, convert this file into a running test
+   like unboxed_record_any_field_inference.ml. *)
+
+type ('a : any) w = W of { id : int; value : 'a }
+
+type t =
+  #{ foo : int
+   ; bar : string
+   }
+
+(* Control: concrete annotation, compiles and behaves correctly. *)
+let g (W { id; value = t } : t w) =
+  ignore (id : int);
+  String.length t.#bar
+
+(* Known bug: wildcard annotation, ICEs in the middle end. *)
+let f (W { id; value = t } : _ w) =
+  ignore (id : int);
+  String.length t.#bar

--- a/testsuite/tests/typing-layouts-products/unboxed_record_any_field_inference.ml
+++ b/testsuite/tests/typing-layouts-products/unboxed_record_any_field_inference.ml
@@ -1,0 +1,72 @@
+(* TEST
+ reference =
+   "${test_source_directory}/unboxed_record_any_field_inference.reference";
+ flambda2;
+ {
+   flags = "-extension layouts_beta";
+   native;
+ }{
+   flags = "-extension layouts_beta -Oclassic";
+   native;
+ }{
+   flags = "-extension layouts_beta -O3";
+   native;
+ }{
+   flags = "-extension layouts_beta";
+   bytecode;
+ }
+*)
+
+(* Regression test: a function parameter whose unboxed-record type has an
+   [('a : any)] field, where ['a] is only discovered to be a nested unboxed
+   product by inference from the function body (via a [_] type annotation).
+   The sorts stored in the pattern used to be defaulted prematurely, making
+   the parameter's unarized layout disagree with the field projections and
+   crashing the middle end. *)
+
+type ('a : any) with_id =
+  #{ id : int
+   ; value : 'a
+   }
+
+type t =
+  #{ foo : int
+   ; bar : string
+   }
+
+(* Wildcard annotation: the payload's sort is discovered from the body. *)
+let f (#{ id; value = t } : _ with_id) = id, t.#foo, t.#bar
+
+(* Control: concrete annotation. *)
+let f' (#{ id; value = t } : t with_id) = id, t.#foo, t.#bar
+
+(* Two [any] fields, both inferred. *)
+type ('a : any, 'b : any) pair2 =
+  #{ fst : 'a
+   ; snd : 'b
+   }
+
+let g (#{ fst; snd } : (_, _) pair2) = fst.#bar, snd + 1
+
+(* Curried: the payload is only resolved in an inner body. *)
+let h (#{ id = _; value = v } : _ with_id) () = v.#foo
+
+(* Inlining at closure conversion (classic mode) used to crash when the
+   callee's unarized params disagreed with the apply's unarized args. *)
+let[@inline] proj (#{ id; value = t } : _ with_id) =
+  ignore (id : int);
+  t.#foo
+
+let apply_proj x = (proj [@inlined]) x
+
+let () =
+  let arg = #{ id = 3; value = #{ foo = 42; bar = "hello" } } in
+  let id, foo, bar = f arg in
+  Printf.printf "f: %d %d %s\n" id foo bar;
+  let id, foo, bar = f' arg in
+  Printf.printf "f': %d %d %s\n" id foo bar;
+  let bar, snd = g #{ fst = #{ foo = 1; bar = "x" }; snd = 10 } in
+  Printf.printf "g: %s %d\n" bar snd;
+  Printf.printf "h: %d\n" (h arg ());
+  Printf.printf "apply_proj: %d\n"
+    (apply_proj #{ id = 7; value = #{ foo = 9; bar = "y" } })

--- a/testsuite/tests/typing-layouts-products/unboxed_record_any_field_inference.reference
+++ b/testsuite/tests/typing-layouts-products/unboxed_record_any_field_inference.reference
@@ -1,0 +1,5 @@
+f: 3 42 hello
+f': 3 42 hello
+g: x 11
+h: 42
+apply_proj: 9

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1018,7 +1018,7 @@ let pats_of_type env ty =
               labels
           in
           let fake_sorts =
-            List.map (fun _ -> fake_sort_const) labels
+            List.map (fun _ -> Jkind.Sort.of_const fake_sort_const) labels
             |> Array.of_list
             |> fun sorts -> Variable sorts
           in
@@ -1031,7 +1031,7 @@ let pats_of_type env ty =
               labels
           in
           let fake_sorts =
-            List.map (fun _ -> fake_sort_const) labels
+            List.map (fun _ -> Jkind.Sort.of_const fake_sort_const) labels
             |> Array.of_list
             |> fun sorts -> Variable sorts
           in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3405,7 +3405,7 @@ and type_pat_aux
         let alloc_mode = simple_pat_mode mode in
         let ty_sort =
           match label_sort record_form label sorts with
-          | `Sort s -> Jkind.Sort.of_const s
+          | `Sort s -> s
           | `Same_as_record_sort -> record_sort
         in
         (label_lid, label, type_pat tps Value ~alloc_mode sarg ty_arg ty_sort)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -554,13 +554,15 @@ let set_private_row env loc p decl =
   in
   set_type_desc rv (Tconstr (p, decl.type_params, ref Mnil))
 
-(* Makes sure a type is representable. When called with a type variable, will
-   lower [any] to a sort variable if [allow_unboxed = true], and to [value]
-   if [allow_unboxed = false]. *)
-let constrain_to_representable ~why env loc kloc typ =
+(* Makes sure a type is representable, returning its sort. *)
+let representable_sort ~why env loc kloc typ =
   match Ctype.type_sort ~why ~fixed:false env typ with
-  | Ok _ -> ()
+  | Ok sort -> sort
   | Error err -> raise (Error (loc,Jkind_sort {env; kloc; typ; err}))
+
+(* Makes sure a type is representable. *)
+let constrain_to_representable ~why env loc kloc typ =
+  ignore (representable_sort ~why env loc kloc typ : Jkind.sort)
 
 let check_no_repr cty =
   match cty.ptyp_desc with
@@ -2397,12 +2399,12 @@ let update_record_inlined_kind env loc lbls jkinds tag vrep : _ Result.t =
       "Typedecl.update_record_kind: unexpected variant representation"
 
 (* Given a record with a variable representation, but updated labels, compute
-   the updated sorts and representation *)
+   the updated representation *)
 let update_record_kind (type rep) env loc (form : rep record_form)
       ~(old_repres : rep) lbls ~warn :
-    _ * (rep, _) Result.t =
+    (rep, _) Result.t =
   let types = List.map snd lbls in
-  let sorts, jkinds = update_label_sorts env loc types ~form in
+  let _sorts, jkinds = update_label_sorts env loc types ~form in
   let reprs, repr_summary = compute_repr_summary env lbls jkinds in
   let rep : (rep, _) Result.t =
     match form, old_repres with
@@ -2437,7 +2439,7 @@ let update_record_kind (type rep) env loc (form : rep record_form)
         Misc.fatal_error
           "Typedecl.update_record_kind: representation already determined"
   in
-  sorts, rep
+  rep
 
 let update_record_representation
       (type rep) ~why ~old_repres
@@ -2447,11 +2449,15 @@ let update_record_representation
     | Legacy -> Record { unboxed = false }
     | Unboxed_product -> Record_unboxed_product
   in
-  List.iter
-    (fun (_lbl, ld_type) ->
-       constrain_to_representable ~why env loc kloc ld_type)
-    lbls_and_types;
-  let sorts, rep =
+  (* We want to allow exactly one side effect here: force the type to be
+     representable, returning its sort from this function. Thus we get the
+     sort here rather than inside the snapshot/backtrack region below. *)
+  let sorts =
+    List.map
+      (fun (_lbl, ld_type) -> representable_sort ~why env loc kloc ld_type)
+      lbls_and_types
+  in
+  let rep =
     let warn =
       (* Only warn during initial typechecking rather than when updating at
          use sites, so that we only warn once and honour suppressed warnings *)
@@ -2469,13 +2475,7 @@ let update_record_representation
     Btype.backtrack snap;
     ans
   in
-  match rep with
-  | Ok rep ->
-    begin match Misc.Stdlib.List.some_if_all_elements_are_some sorts with
-    | Some sorts -> Ok (sorts, rep)
-    | None -> Misc.fatal_error "missing sort for representable field"
-    end
-  | Error _ as e -> e
+  Result.map (fun rep -> sorts, rep) rep
 
 (* This function updates jkind stored in kinds with more accurate jkinds.
    It is called after the circularity checks and the delayed jkind checks

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -123,7 +123,7 @@ val update_record_representation:
     why:Jkind_intf.History.concrete_creation_reason -> old_repres:'rep ->
     Env.t -> Location.t -> 'rep Data_types.record_form ->
     (Types.label_declaration * Types.type_expr) list ->
-    (Jkind.Sort.Const.t list * 'rep, unrepresentable_record) Result.t
+    (Jkind.sort list * 'rep, unrepresentable_record) Result.t
 
 val mixed_block_element :
     Env.t -> type_expr -> _ jkind -> mixed_block_element option

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -157,7 +157,7 @@ and _ poly_param =
 
 type record_sorts =
   | Fixed
-  | Variable of Jkind.Sort.Const.t array
+  | Variable of Jkind.sort array
 
 type pattern = value general_pattern
 and 'k general_pattern = 'k pattern_desc pattern_data
@@ -1690,7 +1690,7 @@ let label_sort (type rep)
   | _ ->
     begin match record_sorts, label.lbl_sort with
     | Variable sorts, _ -> `Sort sorts.(label.lbl_pos)
-    | Fixed, Some sort -> `Sort sort
+    | Fixed, Some sort -> `Sort (Jkind.Sort.of_const sort)
     | Fixed, None ->
       Misc.fatal_errorf "no sort for label %s in fixed-sort record"
         label.lbl_name

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -173,7 +173,7 @@ type record_sorts =
   (** The sorts of this record's fields were determined when the type was
       declared. Invariant: Every description in [lbl_all] for any field has a
       [lbl_sort] that's [Some]. *)
-  | Variable of Jkind.Sort.Const.t array
+  | Variable of Jkind.sort array
   (** This value has the specified sorts for its fields. *)
 
 type pattern = value general_pattern
@@ -1608,13 +1608,13 @@ val map_apply_arg:
 val label_sort:
   'rep Data_types.record_form -> 'rep Data_types.gen_label_description
   -> record_sorts
-  -> [ `Sort of Jkind.Sort.Const.t | `Same_as_record_sort ]
+  -> [ `Sort of Jkind.sort | `Same_as_record_sort ]
 
 (** Computes the sort of a label. Becuase the sepcial case above doesn't apply
     to unboxed records, this doesn't return an option. *)
 val unboxed_label_sort :
-  Data_types.unboxed_label_description -> record_sorts -> Jkind.Sort.Const.t
+  Data_types.unboxed_label_description -> record_sorts -> Jkind.sort
 
 val unboxed_label_all_sorts:
   Data_types.unboxed_label_description -> record_sorts
-  -> Jkind.Sort.Const.t array
+  -> Jkind.sort array


### PR DESCRIPTION
Various places in the typedtree that force a type to be representable (such as accessing a field of a value with that type) carry sort information for that type. In the case of a record access, that sort information is a `record_sorts` value full of `Sort.Const.t`s. Unfortunately, being constants can force those sorts to be defaulted prematurely to `value`. We need to let such sorts be variables so that further typechecking can make them, say, unboxed records. See the new test `unboxed_record_any_field_inference.ml` for an example.

Claude found a related bug while working on this. A failing test case is included as `inline_record_any_field_inference.ml`.