### PR TITLE
Run Cfg_merge_blocks after Cfg_stack_checks

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -446,12 +446,6 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   ++ Cfg_with_infos.cfg_with_layout
   ++ pass_dump_cfg_if ppf_dump Oxcaml_flags.dump_cfg "After cfg_prologue"
   ++ Profile.record ~accumulate:true "cfg_invariants" (cfg_invariants ppf_dump)
-  ++ (fun (cfg_with_layout : Cfg_with_layout.t) ->
-  match !Oxcaml_flags.cfg_merge_blocks with
-  | false -> cfg_with_layout
-  | true ->
-    Profile.record ~accumulate:true "cfg_merge_blocks"
-      Cfg_merge_blocks.run_after_register_allocation cfg_with_layout)
   ++ cfg_with_layout_profile ~accumulate:true "cfg_simplify"
        Regalloc_utils.simplify_cfg
   ++ Profile.record ~accumulate:true "cfg_invariants" (cfg_invariants ppf_dump)
@@ -470,6 +464,14 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
     (Cfg_with_layout.cfg cfg_with_layout).allowed_to_be_irreducible <- true;
     cfg_with_layout_profile ~accumulate:true "cfg_simplify"
       Regalloc_utils.simplify_cfg cfg_with_layout)
+  ++ (fun (cfg_with_layout : Cfg_with_layout.t) ->
+  (* note: [Cfg_merge_blocks] may make the CFG irreducible, so it must be run
+     after the last pass relying on loop infos ([Cfg_stack_checks]). *)
+  match !Oxcaml_flags.cfg_merge_blocks with
+  | false -> cfg_with_layout
+  | true ->
+    Profile.record ~accumulate:true "cfg_merge_blocks"
+      Cfg_merge_blocks.run_after_register_allocation cfg_with_layout)
   ++ cfg_with_layout_profile ~accumulate:true "save_cfg" save_cfg
   ++ cfg_with_layout_profile ~accumulate:true "cfg_reorder_blocks"
        (reorder_blocks_random ppf_dump)

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -447,12 +447,6 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
   ++ Cfg_with_infos.cfg_with_layout
   ++ pass_dump_cfg_if ppf_dump Oxcaml_flags.dump_cfg "After cfg_prologue"
   ++ Profile.record ~accumulate:true "cfg_invariants" (cfg_invariants ppf_dump)
-  ++ (fun (cfg_with_layout : Cfg_with_layout.t) ->
-  match !Oxcaml_flags.cfg_merge_blocks with
-  | false -> cfg_with_layout
-  | true ->
-    Profile.record ~accumulate:true "cfg_merge_blocks"
-      Cfg_merge_blocks.run_after_register_allocation cfg_with_layout)
   ++ cfg_with_layout_profile ~accumulate:true "cfg_simplify"
        Regalloc_utils.simplify_cfg
   ++ Profile.record ~accumulate:true "cfg_invariants" (cfg_invariants ppf_dump)
@@ -471,6 +465,14 @@ let compile_cfg ppf_dump ~funcnames fd_cmm cfg_with_layout =
     (Cfg_with_layout.cfg cfg_with_layout).allowed_to_be_irreducible <- true;
     cfg_with_layout_profile ~accumulate:true "cfg_simplify"
       Regalloc_utils.simplify_cfg cfg_with_layout)
+  ++ (fun (cfg_with_layout : Cfg_with_layout.t) ->
+  (* note: [Cfg_merge_blocks] may make the CFG irreducible, so it must be run
+     after the last pass relying on loop infos ([Cfg_stack_checks]). *)
+  match !Oxcaml_flags.cfg_merge_blocks with
+  | false -> cfg_with_layout
+  | true ->
+    Profile.record ~accumulate:true "cfg_merge_blocks"
+      Cfg_merge_blocks.run_after_register_allocation cfg_with_layout)
   ++ cfg_with_layout_profile ~accumulate:true "save_cfg" save_cfg
   ++ cfg_with_layout_profile ~accumulate:true "cfg_reorder_blocks"
        (reorder_blocks_random ppf_dump)

--- a/backend/cfg/cfg_merge_blocks.mli
+++ b/backend/cfg/cfg_merge_blocks.mli
@@ -4,6 +4,9 @@
    is different from the kind of merge implemented in `Cfg_simplify`, which is
    about concatenating blocks in a straight line. *)
 
