### PR TITLE
Remove bundled_cm temporary files after linking

### DIFF
--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -409,16 +409,21 @@ let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports
   in
   let sourcefile_for_dwarf = sourcefile_for_dwarf ~named_startup_file startup in
   let startup_obj = Filename.temp_file "camlstartup" ext_obj in
-  let ml_objfiles =
+  let bundled_cm_obj =
     if not uses_eval
-    then ml_objfiles
+    then None
     else
       match
         Cm_bundle.make_bundled_cm_file unix ~ppf_dump ~quoted_cmi ~quoted_cmx
           ~named_startup_file ~output_name
       with
       | exception Cm_bundle.Error error -> raise (Error (Cm_bundle_error error))
-      | bundled_cm_obj -> bundled_cm_obj :: ml_objfiles
+      | bundled_cm_obj -> Some bundled_cm_obj
+  in
+  let ml_objfiles =
+    match bundled_cm_obj with
+    | None -> ml_objfiles
+    | Some bundled_cm_obj -> bundled_cm_obj :: ml_objfiles
   in
   Asmgen.compile_unit unix ~output_prefix:output_name ~asm_filename:startup
     ~keep_asm:!Clflags.keep_startup_file ~obj_filename:startup_obj
@@ -474,6 +479,7 @@ let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports
     (fun () -> call_linker ?dissector_args ml_objfiles startup_obj output_name)
     ~always:(fun () ->
       remove_file startup_obj;
+      Option.iter remove_file bundled_cm_obj;
       cleanup_dissector_temp_dir ())
 
 let link unix linkenv ml_objfiles output_name ~cached_genfns_imports ~genfns

--- a/asmcomp/cm_bundle.ml
+++ b/asmcomp/cm_bundle.ml
@@ -106,10 +106,14 @@ let make_bundled_cm_file unix ~ppf_dump ~quoted_cmi ~quoted_cmx ~output_name
   let sourcefile_for_dwarf =
     Some (if named_startup_file then bundled_cm else ".bundled_cm")
   in
+  (* CR xclerc for xclerc: one would expect [Config.ext_obj] rather than ".cmx"
+     below, since the file contains object code; double check whether the
+     extension is used on purpose (e.g. by scripts or for statistics) before
+     changing it. *)
   let bundled_cm_obj = Filename.temp_file "bundled_cm" ".cmx" in
   Asmgen.compile_unit unix ~output_prefix:output_name ~asm_filename:bundled_cm
-    ~keep_asm:true (* TODO *)
-    ~obj_filename:bundled_cm_obj ~may_reduce_heap:true ~ppf_dump (fun () ->
+    ~keep_asm:!Clflags.keep_startup_file ~obj_filename:bundled_cm_obj
+    ~may_reduce_heap:true ~ppf_dump (fun () ->
       Location.input_name := "caml_bundled_cm";
       let bundle_comp_unit =
         CU.create CU.Prefix.empty (CU.Name.of_string "_bundled_cm")

--- a/asmcomp/cm_bundle.mli
+++ b/asmcomp/cm_bundle.mli
@@ -33,6 +33,9 @@ type error = private
 
 exception Error of error
 
+(** Returns the path to a temporary object file containing the bundled cmi and
+    cmx data; the caller is expected to remove that file once linking has
+    completed. *)
 val make_bundled_cm_file :
   (module Compiler_owee.Unix_intf.S) ->
   ppf_dump:Format.formatter ->


### PR DESCRIPTION
Linking a program that uses metaprogramming would leave the bundled_cm assembly and object files in the temporary directory:
- the assembly file was compiled with ~keep_asm:true; it is now kept only with -dstartup, mirroring the startup file (whose flag already drives the choice of a user-visible name for the bundled_cm file);
- the object file was never removed after linking; it is now removed alongside the startup object.