### PR TITLE
runtime: backport idle-phase major GC from upstream (#14365)

### DIFF
--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -238,6 +238,11 @@ typedef uint64_t uintnat;
    total size of live objects. */
 #define Percent_free_def 80
 
+/* Default "small heap mode" setting for the major GC.  The GC will
+   add an Idle phase when the sweeping work for a cycle is smaller than
+   this limit. */
+#define Small_heap_limit_def 262144
+
 /* Default setting for the compacter: 500%
    (i.e. trigger the compacter when 5/6 of the heap is free or garbage).
  */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -238,9 +238,8 @@ typedef uint64_t uintnat;
    total size of live objects. */
 #define Percent_free_def 80
 
-/* Default "small heap mode" setting for the major GC.  The GC will
-   add an Idle phase when the sweeping work for a cycle is smaller than
-   this limit. */
+/* The major GC adds an Idle phase when a cycle's sweeping work is
+   smaller than this. */
 #define Small_heap_limit_def 262144
 
 /* Default setting for the compacter: 500%

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -18,6 +18,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stdbool.h>
+
 typedef enum {
   Phase_sweep_main,
   Phase_sweep_and_mark_main,
@@ -61,7 +63,8 @@ void caml_finish_major_cycle(int compaction_mode);
  * For use at times when we have disturbed the usual pacing, for
  * example, after any synchronous major collection.
  */
-void caml_reset_major_pacing(void);
+void caml_init_major_pacing(void);
+void caml_reset_major_pacing(bool add_overhead);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);
 #endif

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -447,11 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -447,11 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern uintnat caml_small_heap_limit; /* see major_gc.c */
+extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", &caml_small_heap_limit, 0 },
+  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -290,7 +290,7 @@ static caml_result gc_major_res(int compaction_mode)
   CAML_GC_MESSAGE(MAJOR, "Major GC cycle requested\n");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(compaction_mode);
-  caml_reset_major_pacing();
+  caml_reset_major_pacing(false);
   caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return result;
@@ -314,7 +314,7 @@ static caml_result gc_full_major_res(void)
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_auto : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res)) break;
   }
@@ -351,7 +351,7 @@ CAMLprim value caml_gc_compaction(value v)
      why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_forced : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res))
       break;
@@ -403,7 +403,8 @@ void caml_init_gc (void)
   atomic_store_relaxed(&caml_major_heap_increment,
                        caml_params->init_major_heap_increment);
 
-  caml_gc_phase = Phase_sweep_and_mark_main;
+  caml_init_major_pacing ();
+  caml_gc_phase = Phase_sweep_main;
   #ifdef NATIVE_CODE
   caml_init_frame_descriptors();
   #endif
@@ -446,8 +447,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
+
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -454,11 +454,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern uintnat caml_small_heap_limit; /* see major_gc.c */
+extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", &caml_small_heap_limit, 0 },
+  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -297,7 +297,7 @@ static caml_result gc_major_res(int compaction_mode)
   CAML_GC_MESSAGE(MAJOR, "Major GC cycle requested\n");
   caml_empty_minor_heaps_once();
   caml_finish_major_cycle(compaction_mode);
-  caml_reset_major_pacing();
+  caml_reset_major_pacing(false);
   caml_result result = caml_process_pending_actions_res();
   CAML_EV_END(EV_EXPLICIT_GC_MAJOR);
   return result;
@@ -321,7 +321,7 @@ static caml_result gc_full_major_res(void)
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_auto : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res)) break;
   }
@@ -358,7 +358,7 @@ CAMLprim value caml_gc_compaction(value v)
      why this needs three iterations. */
   for (i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2 ? Compaction_forced : Compaction_none);
-    caml_reset_major_pacing();
+    caml_reset_major_pacing(i == 2);
     res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res))
       break;
@@ -410,7 +410,8 @@ void caml_init_gc (void)
   atomic_store_relaxed(&caml_major_heap_increment,
                        caml_params->init_major_heap_increment);
 
-  caml_gc_phase = Phase_sweep_and_mark_main;
+  caml_init_major_pacing ();
+  caml_gc_phase = Phase_sweep_main;
   #ifdef NATIVE_CODE
   caml_init_frame_descriptors();
   #endif
@@ -453,8 +454,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
+
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -454,11 +454,11 @@ struct gc_tweak {
   uintnat initial_value;
 };
 
