### PR TITLE
Emitter plumbing for compact frametables

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -396,6 +396,7 @@ let emit_named_text_section ?(suffix = "") func_name =
     | _ ->
       D.switch_to_section_raw ~names:[".text.startup.caml"] ~flags:(Some "ax")
         ~args:["@progbits"] ~is_delayed:false;
+      Emitaux.enter_code_section ".text.startup.caml";
       (* Warning: We set the internal section ref to Text here, because it
          currently does not supported named text sections. In the rest of this
          file, we pretend the section is called Text rather than the function
@@ -414,16 +415,23 @@ let emit_named_text_section ?(suffix = "") func_name =
          does not support function sections. *) ->
       assert false
     | _ ->
-      D.switch_to_section_raw
-        ~names:[Printf.sprintf ".text.caml.%s%s" (emit_symbol func_name) suffix]
-        ~flags:(Some "ax") ~args:["@progbits"] ~is_delayed:false;
+      let name =
+        Printf.sprintf ".text.caml.%s%s" (emit_symbol func_name) suffix
+      in
+      D.switch_to_section_raw ~names:[name] ~flags:(Some "ax")
+        ~args:["@progbits"] ~is_delayed:false;
+      Emitaux.enter_code_section name;
       (* Warning: We set the internal section ref to Text here, because it
          currently does not supported named text sections. In the rest of this
          file, we pretend the section is called Text rather than the function
          specific text section. *)
       (* CR sspies: Add proper support for named text sections. *)
       D.unsafe_set_internal_section_ref Text)
-  else D.text ()
+  else (
+    D.text ();
+    (* On Mach-O, [Delta_uleb128] evaluates cross-atom deltas via .set, so
+       function boundaries need not break delta chains. *)
+    Emitaux.enter_code_section ".text")
 
 let emit_function_or_basic_block_section_name () =
   let suffix =

--- a/backend/arm64/binary_emitter/binary_emitter.ml
+++ b/backend/arm64/binary_emitter/binary_emitter.ml
@@ -87,7 +87,16 @@ let iter emitter ~all_sections ~on_insn ~on_directive =
         on_directive !current_state d;
         let offset_in_bytes = Section_state.offset_in_bytes !current_state in
         let new_offset =
-          D.Directive.increment_offset_in_bytes d ~offset_in_bytes
+          match[@warning "-4"] d with
+          | Delta_uleb128 { delta } -> (
+            (* Variable-width (ULEB128) encoding of a label difference. *)
+            match
+              Encode_directive.eval_constant !current_state ~all_sections delta
+            with
+            | Some value -> offset_in_bytes + D.Directive.uleb128_size value
+            | None ->
+              Misc.fatal_error "Delta_uleb128: cannot resolve label difference")
+          | _ -> D.Directive.increment_offset_in_bytes d ~offset_in_bytes
         in
         Section_state.set_offset_in_bytes !current_state new_offset)
     (enqueued emitter)
@@ -116,7 +125,7 @@ let compute_label_offsets emitter ~all_sections =
       | Cfi_restore_state | Cfi_def_cfa_register _ | Comment _ | Const _
       | File _ | Indirect_symbol _ | Loc _ | New_line | Private_extern _
       | Section _ | Size _ | Sleb128 _ | Space _ | Type _ | Uleb128 _
-      | Protected _ | Hidden _ | External _ | Reloc _ ->
+      | Protected _ | Hidden _ | External _ | Reloc _ | Delta_uleb128 _ ->
         ())
 
 (* Second pass: emit machine code and data *)

--- a/backend/arm64/binary_emitter/encode_directive.ml
+++ b/backend/arm64/binary_emitter/encode_directive.ml
@@ -590,6 +590,11 @@ let emit_directive state ~current_section ~all_sections
     match eval_constant state ~all_sections constant with
     | Some value -> D.Directive.emit_uleb128 buf value
     | None -> Misc.fatal_error "Cannot emit ULEB128 for external symbol")
