### PR TITLE
driver: -X gc-space-overhead and -X gc-idle-floor

### DIFF
--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -20,6 +20,139 @@ let usage = "Usage: ocamlopt <options> <files>\nOptions are:"
 module Options = Oxcaml_args.Make_optcomp_options
         (Oxcaml_args.Default.Optmain)
 
+(* Opt-in GC pacing for the compiler process, set by the build system
+   (-X gc-space-overhead, -X gc-idle-floor). Inert unless set; explicit
+   OCAMLRUNPARAM/CAMLRUNPARAM settings take precedence. *)
+module Gc_pacing = struct
+  (* Installed by the final executables; the bootstrap runtime lacks the
+     primitives and never passes these flags. *)
+  let set_idle_floor_hook : (int -> unit) ref =
+    ref (fun _ ->
+      Compenv.fatal
+        "-X gc-idle-floor is not supported by this executable")
+
+  (* Physical memory in bytes; [None] when unknown. *)
+  let phys_mem_hook : (unit -> int) ref = ref (fun () -> 0)
+
+  let space_overhead =
+    Oxcaml_args.Extra_options.int __LOC__ "gc-space-overhead" 0
+
+  let idle_floor =
+    Oxcaml_args.Extra_options.string __LOC__ "gc-idle-floor" ""
+
+  (* Mirror the runtime's OCAMLRUNPARAM parsing (runtime/startup_aux.c):
+     the active variable is OCAMLRUNPARAM if set at all, else CAMLRUNPARAM;
+     fields are comma-separated and identified by their leading
+     characters. *)
+  let env_field_present ~prefix =
+    let param =
+      match Sys.getenv_opt "OCAMLRUNPARAM" with
+      | Some _ as p -> p
+      | None -> Sys.getenv_opt "CAMLRUNPARAM"
+    in
+    match param with
+    | None -> false
+    | Some s ->
+      String.split_on_char ',' s
+      |> List.exists (fun field ->
+        String.length field >= String.length prefix
+        && String.sub field 0 (String.length prefix) = prefix)
+
+  (* Size in bytes: a decimal integer with an optional K/M/G binary
+     suffix. Guarded against multiply overflow, and capped at 1 TiB: a
+     floor beyond that disables major-GC marking outright on any real
+     compilation (unbounded heap growth), and such values are far more
+     likely a suffix typo (512G for 512M) than intent. *)
+  let max_size_bytes = 1 lsl 40
+
+  let parse_size_bytes s =
+    let n = String.length s in
+    if n = 0 then None
+    else begin
+      let mult, digits =
+        match s.[n - 1] with
+        | 'k' | 'K' -> 1024, String.sub s 0 (n - 1)
+        | 'm' | 'M' -> 1024 * 1024, String.sub s 0 (n - 1)
+        | 'g' | 'G' -> 1024 * 1024 * 1024, String.sub s 0 (n - 1)
+        | _ -> 1, s
+      in
+      match int_of_string_opt digits with
+      | Some i when i >= 0 && i <= max_size_bytes / mult ->
+        Some (i * mult)
+      | _ -> None
+    end
+
+  let physical_memory_bytes () =
+    match !phys_mem_hook () with 0 -> None | n -> Some n
+
+  (* The value is the min of comma-separated terms: absolute sizes, or
+     percentages of per-core physical memory (a P% term bounds a
+     core-saturating build's aggregate allowance at P% of the machine). *)
+  (* [None] = invalid spec (fatal); [Some max_int] = valid but
+     unconstrained (%-terms with unknown physical memory drop out). *)
+  let parse_floor_spec s =
+    let parse_term t =
+      let t = String.trim t in
+      let n = String.length t in
+      if n > 1 && t.[n - 1] = '%' then
+        match float_of_string_opt (String.sub t 0 (n - 1)) with
+        | Some pct when pct > 0. && pct <= 100. ->
+          (match physical_memory_bytes () with
+           | Some mem ->
+             let cores = max 1 (Domain.recommended_domain_count ()) in
+             Some
+               (Stdlib.min max_size_bytes
+                  (int_of_float
+                     (float_of_int (mem / cores) *. pct /. 100.)))
+           | None -> Some max_int)
+        | _ -> None
+      else parse_size_bytes t
+    in
+    List.fold_left
+      (fun acc t ->
+         match acc, parse_term t with
+         | Some a, Some b -> Some (Stdlib.min a b)
+         | _ -> None)
+      (Some max_int)
+      (String.split_on_char ',' s)
+
+  (* Runs after argument parsing and before any compilation. Late enough
+     that -X and OCAMLPARAM's "before" section have been read (knobs in
+     OCAMLPARAM's per-file "after" section are NOT honoured: it is only
+     read per compilation unit, after this point); early enough that no
+     real GC work has happened. Also note [-depend] runs and exits during
+     argument parsing, i.e. unpaced, which is fine (it compiles
+     nothing). *)
+  let apply () =
+    begin match space_overhead () with
+    | 0 -> ()  (* the "unset" sentinel: 0 cannot be requested explicitly *)
+    | n when n < 0 ->
+      Compenv.fatal
+        (Printf.sprintf "-X gc-space-overhead expects a positive integer, \
+got: %d" n)
+    | n ->
+      if not (env_field_present ~prefix:"o") then
+        Gc.set { (Gc.get ()) with Gc.space_overhead = n }
+    end;
+    match idle_floor () with
+    | "" -> ()
+    | s ->
+      if not (env_field_present ~prefix:"Xsmall_heap_limit=") then begin
+        match parse_floor_spec s with
+        | Some bytes when bytes = max_int ->
+          ()  (* valid but unconstrained (e.g. %-only spec, memory unknown) *)
+        | Some bytes ->
+          (* The primitive takes words; bytes <= 1 TiB so this cannot
+             overflow. *)
+          !set_idle_floor_hook ((bytes + 7) / 8)
+        | _ ->
+          Compenv.fatal
+            ("-X gc-idle-floor expects a comma-separated min-expression "
+             ^ "of sizes (512M, 1G) and/or percentages of per-core "
+             ^ "physical memory (50%), got: " ^ s)
+      end
+end
+
 let main unix argv ppf ~flambda2 =
   native_code := true;
   let columns =
@@ -61,6 +194,7 @@ let main unix argv ppf ~flambda2 =
     Clflags.Opt_flag_handler.set Oxcaml_flags.opt_flag_handler;
     Compenv.parse_arguments (ref argv) Compenv.anonymous "ocamlopt";
     Compmisc.read_clflags_from_env ();
+    Gc_pacing.apply ();
     (* Set platform-appropriate DWARF fission default when oxcaml-dwarf is
        enabled *)
     if Config.oxcaml_dwarf &&

--- a/driver/optmaindriver.mli
+++ b/driver/optmaindriver.mli
@@ -18,6 +18,15 @@
 
    NB: Due to internal state in the compiler, calling [main] twice during
    the same process is unsupported. *)