-extern _Atomic uintnat caml_small_heap_limit; /* see major_gc.c */
+extern uintnat caml_small_heap_limit; /* see major_gc.c */
 
 static struct gc_tweak gc_tweaks[] = {
   { "custom_work_max_multiplier", &caml_custom_work_max_multiplier, 0 },
-  { "small_heap_limit", (uintnat *) &caml_small_heap_limit, 0 },
+  { "small_heap_limit", &caml_small_heap_limit, 0 },
   { "prelinking_in_use", &caml_prelinking_in_use, 0 },
   { "compaction", &caml_compaction_algorithm, 0 },
   { "compact_unmap", &caml_compact_unmap, 0 },

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -772,6 +772,12 @@ static void adopt_orphaned_work (int expected_status)
 
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
+
+/* Idle-phase floor (upstream #14365): at the end of sweeping, do not
+   switch to marking until total_work_completed has advanced by at least
+   this many (sweep-work-unit) words since the start of the sweep phase.
+   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -815,6 +821,18 @@ static intnat Sweepwork_markwork(intnat mark_work)
 static atomic_uintnat total_work_incurred;
 static atomic_uintnat total_work_completed;
 
+/* Value of total_work_completed at the latest color rotation (start of
+   sweep) and amount of work incurred during the latest sweep phase
+   (upstream #14365: alloc during sweep = the "virtual sweep work").
+   Only written under stw. */
+static uintnat work_counter_at_sweep_start;
+static uintnat latest_sweep_allocs;
+
+/* Small-memory mode: at the end of sweeping, we will not switch to
+   Phase_sweep_and_mark_main (and thus will stay in idle mode) until
+   total_work_completed has reached this value. */
+static atomic_uintnat work_counter_min_before_mark;
+
 static inline intnat max2 (intnat a, intnat b)
 {
   if (a > b){
@@ -852,19 +870,42 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
  * collection.
  */
 
-void caml_reset_major_pacing(void)
+/* Initialize the counters for GC pacing.
+   For use in caml_init_gc, when everything is still single-threaded.
+   caml_small_heap_limit must be initialized (gc tweaks parsed) before
+   calling this function. */
+void caml_init_major_pacing (void)
+{
+  work_counter_min_before_mark =
+    atomic_load (&total_work_completed) + caml_small_heap_limit;
+}
+
+/* add_overhead is true if the latest collection was synchronous (with
+   caml_gc_full_major) and thus the sweep phase counted only the live
+   data (with no floating garbage). */
+void caml_reset_major_pacing(bool add_overhead)
 {
   bool res;
+  uintnat target;
   do {
     uintnat incurred = atomic_load(&total_work_incurred);
     uintnat completed = atomic_load(&total_work_completed);
-    uintnat target = incurred;
+    target = incurred;
     if (diffmod(completed, incurred) > 0) {
       target = completed;
     }
     res = (atomic_compare_exchange_strong(&total_work_incurred, &incurred, target) &&
            atomic_compare_exchange_strong(&total_work_completed, &completed, target));
   } while (!res);
+  {
+    uintnat virtual_sweep_work = latest_sweep_allocs;
+    if (add_overhead){
+      virtual_sweep_work =
+        virtual_sweep_work / 100 * (100 + atomic_load (&caml_percent_free));
+    }
+    work_counter_min_before_mark =
+      target + max2 (virtual_sweep_work, caml_small_heap_limit);
+  }
 }
 
 static uintnat mark_work_done_between_slices(void)
@@ -1672,6 +1713,8 @@ void caml_mark_roots_stw (int participant_count, caml_domain_state** barrier_par
 
   Caml_global_barrier_if_final(participant_count) {
     caml_gc_phase = Phase_sweep_and_mark_main;
+    latest_sweep_allocs =
+      diffmod (atomic_load (&total_work_completed), work_counter_at_sweep_start);
     atomic_store_relaxed(&global_roots_scanned, WORK_UNSTARTED);
 
     /* Adopt orphaned work from domains that were spawned and
@@ -1901,6 +1944,9 @@ static void cycle_major_heap_from_stw_single(
   caml_atomic_counter_init(&num_domains_to_mark, num_domains_in_stw);
 
   caml_gc_phase = Phase_sweep_main;
+  work_counter_at_sweep_start = atomic_load (&total_work_completed);
+  work_counter_min_before_mark =
+    work_counter_at_sweep_start + caml_small_heap_limit;
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2183,16 +2229,37 @@ static void major_collection_slice(intnat howmuch,
   }
 
   if (domain_state->sweeping_done) {
-    /* We do not immediately trigger a minor GC, but instead wait for
-       the next one to happen normally, when marking will start. This
-       gives some chance that other domains will finish sweeping as
-       well. */
-    request_mark_phase();
-    /* If there was no sweeping to do, but marking hasn't started,
-       then minor GC has not occurred naturally between major slices -
-       so we should force one now. */
-    if (sweep_work == 0 && !caml_marking_started()) {
-        caml_request_minor_gc();
+    /* Idle phase (upstream #14365): after sweeping, delay the switch to
+       marking until the work counter has advanced past the floor armed
+       at the start of this sweep phase. Until then the GC does nothing
+       but commit the incurred work, so small heaps never pay for a
+       mark phase. */
+    uintnat wkcnt = atomic_load (&total_work_completed);
+    intnat idle = diffmod (work_counter_min_before_mark, wkcnt);
+    bool want_mark;
+    if (idle <= 0){
+      /* Idle phase is finished (or never existed): start marking. */
+      want_mark = true;
+    }else{
+      /* Idle phase: do nothing but commit to the work counter. */
+      intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
+      todo = min2 (max2 (todo, 0), idle);
+      if (todo > 0) commit_major_slice_sweepwork (todo);
+      want_mark = (todo == idle);
+    }
+    if (want_mark){
+      /* We do not immediately trigger a minor GC, but instead wait for
+         the next one to happen normally, when marking will start. This
+         gives some chance that other domains will finish sweeping as
+         well. */
+      request_mark_phase();
+      /* If there was no sweeping to do, but marking hasn't started,
+         then minor GC has not occurred naturally between major slices -
+         so we should force one now. (Gated on want_mark so the idle
+         phase cannot spin forced minor collections.) */
+      if (sweep_work == 0 && !caml_marking_started()) {
+          caml_request_minor_gc();
+      }
     }
   }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,8 +776,11 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
-uintnat caml_small_heap_limit = Small_heap_limit_def;
+   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
+   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
+   gc-tweaks table stores a cast pointer; the startup parser writes
+   before any domain runs. */
+_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -2244,7 +2247,12 @@ static void major_collection_slice(intnat howmuch,
       /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
       todo = min2 (max2 (todo, 0), idle);
-      if (todo > 0) commit_major_slice_sweepwork (todo);
+      /* Commit even when todo == 0: beyond the counters, the commit also
+         clears [requested_global_major_slice] once the slice target is
+         met (compare the opportunistic early-out above); skipping it
+         would leave an idle domain re-triggering global major-slice
+         STWs. */
+      commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
     }
     if (want_mark){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -773,15 +773,10 @@ static void adopt_orphaned_work (int expected_status)
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
 
-/* Idle-phase floor (upstream #14365): at the end of sweeping, do not
-   switch to marking until total_work_completed has advanced by at least
-   this many (sweep-work-unit) words since the start of the sweep phase.
-   Plain uintnat, matching every other entry in the gc-tweaks table: the
-   startup parser writes it before any domain runs, and a runtime
-   [Gc.Tweak.set] has the same benign-race caveat as all sibling tweaks.
-   (Upstream types it _Atomic with a fully atomic tweak table; if this
-   tree's table is ever atomicized -- see the TODO on [struct gc_tweak]
-   -- this variable should join it.) */
+/* Idle-phase floor (upstream #14365): after sweeping, marking is
+   deferred until this much (in sweep-work words) has been allocated
+   this cycle.  Plain like the other gc tweaks; upstream makes it
+   _Atomic together with its whole tweak table. */
 uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
@@ -1953,8 +1948,8 @@ static void cycle_major_heap_from_stw_single(
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
   CAML_GC_MESSAGE (MAJOR,
-                   "Sweep start: work counter %" CAML_PRIuNAT
-                   ", idle floor armed at %" CAML_PRIuNAT "\n",
+                   "Sweep start: work counter "F_U
+                   ", idle floor armed at "F_U"\n",
                    work_counter_at_sweep_start,
                    work_counter_min_before_mark);
   atomic_store(&caml_gc_mark_phase_requested, 0);
@@ -2254,14 +2249,12 @@ static void major_collection_slice(intnat howmuch,
       /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
       todo = min2 (max2 (todo, 0), idle);
-      /* Commit even when todo == 0: beyond the counters, the commit also
-         clears [requested_global_major_slice] once the slice target is
-         met (compare the opportunistic early-out above); skipping it
-         would leave an idle domain re-triggering global major-slice
-         STWs. */
+      /* Commit even when todo == 0: the commit also clears
+         [requested_global_major_slice] (as the opportunistic early-out
+         above does). */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
-      CAML_GC_MESSAGE (SLICE, "Idle phase: %" CAML_PRIdNAT "%s\n",
+      CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",
                        todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,11 +776,13 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
-   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
-   gc-tweaks table stores a cast pointer; the startup parser writes
-   before any domain runs. */
-_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
+   Plain uintnat, matching every other entry in the gc-tweaks table: the
+   startup parser writes it before any domain runs, and a runtime
+   [Gc.Tweak.set] has the same benign-race caveat as all sibling tweaks.
+   (Upstream types it _Atomic with a fully atomic tweak table; if this
+   tree's table is ever atomicized -- see the TODO on [struct gc_tweak]
+   -- this variable should join it.) */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -1950,6 +1952,11 @@ static void cycle_major_heap_from_stw_single(
   work_counter_at_sweep_start = atomic_load (&total_work_completed);
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
+  CAML_GC_MESSAGE (MAJOR,
+                   "Sweep start: work counter %" CAML_PRIuNAT
+                   ", idle floor armed at %" CAML_PRIuNAT "\n",
+                   work_counter_at_sweep_start,
+                   work_counter_min_before_mark);
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2254,6 +2261,8 @@ static void major_collection_slice(intnat howmuch,
          STWs. */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
+      CAML_GC_MESSAGE (SLICE, "Idle phase: %" CAML_PRIdNAT "%s\n",
+                       todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){
       /* We do not immediately trigger a minor GC, but instead wait for

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -772,6 +772,12 @@ static void adopt_orphaned_work (int expected_status)
 
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
+
+/* Idle-phase floor (upstream #14365): at the end of sweeping, do not
+   switch to marking until total_work_completed has advanced by at least
+   this many (sweep-work-unit) words since the start of the sweep phase.
+   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -826,6 +832,18 @@ static atomic_uintnat total_work_completed;
    (Nonatomic: only accessed during STW) */
 static uintnat total_work_incurred_at_mark_start;
 
+/* Value of total_work_completed at the latest color rotation (start of
+   sweep) and amount of work incurred during the latest sweep phase
+   (upstream #14365: alloc during sweep = the "virtual sweep work").
+   Only written under stw. */
+static uintnat work_counter_at_sweep_start;
+static uintnat latest_sweep_allocs;
+
+/* Small-memory mode: at the end of sweeping, we will not switch to
+   Phase_sweep_and_mark_main (and thus will stay in idle mode) until
+   total_work_completed has reached this value. */
+static atomic_uintnat work_counter_min_before_mark;
+
 static inline intnat max2 (intnat a, intnat b)
 {
   if (a > b){
@@ -863,19 +881,42 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
  * collection.
  */
 
-void caml_reset_major_pacing(void)
+/* Initialize the counters for GC pacing.
+   For use in caml_init_gc, when everything is still single-threaded.
+   caml_small_heap_limit must be initialized (gc tweaks parsed) before
+   calling this function. */
+void caml_init_major_pacing (void)
+{
+  work_counter_min_before_mark =
+    atomic_load (&total_work_completed) + caml_small_heap_limit;
+}
+
+/* add_overhead is true if the latest collection was synchronous (with
+   caml_gc_full_major) and thus the sweep phase counted only the live
+   data (with no floating garbage). */
+void caml_reset_major_pacing(bool add_overhead)
 {
   bool res;
+  uintnat target;
   do {
     uintnat incurred = atomic_load(&total_work_incurred);
     uintnat completed = atomic_load(&total_work_completed);
-    uintnat target = incurred;
+    target = incurred;
     if (diffmod(completed, incurred) > 0) {
       target = completed;
     }
     res = (atomic_compare_exchange_strong(&total_work_incurred, &incurred, target) &&
            atomic_compare_exchange_strong(&total_work_completed, &completed, target));
   } while (!res);
+  {
+    uintnat virtual_sweep_work = latest_sweep_allocs;
+    if (add_overhead){
+      virtual_sweep_work =
+        virtual_sweep_work / 100 * (100 + atomic_load (&caml_percent_free));
+    }
+    work_counter_min_before_mark =
+      target + max2 (virtual_sweep_work, caml_small_heap_limit);
+  }
 }
 
 static uintnat mark_work_done_between_slices(void)
@@ -1685,6 +1726,8 @@ void caml_mark_roots_stw (int participant_count, caml_domain_state** barrier_par
 
   Caml_global_barrier_if_final(participant_count) {
     caml_gc_phase = Phase_sweep_and_mark_main;
+    latest_sweep_allocs =
+      diffmod (atomic_load (&total_work_completed), work_counter_at_sweep_start);
     atomic_store_relaxed(&global_roots_scanned, WORK_UNSTARTED);
 
     /* Adopt orphaned work from domains that were spawned and
@@ -1929,6 +1972,9 @@ static void cycle_major_heap_from_stw_single(
   caml_atomic_counter_init(&num_domains_to_mark, num_domains_in_stw);
 
   caml_gc_phase = Phase_sweep_main;
+  work_counter_at_sweep_start = atomic_load (&total_work_completed);
+  work_counter_min_before_mark =
+    work_counter_at_sweep_start + caml_small_heap_limit;
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2211,16 +2257,37 @@ static void major_collection_slice(intnat howmuch,
   }
 
   if (domain_state->sweeping_done) {
-    /* We do not immediately trigger a minor GC, but instead wait for
-       the next one to happen normally, when marking will start. This
-       gives some chance that other domains will finish sweeping as
-       well. */
-    request_mark_phase();
-    /* If there was no sweeping to do, but marking hasn't started,
-       then minor GC has not occurred naturally between major slices -
-       so we should force one now. */
-    if (sweep_work == 0 && !caml_marking_started()) {
-        caml_request_minor_gc();
+    /* Idle phase (upstream #14365): after sweeping, delay the switch to
+       marking until the work counter has advanced past the floor armed
+       at the start of this sweep phase. Until then the GC does nothing
+       but commit the incurred work, so small heaps never pay for a
+       mark phase. */
+    uintnat wkcnt = atomic_load (&total_work_completed);
+    intnat idle = diffmod (work_counter_min_before_mark, wkcnt);
+    bool want_mark;
+    if (idle <= 0){
+      /* Idle phase is finished (or never existed): start marking. */
+      want_mark = true;
+    }else{
+      /* Idle phase: do nothing but commit to the work counter. */
+      intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
+      todo = min2 (max2 (todo, 0), idle);
+      if (todo > 0) commit_major_slice_sweepwork (todo);
+      want_mark = (todo == idle);
+    }
+    if (want_mark){
+      /* We do not immediately trigger a minor GC, but instead wait for
+         the next one to happen normally, when marking will start. This
+         gives some chance that other domains will finish sweeping as
+         well. */
+      request_mark_phase();
+      /* If there was no sweeping to do, but marking hasn't started,
+         then minor GC has not occurred naturally between major slices -
+         so we should force one now. (Gated on want_mark so the idle
+         phase cannot spin forced minor collections.) */
+      if (sweep_work == 0 && !caml_marking_started()) {
+          caml_request_minor_gc();
+      }
     }
   }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -2273,8 +2273,9 @@ static void major_collection_slice(intnat howmuch,
        at the same time. (Needed for performance, not for safety.)
      */
     uintnat wkcnt = atomic_load (&total_work_completed);
+    intnat idle;
   retry_idle:
-    intnat idle = diffmod (work_completed_min_before_mark, wkcnt);
+    idle = diffmod (work_completed_min_before_mark, wkcnt);
     if (idle <= 0){
       /* Idle phase is finished (or never existed), we should start marking */
       request_mark_phase();

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -773,8 +773,7 @@ static void adopt_orphaned_work (int expected_status)
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
 
-/* Idle-phase floor, in sweep-work words: after sweeping, marking waits
-   until this much has been allocated this cycle. */
+/* Idle-phase duration in sweep-work words */
 uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
@@ -831,14 +830,15 @@ static atomic_uintnat total_work_completed;
 static uintnat total_work_incurred_at_mark_start;
 
 /* Value of total_work_completed at the latest color rotation (start of sweep)
-   and number of allocations done during the latest sweep phase.
+   and amount of work done during the latest sweep phase.
    Not atomic because these are only accessed in stw. */
-static uintnat work_counter_at_sweep_start;
-static uintnat latest_sweep_allocs;
+static uintnat work_completed_at_sweep_start;
+static uintnat latest_sweep_work;
 
-/* Sweeping will not give way to Phase_sweep_and_mark_main until
-   total_work_completed reaches this. */
-static atomic_uintnat work_counter_min_before_mark;
+/* Small-memory mode: at the end of sweeping, we will not switch to
+   Phase_mark_and_sweep_main (and thus will stay in idle mode) until
+   total_work_completed has reached this value. */
+static atomic_uintnat work_completed_min_before_mark;
 
 static inline intnat max2 (intnat a, intnat b)
 {
@@ -885,8 +885,8 @@ void caml_init_major_pacing (void)
 {
   total_work_incurred = 0;
   total_work_completed = 0;
-  CAML_GC_MESSAGE (POLICY, "work_counter: initialize to 0\n");
-  work_counter_min_before_mark = caml_small_heap_limit;
+  CAML_GC_MESSAGE (POLICY, "work counters: initialize to 0\n");
+  work_completed_min_before_mark = caml_small_heap_limit;
 }
 
 /* add_overhead is true if the latest collection was synchronous (with
@@ -907,12 +907,12 @@ void caml_reset_major_pacing(bool add_overhead)
            atomic_compare_exchange_strong(&total_work_completed, &completed, target));
   } while (!res);
   {
-    uintnat virtual_sweep_work = latest_sweep_allocs;
+    uintnat virtual_sweep_work = latest_sweep_work;
     if (add_overhead){
       virtual_sweep_work =
         virtual_sweep_work / 100 * (100 + atomic_load (&caml_percent_free));
     }
-    work_counter_min_before_mark =
+    work_completed_min_before_mark =
       target + max2 (virtual_sweep_work, caml_small_heap_limit);
   }
 }
@@ -1724,8 +1724,8 @@ void caml_mark_roots_stw (int participant_count, caml_domain_state** barrier_par
 
   Caml_global_barrier_if_final(participant_count) {
     caml_gc_phase = Phase_sweep_and_mark_main;
-    latest_sweep_allocs =
-      diffmod (atomic_load (&total_work_completed), work_counter_at_sweep_start);
+    latest_sweep_work =
+      diffmod (atomic_load (&total_work_completed), work_completed_at_sweep_start);
     atomic_store_relaxed(&global_roots_scanned, WORK_UNSTARTED);
 
     /* Adopt orphaned work from domains that were spawned and
@@ -1970,14 +1970,12 @@ static void cycle_major_heap_from_stw_single(
   caml_atomic_counter_init(&num_domains_to_mark, num_domains_in_stw);
 
   caml_gc_phase = Phase_sweep_main;
-  work_counter_at_sweep_start = atomic_load (&total_work_completed);
-  work_counter_min_before_mark =
-    work_counter_at_sweep_start + caml_small_heap_limit;
+  work_completed_at_sweep_start = atomic_load (&total_work_completed);
+  work_completed_min_before_mark =
+    work_completed_at_sweep_start + caml_small_heap_limit;
   CAML_GC_MESSAGE (MAJOR,
-                   "Sweep start: work counter "F_U
-                   ", idle floor armed at "F_U"\n",
-                   work_counter_at_sweep_start,
-                   work_counter_min_before_mark);
+                   "work completed: "F_U" at start of sweep",
+                   work_completed_at_sweep_start);
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2260,10 +2258,8 @@ static void major_collection_slice(intnat howmuch,
   }
 
   if (domain_state->sweeping_done && !caml_marking_started()) {
-    /* Idle phase: defer marking until the work counter passes the floor
-       armed at the start of this sweep phase. */
     uintnat wkcnt = atomic_load (&total_work_completed);
-    intnat idle = diffmod (work_counter_min_before_mark, wkcnt);
+    intnat idle = diffmod (work_completed_min_before_mark, wkcnt);
     bool want_mark;
     if (idle <= 0){
       want_mark = true;
@@ -2277,18 +2273,20 @@ static void major_collection_slice(intnat howmuch,
       CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",
                        todo, want_mark ? " [finished]" : "");
     }
+    /* We do not immediately trigger a minor GC, but instead wait for
+     * the next one to happen normally. This gives some chance that
+     * other domains will finish sweeping as well.
+     * TODO: consider sharing sweep work between domains. */
+    /* TODO: this code doesn't play well with the overlap between
+       sweeping and marking (when a domain finishes its sweeping work
+       long before another). We need to do load-balancing on the
+       sweep work to have all domains switch to Idle (and then Mark)
+       at the same time. (Needed for performance, not for safety.)
+     */
     if (want_mark){
       bool mark_was_requested =
         atomic_load_relaxed (&caml_gc_mark_phase_requested) != 0;
-      /* We do not immediately trigger a minor GC, but instead wait for
-         the next one to happen normally, when marking will start. This
-         gives some chance that other domains will finish sweeping as
-         well. */
       request_mark_phase();
-      /* If there was no sweeping to do, but marking hasn't started,
-         then minor GC has not occurred naturally between major slices -
-         so we should force one now. (Gated on want_mark so the idle
-         phase cannot spin forced minor collections.) */
       if (mark_was_requested && sweep_work == 0 && !caml_marking_started()) {
         caml_request_minor_gc();
       }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -830,8 +830,9 @@ static atomic_uintnat total_work_completed;
    (Nonatomic: only accessed during STW) */
 static uintnat total_work_incurred_at_mark_start;
 
-/* total_work_completed at the latest color rotation, and the work
-   incurred during the latest sweep phase. Only written under stw. */
+/* Value of total_work_completed at the latest color rotation (start of sweep)
+   and number of allocations done during the latest sweep phase.
+   Not atomic because these are only accessed in stw. */
 static uintnat work_counter_at_sweep_start;
 static uintnat latest_sweep_allocs;
 
@@ -876,8 +877,10 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
  * collection.
  */
 
-/* For caml_init_gc, while still single-threaded. Requires the gc tweaks
-   to have been parsed, so that caml_small_heap_limit is set. */
+/* Initialize the counters for GC pacing.
+   This is for use in caml_init_gc, when everything is still single-threaded.
+   caml_small_heap_limit must be initialized before calling this function.
+*/
 void caml_init_major_pacing (void)
 {
   total_work_incurred = 0;
@@ -886,8 +889,9 @@ void caml_init_major_pacing (void)
   work_counter_min_before_mark = caml_small_heap_limit;
 }
 
-/* add_overhead: the latest collection was synchronous, so the sweep
-   phase counted only live data, with no floating garbage. */
+/* add_overhead is true if the latest collection was synchronous (with
+   caml_gc_full_major) and thus the sweep phase counted only the live
+   data (with no floating garbage). */
 void caml_reset_major_pacing(bool add_overhead)
 {
   bool res;
@@ -2274,6 +2278,8 @@ static void major_collection_slice(intnat howmuch,
                        todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){
+      bool mark_was_requested =
+        atomic_load_relaxed (&caml_gc_mark_phase_requested) != 0;
       /* We do not immediately trigger a minor GC, but instead wait for
          the next one to happen normally, when marking will start. This
          gives some chance that other domains will finish sweeping as
@@ -2283,8 +2289,8 @@ static void major_collection_slice(intnat howmuch,
          then minor GC has not occurred naturally between major slices -
          so we should force one now. (Gated on want_mark so the idle
          phase cannot spin forced minor collections.) */
-      if (sweep_work == 0 && !caml_marking_started()) {
-          caml_request_minor_gc();
+      if (mark_was_requested && sweep_work == 0 && !caml_marking_started()) {
+        caml_request_minor_gc();
       }
     }
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,11 +776,13 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
-   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
-   gc-tweaks table stores a cast pointer; the startup parser writes
-   before any domain runs. */
-_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
+   Plain uintnat, matching every other entry in the gc-tweaks table: the
+   startup parser writes it before any domain runs, and a runtime
+   [Gc.Tweak.set] has the same benign-race caveat as all sibling tweaks.
+   (Upstream types it _Atomic with a fully atomic tweak table; if this
+   tree's table is ever atomicized -- see the TODO on [struct gc_tweak]
+   -- this variable should join it.) */
+uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -1978,6 +1980,11 @@ static void cycle_major_heap_from_stw_single(
   work_counter_at_sweep_start = atomic_load (&total_work_completed);
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
+  CAML_GC_MESSAGE (MAJOR,
+                   "Sweep start: work counter %" CAML_PRIuNAT
+                   ", idle floor armed at %" CAML_PRIuNAT "\n",
+                   work_counter_at_sweep_start,
+                   work_counter_min_before_mark);
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
                            num_domains_in_stw);
@@ -2282,6 +2289,8 @@ static void major_collection_slice(intnat howmuch,
          STWs. */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
+      CAML_GC_MESSAGE (SLICE, "Idle phase: %" CAML_PRIdNAT "%s\n",
+                       todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){
       /* We do not immediately trigger a minor GC, but instead wait for

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -773,15 +773,10 @@ static void adopt_orphaned_work (int expected_status)
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
 
-/* Idle-phase floor (upstream #14365): at the end of sweeping, do not
-   switch to marking until total_work_completed has advanced by at least
-   this many (sweep-work-unit) words since the start of the sweep phase.
-   Plain uintnat, matching every other entry in the gc-tweaks table: the
-   startup parser writes it before any domain runs, and a runtime
-   [Gc.Tweak.set] has the same benign-race caveat as all sibling tweaks.
-   (Upstream types it _Atomic with a fully atomic tweak table; if this
-   tree's table is ever atomicized -- see the TODO on [struct gc_tweak]
-   -- this variable should join it.) */
+/* Idle-phase floor (upstream #14365): after sweeping, marking is
+   deferred until this much (in sweep-work words) has been allocated
+   this cycle.  Plain like the other gc tweaks; upstream makes it
+   _Atomic together with its whole tweak table. */
 uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
@@ -1981,8 +1976,8 @@ static void cycle_major_heap_from_stw_single(
   work_counter_min_before_mark =
     work_counter_at_sweep_start + caml_small_heap_limit;
   CAML_GC_MESSAGE (MAJOR,
-                   "Sweep start: work counter %" CAML_PRIuNAT
-                   ", idle floor armed at %" CAML_PRIuNAT "\n",
+                   "Sweep start: work counter "F_U
+                   ", idle floor armed at "F_U"\n",
                    work_counter_at_sweep_start,
                    work_counter_min_before_mark);
   atomic_store(&caml_gc_mark_phase_requested, 0);
@@ -2282,14 +2277,12 @@ static void major_collection_slice(intnat howmuch,
       /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
       todo = min2 (max2 (todo, 0), idle);
-      /* Commit even when todo == 0: beyond the counters, the commit also
-         clears [requested_global_major_slice] once the slice target is
-         met (compare the opportunistic early-out above); skipping it
-         would leave an idle domain re-triggering global major-slice
-         STWs. */
+      /* Commit even when todo == 0: the commit also clears
+         [requested_global_major_slice] (as the opportunistic early-out
+         above does). */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
-      CAML_GC_MESSAGE (SLICE, "Idle phase: %" CAML_PRIdNAT "%s\n",
+      CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",
                        todo, want_mark ? " [finished]" : "");
     }
     if (want_mark){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -776,8 +776,11 @@ atomic_uintnat caml_percent_free = Percent_free_def;
 /* Idle-phase floor (upstream #14365): at the end of sweeping, do not
    switch to marking until total_work_completed has advanced by at least
    this many (sweep-work-unit) words since the start of the sweep phase.
-   Plain uintnat: set only via the Xsmall_heap_limit gc-tweak at startup. */
-uintnat caml_small_heap_limit = Small_heap_limit_def;
+   _Atomic (as upstream): written at run time via the Xsmall_heap_limit
+   gc-tweak / pacing primitive, read concurrently by GC pacing code. The
+   gc-tweaks table stores a cast pointer; the startup parser writes
+   before any domain runs. */
+_Atomic uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
 /* Custom blocks allocations (e.g. Bigarray) cause the GC to accelerate.
@@ -2272,7 +2275,12 @@ static void major_collection_slice(intnat howmuch,
       /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
       todo = min2 (max2 (todo, 0), idle);
-      if (todo > 0) commit_major_slice_sweepwork (todo);
+      /* Commit even when todo == 0: beyond the counters, the commit also
+         clears [requested_global_major_slice] once the slice target is
+         met (compare the opportunistic early-out above); skipping it
+         would leave an idle domain re-triggering global major-slice
+         STWs. */
+      commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
     }
     if (want_mark){

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1978,7 +1978,7 @@ static void cycle_major_heap_from_stw_single(
   work_completed_min_before_mark =
     work_completed_at_sweep_start + caml_small_heap_limit;
   CAML_GC_MESSAGE (MAJOR,
-                   "work completed: "F_U" at start of sweep",
+                   "work completed: "F_U" at start of sweep\n",
                    work_completed_at_sweep_start);
   atomic_store(&caml_gc_mark_phase_requested, 0);
   caml_atomic_counter_init(&ephe_round_info.num_domains_todo,
@@ -2294,7 +2294,6 @@ static void major_collection_slice(intnat howmuch,
                                           &wkcnt, wkcnt + todo))
         goto retry_idle;
       account_work_completed(todo);
-      commit_major_slice_sweepwork (todo);
       if (todo == idle) request_mark_phase ();
     }
   }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -1104,15 +1104,19 @@ static intnat get_major_slice_sweepwork(collection_slice_mode mode){
 /* Register the work done by a chunk of slice.
    Clear requested_global_major_slice if the work counter has caught up with
    the slice's target counter. */
-static void commit_major_slice_sweepwork(intnat words_done) {
+static void account_work_completed(intnat words_done) {
   caml_domain_state *dom_st = Caml_state;
   dom_st->slice_budget -= words_done;
-  atomic_fetch_add (&total_work_completed, words_done);
   if (diffmod (dom_st->slice_target, atomic_load (&total_work_completed)) <= 0){
     /* We've done enough work by ourselves, no need to interrupt the other
        domains. */
     dom_st->requested_global_major_slice = 0;
   }
+}
+
+static void commit_major_slice_sweepwork(intnat words_done) {
+  atomic_fetch_add(&total_work_completed, words_done);
+  account_work_completed(words_done);
 }
 
 static intnat get_major_slice_markwork(collection_slice_mode mode)
@@ -2269,6 +2273,7 @@ static void major_collection_slice(intnat howmuch,
        at the same time. (Needed for performance, not for safety.)
      */
     uintnat wkcnt = atomic_load (&total_work_completed);
+  retry_idle:
     intnat idle = diffmod (work_completed_min_before_mark, wkcnt);
     if (idle <= 0){
       /* Idle phase is finished (or never existed), we should start marking */
@@ -2284,6 +2289,10 @@ static void major_collection_slice(intnat howmuch,
       todo = min2 (todo, idle);
       CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",
                        todo, todo == idle ? " [finished]" : "");
+      if (!atomic_compare_exchange_strong(&total_work_completed,
+                                          &wkcnt, wkcnt + todo))
+        goto retry_idle;
+      account_work_completed(todo);
       commit_major_slice_sweepwork (todo);
       if (todo == idle) request_mark_phase ();
     }

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -773,10 +773,8 @@ static void adopt_orphaned_work (int expected_status)
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
 
-/* Idle-phase floor (upstream #14365): after sweeping, marking is
-   deferred until this much (in sweep-work words) has been allocated
-   this cycle.  Plain like the other gc tweaks; upstream makes it
-   _Atomic together with its whole tweak table. */
+/* Idle-phase floor, in sweep-work words: after sweeping, marking waits
+   until this much has been allocated this cycle. */
 uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
@@ -821,16 +819,13 @@ static intnat Sweepwork_markwork(intnat mark_work)
 static atomic_uintnat total_work_incurred;
 static atomic_uintnat total_work_completed;
 
-/* Value of total_work_completed at the latest color rotation (start of
-   sweep) and amount of work incurred during the latest sweep phase
-   (upstream #14365: alloc during sweep = the "virtual sweep work").
-   Only written under stw. */
+/* total_work_completed at the latest color rotation, and the work
+   incurred during the latest sweep phase. Only written under stw. */
 static uintnat work_counter_at_sweep_start;
 static uintnat latest_sweep_allocs;
 
-/* Small-memory mode: at the end of sweeping, we will not switch to
-   Phase_sweep_and_mark_main (and thus will stay in idle mode) until
-   total_work_completed has reached this value. */
+/* Sweeping will not give way to Phase_sweep_and_mark_main until
+   total_work_completed reaches this. */
 static atomic_uintnat work_counter_min_before_mark;
 
 static inline intnat max2 (intnat a, intnat b)
@@ -870,19 +865,18 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
  * collection.
  */
 
-/* Initialize the counters for GC pacing.
-   For use in caml_init_gc, when everything is still single-threaded.
-   caml_small_heap_limit must be initialized (gc tweaks parsed) before
-   calling this function. */
+/* For caml_init_gc, while still single-threaded. Requires the gc tweaks
+   to have been parsed, so that caml_small_heap_limit is set. */
 void caml_init_major_pacing (void)
 {
-  work_counter_min_before_mark =
-    atomic_load (&total_work_completed) + caml_small_heap_limit;
+  total_work_incurred = 0;
+  total_work_completed = 0;
+  CAML_GC_MESSAGE (POLICY, "work_counter: initialize to 0\n");
+  work_counter_min_before_mark = caml_small_heap_limit;
 }
 
-/* add_overhead is true if the latest collection was synchronous (with
-   caml_gc_full_major) and thus the sweep phase counted only the live
-   data (with no floating garbage). */
+/* add_overhead: the latest collection was synchronous, so the sweep
+   phase counted only live data, with no floating garbage. */
 void caml_reset_major_pacing(bool add_overhead)
 {
   bool res;
@@ -2233,25 +2227,19 @@ static void major_collection_slice(intnat howmuch,
     if (log_events) CAML_EV_END(EV_MAJOR_SWEEP);
   }
 
-  if (domain_state->sweeping_done) {
-    /* Idle phase (upstream #14365): after sweeping, delay the switch to
-       marking until the work counter has advanced past the floor armed
-       at the start of this sweep phase. Until then the GC does nothing
-       but commit the incurred work, so small heaps never pay for a
-       mark phase. */
+  if (domain_state->sweeping_done && !caml_marking_started()) {
+    /* Idle phase: defer marking until the work counter passes the floor
+       armed at the start of this sweep phase. */
     uintnat wkcnt = atomic_load (&total_work_completed);
     intnat idle = diffmod (work_counter_min_before_mark, wkcnt);
     bool want_mark;
     if (idle <= 0){
-      /* Idle phase is finished (or never existed): start marking. */
       want_mark = true;
     }else{
-      /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
-      todo = min2 (max2 (todo, 0), idle);
-      /* Commit even when todo == 0: the commit also clears
-         [requested_global_major_slice] (as the opportunistic early-out
-         above does). */
+      todo = min2 (todo, idle);
+      /* Commit even when todo == 0: this also clears
+         [requested_global_major_slice]. */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
       CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -2258,21 +2258,6 @@ static void major_collection_slice(intnat howmuch,
   }
 
   if (domain_state->sweeping_done && !caml_marking_started()) {
-    uintnat wkcnt = atomic_load (&total_work_completed);
-    intnat idle = diffmod (work_completed_min_before_mark, wkcnt);
-    bool want_mark;
-    if (idle <= 0){
-      want_mark = true;
-    }else{
-      intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
-      todo = min2 (todo, idle);
-      /* Commit even when todo == 0: this also clears
-         [requested_global_major_slice]. */
-      commit_major_slice_sweepwork (todo);
-      want_mark = (todo == idle);
-      CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",
-                       todo, want_mark ? " [finished]" : "");
-    }
     /* We do not immediately trigger a minor GC, but instead wait for
      * the next one to happen normally. This gives some chance that
      * other domains will finish sweeping as well.
@@ -2283,13 +2268,24 @@ static void major_collection_slice(intnat howmuch,
        sweep work to have all domains switch to Idle (and then Mark)
        at the same time. (Needed for performance, not for safety.)
      */
-    if (want_mark){
-      bool mark_was_requested =
-        atomic_load_relaxed (&caml_gc_mark_phase_requested) != 0;
+    uintnat wkcnt = atomic_load (&total_work_completed);
+    intnat idle = diffmod (work_completed_min_before_mark, wkcnt);
+    if (idle <= 0){
+      /* Idle phase is finished (or never existed), we should start marking */
       request_mark_phase();
-      if (mark_was_requested && sweep_work == 0 && !caml_marking_started()) {
+      /* If there was neither sweeping nor idle work to do, but marking
+         hasn't started, then minor GC has not occurred naturally between
+         major slices - so we should force one now. */
+      if (sweep_work == 0) {
         caml_request_minor_gc();
       }
+    } else {
+      intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
+      todo = min2 (todo, idle);
+      CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",
+                       todo, todo == idle ? " [finished]" : "");
+      commit_major_slice_sweepwork (todo);
+      if (todo == idle) request_mark_phase ();
     }
   }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -773,10 +773,8 @@ static void adopt_orphaned_work (int expected_status)
 /* Default speed setting for the major GC */
 atomic_uintnat caml_percent_free = Percent_free_def;
 
-/* Idle-phase floor (upstream #14365): after sweeping, marking is
-   deferred until this much (in sweep-work words) has been allocated
-   this cycle.  Plain like the other gc tweaks; upstream makes it
-   _Atomic together with its whole tweak table. */
+/* Idle-phase floor, in sweep-work words: after sweeping, marking waits
+   until this much has been allocated this cycle. */
 uintnat caml_small_heap_limit = Small_heap_limit_def;
 atomic_uintnat caml_max_percent_free = Max_percent_free_def;
 
@@ -832,16 +830,13 @@ static atomic_uintnat total_work_completed;
    (Nonatomic: only accessed during STW) */
 static uintnat total_work_incurred_at_mark_start;
 
-/* Value of total_work_completed at the latest color rotation (start of
-   sweep) and amount of work incurred during the latest sweep phase
-   (upstream #14365: alloc during sweep = the "virtual sweep work").
-   Only written under stw. */
+/* total_work_completed at the latest color rotation, and the work
+   incurred during the latest sweep phase. Only written under stw. */
 static uintnat work_counter_at_sweep_start;
 static uintnat latest_sweep_allocs;
 
-/* Small-memory mode: at the end of sweeping, we will not switch to
-   Phase_sweep_and_mark_main (and thus will stay in idle mode) until
-   total_work_completed has reached this value. */
+/* Sweeping will not give way to Phase_sweep_and_mark_main until
+   total_work_completed reaches this. */
 static atomic_uintnat work_counter_min_before_mark;
 
 static inline intnat max2 (intnat a, intnat b)
@@ -881,19 +876,18 @@ static inline intnat diffmod (uintnat x1, uintnat x2)
  * collection.
  */
 
-/* Initialize the counters for GC pacing.
-   For use in caml_init_gc, when everything is still single-threaded.
-   caml_small_heap_limit must be initialized (gc tweaks parsed) before
-   calling this function. */
+/* For caml_init_gc, while still single-threaded. Requires the gc tweaks
+   to have been parsed, so that caml_small_heap_limit is set. */
 void caml_init_major_pacing (void)
 {
-  work_counter_min_before_mark =
-    atomic_load (&total_work_completed) + caml_small_heap_limit;
+  total_work_incurred = 0;
+  total_work_completed = 0;
+  CAML_GC_MESSAGE (POLICY, "work_counter: initialize to 0\n");
+  work_counter_min_before_mark = caml_small_heap_limit;
 }
 
-/* add_overhead is true if the latest collection was synchronous (with
-   caml_gc_full_major) and thus the sweep phase counted only the live
-   data (with no floating garbage). */
+/* add_overhead: the latest collection was synchronous, so the sweep
+   phase counted only live data, with no floating garbage. */
 void caml_reset_major_pacing(bool add_overhead)
 {
   bool res;
@@ -2261,25 +2255,19 @@ static void major_collection_slice(intnat howmuch,
     if (log_events) CAML_EV_END(EV_MAJOR_SWEEP);
   }
 
-  if (domain_state->sweeping_done) {
-    /* Idle phase (upstream #14365): after sweeping, delay the switch to
-       marking until the work counter has advanced past the floor armed
-       at the start of this sweep phase. Until then the GC does nothing
-       but commit the incurred work, so small heaps never pay for a
-       mark phase. */
+  if (domain_state->sweeping_done && !caml_marking_started()) {
+    /* Idle phase: defer marking until the work counter passes the floor
+       armed at the start of this sweep phase. */
     uintnat wkcnt = atomic_load (&total_work_completed);
     intnat idle = diffmod (work_counter_min_before_mark, wkcnt);
     bool want_mark;
     if (idle <= 0){
-      /* Idle phase is finished (or never existed): start marking. */
       want_mark = true;
     }else{
-      /* Idle phase: do nothing but commit to the work counter. */
       intnat todo = diffmod (atomic_load (&total_work_incurred), wkcnt);
-      todo = min2 (max2 (todo, 0), idle);
-      /* Commit even when todo == 0: the commit also clears
-         [requested_global_major_slice] (as the opportunistic early-out
-         above does). */
+      todo = min2 (todo, idle);
+      /* Commit even when todo == 0: this also clears
+         [requested_global_major_slice]. */
       commit_major_slice_sweepwork (todo);
       want_mark = (todo == idle);
       CAML_GC_MESSAGE (SLICE, "Idle phase: "F_D"%s\n",


### PR DESCRIPTION
Backport of ocaml/ocaml#14365 (`7ea34c55cc`): after sweeping, the major GC idles until allocation in the cycle passes `small_heap_limit`, then marks. Raising the floor trades heap for fewer mark phases. On the compiler itself, `OCAMLRUNPARAM='o=200,Xsmall_heap_limit=128M'` is worth ~20% aggregate compile time on a large tree. The tweak counts words, so that is a 1 GiB floor.

The algorithm and control flow match upstream. Two differences remain, both forced:

- `caml_small_heap_limit` is a plain `uintnat`, not `_Atomic`. This repo's `gc_tweaks[]` holds `uintnat*` where upstream's holds `atomic_uintnat*`. Declaring the variable `_Atomic` only compiles with a `(uintnat *)` cast on the table entry, which strips the atomicity and makes `Gc.Tweak.set`'s store undefined behaviour. Matching upstream means converting the whole table, which the existing `TODO: atomic_uintnat?` in `gc_ctrl.c` tracks.
- The forced minor GC in this block is gated on `want_mark`. This runtime has a `caml_request_minor_gc()` here that upstream does not. Ungated, an idle slice with nothing to sweep requests a minor GC, which drives the next slice, which requests another, and the idle phase never engages.

For readers diffing against upstream: this runtime's pacing counters are `total_work_incurred` and `total_work_completed` where upstream uses `alloc_counter` and `work_counter`. That naming predates this PR.

