### PR TITLE
Resolve link inputs' object files through manifests

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -210,7 +210,12 @@ let mk_I_manifest f =
   \    by the compiler, <actual_path> is where this file is in the\n\
   \    filesystem (relative to [$MANIFEST_FILES_ROOT]). The manifest file\n\
   \    passed to the [-I-manifest] flag should itself be relative to\n\
-  \    [$MANIFEST_FILES_ROOT]."
+  \    [$MANIFEST_FILES_ROOT]. When linking, files given on the command\n\
+  \    line by their bare names (e.g. 'foo.cmx' or 'lib.cmxa') are also\n\
+  \    resolved through manifest entries; if the entry's <actual_path> does\n\
+  \    not retain the extension, the companion object files ('foo.o',\n\
+  \    'lib.a') are resolved the same way and must therefore be listed as\n\
+  \    separate manifest entries."
 
 let mk_H_manifest f =
   "-H-manifest", Arg.String f, "<file>  Same as -I-manifest, but adds given\n\

--- a/optcomp/linkenv.ml
+++ b/optcomp/linkenv.ml
@@ -33,7 +33,10 @@ module Cmx_consistbl = Consistbl.Make (CU) (Unit)
 
 type error =
   | File_not_found of filepath
-  | Companion_object_file_not_found_via_manifest of filepath * filepath
+  | Companion_object_file_not_found_via_manifest of
+      { object_filename : filepath;
+        requested_filename : filepath
+      }
   | Not_an_object_file of filepath
   | Missing_implementations of (Compilation_unit.t * string list) list
   | Inconsistent_interface of Compilation_unit.Name.t * filepath * filepath
@@ -242,13 +245,14 @@ open Format_doc
 let report_error ppf = function
   | File_not_found name ->
     fprintf ppf "Cannot find file %a" Location.Doc.quoted_filename name
-  | Companion_object_file_not_found_via_manifest (object_file, artifact) ->
+  | Companion_object_file_not_found_via_manifest
+      { object_filename; requested_filename } ->
     fprintf ppf
       "@[<hov>Cannot find file %a,@ the object file accompanying %a:@ the \
        latter was resolved through a manifest entry (see -I-manifest),@ so its \
        object file must be listed as a separate manifest entry@]"
-      Location.Doc.quoted_filename object_file Location.Doc.quoted_filename
-      artifact
+      Location.Doc.quoted_filename object_filename Location.Doc.quoted_filename
+      requested_filename
   | Not_an_object_file name ->
     fprintf ppf "The file %a is not a compilation unit description"
       Location.Doc.quoted_filename name

--- a/optcomp/linkenv.ml
+++ b/optcomp/linkenv.ml
@@ -33,6 +33,7 @@ module Cmx_consistbl = Consistbl.Make (CU) (Unit)
 
 type error =
   | File_not_found of filepath
+  | Companion_object_file_not_found_via_manifest of filepath * filepath
   | Not_an_object_file of filepath
   | Missing_implementations of (Compilation_unit.t * string list) list
   | Inconsistent_interface of Compilation_unit.Name.t * filepath * filepath
@@ -241,6 +242,13 @@ open Format_doc
 let report_error ppf = function
   | File_not_found name ->
     fprintf ppf "Cannot find file %a" Location.Doc.quoted_filename name
+  | Companion_object_file_not_found_via_manifest (object_file, artifact) ->
+    fprintf ppf
+      "@[<hov>Cannot find file %a,@ the object file accompanying %a:@ the \
+       latter was resolved through a manifest entry (see -I-manifest),@ so its \
+       object file must be listed as a separate manifest entry@]"
+      Location.Doc.quoted_filename object_file Location.Doc.quoted_filename
+      artifact
   | Not_an_object_file name ->
     fprintf ppf "The file %a is not a compilation unit description"
       Location.Doc.quoted_filename name

--- a/optcomp/linkenv.mli
+++ b/optcomp/linkenv.mli
@@ -85,6 +85,11 @@ val check_consistency :
 
 type error =
   | File_not_found of filepath
+  (* [Companion_object_file_not_found_via_manifest (object_file, artifact)]:
+     [artifact] (a [.cmx] or [.cmxa] link input) was resolved through a manifest
+     entry (see [-I-manifest]), but its accompanying object file [object_file]
+     has no manifest entry and was not found in the load path. *)
+  | Companion_object_file_not_found_via_manifest of filepath * filepath
   | Not_an_object_file of filepath
   | Missing_implementations of (Compilation_unit.t * string list) list
   | Inconsistent_interface of Compilation_unit.Name.t * filepath * filepath

--- a/optcomp/linkenv.mli
+++ b/optcomp/linkenv.mli
@@ -85,11 +85,14 @@ val check_consistency :
 
 type error =
   | File_not_found of filepath
-  (* [Companion_object_file_not_found_via_manifest (object_file, artifact)]:
-     [artifact] (a [.cmx] or [.cmxa] link input) was resolved through a manifest
-     entry (see [-I-manifest]), but its accompanying object file [object_file]
-     has no manifest entry and was not found in the load path. *)
-  | Companion_object_file_not_found_via_manifest of filepath * filepath
+    (* The link input [requested_filename] (a [.cmx] or [.cmxa]) was resolved
+       through a manifest entry (see [-I-manifest]), but its accompanying object
+       file [object_filename] has no manifest entry and was not found in the
+       load path. *)
+  | Companion_object_file_not_found_via_manifest of
+      { object_filename : filepath;
+        requested_filename : filepath
+      }
   | Not_an_object_file of filepath
   | Missing_implementations of (Compilation_unit.t * string list) list
   | Inconsistent_interface of Compilation_unit.Name.t * filepath * filepath

