### PR TITLE
driver: -X gc-space-overhead and -X gc-idle-floor

### DIFF
--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -66,7 +66,12 @@ module Gc_pacing = struct
         && String.sub field 0 (String.length prefix) = prefix)
 
   (* Size in bytes: a decimal integer with an optional K/M/G binary
-     suffix. *)
+     suffix. Guarded against multiply overflow, and capped at 1 TiB: a
+     floor beyond that disables major-GC marking outright on any real
+     compilation (unbounded heap growth), and such values are far more
+     likely a suffix typo (512G for 512M) than intent. *)
+  let max_size_bytes = 1 lsl 40
+
   let parse_size_bytes s =
     let n = String.length s in
     if n = 0 then None
@@ -79,18 +84,25 @@ module Gc_pacing = struct
         | _ -> 1, s
       in
       match int_of_string_opt digits with
-      | Some i when i >= 0 -> Some (i * mult)
+      | Some i when i >= 0 && i <= max_size_bytes / mult ->
+        Some (i * mult)
       | _ -> None
     end
 
   (* Runs after argument parsing and before any compilation. Late enough
-     that both -X and OCAMLPARAM have been read; early enough that no real
-     GC work has happened (space_overhead is re-read continuously and the
-     idle floor re-arms at every sweep-phase start, so mid-startup changes
-     take full effect). *)
+     that -X and OCAMLPARAM's "before" section have been read (knobs in
+     OCAMLPARAM's per-file "after" section are NOT honoured: it is only
+     read per compilation unit, after this point); early enough that no
+     real GC work has happened. Also note [-depend] runs and exits during
+     argument parsing, i.e. unpaced, which is fine (it compiles
+     nothing). *)
   let apply () =
     begin match space_overhead () with
-    | 0 -> ()
+    | 0 -> ()  (* the "unset" sentinel: 0 cannot be requested explicitly *)
+    | n when n < 0 ->
+      Compenv.fatal
+        (Printf.sprintf "-X gc-space-overhead expects a positive integer, \
+got: %d" n)
     | n ->
       if not (env_field_present ~prefix:"o") then
         Gc.set { (Gc.get ()) with Gc.space_overhead = n }
@@ -101,7 +113,8 @@ module Gc_pacing = struct
       if not (env_field_present ~prefix:"Xsmall_heap_limit=") then begin
         match parse_size_bytes s with
         | Some bytes ->
-          (* The primitive takes words. *)
+          (* The primitive takes words; bytes <= 1 TiB so this cannot
+             overflow. *)
           !set_idle_floor_hook ((bytes + 7) / 8)
         | None ->
           Compenv.fatal

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -20,6 +20,96 @@ let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
 module Options = Oxcaml_args.Make_optcomp_options
         (Oxcaml_args.Default.Optmain)
 
