### PR TITLE
Allow DWARF compression for normal compilation

### DIFF
--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -185,16 +185,19 @@ let dwarf_inlined_frames = ref false
 
 let default_gdwarf_compression = "zlib"
 
-let gdwarf_compression = ref default_gdwarf_compression
+let gdwarf_compression : string option ref = ref None
 
 let ddwarf_metrics = ref false
 
 let ddwarf_metrics_output_file : string option ref = ref None
 
 let get_dwarf_compression_flag () =
-  if !dwarf_inlined_frames || not !restrict_to_upstream_dwarf
-  then Some !gdwarf_compression
-  else None
+  match !gdwarf_compression with
+  | Some _ as compression -> compression
+  | None ->
+    if !dwarf_inlined_frames || not !restrict_to_upstream_dwarf
+    then Some default_gdwarf_compression
+    else None
 
 let get_dwarf_compression_format () =
   match get_dwarf_compression_flag () with

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -87,7 +87,11 @@ val dwarf_inlined_frames : bool ref
 
 val default_gdwarf_compression : string
 
-val gdwarf_compression : string ref
+(** DWARF compression format set on the command line. [None] means use the
+    default. The default is no compression for upstream DWARF. The default is
+    [default_gdwarf_compression] when [dwarf_inlined_frames] is enabled or
+    [restrict_to_upstream_dwarf] is disabled. *)
+val gdwarf_compression : string option ref
 
 val ddwarf_metrics : bool ref
 

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -1214,8 +1214,10 @@ let mk_gdwarf_max_function_complexity f =
 let mk_gdwarf_compression f =
   ( "-gdwarf-compression",
     Arg.String f,
-    Format.sprintf " Set the DWARF compression format (default %s)"
-      !Dwarf_flags.gdwarf_compression )
+    Format.sprintf
+      " Set the DWARF compression format (default %s for\n\
+      \     -gno-upstream-dwarf or -gdwarf-inlined-frames, none otherwise)"
+      Dwarf_flags.default_gdwarf_compression )
 
 let mk_gdwarf_fission f =
   ( "-gdwarf-fission",
@@ -2302,7 +2304,7 @@ module Debugging_options_impl = struct
     Debugging.dwarf_max_function_complexity := c
 
   let gdwarf_compression value =
-    Debugging.gdwarf_compression := String.lowercase_ascii value
+    Debugging.gdwarf_compression := Some (String.lowercase_ascii value)
 
   let gdwarf_fission value =
     match String.lowercase_ascii value with


### PR DESCRIPTION
This PR changes the behavior of `-gdwarf-compression` to also take affect when standard DWARF output (`-g` but not `-gno-upstream-dwarf` or `-gdwarf-inlined-frames`) is produced. It preserves the behavior that the default is 
- uncompressed for `-g`
- compressed for `-gdwarf-inlined-frames` and `-gno-upstream-dwarf`