### PR TITLE
Stack checks: skip prologue/epilogue when computing liveness

### DIFF
--- a/backend/cfg/cfg_stack_checks.ml
+++ b/backend/cfg/cfg_stack_checks.ml
@@ -165,12 +165,25 @@ let insert_instruction (cfg : Cfg.t) (label : Label.t) ~max_frame_size =
      instruction's live-in. As [instr.live] is the live-across set, recover the
      live-in by adding the next instruction's arguments. This is what the
      emitter's [save_simd] needs to preserve SIMD registers across the realloc
-     handler (a C call that clobbers caller-save SIMD registers). *)
-  let live =
-    match DLL.hd block.body with
-    | Some hd -> Reg.add_set_array hd.live hd.arg
+     handler (a C call that clobbers caller-save SIMD registers).
+
+     [Prologue] and [Epilogue] are skipped: they are inserted by [Cfg_prologue]
+     after liveness was last computed, so their [live] field is a copy of a
+     neighbour's live-across set that does not account for registers dying at
+     the next instruction (and their [arg] is empty). Since they neither use nor
+     define registers, the block's live-in is the live-in of the first other
+     instruction. *)
+  let rec live_in_from (cell : Cfg.basic Cfg.instruction DLL.cell option) =
+    match cell with
     | None -> Reg.add_set_array block.terminator.live block.terminator.arg
+    | Some cell -> (
+      let instr = DLL.value cell in
+      match instr.desc with
+      | Prologue | Epilogue -> live_in_from (DLL.next cell)
+      | Op _ | Reloadretaddr | Pushtrap _ | Poptrap _ | Stack_check _ ->
+        Reg.add_set_array instr.live instr.arg)
   in
+  let live = live_in_from (DLL.hd_cell block.body) in
   let check : Cfg.basic Cfg.instruction =
     (* CR xclerc for xclerc: double check `available_before` and
        `available_across`.

--- a/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
@@ -10,12 +10,11 @@
    block is also the lowest common dominator of the two call-containing
    sub-branches, so the stack check is inserted at its start, before the
    [Prologue] instruction and before the last use of [x]. The stack-realloc
-   handler must therefore preserve xmm registers, i.e. call
-   [caml_call_realloc_stack_sse]. However, [Cfg_stack_checks] currently
-   recovers the block's live-in from the [Prologue] instruction, whose [live]
-   field does not account for registers dying at the following instruction, so
-   the captured assembly below exhibits the bug: the plain
-   [caml_call_realloc_stack] (which saves no xmm register) is called. *)
+   handler must therefore preserve xmm registers: it must call
+   [caml_call_realloc_stack_sse], not the plain [caml_call_realloc_stack].
+   This is a regression test for [Cfg_stack_checks] recovering the block's
+   live-in by skipping the [Prologue] instruction, whose [live] field does not
+   account for registers dying at the following instruction. *)
 
 external to_float : float# -> float = "%box_float"
 
@@ -94,7 +93,7 @@ f:
   jmp   .L2
 .L11:
   push  $34
-  call  caml_call_realloc_stack@PLT
+  call  caml_call_realloc_stack_sse@PLT
   addq  $8, %rsp
   jmp   .L0
 |}]

--- a/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
@@ -1,0 +1,100 @@
+(* TEST
+ flags += " -O3";
+ only-stack-checks-codegen;
+ expect.opt;
+*)
+
+(* The unboxed float [x] is live (in an xmm register) on entry to the [else]
+   block, and dies at that block's first "real" instruction. The prologue is
+   shrink-wrapped into that block (the [then] branch needs no frame), and the
+   block is also the lowest common dominator of the two call-containing
+   sub-branches, so the stack check is inserted at its start, before the
+   [Prologue] instruction and before the last use of [x]. The stack-realloc
+   handler must therefore preserve xmm registers, i.e. call
+   [caml_call_realloc_stack_sse]. However, [Cfg_stack_checks] currently
+   recovers the block's live-in from the [Prologue] instruction, whose [live]
+   field does not account for registers dying at the following instruction, so
+   the captured assembly below exhibits the bug: the plain
+   [caml_call_realloc_stack] (which saves no xmm register) is called. *)
+
+external to_float : float# -> float = "%box_float"
+
+let[@inline never] g (n : int) : float = float_of_int n
+
+let[@inline never] f (x : float#) (b : bool) (n : int) : float =
+  if b
+  then 0.0
+  else
+    let y = to_float x +. to_float x in
+    if n > 0 then y +. g n else y -. g (n + 1)
+[%%expect_asm_full X86_64{|
+f:
+  movq  %rax, %rdi
+  movq  %rbx, %rax
+  cmpq  $1, %rdi
+  jne   .L6
+  pushq %r10
+  leaq  -384(%rsp), %r10
+  cmpq  40(%r14), %r10
+  popq  %r10
+  jb    .L11
+.L0:
+  subq  $8, %rsp
+  vaddsd %xmm0, %xmm0, %xmm0
+  cmpq  $1, %rax
+  jle   .L3
+  vmovsd %xmm0, (%rsp)
+  movq  <hidden PC-relative offset>(%rip), %rbx
+  movq  24(%rbx), %rbx
+  movq  (%rbx), %rdi
+  call  *%rdi
+.L1:
+  movq  %rax, %rbx
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    .L9
+.L2:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd (%rsp), %xmm0
+  vaddsd (%rbx), %xmm0, %xmm0
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L3:
+  vmovsd %xmm0, (%rsp)
+  movq  <hidden PC-relative offset>(%rip), %rbx
+  movq  24(%rbx), %rbx
+  addq  $2, %rax
+  movq  (%rbx), %rdi
+  call  *%rdi
+.L4:
+  movq  %rax, %rbx
+  subq  $16, %r15
+  cmpq  (%r14), %r15
+  jb    .L7
+.L5:
+  leaq  8(%r15), %rax
+  movq  $1277, -8(%rax)
+  vmovsd (%rsp), %xmm0
+  vsubsd (%rbx), %xmm0, %xmm0
+  vmovsd %xmm0, (%rax)
+  addq  $8, %rsp
+  ret
+.L6:
+  leaq  <hidden PC-relative offset>(%rip), %rax
+  ret
+.L7:
+  call  .Lcaml_call_gc_
+.L8:
+  jmp   .L5
+.L9:
+  call  .Lcaml_call_gc_
+.L10:
+  jmp   .L2
+.L11:
+  push  $34
+  call  caml_call_realloc_stack@PLT
+  addq  $8, %rsp
+  jmp   .L0
+|}]


### PR DESCRIPTION
This is a follow-up to https://github.com/oxcaml/oxcaml/pull/6337.

It is indeed not enough to look at the next
instruction to compute the liveness because
prologue/epilogue instructions are inserted
after liveness has been computed.