### PR TITLE
Add `returns : bool` to `Capply`

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -538,7 +538,8 @@ type operation =
   | Capply of
       { result_type : machtype;
         region : Lambda.region_close;
-        callees : symbol list option
+        callees : symbol list option;
+        returns : bool
       }
   | Cextcall of
       { func : string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -420,9 +420,13 @@ type operation =
   | Capply of
       { result_type : machtype;
         region : Lambda.region_close;
-        callees : symbol list option
+        callees : symbol list option;
             (* List of possible callees, or [None] if not known. The actual
                callee might be a re-optimized versions of one these callees. *)
+        returns : bool
+            (* [false] iff the call is statically known never to return
+               normally, e.g. because its return continuation is unreachable.
+               Such calls may still raise. *)
       }
   | Cextcall of
       { func : string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -424,9 +424,6 @@ type operation =
             (* List of possible callees, or [None] if not known. The actual
                callee might be a re-optimized versions of one these callees. *)
         returns : bool
-            (* [false] iff the call is statically known never to return
-               normally, e.g. because its return continuation is unreachable.
-               Such calls may still raise. *)
       }
   | Cextcall of
       { func : string;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2275,8 +2275,8 @@ let send_function_name arity result (mode : Cmx_format.alloc_mode) =
   let suff = match mode with Alloc_heap -> "" | Alloc_local -> "L" in
   global_symbol ("caml_send" ^ unique_arity_identifier arity ^ res ^ suff)
 
-let call_cached_method obj tag cache pos args args_type result (apos, mode) dbg
-    =
+let call_cached_method obj tag cache pos args args_type result (apos, mode)
+    ~returns dbg =
   Compilenv.need_send_fun
     (List.map Extended_machtype.change_tagged_int_to_val args_type)
     (Extended_machtype.change_tagged_int_to_val result)
@@ -2291,7 +2291,8 @@ let call_cached_method obj tag cache pos args args_type result (apos, mode) dbg
     ( Capply
         { result_type = Extended_machtype.to_machtype result;
           region = apos;
-          callees = Some [sym]
+          callees = Some [sym];
+          returns
         },
       (* See the cases for caml_apply regarding [change_tagged_int_to_val]. *)
       Cconst_symbol (sym, dbg) :: obj :: tag :: cache :: pos :: args,
@@ -3301,7 +3302,8 @@ let split_arity_for_apply arity args =
     let args1, args2 = Misc.Stdlib.List.split_at max_arity args in
     (a1, args1), Some (a2, args2)
 
-let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
+let call_caml_apply extended_ty extended_args_type mut clos args pos mode
+    ~returns dbg =
   (* Treat tagged int arguments and results as [typ_val], to avoid generating
      excessive numbers of caml_apply functions. *)
   let ty = Extended_machtype.to_machtype extended_ty in
@@ -3309,7 +3311,7 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
     let sym = apply_function_sym extended_args_type extended_ty mode in
     let cargs = (Cconst_symbol (sym, dbg) :: args) @ [clos] in
     Cop
-      ( Capply { result_type = ty; region = pos; callees = Some [sym] },
+      ( Capply { result_type = ty; region = pos; callees = Some [sym]; returns },
         cargs,
         dbg )
   in
@@ -3336,7 +3338,12 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
                     dbg ),
                 dbg,
                 Cop
-                  ( Capply { result_type = ty; region = pos; callees = None },
+                  ( Capply
+                      { result_type = ty;
+                        region = pos;
+                        callees = None;
+                        returns
+                      },
                     (get_field_codepointer mut clos 2 dbg :: args) @ [clos],
                     dbg ),
                 dbg,
@@ -3360,7 +3367,7 @@ let maybe_reset_current_region ~dbg ~body_tail ~body_nontail old_region =
            Csequence (Cop (Cendregion, [old_region], dbg ()), Cvar res) )),
       dbg () )
 
-let apply_or_call_caml_apply result arity mut clos args pos mode dbg =
+let apply_or_call_caml_apply result arity mut clos args pos mode ~returns dbg =
   match arity with
   | [_] ->
     bind "fun" clos (fun clos ->
@@ -3368,33 +3375,36 @@ let apply_or_call_caml_apply result arity mut clos args pos mode dbg =
           ( Capply
               { result_type = Extended_machtype.to_machtype result;
                 region = pos;
-                callees = None
+                callees = None;
+                returns
               },
             (get_field_codepointer mut clos 0 dbg :: args) @ [clos],
             dbg ))
-  | _ -> call_caml_apply result arity mut clos args pos mode dbg
+  | _ -> call_caml_apply result arity mut clos args pos mode ~returns dbg
 
 let rec might_split_call_caml_apply ?old_region result arity mut clos args pos
-    mode dbg =
+    mode ~returns dbg =
   match split_arity_for_apply arity args with
   | (arity, args), None -> (
     match old_region with
-    | None -> apply_or_call_caml_apply result arity mut clos args pos mode dbg
+    | None ->
+      apply_or_call_caml_apply result arity mut clos args pos mode ~returns dbg
     | Some old_region ->
       maybe_reset_current_region ~dbg:placeholder_dbg
         ~body_tail:
-          (apply_or_call_caml_apply result arity mut clos args pos mode dbg)
+          (apply_or_call_caml_apply result arity mut clos args pos mode ~returns
+             dbg)
         ~body_nontail:
           (apply_or_call_caml_apply result arity mut clos args Rc_normal
-             Cmx_format.Alloc_local dbg)
+             Cmx_format.Alloc_local ~returns dbg)
         old_region)
   | (arity, args), Some (arity', args') -> (
     let body old_region =
       bind "result"
         (call_caml_apply [| Val |] arity mut clos args Rc_normal
-           Cmx_format.Alloc_local dbg) (fun clos ->
+           Cmx_format.Alloc_local ~returns:true dbg) (fun clos ->
           might_split_call_caml_apply ?old_region result arity' mut clos args'
-            pos mode dbg)
+            pos mode ~returns dbg)
     in
     (* When splitting [caml_applyM] into [caml_applyN] and [caml_applyK] it is
        possible for [caml_applyN] to allocate on the local stack. If we are not
@@ -3413,23 +3423,25 @@ let rec might_split_call_caml_apply ?old_region result arity mut clos args pos
         (fun region -> body (Some region))
     | _ -> body old_region)
 