--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -137,7 +137,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         Resolved_via_manifest_but_not_found_in_load_path object_filename
 
   let scan_file linkenv ~shared genfns requested_filename
-      (full_paths, objfiles, tolink, cached_genfns_imports) =
+      (full_paths, object_pathnames, tolink, cached_genfns_imports) =
     match read_file requested_filename with
     | Unit (resolved_pathname, info, crc) ->
       (* This is a cmx file. It must be linked in any case. *)
@@ -171,19 +171,19 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
           dynunit
         }
       in
-      let object_file_name =
+      let object_pathname =
         match
           find_companion_object_file ~requested_filename ~resolved_pathname
             ~artifact_ext:Backend.ext_flambda_obj ~object_ext:Backend.ext_obj
         with
-        | Adjacent object_file
-        | Resolved_via_manifest_and_found_in_load_path object_file ->
-          object_file
+        | Adjacent object_pathname
+        | Resolved_via_manifest_and_found_in_load_path object_pathname ->
+          object_pathname
         | Resolved_via_manifest_but_not_found_in_load_path object_filename ->
           raise
             (Linkenv.Error
                (Companion_object_file_not_found_via_manifest
-                  (object_filename, requested_filename)))
+                  { object_filename; requested_filename }))
       in
       Profile.record_call ~accumulate:true "link/scan/check_consistency"
         (fun () ->
@@ -202,7 +202,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
           (Linkenv.Error
              (Requires_metaprogramming_without_flag resolved_pathname));
       ( resolved_pathname :: full_paths,
-        object_file_name :: objfiles,
+        object_pathname :: object_pathnames,
         unit :: tolink,
         cached_genfns_imports )
     | Library (resolved_pathname, infos) ->
@@ -224,39 +224,42 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         raise
           (Linkenv.Error
              (Requires_metaprogramming_without_flag resolved_pathname));
-      let objfiles =
+      let object_pathnames =
         match
           find_companion_object_file ~requested_filename ~resolved_pathname
             ~artifact_ext:Backend.ext_flambda_lib ~object_ext:Backend.ext_lib
         with
-        | Adjacent obj_file ->
+        | Adjacent object_pathname ->
           (* MSVC doesn't support empty .lib files, and macOS struggles to make
              them (#6550), so there shouldn't be one if the cmxa contains no
              units. The file_exists check is added to be ultra-defensive for the
              case where a user has manually added things to the .a/.lib file *)
-          if List.is_empty infos.lib_units && not (Sys.file_exists obj_file)
-          then objfiles
-          else obj_file :: objfiles
-        | Resolved_via_manifest_and_found_in_load_path obj_file ->
-          obj_file :: objfiles
+          if
+            List.is_empty infos.lib_units
+            && not (Sys.file_exists object_pathname)
+          then object_pathnames
+          else object_pathname :: object_pathnames
+        | Resolved_via_manifest_and_found_in_load_path object_pathname ->
+          object_pathname :: object_pathnames
         | Resolved_via_manifest_but_not_found_in_load_path object_filename ->
           (* The archive was resolved through a manifest with no entry for the
              corresponding [.a]/[.lib] file. This is only legitimate when the
              archive contains no units (see the comment above about empty .lib
              files). *)
           if List.is_empty infos.lib_units
-          then objfiles
+          then object_pathnames
           else
             raise
               (Linkenv.Error
                  (Companion_object_file_not_found_via_manifest
-                    (object_filename, requested_filename)))
+                    { object_filename; requested_filename }))
       in
-      (* [resolved_pathname] is always returned irrespective of the [objfiles]
-         calculation above and the units calculation below: the aim is to know
-         the full set of files which were provided on the command line. *)
+      (* [resolved_pathname] is always returned irrespective of the
+         [object_pathnames] calculation above and the units calculation below:
+         the aim is to know the full set of files which were provided on the
+         command line. *)
       ( resolved_pathname :: full_paths,
-        objfiles,
+        object_pathnames,
         List.fold_right
           (fun info reqd ->
             let li_name = CU.name info.li_name in

--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -55,18 +55,21 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
     | Library of string * library_infos
 
   (* CR mshinwell: This should not be raising errors from [Linkenv] *)
-  let read_file obj_name =
-    let file_name =
-      try Load_path.find obj_name
-      with Not_found -> raise (Linkenv.Error (File_not_found obj_name))
+  let read_file requested_filename =
+    let resolved_pathname =
+      try Load_path.find requested_filename
+      with Not_found ->
+        raise (Linkenv.Error (File_not_found requested_filename))
     in
-    (* The kind of a link input is normally determined by the extension of the
-       resolved path [file_name]. However, when [obj_name] is resolved through a
-       manifest entry (see [-I-manifest]), the resolved path need not retain the
-       extension (manifests may map filenames to e.g. content-addressed paths),
-       so we also consult the extension of the requested name [obj_name]. *)
+    (* The kind of a link input is normally determined by the extension of
+       [resolved_pathname]. However, when [requested_filename] is resolved
+       through a manifest entry (see [-I-manifest]), the resolved path need not
+       retain the extension (manifests may map filenames to e.g.
+       content-addressed paths), so we also consult the extension of
+       [requested_filename]. *)
     let has_suffix ext =
-      Filename.check_suffix file_name ext || Filename.check_suffix obj_name ext
+      Filename.check_suffix resolved_pathname ext
+      || Filename.check_suffix requested_filename ext
     in
     if has_suffix Backend.ext_flambda_obj
     then
@@ -74,68 +77,76 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
          see which modules it requires. *)
       let info, crc =
         Profile.record_call ~accumulate:true "link/scan/read_cmx" (fun () ->
-            read_unit_info file_name)
+            read_unit_info resolved_pathname)
       in
