### PR TITLE
Add `returns : bool` to `Capply`

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -538,7 +538,8 @@ type operation =
   | Capply of
       { result_type : machtype;
         region : Lambda.region_close;
-        callees : symbol list option
+        callees : symbol list option;
+        returns : bool
       }
   | Cextcall of
       { func : string;

--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -556,7 +556,8 @@ type operation =
   | Capply of
       { result_type : machtype;
         region : Lambda.region_close;
-        callees : symbol list option
+        callees : symbol list option;
+        returns : bool
       }
   | Cextcall of
       { func : string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -420,9 +420,12 @@ type operation =
   | Capply of
       { result_type : machtype;
         region : Lambda.region_close;
-        callees : symbol list option
+        callees : symbol list option;
             (* List of possible callees, or [None] if not known. The actual
                callee might be a re-optimized versions of one these callees. *)
+        returns : bool
+            (* Used for machtype-checking. [true] is the conservative
+               default. *)
       }
   | Cextcall of
       { func : string;

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -428,9 +428,12 @@ type operation =
   | Capply of
       { result_type : machtype;
         region : Lambda.region_close;
-        callees : symbol list option
+        callees : symbol list option;
             (* List of possible callees, or [None] if not known. The actual
                callee might be a re-optimized versions of one these callees. *)
+        returns : bool
+            (* Used for machtype-checking. [true] is the conservative
+               default. *)
       }
   | Cextcall of
       { func : string;

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2275,8 +2275,8 @@ let send_function_name arity result (mode : Cmx_format.alloc_mode) =
   let suff = match mode with Alloc_heap -> "" | Alloc_local -> "L" in
   global_symbol ("caml_send" ^ unique_arity_identifier arity ^ res ^ suff)
 
-let call_cached_method obj tag cache pos args args_type result (apos, mode) dbg
-    =
+let call_cached_method obj tag cache pos args args_type result (apos, mode)
+    ~returns dbg =
   Compilenv.need_send_fun
     (List.map Extended_machtype.change_tagged_int_to_val args_type)
     (Extended_machtype.change_tagged_int_to_val result)
@@ -2291,7 +2291,8 @@ let call_cached_method obj tag cache pos args args_type result (apos, mode) dbg
     ( Capply
         { result_type = Extended_machtype.to_machtype result;
           region = apos;
-          callees = Some [sym]
+          callees = Some [sym];
+          returns
         },
       (* See the cases for caml_apply regarding [change_tagged_int_to_val]. *)
       Cconst_symbol (sym, dbg) :: obj :: tag :: cache :: pos :: args,
@@ -3301,7 +3302,8 @@ let split_arity_for_apply arity args =
     let args1, args2 = Misc.Stdlib.List.split_at max_arity args in
     (a1, args1), Some (a2, args2)
 
-let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
+let call_caml_apply extended_ty extended_args_type mut clos args pos mode
+    ~returns dbg =
   (* Treat tagged int arguments and results as [typ_val], to avoid generating
      excessive numbers of caml_apply functions. *)
   let ty = Extended_machtype.to_machtype extended_ty in
@@ -3309,7 +3311,7 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
     let sym = apply_function_sym extended_args_type extended_ty mode in
     let cargs = (Cconst_symbol (sym, dbg) :: args) @ [clos] in
     Cop
-      ( Capply { result_type = ty; region = pos; callees = Some [sym] },
+      ( Capply { result_type = ty; region = pos; callees = Some [sym]; returns },
         cargs,
         dbg )
   in
@@ -3336,7 +3338,12 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
                     dbg ),
                 dbg,
                 Cop
-                  ( Capply { result_type = ty; region = pos; callees = None },
+                  ( Capply
+                      { result_type = ty;
+                        region = pos;
+                        callees = None;
+                        returns
+                      },
                     (get_field_codepointer mut clos 2 dbg :: args) @ [clos],
                     dbg ),
                 dbg,
@@ -3360,7 +3367,7 @@ let maybe_reset_current_region ~dbg ~body_tail ~body_nontail old_region =
            Csequence (Cop (Cendregion, [old_region], dbg ()), Cvar res) )),
       dbg () )
 
-let apply_or_call_caml_apply result arity mut clos args pos mode dbg =
+let apply_or_call_caml_apply result arity mut clos args pos mode ~returns dbg =
   match arity with
   | [_] ->
     bind "fun" clos (fun clos ->
@@ -3368,33 +3375,36 @@ let apply_or_call_caml_apply result arity mut clos args pos mode dbg =
           ( Capply
               { result_type = Extended_machtype.to_machtype result;
                 region = pos;
-                callees = None
+                callees = None;
+                returns
               },
             (get_field_codepointer mut clos 0 dbg :: args) @ [clos],
             dbg ))
-  | _ -> call_caml_apply result arity mut clos args pos mode dbg
+  | _ -> call_caml_apply result arity mut clos args pos mode ~returns dbg
 
 let rec might_split_call_caml_apply ?old_region result arity mut clos args pos
-    mode dbg =
+    mode ~returns dbg =
   match split_arity_for_apply arity args with
   | (arity, args), None -> (
     match old_region with
-    | None -> apply_or_call_caml_apply result arity mut clos args pos mode dbg
+    | None ->
+      apply_or_call_caml_apply result arity mut clos args pos mode ~returns dbg
     | Some old_region ->
       maybe_reset_current_region ~dbg:placeholder_dbg
         ~body_tail:
-          (apply_or_call_caml_apply result arity mut clos args pos mode dbg)
+          (apply_or_call_caml_apply result arity mut clos args pos mode ~returns
+             dbg)
         ~body_nontail:
           (apply_or_call_caml_apply result arity mut clos args Rc_normal
-             Cmx_format.Alloc_local dbg)
+             Cmx_format.Alloc_local ~returns dbg)
         old_region)
   | (arity, args), Some (arity', args') -> (
     let body old_region =
       bind "result"
         (call_caml_apply [| Val |] arity mut clos args Rc_normal
-           Cmx_format.Alloc_local dbg) (fun clos ->
+           Cmx_format.Alloc_local ~returns:true dbg) (fun clos ->
           might_split_call_caml_apply ?old_region result arity' mut clos args'
-            pos mode dbg)
+            pos mode ~returns dbg)
     in
     (* When splitting [caml_applyM] into [caml_applyN] and [caml_applyK] it is
        possible for [caml_applyN] to allocate on the local stack. If we are not
@@ -3413,23 +3423,25 @@ let rec might_split_call_caml_apply ?old_region result arity mut clos args pos
         (fun region -> body (Some region))
     | _ -> body old_region)
 
-let generic_apply mut clos args args_type result (pos, mode) dbg =
-  might_split_call_caml_apply result args_type mut clos args pos mode dbg
+let generic_apply mut clos args args_type result (pos, mode) ~returns dbg =
+  might_split_call_caml_apply result args_type mut clos args pos mode ~returns
+    dbg
 
-let send kind met obj args args_type result akind dbg =
+let send kind met obj args args_type result akind ~returns dbg =
   let call_met obj args args_type clos =
     (* met is never a simple expression, so it never gets turned into an
        Immutable load *)
     generic_apply Asttypes.Mutable clos (obj :: args)
       (Extended_machtype.typ_val :: args_type)
-      result akind dbg
+      result akind ~returns dbg
   in
   bind "obj" obj (fun obj ->
       match (kind : Lambda.meth_kind), args, args_type with
       | Self, _, _ ->
         bind "met" (lookup_label obj met dbg) (call_met obj args args_type)
       | Cached, cache :: pos :: args, _ :: _ :: args_type ->
-        call_cached_method obj met cache pos args args_type result akind dbg
+        call_cached_method obj met cache pos args args_type result akind
+          ~returns dbg
       | _ -> bind "met" (lookup_tag obj met dbg) (call_met obj args args_type))
 
 (*
@@ -3584,7 +3596,12 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
     | [arg] -> (
       let app =
         Cop
-          ( Capply { result_type = result; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = result;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             [ get_field_codepointer Asttypes.Mutable (Cvar clos) 0 (dbg ());
               Cvar arg;
               Cvar clos ],
@@ -3604,7 +3621,11 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
         ( VP.create newclos,
           Cop
             ( Capply
-                { result_type = typ_val; region = Rc_normal; callees = None },
+                { result_type = typ_val;
+                  region = Rc_normal;
+                  callees = None;
+                  returns = true
+                },
               [ get_field_codepointer Asttypes.Mutable (Cvar clos) 0 (dbg ());
                 Cvar arg;
                 Cvar clos ],
@@ -3635,7 +3656,12 @@ let apply_function_body arity result (mode : Cmx_format.alloc_mode) =
               dbg () ),
           dbg (),
           Cop
-            ( Capply { result_type = result; region = Rc_normal; callees = None },
+            ( Capply
+                { result_type = result;
+                  region = Rc_normal;
+                  callees = None;
+                  returns = true
+                },
               get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ())
               :: List.map (fun s -> Cvar s) all_args,
               dbg () ),
@@ -3764,7 +3790,12 @@ let tuplify_function arity return =
       fun_args = [VP.create arg, typ_val; VP.create clos, typ_val];
       fun_body =
         Cop
-          ( Capply { result_type = return; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = return;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ())
             :: access_components 0
             @ [Cvar clos],
@@ -3907,7 +3938,12 @@ let rec make_curry_apply result narity args_type args clos n =
   match args_type with
   | [] ->
     Cop
-      ( Capply { result_type = result; region = Rc_normal; callees = None },
+      ( Capply
+          { result_type = result;
+            region = Rc_normal;
+            callees = None;
+            returns = true
+          },
         (get_field_codepointer Asttypes.Mutable (Cvar clos) 2 (dbg ()) :: args)
         @ [Cvar clos],
         dbg () )
@@ -4373,7 +4409,12 @@ let entry_point namelist =
     in
     Csequence
       ( Cop
-          ( Capply { result_type = typ_void; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = typ_void;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             [Cop (mk_load_immut Word_int, [f], dbg ())],
             dbg () ),
         incr_global_inited () )
@@ -4878,17 +4919,18 @@ let load ~dbg memory_chunk mutability ~addr =
 let store ~dbg kind init ~addr ~new_value =
   Cop (Cstore (kind, init), [addr; new_value], dbg)
 
-let direct_call ~dbg ty pos f_code_sym args =
+let direct_call ~dbg ~returns ty pos f_code_sym args =
   Cop
-    ( Capply { result_type = ty; region = pos; callees = Some [f_code_sym] },
+    ( Capply
+        { result_type = ty; region = pos; callees = Some [f_code_sym]; returns },
       Cconst_symbol (f_code_sym, dbg) :: args,
       dbg )
 
-let indirect_call ~dbg ty pos alloc_mode f args_type args =
+let indirect_call ~dbg ~returns ty pos alloc_mode f args_type args =
   might_split_call_caml_apply ty args_type Asttypes.Mutable f args pos
-    alloc_mode dbg
+    alloc_mode ~returns dbg
 
-let indirect_full_call ~dbg ty pos f ~callees args_type args =
+let indirect_full_call ~dbg ~returns ty pos f ~callees args_type args =
   (* Use a variable to avoid duplicating the cmm code of the closure [f]. *)
   let v = Backend_var.create_local "*closure*" in
   let v' = Backend_var.With_provenance.create v in
@@ -4909,7 +4951,8 @@ let indirect_full_call ~dbg ty pos f ~callees args_type args =
          ( Capply
              { result_type = Extended_machtype.to_machtype ty;
                region = pos;
-               callees
+               callees;
+               returns
              },
            (fun_ptr :: args) @ [Cvar v],
            dbg ))
@@ -5380,7 +5423,7 @@ let tls_get ~dbg = Cop (Ctls_get, [], dbg)
 
 let domain_index ~dbg = Cop (Cdomain_index, [], dbg)
 
-let perform ~dbg eff =
+let perform ~dbg ~returns eff =
   let cont =
     make_alloc dbg ~tag:Runtimetags.cont_tag
       [int_const dbg 0; int_const dbg 0]
@@ -5390,14 +5433,24 @@ let perform ~dbg eff =
      improves backtraces of paused fibers. *)
   let sym = Cmm.global_symbol "caml_perform" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_nontail; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_nontail;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); eff; cont],
       dbg )
 
-let with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg =
+let with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg ~returns =
   let sym = Cmm.global_symbol "caml_runstack" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
         Cop
           ( Cextcall
@@ -5416,10 +5469,16 @@ let with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg =
         arg ],
       dbg )
 
-let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg =
+let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg
+    ~returns =
   let sym = Cmm.global_symbol "caml_runstack" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
         Cop
           ( Cextcall
@@ -5438,22 +5497,32 @@ let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg =
         arg ],
       dbg )
 
-let resume ~dbg ~cont ~f ~arg =
+let resume ~dbg ~cont ~f ~arg ~returns =
   (* Rc_normal is required here, because there are some uses of effects with
      repeated resumes, and these should consume O(1) stack space by tail-calling
      caml_resume. *)
   let sym = Cmm.global_symbol "caml_resume" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); cont; f; arg],
       dbg )
 
-let reperform ~dbg ~eff ~cont ~last_fiber =
+let reperform ~dbg ~eff ~cont ~last_fiber ~returns =
   (* Rc_normal is required here, this is used in tail position and should tail
      call. *)
   let sym = Cmm.global_symbol "caml_reperform" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); eff; cont; last_fiber],
       dbg )
 

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -2549,8 +2549,8 @@ let send_function_name arity result (mode : Cmx_format.return_mode) =
   in
   global_symbol ("caml_send" ^ unique_arity_identifier arity ^ res ^ suff)
 
