### PR TITLE
Minimal fix for #6433 (CSE over atomic loads / fences)

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -37,8 +37,16 @@ let class_of_operation (op : Operation.t)
     | Ioffset_loc(_, _) -> Class (Op_store true)
     | Ifloatarithmem _ -> Class (Op_load Mutable)
     | Ibswap _ -> Use_default
-    | Irdtsc | Irdpmc
-    | Ilfence | Isfence | Imfence -> Class Op_other
+    | Irdtsc | Irdpmc -> Class Op_other
+    | Ilfence | Imfence ->
+      (* A load that follows a load fence must not be satisfied by an equation
+         over a load that precedes the fence: that would effectively hoist the
+         load above the fence. *)
+      Class (Op_store true)
+    | Isfence ->
+      (* [sfence] only orders stores, and CSE neither eliminates nor moves
+         stores, so it does not need to be a load barrier. *)
+      Class Op_other
     | Ipackf32 -> Class Op_pure
     | Isimd op ->
       Class (of_simd_class (Simd.class_of_operation op))

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -308,14 +308,21 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
     | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
       Op_pure
-    | (Opaque | Pause) as op ->
+    | Opaque as op ->
       Misc.fatal_errorf "Cfg_cse.class_of_operation0: %a is handled specially"
         Operation.dump op
+    | Pause ->
+      (* Pause is used to spin on memory locations, so equations over mutable
+         loads must not survive it. *)
+      Op_store true
     | Stackoffset _ -> Op_other
     | Load { mutability; is_atomic; memory_chunk = _; addressing_mode = _ } ->
-      (* #12173: disable CSE for atomic loads. *)
+      (* #12173: disable CSE for atomic loads. Moreover, an atomic load is an
+         acquire: a load that follows it must not be satisfied by an equation
+         over a load that precedes it, so atomic loads are also load
+         barriers. *)
       if is_atomic
-      then Op_other
+      then Op_store true
       else
         Op_load
           (match mutability with Mutable -> Mutable | Immutable -> Immutable)
@@ -368,10 +375,6 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | Op Opaque ->
       (* Assume arbitrary side effects from Opaque *)
       empty_numbering
-    | Op Pause ->
-      (* We don't want to reorder loads across Pause, since it's used to spin on
-         memory locations. *)
-      kill_loads n
     | Op (Alloc _) | Op Poll ->
       (* For allocations, we must avoid extending the live range of a
          pseudoregister across the allocation if this pseudoreg is a derived
@@ -396,7 +399,7 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          | Intop_atomic _
          | Floatop (_, _)
          | Csel _ | Reinterpret_cast _ | Static_cast _ | Probe_is_enabled _
-         | Specific _ | Name_for_debugger _ ) as op) -> (
+         | Specific _ | Name_for_debugger _ | Pause ) as op) -> (
       match class_of_operation op with
       | (Op_pure | Op_load _) as op_class -> (
         let n1, varg = valnum_regs n i.arg in

--- a/testsuite/tests/codegen/cse_load_barriers.ml
+++ b/testsuite/tests/codegen/cse_load_barriers.ml
@@ -8,10 +8,6 @@
    (acquire) or a cpu-relax hint, since that would effectively hoist the load
    above the barrier.
 
-   The expected output for [load_across_atomic_get] below captures the
-   current, incorrect behaviour: the load following [Atomic.get] is merged
-   with the load preceding it.
-
    The fence intrinsics ("caml_load_fence" etc.) cannot be tested here: this
    machinery executes each phrase in a native toplevel, and those externals
    have no C implementation in the process (they are only rewritten to fence
@@ -29,27 +25,26 @@ no_barrier:
   ret
 |}]
 
-(* The load after [Atomic.get] must not be merged with the one before. The
-   expected output below shows the current, incorrect behaviour: there is a
-   single load, and the sum is computed as [a + a]
-   ([leaq -1(%rax,%rax)]). *)
+(* The load after [Atomic.get] must not be merged with the one before. *)
 let load_across_atomic_get (r : int ref) (flag : int Atomic.t) =
   let a = !r in
   if Atomic.get flag = 1 then a + !r else a
 [%%expect_asm X86_64{|
 load_across_atomic_get:
-  movq  (%rax), %rax
+  movq  %rax, %rdi
+  movq  (%rdi), %rax
   movq  (%rbx), %rbx
   cmpq  $3, %rbx
   jne   .L0
-  leaq  -1(%rax,%rax), %rax
+  movq  (%rdi), %rbx
+  leaq  -1(%rax,%rbx), %rax
   ret
 .L0:
   ret
 |}]
 
 (* [cpu_relax] is used to spin on a memory location, so the load after it
-   must not be merged with the one before (which is already the case). *)
+   must not be merged with the one before. *)
 let load_across_cpu_relax (r : int ref) =
   let a = !r in
   cpu_relax ();


### PR DESCRIPTION
It is a simplified fix, compared to #6434,
so that we can merge the fix here, and
discuss a better design in #6434.