### PR TITLE
Print `poly_` in value descriptions (#6038)

### DIFF
--- a/testsuite/tests/layout_poly/apply_layout.ml
+++ b/testsuite/tests/layout_poly/apply_layout.ml
@@ -7,8 +7,7 @@ module type S = sig
   val f : layout_ x y. ('a : x) ('b : y). 'a -> 'b -> unit
 end
 [%%expect{|
-module type S =
-  sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit end
+module type S = sig val poly_ f : 'a -> 'b -> unit end
 |}]
 
 (* layout instantiation requires static *)
@@ -71,11 +70,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit end
+         sig val poly_ g : 'a -> 'b -> unit end
        is not included in
          sig val g : int end
        Values do not match:
-         val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit
+         val poly_ g : 'a -> 'b -> unit
        is not included in
          val g : int
        The type "'a -> 'b -> unit" is not compatible with the type "int"
@@ -132,11 +131,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val g : '_weak1 -> unit end
        is not included in
-         sig val g : layout_ l. ('b : l). 'b -> unit end
+         sig val poly_ g : 'b -> unit end
        Values do not match:
          val g : '_weak1 -> unit
        is not included in
-         val g : layout_ l. ('b : l). 'b -> unit
+         val poly_ g : 'b -> unit
        The type "'_weak1 -> unit" is not compatible with the type "'a -> unit"
        Type "'_weak1" is not compatible with type "'a"
 |}]
@@ -151,9 +150,8 @@ end = struct
 end
 [%%expect{|
 module F :
-  functor
-    (M : sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit end @ static)
-    -> sig val g : layout_ l. ('b : l). 'b -> unit end
+  functor (M : sig val poly_ f : 'a -> 'b -> unit end @ static) ->
+    sig val poly_ g : 'b -> unit end
 |}]
 
 (* don't work without eta-expansion *)

--- a/testsuite/tests/layout_poly/let_poly.ml
+++ b/testsuite/tests/layout_poly/let_poly.ml
@@ -17,7 +17,7 @@ external to_nativeint : nativeint# -> nativeint = "%box_nativeint"
 (* Simple let poly_ with a polymorphic function *)
 let poly_ id x = x
 [%%expect{|
-val id : layout_ l. ('a : l). 'a -> 'a = <lpoly>
+val poly_ id : 'a -> 'a = <lpoly>
 |}]
 
 let (a, b, c, d) =
@@ -47,9 +47,8 @@ Error: This expression is not allowed in a "let poly_" definition;
 let poly_ const x y = x
 and poly_ apply f x = f x
 [%%expect{|
-val const : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a = <lpoly>
-val apply : layout_ l l0. ('a : l) ('b : l0). ('a -> 'b) -> 'a -> 'b =
-  <lpoly>
+val poly_ const : 'a -> 'b -> 'a = <lpoly>
+val poly_ apply : ('a -> 'b) -> 'a -> 'b = <lpoly>
 |}]
 
 (* CR-soon zqian: Tuple patterns are not yet supported by transl.
@@ -72,14 +71,11 @@ Lines 4-6, characters 6-3:
 6 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig
-           val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
-           val g : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'b
-         end
+         sig val poly_ f : 'a -> 'b -> 'a val poly_ g : 'a -> 'b -> 'b end
        is not included in
          sig val f : int val g : int end
        Values do not match:
-         val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+         val poly_ f : 'a -> 'b -> 'a
        is not included in
          val f : int
        The type "'a -> 'b -> 'a" is not compatible with the type "int"
@@ -100,11 +96,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val regular_id : 'a -> 'a end
        is not included in
-         sig val regular_id : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ regular_id : 'a -> 'a end
        Values do not match:
          val regular_id : 'a -> 'a
        is not included in
-         val regular_id : layout_ l. ('a : l). 'a -> 'a
+         val poly_ regular_id : 'a -> 'a
        the second has 1 more layout parameter that is not used,
        which is not supported yet.
 |}]
@@ -154,11 +150,11 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val id : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ id : 'a -> 'a end
        is not included in
          sig val id : 'a -> 'a end
        Values do not match:
-         val id : layout_ l. ('a : l). 'a -> 'a
+         val poly_ id : 'a -> 'a
        is not included in
          val id : 'a -> 'a
        the first has 1 more layout parameter that is not used,
@@ -178,7 +174,7 @@ Error: This expression is not allowed in a "let poly_" definition;
 (* constructor: passing when all args are syntactic values *)
 let poly_ f = Some (fun x -> x)
 [%%expect{|
-val f : layout_ l. ('a : l). ('a -> 'a) option = <lpoly>
+val poly_ f : ('a -> 'a) option = <lpoly>
 |}]
 
 (* constructor: failing when an arg is not a syntactic value *)
@@ -194,13 +190,13 @@ Error: This expression is not allowed in a "let poly_" definition;
 (* variant: passing - no payload *)
 let poly_ f _ = `A
 [%%expect{|
-val f : layout_ l. ('a : l). 'a -> [> `A ] = <lpoly>
+val poly_ f : 'a -> [> `A ] = <lpoly>
 |}]
 
 (* variant: passing - payload is a syntactic value *)
 let poly_ f = `A (fun x -> x)
 [%%expect{|
-val f : layout_ l. ('a : l). [> `A of 'a -> 'a ] = <lpoly>
+val poly_ f : [> `A of 'a -> 'a ] = <lpoly>
 |}]
 
 (* variant: failing - payload is not a syntactic value *)
@@ -242,7 +238,7 @@ Error: This expression is not allowed in a "let poly_" definition;
 (* unboxed tuple: passing when all components are syntactic values *)
 let poly_ f = #(42, fun x -> x)
 [%%expect{|
-val f : layout_ l. ('a : l). #(int * ('a -> 'a)) = <lpoly>
+val poly_ f : #(int * ('a -> 'a)) = <lpoly>
 |}]
 
 (* unboxed tuple: failing when a component is not a syntactic value *)
@@ -260,7 +256,7 @@ type r = { a : int; b : int -> int }
 let poly_ f _ = { a = 42; b = fun x -> x }
 [%%expect{|
 type r = { a : int; b : int -> int; }
-val f : layout_ l. ('a : l). 'a -> r = <lpoly>
+val poly_ f : 'a -> r = <lpoly>
 |}]
 
 (* record: failing when a field is not a syntactic value *)
@@ -278,7 +274,7 @@ type ur = #{ a : int; b : int }
 let poly_ f _ = #{ a = 42; b = 0 }
 [%%expect{|
 type ur = #{ a : int; b : int; }
-val f : layout_ l. ('a : l). 'a -> ur = <lpoly>
+val poly_ f : 'a -> ur = <lpoly>
 |}]
 
 (* unboxed product record: failing when a field is not a syntactic value *)
@@ -294,13 +290,13 @@ Error: This expression is not allowed in a "let poly_" definition;
 (* RHS might constrain a layout and makes it not polymorphic *)
 let poly_ f x y = #(x, (y, y))
 [%%expect{|
-val f : layout_ l. ('a : l) 'b. 'a -> 'b -> #('a * ('b * 'b)) = <lpoly>
+val poly_ f : 'b. 'a -> 'b -> #('a * ('b * 'b)) = <lpoly>
 |}]
 
 (* [any] doesn't really constrain the layout *)
 let poly_ f x = (x : (_ : any))
 [%%expect{|
-val f : layout_ l. ('a : l). 'a -> 'a = <lpoly>
+val poly_ f : 'a -> 'a = <lpoly>
 |}]
 
 (* [value] does constrain the layout *)
@@ -316,7 +312,7 @@ Error: This binding has no layout variables, so "poly_" has no effect.
 (* [assert false] is layout poly *)
 let poly_ f () = assert false
 [%%expect{|
-val f : layout_ l. ('a : l). unit -> 'a = <lpoly>
+val poly_ f : unit -> 'a = <lpoly>
 |}]
 
 (* We observe that foo is polymorphic on two types sharing the same polymorphic
@@ -338,7 +334,7 @@ let poly_ foo x y =
   let _ = id y in
   ()
 [%%expect{|
-val foo : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> unit = <lpoly>
+val poly_ foo : 'a -> 'b -> unit = <lpoly>
 |}]
 
 (* [rec] prevents layout polymorphism, even for fake recursion (no

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -8,7 +8,7 @@ module type S = sig
   val foo : layout_ x y. ('a : x) ('b : y). 'a -> 'b
 end
 [%%expect{|
-module type S = sig val foo : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+module type S = sig val poly_ foo : 'a -> 'b end
 |}]
 
 (* The following is error, because the module type goes through inclusion check
@@ -113,11 +113,11 @@ Error: Signature mismatch:
        Modules do not match:
          sig val f : layout_ l l0. ('a : l). 'a -> 'a end
        is not included in
-         sig val f : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ f : 'a -> 'a end
        Values do not match:
          val f : layout_ l l0. ('a : l). 'a -> 'a
        is not included in
-         val f : layout_ l. ('a : l). 'a -> 'a
+         val poly_ f : 'a -> 'a
        the first has 1 more layout parameter that is not used,
        which is not supported yet.
 |}]
@@ -134,11 +134,11 @@ Line 5, characters 6-7:
           ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ f : 'a -> 'a end
        is not included in
          sig val f : layout_ l l0. ('a : l). 'a -> 'a end
        Values do not match:
-         val f : layout_ l. ('a : l). 'a -> 'a
+         val poly_ f : 'a -> 'a
        is not included in
          val f : layout_ l l0. ('a : l). 'a -> 'a
        the second has 1 more layout parameter that is not used,
@@ -200,8 +200,8 @@ end) : sig
 end = M
 [%%expect{|
 module F1 :
-  functor (M : sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end) ->
-    sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+  functor (M : sig val poly_ f : 'a -> 'b end) ->
+    sig val poly_ f : 'a -> 'b end
 |}]
 
 (* layout-poly is not included in non-poly functions, even tho the former can be instantiate to the latter. *)
@@ -216,11 +216,11 @@ Line 5, characters 6-7:
           ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l. ('a : l). 'a -> 'a end
+         sig val poly_ f : 'a -> 'a end
        is not included in
          sig val f : 'a -> 'a end
        Values do not match:
-         val f : layout_ l. ('a : l). 'a -> 'a
+         val poly_ f : 'a -> 'a
        is not included in
          val f : 'a -> 'a
        the first has 1 more layout parameter that is not used,
@@ -283,8 +283,8 @@ end) : sig
 end = M
 [%%expect{|
 module FO3 :
-  functor (M : sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end) ->
-    sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+  functor (M : sig val poly_ f : 'a -> 'b end) ->
+    sig val poly_ f : 'a -> 'b end
 |}]
 
 (* Ordering: sorts swapped between sides - should fail *)
@@ -299,11 +299,11 @@ Line 5, characters 6-7:
           ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+         sig val poly_ f : 'a -> 'b end
        is not included in
          sig val f : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b end
        Values do not match:
-         val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b
+         val poly_ f : 'a -> 'b
        is not included in
          val f : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b
        The layout parameter at position 1 in the first
@@ -474,8 +474,7 @@ module type S = sig
   val poly_ foo1 : 'a -> 'b -> #('a * 'b)
 end
 [%%expect {|
-module type S =
-  sig val foo1 : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> #('a * 'b) end
+module type S = sig val poly_ foo1 : 'a -> 'b -> #('a * 'b) end
 |}]
 
 (* When quantified and unconstrained, type variables still have kind value *)
@@ -498,8 +497,7 @@ module type S = sig
   val poly_ foo3 : 'a. 'a -> 'b -> #('a * 'b)
 end
 [%%expect {|
-module type S =
-  sig val foo3 : layout_ l. 'a ('b : l). 'a -> 'b -> #('a * 'b) end
+module type S = sig val poly_ foo3 : 'a. 'a -> 'b -> #('a * 'b) end
 |}]
 
 (* Order of quantified type variables after typing a layout-polymorphic
@@ -508,8 +506,7 @@ module type S = sig
   val poly_ foo4 : 'a. 'b -> 'a -> #('a * 'b)
 end
 [%%expect {|
-module type S =
-  sig val foo4 : layout_ l. ('b : l) 'a. 'b -> 'a -> #('a * 'b) end
+module type S = sig val poly_ foo4 : 'a. 'b -> 'a -> #('a * 'b) end
 |}]
 
 (* Interaction between "val poly_" and "layout_". Currently errors.
@@ -533,9 +530,7 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz1 :
-      layout_ l.
-        'a ('b : immediate) ('c : l). 'a -> #('b * 'c) -> #('a * 'b * 'c)
+    val poly_ baz1 : 'a ('b : immediate). 'a -> #('b * 'c) -> #('a * 'b * 'c)
   end
 |}]
 
@@ -545,9 +540,7 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz2 :
-      layout_ l.
-        ('a : immediate) 'b ('c : l). 'a -> #('b * 'c) -> #('a * 'b * 'c)
+    val poly_ baz2 : ('a : immediate) 'b. 'a -> #('b * 'c) -> #('a * 'b * 'c)
   end
 |}]
 
@@ -557,9 +550,7 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz3 :
-      layout_ l.
-        'b ('a : immediate) ('c : l). 'b -> #('a * 'c) -> #('b * 'a * 'c)
+    val poly_ baz3 : 'b ('a : immediate). 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -585,10 +576,7 @@ end
 [%%expect {|
 module type S =
   sig
-    val baz5 :
-      layout_ l l0.
-        ('b : l) ('a : immediate) ('c : l0).
-          'b -> #('a * 'c) -> #('b * 'a * 'c)
+    val poly_ baz5 : ('a : immediate). 'b -> #('a * 'c) -> #('b * 'a * 'c)
   end
 |}]
 
@@ -599,10 +587,7 @@ module type S = sig
 end
 [%%expect {|
 module type S =
-  sig
-    val baz6 :
-      layout_ l. 'a 'b ('c : l). 'a -> #('a * 'b * 'c) -> #('a * 'b * 'c)
-  end
+  sig val poly_ baz6 : 'a 'b. 'a -> #('a * 'b * 'c) -> #('a * 'b * 'c) end
 |}]
 
 (* "value_or_null" stays the same. *)
@@ -611,10 +596,7 @@ module type S = sig
 end
 [%%expect {|
 module type S =
-  sig
-    val baz7 :
-      layout_ l. 'a 'b ('c : l). 'a -> #('a * 'b * 'c) -> #('a * 'b * 'c)
-  end
+  sig val poly_ baz7 : 'a 'b. 'a -> #('a * 'b * 'c) -> #('a * 'b * 'c) end
 |}]
 
 (* "'c is a value and not layout-polymorphic" *)
@@ -623,9 +605,71 @@ module type S = sig
 end
 [%%expect {|
 module type S =
-  sig
-    val baz8 :
-      layout_ l l0.
-        ('a : l) ('b : l0) 'c. 'a -> 'b -> 'c list -> #('a * 'b * 'c)
-  end
+  sig val poly_ baz8 : 'c. 'a -> 'b -> 'c list -> #('a * 'b * 'c) end
 |}]
+
+(* The shorthand omits the layout binders, so it is only used when the layout
+   variables appear in bound order. Here they don't ([l0] then [l]), so we keep
+   the "layout_" form. *)
+module type S = sig
+  val const : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b -> 'a
+end
+[%%expect {|
+module type S =
+  sig val const : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b -> 'a end
+|}]
+
+(* [l1] is declared but not the jkind of any type variable, so the shorthand
+   (which omits the layout binders) can't represent it; keep the "layout_"
+   form. *)
+module type S = sig
+  val unused : layout_ l0 l1. ('a : l0). 'a -> 'a
+end
+[%%expect {|
+Line 1:
+Error: Module type declarations do not match:
+         module type S =
+           sig val unused : layout_ l l0. ('a : l). 'a -> 'a end
+       does not match
+         module type S =
+           sig val unused : layout_ l l0. ('a : l). 'a -> 'a end
+       At position "module type S = <here>"
+       Module types do not match:
+         sig val unused : layout_ l l0. ('a : l). 'a -> 'a end
+       is not equal to
+         sig val unused : layout_ l l0. ('a : l). 'a -> 'a end
+       At position "module type S = <here>"
+       Values do not match:
+         val unused : layout_ l l0. ('a : l). 'a -> 'a
+       is not included in
+         val unused : layout_ l l0. ('a : l). 'a -> 'a
+       The layout parameter at position 2 in the first
+       is instantiated with an unconstrained layout variable,
+       which is not supported yet.
+|}]
+
+(* A layout variable appearing in a product (rather than as the top-level jkind
+   of a type variable) is rejected before printing, so the shorthand fallback
+   for that case is not yet reachable. *)
+module type S = sig
+  val f : layout_ l. ('a : value & l). 'a -> 'a
+end
+[%%expect {|
+Line 2, characters 27-36:
+2 |   val f : layout_ l. ('a : value & l). 'a -> 'a
+                               ^^^^^^^^^
+Error: Abstract kinds are not yet supported in products.
+|}]
+
+(* CR-soon layouts aivaskovic: uncomment this test once layout variables can
+   appear in products *)
+(* module type S = sig
+ *   val lpoly_prod : layout_ l. ('a : value & l) 'b. 'a -> 'b -> #('a * 'b)
+ * end
+ * [%%expect {|
+ * module type S =
+ *   sig
+ *     val lpoly_prod :
+ *       layout_ l. ('a : value & l) 'b. 'a -> 'b -> #('a * 'b)
+ *   end
+ * |}] *)

--- a/testsuite/tests/layout_poly/val_poly.ml
+++ b/testsuite/tests/layout_poly/val_poly.ml
@@ -619,6 +619,15 @@ module type S =
   sig val const : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b -> 'a end
 |}]
 
+(* [l] is the top jkind of two type variables, not exactly one, so keep the
+   "layout_" form. *)
+module type S = sig
+  val shared : layout_ l. ('a : l) ('b : l). 'a -> 'b
+end
+[%%expect {|
+module type S = sig val shared : layout_ l. ('a : l) ('b : l). 'a -> 'b end
+|}]
+
 (* [l1] is declared but not the jkind of any type variable, so the shorthand
    (which omits the layout binders) can't represent it; keep the "layout_"
    form. *)

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -1731,7 +1731,7 @@ Error: This binding has no layout variables, so "poly_" has no effect.
 
 let poly_ id = fun x -> x
 [%%expect{|
-val id : layout_ l. ('a : l). 'a -> 'a = <lpoly>
+val poly_ id : 'a -> 'a = <lpoly>
 |}]
 
 let poly_ const : 'a 'b. 'a -> 'b -> 'a = fun x _ -> x
@@ -1758,8 +1758,8 @@ Warning 219: This value description has no layout-polymorphic type variables,
 module type S_poly =
   sig
     val f : 'a -> 'a
-    val g : layout_ l. 'a 'b ('c : l). 'a -> 'b -> 'c -> 'a
-    val h : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b -> 'a
+    val poly_ g : 'a 'b. 'a -> 'b -> 'c -> 'a
+    val poly_ h : 'a -> 'b -> 'a
   end
 |}]
 
@@ -1806,5 +1806,5 @@ module type S = sig
   val f : layout_ x y. ('a : x) ('b : y). 'a -> 'b
 end
 [%%expect{|
-module type S = sig val f : layout_ l l0. ('a : l) ('b : l0). 'a -> 'b end
+module type S = sig val poly_ f : 'a -> 'b end
 |}]

--- a/testsuite/tests/tool-toplevel/printval_lpoly.ml
+++ b/testsuite/tests/tool-toplevel/printval_lpoly.ml
@@ -6,5 +6,5 @@
 (* Layout-poly values should print as <lpoly> in the toplevel. *)
 let poly_ id x = x
 [%%expect{|
-val id : layout_ l. ('a : l). 'a -> 'a = <lpoly>
+val poly_ id : 'a -> 'a = <lpoly>
 |}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -213,6 +213,11 @@ module Layout = struct
       | Base _ | Any _ | Univar _ | Genvar _ -> false
       | Product ts -> List.exists (has_component ~component) ts
 
+    let rec has_genvar = function
+      | Genvar _ -> true
+      | Product ts -> List.exists has_genvar ts
+      | Base _ | Any _ | Univar _ -> false
+
     module Debug_printers = struct
       open Format
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -112,6 +112,10 @@ module Layout : sig
     val of_sort_const : Sort.Const.t -> Scannable_axes.t -> t
 
     val to_string : t -> string
+
+    (** Whether the layout mentions a genvar anywhere (including inside a
+        product). *)
+    val has_genvar : t -> bool
   end
 
   val sub : Sort.t t -> Sort.t t -> Sub_result.t

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -948,8 +948,9 @@ and print_out_sig_item ppf =
            | Orec_next  -> "and")
           ppf td
   | Osig_value { oval_name; oval_type; oval_modalities;
-                 oval_prims; oval_attributes } ->
+                 oval_prims; oval_attributes; oval_poly } ->
       let kwd = if oval_prims = [] then "val" else "external" in
+      let poly = if oval_poly then "poly_ " else "" in
       let pr_prims ppf =
         function
           [] -> ()
@@ -957,7 +958,7 @@ and print_out_sig_item ppf =
             fprintf ppf "@ = \"%s\"" s;
             List.iter (fun s -> fprintf ppf "@ \"%s\"" s) sl
       in
-      fprintf ppf "@[<2>%s %a :@ %a%a%a%a@]" kwd value_ident oval_name
+      fprintf ppf "@[<2>%s %s%a :@ %a%a%a%a@]" kwd poly value_ident oval_name
         !out_type oval_type
         print_out_modalities oval_modalities
         pr_prims oval_prims

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1836,9 +1836,8 @@ let zap_qtvs_if_boring qtvs =
   then qtvs
   else []
 
-(* get the free variables with their jkinds; do this *after* converting the
-   type itself, so that the type names are available.
-   This implements Case (C3) from Note [When to print jkind annotations]. *)
+(* Extract the generalized free type variables of [tyl] with their jkinds, as
+   [(var, jkind)] pairs of the real representation, in order of appearance. *)
 let extract_qtvs tyl =
   let fvs = Ctype.free_non_row_variables_of_list tyl in
   (* The [Ctype.free*variables] family of functions returns the free
@@ -1846,8 +1845,12 @@ let extract_qtvs tyl =
   *)
   let fvs = List.rev fvs in
   let tfvs = List.map Transient_expr.repr fvs in
-  let vars_jkinds = tree_of_qtvs tfvs in
-  zap_qtvs_if_boring vars_jkinds
+  List.filter_map (fun v ->
+       match v.desc with
+       | Tvar { jkind } when v.level = generic_level -> Some (v, jkind)
+       | Tunivar { jkind } -> Some (v, jkind)
+       | _ -> None)
+    tfvs
 
 let param_jkind ty =
   match get_desc ty with
@@ -1891,8 +1894,14 @@ let extension_constructor_args_and_ret_type_subtree args ret_type =
   | Some res ->
       let out_ret = tree_of_typexp Type res in
       let out_args = tree_of_constructor_arguments args in
-      let qtvs = extract_qtvs (res :: tys_of_constr_args args) in
-      (out_args, Some (qtvs, out_ret))
+      let qtvs =
+        List.map
+          (fun (v, jkind) ->
+             Variable_names.name_of_type Variable_names.new_name v,
+             out_jkind_option_of_jkind ~ignore_null:true !printing_env jkind)
+          (extract_qtvs (res :: tys_of_constr_args args))
+      in
+      (out_args, Some (zap_qtvs_if_boring qtvs, out_ret))
 
 let tree_of_single_constructor ~all_void cd =
   let name = Ident.name cd.cd_id in
@@ -2249,6 +2258,35 @@ let prepared_extension_constructor id ppf ext =
   !Oprint.out_sig_item ppf
     (prepared_tree_of_extension_constructor id ext Text_first)
 
+let maybe_val_poly_shorthand lpoly_vars qtvs =
+  let module Sort_const = Jkind.Sort.Const in
+  let same_genvar a b =
+    Sort_const.equal (Sort_const.Genvar a) (Sort_const.Genvar b)
+  in
+  let top_genvar (_, jkind) =
+    match Jkind.get_layout !printing_env jkind with
+    | Some layout ->
+      (match Jkind.Layout.Const.get_sort layout with
+       | Some (Sort_const.Genvar v) -> Some v
+       | _ -> None)
+    | None -> None
+  in
+  let matched_genvars, unmatched =
+    List.partition_map
+      (fun q -> match top_genvar q with Some v -> Left v | None -> Right q)
+      qtvs
+  in
+  let no_genvar (_, jkind) =
+    match Jkind.get_layout !printing_env jkind with
+    | Some layout -> not (Jkind.Layout.Const.has_genvar layout)
+    | None -> true
+  in
+  if (not (List.is_empty lpoly_vars))
+     && List.equal same_genvar matched_genvars lpoly_vars
+     && List.for_all no_genvar unmatched
+  then Some unmatched
+  else None
+
 (* Print a value declaration *)
 
 let tree_of_value_description id decl =
@@ -2266,12 +2304,20 @@ let tree_of_value_description id decl =
       Ctype.zap_modalities_to_floor_if_modes_enabled_at Alpha
         decl.val_modalities
   in
-  let qsvs, qtvs =
-    (* Important: process the fvs *after* the type; tree_of_type_scheme
-       resets the naming context. Both must be inside print_with_genvars
-       so that sort poly var names are registered when jkinds are printed. *)
-    Jkind_types.Sort.print_with_genvars (Lpoly.get_exn decl.val_lpoly)
-      (fun names -> names, extract_qtvs [decl.val_type])
+  let oval_poly, qsvs, qtvs =
+    let lpoly_vars = Lpoly.get_exn decl.val_lpoly in
+    let tree_of_qtv (v, jkind) =
+      Variable_names.name_of_type Variable_names.new_name v,
+      out_jkind_option_of_jkind ~ignore_null:true !printing_env jkind
+    in
+    let qtvs = extract_qtvs [decl.val_type] in
+    match maybe_val_poly_shorthand lpoly_vars qtvs with
+    | Some unmatched ->
+      true, [], List.map tree_of_qtv unmatched
+    | None ->
+      Jkind_types.Sort.print_with_genvars lpoly_vars
+        (fun names ->
+           false, names, zap_qtvs_if_boring (List.map tree_of_qtv qtvs))
   in
   let apparent_arity =
     let rec count n typ =
@@ -2310,6 +2356,7 @@ let tree_of_value_description id decl =
   let vd =
     { oval_name = id;
       oval_type = Otyp_newlayout(qsvs, Otyp_poly(qtvs, ty));
+      oval_poly;
       oval_modalities = tree_of_modalities Immutable moda;
       oval_prims = [];
       oval_attributes = attrs

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -81,10 +81,10 @@ module Style = Misc.Style
    (* CR layouts reisenberg: update when the default changes *)
    This is a challenge, though, because the type in a [val] does not
    explicitly quantify its free variables. So we must collect the free
-   variables, look to see whether any have interesting jkinds, and
-   print the whole set of variables if any of them do. This is all
-   implemented in [extract_qtvs], used also in a number of other places
-   we do quantification (e.g. gadt-syntax constructors).
+   variables ([extract_qtvs], used also in a number of other places we do
+   quantification, e.g. gadt-syntax constructors), look to see whether any
+   have interesting jkinds ([tree_of_qtvs]), and print the whole set of
+   variables if any of them do ([zap_qtvs_if_boring]).
 
    Exception (X1). When we are still in the process of inferring a type,
    there may be an unfilled sort variable. Here is an example:
@@ -1535,7 +1535,7 @@ let rec tree_of_modal_typexp mode modal ty =
         (* Make the names delayed, so that the real type is
            printed once when used as proxy *)
         List.iter Aliases.add_delayed tyl;
-        let tl = tree_of_qtvs tyl in
+        let tl = tree_of_univars tyl in
         let tr = Otyp_poly (tl, tree_of_typexp mode alloc_mode ty) in
         (* Forget names when we leave scope *)
         Variable_names.remove_names tyl;
@@ -1620,24 +1620,23 @@ let rec tree_of_modal_typexp mode modal ty =
 and tree_of_typexp mode alloc_mode ty =
   tree_of_modal_typexp mode (Other alloc_mode) ty
 
-(* qtvs = quantified type variables *)
-(* this silently drops any arguments that are not generic Tvar or Tunivar *)
-and tree_of_qtvs qtvs =
-  let tree_of_qtv v : (string * out_jkind option) option =
+and tree_of_qtv v jkind =
     (* CR layouts: We ignore nullability here to avoid needlessly printing
        ['a : value_or_null] when it's not relevant (most cases).
        Unfortunately, this makes error messages really confusing, because
        we don't consider jkind annotations. *)
-    let tree jkind =
-      Some (Variable_names.name_of_type Variable_names.new_name v,
-            out_jkind_option_of_jkind ~ignore_null:true !printing_env jkind)
-    in
-    match v.desc with
-    | Tvar { jkind } when v.level = generic_level -> tree jkind
-    | Tunivar { jkind } -> tree jkind
-    | _ -> None
-  in
-  List.filter_map tree_of_qtv qtvs
+  Variable_names.name_of_type Variable_names.new_name v,
+  out_jkind_option_of_jkind ~ignore_null:true !printing_env jkind
+
+and tree_of_qtvs qtvs =
+  List.map (fun (v, jkind) -> tree_of_qtv v jkind) qtvs
+
+and tree_of_univars vars =
+  List.filter_map
+    (fun v -> match v.desc with
+       | Tunivar { jkind } -> Some (tree_of_qtv v jkind)
+       | _ -> None)
+    vars
 
 (* qsvs = quantified sort variables (for Trepr) *)
 (* Extract names from type variables corresponding to sort variables *)
@@ -1645,8 +1644,6 @@ and tree_of_qsvs qtvs =
   List.filter_map
     (fun v ->
       match v.desc with
-      | Tvar _ when v.level = generic_level ->
-        Some (Variable_names.name_of_type Variable_names.new_name v)
       | Tunivar _ ->
         Some (Variable_names.name_of_type Variable_names.new_name v)
       | _ -> None)
@@ -1837,7 +1834,7 @@ let zap_qtvs_if_boring qtvs =
   else []
 
 (* Extract the generalized free type variables of [tyl] with their jkinds, as
-   [(var, jkind)] pairs of the real representation, in order of appearance. *)
+   [(var, jkind)], in order of appearance. *)
 let extract_qtvs tyl =
   let fvs = Ctype.free_non_row_variables_of_list tyl in
   (* The [Ctype.free*variables] family of functions returns the free
@@ -1848,7 +1845,6 @@ let extract_qtvs tyl =
   List.filter_map (fun v ->
        match v.desc with
        | Tvar { jkind } when v.level = generic_level -> Some (v, jkind)
-       | Tunivar { jkind } -> Some (v, jkind)
        | _ -> None)
     tfvs
 
@@ -1895,13 +1891,11 @@ let extension_constructor_args_and_ret_type_subtree args ret_type =
       let out_ret = tree_of_typexp Type res in
       let out_args = tree_of_constructor_arguments args in
       let qtvs =
-        List.map
-          (fun (v, jkind) ->
-             Variable_names.name_of_type Variable_names.new_name v,
-             out_jkind_option_of_jkind ~ignore_null:true !printing_env jkind)
-          (extract_qtvs (res :: tys_of_constr_args args))
+        (res :: tys_of_constr_args args)
+        |> extract_qtvs
+        |> tree_of_qtvs |> zap_qtvs_if_boring
       in
-      (out_args, Some (zap_qtvs_if_boring qtvs, out_ret))
+      (out_args, Some (qtvs, out_ret))
 
 let tree_of_single_constructor ~all_void cd =
   let name = Ident.name cd.cd_id in
@@ -2306,18 +2300,14 @@ let tree_of_value_description id decl =
   in
   let oval_poly, qsvs, qtvs =
     let lpoly_vars = Lpoly.get_exn decl.val_lpoly in
-    let tree_of_qtv (v, jkind) =
-      Variable_names.name_of_type Variable_names.new_name v,
-      out_jkind_option_of_jkind ~ignore_null:true !printing_env jkind
-    in
     let qtvs = extract_qtvs [decl.val_type] in
     match maybe_val_poly_shorthand lpoly_vars qtvs with
     | Some unmatched ->
-      true, [], List.map tree_of_qtv unmatched
+      true, [], tree_of_qtvs unmatched
     | None ->
       Jkind_types.Sort.print_with_genvars lpoly_vars
         (fun names ->
-           false, names, zap_qtvs_if_boring (List.map tree_of_qtv qtvs))
+           false, names, zap_qtvs_if_boring (tree_of_qtvs qtvs))
   in
   let apparent_arity =
     let rec count n typ =
@@ -2384,7 +2374,7 @@ let tree_of_method mode (lab, priv, virt, ty) =
   let (ty, tyl) = method_type priv ty in
   let tty = tree_of_typexp mode ty in
   let tyl = List.map Transient_expr.repr tyl in
-  let qtvs = tree_of_qtvs tyl in
+  let qtvs = tree_of_univars tyl in
   let qtvs = zap_qtvs_if_boring qtvs in
   Variable_names.remove_names tyl;
   let priv = priv <> Mpublic in

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -242,6 +242,7 @@ and out_type_extension =
 and out_val_decl =
   { oval_name: string;
     oval_type: out_type;
+    oval_poly: bool;
     oval_modalities : out_modality list;
     (* Modalities on value descriptions are always new, even for [global_] *)
     oval_prims: string list;


### PR DESCRIPTION
Based on #6038 (the PR that we previously copied from).

We print the `poly_` shorthand (omitting the `layout_` binders) only when the layout variables are each the top-level jkind of a distinct type variable and appear in the same order they are bound; otherwise we keep the `layout_` form. The check is made on the jkind representation.

Positive example — shorthand is used:

```
val foo : layout_ x y. ('a : x) ('b : y). 'a -> 'b
==>
val poly_ foo : 'a -> 'b
```

Negative examples — shorthand is not used:

```
(* layout variables appear in a different order than they are bound *)
val const : layout_ l l0. ('a : l0) ('b : l). 'a -> 'b -> 'a
==> unchanged

(* l1 is not the jkind of any type variable *)
val unused : layout_ l0 l1. ('a : l0). 'a -> 'a
==> unchanged

(* every variable is explicitly quantified, so none is layout-polymorphic *)
val poly_ ordering : 'a 'b. 'b -> 'a
==> Warning 219: "poly_" has no effect
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
