### PR TITLE
runtime: backport idle-phase major GC from upstream (#14365)

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -238,6 +238,11 @@ typedef uint64_t uintnat;
    total size of live objects. */
 #define Percent_free_def 80
 
+/* Default "small heap mode" setting for the major GC.  The GC will
+   add an Idle phase when the sweeping work for a cycle is smaller than
+   this limit. */
+#define Small_heap_limit_def 262144
+
 /* Default setting for the compacter: 500%
    (i.e. trigger the compacter when 5/6 of the heap is free or garbage).
  */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -18,6 +18,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stdbool.h>
+
 typedef enum {
   Phase_sweep_main,
   Phase_sweep_and_mark_main,
@@ -61,7 +63,8 @@ void caml_finish_major_cycle(int compaction_mode);
  * For use at times when we have disturbed the usual pacing, for
  * example, after any synchronous major collection.
  */
-void caml_reset_major_pacing(void);
+void caml_init_major_pacing(void);
+void caml_reset_major_pacing(bool add_overhead);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);
 #endif

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -447,11 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -447,11 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern uintnat caml_small_heap_limit; /* see major_gc.c */
+extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", &caml_small_heap_limit, 0 },
+  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -290,7 +290,7 @@ static caml_result gc_major_res(int compaction_mode)
   CAML_GC_MESSAGE(MAJOR, "Major GC cycle requested\n");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(compaction_mode);
-  caml_reset_major_pacing();
+  caml_reset_major_pacing(false);
   caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return result;
@@ -314,7 +314,7 @@ static caml_result gc_full_major_res(void)
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_auto : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res)) break;
   }
@@ -351,7 +351,7 @@ CAMLprim value caml_gc_compaction(value v)
      why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_forced : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res))
       break;
@@ -403,7 +403,8 @@ void caml_init_gc (void)
   atomic_store_relaxed(&caml_major_heap_increment,
                        caml_params->init_major_heap_increment);
 
-  caml_gc_phase = Phase_sweep_and_mark_main;
+  caml_init_major_pacing ();
+  caml_gc_phase = Phase_sweep_main;
   #ifdef NATIVE_CODE
   caml_init_frame_descriptors();
   #endif