+(* Opt-in GC pacing for the compiler process itself, intended to be set by
+   the build system (e.g. -X gc-space-overhead=200 -X gc-idle-floor=512M).
+   The compiler is allocation-heavy and short-lived, so a laxer major-GC
+   pace trades bounded extra peak heap for materially less GC work; the
+   idle floor additionally lets small compilations finish without doing
+   any major-GC marking at all (see runtime/major_gc.c, Idle phase).
+   Both knobs are inert unless set. Explicit user settings in
+   OCAMLRUNPARAM/CAMLRUNPARAM take precedence, so a single invocation can
+   always be re-paced by hand when investigating time or memory issues. *)
+module Gc_pacing = struct
+  (* The floor is applied through the [caml_gc_set_idle_floor] primitive
+     (sets the small_heap_limit tweak AND re-arms the current cycle's
+     floor), which the bootstrap toolchain's runtime does not provide; the
+     final executables (driver/oxcaml_main.ml) install it here. The
+     bootstrap build never passes -X gc-idle-floor, so the failing default
+     is unreachable there. *)
+  let set_idle_floor_hook : (int -> unit) ref =
+    ref (fun _ ->
+      Compenv.fatal
+        "-X gc-idle-floor is not supported by this executable")
+
+  let space_overhead =
+    Oxcaml_args.Extra_options.int __LOC__ "gc-space-overhead" 0
+
+  let idle_floor =
+    Oxcaml_args.Extra_options.string __LOC__ "gc-idle-floor" ""
+
+  (* Mirror the runtime's OCAMLRUNPARAM parsing (runtime/startup_aux.c):
+     the active variable is OCAMLRUNPARAM if set at all, else CAMLRUNPARAM;
+     fields are comma-separated and identified by their leading
+     characters. *)
+  let env_field_present ~prefix =
+    let param =
+      match Sys.getenv_opt "OCAMLRUNPARAM" with
+      | Some _ as p -> p
+      | None -> Sys.getenv_opt "CAMLRUNPARAM"
+    in
+    match param with
+    | None -> false
+    | Some s ->
+      String.split_on_char ',' s
+      |> List.exists (fun field ->
+        String.length field >= String.length prefix
+        && String.sub field 0 (String.length prefix) = prefix)
+
+  (* Size in bytes: a decimal integer with an optional K/M/G binary
+     suffix. *)
+  let parse_size_bytes s =
+    let n = String.length s in
+    if n = 0 then None
+    else begin
+      let mult, digits =
+        match s.[n - 1] with
+        | 'k' | 'K' -> 1024, String.sub s 0 (n - 1)
+        | 'm' | 'M' -> 1024 * 1024, String.sub s 0 (n - 1)
+        | 'g' | 'G' -> 1024 * 1024 * 1024, String.sub s 0 (n - 1)
+        | _ -> 1, s
+      in
+      match int_of_string_opt digits with
+      | Some i when i >= 0 -> Some (i * mult)
+      | _ -> None
+    end
+
+  (* Runs after argument parsing and before any compilation. Late enough
+     that both -X and OCAMLPARAM have been read; early enough that no real
+     GC work has happened (space_overhead is re-read continuously and the
+     idle floor re-arms at every sweep-phase start, so mid-startup changes
+     take full effect). *)
+  let apply () =
+    begin match space_overhead () with
+    | 0 -> ()
+    | n ->
+      if not (env_field_present ~prefix:"o") then
+        Gc.set { (Gc.get ()) with Gc.space_overhead = n }
+    end;
+    match idle_floor () with
+    | "" -> ()
+    | s ->
+      if not (env_field_present ~prefix:"Xsmall_heap_limit=") then begin
+        match parse_size_bytes s with
+        | Some bytes ->
+          (* The primitive takes words. *)
+          !set_idle_floor_hook ((bytes + 7) / 8)
+        | None ->
+          Compenv.fatal
+            ("-X gc-idle-floor expects a byte count with an optional "
+             ^ "K/M/G suffix, got: " ^ s)
+      end
+end
+
 let main unix argv ppf ~flambda2 =
   native_code := true;
   let columns =
@@ -61,6 +151,7 @@ let main unix argv ppf ~flambda2 =
     Clflags.Opt_flag_handler.set Oxcaml_flags.opt_flag_handler;
     Compenv.parse_arguments (ref argv) Compenv.anonymous "ocamlopt";
     Compmisc.read_clflags_from_env ();
+    Gc_pacing.apply ();
     (* Set platform-appropriate DWARF fission default when oxcaml-dwarf is
        enabled *)
     if Config.oxcaml_dwarf &&

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -89,6 +89,53 @@ module Gc_pacing = struct
       | _ -> None
     end
 