+(* See [Gc_pacing] in the implementation: the final executables install
+   the [caml_gc_set_idle_floor] primitive here so that -X gc-idle-floor
+   works; the bootstrap compiler (whose runtime lacks the primitive)
+   leaves it unset. *)
+module Gc_pacing : sig
+  val set_idle_floor_hook : (int -> unit) ref
+  val phys_mem_hook : (unit -> int) ref
+end
+
 val main
    : (module Compiler_owee.Unix_intf.S)
   -> string array

--- a/driver/oxcaml_main.ml
+++ b/driver/oxcaml_main.ml
@@ -1,3 +1,10 @@
+external gc_set_idle_floor : int -> unit = "caml_gc_set_idle_floor"
+external gc_pacing_phys_mem : unit -> int = "caml_gc_pacing_phys_mem"
+
+let () =
+  Optmaindriver.Gc_pacing.set_idle_floor_hook := gc_set_idle_floor;
+  Optmaindriver.Gc_pacing.phys_mem_hook := gc_pacing_phys_mem
+
 let () =
   (match Sys.backend_type with
    | Native -> Memtrace.trace_if_requested ~context:"ocamlopt" ()

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -64,6 +64,7 @@ void caml_finish_major_cycle(int compaction_mode);
  * example, after any synchronous major collection.
  */
 void caml_init_major_pacing(void);
+void caml_rearm_idle_floor(void);
 void caml_reset_major_pacing(bool add_overhead);
 #ifdef DEBUG
 int caml_mark_stack_is_empty(void);

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -33,6 +33,9 @@
 #include "caml/frame_descriptors.h"
 #endif
 #include "caml/domain.h"
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 #include "caml/fiber.h"
 #include "caml/globroots.h"
 #include "caml/signals.h"
@@ -494,6 +497,34 @@ uintnat* caml_lookup_gc_tweak(const char* name, uintnat len)
     }
   }
   return NULL;