@@ -446,8 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
+
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -772,6 +772,12 @@ static void adopt_orphaned_work (int expected_status)
 
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
+
+/* Idle-phase floor (upstream #14365): at the end of sweeping, do not
+   switch to marking until total_work_completed has advanced by at least
+   this many (sweep-work-unit) words since the start of the sweep phase.
+   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -815,6 +821,18 @@ static intnat Sweepwork_markwork(intnat mark_work)
 static atomic_uintnat total_work_incurred;
 static atomic_uintnat total_work_completed;
 
+/* Value of total_work_completed at the latest color rotation (start of
+   sweep) and amount of work incurred during the latest sweep phase
+   (upstream #14365: alloc during sweep = the "virtual sweep work").
+   Only written under stw. */
+static uintnat work_counter_at_sweep_start;
+static uintnat latest_sweep_allocs;
+
+/* Small-memory mode: at the end of sweeping, we will not switch to
+   Phase_sweep_and_mark_main (and thus will stay in idle mode) until
+   total_work_completed has reached this value. */
+static atomic_uintnat work_counter_min_before_mark;
+
 static inline intnat max2 (intnat a, intnat b)
 {
   if (a > b){
@@ -852,19 +870,42 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
  * collection.
  */
 
-void caml_reset_major_pacing(void)
+/* Initialize the counters for GC pacing.
+   For use in caml_init_gc, when everything is still single-threaded.
+   caml_small_heap_limit must be initialized (gc tweaks parsed) before
+   calling this function. */
+void caml_init_major_pacing (void)
+{
+  work_counter_min_before_mark =
+    atomic_load (&total_work_completed) + caml_small_heap_limit;
+}
+
+/* add_overhead is true if the latest collection was synchronous (with
+   caml_gc_full_major) and thus the sweep phase counted only the live
+   data (with no floating garbage). */
+void caml_reset_major_pacing(bool add_overhead)
 {
   bool res;
+  uintnat target;
   do {
     uintnat incurred = atomic_load(&total_work_incurred);
     uintnat completed = atomic_load(&total_work_completed);
-    uintnat target = incurred;
+    target = incurred;
     if (diffmod(completed, incurred) > 0) {
       target = completed;
     }
     res = (atomic_compare_exchange_strong(&total_work_incurred, &incurred, target) &&
            atomic_compare_exchange_strong(&total_work_completed, &completed, target));
   } while (!res);
+  {
+    uintnat virtual_sweep_work = latest_sweep_allocs;
+    if (add_overhead){
+      virtual_sweep_work =
+        virtual_sweep_work / 100 * (100 + atomic_load (&caml_percent_free));
+    }
+    work_counter_min_before_mark =
+      target + max2 (virtual_sweep_work, caml_small_heap_limit);
+  }
 }
 
 static uintnat mark_work_done_between_slices(void)
@@ -1672,6 +1713,8 @@ void caml_mark_roots_stw (int participant_count, caml_domain_state** barrier_par
 
   Caml_global_barrier_if_final(participant_count) {
     caml_gc_phase = Phase_sweep_and_mark_main;
+    latest_sweep_allocs =
+      diffmod (atomic_load (&total_work_completed), work_counter_at_sweep_start);
     atomic_store_relaxed(&global_roots_scanned, WORK_UNSTARTED);
 
     /* Adopt orphaned work from domains that were spawned and
@@ -1901,6 +1944,9 @@ static void cycle_major_heap_from_stw_single(
   caml_atomic_counter_init(&num_domains_to_mark, num_domains_in_stw);
 
   caml_gc_phase = Phase_sweep_main;
+  work_counter_at_sweep_start = atomic_load (&total_work_completed);
+  work_counter_min_before_mark =
+    work_counter_at_sweep_start + caml_small_heap_limit;
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2183,16 +2229,37 @@ static void major_collection_slice(intnat howmuch,
   }
 
   if (domain_state->sweeping_done) {
-    /* We do not immediately trigger a minor GC, but instead wait for
-       the next one to happen normally, when marking will start. This
-       gives some chance that other domains will finish sweeping as
-       well. */
-    request_mark_phase();
-    /* If there was no sweeping to do, but marking hasn't started,
-       then minor GC has not occurred naturally between major slices -
-       so we should force one now. */
-    if (sweep_work == 0 && !caml_marking_started()) {
-        caml_request_minor_gc();
+    /* Idle phase (upstream #14365): after sweeping, delay the switch to
+       marking until the work counter has advanced past the floor armed
+       at the start of this sweep phase. Until then the GC does nothing
+       but commit the incurred work, so small heaps never pay for a
+       mark phase. */
+    uintnat wkcnt = atomic_load (&total_work_completed);
+    intnat idle = diffmod (work_counter_min_before_mark, wkcnt);
+    bool want_mark;
+    if (idle <= 0){
+      /* Idle phase is finished (or never existed): start marking. */
+      want_mark = true;
+    }else{
+      /* Idle phase: do nothing but commit to the work counter. */
+      intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
+      todo = min2 (max2 (todo, 0), idle);
+      if (todo > 0) commit_major_slice_sweepwork (todo);
+      want_mark = (todo == idle);
+    }
+    if (want_mark){
+      /* We do not immediately trigger a minor GC, but instead wait for
+         the next one to happen normally, when marking will start. This
+         gives some chance that other domains will finish sweeping as
+         well. */
+      request_mark_phase();
+      /* If there was no sweeping to do, but marking hasn't started,
+         then minor GC has not occurred naturally between major slices -
+         so we should force one now. (Gated on want_mark so the idle
+         phase cannot spin forced minor collections.) */
+      if (sweep_work == 0 && !caml_marking_started()) {
+          caml_request_minor_gc();
+      }
     }
   }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,8 +776,11 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
-uintnat caml_small_heap_limit = Small_heap_limit_def;
+   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
+   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
+   gc-tweaks table stores a cast pointer; the startup parser writes
+   before any domain runs. */
+_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -2244,7 +2247,12 @@ static void major_collection_slice(intnat howmuch,
       /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
       todo = min2 (max2 (todo, 0), idle);
-      if (todo > 0) commit_major_slice_sweepwork (todo);
+      /* Commit even when todo == 0: beyond the counters, the commit also
+         clears [requested_global_major_slice] once the slice target is
+         met (compare the opportunistic early-out above); skipping it
+         would leave an idle domain re-triggering global major-slice
+         STWs. */
+      commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
     }
     if (want_mark){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -773,15 +773,10 @@ static void adopt_orphaned_work (int expected_status)
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
 
-/* Idle-phase floor (upstream #14365): at the end of sweeping, do not
-   switch to marking until total_work_completed has advanced by at least
-   this many (sweep-work-unit) words since the start of the sweep phase.
-   Plain uintnat, matching every other entry in the gc-tweaks table: the
-   startup parser writes it before any domain runs, and a runtime
-   [Gc.Tweak.set] has the same benign-race caveat as all sibling tweaks.
-   (Upstream types it _Atomic with a fully atomic tweak table; if this
-   tree's table is ever atomicized -- see the TODO on [struct gc_tweak]
-   -- this variable should join it.) */
+/* Idle-phase floor (upstream #14365): after sweeping, marking is
+   deferred until this much (in sweep-work words) has been allocated
+   this cycle.  Plain like the other gc tweaks; upstream makes it
+   _Atomic together with its whole tweak table. */
 uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
@@ -1953,8 +1948,8 @@ static void cycle_major_heap_from_stw_single(
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
   CAML_GC_MESSAGE (MAJOR,
-                   "Sweep start: work counter %" CAML_PRIuNAT
-                   ", idle floor armed at %" CAML_PRIuNAT "\n",
+                   "Sweep start: work counter "F_U
+                   ", idle floor armed at "F_U"\n",
                    work_counter_at_sweep_start,
                    work_counter_min_before_mark);
   atomic_store(&caml_gc_mark_phase_requested, 0);
@@ -2254,14 +2249,12 @@ static void major_collection_slice(intnat howmuch,
       /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
       todo = min2 (max2 (todo, 0), idle);
-      /* Commit even when todo == 0: beyond the counters, the commit also
-         clears [requested_global_major_slice] once the slice target is
-         met (compare the opportunistic early-out above); skipping it
-         would leave an idle domain re-triggering global major-slice
-         STWs. */
+      /* Commit even when todo == 0: the commit also clears
+         [requested_global_major_slice] (as the opportunistic early-out
+         above does). */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
-      CAML_GC_MESSAGE (SLICE, "Idle phase: %" CAML_PRIdNAT "%s\n",
+      CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",
                        todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,11 +776,13 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
-   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
-   gc-tweaks table stores a cast pointer; the startup parser writes
-   before any domain runs. */
-_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
+   Plain uintnat, matching every other entry in the gc-tweaks table: the
+   startup parser writes it before any domain runs, and a runtime
+   [Gc.Tweak.set] has the same benign-race caveat as all sibling tweaks.
+   (Upstream types it _Atomic with a fully atomic tweak table; if this
+   tree's table is ever atomicized -- see the TODO on [struct gc_tweak]
+   -- this variable should join it.) */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -1950,6 +1952,11 @@ static void cycle_major_heap_from_stw_single(
   work_counter_at_sweep_start = atomic_load (&total_work_completed);
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
+  CAML_GC_MESSAGE (MAJOR,
+                   "Sweep start: work counter %" CAML_PRIuNAT
+                   ", idle floor armed at %" CAML_PRIuNAT "\n",
+                   work_counter_at_sweep_start,
+                   work_counter_min_before_mark);
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2254,6 +2261,8 @@ static void major_collection_slice(intnat howmuch,
          STWs. */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
+      CAML_GC_MESSAGE (SLICE, "Idle phase: %" CAML_PRIdNAT "%s\n",
+                       todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){
       /* We do not immediately trigger a minor GC, but instead wait for


### PR DESCRIPTION
Backport of ocaml/ocaml 7ea34c55cc: after sweeping, the major GC waits until allocation since the start of the cycle exceeds `small_heap_limit` (a tweak, default 2 MiB) before it starts marking.

Port notes: the pacing counters have different names on this tree; our force-minor branch in the slice is gated behind the mark request; the floor is a plain tweak like the other table entries (upstream makes the whole table atomic).

No behavior change at the default floor; testsuite passes. With the floor raised via the follow-up flags PR (#6482), ~20% less aggregate compile time over a large production tree. Will be subsumed by the next upstream sync.
