### PR TITLE
[arm64] generate "store-release" instead of "memory barrier + store"

### DIFF
--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -28,6 +28,9 @@ let is_asan_enabled = ref false
 (* CR gyorsh: refactor to use [Arch.Extension] like amd64 *)
 let feat_cssc = ref false
 
+(* FEAT_LRCPC2: store-release with an unscaled immediate offset (stlur). *)
+let feat_lrcpc2 = ref false
+
 (* Emit elf notes with trap handling information. *)
 let trap_notes = ref true
 
@@ -43,6 +46,12 @@ let command_line_options = [
   "-fcssc",
     Arg.Set feat_cssc,
     " Enable the Common Short Sequence Compression (CSSC) instructions."
+  ;
+
+  "-flrcpc2",
+    Arg.Set feat_lrcpc2,
+    " Enable FEAT_LRCPC2 store-release with unscaled offset (stlur), used to \
+     avoid an address computation for aligned release stores."
 ]
 
 (* Addressing modes *)

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -20,6 +20,8 @@
 val macosx : bool
 val is_asan_enabled : bool ref
 val feat_cssc : bool ref
+
+val feat_lrcpc2 : bool ref
 val trap_notes : bool ref
 (* Machine-specific command-line options *)
 

--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -1468,6 +1468,11 @@ module Instruction_name = struct
            t
     | LDAR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
     | STLR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
+    | STLUR :
+        ( pair,
+          [`Reg of [`GP of [< `X | `W]]]
+          * [`Mem of [`Offset_nine_signed_unscaled]] )
+        t
     | LDP :
         ('w1, 'w2) LDP_STP_width.t
         -> ( triple,
@@ -2026,6 +2031,7 @@ module Instruction_name = struct
         | INS_V _ -> "ins"
         | LDAR -> "ldar"
         | STLR -> "stlr"
+        | STLUR -> "stlur"
         | LDP _ -> "ldp"
         | LDR -> "ldr"
         | LDR_simd_and_fp -> "ldr"
@@ -2388,6 +2394,9 @@ module Instruction_name = struct
       | STLR ->
         let (Pair (rt, addr)) = ops in
         [| o rt; o addr |]
+      | STLUR ->
+        let (Pair (rt, addr)) = ops in
+        [| o rt; o addr |]
       | LDP _ ->
         let (Triple (rt1, rt2, addr)) = ops in
         [| o rt1; o rt2; o addr |]
@@ -2682,7 +2691,8 @@ module Instruction = struct
     | FMOV_scalar_immediate | FMSUB | FMUL | FMUL_vector | FNEG | FNEG_vector
     | FNMADD | FNMSUB | FNMUL | FRECPE_vector | FRINT _ | FRINT_vector _
     | FRSQRTE_vector | FSQRT | FSQRT_vector | FSUB | FSUB_vector | INS _
-    | INS_V _ | LDAR | STLR | LDP _ | LDR | LDRB | LDRH | LDRSB | LDRSH | LDRSW
+    | INS_V _ | LDAR | STLR | STLUR | LDP _ | LDR | LDRB | LDRH | LDRSB | LDRSH
+    | LDRSW
     | LDR_simd_and_fp | LSLV | LSRV | MADD | MOVI | MOVK | MOVN | MOVZ | MSUB
     | MUL_vector | MVN_vector | NEG_vector | NOP | ORR_immediate
     | ORR_shifted_register | ORR_vector | RBIT | RET | REV | REV16 | SBFM
@@ -2782,6 +2792,11 @@ module DSL = struct
     match Validated_mem_offset.create ~scale ~offset with
     | Some validated -> Ok (Validated_mem_offset.to_operand ~base validated)
     | None -> Offset_out_of_range
+
+  (* Force the unscaled signed 9-bit encoding, as required by stlur. *)
+  let mem_offset_unscaled ~(base : [`GP of [< `X | `SP]] Reg.t) ~offset =
+    check_nine_signed_unscaled offset;
+    Operand.Mem (Offset_nine_signed_unscaled (base, Nine_signed_unscaled offset))
 
   let mem_symbol ~(base : [`GP of [< `X | `SP]] Reg.t) ~symbol =
     Operand.Mem (Offset_sym (base, symbol))

--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -1467,6 +1467,7 @@ module Instruction_name = struct
            )
            t
     | LDAR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
