### PR TITLE
flambda2: fix comparison-to-zero rewrite dropping outer signedness

### DIFF
--- a/middle_end/flambda2/simplify/comparison_result.ml
+++ b/middle_end/flambda2/simplify/comparison_result.ml
@@ -62,20 +62,31 @@ let [@ocamlformat "disable"] print ppf
     prefix Flambda_kind.Standard_int.print_lowercase kind result
 
 let convert_result_compared_to_tagged_zero
-    ({ lhs; rhs; kind; signed; tagged_or_untagged } as t) (op : _ P.comparison)
-    : P.t =
+    ({ lhs; rhs; kind; signed; tagged_or_untagged } as t)
+    (op : P.signed_or_unsigned P.comparison) : P.t option =
   (match tagged_or_untagged with
   | Tagged -> ()
   | Untagged ->
     Misc.fatal_errorf "Comparing untagged result with tagged zero: %a" print t);
-  let new_op : _ P.comparison =
+  (* The compare-function result is in [{-1, 0, 1}], so a *signed* comparison of
+     it against zero recovers the original comparison of [lhs] and [rhs] (with
+     the original comparison's signedness). This equivalence does not hold for
+     an *unsigned* outer comparison: e.g. [compare x y <u 0] is always [false]
+     since [-1] is the largest unsigned value, whereas [x < y] is not. So we
+     only rewrite unsigned outer comparisons when they are (in)equalities, for
+     which signedness is irrelevant. *)
+  let new_op : P.signed_or_unsigned P.comparison option =
     match op with
-    | Eq -> Eq
-    | Neq -> Neq
-    | Lt _ -> Lt signed
-    | Gt _ -> Gt signed
-    | Le _ -> Le signed
-    | Ge _ -> Ge signed
+    | Eq -> Some Eq
+    | Neq -> Some Neq
+    | Lt Signed -> Some (Lt signed)
+    | Gt Signed -> Some (Gt signed)
+    | Le Signed -> Some (Le signed)
+    | Ge Signed -> Some (Ge signed)
+    | Lt Unsigned | Gt Unsigned | Le Unsigned | Ge Unsigned -> None
   in
-  let prim : P.binary_primitive = Int_comp (kind, Yielding_bool new_op) in
-  Binary (prim, lhs, rhs)
+  match new_op with
+  | None -> None
+  | Some new_op ->
+    let prim : P.binary_primitive = Int_comp (kind, Yielding_bool new_op) in
+    Some (Binary (prim, lhs, rhs))

--- a/middle_end/flambda2/simplify/comparison_result.mli
+++ b/middle_end/flambda2/simplify/comparison_result.mli
@@ -20,4 +20,6 @@ val create :
 val print : Format.formatter -> t -> unit
 
 val convert_result_compared_to_tagged_zero :
-  t -> _ Flambda_primitive.comparison -> Flambda_primitive.t
+  t ->
+  Flambda_primitive.signed_or_unsigned Flambda_primitive.comparison ->
+  Flambda_primitive.t option

--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1194,9 +1194,8 @@ let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
                   match DE.find_comparison_result (DA.denv dacc) var with
                   | None -> None
                   | Some comp ->
-                    Some
-                      (Comparison_result.convert_result_compared_to_tagged_zero
-                         comp op))
+                    Comparison_result.convert_result_compared_to_tagged_zero
+                      comp op)
             | _ -> None)
       in
       match try_one_direction arg1 arg2 op with

--- a/testsuite/tests/flambda/comparison_to_zero_signedness.ml
+++ b/testsuite/tests/flambda/comparison_to_zero_signedness.ml
@@ -1,0 +1,29 @@
+(* TEST
+ flambda2;
+ native;
+*)
+
+(* Regression test for a Flambda 2 miscompilation in
+   [Comparison_result.convert_result_compared_to_tagged_zero]. The rewrite of
+   [(compare x y) <op> 0] reused the signedness of the inner three-way
+   comparison and ignored the signedness of the outer comparison [<op>]. For an
+   *unsigned* outer comparison this is unsound: [compare x y] is in {-1, 0, 1},
+   so [compare x y <u 0] is always [false] (-1 is the largest unsigned value),
+   whereas the buggy rewrite produced the signed comparison [x < y].
+
+   Requires a higher optimisation level: the compare result that the rewrite
+   matches on is only registered above -Oclassic. *)
+
+[@@@ocaml.flambda_o3]
+
+external compare_int : int -> int -> int = "%int_compare"
+
+external unsigned_lt : int -> int -> bool = "%int_unsigned_lessthan"
+
+let[@inline never] f x y = unsigned_lt (compare_int x y) 0
+
+let () =
+  Printf.printf "%b %b %b\n"
+    (f (Sys.opaque_identity 1) (Sys.opaque_identity 2))
+    (f (Sys.opaque_identity 2) (Sys.opaque_identity 1))
+    (f (Sys.opaque_identity 3) (Sys.opaque_identity 3))

--- a/testsuite/tests/flambda/comparison_to_zero_signedness.reference
+++ b/testsuite/tests/flambda/comparison_to_zero_signedness.reference
@@ -1,0 +1,1 @@
+false false false


### PR DESCRIPTION
  ## Summary
  Fixes a Flambda 2 miscompilation in `Comparison_result.convert_result_compared_to_tagged_zero`. The rewrite of `(compare x
  y) <op> 0` reused the signedness of the *inner* three-way comparison and ignored the signedness of the *outer* comparison
  `<op>`. For an unsigned outer comparison this is unsound: `compare x y ∈ {-1, 0, 1}`, so `compare x y <u 0` is always
  `false` (−1 is the largest unsigned value), but the rewrite produced the signed comparison `x < y`.

  ## Impact
  Miscompiles legal, type-safe code at `-O3`:
  ```ocaml
  external compare_int : int -> int -> int = "%int_compare"
  external unsigned_lt : int -> int -> bool = "%int_unsigned_lessthan"
  let f x y = unsigned_lt (compare_int x y) 0
  ```
  `f 1 2` returns `true` instead of `false` (also reachable via `Stdlib_stable.Int` unsigned comparison helpers). Real-world
  exposure is low — no idiomatic code compares a three-way-compare result to `0` with an unsigned relation — but it is a
  genuine soundness bug.

  ## Fix
  `convert_result_compared_to_tagged_zero` now returns `option` and bails (`None`) for unsigned outer inequalities, so the
  rewrite is skipped and the original primitive computes the correct result. Equality comparisons are unaffected, since
  signedness is irrelevant there.

  ## Test
  Adds `testsuite/tests/flambda/comparison_to_zero_signedness.ml`; passes with the fix and fails without it (prints `true
  false false`).

 🤖 Generated with [Claude Code](https://claude.com/claude-code)