-let generic_apply mut clos args args_type result (pos, mode) dbg =
-  might_split_call_caml_apply result args_type mut clos args pos mode dbg
+let generic_apply mut clos args args_type result (pos, mode) ~returns dbg =
+  might_split_call_caml_apply result args_type mut clos args pos mode ~returns
+    dbg
 
-let send kind met obj args args_type result akind dbg =
+let send kind met obj args args_type result akind ~returns dbg =
   let call_met obj args args_type clos =
     (* met is never a simple expression, so it never gets turned into an
        Immutable load *)
     generic_apply Asttypes.Mutable clos (obj :: args)
       (Extended_machtype.typ_val :: args_type)
-      result akind dbg
+      result akind ~returns dbg
   in
   bind "obj" obj (fun obj ->
       match (kind : Lambda.meth_kind), args, args_type with
       | Self, _, _ ->
         bind "met" (lookup_label obj met dbg) (call_met obj args args_type)
       | Cached, cache :: pos :: args, _ :: _ :: args_type ->
-        call_cached_method obj met cache pos args args_type result akind dbg
+        call_cached_method obj met cache pos args args_type result akind
+          ~returns dbg
       | _ -> bind "met" (lookup_tag obj met dbg) (call_met obj args args_type))
 
 (*
@@ -3584,7 +3596,12 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
     | [arg] -> (
       let app =
         Cop
-          ( Capply { result_type = result; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = result;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             [ get_field_codepointer Asttypes.Mutable (Cvar clos) 0 (dbg ());
               Cvar arg;
               Cvar clos ],
@@ -3604,7 +3621,11 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
         ( VP.create newclos,
           Cop
             ( Capply
-                { result_type = typ_val; region = Rc_normal; callees = None },
+                { result_type = typ_val;
+                  region = Rc_normal;
+                  callees = None;
+                  returns = true
+                },
               [ get_field_codepointer Asttypes.Mutable (Cvar clos) 0 (dbg ());
                 Cvar arg;
                 Cvar clos ],
@@ -3635,7 +3656,12 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
               dbg () ),
           dbg (),
           Cop
-            ( Capply { result_type = result; region = Rc_normal; callees = None },
+            ( Capply
+                { result_type = result;
+                  region = Rc_normal;
+                  callees = None;
+                  returns = true
+                },
               get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ())
               :: List.map (fun s -> Cvar s) all_args,
               dbg () ),
@@ -3764,7 +3790,12 @@ let tuplify_function arity return =
       fun_args = [VP.create arg, typ_val; VP.create clos, typ_val];
       fun_body =
         Cop
-          ( Capply { result_type = return; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = return;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ())
             :: access_components 0
             @ [Cvar clos],
@@ -3907,7 +3938,12 @@ let rec make_curry_apply result narity args_type args clos n =
   match args_type with
   | [] ->
     Cop
-      ( Capply { result_type = result; region = Rc_normal; callees = None },
+      ( Capply
+          { result_type = result;
+            region = Rc_normal;
+            callees = None;
+            returns = true
+          },
         (get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ()) :: args)
         @ [Cvar clos],
         dbg () )
@@ -4373,7 +4409,12 @@ let entry_point namelist =
     in
     Csequence
       ( Cop
-          ( Capply { result_type = typ_void; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = typ_void;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             [Cop (mk_load_immut Word_int, [f], dbg ())],
             dbg () ),
         incr_global_inited () )
@@ -4878,17 +4919,18 @@ let load ~dbg memory_chunk mutability ~addr =
 let store ~dbg kind init ~addr ~new_value =
   Cop (Cstore (kind, init), [addr; new_value], dbg)
 
-let direct_call ~dbg ty pos f_code_sym args =
+let direct_call ~dbg ~returns ty pos f_code_sym args =
   Cop
-    ( Capply { result_type = ty; region = pos; callees = Some [f_code_sym] },
+    ( Capply
+        { result_type = ty; region = pos; callees = Some [f_code_sym]; returns },
       Cconst_symbol (f_code_sym, dbg) :: args,
       dbg )
 
-let indirect_call ~dbg ty pos alloc_mode f args_type args =
+let indirect_call ~dbg ~returns ty pos alloc_mode f args_type args =
   might_split_call_caml_apply ty args_type Asttypes.Mutable f args pos
-    alloc_mode dbg
+    alloc_mode ~returns dbg
 
-let indirect_full_call ~dbg ty pos f ~callees args_type args =
+let indirect_full_call ~dbg ~returns ty pos f ~callees args_type args =
   (* Use a variable to avoid duplicating the cmm code of the closure [f]. *)
   let v = Backend_var.create_local "*closure*" in
   let v' = Backend_var.With_provenance.create v in
@@ -4909,7 +4951,8 @@ let indirect_full_call ~dbg ty pos f ~callees args_type args =
          ( Capply
              { result_type = Extended_machtype.to_machtype ty;
                region = pos;
-               callees
+               callees;
+               returns
              },
            (fun_ptr :: args) @ [Cvar v],
            dbg ))
@@ -5380,7 +5423,7 @@ let tls_get ~dbg = Cop (Ctls_get, [], dbg)
 
 let domain_index ~dbg = Cop (Cdomain_index, [], dbg)
 
-let perform ~dbg eff =
+let perform ~dbg ~returns eff =
   let cont =
     make_alloc dbg ~tag:Runtimetags.cont_tag
       [int_const dbg 0; int_const dbg 0]
@@ -5389,118 +5432,98 @@ let perform ~dbg eff =
   (* Rc_normal means "allow tailcalls". Preventing them here by using Rc_nontail
      improves backtraces of paused fibers. *)
   let sym = Cmm.global_symbol "caml_perform" in
-  Cop
-    ( Capply { result_type = typ_val; region = Rc_nontail; callees = Some [sym] },
-      [Cconst_symbol (sym, dbg); eff; cont],
-      dbg )
+  direct_call ~dbg ~returns typ_val Rc_nontail sym [eff; cont]
 
-let with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg =
+let with_stack ~dbg ~returns ~valuec ~exnc ~effc ~f ~arg =
   let sym = Cmm.global_symbol "caml_runstack" in
-  Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
-      [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
-        Cop
-          ( Cextcall
-              { func = "caml_alloc_stack";
-                ty = typ_val;
-                alloc = true;
-                builtin = false;
-                returns = true;
-                effects = Arbitrary_effects;
-                coeffects = Has_coeffects;
-                ty_args = [XInt; XInt; XInt]
-              },
-            [valuec; exnc; effc],
-            dbg );
-        f;
-        arg ],
-      dbg )
+  direct_call ~dbg ~returns typ_val Rc_normal sym
+    [ Cop
+        ( Cextcall
+            { func = "caml_alloc_stack";
+              ty = typ_val;
+              alloc = true;
+              builtin = false;
+              returns = true;
+              effects = Arbitrary_effects;
+              coeffects = Has_coeffects;
+              ty_args = [XInt; XInt; XInt]
+            },
+          [valuec; exnc; effc],
+          dbg );
+      f;
+      arg ]
 
-let with_stack_bind ~dbg ~valuec ~exnc ~effc ~dyn ~bind ~f ~arg =
+let with_stack_bind ~dbg ~returns ~valuec ~exnc ~effc ~dyn ~bind ~f ~arg =
   let sym = Cmm.global_symbol "caml_runstack" in
-  Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
-      [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
-        Cop
-          ( Cextcall
-              { func = "caml_alloc_stack_bind";
-                ty = typ_val;
-                alloc = true;
-                builtin = false;
-                returns = true;
-                effects = Arbitrary_effects;
-                coeffects = Has_coeffects;
-                ty_args = [XInt; XInt; XInt; XInt; XInt]
-              },
-            [valuec; exnc; effc; dyn; bind],
-            dbg );
-        f;
-        arg ],
-      dbg )
+  direct_call ~dbg ~returns typ_val Rc_normal sym
+    [ Cop
+        ( Cextcall
+            { func = "caml_alloc_stack_bind";
+              ty = typ_val;
+              alloc = true;
+              builtin = false;
+              returns = true;
+              effects = Arbitrary_effects;
+              coeffects = Has_coeffects;
+              ty_args = [XInt; XInt; XInt; XInt; XInt]
+            },
+          [valuec; exnc; effc; dyn; bind],
+          dbg );
+      f;
+      arg ]
 
-let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg =
+let with_stack_preemptible ~dbg ~returns ~valuec ~exnc ~effc ~handle_tick ~f
+    ~arg =
   let sym = Cmm.global_symbol "caml_runstack" in
-  Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
-      [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
-        Cop
-          ( Cextcall
-              { func = "caml_alloc_stack_preemptible";
-                ty = typ_val;
-                alloc = true;
-                builtin = false;
-                returns = true;
-                effects = Arbitrary_effects;
-                coeffects = Has_coeffects;
-                ty_args = [XInt; XInt; XInt; XInt]
-              },
-            [valuec; exnc; effc; handle_tick],
-            dbg );
-        f;
-        arg ],
-      dbg )
+  direct_call ~dbg ~returns typ_val Rc_normal sym
+    [ Cop
+        ( Cextcall
+            { func = "caml_alloc_stack_preemptible";
+              ty = typ_val;
+              alloc = true;
+              builtin = false;
+              returns = true;
+              effects = Arbitrary_effects;
+              coeffects = Has_coeffects;
+              ty_args = [XInt; XInt; XInt; XInt]
+            },
+          [valuec; exnc; effc; handle_tick],
+          dbg );
+      f;
+      arg ]
 
-let with_stack_bind_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~dyn ~bind
-    ~f ~arg =
+let with_stack_bind_preemptible ~dbg ~returns ~valuec ~exnc ~effc ~handle_tick
+    ~dyn ~bind ~f ~arg =
   let sym = Cmm.global_symbol "caml_runstack" in
-  Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
-      [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
-        Cop
-          ( Cextcall
-              { func = "caml_alloc_stack_bind_preemptible";
-                ty = typ_val;
-                alloc = true;
-                builtin = false;
-                returns = true;
-                effects = Arbitrary_effects;
-                coeffects = Has_coeffects;
-                ty_args = [XInt; XInt; XInt; XInt; XInt; XInt]
-              },
-            [valuec; exnc; effc; handle_tick; dyn; bind],
-            dbg );
-        f;
-        arg ],
-      dbg )
+  direct_call ~dbg ~returns typ_val Rc_normal sym
+    [ Cop
+        ( Cextcall
+            { func = "caml_alloc_stack_bind_preemptible";
+              ty = typ_val;
+              alloc = true;
+              builtin = false;
+              returns = true;
+              effects = Arbitrary_effects;
+              coeffects = Has_coeffects;
+              ty_args = [XInt; XInt; XInt; XInt; XInt; XInt]
+            },
+          [valuec; exnc; effc; handle_tick; dyn; bind],
+          dbg );
+      f;
+      arg ]
 
-let resume ~dbg ~cont ~f ~arg =
+let resume ~dbg ~returns ~cont ~f ~arg =
   (* Rc_normal is required here, because there are some uses of effects with
      repeated resumes, and these should consume O(1) stack space by tail-calling
      caml_resume. *)
   let sym = Cmm.global_symbol "caml_resume" in
-  Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
-      [Cconst_symbol (sym, dbg); cont; f; arg],
-      dbg )
+  direct_call ~dbg ~returns typ_val Rc_normal sym [cont; f; arg]
 
-let reperform ~dbg ~eff ~cont ~last_fiber =
+let reperform ~dbg ~returns ~eff ~cont ~last_fiber =
   (* Rc_normal is required here, this is used in tail position and should tail
      call. *)
   let sym = Cmm.global_symbol "caml_reperform" in
-  Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
-      [Cconst_symbol (sym, dbg); eff; cont; last_fiber],
-      dbg )
+  direct_call ~dbg ~returns typ_val Rc_normal sym [eff; cont; last_fiber]
 
 let poll ~dbg = return_unit dbg (Cop (Cpoll, [], dbg))
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -695,6 +695,7 @@ val send :
   Extended_machtype.t list ->
   Extended_machtype.t ->
   Lambda.region_close * Cmx_format.alloc_mode ->
+  returns:bool ->
   Debuginfo.t ->
   expression
 
@@ -1030,6 +1031,7 @@ val caml_modify_local :
     If a closure needs to be passed, it must be included in [args]. *)
 val direct_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   machtype ->
   Lambda.region_close ->
   symbol ->
