### PR TITLE
Add -support-lto flag

### DIFF
--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -727,6 +727,22 @@ let mk_no_reaper_change_calling_conventions f =
        functions%s (Flambda2 only)"
       (format_not_default Flambda2.Default.reaper_change_calling_conventions) )
 
+let mk_support_lto f =
+  ( "-support-lto",
+    Arg.Unit f,
+    Printf.sprintf
+      " Enable link time dead code elimination (unimplemented)%s (Flambda2 \
+       only)"
+      (format_default Flambda2.Default.support_lto) )
+
+let mk_no_support_lto f =
+  ( "-no-support-lto",
+    Arg.Unit f,
+    Printf.sprintf
+      " Disable link time dead code elimination (unimplemented)%s (Flambda2 \
+       only)"
+      (format_not_default Flambda2.Default.support_lto) )
+
 let mk_flambda2_match_in_match f =
   ( "-flambda2-match-in-match",
     Arg.Unit f,
@@ -1387,6 +1403,8 @@ module type Oxcaml_options = sig
   val reaper_max_unbox_size : int -> unit
   val reaper_change_calling_conventions : unit -> unit
   val no_reaper_change_calling_conventions : unit -> unit
+  val support_lto : unit -> unit
+  val no_support_lto : unit -> unit
   val flambda2_match_in_match : unit -> unit
   val no_flambda2_match_in_match : unit -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit
@@ -1585,6 +1603,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_reaper_change_calling_conventions F.reaper_change_calling_conventions;
       mk_no_reaper_change_calling_conventions
         F.no_reaper_change_calling_conventions;
+      mk_support_lto F.support_lto;
+      mk_no_support_lto F.no_support_lto;
       mk_flambda2_match_in_match F.flambda2_match_in_match;
       mk_no_flambda2_match_in_match F.no_flambda2_match_in_match;
       mk_flambda2_expert_fallback_inlining_heuristic
@@ -2057,6 +2077,9 @@ module Oxcaml_options_impl = struct
 
   let no_reaper_change_calling_conventions =
     clear Flambda2.reaper_change_calling_conventions
+
+  let support_lto = set Flambda2.support_lto
+  let no_support_lto = clear Flambda2.support_lto
 
   let flambda2_expert_fallback_inlining_heuristic =
     set Flambda2.Expert.fallback_inlining_heuristic
@@ -2693,6 +2716,7 @@ module Extra_params = struct
     | "reaper-unbox" -> set Flambda2.reaper_unbox
     | "reaper-change-calling-conventions" ->
         set Flambda2.reaper_change_calling_conventions
+    | "support-lto" -> set Flambda2.support_lto
     | "dissector" -> set' Clflags.dissector
     | "dissector-partition-size" -> (
         match float_of_string_opt v with

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -727,20 +727,22 @@ let mk_no_reaper_change_calling_conventions f =
        functions%s (Flambda2 only)"
       (format_not_default Flambda2.Default.reaper_change_calling_conventions) )
 
+(* CR mvellacott: Update -[no-]-support-lto help text once implemented. *)
+
 let mk_support_lto f =
   ( "-support-lto",
     Arg.Unit f,
     Printf.sprintf
-      " Enable link time dead code elimination (unimplemented)%s (Flambda2 \
-       only)"
+      " Build metadata for use in link time optimisation (unimplemented)%s \
+       (Flambda2 only)"
       (format_default Flambda2.Default.support_lto) )
 
 let mk_no_support_lto f =
   ( "-no-support-lto",
     Arg.Unit f,
     Printf.sprintf
-      " Disable link time dead code elimination (unimplemented)%s (Flambda2 \
-       only)"
+      " Don't build metadata for use in link time optimisation \
+       (unimplemented)%s (Flambda2 only)"
       (format_not_default Flambda2.Default.support_lto) )
 
 let mk_flambda2_match_in_match f =

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -733,16 +733,16 @@ let mk_support_lto f =
   ( "-support-lto",
     Arg.Unit f,
     Printf.sprintf
-      " Build metadata for use in link time optimisation (unimplemented)%s \
-       (Flambda2 only)"
+      " Currently unimplemented. Will eventually be used to enable support for \
+       link time optimisation.%s (Flambda2 only)"
       (format_default Flambda2.Default.support_lto) )
 
 let mk_no_support_lto f =
   ( "-no-support-lto",
     Arg.Unit f,
     Printf.sprintf
-      " Don't build metadata for use in link time optimisation \
-       (unimplemented)%s (Flambda2 only)"
+      " Currently unimplemented. Will eventually be used to disable support \
+       for link time optimisation.%s (Flambda2 only)"
       (format_not_default Flambda2.Default.support_lto) )
 
 let mk_flambda2_match_in_match f =

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -142,6 +142,8 @@ module type Oxcaml_options = sig
   val reaper_max_unbox_size : int -> unit
   val reaper_change_calling_conventions : unit -> unit
   val no_reaper_change_calling_conventions : unit -> unit
+  val support_lto : unit -> unit
+  val no_support_lto : unit -> unit
   val flambda2_match_in_match : unit -> unit
   val no_flambda2_match_in_match : unit -> unit
   val flambda2_expert_fallback_inlining_heuristic : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -192,6 +192,7 @@ module Flambda2 = struct
     let reaper_unbox = true
     let reaper_max_unbox_size = 10
     let reaper_change_calling_conventions = true
+    let support_lto = false
     let unicode = true
     let kind_checks = false
     let match_in_match = false
@@ -212,6 +213,7 @@ module Flambda2 = struct
     reaper_unbox : bool;
     reaper_max_unbox_size : int;
     reaper_change_calling_conventions : bool;
+    support_lto : bool;
     unicode : bool;
     kind_checks : bool;
     match_in_match : bool;
@@ -233,6 +235,7 @@ module Flambda2 = struct
     reaper_max_unbox_size = Default.reaper_max_unbox_size;
     reaper_change_calling_conventions =
       Default.reaper_change_calling_conventions;
+    support_lto = Default.support_lto;
     unicode = Default.unicode;
     kind_checks = Default.kind_checks;
     match_in_match = Default.match_in_match;
@@ -282,6 +285,7 @@ module Flambda2 = struct
   let reaper_unbox = ref Default
   let reaper_max_unbox_size = ref Default
   let reaper_change_calling_conventions = ref Default
+  let support_lto = ref Default
   let match_in_match = ref Default
 
   module Dump = struct

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -155,6 +155,7 @@ module Flambda2 : sig
     val reaper_unbox : bool
     val reaper_max_unbox_size : int
     val reaper_change_calling_conventions : bool
+    val support_lto : bool
     val unicode : bool
     val kind_checks : bool
     val match_in_match : bool
@@ -178,6 +179,7 @@ module Flambda2 : sig
     reaper_unbox : bool;
     reaper_max_unbox_size : int;
     reaper_change_calling_conventions : bool;
+    support_lto : bool;
     unicode : bool;
     kind_checks : bool;
     match_in_match : bool;
@@ -200,6 +202,7 @@ module Flambda2 : sig
   val reaper_unbox : bool or_default ref
   val reaper_max_unbox_size : int or_default ref
   val reaper_change_calling_conventions : bool or_default ref
+  val support_lto : bool or_default ref
   val unicode : bool or_default ref
   val kind_checks : bool or_default ref
   val match_in_match : bool or_default ref

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -266,7 +266,7 @@ let flambda_to_flambda ~ppf_dump ~prefixname ~machine_width ~code_slot_offsets
 let lambda_to_flambda ~ppf_dump:ppf ~prefixname ~machine_width
     (program : Lambda.program) =
   (* CR mvellacott: Placeholder should be removed once LTO is implemented. *)
-  if Flambda_features.support_lto () then Printf.eprintf "LTO enabled";
+  if Flambda_features.support_lto () then Printf.eprintf "LTO enabled\n";
   let module_repr =
     Lambda.main_module_representation program.main_module_block_format
   in

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -265,7 +265,8 @@ let flambda_to_flambda ~ppf_dump ~prefixname ~machine_width ~code_slot_offsets
 
 let lambda_to_flambda ~ppf_dump:ppf ~prefixname ~machine_width
     (program : Lambda.program) =
-  if Flambda_features.support_lto () then prerr_endline "LTO enabled";
+  (* CR mvellacott: Placeholder should be removed once LTO is implemented. *)
+  if Flambda_features.support_lto () then Printf.eprintf "LTO enabled";
   let module_repr =
     Lambda.main_module_representation program.main_module_block_format
   in

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -265,6 +265,7 @@ let flambda_to_flambda ~ppf_dump ~prefixname ~machine_width ~code_slot_offsets
 
 let lambda_to_flambda ~ppf_dump:ppf ~prefixname ~machine_width
     (program : Lambda.program) =
+  if Flambda_features.support_lto () then prerr_endline "LTO enabled";
   let module_repr =
     Lambda.main_module_representation program.main_module_block_format
   in

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -113,6 +113,10 @@ let reaper_change_calling_conventions () =
   !Oxcaml_flags.Flambda2.reaper_change_calling_conventions
   |> with_default ~f:(fun d -> d.reaper_change_calling_conventions)
 
+let support_lto () =
+  !Oxcaml_flags.Flambda2.support_lto
+  |> with_default ~f:(fun d -> d.support_lto)
+
 let flat_float_array () = Config.flat_float_array
 
 let function_result_types ~is_a_functor =

--- a/middle_end/flambda2/ui/flambda_features.ml
+++ b/middle_end/flambda2/ui/flambda_features.ml
@@ -114,8 +114,7 @@ let reaper_change_calling_conventions () =
   |> with_default ~f:(fun d -> d.reaper_change_calling_conventions)
 
 let support_lto () =
-  !Oxcaml_flags.Flambda2.support_lto
-  |> with_default ~f:(fun d -> d.support_lto)
+  !Oxcaml_flags.Flambda2.support_lto |> with_default ~f:(fun d -> d.support_lto)
 
 let flat_float_array () = Config.flat_float_array
 

--- a/middle_end/flambda2/ui/flambda_features.mli
+++ b/middle_end/flambda2/ui/flambda_features.mli
@@ -65,6 +65,8 @@ val reaper_max_unbox_size : unit -> int
 
 val reaper_change_calling_conventions : unit -> bool
 
+val support_lto : unit -> bool
+
 val kind_checks : unit -> bool
 
 val match_in_match : unit -> bool

--- a/testsuite/tests/flambda2/support_lto_flag.compilers.reference
+++ b/testsuite/tests/flambda2/support_lto_flag.compilers.reference
@@ -1,0 +1,1 @@
+LTO enabled

--- a/testsuite/tests/flambda2/support_lto_flag.ml
+++ b/testsuite/tests/flambda2/support_lto_flag.ml
@@ -1,0 +1,16 @@
+(* TEST
+ flambda2;
+ ocamlopt_flags = "-support-lto";
+ compile_only = "true";
+ setup-ocamlopt.opt-build-env;
+ ocamlopt.opt;
+ check-ocamlopt.opt-output;
+*)
+
+(* This test checks that the [-support-lto] flag causes the placeholder
+   "LTO enabled" message to be printed during compilation. *)
+
+(* CR mvellacott: This tests placeholder functionality and will need to be removed when
+   the features is implemented and the placeholder removed. *)
+
+let () = ()


### PR DESCRIPTION
Adds a flag called `-support-lto` to enable link time optimisation, which itself is not yet implemented. Currently, it has no effect except to print a message to stderr.

The changes have been manually tested.