+    | STLR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
     | LDP :
         ('w1, 'w2) LDP_STP_width.t
         -> ( triple,
@@ -2024,6 +2025,7 @@ module Instruction_name = struct
         | INS _ -> "ins"
         | INS_V _ -> "ins"
         | LDAR -> "ldar"
+        | STLR -> "stlr"
         | LDP _ -> "ldp"
         | LDR -> "ldr"
         | LDR_simd_and_fp -> "ldr"
@@ -2383,6 +2385,9 @@ module Instruction_name = struct
       | LDAR ->
         let (Pair (rt, addr)) = ops in
         [| o rt; o addr |]
+      | STLR ->
+        let (Pair (rt, addr)) = ops in
+        [| o rt; o addr |]
       | LDP _ ->
         let (Triple (rt1, rt2, addr)) = ops in
         [| o rt1; o rt2; o addr |]
@@ -2677,7 +2682,7 @@ module Instruction = struct
     | FMOV_scalar_immediate | FMSUB | FMUL | FMUL_vector | FNEG | FNEG_vector
     | FNMADD | FNMSUB | FNMUL | FRECPE_vector | FRINT _ | FRINT_vector _
     | FRSQRTE_vector | FSQRT | FSQRT_vector | FSUB | FSUB_vector | INS _
-    | INS_V _ | LDAR | LDP _ | LDR | LDRB | LDRH | LDRSB | LDRSH | LDRSW
+    | INS_V _ | LDAR | STLR | LDP _ | LDR | LDRB | LDRH | LDRSB | LDRSH | LDRSW
     | LDR_simd_and_fp | LSLV | LSRV | MADD | MOVI | MOVK | MOVN | MOVZ | MSUB
     | MUL_vector | MVN_vector | NEG_vector | NOP | ORR_immediate
     | ORR_shifted_register | ORR_vector | RBIT | RET | REV | REV16 | SBFM

--- a/backend/arm64/ast/ast.mli
+++ b/backend/arm64/ast/ast.mli
@@ -1086,6 +1086,7 @@ module Instruction_name : sig
            )
            t
     | LDAR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
+    | STLR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
     | LDP :
         ('w1, 'w2) LDP_STP_width.t
         -> ( triple,

--- a/backend/arm64/ast/ast.mli
+++ b/backend/arm64/ast/ast.mli
@@ -1087,6 +1087,11 @@ module Instruction_name : sig
            t
     | LDAR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
     | STLR : (pair, [`Reg of [`GP of [< `X | `W]]] * [`Mem of [`Base_reg]]) t
