### PR TITLE
Fix missing `CFI_SIGNAL_FRAME`s

### DIFF
--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -716,7 +716,6 @@ Make_call_realloc_stack(_avx512, ZMM)
 #define Make_call_gc(suffix, simd)                   \
     FUNCTION(caml_call_gc##suffix) ;                 \
     CFI_STARTPROC                     ;              \
-        CFI_SIGNAL_FRAME;                            \
         ENTER_FUNCTION;                              \
 LBL(caml_call_gc ## suffix):                         \
         SAVE_ALL_REGS(simd);                         \
@@ -732,6 +731,7 @@ Make_call_gc(_avx512, ZMM)
 
 FUNCTION(caml_do_call_gc)
 CFI_STARTPROC
+        CFI_SIGNAL_FRAME
         ENTER_FUNCTION
         movq    %r15, Caml_state(gc_regs)
         TSAN_ENTER_FUNCTION(0)
@@ -1469,6 +1469,7 @@ END_FUNCTION(caml_reperform)
 */
 FUNCTION(caml_preempt)
 CFI_STARTPROC
+        CFI_SIGNAL_FRAME
         /* Restore the young_ptr that was saved at the beginning of
            SAVE_ALL_REGS, in caml_call_gc */
         movq Caml_state(young_ptr), %r15

--- a/runtime/arm64.S
+++ b/runtime/arm64.S
@@ -606,6 +606,7 @@ END_FUNCTION(caml_call_gc)
 */
 FUNCTION(caml_preempt)
         CFI_STARTPROC
+        CFI_SIGNAL_FRAME
     /* Inherit caml_call_gc's frame */
         CFI_ADJUST(16)
         CFI_OFFSET(29, -16)
@@ -695,6 +696,7 @@ END_FUNCTION(caml_allocN)
 FUNCTION(caml_call_local_realloc)
         CFI_STARTPROC
 L(caml_call_local_realloc):
+        CFI_SIGNAL_FRAME
     /* Save return address and frame pointer */
         ENTER_FUNCTION
     /* Store all registers (including ALLOC_PTR & TRAP_PTR) */


### PR DESCRIPTION
Currently, `CFI_SIGNAL_FRAME` is present in `Make_call_gc` but not `caml_do_call_gc`, which is reversed (it should appear iff the procedure switches stacks). This breaks gdb backtraces that start inside the GC. 

`CFI_SIGNAL_FRAME` was also missing from `caml_preempt` on both amd64 and arm64, and from `caml_call_local_realloc` on arm64. These have been added.