-      Unit (file_name, info, crc)
+      Unit (resolved_pathname, info, crc)
     else if has_suffix Backend.ext_flambda_lib
     then
       let infos =
         try
           Profile.record_call ~accumulate:true "link/scan/read_cmxa" (fun () ->
-              read_library_info file_name)
+              read_library_info resolved_pathname)
         with Compilenv.Error (Not_a_unit_info filename) ->
           raise (Linkenv.Error (Not_an_object_file filename))
       in
-      Library (file_name, infos)
-    else raise (Linkenv.Error (Not_an_object_file file_name))
+      Library (resolved_pathname, infos)
+    else raise (Linkenv.Error (Not_an_object_file resolved_pathname))
 
-  (* The result of [find_companion_object_file], below. [Adjacent] and
-     [Found_in_load_path] carry the object file's path: the former is obtained
-     by replacing the artifact extension in the artifact's resolved path, the
-     latter by resolving the object file's name through the load path.
-     [Not_found_in_load_path] carries the object file's name, which could not be
-     resolved. *)
+  (* The result of [find_companion_object_file], below. [Adjacent] carries the
+     object file's path, obtained by replacing the artifact extension in the
+     artifact's resolved path. The [Resolved_via_manifest_*] cases arise when
+     the artifact's resolved path does not retain the artifact extension, which
+     only happens when the artifact was resolved through a manifest entry (see
+     [-I-manifest]); the object file is then resolved through the load path
+     itself, yielding its path if found, or the searched-for filename if not. *)
   type companion_object_file =