+    | STLUR :
+        ( pair,
+          [`Reg of [`GP of [< `X | `W]]]
+          * [`Mem of [`Offset_nine_signed_unscaled]] )
+        t
     | LDP :
         ('w1, 'w2) LDP_STP_width.t
         -> ( triple,
@@ -1733,6 +1738,11 @@ module DSL : sig
     [`Mem of [> `Offset_twelve_unsigned_scaled | `Offset_nine_signed_unscaled]]
     Operand.t
     mem_offset_result
+
+  val mem_offset_unscaled :
+    base:[`GP of [< `X | `SP]] Reg.t ->
+    offset:int ->
+    [`Mem of [> `Offset_nine_signed_unscaled]] Operand.t
 
   val mem_symbol :
     base:[`GP of [< `X | `SP]] Reg.t ->

--- a/backend/arm64/binary_emitter/encode_instruction.ml
+++ b/backend/arm64/binary_emitter/encode_instruction.ml
@@ -829,6 +829,11 @@ let encode_instruction : type num operands.
     Load_store_helpers.encode_load_acquire ~rd ~rn
   | Pair (Reg ({ reg_name = GP _; _ } as rd), Mem (Reg rn)), STLR ->
     Load_store_helpers.encode_store_release ~rd ~rn
+  | ( Pair
+        ( Reg ({ reg_name = GP _; _ } as rd),
+          Mem (Offset_nine_signed_unscaled (rn, Nine_signed_unscaled imm9)) ),
+      STLUR ) ->
+    Load_store_helpers.encode_store_release_unscaled ~rd ~rn ~imm9
   | Triple (Reg rt1, Reg rt2, Mem addressing), LDP _ ->
     Load_store_helpers.encode_load_store_pair_gp ~instr_name:"LDP" ~l:1 ~rt1
       ~rt2 addressing

--- a/backend/arm64/binary_emitter/encode_instruction.ml
+++ b/backend/arm64/binary_emitter/encode_instruction.ml
@@ -827,6 +827,8 @@ let encode_instruction : type num operands.
     Simd_helpers.encode_simd_copy ~q:1 ~op:1 ~imm5 ~imm4 ~rn ~rd
   | Pair (Reg ({ reg_name = GP _; _ } as rd), Mem (Reg rn)), LDAR ->
     Load_store_helpers.encode_load_acquire ~rd ~rn
+  | Pair (Reg ({ reg_name = GP _; _ } as rd), Mem (Reg rn)), STLR ->
+    Load_store_helpers.encode_store_release ~rd ~rn
   | Triple (Reg rt1, Reg rt2, Mem addressing), LDP _ ->
     Load_store_helpers.encode_load_store_pair_gp ~instr_name:"LDP" ~l:1 ~rt1
       ~rt2 addressing

--- a/backend/arm64/binary_emitter/load_store_helpers.ml
+++ b/backend/arm64/binary_emitter/load_store_helpers.ml
@@ -374,6 +374,38 @@ let encode_load_acquire : type a.
   let result = logor result (of_int rt) in
   result
 
+(* Store-Release (STLR) encoding. Identical layout to LDAR (load-acquire) but
+   with L=0 (store). Provides at least the load->store ordering of
+   [dmb ishld; str] in a single instruction. *)
+let encode_store_release : type a.
+    rd:[`GP of a] Reg.t -> rn:[`GP of _] Reg.t -> int32 =
+ fun ~rd ~rn ->
+  let size =
+    match rd.reg_name with
+    | GP W | GP WZR | GP WSP -> 0b10
+    | GP X | GP XZR | GP SP | GP LR | GP FP -> 0b11
+  in
+  let rt = Reg.gp_encoding rd in
+  let rn_enc = Reg.gp_encoding rn in
+  let o2 = 1 in
+  let l = 0 in
+  let o1 = 0 in
+  let o0 = 1 in
+  let rs = 0b11111 in
+  let rt2 = 0b11111 in
+  let open Int32 in
+  let result = shift_left (of_int size) 30 in
+  let result = logor result (shift_left (of_int 0b001000) 24) in
+  let result = logor result (shift_left (of_int o2) 23) in
+  let result = logor result (shift_left (of_int l) 22) in
+  let result = logor result (shift_left (of_int o1) 21) in
+  let result = logor result (shift_left (of_int rs) 16) in
+  let result = logor result (shift_left (of_int o0) 15) in
+  let result = logor result (shift_left (of_int rt2) 10) in
+  let result = logor result (shift_left (of_int rn_enc) 5) in
+  let result = logor result (of_int rt) in
+  result
+
 (* Memory barrier encoding. Format: 1101 0101 0000 0011 0011 | CRm[11:8] |
    op2[7:5] | 11111
 

--- a/backend/arm64/binary_emitter/load_store_helpers.ml
+++ b/backend/arm64/binary_emitter/load_store_helpers.ml
@@ -406,6 +406,29 @@ let encode_store_release : type a.
   let result = logor result (of_int rt) in
   result
 
+(* Store-Release unscaled (STLUR, FEAT_LRCPC2) encoding. Ordered-unscaled
+   class: size[31:30] | 011001 | opc[23:22]=00 | 0 | imm9[20:12] | 00 | Rn | Rt.
+   64-bit base is 0xD9000000. Lets an aligned release-store use a [base, #imm9]
+   offset directly, avoiding a separate address computation. *)
+let encode_store_release_unscaled : type a.
+    rd:[`GP of a] Reg.t -> rn:[`GP of _] Reg.t -> imm9:int -> int32 =
+ fun ~rd ~rn ~imm9 ->
+  let size =
+    match rd.reg_name with
+    | GP W | GP WZR | GP WSP -> 0b10
+    | GP X | GP XZR | GP SP | GP LR | GP FP -> 0b11
+  in
+  let rt = Reg.gp_encoding rd in
+  let rn_enc = Reg.gp_encoding rn in
+  let imm9 = imm9 land 0x1FF in
+  let open Int32 in
+  let result = shift_left (of_int size) 30 in
+  let result = logor result (shift_left (of_int 0b011001) 24) in
+  let result = logor result (shift_left (of_int imm9) 12) in
+  let result = logor result (shift_left (of_int rn_enc) 5) in
+  let result = logor result (of_int rt) in
+  result
+
 (* Memory barrier encoding. Format: 1101 0101 0000 0011 0011 | CRm[11:8] |
    op2[7:5] | 11111
 

--- a/backend/arm64/binary_emitter/load_store_helpers.mli
+++ b/backend/arm64/binary_emitter/load_store_helpers.mli
@@ -119,6 +119,8 @@ val encode_load_store_halfword :
 
 val encode_load_acquire : rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> int32
 
+val encode_store_release : rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> int32
+
 val encode_memory_barrier : op2:int -> Memory_barrier.t -> int32
 
 val encode_load_store_pair_gp :

--- a/backend/arm64/binary_emitter/load_store_helpers.mli
+++ b/backend/arm64/binary_emitter/load_store_helpers.mli
@@ -121,6 +121,9 @@ val encode_load_acquire : rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> int32
 
 val encode_store_release : rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> int32
 
+val encode_store_release_unscaled :
+  rd:[`GP of 'a] Reg.t -> rn:[`GP of 'b] Reg.t -> imm9:int -> int32
+
 val encode_memory_barrier : op2:int -> Memory_barrier.t -> int32
 
 val encode_load_store_pair_gp :