-let call_cached_method obj tag cache pos args args_type result (apos, mode) dbg
-    =
+let call_cached_method obj tag cache pos args args_type result (apos, mode)
+    ~returns dbg =
   Compilenv.need_send_fun
     (List.map Extended_machtype.change_tagged_int_to_val args_type)
     (Extended_machtype.change_tagged_int_to_val result)
@@ -2565,7 +2565,8 @@ let call_cached_method obj tag cache pos args args_type result (apos, mode) dbg
     ( Capply
         { result_type = Extended_machtype.to_machtype result;
           region = apos;
-          callees = Some [sym]
+          callees = Some [sym];
+          returns
         },
       (* See the cases for caml_apply regarding [change_tagged_int_to_val]. *)
       Cconst_symbol (sym, dbg) :: obj :: tag :: cache :: pos :: args,
@@ -3579,7 +3580,8 @@ let split_arity_for_apply arity args =
     let args1, args2 = Misc.Stdlib.List.split_at max_arity args in
     (a1, args1), Some (a2, args2)
 
-let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
+let call_caml_apply extended_ty extended_args_type mut clos args pos mode
+    ~returns dbg =
   (* Treat tagged int arguments and results as [typ_val], to avoid generating
      excessive numbers of caml_apply functions. *)
   let ty = Extended_machtype.to_machtype extended_ty in
@@ -3587,7 +3589,7 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
     let sym = apply_function_sym extended_args_type extended_ty mode in
     let cargs = (Cconst_symbol (sym, dbg) :: args) @ [clos] in
     Cop
-      ( Capply { result_type = ty; region = pos; callees = Some [sym] },
+      ( Capply { result_type = ty; region = pos; callees = Some [sym]; returns },
         cargs,
         dbg )
   in
@@ -3614,7 +3616,12 @@ let call_caml_apply extended_ty extended_args_type mut clos args pos mode dbg =
                     dbg ),
                 dbg,
                 Cop
-                  ( Capply { result_type = ty; region = pos; callees = None },
+                  ( Capply
+                      { result_type = ty;
+                        region = pos;
+                        callees = None;
+                        returns
+                      },
                     (get_field_codepointer mut clos 2 dbg :: args) @ [clos],
                     dbg ),
                 dbg,
@@ -3638,7 +3645,7 @@ let maybe_reset_current_region ~dbg ~body_tail ~body_nontail old_region =
            Csequence (Cop (Cendregion, [old_region], dbg ()), Cvar res) )),
       dbg () )
 
