### PR TITLE
Handle boxed numbers in the reaper

### DIFF
--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -328,7 +328,9 @@ and value_slots = one_value_slot list
 
 and one_value_slot =
   { var : value_slot;
-    value : simple
+    value : simple;
+    kind : Flambda_kind.Naked_number_kind.t option
+        (* [None] means kind [Value]. *)
   }
 
 and let_ =

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -803,7 +803,10 @@ let untag_immediate =
   D.(unary "%untag_imm" ~params:param0 (fun _ () -> P.Untag_immediate))
 
 let project_value_slot =
-  (* CR mshinwell: support non-value kinds *)
+  (* CR mshinwell: support non-value kinds in the projection syntax. Note that
+     if the value slot's definition (in a "with" clause, where kinds are
+     supported) has already been parsed, the slot registered under this name
+     will have the correct kind and the kind here is ignored. *)
   let kind = Flambda_kind.value in
   D.(
     unary "%project_value_slot"

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -270,9 +270,24 @@ let set_of_closures env fun_decls value_slots =
   in
   let value_slots = Option.value value_slots ~default:[] in
   let value_slots : Simple.t Value_slot.Map.t =
-    let convert ({ var; value } : Fexpr.one_value_slot) =
-      (* CR mshinwell: support non-value kinds *)
-      fresh_or_existing_value_slot env var Flambda_kind.value, simple env value
+    let convert ({ var; value; kind } : Fexpr.one_value_slot) =
+      let kind =
+        match kind with
+        | None -> Flambda_kind.value
+        | Some naked_number_kind -> Flambda_kind.naked_number naked_number_kind
+      in
+      let value_slot = fresh_or_existing_value_slot env var kind in
+      if not (Flambda_kind.equal (Value_slot.kind value_slot) kind)
+      then
+        (* This can happen if an occurrence of the value slot, such as a
+           projection (which assumes kind [Value], see [Fexpr_prim]), was
+           encountered before this definition. *)
+        Misc.fatal_errorf
+          "Value slot %s: kind %a does not match kind %a of a previous \
+           occurrence of this slot"
+          var.txt Flambda_kind.print kind Flambda_kind.print
+          (Value_slot.kind value_slot);
+      value_slot, simple env value
     in
     List.map convert value_slots |> Value_slot.Map.of_list
   in

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -593,7 +593,11 @@ with_value_slots_opt:
 ;
 
 value_slot:
-  | var = value_slot_for_projection; EQUAL; value = simple; { { var; value; } }
+  | var = value_slot_for_projection; EQUAL; value = simple;
+    { { var; value; kind = None } }
+  | var = value_slot_for_projection; COLON; kind = naked_number_kind;
+    EQUAL; value = simple;
+    { { var; value; kind = Some kind } }
 ;
 
 fun_decl:

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -204,13 +204,17 @@ let prim env (p : Flambda_primitive.t) : Fexpr.prim =
 let value_slots env map =
   List.map
     (fun (var, value) ->
-      let kind = Value_slot.kind var in
-      if not (Flambda_kind.equal kind Flambda_kind.value)
-      then
-        Misc.fatal_errorf "Value slot %a not of kind Value" Simple.print value;
+      let kind : Flambda_kind.Naked_number_kind.t option =
+        match Value_slot.kind var with
+        | Value -> None
+        | Naked_number naked_number_kind -> Some naked_number_kind
+        | (Region | Rec_info) as kind ->
+          Misc.fatal_errorf "Value slot %a of unexpected kind %a" Simple.print
+            value Flambda_kind.print kind
+      in
       let var = Env.translate_value_slot env var in
       let value = simple env value in
-      { Fexpr.var; value })
+      { Fexpr.var; value; kind })
     (map |> Value_slot.Map.bindings)
 
 let function_declaration env code_id function_slot alloc : Fexpr.fun_decl =

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -538,8 +538,13 @@ let value_slots expr_or_static ppf = function
   | Some ces ->
     Format.fprintf ppf "@ @[<hv2>%twith%t {" expr_or_static Flambda_colours.pop;
     pp_list ~sep:";"
-      (fun ppf ({ var; value } : one_value_slot) ->
-        Format.fprintf ppf "@ @[<hv2>%a =@ %a@]" value_slot var simple value)
+      (fun ppf ({ var; value; kind } : one_value_slot) ->
+        match kind with
+        | None ->
+          Format.fprintf ppf "@ @[<hv2>%a =@ %a@]" value_slot var simple value
+        | Some kind ->
+          Format.fprintf ppf "@ @[<hv2>%a :@ %a =@ %a@]" value_slot var
+            naked_number_kind kind simple value)
       ppf ces;
     Format.fprintf ppf "@;<1 -2>}@]"
 

--- a/middle_end/flambda2/reaper/field.ml
+++ b/middle_end/flambda2/reaper/field.ml
@@ -47,6 +47,7 @@ type view =
   | Call_witness of closure_entry_point
   | Is_int
   | Get_tag
+  | Boxed_number of Flambda_kind.Boxable_number.t
   | Return_of_call of return_kind
   | Code_id_of_call_witness
 
@@ -60,6 +61,7 @@ let hash_view = function
   | Return_of_call Exn -> 6
   | Return_of_call (Normal i) -> hash2 7 i
   | Code_id_of_call_witness -> 8
+  | Boxed_number bn -> hash2 9 (Flambda_kind.Boxable_number.hash bn)
 
 let equal_view v1 v2 =
   match v1, v2 with
@@ -73,10 +75,12 @@ let equal_view v1 v2 =
   | Get_tag, Get_tag
   | Code_id_of_call_witness, Code_id_of_call_witness ->
     true
+  | Boxed_number bn1, Boxed_number bn2 ->
+    Flambda_kind.Boxable_number.equal bn1 bn2
   | Return_of_call Exn, Return_of_call Exn -> true
   | Return_of_call (Normal i1), Return_of_call (Normal i2) -> i1 = i2
   | ( ( Block _ | Value_slot _ | Function_slot _ | Call_witness _ | Is_int
-      | Get_tag
+      | Get_tag | Boxed_number _
       | Return_of_call Exn
       | Return_of_call (Normal _)
       | Code_id_of_call_witness ),
@@ -91,6 +95,8 @@ let print_view ppf = function
     Format.fprintf ppf "Code %s" (closure_entry_point_to_string ep)
   | Is_int -> Format.fprintf ppf "Is_int"
   | Get_tag -> Format.fprintf ppf "Get_tag"
+  | Boxed_number bn ->
+    Format.fprintf ppf "Boxed_%a" Flambda_kind.Boxable_number.print_lowercase bn
   | Return_of_call (Normal i) -> Format.fprintf ppf "Apply (Normal %i)" i
   | Return_of_call Exn -> Format.fprintf ppf "Apply Exn"
   | Code_id_of_call_witness -> Format.fprintf ppf "Code_id_of_call_witness"
@@ -131,6 +137,8 @@ let is_int = create Is_int
 
 let get_tag = create Get_tag
 
+let boxed_number bn = create (Boxed_number bn)
+
 let normal_return_of_call n = create (Return_of_call (Normal n))
 
 let exn_return_of_call = create (Return_of_call Exn)
@@ -152,35 +160,38 @@ let kind t =
   | Value_slot vs -> Value_slot.kind vs
   | Function_slot _ -> Flambda_kind.value
   | Is_int | Get_tag -> Flambda_kind.naked_immediate
+  | Boxed_number bn -> Flambda_kind.Boxable_number.unboxed_kind bn
   | (Call_witness _ | Return_of_call _ | Code_id_of_call_witness) as view ->
     Misc.fatal_errorf "[field_kind] for virtual field %a" print_view view
 
 let is_value_slot t =
   match view t with
   | Value_slot _ -> true
-  | Block _ | Function_slot _ | Is_int | Get_tag | Call_witness _
-  | Return_of_call _ | Code_id_of_call_witness ->
+  | Block _ | Function_slot _ | Is_int | Get_tag | Boxed_number _
+  | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ->
     false
 
 let is_function_slot t =
   match view t with
   | Function_slot _ -> true
-  | Block _ | Value_slot _ | Is_int | Get_tag | Call_witness _
+  | Block _ | Value_slot _ | Is_int | Get_tag | Boxed_number _ | Call_witness _
   | Return_of_call _ | Code_id_of_call_witness ->
     false
 
 let is_real_field t =
   match view t with
   | Call_witness _ | Return_of_call _ | Code_id_of_call_witness -> false
-  | Is_int | Get_tag | Block _ | Value_slot _ | Function_slot _ -> true
+  | Is_int | Get_tag | Boxed_number _ | Block _ | Value_slot _ | Function_slot _
+    ->
+    true
 
 let is_virtual_field t = not (is_real_field t)
 
 let must_be_function_slot t =
   match view t with
   | Function_slot fs -> fs
-  | ( Block _ | Value_slot _ | Is_int | Get_tag | Call_witness _
-    | Return_of_call _ | Code_id_of_call_witness ) as view ->
+  | ( Block _ | Value_slot _ | Is_int | Get_tag | Boxed_number _
+    | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ) as view ->
     Misc.fatal_errorf "[must_be_function_slot] got %a instead" print_view view
 
 let is_local f =
@@ -192,7 +203,7 @@ let is_local f =
   | Function_slot fs ->
     Compilation_unit.is_current (Function_slot.get_compilation_unit fs)
   | Block _ | Call_witness _ | Return_of_call _ | Code_id_of_call_witness
-  | Is_int | Get_tag ->
+  | Is_int | Get_tag | Boxed_number _ ->
     false
 
 let debug_nostamps = lazy (Flambda_features.debug_reaper "nostamps")
@@ -207,6 +218,9 @@ let print_for_variable_name ppf x =
     | Value_slot s -> Format.fprintf ppf "%s" (Value_slot.name s)
     | Is_int -> Format.fprintf ppf "is_int"
     | Get_tag -> Format.fprintf ppf "tag"
+    | Boxed_number bn ->
+      Format.fprintf ppf "unboxed_%a"
+        Flambda_kind.Boxable_number.print_lowercase_short bn
     | Function_slot _ | Return_of_call _ | Code_id_of_call_witness
     | Call_witness _ ->
       Misc.fatal_errorf

--- a/middle_end/flambda2/reaper/field.mli
+++ b/middle_end/flambda2/reaper/field.mli
@@ -30,6 +30,9 @@ type view = private
   | Call_witness of closure_entry_point
   | Is_int
   | Get_tag
+  | Boxed_number of Flambda_kind.Boxable_number.t
+      (** The contents of a boxed number. Currently only created for boxed
+          int32, int64 and nativeint values (which are all custom blocks). *)
   | Return_of_call of return_kind
   | Code_id_of_call_witness
 
@@ -58,6 +61,8 @@ val function_slot : Function_slot.t -> t
 val is_int : t
 
 val get_tag : t
+
+val boxed_number : Flambda_kind.Boxable_number.t -> t
 
 (** {2 Virtual fields}
 

--- a/middle_end/flambda2/reaper/field.mli
+++ b/middle_end/flambda2/reaper/field.mli
@@ -31,8 +31,7 @@ type view = private
   | Is_int
   | Get_tag
   | Boxed_number of Flambda_kind.Boxable_number.t
-      (** The contents of a boxed number. Currently only created for boxed
-          int32, int64 and nativeint values. *)
+      (** The contents of a boxed number. *)
   | Return_of_call of return_kind
   | Code_id_of_call_witness
 

--- a/middle_end/flambda2/reaper/field.mli
+++ b/middle_end/flambda2/reaper/field.mli
@@ -32,7 +32,7 @@ type view = private
   | Get_tag
   | Boxed_number of Flambda_kind.Boxable_number.t
       (** The contents of a boxed number. Currently only created for boxed
-          int32, int64 and nativeint values (which are all custom blocks). *)
+          int32, int64 and nativeint values. *)
   | Return_of_call of return_kind
   | Code_id_of_call_witness
 

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -1538,12 +1538,19 @@ let rebuild_singleton_binding_which_is_being_unboxed env bv
         | Left simple -> bind_field_to_simple var simple hole
         | Right arg_fields -> bind_fields var (Unboxed arg_fields) hole)
       to_bind hole
-  | Prim (Unary (Box_number _, contents), _dbg) ->
+  | Prim (Unary (Box_number (prim_bn, _), contents), _dbg) ->
     Field.Map.fold
       (fun field (var : _ Unboxed_fields.u) hole ->
         let arg =
           match Field.view field with
-          | Boxed_number _ -> contents
+          | Boxed_number bn ->
+            if not (K.Boxable_number.equal bn prim_bn)
+            then
+              Misc.fatal_errorf
+                "Field %a does not match the kind of the [Box_number] \
+                 primitive when unboxing boxed number binding for %a"
+                Field.print field Bound_var.print bv;
+            contents
           | Block _ | Is_int | Get_tag | Value_slot _ | Function_slot _
           | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ->
             Misc.fatal_errorf

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -253,6 +253,23 @@ let bind_fields fields arg_fields hole =
         ~size_of_defining_expr:(Code_size.simple simple) ~body:hole)
     fields arg_fields hole
 
