### PR TITLE
Clarify prologue insert w.r.t. push_trap operation

### DIFF
--- a/backend/cfg/cfg_prologue.ml
+++ b/backend/cfg/cfg_prologue.ml
@@ -92,6 +92,19 @@ module Instruction_requirements = struct
       (* Allocations and polls are implemented by calling a function when
          emitted, and therefore need a prologue for the function call. *)
       | Op (Alloc _ | Poll) -> Requirements Requires_prologue
+      (* The prologue must already be on the stack when a trap frame is pushed:
+         [can_place_prologues] refuses to add a prologue at a non-zero stack
+         offset (the frame would be allocated on top of the trap frame), so no
+         prologue can be added later on the path; and the trap handler runs with
+         the frame state of the [Pushtrap] point, while handlers must execute
+         with the frame allocated (see the trap-handler check in [validate], and
+         [Lentertrap] under frame pointers). Since every path to a trap handler
+         goes through a matching [Pushtrap], this requirement also guarantees
+         that handlers are only reachable with a prologue on the stack.
+         [Poptrap] needs no requirement: it only occurs inside a trap region,
+         where the requirement on [Pushtrap] already forces the prologue to be
+         on the stack. *)
+      | Pushtrap _ -> Requirements Requires_prologue
       | Op
           ( Move | Spill | Reload | Const_int _ | Const_float32 _
           | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
@@ -100,7 +113,7 @@ module Instruction_requirements = struct
           | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _ | Opaque
           | Begin_region | End_region | Specific _ | Name_for_debugger _
           | Dls_get | Tls_get | Domain_index | Pause )
-      | Pushtrap _ | Poptrap _ | Reloadretaddr | Stack_check _ ->
+      | Poptrap _ | Reloadretaddr | Stack_check _ ->
         Requirements No_requirements
 end
 

--- a/oxcaml/tests/backend/validators/check_prologue_validation.ml
+++ b/oxcaml/tests/backend/validators/check_prologue_validation.ml
@@ -247,6 +247,12 @@ let () =
       ">> Fatal error: Cfg_prologue: error validating instruction #0000: \
        terminator needs to appear after epilogue but prologue is on stack"
 
+(* Since [Pushtrap] itself requires a prologue, the pushtrap is flagged before
+   the prologue's non-zero stack offset is reached. The "prologue has a non-zero
+   stack offset" check remains in the validator as defense in depth, but it is
+   no longer reachable through a consistently-annotated CFG: creating a non-zero
+   stack offset requires a [Pushtrap] or a [Stackoffset], and both require a
+   prologue first. *)
 let () =
   check "Prologue after Pushtrap"
     (fun () ->
@@ -302,8 +308,8 @@ let () =
       cfg_with_infos)
     ~exp_std:""
     ~exp_err:
-      ">> Fatal error: Cfg_prologue: error validating instruction #0003: \
-       prologue has a non-zero stack offset"
+      ">> Fatal error: Cfg_prologue: error validating instruction #0004: \
+       instruction needs prologue but no prologue on the stack"
 
 let () =
   check "Raise without prologue"
@@ -380,3 +386,133 @@ let () =
       in
       Cfg_desc.make_post_regalloc cfg)
     ~exp_std:"" ~exp_err:""
