### PR TITLE
Add codegen test exhibiting missing polls in loops that only allocate locally & apply fix

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -482,6 +482,25 @@ let is_alloc (instr : basic instruction) =
       | Specific _ | Name_for_debugger _ ) ->
     false
 
+let is_heap_alloc (instr : basic instruction) =
+  match instr.desc with
+  | Op (Alloc { mode = Heap; bytes = _; dbginfo = _ }) -> true
+  | Reloadretaddr | Prologue | Epilogue | Pushtrap _ | Poptrap _ | Stack_check _
+  | Op
+      ( Alloc { mode = Local; bytes = _; dbginfo = _ }
+      | Poll | Move | Spill | Reload | Opaque | Begin_region | End_region
+      | Dls_get | Tls_get | Domain_index | Pause | Const_int _ | Const_float32 _
+      | Const_float _ | Const_symbol _ | Const_vec128 _ | Const_vec256 _
+      | Const_vec512 _ | Stackoffset _ | Load _
+      | Store (_, _, _)
+      | Intop _ | Int128op _
+      | Intop_imm (_, _)
+      | Intop_atomic _
+      | Floatop (_, _)
+      | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
+      | Specific _ | Name_for_debugger _ ) ->
+    false
+
 let is_end_region (b : basic) =
   match b with
   | Op End_region -> true

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -208,6 +208,8 @@ val is_noop_move : basic instruction -> bool
 
 val is_alloc : basic instruction -> bool
 
+val is_heap_alloc : basic instruction -> bool
+
 val is_poll : basic instruction -> bool
 
 val is_end_region : basic -> bool

--- a/backend/cfg/cfg_polling.ml
+++ b/backend/cfg/cfg_polling.ml
@@ -27,7 +27,8 @@ exception Error of error
 
 (* "Might_not_poll" means there exists a path from the function entry to a
    Potentially Recursive Tail Call (an Itailcall_ind or Itailcall_imm to a
-   forward function) that does not go through an Ialloc or Ipoll instruction.
+   forward function) that does not go through an Ialloc (heap allocation) or
+   Ipoll instruction.
 
    "Always_polls", therefore, means the function always polls (via Ialloc or
    Ipoll) before doing a PRTC. *)
@@ -114,15 +115,16 @@ let () =
     | _ -> None)
 
 (* Compututation of the "safe" map, which is a map from labels to booleans where
-   `true` indicates the block contains a safe point such as a poll or an alloc
-   instruction. *)
+   `true` indicates the block contains a safe point such as a poll or a heap
+   allocation instruction. (Local allocations do not call the GC, and are hence
+   not safe points.) *)
 
 (* CR-soon xclerc for xclerc: given how we use the safe map below, it is not
    clear taking into accounts terminator makes a difference; maybe matching over
    the terminator to always return `false` would be better. *)
 
 let is_safe_basic : Cfg.basic Cfg.instruction -> bool =
- fun instr -> Cfg.is_alloc instr || Cfg.is_poll instr
+ fun instr -> Cfg.is_heap_alloc instr || Cfg.is_poll instr
 
 let is_safe_terminator : Cfg.terminator Cfg.instruction -> bool =
  fun term ->
@@ -157,11 +159,11 @@ let safe_map_of_cfg : Cfg.t -> bool Label.Tbl.t =
 
    "Might_not_poll" means there exists a path from the function entry to a
    Potentially Recursive Tail Call (a Tailcall_self of Tailcall_func which is
-   either indirect or to a forward function) that does not go through an Alloc
-   or Poll instruction.
+   either indirect or to a forward function) that does not go through a heap
+   allocation or Poll instruction.
 
-   "Always_polls", therefore, means the function always polls (via Alloc or
-   Poll) before doing a PRTC. *)
+   "Always_polls", therefore, means the function always polls (via a heap
+   allocation or Poll) before doing a PRTC. *)
 
 module Polls_before_prtc_domain = struct
   type t = Polls_before_prtc.t
@@ -191,7 +193,11 @@ module Polls_before_prtc_transfer = struct
       if InstructionId.equal instr.id optimistic_prologue_poll_instr_id
       then Ok dom
       else Ok Always_polls
