### PR TITLE
Factor out `Env.Current_unit`

### DIFF
--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -104,19 +104,18 @@ let reset () =
     (fun pass (cfg_unit_info : Cfg_format.cfg_unit_info) ->
       if should_save_ir_after pass || should_save_ir_before pass
       then (
-        cfg_unit_info.unit <- Compilation_unit.get_current_or_dummy ();
+        cfg_unit_info.unit <- Current_unit.get_cu_or_dummy ();
         cfg_unit_info.items <- [];
-        cfg_before_regalloc_unit_info.unit
-          <- Compilation_unit.get_current_or_dummy ();
+        cfg_before_regalloc_unit_info.unit <- Current_unit.get_cu_or_dummy ();
         cfg_before_regalloc_unit_info.items <- []))
     pass_to_cfg;
   if should_save_before_emit ()
   then (
-    linear_unit_info.unit <- Compilation_unit.get_current_or_dummy ();
+    linear_unit_info.unit <- Current_unit.get_cu_or_dummy ();
     linear_unit_info.items <- []);
   if should_save_cfg_before_emit ()
   then (
-    cfg_unit_info.unit <- Compilation_unit.get_current_or_dummy ();
+    cfg_unit_info.unit <- Current_unit.get_cu_or_dummy ();
     cfg_unit_info.items <- [])
 
 let save_data dl =

--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -1269,7 +1269,7 @@ let offset_into_dwarf_section_symbol ?comment:_comment
         true
         (* CR mshinwell: old code was:
 
-           Compilation_unit.equal (Compilation_unit.get_current_exn ())
+           Compilation_unit.equal (Current_unit.get_cu_exn ())
            (Asm_symbol.compilation_unit upper) *)
       in
       if in_current_unit
@@ -1285,7 +1285,7 @@ let offset_into_dwarf_section_symbol ?comment:_comment
            in compilation unit XXX)"
           (* Asm_section.print upper_section *) Asm_symbol.print upper
           (Format_doc.compat Compilation_unit.print)
-          (Compilation_unit.get_current_exn ())
+          (Current_unit.get_cu_exn ())
           (Format_doc.compat Compilation_unit.print)
       (* (Asm_symbol.compilation_unit upper) *)
     else const_symbol upper

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4290,7 +4290,7 @@ let emit_float_array_constant symb fields cont =
 let make_symbol ?compilation_unit name =
   let compilation_unit =
     match compilation_unit with
