### PR TITLE
Erase debug uids in `Lambda.make_key` to restore match action sharing

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1508,15 +1508,17 @@ let make_key e =
         tr_rec (Ident.add x ex env) e
     | Llet ((Strict | StrictOpt),_k,x,_x_duid,ex,Lvar v) when Ident.same v x ->
         tr_rec env ex
-    | Llet (str,k,x,x_duid,ex,e) ->
-     (* Because of side effects, keep other lets with normalized names *)
+    | Llet (str,k,x,_x_duid,ex,e) ->
+     (* Because of side effects, keep other lets with normalized names.
+        Debug uids are erased, like locations, so that they do not get in
+        the way of sharing. *)
         let ex = tr_rec env ex in
         let y = make_key x in
-        Llet (str,k,y,x_duid,ex,tr_rec (Ident.add x (Lvar y) env) e)
-    | Lmutlet (k,x,x_duid,ex,e) ->
+        Llet (str,k,y,debug_uid_none,ex,tr_rec (Ident.add x (Lvar y) env) e)
+    | Lmutlet (k,x,_x_duid,ex,e) ->
         let ex = tr_rec env ex in
         let y = make_key x in
-        Lmutlet (k,y,x_duid,ex,tr_rec (Ident.add x (Lmutvar y) env) e)
+        Lmutlet (k,y,debug_uid_none,ex,tr_rec (Ident.add x (Lmutvar y) env) e)
     | Lprim (p,es,_) ->
         Lprim (p,tr_recs env es, Loc_unknown)
     | Lswitch (e,sw,loc,kind) ->

--- a/testsuite/tests/codegen/variants.ml
+++ b/testsuite/tests/codegen/variants.ml
@@ -62,6 +62,20 @@ Variant_with_uneven_mutability.get:
 |}]
 
 
+module Or_pattern_on_mutable = struct
+  type t =
+    | A of { mutable x : string }
+    | B of { mutable x : string }
+
+  let get (t : t) = match t with A { x } | B { x } -> x
+end
+[%%expect_asm X86_64{|
+Or_pattern_on_mutable.get:
+  movq  (%rax), %rax
+  ret
+|}]
+
+
 type t =
   | A
   | B


### PR DESCRIPTION
## Erase debug uids in `Lambda.make_key` to restore match action sharing

  The match compiler shares identical switch arms by comparing normalization keys
  from `Lambda.make_key`, which alpha-renames binders and erases locations. The
  debug uids on `Llet`/`Lmutlet` binders were kept in the key, so alpha-equivalent
  or-pattern arms never compared equal. This only affects arms binding **mutable**
  fields — immutable binds are `Alias` lets that get substituted away before
  comparison. So
  ```ocaml
  type t = A of { mutable x : string } | B of { mutable x : string }
  let get (t : t) = match t with A { x } | B { x } -> x
  ```
  compiled to a tag switch with one load per arm instead of a single load.

  Fix: erase the debug uid in the key, exactly like locations.