### PR TITLE
Improve test output normalizer.

### DIFF
--- a/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
+++ b/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
@@ -44,7 +44,9 @@ sed \
   -e '/caml_input_value_from_bytes/s|str=#\?[0-9]\{10,\}L\?|str=<PTR>|g' \
   -e '/caml_md5_string/s|str=#\?[0-9]\{5,\}L\?|str=<PTR>|g' \
   -e '/caml_sys_getenv/s|var=#\?[0-9]\{5,\}L\?|var=<PTR>|g' \
-  -e '/caml_ba_create/s|vdim=#\?[0-9]\{5,\}L\?|vdim=<PTR>|g' | \
+  -e '/caml_ba_create/s|vdim=#\?[0-9]\{5,\}L\?|vdim=<PTR>|g' \
+  -e 's|closure=#\?[0-9]\{5,\}L\?|closure=<PTR>|g' \
+  -e 's|body_callback=#\?[0-9]\{5,\}L\?|body_callback=<PTR>|g' | \
 # grep: Remove LLDB noise
 grep -v \
   -e '^(lldb) ' \

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
@@ -76,8 +76,8 @@
   * frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_callback_inner(param=0 : ocaml_value)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_start_program
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`callback(closure=<unavailable>, arg=<unavailable>)
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_callback_exn(arg=1, closure=93824994011000) [inlined]
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_with_async_exns(body_callback=93824994011000)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_callback_exn(arg=1, closure=<PTR>) [inlined]
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_with_async_exns(body_callback=<PTR>)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_c_call + N
 === Testing OCaml/C boundary - finalizer (C calls OCaml during GC) ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_my_finalizer(param=[42] : ocaml_value)


### PR DESCRIPTION
#6384 broke a test by improving LLDB: values of closures (etc) are printed. #6359 then fixed the test by promoting the output on a particular machine at a particular time. These values are very fragile to changes in (among other things) code generation, so it's better to normalize them away.

Code by Claude, reviewed by me.