### PR TITLE
Disallow functional updates that implicitly load atomic fields

### DIFF
--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2212,14 +2212,12 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
       match definition with
       | Kept _ ->
         if Types.is_atomic lbl.lbl_mut then
-          (* Should have been rejected during typechecking. Defensive check to
-             shield users from atomically accessing the result of nonatomic
-             shallow copy. *)
+          (* Rejected during typechecking to avoid need for
+             implicit atomic loads *)
           fatal_error
             "transl_record: update expr implicitly copies atomic field";
         cont
       | Overridden (_lid, expr) ->
-          (* CR-soon jkerrigan: do these Setfields need to be atomic aware? *)
           let upd =
             match repres with
               Record_boxed
@@ -2290,7 +2288,6 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
            match definition with
            | Kept (typ, mut, _) ->
                if Types.is_atomic lbl.lbl_mut then
-                 (* Defensive check to avoid emitting a nonatomic read. *)
                  fatal_error
                    "transl_record: update expr implicitly copies atomic field";
                let field_layout = layout env lbl.lbl_loc lbl_sort typ in

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2210,8 +2210,16 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
       let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
       (* CR layouts v5: allow more unboxed types here. *)
       match definition with
-      | Kept _ -> cont
+      | Kept _ ->
+        if Types.is_atomic lbl.lbl_mut then
+          (* Should have been rejected during typechecking. Defensive check to
+             shield users from atomically accessing the result of nonatomic
+             shallow copy. *)
+          fatal_error
+            "transl_record: update expr implicitly copies atomic field";
+        cont
       | Overridden (_lid, expr) ->
+          (* CR-soon jkerrigan: do these Setfields need to be atomic aware? *)
           let upd =
             match repres with
               Record_boxed
@@ -2281,6 +2289,10 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
            let lbl_sort = Jkind.Sort.default_for_transl_and_get lbl_sort in
            match definition with
            | Kept (typ, mut, _) ->
+               if Types.is_atomic lbl.lbl_mut then
+                 (* Defensive check to avoid emitting a nonatomic read. *)
+                 fatal_error
+                   "transl_record: update expr implicitly copies atomic field";
                let field_layout = layout env lbl.lbl_loc lbl_sort typ in
                let sem =
                  if Types.is_mutable mut then Reads_vary else Reads_agree

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -499,6 +499,128 @@ module Pattern_matching_wildcard :
   end
 |}]
 