+  (* Physical memory in bytes, for %-terms. Read only when a %-term is
+     present, so machine-dependent behaviour is opt-in and visible in
+     the flag value. *)
+  let physical_memory_bytes () =
+    match open_in "/proc/meminfo" with
+    | exception _ -> None
+    | ic ->
+      let rec find () =
+        match input_line ic with
+        | exception _ -> None
+        | line ->
+          if String.length line > 9 && String.sub line 0 9 = "MemTotal:"
+          then Scanf.sscanf_opt line "MemTotal: %d kB" (fun kb -> kb * 1024)
+          else find ()
+      in
+      let r = find () in
+      close_in_noerr ic;
+      r
+
+  (* The flag value is the MIN of comma-separated terms; a term is
+     either an absolute SIZE or PERCENT'%' of physical memory.  E.g.
+     [1G,1.5%] = 1 GiB, but at most 1.5% of RAM -- the full value on
+     large build machines, proportionally less on small development
+     ones, with the whole policy explicit in the (build-system-provided)
+     flag rather than implicit in the compiler. *)
+  let parse_floor_spec s =
+    let parse_term t =
+      let n = String.length t in
+      if n > 1 && t.[n - 1] = '%' then
+        match float_of_string_opt (String.sub t 0 (n - 1)) with
+        | Some pct when pct > 0. && pct <= 100. ->
+          (match physical_memory_bytes () with
+           | Some mem -> Some (int_of_float (float_of_int mem *. pct /. 100.))
+           | None -> None)
+        | _ -> None
+      else parse_size_bytes t
+    in
+    match String.split_on_char ',' s with
+    | [] -> None
+    | terms ->
+      List.fold_left
+        (fun acc t ->
+           match acc, parse_term t with
+           | Some a, Some b -> Some (Stdlib.min a b)
+           | _ -> None)
+        (Some max_int) terms
+
   (* Runs after argument parsing and before any compilation. Late enough
      that -X and OCAMLPARAM's "before" section have been read (knobs in
      OCAMLPARAM's per-file "after" section are NOT honoured: it is only
@@ -111,15 +158,16 @@ got: %d" n)
     | "" -> ()
     | s ->
       if not (env_field_present ~prefix:"Xsmall_heap_limit=") then begin
-        match parse_size_bytes s with
-        | Some bytes ->
+        match parse_floor_spec s with
+        | Some bytes when bytes < max_int ->
           (* The primitive takes words; bytes <= 1 TiB so this cannot
              overflow. *)
           !set_idle_floor_hook ((bytes + 7) / 8)
-        | None ->
+        | _ ->
           Compenv.fatal
-            ("-X gc-idle-floor expects a byte count with an optional "
-             ^ "K/M/G suffix, got: " ^ s)
+            ("-X gc-idle-floor expects a comma-separated min-expression "
+             ^ "of sizes (512M, 1G) and/or percentages of physical "
+             ^ "memory (1.5%), got: " ^ s)
       end
 end
 

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -109,11 +109,16 @@ module Gc_pacing = struct
       r
 
   (* The flag value is the MIN of comma-separated terms; a term is
-     either an absolute SIZE or PERCENT'%' of physical memory.  E.g.
-     [1G,1.5%] = 1 GiB, but at most 1.5% of RAM -- the full value on
-     large build machines, proportionally less on small development
-     ones, with the whole policy explicit in the (build-system-provided)
-     flag rather than implicit in the compiler. *)
+     either an absolute SIZE or PERCENT'%' of physical memory PER CORE.
+     Per core because the floor is a per-process allowance and the worst
+     case is one compiler per core: a term of P% bounds the aggregate
+     floor allowance of a core-saturating build at P% of the machine's
+     memory, uniformly across machines with very different
+     memory-to-core ratios.  E.g. [1G,50%] = 1 GiB, but at most half the
+     per-core memory -- the full value on large build machines,
+     proportionally less on small development ones, with the whole
+     policy explicit in the (build-system-provided) flag rather than
+     implicit in the compiler. *)
   let parse_floor_spec s =
     let parse_term t =
       let n = String.length t in
@@ -121,7 +126,11 @@ module Gc_pacing = struct
         match float_of_string_opt (String.sub t 0 (n - 1)) with
         | Some pct when pct > 0. && pct <= 100. ->
           (match physical_memory_bytes () with
-           | Some mem -> Some (int_of_float (float_of_int mem *. pct /. 100.))
+           | Some mem ->
+             let cores = max 1 (Domain.recommended_domain_count ()) in
+             Some
+               (int_of_float
+                  (float_of_int (mem / cores) *. pct /. 100.))
            | None -> None)
         | _ -> None
       else parse_size_bytes t