-    | Adjacent of string
-    | Found_in_load_path of string
-    | Not_found_in_load_path of string
+    | Adjacent of Misc.filepath
+    | Resolved_via_manifest_and_found_in_load_path of Misc.filepath
+    | Resolved_via_manifest_but_not_found_in_load_path of Misc.filepath
 
   (* Locate the object file ([.o] or [.a]/[.lib]) that accompanies a compilation
      artifact ([.cmx] or [.cmxa]).
 
      Normally the object file sits next to the artifact, and we obtain its path
      by replacing the artifact extension in the artifact's resolved path
-     [resolved_name].
+     [resolved_pathname].
 
      However, when the artifact was resolved through a manifest entry (see
      [-I-manifest]), its resolved path need not retain the extension, and the
      object file need not sit next to it. In that case we form the object file's
-     name from the name the artifact was requested under ([requested_name],
+     name from the name the artifact was requested under ([requested_filename],
      which must then carry the artifact extension, since [read_file] dispatched
      on it) and resolve that name through the load path. In other words,
      manifests must list the object files as separate entries. *)
-  let find_companion_object_file ~requested_name ~resolved_name ~artifact_ext
-      ~object_ext =
-    if Filename.check_suffix resolved_name artifact_ext
-    then Adjacent (Filename.chop_suffix resolved_name artifact_ext ^ object_ext)
-    else
-      let object_name =
-        Filename.chop_suffix requested_name artifact_ext ^ object_ext
+  let find_companion_object_file ~requested_filename ~resolved_pathname
+      ~artifact_ext ~object_ext =
+    if Filename.check_suffix resolved_pathname artifact_ext
+    then
+      let object_pathname =
+        Filename.chop_suffix resolved_pathname artifact_ext ^ object_ext
       in
-      match Load_path.find object_name with
-      | object_path -> Found_in_load_path object_path
-      | exception Not_found -> Not_found_in_load_path object_name
+      Adjacent object_pathname
+    else
+      let object_filename =
+        Filename.chop_suffix requested_filename artifact_ext ^ object_ext
+      in
+      match Load_path.find object_filename with
+      | object_pathname ->
+        Resolved_via_manifest_and_found_in_load_path object_pathname
+      | exception Not_found ->
+        Resolved_via_manifest_but_not_found_in_load_path object_filename
 
-  let scan_file linkenv ~shared genfns file
+  let scan_file linkenv ~shared genfns requested_filename
       (full_paths, objfiles, tolink, cached_genfns_imports) =
-    match read_file file with
-    | Unit (file_name, info, crc) ->
+    match read_file requested_filename with
+    | Unit (resolved_pathname, info, crc) ->
       (* This is a cmx file. It must be linked in any case. *)
       Linkenv.remove_required linkenv info.ui_unit;
       Linkenv.add_quoted_cmi linkenv info.ui_quoted_cmi;
       Linkenv.add_quoted_cmx linkenv info.ui_quoted_cmx;
       List.iter
-        (fun import -> Linkenv.add_required linkenv (file_name, None) import)
+        (fun import ->
+          Linkenv.add_required linkenv (resolved_pathname, None) import)
         info.ui_imports_cmx;
       let dynunit : Cmxs_format.dynunit option =
         if not shared
@@ -155,20 +166,24 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         { name = info.ui_unit;
           crc;
           defines = info.ui_defines;
-          file_name;
+          file_name = resolved_pathname;
           imports_cmx = info.ui_imports_cmx;
           dynunit
         }
       in
       let object_file_name =
         match
-          find_companion_object_file ~requested_name:file
-            ~resolved_name:file_name ~artifact_ext:Backend.ext_flambda_obj
-            ~object_ext:Backend.ext_obj
+          find_companion_object_file ~requested_filename ~resolved_pathname
+            ~artifact_ext:Backend.ext_flambda_obj ~object_ext:Backend.ext_obj
         with
-        | Adjacent object_file | Found_in_load_path object_file -> object_file
-        | Not_found_in_load_path object_name ->
-          raise (Linkenv.Error (File_not_found object_name))
+        | Adjacent object_file
+        | Resolved_via_manifest_and_found_in_load_path object_file ->
+          object_file
+        | Resolved_via_manifest_but_not_found_in_load_path object_filename ->
+          raise
+            (Linkenv.Error
+               (Companion_object_file_not_found_via_manifest
+                  (object_filename, requested_filename)))
       in
       Profile.record_call ~accumulate:true "link/scan/check_consistency"
         (fun () ->
@@ -183,54 +198,64 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         (not shared) && info.ui_requires_metaprogramming
         && not !Clflags.uses_metaprogramming
       then
-        raise (Linkenv.Error (Requires_metaprogramming_without_flag file_name));
-      ( file_name :: full_paths,
+        raise
+          (Linkenv.Error
+             (Requires_metaprogramming_without_flag resolved_pathname));
+      ( resolved_pathname :: full_paths,
         object_file_name :: objfiles,
         unit :: tolink,
         cached_genfns_imports )
-    | Library (file_name, infos) ->
+    | Library (resolved_pathname, infos) ->
       (* This is an archive file. Each unit contained in it will be linked in
          only if needed. *)
-      Linkenv.add_ccobjs linkenv (Filename.dirname file_name) infos;
+      Linkenv.add_ccobjs linkenv (Filename.dirname resolved_pathname) infos;
       let cached_genfns_imports =
         Generic_fns.Tbl.add ~imports:cached_genfns_imports genfns
           infos.lib_generic_fns
       in
-      Linkenv.check_cmi_consistency linkenv file_name infos.lib_imports_cmi;
-      Linkenv.check_cmx_consistency linkenv file_name infos.lib_imports_cmx;
+      Linkenv.check_cmi_consistency linkenv resolved_pathname
+        infos.lib_imports_cmi;
+      Linkenv.check_cmx_consistency linkenv resolved_pathname
+        infos.lib_imports_cmx;
       if
         (not shared) && infos.lib_requires_metaprogramming
         && not !Clflags.uses_metaprogramming
       then
-        raise (Linkenv.Error (Requires_metaprogramming_without_flag file_name));
+        raise
+          (Linkenv.Error
+             (Requires_metaprogramming_without_flag resolved_pathname));
       let objfiles =
         match
-          find_companion_object_file ~requested_name:file
-            ~resolved_name:file_name ~artifact_ext:Backend.ext_flambda_lib
-            ~object_ext:Backend.ext_lib
+          find_companion_object_file ~requested_filename ~resolved_pathname
+            ~artifact_ext:Backend.ext_flambda_lib ~object_ext:Backend.ext_lib
         with
         | Adjacent obj_file ->
           (* MSVC doesn't support empty .lib files, and macOS struggles to make
              them (#6550), so there shouldn't be one if the cmxa contains no
              units. The file_exists check is added to be ultra-defensive for the
              case where a user has manually added things to the .a/.lib file *)
-          if infos.lib_units = [] && not (Sys.file_exists obj_file)
+          if List.is_empty infos.lib_units && not (Sys.file_exists obj_file)
           then objfiles
           else obj_file :: objfiles
-        | Found_in_load_path obj_file -> obj_file :: objfiles
-        | Not_found_in_load_path obj_name ->
+        | Resolved_via_manifest_and_found_in_load_path obj_file ->
+          obj_file :: objfiles
+        | Resolved_via_manifest_but_not_found_in_load_path object_filename ->
           (* The archive was resolved through a manifest with no entry for the
              corresponding [.a]/[.lib] file. This is only legitimate when the
              archive contains no units (see the comment above about empty .lib
              files). *)
-          if infos.lib_units = []
+          if List.is_empty infos.lib_units
           then objfiles
-          else raise (Linkenv.Error (File_not_found obj_name))
+          else
+            raise
+              (Linkenv.Error
+                 (Companion_object_file_not_found_via_manifest
+                    (object_filename, requested_filename)))
       in
-      (* [file_name] is always returned irrespective of the [objfiles]
+      (* [resolved_pathname] is always returned irrespective of the [objfiles]
          calculation above and the units calculation below: the aim is to know
          the full set of files which were provided on the command line. *)
-      ( file_name :: full_paths,
+      ( resolved_pathname :: full_paths,
         objfiles,
         List.fold_right
           (fun info reqd ->
@@ -240,7 +265,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
               || Linkenv.is_required linkenv info.li_name
             then (
               Linkenv.remove_required linkenv info.li_name;
-              let req_by = file_name, Some li_name in
+              let req_by = resolved_pathname, Some li_name in
               info.li_imports_cmx
               |> Misc.Bitmap.iter (fun i ->
                   let import = infos.lib_imports_cmx.(i) in
@@ -283,7 +308,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
                 { name = info.li_name;
                   crc = info.li_crc;
                   defines = info.li_defines;
-                  file_name;
+                  file_name = resolved_pathname;
                   imports_cmx;
                   dynunit
                 }

--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -89,15 +89,16 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
       Library (file_name, infos)
     else raise (Linkenv.Error (Not_an_object_file file_name))
 
-  (* The result of [find_companion_object_file], below. *)
+  (* The result of [find_companion_object_file], below. [Adjacent] and
+     [Found_in_load_path] carry the object file's path: the former is obtained
+     by replacing the artifact extension in the artifact's resolved path, the
+     latter by resolving the object file's name through the load path.
+     [Not_found_in_load_path] carries the object file's name, which could not be
+     resolved. *)
   type companion_object_file =
     | Adjacent of string
-        (* The object file's path, obtained by replacing the artifact extension
-           in the artifact's resolved path. *)
     | Found_in_load_path of string
-        (* The object file's path, as resolved through the load path. *)
     | Not_found_in_load_path of string
-        (* The object file's name, which could not be resolved. *)
 
   (* Locate the object file ([.o] or [.a]/[.lib]) that accompanies a compilation
      artifact ([.cmx] or [.cmxa]).
@@ -116,8 +117,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
   let find_companion_object_file ~requested_name ~resolved_name ~artifact_ext
       ~object_ext =
     if Filename.check_suffix resolved_name artifact_ext
-    then
-      Adjacent (Filename.chop_suffix resolved_name artifact_ext ^ object_ext)
+    then Adjacent (Filename.chop_suffix resolved_name artifact_ext ^ object_ext)
     else
       let object_name =
         Filename.chop_suffix requested_name artifact_ext ^ object_ext

--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -89,6 +89,16 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
       Library (file_name, infos)
     else raise (Linkenv.Error (Not_an_object_file file_name))
 
+  (* The result of [find_companion_object_file], below. *)
+  type companion_object_file =
+    | Adjacent of string
+        (* The object file's path, obtained by replacing the artifact extension
+           in the artifact's resolved path. *)
+    | Found_in_load_path of string
+        (* The object file's path, as resolved through the load path. *)
+    | Not_found_in_load_path of string
+        (* The object file's name, which could not be resolved. *)
+
   (* Locate the object file ([.o] or [.a]/[.lib]) that accompanies a compilation
      artifact ([.cmx] or [.cmxa]).
 
@@ -106,14 +116,15 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
   let find_companion_object_file ~requested_name ~resolved_name ~artifact_ext
       ~object_ext =
     if Filename.check_suffix resolved_name artifact_ext
-    then `Adjacent (Filename.chop_suffix resolved_name artifact_ext ^ object_ext)
+    then
+      Adjacent (Filename.chop_suffix resolved_name artifact_ext ^ object_ext)
     else
       let object_name =
         Filename.chop_suffix requested_name artifact_ext ^ object_ext
       in
       match Load_path.find object_name with
-      | object_path -> `Found_in_load_path object_path
-      | exception Not_found -> `Not_found object_name
+      | object_path -> Found_in_load_path object_path
+      | exception Not_found -> Not_found_in_load_path object_name
 
   let scan_file linkenv ~shared genfns file
       (full_paths, objfiles, tolink, cached_genfns_imports) =
@@ -155,8 +166,8 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
             ~resolved_name:file_name ~artifact_ext:Backend.ext_flambda_obj
             ~object_ext:Backend.ext_obj
         with
-        | `Adjacent object_file | `Found_in_load_path object_file -> object_file
-        | `Not_found object_name ->
+        | Adjacent object_file | Found_in_load_path object_file -> object_file
+        | Not_found_in_load_path object_name ->
           raise (Linkenv.Error (File_not_found object_name))
       in
       Profile.record_call ~accumulate:true "link/scan/check_consistency"
@@ -198,7 +209,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
             ~resolved_name:file_name ~artifact_ext:Backend.ext_flambda_lib
             ~object_ext:Backend.ext_lib
         with
-        | `Adjacent obj_file ->
+        | Adjacent obj_file ->
           (* MSVC doesn't support empty .lib files, and macOS struggles to make
              them (#6550), so there shouldn't be one if the cmxa contains no
              units. The file_exists check is added to be ultra-defensive for the
@@ -206,8 +217,8 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
           if infos.lib_units = [] && not (Sys.file_exists obj_file)
           then objfiles
           else obj_file :: objfiles
-        | `Found_in_load_path obj_file -> obj_file :: objfiles
-        | `Not_found obj_name ->
+        | Found_in_load_path obj_file -> obj_file :: objfiles
+        | Not_found_in_load_path obj_name ->
           (* The archive was resolved through a manifest with no entry for the
              corresponding [.a]/[.lib] file. This is only legitimate when the
              archive contains no units (see the comment above about empty .lib

--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -60,7 +60,15 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
       try Load_path.find obj_name
       with Not_found -> raise (Linkenv.Error (File_not_found obj_name))
     in
-    if Filename.check_suffix file_name Backend.ext_flambda_obj
+    (* The kind of a link input is normally determined by the extension of the
+       resolved path [file_name]. However, when [obj_name] is resolved through a
+       manifest entry (see [-I-manifest]), the resolved path need not retain the
+       extension (manifests may map filenames to e.g. content-addressed paths),
+       so we also consult the extension of the requested name [obj_name]. *)
+    let has_suffix ext =
+      Filename.check_suffix file_name ext || Filename.check_suffix obj_name ext
+    in
+    if has_suffix Backend.ext_flambda_obj
     then
       (* This is a cmx file. It must be linked in any case. Read the infos to
          see which modules it requires. *)
@@ -69,7 +77,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
             read_unit_info file_name)
       in
       Unit (file_name, info, crc)
-    else if Filename.check_suffix file_name Backend.ext_flambda_lib
+    else if has_suffix Backend.ext_flambda_lib
     then
       let infos =
         try
@@ -80,6 +88,32 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
       in
       Library (file_name, infos)
     else raise (Linkenv.Error (Not_an_object_file file_name))
+
+  (* Locate the object file ([.o] or [.a]/[.lib]) that accompanies a compilation
+     artifact ([.cmx] or [.cmxa]).
+
+     Normally the object file sits next to the artifact, and we obtain its path
+     by replacing the artifact extension in the artifact's resolved path
+     [resolved_name].
+
+     However, when the artifact was resolved through a manifest entry (see
+     [-I-manifest]), its resolved path need not retain the extension, and the
+     object file need not sit next to it. In that case we form the object file's
+     name from the name the artifact was requested under ([requested_name],
+     which must then carry the artifact extension, since [read_file] dispatched
+     on it) and resolve that name through the load path. In other words,
+     manifests must list the object files as separate entries. *)
+  let find_companion_object_file ~requested_name ~resolved_name ~artifact_ext
+      ~object_ext =
+    if Filename.check_suffix resolved_name artifact_ext
+    then `Adjacent (Filename.chop_suffix resolved_name artifact_ext ^ object_ext)
+    else
+      let object_name =
+        Filename.chop_suffix requested_name artifact_ext ^ object_ext
+      in
+      match Load_path.find object_name with
+      | object_path -> `Found_in_load_path object_path
+      | exception Not_found -> `Not_found object_name
 
   let scan_file linkenv ~shared genfns file
       (full_paths, objfiles, tolink, cached_genfns_imports) =
@@ -116,7 +150,14 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         }
       in
       let object_file_name =
-        Filename.chop_suffix file_name Backend.ext_flambda_obj ^ Backend.ext_obj
+        match
+          find_companion_object_file ~requested_name:file
+            ~resolved_name:file_name ~artifact_ext:Backend.ext_flambda_obj
+            ~object_ext:Backend.ext_obj
+        with
+        | `Adjacent object_file | `Found_in_load_path object_file -> object_file
+        | `Not_found object_name ->
+          raise (Linkenv.Error (File_not_found object_name))
       in
       Profile.record_call ~accumulate:true "link/scan/check_consistency"
         (fun () ->
@@ -152,17 +193,28 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
       then
         raise (Linkenv.Error (Requires_metaprogramming_without_flag file_name));
       let objfiles =
-        let obj_file =
-          Filename.chop_suffix file_name Backend.ext_flambda_lib
-          ^ Backend.ext_lib
-        in
-        (* MSVC doesn't support empty .lib files, and macOS struggles to make
-           them (#6550), so there shouldn't be one if the cmxa contains no
-           units. The file_exists check is added to be ultra-defensive for the
-           case where a user has manually added things to the .a/.lib file *)
-        if infos.lib_units = [] && not (Sys.file_exists obj_file)
-        then objfiles
-        else obj_file :: objfiles
+        match
+          find_companion_object_file ~requested_name:file
+            ~resolved_name:file_name ~artifact_ext:Backend.ext_flambda_lib
+            ~object_ext:Backend.ext_lib
+        with
+        | `Adjacent obj_file ->
+          (* MSVC doesn't support empty .lib files, and macOS struggles to make
+             them (#6550), so there shouldn't be one if the cmxa contains no
+             units. The file_exists check is added to be ultra-defensive for the
+             case where a user has manually added things to the .a/.lib file *)
+          if infos.lib_units = [] && not (Sys.file_exists obj_file)
+          then objfiles
+          else obj_file :: objfiles
+        | `Found_in_load_path obj_file -> obj_file :: objfiles
+        | `Not_found obj_name ->
+          (* The archive was resolved through a manifest with no entry for the
+             corresponding [.a]/[.lib] file. This is only legitimate when the
+             archive contains no units (see the comment above about empty .lib
+             files). *)
+          if infos.lib_units = []
+          then objfiles
+          else raise (Linkenv.Error (File_not_found obj_name))
       in
       (* [file_name] is always returned irrespective of the [objfiles]
          calculation above and the units calculation below: the aim is to know

--- a/testsuite/tests/manifests-link/helper.ml
+++ b/testsuite/tests/manifests-link/helper.ml
@@ -1,0 +1,1 @@
+let greeting () = "hello from manifest-linked module"

--- a/testsuite/tests/manifests-link/lib_a.ml
+++ b/testsuite/tests/manifests-link/lib_a.ml
@@ -1,0 +1,1 @@
+let name = "lib_a"

--- a/testsuite/tests/manifests-link/lib_b.ml
+++ b/testsuite/tests/manifests-link/lib_b.ml
@@ -1,0 +1,1 @@
+let name = "lib_b"

--- a/testsuite/tests/manifests-link/link.sh
+++ b/testsuite/tests/manifests-link/link.sh
@@ -85,4 +85,9 @@ if [ "$EXT" = "cmx" ]; then
     cat negative.err >&2
     exit 1
   fi
+  if ! grep -q "manifest" negative.err; then
+    echo "ERROR: expected the error to mention manifests, got:" >&2
+    cat negative.err >&2
+    exit 1
+  fi
 fi

--- a/testsuite/tests/manifests-link/link.sh
+++ b/testsuite/tests/manifests-link/link.sh
@@ -6,7 +6,7 @@
 # Arguments: $1=build_dir $2=ocamlrun $3=compiler $4=stdlib $5=runtime_dir
 #            $6=ext (cmx or cmo) $7...=extra flags (optional)
 
-set -e
+set -eu
 
 BUILD_DIR="$1"
 OCAMLRUN="$2"

--- a/testsuite/tests/manifests-link/link.sh
+++ b/testsuite/tests/manifests-link/link.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Link a program whose inputs are resolved through a manifest file
+# (see -I-manifest), simulating a content-addressed store: artifacts are
+# stored under extensionless blob names and referenced by manifest entries.
+#
+# Arguments: $1=build_dir $2=ocamlrun $3=compiler $4=stdlib $5=runtime_dir
+#            $6=ext (cmx or cmo) $7...=extra flags (optional)
+
+set -e
+
+BUILD_DIR="$1"
+OCAMLRUN="$2"
+COMPILER="$3"
+STDLIB="$4"
+RUNTIME_DIR="$5"
+EXT="$6"
+shift 6
+
+cd "$BUILD_DIR"
+
+if [ "$EXT" = "cmx" ]; then LIBEXT=cmxa; else LIBEXT=cma; fi
+
+compile () {
+  "$OCAMLRUN" "$COMPILER" -nostdlib -I "$STDLIB" -I "$RUNTIME_DIR" "$@"
+}
+
+# A regular archive with two units, and an empty archive (no units).
+compile -a -o mylib.$LIBEXT lib_a.$EXT lib_b.$EXT
+compile -a -o empty.$LIBEXT
+
+# Move the artifacts into a simulated content-addressed store, under
+# extensionless blob names, so that:
+#  - lookups cannot accidentally be satisfied by the current directory;
+#  - file-type dispatch and companion-object ('.o'/'.a') resolution must use
+#    the requested (logical) name, not the resolved path.
+mkdir -p cas
+mv helper.$EXT cas/blob_helper
+mv link_manifest.$EXT cas/blob_main
+mv mylib.$LIBEXT cas/blob_mylib
+mv empty.$LIBEXT cas/blob_empty
+
+cat > manifest.txt <<EOF
+file helper.$EXT cas/blob_helper
+file link_manifest.$EXT cas/blob_main
+file mylib.$LIBEXT cas/blob_mylib
+file empty.$LIBEXT cas/blob_empty
+EOF
+
+if [ "$EXT" = "cmx" ]; then
+  # Native: '.o'/'.a' companions become separate store entries. The empty
+  # archive deliberately has no '.a' entry (there may not even be a '.a' file
+  # for an archive with no units).
+  mv helper.o cas/blob_helper_o
+  mv link_manifest.o cas/blob_main_o
+  mv mylib.a cas/blob_mylib_a
+  rm -f empty.a
+  cat >> manifest.txt <<EOF
+file helper.o cas/blob_helper_o
+file link_manifest.o cas/blob_main_o
+file mylib.a cas/blob_mylib_a
+EOF
+fi
+
+# Link by bare (logical) names: every input below is resolved through the
+# manifest. The empty archive exercises the missing-'.a'-is-fine case.
+MANIFEST_FILES_ROOT="$BUILD_DIR"
+export MANIFEST_FILES_ROOT
+
+compile "$@" -I-manifest manifest.txt \
+  helper.$EXT mylib.$LIBEXT empty.$LIBEXT link_manifest.$EXT \
+  -o link_manifest.exe
+
+if [ "$EXT" = "cmx" ]; then
+  # Negative test: dropping the '.a' entry of a non-empty archive must fail,
+  # mentioning the missing file.
+  grep -v "^file mylib\.a " manifest.txt > manifest_no_a.txt
+  if compile "$@" -I-manifest manifest_no_a.txt \
+       helper.$EXT mylib.$LIBEXT empty.$LIBEXT link_manifest.$EXT \
+       -o should_fail.exe 2> negative.err; then
+    echo "ERROR: link unexpectedly succeeded without a mylib.a entry" >&2
+    exit 1
+  fi
+  if ! grep -q "mylib\.a" negative.err; then
+    echo "ERROR: expected the error to mention mylib.a, got:" >&2
+    cat negative.err >&2
+    exit 1
+  fi
+fi

--- a/testsuite/tests/manifests-link/link_manifest.ml
+++ b/testsuite/tests/manifests-link/link_manifest.ml
@@ -1,15 +1,3 @@
-(* Test that link inputs given by their bare names ('foo.cmx', 'lib.cmxa') are
-   resolved through manifest files (-I-manifest), including when the manifest
-   maps them to content-addressed paths that do not retain the extension. In
-   that case the companion object files ('foo.o', 'lib.a') must be listed as
-   separate manifest entries and are resolved through the load path too.
-
-   See link.sh for the details: it moves all compilation artifacts into a
-   simulated content-addressed store (extensionless blob names), writes a
-   manifest, and links the program by bare names only. It also checks that a
-   missing '.a' entry is an error for a non-empty archive, and is accepted for
-   an empty archive. *)
-
 (* TEST
  readonly_files = "helper.ml lib_a.ml lib_b.ml link.sh";
  {
@@ -54,6 +42,18 @@
    check-program-output;
  }
 *)
+
+(* Test that link inputs given by their bare names ('foo.cmx', 'lib.cmxa') are
+   resolved through manifest files (-I-manifest), including when the manifest
+   maps them to content-addressed paths that do not retain the extension. In
+   that case the companion object files ('foo.o', 'lib.a') must be listed as
+   separate manifest entries and are resolved through the load path too.
+
+   See link.sh for the details: it moves all compilation artifacts into a
+   simulated content-addressed store (extensionless blob names), writes a
+   manifest, and links the program by bare names only. It also checks that a
+   missing '.a' entry is an error for a non-empty archive, and is accepted for
+   an empty archive. *)
 
 let () =
   print_endline (Helper.greeting ());

--- a/testsuite/tests/manifests-link/link_manifest.ml
+++ b/testsuite/tests/manifests-link/link_manifest.ml
@@ -1,0 +1,60 @@
+(* Test that link inputs given by their bare names ('foo.cmx', 'lib.cmxa') are
+   resolved through manifest files (-I-manifest), including when the manifest
+   maps them to content-addressed paths that do not retain the extension. In
+   that case the companion object files ('foo.o', 'lib.a') must be listed as
+   separate manifest entries and are resolved through the load path too.
+
+   See link.sh for the details: it moves all compilation artifacts into a
+   simulated content-addressed store (extensionless blob names), writes a
+   manifest, and links the program by bare names only. It also checks that a
+   missing '.a' entry is an error for a non-empty archive, and is accepted for
+   an empty archive. *)
+
+(* TEST
+ readonly_files = "helper.ml lib_a.ml lib_b.ml link.sh";
+ {
+   setup-ocamlopt.byte-build-env;
+   module = "helper.ml";
+   ocamlopt.byte;
+   module = "lib_a.ml";
+   ocamlopt.byte;
+   module = "lib_b.ml";
+   ocamlopt.byte;
+   module = "link_manifest.ml";
+   flags = "-c";
+   ocamlopt.byte;
+   script = "sh ${test_source_directory}/link.sh \
+     ${test_build_directory} ${ocamlrun} ${ocamlopt_byte} \
+     ${ocamlsrcdir}/stdlib ${ocamlsrcdir}/${runtime_dir} \
+     cmx";
+   output = "${compiler_output}";
+   script;
+   program = "${test_build_directory}/link_manifest.exe";
+   run;
+   check-program-output;
+ }{
+   setup-ocamlc.byte-build-env;
+   module = "helper.ml";
+   ocamlc.byte;
+   module = "lib_a.ml";
+   ocamlc.byte;
+   module = "lib_b.ml";
+   ocamlc.byte;
+   module = "link_manifest.ml";
+   flags = "-c";
+   ocamlc.byte;
+   script = "sh ${test_source_directory}/link.sh \
+     ${test_build_directory} ${ocamlrun} ${ocamlc_byte} \
+     ${ocamlsrcdir}/stdlib ${ocamlsrcdir}/${runtime_dir} \
+     cmo -use-runtime ${ocamlrun}";
+   output = "${compiler_output}";
+   script;
+   program = "${test_build_directory}/link_manifest.exe";
+   run;
+   check-program-output;
+ }
+*)
+
+let () =
+  print_endline (Helper.greeting ());
+  Printf.printf "archive units: %s %s\n" Lib_a.name Lib_b.name

--- a/testsuite/tests/manifests-link/link_manifest.reference
+++ b/testsuite/tests/manifests-link/link_manifest.reference
@@ -1,0 +1,2 @@
+hello from manifest-linked module
+archive units: lib_a lib_b


### PR DESCRIPTION
Bare-name link inputs (e.g. `foo.cmx`, `lib.cmxa`) already resolve through manifest entries (see `-I-manifest`), but linking fails when the entry's target path doesn't retain the extension: the input's kind is dispatched on the resolved path, and companion object files (`foo.o`, `lib.a`) are assumed to sit next to it. This PR dispatches on the requested name as a fallback and resolves companions through the load path (i.e. via separate manifest entries), allowing build systems to link executables directly from a content-addressed artifact store. Non-manifest linking is unchanged.

The `-dissector` pass needs a companion fix for such paths: #6501.