-    | None -> Compilation_unit.get_current_exn ()
+    | None -> Current_unit.get_cu_exn ()
     | Some compilation_unit -> compilation_unit
   in
   (* CR sspies: [make_symbol] always uses flat name mangling. Structured

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
@@ -154,7 +154,7 @@ let find state ~compilation_unit_proto_die (dbg : Debuginfo.t) =
   DS.Debug.log "found comp unit %a\n%!"
     (Format_doc.compat Compilation_unit.print)
     dbg_comp_unit;
-  let this_comp_unit = Compilation_unit.get_current_exn () in
+  let this_comp_unit = Current_unit.get_cu_exn () in
   if Compilation_unit.equal dbg_comp_unit this_comp_unit
   then (
     DS.Debug.log "looking in function_abstract_instances for %a\n%!"

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_variables_and_parameters.ml
@@ -267,7 +267,7 @@ let dwarf_for_variable state ~value_type_proto_die ~function_symbol
 
 let iterate_over_variable_like_things state ~available_ranges_vars ~f =
   ARV.iter available_ranges_vars ~f:(fun var range ->
-      let ident_for_type = Some (Compilation_unit.get_current_exn (), var) in
+      let ident_for_type = Some (Current_unit.get_cu_exn (), var) in
       f var ~ident_for_type ~range)
 
 let dwarf state ~value_type_proto_die ~function_symbol ~function_proto_die

--- a/backend/emitaux.ml
+++ b/backend/emitaux.ml
@@ -452,8 +452,8 @@ module Dwarf_helpers = struct
       Asm_targets.Asm_directives.debug_header ~get_file_num;
       let unit_name =
         (* CR lmaurer: This doesn't actually need to be an [Ident.t] *)
-        Symbol.for_current_unit () |> Symbol.linkage_name
-        |> Linkage_name.to_string |> Ident.create_persistent
+        Current_unit.symbol () |> Symbol.linkage_name |> Linkage_name.to_string
+        |> Ident.create_persistent
       in
       let code_begin = Asm_targets.Asm_symbol.create_global code_begin in
       let code_end = Asm_targets.Asm_symbol.create_global code_end in

--- a/backend/llvm/llvmize.ml
+++ b/backend/llvm/llvmize.ml
@@ -1647,7 +1647,8 @@ let make_temp_data_symbol =
   let idx = ref 0 in
   fun () ->
     let module_name =
-      Compilation_unit.(get_current_or_dummy () |> name |> Name.to_string)
+      Compilation_unit.(
+        Current_unit.get_cu_or_dummy () |> name |> Name.to_string)
     in
     let res = Format.asprintf "temp.%s.%d" module_name !idx in
     incr idx;
@@ -1981,7 +1982,9 @@ let write_module_metadata t =
   let module_name =
     if t.is_startup
     then "_startup" (* LLVM will put the "caml" in front *)
-    else Compilation_unit.(get_current_or_dummy () |> name |> Name.to_string)
+    else
+      Compilation_unit.(
+        Current_unit.get_cu_or_dummy () |> name |> Name.to_string)
   in
   F.pp_line t.ppf "";
   F.pp_line t.ppf {|!0 = !{ i32 1, !"oxcaml_module", !"%s" }|} module_name;

--- a/dune
+++ b/dune
@@ -211,6 +211,7 @@
   ;; TYPING
   ident
   path
+  current_unit
   jkind
   scalar
   primitive

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2095,7 +2095,7 @@ let lambda_of_loc kind sloc =
   | Loc_FILE -> Lconst (Const_immstring file)
   | Loc_MODULE ->
     let filename = Filename.basename file in
-    let name = Compilation_unit.get_current () in
+    let name = Current_unit.get_cu () in
     let module_name =
       match name with
       | None -> "//"^filename^"//"

--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -224,7 +224,7 @@ let get_unit_export_info comp_unit =
   end
 
 let which_cmx_file comp_unit =
-  CU.which_cmx_file comp_unit ~accessed_by:(CU.get_current_exn ())
+  CU.which_cmx_file comp_unit ~accessed_by:(Current_unit.get_cu_exn ())
 
 let get_global_export_info comp_unit =
   get_unit_export_info (which_cmx_file comp_unit)
@@ -345,7 +345,7 @@ let save_unit_info filename ~main_module_block_format ~arg_descr =
   write_unit_info current_unit filename
 
 let new_const_symbol () =
-  Symbol.for_new_const_in_current_unit ()
+  Current_unit.symbol_for_new_const ()
   |> Symbol.linkage_name
   |> Linkage_name.to_string
 

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -28,7 +28,7 @@ type loader =
 let load_cmx_file_contents loader comp_unit =
   let accessible_comp_unit =
     Compilation_unit.which_cmx_file comp_unit
-      ~accessed_by:(Compilation_unit.get_current_exn ())
+      ~accessed_by:(Current_unit.get_cu_exn ())
   in
   let cmx_file =
     Compilation_unit.to_global_name_without_prefix accessible_comp_unit
@@ -117,9 +117,7 @@ let compute_reachable_names_and_code ~module_symbol ~free_names_of_name code =
       in
       let fold_code_id names_to_add code_id =
         if
-          not
-            (Code_id.in_compilation_unit code_id
-               (Compilation_unit.get_current_exn ()))
+          not (Code_id.in_compilation_unit code_id (Current_unit.get_cu_exn ()))
         then
           (* Code in units upon which the current unit depends cannot reference
              this unit. *)
@@ -145,7 +143,7 @@ let compute_reachable_names_and_code ~module_symbol ~free_names_of_name code =
           not
             (Compilation_unit.equal
                (Name.compilation_unit name)
-               (Compilation_unit.get_current_exn ()))
+               (Current_unit.get_cu_exn ()))
         then
           (* Names in units upon which the current unit depends cannot reference
              this unit. *)

--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -89,7 +89,7 @@ let create_raw ~final_typing_env ~all_code ~exported_offsets ~used_value_slots
       ~add_section:(File_sections.Builder.add sections)
       all_code
   in
-  [ { original_compilation_unit = Compilation_unit.get_current_exn ();
+  [ { original_compilation_unit = Current_unit.get_cu_exn ();
       final_typing_env;
       all_code;
       exported_offsets;

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -59,9 +59,7 @@ let manufacture_symbol acc proposed_name =
     then Acc.manufacture_symbol_short_name acc
     else acc, Linkage_name.of_string proposed_name
   in
-  let symbol =
-    Symbol.create (Compilation_unit.get_current_exn ()) linkage_name
-  in
+  let symbol = Symbol.create (Current_unit.get_cu_exn ()) linkage_name in
   acc, symbol
 
 let declare_symbol_for_function_slot env acc ident function_slot :
@@ -2990,7 +2988,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
 
 let close_functions acc external_env ~current_alloc_region ~current_region
     function_declarations =
-  let compilation_unit = Compilation_unit.get_current_exn () in
+  let compilation_unit = Current_unit.get_cu_exn () in
   let value_slots_from_idents =
     Ident.Set.fold
       (fun id map ->
@@ -3363,7 +3361,7 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
   (* CR sspies: In the future, improve the debugging UIDs here if possible. *)
   let function_slot =
     Function_slot.create
-      (Compilation_unit.get_current_exn ())
+      (Current_unit.get_cu_exn ())
       ~name:(Ident.name wrapper_id) ~is_always_immediate:false K.value
   in
   let num_provided = Flambda_arity.num_params provided_arity in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -177,7 +177,7 @@ module Env = struct
   let current_depth t = t.current_depth
 
   let create ~big_endian =
-    let current_unit = Compilation_unit.get_current_exn () in
+    let current_unit = Current_unit.get_cu_exn () in
     { variables = Ident.Map.empty;
       globals = Numeric_types.Int.Map.empty;
       simples_to_substitute = Ident.Map.empty;

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1493,7 +1493,7 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
     else
       let unboxed_function_slot =
         Function_slot.create
-          (Compilation_unit.get_current_exn ())
+          (Current_unit.get_cu_exn ())
           ~name:(Ident.name fid ^ "_unboxed")
           ~is_always_immediate:false Flambda_kind.value
       in
@@ -1556,7 +1556,7 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
   in
   let function_slot =
     Function_slot.create
-      (Compilation_unit.get_current_exn ())
+      (Current_unit.get_cu_exn ())
       ~name:(Ident.name fid) ~is_always_immediate:false Flambda_kind.value
   in
   let unboxed_products = ref Ident.Map.empty in

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -114,7 +114,7 @@ let reset () = initialise ()
 
 let create ?sort ?name () : t =
   let sort = Option.value sort ~default:Sort.Normal_or_exn in
-  let compilation_unit = Compilation_unit.get_current_exn () in
+  let compilation_unit = Current_unit.get_cu_exn () in
   let name_stamp = next_stamp () in
   let name =
     let default =

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -489,7 +489,7 @@ module Variable = struct
       !previous_name_stamp
     in
     let data : Variable_data.t =
-      { compilation_unit = Compilation_unit.get_current_exn ();
+      { compilation_unit = Current_unit.get_cu_exn ();
         name;
         name_stamp;
         kind;
@@ -507,7 +507,7 @@ module Variable = struct
 
     let print ppf t =
       let cu = compilation_unit t in
-      if Compilation_unit.equal cu (Compilation_unit.get_current_exn ())
+      if Compilation_unit.equal cu (Current_unit.get_cu_exn ())
       then
         Format.fprintf ppf "%s/%d%s" (name t) (name_stamp t)
           (if user_visible t then "UV" else "N")
@@ -876,12 +876,12 @@ module Code_id = struct
     Table.add !grand_table_of_code_ids data
 
   let rename t =
-    create ~name:(name t) ~debug:(debug t) (Compilation_unit.get_current_exn ())
+    create ~name:(name t) ~debug:(debug t) (Current_unit.get_cu_exn ())
 
   let in_compilation_unit t comp_unit =
     Compilation_unit.equal (get_compilation_unit t) comp_unit
 
-  let is_imported t = not (Compilation_unit.is_current (get_compilation_unit t))
+  let is_imported t = not (Current_unit.is_current (get_compilation_unit t))
 
   module T0 = struct
     let compare = Id.compare

--- a/middle_end/flambda2/identifiers/name.ml
+++ b/middle_end/flambda2/identifiers/name.ml
@@ -56,7 +56,7 @@ let compilation_unit t =
     ~symbol:(fun sym -> Symbol.compilation_unit sym)
 
 let is_imported t =
-  let current = Compilation_unit.get_current_exn () in
+  let current = Current_unit.get_cu_exn () in
   not (Compilation_unit.equal current (compilation_unit t))
 
 let must_be_var_opt t =

--- a/middle_end/flambda2/identifiers/slot.ml
+++ b/middle_end/flambda2/identifiers/slot.ml
@@ -86,9 +86,7 @@ end) : S = struct
 
     let print ppf t =
       Format.fprintf ppf "@[%t(" P.colour;
-      if
-        Compilation_unit.equal t.compilation_unit
-          (Compilation_unit.get_current_exn ())
+      if Compilation_unit.equal t.compilation_unit (Current_unit.get_cu_exn ())
       then Format.fprintf ppf "%s/%d" t.name t.name_stamp
       else
         Format.fprintf ppf "%a.%s/%d"
@@ -127,7 +125,7 @@ end) : S = struct
   let in_compilation_unit t compilation_unit =
     Compilation_unit.equal compilation_unit t.compilation_unit
 
-  let is_imported t = not (Compilation_unit.is_current t.compilation_unit)
+  let is_imported t = not (Current_unit.is_current t.compilation_unit)
 
   let to_string t = t.name ^ "_" ^ string_of_int t.name_stamp
 

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -807,8 +807,7 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
             ~dbg:Debuginfo.none ~is_tupled ~is_my_closure_used
             ~inlining_decision:Never_inline_attribute
             ~absolute_history:
-              (Inlining_history.Absolute.empty
-                 (Compilation_unit.get_current_exn ()))
+              (Inlining_history.Absolute.empty (Current_unit.get_cu_exn ()))
             ~relative_history:Inlining_history.Relative.empty ~loopify
         in
         acc, Flambda.Static_const_or_code.create_code code

--- a/middle_end/flambda2/parser/fexpr_to_flambda_commons.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda_commons.ml
@@ -155,8 +155,7 @@ let fresh_or_existing_code_id env { Fexpr.txt = name; loc = _ } =
   | Some code_id -> code_id
   | None ->
     let c =
-      Code_id.create ~name ~debug:Debuginfo.none
-        (Compilation_unit.get_current_exn ())
+      Code_id.create ~name ~debug:Debuginfo.none (Current_unit.get_cu_exn ())
     in
     DM.add env.code_ids name c;
     c
@@ -164,7 +163,7 @@ let fresh_or_existing_code_id env { Fexpr.txt = name; loc = _ } =
 let fresh_function_slot env { Fexpr.txt = name; loc = _ } =
   let c =
     Function_slot.create
-      (Compilation_unit.get_current_exn ())
+      (Current_unit.get_cu_exn ())
       ~name ~is_always_immediate:false Flambda_kind.value
   in
   UT.add env.function_slots name c;
@@ -178,7 +177,7 @@ let fresh_or_existing_function_slot env ({ Fexpr.txt = name; loc = _ } as id) =
 let fresh_value_slot env { Fexpr.txt = name; loc = _ } kind =
   let c =
     Value_slot.create
-      (Compilation_unit.get_current_exn ())
+      (Current_unit.get_cu_exn ())
       ~name ~is_always_immediate:false kind
   in
   WT.add env.vars_within_closures name c;
@@ -211,7 +210,7 @@ let declare_symbol (env : env) ({ Fexpr.txt = cu, name; loc } as symbol) =
     | None ->
       let cunit =
         match cu with
-        | None -> Compilation_unit.get_current_exn ()
+        | None -> Current_unit.get_cu_exn ()
         | Some cu -> compilation_unit cu
       in
       let symbol = Symbol.unsafe_create cunit (Linkage_name.of_string name) in

--- a/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
@@ -311,14 +311,14 @@ end = struct
     let is_local =
       Compilation_unit.equal
         (Symbol.compilation_unit s)
-        (Compilation_unit.get_current_exn ())
+        (Current_unit.get_cu_exn ())
     in
     if not is_local
     then
       Misc.fatal_errorf "Cannot bind non-local symbol %a@ Current unit is %a"
         Symbol.print s
         (Format_doc.compat Compilation_unit.print)
-        (Compilation_unit.get_current_exn ());
+        (Current_unit.get_cu_exn ());
     let s = Symbol_name_map.translate t.symbols s in
     (None, s) |> nowhere, t
 
@@ -347,9 +347,7 @@ end = struct
 
   let find_symbol_exn t s =
     let cunit = Symbol.compilation_unit s in
-    let is_local =
-      Compilation_unit.equal cunit (Compilation_unit.get_current_exn ())
-    in
+    let is_local = Compilation_unit.equal cunit (Current_unit.get_cu_exn ()) in
     if is_local
     then (None, Symbol_name_map.translate t.symbols s) |> nowhere
     else

--- a/middle_end/flambda2/reaper/field.ml
+++ b/middle_end/flambda2/reaper/field.ml
@@ -199,9 +199,9 @@ let is_local f =
   &&
   match view f with
   | Value_slot vs ->
-    Compilation_unit.is_current (Value_slot.get_compilation_unit vs)
+    Current_unit.is_current (Value_slot.get_compilation_unit vs)
   | Function_slot fs ->
-    Compilation_unit.is_current (Function_slot.get_compilation_unit fs)
+    Current_unit.is_current (Function_slot.get_compilation_unit fs)
   | Block _ | Call_witness _ | Return_of_call _ | Code_id_of_call_witness
   | Is_int | Get_tag | Boxed_number _ ->
     false

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -103,7 +103,7 @@ let is_used (env : env) cn = Analysis.has_use env.uses cn
 
 let is_code_id_used (env : env) code_id =
   is_used env (Code_id_or_name.code_id code_id)
-  || not (Compilation_unit.is_current (Code_id.get_compilation_unit code_id))
+  || not (Current_unit.is_current (Code_id.get_compilation_unit code_id))
 
 let is_symbol_used (env : env) symbol =
   is_used env (Code_id_or_name.symbol symbol)
@@ -1079,8 +1079,7 @@ let decide_whether_apply_needs_calling_convention_change env apply =
           | No ->
             if
               not
-                (Compilation_unit.is_current
-                   (Code_id.get_compilation_unit code_id))
+                (Current_unit.is_current (Code_id.get_compilation_unit code_id))
             then call_kind
             else Call_kind.indirect_function_call_known_arity ~code_ids:Unknown
           | Auto ->
@@ -1831,9 +1830,7 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
         (Cost_metrics.set_of_closures
            ~find_code_characteristics:(fun code_id ->
              let code_metadata =
-               if
-                 Compilation_unit.is_current
-                   (Code_id.get_compilation_unit code_id)
+               if Current_unit.is_current (Code_id.get_compilation_unit code_id)
                then
                  match Code_id.Map.find code_id res.all_code with
                  | exception Not_found ->
@@ -2402,8 +2399,7 @@ and rebuild_code env res
         (function_params_and_body_free_names params_and_body)
   in
   assert (
-    Compilation_unit.is_current
-      (Code_id.get_compilation_unit (Code.code_id code)));
+    Current_unit.is_current (Code_id.get_compilation_unit (Code.code_id code)));
   let res =
     { res with
       all_code = Code_id.Map.add (Code.code_id code) code res.all_code

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -363,7 +363,7 @@ let traverse_call_kind denv acc apply ~exn_arg ~return_args ~default_acc =
     in
     let callee = Apply.callee apply in
     let is_external =
-      not (Compilation_unit.is_current (Code_id.get_compilation_unit code_id))
+      not (Current_unit.is_current (Code_id.get_compilation_unit code_id))
     in
     let[@local] add_apply acc ~only_if_closure_any_source =
       let callee, call_widget =
@@ -861,7 +861,7 @@ type result =
   }
 
 let create_symbol_and_add_any_source acc name =
-  let cu = Compilation_unit.get_current_exn () in
+  let cu = Current_unit.get_cu_exn () in
   let sym = Symbol.create cu (Linkage_name.of_string name) in
   Acc.add_any_source acc (Code_id_or_name.symbol sym);
   sym

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -96,7 +96,7 @@ let simple_to_node t ~all_constants simple =
     ~const:(fun _ -> Code_id_or_name.name all_constants)
     ~var:(fun v ~coercion:_ -> Code_id_or_name.var v)
     ~symbol:(fun s ~coercion:_ ->
-      if not (Compilation_unit.is_current (Symbol.compilation_unit s))
+      if not (Current_unit.is_current (Symbol.compilation_unit s))
       then Graph.add_any_source t.deps (Code_id_or_name.symbol s);
       Code_id_or_name.symbol s)
 
@@ -211,8 +211,7 @@ let add_set_of_closures_dep t let_bound_name_of_the_closure ~closure_code_id
   match defined_in_code_id with
   | None -> ()
   | Some defined_in_code_id ->
-    if
-      Compilation_unit.is_current (Code_id.get_compilation_unit closure_code_id)
+    if Current_unit.is_current (Code_id.get_compilation_unit closure_code_id)
     then
       t.set_of_closures_graph
         <- Code_id.Map.update closure_code_id
@@ -454,8 +453,7 @@ let record_set_of_closures_deps_one_closure t
      in code that will be rewritten for unbox-fv-closures anyway. *)
   match find_code_dep t code_id with
   | None ->
-    assert (
-      not (Compilation_unit.is_current (Code_id.get_compilation_unit code_id)));
+    assert (not (Current_unit.is_current (Code_id.get_compilation_unit code_id)));
     (* The code comes from another compilation unit, so we don't know what
        happens once it is applied. As such, it must cause the whole block to
        escape. *)

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -830,10 +830,10 @@ module Rewriter = struct
             function_slot_types
         in
         let is_local_value_slot vs _ =
-          Compilation_unit.is_current (Value_slot.get_compilation_unit vs)
+          Current_unit.is_current (Value_slot.get_compilation_unit vs)
         in
         let is_local_function_slot fs _ =
-          Compilation_unit.is_current (Function_slot.get_compilation_unit fs)
+          Current_unit.is_current (Function_slot.get_compilation_unit fs)
         in
         let has_local_fields =
           Value_slot.Map.exists is_local_value_slot value_slot_types
@@ -863,7 +863,7 @@ module Rewriter = struct
                    match code_id with
                    | Or_unknown.Unknown -> false
                    | Or_unknown.Known code_id ->
-                     Compilation_unit.is_current
+                     Current_unit.is_current
                        (Code_id.get_compilation_unit code_id))
                  code_id_of_function_slots
           then Must_be_local
@@ -1234,7 +1234,7 @@ let rewrite_typing_env context ~unit_symbol:_ typing_env =
   then Format.eprintf "OLD typing env: %a@." Typing_env.print typing_env;
   let db = context.db in
   let symbol_metadata sym =
-    if not (Compilation_unit.is_current (Symbol.compilation_unit sym))
+    if not (Current_unit.is_current (Symbol.compilation_unit sym))
     then context, Rewriter.Many_sources_any_usage
     else
       let sym = Code_id_or_name.symbol sym in

--- a/middle_end/flambda2/reaper/unboxing_analysis.ml
+++ b/middle_end/flambda2/reaper/unboxing_analysis.ml
@@ -735,7 +735,7 @@ let perform_analysis db ~stats =
               | Set_of_closures l ->
                 let mk kind name =
                   Value_slot.create
-                    (Compilation_unit.get_current_exn ())
+                    (Current_unit.get_cu_exn ())
                     ~name ~is_always_immediate:false kind
                 in
                 let fields =
@@ -753,7 +753,7 @@ let perform_analysis db ~stats =
                     (fun acc (fs, _) ->
                       Function_slot.Map.add fs
                         (Function_slot.create
-                           (Compilation_unit.get_current_exn ())
+                           (Current_unit.get_cu_exn ())
                            ~name:(Function_slot.name fs)
                            ~is_always_immediate:false Flambda_kind.value)
                         acc)
@@ -788,5 +788,5 @@ let cannot_change_calling_convention_query =
 
 let cannot_change_calling_convention uses v =
   (not (Flambda_features.reaper_change_calling_conventions ()))
-  || (not (Compilation_unit.is_current (Code_id.get_compilation_unit v)))
+  || (not (Current_unit.is_current (Code_id.get_compilation_unit v)))
   || cannot_change_calling_convention_query [Code_id_or_name.code_id v] uses.db

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -242,7 +242,7 @@ let create ~round ~machine_width ~(resolver : resolver)
       all_code = Code_id.Map.empty;
       get_imported_code;
       inlining_history_tracker =
-        Inlining_history.Tracker.empty (Compilation_unit.get_current_exn ());
+        Inlining_history.Tracker.empty (Current_unit.get_cu_exn ());
       loopify_state = Loopify_state.do_not_loopify;
       replay_history = Replay_history.first_pass;
       specialization_cost = Specialization_cost.cannot_specialize At_toplevel;
@@ -543,10 +543,7 @@ let find_code_exn t id =
     Exported_code.find_exn (t.get_imported_code ()) id
 
 let define_code t ~code_id ~code =
-  if
-    not
-      (Code_id.in_compilation_unit code_id
-         (Compilation_unit.get_current_exn ()))
+  if not (Code_id.in_compilation_unit code_id (Current_unit.get_cu_exn ()))
   then
     Misc.fatal_errorf "Cannot define code ID %a as it is from another unit:@ %a"
       Code_id.print code_id Code.print code;

--- a/middle_end/flambda2/simplify/lifting/reification.ml
+++ b/middle_end/flambda2/simplify/lifting/reification.ml
@@ -109,7 +109,7 @@ let lift dacc ty ~bound_to static_const : _ Or_invalid.t * DA.t =
     | None ->
       let symbol =
         Symbol.create
-          (Compilation_unit.get_current_exn ())
+          (Current_unit.get_cu_exn ())
           (Linkage_name.of_string (Variable.unique_name bound_to))
       in
       if not (K.equal (T.kind ty) K.value)

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -463,7 +463,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
   in
   let wrapper_var = Variable.create "partial_app" K.value in
   let wrapper_var_duid = Flambda_debug_uid.none in
-  let compilation_unit = Compilation_unit.get_current_exn () in
+  let compilation_unit = Current_unit.get_cu_exn () in
   let wrapper_function_slot =
     Function_slot.create compilation_unit ~name:"partial_app_closure"
       ~is_always_immediate:false K.value
@@ -702,7 +702,7 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
                ~name
         in
         let code_id =
-          Code_id.create ~name ~debug:dbg (Compilation_unit.get_current_exn ())
+          Code_id.create ~name ~debug:dbg (Current_unit.get_cu_exn ())
         in
         (* We could create better result types by combining the types for the
            first arguments with the result types from the called function.

--- a/middle_end/flambda2/simplify/simplify_set_of_closures.ml
+++ b/middle_end/flambda2/simplify/simplify_set_of_closures.ml
@@ -708,7 +708,7 @@ let simplify_and_lift_set_of_closures dacc ~closure_bound_vars_inverse
           function_slot |> Function_slot.rename |> Function_slot.to_string
           |> Linkage_name.of_string
         in
-        Symbol.create (Compilation_unit.get_current_exn ()) name)
+        Symbol.create (Current_unit.get_cu_exn ()) name)
       (Function_declarations.funs_in_order function_decls)
   in
   let closure_symbols_map =

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -498,7 +498,7 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
   let block_sym =
     let var = Variable.create "switch_block" K.value in
     Symbol.create
-      (Compilation_unit.get_current_exn ())
+      (Current_unit.get_cu_exn ())
       (Linkage_name.of_string (Variable.unique_name var))
   in
   let uacc, array_kind, array_load_kind, loaded_kind =

--- a/middle_end/flambda2/simplify_shared/exported_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/exported_offsets.ml
@@ -152,7 +152,7 @@ let reexport_function_slots function_slot_set offsets =
   Function_slot.Set.fold
     (fun function_slot offsets ->
       if
-        Compilation_unit.is_current
+        Current_unit.is_current
           (Function_slot.get_compilation_unit function_slot)
       then offsets
       else
@@ -169,8 +169,7 @@ let reexport_value_slots value_slot_set offsets =
   let imported_offsets = imported_offsets () in
   Value_slot.Set.fold
     (fun value_slot offsets ->
-      if
-        Compilation_unit.is_current (Value_slot.get_compilation_unit value_slot)
+      if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
       then offsets
       else
         match value_slot_offset imported_offsets value_slot with

--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -705,7 +705,7 @@ let output_then_forget_decisions ~output_prefix =
          (that is not one of the numbered warnings)? *)
       Format.eprintf "WARNING: inlining report output failed@.")
     (fun () ->
-      let compilation_unit = Compilation_unit.get_current_exn () in
+      let compilation_unit = Current_unit.get_cu_exn () in
       let tree =
         lazy
           (List.fold_left

--- a/middle_end/flambda2/simplify_shared/slot_offsets.ml
+++ b/middle_end/flambda2/simplify_shared/slot_offsets.ml
@@ -33,17 +33,17 @@ type used_slots =
   }
 
 let[@inline] function_slot_is_used ~used_function_slots v =
-  if Compilation_unit.is_current (Function_slot.get_compilation_unit v)
+  if Current_unit.is_current (Function_slot.get_compilation_unit v)
   then Function_slot.Set.mem v used_function_slots
   else true
 
 let[@inline] unboxed_slot_is_used ~used_unboxed_slots v =
-  if Compilation_unit.is_current (Value_slot.get_compilation_unit v)
+  if Current_unit.is_current (Value_slot.get_compilation_unit v)
   then Value_slot.Set.mem v used_unboxed_slots
   else true
 
 let[@inline] value_slot_is_used ~used_value_slots v =
-  if Compilation_unit.is_current (Value_slot.get_compilation_unit v)
+  if Current_unit.is_current (Value_slot.get_compilation_unit v)
   then Value_slot.Set.mem v used_value_slots
   else true
 
@@ -724,8 +724,7 @@ end = struct
   let create_function_slot set state get_code_metadata function_slot
       (code_id : Function_declarations.code_id_in_function_declaration) =
     if
-      Compilation_unit.is_current
-        (Function_slot.get_compilation_unit function_slot)
+      Current_unit.is_current (Function_slot.get_compilation_unit function_slot)
     then (
       let size =
         match code_id with
@@ -769,7 +768,7 @@ end = struct
         s
 
   let create_unboxed_slot set state value_slot size =
-    if Compilation_unit.is_current (Value_slot.get_compilation_unit value_slot)
+    if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
     then (
       let s = create_slot ~size (Unboxed_slot value_slot) Unassigned in
       add_unboxed_slot state value_slot s;
@@ -806,7 +805,7 @@ end = struct
         s
 
   let create_value_slot set state value_slot =
-    if Compilation_unit.is_current (Value_slot.get_compilation_unit value_slot)
+    if Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
     then (
       let s =
         create_slot ~size:1 (Scannable_value_slot value_slot) Unassigned
@@ -1091,7 +1090,7 @@ end = struct
       Function_slot.Set.filter
         (fun function_slot ->
           if
-            Compilation_unit.is_current
+            Current_unit.is_current
               (Function_slot.get_compilation_unit function_slot)
           then (
             match find_function_slot state function_slot with
@@ -1108,8 +1107,7 @@ end = struct
       Value_slot.Set.filter
         (fun value_slot ->
           if
-            Compilation_unit.is_current
-              (Value_slot.get_compilation_unit value_slot)
+            Current_unit.is_current (Value_slot.get_compilation_unit value_slot)
           then
             (* a value slot appears in a set of closures iff it has a slot *)
             match

--- a/middle_end/flambda2/terms/inlining_history.ml
+++ b/middle_end/flambda2/terms/inlining_history.ml
@@ -251,7 +251,7 @@ module Tracker = struct
   let unknown_call ~dbg ~relative { absolute; _ } =
     extend_absolute absolute
       (Relative.call ~dbg
-         ~callee:(Absolute.empty (Compilation_unit.get_current_exn ()))
+         ~callee:(Absolute.empty (Current_unit.get_cu_exn ()))
          relative)
 
   let call ~dbg ~callee ~relative { absolute; _ } =

--- a/middle_end/flambda2/tests/meet_test.ml
+++ b/middle_end/flambda2/tests/meet_test.ml
@@ -30,7 +30,7 @@ let test_meet_chains_two_vars () =
   let env = TE.add_equation env (Name.var var2) first_type_for_var2 in
   let symbol =
     Symbol.create
-      (Compilation_unit.get_current_exn ())
+      (Current_unit.get_cu_exn ())
       (Linkage_name.of_string "my_symbol")
   in
   let env = TE.add_definition env (Bound_name.create_symbol symbol) K.value in
@@ -68,7 +68,7 @@ let test_meet_chains_three_vars () =
   let env = TE.add_equation env (Name.var var3) first_type_for_var3 in
   let symbol =
     Symbol.create
-      (Compilation_unit.get_current_exn ())
+      (Current_unit.get_cu_exn ())
       (Linkage_name.of_string "my_symbol")
   in
   let env = TE.add_definition env (Bound_name.create_symbol symbol) K.value in

--- a/middle_end/flambda2/to_cmm/to_cmm_result.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_result.ml
@@ -62,7 +62,7 @@ let symbol res sym =
   let sym_name = Linkage_name.to_string (Symbol.linkage_name sym) in
   let sym_global =
     if
-      Compilation_unit.is_current (Symbol.compilation_unit sym)
+      Current_unit.is_current (Symbol.compilation_unit sym)
       && not (Name_occurrences.mem_symbol res.reachable_names sym)
     then Cmm.Local
     else Cmm.Global
@@ -84,7 +84,7 @@ let symbol_of_code_id res code_id ~currently_in_inlined_body : Cmm.symbol =
   in
   let sym_global =
     if
-      Compilation_unit.is_current (Code_id.get_compilation_unit code_id)
+      Current_unit.is_current (Code_id.get_compilation_unit code_id)
       && not (Name_occurrences.mem_code_id res.reachable_names code_id)
     then Cmm.Local
     else Cmm.Global

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -702,7 +702,7 @@ let let_static_set_of_closures env res closure_symbols set ~prev_updates =
 let lift_set_of_closures env res ~body ~bound_vars layout set
     ~(translate_expr : translate_expr) ~num_normal_occurrences_of_bound_vars =
   (* Generate symbols for the set of closures, and each of the closures *)
-  let comp_unit = Compilation_unit.get_current_exn () in
+  let comp_unit = Current_unit.get_cu_exn () in
   let dbg = debuginfo_for_set_of_closures env set in
   let cids =
     Function_declarations.funs_in_order (Set_of_closures.function_decls set)

--- a/middle_end/flambda2/to_cmm/to_cmm_shared.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_shared.ml
@@ -359,7 +359,7 @@ let invalid res ~message =
     | None ->
       let message_sym =
         Symbol.create
-          (Compilation_unit.get_current_exn ())
+          (Current_unit.get_cu_exn ())
           (Linkage_name.of_string
              (Variable.unique_name
                 (Variable.create "invalid" Flambda_kind.value)))

--- a/middle_end/flambda2/to_jsir/to_jsir_env.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_env.ml
@@ -192,7 +192,7 @@ let get_external_symbol ~res symbol =
       var, To_jsir_result.add_instr_exn res (Let (var, expr)))
 
 let get_symbol t ~res symbol =
-  match Symbol.compilation_unit symbol |> Compilation_unit.is_current with
+  match Symbol.compilation_unit symbol |> Current_unit.is_current with
   | true -> Option.map (fun v -> v, res) (Symbol.Map.find_opt symbol t.symbols)
   | false -> Some (get_external_symbol ~res symbol)
 

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -85,7 +85,7 @@ let find_symbol_projection t var =
 
 let clean_for_export t ~reachable_names =
   (* Names coming from other compilation units or unreachable are removed *)
-  let current_compilation_unit = Compilation_unit.get_current_exn () in
+  let current_compilation_unit = Current_unit.get_cu_exn () in
   let names_to_types =
     Name.Map.filter_map
       (fun name (ty, binding_time_and_mode) ->

--- a/middle_end/flambda2/types/env/code_age_relation.ml
+++ b/middle_end/flambda2/types/env/code_age_relation.ml
@@ -35,7 +35,7 @@ let rec has_older_version_in t ~resolver id candidates : _ Or_unknown.t =
     match Code_id.Map.find_or_null id t with
     | Null -> (
       let comp_unit = Code_id.get_compilation_unit id in
-      if Compilation_unit.equal comp_unit (Compilation_unit.get_current_exn ())
+      if Compilation_unit.equal comp_unit (Current_unit.get_cu_exn ())
       then Known false
       else
         match resolver comp_unit with

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1282,7 +1282,7 @@ end = struct
     then
       if
         not
-          (Compilation_unit.is_current
+          (Current_unit.is_current
              (Variable.compilation_unit
                 (var : Variable_in_one_joined_env.t :> Variable.t)))
       then

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -390,7 +390,7 @@ let variable_is_from_missing_cmx_file t name =
   then false
   else
     let comp_unit = Name.compilation_unit name in
-    if Compilation_unit.equal comp_unit (Compilation_unit.get_current_exn ())
+    if Compilation_unit.equal comp_unit (Current_unit.get_cu_exn ())
     then false
     else
       match (resolver t) comp_unit with
@@ -416,7 +416,7 @@ let find_with_binding_time_and_mode' t name kind =
   match Name.Map.find_or_null name (names_to_types t) with
   | Null -> (
     let comp_unit = Name.compilation_unit name in
-    if Compilation_unit.equal comp_unit (Compilation_unit.get_current_exn ())
+    if Compilation_unit.equal comp_unit (Current_unit.get_cu_exn ())
     then
       let[@inline always] var var =
         Misc.fatal_errorf "Variable %a not bound in typing environment:@ %a"
@@ -515,7 +515,7 @@ let binding_time_and_mode t name =
   Name.pattern_match name
     ~var:(fun var ->
       let comp_unit = Variable.compilation_unit var in
-      if Compilation_unit.is_current comp_unit
+      if Current_unit.is_current comp_unit
       then
         let _typ, binding_time_and_mode =
           find_with_binding_time_and_mode t name None
@@ -535,7 +535,7 @@ let mem ?min_name_mode t name =
       let name_mode =
         match Name.Map.find_or_null name (names_to_types t) with
         | Null ->
-          if Compilation_unit.is_current (Name.compilation_unit name)
+          if Current_unit.is_current (Name.compilation_unit name)
           then None
           else Some Name_mode.in_types
         | This (_ty, binding_time_and_mode) ->
@@ -554,7 +554,7 @@ let mem ?min_name_mode t name =
         | Some c -> c <= 0))
     ~symbol:(fun sym ->
       Symbol.Set.mem sym t.defined_symbols
-      || not (Compilation_unit.is_current (Name.compilation_unit name)))
+      || not (Current_unit.is_current (Name.compilation_unit name)))
 
 let mem_simple ?min_name_mode t simple =
   Simple.pattern_match simple
@@ -652,7 +652,7 @@ let add_variable_definition t var kind name_mode =
      compilation units' variables or symbols (except for predefined symbols such
      as exceptions) in our own compilation unit. *)
   let comp_unit = Variable.compilation_unit var in
-  let this_comp_unit = Compilation_unit.get_current_exn () in
+  let this_comp_unit = Current_unit.get_cu_exn () in
   if not (Compilation_unit.equal comp_unit this_comp_unit)
   then
     Misc.fatal_errorf
@@ -687,7 +687,7 @@ let add_variable_definition t var kind name_mode =
 let add_symbol_definition t sym =
   (* CR-someday mshinwell: check for redefinition when invariants enabled? *)
   let comp_unit = Symbol.compilation_unit sym in
-  let this_comp_unit = Compilation_unit.get_current_exn () in
+  let this_comp_unit = Current_unit.get_cu_exn () in
   if not (Compilation_unit.equal comp_unit this_comp_unit)
   then
     Misc.fatal_errorf
@@ -765,7 +765,7 @@ let invariant_for_new_equation (t : t) name ty =
       let has_local_unbound_name =
         Name_occurrences.fold_names unbound_names ~init:false
           ~f:(fun acc name ->
-            acc || Compilation_unit.is_current (Name.compilation_unit name))
+            acc || Current_unit.is_current (Name.compilation_unit name))
       in
       if has_local_unbound_name
       then
@@ -803,7 +803,7 @@ let replace_equation (t : t) name ty =
           if
             Compilation_unit.equal
               (Variable.compilation_unit var)
-              (Compilation_unit.get_current_exn ())
+              (Current_unit.get_cu_exn ())
           then
             Cached_level.replace_variable_binding
               (One_level.just_after_level t.current_level)

--- a/middle_end/flambda2/types/grammar/set_of_closures_contents.ml
+++ b/middle_end/flambda2/types/grammar/set_of_closures_contents.ml
@@ -81,9 +81,7 @@ let remove_unused_value_slots { closures; value_slots } ~used_value_slots =
   let value_slots =
     Value_slot.Set.filter
       (fun var ->
-        (not
-           (Value_slot.in_compilation_unit var
-              (Compilation_unit.get_current_exn ())))
+        (not (Value_slot.in_compilation_unit var (Current_unit.get_cu_exn ())))
         || Value_slot.Set.mem var used_value_slots)
       value_slots
   in

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -2708,7 +2708,7 @@ and remove_unused_value_slots_and_shortcut_aliases_value_slot_indexed_product
         if
           (not
              (Value_slot.in_compilation_unit value_slot
-                (Compilation_unit.get_current_exn ())))
+                (Current_unit.get_cu_exn ())))
           || Value_slot.Set.mem value_slot used_value_slots
         then
           Some

--- a/middle_end/flambda2/types/join_levels_old.ml
+++ b/middle_end/flambda2/types/join_levels_old.ml
@@ -98,7 +98,7 @@ let join_types ~env_at_fork envs_with_levels =
         let same_unit =
           Compilation_unit.equal
             (Name.compilation_unit name)
-            (Compilation_unit.get_current_exn ())
+            (Current_unit.get_cu_exn ())
         in
         if same_unit && not (TE.mem base_env name)
         then

--- a/middle_end/flambda2/types/traversals.ml
+++ b/middle_end/flambda2/types/traversals.ml
@@ -926,7 +926,7 @@ struct
                     not
                       (Compilation_unit.equal
                          (Variable.compilation_unit variable)
-                         (Compilation_unit.get_current_exn ()))
+                         (Current_unit.get_cu_exn ()))
                   then variable
                   else
                     let canonical_var, acc =
@@ -955,7 +955,7 @@ struct
               not
                 (Compilation_unit.equal
                    (Name.compilation_unit name)
-                   (Compilation_unit.get_current_exn ()))
+                   (Current_unit.get_cu_exn ()))
             then canonical, acc
             else
               let canonical_name, acc =

--- a/optcomp/optpackager.ml
+++ b/optcomp/optpackager.ml
@@ -104,7 +104,7 @@ end) : S = struct
                avoid collisions with MSVC's link /lib in case of successive
                packs *)
             let name =
-              Symbol.for_current_unit () |> Symbol.linkage_name
+              Current_unit.symbol () |> Symbol.linkage_name
               |> Linkage_name.to_string
             in
             Filename.temp_file name Config.ext_obj
@@ -115,7 +115,7 @@ end) : S = struct
               match m.pm_kind with
               | PM_intf -> None
               | PM_impl _ ->
-                Some (CU.create_child (CU.get_current_exn ()) m.pm_name))
+                Some (CU.create_child (Current_unit.get_cu_exn ()) m.pm_name))
             members
         in
         let compilation_unit = Unit_info.Artifact.modname target in

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -114,6 +114,7 @@
   ident
   path
   unit_info
+  current_unit
   shape
   shape_reduce
   allowance
@@ -389,6 +390,8 @@
 
 (copy_files ../../typing/persistent_env.ml)
 
+(copy_files ../../typing/current_unit.ml)
+
 (copy_files ../../typing/env.ml)
 
 (copy_files ../../lambda/debuginfo.ml)
@@ -589,6 +592,8 @@
 
 (copy_files ../../typing/persistent_env.mli)
 
+(copy_files ../../typing/current_unit.mli)
+
 (copy_files ../../typing/env.mli)
 
 (copy_files ../../lambda/debuginfo.mli)
@@ -740,6 +745,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Ldd_intf.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Ldd.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Unit_info.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Current_unit.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Shape.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Types.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Attr_helper.cmo
@@ -873,6 +879,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Ldd_intf.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Ldd.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Unit_info.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Current_unit.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Shape.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Types.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Attr_helper.cmx

--- a/typing/current_unit.ml
+++ b/typing/current_unit.ml
@@ -1,0 +1,74 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* The compilation unit currently being compiled. *)
+
+let current_unit : Unit_info.t option ref =
+  ref None
+
+let get () =
+  !current_unit
+
+let get_cu () =
+  Option.map Unit_info.modname (get ())
+
+let get_cu_or_dummy () =
+  Option.value (get_cu ()) ~default:Compilation_unit.dummy
+
+let get_cu_exn () =
+  match get_cu () with
+  | Some t -> t
+  | None -> Misc.fatal_error "No compilation unit set"
+
+let is_current t =
+  match get_cu () with
+  | None -> false
+  | Some t' -> Compilation_unit.equal t t'
+
+let set cu =
+  current_unit := Some cu
+
+let unset () =
+  current_unit := None
+
+module Name = struct
+  let get () =
+    match !current_unit with
+    | None -> ""
+    | Some cu ->
+      Compilation_unit.Name.to_string
+        (Compilation_unit.name (Unit_info.modname cu))
+  let is name =
+    get () = name
+  let is_ident id =
+    Ident.is_global id && is (Ident.name id)
+  let is_path = function
+  | Path.Pident id -> is_ident id
+  | Path.Pdot _ | Path.Papply _ | Path.Pextra_ty _ -> false
+end
+
+let symbol_for_local_ident id =
+  assert (not (Ident.is_global_or_predef id));
+  let compilation_unit = get_cu_exn () in
+  Symbol.for_name compilation_unit (Ident.unique_name id)
+
+let symbol () =
+  Symbol.for_compilation_unit (get_cu_exn ())
+
+let const_label = ref 0
+
+let symbol_for_new_const () =
+  incr const_label;
+  Symbol.for_name (get_cu_exn ()) (Int.to_string !const_label)

--- a/typing/current_unit.mli
+++ b/typing/current_unit.mli
@@ -1,0 +1,36 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* The compilation unit currently being compiled. *)
+
+val get : unit -> Unit_info.t option
+val get_cu : unit -> Compilation_unit.t option
+val get_cu_or_dummy : unit -> Compilation_unit.t
+val get_cu_exn : unit -> Compilation_unit.t
+val is_current : Compilation_unit.t -> bool
+val set : Unit_info.t -> unit
+val unset : unit -> unit
+
+module Name : sig
+  val get : unit -> string
+  val is : string -> bool
+  val is_ident : Ident.t -> bool
+  val is_path : Path.t -> bool
+end
+
+(** It is assumed that the provided [Ident.t] is in the current unit. *)
+val symbol_for_local_ident : Ident.t -> Symbol.t
+val symbol : unit -> Symbol.t
+val symbol_for_new_const : unit -> Symbol.t

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1120,48 +1120,6 @@ let rec address_head = function
   | Alocal id -> AHlocal id
   | Adot (a, _, _) -> address_head a
 
