### PR TITLE
Add keyword handling

### DIFF
--- a/external/merlin/src/ocaml/preprocess/lexer_raw.mll
+++ b/external/merlin/src/ocaml/preprocess/lexer_raw.mll
@@ -86,89 +86,110 @@ let rec catch m f = match m with
 
 (* The table of keywords *)
 
-let keyword_table : keywords =
-  create_hashtable 149 [
-    "and", AND;
-    "as", AS;
-    "assert", ASSERT;
-    "begin", BEGIN;
-    "class", CLASS;
-    "constraint", CONSTRAINT;
-    "do", DO;
-    "done", DONE;
-    "downto", DOWNTO;
-    "effect", EFFECT;
-    "else", ELSE;
-    "end", END;
-    "exception", EXCEPTION;
-    "exclave_", EXCLAVE;
-    "external", EXTERNAL;
-    "false", FALSE;
-    "for", FOR;
-    "fun", FUN;
-    "function", FUNCTION;
-    "functor", FUNCTOR;
-    "global_", GLOBAL;
-    "if", IF;
-    "in", IN;
-    "include", INCLUDE;
-    "inherit", INHERIT;
-    "initializer", INITIALIZER;
-    "kind_", KIND;
-    "kind_of_", KIND_OF;
-    "layout_", LAYOUT;
-    "lazy", LAZY;
-    "let", LET;
-    "local_", LOCAL;
-    "match", MATCH;
-    "method", METHOD;
-    "mod", MOD;
-    "module", MODULE;
-    "mutable", MUTABLE;
-    "new", NEW;
-    "nonrec", NONREC;
-    "object", OBJECT;
-    "of", OF;
-    "open", OPEN;
-    "or", OR;
-    "overwrite_", OVERWRITE;
+let all_keywords =
+  let v5_3 = Some (5,3) in
+  let v1_0 = Some (1,0) in
+  let v1_6 = Some (1,6) in
+  let v4_2 = Some (4,2) in
+  let always = None in
+  let oxcaml = None in
+  [
+    "and", AND, always;
+    "as", AS, always;
+    "assert", ASSERT, v1_6;
+    "begin", BEGIN, always;
+    "borrow_", BORROW, oxcaml;
+    "class", CLASS, v1_0;
+    "constraint", CONSTRAINT, v1_0;
+    "do", DO, always;
+    "done", DONE, always;
+    "downto", DOWNTO, always;
+    "effect", EFFECT, v5_3;
+    "else", ELSE, always;
+    "end", END, always;
+    "exception", EXCEPTION, always;
+    "exclave_", EXCLAVE, oxcaml;
+    "external", EXTERNAL, always;
+    "false", FALSE, always;
+    "for", FOR, always;
+    "fun", FUN, always;
+    "function", FUNCTION, always;
+    "functor", FUNCTOR, always;
+    "global_", GLOBAL, oxcaml;
+    "if", IF, always;
+    "in", IN, always;
+    "include", INCLUDE, always;
+    "inherit", INHERIT, v1_0;
+    "initializer", INITIALIZER, v1_0;
+    "kind_", KIND, oxcaml;
+    "kind_of_", KIND_OF, oxcaml;
+    "layout_", LAYOUT, oxcaml;
+    "lazy", LAZY, v1_6;
+    "let", LET, always;
+    "local_", LOCAL, oxcaml;
+    "match", MATCH, always;
+    "method", METHOD, v1_0;
+    "mod", MOD, always;
+    "module", MODULE, always;
+    "mutable", MUTABLE, always;
+    "new", NEW, v1_0;
+    "nonrec", NONREC, v4_2;
+    "object", OBJECT, v1_0;
+    "of", OF, always;
+    "open", OPEN, always;
+    "or", OR, always;
+    "overwrite_", OVERWRITE, oxcaml;
 (*  "parser", PARSER; *)
-    "poly_", POLY;
-    "private", PRIVATE;
-    "rec", REC;
-    "repr_", REPR;
-    "sig", SIG;
-    "stack_", STACK;
-    "borrow_", BORROW;
-    "struct", STRUCT;
-    "then", THEN;
-    "to", TO;
-    "true", TRUE;
-    "try", TRY;
-    "type", TYPE;
-    "val", VAL;
-    "virtual", VIRTUAL;
-    "when", WHEN;
-    "while", WHILE;
-    "with", WITH;
+    "poly_", POLY, oxcaml;
+    "private", PRIVATE, v1_0;
+    "rec", REC, always;
+    "repr_", REPR, oxcaml;
+    "sig", SIG, always;
+    "stack_", STACK, oxcaml;
+    "struct", STRUCT, always;
+    "then", THEN, always;
+    "to", TO, always;
+    "true", TRUE, always;
+    "try", TRY, always;
+    "type", TYPE, always;
+    "val", VAL, always;
+    "virtual", VIRTUAL, v1_0;
+    "when", WHEN, always;
+    "while", WHILE, always;
+    "with", WITH, always;
 
-    "lor", INFIXOP3("lor"); (* Should be INFIXOP2 *)
-    "lxor", INFIXOP3("lxor"); (* Should be INFIXOP2 *)
-    "land", INFIXOP3("land");
-    "lsl", INFIXOP4("lsl");
-    "lsr", INFIXOP4("lsr");
-    "asr", INFIXOP4("asr");
+    "lor", INFIXOP3("lor"), always; (* Should be INFIXOP2 *)
+    "lxor", INFIXOP3("lxor"), always; (* Should be INFIXOP2 *)
+    "land", INFIXOP3("land"), always;
+    "lsl", INFIXOP4("lsl"), always;
+    "lsr", INFIXOP4("lsr"), always;
+    "asr", INFIXOP4("asr"), always
 ]
 
+let keyword_table = Hashtbl.create 149
+
+let populate_keywords (version,keywords) =
+  let greater (x:(int*int) option) (y:(int*int) option) =
+    match x, y with
+    | None, _ | _, None -> true
+    | Some x, Some y -> x >= y
+  in
+  let tbl = keyword_table in
+  Hashtbl.clear tbl;
+  let add_keyword (name, token, since) =
+    if greater version since then Hashtbl.replace tbl name (Some token)
+  in
+  List.iter ~f:add_keyword all_keywords;
+  List.iter ~f:(fun name ->
+    match List.find ~f:(fun (n,_,_) -> n = name) all_keywords with
+    | (_,tok,_) -> Hashtbl.replace tbl name (Some tok)
+    | exception Not_found -> Hashtbl.replace tbl name None
+    ) keywords
+
+(* FIXME: Merlin: this could be made configurable *)
+let () = populate_keywords (None,[])
+
 let keywords l = create_hashtable 11 l
-
-let lookup_keyword name =
-  match Hashtbl.find keyword_table name with
-  | kw -> kw
-  | exception Not_found ->
-     LIDENT name
-
-(* To buffer string literals *)
 
 let list_keywords =
   let add_kw str _tok kws = str :: kws in
@@ -446,14 +467,24 @@ let uchar_for_uchar_escape lexbuf =
 
 let keyword_or state s default =
   try Hashtbl.find state.keywords s
-      with Not_found -> try Hashtbl.find keyword_table s
-  with Not_found -> default
+  with Not_found ->
+    try Option.value ~default @@ Hashtbl.find keyword_table s
+    with Not_found -> default
 
 let is_keyword name =
-  match lookup_keyword name with
-  | LIDENT _ -> false
-  | _ -> true
+  Hashtbl.mem keyword_table name
+
 let () = Lexer.is_keyword_ref := is_keyword
+
+let find_keyword lexbuf name default =
+  match Hashtbl.find keyword_table name with
+  | Some x -> return x
+  | None -> fail lexbuf (Unknown_keyword name)
+  | exception Not_found -> return default
+
+let find_keyword state lexbuf ~name ~default =
+  try return @@ Hashtbl.find state.keywords name
+  with Not_found -> find_keyword lexbuf name default
 
 let check_label_name lexbuf name =
   if is_keyword name
@@ -693,21 +724,15 @@ rule token state = parse
   | (lowercase identchar * as name) ('#' symbolchar_or_hash+ as hashop)
       (* See Note [Lexing hack for hash operators] *)
       { enqueue_hashop_from_end_of_lexbuf_window lexbuf ~hashop;
-        return (try Hashtbl.find state.keywords name
-              with Not_found ->
-              lookup_keyword name) }
+        find_keyword state lexbuf ~name ~default:(LIDENT name) }
   | (lowercase identchar * as name) '#'
       (* See Note [Lexing hack for float#] *)
       { enqueue_hash_suffix_from_end_of_lexbuf_window lexbuf;
-        return (try Hashtbl.find state.keywords name
-              with Not_found ->
-              lookup_keyword name) }
+        find_keyword state lexbuf ~name ~default:(LIDENT name)}
   | raw_ident_escape (lowercase identchar * as name)
     { return (LIDENT name) }
   | lowercase identchar * as name
-    { return (try Hashtbl.find state.keywords name
-              with Not_found ->
-              lookup_keyword name) }
+    { find_keyword state lexbuf ~name ~default:(LIDENT name) }
   (* Lowercase latin1 identifiers are split into 3 cases, and the order matters
      (longest to shortest).
   *)
@@ -726,11 +751,7 @@ rule token state = parse
       { warn_latin1 lexbuf; return (LIDENT name) }
   | uppercase identchar * as name
     { (* Capitalized keywords for OUnit *)
-      return (try Hashtbl.find state.keywords name
-              with Not_found ->
-              try Hashtbl.find keyword_table name
-              with Not_found ->
-                UIDENT name) }
+      find_keyword state lexbuf ~name ~default:(UIDENT name)}
   | uppercase_latin1 identchar_latin1 * as name
       { warn_latin1 lexbuf; return (UIDENT name) }
   (* This matches either an integer literal or a directive. If the text "#2"


### PR DESCRIPTION
This PR cherry-picks the upstream Merlin commit [383f7c7](https://github.com/ocaml/merlin/commit/383f7c7b28e027582f20a273ac8fdd902246f3d5). This commit corresponds to [upstream compiler PR 13471](https://github.com/ocaml/ocaml/pull/13471), which adds the ability to toggle whether certain keywords are enabled.

OCaml 5.3 added the `effect` keyword to the language, which we disable internally by configuring the compiler to default to keywords version 5.2 when building it for interanl use. (Note that we *do not* have dune pass the `-keywords` flag to the compiler; we only rely on the default value being configured correctly.) Currently though, OxCaml Merlin always has all keywords enabled.

With the changes of this PR, it is still true that all keywords are unconditionally enabled. Additionally, this PR does not add the ability for Merlin to understand the `-keywords` flag (indeed, upstream Merlin does not have this ability either). However, it allows us to easily change the default by modifying [this line](https://github.com/oxcaml/oxcaml/blob/a7117e07c6c5835cc00defee1af0ce7e21bbb4f6/external/merlin/src/ocaml/preprocess/lexer_raw.mll#L190).

My intention is to patch Merlin when building it for internal use to change the default keyword edition to `5.2`. This mimicks how the compiler handles this, in that we override the default when building it for internal use. (I tested that we get the intended behavior when we do this patching.)