@@ -166,8 +175,8 @@ got: %d" n)
         | _ ->
           Compenv.fatal
             ("-X gc-idle-floor expects a comma-separated min-expression "
-             ^ "of sizes (512M, 1G) and/or percentages of physical "
-             ^ "memory (1.5%), got: " ^ s)
+             ^ "of sizes (512M, 1G) and/or percentages of per-core "
+             ^ "physical memory (50%), got: " ^ s)
       end
 end
 

--- a/driver/optmaindriver.mli
+++ b/driver/optmaindriver.mli
@@ -18,6 +18,14 @@
 
    NB: Due to internal state in the compiler, calling [main] twice during
    the same process is unsupported. *)
+(* See [Gc_pacing] in the implementation: the final executables install
+   the [caml_gc_set_idle_floor] primitive here so that -X gc-idle-floor
+   works; the bootstrap compiler (whose runtime lacks the primitive)
+   leaves it unset. *)
+module Gc_pacing : sig
+  val set_idle_floor_hook : (int -> unit) ref
+end
+
 val main
    : (module Compiler_owee.Unix_intf.S)
   -> string array

--- a/driver/oxcaml_main.ml
+++ b/driver/oxcaml_main.ml
@@ -1,3 +1,7 @@
+external gc_set_idle_floor : int -> unit = "caml_gc_set_idle_floor"
+
+let () = Optmaindriver.Gc_pacing.set_idle_floor_hook := gc_set_idle_floor
+
 let () =
   (match Sys.backend_type with
    | Native -> Memtrace.trace_if_requested ~context:"ocamlopt" ()

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -238,6 +238,11 @@ typedef uint64_t uintnat;
    total size of live objects. */
 #define Percent_free_def 80
 
+/* Default "small heap mode" setting for the major GC.  The GC will
+   add an Idle phase when the sweeping work for a cycle is smaller than
+   this limit. */
+#define Small_heap_limit_def 262144
+
 /* Default setting for the compacter: 500%
    (i.e. trigger the compacter when 5/6 of the heap is free or garbage).
  */

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -64,6 +64,7 @@ void caml_finish_major_cycle(int compaction_mode);
  * example, after any synchronous major collection.
  */
 void caml_init_major_pacing(void);
+void caml_rearm_idle_floor(void);
 void caml_reset_major_pacing(bool add_overhead);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -18,6 +18,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stdbool.h>
+
 typedef enum {
   Phase_sweep_main,
   Phase_sweep_and_mark_main,
@@ -61,7 +63,8 @@ void caml_finish_major_cycle(int compaction_mode);
  * For use at times when we have disturbed the usual pacing, for
  * example, after any synchronous major collection.
  */
-void caml_reset_major_pacing(void);
+void caml_init_major_pacing(void);
+void caml_reset_major_pacing(bool add_overhead);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);
 #endif

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -496,6 +496,17 @@ uintnat* caml_lookup_gc_tweak(const char* name, uintnat len)
   return NULL;
 }
 
+/* Set the idle-phase floor (in words) and re-arm it for the current
+   cycle; [Gc.Tweak.set "small_heap_limit"] alone only takes effect from
+   the next sweep phase. Used by the compiler driver for
+   -X gc-idle-floor. */
+CAMLprim value caml_gc_set_idle_floor(value words)
+{
+  caml_small_heap_limit = Long_val(words);
+  caml_rearm_idle_floor();
+  return Val_unit;
+}
+
 CAMLprim value caml_gc_tweak_get(value name)
 {
   CAMLparam1(name);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -447,11 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -290,7 +290,7 @@ static caml_result gc_major_res(int compaction_mode)
   CAML_GC_MESSAGE(MAJOR, "Major GC cycle requested\n");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(compaction_mode);
-  caml_reset_major_pacing();
+  caml_reset_major_pacing(false);
   caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return result;
@@ -314,7 +314,7 @@ static caml_result gc_full_major_res(void)
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_auto : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res)) break;
   }