+(* Bind the variable of an unboxed field, which must not itself be further
+   unboxed, to the given simple. *)
+let bind_field_to_simple (var : _ Unboxed_fields.u) simple hole =
+  let var =
+    match var with
+    | Not_unboxed var -> var
+    | Unboxed _ -> Misc.fatal_errorf "Trying to unbox non-unboxable"
+  in
+  let bp =
+    Bound_pattern.singleton
+      (Bound_var.create var Flambda_debug_uid.none Name_mode.normal)
+    (* CR sspies: Missing debug uid. *)
+  in
+  RE.create_let bp
+    (Named.create_simple simple)
+    ~size_of_defining_expr:(Code_size.simple simple) ~body:hole
+
 let bound_vars_will_be_unboxed env bvs =
   List.exists
     (fun bv ->
@@ -449,7 +466,7 @@ let rewrite_set_of_closures env res ~(bound : Name.t list) ~is_phantom
         Field.Map.fold
           (fun field (uf : _ Unboxed_fields.u) value_slots ->
             match Field.view field with
-            | Is_int | Get_tag | Block _ ->
+            | Is_int | Get_tag | Block _ | Boxed_number _ ->
               Misc.fatal_errorf
                 "Unexpected field kind %a in closure representation rewrite \
                  for set of closures bound to [%a]"
@@ -743,6 +760,9 @@ let rebuild_named_default_case env (named : Named.t) =
     rewrite_field_access arg Field.is_int
   | Prim (Unary (Get_tag, arg), _dbg) when simple_is_unboxable env arg ->
     rewrite_field_access arg Field.get_tag
+  | Prim (Unary (Unbox_number bn, arg), _dbg) when simple_is_unboxable env arg
+    ->
+    rewrite_field_access arg (Field.boxed_number bn)
   | Prim (Unary (Block_load { kind; field; mut; _ }, arg), dbg)
     when simple_changed_repr env arg ->
     let kind = P.Block_access_kind.element_kind_for_load kind in
@@ -1508,28 +1528,30 @@ let rebuild_singleton_binding_which_is_being_unboxed env bv
             Left
               (Simple.untagged_const_int
                  (Tag.to_targetint_31_63 env.machine_width tag))
-          | Value_slot _ | Function_slot _ | Call_witness _ | Return_of_call _
-          | Code_id_of_call_witness ->
+          | Value_slot _ | Function_slot _ | Boxed_number _ | Call_witness _
+          | Return_of_call _ | Code_id_of_call_witness ->
             Misc.fatal_errorf
               "Unexpected field kind %a when unboxing block binding for %a"
               Field.print field Bound_var.print bv
         in
         match arg with
-        | Left simple ->
-          let var =
-            match var with
-            | Not_unboxed var -> var
-            | Unboxed _ -> Misc.fatal_errorf "Trying to unbox non-unboxable"
-          in
-          let bp =
-            Bound_pattern.singleton
-              (Bound_var.create var Flambda_debug_uid.none Name_mode.normal)
-            (* CR sspies: Missing debug uid. *)
-          in
-          RE.create_let bp
-            (Named.create_simple simple)
-            ~size_of_defining_expr:(Code_size.simple simple) ~body:hole
+        | Left simple -> bind_field_to_simple var simple hole
         | Right arg_fields -> bind_fields var (Unboxed arg_fields) hole)
+      to_bind hole
+  | Prim (Unary (Box_number _, contents), _dbg) ->
+    Field.Map.fold
+      (fun field (var : _ Unboxed_fields.u) hole ->
+        let arg =
+          match Field.view field with
+          | Boxed_number _ -> contents
+          | Block _ | Is_int | Get_tag | Value_slot _ | Function_slot _
+          | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ->
+            Misc.fatal_errorf
+              "Unexpected field kind %a when unboxing boxed number binding for \
+               %a"
+              Field.print field Bound_var.print bv
+        in
+        bind_field_to_simple var arg hole)
       to_bind hole
   | Prim (Unary (Block_load { field; kind; _ }, arg), dbg) ->
     let field =
@@ -1582,23 +1604,9 @@ let rebuild_set_of_closures_binding_which_is_being_unboxed env bvs
               let arg = Value_slot.Map.find value_slot value_slots in
               if simple_is_unboxable env arg
               then bind_fields var (Unboxed (get_simple_unboxable env arg)) hole
-              else
-                let var =
-                  match var with
-                  | Not_unboxed var -> var
-                  | Unboxed _ ->
-                    Misc.fatal_errorf "Trying to unbox non-unboxable"
-                in
-                let bp =
-                  Bound_pattern.singleton
-                    (Bound_var.create var Flambda_debug_uid.none
-                       Name_mode.normal)
-                  (* CR sspies: Missing debug uid. *)
-                in
-                RE.create_let bp (Named.create_simple arg)
-                  ~size_of_defining_expr:(Code_size.simple arg) ~body:hole
-            | Block _ | Is_int | Get_tag | Function_slot _ | Call_witness _
-            | Return_of_call _ | Code_id_of_call_witness ->
+              else bind_field_to_simple var arg hole
+            | Block _ | Is_int | Get_tag | Boxed_number _ | Function_slot _
+            | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ->
               Misc.fatal_errorf
                 "Unexpected field kind %a when unboxing set of closures \
                  binding for %a"
@@ -1692,8 +1700,8 @@ let rebuild_singleton_binding_whose_representation_is_being_changed env bp bv
                 (rewrite_simple env (Simple.const_one env.machine_width))
                 mp
             | Unboxed _ -> Misc.fatal_errorf "trying to unbox simple")
-          | Value_slot _ | Function_slot _ | Return_of_call _ | Call_witness _
-          | Code_id_of_call_witness ->
+          | Value_slot _ | Function_slot _ | Boxed_number _ | Return_of_call _
+          | Call_witness _ | Code_id_of_call_witness ->
             Misc.fatal_errorf
               "Unexpected field kind %a when rebuilding Make_block for %a \
                whose representation is being changed"

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -1895,6 +1895,19 @@ let rebuild_let_expr_singleton (env : env) res bv ~(defining_expr : Named.t)
       ( rebuild_make_block_default_case env bound_pattern ~block_kind
           ~mutability ~alloc_mode ~fields ~hole dbg,
         res )
+    | Flambda.Prim (Unary (Box_number (bn, _alloc_mode), _contents), _dbg)
+      when not
+             (Analysis.field_used env.uses
+                (Code_id_or_name.var (Bound_var.var bv))
+                (Field.boxed_number bn)) ->
+      (* The contents of the boxed number are never read, so the whole primitive
+         can be replaced by a poison value (as for the unused fields of blocks
+         in [rebuild_make_block_default_case]). *)
+      let simple = poison "reaper_unused_boxed_number" K.value in
+      ( RE.create_let bound_pattern
+          (Named.create_simple simple)
+          ~size_of_defining_expr:(Code_size.simple simple) ~body:hole,
+        res )
     | _ ->
       let defining_expr, size_of_defining_expr =
         rebuild_named_default_case env defining_expr

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -199,6 +199,22 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
     let name = Acc.simple_to_node acc ~denv arg in
     default_bp (fun to_ ->
         Acc.add_accessor_dep acc ~to_ Field.get_tag ~base:name)
+  | Unary
+      ( Box_number
+          (((Naked_int32 | Naked_int64 | Naked_nativeint) as bn), _alloc_mode),
+        contents ) ->
+    (* Boxed numbers are treated like blocks with a single field. Unlike blocks,
+       no [Is_int] or [Get_tag] fields are needed: those primitives arise from
+       matches on variants and are never applied to boxed numbers. *)
+    let from = Acc.simple_to_node acc ~denv contents in
+    default_bp (fun base ->
+        Acc.add_constructor_dep acc ~base (Field.boxed_number bn) ~from)
+  | Unary
+      (Unbox_number ((Naked_int32 | Naked_int64 | Naked_nativeint) as bn), arg)
+    ->
+    let name = Acc.simple_to_node acc ~denv arg in
+    default_bp (fun to_ ->
+        Acc.add_accessor_dep acc ~to_ (Field.boxed_number bn) ~base:name)
   | Nullary
       ( Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _
       | Dls_get | Tls_get | Domain_index | Poll | Cpu_relax )
@@ -208,7 +224,14 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
         | Is_null | Array_length _ | Bigarray_length _ | String_length _
         | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Float_arith _
         | Num_conv _ | Boolean_not | Reinterpret_64_bit_word _
-        | Reinterpret_boxed_vector | Unbox_number _ | Box_number _
+        | Reinterpret_boxed_vector
+        | Unbox_number
+            ( Naked_float | Naked_float32 | Naked_vec128 | Naked_vec256
+            | Naked_vec512 )
+        | Box_number
+            ( ( Naked_float | Naked_float32 | Naked_vec128 | Naked_vec256
+              | Naked_vec512 ),
+              _ )
         | Untag_immediate | Tag_immediate | Is_boxed_float | Is_flat_float_array
         | End_region _ | End_try_region _ | Obj_dup | Get_header | Peek _
         | Make_lazy _ ),

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -199,19 +199,14 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
     let name = Acc.simple_to_node acc ~denv arg in
     default_bp (fun to_ ->
         Acc.add_accessor_dep acc ~to_ Field.get_tag ~base:name)
-  | Unary
-      ( Box_number
-          (((Naked_int32 | Naked_int64 | Naked_nativeint) as bn), _alloc_mode),
-        contents ) ->
+  | Unary (Box_number (bn, _alloc_mode), contents) ->
     (* Boxed numbers are treated like blocks with a single field. Unlike blocks,
        no [Is_int] or [Get_tag] fields are needed: those primitives arise from
        matches on variants and are never applied to boxed numbers. *)
     let from = Acc.simple_to_node acc ~denv contents in
     default_bp (fun base ->
         Acc.add_constructor_dep acc ~base (Field.boxed_number bn) ~from)
-  | Unary
-      (Unbox_number ((Naked_int32 | Naked_int64 | Naked_nativeint) as bn), arg)
-    ->
+  | Unary (Unbox_number bn, arg) ->
     let name = Acc.simple_to_node acc ~denv arg in
     default_bp (fun to_ ->
         Acc.add_accessor_dep acc ~to_ (Field.boxed_number bn) ~base:name)
@@ -224,17 +219,9 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
         | Is_null | Array_length _ | Bigarray_length _ | String_length _
         | Int_as_pointer _ | Opaque_identity _ | Int_arith _ | Float_arith _
         | Num_conv _ | Boolean_not | Reinterpret_64_bit_word _