--- a/backend/arm64/cfg_selection.ml
+++ b/backend/arm64/cfg_selection.ml
@@ -30,8 +30,9 @@ let scale_of_chunk : Cmm.memory_chunk -> int = function
   | Fivetwelve_aligned ->
     Misc.fatal_error "arm64: got 256/512 bit vector"
   | ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-    | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Word_int | Word_val
-    | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned ) as chunk ->
+    | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Word_int
+    | Word_int_unaligned | Word_val | Double | Onetwentyeight_unaligned
+    | Onetwentyeight_aligned ) as chunk ->
     Cmm.size_of_memory_chunk chunk
 
 let is_offset chunk n =

--- a/backend/arm64/dsl_helpers.ml
+++ b/backend/arm64/dsl_helpers.ml
@@ -176,6 +176,8 @@ let mem_label base ~(reloc : [`Twelve] Ast.Symbol.same_unit_or_reloc) ?offset
 
 let mem base = Ast.DSL.mem ~base
 
+let mem_offset_unscaled base offset = Ast.DSL.mem_offset_unscaled ~base ~offset
+
 (* See .mli for why this returns [`X] and not [`X | `SP]. *)
 let gp_reg_of_reg r : [`GP of [`X]] Ast.Reg.t =
   let index = reg_index r in

--- a/backend/arm64/dsl_helpers.mli
+++ b/backend/arm64/dsl_helpers.mli
@@ -159,6 +159,11 @@ val gp_reg_of_reg : Reg.t -> [`GP of [`X]] Ast.Reg.t
 val mem :
   [`GP of [< `X | `SP]] Ast.Reg.t -> [`Mem of [> `Base_reg]] Ast.Operand.t
 
+val mem_offset_unscaled :
+  [`GP of [< `X | `SP]] Ast.Reg.t ->
+  int ->
+  [`Mem of [> `Offset_nine_signed_unscaled]] Ast.Operand.t
+
 val addressing :
   Arch.addressing_mode ->
   Reg.t ->

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1619,7 +1619,12 @@ let emit_instr env i =
         match addr with
         | Iindexed v ->
           let ofs = Validated_mem_offset.offset v in
