### PR TITLE
Dissector: parse each partition once and parallelize partial linking

### DIFF
--- a/asmcomp/dissector/build_igot_and_iplt.ml
+++ b/asmcomp/dissector/build_igot_and_iplt.ml
@@ -29,18 +29,12 @@
 
 type t =
   { igot : Igot.t;
-    iplt : Iplt.t;
-    plt_symbols : string list;
-    got_symbols : string list
+    iplt : Iplt.t
   }
 
 let igot t = t.igot
 
 let iplt t = t.iplt
-
-let plt_symbols t = t.plt_symbols
-
-let got_symbols t = t.got_symbols
 
 let build ~prefix relocations =
   (* Extract unique symbol names from PLT32 relocations *)
@@ -60,7 +54,7 @@ let build ~prefix relocations =
   let igot = Igot.build ~prefix ~symbols:all_got_symbols in
   (* Build IPLT for PLT symbols only *)
   let iplt = Iplt.build ~prefix ~igot ~symbols:plt_syms in
-  { igot; iplt; plt_symbols = plt_syms; got_symbols = got_only_symbols }
+  { igot; iplt }
 
 let igot_symbol_for_got_reloc t reloc =
   let symbol = Extract_relocations.Relocation_entry.symbol_name reloc in

--- a/asmcomp/dissector/build_igot_and_iplt.mli
+++ b/asmcomp/dissector/build_igot_and_iplt.mli
@@ -53,15 +53,6 @@ val igot : t -> Igot.t
 (** Returns the built IPLT. *)
 val iplt : t -> Iplt.t
 
