### PR TITLE
flambda2: defensive guards for four invariant-dependent leads

### DIFF
--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -818,8 +818,18 @@ let simplify_obj_dup dbg dacc ~original_term ~arg ~arg_ty ~result_var =
         ~try_reify:true dacc)
   | Unknown -> (
     match T.prove_strings typing_env arg_ty with
-    | Proved _ -> elide_primitive ()
-    | Unknown -> SPR.create_unknown dacc ~result_var K.value ~original_term)
+    | Proved strs
+      when String_info.Set.for_all
+             (fun info ->
+               match String_info.contents info with
+               | String_info.Contents _ -> true
+               | String_info.Unknown_or_mutable -> false)
+             strs ->
+      (* Only elide when the contents are statically known immutable; a mutable
+         string (or one whose contents are unknown) must be duplicated. *)
+      elide_primitive ()
+    | Proved _ | Unknown ->
+      SPR.create_unknown dacc ~result_var K.value ~original_term)
 
 let simplify_get_header ~original_prim dacc ~original_term ~arg:_ ~arg_ty:_
     ~result_var =

--- a/middle_end/flambda2/terms/switch_expr.ml
+++ b/middle_end/flambda2/terms/switch_expr.ml
@@ -69,7 +69,16 @@ let print ppf { condition_dbg; scrutinee; arms } =
     Flambda_colours.debuginfo Debuginfo.print_compact condition_dbg
     Flambda_colours.pop print_arms arms
 
-let create ~condition_dbg ~scrutinee ~arms = { condition_dbg; scrutinee; arms }
+let create ~condition_dbg ~scrutinee ~arms =
+  (* Switch discriminants are non-negative by construction. *)
+  Target_ocaml_int.Map.iter
+    (fun discr _action ->
+      if not (Target_ocaml_int.is_non_negative discr)
+      then
+        Misc.fatal_errorf "Switch discriminant must be non-negative:@ %a"
+          Target_ocaml_int.print discr)
+    arms;
+  { condition_dbg; scrutinee; arms }
 
 let if_then_else ~machine_width ~condition_dbg ~scrutinee ~if_true ~if_false =
   let arms =

--- a/middle_end/flambda2/to_cmm/to_cmm_expr.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_expr.ml
@@ -758,7 +758,8 @@ and let_expr0 env res let_expr (bound_pattern : Bound_pattern.t)
   | Singleton _, Prim (Nullary (Enter_inlined_apply { dbg }), _) ->
     let env = Env.enter_inlined_apply env dbg in
     expr env res body
-  | Singleton v, Prim ((Unary (End_region _, _) as p), dbg) ->
+  | Singleton v, Prim ((Unary ((End_region _ | End_try_region _), _) as p), dbg)
+    ->
     (* CR gbury: this is a hack to prevent moving of expressions past an
        End_region. We have to do this manually because we currently have effects
        and coeffects that are not precise enough. Particularly, an immutable

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -4287,8 +4287,11 @@ let tagged_immediate_alias_to ~naked_immediate : t =
 let is_int_for_scrutinee ~machine_width ~scrutinee : t =
   let descr =
     Simple.pattern_match scrutinee
-      ~const:(fun _ ->
-        TD.create_equals (Simple.untagged_const_true machine_width))
+      ~const:(fun const ->
+        (* A constant is never a block, so [%is_int] is [true] unless the
+           constant is null (mirroring [Relation.of_const]). *)
+        TD.create_equals
+          (Simple.untagged_const_bool machine_width (not (RWC.is_null const))))
       ~name:(fun name ~coercion:_ ->
         let head =
           create_head_of_kind_naked_immediate


### PR DESCRIPTION
## Summary
  Four small defensive guards that make unstated Flambda 2 invariants explicit, surfaced by an adversarial soundness study of
  the Flambda 2 formalism. Each case was judged safe (no live miscompile) but relied on an invariant not enforced locally;
  these guards stay conservative / fail loudly without changing behaviour on valid input.

  - **`type_grammar.ml`** (`is_int_for_scrutinee`): the constant branch now mirrors `Relation.of_const`, returning `is_int = 
  false` for null constants instead of unconditionally `true`.
  - **`simplify_unary_primitive.ml`** (`simplify_obj_dup`): only elide `Obj.dup` when the string's contents are statically
  immutable (`Contents _`); fall through to an unknown result for `Unknown_or_mutable`, since elision aliases the argument.
  - **`switch_expr.ml`** (`create`): assert that switch discriminants are non-negative.
  - **`to_cmm_expr.ml`** (`let_expr0`): flush before `End_try_region` as well as `End_region`, preventing unsound code motion 
  across the region close.

  ## Testing
  `make -s boot-compiler` clean; `make -s test-one DIR=flambda2` = 183 passed / 0 failed.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)