@@ -1039,6 +1041,7 @@ val direct_call :
 (** Same as {!direct_call} but for an indirect call. *)
 val indirect_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   Extended_machtype.t ->
   Lambda.region_close ->
   Cmx_format.alloc_mode ->
@@ -1051,6 +1054,7 @@ val indirect_call :
     application (since this enables a few optimisations). *)
 val indirect_full_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   Extended_machtype.t ->
   Lambda.region_close ->
   expression ->
@@ -1226,10 +1230,11 @@ val atomic_compare_exchange_field :
 
 val emit_gc_roots_table : symbols:symbol list -> phrase list -> phrase list
 
-val perform : dbg:Debuginfo.t -> expression -> expression
+val perform : dbg:Debuginfo.t -> returns:bool -> expression -> expression
 
 val with_stack :
   dbg:Debuginfo.t ->
+  returns:bool ->
   valuec:expression ->
   exnc:expression ->
   effc:expression ->
@@ -1239,6 +1244,7 @@ val with_stack :
 
 val with_stack_bind :
   dbg:Debuginfo.t ->
+  returns:bool ->
   valuec:expression ->
   exnc:expression ->
   effc:expression ->
@@ -1250,6 +1256,7 @@ val with_stack_bind :
 
 val with_stack_preemptible :
   dbg:Debuginfo.t ->