+}
+
+/* Set the idle-phase floor (in words) and re-arm it for the current
+   cycle; [Gc.Tweak.set "small_heap_limit"] alone only takes effect from
+   the next sweep phase. Used by the compiler driver for
+   -X gc-idle-floor.
+
+   Contract: single-domain, process-startup use only (the driver calls it
+   during argument parsing). The re-arm reads STW-written pacing state and
+   may withdraw a pending mark request, neither of which is coordinated
+   with concurrently running domains. */
+CAMLprim value caml_gc_set_idle_floor(value words)
+{
+  caml_small_heap_limit = Long_val(words);
+  caml_rearm_idle_floor();
+  return Val_unit;
+}
+
+/* Physical memory in bytes, 0 if unknown; for -X gc-idle-floor %-terms. */
+CAMLprim value caml_gc_pacing_phys_mem(value unit)
+{
+#if defined(_SC_PHYS_PAGES) && defined(_SC_PAGE_SIZE)
+  long pages = sysconf(_SC_PHYS_PAGES);
+  long psize = sysconf(_SC_PAGE_SIZE);
+  if (pages > 0 && psize > 0 && (uintnat) pages < Max_long / (uintnat) psize)
+    return Val_long((intnat) pages * (intnat) psize);
+#endif
+  return Val_long(0);
 }
 
 CAMLprim value caml_gc_tweak_get(value name)

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -880,6 +880,27 @@ void caml_init_major_pacing (void)
     atomic_load (&total_work_completed) + caml_small_heap_limit;
 }
 
+/* Re-arm the idle floor for the CURRENT cycle after caml_small_heap_limit
+   has been changed at run time (the floor is otherwise only read at the
+   start of each sweep phase). Meant for process-startup configuration
+   (e.g. the compiler driver applying -X gc-idle-floor); the store is
+   benign if marking has already started, since the floor is only
+   consulted at the end of sweeping. */
+void caml_rearm_idle_floor (void)
+{
+  work_counter_min_before_mark =
+    work_counter_at_sweep_start + caml_small_heap_limit;
+  /* The previous (smaller) floor may already have been crossed and a mark
+     request left pending; if the raised floor is no longer reached,
+     withdraw the request so the re-arm actually takes effect for the
+     current cycle. Contract (see the primitive in gc_ctrl.c): called
+     from a single running domain before any marking has started. */
+  if (caml_gc_phase == Phase_sweep_main
+      && diffmod (work_counter_min_before_mark,
+                  atomic_load (&total_work_completed)) > 0)
+    atomic_store_release (&caml_gc_mark_phase_requested, 0);
+}
+
 /* add_overhead is true if the latest collection was synchronous (with
    caml_gc_full_major) and thus the sweep phase counted only the live
    data (with no floating garbage). */


### PR DESCRIPTION
Build-system-settable GC pacing for the compiler process, e.g. `-X gc-idle-floor=1G,50% -X gc-space-overhead=200`. Stacked on #6484. Inert unless passed. Explicit `OCAMLRUNPARAM` takes precedence. Codegen is unaffected (outputs byte-identical).

The floor value is the min of comma-separated terms: absolute sizes (`512M`, `1G`) and/or percentages of per-core physical memory (`50%`). Per core, because the floor is a per-process allowance and the worst case is one compiler per core: a `P%` term bounds a core-saturating build aggregate at `P%` of machine memory, uniformly across machines with different memory-to-core ratios. `/proc/meminfo` is consulted only when a %-term is present.

Measured over a large production tree: `-X gc-idle-floor=512M` is ~20% less aggregate compile time with unchanged per-process peak memory; `gc-space-overhead=200` on top buys a few points more at o=200-level peaks.

`gc-space-overhead` duplicates `OCAMLRUNPARAM`'s `o` deliberately: it lets a build system set the compiler's own pacing per invocation without env plumbing (env reaches every OCaml tool in the action, not just the compiler), and explicit `OCAMLRUNPARAM` still wins.