-let apply_or_call_caml_apply result arity mut clos args pos mode dbg =
+let apply_or_call_caml_apply result arity mut clos args pos mode ~returns dbg =
   match arity with
   | [_] ->
     bind "fun" clos (fun clos ->
@@ -3646,33 +3653,36 @@ let apply_or_call_caml_apply result arity mut clos args pos mode dbg =
           ( Capply
               { result_type = Extended_machtype.to_machtype result;
                 region = pos;
-                callees = None
+                callees = None;
+                returns
               },
             (get_field_codepointer mut clos 0 dbg :: args) @ [clos],
             dbg ))
-  | _ -> call_caml_apply result arity mut clos args pos mode dbg
+  | _ -> call_caml_apply result arity mut clos args pos mode ~returns dbg
 
 let rec might_split_call_caml_apply ?old_region result arity mut clos args pos
-    mode dbg =
+    mode ~returns dbg =
   match split_arity_for_apply arity args with
   | (arity, args), None -> (
     match old_region with
-    | None -> apply_or_call_caml_apply result arity mut clos args pos mode dbg
+    | None ->
+      apply_or_call_caml_apply result arity mut clos args pos mode ~returns dbg
     | Some old_region ->
       maybe_reset_current_region ~dbg:placeholder_dbg
         ~body_tail:
-          (apply_or_call_caml_apply result arity mut clos args pos mode dbg)
+          (apply_or_call_caml_apply result arity mut clos args pos mode ~returns
+             dbg)
         ~body_nontail:
           (apply_or_call_caml_apply result arity mut clos args Rc_normal
-             Cmx_format.Maybe_alloc_stack dbg)
+             Cmx_format.Maybe_alloc_stack ~returns dbg)
         old_region)
   | (arity, args), Some (arity', args') -> (
     let body old_region =
       bind "result"
         (call_caml_apply [| Val |] arity mut clos args Rc_normal
-           Cmx_format.Maybe_alloc_stack dbg) (fun clos ->
+           Cmx_format.Maybe_alloc_stack ~returns:true dbg) (fun clos ->
           might_split_call_caml_apply ?old_region result arity' mut clos args'
-            pos mode dbg)
+            pos mode ~returns dbg)
     in
     (* When splitting [caml_applyM] into [caml_applyN] and [caml_applyK] it is
        possible for [caml_applyN] to allocate on the local stack. If we are not
@@ -3691,23 +3701,25 @@ let rec might_split_call_caml_apply ?old_region result arity mut clos args pos
         (fun region -> body (Some region))
     | _ -> body old_region)
 