@@ -351,7 +351,7 @@ CAMLprim value caml_gc_compaction(value v)
      why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_forced : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res))
       break;
@@ -403,7 +403,8 @@ void caml_init_gc (void)
   atomic_store_relaxed(&caml_major_heap_increment,
                        caml_params->init_major_heap_increment);
 
-  caml_gc_phase = Phase_sweep_and_mark_main;
+  caml_init_major_pacing ();
+  caml_gc_phase = Phase_sweep_main;
   #ifdef NATIVE_CODE
   caml_init_frame_descriptors();
   #endif
@@ -446,8 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
+
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -447,11 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern uintnat caml_small_heap_limit; /* see major_gc.c */
+extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", &caml_small_heap_limit, 0 },
+  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },
@@ -499,7 +499,12 @@ uintnat* caml_lookup_gc_tweak(const char* name, uintnat len)
 /* Set the idle-phase floor (in words) and re-arm it for the current
    cycle; [Gc.Tweak.set "small_heap_limit"] alone only takes effect from
    the next sweep phase. Used by the compiler driver for
-   -X gc-idle-floor. */
+   -X gc-idle-floor.
+
+   Contract: single-domain, process-startup use only (the driver calls it
+   during argument parsing). The re-arm reads STW-written pacing state and
+   may withdraw a pending mark request, neither of which is coordinated
+   with concurrently running domains. */
 CAMLprim value caml_gc_set_idle_floor(value words)
 {
   caml_small_heap_limit = Long_val(words);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -772,6 +772,12 @@ static void adopt_orphaned_work (int expected_status)
 
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
+
+/* Idle-phase floor (upstream #14365): at the end of sweeping, do not
+   switch to marking until total_work_completed has advanced by at least
+   this many (sweep-work-unit) words since the start of the sweep phase.
+   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -815,6 +821,18 @@ static intnat Sweepwork_markwork(intnat mark_work)
 static atomic_uintnat total_work_incurred;
 static atomic_uintnat total_work_completed;
 
+/* Value of total_work_completed at the latest color rotation (start of
+   sweep) and amount of work incurred during the latest sweep phase
+   (upstream #14365: alloc during sweep = the "virtual sweep work").
+   Only written under stw. */
+static uintnat work_counter_at_sweep_start;
+static uintnat latest_sweep_allocs;
+
+/* Small-memory mode: at the end of sweeping, we will not switch to
+   Phase_sweep_and_mark_main (and thus will stay in idle mode) until
+   total_work_completed has reached this value. */
+static atomic_uintnat work_counter_min_before_mark;
+
 static inline intnat max2 (intnat a, intnat b)
 {
   if (a > b){
@@ -852,19 +870,42 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
  * collection.
  */
 
-void caml_reset_major_pacing(void)
+/* Initialize the counters for GC pacing.
+   For use in caml_init_gc, when everything is still single-threaded.
+   caml_small_heap_limit must be initialized (gc tweaks parsed) before
+   calling this function. */
+void caml_init_major_pacing (void)
+{
+  work_counter_min_before_mark =
+    atomic_load (&total_work_completed) + caml_small_heap_limit;
+}
+
+/* add_overhead is true if the latest collection was synchronous (with
+   caml_gc_full_major) and thus the sweep phase counted only the live
+   data (with no floating garbage). */
+void caml_reset_major_pacing(bool add_overhead)
 {
   bool res;
+  uintnat target;
   do {
     uintnat incurred = atomic_load(&total_work_incurred);
     uintnat completed = atomic_load(&total_work_completed);
-    uintnat target = incurred;
+    target = incurred;
     if (diffmod(completed, incurred) > 0) {
       target = completed;
     }
     res = (atomic_compare_exchange_strong(&total_work_incurred, &incurred, target) &&
            atomic_compare_exchange_strong(&total_work_completed, &completed, target));
   } while (!res);
+  {
+    uintnat virtual_sweep_work = latest_sweep_allocs;
+    if (add_overhead){
+      virtual_sweep_work =
+        virtual_sweep_work / 100 * (100 + atomic_load (&caml_percent_free));
+    }
+    work_counter_min_before_mark =
+      target + max2 (virtual_sweep_work, caml_small_heap_limit);
+  }
 }
 
 static uintnat mark_work_done_between_slices(void)
@@ -1672,6 +1713,8 @@ void caml_mark_roots_stw (int participant_count, caml_domain_state** barrier_par
 
   Caml_global_barrier_if_final(participant_count) {
     caml_gc_phase = Phase_sweep_and_mark_main;
+    latest_sweep_allocs =
+      diffmod (atomic_load (&total_work_completed), work_counter_at_sweep_start);
     atomic_store_relaxed(&global_roots_scanned, WORK_UNSTARTED);
 
     /* Adopt orphaned work from domains that were spawned and
@@ -1901,6 +1944,9 @@ static void cycle_major_heap_from_stw_single(
   caml_atomic_counter_init(&num_domains_to_mark, num_domains_in_stw);
 
   caml_gc_phase = Phase_sweep_main;
+  work_counter_at_sweep_start = atomic_load (&total_work_completed);
+  work_counter_min_before_mark =
+    work_counter_at_sweep_start + caml_small_heap_limit;
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2183,16 +2229,37 @@ static void major_collection_slice(intnat howmuch,
   }
 
   if (domain_state->sweeping_done) {
-    /* We do not immediately trigger a minor GC, but instead wait for
-       the next one to happen normally, when marking will start. This
-       gives some chance that other domains will finish sweeping as
-       well. */
-    request_mark_phase();
-    /* If there was no sweeping to do, but marking hasn't started,
-       then minor GC has not occurred naturally between major slices -
-       so we should force one now. */
-    if (sweep_work == 0 && !caml_marking_started()) {
-        caml_request_minor_gc();
+    /* Idle phase (upstream #14365): after sweeping, delay the switch to
+       marking until the work counter has advanced past the floor armed
+       at the start of this sweep phase. Until then the GC does nothing
+       but commit the incurred work, so small heaps never pay for a
+       mark phase. */
+    uintnat wkcnt = atomic_load (&total_work_completed);
+    intnat idle = diffmod (work_counter_min_before_mark, wkcnt);
+    bool want_mark;
+    if (idle <= 0){
+      /* Idle phase is finished (or never existed): start marking. */
+      want_mark = true;
+    }else{
+      /* Idle phase: do nothing but commit to the work counter. */
+      intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
+      todo = min2 (max2 (todo, 0), idle);
+      if (todo > 0) commit_major_slice_sweepwork (todo);
+      want_mark = (todo == idle);
+    }
+    if (want_mark){
+      /* We do not immediately trigger a minor GC, but instead wait for
+         the next one to happen normally, when marking will start. This
+         gives some chance that other domains will finish sweeping as
+         well. */
+      request_mark_phase();
+      /* If there was no sweeping to do, but marking hasn't started,
+         then minor GC has not occurred naturally between major slices -
+         so we should force one now. (Gated on want_mark so the idle
+         phase cannot spin forced minor collections.) */
+      if (sweep_work == 0 && !caml_marking_started()) {
+          caml_request_minor_gc();
+      }
     }
   }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,11 +776,13 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
-   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
-   gc-tweaks table stores a cast pointer; the startup parser writes
-   before any domain runs. */
-_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
+   Plain uintnat, matching every other entry in the gc-tweaks table: the
+   startup parser writes it before any domain runs, and a runtime
+   [Gc.Tweak.set] has the same benign-race caveat as all sibling tweaks.
+   (Upstream types it _Atomic with a fully atomic tweak table; if this
+   tree's table is ever atomicized -- see the TODO on [struct gc_tweak]
+   -- this variable should join it.) */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -1971,6 +1973,11 @@ static void cycle_major_heap_from_stw_single(
   work_counter_at_sweep_start = atomic_load (&total_work_completed);
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
+  CAML_GC_MESSAGE (MAJOR,
+                   "Sweep start: work counter %" CAML_PRIuNAT
+                   ", idle floor armed at %" CAML_PRIuNAT "\n",
+                   work_counter_at_sweep_start,
+                   work_counter_min_before_mark);
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2275,6 +2282,8 @@ static void major_collection_slice(intnat howmuch,
          STWs. */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
+      CAML_GC_MESSAGE (SLICE, "Idle phase: %" CAML_PRIdNAT "%s\n",
+                       todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){
       /* We do not immediately trigger a minor GC, but instead wait for

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,8 +776,11 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
-uintnat caml_small_heap_limit = Small_heap_limit_def;
+   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
+   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
+   gc-tweaks table stores a cast pointer; the startup parser writes
+   before any domain runs. */
+_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -890,6 +893,15 @@ void caml_rearm_idle_floor (void)
 {
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
+  /* The previous (smaller) floor may already have been crossed and a mark
+     request left pending; if the raised floor is no longer reached,
+     withdraw the request so the re-arm actually takes effect for the
+     current cycle. Contract (see the primitive in gc_ctrl.c): called
+     from a single running domain before any marking has started. */
+  if (caml_gc_phase == Phase_sweep_main
+      && diffmod (work_counter_min_before_mark,
+                  atomic_load (&total_work_completed)) > 0)
+    atomic_store_release (&caml_gc_mark_phase_requested, 0);
 }
 
 /* add_overhead is true if the latest collection was synchronous (with
@@ -2256,7 +2268,12 @@ static void major_collection_slice(intnat howmuch,
       /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
       todo = min2 (max2 (todo, 0), idle);
-      if (todo > 0) commit_major_slice_sweepwork (todo);
+      /* Commit even when todo == 0: beyond the counters, the commit also
+         clears [requested_global_major_slice] once the slice target is
+         met (compare the opportunistic early-out above); skipping it
+         would leave an idle domain re-triggering global major-slice
+         STWs. */
+      commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
     }
     if (want_mark){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -880,6 +880,18 @@ void caml_init_major_pacing (void)
     atomic_load (&total_work_completed) + caml_small_heap_limit;
 }
 
+/* Re-arm the idle floor for the CURRENT cycle after caml_small_heap_limit
+   has been changed at run time (the floor is otherwise only read at the
+   start of each sweep phase). Meant for process-startup configuration
+   (e.g. the compiler driver applying -X gc-idle-floor); the store is
+   benign if marking has already started, since the floor is only
+   consulted at the end of sweeping. */
+void caml_rearm_idle_floor (void)
+{
+  work_counter_min_before_mark =
+    work_counter_at_sweep_start + caml_small_heap_limit;
+}
+
 /* add_overhead is true if the latest collection was synchronous (with
    caml_gc_full_major) and thus the sweep phase counted only the live
    data (with no floating garbage). */


### PR DESCRIPTION
Build-system-settable GC pacing for the compiler process, e.g. `-X gc-idle-floor=1G,50% -X gc-space-overhead=200`. Requires #6481. Inert unless passed. Explicit `OCAMLRUNPARAM` takes precedence. Codegen is unaffected (outputs byte-identical).

The floor value is the min of comma-separated terms: absolute sizes (`512M`, `1G`) and/or percentages of per-core physical memory (`50%`). Per core, because the floor is a per-process allowance and the worst case is one compiler per core: a `P%` term bounds a core-saturating build aggregate at `P%` of machine memory, uniformly across machines with different memory-to-core ratios. `/proc/meminfo` is consulted only when a %-term is present.

Measured over a large production tree: `-X gc-idle-floor=512M` is ~20% less aggregate compile time with unchanged per-process peak memory; `gc-space-overhead=200` on top buys a few points more at o=200-level peaks.