-    | Op (Alloc _) -> Ok Always_polls
+    | Op (Alloc { mode = Heap; bytes = _; dbginfo = _ }) -> Ok Always_polls
+    | Op (Alloc { mode = Local; bytes = _; dbginfo = _ }) ->
+      (* A local allocation does not call the GC, and is hence not a polling
+         point. *)
+      Ok dom
     | Op
         ( Move | Spill | Reload | Opaque | Begin_region | End_region | Dls_get
         | Tls_get | Domain_index | Pause | Const_int _ | Const_float32 _

--- a/testsuite/tests/codegen/polling_local_allocs.ml
+++ b/testsuite/tests/codegen/polling_local_allocs.ml
@@ -1,0 +1,129 @@
+(* TEST
+ poll-insertion;
+ no-stack-checks;
+ no-frame_pointers;
+ no-address-sanitizer;
+ expect.opt;
+*)
+
+(* [opaque] is used (rather than [Sys.opaque_identity]) so that the local
+   allocations below cannot be elided by the middle end. *)
+external opaque : ('a[@local_opt]) -> ('a[@local_opt]) = "%opaque"
+
+(* Control: a loop with no allocation gets a poll on its back edge (this is
+   what proves that poll insertion is active in this configuration). *)
+let[@inline never] no_alloc_loop n =
+  for i = 0 to n do
+    let (_ : int) = opaque i in
+    ()
+  done
+[%%expect_asm_full X86_64{|
+no_alloc_loop:
+  cmpq  $1, %rax
+  jl    .L3
+  subq  $8, %rsp
+  sarq  $1, %rax
+  xorl  %ebx, %ebx
+.L0:
+  leaq  1(%rbx,%rbx), %rdi
+  incq  %rbx
+  cmpq  %rax, %rbx
+  jg    .L2
+  cmpq  (%r14), %r15
+  jbe   .L4
+.L1:
+  jmp   .L0
+.L2:
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+.L3:
+  movl  $1, %eax
+  ret
+.L4:
+  call  .Lcaml_call_gc_
+.L5:
+  jmp   .L1
+|}]
+
+(* Control: a loop with a heap allocation gets no poll; the allocation's
+   [young_limit] check is the safe point. *)
+let[@inline never] heap_alloc_loop n =
+  for i = 0 to n do
+    let r @ global = ref (opaque i) in
+    let (_ : int ref) = Sys.opaque_identity r in
+    ()
+  done
+[%%expect_asm_full X86_64{|
+heap_alloc_loop:
+  cmpq  $1, %rax
+  jl    .L2
+  subq  $8, %rsp
+  sarq  $1, %rax
+  xorl  %ebx, %ebx
+.L0:
+  leaq  1(%rbx,%rbx), %rdi
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    .L3
+.L1:
+  leaq  8(%r15), %rsi
+  movq  $1024, -8(%rsi)
+  movq  %rdi, (%rsi)
+  incq  %rbx
+  cmpq  %rax, %rbx
+  jle   .L0
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+.L2:
+  movl  $1, %eax
+  ret
+.L3:
+  call  .Lcaml_call_gc_
+.L4:
+  jmp   .L1
+|}]
+
+(* BUG: a loop whose only allocation is local gets no poll at all: there is
+   no [young_limit] check anywhere in the code below. *)
+let[@inline never] local_alloc_loop n =
+  for i = 0 to n do
+    let local_ r = ref (opaque i) in
+    let (_ : int ref) = opaque r in
+    ()
+  done
+[%%expect_asm_full X86_64{|
+local_alloc_loop:
+  cmpq  $1, %rax
+  jl    .L2
+  subq  $8, %rsp
+  sarq  $1, %rax
+  xorl  %ebx, %ebx
+.L0:
+  movq  64(%r14), %rdi
+  leaq  1(%rbx,%rbx), %rsi
+  movq  64(%r14), %rdx
+  subq  $16, %rdx
+  movq  %rdx, 64(%r14)
+  cmpq  80(%r14), %rdx
+  jl    .L3
+.L1:
+  addq  72(%r14), %rdx
+  addq  $8, %rdx
+  movq  $1792, -8(%rdx)
+  movq  %rsi, (%rdx)
+  movq  %rdi, 64(%r14)
+  incq  %rbx
+  cmpq  %rax, %rbx
+  jle   .L0
+  movl  $1, %eax
+  addq  $8, %rsp
+  ret
+.L2:
+  movl  $1, %eax
+  ret
+.L3:
+  call  caml_call_local_realloc@PLT
+  jmp   .L1
+|}]

--- a/testsuite/tests/codegen/polling_local_allocs.ml
+++ b/testsuite/tests/codegen/polling_local_allocs.ml
@@ -85,8 +85,10 @@ heap_alloc_loop:
   jmp   .L1
 |}]
 
-(* BUG: a loop whose only allocation is local gets no poll at all: there is
-   no [young_limit] check anywhere in the code below. *)
+(* A loop whose only allocation is local gets a poll on its back edge: a
+   local allocation does not call the GC (neither on its fast path,
+   which only involves [local_sp]/[local_limit], nor in
+   [caml_local_realloc]), and is therefore not a safe point. *)
 let[@inline never] local_alloc_loop n =
   for i = 0 to n do
     let local_ r = ref (opaque i) in
@@ -96,7 +98,7 @@ let[@inline never] local_alloc_loop n =
 [%%expect_asm_full X86_64{|
 local_alloc_loop:
   cmpq  $1, %rax
-  jl    .L2
+  jl    .L4
   subq  $8, %rsp
   sarq  $1, %rax
   xorl  %ebx, %ebx
@@ -107,7 +109,7 @@ local_alloc_loop:
   subq  $16, %rdx
   movq  %rdx, 64(%r14)
   cmpq  80(%r14), %rdx
-  jl    .L3
+  jl    .L7
 .L1:
   addq  72(%r14), %rdx
   addq  $8, %rdx
@@ -116,14 +118,23 @@ local_alloc_loop:
   movq  %rdi, 64(%r14)
   incq  %rbx
   cmpq  %rax, %rbx
-  jle   .L0
+  jg    .L3
+  cmpq  (%r14), %r15
+  jbe   .L5
+.L2:
+  jmp   .L0
+.L3:
   movl  $1, %eax
   addq  $8, %rsp
   ret
-.L2:
+.L4:
   movl  $1, %eax
   ret
-.L3:
+.L5:
+  call  .Lcaml_call_gc_
+.L6:
+  jmp   .L2
+.L7:
   call  caml_call_local_realloc@PLT
   jmp   .L1
 |}]


### PR DESCRIPTION
(It is another instance of #6444, which was
merged by mistake.)