### PR TITLE
typing: skip Result boxing in Global_module.Name.create_no_args

### DIFF
--- a/typing/global_module.ml
+++ b/typing/global_module.ml
@@ -164,7 +164,7 @@ end = struct
       Misc.fatal_errorf "Names of instance arguments must be unique:@ %a"
         (Fmt.compat print) { head; args }
 
-  let create_no_args head = create_exn head []
+  let create_no_args head = { head; args = [] }
 
   let of_parameter_name param = create_no_args param
 


### PR DESCRIPTION
`create_exn name []` sorted and checked an empty list and boxed the result. Build the record directly; equivalent by construction.