-          if ofs = 0
+          if !Arch.feat_lrcpc2 && ofs >= -256 && ofs <= 255
+          then
+            (* stlur takes a [base, #imm9] offset directly, no address calc. *)
+            A.ins2 STLUR (H.reg_x src)
+              (H.mem_offset_unscaled (H.gp_reg_of_reg base) ofs)
+          else if ofs = 0
           then A.ins2 STLR (H.reg_x src) (H.mem (H.gp_reg_of_reg base))
           else (
             (if ofs >= 0
@@ -2233,6 +2238,12 @@ let begin_assembly _unix =
       D.Directive.print asm_line_buffer d;
       Buffer.add_string asm_line_buffer "\n";
       Emitaux.emit_buffer asm_line_buffer);
+  (* stlur (from -flrcpc2) needs the GNU assembler at armv8.4-a; macOS's
+     assembler already accepts it.  Keep any enabled CSSC extension. *)
+  if !Arch.feat_lrcpc2 && not macosx
+  then
+    Emitaux.emit_string
+      (if !Arch.feat_cssc then "\t.arch armv8.4-a+cssc\n" else "\t.arch armv8.4-a\n");
   D.file ~file_num:None ~file_name:"";
   (* PR#7037 *)
   let data_begin = Cmm_helpers.make_symbol "data_begin" in

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1599,10 +1599,38 @@ let emit_instr env i =
     | Single { reg = Float64 } ->
       A.ins2 FCVT reg_s7 (H.reg_d src);
       A.ins2 STR_simd_and_fp reg_s7 addressing
-    | Word_int | Word_int_unaligned | Word_val ->
-      (* memory model barrier for non-initializing store *)
+    | Word_int_unaligned ->
+      (* May be unaligned (e.g. [Bytes.set_int64]); store-release requires
+         natural alignment, so keep the [dmb ishld; str] fence form, which
+         tolerates unaligned addresses. *)
       if assignment then A.ins0 (DMB ISHLD);
       A.ins2 STR (H.reg_x src) addressing
+    | Word_int | Word_val ->
+      if assignment
+      then (
+        (* OCaml 5 memory model: a non-initializing store needs load->store
+           ordering on weakly-ordered targets.  Rather than the pipeline-
+           draining [dmb ishld; str], use a store-release (stlr), which
+           provides at least that ordering in a single instruction and is far
+           cheaper on cores where [dmb] is expensive.  stlr requires natural
+           alignment (hence only the aligned chunks reach here) and has no
+           offset addressing, so the effective address is first materialised
+           in reg_tmp1 (x16). *)
+        match addr with
+        | Iindexed v ->
+          let ofs = Validated_mem_offset.offset v in
+          if ofs = 0
+          then A.ins2 STLR (H.reg_x src) (H.mem (H.gp_reg_of_reg base))
+          else (
+            (if ofs >= 0
+            then emit_addimm reg_x_tmp1 (H.reg_x base) ofs
+            else emit_subimm reg_x_tmp1 (H.reg_x base) (-ofs));
+            A.ins2 STLR (H.reg_x src) (H.mem reg_tmp1_base))
+        | Ibased _ ->
+          (* rare: statically-allocated mutable data; keep the barrier form *)
+          A.ins0 (DMB ISHLD);
+          A.ins2 STR (H.reg_x src) addressing)
+      else A.ins2 STR (H.reg_x src) addressing
     | Double -> A.ins2 STR_simd_and_fp (H.reg_d src) addressing
     | Single { reg = Float32 } ->
       A.ins2 STR_simd_and_fp (H.reg_s src) addressing

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1546,7 +1546,7 @@ let emit_instr env i =
     | Single { reg = Float64 } ->
       A.ins2 LDR_simd_and_fp reg_s7 addressing;
       A.ins2 FCVT (H.reg_d dst) reg_s7
-    | Word_int | Word_val ->
+    | Word_int | Word_int_unaligned | Word_val ->
       if is_atomic
       then (
         assert (
@@ -1599,7 +1599,7 @@ let emit_instr env i =
     | Single { reg = Float64 } ->
       A.ins2 FCVT reg_s7 (H.reg_d src);
       A.ins2 STR_simd_and_fp reg_s7 addressing
-    | Word_int | Word_val ->
+    | Word_int | Word_int_unaligned | Word_val ->
       (* memory model barrier for non-initializing store *)
       if assignment then A.ins0 (DMB ISHLD);
       A.ins2 STR (H.reg_x src) addressing

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -294,12 +294,14 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
   | Op (Load
           {memory_chunk=(Byte_unsigned|Byte_signed|Sixteen_unsigned|
                          Sixteen_signed|Thirtytwo_unsigned|Thirtytwo_signed|
-                         Word_int|Word_val|Double|Onetwentyeight_unaligned|
+                         Word_int|Word_int_unaligned|Word_val|Double|
+                         Onetwentyeight_unaligned|
                          Onetwentyeight_aligned);
            _ })
   | Op (Store
           ((Byte_unsigned|Byte_signed|Sixteen_unsigned|Sixteen_signed|
-            Thirtytwo_unsigned|Thirtytwo_signed|Word_int|Word_val|Double|
+            Thirtytwo_unsigned|Thirtytwo_signed|Word_int|Word_int_unaligned|
+            Word_val|Double|
             Onetwentyeight_unaligned|Onetwentyeight_aligned),
            _, _))
     -> [||]

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -371,6 +371,7 @@ type memory_chunk =
   | Thirtytwo_unsigned
   | Thirtytwo_signed
   | Word_int
+  | Word_int_unaligned
   | Word_val
   | Single of { reg : float_width }
   | Double
@@ -385,7 +386,7 @@ let size_of_memory_chunk : memory_chunk -> int = function
   | Byte_unsigned | Byte_signed -> 1
   | Sixteen_unsigned | Sixteen_signed -> 2
   | Thirtytwo_unsigned | Thirtytwo_signed | Single _ -> 4
-  | Word_int | Word_val | Double -> 8
+  | Word_int | Word_int_unaligned | Word_val | Double -> 8
   | Onetwentyeight_unaligned | Onetwentyeight_aligned -> 16
   | Twofiftysix_unaligned | Twofiftysix_aligned -> 32
   | Fivetwelve_unaligned | Fivetwelve_aligned -> 64
@@ -1049,6 +1050,7 @@ let equal_memory_chunk left right =
   | Thirtytwo_unsigned, Thirtytwo_unsigned -> true
   | Thirtytwo_signed, Thirtytwo_signed -> true
   | Word_int, Word_int -> true
+  | Word_int_unaligned, Word_int_unaligned -> true
   | Word_val, Word_val -> true
   | Single { reg = regl }, Single { reg = regr } -> equal_float_width regl regr
   | Double, Double -> true
@@ -1058,96 +1060,12 @@ let equal_memory_chunk left right =
   | Twofiftysix_aligned, Twofiftysix_aligned -> true
   | Fivetwelve_unaligned, Fivetwelve_unaligned -> true
   | Fivetwelve_aligned, Fivetwelve_aligned -> true
-  | ( Byte_unsigned,
-      ( Byte_signed | Sixteen_unsigned | Sixteen_signed | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Byte_signed,
-      ( Byte_unsigned | Sixteen_unsigned | Sixteen_signed | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Sixteen_unsigned,
-      ( Byte_unsigned | Byte_signed | Sixteen_signed | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Sixteen_signed,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Thirtytwo_unsigned
-      | Thirtytwo_signed | Word_int | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Thirtytwo_unsigned,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_signed | Word_int | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Thirtytwo_signed,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Word_int | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Word_int,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_val | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Word_val,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Single _ | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Double,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) )
-  | ( Onetwentyeight_unaligned,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Double | Onetwentyeight_aligned | Twofiftysix_unaligned
-      | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
-  | ( Onetwentyeight_aligned,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Double | Onetwentyeight_unaligned | Twofiftysix_unaligned
-      | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
-  | ( Twofiftysix_unaligned,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
-  | ( Twofiftysix_aligned,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Fivetwelve_unaligned | Fivetwelve_aligned ) )
-  | ( Fivetwelve_unaligned,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_aligned ) )
-  | ( Fivetwelve_aligned,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Single _
-      | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned ) )
-  | ( Single _,
-      ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_val | Double
-      | Onetwentyeight_unaligned | Onetwentyeight_aligned
-      | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-      | Fivetwelve_aligned ) ) ->
+  | ( ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
+      | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_int_unaligned
+      | Word_val | Single _ | Double | Onetwentyeight_unaligned
+      | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+      | Fivetwelve_unaligned | Fivetwelve_aligned ),
+      _ ) ->
     false
 
 let equal_integer_comparison = Scalar.Integer_comparison.equal

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -291,6 +291,10 @@ type memory_chunk =
   | Thirtytwo_unsigned
   | Thirtytwo_signed
   | Word_int (* integer or pointer outside heap *)
+  | Word_int_unaligned
+    (* 64-bit integer that may be stored at an unaligned address (e.g.
+       [Bytes.set_int64]); must not use ordered (release/acquire) accesses,
+       which require natural alignment on Arm. *)
   | Word_val (* pointer inside heap or encoded int *)
   | Single of { reg : float_width }
     (* F32 on the heap, may be F32 or F64 in registers. *)

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1570,7 +1570,7 @@ let memory_chunk_width_in_bytes : memory_chunk -> int = function
   | Sixteen_unsigned | Sixteen_signed -> 2
   | Thirtytwo_unsigned | Thirtytwo_signed -> 4
   | Single { reg = Float64 | Float32 } -> 4
-  | Word_int -> size_int
+  | Word_int | Word_int_unaligned -> size_int
   | Word_val -> size_addr
   | Double -> size_float
   | Onetwentyeight_unaligned | Onetwentyeight_aligned -> size_vec128
@@ -2314,7 +2314,7 @@ let memory_chunk_size_in_words_for_mixed_block = function
         "Unable to compile mixed blocks on a platform where a float is not the \
          same width as a value.";
     1
-  | Word_int | Word_val -> 1
+  | Word_int | Word_int_unaligned | Word_val -> 1
   | Onetwentyeight_unaligned | Onetwentyeight_aligned -> 2
   | Twofiftysix_unaligned | Twofiftysix_aligned -> 4
   | Fivetwelve_unaligned | Fivetwelve_aligned -> 8
@@ -2328,7 +2328,7 @@ let alloc_generic_set_fn block ofs newval memory_chunk dbg =
   | Word_val ->
     (* Values must go through "caml_initialize" *)
     addr_array_initialize block ofs newval dbg
-  | Word_int -> generic_case ()
+  | Word_int | Word_int_unaligned -> generic_case ()
   (* Generic cases that may differ under big endian archs *)
   | Single _ | Double | Thirtytwo_unsigned | Thirtytwo_signed
   | Onetwentyeight_unaligned | Onetwentyeight_aligned | Twofiftysix_unaligned
@@ -2444,20 +2444,20 @@ let make_mixed_alloc ~mode dbg ~tag ~value_prefix_size args args_memory_chunks =
           (* regular scanned part of a block *)
           match memory_chunk with
           | Word_int | Word_val -> ok ()
-          | Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-          | Thirtytwo_unsigned | Thirtytwo_signed | Single _ | Double
-          | Onetwentyeight_unaligned | Onetwentyeight_aligned
+          | Word_int_unaligned | Byte_unsigned | Byte_signed | Sixteen_unsigned
+          | Sixteen_signed | Thirtytwo_unsigned | Thirtytwo_signed | Single _
+          | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
           | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
           | Fivetwelve_aligned ->
             error "the value prefix of a mixed block"
         else
           (* flat suffix part of the block *)
           match memory_chunk with
-          | Word_int | Thirtytwo_unsigned | Thirtytwo_signed | Double
-          | Onetwentyeight_unaligned | Onetwentyeight_aligned
-          | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
-          | Fivetwelve_aligned | Single _ | Byte_unsigned | Byte_signed
-          | Sixteen_unsigned | Sixteen_signed ->
+          | Word_int | Word_int_unaligned | Thirtytwo_unsigned
+          | Thirtytwo_signed | Double | Onetwentyeight_unaligned
+          | Onetwentyeight_aligned | Twofiftysix_unaligned | Twofiftysix_aligned
+          | Fivetwelve_unaligned | Fivetwelve_aligned | Single _ | Byte_unsigned
+          | Byte_signed | Sixteen_unsigned | Sixteen_signed ->
             ok ()
           | Word_val -> error "the flat suffix of a mixed block")
       0 args_memory_chunks
@@ -2913,7 +2913,7 @@ let unaligned_set_64 ~ptr_out_of_heap ptr idx newval dbg =
   if Arch.allow_unaligned_access
   then
     Cop
-      ( Cstore (Word_int, Assignment),
+      ( Cstore (Word_int_unaligned, Assignment),
         [add_int_ptr ~ptr_out_of_heap ptr idx dbg; newval],
         dbg )
   else

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1090,7 +1090,7 @@ let load t (i : Cfg.basic Cfg.instruction) (memory_chunk : Cmm.memory_chunk)
     store_into_reg t i.res.(0) extended
   in
   match memory_chunk with
-  | Word_int -> basic T.i64
+  | Word_int | Word_int_unaligned -> basic T.i64
   | Word_val -> basic T.val_ptr
   | Byte_unsigned -> extend Zext ~from:T.i8 ~to_:T.i64
   | Byte_signed -> extend Sext ~from:T.i8 ~to_:T.i64
@@ -1118,7 +1118,7 @@ let store t (i : Cfg.basic Cfg.instruction) (memory_chunk : Cmm.memory_chunk)
     emit_ins_no_res t (I.store ~ptr ~to_store)
   in
   match memory_chunk with
-  | Word_int -> basic T.i64
+  | Word_int | Word_int_unaligned -> basic T.i64
   | Word_val -> basic T.val_ptr
   | Byte_unsigned | Byte_signed -> trunc Trunc T.i8
   | Sixteen_unsigned | Sixteen_signed -> trunc Trunc T.i16

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -150,6 +150,7 @@ let chunk = function
   | Fivetwelve_unaligned -> "unaligned vec512"
   | Fivetwelve_aligned -> "aligned vec512"
   | Word_int -> "int"
+  | Word_int_unaligned -> "unaligned int"
   | Word_val -> "val"
   | Single { reg = Float64 } -> "float32_as_float64"
   | Single { reg = Float32 } -> "float32"

--- a/backend/vectorize_utils.ml
+++ b/backend/vectorize_utils.ml
@@ -18,7 +18,7 @@ module Width_in_bits = struct
     | Byte_unsigned | Byte_signed -> W8
     | Sixteen_unsigned | Sixteen_signed -> W16
     | Thirtytwo_unsigned | Thirtytwo_signed | Single _ -> W32
-    | Word_int | Word_val | Double -> W64
+    | Word_int | Word_int_unaligned | Word_val | Double -> W64
     | Onetwentyeight_unaligned | Onetwentyeight_aligned -> W128
     | Twofiftysix_unaligned | Twofiftysix_aligned -> W256
     | Fivetwelve_unaligned | Fivetwelve_aligned -> W512

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -149,10 +149,10 @@ let memory_chunk_of_non_scannable_kind kind : Cmm.memory_chunk =
   match memory_chunk_of_kind kind with
   | Word_val -> Word_int
   | ( Byte_unsigned | Byte_signed | Sixteen_unsigned | Sixteen_signed
-    | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Single _ | Double
-    | Onetwentyeight_unaligned | Onetwentyeight_aligned | Twofiftysix_unaligned
-    | Twofiftysix_aligned | Fivetwelve_unaligned | Fivetwelve_aligned ) as mem
-    ->
+    | Thirtytwo_unsigned | Thirtytwo_signed | Word_int | Word_int_unaligned
+    | Single _ | Double | Onetwentyeight_unaligned | Onetwentyeight_aligned
+    | Twofiftysix_unaligned | Twofiftysix_aligned | Fivetwelve_unaligned
+    | Fivetwelve_aligned ) as mem ->
     mem
 
 let machtype_of_kinded_parameter p = Bound_parameter.kind p |> machtype_of_kind


### PR DESCRIPTION
3 separate changes to generate `stlr/stlur` instead of `dmb ishld`:
- transmit store alignment via Word_int_unaligned memory chunk
- use store-release (stlr) for aligned word stores
- use stlur (FEAT_LRCPC2) for aligned release stores under -flrcpc2

Performance (single core, Sandmark fannkuchredux 12, -O3 -unsafe -flrcpc2):
```
  NVIDIA Vera:  80.8s -> 20.5s with stlr  (3.94x)
                20.5s -> 19.4s with -flrcpc2/stlur
  End-to-end:   80.8s -> 19.4s  (4.18x)
```
With the per-store `dmb` gone, Vera is competitive on this benchmark
with Intel GNR (~19.5s) and AMD Turin (~22.0s). The big win is on
serial code: OCaml 5 emits a fence before every non-initializing
word store for the memory model, and `dmb ishld` is very expensive
on Vera (~73% backend stall; IPC 0.81 -> 3.18).

### Why the replacement is correct
OCaml 5 needs load->store ordering on weakly ordered targets for
non-initializing (assignment) stores. The current sequence is:
```
  dmb ishld; str
```
`dmb ishld (DMB LD)` orders prior loads before later loads/stores; it
does not order prior stores. Paired with `str`, that gives the required
load->store ordering.

`stlr` (store-release) orders all prior explicit memory accesses
(loads and stores) before the release store is observed. That is at
least as strong as `dmb ishld; str` for OCaml's requirement (slightly
stronger on prior stores). Unaligned Bytes/String stores keep the
fence form via `Word_int_unaligned`, because `stlr` requires natural
alignment.

`stlr` only addresses `[Xn]` a memory operand to a base register with no offset.
With `-flrcpc2` (compile-time opt-in), we emit `stlur` when the offset
fits in `imm9` (`ofs >= -256 && ofs <= 255`, signed 9-bit range),
avoiding an extra address materialization. `stlur` needs `FEAT_LRCPC2`
(ARMv8.4); the flag `-flrcpc2` must only be used when targeting such hardware.