### PR TITLE
Add `float32_u` to predef

### DIFF
--- a/testsuite/tests/typing-layouts/renamed_unboxed_numbers.ml
+++ b/testsuite/tests/typing-layouts/renamed_unboxed_numbers.ml
@@ -1,21 +1,26 @@
 (* TEST
+ flags = "-extension small_numbers";
  expect;
 *)
 
 let nativeint (x : nativeint_u) : nativeint# = x
 let int32 (x : int32_u) : int32# = x
 let int64 (x : int64_u) : int64# = x
+let float32 (x : float32_u) : float32# = x
 [%%expect{|
 val nativeint : nativeint_u -> nativeint# = <fun>
 val int32 : int32_u -> int32# = <fun>
 val int64 : int64_u -> int64# = <fun>
+val float32 : float32_u -> float32# = <fun>
 |}]
 
 type nativeint_u_kind : word = nativeint_u
 type int32_u_kind : bits32 = int32_u
 type int64_u_kind : bits64 = int64_u
+type float32_u_kind : float32 = float32_u
 [%%expect{|
 type nativeint_u_kind = nativeint_u
 type int32_u_kind = int32_u
 type int64_u_kind = int64_u
+type float32_u_kind = float32_u
 |}]

--- a/testsuite/tests/typing-simd/test_disabled.ml
+++ b/testsuite/tests/typing-simd/test_disabled.ml
@@ -45,7 +45,7 @@ Line 1, characters 9-18:
 1 | type t = float32x4;;
              ^^^^^^^^^
 Error: Unbound type constructor "float32x4"
-Hint:              Did you mean "float32"?
+Hint:              Did you mean "float32" or "float32_u"?
 |}];;
 
 type t = float64x2;;

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -61,6 +61,7 @@ type abstract_non_value_type_constr = [
   | `Nativeint_u
   | `Int32_u
   | `Int64_u
+  | `Float32_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -166,6 +167,7 @@ let simd_alpha_extension_type_constrs : type_constr list = [
 
 let small_number_extension_type_constrs : type_constr list = [
   `Float32;
+  `Float32_u;
   `Int8;
   `Int16;
 ]
@@ -219,6 +221,7 @@ and ident_box = ident_create "box"
 and ident_nativeint_u = ident_create "nativeint_u"
 and ident_int32_u = ident_create "int32_u"
 and ident_int64_u = ident_create "int64_u"
+and ident_float32_u = ident_create "float32_u"
 and ident_or_null = ident_create "or_null"
 and ident_idx_imm = ident_create "idx_imm"
 and ident_idx_mut = ident_create "idx_mut"
@@ -277,6 +280,7 @@ let ident_of_type_constr : type_constr -> Ident.t = function
   | `Nativeint_u -> ident_nativeint_u
   | `Int32_u -> ident_int32_u
   | `Int64_u -> ident_int64_u
+  | `Float32_u -> ident_float32_u
   | `Idx_imm -> ident_idx_imm
   | `Idx_mut -> ident_idx_mut
   | `Int8x16 -> ident_int8x16
@@ -330,6 +334,7 @@ and path_lexing_position = Pident ident_lexing_position
 and path_nativeint_u = Pident ident_nativeint_u
 and path_int32_u = Pident ident_int32_u
 and path_int64_u = Pident ident_int64_u
+and path_float32_u = Pident ident_float32_u
 and path_idx_imm = Pident ident_idx_imm
 and path_idx_mut = Pident ident_idx_mut
 and path_code = Pident ident_code
@@ -439,6 +444,7 @@ and type_unboxed_int16 = tconstr path_unboxed_int16 []
 and type_nativeint_u = tconstr path_nativeint_u []
 and type_int32_u = tconstr path_int32_u []
 and type_int64_u = tconstr path_int64_u []
+and type_float32_u = tconstr path_float32_u []
 and type_or_null t = tconstr path_or_null [t]
 and type_idx_imm t1 t2 = tconstr path_idx_imm [t1; t2]
 and type_idx_mut t1 t2 = tconstr path_idx_mut [t1; t2]
@@ -890,6 +896,9 @@ let decl_of_type_constr type_constr =
   | `Int64_u ->
     decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int64)
       ~manifest:(tconstr (Path.unboxed_version path_int64) []) ()
+  | `Float32_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_float32)
+      ~manifest:(tconstr (Path.unboxed_version path_float32) []) ()
   | `Idx_imm ->
     decl2 ~variance:(Variance.full, Variance.covariant)
        ~param_jkinds:(

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -45,6 +45,7 @@ type abstract_non_value_type_constr = [
   | `Nativeint_u
   | `Int32_u
   | `Int64_u
+  | `Float32_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -126,6 +127,7 @@ val type_unboxed_int64:type_expr
 val type_nativeint_u: type_expr
 val type_int32_u: type_expr
 val type_int64_u: type_expr
+val type_float32_u: type_expr
 val type_or_null: type_expr -> type_expr
 val type_idx_imm : type_expr -> type_expr -> type_expr
 val type_idx_mut : type_expr -> type_expr -> type_expr
@@ -217,6 +219,7 @@ val path_unboxed_int64: Path.t
 val path_nativeint_u: Path.t
 val path_int32_u: Path.t
 val path_int64_u: Path.t
+val path_float32_u: Path.t
 val path_or_null: Path.t
 val path_idx_imm: Path.t
 val path_idx_mut: Path.t


### PR DESCRIPTION
See also https://github.com/oxcaml/oxcaml/pull/6321/.

Add the following type to the predef.
```ocaml
type float32_u = float32#
```

In the future, this types will be abstract, and we will delete `float32#` as it is not "truly" the unboxed version of `float32` (which is a custom block and thus should not have unboxed versions).