-(* The name of the compilation unit currently compiled. *)
-module Current_unit : sig
-  val get : unit -> Unit_info.t option
-  val get_cu : unit -> Compilation_unit.t option
-  val set : Unit_info.t -> unit
-  val unset : unit -> unit
-
-  module Name : sig
-    val get : unit -> string
-    val is : string -> bool
-    val is_ident : Ident.t -> bool
-    val is_path : Path.t -> bool
-  end
-end = struct
-  let current_unit : Unit_info.t option ref =
-    ref None
-  let get () =
-    !current_unit
-  let get_cu () =
-    Option.map Unit_info.modname (get ())
-  let set cu =
-    current_unit := Some cu
-  let unset () =
-    current_unit := None
-
-  module Name = struct
-    let get () =
-      match !current_unit with
-      | None -> ""
-      | Some cu ->
-        Compilation_unit.Name.to_string
-          (Compilation_unit.name (Unit_info.modname cu))
-    let is name =
-      get () = name
-    let is_ident id =
-      Ident.is_global id && is (Ident.name id)
-    let is_path = function
-    | Pident id -> is_ident id
-    | Pdot _ | Papply _ | Pextra_ty _ -> false
-  end
-end
-
 let set_current_unit = Current_unit.set
 let get_current_unit = Current_unit.get
 let get_current_unit_name = Current_unit.Name.get