+(* We disallow functional updates that perform implicit loads of atomic fields. *)
+
+module Functional_update_error = struct
+  type t = { x : int ; mutable y : int [@atomic] }
+
+  (* The update performs an implicit atomic load of y. Not allowed! *)
+  let forbidden t = { t with x = 42 }
+end
+[%%expect{|
+Line 5, characters 22-23:
+5 |   let forbidden t = { t with x = 42 }
+                          ^
+Error: Functional updates that implicitly read atomic fields (here "y")
+       are forbidden. Hint: if you intend to copy the value
+       of an atomic field, do so explicitly: "{ t with y = t.y }"
+|}]
+
+(* Updates that overwrite all of the old record's atomic fields are allowed. *)
+
+module Functional_update_ok = struct
+  type t = { x : int ; mutable y : int [@atomic] }
+
+  (* The update performs no implicit atomic loads. Allowed! *)
+  let allowed t = { t with y = 42 }
+end
+[%%expect{|
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/479"
+  (let
+    (allowed =
+       (function {nlocal = 0} t
+         (makemutable 0 (value<int>,value<int>) (field_int 0 t) 42)))
+    (makeblock 0 allowed)))
+module Functional_update_ok :
+  sig
+    type t = { x : int; mutable y : int [@atomic]; }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_copy_ok = struct
+  type t = { x : int ; mutable y : int [@atomic] }
+
+  (* The update performs an explicit atomic load. Allowed! *)
+  let allowed t = { t with y = t.y }
+end
+[%%expect{|
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/487"
+  (let
+    (allowed =
+       (function {nlocal = 0} t
+         (makemutable 0 (value<int>,value<int>) (field_int 0 t)
+           (atomic_load_field_imm t 1))))
+    (makeblock 0 allowed)))
+module Functional_update_copy_ok :
+  sig
+    type t = { x : int; mutable y : int [@atomic]; }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_multi_error = struct
+  type t = { x : int ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let forbidden t = { t with y = 42 } (* implicit atomic load of z *)
+end
+[%%expect{|
+Line 4, characters 22-23:
+4 |   let forbidden t = { t with y = 42 } (* implicit atomic load of z *)
+                          ^
+Error: Functional updates that implicitly read atomic fields (here "z")
+       are forbidden. Hint: if you intend to copy the value
+       of an atomic field, do so explicitly: "{ t with z = t.z }"
+|}]
+
+module Functional_update_multi_ok = struct
+  type t = { x : int ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
+end
+[%%expect{|
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/503"
+  (let
+    (allowed =
+       (function {nlocal = 0} t
+         (makemutable 0 (value<int>,value<int>,value<int>) (field_int 0 t) 42
+           67)))
+    (makeblock 0 allowed)))
+module Functional_update_multi_ok :
+  sig
+    type t = {
+      x : int;
+      mutable y : int [@atomic];
+      mutable z : int [@atomic];
+    }
+    val allowed : t -> t
+  end
+|}]
+
+module Functional_update_multi_copy_ok = struct
+  type t = { x : int ; mutable y : int [@atomic]; mutable z : int [@atomic] }
+
+  let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
+end
+[%%expect{|
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/512"
+  (let
+    (allowed =
+       (function {nlocal = 0} t
+         (makemutable 0 (value<int>,value<int>,value<int>) (field_int 0 t)
+           (atomic_load_field_imm t 1) (atomic_load_field_imm t 2))))
+    (makeblock 0 allowed)))
+module Functional_update_multi_copy_ok :
+  sig
+    type t = {
+      x : int;
+      mutable y : int [@atomic];
+      mutable z : int [@atomic];
+    }
+    val allowed : t -> t
+  end
+|}]
+
 (* Test atomic record fields in mixed blocks *)
 
 module Mixed_blocks = struct

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3254,9 +3254,6 @@ let forbid_atomic_field_patterns loc penv (label_lid, label, pat) =
     raise (Error (loc, !!penv, Atomic_in_pattern label_lid.txt))
 
 let forbid_atomic_in_record_update loc env lbl =
-  (* Functional updates that implicitly load atomic fields are not allowed.
-     expect_type_record enforces this by calling this function on every field
-     copied from the old record.*)
   if Types.is_atomic lbl.lbl_mut then
     raise (Error (loc, env, Atomic_in_functional_update lbl.lbl_name))
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -246,6 +246,7 @@ type error =
   | Invalid_atomic_loc_payload
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
+  | Atomic_in_functional_update of label
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string
@@ -3251,6 +3252,13 @@ let forbid_atomic_field_patterns loc penv (label_lid, label, pat) =
   in
   if Types.is_atomic label.lbl_mut && not (wildcard pat) then
     raise (Error (loc, !!penv, Atomic_in_pattern label_lid.txt))
+
+let forbid_atomic_in_record_update loc env lbl =
+  (* Functional updates that implicitly load atomic fields are not allowed.
+     expect_type_record enforces this by calling this function on every field
+     copied from the old record.*)
+  if Types.is_atomic lbl.lbl_mut then
+    raise (Error (loc, env, Atomic_in_functional_update lbl.lbl_name))
 
 (** [type_pat] propagates the expected type, and
     unification may update the typing environment. *)
@@ -6686,6 +6694,7 @@ and type_expect_
                 unify_exp_types record_loc env (instance ty_expected) ty_res2);
               check_project_mutability ~loc:extended_expr_loc ~env
                 (Record_field lbl.lbl_name) lbl.lbl_mut mode;
+              forbid_atomic_in_record_update extended_expr_loc env lbl;
               let is_contained_by : Mode.Hint.is_contained_by =
                 { containing = Record (lbl.lbl_name, Modality);
                   container = (extended_expr_loc, Expression) }
@@ -12940,6 +12949,13 @@ let report_error ~loc env =
          will happen during pattern matching:@ the field may be read@ \
          zero, one or several times depending on the patterns around it."
         quoted_longident lid
+  | Atomic_in_functional_update l ->
+      Location.errorf ~loc
+        "Functional updates that implicitly read atomic fields (here %a)@ \
+         are forbidden. @{<hint>Hint@}: if you intend to copy the value@ \
+         of an atomic field, do so explicitly:@ %a"
+        Style.inline_code l
+        Style.inline_code ("{ t with " ^ l ^ " = t." ^ l ^ " }")
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -296,6 +296,7 @@ type error =
   | Invalid_atomic_loc_payload
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
+  | Atomic_in_functional_update of label
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string


### PR DESCRIPTION
A functional record update (`{ t with x = 42 }`) implicitly copies the fields not overridden. When one of those kept fields is atomic, this results in a nonatomic read of an atomic field.

Reject such updates during typechecking. Add defensive `fatal_error`s in `transl_record`.

Fixes upstream issue https://github.com/ocaml/ocaml/issues/14918.