+  | Delta_uleb128 { delta } -> (
+    (* ULEB128 difference of two labels in the same text section *)
+    match eval_constant state ~all_sections delta with
+    | Some value -> D.Directive.emit_uleb128 buf value
+    | None -> Misc.fatal_error "Delta_uleb128: cannot resolve label difference")
   (* Directives that don't emit data *)
   | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_endproc | Cfi_offset _
   | Cfi_startproc | Cfi_remember_state | Cfi_restore_state

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1217,15 +1217,20 @@ let emit_named_text_section func_name =
   then (
     (* CR sspies: Clean this up and add proper support for function sections in
        the new asm directives. *)
-    D.switch_to_section_raw
-      ~names:[".text.caml." ^ S.encode (S.create_global func_name)]
-      ~flags:(Some "ax") ~args:["%progbits"] ~is_delayed:false;
+    let name = ".text.caml." ^ S.encode (S.create_global func_name) in
+    D.switch_to_section_raw ~names:[name] ~flags:(Some "ax") ~args:["%progbits"]
+      ~is_delayed:false;
+    Emitaux.enter_code_section name;
     (* Warning: We set the internal section ref to Text here, because it
        currently does not supported named text sections. In the rest of this
        file, we pretend the section is called Text rather than the function
        specific text section. *)
     D.unsafe_set_internal_section_ref Text)
-  else D.text ()
+  else (
+    D.text ();
+    (* On Mach-O, [Delta_uleb128] evaluates cross-atom deltas via .set, so
+       function boundaries need not break delta chains. *)
+    Emitaux.enter_code_section ".text")
 
 (* Emit code to load an emitted literal *)
 

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -283,8 +283,19 @@ module Directive = struct
           target_symbol : Asm_symbol.t;
           addend : int64
         }
+    | Delta_uleb128 of { delta : Constant.t }
+  (* A constant (typically a label difference) emitted as ULEB128 *)
 
   let bprintf = Printf.bprintf
+
+  (* Fresh names for Mach-O [Delta_uleb128] .set temporaries. Never reset:
+     uniqueness within each emitted file is all that is required. *)
+  let delta_temp_var_counter = ref 0
+
+  let new_delta_temp_var () =
+    let id = !delta_temp_var_counter in
+    incr delta_temp_var_counter;
+    Printf.sprintf "Ldelta%d" id
 
   let string_of_substring_literal ~start:k ~length:n s =
     let between x low high =
@@ -411,6 +422,19 @@ module Directive = struct
       | _, _ -> print_ascii_string_gas ~chunk_size:80 buf str);
       bprintf buf "%s" (gas_comment_opt comment)
     | Comment s -> if emit_comments () then bprintf buf "\t\t\t\t/* %s */" s
+    | Delta_uleb128 { delta } -> (
+      (* Typically a difference of two same-section labels, which the assembler
+         computes; the value must be non-negative. *)
+      match TS.assembler () with
+      | MacOS ->
+        (* Mach-O assemblers refuse a cross-atom label difference emitted
+           inline, but accept one bound with .set, which forces assembly-time
+           evaluation (compare [Direct_assignment]). The L prefix keeps the
+           temporary assembler-local. *)
+        let temp = new_delta_temp_var () in
+        bprintf buf "\t.set %s, (%a)\n\t.uleb128 %s" temp Constant.print delta
+          temp
+      | _ -> bprintf buf "\t.uleb128 (%a)" Constant.print delta)
     | Global sym -> bprintf buf "\t.globl\t%s" (Asm_symbol.encode sym)
     | New_label (Label lbl, _typ) -> bprintf buf "%s:" (Asm_label.encode lbl)
     | New_label (Symbol sym, _typ) -> bprintf buf "%s:" (Asm_symbol.encode sym)
@@ -573,6 +597,7 @@ module Directive = struct
     | External sym -> bprintf buf "\tEXTRN\t%s: NEAR" (Asm_symbol.encode sym)
     (* The only supported "type" on EXTRN declarations is NEAR. *)
     | Reloc _ -> unsupported "Reloc"