-let generic_apply mut clos args args_type result (pos, mode) dbg =
-  might_split_call_caml_apply result args_type mut clos args pos mode dbg
+let generic_apply mut clos args args_type result (pos, mode) ~returns dbg =
+  might_split_call_caml_apply result args_type mut clos args pos mode ~returns
+    dbg
 
-let send kind met obj args args_type result akind dbg =
+let send kind met obj args args_type result akind ~returns dbg =
   let call_met obj args args_type clos =
     (* met is never a simple expression, so it never gets turned into an
        Immutable load *)
     generic_apply Asttypes.Mutable clos (obj :: args)
       (Extended_machtype.typ_val :: args_type)
-      result akind dbg
+      result akind ~returns dbg
   in
   bind "obj" obj (fun obj ->
       match (kind : Lambda.meth_kind), args, args_type with
       | Self, _, _ ->
         bind "met" (lookup_label obj met dbg) (call_met obj args args_type)
       | Cached, cache :: pos :: args, _ :: _ :: args_type ->
-        call_cached_method obj met cache pos args args_type result akind dbg
+        call_cached_method obj met cache pos args args_type result akind
+          ~returns dbg
       | _ -> bind "met" (lookup_tag obj met dbg) (call_met obj args args_type))
 
 (*
@@ -3862,7 +3874,12 @@ let apply_function_body arity result (mode : Cmx_format.return_mode) =
     | [arg] -> (
       let app =
         Cop
-          ( Capply { result_type = result; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = result;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             (* The code pointer and closure info of a closure are write-once;
                reading them immutably is correct and lets the debugger describe
                the call target (and closure projections) for call sites. *)
@@ -3885,7 +3902,11 @@ let apply_function_body arity result (mode : Cmx_format.return_mode) =
         ( VP.create newclos,
           Cop
             ( Capply
-                { result_type = typ_val; region = Rc_normal; callees = None },
+                { result_type = typ_val;
+                  region = Rc_normal;
+                  callees = None;
+                  returns = true
+                },
               [ get_field_codepointer Asttypes.Immutable (Cvar clos) 0 (dbg ());
                 Cvar arg;
                 Cvar clos ],
@@ -3916,7 +3937,12 @@ let apply_function_body arity result (mode : Cmx_format.return_mode) =
               dbg () ),
           dbg (),
           Cop
-            ( Capply { result_type = result; region = Rc_normal; callees = None },
+            ( Capply
+                { result_type = result;
+                  region = Rc_normal;
+                  callees = None;
+                  returns = true
+                },
               get_field_codepointer Asttypes.Immutable (Cvar clos) 2 (dbg ())
               :: List.map (fun s -> Cvar s) all_args,
               dbg () ),
@@ -4045,7 +4071,12 @@ let tuplify_function arity return =
       fun_args = [VP.create arg, typ_val; VP.create clos, typ_val];
       fun_body =
         Cop
-          ( Capply { result_type = return; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = return;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             (* The closure code pointer is write-once; see
                [apply_function_body]. *)
             get_field_codepointer Asttypes.Immutable (Cvar clos) 2 (dbg ())
@@ -4198,7 +4229,12 @@ let rec make_curry_apply result narity args_type args clos n =
   match args_type with
   | [] ->
     Cop
-      ( Capply { result_type = result; region = Rc_normal; callees = None },
+      ( Capply
+          { result_type = result;
+            region = Rc_normal;
+            callees = None;
+            returns = true
+          },
         (* Code pointer and chain links of a partial-application closure are
            write-once; reading them immutably lets the debugger describe the
            call target and the recovered arguments as closure projections. *)
@@ -4696,7 +4732,12 @@ let entry_point namelist =
     in
     Csequence
       ( Cop
-          ( Capply { result_type = typ_void; region = Rc_normal; callees = None },
+          ( Capply
+              { result_type = typ_void;
+                region = Rc_normal;
+                callees = None;
+                returns = true
+              },
             [Cop (mk_load_immut Word_int, [f], dbg ())],
             dbg () ),
         incr_global_inited () )
@@ -5204,17 +5245,18 @@ let load ~dbg memory_chunk mutability ~addr =
 let store ~dbg kind init ~addr ~new_value =
   Cop (Cstore (kind, init), [addr; new_value], dbg)
 
-let direct_call ~dbg ty pos f_code_sym args =
+let direct_call ~dbg ~returns ty pos f_code_sym args =
   Cop
-    ( Capply { result_type = ty; region = pos; callees = Some [f_code_sym] },
+    ( Capply
+        { result_type = ty; region = pos; callees = Some [f_code_sym]; returns },
       Cconst_symbol (f_code_sym, dbg) :: args,
       dbg )
 
-let indirect_call ~dbg ty pos alloc_mode f args_type args =
+let indirect_call ~dbg ~returns ty pos alloc_mode f args_type args =
   might_split_call_caml_apply ty args_type Asttypes.Mutable f args pos
-    alloc_mode dbg
+    alloc_mode ~returns dbg
 
-let indirect_full_call ~dbg ty pos f ~callees args_type args =
+let indirect_full_call ~dbg ~returns ty pos f ~callees args_type args =
   (* Use a variable to avoid duplicating the cmm code of the closure [f]. *)
   let v = Backend_var.create_local "*closure*" in
   let v' = Backend_var.With_provenance.create v in
@@ -5235,7 +5277,8 @@ let indirect_full_call ~dbg ty pos f ~callees args_type args =
          ( Capply
              { result_type = Extended_machtype.to_machtype ty;
                region = pos;
-               callees
+               callees;
+               returns
              },
            (fun_ptr :: args) @ [Cvar v],
            dbg ))
@@ -5726,7 +5769,7 @@ let tls_get ~dbg = Cop (Ctls_get, [], dbg)
 
 let domain_index ~dbg = Cop (Cdomain_index, [], dbg)
 
-let perform ~dbg eff =
+let perform ~dbg ~returns eff =
   let cont =
     make_alloc dbg ~tag:Runtimetags.cont_tag
       [int_const dbg 0; int_const dbg 0]
@@ -5736,14 +5779,24 @@ let perform ~dbg eff =
      improves backtraces of paused fibers. *)
   let sym = Cmm.global_symbol "caml_perform" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_nontail; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_nontail;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); eff; cont],
       dbg )
 
-let with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg =
+let with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg ~returns =
   let sym = Cmm.global_symbol "caml_runstack" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
         Cop
           ( Cextcall
@@ -5762,10 +5815,16 @@ let with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg =
         arg ],
       dbg )
 
-let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg =
+let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg
+    ~returns =
   let sym = Cmm.global_symbol "caml_runstack" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [ Cconst_symbol (Cmm.global_symbol "caml_runstack", dbg);
         Cop
           ( Cextcall
@@ -5789,33 +5848,53 @@ let with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg =
    repeated resumes, and these should consume O(1) stack space by tail-calling
    the runtime resume function. *)
 
-let continue ~dbg ~cont ~value =
+let continue ~dbg ~cont ~value ~returns =
   let sym = Cmm.global_symbol "caml_continue" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); cont; value],
       dbg )
 
-let discontinue ~dbg ~cont ~exn =
+let discontinue ~dbg ~cont ~exn ~returns =
   let sym = Cmm.global_symbol "caml_discontinue" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); cont; exn],
       dbg )
 
-let discontinue_with_backtrace ~dbg ~cont ~exn ~bt =
+let discontinue_with_backtrace ~dbg ~cont ~exn ~returns ~bt =
   let sym = Cmm.global_symbol "caml_discontinue_with_backtrace" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); cont; exn; bt],
       dbg )
 