-(** Returns the original symbols that had PLT32 relocations (need IPLT entries).
-*)
-val plt_symbols : t -> string list
-
-(** Returns the original symbols that had GOTPCRELX relocations (need IGOT
-    entries, but not IPLT entries). These are in addition to the PLT symbols
-    which also get IGOT entries. *)
-val got_symbols : t -> string list
-
 (** [build ~prefix relocations] builds IGOT and IPLT sections from the extracted
     relocations.
 

--- a/asmcomp/dissector/build_igot_and_iplt.mli
+++ b/asmcomp/dissector/build_igot_and_iplt.mli
@@ -61,17 +61,15 @@ val iplt : t -> Iplt.t
       The relocations extracted from the partition's object files *)
 val build : prefix:string -> Extract_relocations.t -> t
 
-(** [igot_symbol_for_plt_reloc t reloc] returns the IGOT symbol name that should
-    replace the original PLT32 relocation target, or [None] if the relocation
-    doesn't need conversion.
+(** [igot_symbol_for_got_reloc t symbol] returns the IGOT symbol name that
+    should replace [symbol] as the target of a REX_GOTPCRELX relocation, or
+    [None] if the relocation doesn't need conversion.
 
     Note: PLT32 relocations are redirected to IPLT entries, not directly to
     IGOT. Use [iplt_symbol_for_plt_reloc] instead. *)
-val igot_symbol_for_got_reloc :
-  t -> Extract_relocations.Relocation_entry.t -> string option
+val igot_symbol_for_got_reloc : t -> Relocatable_symbol_name.t -> string option
 
-(** [iplt_symbol_for_plt_reloc t reloc] returns the IPLT symbol name that should
-    replace the original PLT32 relocation target, or [None] if the relocation
-    doesn't need conversion. *)
-val iplt_symbol_for_plt_reloc :
-  t -> Extract_relocations.Relocation_entry.t -> string option
+(** [iplt_symbol_for_plt_reloc t symbol] returns the IPLT symbol name that
+    should replace [symbol] as the target of a PLT32 relocation, or [None] if
+    the relocation doesn't need conversion. *)
+val iplt_symbol_for_plt_reloc : t -> Relocatable_symbol_name.t -> string option

--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -160,46 +160,47 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
   log "partitioned into %d partition(s)" (List.length partitions);
   log "%d passthrough file(s) (will bypass partial linking)"
     (List.length passthrough_files);
-  let linked_partitions =
-    try
-      Profile.record_call "dissector/partial_link" (fun () ->
-          Partial_link.link_partitions unix ~temp_dir partitions)
-    with Partial_link.Error err -> raise (Error (Partial_link_error err))
-  in
-  log "partially linked %d partition(s)" (List.length linked_partitions);
   (* For each partition, we extract the relocations and then rewrite it
      immediately. This avoids holding on to relocations (of other partitions)
      for longer than necessary. *)
-  let total_plt, total_got =
-    List.fold_left
-      (fun (plt_acc, got_acc) linked ->
-        let kind = Partition.kind (Partition.Linked.partition linked) in
-        let prefix = Partition.symbol_prefix kind in
-        let input_file = Partition.Linked.linked_object linked in
-        let mapped_partition_file, relocations =
-          Profile.record_call ~accumulate:true "dissector/extract_relocations"
-            (fun () ->
-              let file =
-                Extract_relocations.Mapped_object_file.read unix
-                  ~filename:input_file
-              in
-              file, Extract_relocations.extract file)
-        in
-        let n_plt = Extract_relocations.num_plt relocations in
-        let n_got = Extract_relocations.num_got relocations in
-        let igot_and_iplt = Build_igot_and_iplt.build ~prefix relocations in
-        log "built IGOT with %d entries, IPLT with %d entries (prefix=%s)"
-          (Igot.num_entries (Build_igot_and_iplt.igot igot_and_iplt))
-          (Iplt.num_entries (Build_igot_and_iplt.iplt igot_and_iplt))
-          prefix;
-        let output_file = input_file ^ ".rewritten" in
-        Profile.record_call ~accumulate:true "dissector/rewrite" (fun () ->
-            Rewrite_sections.rewrite unix ~mapped_partition_file ~output_file
-              ~partition_kind:kind ~igot_and_iplt ~relocations);
-        log "rewrote %s -> %s" input_file output_file;
-        plt_acc + n_plt, got_acc + n_got)
-      (0, 0) linked_partitions
+  let process_partition (rev_linked, plt_acc, got_acc) linked =
+    let kind = Partition.kind (Partition.Linked.partition linked) in
+    let prefix = Partition.symbol_prefix kind in
+    let input_file = Partition.Linked.linked_object linked in
+    let mapped_partition_file, relocations =
+      Profile.record_call ~accumulate:true "dissector/extract_relocations"
+        (fun () ->
+          let file =
+            Extract_relocations.Mapped_object_file.read unix
+              ~filename:input_file
+          in
+          file, Extract_relocations.extract file)
+    in
+    let n_plt = Extract_relocations.num_plt relocations in
+    let n_got = Extract_relocations.num_got relocations in
+    let igot_and_iplt = Build_igot_and_iplt.build ~prefix relocations in
+    log "built IGOT with %d entries, IPLT with %d entries (prefix=%s)"
+      (Igot.num_entries (Build_igot_and_iplt.igot igot_and_iplt))
+      (Iplt.num_entries (Build_igot_and_iplt.iplt igot_and_iplt))
+      prefix;
+    let output_file = input_file ^ ".rewritten" in
+    Profile.record_call ~accumulate:true "dissector/rewrite" (fun () ->
+        Rewrite_sections.rewrite unix ~mapped_partition_file ~output_file
+          ~partition_kind:kind ~igot_and_iplt ~relocations);
+    log "rewrote %s -> %s" input_file output_file;
+    linked :: rev_linked, plt_acc + n_plt, got_acc + n_got
   in
+  let rev_linked, total_plt, total_got =
+    try
+      Profile.record_call "dissector/partial_link" (fun () ->
+          Partial_link.link_all unix ~temp_dir
+            ~max_parallelism:!Oxcaml_flags.dissector_max_linker_parallelism
+            ~init:([], 0, 0) ~f:process_partition partitions)
+    with Partial_link.Error err -> raise (Error (Partial_link_error err))
+  in
+  let linked_partitions = List.rev rev_linked in
+  log "partially linked and rewrote %d partition(s)"
+    (List.length linked_partitions);
   log "total: %d PLT relocations, %d GOT relocations" total_plt total_got;
   let existing_script = extract_linker_script_from_ccopts !Clflags.all_ccopts in
   (match existing_script with

--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -163,7 +163,7 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
   let linked_partitions =
     try
       Profile.record_call "dissector/partial_link" (fun () ->
-          Partial_link.link_partitions ~temp_dir partitions)
+          Partial_link.link_partitions unix ~temp_dir partitions)
     with Partial_link.Error err -> raise (Error (Partial_link_error err))
   in
   log "partially linked %d partition(s)" (List.length linked_partitions);

--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -176,12 +176,14 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
         let kind = Partition.kind (Partition.Linked.partition linked) in
         let prefix = Partition.symbol_prefix kind in
         let input_file = Partition.Linked.linked_object linked in
-        let relocations =
+        let mapped_partition_file, relocations =
           Profile.record_call ~accumulate:true "dissector/extract_relocations"
             (fun () ->
-              Extract_relocations.extract
-                (Extract_relocations.Mapped_object_file.read unix
-                   ~filename:input_file))
+              let file =
+                Extract_relocations.Mapped_object_file.read unix
+                  ~filename:input_file
+              in
+              file, Extract_relocations.extract file)
         in
         let n_plt = Extract_relocations.num_plt relocations in
         let n_got = Extract_relocations.num_got relocations in
@@ -192,7 +194,7 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
           prefix;
         let output_file = input_file ^ ".rewritten" in
         Profile.record_call ~accumulate:true "dissector/rewrite" (fun () ->
-            Rewrite_sections.rewrite unix ~input_file ~output_file
+            Rewrite_sections.rewrite unix ~mapped_partition_file ~output_file
               ~partition_kind:kind ~igot_and_iplt ~relocations);
         log "rewrote %s -> %s" input_file output_file;
         plt_acc + n_plt, got_acc + n_got)

--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -178,7 +178,10 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
         let input_file = Partition.Linked.linked_object linked in
         let relocations =
           Profile.record_call ~accumulate:true "dissector/extract_relocations"
-            (fun () -> Extract_relocations.extract unix ~filename:input_file)
+            (fun () ->
+              Extract_relocations.extract
+                (Extract_relocations.Mapped_object_file.read unix
+                   ~filename:input_file))
         in
         let n_plt = Extract_relocations.num_plt relocations in
         let n_got = Extract_relocations.num_got relocations in

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -58,9 +58,6 @@ let num_plt t = t.num_plt
 
 let num_got t = t.num_got
 
-let empty =
-  { convert_to_plt = []; convert_to_got = []; num_plt = 0; num_got = 0 }
-
 (* Accumulator for efficient merging - stores lists in reverse order *)
 type accumulator =
   { acc_plt : Relocation_entry.t list;

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -44,6 +44,79 @@ module Relocation_entry = struct
   let offset t = t.offset
 end
 
+(* A partition's partially-linked object file. *)
+module Mapped_object_file = struct
+  type t =
+    { filename : string;
+      buf : Buf.t;
+      header : Elf.header;
+      sections : Elf.section array;
+      symbols : Elf.symbol array;
+      rela_text_sections : (Elf.section * Buf.t) list
+    }
+
+  let filename t = t.filename
+
+  let buf t = t.buf
+
+  let header t = t.header
+
+  let sections t = t.sections
+
+  let symbols t = t.symbols
+
+  let rela_text_sections t = t.rela_text_sections
+
+  (* Find all sections with names starting with prefix *)
+  let find_sections_with_prefix sections prefix =
+    Array.to_list sections
+    |> List.filter (fun (section : Elf.section) ->
+        String.starts_with ~prefix section.sh_name_str)
+
+  (* Find the symbol table section *)
+  let find_symtab_section sections =
+    Array.find_opt
+      (fun (section : Elf.section) ->
+        Elf.Section_type.(equal (of_u32 section.sh_type) sht_symtab))
+      sections
+
+  let read (unix : (module Compiler_owee.Unix_intf.S)) ~filename =
+    let module Unix = (val unix) in
+    log_verbose "extracting relocations from %s" filename;
+    let buf = Buf.map_binary (module Unix) filename in
+    let header, sections = Elf.read_elf buf in
+    (* Find all .rela.text* sections (handles function sections: .rela.text,
+       .rela.text.foo, .rela.text.bar, etc.) *)
+    let rela_text_sections = find_sections_with_prefix sections ".rela.text" in
+    (match rela_text_sections with
+    | [] -> log_verbose "  no .rela.text* sections found"
+    | _ ->
+      log_verbose "  found %d .rela.text* sections"
+        (List.length rela_text_sections));
+    (* Find symbol table *)
+    let symtab_section =
+      match find_symtab_section sections with
+      | Some section -> section
+      | None ->
+        Misc.fatal_errorf "Dissector: no symbol table found in %s" filename
+    in
+    (* Find string table (sh_link of symtab points to it) *)
+    let strtab_index = symtab_section.sh_link in
+    if strtab_index >= Array.length sections
+    then
+      Misc.fatal_errorf "Dissector: symtab sh_link out of range in %s" filename;
+    let strtab_section = sections.(strtab_index) in
+    let symtab_body = Elf.section_body buf symtab_section in
+    let strtab_body = Elf.section_body buf strtab_section in
+    let symbols = Elf.read_symbols ~symtab_body ~strtab_body in
+    let rela_text_sections =
+      List.map
+        (fun (section : Elf.section) -> section, Elf.section_body buf section)
+        rela_text_sections
+    in
+    { filename; buf; header; sections; symbols; rela_text_sections }
+end
+
 type t =
   { convert_to_plt : Relocation_entry.t list;
     convert_to_got : Relocation_entry.t list;
@@ -147,79 +220,6 @@ let parse_rela_section ~rela_body ~symbols =
   let convert_to_plt, num_plt = rev_and_count !convert_to_plt in
   let convert_to_got, num_got = rev_and_count !convert_to_got in
   { convert_to_plt; convert_to_got; num_plt; num_got }
-
-(* A partition's partially-linked object file. *)
-module Mapped_object_file = struct
-  type t =
-    { filename : string;
-      buf : Buf.t;
-      header : Elf.header;
-      sections : Elf.section array;
-      symbols : Elf.symbol array;
-      rela_text_sections : (Elf.section * Buf.t) list
-    }
-
-  let filename t = t.filename
-
-  let buf t = t.buf
-
-  let header t = t.header
-
-  let sections t = t.sections
-
-  let symbols t = t.symbols
-
-  let rela_text_sections t = t.rela_text_sections
-
-  (* Find all sections with names starting with prefix *)
-  let find_sections_with_prefix sections prefix =
-    Array.to_list sections
-    |> List.filter (fun (section : Elf.section) ->
-        String.starts_with ~prefix section.sh_name_str)
-
-  (* Find the symbol table section *)
-  let find_symtab_section sections =
-    Array.find_opt
-      (fun (section : Elf.section) ->
-        Elf.Section_type.(equal (of_u32 section.sh_type) sht_symtab))
-      sections
-
-  let read (unix : (module Compiler_owee.Unix_intf.S)) ~filename =
-    let module Unix = (val unix) in
-    log_verbose "extracting relocations from %s" filename;
-    let buf = Buf.map_binary (module Unix) filename in
-    let header, sections = Elf.read_elf buf in
-    (* Find all .rela.text* sections (handles function sections: .rela.text,
-       .rela.text.foo, .rela.text.bar, etc.) *)
-    let rela_text_sections = find_sections_with_prefix sections ".rela.text" in
-    (match rela_text_sections with
-    | [] -> log_verbose "  no .rela.text* sections found"
-    | _ ->
-      log_verbose "  found %d .rela.text* sections"
-        (List.length rela_text_sections));
-    (* Find symbol table *)
-    let symtab_section =
-      match find_symtab_section sections with
-      | Some section -> section
-      | None ->
-        Misc.fatal_errorf "Dissector: no symbol table found in %s" filename
-    in
-    (* Find string table (sh_link of symtab points to it) *)
-    let strtab_index = symtab_section.sh_link in
-    if strtab_index >= Array.length sections
-    then
-      Misc.fatal_errorf "Dissector: symtab sh_link out of range in %s" filename;
-    let strtab_section = sections.(strtab_index) in
-    let symtab_body = Elf.section_body buf symtab_section in
-    let strtab_body = Elf.section_body buf strtab_section in
-    let symbols = Elf.read_symbols ~symtab_body ~strtab_body in
-    let rela_text_sections =
-      List.map
-        (fun (section : Elf.section) -> section, Elf.section_body buf section)
-        rela_text_sections
-    in
-    { filename; buf; header; sections; symbols; rela_text_sections }
-end
 
 let extract_from_rela_text_sections ~symbols sections =
   List.fold_left

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -28,6 +28,7 @@
 (* CR mshinwell: This file needs to be code reviewed *)
 
 module Elf = Compiler_owee.Owee_elf
+module Buf = Compiler_owee.Owee_buf
 module Rela = Compiler_owee.Owee_elf_relocation
 
 let log_verbose = Dissector_log.log_verbose
@@ -147,63 +148,88 @@ let parse_rela_section ~rela_body ~symbols =
   let convert_to_got, num_got = rev_and_count !convert_to_got in
   { convert_to_plt; convert_to_got; num_plt; num_got }
 
-(* Find a section by name *)
-let find_section sections name =
-  Array.find_opt
-    (fun (section : Elf.section) -> String.equal section.sh_name_str name)
-    sections
+(* A partition's partially-linked object file. *)
+module Mapped_object_file = struct
+  type t =
+    { filename : string;
+      buf : Buf.t;
+      header : Elf.header;
+      sections : Elf.section array;
+      symbols : Elf.symbol array;
+      rela_text_sections : (Elf.section * Buf.t) list
+    }
 
-(* Find all sections with names starting with prefix *)
-let find_sections_with_prefix sections prefix =
-  Array.to_list sections
-  |> List.filter (fun (section : Elf.section) ->
-      String.starts_with ~prefix section.sh_name_str)
+  let filename t = t.filename
 
-(* Find the symbol table section *)
-let find_symtab_section sections =
-  Array.find_opt
-    (fun (section : Elf.section) ->
-      Elf.Section_type.(equal (of_u32 section.sh_type) sht_symtab))
-    sections
+  let buf t = t.buf
 
-(* Internal version that adds to an accumulator *)
-let extract_into_accumulator (unix : (module Compiler_owee.Unix_intf.S))
-    ~filename acc =
-  let module Unix = (val unix) in
-  log_verbose "extracting relocations from %s" filename;
-  let buf = Compiler_owee.Owee_buf.map_binary (module Unix) filename in
-  let _header, sections = Elf.read_elf buf in
-  (* Find all .rela.text* sections (handles function sections: .rela.text,
-     .rela.text.foo, .rela.text.bar, etc.) *)
-  let rela_text_sections = find_sections_with_prefix sections ".rela.text" in
-  match rela_text_sections with
-  | [] ->
-    log_verbose "  no .rela.text* sections found";
-    acc
-  | _ -> (
-    log_verbose "  found %d .rela.text* sections"
-      (List.length rela_text_sections);
+  let header t = t.header
+
+  let sections t = t.sections
+
+  let symbols t = t.symbols
+
+  let rela_text_sections t = t.rela_text_sections
+
+  (* Find all sections with names starting with prefix *)
+  let find_sections_with_prefix sections prefix =
+    Array.to_list sections
+    |> List.filter (fun (section : Elf.section) ->
+        String.starts_with ~prefix section.sh_name_str)
+
+  (* Find the symbol table section *)
+  let find_symtab_section sections =
+    Array.find_opt
+      (fun (section : Elf.section) ->
+        Elf.Section_type.(equal (of_u32 section.sh_type) sht_symtab))
+      sections
+
+  let read (unix : (module Compiler_owee.Unix_intf.S)) ~filename =
+    let module Unix = (val unix) in
+    log_verbose "extracting relocations from %s" filename;
+    let buf = Buf.map_binary (module Unix) filename in
+    let header, sections = Elf.read_elf buf in
+    (* Find all .rela.text* sections (handles function sections: .rela.text,
+       .rela.text.foo, .rela.text.bar, etc.) *)
+    let rela_text_sections = find_sections_with_prefix sections ".rela.text" in
+    (match rela_text_sections with
+    | [] -> log_verbose "  no .rela.text* sections found"
+    | _ ->
+      log_verbose "  found %d .rela.text* sections"
+        (List.length rela_text_sections));
     (* Find symbol table *)
-    match find_symtab_section sections with
-    | None -> acc
-    | Some symtab_section ->
-      (* Find string table (sh_link of symtab points to it) *)
-      let strtab_index = symtab_section.sh_link in
-      if strtab_index >= Array.length sections
-      then acc
-      else
-        let strtab_section = sections.(strtab_index) in
-        let symtab_body = Elf.section_body buf symtab_section in
-        let strtab_body = Elf.section_body buf strtab_section in
-        let symbols = Elf.read_symbols ~symtab_body ~strtab_body in
-        (* Process all .rela.text* sections and accumulate results *)
-        List.fold_left
-          (fun acc (rela_section : Elf.section) ->
-            log_verbose "  processing section %s" rela_section.sh_name_str;
-            let rela_body = Elf.section_body buf rela_section in
-            let result = parse_rela_section ~rela_body ~symbols in
-            accumulate acc result)
-          acc rela_text_sections)
+    let symtab_section =
+      match find_symtab_section sections with
+      | Some section -> section
+      | None ->
+        Misc.fatal_errorf "Dissector: no symbol table found in %s" filename
+    in
+    (* Find string table (sh_link of symtab points to it) *)
+    let strtab_index = symtab_section.sh_link in
+    if strtab_index >= Array.length sections
+    then
+      Misc.fatal_errorf "Dissector: symtab sh_link out of range in %s" filename;
+    let strtab_section = sections.(strtab_index) in
+    let symtab_body = Elf.section_body buf symtab_section in
+    let strtab_body = Elf.section_body buf strtab_section in
+    let symbols = Elf.read_symbols ~symtab_body ~strtab_body in
+    let rela_text_sections =
+      List.map
+        (fun (section : Elf.section) -> section, Elf.section_body buf section)
+        rela_text_sections
+    in
+    { filename; buf; header; sections; symbols; rela_text_sections }
+end
 
-let extract unix ~filename =
-  finalize (extract_into_accumulator unix ~filename empty_accumulator)
+let extract_from_rela_text_sections ~symbols sections =
+  List.fold_left
+    (fun acc ((rela_section : Elf.section), rela_body) ->
+      log_verbose "  processing section %s" rela_section.sh_name_str;
+      accumulate acc (parse_rela_section ~rela_body ~symbols))
+    empty_accumulator sections
+
+let extract (input : Mapped_object_file.t) =
+  let symbols = Mapped_object_file.symbols input in
+  finalize
+    (extract_from_rela_text_sections ~symbols
+       (Mapped_object_file.rela_text_sections input))

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -33,17 +33,6 @@ module Rela = Compiler_owee.Owee_elf_relocation
 
 let log_verbose = Dissector_log.log_verbose
 
-module Relocation_entry = struct
-  type t =
-    { symbol_name : string;
-      offset : int64
-    }
-
-  let symbol_name t = t.symbol_name
-
-  let offset t = t.offset
-end
-
 (* A partition's partially-linked object file. *)
 module Mapped_object_file = struct
   type t =
@@ -118,15 +107,15 @@ module Mapped_object_file = struct
 end
 
 type t =
-  { convert_to_plt : Relocation_entry.t list;
-    convert_to_got : Relocation_entry.t list;
+  { plt_symbols : Relocatable_symbol_name.t list;
+    got_symbols : Relocatable_symbol_name.t list;
     num_plt : int;
     num_got : int
   }
 
-let convert_to_plt t = t.convert_to_plt
+let plt_symbols t = t.plt_symbols
 
-let convert_to_got t = t.convert_to_got
+let got_symbols t = t.got_symbols
 
 let num_plt t = t.num_plt
 
@@ -134,8 +123,8 @@ let num_got t = t.num_got
 
 (* Accumulator for efficient merging - stores lists in reverse order *)
 type accumulator =
-  { acc_plt : Relocation_entry.t list;
-    acc_got : Relocation_entry.t list;
+  { acc_plt : Relocatable_symbol_name.t list;
+    acc_got : Relocatable_symbol_name.t list;
     acc_num_plt : int;
     acc_num_got : int
   }
@@ -145,16 +134,16 @@ let empty_accumulator =
 
 (* Add entries to accumulator - O(n) where n is size of entries being added *)
 let accumulate acc entries =
-  { acc_plt = List.rev_append entries.convert_to_plt acc.acc_plt;
-    acc_got = List.rev_append entries.convert_to_got acc.acc_got;
+  { acc_plt = List.rev_append entries.plt_symbols acc.acc_plt;
+    acc_got = List.rev_append entries.got_symbols acc.acc_got;
     acc_num_plt = acc.acc_num_plt + entries.num_plt;
     acc_num_got = acc.acc_num_got + entries.num_got
   }
 
 (* Finalize accumulator into result - reverses the lists *)
 let finalize acc =
-  { convert_to_plt = List.rev acc.acc_plt;
-    convert_to_got = List.rev acc.acc_got;
+  { plt_symbols = List.rev acc.acc_plt;
+    got_symbols = List.rev acc.acc_got;
     num_plt = acc.acc_num_plt;
     num_got = acc.acc_num_got
   }
@@ -170,8 +159,8 @@ let finalize acc =
    PC32 relocations to undefined symbols are an error. They occur when code is
    compiled with -nodynlink, which is incompatible with the dissector. *)
 let parse_rela_section ~rela_body ~symbols =
-  let convert_to_plt = ref [] in
-  let convert_to_got = ref [] in
+  let plt_symbols = ref [] in
+  let got_symbols = ref [] in
   Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
       (* Check for PC32 relocations to undefined symbols - these are an error *)
       if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.pc32
@@ -208,18 +197,16 @@ let parse_rela_section ~rela_body ~symbols =
           log_verbose "  reloc %s at 0x%Lx -> %s (UNDEF)"
             (Rela.Reloc_type.name entry.r_type)
             entry.r_offset symbol_name;
-          let reloc_entry =
-            { Relocation_entry.symbol_name; offset = entry.r_offset }
-          in
+          let name = Relocatable_symbol_name.of_string symbol_name in
           if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-          then convert_to_plt := reloc_entry :: !convert_to_plt
-          else convert_to_got := reloc_entry :: !convert_to_got);
+          then plt_symbols := name :: !plt_symbols
+          else got_symbols := name :: !got_symbols);
   let rev_and_count lst =
     List.fold_left (fun (acc, n) x -> x :: acc, n + 1) ([], 0) lst
   in
-  let convert_to_plt, num_plt = rev_and_count !convert_to_plt in
-  let convert_to_got, num_got = rev_and_count !convert_to_got in
-  { convert_to_plt; convert_to_got; num_plt; num_got }
+  let plt_symbols, num_plt = rev_and_count !plt_symbols in
+  let got_symbols, num_got = rev_and_count !got_symbols in
+  { plt_symbols; got_symbols; num_plt; num_got }
 
 let extract_from_rela_text_sections ~symbols sections =
   List.fold_left

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -121,6 +121,18 @@ let num_plt t = t.num_plt
 
 let num_got t = t.num_got
 
+(* Record a relocation; we only care about which symbols relocations occur
+   against, not their frequency, so we use a bitmap to deduplicate. *)
+let record_relocation ~seen ~acc ~num ~sym_index ~symbol_name =
+  (* [num] counts every site, not deduplicated symbols: it feeds the
+     per-partition log summary in [Dissector.run]. *)
+  incr num;
+  if not (Misc.Bitmap.get seen sym_index)
+  then begin
+    Misc.Bitmap.set seen sym_index;
+    acc := Relocatable_symbol_name.of_string symbol_name :: !acc
+  end
+
 (* Parse RELA entries and extract PLT32 and REX_GOTPCRELX relocations for
    undefined symbols (st_shndx = SHN_UNDEF). Only undefined symbols need PLT/GOT
    entries since defined symbols can be resolved directly.
@@ -169,27 +181,35 @@ let parse_rela_section ~rela_body ~symbols ~record_plt ~record_got =
             (Rela.Reloc_type.name entry.r_type)
             entry.r_offset symbol_name;
           if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-          then record_plt ~symbol_name
-          else record_got ~symbol_name)
+          then record_plt ~sym_index:entry.r_sym ~symbol_name
+          else record_got ~sym_index:entry.r_sym ~symbol_name)
 
 let extract_from_rela_text_sections ~symbols sections =
+  (* Symbols are deduplicated, keyed on the symbol table index. One "seen"
+     bitmap per list: a symbol may need both an IPLT and an IGOT entry. *)
+  let num_symbols = Array.length symbols in
+  let plt_seen = Misc.Bitmap.make num_symbols in
+  let got_seen = Misc.Bitmap.make num_symbols in
   let plt_symbols = ref [] in
   let got_symbols = ref [] in
   let num_plt = ref 0 in
   let num_got = ref 0 in
-  let record_plt ~symbol_name =
-    incr num_plt;
-    plt_symbols := Relocatable_symbol_name.of_string symbol_name :: !plt_symbols
+  let record_plt ~sym_index ~symbol_name =
+    record_relocation ~seen:plt_seen ~acc:plt_symbols ~num:num_plt ~sym_index
+      ~symbol_name
   in
-  let record_got ~symbol_name =
-    incr num_got;
-    got_symbols := Relocatable_symbol_name.of_string symbol_name :: !got_symbols
+  let record_got ~sym_index ~symbol_name =
+    record_relocation ~seen:got_seen ~acc:got_symbols ~num:num_got ~sym_index
+      ~symbol_name
   in
   List.iter
     (fun ((rela_section : Elf.section), rela_body) ->
       log_verbose "  processing section %s" rela_section.sh_name_str;
       parse_rela_section ~rela_body ~symbols ~record_plt ~record_got)
     sections;
+  (* CR sspies: The reversal here affects the order in which entries are written
+     into the respective tables. The order should not matter, so we can
+     eventually remove this reversal as well. *)
   { plt_symbols = List.rev !plt_symbols;
     got_symbols = List.rev !got_symbols;
     num_plt = !num_plt;

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -144,7 +144,7 @@ let record_relocation ~seen ~acc ~num ~sym_index ~symbol_name =
    PC32 relocations to undefined symbols are an error. They occur when code is
    compiled with -nodynlink, which is incompatible with the dissector. *)
 let parse_rela_section ~rela_body ~symbols ~record_plt ~record_got =
-  Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
+  Rela.iteri_rela_entries ~rela_body ~f:(fun ~index:_ entry ->
       (* Check for PC32 relocations to undefined symbols - these are an error *)
       if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.pc32
       then

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -146,9 +146,9 @@ let record_relocation ~seen ~acc ~num ~sym_index ~symbol_name =
    compiled with -nodynlink, which is incompatible with the dissector. *)
 let parse_rela_section ~rela_body ~symbols ~record_plt ~record_got =
   Rela.iteri_rela_entries ~rela_body ~f:(fun ~index:_ entry ->
-      (* Check for PC32 relocations to undefined symbols - these are an error *)
-      if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.pc32
-      then
+      match entry.r_type with
+      (* PC32 relocations to undefined symbols are an error *)
+      | rt when Rela.Reloc_type.equal rt Rela.Reloc_type.pc32 -> (
         match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
         | Some sym when Rela.Section_index.is_undef sym.Elf.st_shndx ->
           let symbol_name =
@@ -160,11 +160,10 @@ let parse_rela_section ~rela_body ~symbols ~record_plt ~record_got =
              The dissector requires code to be compiled without -nodynlink \
              (i.e., with dynamic linking support enabled)."
             symbol_name entry.r_offset
-        | _ -> ()
-      else if
-        Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-        || Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.rex_gotpcrelx
-      then
+        | _ -> ())
+      | rt
+        when Rela.Reloc_type.equal rt Rela.Reloc_type.plt32
+             || Rela.Reloc_type.equal rt Rela.Reloc_type.rex_gotpcrelx -> (
         (* Only process relocations for undefined symbols *)
         match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
         | None ->
@@ -184,6 +183,7 @@ let parse_rela_section ~rela_body ~symbols ~record_plt ~record_got =
           if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
           then record_plt ~sym_index:entry.r_sym ~symbol_name
           else record_got ~sym_index:entry.r_sym ~symbol_name)
+      | _ -> ())
 
 let extract_from_rela_text_sections ~symbols sections =
   (* Symbols are deduplicated, keyed on the symbol table index. One "seen"
@@ -203,6 +203,8 @@ let extract_from_rela_text_sections ~symbols sections =
     record_relocation ~seen:got_seen ~acc:got_symbols ~num:num_got ~sym_index
       ~symbol_name
   in
+  (* CR sspies: Consider rewriting this accumulation as a fold (possibly with
+     TMC) so that the refs and the final reversals are not needed. See #6447. *)
   List.iter
     (fun ((rela_section : Elf.section), rela_body) ->
       log_verbose "  processing section %s" rela_section.sh_name_str;

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -58,9 +58,10 @@ module Mapped_object_file = struct
 
   (* Find all sections with names starting with prefix *)
   let find_sections_with_prefix sections prefix =
-    Array.to_list sections
-    |> List.filter (fun (section : Elf.section) ->
+    Array.to_seq sections
+    |> Seq.filter (fun (section : Elf.section) ->
         String.starts_with ~prefix section.sh_name_str)
+    |> List.of_seq
 
   (* Find the symbol table section *)
   let find_symtab_section sections =

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -210,7 +210,7 @@ let extract_from_rela_text_sections ~symbols sections =
     sections;
   (* CR sspies: The reversal here affects the order in which entries are written
      into the respective tables. The order should not matter, so we can
-     eventually remove this reversal as well. *)
+     eventually remove this reversal as well. See #6447. *)
   { plt_symbols = List.rev !plt_symbols;
     got_symbols = List.rev !got_symbols;
     num_plt = !num_plt;

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -103,8 +103,7 @@ let parse_rela_section ~rela_body ~symbols =
       if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.pc32
       then
         match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
-        | Some sym when Rela.Section_index.(is_undef (of_int sym.Elf.st_shndx))
-          ->
+        | Some sym when Rela.Section_index.is_undef sym.Elf.st_shndx ->
           let symbol_name =
             if String.equal sym.Elf.name "" then "<unknown>" else sym.Elf.name
           in
@@ -125,11 +124,11 @@ let parse_rela_section ~rela_body ~symbols =
           log_verbose "  reloc %s at 0x%Lx: no symbol shndx"
             (Rela.Reloc_type.name entry.r_type)
             entry.r_offset
-        | Some sym
-          when Rela.Section_index.(is_defined (of_int sym.Elf.st_shndx)) ->
+        | Some sym when Rela.Section_index.is_defined sym.Elf.st_shndx ->
           log_verbose "  reloc %s at 0x%Lx: symbol defined (shndx=%d), skipping"
             (Rela.Reloc_type.name entry.r_type)
-            entry.r_offset sym.Elf.st_shndx
+            entry.r_offset
+            (Rela.Section_index.to_int sym.Elf.st_shndx)
         | Some sym ->
           let symbol_name = sym.Elf.name in
           log_verbose "  reloc %s at 0x%Lx -> %s (UNDEF)"

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -95,22 +95,18 @@ let finalize acc =
 
    PC32 relocations to undefined symbols are an error. They occur when code is
    compiled with -nodynlink, which is incompatible with the dissector. *)
-let parse_rela_section ~rela_body ~symtab_body ~strtab_body =
+let parse_rela_section ~rela_body ~symbols =
   let convert_to_plt = ref [] in
   let convert_to_got = ref [] in
   Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
       (* Check for PC32 relocations to undefined symbols - these are an error *)
       if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.pc32
       then
-        match Rela.read_symbol_shndx ~symtab_body ~sym_index:entry.r_sym with
-        | Some shndx when Rela.Section_index.is_undef shndx ->
+        match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
+        | Some sym when Rela.Section_index.(is_undef (of_int sym.Elf.st_shndx))
+          ->
           let symbol_name =
-            match
-              Rela.read_symbol_name ~symtab_body ~strtab_body
-                ~sym_index:entry.r_sym
-            with
-            | Some name -> name
-            | None -> "<unknown>"
+            if String.equal sym.Elf.name "" then "<unknown>" else sym.Elf.name
           in
           Misc.fatal_errorf
             "Dissector: R_X86_64_PC32 relocation to undefined symbol %s at \
@@ -124,35 +120,27 @@ let parse_rela_section ~rela_body ~symtab_body ~strtab_body =
         || Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.rex_gotpcrelx
       then
         (* Only process relocations for undefined symbols *)
-        match Rela.read_symbol_shndx ~symtab_body ~sym_index:entry.r_sym with
+        match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
         | None ->
           log_verbose "  reloc %s at 0x%Lx: no symbol shndx"
             (Rela.Reloc_type.name entry.r_type)
             entry.r_offset
-        | Some shndx when Rela.Section_index.is_defined shndx ->
+        | Some sym
+          when Rela.Section_index.(is_defined (of_int sym.Elf.st_shndx)) ->
           log_verbose "  reloc %s at 0x%Lx: symbol defined (shndx=%d), skipping"
             (Rela.Reloc_type.name entry.r_type)
-            entry.r_offset
-            (Rela.Section_index.to_int shndx)
-        | Some _ -> (
-          match
-            Rela.read_symbol_name ~symtab_body ~strtab_body
-              ~sym_index:entry.r_sym
-          with
-          | None ->
-            log_verbose "  reloc %s at 0x%Lx: no symbol name"
-              (Rela.Reloc_type.name entry.r_type)
-              entry.r_offset
-          | Some symbol_name ->
-            log_verbose "  reloc %s at 0x%Lx -> %s (UNDEF)"
-              (Rela.Reloc_type.name entry.r_type)
-              entry.r_offset symbol_name;
-            let reloc_entry =
-              { Relocation_entry.symbol_name; offset = entry.r_offset }
-            in
-            if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-            then convert_to_plt := reloc_entry :: !convert_to_plt
-            else convert_to_got := reloc_entry :: !convert_to_got));
+            entry.r_offset sym.Elf.st_shndx
+        | Some sym ->
+          let symbol_name = sym.Elf.name in
+          log_verbose "  reloc %s at 0x%Lx -> %s (UNDEF)"
+            (Rela.Reloc_type.name entry.r_type)
+            entry.r_offset symbol_name;
+          let reloc_entry =
+            { Relocation_entry.symbol_name; offset = entry.r_offset }
+          in
+          if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
+          then convert_to_plt := reloc_entry :: !convert_to_plt
+          else convert_to_got := reloc_entry :: !convert_to_got);
   let rev_and_count lst =
     List.fold_left (fun (acc, n) x -> x :: acc, n + 1) ([], 0) lst
   in
@@ -208,14 +196,13 @@ let extract_into_accumulator (unix : (module Compiler_owee.Unix_intf.S))
         let strtab_section = sections.(strtab_index) in
         let symtab_body = Elf.section_body buf symtab_section in
         let strtab_body = Elf.section_body buf strtab_section in
+        let symbols = Elf.read_symbols ~symtab_body ~strtab_body in
         (* Process all .rela.text* sections and accumulate results *)
         List.fold_left
           (fun acc (rela_section : Elf.section) ->
             log_verbose "  processing section %s" rela_section.sh_name_str;
             let rela_body = Elf.section_body buf rela_section in
-            let result =
-              parse_rela_section ~rela_body ~symtab_body ~strtab_body
-            in
+            let result = parse_rela_section ~rela_body ~symbols in
             accumulate acc result)
           acc rela_text_sections)
 

--- a/asmcomp/dissector/extract_relocations.ml
+++ b/asmcomp/dissector/extract_relocations.ml
@@ -121,33 +121,6 @@ let num_plt t = t.num_plt
 
 let num_got t = t.num_got
 
-(* Accumulator for efficient merging - stores lists in reverse order *)
-type accumulator =
-  { acc_plt : Relocatable_symbol_name.t list;
-    acc_got : Relocatable_symbol_name.t list;
-    acc_num_plt : int;
-    acc_num_got : int
-  }
-
-let empty_accumulator =
-  { acc_plt = []; acc_got = []; acc_num_plt = 0; acc_num_got = 0 }
-
-(* Add entries to accumulator - O(n) where n is size of entries being added *)
-let accumulate acc entries =
-  { acc_plt = List.rev_append entries.plt_symbols acc.acc_plt;
-    acc_got = List.rev_append entries.got_symbols acc.acc_got;
-    acc_num_plt = acc.acc_num_plt + entries.num_plt;
-    acc_num_got = acc.acc_num_got + entries.num_got
-  }
-
-(* Finalize accumulator into result - reverses the lists *)
-let finalize acc =
-  { plt_symbols = List.rev acc.acc_plt;
-    got_symbols = List.rev acc.acc_got;
-    num_plt = acc.acc_num_plt;
-    num_got = acc.acc_num_got
-  }
-
 (* Parse RELA entries and extract PLT32 and REX_GOTPCRELX relocations for
    undefined symbols (st_shndx = SHN_UNDEF). Only undefined symbols need PLT/GOT
    entries since defined symbols can be resolved directly.
@@ -158,9 +131,7 @@ let finalize acc =
 
    PC32 relocations to undefined symbols are an error. They occur when code is
    compiled with -nodynlink, which is incompatible with the dissector. *)
-let parse_rela_section ~rela_body ~symbols =
-  let plt_symbols = ref [] in
-  let got_symbols = ref [] in
+let parse_rela_section ~rela_body ~symbols ~record_plt ~record_got =
   Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
       (* Check for PC32 relocations to undefined symbols - these are an error *)
       if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.pc32
@@ -197,26 +168,35 @@ let parse_rela_section ~rela_body ~symbols =
           log_verbose "  reloc %s at 0x%Lx -> %s (UNDEF)"
             (Rela.Reloc_type.name entry.r_type)
             entry.r_offset symbol_name;
-          let name = Relocatable_symbol_name.of_string symbol_name in
           if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-          then plt_symbols := name :: !plt_symbols
-          else got_symbols := name :: !got_symbols);
-  let rev_and_count lst =
-    List.fold_left (fun (acc, n) x -> x :: acc, n + 1) ([], 0) lst
-  in
-  let plt_symbols, num_plt = rev_and_count !plt_symbols in
-  let got_symbols, num_got = rev_and_count !got_symbols in
-  { plt_symbols; got_symbols; num_plt; num_got }
+          then record_plt ~symbol_name
+          else record_got ~symbol_name)
 
 let extract_from_rela_text_sections ~symbols sections =
-  List.fold_left
-    (fun acc ((rela_section : Elf.section), rela_body) ->
+  let plt_symbols = ref [] in
+  let got_symbols = ref [] in
+  let num_plt = ref 0 in
+  let num_got = ref 0 in
+  let record_plt ~symbol_name =
+    incr num_plt;
+    plt_symbols := Relocatable_symbol_name.of_string symbol_name :: !plt_symbols
+  in
+  let record_got ~symbol_name =
+    incr num_got;
+    got_symbols := Relocatable_symbol_name.of_string symbol_name :: !got_symbols
+  in
+  List.iter
+    (fun ((rela_section : Elf.section), rela_body) ->
       log_verbose "  processing section %s" rela_section.sh_name_str;
-      accumulate acc (parse_rela_section ~rela_body ~symbols))
-    empty_accumulator sections
+      parse_rela_section ~rela_body ~symbols ~record_plt ~record_got)
+    sections;
+  { plt_symbols = List.rev !plt_symbols;
+    got_symbols = List.rev !got_symbols;
+    num_plt = !num_plt;
+    num_got = !num_got
+  }
 
 let extract (input : Mapped_object_file.t) =
   let symbols = Mapped_object_file.symbols input in
-  finalize
-    (extract_from_rela_text_sections ~symbols
-       (Mapped_object_file.rela_text_sections input))
+  extract_from_rela_text_sections ~symbols
+    (Mapped_object_file.rela_text_sections input)

--- a/asmcomp/dissector/extract_relocations.mli
+++ b/asmcomp/dissector/extract_relocations.mli
@@ -60,9 +60,39 @@ val num_plt : t -> int
 (** Returns the number of GOT relocations (O(1)). *)
 val num_got : t -> int
 
-(** [extract unix ~filename] reads the ELF object file at [filename] and
-    extracts relocations from the .rela.text section that need to be converted
-    for the medium code model.
+(** A partition's partially-linked object file. *)
+module Mapped_object_file : sig
+  type t
+
+  (** Map the ELF object file at [filename] and parse its header, section table,
+      symbol table and .rela.text* sections. Fatal error if the file has no
+      symbol table. *)
+  val read : (module Compiler_owee.Unix_intf.S) -> filename:string -> t
+
+  (** The filename passed to [read]. *)
+  val filename : t -> string
+
+  (** The whole mapped file. *)
+  val buf : t -> Compiler_owee.Owee_buf.t
+
+  (** The ELF header. *)
+  val header : t -> Compiler_owee.Owee_elf.header
+
+  (** The section table. *)
+  val sections : t -> Compiler_owee.Owee_elf.section array
+
+  (** The symbol table, indexed by symbol index. *)
+  val symbols : t -> Compiler_owee.Owee_elf.symbol array
+
+  (** All .rela.text* sections with their bodies, in section table order.
+      Handles both a traditional single .rela.text section and function
+      sections: .rela.text.foo, .rela.text.bar, etc. *)
+  val rela_text_sections :
+    t -> (Compiler_owee.Owee_elf.section * Compiler_owee.Owee_buf.t) list
+end
+
+(** [extract input] scans the .rela.text* sections of [input] for relocations
+    that need to be converted for the medium code model.
 
     Returns the lists of PLT32 and REX_GOTPCRELX relocations found. *)
-val extract : (module Compiler_owee.Unix_intf.S) -> filename:string -> t
+val extract : Mapped_object_file.t -> t

--- a/asmcomp/dissector/extract_relocations.mli
+++ b/asmcomp/dissector/extract_relocations.mli
@@ -44,22 +44,6 @@ module Relocation_entry : sig
   val offset : t -> int64
 end
 
-(** The result of extracting relocations from object files. *)
-type t
-
-(** Returns relocations with type R_X86_64_PLT32 that need PLT entries. *)
-val convert_to_plt : t -> Relocation_entry.t list
-
-(** Returns relocations with type R_X86_64_REX_GOTPCRELX that need GOT entries.
-*)
-val convert_to_got : t -> Relocation_entry.t list
-
-(** Returns the number of PLT relocations (O(1)). *)
-val num_plt : t -> int
-
-(** Returns the number of GOT relocations (O(1)). *)
-val num_got : t -> int
-
 (** A partition's partially-linked object file. *)
 module Mapped_object_file : sig
   type t
@@ -90,6 +74,22 @@ module Mapped_object_file : sig
   val rela_text_sections :
     t -> (Compiler_owee.Owee_elf.section * Compiler_owee.Owee_buf.t) list
 end
+
+(** The result of extracting relocations from object files. *)
+type t
+
+(** Returns relocations with type R_X86_64_PLT32 that need PLT entries. *)
+val convert_to_plt : t -> Relocation_entry.t list
+
+(** Returns relocations with type R_X86_64_REX_GOTPCRELX that need GOT entries.
+*)
+val convert_to_got : t -> Relocation_entry.t list
+
+(** Returns the number of PLT relocations (O(1)). *)
+val num_plt : t -> int
+
+(** Returns the number of GOT relocations (O(1)). *)
+val num_got : t -> int
 
 (** [extract input] scans the .rela.text* sections of [input] for relocations
     that need to be converted for the medium code model.

--- a/asmcomp/dissector/extract_relocations.mli
+++ b/asmcomp/dissector/extract_relocations.mli
@@ -29,20 +29,9 @@
 
 (** Extract relocations from partially-linked object files.
 
-    This module reads ELF object files and extracts relocations that need to be
-    converted to use an intermediate PLT or GOT when linking with the dissector
-    code model. *)
-
-(** Information about a single relocation that needs conversion. *)
-module Relocation_entry : sig
-  type t
-
-  (** Returns the symbol name for the relocation. *)
-  val symbol_name : t -> string
-
-  (** Returns the offset of the relocation within the section. *)
-  val offset : t -> int64
-end
+    This module reads ELF object files and extracts the symbols whose
+    relocations need to be converted to use an intermediate PLT or GOT when
+    linking with the dissector code model. *)
 
 (** A partition's partially-linked object file. *)
 module Mapped_object_file : sig
@@ -78,12 +67,13 @@ end
 (** The result of extracting relocations from object files. *)
 type t
 
-(** Returns relocations with type R_X86_64_PLT32 that need PLT entries. *)
-val convert_to_plt : t -> Relocation_entry.t list
+(** Returns the symbol name of each relocation with type R_X86_64_PLT32 that
+    needs a PLT entry (one element per relocation site). *)
+val plt_symbols : t -> Relocatable_symbol_name.t list
 
-(** Returns relocations with type R_X86_64_REX_GOTPCRELX that need GOT entries.
-*)
-val convert_to_got : t -> Relocation_entry.t list
+(** Returns the symbol name of each relocation with type R_X86_64_REX_GOTPCRELX
+    that needs a GOT entry (one element per relocation site). *)
+val got_symbols : t -> Relocatable_symbol_name.t list
 
 (** Returns the number of PLT relocations (O(1)). *)
 val num_plt : t -> int
@@ -94,5 +84,6 @@ val num_got : t -> int
 (** [extract input] scans the .rela.text* sections of [input] for relocations
     that need to be converted for the medium code model.
 
-    Returns the lists of PLT32 and REX_GOTPCRELX relocations found. *)
+    Returns the symbol names of the PLT32 and REX_GOTPCRELX relocations found.
+*)
 val extract : Mapped_object_file.t -> t

--- a/asmcomp/dissector/extract_relocations.mli
+++ b/asmcomp/dissector/extract_relocations.mli
@@ -68,17 +68,20 @@ end
 type t
 
 (** Returns the symbol name of each relocation with type R_X86_64_PLT32 that
-    needs a PLT entry (one element per relocation site). *)
+    needs a PLT entry. The names are unique, in order of first appearance; this
+    order determines IPLT entry order in [Build_igot_and_iplt]. *)
 val plt_symbols : t -> Relocatable_symbol_name.t list
 
 (** Returns the symbol name of each relocation with type R_X86_64_REX_GOTPCRELX
-    that needs a GOT entry (one element per relocation site). *)
+    that needs a GOT entry. The names are unique, in order of first appearance;
+    they may overlap with [plt_symbols], and together the two lists determine
+    IGOT entry order in [Build_igot_and_iplt]. *)
 val got_symbols : t -> Relocatable_symbol_name.t list
 
-(** Returns the number of PLT relocations (O(1)). *)
+(** Returns the number of PLT relocation sites (not deduplicated; O(1)). *)
 val num_plt : t -> int
 
-(** Returns the number of GOT relocations (O(1)). *)
+(** Returns the number of GOT relocation sites (not deduplicated; O(1)). *)
 val num_got : t -> int
 
 (** [extract input] scans the .rela.text* sections of [input] for relocations

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -216,22 +216,22 @@ let build_symbol_rewrite_map ~igot_and_iplt ~relocations =
         Build_igot_and_iplt.iplt_symbol_for_plt_reloc igot_and_iplt entry
       with
       | Some sym ->
-        let orig_sym = Extract_relocations.Relocation_entry.symbol_name entry in
+        let orig_sym = Relocatable_symbol_name.to_string entry in
         if not (String.Tbl.mem plt_map orig_sym)
         then String.Tbl.add plt_map orig_sym sym
       | None -> ())
-    (Extract_relocations.convert_to_plt relocations);
+    (Extract_relocations.plt_symbols relocations);
   List.iter
     (fun entry ->
       match
         Build_igot_and_iplt.igot_symbol_for_got_reloc igot_and_iplt entry
       with
       | Some sym ->
-        let orig_sym = Extract_relocations.Relocation_entry.symbol_name entry in
+        let orig_sym = Relocatable_symbol_name.to_string entry in
         if not (String.Tbl.mem got_map orig_sym)
         then String.Tbl.add got_map orig_sym sym
       | None -> ())
-    (Extract_relocations.convert_to_got relocations);
+    (Extract_relocations.got_symbols relocations);
   plt_map, got_map
 
 (* Rewrite a single .rela.text* section. Looks up each relocation's target

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -249,6 +249,8 @@ let build_symbol_rewrite_map ~igot_and_iplt ~relocations =
    the list does not affect the output. *)
 let rewrite_rela_section ~rela_body ~symbols ~symbol_to_index ~plt_rewrite_map
     ~got_rewrite_map =
+  (* CR sspies: Consider folding over the rela entries instead of accumulating
+     the changed entries through a ref. See #6447. *)
   let changed_entries = ref [] in
   Rela.iteri_rela_entries ~rela_body ~f:(fun ~index entry ->
       (* Look up the original symbol for this relocation *)
@@ -258,12 +260,12 @@ let rewrite_rela_section ~rela_body ~symbols ~symbol_to_index ~plt_rewrite_map
         let sym_name = sym.Elf.name in
         (* Check if this relocation type/symbol should be rewritten *)
         let rewrite_to =
-          if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-          then String.Tbl.find_opt plt_rewrite_map sym_name
-          else if
-            Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.rex_gotpcrelx
-          then String.Tbl.find_opt got_rewrite_map sym_name
-          else None
+          match entry.r_type with
+          | rt when Rela.Reloc_type.equal rt Rela.Reloc_type.plt32 ->
+            String.Tbl.find_opt plt_rewrite_map sym_name
+          | rt when Rela.Reloc_type.equal rt Rela.Reloc_type.rex_gotpcrelx ->
+            String.Tbl.find_opt got_rewrite_map sym_name
+          | _ -> None
         in
         match rewrite_to with
         | Some new_sym_name -> (

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -39,29 +39,6 @@ let align_up64 value alignment =
   let mask = Int64.sub alignment 1L in
   Int64.logand (Int64.add value mask) (Int64.lognot mask)
 
-module Symbol_entry = struct
-  type t =
-    { name : string;
-      st_info : int;
-      st_other : int;
-      st_shndx : int;
-      st_value : int64;
-      st_size : int64
-    }
-
-  let name s = s.name
-
-  let st_info s = s.st_info
-
-  let st_other s = s.st_other
-
-  let st_shndx s = s.st_shndx
-
-  let st_value s = s.st_value
-
-  let st_size s = s.st_size
-end
-
 module Section_layout = struct
   type t =
     { offset : int64;
@@ -121,7 +98,7 @@ module Rewritten_rela_section = struct
 end
 
 type t =
-  { original_symbols : Symbol_entry.t array;
+  { original_symbols : Elf.symbol array;
     symbol_to_index : int String.Tbl.t;
     total_symbols : int;
     rewritten_rela_sections : Rewritten_rela_section.t list;
@@ -200,20 +177,11 @@ let symtab_shndx_name_offset t = t.symtab_shndx_name_offset
 
 let layout t = t.layout
 
-let read_symbols ~symtab_body ~strtab_body =
-  let symbols = ref [] in
-  Elf.iter_symbols ~symtab_body ~strtab_body
-    ~f:(fun ~name ~st_info ~st_other ~st_shndx ~st_value ~st_size ->
-      symbols
-        := { Symbol_entry.name; st_info; st_other; st_shndx; st_value; st_size }
-           :: !symbols);
-  Array.of_list (List.rev !symbols)
-
 let build_symbol_index_map ~original_symbols ~igot_and_iplt strtab =
   let symbol_to_index = String.Tbl.create 256 in
   Array.iteri
-    (fun index sym ->
-      let name = Symbol_entry.name sym in
+    (fun index (sym : Elf.symbol) ->
+      let name = sym.name in
       if not (String.Tbl.mem symbol_to_index name)
       then String.Tbl.add symbol_to_index name index;
       ignore (Strtab.add strtab name))
@@ -403,7 +371,7 @@ let compute ~header ~sections ~symtab_body ~strtab_body ~rela_text_sections
     ~partition_kind ~igot_and_iplt ~relocations =
   log_verbose "forming rewrite plan for partition %s"
     (Partition.symbol_prefix partition_kind);
-  let original_symbols = read_symbols ~symtab_body ~strtab_body in
+  let original_symbols = Elf.read_symbols ~symtab_body ~strtab_body in
   let strtab = Strtab.create () in
   let symbol_to_index, total_symbols =
     build_symbol_index_map ~original_symbols ~igot_and_iplt strtab

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -89,12 +89,14 @@ end
 module Rewritten_rela_section = struct
   type t =
     { section_offset : int64; (* Original file offset of this section *)
-      entries : Rela.rela_entry list
+      changed_entries : (int * Rela.rela_entry) list
+          (* Rewritten entries with their index within the section; entries not
+             listed are unchanged. *)
     }
 
   let section_offset t = t.section_offset
 
-  let entries t = t.entries
+  let changed_entries t = t.changed_entries
 end
 
 type t =
@@ -239,46 +241,49 @@ let build_symbol_rewrite_map ~igot_and_iplt ~relocations =
    the synthetic IPLT/IGOT symbols.
 
    - PLT32: function calls -> PC32 to IPLT entry - GOTPCRELX: GOT references ->
-   PC32 to IGOT entry *)
+   PC32 to IGOT entry
+
+   Only the changed entries are returned, with their index within the section.
+   The resulting list is in reverse section order, which is fine: each changed
+   entry is written back at the offset determined by its index, so the order of
+   the list does not affect the output. *)
 let rewrite_rela_section ~rela_body ~symbols ~symbol_to_index ~plt_rewrite_map
     ~got_rewrite_map =
-  let entries = ref [] in
-  Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
-      let new_entry =
-        (* Look up the original symbol for this relocation *)
-        match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
-        | None -> entry
-        | Some sym -> (
-          let sym_name = sym.Elf.name in
-          (* Check if this relocation type/symbol should be rewritten *)
-          let rewrite_to =
-            if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
-            then String.Tbl.find_opt plt_rewrite_map sym_name
-            else if
-              Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.rex_gotpcrelx
-            then String.Tbl.find_opt got_rewrite_map sym_name
-            else None
-          in
-          match rewrite_to with
-          | Some new_sym_name -> (
-            match String.Tbl.find_opt symbol_to_index new_sym_name with
-            | Some idx ->
-              log_verbose "  rewrite reloc at 0x%Lx: %s %s -> PC32 to %s"
-                entry.r_offset
-                (Rela.Reloc_type.name entry.r_type)
-                sym_name new_sym_name;
+  let changed_entries = ref [] in
+  Rela.iteri_rela_entries ~rela_body ~f:(fun ~index entry ->
+      (* Look up the original symbol for this relocation *)
+      match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
+      | None -> ()
+      | Some sym -> (
+        let sym_name = sym.Elf.name in
+        (* Check if this relocation type/symbol should be rewritten *)
+        let rewrite_to =
+          if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
+          then String.Tbl.find_opt plt_rewrite_map sym_name
+          else if
+            Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.rex_gotpcrelx
+          then String.Tbl.find_opt got_rewrite_map sym_name
+          else None
+        in
+        match rewrite_to with
+        | Some new_sym_name -> (
+          match String.Tbl.find_opt symbol_to_index new_sym_name with
+          | Some idx ->
+            log_verbose "  rewrite reloc at 0x%Lx: %s %s -> PC32 to %s"
+              entry.r_offset
+              (Rela.Reloc_type.name entry.r_type)
+              sym_name new_sym_name;
+            let new_entry =
               { entry with r_sym = idx; r_type = Rela.Reloc_type.pc32 }
-            | None ->
-              log_verbose
-                "  rewrite reloc at 0x%Lx: %s -> %s NOT FOUND in symtab"
-                entry.r_offset
-                (Rela.Reloc_type.name entry.r_type)
-                new_sym_name;
-              entry)
-          | None -> entry)
-      in
-      entries := new_entry :: !entries);
-  List.rev !entries
+            in
+            changed_entries := (index, new_entry) :: !changed_entries
+          | None ->
+            log_verbose "  rewrite reloc at 0x%Lx: %s -> %s NOT FOUND in symtab"
+              entry.r_offset
+              (Rela.Reloc_type.name entry.r_type)
+              new_sym_name)
+        | None -> ()));
+  !changed_entries
 
 (* Each entry in SYMTAB_SHNDX is 4 bytes (Elf64_Word) *)
 let symtab_shndx_entry_size = 4
@@ -382,12 +387,12 @@ let compute ~header ~sections ~symbols ~rela_text_sections ~partition_kind
     List.map
       (fun (section, rela_body) ->
         log_verbose "  rewriting section %s" section.Elf.sh_name_str;
-        let entries =
+        let changed_entries =
           rewrite_rela_section ~rela_body ~symbols:original_symbols
             ~symbol_to_index ~plt_rewrite_map ~got_rewrite_map
         in
         { Rewritten_rela_section.section_offset = section.Elf.sh_offset;
-          entries
+          changed_entries
         })
       rela_text_sections
   in

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -369,6 +369,8 @@ let compute ~header ~sections ~symtab_body ~strtab_body ~rela_text_sections
     ~partition_kind ~igot_and_iplt ~relocations =
   log_verbose "forming rewrite plan for partition %s"
     (Partition.symbol_prefix partition_kind);
+  (* CR sspies: This is inefficient. We should read the symbols only once. This
+     read will be removed in a subsequent change. *)
   let original_symbols = Elf.read_symbols ~symtab_body ~strtab_body in
   let strtab = Strtab.create () in
   let symbol_to_index, total_symbols =

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -240,18 +240,16 @@ let build_symbol_rewrite_map ~igot_and_iplt ~relocations =
 
    - PLT32: function calls -> PC32 to IPLT entry - GOTPCRELX: GOT references ->
    PC32 to IGOT entry *)
-let rewrite_rela_section ~rela_body ~symtab_body ~strtab_body ~symbol_to_index
-    ~plt_rewrite_map ~got_rewrite_map =
+let rewrite_rela_section ~rela_body ~symbols ~symbol_to_index ~plt_rewrite_map
+    ~got_rewrite_map =
   let entries = ref [] in
   Rela.iter_rela_entries ~rela_body ~f:(fun entry ->
       let new_entry =
-        (* Look up the original symbol name for this relocation *)
-        let sym_name_opt =
-          Rela.read_symbol_name ~symtab_body ~strtab_body ~sym_index:entry.r_sym
-        in
-        match sym_name_opt with
+        (* Look up the original symbol for this relocation *)
+        match Elf.symbol_table_lookup symbols ~sym_index:entry.r_sym with
         | None -> entry
-        | Some sym_name -> (
+        | Some sym -> (
+          let sym_name = sym.Elf.name in
           (* Check if this relocation type/symbol should be rewritten *)
           let rewrite_to =
             if Rela.Reloc_type.equal entry.r_type Rela.Reloc_type.plt32
@@ -385,7 +383,7 @@ let compute ~header ~sections ~symtab_body ~strtab_body ~rela_text_sections
       (fun (section, rela_body) ->
         log_verbose "  rewriting section %s" section.Elf.sh_name_str;
         let entries =
-          rewrite_rela_section ~rela_body ~symtab_body ~strtab_body
+          rewrite_rela_section ~rela_body ~symbols:original_symbols
             ~symbol_to_index ~plt_rewrite_map ~got_rewrite_map
         in
         { Rewritten_rela_section.section_offset = section.Elf.sh_offset;

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -365,13 +365,11 @@ let rename_section ~(partition_kind : Partition.kind) name =
 (* [rela_text_sections] is a list of (section, body) pairs for all .rela.text*
    sections in the input file. Each section's relocations will be rewritten to
    use the synthetic IGOT/IPLT symbols. *)
-let compute ~header ~sections ~symtab_body ~strtab_body ~rela_text_sections
-    ~partition_kind ~igot_and_iplt ~relocations =
+let compute ~header ~sections ~symbols ~rela_text_sections ~partition_kind
+    ~igot_and_iplt ~relocations =
   log_verbose "forming rewrite plan for partition %s"
     (Partition.symbol_prefix partition_kind);
-  (* CR sspies: This is inefficient. We should read the symbols only once. This
-     read will be removed in a subsequent change. *)
-  let original_symbols = Elf.read_symbols ~symtab_body ~strtab_body in
+  let original_symbols = symbols in
   let strtab = Strtab.create () in
   let symbol_to_index, total_symbols =
     build_symbol_index_map ~original_symbols ~igot_and_iplt strtab

--- a/asmcomp/dissector/form_rewrite_plan.ml
+++ b/asmcomp/dissector/form_rewrite_plan.ml
@@ -335,13 +335,13 @@ let compute_file_layout ~original_data_end ~igot_and_iplt ~total_symbols
   let iplt_t = Build_igot_and_iplt.iplt igot_and_iplt in
   let igot = alloc 16 (Igot.section_size igot_t) in
   let rela_igot =
-    let count = List.length (Igot.relocations igot_t) in
-    alloc 8 (count * Rela.rela_entry_size)
+    (* One relocation per IGOT entry *)
+    alloc 8 (Igot.num_entries igot_t * Rela.rela_entry_size)
   in
   let iplt = alloc 16 (Iplt.section_size iplt_t) in
   let rela_iplt =
-    let count = List.length (Iplt.relocations iplt_t) in
-    alloc 8 (count * Rela.rela_entry_size)
+    (* One relocation per IPLT entry *)
+    alloc 8 (Iplt.num_entries iplt_t * Rela.rela_entry_size)
   in
   let symtab = alloc 8 (total_symbols * Rela.sym_entry_size) in
   (* Allocate SYMTAB_SHNDX section if input has one *)

--- a/asmcomp/dissector/form_rewrite_plan.mli
+++ b/asmcomp/dissector/form_rewrite_plan.mli
@@ -172,9 +172,12 @@ val symtab_shndx_name_offset : t -> int option
 (** Returns the layout of all sections in the output file. *)
 val layout : t -> Layout.t
 
-(** [compute ~header ~sections ~symtab_body ~strtab_body ~rela_text_sections
-     ~partition_kind ~igot_and_iplt ~relocations] analyzes the ELF structure and
-    builds a rewrite plan.
+(** [compute ~header ~sections ~symbols ~rela_text_sections ~partition_kind
+     ~igot_and_iplt ~relocations] analyzes the ELF structure and builds a
+    rewrite plan.
+
+    [symbols] is the partition file's symbol table, as parsed by
+    [Extract_relocations.Mapped_object_file].
 
     [rela_text_sections] is a list of (section, body) pairs for all .rela.text*
     sections in the input file. This handles both traditional single .rela.text
@@ -185,8 +188,7 @@ val layout : t -> Layout.t
 val compute :
   header:Compiler_owee.Owee_elf.header ->
   sections:Compiler_owee.Owee_elf.section array ->
-  symtab_body:Compiler_owee.Owee_buf.t ->
-  strtab_body:Compiler_owee.Owee_buf.t ->
+  symbols:Compiler_owee.Owee_elf.symbol array ->
   rela_text_sections:
     (Compiler_owee.Owee_elf.section * Compiler_owee.Owee_buf.t) list ->
   partition_kind:Partition.kind ->

--- a/asmcomp/dissector/form_rewrite_plan.mli
+++ b/asmcomp/dissector/form_rewrite_plan.mli
@@ -86,8 +86,11 @@ module Rewritten_rela_section : sig
   (** Original file offset of this section. *)
   val section_offset : t -> int64
 
-  (** The rewritten relocation entries. *)
-  val entries : t -> Compiler_owee.Owee_elf_relocation.rela_entry list
+  (** The rewritten relocation entries, each with its index within the section
+      (the entry lies at byte offset [index * rela_entry_size] within the
+      section). Entries not listed are unchanged. *)
+  val changed_entries :
+    t -> (int * Compiler_owee.Owee_elf_relocation.rela_entry) list
 end
 
 (** A rewrite plan for an ELF file. *)

--- a/asmcomp/dissector/form_rewrite_plan.mli
+++ b/asmcomp/dissector/form_rewrite_plan.mli
@@ -33,29 +33,6 @@
     modifications needed: new sections, relocated symbols, and file layout. The
     plan can then be executed by [Rewrite_sections]. *)
 
-(** Information about an original symbol from the ELF symbol table. *)
-module Symbol_entry : sig
-  type t
-
-  (** Returns the symbol name. *)
-  val name : t -> string
-
-  (** Returns st_info (binding and type packed into one byte). *)
-  val st_info : t -> int
-
-  (** Returns st_other (visibility). *)
-  val st_other : t -> int
-
-  (** Returns st_shndx (section index). *)
-  val st_shndx : t -> int
-
-  (** Returns st_value (symbol value/address). *)
-  val st_value : t -> int64
-
-  (** Returns st_size (symbol size). *)
-  val st_size : t -> int64
-end
-
 (** Layout of a section in the output file. *)
 module Section_layout : sig
   type t
@@ -117,7 +94,7 @@ end
 type t
 
 (** Returns the original symbols from the input file's symbol table. *)
-val original_symbols : t -> Symbol_entry.t array
+val original_symbols : t -> Compiler_owee.Owee_elf.symbol array
 
 (** Returns a map from symbol name to index in the output symbol table. *)
 val symbol_to_index : t -> int Misc.Stdlib.String.Tbl.t

--- a/asmcomp/dissector/igot.ml
+++ b/asmcomp/dissector/igot.ml
@@ -67,31 +67,24 @@ let igot_symbol_name ~prefix ~symbol =
 let build ~prefix ~symbols =
   (* Remove duplicates while preserving order, and build lookup table *)
   let by_original_symbol = String.Tbl.create 256 in
-  let unique_symbols =
-    List.filter
-      (fun sym ->
-        if String.Tbl.mem by_original_symbol sym
-        then false
-        else (
-          (* Placeholder entry - will be replaced below *)
-          String.Tbl.add by_original_symbol sym
-            { Entry.index = 0; original_symbol = sym; igot_symbol = "" };
-          true))
-      symbols
+  let rev_entries, num_entries =
+    List.fold_left
+      (fun (rev_entries, index) original_symbol ->
+        if String.Tbl.mem by_original_symbol original_symbol
+        then rev_entries, index
+        else
+          let igot_symbol = igot_symbol_name ~prefix ~symbol:original_symbol in
+          log_verbose "  IGOT entry %d: %s -> %s" index original_symbol
+            igot_symbol;
+          let entry = { Entry.index; original_symbol; igot_symbol } in
+          String.Tbl.add by_original_symbol original_symbol entry;
+          entry :: rev_entries, index + 1)
+      ([], 0) symbols
   in
-  let entries =
-    List.mapi
-      (fun index original_symbol ->
-        let igot_symbol = igot_symbol_name ~prefix ~symbol:original_symbol in
-        log_verbose "  IGOT entry %d: %s -> %s" index original_symbol
-          igot_symbol;
-        let entry = { Entry.index; original_symbol; igot_symbol } in
-        String.Tbl.replace by_original_symbol original_symbol entry;
-        entry)
-      unique_symbols
-  in
+  (* CR sspies: The order of entries does not matter here, so we should remove
+     the list reversal at some point. *)
+  let entries = List.rev rev_entries in
   (* Section data is zero-initialized *)
-  let num_entries = String.Tbl.length by_original_symbol in
   let section_data = Bytes.make (num_entries * entry_size) '\x00' in
   { entries; num_entries; by_original_symbol; section_data }
 

--- a/asmcomp/dissector/igot.ml
+++ b/asmcomp/dissector/igot.ml
@@ -69,7 +69,8 @@ let build ~prefix ~symbols =
   let by_original_symbol = String.Tbl.create 256 in
   let rev_entries, num_entries =
     List.fold_left
-      (fun (rev_entries, index) original_symbol ->
+      (fun (rev_entries, index) symbol ->
+        let original_symbol = Relocatable_symbol_name.to_string symbol in
         if String.Tbl.mem by_original_symbol original_symbol
         then rev_entries, index
         else
@@ -96,7 +97,9 @@ let section_data t = t.section_data
 
 let section_size t = Bytes.length t.section_data
 
-let find_entry t ~symbol = String.Tbl.find_opt t.by_original_symbol symbol
+let find_entry t ~symbol =
+  String.Tbl.find_opt t.by_original_symbol
+    (Relocatable_symbol_name.to_string symbol)
 
 module Relocation = struct
   type t =

--- a/asmcomp/dissector/igot.mli
+++ b/asmcomp/dissector/igot.mli
@@ -62,7 +62,7 @@ type t
 
     @param prefix A unique prefix for this partition (e.g., "0", "1")
     @param symbols List of original symbol names needing GOT entries *)
-val build : prefix:string -> symbols:string list -> t
+val build : prefix:string -> symbols:Relocatable_symbol_name.t list -> t
 
 (** Returns the list of entries in the IGOT. *)
 val entries : t -> Entry.t list
@@ -78,7 +78,7 @@ val section_size : t -> int
 
 (** [find_entry t ~symbol] returns the entry for [symbol], or [None] if not
     found. *)
-val find_entry : t -> symbol:string -> Entry.t option
+val find_entry : t -> symbol:Relocatable_symbol_name.t -> Entry.t option
 
 (** [igot_symbol_name ~prefix ~symbol] returns the IGOT symbol name for the
     given original symbol. *)

--- a/asmcomp/dissector/iplt.ml
+++ b/asmcomp/dissector/iplt.ml
@@ -93,7 +93,8 @@ let build ~prefix ~igot ~symbols =
   let by_original_symbol = String.Tbl.create 256 in
   let rev_entries, num_entries =
     List.fold_left
-      (fun (rev_entries, index) original_symbol ->
+      (fun (rev_entries, index) symbol ->
+        let original_symbol = Relocatable_symbol_name.to_string symbol in
         if String.Tbl.mem by_original_symbol original_symbol
         then rev_entries, index
         else
@@ -102,7 +103,7 @@ let build ~prefix ~igot ~symbols =
             Igot.igot_symbol_name ~prefix ~symbol:original_symbol
           in
           (* Verify the IGOT entry exists *)
-          (match Igot.find_entry igot ~symbol:original_symbol with
+          (match Igot.find_entry igot ~symbol with
           | None ->
             Misc.fatal_errorf "IPLT: no IGOT entry for symbol %s"
               original_symbol
@@ -135,7 +136,9 @@ let section_data t = t.section_data
 
 let section_size t = Bytes.length t.section_data
 
-let find_entry t ~symbol = String.Tbl.find_opt t.by_original_symbol symbol
+let find_entry t ~symbol =
+  String.Tbl.find_opt t.by_original_symbol
+    (Relocatable_symbol_name.to_string symbol)
 
 module Relocation = struct
   type t =

--- a/asmcomp/dissector/iplt.ml
+++ b/asmcomp/dissector/iplt.ml
@@ -91,45 +91,35 @@ let plt_entry_template =
 let build ~prefix ~igot ~symbols =
   (* Remove duplicates while preserving order, and build lookup table *)
   let by_original_symbol = String.Tbl.create 256 in
-  let unique_symbols =
-    List.filter
-      (fun sym ->
-        if String.Tbl.mem by_original_symbol sym
-        then false
-        else (
-          (* Placeholder - will be replaced below *)
-          String.Tbl.add by_original_symbol sym
-            { Entry.index = 0;
-              original_symbol = sym;
-              iplt_symbol = "";
-              igot_symbol = ""
-            };
-          true))
-      symbols
+  let rev_entries, num_entries =
+    List.fold_left
+      (fun (rev_entries, index) original_symbol ->
+        if String.Tbl.mem by_original_symbol original_symbol
+        then rev_entries, index
+        else
+          let iplt_symbol = iplt_symbol_name ~prefix ~symbol:original_symbol in
+          let igot_symbol =
+            Igot.igot_symbol_name ~prefix ~symbol:original_symbol
+          in
+          (* Verify the IGOT entry exists *)
+          (match Igot.find_entry igot ~symbol:original_symbol with
+          | None ->
+            Misc.fatal_errorf "IPLT: no IGOT entry for symbol %s"
+              original_symbol
+          | Some _ -> ());
+          log_verbose "  IPLT entry %d: %s -> %s (via %s)" index original_symbol
+            iplt_symbol igot_symbol;
+          let entry =
+            { Entry.index; original_symbol; iplt_symbol; igot_symbol }
+          in
+          String.Tbl.add by_original_symbol original_symbol entry;
+          entry :: rev_entries, index + 1)
+      ([], 0) symbols
   in
-  let entries =
-    List.mapi
-      (fun index original_symbol ->
-        let iplt_symbol = iplt_symbol_name ~prefix ~symbol:original_symbol in
-        let igot_symbol =
-          Igot.igot_symbol_name ~prefix ~symbol:original_symbol
-        in
-        (* Verify the IGOT entry exists *)
-        (match Igot.find_entry igot ~symbol:original_symbol with
-        | None ->
-          Misc.fatal_errorf "IPLT: no IGOT entry for symbol %s" original_symbol
-        | Some _ -> ());
-        log_verbose "  IPLT entry %d: %s -> %s (via %s)" index original_symbol
-          iplt_symbol igot_symbol;
-        let entry =
-          { Entry.index; original_symbol; iplt_symbol; igot_symbol }
-        in
-        String.Tbl.replace by_original_symbol original_symbol entry;
-        entry)
-      unique_symbols
-  in
+  (* CR sspies: The order of entries does not matter here, so we should remove
+     the list reversal at some point. *)
+  let entries = List.rev rev_entries in
   (* Build section data *)
-  let num_entries = List.length entries in
   let section_data = Bytes.make (num_entries * entry_size) '\x00' in
   for i = 0 to num_entries - 1 do
     Bytes.blit_string plt_entry_template 0 section_data (i * entry_size)

--- a/asmcomp/dissector/iplt.mli
+++ b/asmcomp/dissector/iplt.mli
@@ -77,7 +77,8 @@ type t
     @param prefix A unique prefix for this partition (e.g., "0", "1")
     @param igot The intermediate GOT (must contain entries for all symbols)
     @param symbols List of original symbol names needing PLT entries *)
-val build : prefix:string -> igot:Igot.t -> symbols:string list -> t
+val build :
+  prefix:string -> igot:Igot.t -> symbols:Relocatable_symbol_name.t list -> t
 
 (** Returns the list of entries in the IPLT. *)
 val entries : t -> Entry.t list
@@ -93,7 +94,7 @@ val section_size : t -> int
 
 (** [find_entry t ~symbol] returns the entry for [symbol], or [None] if not
     found. *)
-val find_entry : t -> symbol:string -> Entry.t option
+val find_entry : t -> symbol:Relocatable_symbol_name.t -> Entry.t option
 
 (** [iplt_symbol_name ~prefix ~symbol] returns the IPLT symbol name for the
     given original symbol. *)

--- a/asmcomp/dissector/partial_link.ml
+++ b/asmcomp/dissector/partial_link.ml
@@ -120,6 +120,12 @@ end = struct
 
   let output_file t = t.output_file
 
+  (* [/bin/sh] is hardcoded here as [shell] is in the [Unix] module (see
+     [otherlibs/unix]): running a command line means handing it to the shell,
+     [/bin/sh -c <cmd>]. This is exactly what [Unix.system] does, except that we
+     do not wait here, so the caller obtains the pid. *)
+  let shell = "/bin/sh"
+
   let start (unix : (module Compiler_owee.Unix_intf.S)) ~partition
       ~partition_index ~response_file ~output_file =
     (* Config.native_pack_linker is something like "ld -r -o " *)
@@ -130,10 +136,11 @@ end = struct
         (Filename.quote response_file)
     in
     let module Unix = (val unix) in
-    let spawn prog argv =
-      Unix.create_process prog argv Unix.stdin Unix.stdout Unix.stderr
+    Ccomp.echo_if_verbose cmd;
+    let pid =
+      Unix.create_process shell [| shell; "-c"; cmd |] Unix.stdin Unix.stdout
+        Unix.stderr
     in
-    let pid = Ccomp.start_command ~spawn cmd in
     { unix; pid; cmd; partition; partition_index; response_file; output_file }
 
   type exit_condition =

--- a/asmcomp/dissector/partial_link.ml
+++ b/asmcomp/dissector/partial_link.ml
@@ -63,7 +63,93 @@ let write_response_file ~filename files =
     files;
   close_out oc
 
-let link_one_partition ~temp_dir ~partition_index partition =
+(* A linker invocation running in a child process, partially linking one
+   partition. *)
+module Link_job : sig
+  type t
+
+  val partition : t -> Partition.t
+
+  val partition_index : t -> int
+
+  val response_file : t -> string
+
+  val output_file : t -> string
+
+  (* Starts the linker in a child process, linking the files listed in
+     [response_file] into [output_file]. The response file must already have
+     been written. *)
+  val start :
+    (module Compiler_owee.Unix_intf.S) ->
+    partition:Partition.t ->
+    partition_index:int ->
+    response_file:string ->
+    output_file:string ->
+    t
+
+  (* The exit condition of the child process running the linker command. *)
+  type exit_condition =
+    | Success
+    | Failed of { exit_code : int } (* nonzero *)
+    | Could_not_run of { cmd : string }
+      (* the shell exits with code 127, as for [Sys.command] *)
+    | Killed_or_stopped_by_signal of { signal : int }
+
+  (* Waits for the child process to exit. *)
+  val wait : t -> exit_condition
+end = struct
+  type t =
+    { unix : (module Compiler_owee.Unix_intf.S);
+      pid : int;
+      cmd : string;
+      partition : Partition.t;
+      partition_index : int;
+      response_file : string;
+      output_file : string
+    }
+
+  let partition t = t.partition
+
+  let partition_index t = t.partition_index
+
+  let response_file t = t.response_file
+
+  let output_file t = t.output_file
+
+  let start (unix : (module Compiler_owee.Unix_intf.S)) ~partition
+      ~partition_index ~response_file ~output_file =
+    (* Config.native_pack_linker is something like "ld -r -o " *)
+    let cmd =
+      Printf.sprintf "%s%s --whole-archive @%s --no-whole-archive"
+        Config.native_pack_linker
+        (Filename.quote output_file)
+        (Filename.quote response_file)
+    in
+    let module Unix = (val unix) in
+    let spawn prog argv =
+      Unix.create_process prog argv Unix.stdin Unix.stdout Unix.stderr
+    in
+    let pid = Ccomp.start_command ~spawn cmd in
+    { unix; pid; cmd; partition; partition_index; response_file; output_file }
+
+  type exit_condition =
+    | Success
+    | Failed of { exit_code : int } (* nonzero *)
+    | Could_not_run of { cmd : string }
+      (* the shell exits with code 127, as for [Sys.command] *)
+    | Killed_or_stopped_by_signal of { signal : int }
+
+  let wait { unix; pid; cmd; _ } =
+    let module Unix = (val unix) in
+    match snd (Unix.waitpid [] pid) with
+    | WEXITED 0 -> Success
+    | WEXITED 127 -> Could_not_run { cmd }
+    | WEXITED exit_code -> Failed { exit_code }
+    | WSIGNALED signal | WSTOPPED signal ->
+      Killed_or_stopped_by_signal { signal }
+end
+
+let start unix ~temp_dir ~partition_index partition =
   let response_file =
     Filename.concat temp_dir (Printf.sprintf "partition%d.txt" partition_index)
   in
@@ -71,27 +157,38 @@ let link_one_partition ~temp_dir ~partition_index partition =
     Filename.concat temp_dir (Printf.sprintf "partition%d.o" partition_index)
   in
   write_response_file ~filename:response_file (Partition.files partition);
+  Link_job.start unix ~partition ~partition_index ~response_file ~output_file
+
+let wait job =
   Misc.try_finally
     (fun () ->
-      (* Config.native_pack_linker is something like "ld -r -o " *)
-      let cmd =
-        Printf.sprintf "%s%s --whole-archive @%s --no-whole-archive"
-          Config.native_pack_linker
-          (Filename.quote output_file)
-          (Filename.quote response_file)
-      in
-      let exit_code = Ccomp.command cmd in
-      (if exit_code <> 0
-       then
-         let files =
-           List.map MOF.File_size.filename (Partition.files partition)
-         in
-         raise (Error (Linker_error { partition_index; exit_code; files })));
-      Partition.Linked.create ~partition ~linked_object:output_file)
-    ~always:(fun () -> Misc.remove_file response_file)
+      let partition = Link_job.partition job in
+      let partition_index = Link_job.partition_index job in
+      match Link_job.wait job with
+      | Success ->
+        Partition.Linked.create ~partition
+          ~linked_object:(Link_job.output_file job)
+      | Could_not_run { cmd } ->
+        (* As for [Ccomp.command] *)
+        raise (Sys_error cmd)
+      | Failed { exit_code } ->
+        let files =
+          List.map MOF.File_size.filename (Partition.files partition)
+        in
+        raise (Error (Linker_error { partition_index; exit_code; files }))
+      | Killed_or_stopped_by_signal { signal } ->
+        (* [signal] uses OCaml's signal numbering (see [Sys.sigabrt] etc.) *)
+        Misc.fatal_errorf
+          "Dissector: partial link of partition %d was killed or stopped by \
+           signal %d"
+          partition_index signal)
+    ~always:(fun () -> Misc.remove_file (Link_job.response_file job))
 
-let link_partitions ~temp_dir partitions =
+let link_one_partition unix ~temp_dir ~partition_index partition =
+  wait (start unix ~temp_dir ~partition_index partition)
+
+let link_partitions unix ~temp_dir partitions =
   List.mapi
     (fun partition_index partition ->
-      link_one_partition ~temp_dir ~partition_index partition)
+      link_one_partition unix ~temp_dir ~partition_index partition)
     partitions

--- a/asmcomp/dissector/partial_link.ml
+++ b/asmcomp/dissector/partial_link.ml
@@ -97,6 +97,10 @@ module Link_job : sig
 
   (* Waits for the child process to exit. *)
   val wait : t -> exit_condition
+
+  (* Sends SIGTERM to the child process; does not wait for it. Must not be
+     called after [wait] has returned: the pid may have been recycled. *)
+  val kill : t -> unit
 end = struct
   type t =
     { unix : (module Compiler_owee.Unix_intf.S);
@@ -147,6 +151,10 @@ end = struct
     | WEXITED exit_code -> Failed { exit_code }
     | WSIGNALED signal | WSTOPPED signal ->
       Killed_or_stopped_by_signal { signal }
+
+  let kill { unix; pid; _ } =
+    let module Unix = (val unix) in
+    Unix.kill pid Sys.sigterm
 end
 
 let start unix ~temp_dir ~partition_index partition =
@@ -187,8 +195,98 @@ let wait job =
 let link_one_partition unix ~temp_dir ~partition_index partition =
   wait (start unix ~temp_dir ~partition_index partition)
 
-let link_partitions unix ~temp_dir partitions =
-  List.mapi
-    (fun partition_index partition ->
-      link_one_partition unix ~temp_dir ~partition_index partition)
-    partitions
+(* A window of concurrently running partial links over the partitions. Links are
+   started in partition order and their results are returned in partition
+   order. *)
+module Link_window = struct
+  type t =
+    { bound : Misc.Maybe_bounded.t;
+      mutable in_flight : Link_job.t list; (* oldest link first *)
+      mutable unstarted : (int * Partition.t) list;
+      start_link : int * Partition.t -> Link_job.t;
+      wait_link : Link_job.t -> Partition.Linked.t
+    }
+
+  (* No links are started yet; see [start_linking]. *)
+  let create ~bound ~start_link ~wait_link partitions =
+    { bound;
+      in_flight = [];
+      unstarted =
+        List.mapi (fun partition_index p -> partition_index, p) partitions;
+      start_link;
+      wait_link
+    }
+
+  (* Starts the links of the first [bound] partitions. *)
+  let start_linking t =
+    let first_window, unstarted =
+      List.partition
+        (fun (partition_index, _) ->
+          Misc.Maybe_bounded.is_in_bounds partition_index t.bound)
+        t.unstarted
+    in
+    t.unstarted <- unstarted;
+    List.iter
+      (fun next -> t.in_flight <- t.in_flight @ [t.start_link next])
+      first_window
+
+  (* Waits for the oldest in-flight link, then refills the window by starting
+     the next unstarted link. The refill happens only after the wait returns, so
+     at most [bound] children run at any time. [None] once every partition has
+     been linked. The oldest link is popped before the wait, which reaps it
+     whether it returns or raises; [kill_and_reap_in_flight] must not see it. *)
+  let next_linked t =
+    match t.in_flight with
+    | [] -> None
+    | oldest :: in_flight ->
+      t.in_flight <- in_flight;
+      let linked = t.wait_link oldest in
+      (match t.unstarted with
+      | [] -> ()
+      | next :: unstarted ->
+        t.unstarted <- unstarted;
+        t.in_flight <- t.in_flight @ [t.start_link next]);
+      Some linked
+
+  (* Best-effort cleanup when linking is aborted: kill (SIGTERM) and reap the
+     in-flight children, so that none outlives the failing compilation, and
+     remove their response files. *)
+  let kill_and_reap_in_flight t =
+    let jobs = t.in_flight in
+    t.in_flight <- [];
+    List.iter (fun job -> try Link_job.kill job with _ -> ()) jobs;
+    List.iter
+      (fun job ->
+        (match Link_job.wait job with
+        | (_ : Link_job.exit_condition) -> ()
+        | exception _ -> ());
+        Misc.remove_file (Link_job.response_file job))
+      jobs
+
+  (* [fold_linked ~init ~f window] starts the links of [window], whose links
+     must not have been started yet, and folds [f] over the linked partitions in
+     partition order. *)
+  let fold_linked ~init ~f window =
+    start_linking window;
+    let rec aux acc =
+      match next_linked window with
+      | None -> acc
+      | Some linked -> aux (f acc linked)
+    in
+    aux init
+end
+
+let link_all unix ~temp_dir ~max_parallelism ~init ~f partitions =
+  let start_link (partition_index, partition) =
+    start unix ~temp_dir ~partition_index partition
+  in
+  let wait_link job =
+    Profile.record_call ~accumulate:true "dissector/partial_link_wait"
+      (fun () -> wait job)
+  in
+  let window =
+    Link_window.create ~bound:max_parallelism ~start_link ~wait_link partitions
+  in
+  Misc.try_finally
+    ~always:(fun () -> Link_window.kill_and_reap_in_flight window)
+    (fun () -> Link_window.fold_linked ~init ~f window)

--- a/asmcomp/dissector/partial_link.mli
+++ b/asmcomp/dissector/partial_link.mli
@@ -65,11 +65,21 @@ val link_one_partition :
   Partition.t ->
   Partition.Linked.t
 
-(** [link_partitions unix ~temp_dir partitions] partially links each partition
-    in sequence, as for [link_one_partition], returning the linked partitions in
-    order. *)
-val link_partitions :
+(** [link_all unix ~temp_dir ~max_parallelism ~init ~f partitions] partially
+    links each partition as for [link_one_partition] and folds [f] over the
+    linked partitions, in partition order, as their links complete.
+
+    Up to [max_parallelism] linker child processes run concurrently; [f] runs in
+    the driver while the started links proceed in the background. Raises [Error]
+    if a link fails. If a link fails or [f] raises, the in-flight children are
+    killed (SIGTERM) and reaped before the exception propagates.
+
+    @param temp_dir Directory for temporary and output files *)
+val link_all :
   (module Compiler_owee.Unix_intf.S) ->
   temp_dir:string ->
+  max_parallelism:Misc.Maybe_bounded.t ->
+  init:'acc ->
+  f:('acc -> Partition.Linked.t -> 'acc) ->
   Partition.t list ->
-  Partition.Linked.t list
+  'acc

--- a/asmcomp/dissector/partial_link.mli
+++ b/asmcomp/dissector/partial_link.mli
@@ -47,15 +47,29 @@ exception Error of error
 (** Pretty-print a partial linking error. *)
 val report_error : Format_doc.formatter -> error -> unit
 
-(** [link_partitions ~temp_dir partitions] partially links each partition into a
-    single relocatable object file.
+(** [link_one_partition unix ~temp_dir ~partition_index partition] partially
+    links [partition] into a single relocatable object file.
 
-    For each partition, creates a response file listing the input files, then
-    invokes the linker with:
+    Creates a response file listing the input files, then invokes the linker
+    with:
     {v   ld --whole-archive @<response_file> --relocatable -o <output.o> v}
 
-    Returns the list of linked partitions with paths to the output .o files.
+    Returns the linked partition with the path to the output .o file. Raises
+    [Error] if the link fails.
 
     @param temp_dir Directory for temporary and output files *)
+val link_one_partition :
+  (module Compiler_owee.Unix_intf.S) ->
+  temp_dir:string ->
+  partition_index:int ->
+  Partition.t ->
+  Partition.Linked.t
+
+(** [link_partitions unix ~temp_dir partitions] partially links each partition
+    in sequence, as for [link_one_partition], returning the linked partitions in
+    order. *)
 val link_partitions :
-  temp_dir:string -> Partition.t list -> Partition.Linked.t list
+  (module Compiler_owee.Unix_intf.S) ->
+  temp_dir:string ->
+  Partition.t list ->
+  Partition.Linked.t list

--- a/asmcomp/dissector/relocatable_symbol_name.ml
+++ b/asmcomp/dissector/relocatable_symbol_name.ml
@@ -25,35 +25,8 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-(* CR mshinwell: This file needs to be code reviewed *)
+type t = string
 
-type t =
-  { igot : Igot.t;
-    iplt : Iplt.t
-  }
+let of_string name = name
 
-let igot t = t.igot
-
-let iplt t = t.iplt
-
-let build ~prefix relocations =
-  let plt_syms = Extract_relocations.plt_symbols relocations in
-  let got_only_symbols = Extract_relocations.got_symbols relocations in
-  (* IGOT needs entries for both PLT symbols (PLT jumps through GOT) and
-     GOT-only symbols. Combine the lists - Igot.build will deduplicate. *)
-  let all_got_symbols = plt_syms @ got_only_symbols in
-  (* Build IGOT first (IPLT depends on it) *)
-  let igot = Igot.build ~prefix ~symbols:all_got_symbols in
-  (* Build IPLT for PLT symbols only *)
-  let iplt = Iplt.build ~prefix ~igot ~symbols:plt_syms in
-  { igot; iplt }
-
-let igot_symbol_for_got_reloc t symbol =
-  match Igot.find_entry t.igot ~symbol with
-  | None -> None
-  | Some entry -> Some (Igot.Entry.igot_symbol entry)
-
-let iplt_symbol_for_plt_reloc t symbol =
-  match Iplt.find_entry t.iplt ~symbol with
-  | None -> None
-  | Some entry -> Some (Iplt.Entry.iplt_symbol entry)
+let to_string name = name

--- a/asmcomp/dissector/relocatable_symbol_name.mli
+++ b/asmcomp/dissector/relocatable_symbol_name.mli
@@ -25,35 +25,16 @@
  * DEALINGS IN THE SOFTWARE.                                                  *
  ******************************************************************************)
 
-(* CR mshinwell: This file needs to be code reviewed *)
+(** The name of a symbol that needs relocation through the IGOT/IPLT: the target
+    of a PLT32 or REX_GOTPCRELX relocation against an undefined symbol. These
+    are the original names from the input's symbol table (e.g. [caml_apply2]),
+    not the synthetic IGOT/IPLT symbol names that the relocations will be
+    redirected to (e.g. [iplt🐍p1🐍caml_apply2], see [Iplt.build]). *)
+type t
 
-type t =
-  { igot : Igot.t;
-    iplt : Iplt.t
-  }
+(** [of_string name] views [name], a symbol name read from an input's symbol
+    table, as a relocatable symbol name. *)
+val of_string : string -> t
 
-let igot t = t.igot
-
-let iplt t = t.iplt
-
-let build ~prefix relocations =
-  let plt_syms = Extract_relocations.plt_symbols relocations in
-  let got_only_symbols = Extract_relocations.got_symbols relocations in
-  (* IGOT needs entries for both PLT symbols (PLT jumps through GOT) and
-     GOT-only symbols. Combine the lists - Igot.build will deduplicate. *)
-  let all_got_symbols = plt_syms @ got_only_symbols in
-  (* Build IGOT first (IPLT depends on it) *)
-  let igot = Igot.build ~prefix ~symbols:all_got_symbols in
-  (* Build IPLT for PLT symbols only *)
-  let iplt = Iplt.build ~prefix ~igot ~symbols:plt_syms in
-  { igot; iplt }
-
-let igot_symbol_for_got_reloc t symbol =
-  match Igot.find_entry t.igot ~symbol with
-  | None -> None
-  | Some entry -> Some (Igot.Entry.igot_symbol entry)
-
-let iplt_symbol_for_plt_reloc t symbol =
-  match Iplt.find_entry t.iplt ~symbol with
-  | None -> None
-  | Some entry -> Some (Iplt.Entry.iplt_symbol entry)
+(** The underlying symbol name. *)
+val to_string : t -> string

--- a/asmcomp/dissector/rewrite_sections.ml
+++ b/asmcomp/dissector/rewrite_sections.ml
@@ -43,15 +43,14 @@ let int64_to_int value =
     Misc.fatal_errorf "Dissector: offset %Ld exceeds platform int range" value
   else Int64.to_int value
 
-let write_symbol ~cursor ~strtab sym =
-  let module SE = FRP.Symbol_entry in
+let write_symbol ~cursor ~strtab (sym : Elf.symbol) =
   Rela.write_sym_entry ~cursor
-    { st_name = Strtab.add strtab (SE.name sym);
-      st_info = SE.st_info sym;
-      st_other = SE.st_other sym;
-      st_shndx = SE.st_shndx sym;
-      st_value = SE.st_value sym;
-      st_size = SE.st_size sym
+    { st_name = Strtab.add strtab sym.name;
+      st_info = sym.st_info;
+      st_other = sym.st_other;
+      st_shndx = sym.st_shndx;
+      st_value = sym.st_value;
+      st_size = sym.st_size
     }
 
 (* When section_index >= SHN_LORESERVE, we must use SHN_XINDEX and store the

--- a/asmcomp/dissector/rewrite_sections.ml
+++ b/asmcomp/dissector/rewrite_sections.ml
@@ -60,8 +60,8 @@ let write_synthetic_symbol ~cursor ~strtab ~name ~section_index ~offset ~size
   let section_index' = Rela.Section_index.of_int section_index in
   let st_shndx =
     if Rela.Section_index.needs_extended section_index'
-    then Rela.Section_index.(to_int xindex)
-    else section_index
+    then Rela.Section_index.xindex
+    else section_index'
   in
   Rela.write_sym_entry ~cursor
     { st_name = Strtab.add strtab name;

--- a/asmcomp/dissector/rewrite_sections.ml
+++ b/asmcomp/dissector/rewrite_sections.ml
@@ -223,18 +223,22 @@ let execute_plan unix ~input_buf ~output_file ~header ~sections ~igot_and_iplt
   | None, None -> ()
   | Some _, None ->
     Misc.fatal_error "SYMTAB_SHNDX in input but no layout allocated");
-  (* Write rewritten .rela.text* sections back to their original locations *)
+  (* Write the changed .rela.text* entries back to their original locations. The
+     unchanged entries are already in place, copied by the blit above. *)
   List.iter
     (fun rewritten_section ->
-      let cursor =
-        Buf.cursor output_buf
-          ~at:
-            (int64_to_int
-               (FRP.Rewritten_rela_section.section_offset rewritten_section))
+      let section_offset =
+        int64_to_int
+          (FRP.Rewritten_rela_section.section_offset rewritten_section)
       in
       List.iter
-        (fun e -> Rela.write_rela_entry ~cursor e)
-        (FRP.Rewritten_rela_section.entries rewritten_section))
+        (fun (index, e) ->
+          let cursor =
+            Buf.cursor output_buf
+              ~at:(section_offset + (index * Rela.rela_entry_size))
+          in
+          Rela.write_rela_entry ~cursor e)
+        (FRP.Rewritten_rela_section.changed_entries rewritten_section))
     (FRP.rewritten_rela_sections plan);
   Buf.Write.fixed_bytes
     (Buf.cursor output_buf ~at:(int64_to_int (SL.offset shstrtab_layout)))

--- a/asmcomp/dissector/rewrite_sections.ml
+++ b/asmcomp/dissector/rewrite_sections.ml
@@ -82,12 +82,11 @@ let write_rela ~cursor ~symbol_to_index ~r_offset ~symbol ~r_type ~r_addend =
   Rela.write_rela_entry ~cursor
     { r_offset = Int64.of_int r_offset; r_sym; r_type; r_addend }
 
-let execute_plan unix ~input_file ~output_file ~header ~sections
-    ~shstrtab_section ~igot_and_iplt ~plan =
+let execute_plan unix ~input_buf ~output_file ~header ~sections ~igot_and_iplt
+    ~plan =
   let module Unix = (val unix : Compiler_owee.Unix_intf.S) in
   let module SL = FRP.Section_layout in
   let module L = FRP.Layout in
-  let input_buf = Buf.map_binary (module Unix) input_file in
   let layout = FRP.layout plan in
   let output_buf =
     Buf.map_binary_write
@@ -350,44 +349,17 @@ let execute_plan unix ~input_file ~output_file ~header ~sections
   in
   Elf.write_elf output_buf new_header new_sections
 
-(* Find all sections with names starting with prefix *)
-let find_sections_with_prefix sections prefix =
-  Array.to_list sections
-  |> List.filter (fun (section : Elf.section) ->
-      String.starts_with ~prefix section.sh_name_str)
-
-let rewrite unix ~input_file ~output_file ~partition_kind ~igot_and_iplt
-    ~relocations =
-  let module Unix = (val unix : Compiler_owee.Unix_intf.S) in
-  let input_buf = Buf.map_binary (module Unix) input_file in
-  let header, sections = Elf.read_elf input_buf in
-  let symtab_section =
-    match
-      Array.find_opt
-        (fun (s : Elf.section) ->
-          Elf.Section_type.(equal (of_u32 s.sh_type) sht_symtab))
-        sections
-    with
-    | Some s -> s
-    | None -> Misc.fatal_error "rewrite_sections: no symbol table found"
-  in
-  let strtab_section = sections.(symtab_section.sh_link) in
-  (* Find all .rela.text* sections (handles function sections) *)
-  let rela_text_section_list =
-    find_sections_with_prefix sections ".rela.text"
-  in
-  let shstrtab_section = sections.(header.e_shstrndx) in
-  let symtab_body = Elf.section_body input_buf symtab_section in
-  let strtab_body = Elf.section_body input_buf strtab_section in
-  (* Build list of (section, body) pairs *)
-  let rela_text_sections =
-    List.map
-      (fun section -> section, Elf.section_body input_buf section)
-      rela_text_section_list
-  in
+let rewrite unix ~mapped_partition_file ~output_file ~partition_kind
+    ~igot_and_iplt ~relocations =
+  let module MPF = Extract_relocations.Mapped_object_file in
+  let header = MPF.header mapped_partition_file in
+  let sections = MPF.sections mapped_partition_file in
+  let symbols = MPF.symbols mapped_partition_file in
+  let rela_text_sections = MPF.rela_text_sections mapped_partition_file in
+  let input_buf = MPF.buf mapped_partition_file in
   let plan =
-    FRP.compute ~header ~sections ~symtab_body ~strtab_body ~rela_text_sections
-      ~partition_kind ~igot_and_iplt ~relocations
+    FRP.compute ~header ~sections ~symbols ~rela_text_sections ~partition_kind
+      ~igot_and_iplt ~relocations
   in
-  execute_plan unix ~input_file ~output_file ~header ~sections ~shstrtab_section
-    ~igot_and_iplt ~plan
+  execute_plan unix ~input_buf ~output_file ~header ~sections ~igot_and_iplt
+    ~plan

--- a/asmcomp/dissector/rewrite_sections.mli
+++ b/asmcomp/dissector/rewrite_sections.mli
@@ -48,15 +48,16 @@
     - Modified .rela.text entries pointing to IPLT/IGOT symbols instead of
       original external symbols *)
 
-(** [rewrite unix ~input_file ~output_file ~partition_kind ~igot_and_iplt
-     ~relocations] reads the ELF object file at [input_file], adds IGOT and IPLT
-    sections, rewrites relocations, and writes the result to [output_file].
+(** [rewrite unix ~mapped_partition_file ~output_file ~partition_kind
+     ~igot_and_iplt ~relocations] takes the parsed ELF object file
+    [mapped_partition_file], adds IGOT and IPLT sections, rewrites relocations,
+    and writes the result to [output_file].
 
     For [Large_code] partitions, section names are also prefixed (e.g., .text ->
     .caml.p1.text). [Main] partition sections keep their original names.
 
     @param unix First-class Unix module for file operations
-    @param input_file Path to the input partially-linked object file
+    @param mapped_partition_file The input partially-linked object file
     @param output_file Path to write the rewritten object file
     @param partition_kind The kind of partition (Main or Large_code)
     @param igot_and_iplt The IGOT and IPLT structures to add
@@ -64,7 +65,7 @@
       The extracted relocations identifying which entries need rewriting *)
 val rewrite :
   (module Compiler_owee.Unix_intf.S) ->
-  input_file:string ->
+  mapped_partition_file:Extract_relocations.Mapped_object_file.t ->
   output_file:string ->
   partition_kind:Partition.kind ->
   igot_and_iplt:Build_igot_and_iplt.t ->

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -460,9 +460,9 @@ let mk_dissector_partition_size f =
 
 let mk_dissector_max_linker_parallelism f =
   ( "-dissector-max-linker-parallelism",
-    Arg.String f,
-    "<n|none>  Run at most <n> partial links concurrently in the dissector \
-     pass (default: none, i.e. no limit)" )
+    Arg.Int f,
+    "<n>  Run at most <n> partial links concurrently in the dissector pass; 0 \
+     means no limit (default: 0)" )
 
 let mk_ddissector f =
   ("-ddissector", Arg.Unit f, " Print verbose logging from the dissector pass")
@@ -1351,7 +1351,7 @@ module type Oxcaml_options = sig
   val verify_binary_emitter : unit -> unit
   val dissector : unit -> unit
   val dissector_partition_size : float -> unit
-  val dissector_max_linker_parallelism : string -> unit
+  val dissector_max_linker_parallelism : int -> unit
   val ddissector : unit -> unit
   val ddissector_sizes : unit -> unit
   val ddissector_verbose : unit -> unit
@@ -1683,18 +1683,16 @@ let set_dissector_partition_size f =
          "-dissector-partition-size must be greater than 0 and less than 2 GiB");
   Clflags.dissector_partition_size := Some f
 
-let set_dissector_max_linker_parallelism v =
+let set_dissector_max_linker_parallelism n =
   let bound =
-    match v with
-    | "none" -> Misc.Maybe_bounded.Unbounded
-    | v -> (
-        match int_of_string_opt v with
-        | Some n when n >= 1 -> Misc.Maybe_bounded.Bounded { bound = n }
-        | Some _ | None ->
-            raise
-              (Arg.Bad
-                 "-dissector-max-linker-parallelism must be a positive integer \
-                  or \"none\""))
+    match n with
+    | 0 -> Misc.Maybe_bounded.Unbounded
+    | n when n >= 1 -> Misc.Maybe_bounded.Bounded { bound = n }
+    | _ ->
+        raise
+          (Arg.Bad
+             "-dissector-max-linker-parallelism must be a nonnegative integer \
+              (0 means no limit)")
   in
   Oxcaml_flags.dissector_max_linker_parallelism := bound
 
@@ -2726,9 +2724,14 @@ module Extra_params = struct
         | None ->
             raise
               (Arg.Bad (Printf.sprintf "Expected float for %s, got %S" name v)))
-    | "dissector-max-linker-parallelism" ->
-        set_dissector_max_linker_parallelism v;
-        true
+    | "dissector-max-linker-parallelism" -> (
+        match int_of_string_opt v with
+        | Some n ->
+            set_dissector_max_linker_parallelism n;
+            true
+        | None ->
+            raise
+              (Arg.Bad (Printf.sprintf "Expected int for %s, got %S" name v)))
     | "ddissector" -> set' Clflags.ddissector
     | "ddissector-sizes" -> set' Clflags.ddissector_sizes
     | "ddissector-verbose" -> set' Clflags.ddissector_verbose

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -458,6 +458,12 @@ let mk_dissector_partition_size f =
        pass (default: %g)"
       Clflags.dissector_partition_size_default )
 
+let mk_dissector_max_linker_parallelism f =
+  ( "-dissector-max-linker-parallelism",
+    Arg.String f,
+    "<n|none>  Run at most <n> partial links concurrently in the dissector \
+     pass (default: none, i.e. no limit)" )
+
 let mk_ddissector f =
   ("-ddissector", Arg.Unit f, " Print verbose logging from the dissector pass")
 
@@ -1345,6 +1351,7 @@ module type Oxcaml_options = sig
   val verify_binary_emitter : unit -> unit
   val dissector : unit -> unit
   val dissector_partition_size : float -> unit
+  val dissector_max_linker_parallelism : string -> unit
   val ddissector : unit -> unit
   val ddissector_sizes : unit -> unit
   val ddissector_verbose : unit -> unit
@@ -1535,6 +1542,7 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_verify_binary_emitter F.verify_binary_emitter;
       mk_dissector F.dissector;
       mk_dissector_partition_size F.dissector_partition_size;
+      mk_dissector_max_linker_parallelism F.dissector_max_linker_parallelism;
       mk_ddissector F.ddissector;
       mk_ddissector_sizes F.ddissector_sizes;
       mk_ddissector_verbose F.ddissector_verbose;
@@ -1674,6 +1682,21 @@ let set_dissector_partition_size f =
       (Arg.Bad
          "-dissector-partition-size must be greater than 0 and less than 2 GiB");
   Clflags.dissector_partition_size := Some f
+
+let set_dissector_max_linker_parallelism v =
+  let bound =
+    match v with
+    | "none" -> Misc.Maybe_bounded.Unbounded
+    | v -> (
+        match int_of_string_opt v with
+        | Some n when n >= 1 -> Misc.Maybe_bounded.Bounded { bound = n }
+        | Some _ | None ->
+            raise
+              (Arg.Bad
+                 "-dissector-max-linker-parallelism must be a positive integer \
+                  or \"none\""))
+  in
+  Oxcaml_flags.dissector_max_linker_parallelism := bound
 
 module Extra_options = struct
   type 'a arg_parser = string -> 'a ref -> string -> unit
@@ -1955,6 +1978,7 @@ module Oxcaml_options_impl = struct
   let verify_binary_emitter = set' Oxcaml_flags.verify_binary_emitter
   let dissector = set' Clflags.dissector
   let dissector_partition_size = set_dissector_partition_size
+  let dissector_max_linker_parallelism = set_dissector_max_linker_parallelism
   let ddissector = set' Clflags.ddissector
   let ddissector_sizes = set' Clflags.ddissector_sizes
   let ddissector_verbose = set' Clflags.ddissector_verbose
@@ -2702,6 +2726,9 @@ module Extra_params = struct
         | None ->
             raise
               (Arg.Bad (Printf.sprintf "Expected float for %s, got %S" name v)))
+    | "dissector-max-linker-parallelism" ->
+        set_dissector_max_linker_parallelism v;
+        true
     | "ddissector" -> set' Clflags.ddissector
     | "ddissector-sizes" -> set' Clflags.ddissector_sizes
     | "ddissector-verbose" -> set' Clflags.ddissector_verbose

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -100,6 +100,7 @@ module type Oxcaml_options = sig
   val verify_binary_emitter : unit -> unit
   val dissector : unit -> unit
   val dissector_partition_size : float -> unit
+  val dissector_max_linker_parallelism : string -> unit
   val ddissector : unit -> unit
   val ddissector_sizes : unit -> unit
   val ddissector_verbose : unit -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -100,7 +100,7 @@ module type Oxcaml_options = sig
   val verify_binary_emitter : unit -> unit
   val dissector : unit -> unit
   val dissector_partition_size : float -> unit
-  val dissector_max_linker_parallelism : string -> unit
+  val dissector_max_linker_parallelism : int -> unit
   val ddissector : unit -> unit
   val ddissector_sizes : unit -> unit
   val ddissector_verbose : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -588,6 +588,9 @@ let cached_generic_functions_path =
 let dissector_assume_lld_without_64_bit_eh_frames = ref true
   (* -[no-]dissector-assume-lld-without-64-bit-eh-frames *)
 
+let dissector_max_linker_parallelism = ref Misc.Maybe_bounded.Unbounded
+  (* -dissector-max-linker-parallelism *)
+
 let manual_module_init = ref false
   (* -[no-]manual-module-init *)
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -127,6 +127,8 @@ val cached_generic_functions_path : string ref
 
 val dissector_assume_lld_without_64_bit_eh_frames : bool ref
 
+val dissector_max_linker_parallelism : Misc.Maybe_bounded.t ref
+
 val manual_module_init : bool ref
 
 val symbol_visibility_protected : bool ref

--- a/driver/oxcaml_main.ml
+++ b/driver/oxcaml_main.ml
@@ -1,7 +1,18 @@
+(* Eta-expansion gives [create_process] and [waitpid] the unannotated types
+   required by [Compiler_owee.Unix_intf.S]. *)
+module Unix_for_owee = struct
+  include Unix
+
+  let create_process prog args stdin stdout stderr =
+    Unix.create_process prog args stdin stdout stderr
+
+  let waitpid flags pid = Unix.waitpid flags pid
+end
+
 let () =
   (match Sys.backend_type with
    | Native -> Memtrace.trace_if_requested ~context:"ocamlopt" ()
    | Bytecode | Other _ -> ());
-  exit (Optmaindriver.main (module Unix : Compiler_owee.Unix_intf.S)
+  exit (Optmaindriver.main (module Unix_for_owee : Compiler_owee.Unix_intf.S)
     Sys.argv Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)

--- a/dune
+++ b/dune
@@ -571,6 +571,7 @@
   partial_link
   partition
   partition_object_files
+  relocatable_symbol_name
   rewrite_sections
   ;; backend/
   afl_instrument

--- a/external/ocaml-jit/lib/jit.ml
+++ b/external/ocaml-jit/lib/jit.ml
@@ -16,6 +16,17 @@
 
 open Import
 
+(* Eta-expansion gives [create_process] and [waitpid] the unannotated types
+   required by [Compiler_owee.Unix_intf.S]. *)
+module Unix_for_owee = struct
+  include Unix
+
+  let create_process prog args stdin stdout stderr =
+    Unix.create_process prog args stdin stdout stderr
+
+  let waitpid flags pid = Unix.waitpid flags pid
+end
+
 type evaluation_outcome = Result of Obj.t | Exception of exn
 
 let outcome_global : evaluation_outcome option ref = ref None
@@ -300,7 +311,7 @@ let jit_load_lambda ~phrase_name ppf (program : Lambda.program) =
       (Flambda2.lambda_to_cmm ~machine_width ~keep_symbol_tables:true)
   in
   Asmgen.compile_implementation
-    (module Unix : Compiler_owee.Unix_intf.S)
+    (module Unix_for_owee : Compiler_owee.Unix_intf.S)
     ~toplevel:need_symbol ~pipeline ~sourcefile:(Some filename)
     ~prefixname:filename ~ppf_dump:ppf program;
   match !outcome_global with

--- a/external/owee/owee_elf.ml
+++ b/external/owee/owee_elf.ml
@@ -585,6 +585,11 @@ let read_symbols ~symtab_body ~strtab_body =
     in
     { name; st_info; st_other; st_shndx; st_value; st_size })
 
+let symbol_table_lookup symbols ~sym_index =
+  if sym_index >= 0 && sym_index < Array.length symbols
+  then Some symbols.(sym_index)
+  else None
+
 (* Extract section body as a string *)
 let section_body_string buf section =
   let body = section_body buf section in

--- a/external/owee/owee_elf.ml
+++ b/external/owee/owee_elf.ml
@@ -555,9 +555,18 @@ let find_symbol_table buf sections =
   | None -> None
   | Some symtab -> Some (Symbol_table.create [symtab])
 
-let iter_symbols ~symtab_body ~strtab_body ~f =
+type symbol = {
+  name : string;
+  st_info : int;
+  st_other : int;
+  st_shndx : int;
+  st_value : int64;
+  st_size : int64;
+}
+
+let read_symbols ~symtab_body ~strtab_body =
   let num_symbols = (size symtab_body) / Symbol_table.Symbol.struct_size in
-  for i = 0 to num_symbols - 1 do
+  Array.init num_symbols (fun i ->
     let sym_cursor = cursor symtab_body ~at:(i * Symbol_table.Symbol.struct_size) in
     let st_name_offset = Read.u32 sym_cursor in
     let st_info = Read.u8 sym_cursor in
@@ -574,8 +583,7 @@ let iter_symbols ~symtab_body ~strtab_body ~f =
         | Some s -> s
         | None -> ""
     in
-    f ~name ~st_info ~st_other ~st_shndx ~st_value ~st_size
-  done
+    { name; st_info; st_other; st_shndx; st_value; st_size })
 
 (* Extract section body as a string *)
 let section_body_string buf section =

--- a/external/owee/owee_elf.ml
+++ b/external/owee/owee_elf.ml
@@ -559,7 +559,7 @@ type symbol = {
   name : string;
   st_info : int;
   st_other : int;
-  st_shndx : int;
+  st_shndx : Owee_elf_relocation.Section_index.t;
   st_value : int64;
   st_size : int64;
 }
@@ -571,7 +571,7 @@ let read_symbols ~symtab_body ~strtab_body =
     let st_name_offset = Read.u32 sym_cursor in
     let st_info = Read.u8 sym_cursor in
     let st_other = Read.u8 sym_cursor in
-    let st_shndx = Read.u16 sym_cursor in
+    let st_shndx = Owee_elf_relocation.Section_index.of_int (Read.u16 sym_cursor) in
     let st_value = Read.u64 sym_cursor in
     let st_size = Read.u64 sym_cursor in
     let name =

--- a/external/owee/owee_elf.mli
+++ b/external/owee/owee_elf.mli
@@ -258,6 +258,10 @@ type symbol = {
 val read_symbols :
   symtab_body:Owee_buf.t -> strtab_body:Owee_buf.t -> symbol array
 
+(** [symbol_table_lookup symbols ~sym_index] returns the symbol at
+    [sym_index], or [None] if the index is out of range. *)
+val symbol_table_lookup : symbol array -> sym_index:int -> symbol option
+
 (** Extract section body as a string. *)
 val section_body_string : Owee_buf.t -> section -> string
 

--- a/external/owee/owee_elf.mli
+++ b/external/owee/owee_elf.mli
@@ -242,21 +242,21 @@ end
     from the given ELF buffer and section array. *)
 val find_symbol_table : Owee_buf.t -> section array -> Symbol_table.t option
 
-(** [iter_symbols ~symtab_body ~strtab_body ~f] iterates over all symbols in
-    the symbol table, calling [f] with each symbol's name and raw fields.
-    This is a lower-level interface than Symbol_table for cases where you need
-    to process all symbols sequentially. *)
-val iter_symbols :
-  symtab_body:Owee_buf.t ->
-  strtab_body:Owee_buf.t ->
-  f:(name:string ->
-     st_info:int ->
-     st_other:int ->
-     st_shndx:int ->
-     st_value:int64 ->
-     st_size:int64 ->
-     unit) ->
-  unit
+(** A symbol table entry with its name resolved from the string table.
+    Symbols with a missing or unreadable name have [name = ""]. *)
+type symbol = {
+  name : string;
+  st_info : int;
+  st_other : int;
+  st_shndx : int;
+  st_value : int64;
+  st_size : int64;
+}
+
+(** [read_symbols ~symtab_body ~strtab_body] reads the whole symbol table
+    into an array, indexed by symbol index. *)
+val read_symbols :
+  symtab_body:Owee_buf.t -> strtab_body:Owee_buf.t -> symbol array
 
 (** Extract section body as a string. *)
 val section_body_string : Owee_buf.t -> section -> string

--- a/external/owee/owee_elf.mli
+++ b/external/owee/owee_elf.mli
@@ -248,7 +248,7 @@ type symbol = {
   name : string;
   st_info : int;
   st_other : int;
-  st_shndx : int;
+  st_shndx : Owee_elf_relocation.Section_index.t;
   st_value : int64;
   st_size : int64;
 }

--- a/external/owee/owee_elf_relocation.ml
+++ b/external/owee/owee_elf_relocation.ml
@@ -92,9 +92,9 @@ let iter_rela_entries ~rela_body ~f =
       "RELA section size %d is not a multiple of entry size %d" size
       rela_entry_size;
   let num_entries = size / rela_entry_size in
-  for i = 0 to num_entries - 1 do
-    let entry_offset = i * rela_entry_size in
-    let cursor = Owee_buf.cursor rela_body ~at:entry_offset in
+  (* A single cursor advances through the whole section. *)
+  let cursor = Owee_buf.cursor rela_body in
+  for _ = 1 to num_entries do
     let r_offset = Owee_buf.Read.u64 cursor in
     let r_info = Owee_buf.Read.u64 cursor in
     let r_addend = Owee_buf.Read.u64 cursor in

--- a/external/owee/owee_elf_relocation.ml
+++ b/external/owee/owee_elf_relocation.ml
@@ -167,7 +167,7 @@ type sym_entry =
   { st_name : int;
     st_info : int;
     st_other : int;
-    st_shndx : int;
+    st_shndx : Section_index.t;
     st_value : int64;
     st_size : int64
   }
@@ -176,6 +176,6 @@ let write_sym_entry ~cursor entry =
   Owee_buf.Write.u32 cursor entry.st_name;
   Owee_buf.Write.u8 cursor entry.st_info;
   Owee_buf.Write.u8 cursor entry.st_other;
-  Owee_buf.Write.u16 cursor entry.st_shndx;
+  Owee_buf.Write.u16 cursor (Section_index.to_int entry.st_shndx);
   Owee_buf.Write.u64 cursor entry.st_value;
   Owee_buf.Write.u64 cursor entry.st_size

--- a/external/owee/owee_elf_relocation.ml
+++ b/external/owee/owee_elf_relocation.ml
@@ -84,7 +84,7 @@ let r_sym_of_info r_info = Int64.to_int (Int64.shift_right_logical r_info 32)
 (* Extract relocation type from r_info (lower 32 bits) *)
 let r_type_of_info r_info = Int64.logand r_info 0xFFFFFFFFL
 
-let iter_rela_entries ~rela_body ~f =
+let iteri_rela_entries ~rela_body ~f =
   let size = Owee_buf.size rela_body in
   if size mod rela_entry_size <> 0
   then
@@ -94,7 +94,7 @@ let iter_rela_entries ~rela_body ~f =
   let num_entries = size / rela_entry_size in
   (* A single cursor advances through the whole section. *)
   let cursor = Owee_buf.cursor rela_body in
-  for _ = 1 to num_entries do
+  for i = 0 to num_entries - 1 do
     let r_offset = Owee_buf.Read.u64 cursor in
     let r_info = Owee_buf.Read.u64 cursor in
     let r_addend = Owee_buf.Read.u64 cursor in
@@ -105,7 +105,7 @@ let iter_rela_entries ~rela_body ~f =
         r_addend
       }
     in
-    f entry
+    f ~index:i entry
   done
 
 (* Construct r_info from symbol index and relocation type *)

--- a/external/owee/owee_elf_relocation.ml
+++ b/external/owee/owee_elf_relocation.ml
@@ -108,37 +108,6 @@ let iter_rela_entries ~rela_body ~f =
     f entry
   done
 
-(* Elf64_Sym layout:
-   st_name  (4 bytes, offset 0)  - index into string table
-   st_info  (1 byte,  offset 4)  - type and binding
-   st_other (1 byte,  offset 5)  - visibility
-   st_shndx (2 bytes, offset 6)  - section header index
-   st_value (8 bytes, offset 8)  - value
-   st_size  (8 bytes, offset 16) - size *)
-
-let read_symbol_name ~symtab_body ~strtab_body ~sym_index =
-  let sym_offset = sym_index * sym_entry_size in
-  if sym_offset >= Owee_buf.size symtab_body
-  then None
-  else
-    let cursor = Owee_buf.cursor symtab_body ~at:sym_offset in
-    let st_name = Owee_buf.Read.u32 cursor in
-    (* Read null-terminated string from strtab *)
-    if st_name >= Owee_buf.size strtab_body
-    then None
-    else
-      let cursor = Owee_buf.cursor strtab_body ~at:st_name in
-      Owee_buf.Read.zero_string cursor ()
-
-let read_symbol_shndx ~symtab_body ~sym_index =
-  let sym_offset = sym_index * sym_entry_size in
-  if sym_offset >= Owee_buf.size symtab_body
-  then None
-  else
-    (* st_shndx is at offset 6 within the symbol entry *)
-    let cursor = Owee_buf.cursor symtab_body ~at:(sym_offset + 6) in
-    Some (Section_index.of_int (Owee_buf.Read.u16 cursor))
-
 (* Construct r_info from symbol index and relocation type *)
 let make_r_info ~sym ~typ =
   Int64.logor (Int64.shift_left (Int64.of_int sym) 32) (Reloc_type.to_int64 typ)
@@ -187,6 +156,13 @@ end
 let make_st_info ~binding ~typ =
   (Symbol_binding.to_int binding lsl 4) lor Symbol_type.to_int typ
 
+(* Elf64_Sym layout:
+   st_name  (4 bytes, offset 0)  - index into string table
+   st_info  (1 byte,  offset 4)  - type and binding
+   st_other (1 byte,  offset 5)  - visibility
+   st_shndx (2 bytes, offset 6)  - section header index
+   st_value (8 bytes, offset 8)  - value
+   st_size  (8 bytes, offset 16) - size *)
 type sym_entry =
   { st_name : int;
     st_info : int;

--- a/external/owee/owee_elf_relocation.mli
+++ b/external/owee/owee_elf_relocation.mli
@@ -109,9 +109,11 @@ type rela_entry =
     (** Addend for the relocation. *)
   }
 
-(** [iter_rela_entries ~rela_body ~f] iterates over all RELA entries in
-    the given section body, calling [f] for each entry. *)
-val iter_rela_entries : rela_body:Owee_buf.t -> f:(rela_entry -> unit) -> unit
+(** [iteri_rela_entries ~rela_body ~f] iterates over all RELA entries in
+    the given section body, calling [f] with each entry and its index within
+    the section (the entry lies at byte offset [index * rela_entry_size]). *)
+val iteri_rela_entries :
+  rela_body:Owee_buf.t -> f:(index:int -> rela_entry -> unit) -> unit
 
 (** {1 Entry Sizes} *)
 

--- a/external/owee/owee_elf_relocation.mli
+++ b/external/owee/owee_elf_relocation.mli
@@ -113,23 +113,6 @@ type rela_entry =
     the given section body, calling [f] for each entry. *)
 val iter_rela_entries : rela_body:Owee_buf.t -> f:(rela_entry -> unit) -> unit
 
-(** {1 Symbol Name Lookup} *)
-
-(** [read_symbol_name ~symtab_body ~strtab_body ~sym_index] reads the name
-    of the symbol at the given index from the symbol table.
-
-    Returns [None] if the index is out of bounds or the name cannot be read. *)
-val read_symbol_name :
-  symtab_body:Owee_buf.t -> strtab_body:Owee_buf.t -> sym_index:int -> string option
-
-(** [read_symbol_shndx ~symtab_body ~sym_index] reads the section header index
-    (st_shndx) of the symbol at the given index.
-
-    Returns [None] if the index is out of bounds.
-    Use [Section_index.is_undef] to check for undefined symbols. *)
-val read_symbol_shndx :
-  symtab_body:Owee_buf.t -> sym_index:int -> Section_index.t option
-
 (** {1 Entry Sizes} *)
 
 val rela_entry_size : int

--- a/external/owee/owee_elf_relocation.mli
+++ b/external/owee/owee_elf_relocation.mli
@@ -180,7 +180,7 @@ type sym_entry =
     (** Symbol type and binding. *)
     st_other : int;
     (** Symbol visibility. *)
-    st_shndx : int;
+    st_shndx : Section_index.t;
     (** Section header index. *)
     st_value : int64;
     (** Symbol value. *)

--- a/external/owee/unix_intf.ml
+++ b/external/owee/unix_intf.ml
@@ -45,4 +45,24 @@ module type S = sig
     ('a, 'b, 'c) Stdlib.Bigarray.Genarray.t
 
   val getpid : unit -> int
+
+  val stdin : file_descr
+
+  val stdout : file_descr
+
+  val stderr : file_descr
+
+  val create_process :
+    string -> string array -> file_descr -> file_descr -> file_descr -> int
+
+  type wait_flag =
+      WNOHANG
+    | WUNTRACED
+
+  type process_status =
+      WEXITED of int
+    | WSIGNALED of int
+    | WSTOPPED of int
+
+  val waitpid : wait_flag list -> int -> int * process_status
 end

--- a/external/owee/unix_intf.ml
+++ b/external/owee/unix_intf.ml
@@ -52,6 +52,10 @@ module type S = sig
 
   val stderr : file_descr
 
+  (* CR sspies: [create_process] and [waitpid] carry OxCaml mode annotations on
+     their types in the [Unix] module, but this signature must not mention them.
+     Consequently, we state them without annotations and implementations of this
+     module eta-expand the implementations from the [Unix] module. *)
   val create_process :
     string -> string array -> file_descr -> file_descr -> file_descr -> int
 
@@ -61,10 +65,10 @@ module type S = sig
 
   type process_status =
       WEXITED of int
-    | WSIGNALED of int
-    | WSTOPPED of int
+    | WSIGNALED of Sys.signal
+    | WSTOPPED of Sys.signal
 
   val waitpid : wait_flag list -> int -> int * process_status
 
-  val kill : int -> int -> unit
+  val kill : int -> Sys.signal -> unit
 end

--- a/external/owee/unix_intf.ml
+++ b/external/owee/unix_intf.ml
@@ -65,4 +65,6 @@ module type S = sig
     | WSTOPPED of int
 
   val waitpid : wait_flag list -> int -> int * process_status
+
+  val kill : int -> int -> unit
 end

--- a/oxcaml/tests/backend/binary_emitter/verify/test_verify.ml
+++ b/oxcaml/tests/backend/binary_emitter/verify/test_verify.ml
@@ -27,7 +27,18 @@
 
 (* Test harness for Binary_emitter_verify.For_testing *)
 
-let unix = (module Unix : Compiler_owee.Unix_intf.S)
+(* Eta-expansion gives [create_process] and [waitpid] the unannotated types
+   required by [Compiler_owee.Unix_intf.S]. *)
+module Unix_for_owee = struct
+  include Unix
+
+  let create_process prog args stdin stdout stderr =
+    Unix.create_process prog args stdin stdout stderr
+
+  let waitpid flags pid = Unix.waitpid flags pid
+end
+
+let unix = (module Unix_for_owee : Compiler_owee.Unix_intf.S)
 
 let failures = ref 0
 

--- a/oxcaml/testsuite/tools/codegen_main.ml
+++ b/oxcaml/testsuite/tools/codegen_main.ml
@@ -14,6 +14,18 @@
 (**************************************************************************)
 
 open Clflags
+
+(* Eta-expansion gives [create_process] and [waitpid] the unannotated types
+   required by [Compiler_owee.Unix_intf.S]. *)
+module Unix_for_owee = struct
+  include Unix
+
+  let create_process prog args stdin stdout stderr =
+    Unix.create_process prog args stdin stdout stderr
+
+  let waitpid flags pid = Unix.waitpid flags pid
+end
+
 let write_asm_file = ref false
 
 let compile_file filename =
@@ -24,7 +36,7 @@ let compile_file filename =
   let compilation_unit = "test" |> Compilation_unit.of_string in
   let unit_info = Unit_info.make_dummy ~input_name:"test" compilation_unit in
   Compilenv.reset unit_info;
-  Emit.begin_assembly (module Unix : Compiler_owee.Unix_intf.S);
+  Emit.begin_assembly (module Unix_for_owee : Compiler_owee.Unix_intf.S);
   let ic = open_in filename in
   let lb = Lexing.from_channel ic in
   lb.Lexing.lex_curr_p <- Lexing.{ lb.lex_curr_p with pos_fname = filename };

--- a/tools/generate_cached_generic_functions.ml
+++ b/tools/generate_cached_generic_functions.ml
@@ -30,6 +30,17 @@ open Config
 
 module CU = Compilation_unit
 
+(* Eta-expansion gives [create_process] and [waitpid] the unannotated types
+   required by [Compiler_owee.Unix_intf.S]. *)
+module Unix_for_owee = struct
+  include Unix
+
+  let create_process prog args stdin stdout stderr =
+    Unix.create_process prog args stdin stdout stderr
+
+  let waitpid flags pid = Unix.waitpid flags pid
+end
+
 let make_cached_generic_functions unix ~ppf_dump ~id genfns =
   let name = Generic_fns.Partition.name id in
   Location.input_name := name; (* set name of "current" input *)
@@ -62,7 +73,7 @@ let cached_generic_functions unix ~ppf_dump ~id output_name genfns =
   )
 
 let main filename =
-  let unix = (module Unix : Compiler_owee.Unix_intf.S) in
+  let unix = (module Unix_for_owee : Compiler_owee.Unix_intf.S) in
   Clflags.native_code := true;
   Clflags.use_linscan := true;
   Clflags.function_sections := Config.function_sections;

--- a/toplevel/native/opttoploop.ml
+++ b/toplevel/native/opttoploop.ml
@@ -26,6 +26,17 @@ open Ast_helper
 
 module Genprintval = Genprintval_native
 
+(* Eta-expansion gives [create_process] and [waitpid] the unannotated types
+   required by [Compiler_owee.Unix_intf.S]. *)
+module Unix_for_owee = struct
+  include Unix
+
+  let create_process prog args stdin stdout stderr =
+    Unix.create_process prog args stdin stdout stderr
+
+  let waitpid flags pid = Unix.waitpid flags pid
+end
+
 type input =
   | Stdin
   | File of string
@@ -316,7 +327,7 @@ let default_load ppf (program : Lambda.program) =
       (Flambda2.lambda_to_cmm ~machine_width ~keep_symbol_tables:true)
   in
   Asmgen.compile_implementation
-    (module Unix : Compiler_owee.Unix_intf.S)
+    (module Unix_for_owee : Compiler_owee.Unix_intf.S)
     ~toplevel:need_symbol
     ~sourcefile:(Some filename) ~prefixname:filename
     ~pipeline ~ppf_dump:ppf
@@ -880,7 +891,7 @@ let run_script ppf name args =
 
 
 module Compiler = (val Optcompile.native
-                   (module Unix : Compiler_owee.Unix_intf.S)
+                   (module Unix_for_owee : Compiler_owee.Unix_intf.S)
                    ~flambda2:Flambda2.lambda_to_cmm)
 
 (* Load in-core a .cmxs file *)

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -27,6 +27,14 @@ let command cmdline =
 
 let run_command cmdline = ignore(command cmdline)
 
+let start_command ~spawn cmdline =
+  if !Clflags.verbose then begin
+    prerr_string "+ ";
+    prerr_string cmdline;
+    prerr_newline()
+  end;
+  spawn "/bin/sh" [| "/bin/sh"; "-c"; cmdline |]
+
 (* Build @responsefile to work around OS limitations on
    command-line length.
    Under Windows, the max length is 8187 minus the length of the

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -15,25 +15,20 @@
 
 (* Compiling C files and building C libraries *)
 
-let command cmdline =
+let echo_if_verbose cmdline =
   if !Clflags.verbose then begin
     prerr_string "+ ";
     prerr_string cmdline;
     prerr_newline()
-  end;
+  end
+
+let command cmdline =
+  echo_if_verbose cmdline;
   let res = Sys.command cmdline in
   if res = 127 then raise (Sys_error cmdline);
   res
 
 let run_command cmdline = ignore(command cmdline)
-
-let start_command ~spawn cmdline =
-  if !Clflags.verbose then begin
-    prerr_string "+ ";
-    prerr_string cmdline;
-    prerr_newline()
-  end;
-  spawn "/bin/sh" [| "/bin/sh"; "-c"; cmdline |]
 
 (* Build @responsefile to work around OS limitations on
    command-line length.

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -22,6 +22,13 @@
 
 val command: string -> int
 val run_command: string -> unit
+
+(** [start_command ~spawn cmdline] starts [cmdline] through the shell, as
+    [command] does, but without waiting for it to finish. [spawn prog argv]
+    must create the process and return its pid; the caller is responsible for
+    waiting on it and for applying [command]'s convention that exit code 127
+    means the command could not be run. Unix only. *)
+val start_command: spawn:(string -> string array -> int) -> string -> int
 val compile_file:
   ?output:string -> ?opt:string -> ?stable_name:string -> string -> int
 val create_archive: string -> string list -> int

--- a/utils/ccomp.mli
+++ b/utils/ccomp.mli
@@ -23,12 +23,14 @@
 val command: string -> int
 val run_command: string -> unit
 
-(** [start_command ~spawn cmdline] starts [cmdline] through the shell, as
-    [command] does, but without waiting for it to finish. [spawn prog argv]
-    must create the process and return its pid; the caller is responsible for
-    waiting on it and for applying [command]'s convention that exit code 127
-    means the command could not be run. Unix only. *)
-val start_command: spawn:(string -> string array -> int) -> string -> int
+(** [echo_if_verbose cmdline] prints [cmdline] to stderr (prefixed with ["+ "])
+    when [-verbose] is set, matching how [command] logs the commands it runs.
+
+    Exposed so that commands which cannot go through [command] can still produce
+    the same [-verbose] output. In particular this covers platform-specific
+    commands run such as the dissector's partial linking, which spawns the
+    linker directly via [Unix] to obtain a pid to wait on. *)
+val echo_if_verbose: string -> unit
 val compile_file:
   ?output:string -> ?opt:string -> ?stable_name:string -> string -> int
 val create_archive: string -> string list -> int


### PR DESCRIPTION
Performance improvements for the dissector pass, along two axes: each
partition's object file is now parsed once and shared across the whole
pipeline, and the per-partition partial links run concurrently under a
configurable limit.

##### Parse once, reuse everywhere
- `Owee_elf` gains `read_symbols`/`symbol_table_lookup`: the symbol table is
  parsed once into an array instead of being re-read per relocation through
  cursor lookups (`read_symbol_name`/`read_symbol_shndx`, now removed) or the
  callback-based `iter_symbols` (also removed).
- `Extract_relocations.Mapped_object_file` maps and parses a partition's ELF
  file (header, sections, symtab, `.rela.text*` bodies) exactly once;
  extraction, plan formation, and section rewriting all reuse it.

##### Less work per relocation
- Extraction now produces the deduplicated set of symbols needing IGOT/IPLT
  entries (new abstract type `Relocatable_symbol_name.t`), deduplicating early
  via bitmaps keyed on symbol index, rather than one record per relocation
  site; relocation offsets, which were never used, are no longer retained.
- The rewrite plan records only the rela entries that actually change, and
  write-back patches exactly those slots — unchanged entries are covered by
  the initial whole-file copy.
- Rela sections are decoded with a single advancing cursor instead of one
  cursor per entry, and `st_shndx` is typed as `Section_index.t` end to end.

##### Parallel partial linking
- The linking step is split into spawn and wait (`Link_job`, built on the new
  `Ccomp.start_command`; `Unix_intf.S` gains `create_process`, `waitpid` and
  `kill`, with a small eta-expansion wrapper at the main-context packing
  sites to strip mode annotations).
- `Partial_link.link_all` runs the links through a sliding window: up to N
  linker children run concurrently while the driver extracts and rewrites
  already-linked partitions, still in partition order. Controlled by the new
  flag `-dissector-max-linker-parallelism <n|none>` (default: no limit).
- If linking is aborted (a link fails, or extraction/rewriting raises), the
  remaining in-flight linker children are killed (SIGTERM) and reaped, and
  their response files removed.

##### Behavior notes
- A partition object with no symbol table (or an out-of-range strtab link) is
  now a fatal error instead of silently contributing no relocations.
- The `dissector/partial_link` profile column now spans the overlapped
  link+extract+rewrite pipeline; the new `dissector/partial_link_wait` counter
  isolates time actually blocked on linker children.