@@ -5529,9 +5487,3 @@ let () =
       | _ ->
           None
     )
-
-let () =
-  let get_current_compilation_unit () =
-    Option.map Unit_info.modname (get_current_unit ())
-  in
-  Compilation_unit.Private.fwd_get_current := get_current_compilation_unit

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -34,7 +34,7 @@ let fresh_unknown_uid () : Types.Uid.t =
   let current_unit =
     Some
       (Unit_info.make_dummy ~input_name:"<ikind>"
-         (Compilation_unit.get_current_or_dummy ()))
+         (Current_unit.get_cu_or_dummy ()))
   in
   Types.Uid.mk ~current_unit
 

--- a/typing/persistent_env.ml
+++ b/typing/persistent_env.ml
@@ -351,7 +351,7 @@ let acknowledge_import penv ~check modname pers_sig =
         | Alerts _ -> ()
         | Opaque -> register_import_as_opaque penv modname)
     flags;
-  begin match kind, CU.get_current () with
+  begin match kind, Current_unit.get_cu () with
   | Normal { cmi_impl = imported_unit }, Some current_unit ->
       let access_allowed =
         CU.can_access_by_name imported_unit ~accessed_by:current_unit
@@ -498,7 +498,7 @@ let rec approximate_global_by_name penv global_name =
   global
 
 let current_unit_is_aux name ~allow_args =