+
+(* Reproduction for the interaction between shrink-wrapping and trap handlers.
+   The trap handler is reachable only via a [Raise Raise_notrace] whose path
+   contains no other prologue-requiring instruction, while the prologue-free
+   path through [normal_return_label] keeps shrink-wrapping going. Since
+   [Pushtrap] requires a prologue, the placement stops at the pushtrap block, so
+   the handler is only reachable with a prologue on the stack. Before [Pushtrap]
+   required a prologue, nothing on the path to the raise did: the placement
+   chose the trap handler itself as the prologue block, and validation then
+   failed with "can reach trap handler with no prologue". *)
+let () =
+  let pushtrap_label = new_label 1 in
+  let raise_label = new_label 2 in
+  let normal_return_label = new_label 3 in
+  let handler_label = new_label 4 in
+  Utils.check "Shrink-wrapping a trap handler reached through raise_notrace"
+    (fun () ->
+      seq := InstructionId.make_sequence ();
+      let cfg : Cfg_desc.t =
+        { fun_args = [||];
+          blocks =
+            [ { start = entry_label;
+                body = [];
+                exn = None;
+                terminator =
+                  { id = make_id ();
+                    desc =
+                      Truth_test
+                        { ifso = normal_return_label; ifnot = pushtrap_label };
+                    arg = [| int.(0) |];
+                    res = [||]
+                  }
+              };
+              { start = normal_return_label;
+                body = [];
+                exn = None;
+                terminator =
+                  { id = make_id (); desc = Return; arg = [||]; res = [||] }
+              };
+              { start = pushtrap_label;
+                body =
+                  [ { id = make_id ();
+                      desc = Pushtrap { lbl_handler = handler_label };
+                      arg = [||];
+                      res = [||]
+                    } ];
+                exn = None;
+                terminator =
+                  { id = make_id ();
+                    desc = Always raise_label;
+                    arg = [||];
+                    res = [||]
+                  }
+              };
+              { start = raise_label;
+                body = [];
+                exn = Some handler_label;
+                terminator =
+                  { id = make_id ();
+                    desc = Raise Raise_notrace;
+                    arg = [||];
+                    res = [||]
+                  }
+              };
+              { start = handler_label;
+                body = [];
+                exn = None;
+                terminator =
+                  { id = make_id (); desc = Return; arg = [||]; res = [||] }
+              } ];
+          fun_contains_calls = true;
+          fun_ret_type = Cmm.typ_void
+        }
+      in
+      let cfg_with_infos = Cfg_desc.make_post_regalloc cfg in
+      (* Model the stack offset of the trap region: only the raise block is
+         inside it. The pass does not currently consult these offsets on this
+         CFG, but keeping them accurate protects the test if it ever does. *)
+      let cfg = Cfg_with_infos.cfg cfg_with_infos in
+      let raise_block = Cfg.get_block_exn cfg raise_label in
+      raise_block.stack_offset <- Proc.trap_frame_size_in_bytes;
+      raise_block.terminator.stack_offset <- Proc.trap_frame_size_in_bytes;
+      cfg_with_infos)
+    ~validate:(fun cfg_with_infos ->
+      try
+        let cfg_with_infos =
+          Misc.protect_refs
+            [ R (Oxcaml_flags.cfg_prologue_validate, true);
+              R (Oxcaml_flags.cfg_prologue_shrink_wrap, true) ]
+            (fun () -> Cfg_prologue.validate (Cfg_prologue.run cfg_with_infos))
+        in
+        let cfg = Cfg_with_infos.cfg cfg_with_infos in
+        let block_contains label ~f =
+          DLL.exists (Cfg.get_block_exn cfg label).body
+            ~f:(fun (instr : Cfg.basic Cfg.instruction) -> f instr.desc)
+        in
+        let is_prologue : Cfg.basic -> bool = function
+          | Prologue -> true
+          | Epilogue | Op _ | Reloadretaddr | Pushtrap _ | Poptrap _
+          | Stack_check _ ->
+            false
+        in
+        let is_epilogue : Cfg.basic -> bool = function
+          | Epilogue -> true
+          | Prologue | Op _ | Reloadretaddr | Pushtrap _ | Poptrap _
+          | Stack_check _ ->
+            false
+        in
+        Format.printf "prologue in pushtrap block: %b\n"
+          (block_contains pushtrap_label ~f:is_prologue);
+        Format.printf "prologue in trap handler: %b\n"
+          (block_contains handler_label ~f:is_prologue);
+        Format.printf "epilogue in trap handler: %b\n"
+          (block_contains handler_label ~f:is_epilogue);
+        Format.printf "epilogue in prologue-free return block: %b\n"
+          (block_contains normal_return_label ~f:is_epilogue)
+      with
+      | Misc.Fatal_error -> ()
+      | exn -> Format.printf "Unexpected exception: %s" (Printexc.to_string exn))
+    ~save:(fun cfg ->
+      let cfg_with_layout = Cfg_with_infos.cfg_with_layout cfg in
+      Cfg_with_layout.save_as_dot ~filename:"/tmp/test.dot" cfg_with_layout
+        "test-cfg";
+      Format.printf "The failing cfg was put in /tmp/test.dot\n")
+    ~exp_std:
+      "prologue in pushtrap block: true\n\
+       prologue in trap handler: false\n\
+       epilogue in trap handler: true\n\
+       epilogue in prologue-free return block: false"
+    ~exp_err:""


### PR DESCRIPTION
The current implementation rightly fails if
we try to insert a prologue inside an
exception handler, but states that a
`Push_trap` operation has no requirements.
This pull request changes the requirements
to ask for a prologue.