-let reperform ~dbg ~eff ~cont ~last_fiber =
+let reperform ~dbg ~eff ~cont ~last_fiber ~returns =
   (* Rc_normal is required here, this is used in tail position and should tail
      call. *)
   let sym = Cmm.global_symbol "caml_reperform" in
   Cop
-    ( Capply { result_type = typ_val; region = Rc_normal; callees = Some [sym] },
+    ( Capply
+        { result_type = typ_val;
+          region = Rc_normal;
+          callees = Some [sym];
+          returns
+        },
       [Cconst_symbol (sym, dbg); eff; cont; last_fiber],
       dbg )
 

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -695,6 +695,7 @@ val send :
   Extended_machtype.t list ->
   Extended_machtype.t ->
   Lambda.region_close * Cmx_format.alloc_mode ->
+  returns:bool ->
   Debuginfo.t ->
   expression
 
@@ -1030,6 +1031,7 @@ val caml_modify_local :
     If a closure needs to be passed, it must be included in [args]. *)
 val direct_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   machtype ->
   Lambda.region_close ->
   symbol ->
@@ -1039,6 +1041,7 @@ val direct_call :
 (** Same as {!direct_call} but for an indirect call. *)
 val indirect_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   Extended_machtype.t ->
   Lambda.region_close ->
   Cmx_format.alloc_mode ->