-  match CU.get_current () with
+  match Current_unit.get_cu () with
   | None -> false
   | Some current ->
       match CU.to_global_name current with

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -332,7 +332,7 @@ module Type_shape = struct
                 "Linking and substitution should not reach this stage. Found \
                  %s type in file %s."
                 str
-                (match Compilation_unit.get_current () with
+                (match Current_unit.get_cu () with
                 | None -> "<unknown>"
                 | Some cu -> Compilation_unit.full_path_as_string cu)
               (* We cannot access the type printer here, so this

--- a/utils/compilation_unit.ml
+++ b/utils/compilation_unit.ml
@@ -710,21 +710,3 @@ let name_mangling_scheme_for_current_unit () =
   match !name_mangling_scheme_override with
   | Some scheme -> scheme
   | None -> Config.name_mangling_scheme
-
-let fwd_get_current : (unit -> t option) ref = ref (fun () -> assert false)
-
-let get_current () = !fwd_get_current ()
-
-let get_current_or_dummy () = Option.value (get_current ()) ~default:dummy
-
-let get_current_exn () =
-  match get_current () with
-  | Some t -> t
-  | None -> Misc.fatal_error "No compilation unit set"
-
-let is_current t =
-  match get_current () with None -> false | Some t' -> equal t t'
-
-module Private = struct
-  let fwd_get_current = fwd_get_current
-end

--- a/utils/compilation_unit.ml
+++ b/utils/compilation_unit.ml
@@ -700,6 +700,17 @@ let print_debug ppf t =
 
 let print_as_inline_code = Misc.Style.as_inline_code print
 
+let name_mangling_scheme_override : Config.name_mangling_scheme option ref =
+  ref None
+
+let set_name_mangling_scheme_override scheme =
+  name_mangling_scheme_override := Some scheme
+
+let name_mangling_scheme_for_current_unit () =
+  match !name_mangling_scheme_override with
+  | Some scheme -> scheme
+  | None -> Config.name_mangling_scheme
+
 let fwd_get_current : (unit -> t option) ref = ref (fun () -> assert false)
 
 let get_current () = !fwd_get_current ()
@@ -713,17 +724,6 @@ let get_current_exn () =
 
 let is_current t =
   match get_current () with None -> false | Some t' -> equal t t'
-
-let name_mangling_scheme_override : Config.name_mangling_scheme option ref =
-  ref None
-
-let set_name_mangling_scheme_override scheme =
-  name_mangling_scheme_override := Some scheme
-
-let name_mangling_scheme_for_current_unit () =
-  match !name_mangling_scheme_override with
-  | Some scheme -> scheme
-  | None -> Config.name_mangling_scheme
 
 module Private = struct
   let fwd_get_current = fwd_get_current

--- a/utils/compilation_unit.mli
+++ b/utils/compilation_unit.mli
@@ -311,15 +311,3 @@ val set_name_mangling_scheme_override : Config.name_mangling_scheme -> unit
     compiled and serialised with its [.cmx], so when reading another unit we
     never need to know which scheme it was compiled under. *)
 val name_mangling_scheme_for_current_unit : unit -> Config.name_mangling_scheme
-
-val get_current : unit -> t option
-
-val get_current_or_dummy : unit -> t
-
-val get_current_exn : unit -> t
-
-val is_current : t -> bool
-
-module Private : sig
-  val fwd_get_current : (unit -> t option) ref
-end

--- a/utils/compilation_unit.mli
+++ b/utils/compilation_unit.mli
@@ -297,14 +297,6 @@ type error = private
 (** The exception raised by conversion functions in this module. *)
 exception Error of error
 
-val get_current : unit -> t option
-
-val get_current_or_dummy : unit -> t
-
-val get_current_exn : unit -> t
-
-val is_current : t -> bool
-
 (** Set an override for the name mangling scheme used while compiling the
     current unit. Typically called by the driver when the
     [-name-mangling-scheme] command-line option is used. The override applies
@@ -319,6 +311,14 @@ val set_name_mangling_scheme_override : Config.name_mangling_scheme -> unit
     compiled and serialised with its [.cmx], so when reading another unit we
     never need to know which scheme it was compiled under. *)
 val name_mangling_scheme_for_current_unit : unit -> Config.name_mangling_scheme
+
+val get_current : unit -> t option
+
+val get_current_or_dummy : unit -> t
+
+val get_current_exn : unit -> t
+
+val is_current : t -> bool
 
 module Private : sig
   val fwd_get_current : (unit -> t option) ref

--- a/utils/symbol.ml
+++ b/utils/symbol.ml
@@ -115,26 +115,12 @@ let for_structured_mangling_path ~compilation_unit ~path ~suffix =
     linkage_name;
     hash = Hashtbl.hash linkage_name; }
 