+    | Delta_uleb128 _ -> unsupported "Delta_uleb128"
 
   let print b t =
     match TS.assembler () with
@@ -663,6 +688,13 @@ module Directive = struct
       | This | Label _ | Symbol _ | Variable _ | Add _ | Sub _ ->
         Misc.fatal_error
           "increment_offset_in_bytes: uleb128 with non-integer constant")
+    | Delta_uleb128 _ ->
+      (* Variable-width, and the delta's value is not available here:
+         offset-accounting callers must special-case this directive by
+         evaluating the label difference themselves (see
+         [Arm64_binary_emitter.Binary_emitter.iter]). *)
+      Misc.fatal_error
+        "increment_offset_in_bytes: Delta_uleb128 is not supported"
     (* Directives that don't contribute to section size *)
     | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_endproc
     | Cfi_offset _ | Cfi_startproc | Cfi_remember_state | Cfi_restore_state
@@ -1125,6 +1157,13 @@ let between_labels_32_bit ?comment:_comment ~upper ~lower () =
 let between_labels_64_bit ?comment:_ ~upper:_ ~lower:_ () =
   (* CR poechsel: use the arguments *)
   Misc.fatal_error "between_labels_64_bit not implemented yet"
+
+let delta_uleb128 ~upper ~lower =
+  let delta =
+    Directive.Constant.Sub
+      (Directive.Constant.Label upper, Directive.Constant.Label lower)
+  in
+  emit (Delta_uleb128 { delta })
 
 let between_labels_64_bit_with_offsets ?comment:_comment ~upper ~upper_offset
     ~lower ~lower_offset () =

--- a/backend/asm_targets/asm_directives.mli
+++ b/backend/asm_targets/asm_directives.mli
@@ -286,6 +286,10 @@ val between_labels_32_bit :
 val between_labels_64_bit :
   ?comment:string -> upper:Asm_label.t -> lower:Asm_label.t -> unit -> unit
 
+(** Emit the difference [upper - lower] of two same-section labels as a ULEB128
+    value. Supported only on the GAS text backend. *)
+val delta_uleb128 : upper:Asm_label.t -> lower:Asm_label.t -> unit
+
 (** Like [between_symbols], but for two labels with additional offsets, emitting
     a 64-bit-wide reference. The labels must be in the same section. *)
 val between_labels_64_bit_with_offsets :
@@ -477,6 +481,8 @@ module Directive : sig
           target_symbol : Asm_symbol.t;
           addend : int64
         }
+    | Delta_uleb128 of { delta : Constant.t }
+        (** Variable-width return-address delta for a short frame descriptor *)
 
   (** Translate the given directive to textual form. This produces output
       suitable for either gas or MASM as appropriate. *)
@@ -490,6 +496,10 @@ module Directive : sig
       padding (Align). Directives that don't emit data return the offset
       unchanged. *)
   val increment_offset_in_bytes : t -> offset_in_bytes:int -> int
+
+  (** The number of bytes in the ULEB128 encoding of a value (which must be
+      non-negative). *)
+  val uleb128_size : int64 -> int
 
   (** Emit an unsigned LEB128 encoded value to a buffer. *)
   val emit_uleb128 : Buffer.t -> int64 -> unit

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -51,6 +51,21 @@ type frame_descr =
 
 let frame_descriptors = ref ([] : frame_descr list)
 
+(* The epoch bumps at each text-section change. It prepares for a compact
+   frame-descriptor format in which a return address is a delta from the
+   previous descriptor's -- an assembly-time constant only when both lie in the
+   same section -- so descriptors will record the epoch to decide where delta
+   chains must break. *)
+let frame_section_epoch = ref 0
+
+let current_code_section = ref ""
+
+let enter_code_section name =
+  if not (String.equal name !current_code_section)
+  then (
+    current_code_section := name;
+    incr frame_section_epoch)
+
 let is_none_dbg d = Debuginfo.Dbg.is_none (Debuginfo.get_dbg d)
 
 let get_flags debuginfo =