-        | Reinterpret_boxed_vector
-        | Unbox_number
-            ( Naked_float | Naked_float32 | Naked_vec128 | Naked_vec256
-            | Naked_vec512 )
-        | Box_number
-            ( ( Naked_float | Naked_float32 | Naked_vec128 | Naked_vec256
-              | Naked_vec512 ),
-              _ )
-        | Untag_immediate | Tag_immediate | Is_boxed_float | Is_flat_float_array
-        | End_region _ | End_try_region _ | Obj_dup | Get_header | Peek _
-        | Make_lazy _ ),
+        | Reinterpret_boxed_vector | Untag_immediate | Tag_immediate
+        | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
+        | Obj_dup | Get_header | Peek _ | Make_lazy _ ),
         _ )
   | Binary
       ( ( Block_set _ | Array_load _ | String_or_bigstring_load _

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -25,6 +25,7 @@ type 'a block_or_closure_fields =
         fields : (Flambda_kind.t * 'a) option list
       }
   | Closure_fields of 'a Value_slot.Map.t * 'a Function_slot.Map.t
+  | Boxed_number_field of Flambda_kind.Boxable_number.t * 'a
   | Block_and_closure_fields
 
 let classify_field_map fields =
@@ -33,6 +34,10 @@ let classify_field_map fields =
       (fun field x acc ->
         match acc with
         | `Block_and_closure_fields -> `Block_and_closure_fields
+        | `Boxed_number_field _ ->
+          (* A boxed number has a single field, so it cannot be combined with
+             any other field. *)
+          `Block_and_closure_fields
         | (`Block_fields _ | `Closure_fields _ | `Empty) as acc -> (
           let[@inline] block_fields k =
             let[@local] k is_int get_tag fields =
@@ -56,6 +61,10 @@ let classify_field_map fields =
           match Field.view field with
           | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ->
             `Block_and_closure_fields
+          | Boxed_number bn -> (
+            match acc with
+            | `Empty -> `Boxed_number_field (bn, x)
+            | `Block_fields _ | `Closure_fields _ -> `Block_and_closure_fields)
           | Value_slot vs ->
             closure_fields (fun ~value_slots ~function_slots ->
                 `Closure_fields
@@ -86,6 +95,7 @@ let classify_field_map fields =
   match r with
   | `Empty -> Empty
   | `Block_and_closure_fields -> Block_and_closure_fields
+  | `Boxed_number_field (bn, x) -> Boxed_number_field (bn, x)
   | `Closure_fields (vs, fs) -> Closure_fields (vs, fs)
   | `Block_fields (is_int, get_tag, fields) ->
     let n =
@@ -138,6 +148,15 @@ let[@inline] erase kind =
     Flambda_kind.With_subkind.Non_null_value_subkind.Anything
     (Flambda_kind.With_subkind.nullable kind)
 
+let rewrite_boxed_number_kind context usages kind bn =
+  (* The contents of boxed int32/int64/nativeint values are tracked via
+     [Boxed_number] fields. If the contents are read, the value must really be a
+     boxed number (in particular, it cannot have been replaced by a poison
+     value), so the subkind can be kept. *)
+  match PTA.get_one_field_usage context.db (Field.boxed_number bn) usages with
+  | Bottom -> erase kind
+  | Unknown | Ok _ -> kind
+
 let rec rewrite_kind_with_subkind_not_top_not_bottom context usages kind =
   (* CR ncourant: rewrite changed representation, or at least replace with Top.
      Not needed while we don't change representation of blocks. *)
@@ -145,13 +164,16 @@ let rec rewrite_kind_with_subkind_not_top_not_bottom context usages kind =
   | Anything -> kind
   | Tagged_immediate ->
     kind (* Always correct, since poison is a tagged immediate *)
-  | Boxed_float32 | Boxed_float | Boxed_int32 | Boxed_int64 | Boxed_nativeint
-  | Boxed_vec128 | Boxed_vec256 | Boxed_vec512 | Float_block _ | Float_array
-  | Immediate_array | Value_array | Generic_array | Unboxed_float32_array
-  | Untagged_int_array | Untagged_int8_array | Untagged_int16_array
-  | Unboxed_int32_array | Unboxed_int64_array | Unboxed_nativeint_array
-  | Unboxed_vec128_array | Unboxed_vec256_array | Unboxed_vec512_array
-  | Unboxed_product_array ->
+  | Boxed_int32 -> rewrite_boxed_number_kind context usages kind Naked_int32
+  | Boxed_int64 -> rewrite_boxed_number_kind context usages kind Naked_int64
+  | Boxed_nativeint ->
+    rewrite_boxed_number_kind context usages kind Naked_nativeint
+  | Boxed_float32 | Boxed_float | Boxed_vec128 | Boxed_vec256 | Boxed_vec512
+  | Float_block _ | Float_array | Immediate_array | Value_array | Generic_array
+  | Unboxed_float32_array | Untagged_int_array | Untagged_int8_array
+  | Untagged_int16_array | Unboxed_int32_array | Unboxed_int64_array
+  | Unboxed_nativeint_array | Unboxed_vec128_array | Unboxed_vec256_array
+  | Unboxed_vec512_array | Unboxed_product_array ->
     (* For all these subkinds, we don't track fields (for now). Thus, being in
        this case without being top or bottom means that we never use this
        particular value, but that it syntactically looks like it could be used.
@@ -310,7 +332,7 @@ module Rewriter = struct
             | Call_witness _ | Code_id_of_call_witness | Return_of_call _ ->
               (* Virtual fields *) ()
             | Function_slot _ -> (* Shortcut *) ()
-            | Block _ | Value_slot _ | Is_int | Get_tag -> (
+            | Block _ | Value_slot _ | Is_int | Get_tag | Boxed_number _ -> (
               let field_source =
                 PTA.get_single_field_source db unboxed_block field
               in
@@ -397,6 +419,15 @@ module Rewriter = struct
     | Empty | Block_and_closure_fields ->
       ( Field.Map.map (fun (_, unboxed_fields) -> forget unboxed_fields) combined,
         Pattern.any )
+    | Boxed_number_field (bn, use) ->
+      if Option.is_some patterns_for_function_slots
+      then
+        Misc.fatal_errorf
+          "[patterns_for_unboxed_fields] sees a boxed number but needs to bind \
+           function slots";
+      let field = Field.boxed_number bn in
+      let vars, pat = for_one_use field use in
+      Field.Map.singleton field vars, Pattern.boxed_number bn pat
     | Block_fields { is_int; get_tag; fields } ->
       if Option.is_some patterns_for_function_slots
       then

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -26,25 +26,25 @@ type 'a block_or_closure_fields =
       }
   | Closure_fields of 'a Value_slot.Map.t * 'a Function_slot.Map.t
   | Boxed_number_field of Flambda_kind.Boxable_number.t * 'a
-  | Block_and_closure_fields
+  | Fields_from_distinct_subkinds
 
 let classify_field_map fields =
   let r =
     Field.Map.fold
       (fun field x acc ->
         match acc with
-        | `Block_and_closure_fields -> `Block_and_closure_fields
+        | `Fields_from_distinct_subkinds -> `Fields_from_distinct_subkinds
         | `Boxed_number_field _ ->
           (* A boxed number has a single field, so it cannot be combined with
              any other field. *)
-          `Block_and_closure_fields
+          `Fields_from_distinct_subkinds
         | (`Block_fields _ | `Closure_fields _ | `Empty) as acc -> (
           let[@inline] block_fields k =
             let[@local] k is_int get_tag fields =
               (k [@inlined hint]) ~is_int ~get_tag ~fields
             in
             match acc with
-            | `Closure_fields _ -> `Block_and_closure_fields
+            | `Closure_fields _ -> `Fields_from_distinct_subkinds
             | `Block_fields (is_int, get_tag, fields) -> k is_int get_tag fields
             | `Empty -> k None None Numeric_types.Int.Map.empty
           in
@@ -55,16 +55,17 @@ let classify_field_map fields =
             match acc with
             | `Closure_fields (value_slots, function_slots) ->
               k value_slots function_slots
-            | `Block_fields _ -> `Block_and_closure_fields
+            | `Block_fields _ -> `Fields_from_distinct_subkinds
             | `Empty -> k Value_slot.Map.empty Function_slot.Map.empty
           in
           match Field.view field with
           | Call_witness _ | Return_of_call _ | Code_id_of_call_witness ->
-            `Block_and_closure_fields
+            `Fields_from_distinct_subkinds
           | Boxed_number bn -> (
             match acc with
             | `Empty -> `Boxed_number_field (bn, x)
-            | `Block_fields _ | `Closure_fields _ -> `Block_and_closure_fields)
+            | `Block_fields _ | `Closure_fields _ ->
+              `Fields_from_distinct_subkinds)
           | Value_slot vs ->
             closure_fields (fun ~value_slots ~function_slots ->
                 `Closure_fields
@@ -84,7 +85,7 @@ let classify_field_map fields =
           | Block (i, kind) ->
             block_fields (fun ~is_int ~get_tag ~fields ->
                 if Numeric_types.Int.Map.mem i fields
-                then `Block_and_closure_fields
+                then `Fields_from_distinct_subkinds
                 else
                   `Block_fields
                     ( is_int,
@@ -94,7 +95,7 @@ let classify_field_map fields =
   in
   match r with
   | `Empty -> Empty
-  | `Block_and_closure_fields -> Block_and_closure_fields
+  | `Fields_from_distinct_subkinds -> Fields_from_distinct_subkinds
   | `Boxed_number_field (bn, x) -> Boxed_number_field (bn, x)
   | `Closure_fields (vs, fs) -> Closure_fields (vs, fs)
   | `Block_fields (is_int, get_tag, fields) ->
@@ -152,7 +153,16 @@ let rewrite_boxed_number_kind context usages kind bn =
   (* The contents of boxed int32/int64/nativeint values are tracked via
      [Boxed_number] fields. If the contents are read, the value must really be a
      boxed number (in particular, it cannot have been replaced by a poison
-     value), so the subkind can be kept. *)
+     value), so the subkind can be kept.
+
+     Note that the [Bottom] case below is reachable even though this function is
+     only called for values with usages: the value's usages may all read a
+     different field, for example when the value flows into a parameter that is
+     also fed by values of a different shape and only the fields of those other
+     values are read. Such a read is invalid when it is reached with a value of
+     this kind, but not immediately invalid (it may be behind a branch), so the
+     value here can still have been replaced by a poison value and the subkind
+     must be erased. *)
   match PTA.get_one_field_usage context.db (Field.boxed_number bn) usages with
   | Bottom -> erase kind
   | Unknown | Ok _ -> kind
@@ -416,7 +426,7 @@ module Rewriter = struct
     match classify_field_map combined with
     | Empty when Option.is_some patterns_for_function_slots ->
       closure Value_slot.Map.empty
-    | Empty | Block_and_closure_fields ->
+    | Empty | Fields_from_distinct_subkinds ->
       ( Field.Map.map (fun (_, unboxed_fields) -> forget unboxed_fields) combined,
         Pattern.any )
     | Boxed_number_field (bn, use) ->

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -150,10 +150,10 @@ let[@inline] erase kind =
     (Flambda_kind.With_subkind.nullable kind)
 
 let rewrite_boxed_number_kind context usages kind bn =
-  (* The contents of boxed int32/int64/nativeint values are tracked via
-     [Boxed_number] fields. If the contents are read, the value must really be a
-     boxed number (in particular, it cannot have been replaced by a poison
-     value), so the subkind can be kept.
+  (* The contents of boxed numbers are tracked via [Boxed_number] fields. If the
+     contents are read, the value must really be a boxed number (in particular,
+     it cannot have been replaced by a poison value), so the subkind can be
+     kept.
 
      Note that the [Bottom] case below is reachable even though this function is
      only called for values with usages: the value's usages may all read a
@@ -174,11 +174,15 @@ let rec rewrite_kind_with_subkind_not_top_not_bottom context usages kind =
   | Anything -> kind
   | Tagged_immediate ->
     kind (* Always correct, since poison is a tagged immediate *)
+  | Boxed_float32 -> rewrite_boxed_number_kind context usages kind Naked_float32
+  | Boxed_float -> rewrite_boxed_number_kind context usages kind Naked_float
   | Boxed_int32 -> rewrite_boxed_number_kind context usages kind Naked_int32
   | Boxed_int64 -> rewrite_boxed_number_kind context usages kind Naked_int64
   | Boxed_nativeint ->
     rewrite_boxed_number_kind context usages kind Naked_nativeint
-  | Boxed_float32 | Boxed_float | Boxed_vec128 | Boxed_vec256 | Boxed_vec512
+  | Boxed_vec128 -> rewrite_boxed_number_kind context usages kind Naked_vec128
+  | Boxed_vec256 -> rewrite_boxed_number_kind context usages kind Naked_vec256
+  | Boxed_vec512 -> rewrite_boxed_number_kind context usages kind Naked_vec512
   | Float_block _ | Float_array | Immediate_array | Value_array | Generic_array
   | Unboxed_float32_array | Untagged_int_array | Untagged_int8_array
   | Untagged_int16_array | Unboxed_int32_array | Unboxed_int64_array

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -21,10 +21,11 @@
    have a unique allocation point for each of its uses that read from it.
    Formally, a value allocated at a given point $x$ can be unboxed if, for each
    usage $y$ of $x$ that reads from $x$ for one of the fields [Block],
-   [Value_slot], [Function_slot], [Is_int] or [Get_tag], (but not [Call_witness]
-   which connects the call witness which is not read at runtime from $x$, nor
-   [Apply] or [Code_id_of_call_witnes] which are only read from call witnesses),
-   $y$ has known sources, and the only source of $y$ is $x$.
+   [Value_slot], [Function_slot], [Is_int], [Get_tag] or [Boxed_number], (but
+   not [Call_witness] which connects the call witness which is not read at
+   runtime from $x$, nor [Apply] or [Code_id_of_call_witnes] which are only read
+   from call witnesses), $y$ has known sources, and the only source of $y$ is
+   $x$.
 
    In the case where $x$ has unknown usages, we can assume any field defined in
    $x$ that is not local might be read from it. As such, as soon as $x$ has a
@@ -368,13 +369,13 @@ let datalog_rules =
        [cannot_change_representation1 x] ==> cannot_change_representation x);
       (* Due to value_kinds rewriting not taking representation changes into
          account for now, blocks cannot have their representation changed, so we
-         prevent it here. *)
+         prevent it here. The same applies to boxed numbers. *)
       (let$ [x; field; y] = ["x"; "field"; "y"] in
        [ constructor ~base:x field ~from:y;
          when1
            (fun f ->
              match Field.view f with
-             | Block _ | Is_int | Get_tag -> true
+             | Block _ | Is_int | Get_tag | Boxed_number _ -> true
              | Value_slot _ | Function_slot _ | Call_witness _
              | Return_of_call _ | Code_id_of_call_witness ->
                false)
@@ -511,7 +512,7 @@ let rec mk_unboxed_fields ~has_to_be_unboxed ~mk db unboxed_block fields
         Misc.fatal_errorf "Unexpected field kind %a in [mk_unboxed_fields]"
           Field.print field
       | Call_witness _ -> None
-      | Block _ | Value_slot _ | Is_int | Get_tag -> (
+      | Block _ | Value_slot _ | Is_int | Get_tag | Boxed_number _ -> (
         let field_source = PTA.get_single_field_source db unboxed_block field in
         match field_source with
         | No_source -> None

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -369,7 +369,12 @@ let datalog_rules =
        [cannot_change_representation1 x] ==> cannot_change_representation x);
       (* Due to value_kinds rewriting not taking representation changes into
          account for now, blocks cannot have their representation changed, so we
-         prevent it here. The same applies to boxed numbers. *)
+         prevent it here. Boxed numbers are also prevented from changing their
+         representation, but for a different reason: since they only have a
+         single field, a representation change could never be useful. Either
+         that field is used, and no representation change is necessary, or it is
+         unused, and the whole boxed number should be replaced by a poison value
+         instead. *)
       (let$ [x; field; y] = ["x"; "field"; "y"] in
        [ constructor ~base:x field ~from:y;
          when1

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -1001,6 +1001,10 @@ module Rewriter : sig
     val function_slot : Function_slot.t -> 'a t -> 'a closure_field
 
     val closure : 'a closure_field list -> 'a t
+
+    (** [boxed_number bn t] matches a boxed number of the given kind, with [t]
+        matching the type of its (unboxed) contents. *)
+    val boxed_number : Flambda_kind.Boxable_number.t -> 'a t -> 'a t
   end
 
   type 'a expr

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -62,6 +62,7 @@ type discriminant =
   | Block of Tag.t option
   | Array
   | Closure
+  | Boxed_number of K.Boxable_number.t
 
 type accessor =
   | Untag_imm
@@ -72,6 +73,7 @@ type accessor =
   | Value_slot of Value_slot.t
   | Function_slot of Function_slot.t
   | Rec_info of Function_slot.t
+  | Unbox_number of K.Boxable_number.t
 
 module Accessor = struct
   module T0 = struct
@@ -100,6 +102,9 @@ module Accessor = struct
       | Rec_info function_slot ->
         Format.fprintf ppf "@[<hov 1>(rec_info@ %a)@]" Function_slot.print
           function_slot
+      | Unbox_number boxable_number ->
+        Format.fprintf ppf "@[<hov 1>(unbox_number@ %a)@]"
+          K.Boxable_number.print boxable_number
 
     let equal accessor1 accessor2 =
       match accessor1, accessor2 with
@@ -112,8 +117,9 @@ module Accessor = struct
       | Function_slot slot1, Function_slot slot2 ->
         Function_slot.equal slot1 slot2
       | Rec_info slot1, Rec_info slot2 -> Function_slot.equal slot1 slot2
+      | Unbox_number bn1, Unbox_number bn2 -> K.Boxable_number.equal bn1 bn2
       | ( ( Untag_imm | Is_int | Get_tag | Block_field _ | Array_field _
-          | Value_slot _ | Function_slot _ | Rec_info _ ),
+          | Value_slot _ | Function_slot _ | Rec_info _ | Unbox_number _ ),
           _ ) ->
         false
 
@@ -130,23 +136,27 @@ module Accessor = struct
       | Function_slot slot1, Function_slot slot2 ->
         Function_slot.compare slot1 slot2
       | Rec_info slot1, Rec_info slot2 -> Function_slot.compare slot1 slot2
+      | Unbox_number bn1, Unbox_number bn2 -> K.Boxable_number.compare bn1 bn2
       | ( Untag_imm,
           ( Is_int | Get_tag | Block_field _ | Array_field _ | Value_slot _
-          | Function_slot _ | Rec_info _ ) )
+          | Function_slot _ | Rec_info _ | Unbox_number _ ) )
       | ( Is_int,
           ( Get_tag | Block_field _ | Array_field _ | Value_slot _
-          | Function_slot _ | Rec_info _ ) )
+          | Function_slot _ | Rec_info _ | Unbox_number _ ) )
       | ( Get_tag,
           ( Block_field _ | Array_field _ | Value_slot _ | Function_slot _
-          | Rec_info _ ) )
+          | Rec_info _ | Unbox_number _ ) )
       | ( Block_field _,
-          (Array_field _ | Value_slot _ | Function_slot _ | Rec_info _) )
-      | Array_field _, (Value_slot _ | Function_slot _ | Rec_info _)
-      | Value_slot _, (Function_slot _ | Rec_info _)
-      | Function_slot _, Rec_info _ ->
+          ( Array_field _ | Value_slot _ | Function_slot _ | Rec_info _
+          | Unbox_number _ ) )
+      | ( Array_field _,
+          (Value_slot _ | Function_slot _ | Rec_info _ | Unbox_number _) )
+      | Value_slot _, (Function_slot _ | Rec_info _ | Unbox_number _)
+      | Function_slot _, (Rec_info _ | Unbox_number _)
+      | Rec_info _, Unbox_number _ ->
         -1
       | ( ( Is_int | Get_tag | Block_field _ | Array_field _ | Value_slot _
-          | Function_slot _ | Rec_info _ ),
+          | Function_slot _ | Rec_info _ | Unbox_number _ ),
           _ ) ->
         1
 
@@ -160,6 +170,8 @@ module Accessor = struct
       | Value_slot slot -> Hashtbl.hash (2, Value_slot.hash slot)
       | Function_slot slot -> Hashtbl.hash (3, Function_slot.hash slot)
       | Rec_info slot -> Hashtbl.hash (4, Function_slot.hash slot)
+      | Unbox_number boxable_number ->
+        Hashtbl.hash (5, K.Boxable_number.hash boxable_number)
   end
 
   include T0
@@ -174,6 +186,8 @@ let unknown_accessor ~machine_width = function
   | Function_slot function_slot ->
     MTC.unknown (Function_slot.kind function_slot)
   | Rec_info _ -> MTC.unknown K.rec_info
+  | Unbox_number boxable_number ->
+    MTC.unknown (K.Boxable_number.unboxed_kind boxable_number)
 
 let bottom_accessor ~machine_width accessor =
   MTC.bottom_like (unknown_accessor ~machine_width accessor)
@@ -284,9 +298,27 @@ and destructure_head_of_kind_value_non_null ~machine_width discriminant accessor
       | Bottom -> bottom_accessor ~machine_width accessor
       | Unknown -> unknown_accessor ~machine_width accessor
       | Ok function_type -> TG.Function_type.rec_info function_type))
-  | ( (Tagged_immediate | Block _ | Array | Closure),
+  | Boxed_number boxable_number, Unbox_number _, head -> (
+    match boxable_number, head with
+    | Naked_float32, Boxed_float32 (ty, _alloc_mode)
+    | Naked_float, Boxed_float (ty, _alloc_mode)
+    | Naked_int32, Boxed_int32 (ty, _alloc_mode)
+    | Naked_int64, Boxed_int64 (ty, _alloc_mode)
+    | Naked_nativeint, Boxed_nativeint (ty, _alloc_mode)
+    | Naked_vec128, Boxed_vec128 (ty, _alloc_mode)
+    | Naked_vec256, Boxed_vec256 (ty, _alloc_mode)
+    | Naked_vec512, Boxed_vec512 (ty, _alloc_mode) ->
+      ty
+    | ( ( Naked_float32 | Naked_float | Naked_int32 | Naked_int64
+        | Naked_nativeint | Naked_vec128 | Naked_vec256 | Naked_vec512 ),
+        ( Variant _ | Mutable_block _ | Boxed_float32 _ | Boxed_float _
+        | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _ | Boxed_vec128 _
+        | Boxed_vec256 _ | Boxed_vec512 _ | Closures _ | String _ | Array _ ) )
+      ->
+      bottom_accessor ~machine_width accessor)
+  | ( (Tagged_immediate | Block _ | Array | Closure | Boxed_number _),
       ( Untag_imm | Is_int | Get_tag | Block_field _ | Array_field _
-      | Value_slot _ | Function_slot _ | Rec_info _ ),
+      | Value_slot _ | Function_slot _ | Rec_info _ | Unbox_number _ ),
       ( Variant _ | Mutable_block _ | Boxed_float32 _ | Boxed_float _
       | Boxed_int32 _ | Boxed_int64 _ | Boxed_nativeint _ | Boxed_vec128 _
       | Boxed_vec256 _ | Boxed_vec512 _ | Closures _ | String _ | Array _ ) ) ->
@@ -405,6 +437,8 @@ module Pattern : sig
   val function_slot : Function_slot.t -> 'a t -> 'a closure_field
 
   val closure : 'a closure_field list -> 'a t
+
+  val boxed_number : K.Boxable_number.t -> 'a t -> 'a t
 end = struct
   type 'a t = 'a pattern
 
@@ -448,6 +482,10 @@ end = struct
   let array fields = unbox Array fields
 
   let closure fields = unbox Closure fields
+
+  let boxed_number boxable_number t =
+    unbox (Boxed_number boxable_number)
+      [accessor (Unbox_number boxable_number) t]
 end
 
 let rec fold_destructuring ~f destructuring env ty acc =

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -298,7 +298,11 @@ and destructure_head_of_kind_value_non_null ~machine_width discriminant accessor
       | Bottom -> bottom_accessor ~machine_width accessor
       | Unknown -> unknown_accessor ~machine_width accessor
       | Ok function_type -> TG.Function_type.rec_info function_type))
-  | Boxed_number boxable_number, Unbox_number _, head -> (
+  (* The type returned here must have the kind stored in the accessor (the
+     [Boxed_number] discriminant and [Unbox_number] accessor kinds always match
+     when built via [Pattern.boxed_number], but the accessor's kind is the
+     authoritative one). *)
+  | Boxed_number _, Unbox_number boxable_number, head -> (
     match boxable_number, head with
     | Naked_float32, Boxed_float32 (ty, _alloc_mode)
     | Naked_float, Boxed_float (ty, _alloc_mode)

--- a/middle_end/flambda2/types/traversals.mli
+++ b/middle_end/flambda2/types/traversals.mli
@@ -73,6 +73,10 @@ module Pattern : sig
   val function_slot : Function_slot.t -> 'a t -> 'a closure_field
 
   val closure : 'a closure_field list -> 'a t
+
+  (** [boxed_number bn t] matches a boxed number of the given kind, with [t]
+      matching the type of its (unboxed) contents. *)
+  val boxed_number : Flambda_kind.Boxable_number.t -> 'a t -> 'a t
 end
 
 type 'a expr

--- a/testsuite/tests/reaper/boxed_number_escape.ml
+++ b/testsuite/tests/reaper/boxed_number_escape.ml
@@ -1,0 +1,16 @@
+(* TEST
+   flambda2;
+   flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
+   { native with dump-reaper; check-fexpr-dump; }
+ *)
+
+(* [r] is exported by the .mli, so the store into it makes the boxed int64
+   escape: it must not be unboxed, and a [%box_num] operation must remain in
+   the output. *)
+
+let r = ref 0L
+
+let escape n =
+  let b = Int64.of_int n in
+  r := b;
+  Int64.to_int b

--- a/testsuite/tests/reaper/boxed_number_escape.ml
+++ b/testsuite/tests/reaper/boxed_number_escape.ml
@@ -1,12 +1,25 @@
 (* TEST
    flambda2;
    flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
-   { native with dump-reaper; check-fexpr-dump; }
+   {
+     flags += " -no-reaper-local-fields";
+     native with dump-reaper;
+     check-fexpr-dump;
+   }{
+     flags += " -reaper-local-fields";
+     fexpr_reference_suffix = "local-fields.reference";
+     native with dump-reaper;
+     check-fexpr-dump;
+   }
  *)
 
 (* [r] is exported by the .mli, so the store into it makes the boxed int64
    escape: it must not be unboxed, and a [%box_num] operation must remain in
-   the output. *)
+   the output.
+
+   The two configurations above need separate reference files: with
+   -reaper-local-fields, the representation of the (escaping) closure of
+   [escape] can still be changed, which renames its value slot. *)
 
 let r = ref 0L
 

--- a/testsuite/tests/reaper/boxed_number_escape.mli
+++ b/testsuite/tests/reaper/boxed_number_escape.mli
@@ -1,0 +1,3 @@
+val r : int64 ref
+
+val escape : int -> int

--- a/testsuite/tests/reaper/boxed_number_escape.reaper.local-fields.reference
+++ b/testsuite/tests/reaper/boxed_number_escape.reaper.local-fields.reference
@@ -1,0 +1,27 @@
+let code escape_0 deleted in
+let $camlBoxed_number_escape__int644 = 0L in
+let r = %block.mut.[`0`] ($camlBoxed_number_escape__int644) in
+let $camlBoxed_number_escape__escape_1 =
+  closure escape_0_1 @escape
+and code loopify(never) size(14) newer_version_of(escape_0)
+      escape_0_1 (n : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let r_1 =
+    %project_value_slot.[escape].[unboxed_field_r]
+      ($camlBoxed_number_escape__escape_1)
+  in
+  let prim = %untag_imm (n) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let b = %box_num.`int64` (prim_1) in
+  let Psetfield = %block_set.[`0`] (r_1, b) in
+  let prim_2 = %num_conv.[`int64`].[`imm`] (prim_1) in
+  let int_of_int64 = %tag_imm (prim_2) in
+  cont k (int_of_int64)
+  with { unboxed_field_r = r }
+in
+let $camlBoxed_number_escape =
+  Block 0 (r, $camlBoxed_number_escape__escape_1)
+in
+cont done ($camlBoxed_number_escape)

--- a/testsuite/tests/reaper/boxed_number_escape.reaper.reference
+++ b/testsuite/tests/reaper/boxed_number_escape.reaper.reference
@@ -1,0 +1,26 @@
+let code escape_0 deleted in
+let $camlBoxed_number_escape__int644 = 0L in
+let r = %block.mut.[`0`] ($camlBoxed_number_escape__int644) in
+let $camlBoxed_number_escape__escape_1 =
+  closure escape_0_1 @escape
+and code loopify(never) size(14) newer_version_of(escape_0)
+      escape_0_1 (n : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let r_1 =
+    %project_value_slot.[escape].[r] ($camlBoxed_number_escape__escape_1)
+  in
+  let prim = %untag_imm (n) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let b = %box_num.`int64` (prim_1) in
+  let Psetfield = %block_set.[`0`] (r_1, b) in
+  let prim_2 = %num_conv.[`int64`].[`imm`] (prim_1) in
+  let int_of_int64 = %tag_imm (prim_2) in
+  cont k (int_of_int64)
+  with { r = r }
+in
+let $camlBoxed_number_escape =
+  Block 0 (r, $camlBoxed_number_escape__escape_1)
+in
+cont done ($camlBoxed_number_escape)

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.ml
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.ml
@@ -1,0 +1,23 @@
+(* TEST
+   flambda2;
+   flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
+   { native with dump-simplify, dump-reaper; check-fexpr-dump; }
+ *)
+
+(* The continuation [joined] has a parameter [a] of value_kind boxed int32.
+   [a] has usages (its flow is merged with that of [b] inside [merge_usages]),
+   but none of those usages read the contents of an int32 box.  The reaper
+   must therefore erase the [boxed_int32] value_kind of [a], since the values
+   flowing into it may be replaced by poison values (which are not boxed
+   int32s). *)
+
+let f b x y =
+  let[@inline never] [@local never] merge_usages u = u in
+  let[@local] joined (a : int32) b =
+    let _ = merge_usages a in
+    let b = merge_usages b in
+    Int64.add b b
+  in
+  if b
+  then joined (Int32.add x x) (Int64.add y y)
+  else joined (Int32.mul x x) (Int64.mul y y)

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.mli
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.mli
@@ -1,0 +1,1 @@
+val f : bool -> int32 -> int64 -> int64

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
@@ -9,7 +9,7 @@ in
 let $camlBoxed_number_subkind_erasure__merge_usages_3 =
   closure merge_usages_1_1 @merge_usages
 in
-let code loopify(never) size(60) newer_version_of(f_0)
+let code loopify(never) size(50) newer_version_of(f_0)
       f_0_1 (b : imm tagged, x : int32 boxed, y : int64 boxed)
         my_closure _region _ghost_region my_depth
         -> k * k1
@@ -22,13 +22,13 @@ let code loopify(never) size(60) newer_version_of(f_0)
       let prim = %unbox_num.`int64` (y) in
       let prim_1 = %int_barith.`int64`.add (prim, prim) in
       let int64_add = %box_num.`int64` (prim_1) in
-      let int32_add = %box_num.`int32` (poison.int32.reaper_unused_name) in
+      let int32_add = poison.val.reaper_unused_boxed_number in
       cont k2 (int32_add, int64_add)
     where k3 =
       let prim = %unbox_num.`int64` (y) in
       let prim_1 = %int_barith.`int64`.mul (prim, prim) in
       let int64_mul = %box_num.`int64` (prim_1) in
-      let int32_mul = %box_num.`int32` (poison.int32.reaper_unused_name) in
+      let int32_mul = poison.val.reaper_unused_boxed_number in
       cont k2 (int32_mul, int64_mul)
     where k2 (a : val, b_1 : int64 boxed) =
       (apply direct(merge_usages_1_1)

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
@@ -1,0 +1,55 @@
+let code merge_usages_1 deleted in
+let code f_0 deleted in
+let code inline(never) loopify(never) size(1) newer_version_of(merge_usages_1)
+      merge_usages_1_1 (u)
+        my_closure _region _ghost_region my_depth
+        -> k * k1 =
+  cont k (u)
+in
+let $camlBoxed_number_subkind_erasure__merge_usages_3 =
+  closure merge_usages_1_1 @merge_usages
+in
+let code loopify(never) size(60) newer_version_of(f_0)
+      f_0_1 (b : imm tagged, x : int32 boxed, y : int64 boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : int64 boxed =
+  (let untagged = %untag_imm (b) in
+   switch untagged
+     | 0 -> k3
+     | 1 -> k4)
+    where k4 =
+      let prim = %unbox_num.`int64` (y) in
+      let prim_1 = %int_barith.`int64`.add (prim, prim) in
+      let int64_add = %box_num.`int64` (prim_1) in
+      let int32_add = %box_num.`int32` (poison.int32.reaper_unused_name) in
+      cont k2 (int32_add, int64_add)
+    where k3 =
+      let prim = %unbox_num.`int64` (y) in
+      let prim_1 = %int_barith.`int64`.mul (prim, prim) in
+      let int64_mul = %box_num.`int64` (prim_1) in
+      let int32_mul = %box_num.`int32` (poison.int32.reaper_unused_name) in
+      cont k2 (int32_mul, int64_mul)
+    where k2 (a : val, b_1 : int64 boxed) =
+      (apply direct(merge_usages_1_1)
+         $camlBoxed_number_subkind_erasure__merge_usages_3 (a) -> k4 * k1
+         where k4 (function_return_0_merge_usages_1) =
+           cont k3
+         where k3 =
+           cont k2
+         where k2 =
+           (apply direct(merge_usages_1_1)
+              $camlBoxed_number_subkind_erasure__merge_usages_3
+                (b_1)
+                -> k2 * k1
+              where k2 (b_2 : int64 boxed) =
+                let prim = %unbox_num.`int64` (b_2) in
+                let prim_1 = %int_barith.`int64`.add (prim, prim) in
+                let int64_add = %box_num.`int64` (prim_1) in
+                cont k (int64_add)))
+in
+let $camlBoxed_number_subkind_erasure__f_2 = closure f_0_1 @f in
+let $camlBoxed_number_subkind_erasure =
+  Block 0 ($camlBoxed_number_subkind_erasure__f_2)
+in
+cont done ($camlBoxed_number_subkind_erasure)

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.simplify.reference
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.simplify.reference
@@ -1,0 +1,61 @@
+let code merge_usages_1 deleted in
+let code f_0 deleted in
+let code inline(never) loopify(never) size(1) newer_version_of(merge_usages_1)
+      merge_usages_1_1 (u)
+        my_closure _region _ghost_region my_depth
+        -> k * k1 =
+  cont k (u)
+in
+let $camlBoxed_number_subkind_erasure__merge_usages_3 =
+  closure merge_usages_1_1 @merge_usages
+in
+let code loopify(never) size(65) newer_version_of(f_0)
+      f_0_1 (b : imm tagged, x : int32 boxed, y : int64 boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : int64 boxed =
+  (let untagged = %untag_imm (b) in
+   switch untagged
+     | 0 -> k3
+     | 1 -> k4)
+    where k4 =
+      let prim = %unbox_num.`int64` (y) in
+      let prim_1 = %int_barith.`int64`.add (prim, prim) in
+      let int64_add = %box_num.`int64` (prim_1) in
+      let prim_2 = %unbox_num.`int32` (x) in
+      let prim_3 = %int_barith.`int32`.add (prim_2, prim_2) in
+      let int32_add = %box_num.`int32` (prim_3) in
+      cont k2 (int32_add, int64_add)
+    where k3 =
+      let prim = %unbox_num.`int64` (y) in
+      let prim_1 = %int_barith.`int64`.mul (prim, prim) in
+      let int64_mul = %box_num.`int64` (prim_1) in
+      let prim_2 = %unbox_num.`int32` (x) in
+      let prim_3 = %int_barith.`int32`.mul (prim_2, prim_2) in
+      let int32_mul = %box_num.`int32` (prim_3) in
+      cont k2 (int32_mul, int64_mul)
+    where k2 (a : int32 boxed, b_1 : int64 boxed) =
+      (apply direct(merge_usages_1_1)
+         ($camlBoxed_number_subkind_erasure__merge_usages_3
+          : _ -> int32 boxed)
+           (a)
+           -> k3 * k1
+         where k3 (param) =
+           cont k2
+         where k2 =
+           (apply direct(merge_usages_1_1)
+              ($camlBoxed_number_subkind_erasure__merge_usages_3
+               : _ -> int64 boxed)
+                (b_1)
+                -> k2 * k1
+              where k2 (b_2 : int64 boxed) =
+                let prim = %unbox_num.`int64` (b_2) in
+                let prim_1 = %int_barith.`int64`.add (prim, prim) in
+                let int64_add = %box_num.`int64` (prim_1) in
+                cont k (int64_add)))
+in
+let $camlBoxed_number_subkind_erasure__f_2 = closure f_0_1 @f in
+let $camlBoxed_number_subkind_erasure =
+  Block 0 ($camlBoxed_number_subkind_erasure__f_2)
+in
+cont done ($camlBoxed_number_subkind_erasure)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.ml
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.ml
@@ -1,7 +1,7 @@
 (* TEST
    flambda2;
    flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
-   { native with dump-reaper; check-fexpr-dump; }
+   { native with dump-simplify, dump-reaper; check-fexpr-dump; }
  *)
 
 (* The .mli ensures that only the [test_*] functions escape, so the reaper is
@@ -28,6 +28,16 @@ let test_value_slot n =
   let b = Int64.of_int n in
   let[@inline never] [@local never] read () = Int64.to_int b in
   read () + 1
+
+(* As for [test_value_slot], but here the closure [read] is called indirectly
+   and so cannot itself be unboxed.  Its representation can however still be
+   changed: the boxed number's value slot is replaced by a value slot of kind
+   naked int64. *)
+let test_value_slot_not_unboxed n =
+  let b = Int64.of_int n in
+  let[@inline never] [@local never] read () = Int64.to_int b in
+  let[@inline never] [@local never] indirect read = read () in
+  indirect read + 1
 
 (* Boxed numbers inside an unboxed block: the pair is unboxed into its
    components, whose boxes are unboxed in turn (and the unused second

--- a/testsuite/tests/reaper/unbox_boxed_numbers.ml
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.ml
@@ -1,0 +1,38 @@
+(* TEST
+   flambda2;
+   flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
+   { native with dump-reaper; check-fexpr-dump; }
+ *)
+
+(* The .mli ensures that only the [test_*] functions escape, so the reaper is
+   able to change the calling conventions of the [add_*] and [read] functions
+   below and unbox the boxed numbers flowing through them.  There should be no
+   [%box_num] or [%unbox_num] operations left in the output. *)
+
+let[@inline never] [@local never] add_int64 x y = Int64.add x y
+
+let[@inline never] [@local never] add_int32 x y = Int32.add x y
+
+let[@inline never] [@local never] add_nativeint x y = Nativeint.add x y
+
+let test_int64 a b = Int64.to_int (add_int64 (Int64.of_int a) (Int64.of_int b))
+
+let test_int32 a b = Int32.to_int (add_int32 (Int32.of_int a) (Int32.of_int b))
+
+let test_nativeint a b =
+  Nativeint.to_int (add_nativeint (Nativeint.of_int a) (Nativeint.of_int b))
+
+(* A boxed number captured in a closure: the closure is unboxed, and the
+   contents of its value slot along with it. *)
+let test_value_slot n =
+  let b = Int64.of_int n in
+  let[@inline never] [@local never] read () = Int64.to_int b in
+  read () + 1
+
+(* Boxed numbers inside an unboxed block: the pair is unboxed into its
+   components, whose boxes are unboxed in turn (and the unused second
+   component is deleted entirely). *)
+let[@inline never] [@local never] pair_first (p : int64 * int64) =
+  Int64.to_int (fst p)
+
+let test_pair a b = pair_first (Int64.of_int a, Int64.of_int b)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.ml
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.ml
@@ -1,6 +1,6 @@
 (* TEST
    flambda2;
-   flags += "-flambda2-reaper -reaper-debug-flags=nostamps";
+   flags += "-flambda2-reaper -reaper-debug-flags=nostamps -extension small_numbers";
    { native with dump-simplify, dump-reaper; check-fexpr-dump; }
  *)
 
@@ -21,6 +21,21 @@ let test_int32 a b = Int32.to_int (add_int32 (Int32.of_int a) (Int32.of_int b))
 
 let test_nativeint a b =
   Nativeint.to_int (add_nativeint (Nativeint.of_int a) (Nativeint.of_int b))
+
+external float32_of_int : int -> float32 = "%float32ofint"
+
+external float32_to_int : float32 -> int = "%intoffloat32"
+
+external ( +$ ) : float32 -> float32 -> float32 = "%addfloat32"
+
+let[@inline never] [@local never] add_float x y = x +. y
+
+let[@inline never] [@local never] add_float32 x y = x +$ y
+
+let test_float a b = int_of_float (add_float (float_of_int a) (float_of_int b))
+
+let test_float32 a b =
+  float32_to_int (add_float32 (float32_of_int a) (float32_of_int b))
 
 (* A boxed number captured in a closure: the closure is unboxed, and the
    contents of its value slot along with it. *)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.mli
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.mli
@@ -6,4 +6,6 @@ val test_nativeint : int -> int -> int
 
 val test_value_slot : int -> int
 
+val test_value_slot_not_unboxed : int -> int
+
 val test_pair : int -> int -> int

--- a/testsuite/tests/reaper/unbox_boxed_numbers.mli
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.mli
@@ -4,6 +4,10 @@ val test_int32 : int -> int -> int
 
 val test_nativeint : int -> int -> int
 
+val test_float : int -> int -> int
+
+val test_float32 : int -> int -> int
+
 val test_value_slot : int -> int
 
 val test_value_slot_not_unboxed : int -> int

--- a/testsuite/tests/reaper/unbox_boxed_numbers.mli
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.mli
@@ -1,0 +1,9 @@
+val test_int64 : int -> int -> int
+
+val test_int32 : int -> int -> int
+
+val test_nativeint : int -> int -> int
+
+val test_value_slot : int -> int
+
+val test_pair : int -> int -> int

--- a/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
@@ -6,8 +6,11 @@ let code test_int32_4 deleted in
 let code test_nativeint_5 deleted in
 let code read_7 deleted in
 let code test_value_slot_6 deleted in
-let code pair_first_8 deleted in
-let code test_pair_9 deleted in
+let code read_9 deleted in
+let code indirect_10 deleted in
+let code test_value_slot_not_unboxed_8 deleted in
+let code pair_first_11 deleted in
+let code test_pair_12 deleted in
 let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
       add_int64_0_1
         (int64_of_int_into_x_field_unboxed_int64 : int64,
@@ -21,7 +24,7 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
   let int64_add_into_int64_add_field_unboxed_int64 = prim_2 in
   cont k (int64_add_into_int64_add_field_unboxed_int64)
 in
-let $camlUnbox_boxed_numbers__add_int64_10 = closure add_int64_0_1 @add_int64
+let $camlUnbox_boxed_numbers__add_int64_13 = closure add_int64_0_1 @add_int64
 in
 let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
       add_int32_1_1
@@ -36,7 +39,7 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
   let int32_add_into_int32_add_field_unboxed_int32 = prim_2 in
   cont k (int32_add_into_int32_add_field_unboxed_int32)
 in
-let $camlUnbox_boxed_numbers__add_int32_11 = closure add_int32_1_1 @add_int32
+let $camlUnbox_boxed_numbers__add_int32_14 = closure add_int32_1_1 @add_int32
 in
 let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
       add_nativeint_2_1
@@ -51,7 +54,7 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
   let nativeint_add_into_nativeint_add_field_unboxed_nativeint = prim_2 in
   cont k (nativeint_add_into_nativeint_add_field_unboxed_nativeint)
 in
-let $camlUnbox_boxed_numbers__add_nativeint_12 =
+let $camlUnbox_boxed_numbers__add_nativeint_15 =
   closure add_nativeint_2_1 @add_nativeint
 in
 let code loopify(never) size(9) newer_version_of(test_int64_3)
@@ -66,7 +69,7 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
    let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
    let int64_of_int_into_int64_of_int_field_unboxed_int64_1 = prim_3 in
    apply direct(add_int64_0_1)
-     ($camlUnbox_boxed_numbers__add_int64_10 : _ -> int64)
+     ($camlUnbox_boxed_numbers__add_int64_13 : _ -> int64)
        (int64_of_int_into_int64_of_int_field_unboxed_int64_1,
         int64_of_int_into_int64_of_int_field_unboxed_int64)
        -> k2 * k1)
@@ -76,7 +79,7 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
       let int_of_int64 = %tag_imm (prim_1) in
       cont k (int_of_int64)
 in
-let $camlUnbox_boxed_numbers__test_int64_13 =
+let $camlUnbox_boxed_numbers__test_int64_16 =
   closure test_int64_3_1 @test_int64
 in
 let code loopify(never) size(11) newer_version_of(test_int32_4)
@@ -91,7 +94,7 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
    let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
    let int32_of_int_into_int32_of_int_field_unboxed_int32_1 = prim_3 in
    apply direct(add_int32_1_1)
-     ($camlUnbox_boxed_numbers__add_int32_11 : _ -> int32)
+     ($camlUnbox_boxed_numbers__add_int32_14 : _ -> int32)
        (int32_of_int_into_int32_of_int_field_unboxed_int32_1,
         int32_of_int_into_int32_of_int_field_unboxed_int32)
        -> k2 * k1)
@@ -101,7 +104,7 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
       let int_of_int32 = %tag_imm (prim_1) in
       cont k (int_of_int32)
 in
-let $camlUnbox_boxed_numbers__test_int32_14 =
+let $camlUnbox_boxed_numbers__test_int32_17 =
   closure test_int32_4_1 @test_int32
 in
 let code loopify(never) size(10) newer_version_of(test_nativeint_5)
@@ -120,7 +123,7 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
      prim_3
    in
    apply direct(add_nativeint_2_1)
-     ($camlUnbox_boxed_numbers__add_nativeint_12 : _ -> nativeint)
+     ($camlUnbox_boxed_numbers__add_nativeint_15 : _ -> nativeint)
        (nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint_1,
         nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint)
        -> k2 * k1)
@@ -132,7 +135,7 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
       let int_of_nativeint = %tag_imm (prim_1) in
       cont k (int_of_nativeint)
 in
-let $camlUnbox_boxed_numbers__test_nativeint_15 =
+let $camlUnbox_boxed_numbers__test_nativeint_18 =
   closure test_nativeint_5_1 @test_nativeint
 in
 let code inline(never) loopify(never) size(3) newer_version_of(read_7)
@@ -167,11 +170,59 @@ let code loopify(never) size(10) newer_version_of(test_value_slot_6)
       let `unit` = %end_region (`region`) in
       cont k (int_add)
 in
-let $camlUnbox_boxed_numbers__test_value_slot_16 =
+let $camlUnbox_boxed_numbers__test_value_slot_19 =
   closure test_value_slot_6_1 @test_value_slot
 in
-let code inline(never) loopify(never) size(3) newer_version_of(pair_first_8)
-      pair_first_8_1 (Pmakeblock_into_p_field_0_field_unboxed_int64 : int64)
+let code inline(never) loopify(never) size(6) newer_version_of(indirect_10)
+      indirect_10_1 (read : val)
+        my_closure _region _ghost_region my_depth
+        -> k * k1 =
+  apply read (0) -> k * k1
+in
+let $camlUnbox_boxed_numbers__indirect_21 = closure indirect_10_1 @indirect
+in
+let code inline(never) loopify(never) size(4) newer_version_of(read_9)
+      read_9_1 (param : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let b_into_b_field_unboxed_int64 =
+    %project_value_slot.[read].[unboxed_field_b_field_unboxed_int64]
+      (my_closure)
+  in
+  let prim = b_into_b_field_unboxed_int64 in
+  let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+  let int_of_int64 = %tag_imm (prim_1) in
+  cont k (int_of_int64)
+in
+let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_8)
+      test_value_slot_not_unboxed_8_1 (n : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `region` = %begin_region () in
+  let prim = %untag_imm (n) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let b_into_b_field_unboxed_int64 = prim_1 in
+  let read = closure read_9_1 @read
+  with {
+    unboxed_field_b_field_unboxed_int64 :
+      int64 =
+      b_into_b_field_unboxed_int64
+  }
+  in
+  apply direct(indirect_10_1)
+    $camlUnbox_boxed_numbers__indirect_21 (read) -> k2 * k1
+    where k2 (apply_result : imm tagged) =
+      let int_add = %int_barith.add (apply_result, 1) in
+      let `unit` = %end_region (`region`) in
+      cont k (int_add)
+in
+let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20 =
+  closure test_value_slot_not_unboxed_8_1 @test_value_slot_not_unboxed
+in
+let code inline(never) loopify(never) size(3) newer_version_of(pair_first_11)
+      pair_first_11_1 (Pmakeblock_into_p_field_0_field_unboxed_int64 : int64)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -183,11 +234,11 @@ let code inline(never) loopify(never) size(3) newer_version_of(pair_first_8)
   let int_of_int64 = %tag_imm (prim_1) in
   cont k (int_of_int64)
 in
-let $camlUnbox_boxed_numbers__pair_first_17 =
-  closure pair_first_8_1 @pair_first
+let $camlUnbox_boxed_numbers__pair_first_22 =
+  closure pair_first_11_1 @pair_first
 in
-let code loopify(never) size(5) newer_version_of(test_pair_9)
-      test_pair_9_1 (a : imm tagged, b : imm tagged)
+let code loopify(never) size(5) newer_version_of(test_pair_12)
+      test_pair_12_1 (a : imm tagged, b : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -197,18 +248,20 @@ let code loopify(never) size(5) newer_version_of(test_pair_9)
   let Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64 =
     int64_of_int_into_int64_of_int_field_unboxed_int64
   in
-  apply direct(pair_first_8_1)
-    ($camlUnbox_boxed_numbers__pair_first_17 : _ -> imm tagged)
+  apply direct(pair_first_11_1)
+    ($camlUnbox_boxed_numbers__pair_first_22 : _ -> imm tagged)
       (Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64)
       -> k * k1
 in
-let $camlUnbox_boxed_numbers__test_pair_18 = closure test_pair_9_1 @test_pair
+let $camlUnbox_boxed_numbers__test_pair_23 =
+  closure test_pair_12_1 @test_pair
 in
 let $camlUnbox_boxed_numbers =
-  Block 0 ($camlUnbox_boxed_numbers__test_int64_13,
-           $camlUnbox_boxed_numbers__test_int32_14,
-           $camlUnbox_boxed_numbers__test_nativeint_15,
-           $camlUnbox_boxed_numbers__test_value_slot_16,
-           $camlUnbox_boxed_numbers__test_pair_18)
+  Block 0 ($camlUnbox_boxed_numbers__test_int64_16,
+           $camlUnbox_boxed_numbers__test_int32_17,
+           $camlUnbox_boxed_numbers__test_nativeint_18,
+           $camlUnbox_boxed_numbers__test_value_slot_19,
+           $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20,
+           $camlUnbox_boxed_numbers__test_pair_23)
 in
 cont done ($camlUnbox_boxed_numbers)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
@@ -1,0 +1,214 @@
+let code add_int64_0 deleted in
+let code add_int32_1 deleted in
+let code add_nativeint_2 deleted in
+let code test_int64_3 deleted in
+let code test_int32_4 deleted in
+let code test_nativeint_5 deleted in
+let code read_7 deleted in
+let code test_value_slot_6 deleted in
+let code pair_first_8 deleted in
+let code test_pair_9 deleted in
+let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
+      add_int64_0_1
+        (int64_of_int_into_x_field_unboxed_int64 : int64,
+         int64_of_int_into_y_field_unboxed_int64 : int64)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : int64 =
+  let prim = int64_of_int_into_y_field_unboxed_int64 in
+  let prim_1 = int64_of_int_into_x_field_unboxed_int64 in
+  let prim_2 = %int_barith.`int64`.add (prim_1, prim) in
+  let int64_add_into_int64_add_field_unboxed_int64 = prim_2 in
+  cont k (int64_add_into_int64_add_field_unboxed_int64)
+in
+let $camlUnbox_boxed_numbers__add_int64_10 = closure add_int64_0_1 @add_int64
+in
+let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
+      add_int32_1_1
+        (int32_of_int_into_x_field_unboxed_int32 : int32,
+         int32_of_int_into_y_field_unboxed_int32 : int32)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : int32 =
+  let prim = int32_of_int_into_y_field_unboxed_int32 in
+  let prim_1 = int32_of_int_into_x_field_unboxed_int32 in
+  let prim_2 = %int_barith.`int32`.add (prim_1, prim) in
+  let int32_add_into_int32_add_field_unboxed_int32 = prim_2 in
+  cont k (int32_add_into_int32_add_field_unboxed_int32)
+in
+let $camlUnbox_boxed_numbers__add_int32_11 = closure add_int32_1_1 @add_int32
+in
+let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
+      add_nativeint_2_1
+        (nativeint_of_int_into_x_field_unboxed_nativeint : nativeint,
+         nativeint_of_int_into_y_field_unboxed_nativeint : nativeint)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : nativeint =
+  let prim = nativeint_of_int_into_y_field_unboxed_nativeint in
+  let prim_1 = nativeint_of_int_into_x_field_unboxed_nativeint in
+  let prim_2 = %int_barith.`nativeint`.add (prim_1, prim) in
+  let nativeint_add_into_nativeint_add_field_unboxed_nativeint = prim_2 in
+  cont k (nativeint_add_into_nativeint_add_field_unboxed_nativeint)
+in
+let $camlUnbox_boxed_numbers__add_nativeint_12 =
+  closure add_nativeint_2_1 @add_nativeint
+in
+let code loopify(never) size(9) newer_version_of(test_int64_3)
+      test_int64_3_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+   let int64_of_int_into_int64_of_int_field_unboxed_int64 = prim_1 in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
+   let int64_of_int_into_int64_of_int_field_unboxed_int64_1 = prim_3 in
+   apply direct(add_int64_0_1)
+     ($camlUnbox_boxed_numbers__add_int64_10 : _ -> int64)
+       (int64_of_int_into_int64_of_int_field_unboxed_int64_1,
+        int64_of_int_into_int64_of_int_field_unboxed_int64)
+       -> k2 * k1)
+    where k2 (int64_add_into_apply_result_field_unboxed_int64 : int64) =
+      let prim = int64_add_into_apply_result_field_unboxed_int64 in
+      let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+      let int_of_int64 = %tag_imm (prim_1) in
+      cont k (int_of_int64)
+in
+let $camlUnbox_boxed_numbers__test_int64_13 =
+  closure test_int64_3_1 @test_int64
+in
+let code loopify(never) size(11) newer_version_of(test_int32_4)
+      test_int32_4_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`int32`] (prim) in
+   let int32_of_int_into_int32_of_int_field_unboxed_int32 = prim_1 in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
+   let int32_of_int_into_int32_of_int_field_unboxed_int32_1 = prim_3 in
+   apply direct(add_int32_1_1)
+     ($camlUnbox_boxed_numbers__add_int32_11 : _ -> int32)
+       (int32_of_int_into_int32_of_int_field_unboxed_int32_1,
+        int32_of_int_into_int32_of_int_field_unboxed_int32)
+       -> k2 * k1)
+    where k2 (int32_add_into_apply_result_field_unboxed_int32 : int32) =
+      let prim = int32_add_into_apply_result_field_unboxed_int32 in
+      let prim_1 = %num_conv.[`int32`].[`imm`] (prim) in
+      let int_of_int32 = %tag_imm (prim_1) in
+      cont k (int_of_int32)
+in
+let $camlUnbox_boxed_numbers__test_int32_14 =
+  closure test_int32_4_1 @test_int32
+in
+let code loopify(never) size(10) newer_version_of(test_nativeint_5)
+      test_nativeint_5_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`nativeint`] (prim) in
+   let nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint =
+     prim_1
+   in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`nativeint`] (prim_2) in
+   let nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint_1 =
+     prim_3
+   in
+   apply direct(add_nativeint_2_1)
+     ($camlUnbox_boxed_numbers__add_nativeint_12 : _ -> nativeint)
+       (nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint_1,
+        nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint)
+       -> k2 * k1)
+    where k2
+            (nativeint_add_into_apply_result_field_unboxed_nativeint :
+               nativeint) =
+      let prim = nativeint_add_into_apply_result_field_unboxed_nativeint in
+      let prim_1 = %num_conv.[`nativeint`].[`imm`] (prim) in
+      let int_of_nativeint = %tag_imm (prim_1) in
+      cont k (int_of_nativeint)
+in
+let $camlUnbox_boxed_numbers__test_nativeint_15 =
+  closure test_nativeint_5_1 @test_nativeint
+in
+let code inline(never) loopify(never) size(3) newer_version_of(read_7)
+      read_7_1 (read_into_my_closure_field_b_field_unboxed_int64 : int64)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let b_into_b_field_unboxed_int64 =
+    read_into_my_closure_field_b_field_unboxed_int64
+  in
+  let prim = b_into_b_field_unboxed_int64 in
+  let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+  let int_of_int64 = %tag_imm (prim_1) in
+  cont k (int_of_int64)
+in
+let code loopify(never) size(10) newer_version_of(test_value_slot_6)
+      test_value_slot_6_1 (n : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `region` = %begin_region () in
+  let prim = %untag_imm (n) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let b_into_b_field_unboxed_int64 = prim_1 in
+  let read_into_read_field_b_field_unboxed_int64 =
+    b_into_b_field_unboxed_int64
+  in
+  apply direct(read_7_1)
+     (read_into_read_field_b_field_unboxed_int64) -> k2 * k1
+    where k2 (apply_result : imm tagged) =
+      let int_add = %int_barith.add (apply_result, 1) in
+      let `unit` = %end_region (`region`) in
+      cont k (int_add)
+in
+let $camlUnbox_boxed_numbers__test_value_slot_16 =
+  closure test_value_slot_6_1 @test_value_slot
+in
+let code inline(never) loopify(never) size(3) newer_version_of(pair_first_8)
+      pair_first_8_1 (Pmakeblock_into_p_field_0_field_unboxed_int64 : int64)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let int64_of_int_into_Pfield_field_unboxed_int64 =
+    Pmakeblock_into_p_field_0_field_unboxed_int64
+  in
+  let prim = int64_of_int_into_Pfield_field_unboxed_int64 in
+  let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+  let int_of_int64 = %tag_imm (prim_1) in
+  cont k (int_of_int64)
+in
+let $camlUnbox_boxed_numbers__pair_first_17 =
+  closure pair_first_8_1 @pair_first
+in
+let code loopify(never) size(5) newer_version_of(test_pair_9)
+      test_pair_9_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let prim = %untag_imm (a) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let int64_of_int_into_int64_of_int_field_unboxed_int64 = prim_1 in
+  let Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64 =
+    int64_of_int_into_int64_of_int_field_unboxed_int64
+  in
+  apply direct(pair_first_8_1)
+    ($camlUnbox_boxed_numbers__pair_first_17 : _ -> imm tagged)
+      (Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64)
+      -> k * k1
+in
+let $camlUnbox_boxed_numbers__test_pair_18 = closure test_pair_9_1 @test_pair
+in
+let $camlUnbox_boxed_numbers =
+  Block 0 ($camlUnbox_boxed_numbers__test_int64_13,
+           $camlUnbox_boxed_numbers__test_int32_14,
+           $camlUnbox_boxed_numbers__test_nativeint_15,
+           $camlUnbox_boxed_numbers__test_value_slot_16,
+           $camlUnbox_boxed_numbers__test_pair_18)
+in
+cont done ($camlUnbox_boxed_numbers)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
@@ -4,13 +4,17 @@ let code add_nativeint_2 deleted in
 let code test_int64_3 deleted in
 let code test_int32_4 deleted in
 let code test_nativeint_5 deleted in
-let code read_7 deleted in
-let code test_value_slot_6 deleted in
-let code read_9 deleted in
-let code indirect_10 deleted in
-let code test_value_slot_not_unboxed_8 deleted in
-let code pair_first_11 deleted in
-let code test_pair_12 deleted in
+let code add_float_6 deleted in
+let code add_float32_7 deleted in
+let code test_float_8 deleted in
+let code test_float32_9 deleted in
+let code read_11 deleted in
+let code test_value_slot_10 deleted in
+let code read_13 deleted in
+let code indirect_14 deleted in
+let code test_value_slot_not_unboxed_12 deleted in
+let code pair_first_15 deleted in
+let code test_pair_16 deleted in
 let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
       add_int64_0_1
         (int64_of_int_into_x_field_unboxed_int64 : int64,
@@ -24,7 +28,7 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
   let int64_add_into_int64_add_field_unboxed_int64 = prim_2 in
   cont k (int64_add_into_int64_add_field_unboxed_int64)
 in
-let $camlUnbox_boxed_numbers__add_int64_13 = closure add_int64_0_1 @add_int64
+let $camlUnbox_boxed_numbers__add_int64_17 = closure add_int64_0_1 @add_int64
 in
 let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
       add_int32_1_1
@@ -39,7 +43,7 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
   let int32_add_into_int32_add_field_unboxed_int32 = prim_2 in
   cont k (int32_add_into_int32_add_field_unboxed_int32)
 in
-let $camlUnbox_boxed_numbers__add_int32_14 = closure add_int32_1_1 @add_int32
+let $camlUnbox_boxed_numbers__add_int32_18 = closure add_int32_1_1 @add_int32
 in
 let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
       add_nativeint_2_1
@@ -54,7 +58,7 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
   let nativeint_add_into_nativeint_add_field_unboxed_nativeint = prim_2 in
   cont k (nativeint_add_into_nativeint_add_field_unboxed_nativeint)
 in
-let $camlUnbox_boxed_numbers__add_nativeint_15 =
+let $camlUnbox_boxed_numbers__add_nativeint_19 =
   closure add_nativeint_2_1 @add_nativeint
 in
 let code loopify(never) size(9) newer_version_of(test_int64_3)
@@ -69,7 +73,7 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
    let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
    let int64_of_int_into_int64_of_int_field_unboxed_int64_1 = prim_3 in
    apply direct(add_int64_0_1)
-     ($camlUnbox_boxed_numbers__add_int64_13 : _ -> int64)
+     ($camlUnbox_boxed_numbers__add_int64_17 : _ -> int64)
        (int64_of_int_into_int64_of_int_field_unboxed_int64_1,
         int64_of_int_into_int64_of_int_field_unboxed_int64)
        -> k2 * k1)
@@ -79,7 +83,7 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
       let int_of_int64 = %tag_imm (prim_1) in
       cont k (int_of_int64)
 in
-let $camlUnbox_boxed_numbers__test_int64_16 =
+let $camlUnbox_boxed_numbers__test_int64_20 =
   closure test_int64_3_1 @test_int64
 in
 let code loopify(never) size(11) newer_version_of(test_int32_4)
@@ -94,7 +98,7 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
    let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
    let int32_of_int_into_int32_of_int_field_unboxed_int32_1 = prim_3 in
    apply direct(add_int32_1_1)
-     ($camlUnbox_boxed_numbers__add_int32_14 : _ -> int32)
+     ($camlUnbox_boxed_numbers__add_int32_18 : _ -> int32)
        (int32_of_int_into_int32_of_int_field_unboxed_int32_1,
         int32_of_int_into_int32_of_int_field_unboxed_int32)
        -> k2 * k1)
@@ -104,7 +108,7 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
       let int_of_int32 = %tag_imm (prim_1) in
       cont k (int_of_int32)
 in
-let $camlUnbox_boxed_numbers__test_int32_17 =
+let $camlUnbox_boxed_numbers__test_int32_21 =
   closure test_int32_4_1 @test_int32
 in
 let code loopify(never) size(10) newer_version_of(test_nativeint_5)
@@ -123,7 +127,7 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
      prim_3
    in
    apply direct(add_nativeint_2_1)
-     ($camlUnbox_boxed_numbers__add_nativeint_15 : _ -> nativeint)
+     ($camlUnbox_boxed_numbers__add_nativeint_19 : _ -> nativeint)
        (nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint_1,
         nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint)
        -> k2 * k1)
@@ -135,11 +139,92 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
       let int_of_nativeint = %tag_imm (prim_1) in
       cont k (int_of_nativeint)
 in
-let $camlUnbox_boxed_numbers__test_nativeint_18 =
+let $camlUnbox_boxed_numbers__test_nativeint_22 =
   closure test_nativeint_5_1 @test_nativeint
 in
-let code inline(never) loopify(never) size(3) newer_version_of(read_7)
-      read_7_1 (read_into_my_closure_field_b_field_unboxed_int64 : int64)
+let code inline(never) loopify(never) size(3) newer_version_of(add_float_6)
+      add_float_6_1
+        (float_of_int_into_x_field_unboxed_float : float,
+         float_of_int_into_y_field_unboxed_float : float)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : float =
+  let prim = float_of_int_into_y_field_unboxed_float in
+  let prim_1 = float_of_int_into_x_field_unboxed_float in
+  let prim_2 = %bfloat_arith.add (prim_1, prim) in
+  let float_add_into_float_add_field_unboxed_float = prim_2 in
+  cont k (float_add_into_float_add_field_unboxed_float)
+in
+let $camlUnbox_boxed_numbers__add_float_23 = closure add_float_6_1 @add_float
+in
+let code inline(never) loopify(never) size(3) newer_version_of(add_float32_7)
+      add_float32_7_1
+        (float32_of_int_into_x_field_unboxed_float32 : float32,
+         float32_of_int_into_y_field_unboxed_float32 : float32)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : float32 =
+  let prim = float32_of_int_into_y_field_unboxed_float32 in
+  let prim_1 = float32_of_int_into_x_field_unboxed_float32 in
+  let prim_2 = %bfloat_arith.`float32`.add (prim_1, prim) in
+  let float32_add_into_float32_add_field_unboxed_float32 = prim_2 in
+  cont k (float32_add_into_float32_add_field_unboxed_float32)
+in
+let $camlUnbox_boxed_numbers__add_float32_24 =
+  closure add_float32_7_1 @add_float32
+in
+let code loopify(never) size(12) newer_version_of(test_float_8)
+      test_float_8_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`float`] (prim) in
+   let float_of_int_into_float_of_int_field_unboxed_float = prim_1 in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`float`] (prim_2) in
+   let float_of_int_into_float_of_int_field_unboxed_float_1 = prim_3 in
+   apply direct(add_float_6_1)
+     ($camlUnbox_boxed_numbers__add_float_23 : _ -> float)
+       (float_of_int_into_float_of_int_field_unboxed_float_1,
+        float_of_int_into_float_of_int_field_unboxed_float)
+       -> k2 * k1)
+    where k2 (float_add_into_apply_result_field_unboxed_float : float) =
+      let prim = float_add_into_apply_result_field_unboxed_float in
+      let prim_1 = %num_conv.[`float`].[`imm`] (prim) in
+      let int_of_float = %tag_imm (prim_1) in
+      cont k (int_of_float)
+in
+let $camlUnbox_boxed_numbers__test_float_25 =
+  closure test_float_8_1 @test_float
+in
+let code loopify(never) size(12) newer_version_of(test_float32_9)
+      test_float32_9_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`float32`] (prim) in
+   let float32_of_int_into_float32_of_int_field_unboxed_float32 = prim_1 in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`float32`] (prim_2) in
+   let float32_of_int_into_float32_of_int_field_unboxed_float32_1 = prim_3 in
+   apply direct(add_float32_7_1)
+     ($camlUnbox_boxed_numbers__add_float32_24 : _ -> float32)
+       (float32_of_int_into_float32_of_int_field_unboxed_float32_1,
+        float32_of_int_into_float32_of_int_field_unboxed_float32)
+       -> k2 * k1)
+    where k2 (float32_add_into_apply_result_field_unboxed_float32 : float32) =
+      let prim = float32_add_into_apply_result_field_unboxed_float32 in
+      let prim_1 = %num_conv.[`float32`].[`imm`] (prim) in
+      let int_of_float32 = %tag_imm (prim_1) in
+      cont k (int_of_float32)
+in
+let $camlUnbox_boxed_numbers__test_float32_26 =
+  closure test_float32_9_1 @test_float32
+in
+let code inline(never) loopify(never) size(3) newer_version_of(read_11)
+      read_11_1 (read_into_my_closure_field_b_field_unboxed_int64 : int64)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -151,8 +236,8 @@ let code inline(never) loopify(never) size(3) newer_version_of(read_7)
   let int_of_int64 = %tag_imm (prim_1) in
   cont k (int_of_int64)
 in
-let code loopify(never) size(10) newer_version_of(test_value_slot_6)
-      test_value_slot_6_1 (n : imm tagged)
+let code loopify(never) size(10) newer_version_of(test_value_slot_10)
+      test_value_slot_10_1 (n : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -163,26 +248,26 @@ let code loopify(never) size(10) newer_version_of(test_value_slot_6)
   let read_into_read_field_b_field_unboxed_int64 =
     b_into_b_field_unboxed_int64
   in
-  apply direct(read_7_1)
+  apply direct(read_11_1)
      (read_into_read_field_b_field_unboxed_int64) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
       cont k (int_add)
 in
-let $camlUnbox_boxed_numbers__test_value_slot_19 =
-  closure test_value_slot_6_1 @test_value_slot
+let $camlUnbox_boxed_numbers__test_value_slot_27 =
+  closure test_value_slot_10_1 @test_value_slot
 in
-let code inline(never) loopify(never) size(6) newer_version_of(indirect_10)
-      indirect_10_1 (read : val)
+let code inline(never) loopify(never) size(6) newer_version_of(indirect_14)
+      indirect_14_1 (read : val)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   apply read (0) -> k * k1
 in
-let $camlUnbox_boxed_numbers__indirect_21 = closure indirect_10_1 @indirect
+let $camlUnbox_boxed_numbers__indirect_29 = closure indirect_14_1 @indirect
 in
-let code inline(never) loopify(never) size(4) newer_version_of(read_9)
-      read_9_1 (param : imm tagged)
+let code inline(never) loopify(never) size(4) newer_version_of(read_13)
+      read_13_1 (param : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -195,8 +280,8 @@ let code inline(never) loopify(never) size(4) newer_version_of(read_9)
   let int_of_int64 = %tag_imm (prim_1) in
   cont k (int_of_int64)
 in
-let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_8)
-      test_value_slot_not_unboxed_8_1 (n : imm tagged)
+let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_12)
+      test_value_slot_not_unboxed_12_1 (n : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -204,25 +289,25 @@ let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_8)
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
   let b_into_b_field_unboxed_int64 = prim_1 in
-  let read = closure read_9_1 @read
+  let read = closure read_13_1 @read
   with {
     unboxed_field_b_field_unboxed_int64 :
       int64 =
       b_into_b_field_unboxed_int64
   }
   in
-  apply direct(indirect_10_1)
-    $camlUnbox_boxed_numbers__indirect_21 (read) -> k2 * k1
+  apply direct(indirect_14_1)
+    $camlUnbox_boxed_numbers__indirect_29 (read) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
       cont k (int_add)
 in
-let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20 =
-  closure test_value_slot_not_unboxed_8_1 @test_value_slot_not_unboxed
+let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_28 =
+  closure test_value_slot_not_unboxed_12_1 @test_value_slot_not_unboxed
 in
-let code inline(never) loopify(never) size(3) newer_version_of(pair_first_11)
-      pair_first_11_1 (Pmakeblock_into_p_field_0_field_unboxed_int64 : int64)
+let code inline(never) loopify(never) size(3) newer_version_of(pair_first_15)
+      pair_first_15_1 (Pmakeblock_into_p_field_0_field_unboxed_int64 : int64)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -234,11 +319,11 @@ let code inline(never) loopify(never) size(3) newer_version_of(pair_first_11)
   let int_of_int64 = %tag_imm (prim_1) in
   cont k (int_of_int64)
 in
-let $camlUnbox_boxed_numbers__pair_first_22 =
-  closure pair_first_11_1 @pair_first
+let $camlUnbox_boxed_numbers__pair_first_30 =
+  closure pair_first_15_1 @pair_first
 in
-let code loopify(never) size(5) newer_version_of(test_pair_12)
-      test_pair_12_1 (a : imm tagged, b : imm tagged)
+let code loopify(never) size(5) newer_version_of(test_pair_16)
+      test_pair_16_1 (a : imm tagged, b : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -248,20 +333,22 @@ let code loopify(never) size(5) newer_version_of(test_pair_12)
   let Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64 =
     int64_of_int_into_int64_of_int_field_unboxed_int64
   in
-  apply direct(pair_first_11_1)
-    ($camlUnbox_boxed_numbers__pair_first_22 : _ -> imm tagged)
+  apply direct(pair_first_15_1)
+    ($camlUnbox_boxed_numbers__pair_first_30 : _ -> imm tagged)
       (Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64)
       -> k * k1
 in
-let $camlUnbox_boxed_numbers__test_pair_23 =
-  closure test_pair_12_1 @test_pair
+let $camlUnbox_boxed_numbers__test_pair_31 =
+  closure test_pair_16_1 @test_pair
 in
 let $camlUnbox_boxed_numbers =
-  Block 0 ($camlUnbox_boxed_numbers__test_int64_16,
-           $camlUnbox_boxed_numbers__test_int32_17,
-           $camlUnbox_boxed_numbers__test_nativeint_18,
-           $camlUnbox_boxed_numbers__test_value_slot_19,
-           $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20,
-           $camlUnbox_boxed_numbers__test_pair_23)
+  Block 0 ($camlUnbox_boxed_numbers__test_int64_20,
+           $camlUnbox_boxed_numbers__test_int32_21,
+           $camlUnbox_boxed_numbers__test_nativeint_22,
+           $camlUnbox_boxed_numbers__test_float_25,
+           $camlUnbox_boxed_numbers__test_float32_26,
+           $camlUnbox_boxed_numbers__test_value_slot_27,
+           $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_28,
+           $camlUnbox_boxed_numbers__test_pair_31)
 in
 cont done ($camlUnbox_boxed_numbers)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
@@ -1,0 +1,239 @@
+let code add_int64_0 deleted in
+let code add_int32_1 deleted in
+let code add_nativeint_2 deleted in
+let code test_int64_3 deleted in
+let code test_int32_4 deleted in
+let code test_nativeint_5 deleted in
+let code read_7 deleted in
+let code test_value_slot_6 deleted in
+let code read_9 deleted in
+let code indirect_10 deleted in
+let code test_value_slot_not_unboxed_8 deleted in
+let code pair_first_11 deleted in
+let code test_pair_12 deleted in
+let code inline(never) loopify(never) size(11) newer_version_of(add_int64_0)
+      add_int64_0_1 (x : int64 boxed, y : int64 boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : int64 boxed =
+  let prim = %unbox_num.`int64` (y) in
+  let prim_1 = %unbox_num.`int64` (x) in
+  let prim_2 = %int_barith.`int64`.add (prim_1, prim) in
+  let int64_add = %box_num.`int64` (prim_2) in
+  cont k (int64_add)
+in
+let $camlUnbox_boxed_numbers__add_int64_13 = closure add_int64_0_1 @add_int64
+in
+let code inline(never) loopify(never) size(12) newer_version_of(add_int32_1)
+      add_int32_1_1 (x : int32 boxed, y : int32 boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : int32 boxed =
+  let prim = %unbox_num.`int32` (y) in
+  let prim_1 = %unbox_num.`int32` (x) in
+  let prim_2 = %int_barith.`int32`.add (prim_1, prim) in
+  let int32_add = %box_num.`int32` (prim_2) in
+  cont k (int32_add)
+in
+let $camlUnbox_boxed_numbers__add_int32_14 = closure add_int32_1_1 @add_int32
+in
+let code inline(never) loopify(never) size(11) newer_version_of(add_nativeint_2)
+      add_nativeint_2_1 (x : nativeint boxed, y : nativeint boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : nativeint boxed =
+  let prim = %unbox_num.`nativeint` (y) in
+  let prim_1 = %unbox_num.`nativeint` (x) in
+  let prim_2 = %int_barith.`nativeint`.add (prim_1, prim) in
+  let nativeint_add = %box_num.`nativeint` (prim_2) in
+  cont k (nativeint_add)
+in
+let $camlUnbox_boxed_numbers__add_nativeint_15 =
+  closure add_nativeint_2_1 @add_nativeint
+in
+let code loopify(never) size(21) newer_version_of(test_int64_3)
+      test_int64_3_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+   let int64_of_int = %box_num.`int64` (prim_1) in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
+   let int64_of_int_1 = %box_num.`int64` (prim_3) in
+   apply direct(add_int64_0_1)
+     ($camlUnbox_boxed_numbers__add_int64_13 : _ -> int64 boxed)
+       (int64_of_int_1, int64_of_int)
+       -> k2 * k1)
+    where k2 (apply_result : int64 boxed) =
+      let prim = %unbox_num.`int64` (apply_result) in
+      let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+      let int_of_int64 = %tag_imm (prim_1) in
+      cont k (int_of_int64)
+in
+let $camlUnbox_boxed_numbers__test_int64_16 =
+  closure test_int64_3_1 @test_int64
+in
+let code loopify(never) size(25) newer_version_of(test_int32_4)
+      test_int32_4_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`int32`] (prim) in
+   let int32_of_int = %box_num.`int32` (prim_1) in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
+   let int32_of_int_1 = %box_num.`int32` (prim_3) in
+   apply direct(add_int32_1_1)
+     ($camlUnbox_boxed_numbers__add_int32_14 : _ -> int32 boxed)
+       (int32_of_int_1, int32_of_int)
+       -> k2 * k1)
+    where k2 (apply_result : int32 boxed) =
+      let prim = %unbox_num.`int32` (apply_result) in
+      let prim_1 = %num_conv.[`int32`].[`imm`] (prim) in
+      let int_of_int32 = %tag_imm (prim_1) in
+      cont k (int_of_int32)
+in
+let $camlUnbox_boxed_numbers__test_int32_17 =
+  closure test_int32_4_1 @test_int32
+in
+let code loopify(never) size(22) newer_version_of(test_nativeint_5)
+      test_nativeint_5_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`nativeint`] (prim) in
+   let nativeint_of_int = %box_num.`nativeint` (prim_1) in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`nativeint`] (prim_2) in
+   let nativeint_of_int_1 = %box_num.`nativeint` (prim_3) in
+   apply direct(add_nativeint_2_1)
+     ($camlUnbox_boxed_numbers__add_nativeint_15 : _ -> nativeint boxed)
+       (nativeint_of_int_1, nativeint_of_int)
+       -> k2 * k1)
+    where k2 (apply_result : nativeint boxed) =
+      let prim = %unbox_num.`nativeint` (apply_result) in
+      let prim_1 = %num_conv.[`nativeint`].[`imm`] (prim) in
+      let int_of_nativeint = %tag_imm (prim_1) in
+      cont k (int_of_nativeint)
+in
+let $camlUnbox_boxed_numbers__test_nativeint_18 =
+  closure test_nativeint_5_1 @test_nativeint
+in
+let code inline(never) loopify(never) size(6) newer_version_of(read_7)
+      read_7_1 (param : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let b = %project_value_slot.[read].[b] (my_closure) in
+  let prim = %unbox_num.`int64` (b) in
+  let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+  let int_of_int64 = %tag_imm (prim_1) in
+  cont k (int_of_int64)
+in
+let code loopify(never) size(29) newer_version_of(test_value_slot_6)
+      test_value_slot_6_1 (n : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `region` = %begin_region () in
+  let prim = %untag_imm (n) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let b = %box_num.`int64`.`local`[`region`] (prim_1) in
+  let read = closure read_7_1 @read with { b = b } in
+  apply direct(read_7_1) (read : _ -> imm tagged) (0) -> k2 * k1
+    where k2 (apply_result : imm tagged) =
+      let int_add = %int_barith.add (apply_result, 1) in
+      let `unit` = %end_region (`region`) in
+      cont k (int_add)
+in
+let $camlUnbox_boxed_numbers__test_value_slot_19 =
+  closure test_value_slot_6_1 @test_value_slot
+in
+let code inline(never) loopify(never) size(6) newer_version_of(indirect_10)
+      indirect_10_1 (read : val)
+        my_closure _region _ghost_region my_depth
+        -> k * k1 =
+  apply read (0) -> k * k1
+in
+let $camlUnbox_boxed_numbers__indirect_21 = closure indirect_10_1 @indirect
+in
+let code inline(never) loopify(never) size(6) newer_version_of(read_9)
+      read_9_1 (param : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let b = %project_value_slot.[read_1].[b_1] (my_closure) in
+  let prim = %unbox_num.`int64` (b) in
+  let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+  let int_of_int64 = %tag_imm (prim_1) in
+  cont k (int_of_int64)
+in
+let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_8)
+      test_value_slot_not_unboxed_8_1 (n : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let `region` = %begin_region () in
+  let prim = %untag_imm (n) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let b = %box_num.`int64`.`local`[`region`] (prim_1) in
+  let read = closure read_9_1 @read_1 with { b_1 = b } in
+  apply direct(indirect_10_1)
+    ($camlUnbox_boxed_numbers__indirect_21 : _ -> imm tagged)
+      (read)
+      -> k2 * k1
+    where k2 (apply_result : imm tagged) =
+      let int_add = %int_barith.add (apply_result, 1) in
+      let `unit` = %end_region (`region`) in
+      cont k (int_add)
+in
+let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20 =
+  closure test_value_slot_not_unboxed_8_1 @test_value_slot_not_unboxed
+in
+let code inline(never) loopify(never) size(6) newer_version_of(pair_first_11)
+      pair_first_11_1 (p : [ 0 of int64 boxed * int64 boxed ])
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Pfield = %block_load.[`0`] (p) in
+  let prim = %unbox_num.`int64` (Pfield) in
+  let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
+  let int_of_int64 = %tag_imm (prim_1) in
+  cont k (int_of_int64)
+in
+let $camlUnbox_boxed_numbers__pair_first_22 =
+  closure pair_first_11_1 @pair_first
+in
+let code loopify(never) size(23) newer_version_of(test_pair_12)
+      test_pair_12_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  let prim = %untag_imm (b) in
+  let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
+  let int64_of_int = %box_num.`int64` (prim_1) in
+  let prim_2 = %untag_imm (a) in
+  let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
+  let int64_of_int_1 = %box_num.`int64` (prim_3) in
+  let Pmakeblock = %block.[`0`] (int64_of_int_1, int64_of_int) in
+  apply direct(pair_first_11_1)
+    ($camlUnbox_boxed_numbers__pair_first_22 : _ -> imm tagged)
+      (Pmakeblock)
+      -> k * k1
+in
+let $camlUnbox_boxed_numbers__test_pair_23 =
+  closure test_pair_12_1 @test_pair
+in
+let $camlUnbox_boxed_numbers =
+  Block 0 ($camlUnbox_boxed_numbers__test_int64_16,
+           $camlUnbox_boxed_numbers__test_int32_17,
+           $camlUnbox_boxed_numbers__test_nativeint_18,
+           $camlUnbox_boxed_numbers__test_value_slot_19,
+           $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20,
+           $camlUnbox_boxed_numbers__test_pair_23)
+in
+cont done ($camlUnbox_boxed_numbers)

--- a/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
@@ -4,13 +4,17 @@ let code add_nativeint_2 deleted in
 let code test_int64_3 deleted in
 let code test_int32_4 deleted in
 let code test_nativeint_5 deleted in
-let code read_7 deleted in
-let code test_value_slot_6 deleted in
-let code read_9 deleted in
-let code indirect_10 deleted in
-let code test_value_slot_not_unboxed_8 deleted in
-let code pair_first_11 deleted in
-let code test_pair_12 deleted in
+let code add_float_6 deleted in
+let code add_float32_7 deleted in
+let code test_float_8 deleted in
+let code test_float32_9 deleted in
+let code read_11 deleted in
+let code test_value_slot_10 deleted in
+let code read_13 deleted in
+let code indirect_14 deleted in
+let code test_value_slot_not_unboxed_12 deleted in
+let code pair_first_15 deleted in
+let code test_pair_16 deleted in
 let code inline(never) loopify(never) size(11) newer_version_of(add_int64_0)
       add_int64_0_1 (x : int64 boxed, y : int64 boxed)
         my_closure _region _ghost_region my_depth
@@ -22,7 +26,7 @@ let code inline(never) loopify(never) size(11) newer_version_of(add_int64_0)
   let int64_add = %box_num.`int64` (prim_2) in
   cont k (int64_add)
 in
-let $camlUnbox_boxed_numbers__add_int64_13 = closure add_int64_0_1 @add_int64
+let $camlUnbox_boxed_numbers__add_int64_17 = closure add_int64_0_1 @add_int64
 in
 let code inline(never) loopify(never) size(12) newer_version_of(add_int32_1)
       add_int32_1_1 (x : int32 boxed, y : int32 boxed)
@@ -35,7 +39,7 @@ let code inline(never) loopify(never) size(12) newer_version_of(add_int32_1)
   let int32_add = %box_num.`int32` (prim_2) in
   cont k (int32_add)
 in
-let $camlUnbox_boxed_numbers__add_int32_14 = closure add_int32_1_1 @add_int32
+let $camlUnbox_boxed_numbers__add_int32_18 = closure add_int32_1_1 @add_int32
 in
 let code inline(never) loopify(never) size(11) newer_version_of(add_nativeint_2)
       add_nativeint_2_1 (x : nativeint boxed, y : nativeint boxed)
@@ -48,7 +52,7 @@ let code inline(never) loopify(never) size(11) newer_version_of(add_nativeint_2)
   let nativeint_add = %box_num.`nativeint` (prim_2) in
   cont k (nativeint_add)
 in
-let $camlUnbox_boxed_numbers__add_nativeint_15 =
+let $camlUnbox_boxed_numbers__add_nativeint_19 =
   closure add_nativeint_2_1 @add_nativeint
 in
 let code loopify(never) size(21) newer_version_of(test_int64_3)
@@ -63,7 +67,7 @@ let code loopify(never) size(21) newer_version_of(test_int64_3)
    let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
    let int64_of_int_1 = %box_num.`int64` (prim_3) in
    apply direct(add_int64_0_1)
-     ($camlUnbox_boxed_numbers__add_int64_13 : _ -> int64 boxed)
+     ($camlUnbox_boxed_numbers__add_int64_17 : _ -> int64 boxed)
        (int64_of_int_1, int64_of_int)
        -> k2 * k1)
     where k2 (apply_result : int64 boxed) =
@@ -72,7 +76,7 @@ let code loopify(never) size(21) newer_version_of(test_int64_3)
       let int_of_int64 = %tag_imm (prim_1) in
       cont k (int_of_int64)
 in
-let $camlUnbox_boxed_numbers__test_int64_16 =
+let $camlUnbox_boxed_numbers__test_int64_20 =
   closure test_int64_3_1 @test_int64
 in
 let code loopify(never) size(25) newer_version_of(test_int32_4)
@@ -87,7 +91,7 @@ let code loopify(never) size(25) newer_version_of(test_int32_4)
    let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
    let int32_of_int_1 = %box_num.`int32` (prim_3) in
    apply direct(add_int32_1_1)
-     ($camlUnbox_boxed_numbers__add_int32_14 : _ -> int32 boxed)
+     ($camlUnbox_boxed_numbers__add_int32_18 : _ -> int32 boxed)
        (int32_of_int_1, int32_of_int)
        -> k2 * k1)
     where k2 (apply_result : int32 boxed) =
@@ -96,7 +100,7 @@ let code loopify(never) size(25) newer_version_of(test_int32_4)
       let int_of_int32 = %tag_imm (prim_1) in
       cont k (int_of_int32)
 in
-let $camlUnbox_boxed_numbers__test_int32_17 =
+let $camlUnbox_boxed_numbers__test_int32_21 =
   closure test_int32_4_1 @test_int32
 in
 let code loopify(never) size(22) newer_version_of(test_nativeint_5)
@@ -111,7 +115,7 @@ let code loopify(never) size(22) newer_version_of(test_nativeint_5)
    let prim_3 = %num_conv.[`imm`].[`nativeint`] (prim_2) in
    let nativeint_of_int_1 = %box_num.`nativeint` (prim_3) in
    apply direct(add_nativeint_2_1)
-     ($camlUnbox_boxed_numbers__add_nativeint_15 : _ -> nativeint boxed)
+     ($camlUnbox_boxed_numbers__add_nativeint_19 : _ -> nativeint boxed)
        (nativeint_of_int_1, nativeint_of_int)
        -> k2 * k1)
     where k2 (apply_result : nativeint boxed) =
@@ -120,11 +124,86 @@ let code loopify(never) size(22) newer_version_of(test_nativeint_5)
       let int_of_nativeint = %tag_imm (prim_1) in
       cont k (int_of_nativeint)
 in
-let $camlUnbox_boxed_numbers__test_nativeint_18 =
+let $camlUnbox_boxed_numbers__test_nativeint_22 =
   closure test_nativeint_5_1 @test_nativeint
 in
-let code inline(never) loopify(never) size(6) newer_version_of(read_7)
-      read_7_1 (param : imm tagged)
+let code inline(never) loopify(never) size(10) newer_version_of(add_float_6)
+      add_float_6_1 (x : float boxed, y : float boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : float boxed =
+  let prim = %unbox_num.`float` (y) in
+  let prim_1 = %unbox_num.`float` (x) in
+  let prim_2 = %bfloat_arith.add (prim_1, prim) in
+  let float_add = %box_num.`float` (prim_2) in
+  cont k (float_add)
+in
+let $camlUnbox_boxed_numbers__add_float_23 = closure add_float_6_1 @add_float
+in
+let code inline(never) loopify(never) size(10) newer_version_of(add_float32_7)
+      add_float32_7_1 (x : float32 boxed, y : float32 boxed)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : float32 boxed =
+  let prim = %unbox_num.fnt32 (y) in
+  let prim_1 = %unbox_num.fnt32 (x) in
+  let prim_2 = %bfloat_arith.`float32`.add (prim_1, prim) in
+  let float32_add = %box_num.fnt32 (prim_2) in
+  cont k (float32_add)
+in
+let $camlUnbox_boxed_numbers__add_float32_24 =
+  closure add_float32_7_1 @add_float32
+in
+let code loopify(never) size(23) newer_version_of(test_float_8)
+      test_float_8_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`float`] (prim) in
+   let float_of_int = %box_num.`float` (prim_1) in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`float`] (prim_2) in
+   let float_of_int_1 = %box_num.`float` (prim_3) in
+   apply direct(add_float_6_1)
+     ($camlUnbox_boxed_numbers__add_float_23 : _ -> float boxed)
+       (float_of_int_1, float_of_int)
+       -> k2 * k1)
+    where k2 (apply_result : float boxed) =
+      let prim = %unbox_num.`float` (apply_result) in
+      let prim_1 = %num_conv.[`float`].[`imm`] (prim) in
+      let int_of_float = %tag_imm (prim_1) in
+      cont k (int_of_float)
+in
+let $camlUnbox_boxed_numbers__test_float_25 =
+  closure test_float_8_1 @test_float
+in
+let code loopify(never) size(23) newer_version_of(test_float32_9)
+      test_float32_9_1 (a : imm tagged, b : imm tagged)
+        my_closure _region _ghost_region my_depth
+        -> k * k1
+        : imm tagged =
+  (let prim = %untag_imm (b) in
+   let prim_1 = %num_conv.[`imm`].[`float32`] (prim) in
+   let float32_of_int = %box_num.fnt32 (prim_1) in
+   let prim_2 = %untag_imm (a) in
+   let prim_3 = %num_conv.[`imm`].[`float32`] (prim_2) in
+   let float32_of_int_1 = %box_num.fnt32 (prim_3) in
+   apply direct(add_float32_7_1)
+     ($camlUnbox_boxed_numbers__add_float32_24 : _ -> float32 boxed)
+       (float32_of_int_1, float32_of_int)
+       -> k2 * k1)
+    where k2 (apply_result : float32 boxed) =
+      let prim = %unbox_num.fnt32 (apply_result) in
+      let prim_1 = %num_conv.[`float32`].[`imm`] (prim) in
+      let int_of_float32 = %tag_imm (prim_1) in
+      cont k (int_of_float32)
+in
+let $camlUnbox_boxed_numbers__test_float32_26 =
+  closure test_float32_9_1 @test_float32
+in
+let code inline(never) loopify(never) size(6) newer_version_of(read_11)
+      read_11_1 (param : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -134,8 +213,8 @@ let code inline(never) loopify(never) size(6) newer_version_of(read_7)
   let int_of_int64 = %tag_imm (prim_1) in
   cont k (int_of_int64)
 in
-let code loopify(never) size(29) newer_version_of(test_value_slot_6)
-      test_value_slot_6_1 (n : imm tagged)
+let code loopify(never) size(29) newer_version_of(test_value_slot_10)
+      test_value_slot_10_1 (n : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -143,26 +222,26 @@ let code loopify(never) size(29) newer_version_of(test_value_slot_6)
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
   let b = %box_num.`int64`.`local`[`region`] (prim_1) in
-  let read = closure read_7_1 @read with { b = b } in
-  apply direct(read_7_1) (read : _ -> imm tagged) (0) -> k2 * k1
+  let read = closure read_11_1 @read with { b = b } in
+  apply direct(read_11_1) (read : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
       cont k (int_add)
 in
-let $camlUnbox_boxed_numbers__test_value_slot_19 =
-  closure test_value_slot_6_1 @test_value_slot
+let $camlUnbox_boxed_numbers__test_value_slot_27 =
+  closure test_value_slot_10_1 @test_value_slot
 in
-let code inline(never) loopify(never) size(6) newer_version_of(indirect_10)
-      indirect_10_1 (read : val)
+let code inline(never) loopify(never) size(6) newer_version_of(indirect_14)
+      indirect_14_1 (read : val)
         my_closure _region _ghost_region my_depth
         -> k * k1 =
   apply read (0) -> k * k1
 in
-let $camlUnbox_boxed_numbers__indirect_21 = closure indirect_10_1 @indirect
+let $camlUnbox_boxed_numbers__indirect_29 = closure indirect_14_1 @indirect
 in
-let code inline(never) loopify(never) size(6) newer_version_of(read_9)
-      read_9_1 (param : imm tagged)
+let code inline(never) loopify(never) size(6) newer_version_of(read_13)
+      read_13_1 (param : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -172,8 +251,8 @@ let code inline(never) loopify(never) size(6) newer_version_of(read_9)
   let int_of_int64 = %tag_imm (prim_1) in
   cont k (int_of_int64)
 in
-let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_8)
-      test_value_slot_not_unboxed_8_1 (n : imm tagged)
+let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_12)
+      test_value_slot_not_unboxed_12_1 (n : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -181,9 +260,9 @@ let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_8)
   let prim = %untag_imm (n) in
   let prim_1 = %num_conv.[`imm`].[`int64`] (prim) in
   let b = %box_num.`int64`.`local`[`region`] (prim_1) in
-  let read = closure read_9_1 @read_1 with { b_1 = b } in
-  apply direct(indirect_10_1)
-    ($camlUnbox_boxed_numbers__indirect_21 : _ -> imm tagged)
+  let read = closure read_13_1 @read_1 with { b_1 = b } in
+  apply direct(indirect_14_1)
+    ($camlUnbox_boxed_numbers__indirect_29 : _ -> imm tagged)
       (read)
       -> k2 * k1
     where k2 (apply_result : imm tagged) =
@@ -191,11 +270,11 @@ let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_8)
       let `unit` = %end_region (`region`) in
       cont k (int_add)
 in
-let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20 =
-  closure test_value_slot_not_unboxed_8_1 @test_value_slot_not_unboxed
+let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_28 =
+  closure test_value_slot_not_unboxed_12_1 @test_value_slot_not_unboxed
 in
-let code inline(never) loopify(never) size(6) newer_version_of(pair_first_11)
-      pair_first_11_1 (p : [ 0 of int64 boxed * int64 boxed ])
+let code inline(never) loopify(never) size(6) newer_version_of(pair_first_15)
+      pair_first_15_1 (p : [ 0 of int64 boxed * int64 boxed ])
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -205,11 +284,11 @@ let code inline(never) loopify(never) size(6) newer_version_of(pair_first_11)
   let int_of_int64 = %tag_imm (prim_1) in
   cont k (int_of_int64)
 in
-let $camlUnbox_boxed_numbers__pair_first_22 =
-  closure pair_first_11_1 @pair_first
+let $camlUnbox_boxed_numbers__pair_first_30 =
+  closure pair_first_15_1 @pair_first
 in
-let code loopify(never) size(23) newer_version_of(test_pair_12)
-      test_pair_12_1 (a : imm tagged, b : imm tagged)
+let code loopify(never) size(23) newer_version_of(test_pair_16)
+      test_pair_16_1 (a : imm tagged, b : imm tagged)
         my_closure _region _ghost_region my_depth
         -> k * k1
         : imm tagged =
@@ -220,20 +299,22 @@ let code loopify(never) size(23) newer_version_of(test_pair_12)
   let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
   let int64_of_int_1 = %box_num.`int64` (prim_3) in
   let Pmakeblock = %block.[`0`] (int64_of_int_1, int64_of_int) in
-  apply direct(pair_first_11_1)
-    ($camlUnbox_boxed_numbers__pair_first_22 : _ -> imm tagged)
+  apply direct(pair_first_15_1)
+    ($camlUnbox_boxed_numbers__pair_first_30 : _ -> imm tagged)
       (Pmakeblock)
       -> k * k1
 in
-let $camlUnbox_boxed_numbers__test_pair_23 =
-  closure test_pair_12_1 @test_pair
+let $camlUnbox_boxed_numbers__test_pair_31 =
+  closure test_pair_16_1 @test_pair
 in
 let $camlUnbox_boxed_numbers =
-  Block 0 ($camlUnbox_boxed_numbers__test_int64_16,
-           $camlUnbox_boxed_numbers__test_int32_17,
-           $camlUnbox_boxed_numbers__test_nativeint_18,
-           $camlUnbox_boxed_numbers__test_value_slot_19,
-           $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_20,
-           $camlUnbox_boxed_numbers__test_pair_23)
+  Block 0 ($camlUnbox_boxed_numbers__test_int64_20,
+           $camlUnbox_boxed_numbers__test_int32_21,
+           $camlUnbox_boxed_numbers__test_nativeint_22,
+           $camlUnbox_boxed_numbers__test_float_25,
+           $camlUnbox_boxed_numbers__test_float32_26,
+           $camlUnbox_boxed_numbers__test_value_slot_27,
+           $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_28,
+           $camlUnbox_boxed_numbers__test_pair_31)
 in
 cont done ($camlUnbox_boxed_numbers)


### PR DESCRIPTION
This PR extends the reaper's unboxing transformation to boxed numbers of kinds `int32`, `int64` and `nativeint`. Boxed numbers are modelled as another kind of field: a new `Boxed_number` constructor (carrying a `Flambda_kind.Boxable_number.t`) is added to the reaper's `Field.t`, representing the (naked) contents of the box.

In the traversal, `Box_number` primitives of the three supported kinds are now recognised as constructors defining the `Boxed_number` field, and `Unbox_number` primitives as accessors reading it, instead of falling into the conservative default case that makes everything escape. Unlike blocks, no `Is_int`/`Get_tag` fields are recorded for boxed numbers: those primitives arise only from matches on variants and are never applied to boxed numbers. Boxed `float`s, `float32`s and vectors are deliberately left untracked and continue to escape as before (these will be dealt with in a follow-up PR).

The unboxing analysis treats `Boxed_number` as a real field, so the existing machinery (single-source criteria, calling-convention changes, nested unboxing through blocks, closures, parameters and results) applies unchanged. As with blocks, representation changes are prevented for boxed numbers; they are either unboxed entirely or left alone.

During rebuilding, an `Unbox_number` load from an unboxed value is rewritten to a direct use of the corresponding unboxed variable, and a `Box_number` binding that is itself being unboxed simply binds the contents to the field's variable (the common bind-a-field-variable-to-a-simple code is factored out into a shared `bind_field_to_simple` helper).

To support rewriting the flambda types of functions whose calling conventions change (in particular result types), a `boxed_number` destructuring pattern is added to `Flambda2_types.Rewriter` in `types/traversals.ml`: a new `Boxed_number` discriminant plus an `Unbox_number` accessor extract the contents type from `Boxed_int32`/`Boxed_int64`/`Boxed_nativeint` heads, mirroring the existing block and closure patterns. The reaper's types rewriter classifies a lone `Boxed_number` field accordingly and emits this pattern. In addition, the kind-with-subkind rewriting now keeps the `boxed_int32`/`boxed_int64`/`boxed_nativeint` subkinds when the contents of the box are provably read (in which case the value cannot have been replaced by a poison value), using a single-field usage query; previously these subkinds were always erased.

Two fexpr tests are added in `testsuite/tests/reaper`. `unbox_boxed_numbers` checks that boxes of all three kinds are removed across non-inlined function boundaries (arguments and results), through a closure value slot, and when nested inside an unboxed pair; the reaper dump contains no remaining `%box_num`/`%unbox_num` operations. `boxed_number_escape` checks that a boxed int64 stored into an escaping reference is not unboxed. Both tests use `.mli` files so that the functions under test do not escape, allowing their calling conventions to be changed.