@@ -1051,6 +1054,7 @@ val indirect_call :
     application (since this enables a few optimisations). *)
 val indirect_full_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   Extended_machtype.t ->
   Lambda.region_close ->
   expression ->
@@ -1226,7 +1230,7 @@ val atomic_compare_exchange_field :
 
 val emit_gc_roots_table : symbols:symbol list -> phrase list -> phrase list
 
-val perform : dbg:Debuginfo.t -> expression -> expression
+val perform : dbg:Debuginfo.t -> returns:bool -> expression -> expression
 
 val with_stack :
   dbg:Debuginfo.t ->
@@ -1235,6 +1239,7 @@ val with_stack :
   effc:expression ->
   f:expression ->
   arg:expression ->
+  returns:bool ->
   expression
 
 val with_stack_preemptible :
@@ -1245,6 +1250,7 @@ val with_stack_preemptible :
   handle_tick:expression ->
   f:expression ->
   arg:expression ->
+  returns:bool ->
   expression
 
 val resume :
@@ -1252,6 +1258,7 @@ val resume :
   cont:expression ->
   f:expression ->
   arg:expression ->
+  returns:bool ->
   expression
 
 val reperform :
@@ -1259,6 +1266,7 @@ val reperform :
   eff:expression ->
   cont:expression ->
   last_fiber:expression ->
+  returns:bool ->
   expression
 
 (* CR mshinwell: change unboxed scalar arrays to use mixed block (or similar)

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -739,6 +739,7 @@ val send :
   Extended_machtype.t list ->
   Extended_machtype.t ->
   Lambda.region_close * Cmx_format.return_mode ->
+  returns:bool ->
   Debuginfo.t ->
   expression
 
@@ -1079,6 +1080,7 @@ val caml_modify_local :
     If a closure needs to be passed, it must be included in [args]. *)
 val direct_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   machtype ->
   Lambda.region_close ->
   symbol ->
@@ -1088,6 +1090,7 @@ val direct_call :
 (** Same as {!direct_call} but for an indirect call. *)
 val indirect_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   Extended_machtype.t ->
   Lambda.region_close ->
   Cmx_format.return_mode ->
@@ -1100,6 +1103,7 @@ val indirect_call :
     application (since this enables a few optimisations). *)
 val indirect_full_call :
   dbg:Debuginfo.t ->
+  returns:bool ->
   Extended_machtype.t ->
   Lambda.region_close ->
   expression ->
@@ -1286,7 +1290,7 @@ val atomic_compare_exchange_field :
 
 val emit_gc_roots_table : symbols:symbol list -> phrase list -> phrase list
 
-val perform : dbg:Debuginfo.t -> expression -> expression
+val perform : dbg:Debuginfo.t -> returns:bool -> expression -> expression
 
 val with_stack :
   dbg:Debuginfo.t ->
@@ -1295,6 +1299,7 @@ val with_stack :
   effc:expression ->
   f:expression ->
   arg:expression ->
+  returns:bool ->
   expression
 
 val with_stack_preemptible :
@@ -1305,18 +1310,28 @@ val with_stack_preemptible :
   handle_tick:expression ->
   f:expression ->
   arg:expression ->
+  returns:bool ->
   expression
 
 val continue :
-  dbg:Debuginfo.t -> cont:expression -> value:expression -> expression
+  dbg:Debuginfo.t ->
+  cont:expression ->
+  value:expression ->
+  returns:bool ->
+  expression
 
 val discontinue :
-  dbg:Debuginfo.t -> cont:expression -> exn:expression -> expression
+  dbg:Debuginfo.t ->
+  cont:expression ->
+  exn:expression ->
+  returns:bool ->
+  expression
 
 val discontinue_with_backtrace :
   dbg:Debuginfo.t ->
   cont:expression ->
   exn:expression ->
+  returns:bool ->
   bt:expression ->
   expression
 
@@ -1325,6 +1340,7 @@ val reperform :
   eff:expression ->
   cont:expression ->
   last_fiber:expression ->