@@ -374,10 +389,14 @@ let with_snapshot ~f =
   let saved_file_pos_nums = !file_pos_nums in
   let saved_file_pos_num_cnt = !file_pos_num_cnt in
   let saved_frame_descriptors = !frame_descriptors in
+  let saved_frame_section_epoch = !frame_section_epoch in
+  let saved_current_code_section = !current_code_section in
   let result = f () in
   file_pos_nums := saved_file_pos_nums;
   file_pos_num_cnt := saved_file_pos_num_cnt;
   frame_descriptors := saved_frame_descriptors;
+  frame_section_epoch := saved_frame_section_epoch;
+  current_code_section := saved_current_code_section;
   result
 
 let get_file_num ~file_emitter file_name =

--- a/backend/emitaux.mli
+++ b/backend/emitaux.mli
@@ -52,6 +52,13 @@ val record_frame_descr :
   (* Location, if any *)
   unit
 
+(** The backends call this whenever they switch text section, with the section's
+    name; it maintains a section epoch, in preparation for a compact
+    frame-descriptor format whose return addresses are deltas from the previous
+    descriptor -- an assembly-time constant only when both lie in the same
+    section. Re-entering the current section does not bump the epoch. *)
+val enter_code_section : string -> unit
+
 (** [with_snapshot f] runs [f] and returns its result, but also ensures that the
     state of this [Emitaux] module is unchanged after [f] returns. *)
 val with_snapshot : f:(unit -> 'a) -> 'a

--- a/backend/internal_assembler/internal_assembler.ml
+++ b/backend/internal_assembler/internal_assembler.ml
@@ -181,10 +181,19 @@ let assemble_one_section ~name instructions =
     }
 
 let get_sections ~delayed sections =
+  X86_binary_emitter.clear_cross_section_labels ();
   let get acc sections =
+    (* Assemble text-like sections first: data sections may contain
+       [Delta_uleb128] label differences that resolve only once the text
+       sections holding those labels have been assembled. *)
+    let text, others =
+      List.partition
+        (fun (name, _) -> Section_name.is_text_like name)
+        sections
+    in
     List.fold_left (fun acc (name, instructions) ->
       Section_name.Map.add name (assemble_one_section ~name instructions) acc)