+  returns:bool ->
   valuec:expression ->
   exnc:expression ->
   effc:expression ->
@@ -1260,6 +1267,7 @@ val with_stack_preemptible :
 
 val with_stack_bind_preemptible :
   dbg:Debuginfo.t ->
+  returns:bool ->
   valuec:expression ->
   exnc:expression ->
   effc:expression ->
@@ -1272,6 +1280,7 @@ val with_stack_bind_preemptible :
 
 val resume :
   dbg:Debuginfo.t ->
+  returns:bool ->
   cont:expression ->
   f:expression ->
   arg:expression ->
@@ -1279,6 +1288,7 @@ val resume :
 
 val reperform :
   dbg:Debuginfo.t ->
+  returns:bool ->
   eff:expression ->
   cont:expression ->
   last_fiber:expression ->

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -254,7 +254,8 @@ let static_cast : Cmm.static_cast -> string = function
   | V512_of_scalar ty -> Printf.sprintf "scalar->%s" (vec512_name ty)
 
 let operation d = function
-  | Capply { result_type = _ty; region = _; callees = _ } -> "app" ^ location d
+  | Capply { result_type = _ty; region = _; callees = _; returns = _ } ->
+    "app" ^ location d
   | Cextcall { func = lbl; _ } ->
     Printf.sprintf "extcall \"%s\"%s" lbl (location d)
   | Cload { memory_chunk; mutability; is_atomic } -> (
@@ -400,7 +401,10 @@ let rec expr ppf = function
         fprintf ppf "@[<2>(%s" (operation dbg op);
         List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
         (match[@warning "-4"] op with
-        | Capply { result_type = mty; _ } -> fprintf ppf "@ %a" machtype mty
+        | Capply { result_type = mty; returns; _ } ->
+          if returns
+          then fprintf ppf "@ %a" machtype mty
+          else fprintf ppf "@ ->."
         | Cextcall
             { ty;
               ty_args;

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -282,6 +282,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     aux args args_arity
   in
   let return_ty = C.extended_machtype_of_return_arity return_arity in
+  let returns = Apply.returns apply in
   match Apply.call_kind apply with
   | Function { function_call = Direct code_id } -> (
     let code_metadata = Env.get_code_metadata env code_id in
@@ -309,7 +310,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     in
     match Apply.probe apply with
     | None ->
-      ( C.direct_call ~dbg
+      ( C.direct_call ~dbg ~returns
           (C.Extended_machtype.to_machtype return_ty)
           pos code_sym args,
         free_vars,
@@ -334,7 +335,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           "Application expression did not provide callee for indirect call:@ %a"
           Apply.print apply
     in
-    ( C.indirect_call ~dbg return_ty pos
+    ( C.indirect_call ~dbg ~returns return_ty pos
         (C.alloc_mode_for_applications_to_cmx (Apply_expr.alloc_mode apply))
         callee args_ty (split_args ()),
       free_vars,
@@ -368,7 +369,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         "To_cmm expects indirect_known_arity calls to be full applications in \
          order to translate them"
     else
-      ( C.indirect_full_call ~dbg return_ty pos callee ~callees args_ty args,
+      ( C.indirect_full_call ~dbg ~returns return_ty pos callee ~callees args_ty
+          args,
         free_vars,
         env,
         res,
@@ -400,7 +402,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       C.alloc_mode_for_applications_to_cmx (Apply_expr.alloc_mode apply)
     in
     ( C.send kind callee obj (split_args ()) args_ty return_ty (pos, alloc_mode)
-        dbg,
+        ~returns dbg,
       free_vars,
       env,
       res,
@@ -414,7 +416,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       let { env; res; expr = { cmm = eff; free_vars; effs = _ } } =
         simple env res eff
       in
-      C.perform ~dbg eff, free_vars, env, res, Ece.all
+      C.perform ~dbg ~returns eff, free_vars, env, res, Ece.all
     | Reperform { eff; cont; last_fiber } ->
       let { env; res; expr = { cmm = eff; free_vars = fv0; effs = _ } } =
         simple env res eff
@@ -426,7 +428,11 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res last_fiber
       in
       let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
-      C.reperform ~dbg ~eff ~cont ~last_fiber, free_vars, env, res, Ece.all
+      ( C.reperform ~dbg ~returns ~eff ~cont ~last_fiber,
+        free_vars,
+        env,
+        res,
+        Ece.all )
     | With_stack { valuec; exnc; effc; f; arg } ->
       let { env; res; expr = { cmm = valuec; free_vars = fv0; effs = _ } } =
         simple env res valuec
@@ -448,7 +454,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           (BV.Set.union fv0 (BV.Set.union fv1 fv2))
           (BV.Set.union fv3 fv4)
       in
-      ( C.with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg,
+      ( C.with_stack ~dbg ~returns ~valuec ~exnc ~effc ~f ~arg,
         free_vars,
         env,
         res,
@@ -482,7 +488,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
              (BV.Set.union fv3 fv4))
           (BV.Set.union fv5 fv6)
       in
-      ( C.with_stack_bind ~dbg ~valuec ~exnc ~effc ~dyn ~bind ~f ~arg,
+      ( C.with_stack_bind ~dbg ~returns ~valuec ~exnc ~effc ~dyn ~bind ~f ~arg,
         free_vars,
         env,
         res,
@@ -512,7 +518,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           (BV.Set.union fv0 (BV.Set.union fv1 fv2))
           (BV.Set.union fv3 (BV.Set.union fv4 fv5))
       in
-      ( C.with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg,
+      ( C.with_stack_preemptible ~dbg ~returns ~valuec ~exnc ~effc ~handle_tick
+          ~f ~arg,
         free_vars,
         env,
         res,
@@ -551,8 +558,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
              (BV.Set.union fv3 fv4))
           (BV.Set.union fv5 (BV.Set.union fv6 fv7))
       in
-      ( C.with_stack_bind_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~dyn
-          ~bind ~f ~arg,
+      ( C.with_stack_bind_preemptible ~dbg ~returns ~valuec ~exnc ~effc
+          ~handle_tick ~dyn ~bind ~f ~arg,
         free_vars,
         env,
         res,
@@ -568,7 +575,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res arg
       in
       let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
-      C.resume ~dbg ~cont ~f ~arg, free_vars, env, res, Ece.all)
+      C.resume ~dbg ~returns ~cont ~f ~arg, free_vars, env, res, Ece.all)
 
 let translate_apply env res apply =
   let dbg = Env.add_inlined_debuginfo env (Apply.dbg apply) in

--- a/oxcaml/testsuite/tools/parsecmm.mly
+++ b/oxcaml/testsuite/tools/parsecmm.mly
@@ -224,7 +224,8 @@ expr:
                 { Cop(Capply {
                         result_type = $6;
                         region = Lambda.Rc_normal;
-                        callees = None
+                        callees = None;
+                        returns = true
                       },
                       $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN


### PR DESCRIPTION
This mirror `Cextcall`. This is useful for a subsequent PR that implements machtype checking. For example, consider the pseudo-Cmm expression:
```
Cifthenelse (sexp_valid, execute_normally, Cop (Capply, fatal_error, "invalid sexp"))
```
Normally, both branches of an `if` need to return the same machtype, but in this case, the `Capply` never returns, so we don't need to check anything. To know if any particular `Capply` returns, we simply thread it in from flambda, which is what is done in this PR.