-let for_local_ident id =
-  assert (not (Ident.is_global_or_predef id));
-  let compilation_unit = CU.get_current_exn () in
-  for_name compilation_unit (Ident.unique_name id)
-
 let for_compilation_unit compilation_unit =
   let linkage_name = linkage_name_for_compilation_unit compilation_unit in
   { compilation_unit;
     linkage_name;
     hash = Hashtbl.hash linkage_name;
   }
-
-let for_current_unit () =
-  for_compilation_unit (CU.get_current_exn ())
-
-let const_label = ref 0
-
-let for_new_const_in_current_unit () =
-  incr const_label;
-  for_name (Compilation_unit.get_current_exn ()) (Int.to_string !const_label)
 
 let is_predef_exn t =
   CU.equal t.compilation_unit CU.predef_exn

--- a/utils/symbol.mli
+++ b/utils/symbol.mli
@@ -23,9 +23,6 @@ type t
 (* For predefined exception identifiers. *)
 val for_predef_ident : Ident.t -> t
 
-(** It is assumed that the provided [Ident.t] is in the current unit. *)
-val for_local_ident : Ident.t -> t
-
 (** To be avoided if possible. Linkage names are intended to be generated
     by this module. *)
 val unsafe_create : Compilation_unit.t -> Linkage_name.t -> t
@@ -39,8 +36,6 @@ val for_structured_mangling_path :
     t
 
 val for_compilation_unit : Compilation_unit.t -> t
-val for_current_unit : unit -> t
-val for_new_const_in_current_unit : unit -> t
 
 val compilation_unit : t -> Compilation_unit.t
 


### PR DESCRIPTION
This is the foundation part of a split of ocamlcommon to eject the frontend from it.

The fundamental goal of this PR is to remove the indirect dependency between `Compilation_unit` and `Symbol` on `Env` which arises from `Env` setting the `Compilation_unit.Private.fwd_get_current`.

`Env.Current_unit` can be exposed without breaking any abstractions already. I've left it in typing/, but morally its more a driver/ file.