-      acc sections
+      acc (text @ others)
   in
   (* DWARF sections must be emitted after .text and .data because they
      contain information that is produced when .text and .data are emitted.

--- a/backend/jit_backend.ml
+++ b/backend/jit_backend.ml
@@ -58,6 +58,15 @@ let register callback =
     (* Save old x86 internal assembler and register our hook *)
     saved_x86_internal_assembler := !X86_proc.internal_assembler;
     X86_proc.register_internal_assembler (fun ~delayed:_ sections _filename ->
+        X86_binary_emitter.clear_cross_section_labels ();
+        (* Assemble text-like sections first: data sections may contain
+           [Delta_uleb128] directives referencing text labels. *)
+        let text, others =
+          List.partition
+            (fun (name, _) -> X86_proc.Section_name.is_text_like name)
+            sections
+        in
+        let sections = text @ others in
         (* Assemble each section *)
         let sections_map =
           List.fold_left

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1985,7 +1985,10 @@ let write_module_metadata t =
   in
   F.pp_line t.ppf "";
   F.pp_line t.ppf {|!0 = !{ i32 1, !"oxcaml_module", !"%s" }|} module_name;
-  F.pp_line t.ppf {|!llvm.module.flags = !{ !0 }|}
+  (* Tell LLVM's frametable printer which frame-descriptor layout this runtime
+     expects. 0 is the classic layout. *)
+  F.pp_line t.ppf {|!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }|};
+  F.pp_line t.ppf {|!llvm.module.flags = !{ !0, !1 }|}
 
 let write_llvmir_to_file t =
   (match t.sourcefile with

--- a/backend/x86_binary_emitter.ml
+++ b/backend/x86_binary_emitter.ml
@@ -174,6 +174,14 @@ let local_labels = String.Tbl.create 100
 
 let forced_long_jumps = ref IntSet.empty
 
+(* Final positions of labels in sections that have already been assembled,
+   keyed by encoded label name. Used to resolve [Delta_uleb128].
+   Drivers clear this per program and assemble text-like sections first. *)
+let cross_section_labels : (Section_name.t * int) String.Tbl.t =
+  String.Tbl.create 100
+
+let clear_cross_section_labels () = String.Tbl.clear cross_section_labels
+
 let new_buffer sec =
   {
     sec;
@@ -1626,6 +1634,41 @@ let assemble_line b loc ins =
             buf_int8 b 0
           done
     | Directive (D.Hidden _) | Directive D.New_line -> ()
+    | Directive (D.Delta_uleb128 { delta }) -> (
+      (* ULEB128 difference of two labels in the same section. *)
+      match delta with
+      | C.Sub (C.Label upper, C.Label lower) ->
+          let resolve lbl =
+            let name = Asm_label.encode lbl in
+            let local =
+              match String.Tbl.find b.labels name with
+              | { sy_pos = Some pos; _ } -> Some (b.sec.sec_name, pos)
+              | _ -> None
+              | exception Not_found -> None
+            in
+            match local with
+            | Some entry -> entry
+            | None -> (
+                match String.Tbl.find cross_section_labels name with
+                | entry -> entry
+                | exception Not_found ->
+                    Misc.fatal_errorf
+                      "x86_binary_emitter: Delta_uleb128 label %s not \
+                       defined in any assembled section"
+                      name)
+          in
+          let sec_u, pos_u = resolve upper in
+          let sec_l, pos_l = resolve lower in
+          if not (Section_name.equal sec_u sec_l) then
+            Misc.fatal_error
+              "x86_binary_emitter: Delta_uleb128 labels in different \
+               sections";
+          if pos_u < pos_l then
+            Misc.fatal_error "x86_binary_emitter: negative Delta_uleb128";
+          D.emit_uleb128 b.buf (Int64.of_int (pos_u - pos_l))
+      | C.Signed_int _ | C.Unsigned_int _ | C.This | C.Label _ | C.Symbol _
+      | C.Variable _ | C.Add _ | C.Sub _ ->
+          Misc.fatal_error "x86_binary_emitter: malformed Delta_uleb128")
     | Directive
         (D.Reloc
           { name = D.R_X86_64_PLT32;
@@ -1741,7 +1784,17 @@ and assemble_section0 _arch section =
 
     if !retry then iter_assemble () else b
   in
-  iter_assemble ()
+  let b = iter_assemble () in
+  (* Record this section's final label positions for cross-section
+     [Delta_uleb128] resolution in sections assembled later. *)
+  String.Tbl.iter
+    (fun name sym ->
+      match sym.sy_pos with
+      | Some pos ->
+          String.Tbl.replace cross_section_labels name (b.sec.sec_name, pos)
+      | None -> ())
+    b.labels;
+  b
 
 (* Relocations: we should compute all non-local relocations completely at the
    end. We should keep the last string/bytes couple to avoid duplication.

--- a/backend/x86_binary_emitter.mli
+++ b/backend/x86_binary_emitter.mli
@@ -59,6 +59,10 @@ val relocations : buffer -> Relocation.t list
 
 val assemble_section : arch -> section -> buffer
 
+(** Forget label positions recorded by previous [assemble_section] calls.
+    Call once per program, before assembling its first section. *)
+val clear_cross_section_labels : unit -> unit
+
 val get_symbol : buffer -> StringMap.key -> symbol
 
 val contents_mut : buffer -> bytes

--- a/backend/x86_peephole/x86_peephole_utils.ml
+++ b/backend/x86_peephole/x86_peephole_utils.ml
@@ -29,7 +29,7 @@ let is_hard_barrier = function
     | Comment _ | Const _ | Direct_assignment _ | File _ | Global _
     | Indirect_symbol _ | Loc _ | New_line | Private_extern _ | Size _
     | Sleb128 _ | Space _ | Type _ | Uleb128 _ | Protected _ | Hidden _ | Weak _
-    | External _ | Reloc _ ->
+    | External _ | Reloc _ | Delta_uleb128 _ ->
       false)
   | Ins instr -> is_control_flow instr
 

--- a/oxcaml/tests/backend/llvmize/alloc_ir.output
+++ b/oxcaml/tests/backend/llvmize/alloc_ir.output
@@ -1180,4 +1180,5 @@ declare i1 @llvm.expect.i1(i1, i1)
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Alloc" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/array_rev_ir.output
+++ b/oxcaml/tests/backend/llvmize/array_rev_ir.output
@@ -296,4 +296,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Array_rev" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/const_val_ir.output
+++ b/oxcaml/tests/backend/llvmize/const_val_ir.output
@@ -47,4 +47,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Const_val" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/csel_ir.output
+++ b/oxcaml/tests/backend/llvmize/csel_ir.output
@@ -622,4 +622,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Csel" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/data_decl_ir.output
+++ b/oxcaml/tests/backend/llvmize/data_decl_ir.output
@@ -546,4 +546,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Data_decl" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/dls_get.output
+++ b/oxcaml/tests/backend/llvmize/dls_get.output
@@ -111,4 +111,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Dls_get" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/exn_part2_ir.output
+++ b/oxcaml/tests/backend/llvmize/exn_part2_ir.output
@@ -2180,4 +2180,5 @@ module asm "  movq camlExn_part2__catch_wildcard_HIDE_STAMP.recover_rbp_var.L428
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Exn_part2" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/extcalls_ir.output
+++ b/oxcaml/tests/backend/llvmize/extcalls_ir.output
@@ -562,4 +562,5 @@ module asm "  movq camlExtcalls__call_too_many_with_try_HIDE_STAMP.recover_rbp_v
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Extcalls" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/float_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/float_ops_ir.output
@@ -342,4 +342,5 @@ declare double @llvm.fabs.double(double)
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Float_ops" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/gcd_ir.output
+++ b/oxcaml/tests/backend/llvmize/gcd_ir.output
@@ -236,4 +236,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Gcd" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/id_fn.output
+++ b/oxcaml/tests/backend/llvmize/id_fn.output
@@ -74,4 +74,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Id_fn" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/indirect_call_ir.output
+++ b/oxcaml/tests/backend/llvmize/indirect_call_ir.output
@@ -105,4 +105,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Indirect_call" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/int_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/int_ops_ir.output
@@ -1538,4 +1538,5 @@ declare i64 @llvm.cttz.i64(i64, i1)
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Int_ops" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/many_args_ir.output
+++ b/oxcaml/tests/backend/llvmize/many_args_ir.output
@@ -170,4 +170,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Many_args" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/multi_ret_ir.output
+++ b/oxcaml/tests/backend/llvmize/multi_ret_ir.output
@@ -104,4 +104,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Multi_ret" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/switch_ir.output
+++ b/oxcaml/tests/backend/llvmize/switch_ir.output
@@ -2132,4 +2132,5 @@ module asm "  movq camlSwitch__entry.recover_rbp_var.L367(%rip), %rbx"
 module asm "  jmpq *%rbx"
 
 !0 = !{ i32 1, !"oxcaml_module", !"Switch" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }

--- a/oxcaml/tests/backend/llvmize/tailcall_ir.output
+++ b/oxcaml/tests/backend/llvmize/tailcall_ir.output
@@ -965,4 +965,5 @@ define private oxcamlcc { { i64, i64 }, { i64 } } @wrap_try(i64 %0, i64 %1) retu
 
 
 !0 = !{ i32 1, !"oxcaml_module", !"Tailcall" }
-!llvm.module.flags = !{ !0 }
+!1 = !{ i32 1, !"oxcaml_short_frametables", i32 0 }
+!llvm.module.flags = !{ !0, !1 }


### PR DESCRIPTION
Various changes to backend code emitters to enable #6399 (shorter frametables).
Basically this lets the backends emit ULEB128-encoded deltas between code labels, and to notice when code sections change (to disable the compact frametable format when a return-address delta isn't a compile-time constant).