### PR TITLE
Allocation mode axis fix for multi-argument functions and partial application

### DIFF
--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -591,23 +591,11 @@ val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
    optional-argument wrapping). *)
 let (alloc_optional_arg @ noalloc_strict) ?a () = a
 [%%expect{|
-Line 1, characters 45-51:
-1 | let (alloc_optional_arg @ noalloc_strict) ?a () = a
-                                                 ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 42-51
-         which is expected to be "noalloc_strict".
+val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
 |}]
 let (alloc_optional_arg @ noalloc) ?a () = a
 [%%expect{|
-Line 1, characters 38-44:
-1 | let (alloc_optional_arg @ noalloc) ?a () = a
-                                          ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 35-44
-         which is expected to be "noalloc".
+val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
 |}]
 
 (* Building a closure that captures a variable allocates. *)
@@ -616,20 +604,20 @@ let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
 Line 1, characters 49-60:
 1 | let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
                                                      ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-60
-         which is expected to be "noalloc_strict".
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 let (alloc_closure @ noalloc) (a : int) = fun () -> a
 [%%expect{|
 Line 1, characters 42-53:
 1 | let (alloc_closure @ noalloc) (a : int) = fun () -> a
                                               ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 30-53
-         which is expected to be "noalloc".
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 
 (* The same closure, but [stack_]-marked. *)
@@ -715,24 +703,14 @@ val alloc_tuple : unit -> int * int @ local = <fun>
 let (alloc_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
 [%%expect{|
-Line 2, characters 58-63:
-2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
-                                                              ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 2, characters 6-63
-         which is expected to be "noalloc_strict".
+val alloc_partial_app :
+  (int -> int -> int -> int) @ noalloc_strict -> int -> int = <fun>
 |}]
 let (alloc_partial_app @ noalloc)
       (f : (int -> int -> int -> int) @ noalloc) = f 1 2
 [%%expect{|
-Line 2, characters 51-56:
-2 |       (f : (int -> int -> int -> int) @ noalloc) = f 1 2
-                                                       ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 2, characters 6-56
-         which is expected to be "noalloc".
+val alloc_partial_app : (int -> int -> int -> int) @ noalloc -> int -> int =
+  <fun>
 |}]
 
 (* [stack_] on a partial application is rejected: it is an application, not a
@@ -744,10 +722,7 @@ let (stack_partial_app @ noalloc_strict)
 Line 2, characters 74-81:
 2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
                                                                               ^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 2, characters 6-81
-         which is expected to be "noalloc_strict".
+Error: This expression is not an allocation site.
 |}]
 
 (* Partial application whose result is a function hidden behind a
@@ -761,13 +736,8 @@ let (alloc_partial_app_abbrev @ noalloc_strict)
       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
 [%%expect{|
 type myfun = int -> int
-Line 3, characters 53-58:
-3 |       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
-                                                         ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 6-58
-         which is expected to be "noalloc_strict".
+val alloc_partial_app_abbrev :
+  (int -> int -> myfun) @ noalloc_strict -> myfun = <fun>
 |}]
 
 (* A function [f] with mixed arguments: optional [a], mandatory [b], optional
@@ -796,9 +766,9 @@ let (call_one_opt_one_mand @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
   f ~a:1 2
 [%%expect{|
-Line 3, characters 2-10:
+Line 3, characters 7-8:
 3 |   f ~a:1 2
-      ^^^^^^^^
+           ^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 2-3, characters 6-10
@@ -812,9 +782,9 @@ let (call_one_opt_one_mand @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int)) =
   f ~a:1 2
 [%%expect{|
-Line 3, characters 2-10:
+Line 3, characters 7-8:
 3 |   f ~a:1 2
-      ^^^^^^^^
+           ^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 2-3, characters 6-10
@@ -1508,9 +1478,9 @@ let stack_inner_partial_application
   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
   ()
 [%%expect{|
-Line 3, characters 48-62:
+Line 3, characters 51-59:
 3 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
-                                                    ^^^^^^^^^^^^^^
+                                                       ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at line 3, characters 27-62
@@ -1674,24 +1644,15 @@ Line 1, characters 32-51:
 Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
-(** Test 5.10:
 
-    CR shsong: a curried multi-argument function cannot be [noalloc]/
-    [noalloc_strict].
+(** Test 6: Muti-argument function (currying) and partial application *)
 
-    Writing [let f x y = x] desugars to [fun x -> (fun y -> x)]. Applying [f] to
-    one argument builds the inner closure [fun y -> x], preventing [f] from
-    begin [noalloc]/[noalloc_strict]. *)
+(** Test 6.1: a curried multi-argument function can be [noalloc]/
+  [noalloc_strict], but the inner closure (its codomain) must be [local]. *)
 
 let (f @ noalloc_strict) x y = x
 [%%expect{|
-Line 10, characters 27-32:
-10 | let (f @ noalloc_strict) x y = x
-                                ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 10, characters 25-32
-         which is expected to be "noalloc_strict".
+val f : 'a -> ('b -> 'a) @ local = <fun>
 |}]
 
 let (f_explicit @ noalloc_strict) x = fun y -> x
@@ -1699,61 +1660,125 @@ let (f_explicit @ noalloc_strict) x = fun y -> x
 Line 1, characters 38-48:
 1 | let (f_explicit @ noalloc_strict) x = fun y -> x
                                           ^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-48
-         which is expected to be "noalloc_strict".
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 
-let (f_n @ noalloc) x y = x
+let (f_explicit_exclave @ noalloc_strict) x = exclave_ fun y -> x
 [%%expect{|
-Line 1, characters 22-27:
-1 | let (f_n @ noalloc) x y = x
-                          ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 20-27
-         which is expected to be "noalloc".
+val f_explicit_exclave : 'a -> ('b -> 'a) @ local = <fun>
 |}]
 
-(* Contrast: a single-argument function builds no inner closure and so is
-   accepted at [noalloc_strict]. *)
+let (f @ noalloc) x y = x
+[%%expect{|
+val f : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+let (f_explicit @ noalloc) x = fun y -> x
+[%%expect{|
+Line 1, characters 31-41:
+1 | let (f_explicit @ noalloc) x = fun y -> x
+                                   ^^^^^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+|}]
+
+let (f_explicit_exclave @ noalloc) x = exclave_ fun y -> x
+[%%expect{|
+val f_explicit_exclave : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* Contrast: a single-argument function builds no inner closure.
+  Its return type is not a closure, so it can be global. *)
 let (g @ noalloc_strict) x = x
 [%%expect{|
 val g : 'a -> 'a = <fun>
 |}]
 
-let (f_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
+let (g @ noalloc) x = x
 [%%expect{|
-Line 1, characters 46-58:
-1 | let (f_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
-                                                  ^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 33-58
-         which is expected to be "noalloc_strict".
-|}]
-
-(* The exemption extends down the whole curry chain: a three-argument function
-   is accepted, with a [local] codomain at each step. *)
-let (f3 @ noalloc_strict) x y z = x
-[%%expect{|
+val g : 'a -> 'a = <fun>
 |}]
 
 (* Soundness: the returned closure is pinned [local], so it cannot escape to a
-   [global] (heap) position -- using [f] where a [global] codomain is expected
-   is rejected. *)
+  [global] (heap) position -- using [f] where a [global] codomain is expected
+  is rejected. *)
+let (f @ noalloc_strict) x y = x
 let escapes = (f : _ -> (_ -> _) @ global)
 [%%expect{|
+val f : 'a -> ('b -> 'a) @ local = <fun>
+Line 2, characters 15-16:
+2 | let escapes = (f : _ -> (_ -> _) @ global)
+                   ^
+Error: The value "f" has type "'a -> ('b -> 'a) @ local"
+       but an expression was expected of type "'c -> 'd -> 'e"
+|}]
+
+(* The local requirement is passed down the whole curry chain:
+  a three-argument function is accepted, with [local] mode at each layer of
+  codomain. Although [local] for inner layers is not printed, we have the
+  following sanity checks to validate this. *)
+let (f3 @ noalloc_strict) x y z = x
+[%%expect{|
+val f3 : 'a -> ('b -> 'c -> 'a) @ local = <fun>
+|}]
+
+(* Sanity check: [c' -> 'a] above is local and cannot be returned *)
+let g () = f3 0 1
+[%%expect{|
+Line 1, characters 11-17:
+1 | let g () = f3 0 1
+               ^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+Hint: This is a partial application
+      Adding 1 more argument will make the value non-local
+|}]
+
+(* Sanity check: Prove local constraints on inner steps with coercions.
+  Requiring the inner arrow ([_ -> _], the result of [f3 x y]) to be
+  [local] is accepted. *)
+let f3_inner_local = (f3 : _ -> ((_ -> (_ -> _) @ local)) @ local)
+[%%expect{|
+val f3_inner_local : 'a -> ('b -> 'c -> 'a) @ local = <fun>
+|}]
+
+(* Sanity check: Conversely, requiring that same inner arrow to be [global]
+  is rejected: it is really [local]. This is the definitive evidence that
+  the propagation reaches the inner step; the missing [@ local] in the
+  printed signature above is only a type-printer elision. *)
+let f3_inner_not_global = (f3 : _ -> ((_ -> (_ -> _) @ global)) @ local)
+[%%expect{|
+Line 1, characters 27-29:
+1 | let f3_inner_not_global = (f3 : _ -> ((_ -> (_ -> _) @ global)) @ local)
+                               ^^
+Error: The value "f3" has type "'a -> ('b -> 'c -> 'a) @ local"
+       but an expression was expected of type
+         "'a -> ('d -> ('e -> 'f)) @ local"
+       Type "'b -> ('c -> 'a) @ local" is not compatible with type
+         "'d -> 'e -> 'f"
 |}]
 
 (* Soundness: a genuine allocation in the body (here a tuple) is still counted;
    only the curried intermediate closures are exempt. *)
 let (f_body_alloc @ noalloc_strict) x y = (x, y)
 [%%expect{|
+Line 1, characters 42-48:
+1 | let (f_body_alloc @ noalloc_strict) x y = (x, y)
+                                              ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-48
+         which is expected to be "noalloc_strict".
 |}]
 
-(** Test 5.11: forcing the codomain of a [noalloc] curried function to [local]
+(** Test 6.2: forcing the codomain of a [noalloc] curried function to [local]
     interacts with an explicit codomain areality annotation. Because the
     codomain arrow is forced to [local], an explicit [@ global] on it conflicts,
     while an explicit [@ local] agrees (and the function is accepted). *)
@@ -1762,22 +1787,208 @@ let (f_body_alloc @ noalloc_strict) x y = (x, y)
    [@ global] on the returned arrow. *)
 let (f : int -> (int -> int) @ global) @ noalloc_strict = fun x y -> x
 [%%expect{|
+Line 8, characters 64-70:
+8 | let (f : int -> (int -> int) @ global) @ noalloc_strict = fun x y -> x
+                                                                    ^^^^^^
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Contrast: without the [noalloc_strict] annotation the codomain is NOT forced,
    so the same [@ global] arrow is accepted. *)
 let (f : int -> (int -> int) @ global) = fun x y -> x
 [%%expect{|
+val f : int -> int -> int = <fun>
 |}]
 
 (* Annotating the codomain [@ local] agrees with the forcing, so the function
    is accepted. *)
 let (f : int -> (int -> int) @ local) @ noalloc_strict = fun x y -> x
 [%%expect{|
+val f : int -> (int -> int) @ local = <fun>
 |}]
 
+(* Sanity check: [f 0] is local *)
+let g () = f 0
+[%%expect{|
+Line 1, characters 11-14:
+1 | let g () = f 0
+               ^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+Hint: This is a partial application
+      Adding 1 more argument will make the value non-local
+|}]
 
-(** Test 6: Misc *)
+(** Test 6.3: propagation of [strictly_local_closure] to inner layers.
+
+    A closure built inside a [noalloc_strict] / [noalloc] function (if
+    the information is known when type check the closure) is forced to be
+    [local] and on stack. It is also exempted from the allocation check.
+    We probe each syntactic position for a nested closure.
+
+    Reading the results:
+    - Acceptance (a [val ... = <fun>] with a [@ local] codomain) means the flag
+      reached that position: the closure was exempted.
+    - "The allocation is "alloc" ... expected to be "noalloc_strict"" means the
+      flag did NOT reach that position (a propagation gap): the closure counts as
+      a heap allocation and forces the enclosing function.
+
+    [exclave_] is used as a uniform wrapper so a returned [local] closure is
+    allowed to escape its region; it does NOT by itself skip the allocation
+    lock-walk (that is what [strictly_local_closure] does), so acceptance below
+    genuinely reflects propagation -- see the control at the end of Part B. *)
+
+(* --- Part A: positions that DO receive the flag (closure exempted) --- *)
+
+(* Inner function parameter / curried closure (no [exclave_] needed). *)
+let (p_curried @ noalloc_strict) x y = x
+[%%expect{|
+val p_curried : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* Function body / return via [exclave_]. *)
+let (p_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
+[%%expect{|
+val p_exclave : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* Mode annotation on the returned closure ([mode_morph]/[type_expect_mode]). We
+   annotate a NON-locality axis ([contended]) on purpose: the [contended] in the
+   result shows the annotation itself took effect (so the [mode_morph] path is
+   exercised), while the [@ local] codomain is enforced by annotating the outer
+   closure p_mode_annot with [@ noalloc_strict]. *)
+let (p_mode_annot @ noalloc_strict) x = exclave_ (fun y -> x : _ @ contended)
+[%%expect{|
+val p_mode_annot : 'a -> ('b -> 'a) @ local contended = <fun>
+|}]
+
+(* Type constraint on the returned closure ([type_argument] reuses the expected
+   mode). *)
+let (p_constraint @ noalloc_strict) x = exclave_ ((fun y -> x) : _ -> _)
+[%%expect{|
+val p_constraint : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* [if] branches (reuse the expected mode). *)
+let (p_if @ noalloc_strict) b x =
+  exclave_ (if b then (fun y -> x) else (fun y -> x))
+[%%expect{|
+val p_if : bool -> ('a -> 'b -> 'a) @ local = <fun>
+|}]
+
+(* [match] branches (reuse the expected mode). *)
+let (p_match @ noalloc_strict) o x =
+  exclave_ (match o with Some _ -> (fun y -> x) | None -> (fun y -> x))
+[%%expect{|
+val p_match : 'a option -> ('b -> 'c -> 'b) @ local = <fun>
+|}]
+
+(* Record field via a modality ([mode_is_contained_by]); the record block is
+   [stack_]-allocated so the field closure is the only thing exercising the
+   propagation. *)
+type box = { g : unit -> int }
+[%%expect{|
+type box = { g : unit -> int; }
+|}]
+let (p_record @ noalloc_strict) (x : int) = exclave_ stack_ { g = (fun () -> x) }
+[%%expect{|
+val p_record : int -> box @ local = <fun>
+|}]
+
+(* --- Part B: positions that do NOT yet receive the flag (propagation gaps) --- *)
+
+(* [let]-binding RHS: [pat_modes] rebuilds the RHS mode with [mode_default] and
+   drops the flag. The closure is treated as a heap allocation. *)
+let (g_let @ noalloc_strict) (x : int) =
+  let h = fun () -> x in
+  h ()
+[%%expect{|
+Line 2, characters 10-21:
+2 |   let h = fun () -> x in
+              ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-3, characters 29-6
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Application argument: [mode_argument] returns [mode_default] without the
+   flag, so the argument closure is not exempted. [use] and [g_arg] are wrapped
+   in an outer function so [use] stays a local [noalloc_strict] value -- a
+   top-level [use] would instead be exported at [alloc] and trip the capture rule
+   first. The only allocation here is the argument closure [fun () -> x], which
+   is what the error correctly points at. *)
+let g_app_arg () =
+  let (use @ noalloc_strict) (g : unit -> int) = g () in
+  let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
+  ()
+[%%expect{|
+Line 3, characters 47-60:
+3 |   let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
+                                                   ^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 31-60
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Region body ([for]/[while]/comprehension): [mode_region] rebuilds the body
+   mode with [mode_default] and drops the flag. *)
+let (g_region @ noalloc_strict) (x : int) =
+  for _i = 0 to 0 do
+    let _g = fun () -> x in ()
+  done
+[%%expect{|
+Line 3, characters 13-24:
+3 |     let _g = fun () -> x in ()
+                 ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-4, characters 32-6
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Let-binding operator (letop): the [let*] body is a continuation closure typed
+   at legacy via [mode_return] in [type_binding_op] (the [mode_return Value.legacy]
+   there), so it does not receive the flag. In practice the failure surfaces even
+   earlier: the [let*] operator is itself an [alloc] value, so referencing it
+   inside a [noalloc_strict] function trips the capture rule first. Either way,
+   [let*] does not currently compose with [noalloc_strict]. *)
+let ( let* ) o f = match o with None -> None | Some x -> f x
+[%%expect{|
+val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
+|}]
+let (g_letop @ noalloc_strict) (x : int) =
+  let* _ = Some 0 in
+  fun () -> x
+[%%expect{|
+Line 2, characters 2-6:
+2 |   let* _ = Some 0 in
+      ^^^^
+Error: The value "( let* )" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-3, characters 31-13
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Control: [exclave_] does NOT rescue a gap position -- it forces [local] but
+   does not skip the lock-walk, so the [let]-RHS closure still errors. This
+   confirms the acceptances in Part A are due to [strictly_local_closure]
+   propagation, not to [exclave_]. *)
+let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
+[%%expect{|
+Line 1, characters 67-78:
+1 | let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
+                                                                       ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 37-84
+         which is expected to be "noalloc_strict".
+|}]
+
+(** Test 7: Misc *)
 
 type record_t = { x : float; y : float }
 [%%expect{|

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -604,20 +604,14 @@ let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
 Line 1, characters 49-60:
 1 | let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
                                                      ^^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_closure @ noalloc) (a : int) = fun () -> a
 [%%expect{|
 Line 1, characters 42-53:
 1 | let (alloc_closure @ noalloc) (a : int) = fun () -> a
                                               ^^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* The same closure, but [stack_]-marked. *)
@@ -1223,10 +1217,9 @@ let (layers3_ss @ noalloc_strict) (a : int) =
   in
   g
 [%%expect{|
-Lines 13-15, characters 27-5:
-13 | ...........................() =
+Line 14, characters 34-40:
 14 |     let (h @ noalloc_strict) () = Just a in
-15 |     h
+                                       ^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 12-17, characters 34-3
@@ -1241,10 +1234,9 @@ let (layers3_n @ noalloc) (a : int) =
   in
   g
 [%%expect{|
-Lines 2-4, characters 20-5:
-2 | ....................() =
+Line 3, characters 27-33:
 3 |     let (h @ noalloc) () = Just a in
-4 |     h
+                               ^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 26-3
@@ -1260,9 +1252,9 @@ let layers_middle (a : int) =
   in
   g
 [%%expect{|
-Line 3, characters 10-21:
+Line 3, characters 15-21:
 3 |     let h () = Just a in
-              ^^^^^^^^^^^
+                   ^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 2-4, characters 27-5
@@ -1660,10 +1652,7 @@ let (f_explicit @ noalloc_strict) x = fun y -> x
 Line 1, characters 38-48:
 1 | let (f_explicit @ noalloc_strict) x = fun y -> x
                                           ^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let (f_explicit_exclave @ noalloc_strict) x = exclave_ fun y -> x
@@ -1681,10 +1670,7 @@ let (f_explicit @ noalloc) x = fun y -> x
 Line 1, characters 31-41:
 1 | let (f_explicit @ noalloc) x = fun y -> x
                                    ^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let (f_explicit_exclave @ noalloc) x = exclave_ fun y -> x
@@ -1821,26 +1807,11 @@ Hint: This is a partial application
       Adding 1 more argument will make the value non-local
 |}]
 
-(** Test 6.3: propagation of [strictly_local_closure] to inner layers.
-
-    A closure built inside a [noalloc_strict] / [noalloc] function (if
-    the information is known when type check the closure) is forced to be
-    [local] and on stack. It is also exempted from the allocation check.
+(** Test 6.3: A closure built inside a [noalloc_strict] / [noalloc] function
+    (if the information is known when type check the function) is forced to
+    be [local] and on stack. It is also exempted from the allocation check.
     We probe each syntactic position for a nested closure.
-
-    Reading the results:
-    - Acceptance (a [val ... = <fun>] with a [@ local] codomain) means the flag
-      reached that position: the closure was exempted.
-    - "The allocation is "alloc" ... expected to be "noalloc_strict"" means the
-      flag did NOT reach that position (a propagation gap): the closure counts as
-      a heap allocation and forces the enclosing function.
-
-    [exclave_] is used as a uniform wrapper so a returned [local] closure is
-    allowed to escape its region; it does NOT by itself skip the allocation
-    lock-walk (that is what [strictly_local_closure] does), so acceptance below
-    genuinely reflects propagation -- see the control at the end of Part B. *)
-
-(* --- Part A: positions that DO receive the flag (closure exempted) --- *)
+*)
 
 (* Inner function parameter / curried closure (no [exclave_] needed). *)
 let (p_curried @ noalloc_strict) x y = x
@@ -1854,10 +1825,11 @@ let (p_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
 val p_exclave : 'a -> ('b -> 'a) @ local = <fun>
 |}]
 
-(* Mode annotation on the returned closure ([mode_morph]/[type_expect_mode]). We
-   annotate a NON-locality axis ([contended]) on purpose: the [contended] in the
-   result shows the annotation itself took effect (so the [mode_morph] path is
-   exercised), while the [@ local] codomain is enforced by annotating the outer
+(* Closure created inside mode annotation on the returned closure
+   ([mode_morph]/[type_expect_mode]). We annotate a NON-locality axis
+   ([contended]) on purpose: the [contended] in the result shows the
+   annotation itself took effect (so the [mode_morph] path is exercised),
+   while the [@ local] codomain is enforced by annotating the outer
    closure p_mode_annot with [@ noalloc_strict]. *)
 let (p_mode_annot @ noalloc_strict) x = exclave_ (fun y -> x : _ @ contended)
 [%%expect{|
@@ -1897,29 +1869,20 @@ let (p_record @ noalloc_strict) (x : int) = exclave_ stack_ { g = (fun () -> x) 
 val p_record : int -> box @ local = <fun>
 |}]
 
-(* --- Part B: positions that do NOT yet receive the flag (propagation gaps) --- *)
-
-(* [let]-binding RHS: [pat_modes] rebuilds the RHS mode with [mode_default] and
-   drops the flag. The closure is treated as a heap allocation. *)
+(* [let]-binding RHS. *)
 let (g_let @ noalloc_strict) (x : int) =
   let h = fun () -> x in
   h ()
 [%%expect{|
-Line 2, characters 10-21:
-2 |   let h = fun () -> x in
-              ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-3, characters 29-6
-         which is expected to be "noalloc_strict".
+Line 3, characters 2-3:
+3 |   h ()
+      ^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is the function in a tail call.
 |}]
 
-(* Application argument: [mode_argument] returns [mode_default] without the
-   flag, so the argument closure is not exempted. [use] and [g_arg] are wrapped
-   in an outer function so [use] stays a local [noalloc_strict] value -- a
-   top-level [use] would instead be exported at [alloc] and trip the capture rule
-   first. The only allocation here is the argument closure [fun () -> x], which
-   is what the error correctly points at. *)
+(* Application argument. *)
 let g_app_arg () =
   let (use @ noalloc_strict) (g : unit -> int) = g () in
   let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
@@ -1928,34 +1891,25 @@ let g_app_arg () =
 Line 3, characters 47-60:
 3 |   let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
                                                    ^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 31-60
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* Region body ([for]/[while]/comprehension): [mode_region] rebuilds the body
-   mode with [mode_default] and drops the flag. *)
+(* Region body ([for]/[while]/comprehension). *)
 let (g_region @ noalloc_strict) (x : int) =
   for _i = 0 to 0 do
     let _g = fun () -> x in ()
   done
 [%%expect{|
-Line 3, characters 13-24:
-3 |     let _g = fun () -> x in ()
-                 ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-4, characters 32-6
-         which is expected to be "noalloc_strict".
+val g_region : int -> unit = <fun>
 |}]
 
-(* Let-binding operator (letop): the [let*] body is a continuation closure typed
-   at legacy via [mode_return] in [type_binding_op] (the [mode_return Value.legacy]
-   there), so it does not receive the flag. In practice the failure surfaces even
-   earlier: the [let*] operator is itself an [alloc] value, so referencing it
-   inside a [noalloc_strict] function trips the capture rule first. Either way,
-   [let*] does not currently compose with [noalloc_strict]. *)
+(* Special case: Let-binding operator (letop): the [let*] body is a continuation
+   closure typed at legacy via [mode_return] in [type_binding_op]
+   (the [mode_return Value.legacy] there), so we cannot make it local.
+   In practice the failure surfaces even earlier: the [let*] operator is itself
+   an [alloc] value, so referencing it inside a [noalloc_strict] function trips
+   the capture rule first. Either way, [let*] does not currently compose with
+   [noalloc_strict]. *)
 let ( let* ) o f = match o with None -> None | Some x -> f x
 [%%expect{|
 val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
@@ -1970,21 +1924,6 @@ Line 2, characters 2-6:
 Error: The value "( let* )" is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 1-3, characters 31-13
-         which is expected to be "noalloc_strict".
-|}]
-
-(* Control: [exclave_] does NOT rescue a gap position -- it forces [local] but
-   does not skip the lock-walk, so the [let]-RHS closure still errors. This
-   confirms the acceptances in Part A are due to [strictly_local_closure]
-   propagation, not to [exclave_]. *)
-let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
-[%%expect{|
-Line 1, characters 67-78:
-1 | let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
-                                                                       ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-84
          which is expected to be "noalloc_strict".
 |}]
 
@@ -2098,9 +2037,9 @@ let (secretly_allocates @ noalloc) () =
   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
   whitewashed ()
 [%%expect{|
-Line 2, characters 30-58:
+Line 2, characters 40-58:
 2 |   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                            ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-3, characters 35-16
@@ -2114,9 +2053,9 @@ let (secretly_allocates' @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-Line 3, characters 30-60:
+Line 3, characters 41-59:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                             ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 36-17
@@ -2130,9 +2069,9 @@ let (secretly_allocates @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-Line 3, characters 30-60:
+Line 3, characters 41-59:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                             ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 35-17

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -585,10 +585,12 @@ let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
 val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
 |}]
 
-(* CR shsong: Currently it may also because multi-argument function
-    always allocates. Revisit this in the next PR. *)
-(* A function that takes an optional argument allocates (to handle the
-   optional-argument wrapping). *)
+
+(* A function that takes an optional argument can still be noalloc.
+  Calling the function without providing the optional argument does not
+  trigger allocation.
+  Calling the function with providing the optional argument triggers
+  allocation, which is successfully detected. *)
 let (alloc_optional_arg @ noalloc_strict) ?a () = a
 [%%expect{|
 val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
@@ -598,7 +600,52 @@ let (alloc_optional_arg @ noalloc) ?a () = a
 val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
 |}]
 
-(* Building a closure that captures a variable allocates. *)
+let test_missing_arg () =
+  let (f @ noalloc_strict) ?a () = a in
+  let (g @ noalloc_strict) () = f () in
+  g ()
+[%%expect{|
+val test_missing_arg : unit -> 'a option = <fun>
+|}]
+
+let test_passing_arg () =
+  let (f @ noalloc_strict) ?a () = a in
+  let (g @ noalloc_strict) () = f ~a:1 () in
+  g ()
+[%%expect{|
+Line 3, characters 37-38:
+3 |   let (g @ noalloc_strict) () = f ~a:1 () in
+                                         ^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 27-41
+         which is expected to be "noalloc_strict".
+|}]
+
+let test_missing_arg () =
+  let (f @ noalloc_strict) ?(a=0) () = a in
+  let (g @ noalloc_strict) () = f () in
+  g ()
+[%%expect{|
+val test_missing_arg : unit -> int = <fun>
+|}]
+
+let test_passing_arg () =
+  let (f @ noalloc_strict) ?(a=0) () = a in
+  let (g @ noalloc_strict) () = f ~a:1 () in
+  g ()
+[%%expect{|
+Line 3, characters 37-38:
+3 |   let (g @ noalloc_strict) () = f ~a:1 () in
+                                         ^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 27-41
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Building a closure inside a noalloc function forcing the closure
+  to be local. *)
 let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
 [%%expect{|
 Line 1, characters 49-60:
@@ -614,12 +661,12 @@ Line 1, characters 42-53:
 Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same closure, but [stack_]-marked. *)
-let (alloc_closure @ noalloc_strict) (a : int) = exclave_ stack_ (fun () -> a)
+(* The same closure, but [exclave_]-marked. *)
+let (alloc_closure @ noalloc_strict) (a : int) = exclave_ (fun () -> a)
 [%%expect{|
 val alloc_closure : int -> (unit -> int) @ local = <fun>
 |}]
-let (alloc_closure @ noalloc) (a : int) = exclave_ stack_ (fun () -> a)
+let (alloc_closure @ noalloc) (a : int) = exclave_ (fun () -> a)
 [%%expect{|
 val alloc_closure : int -> (unit -> int) @ local = <fun>
 |}]
@@ -690,10 +737,9 @@ let (alloc_tuple @ noalloc) () = exclave_ stack_ (1, 2)
 val alloc_tuple : unit -> int * int @ local = <fun>
 |}]
 
-(* Partial application allocates a closure.
-   We receive [f] as a parameter (rather than defining a multi-argument
-   function, whose curried closures would themselves be flagged)
-   so the only allocation here is the partial-application closure. *)
+(* We do not check partial application to detect potential allocation triggered
+  by it. Instead, we guarantee that if a function is noalloc, then
+  calling it with partial application does not trigger any heap allocation. *)
 let (alloc_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
 [%%expect{|
@@ -708,8 +754,7 @@ val alloc_partial_app : (int -> int -> int -> int) @ noalloc -> int -> int =
 |}]
 
 (* [stack_] on a partial application is rejected: it is an application, not a
-   recognized allocation form. [f] is received as a parameter to avoid the
-   currying closures of a multi-argument definition. *)
+   recognized allocation form. *)
 let (stack_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
 [%%expect{|
@@ -720,11 +765,7 @@ Error: This expression is not an allocation site.
 |}]
 
 (* Partial application whose result is a function hidden behind a
-   type abbreviation ([myfun = int -> int]). Here [f 1 2] is a partial
-   application returning [myfun], so it allocates a closure. The detection uses
-   [get_desc (expand_head env ty_ret)]: [expand_head] unfolds [myfun] to
-   [int -> int] and the [Tarrow] is seen, so the allocation IS currently
-   caught. *)
+   type abbreviation ([myfun = int -> int]). *)
 type myfun = int -> int
 let (alloc_partial_app_abbrev @ noalloc_strict)
       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
@@ -734,16 +775,18 @@ val alloc_partial_app_abbrev :
   (int -> int -> myfun) @ noalloc_strict -> myfun = <fun>
 |}]
 
-(* A function [f] with mixed arguments: optional [a], mandatory [b], optional
-   [c], mandatory [d], optional [e], mandatory [g]. It ends in a mandatory
-   argument [g], so it can be fully applied. It is received as a parameter so
-   referencing it (in function position) does not itself trigger the capture
-   rule; the only allocations come from how it is called. *)
+(* At function call site, we only detect allocation by passing an optional
+  argument, but do not detect potential allocation by partial application.
+
+  A function [f] with mixed arguments: optional [a], mandatory [b], optional
+  [c], mandatory [d], optional [e], mandatory [g]. It ends in a mandatory
+  argument [g], so it can be fully applied. It is received as a parameter so
+  referencing it (in function position) does not itself trigger the capture
+  rule; the only allocations come from how it is called. *)
 
 (* Case 1: call with all mandatory args ([b], [d], [g]); all optionals are
-   omitted, so they default to [None] (constant constructors, no [Some]
-   wrapping). The call is fully applied (not partial), so it allocates nothing
-   and is accepted. *)
+  omitted, so they default to [None] (constant constructors, no [Some]
+  wrapping). Furthermore, [f] is fully applied. Thus, it is accepted. *)
 let (call_all_mandatory @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
   f 1 2 3
@@ -752,10 +795,24 @@ val call_all_mandatory :
   (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int) -> int = <fun>
 |}]
 
-(* Case 2: call with one optional ([~a:1]) and one mandatory ([b]). The mandatory
-   args [d] and [g] are still missing, so this is a partial application, which
-   allocates a closure and is rejected. (The provided [~a:1] would additionally
-   be wrapped in [Some], but the partial-application check fires first.) *)
+(* Case 2: call with two mandatory args ([b], [d]); all optionals are
+  omitted, so they default to [None] (constant constructors, no [Some]
+  wrapping). One mandatory arg is missing. Note that [call_two_mand]
+  does not allocate as long as [f] is noalloc, since our typing rule
+  guarantee that noalloc function does not allocate even when partially
+  applied. Thus, call_two_mand can be noalloc. *)
+let (call_two_mand @ noalloc_strict)
+      (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
+  f 1 2
+[%%expect{|
+val call_two_mand :
+  (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int) ->
+  ?e:int -> int -> int = <fun>
+|}]
+
+(* Case 3: call with one optional ([~a:1]) and one mandatory ([b]). The provided
+  [~a:1] would be wrapped in [Some], which triggers allocation. Thus, it is
+  rejected. *)
 let (call_one_opt_one_mand @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
   f ~a:1 2
@@ -768,23 +825,6 @@ Error: The allocation is "alloc"
          because it is used inside the function at lines 2-3, characters 6-10
          which is expected to be "noalloc_strict".
 |}]
-
-(* Case 3: call a function whose last agument is optional argument and
-   all mandatory arguments are applied. Since the last argument is optional
-   the result still allocates. *)
-let (call_one_opt_one_mand @ noalloc_strict)
-      (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int)) =
-  f ~a:1 2
-[%%expect{|
-Line 3, characters 7-8:
-3 |   f ~a:1 2
-           ^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-3, characters 6-10
-         which is expected to be "noalloc_strict".
-|}]
-
 
 (* A lazy block allocates on the heap *)
 let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
@@ -1576,67 +1616,6 @@ Error: This value is "local" because it is "stack_"-allocated.
 |}]
 
 
-(** Test 5.9: annotating the codomain of the arrow with [@ noalloc_strict]
-    constrains the mode of the application result. With
-    [foo : int -> t @ noalloc_strict], applying [M.foo 1] yields a
-    [noalloc_strict] value (and likewise [M.foo_int 1]). Note the codomain mode
-    [@ noalloc_strict] must precede the [@@ noalloc_strict] modality; writing it
-    as [(t @ noalloc_strict) @@ ...] is a syntax error. *)
-
-module M : sig
-  type t
-  val foo : int -> t @ noalloc_strict @@ noalloc_strict
-
-  type int_t
-  val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
-  val foo_int_default : int -> int_t @@ noalloc_strict
-end = struct
-  type t = (int -> unit) -> unit
-  let g0 : t = fun g -> g 0
-  let foo (_ : int) = g0
-
-  type int_t = int
-  let foo_int x = x
-  let foo_int_default x = x
-end
-[%%expect{|
-module M :
-  sig
-    type t
-    val foo : int -> t @ noalloc_strict @@ noalloc_strict
-    type int_t
-    val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
-    val foo_int_default : int -> int_t @@ noalloc_strict
-  end @@ stateless noalloc_strict
-|}]
-
-(* CR shsong: Error expected -- [M.foo 1] is a partial application,
-    which causes allocation. The current partial application detection
-    cannot detect whether an abstract type is an arrow type. *)
-let apply_one () = (M.foo 1 : _ @ noalloc_strict)
-[%%expect{|
-val apply_one : unit -> M.t = <fun>
-|}]
-
-let apply_zero () = (M.foo : _ @ noalloc_strict)
-[%%expect{|
-val apply_zero : unit -> int -> M.t @ noalloc_strict = <fun>
-|}]
-
-let apply_foo_int () = (M.foo_int 1 : _ @ noalloc_strict)
-[%%expect{|
-val apply_foo_int : unit -> M.int_t = <fun>
-|}]
-
-let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
-[%%expect{|
-Line 1, characters 32-51:
-1 | let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
-                                    ^^^^^^^^^^^^^^^^^^^
-Error: This value is "alloc" but is expected to be "noalloc_strict".
-|}]
-
-
 (** Test 6: Muti-argument function (currying) and partial application *)
 
 (** Test 6.1: a curried multi-argument function can be [noalloc]/
@@ -1925,6 +1904,60 @@ Error: The value "( let* )" is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 1-3, characters 31-13
          which is expected to be "noalloc_strict".
+|}]
+
+(** Test 6.4: Misc test regarding abstract type
+
+    CR shsong: Chek whether backend guarantee that foo does not allocate for the
+    returned global closure g0. *)
+module M : sig
+  type t
+  val foo : int -> t @ noalloc_strict @@ noalloc_strict
+
+  type int_t
+  val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
+  val foo_int_default : int -> int_t @@ noalloc_strict
+end = struct
+  type t = (int -> unit) -> unit
+  let g0 : t = fun g -> g 0
+  let foo (_ : int) = g0
+
+  type int_t = int
+  let foo_int x = x
+  let foo_int_default x = x
+end
+[%%expect{|
+module M :
+  sig
+    type t
+    val foo : int -> t @ noalloc_strict @@ noalloc_strict
+    type int_t
+    val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
+    val foo_int_default : int -> int_t @@ noalloc_strict
+  end @@ stateless noalloc_strict
+|}]
+
+let apply_one () = (M.foo 1 : _ @ noalloc_strict)
+[%%expect{|
+val apply_one : unit -> M.t = <fun>
+|}]
+
+let apply_zero () = (M.foo : _ @ noalloc_strict)
+[%%expect{|
+val apply_zero : unit -> int -> M.t @ noalloc_strict = <fun>
+|}]
+
+let apply_foo_int () = (M.foo_int 1 : _ @ noalloc_strict)
+[%%expect{|
+val apply_foo_int : unit -> M.int_t = <fun>
+|}]
+
+let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
+[%%expect{|
+Line 1, characters 32-51:
+1 | let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
+                                    ^^^^^^^^^^^^^^^^^^^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
 (** Test 7: Misc *)

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1734,6 +1734,49 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
+(* The exemption extends down the whole curry chain: a three-argument function
+   is accepted, with a [local] codomain at each step. *)
+let (f3 @ noalloc_strict) x y z = x
+[%%expect{|
+|}]
+
+(* Soundness: the returned closure is pinned [local], so it cannot escape to a
+   [global] (heap) position -- using [f] where a [global] codomain is expected
+   is rejected. *)
+let escapes = (f : _ -> (_ -> _) @ global)
+[%%expect{|
+|}]
+
+(* Soundness: a genuine allocation in the body (here a tuple) is still counted;
+   only the curried intermediate closures are exempt. *)
+let (f_body_alloc @ noalloc_strict) x y = (x, y)
+[%%expect{|
+|}]
+
+(** Test 5.11: forcing the codomain of a [noalloc] curried function to [local]
+    interacts with an explicit codomain areality annotation. Because the
+    codomain arrow is forced to [local], an explicit [@ global] on it conflicts,
+    while an explicit [@ local] agrees (and the function is accepted). *)
+
+(* The codomain is forced to [local], which conflicts with the explicit
+   [@ global] on the returned arrow. *)
+let (f : int -> (int -> int) @ global) @ noalloc_strict = fun x y -> x
+[%%expect{|
+|}]
+
+(* Contrast: without the [noalloc_strict] annotation the codomain is NOT forced,
+   so the same [@ global] arrow is accepted. *)
+let (f : int -> (int -> int) @ global) = fun x y -> x
+[%%expect{|
+|}]
+
+(* Annotating the codomain [@ local] agrees with the forcing, so the function
+   is accepted. *)
+let (f : int -> (int -> int) @ local) @ noalloc_strict = fun x y -> x
+[%%expect{|
+|}]
+
+
 (** Test 6: Misc *)
 
 type record_t = { x : float; y : float }

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -2001,6 +2001,49 @@ Line 1, characters 32-51:
 Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
+(** Test 6.4: Nested noalloc functions *)
+(* CR shsong: f cannot be implied as noalloc_strict unless explicitly annotated.
+    Analysis: In walk_locks_for_allocation, we force closures to be alloc until
+    we encounter a [Closure_noalloc_lock]. Everything outside [Closure_noalloc_lock]
+    will still be forced to be alloc.
+    An alternative implementation: loop over all locks and see whether there is a
+    [Closure_noalloc_lock] before adding any submode constraints.
+    Tradeoff:
+    1. the alternative implementation should allow us to accept the
+    [nested_noalloc_func_implicit] case. However, the current implementation is ok
+    if we expect user to always annotate functions if they want it them to be noalloc.
+    2. the alternative implementation avoids the current check on whether the
+    Allocation mode axis is changed while walking locks.
+    3. the alternative implementation requires iterate over the locks twice, which
+    affects the performance.
+*)
+let nested_noalloc_func_implicit () =
+  let f () = exclave_
+    let (g @ noalloc_strict) () = exclave_ (fun x -> x) in
+    g
+  in
+  (f : _ @ noalloc_strict)
+[%%expect{|
+Line 6, characters 3-4:
+6 |   (f : _ @ noalloc_strict)
+       ^
+Error: This value is "alloc"
+         because it closes over the allocation for closure at line 3, characters 29-55
+         which is "alloc".
+       However, the highlighted expression is expected to be "noalloc_strict".
+|}]
+
+let nested_noalloc_func_explicit () =
+  let (f @ noalloc_strict) () = exclave_
+    let (g @ noalloc_strict) () = exclave_ (fun x -> x) in
+    g
+  in
+  (f : _ @ noalloc_strict)
+[%%expect{|
+val nested_noalloc_func_explicit : unit -> unit -> (unit -> 'a -> 'a) @ local =
+  <fun>
+|}]
+
 (** Test 7: Misc *)
 
 type record_t = { x : float; y : float }

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1657,6 +1657,47 @@ let (f_explicit_exclave @ noalloc) x = exclave_ fun y -> x
 val f_explicit_exclave : 'a -> ('b -> 'a) @ local = <fun>
 |}]
 
+(* Other variations to test whether we can detect different format of noalloc
+  annotation. *)
+let f_explicit: _ @ noalloc_strict = fun x -> (fun y -> x)
+[%%expect{|
+Line 1, characters 46-58:
+1 | let f_explicit: _ @ noalloc_strict = fun x -> (fun y -> x)
+                                                  ^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let f_explicit_exclave: _ @ noalloc_strict = fun x -> exclave_ (fun y -> x)
+[%%expect{|
+val f_explicit_exclave : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+let f_explicit = (fun x -> (fun y -> x) : (int -> int -> int) @ noalloc_strict)
+[%%expect{|
+Line 1, characters 27-39:
+1 | let f_explicit = (fun x -> (fun y -> x) : (int -> int -> int) @ noalloc_strict)
+                               ^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let f_explicit_exclave = (fun x -> exclave_ (fun y -> x) : (int -> (int -> int) @ local) @ noalloc_strict)
+[%%expect{|
+val f_explicit_exclave : int -> (int -> int) @ local = <fun>
+|}]
+
+let f_explicit = (fun x -> (fun y -> x) : _ @ noalloc_strict)
+[%%expect{|
+Line 1, characters 27-39:
+1 | let f_explicit = (fun x -> (fun y -> x) : _ @ noalloc_strict)
+                               ^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let f_explicit_exclave = (fun x -> exclave_ (fun y -> x) : _ @ noalloc_strict)
+[%%expect{|
+val f_explicit_exclave : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
 (* Contrast: a single-argument function builds no inner closure.
   Its return type is not a closure, so it can be global. *)
 let (g @ noalloc_strict) x = x

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -177,6 +177,7 @@ type lock =
   | Const_closure_lock of bool * Mode.Hint.pinpoint *
       Mode.Value.Comonadic.Const.t
   | Closure_lock of Mode.Hint.pinpoint * Mode.Value.Comonadic.r
+  | Closure_noalloc_lock
   | Region_lock
   | Exclave_lock
   | Unboxed_lock (* to prevent capture of terms with non-value types *)
@@ -3131,6 +3132,8 @@ let add_closure_lock closure_context comonadic env =
   in
   add_lock lock env
 
+let add_closure_noalloc_lock env = add_lock Closure_noalloc_lock env
+
 let add_region_lock env = add_lock Region_lock env
 
 let add_exclave_lock env = add_lock Exclave_lock env
@@ -3732,6 +3735,14 @@ let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
   in
   {Mode.monadic; comonadic}
 
+let closure_noalloc_mode (pp : Mode.Hint.pinpoint) vmode =
+  let _, pp_desc = pp in
+  match pp_desc with
+  | Mode.Hint.Allocation true ->
+    Mode.Value.meet_const_with Allocation Mode.Allocation.Const.Noalloc_strict
+      vmode
+  | _ -> vmode
+
 let const_closure_mode pp {Mode.monadic; comonadic}
   closure_context comonadic0 =
   Mode.Value.Comonadic.(submode_err pp comonadic
@@ -3794,6 +3805,7 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
           const_closure_mode pp vmode closure_context comonadic
       | Closure_lock (closure_context, comonadic) ->
           closure_mode pp vmode closure_context comonadic
+      | Closure_noalloc_lock -> closure_noalloc_mode pp vmode
       | Exclave_lock ->
           exclave_mode ~errors ~env ~pp vmode
       | Unboxed_lock ->
@@ -3805,10 +3817,9 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
 let walk_locks_with_mode_constraint ~env pp ~mode =
   let locks = IdTbl.get_all_locks env.values in
   let _stage_locks, locks = partition_locks locks in
-  ignore
-    (walk_locks ~errors:true ~env ~pp
-       (Mode.Value.disallow_right mode) None locks
-      : Mode.Value.l)
+  (walk_locks ~errors:true ~env ~pp
+      (Mode.Value.disallow_right mode) None locks
+    : Mode.Value.l)
 
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
@@ -3816,7 +3827,7 @@ let walk_locks_with_mode_constraint ~env pp ~mode =
     effect handlers) that force enclosing functions to be nonportable and
     stateful. *)
 let walk_locks_for_legacy_construct ~env pp =
-  walk_locks_with_mode_constraint ~env pp ~mode:Mode.Value.legacy
+  ignore (walk_locks_with_mode_constraint ~env pp ~mode:Mode.Value.legacy)
 
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
@@ -3824,8 +3835,17 @@ let walk_locks_for_legacy_construct ~env pp =
 (* CR shsong: currently it only considers noalloc_strict and alloc,
     need to customize this to support noalloc later *)
 let walk_locks_for_allocation ~env pp =
-  walk_locks_with_mode_constraint ~env pp
-    ~mode:(Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc)
+  let post_mode =
+    walk_locks_with_mode_constraint ~env pp
+      ~mode:(Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc)
+  in
+  match
+    Mode.Allocation.submode
+      (Mode.Value.proj_comonadic Allocation post_mode)
+      Mode.Allocation.noalloc
+  with
+  | Ok () -> true
+  | Error _ -> false
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
   and [locks] which is the locks between the declaration and the usage (either
@@ -3856,7 +3876,7 @@ let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
           to be [local]. If [m0] is [local], that would trigger type error
           elsewhere, so what we return here doesn't matter. *)
           mode |> Mode.value_to_alloc_r2l |> Mode.alloc_as_value
-      | Const_closure_lock (true, _, _) ->
+      | Const_closure_lock (true, _, _) | Closure_noalloc_lock ->
           mode
       | Const_closure_lock (false, pp, _) | Closure_lock (pp, _) ->
           may_lookup_error errors loc env

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -329,7 +329,7 @@ val walk_locks_for_legacy_construct : env:t -> Mode.Hint.pinpoint -> unit
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
     alloc (rather than noalloc_strict) *)
-val walk_locks_for_allocation : env:t -> Mode.Hint.pinpoint -> unit
+val walk_locks_for_allocation : env:t -> Mode.Hint.pinpoint -> bool
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
@@ -591,6 +591,9 @@ messages. [ghost = true] means the closure is not a value (such as
 a loop) *)
 val add_const_closure_lock : ?ghost:bool -> Mode.Hint.pinpoint ->
   Mode.Value.Comonadic.Const.t -> t -> t
+
+(** Add a lock recording that the enclosing function is not [alloc]. *)
+val add_closure_noalloc_lock : t -> t
 
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5960,10 +5960,6 @@ module Allocation = struct
   let legacy = of_const Const.legacy
 
   let zap_to_legacy = zap_to_ceil
-
-  module Guts = struct
-    let get_loose_ceil = Guts.get_loose_ceil
-  end
 end
 
 module type Areality = sig

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4806,7 +4806,10 @@ module Report = struct
       Some (print_article_noun Consonant "pattern match with effect cases")
     | Effect_try ->
       Some (print_article_noun Consonant "try-with with effect cases")
-    | Allocation -> Some (print_article_noun Vowel "allocation")
+    | Allocation closure ->
+      if closure
+      then Some (print_article_noun Vowel "allocation for closure")
+      else Some (print_article_noun Vowel "allocation")
     | Class -> Some (print_article_noun Consonant "class")
     | Object -> Some (print_article_noun Vowel "object")
     | Loop -> Some (print_article_noun Consonant "loop")
@@ -5957,6 +5960,10 @@ module Allocation = struct
   let legacy = of_const Const.legacy
 
   let zap_to_legacy = zap_to_ceil
+
+  module Guts = struct
+    let get_loose_ceil = Guts.get_loose_ceil
+  end
 end
 
 module type Areality = sig

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -34,7 +34,9 @@ type pinpoint_desc =
   | Structure  (** A structure definition *)
   | Lazy  (** A lazy expression *)
   | Quote  (** A quoted expression *)
-  | Allocation  (** An allocation *)
+  | Allocation of bool
+      (** An allocation, the boolean indicates whether the allocation is for a
+          closure or not *)
   | Expression  (** An arbitrary expression *)
   | Effect_match  (** A pattern match with effect cases *)
   | Effect_try  (** A try-with expression with effect cases *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -585,13 +585,6 @@ module type S = sig
     val noalloc : lr
 
     val alloc : lr
-
-    module Guts : sig
-      (** This module exposes some functions that allow callers to inspect modes
-          directly. *)
-
-      val get_loose_ceil : ('l * 'r) t -> Const.t
-    end
   end
 
   type 'a comonadic_with =

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -585,6 +585,13 @@ module type S = sig
     val noalloc : lr
 
     val alloc : lr
+
+    module Guts : sig
+      (** This module exposes some functions that allow callers to inspect modes
+          directly. *)
+
+      val get_loose_ceil : ('l * 'r) t -> Const.t
+    end
   end
 
   type 'a comonadic_with =

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -667,6 +667,9 @@ let mode_strictly_stack expected_mode =
     with strictly_stack = true
   }
 
+let mode_alloc_annot expected_mode alloc_annot =
+  { expected_mode with alloc_annot }
+
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
 
@@ -6468,9 +6471,8 @@ let pat_modes ~env ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
     else None, exp_mode
   in
   let exp_mode =
-    { exp_mode with
-      alloc_annot =
-      (mode_annots_from_pat spat).mode_modes.allocation }
+    mode_alloc_annot exp_mode
+      ((mode_annots_from_pat spat).mode_modes.allocation)
   in
   attrs, pat_mode, env_alloc_mode, exp_mode, spat
 
@@ -11662,9 +11664,7 @@ and type_expect_mode ~loc ~env ~(modes : Alloc.Const.Option.t) expected_mode =
       | Some Local -> mode_strictly_local expected_mode
       | _ -> expected_mode
     in
-    let expected_mode =
-      { expected_mode with alloc_annot = modes.allocation }
-    in
+    let expected_mode = mode_alloc_annot expected_mode modes.allocation in
     expected_mode
 
 and type_n_ary_function

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6241,11 +6241,11 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-    let alloc_mode, closed_over_mode =
+  let alloc_mode, closed_over_mode =
     register_closure_allocation ~env ~stack:expected_mode.strictly_stack ~loc
       (as_single_mode expected_mode)
   in
-    if expected_mode.strictly_local then
+  if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
       (Alloc.proj_comonadic Areality alloc_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -456,6 +456,10 @@ type expected_mode =
     strictly_stack. However, if we do that, there would be uncaught exception
     in Test 5h in test typing-modes/zero_alloc.ml. We will review this later. *)
 
+    alloc_annot : Allocation.Const.t option;
+    (** [Some c] iff the function was directly annotated with the allocation
+    mode [c] on its binding (e.g. [let (f @ noalloc) x = ...]). *)
+
     tuple_modes : (Value.r * Location.t) list option;
     (** No invariant between this and [mode]. It is UNSOUND to ignore this
         field. If this is [Some [x0; x1; ..]]:
@@ -539,6 +543,7 @@ let mode_default mode =
     mode = Value.disallow_left mode;
     strictly_local = false;
     strictly_stack = false;
+    alloc_annot = None;
     tuple_modes = None }
 
 let mode_legacy = mode_default Value.legacy
@@ -661,13 +666,6 @@ let mode_strictly_stack expected_mode =
   { expected_mode
     with strictly_stack = true
   }
-
-let is_not_alloc_mode expected_mode =
-  let ceil =
-    Allocation.Guts.get_loose_ceil
-      (Value.proj_comonadic Allocation expected_mode.mode)
-  in
-  not (Allocation.Const.le Allocation.Const.max ceil)
 
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
@@ -6283,9 +6281,10 @@ let split_function_ty
     | false -> env
     | true ->
         let env =
-          if is_not_alloc_mode expected_mode
-          then Env.add_closure_noalloc_lock env
-          else env
+          match expected_mode.alloc_annot with
+          | Some (Noalloc | Noalloc_strict) ->
+            Env.add_closure_noalloc_lock env
+          | Some Alloc | None -> env
         in
         let env =
           Env.add_closure_lock
@@ -6467,6 +6466,11 @@ let pat_modes ~env ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
       in
       Some env_alloc_mode, mode_default exp_mode
     else None, exp_mode
+  in
+  let exp_mode =
+    { exp_mode with
+      alloc_annot =
+      (mode_annots_from_pat spat).mode_modes.allocation }
   in
   attrs, pat_mode, env_alloc_mode, exp_mode, spat
 
@@ -11657,6 +11661,9 @@ and type_expect_mode ~loc ~env ~(modes : Alloc.Const.Option.t) expected_mode =
       match modes.areality with
       | Some Local -> mode_strictly_local expected_mode
       | _ -> expected_mode
+    in
+    let expected_mode =
+      { expected_mode with alloc_annot = modes.allocation }
     in
     expected_mode
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -662,6 +662,13 @@ let mode_strictly_stack expected_mode =
     with strictly_stack = true
   }
 
+let is_not_alloc_mode expected_mode =
+  let ceil =
+    Allocation.Guts.get_loose_ceil
+      (Value.proj_comonadic Allocation expected_mode.mode)
+  in
+  not (Allocation.Const.le Allocation.Const.max ceil)
+
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
 
@@ -815,11 +822,24 @@ let allocations : Alloc.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
-let register_allocation_mode ~env ~loc ?(stack = false) alloc_mode =
+let register_allocation_mode ~env ~loc
+    ?(stack = false) ?(closure = false) alloc_mode =
   (* [stack_]-marked allocations are stack-allocated and so do not count
      towards the allocation axis; only heap allocations walk the locks. *)
   if not stack then
-    Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+    let local_closure =
+      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation closure)
+    in
+    if local_closure then
+      (match
+        Value.submode ~pp:(loc, Function)
+          (Value.min_with_comonadic Areality Regionality.local)
+          (alloc_as_value alloc_mode)
+      with
+      | Ok () -> ()
+      | Error failure_reason ->
+        let error = Submode_failed(failure_reason, Other) in
+        raise (Error (loc, env, error)));
   let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
@@ -847,7 +867,8 @@ let register_closure_allocation ~env ?(stack = false) (mode : Value.r) ~loc
   let (alloc_mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode ~env ~loc ~stack (Alloc.disallow_left alloc_mode);
+  register_allocation_mode ~env ~loc ~stack ~closure:true
+    (Alloc.disallow_left alloc_mode);
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
   in
@@ -4938,30 +4959,13 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
   loop ty_fun0 mode_fun rev_args sargs
 
 (* See Note [Type-checking applications] for an overview *)
-let collect_apply_args env loc funct ignore_labels ty_fun ty_fun0 mode_fun sargs
+let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs
       ret_tvar =
   let warned = ref false in
   let rec loop ty_fun ty_fun0 mode_fun rev_args sargs =
-    if sargs = [] then begin
-      (* Allocation axis check: partial application of a function returns
-         an arrow type and allocates *)
-      let ty_fun' = expand_head env ty_fun in
-      let ty_fun_is_arrow =
-        match get_desc ty_fun' with Tarrow _ -> true | _ -> false
-      in
-      (* CR shsong: this check for partial application is not strong enough
-          to guarantee soundness. Especially for the case where the partial
-          application's return type is an abstract type and is actually a
-          function. *)
-      (* CR shsong: Alternative design: only register_allocation_mode if
-          partial_app = is_partial_apply untyped_args (where untyped_args
-          are in the return value) is false, since if partial_app is true,
-          there are Omitted args and the code walks the locks already *)
-      if ty_fun_is_arrow then
-        register_allocation_mode ~env ~loc Alloc.legacy;
+    if sargs = [] then
       collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
         ret_tvar
-    end
     else
     let ty_fun' = expand_head env ty_fun in
     let lv = get_level ty_fun' in
@@ -6239,11 +6243,11 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, closed_over_mode =
+    let alloc_mode, closed_over_mode =
     register_closure_allocation ~env ~stack:expected_mode.strictly_stack ~loc
       (as_single_mode expected_mode)
   in
-  if expected_mode.strictly_local then
+    if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
       (Alloc.proj_comonadic Areality alloc_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
@@ -6278,6 +6282,11 @@ let split_function_ty
     match is_first_val_param with
     | false -> env
     | true ->
+        let env =
+          if is_not_alloc_mode expected_mode
+          then Env.add_closure_noalloc_lock env
+          else env
+        in
         let env =
           Env.add_closure_lock
             (loc, Function)
@@ -8578,7 +8587,7 @@ and type_expect_
             Alloc.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
           in
-          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
+          Alloc.submode_err (exp.exp_loc, Allocation false) local alloc_mode
         end
       | Texp_list_comprehension _ -> unsupported List_comprehension
       | Texp_array_comprehension _ -> unsupported Array_comprehension
@@ -10320,7 +10329,7 @@ and type_application env app_loc expected_mode position_and_mode
             (fun (label, e) -> Typetexp.transl_label_from_expr label e) sargs
           in
           let ty_ret, mode_ret, untyped_args =
-            collect_apply_args env app_loc funct ignore_labels ty (instance ty)
+            collect_apply_args env funct ignore_labels ty (instance ty)
               (value_to_alloc_r2l funct_mode) sargs ret_tvar
           in
           (* example: [collect_apply_args] returns

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -116,7 +116,8 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   mode
 
 let register_allocation ~env ~loc : Alloc.lr * Value.lr =
-  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+  ignore
+    (Env.walk_locks_for_allocation ~env (loc, Hint.Allocation false) : bool);
   let upper_bound =
     Alloc.of_const
       ~hint_comonadic:Module_allocated_on_heap


### PR DESCRIPTION
- A closure built inside a [noalloc_strict] / [noalloc] function (if the information is known when type check the function) is forced to be [local] and on stack. It is also exempted from the allocation check.
- This allows user to make multi-argument functions noalloc despite closure allocation by currying
- Ensure that noalloc function do not trigger heap allocation when either fully or partially applied, thereby fixing the soundness issue regarding partial application in the last PR.


Testing
-------
Add more tests in `testsuite/tests/typing-modes/zero_alloc.ml`
- Closure inside noalloc functions are enforced to be local