+  returns:bool ->
   expression
 
 (* CR mshinwell: change unboxed scalar arrays to use mixed block (or similar)

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -254,7 +254,8 @@ let static_cast : Cmm.static_cast -> string = function
   | V512_of_scalar ty -> Printf.sprintf "scalar->%s" (vec512_name ty)
 
 let operation d = function
-  | Capply { result_type = _ty; region = _; callees = _ } -> "app" ^ location d
+  | Capply { result_type = _ty; region = _; callees = _; returns = _ } ->
+    "app" ^ location d
   | Cextcall { func = lbl; _ } ->
     Printf.sprintf "extcall \"%s\"%s" lbl (location d)
   | Cload { memory_chunk; mutability; is_atomic } -> (
@@ -400,7 +401,9 @@ let rec expr ppf = function
         fprintf ppf "@[<2>(%s" (operation dbg op);
         List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
         (match[@warning "-4"] op with
-        | Capply { result_type = mty; _ } -> fprintf ppf "@ %a" machtype mty
+        | Capply { result_type = mty; returns; _ } ->
+          fprintf ppf "@ %a" machtype mty;
+          if not returns then fprintf ppf "@ ->."
         | Cextcall
             { ty;
               ty_args;

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -258,7 +258,8 @@ let static_cast : Cmm.static_cast -> string = function
   | V512_of_scalar ty -> Printf.sprintf "scalar->%s" (vec512_name ty)
 
 let operation d = function
-  | Capply { result_type = _ty; region = _; callees = _ } -> "app" ^ location d
+  | Capply { result_type = _ty; region = _; callees = _; returns = _ } ->
+    "app" ^ location d
   | Cextcall { func = lbl; _ } ->
     Printf.sprintf "extcall \"%s\"%s" lbl (location d)
   | Cload { memory_chunk; mutability; is_atomic } -> (
@@ -407,7 +408,9 @@ let rec expr ppf = function
         fprintf ppf "@[<2>(%s" (operation dbg op);
         List.iter (fun e -> fprintf ppf "@ %a" expr e) el;
         (match[@warning "-4"] op with
-        | Capply { result_type = mty; _ } -> fprintf ppf "@ %a" machtype mty
+        | Capply { result_type = mty; returns; _ } ->
+          fprintf ppf "@ %a" machtype mty;
+          if not returns then fprintf ppf "@ ->."
         | Cextcall
             { ty;
               ty_args;

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -282,6 +282,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     aux args args_arity
   in
   let return_ty = C.extended_machtype_of_return_arity return_arity in
+  let returns = Apply.returns apply in
   match Apply.call_kind apply with
   | Function { function_call = Direct code_id } -> (
     let code_metadata = Env.get_code_metadata env code_id in
@@ -309,7 +310,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     in
     match Apply.probe apply with
     | None ->
-      ( C.direct_call ~dbg
+      ( C.direct_call ~dbg ~returns
           (C.Extended_machtype.to_machtype return_ty)
           pos code_sym args,
         free_vars,
@@ -334,7 +335,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           "Application expression did not provide callee for indirect call:@ %a"
           Apply.print apply
     in
-    ( C.indirect_call ~dbg return_ty pos
+    ( C.indirect_call ~dbg ~returns return_ty pos
         (C.alloc_mode_for_applications_to_cmx (Apply_expr.alloc_mode apply))
         callee args_ty (split_args ()),
       free_vars,
@@ -368,7 +369,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         "To_cmm expects indirect_known_arity calls to be full applications in \
          order to translate them"
     else
-      ( C.indirect_full_call ~dbg return_ty pos callee ~callees args_ty args,
+      ( C.indirect_full_call ~dbg ~returns return_ty pos callee ~callees args_ty
+          args,
         free_vars,
         env,
         res,
@@ -400,7 +402,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       C.alloc_mode_for_applications_to_cmx (Apply_expr.alloc_mode apply)
     in
     ( C.send kind callee obj (split_args ()) args_ty return_ty (pos, alloc_mode)
-        dbg,
+        ~returns dbg,
       free_vars,
       env,
       res,
@@ -414,7 +416,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       let { env; res; expr = { cmm = eff; free_vars; effs = _ } } =
         simple env res eff
       in
-      C.perform ~dbg eff, free_vars, env, res, Ece.all
+      C.perform ~dbg ~returns eff, free_vars, env, res, Ece.all
     | Reperform { eff; cont; last_fiber } ->
       let { env; res; expr = { cmm = eff; free_vars = fv0; effs = _ } } =
         simple env res eff
@@ -426,7 +428,11 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res last_fiber
       in
       let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
-      C.reperform ~dbg ~eff ~cont ~last_fiber, free_vars, env, res, Ece.all
+      ( C.reperform ~dbg ~returns ~eff ~cont ~last_fiber,
+        free_vars,
+        env,
+        res,
+        Ece.all )
     | With_stack { valuec; exnc; effc; f; arg } ->
       let { env; res; expr = { cmm = valuec; free_vars = fv0; effs = _ } } =
         simple env res valuec
@@ -448,7 +454,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           (BV.Set.union fv0 (BV.Set.union fv1 fv2))
           (BV.Set.union fv3 fv4)
       in
-      ( C.with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg,
+      ( C.with_stack ~dbg ~returns ~valuec ~exnc ~effc ~f ~arg,
         free_vars,
         env,
         res,
@@ -478,7 +484,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           (BV.Set.union fv0 (BV.Set.union fv1 fv2))
           (BV.Set.union fv3 (BV.Set.union fv4 fv5))
       in
-      ( C.with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg,
+      ( C.with_stack_preemptible ~dbg ~returns ~valuec ~exnc ~effc ~handle_tick
+          ~f ~arg,
         free_vars,
         env,
         res,
@@ -494,7 +501,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res arg
       in
       let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
-      C.resume ~dbg ~cont ~f ~arg, free_vars, env, res, Ece.all)
+      C.resume ~dbg ~returns ~cont ~f ~arg, free_vars, env, res, Ece.all)
 
 let translate_apply env res apply =
   let dbg = Env.add_inlined_debuginfo env (Apply.dbg apply) in

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -283,6 +283,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     aux args args_arity
   in
   let return_ty = C.extended_machtype_of_return_arity return_arity in
+  let returns = Apply.returns apply in
   match Apply.call_kind apply with
   | Function { function_call = Direct code_id } -> (
     let code_metadata = Env.get_code_metadata env code_id in
@@ -310,7 +311,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
     in
     match Apply.probe apply with
     | None ->
-      ( C.direct_call ~dbg
+      ( C.direct_call ~dbg ~returns
           (C.Extended_machtype.to_machtype return_ty)
           pos code_sym args,
         free_vars,
@@ -335,7 +336,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           "Application expression did not provide callee for indirect call:@ %a"
           Apply.print apply
     in
-    ( C.indirect_call ~dbg return_ty pos
+    ( C.indirect_call ~dbg ~returns return_ty pos
         (C.alloc_mode_for_applications_to_cmx (Apply_expr.return_mode apply))
         callee args_ty (split_args ()),
       free_vars,
@@ -369,7 +370,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         "To_cmm expects indirect_known_arity calls to be full applications in \
          order to translate them"
     else
-      ( C.indirect_full_call ~dbg return_ty pos callee ~callees args_ty args,
+      ( C.indirect_full_call ~dbg ~returns return_ty pos callee ~callees args_ty
+          args,
         free_vars,
         env,
         res,
@@ -401,7 +403,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       C.alloc_mode_for_applications_to_cmx (Apply_expr.return_mode apply)
     in
     ( C.send kind callee obj (split_args ()) args_ty return_ty (pos, alloc_mode)
-        dbg,
+        ~returns dbg,
       free_vars,
       env,
       res,
@@ -415,7 +417,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
       let { env; res; expr = { cmm = eff; free_vars; effs = _ } } =
         simple env res eff
       in
-      C.perform ~dbg eff, free_vars, env, res, Ece.all
+      C.perform ~dbg ~returns eff, free_vars, env, res, Ece.all
     | Reperform { eff; cont; last_fiber } ->
       let { env; res; expr = { cmm = eff; free_vars = fv0; effs = _ } } =
         simple env res eff
@@ -427,7 +429,11 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res last_fiber
       in
       let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
-      C.reperform ~dbg ~eff ~cont ~last_fiber, free_vars, env, res, Ece.all
+      ( C.reperform ~dbg ~returns ~eff ~cont ~last_fiber,
+        free_vars,
+        env,
+        res,
+        Ece.all )
     | With_stack { valuec; exnc; effc; f; arg } ->
       let { env; res; expr = { cmm = valuec; free_vars = fv0; effs = _ } } =
         simple env res valuec
@@ -449,7 +455,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           (BV.Set.union fv0 (BV.Set.union fv1 fv2))
           (BV.Set.union fv3 fv4)
       in
-      ( C.with_stack ~dbg ~valuec ~exnc ~effc ~f ~arg,
+      ( C.with_stack ~dbg ~returns ~valuec ~exnc ~effc ~f ~arg,
         free_vars,
         env,
         res,
@@ -479,7 +485,8 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
           (BV.Set.union fv0 (BV.Set.union fv1 fv2))
           (BV.Set.union fv3 (BV.Set.union fv4 fv5))
       in
-      ( C.with_stack_preemptible ~dbg ~valuec ~exnc ~effc ~handle_tick ~f ~arg,
+      ( C.with_stack_preemptible ~dbg ~returns ~valuec ~exnc ~effc ~handle_tick
+          ~f ~arg,
         free_vars,
         env,
         res,
@@ -492,7 +499,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res value
       in
       let free_vars = BV.Set.union fv0 fv1 in
-      C.continue ~dbg ~cont ~value, free_vars, env, res, Ece.all
+      C.continue ~dbg ~returns ~cont ~value, free_vars, env, res, Ece.all
     | Discontinue { cont; exn } ->
       let { env; res; expr = { cmm = cont; free_vars = fv0; effs = _ } } =
         simple env res cont
@@ -501,7 +508,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res exn
       in
       let free_vars = BV.Set.union fv0 fv1 in
-      C.discontinue ~dbg ~cont ~exn, free_vars, env, res, Ece.all
+      C.discontinue ~dbg ~returns ~cont ~exn, free_vars, env, res, Ece.all
     | Discontinue_with_backtrace { cont; exn; bt } ->
       let { env; res; expr = { cmm = cont; free_vars = fv0; effs = _ } } =
         simple env res cont
@@ -513,7 +520,7 @@ let translate_apply0 ~dbg_with_inlined:dbg env res apply =
         simple env res bt
       in
       let free_vars = BV.Set.union (BV.Set.union fv0 fv1) fv2 in
-      ( C.discontinue_with_backtrace ~dbg ~cont ~exn ~bt,
+      ( C.discontinue_with_backtrace ~dbg ~returns ~cont ~exn ~bt,
         free_vars,
         env,
         res,

--- a/oxcaml/testsuite/tools/parsecmm.mly
+++ b/oxcaml/testsuite/tools/parsecmm.mly
@@ -224,7 +224,8 @@ expr:
                 { Cop(Capply {
                         result_type = $6;
                         region = Lambda.Rc_normal;
-                        callees = None
+                        callees = None;
+                        returns = true
                       },
                       $4 :: List.rev $5, debuginfo ?loc:$3 ()) }
   | LPAREN EXTCALL STRING exprlist machtype RPAREN


### PR DESCRIPTION
This mirrors `Cextcall`. This is useful for a subsequent PR that implements machtype checking, as some expressions generated by the reaper never return and aren't given a compatible machtype.