### PR TITLE
Cmm int casts

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1676,38 +1676,29 @@ let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
 let emit_static_cast (cast : Cmm.static_cast) i =
   let open Simd_instrs in
   let distinct = not (Reg.same_loc i.arg.(0) i.res.(0)) in
-  let extend_using_shift r ~by ~shift_right =
-    if not (Reg.same_loc r i.res.(0)) then I.mov (reg r) (res i 0);
+  let extend_using_shift ~by ~shift_right =
+    if distinct then I.mov (arg i 0) (res i 0);
     I.sal (int by) (res i 0);
     shift_right (int by) (res i 0)
-  in
-  let sign_extend (w : Cmm.int_width) ~(src : Reg.t) =
-    match w with
-    | Int8 -> extend_using_shift ~by:56 ~shift_right:I.sar src
-    | Int16 -> extend_using_shift ~by:48 ~shift_right:I.sar src
-    | Int32 -> I.movsxd (emit_subreg reg_low_32_name DWORD src) (res i 0)
-    | Int63 -> extend_using_shift ~by:1 ~shift_right:I.sar src
-    | Int64 ->
-      if not (Reg.same_loc src i.res.(0)) then I.mov (reg src) (res i 0)
-  in
-  let zero_extend (w : Cmm.int_width) ~(src : Reg.t) =
-    match w with
-    | Int8 -> extend_using_shift ~by:56 ~shift_right:I.shr src
-    | Int16 -> extend_using_shift ~by:48 ~shift_right:I.shr src
-    | Int32 -> I.mov (emit_subreg reg_low_32_name DWORD src) (res32 i 0)
-    | Int63 -> extend_using_shift ~by:1 ~shift_right:I.shr src
-    | Int64 ->
-      if not (Reg.same_loc src i.res.(0)) then I.mov (reg src) (res i 0)
   in
   match cast with
   | Int_conv cast -> (
     match Cmm.class_of_int_cast cast with
     | Identity -> if distinct then I.mov (arg i 0) (res i 0)
-    | Sign_extend w -> sign_extend w ~src:i.arg.(0)
-    | Zero_extend w -> zero_extend w ~src:i.arg.(0)
-    | Zero_then_sign_extend { zero_extend_from; sign_extend_from } ->
-      zero_extend zero_extend_from ~src:i.arg.(0);
-      sign_extend sign_extend_from ~src:i.res.(0))
+    | Sign_extend w -> (
+      match w with
+      | Int8 -> extend_using_shift ~by:56 ~shift_right:I.sar
+      | Int16 -> extend_using_shift ~by:48 ~shift_right:I.sar
+      | Int32 -> I.movsxd (arg32 i 0) (res i 0)
+      | Int63 -> extend_using_shift ~by:1 ~shift_right:I.sar
+      | Int64 -> Misc.fatal_error "unexpected Sign_extend Int64")
+    | Zero_extend w -> (
+      match w with
+      | Int8 -> extend_using_shift ~by:56 ~shift_right:I.shr
+      | Int16 -> extend_using_shift ~by:48 ~shift_right:I.shr
+      | Int32 -> I.mov (arg32 i 0) (res32 i 0)
+      | Int63 -> extend_using_shift ~by:1 ~shift_right:I.shr
+      | Int64 -> Misc.fatal_error "unexpected Zero_extend Int64"))
   | Tagged_int_of_int64 ->
     let r =
       (* CR jrayman: Should we have this check or change

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1651,7 +1651,7 @@ let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
   let open Simd_instrs in
   let distinct = not (Reg.same_loc i.arg.(0) i.res.(0)) in
   match cast with
-  | Int64_of_value | Value_of_int64 ->
+  | Int64_of_value | Value_of_int64 | Tagged_int_of_value ->
     if distinct then I.mov (arg i 0) (res i 0)
   | Float_of_float32 | Float32_of_float ->
     if distinct then movss (arg i 0) (res i 0)

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1682,8 +1682,8 @@ let emit_static_cast (cast : Cmm.static_cast) i =
     shift_right (int by) (res i 0)
   in
   match cast with
-  | Int_conv cast -> (
-    match Cmm.class_of_int_cast cast with
+  | Int_conv ic -> (
+    match Cmm.class_of_int_conv ic with
     | Identity -> if distinct then I.mov (arg i 0) (res i 0)
     | Sign_extend w -> (
       match w with

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -1676,7 +1676,55 @@ let emit_reinterpret_cast (cast : Cmm.reinterpret_cast) i =
 let emit_static_cast (cast : Cmm.static_cast) i =
   let open Simd_instrs in
   let distinct = not (Reg.same_loc i.arg.(0) i.res.(0)) in
+  let extend_using_shift r ~by ~shift_right =
+    if not (Reg.same_loc r i.res.(0)) then I.mov (reg r) (res i 0);
+    I.sal (int by) (res i 0);
+    shift_right (int by) (res i 0)
+  in
+  let sign_extend (w : Cmm.int_width) ~(src : Reg.t) =
+    match w with
+    | Int8 -> extend_using_shift ~by:56 ~shift_right:I.sar src
+    | Int16 -> extend_using_shift ~by:48 ~shift_right:I.sar src
+    | Int32 -> I.movsxd (emit_subreg reg_low_32_name DWORD src) (res i 0)
+    | Int63 -> extend_using_shift ~by:1 ~shift_right:I.sar src
+    | Int64 ->
+      if not (Reg.same_loc src i.res.(0)) then I.mov (reg src) (res i 0)
+  in
+  let zero_extend (w : Cmm.int_width) ~(src : Reg.t) =
+    match w with
+    | Int8 -> extend_using_shift ~by:56 ~shift_right:I.shr src
+    | Int16 -> extend_using_shift ~by:48 ~shift_right:I.shr src
+    | Int32 -> I.mov (emit_subreg reg_low_32_name DWORD src) (res32 i 0)
+    | Int63 -> extend_using_shift ~by:1 ~shift_right:I.shr src
+    | Int64 ->
+      if not (Reg.same_loc src i.res.(0)) then I.mov (reg src) (res i 0)
+  in
   match cast with
+  | Int_conv cast -> (
+    match Cmm.class_of_int_cast cast with
+    | Identity -> if distinct then I.mov (arg i 0) (res i 0)
+    | Sign_extend w -> sign_extend w ~src:i.arg.(0)
+    | Zero_extend w -> zero_extend w ~src:i.arg.(0)
+    | Zero_then_sign_extend { zero_extend_from; sign_extend_from } ->
+      zero_extend zero_extend_from ~src:i.arg.(0);
+      sign_extend sign_extend_from ~src:i.res.(0))
+  | Tagged_int_of_int64 ->
+    let r =
+      (* CR jrayman: Should we have this check or change
+         [regalloc_stack_operands.ml]? *)
+      if Reg.is_stack i.arg.(0)
+      then (
+        I.mov (arg i 0) (res i 0);
+        reg64 i.res.(0))
+      else arg64 i 0
+    in
+    I.lea (mem64 NONE ~base:r 1 (Scalar r)) (res i 0)
+  | Int64_of_tagged_int { signedness } ->
+    if distinct then I.mov (arg i 0) (res i 0);
+    begin match signedness with
+    | Signed -> I.sar (int 1) (res i 0)
+    | Unsigned -> I.shr (int 1) (res i 0)
+    end
   | Float_of_int64 Float64 ->
     sse_or_avx_dst cvtsi2sd_X_r64m64 vcvtsi2sd_X_X_r64m64 (arg i 0) (res i 0)
   | Int64_of_float Float64 ->

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -727,7 +727,8 @@ let operation_supported = function
                        Float32_of_float | Float_of_float32 |
                        Float32_of_int32 | Int32_of_float32 |
                        V128_of_vec Vec128)
-  | Cstatic_cast (Float_of_float32 | Float32_of_float |
+  | Cstatic_cast (Int_conv _ | Tagged_int_of_int64 | Int64_of_tagged_int _ |
+                  Float_of_float32 | Float32_of_float |
                   Int64_of_float Float32 | Float_of_int64 Float32 |
                   Float_of_int64 Float64 | Int64_of_float Float64 |
                   V128_of_scalar _ | Scalar_of_v128 _) ->

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -722,7 +722,7 @@ let operation_supported = function
   | Cdomain_index
   | Cpoll
   | Cpause
-  | Creinterpret_cast (Int64_of_value | Value_of_int64 |
+  | Creinterpret_cast (Int64_of_value | Value_of_int64 | Tagged_int_of_value |
                        Int64_of_float | Float_of_int64 |
                        Float32_of_float | Float_of_float32 |
                        Float32_of_int32 | Int32_of_float32 |

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -230,7 +230,8 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
     may_use_stack_operand_for_result map instr ~num_args:1
   | Op
       (Static_cast
-         ( Float_of_int64 (Float32 | Float64)
+         ( Int_conv _ | Tagged_int_of_int64 | Int64_of_tagged_int _
+         | Float_of_int64 (Float32 | Float64)
          | Int64_of_float (Float32 | Float64)
          | Float_of_float32 | Float32_of_float )) ->
     may_use_stack_operand_for_only_argument map instr ~has_result:true

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -273,7 +273,8 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
       | Const_vec512 _ | Stackoffset _ | Load _ | Store _ | Name_for_debugger _
       | Probe_is_enabled _ | Opaque | Begin_region | End_region | Dls_get
       | Tls_get | Domain_index | Poll | Pause | Alloc _ )
-  | Op (Reinterpret_cast (Int64_of_value | Value_of_int64))
+  | Op
+      (Reinterpret_cast (Int64_of_value | Value_of_int64 | Tagged_int_of_value))
   | Op
       (Specific
          ( Isextend32 | Izextend32 | Ilea _

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1333,32 +1333,21 @@ let emit_static_cast (cast : Cmm.static_cast) i =
   let distinct = not (Reg.same_loc src dst) in
   match cast with
   | Int_conv cast -> (
-    let mov (src : Reg.t) =
-      if not (Reg.same_loc src dst)
-      then A.ins_mov_reg (H.reg_x dst) (H.reg_x src)
-    in
-    let sign_extend (w : Cmm.int_width) ~(src : Reg.t) =
+    match Cmm.class_of_int_cast cast with
+    | Identity -> if distinct then A.ins_mov_reg (H.reg_x dst) (H.reg_x src)
+    | Sign_extend w -> (
       match w with
       | Int8 | Int16 | Int32 | Int63 ->
         A.ins4 SBFM (H.reg_x dst) (H.reg_x src) (O.imm_six 0)
           (O.imm_six (Cmm.bits_of_int_width w - 1))
-      | Int64 -> mov src
-    in
-    let zero_extend (w : Cmm.int_width) ~(src : Reg.t) =
+      | Int64 -> Misc.fatal_error "unexpected Sign_extend Int64")
+    | Zero_extend w -> (
       match w with
       | Int8 | Int16 | Int63 ->
         A.ins4 UBFM (H.reg_x dst) (H.reg_x src) (O.imm_six 0)
           (O.imm_six (Cmm.bits_of_int_width w - 1))
       | Int32 -> A.ins_mov_reg_w (H.reg_w dst) (H.reg_w src)
-      | Int64 -> mov src
-    in
-    match Cmm.class_of_int_cast cast with
-    | Identity -> mov src
-    | Sign_extend w -> sign_extend w ~src
-    | Zero_extend w -> zero_extend w ~src
-    | Zero_then_sign_extend { zero_extend_from; sign_extend_from } ->
-      zero_extend zero_extend_from ~src;
-      sign_extend sign_extend_from ~src:dst)
+      | Int64 -> Misc.fatal_error "unexpected Zero_extend Int64"))
   | Tagged_int_of_int64 ->
     A.ins_lsl_immediate (H.reg_x dst) (H.reg_x src) ~shift_in_bits:1;
     A.ins3 ORR_immediate (H.reg_x dst) (H.reg_x dst) (O.bitmask 1n)

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1325,7 +1325,7 @@ let emit_reinterpret_cast env (cast : Cmm.reinterpret_cast) i =
     then A.ins_mov_vector (H.reg_v16b_operand dst) (H.reg_v16b_operand src)
   | V128_of_vec (Vec256 | Vec512) | V256_of_vec _ | V512_of_vec _ ->
     Misc.fatal_error "arm64: got 256/512 bit vector"
-  | Int64_of_value | Value_of_int64 -> move env src dst
+  | Int64_of_value | Value_of_int64 | Tagged_int_of_value -> move env src dst
 
 let emit_static_cast (cast : Cmm.static_cast) i =
   let dst = i.res.(0) in

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1332,8 +1332,8 @@ let emit_static_cast (cast : Cmm.static_cast) i =
   let src = i.arg.(0) in
   let distinct = not (Reg.same_loc src dst) in
   match cast with
-  | Int_conv cast -> (
-    match Cmm.class_of_int_cast cast with
+  | Int_conv ic -> (
+    match Cmm.class_of_int_conv ic with
     | Identity -> if distinct then A.ins_mov_reg (H.reg_x dst) (H.reg_x src)
     | Sign_extend w -> (
       match w with

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1332,6 +1332,41 @@ let emit_static_cast (cast : Cmm.static_cast) i =
   let src = i.arg.(0) in
   let distinct = not (Reg.same_loc src dst) in
   match cast with
+  | Int_conv cast -> (
+    let mov (src : Reg.t) =
+      if not (Reg.same_loc src dst)
+      then A.ins_mov_reg (H.reg_x dst) (H.reg_x src)
+    in
+    let sign_extend (w : Cmm.int_width) ~(src : Reg.t) =
+      match w with
+      | Int8 | Int16 | Int32 | Int63 ->
+        A.ins4 SBFM (H.reg_x dst) (H.reg_x src) (O.imm_six 0)
+          (O.imm_six (Cmm.bits_of_int_width w - 1))
+      | Int64 -> mov src
+    in
+    let zero_extend (w : Cmm.int_width) ~(src : Reg.t) =
+      match w with
+      | Int8 | Int16 | Int63 ->
+        A.ins4 UBFM (H.reg_x dst) (H.reg_x src) (O.imm_six 0)
+          (O.imm_six (Cmm.bits_of_int_width w - 1))
+      | Int32 -> A.ins_mov_reg_w (H.reg_w dst) (H.reg_w src)
+      | Int64 -> mov src
+    in
+    match Cmm.class_of_int_cast cast with
+    | Identity -> mov src
+    | Sign_extend w -> sign_extend w ~src
+    | Zero_extend w -> zero_extend w ~src
+    | Zero_then_sign_extend { zero_extend_from; sign_extend_from } ->
+      zero_extend zero_extend_from ~src;
+      sign_extend sign_extend_from ~src:dst)
+  | Tagged_int_of_int64 ->
+    A.ins_lsl_immediate (H.reg_x dst) (H.reg_x src) ~shift_in_bits:1;
+    A.ins3 ORR_immediate (H.reg_x dst) (H.reg_x dst) (O.bitmask 1n)
+  | Int64_of_tagged_int { signedness } -> (
+    match signedness with
+    | Signed -> A.ins_asr_immediate (H.reg_x dst) (H.reg_x src) ~shift_in_bits:1
+    | Unsigned ->
+      A.ins_lsr_immediate (H.reg_x dst) (H.reg_x src) ~shift_in_bits:1)
   | Int64_of_float Float64 -> A.ins2 FCVTZS (H.reg_x dst) (H.reg_d src)
   | Int64_of_float Float32 -> A.ins2 FCVTZS (H.reg_x dst) (H.reg_s src)
   | Float_of_int64 Float64 -> A.ins2 SCVTF (H.reg_d dst) (H.reg_x src)

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -304,7 +304,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
            _, _))
     -> [||]
   | Op (Static_cast
-          (Int64_of_float _ | Float_of_int64 _
+          (Int_conv _ | Tagged_int_of_int64 | Int64_of_tagged_int _
+          | Int64_of_float _ | Float_of_int64 _
           | Float_of_float32|Float32_of_float))
     -> [||]
   | Op (Static_cast
@@ -527,7 +528,8 @@ let operation_supported : Cmm.operation -> bool = function
                        Float32_of_float | Float_of_float32 |
                        Float32_of_int32 | Int32_of_float32 |
                        V128_of_vec Vec128)
-  | Cstatic_cast (Float_of_float32 | Float32_of_float |
+  | Cstatic_cast (Int_conv _ | Tagged_int_of_int64 | Int64_of_tagged_int _ |
+                  Float_of_float32 | Float32_of_float |
                   Int64_of_float Float32 | Float_of_int64 Float32 |
                   Float_of_int64 Float64 | Int64_of_float Float64 |
                   V128_of_scalar _ | Scalar_of_v128 _) ->

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -329,7 +329,8 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
         | Name_for_debugger _ | Probe_is_enabled _ | Opaque | Pause
         | Begin_region | End_region | Dls_get | Tls_get | Domain_index)
   | Poptrap _ | Prologue | Epilogue
-  | Op (Reinterpret_cast (Int64_of_value | Value_of_int64 | Float_of_float32 |
+  | Op (Reinterpret_cast (Int64_of_value | Value_of_int64 |
+                          Tagged_int_of_value | Float_of_float32 |
                           Float32_of_float | Float_of_int64 | Int64_of_float |
                           Float32_of_int32 | Int32_of_float32 |
                           V128_of_vec Vec128))
@@ -523,7 +524,7 @@ let operation_supported : Cmm.operation -> bool = function
   | Ctls_get
   | Cdomain_index
   | Cpoll
-  | Creinterpret_cast (Int64_of_value | Value_of_int64 |
+  | Creinterpret_cast (Int64_of_value | Value_of_int64 | Tagged_int_of_value |
                        Int64_of_float | Float_of_int64 |
                        Float32_of_float | Float_of_float32 |
                        Float32_of_int32 | Int32_of_float32 |

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -17,6 +17,33 @@
 
 open! Int_replace_polymorphic_compare [@@warning "-66"]
 
+type int_width = Cmx_format.int_width =
+  | Int64
+  | Int63
+  | Int32
+  | Int16
+  | Int8
+
+let bits_of_int_width = function
+  | Int64 -> 64
+  | Int63 -> 63
+  | Int32 -> 32
+  | Int16 -> 16
+  | Int8 -> 8
+
+let equal_int_width x y =
+  match x, y with
+  | Int64, Int64 | Int63, Int63 | Int32, Int32 | Int16, Int16 | Int8, Int8 ->
+    true
+  | (Int64 | Int63 | Int32 | Int16 | Int8), _ -> false
+
+let string_of_int_width = function
+  | Int64 -> "Int64"
+  | Int63 -> "Int63"
+  | Int32 -> "Int32"
+  | Int16 -> "Int16"
+  | Int8 -> "Int8"
+
 type machtype_component = Cmx_format.machtype_component =
   | Val
   | Addr
@@ -415,6 +442,9 @@ type reinterpret_cast =
   | V512_of_vec of vector_width
 
 type static_cast =
+  | Int_conv of int_cast
+  | Tagged_int_of_int64
+  | Int64_of_tagged_int of { signedness : Scalar.Signedness.t }
   | Float_of_int64 of float_width
   | Int64_of_float of float_width
   | Float_of_float32
@@ -425,6 +455,34 @@ type static_cast =
   | Scalar_of_v256 of vec256_type
   | V512_of_scalar of vec512_type
   | Scalar_of_v512 of vec512_type
+
+and int_cast =
+  { src : int_width;
+    dst : int_width;
+    signedness : Scalar.Signedness.t
+  }
+
+type int_cast_class =
+  | Sign_extend of int_width
+  | Zero_extend of int_width
+  | Zero_then_sign_extend of
+      { zero_extend_from : int_width;
+        sign_extend_from : int_width
+      }
+  | Identity
+
+let class_of_int_cast { src; dst; signedness } =
+  let src_bits = bits_of_int_width src in
+  let dst_bits = bits_of_int_width dst in
+  if src_bits = dst_bits
+  then Identity
+  else if dst_bits < src_bits
+  then Sign_extend dst
+  else
+    match signedness with
+    | Signed -> Identity
+    | Unsigned ->
+      Zero_then_sign_extend { zero_extend_from = src; sign_extend_from = dst }
 
 module Alloc_mode = struct
   type t =
@@ -1011,6 +1069,14 @@ let equal_reinterpret_cast (left : reinterpret_cast) (right : reinterpret_cast)
 
 let equal_static_cast (left : static_cast) (right : static_cast) =
   match left, right with
+  | ( Int_conv { src = src1; dst = dst1; signedness = s1 },
+      Int_conv { src = src2; dst = dst2; signedness = s2 } ) ->
+    equal_int_width src1 src2 && equal_int_width dst1 dst2
+    && Scalar.Signedness.equal s1 s2
+  | Tagged_int_of_int64, Tagged_int_of_int64 -> true
+  | ( Int64_of_tagged_int { signedness = s1 },
+      Int64_of_tagged_int { signedness = s2 } ) ->
+    Scalar.Signedness.equal s1 s2
   | Float32_of_float, Float32_of_float -> true
   | Float_of_float32, Float_of_float32 -> true
   | Float_of_int64 f1, Float_of_int64 f2 -> equal_float_width f1 f2
@@ -1021,7 +1087,8 @@ let equal_static_cast (left : static_cast) (right : static_cast) =
   | V256_of_scalar v1, V256_of_scalar v2 -> equal_vec256_type v1 v2
   | Scalar_of_v512 v1, Scalar_of_v512 v2 -> equal_vec512_type v1 v2
   | V512_of_scalar v1, V512_of_scalar v2 -> equal_vec512_type v1 v2
-  | ( ( Float32_of_float | Float_of_float32 | Float_of_int64 _
+  | ( ( Int_conv _ | Tagged_int_of_int64 | Int64_of_tagged_int _
+      | Float32_of_float | Float_of_float32 | Float_of_int64 _
       | Int64_of_float _ | Scalar_of_v128 _ | V128_of_scalar _
       | Scalar_of_v256 _ | V256_of_scalar _ | Scalar_of_v512 _
       | V512_of_scalar _ ),

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -17,7 +17,7 @@
 
 open! Int_replace_polymorphic_compare [@@warning "-66"]
 
-type int_width = Cmx_format.int_width =
+type int_width =
   | Int64
   | Int63
   | Int32
@@ -441,8 +441,14 @@ type reinterpret_cast =
   | V256_of_vec of vector_width
   | V512_of_vec of vector_width
 
+type int_conv =
+  { src : int_width;
+    dst : int_width;
+    signedness : Scalar.Signedness.t
+  }
+
 type static_cast =
-  | Int_conv of int_cast
+  | Int_conv of int_conv
   | Tagged_int_of_int64
   | Int64_of_tagged_int of { signedness : Scalar.Signedness.t }
   | Float_of_int64 of float_width
@@ -456,18 +462,12 @@ type static_cast =
   | V512_of_scalar of vec512_type
   | Scalar_of_v512 of vec512_type
 
-and int_cast =
-  { src : int_width;
-    dst : int_width;
-    signedness : Scalar.Signedness.t
-  }
-
-type int_cast_class =
+type int_conv_class =
   | Sign_extend of int_width
   | Zero_extend of int_width
   | Identity
 
-let class_of_int_cast { src; dst; signedness } =
+let class_of_int_conv { src; dst; signedness } =
   let src_bits = bits_of_int_width src in
   let dst_bits = bits_of_int_width dst in
   if src_bits = dst_bits

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -431,6 +431,7 @@ let machtype_of_memory_chunk : memory_chunk -> machtype = function
 type reinterpret_cast =
   | Int64_of_value
   | Value_of_int64
+  | Tagged_int_of_value
   | Float_of_float32
   | Float32_of_float
   | Float_of_int64
@@ -1043,6 +1044,7 @@ let equal_reinterpret_cast (left : reinterpret_cast) (right : reinterpret_cast)
   match left, right with
   | Int64_of_value, Int64_of_value -> true
   | Value_of_int64, Value_of_int64 -> true
+  | Tagged_int_of_value, Tagged_int_of_value -> true
   | Float_of_float32, Float_of_float32 -> true
   | Float32_of_float, Float32_of_float -> true
   | Float_of_int64, Float_of_int64 -> true
@@ -1053,9 +1055,9 @@ let equal_reinterpret_cast (left : reinterpret_cast) (right : reinterpret_cast)
   | V256_of_vec w1, V256_of_vec w2
   | V512_of_vec w1, V512_of_vec w2 ->
     equal_vector_width w1 w2
-  | ( ( Int64_of_value | Value_of_int64 | Float_of_float32 | Float32_of_float
-      | Float_of_int64 | Int64_of_float | Float32_of_int32 | Int32_of_float32
-      | V128_of_vec _ | V256_of_vec _ | V512_of_vec _ ),
+  | ( ( Int64_of_value | Value_of_int64 | Tagged_int_of_value | Float_of_float32
+      | Float32_of_float | Float_of_int64 | Int64_of_float | Float32_of_int32
+      | Int32_of_float32 | V128_of_vec _ | V256_of_vec _ | V512_of_vec _ ),
       _ ) ->
     false
 

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -465,10 +465,6 @@ and int_cast =
 type int_cast_class =
   | Sign_extend of int_width
   | Zero_extend of int_width
-  | Zero_then_sign_extend of
-      { zero_extend_from : int_width;
-        sign_extend_from : int_width
-      }
   | Identity
 
 let class_of_int_cast { src; dst; signedness } =
@@ -476,13 +472,9 @@ let class_of_int_cast { src; dst; signedness } =
   let dst_bits = bits_of_int_width dst in
   if src_bits = dst_bits
   then Identity
-  else if dst_bits < src_bits
+  else if src_bits > dst_bits
   then Sign_extend dst
-  else
-    match signedness with
-    | Signed -> Identity
-    | Unsigned ->
-      Zero_then_sign_extend { zero_extend_from = src; sign_extend_from = dst }
+  else match signedness with Signed -> Identity | Unsigned -> Zero_extend src
 
 module Alloc_mode = struct
   type t =

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -38,11 +38,11 @@ let equal_int_width x y =
   | (Int64 | Int63 | Int32 | Int16 | Int8), _ -> false
 
 let string_of_int_width = function
-  | Int64 -> "Int64"
-  | Int63 -> "Int63"
-  | Int32 -> "Int32"
-  | Int16 -> "Int16"
-  | Int8 -> "Int8"
+  | Int64 -> "int64"
+  | Int63 -> "int63"
+  | Int32 -> "int32"
+  | Int16 -> "int16"
+  | Int8 -> "int8"
 
 type machtype_component = Cmx_format.machtype_component =
   | Val

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -323,6 +323,7 @@ val machtype_of_memory_chunk : memory_chunk -> machtype
 type reinterpret_cast =
   | Int64_of_value
   | Value_of_int64
+  | Tagged_int_of_value
   | Float_of_float32
     (* Only writes the bottom 32 bits of the target float register. All other
        bits are unspecified. *)

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -17,7 +17,7 @@
 
 [@@@ocaml.warning "+a-40-41-42"]
 
-type int_width = Cmx_format.int_width =
+type int_width =
   | Int64
   | Int63
   | Int32
@@ -337,10 +337,17 @@ type reinterpret_cast =
   | V256_of_vec of vector_width
   | V512_of_vec of vector_width
 
+(* Converts between naked integers. *)
+type int_conv =
+  { src : int_width;
+    dst : int_width;
+    signedness : Scalar.Signedness.t
+  }
+
 (* These casts may require a particular value-preserving operation, e.g.
    truncating a float to an int. *)
 type static_cast =
-  | Int_conv of int_cast
+  | Int_conv of int_conv
   | Tagged_int_of_int64
   | Int64_of_tagged_int of { signedness : Scalar.Signedness.t }
   | Float_of_int64 of float_width
@@ -354,18 +361,15 @@ type static_cast =
   | V512_of_scalar of vec512_type
   | Scalar_of_v512 of vec512_type
 
-and int_cast =
-  { src : int_width;
-    dst : int_width;
-    signedness : Scalar.Signedness.t
-  }
-
-type int_cast_class =
+(* Describes how to perform an [Int_conv] cast. This is separate from [int_conv]
+   so the convention on upper bits of small ints is encapsulated in a single
+   function: [class_of_int_conv]. *)
+type int_conv_class =
   | Sign_extend of int_width
   | Zero_extend of int_width
   | Identity
 
-val class_of_int_cast : int_cast -> int_cast_class
+val class_of_int_conv : int_conv -> int_conv_class
 
 module Alloc_mode : sig
   type t =

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -363,10 +363,6 @@ and int_cast =
 type int_cast_class =
   | Sign_extend of int_width
   | Zero_extend of int_width
-  | Zero_then_sign_extend of
-      { zero_extend_from : int_width;
-        sign_extend_from : int_width
-      }
   | Identity
 
 val class_of_int_cast : int_cast -> int_cast_class

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -26,6 +26,8 @@ type int_width = Cmx_format.int_width =
 
 val string_of_int_width : int_width -> string
 
+val bits_of_int_width : int_width -> int
+
 type machtype_component = Cmx_format.machtype_component =
   | Val
   | Addr

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -17,6 +17,15 @@
 
 [@@@ocaml.warning "+a-40-41-42"]
 
+type int_width = Cmx_format.int_width =
+  | Int64
+  | Int63
+  | Int32
+  | Int16
+  | Int8
+
+val string_of_int_width : int_width -> string
+
 type machtype_component = Cmx_format.machtype_component =
   | Val
   | Addr
@@ -329,6 +338,9 @@ type reinterpret_cast =
 (* These casts may require a particular value-preserving operation, e.g.
    truncating a float to an int. *)
 type static_cast =
+  | Int_conv of int_cast
+  | Tagged_int_of_int64
+  | Int64_of_tagged_int of { signedness : Scalar.Signedness.t }
   | Float_of_int64 of float_width
   | Int64_of_float of float_width
   | Float_of_float32
@@ -339,6 +351,23 @@ type static_cast =
   | Scalar_of_v256 of vec256_type
   | V512_of_scalar of vec512_type
   | Scalar_of_v512 of vec512_type
+
+and int_cast =
+  { src : int_width;
+    dst : int_width;
+    signedness : Scalar.Signedness.t
+  }
+
+type int_cast_class =
+  | Sign_extend of int_width
+  | Zero_extend of int_width
+  | Zero_then_sign_extend of
+      { zero_extend_from : int_width;
+        sign_extend_from : int_width
+      }
+  | Identity
+
+val class_of_int_cast : int_cast -> int_cast_class
 
 module Alloc_mode : sig
   type t =

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -218,6 +218,9 @@ let reinterpret_cast_arg_type : reinterpret_cast -> machtype = function
     machtype_of_vector_width width
 
 let static_cast_arg_type : static_cast -> machtype = function
+  | Int_conv _ -> typ_int
+  | Tagged_int_of_int64 -> typ_int
+  | Int64_of_tagged_int _ -> typ_int
   | Float_of_int64 (_ : float_width) -> typ_int
   | Int64_of_float width -> machtype_of_float_width width
   | Float_of_float32 -> typ_float32

--- a/backend/cmm_invariants.ml
+++ b/backend/cmm_invariants.ml
@@ -208,6 +208,7 @@ let machtype_of_vec512_scalar : vec512_type -> machtype = function
 let reinterpret_cast_arg_type : reinterpret_cast -> machtype = function
   | Int64_of_value -> typ_val
   | Value_of_int64 -> typ_int
+  | Tagged_int_of_value -> typ_int
   | Float_of_float32 -> typ_float32
   | Float32_of_float -> typ_float
   | Float_of_int64 -> typ_int

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1296,9 +1296,9 @@ let basic_op t (i : Cfg.basic Cfg.instruction) (op : Operation.t) =
       not_implemented_basic ~msg:"static cast" i)
   | Reinterpret_cast cast_op -> (
     match cast_op with
-    | Int64_of_value | Value_of_int64 | Float_of_int64 | Int64_of_float
-    | Float32_of_int32 | Int32_of_float32 | Float_of_float32 | Float32_of_float
-      ->
+    | Int64_of_value | Value_of_int64 | Tagged_int_of_value | Float_of_int64
+    | Int64_of_float | Float32_of_int32 | Int32_of_float32 | Float_of_float32
+    | Float32_of_float ->
       let arg = load_reg_to_temp t i.arg.(0) in
       let converted =
         emit_ins t (I.convert Bitcast ~arg ~to_:(T.of_reg i.res.(0)))

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1268,7 +1268,11 @@ let basic_op t (i : Cfg.basic Cfg.instruction) (op : Operation.t) =
       store_into_reg t i.res.(0) converted
     in
     match cast_op with
-    | Int_conv _ -> not_implemented_basic ~msg:"static cast" i
+    | Int_conv _ ->
+      (* CR-soon jrayman: I'm holding off on implementing until we get LLVM
+         working again or we start accepting garbage in the upper bits, which
+         ever comes first. *)
+      not_implemented_basic ~msg:"Int_conv static cast" i
     | Tagged_int_of_int64 ->
       let arg = load_reg_to_temp ~typ:T.i64 t i.arg.(0) in
       let shifted = emit_ins t (I.binary Shl ~arg1:arg ~arg2:(V.of_int 1)) in

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1268,6 +1268,19 @@ let basic_op t (i : Cfg.basic Cfg.instruction) (op : Operation.t) =
       store_into_reg t i.res.(0) converted
     in
     match cast_op with
+    | Int_conv _ -> not_implemented_basic ~msg:"static cast" i
+    | Tagged_int_of_int64 ->
+      let arg = load_reg_to_temp ~typ:T.i64 t i.arg.(0) in
+      let shifted = emit_ins t (I.binary Shl ~arg1:arg ~arg2:(V.of_int 1)) in
+      let tagged = emit_ins t (I.binary Or ~arg1:shifted ~arg2:(V.of_int 1)) in
+      store_into_reg t i.res.(0) tagged
+    | Int64_of_tagged_int { signedness } ->
+      let arg = load_reg_to_temp ~typ:T.i64 t i.arg.(0) in
+      let op : LL.Instruction.binary_op =
+        match signedness with Signed -> Ashr | Unsigned -> Lshr
+      in
+      let untagged = emit_ins t (I.binary op ~arg1:arg ~arg2:(V.of_int 1)) in
+      store_into_reg t i.res.(0) untagged
     | Float_of_int64 width ->
       do_conv Sitofp ~from:T.i64 ~to_:(T.of_float_width width)
     | Int64_of_float width ->

--- a/backend/operation.ml
+++ b/backend/operation.ml
@@ -358,7 +358,8 @@ let is_pure = function
   | Static_cast _ -> true
   (* Conservative to ensure valueofint/intofvalue are not eliminated before
      emit. *)
-  | Reinterpret_cast (Value_of_int64 | Int64_of_value) -> false
+  | Reinterpret_cast (Value_of_int64 | Int64_of_value | Tagged_int_of_value) ->
+    false
   | Probe_is_enabled _ -> true
   | Opaque -> false
   | Begin_region -> false

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -248,12 +248,12 @@ let static_cast : Cmm.static_cast -> string = function
       (Cmm.string_of_int_width src)
       unsigned_sigil
       (Cmm.string_of_int_width dst)
-  | Tagged_int_of_int64 -> "Int64->Tagged_int"
+  | Tagged_int_of_int64 -> "int64->tagged_int"
   | Int64_of_tagged_int { signedness } ->
     let unsigned_sigil =
       match signedness with Signed -> "" | Unsigned -> "U"
     in
-    Printf.sprintf "%sTagged_int->%sInt64" unsigned_sigil unsigned_sigil
+    Printf.sprintf "tagged_%sint->%sint64" unsigned_sigil unsigned_sigil
   | Int64_of_float Float64 -> "float->int64"
   | Float_of_int64 Float64 -> "int64->float"
   | Int64_of_float Float32 -> "float32->int64"

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -232,6 +232,7 @@ let reinterpret_cast : Cmm.reinterpret_cast -> string = function
   | V512_of_vec w -> Printf.sprintf "%s as vec512" (vector_width w)
   | Value_of_int64 -> "int64 as value"
   | Int64_of_value -> "value as int64"
+  | Tagged_int_of_value -> "value as tagged_int"
   | Float32_of_float -> "float as float32"
   | Float_of_float32 -> "float32 as float"
   | Float_of_int64 -> "int64 as float"

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -240,6 +240,20 @@ let reinterpret_cast : Cmm.reinterpret_cast -> string = function
   | Int32_of_float32 -> "float32 as int32"
 
 let static_cast : Cmm.static_cast -> string = function
+  | Int_conv { src; dst; signedness } ->
+    let unsigned_sigil =
+      match signedness with Signed -> "" | Unsigned -> "U"
+    in
+    Printf.sprintf "%s%s->%s%s" unsigned_sigil
+      (Cmm.string_of_int_width src)
+      unsigned_sigil
+      (Cmm.string_of_int_width dst)
+  | Tagged_int_of_int64 -> "Int64->Tagged_int"
+  | Int64_of_tagged_int { signedness } ->
+    let unsigned_sigil =
+      match signedness with Signed -> "" | Unsigned -> "U"
+    in
+    Printf.sprintf "%sTagged_int->%sInt64" unsigned_sigil unsigned_sigil
   | Int64_of_float Float64 -> "float->int64"
   | Float_of_int64 Float64 -> "int64->float"
   | Int64_of_float Float32 -> "float32->int64"

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -212,6 +212,7 @@ let oper_result_type = function
   | Creinterpret_cast (Float_of_int64 | Float_of_float32) -> typ_float
   | Creinterpret_cast (Float32_of_int32 | Float32_of_float) -> typ_float32
   | Creinterpret_cast (Int64_of_value | Int64_of_float) -> typ_int
+  | Creinterpret_cast Tagged_int_of_value -> typ_int
   | Creinterpret_cast Int32_of_float32 -> typ_int
   | Cstatic_cast (Int_conv _) -> typ_int
   | Cstatic_cast Tagged_int_of_int64 -> typ_int

--- a/backend/select_utils.ml
+++ b/backend/select_utils.ml
@@ -211,8 +211,11 @@ let oper_result_type = function
   | Creinterpret_cast (V512_of_vec _) -> typ_vec512
   | Creinterpret_cast (Float_of_int64 | Float_of_float32) -> typ_float
   | Creinterpret_cast (Float32_of_int32 | Float32_of_float) -> typ_float32
-  | Creinterpret_cast (Int64_of_value | Int64_of_float | Int32_of_float32) ->
-    typ_int
+  | Creinterpret_cast (Int64_of_value | Int64_of_float) -> typ_int
+  | Creinterpret_cast Int32_of_float32 -> typ_int
+  | Cstatic_cast (Int_conv _) -> typ_int
+  | Cstatic_cast Tagged_int_of_int64 -> typ_int
+  | Cstatic_cast (Int64_of_tagged_int _) -> typ_int
   | Cstatic_cast (Float_of_float32 | Float_of_int64 Float64) -> typ_float
   | Cstatic_cast (Float32_of_float | Float_of_int64 Float32) -> typ_float32
   | Cstatic_cast (Int64_of_float (Float64 | Float32)) -> typ_int

--- a/backend/zero_alloc_checker.ml
+++ b/backend/zero_alloc_checker.ml
@@ -2641,7 +2641,8 @@ end = struct
             Misc.fatal_errorf "Expected pure operation, got %a\n" Operation.dump
               op;
           next
-        | Reinterpret_cast (Int64_of_value | Value_of_int64)
+        | Reinterpret_cast
+            (Int64_of_value | Value_of_int64 | Tagged_int_of_value)
         | Name_for_debugger _ | Stackoffset _ | Probe_is_enabled _ | Opaque
         | Begin_region | End_region | Intop_atomic _ | Store _ | Pause ->
           next

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -31,13 +31,6 @@ open Misc
    The .cmx file contains these infos (as an externed record) plus a MD5
    of these infos *)
 
-type int_width =
-  | Int64
-  | Int63
-  | Int32
-  | Int16
-  | Int8
-
 (* Declare machtype here to avoid depending on [Cmm]. *)
 type machtype_component =
   Val | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Float32 | Valx2

--- a/file_formats/cmx_format.mli
+++ b/file_formats/cmx_format.mli
@@ -31,6 +31,13 @@ open Misc
    The .cmx file contains these infos (as an externed record) plus a MD5
    of these infos *)
 
+type int_width =
+  | Int64
+  | Int63
+  | Int32
+  | Int16
+  | Int8
+
 (* Declare machtype here to avoid depending on [Cmm]. *)
 type machtype_component =
   Val | Addr | Int | Float | Vec128 | Vec256 | Vec512 | Float32 | Valx2


### PR DESCRIPTION
Add `Tagged_int_of_int64`, `Int64_of_tagged_int`, and `Int_conv` constructors to `Cmm.static_cast`. `Int_conv` represents conversions between naked integers, and `Int64_of_tagged_int` and `Int_conv` take a signedness.

Previously, all int conversions, including tags and untags, were translated to arithmetic expressions in Cmm (involving shifts and, for tags, add 1). This approach carries no int type information with it, so it is in theory easy to mess up, especially with peephole optimizations. It is also incompatible with the strict machtype checking we plan to implement.

Maybe I should make it `Tagged_int_of_int63`, and `Int63_of_tagged_int` so neither take a signedness.