+(* CR-soon xclerc for xclerc: [run_before_register_allocation] is not used by
+   the compiler (it is currently kept only for testing purposes); it should
+   eventually be removed. *)
 val run_before_register_allocation : Cfg_with_layout.t -> Cfg_with_layout.t
 
 val run_after_register_allocation : Cfg_with_layout.t -> Cfg_with_layout.t

--- a/oxcaml/testsuite/tests/asmcomp/cfg_merge_blocks_irreducible.ml
+++ b/oxcaml/testsuite/tests/asmcomp/cfg_merge_blocks_irreducible.ml
@@ -1,0 +1,33 @@
+(* TEST
+ flags += " -cfg-merge-blocks -dcfg-invariants";
+ native;
+*)
+
+(* Regression test for [Cfg_merge_blocks] making the CFG irreducible: after
+   register allocation, the return continuations of the two [g x] calls below
+   (one in the [if], one in the loop body) become identical blocks and get
+   merged, redirecting the [if] path into the middle of the [while] loop while
+   the [else] path still enters at the loop header. The resulting CFG has no
+   dominating loop header, i.e. is irreducible, so [Cfg_merge_blocks] must run
+   after the last pass relying on loop infos ([Cfg_stack_checks]). When the
+   pass ran before stack checks, compiling this file used to fail with "Cfg
+   invariant failed: CFG is not reducible". *)
+
+let[@inline never] g r = decr r
+
+let[@inline never] f a b =
+  let x = ref a in
+  let z = ref 0 in
+  g x;
+  g z;
+  (if b then g x else incr z);
+  while !x > 0 do
+    g x
+  done;
+  !x + !z
+
+let () =
+  assert (f 5 true = -1);
+  assert (f 5 false = 0);
+  assert (f (-5) true = -8);
+  assert (f (-5) false = -6)

--- a/oxcaml/testsuite/tests/asmcomp/cfg_merge_blocks_irreducible.ml
+++ b/oxcaml/testsuite/tests/asmcomp/cfg_merge_blocks_irreducible.ml
@@ -1,0 +1,42 @@
+(* TEST
+ flags += " -O3";
+ flags += " -experimental-optimizations";
+ flags += " -dcfg-invariants";
+ only-default-codegen;
+ native;
+*)
+
+(* Regression test for [Cfg_merge_blocks] making the CFG irreducible: after
+   register allocation, the return continuations of the two [g x] calls below
+   (one in the [if], one in the loop body) become identical blocks and get
+   merged, redirecting the [if] path into the middle of the [while] loop while
+   the [else] path still enters at the loop header. The resulting CFG has no
+   dominating loop header, i.e. is irreducible, so [Cfg_merge_blocks] must run
+   after the last pass relying on loop infos ([Cfg_stack_checks]). When the
+   pass ran before stack checks, compiling this file used to fail with "Cfg
+   invariant failed: CFG is not reducible". *)
+
+(* CR-soon xclerc for xclerc: the scenario above relies on register allocation
+   assigning the same registers to both return continuations of [g x]; if a
+   future allocator or configuration makes them differ, nothing gets merged and
+   this test passes vacuously. Consider asserting that the merge actually
+   happens (e.g. by checking a dump of the pass). *)
+
+let[@inline never] g r = decr r
+
+let[@inline never] f a b =
+  let x = ref a in
+  let z = ref 0 in
+  g x;
+  g z;
+  (if b then g x else incr z);
+  while !x > 0 do
+    g x
+  done;
+  !x + !z
+
+let () =
+  assert (f 5 true = -1);
+  assert (f 5 false = 0);
+  assert (f (-5) true = -8);
+  assert (f (-5) false = -6)


### PR DESCRIPTION
Cfg_merge_blocks redirects the predecessors of a merged-away block to its surviving twin; when the twin is inside a loop whose header keeps a distinct external entry, this creates a second entry into the cycle, making the CFG irreducible. The pass previously ran while allowed_to_be_irreducible was still false on the stack-checks-enabled path (the default), so compiling such code with -cfg-merge-blocks -dcfg-invariants failed with "CFG is not reducible", and in regular builds Cfg_stack_checks could silently compute loop infos on an irreducible graph, defeating its never-put-a-check-in-a-loop heuristic (coverage was unaffected, as placement is dominator-based).

Move the pass after Cfg_stack_checks, the last pass relying on loop infos, where irreducibility is explicitly allowed on both paths. A side benefit is that the pass now runs after no-op moves are removed by the preceding simplification passes, exposing more merge candidates.

Also add a regression test exercising the previously-failing shape, and a CR-soon noting that run_before_register_allocation, which has no caller in the compiler, should eventually be removed.