### PR TITLE
Give custom [@@or_null] variants the same precise kind as or_null

### DIFF
--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -259,8 +259,8 @@ Lines 1-4, characters 0-11:
 4 | [@@or_null]
 Error: The kind of type "nonportable_payload" is
            value_or_null non_float mod aliased immutable
-         because an [@@or_null] type gets its kind by applying or_null to its
-         payload kind.
+         because an [@@or_null] type gets the kind of or_null
+         applied to its payload type.
        But the kind of type "nonportable_payload" must be a subkind of
            value_or_null mod portable
          because of the annotation on the declaration of the type nonportable_payload.
@@ -276,20 +276,7 @@ type 'a crosses_like_or_null
 [@@or_null]
 
 [%%expect{|
-Lines 1-5, characters 0-11:
-1 | type 'a crosses_like_or_null
-2 |   : value_or_null mod many forkable portable contended unyielding with 'a =
-3 |   | Cross_some of 'a
-4 |   | Cross_none
-5 | [@@or_null]
-Error: The kind of type "crosses_like_or_null" is value_or_null
-         because an [@@or_null] type gets its kind by applying or_null to its
-         payload kind.
-       But the kind of type "crosses_like_or_null" must be a subkind of
-           value_or_null
-             mod forkable unyielding many portable contended
-             with 'a
-         because of the annotation on the declaration of the type crosses_like_or_null.
+type 'a crosses_like_or_null = Cross_some of 'a | Cross_none [@@or_null]
 |}]
 
 (* [int crosses_like_or_null] crosses contention, like [int or_null]. *)
@@ -298,10 +285,8 @@ let cross_contention (x : int crosses_like_or_null @ contended) =
   (x : _ @ uncontended)
 
 [%%expect{|
-Line 1, characters 30-50:
-1 | let cross_contention (x : int crosses_like_or_null @ contended) =
-                                  ^^^^^^^^^^^^^^^^^^^^
-Error: Unbound type constructor "crosses_like_or_null"
+val cross_contention :
+  int crosses_like_or_null @ contended -> int crosses_like_or_null = <fun>
 |}]
 
 (* But the crossing depends on the payload: [int ref crosses_like_or_null]
@@ -311,10 +296,10 @@ let bad_cross_contention (x : int ref crosses_like_or_null @ contended) =
   (x : _ @ uncontended)
 
 [%%expect{|
-Line 1, characters 38-58:
-1 | let bad_cross_contention (x : int ref crosses_like_or_null @ contended) =
-                                          ^^^^^^^^^^^^^^^^^^^^
-Error: Unbound type constructor "crosses_like_or_null"
+Line 2, characters 3-4:
+2 |   (x : _ @ uncontended)
+       ^
+Error: This value is "contended" but is expected to be "uncontended".
 |}]
 
 (* A payload under a modality contributes its with-bound under that modality:
@@ -348,26 +333,8 @@ end = struct
 end
 
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   type 'a t = Mk_some of 'a | Mk_none [@@or_null]
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig type 'a t = Mk_some of 'a | Mk_none [@@or_null] end
-       is not included in
-         sig
-           type 'a t : value_or_null mod many portable contended with 'a
-         end
-       Type declarations do not match:
-         type 'a t = Mk_some of 'a | Mk_none [@@or_null]
-       is not included in
-         type 'a t : value_or_null mod many portable contended with 'a
-       The kind of the first is value_or_null
-         because of the definition of t at line 4, characters 2-49.
-       But the kind of the first must be a subkind of
-           value_or_null mod many portable contended with 'a
-         because of the definition of t at line 2, characters 2-63.
+module M_crosses :
+  sig type 'a t : value_or_null mod many portable contended with 'a end
 |}]
 
 type probe_result : value =
@@ -382,8 +349,8 @@ Lines 1-4, characters 0-11:
 3 |   | Probe_some of int
 4 | [@@or_null]
 Error: The layout of type "probe_result" is value_or_null non_pointer
-         because an [@@or_null] type gets its layout by applying or_null to its
-         payload layout.
+         because an [@@or_null] type gets the layout of or_null
+         applied to its payload type.
        But the layout of type "probe_result" must be a sublayout of value
          because of the annotation on the declaration of the type probe_result.
 |}]
@@ -625,8 +592,8 @@ Lines 1-4, characters 0-11:
 3 |   | B of 'a
 4 | [@@or_null]
 Error: The layout of type "wrong_result_kind" is value_or_null
-         because an [@@or_null] type gets its layout by applying or_null to its
-         payload layout.
+         because an [@@or_null] type gets the layout of or_null
+         applied to its payload type.
        But the layout of type "wrong_result_kind" must be a sublayout of value
          because of the annotation on the declaration of the type wrong_result_kind.
 |}]

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -337,6 +337,113 @@ module M_crosses :
   sig type 'a t : value_or_null mod many portable contended with 'a end
 |}]
 
+(* The kind is a subkind of weaker kinds. The declaration below carries no
+   kind annotation, so the equations check the computed kind. ['a] staying
+   unconstrained in the printed outputs is part of the test: the checker
+   could otherwise satisfy the annotations by strengthening the parameter's
+   kind. *)
+
+type 'a plain = Plain_some of 'a | Plain_none [@@or_null]
+
+type 'a sub_top : value_or_null = 'a plain
+
+type 'a sub_portable : value_or_null mod portable with 'a = 'a plain
+
+[%%expect{|
+type 'a plain = Plain_some of 'a | Plain_none [@@or_null]
+type 'a sub_top = 'a plain
+type 'a sub_portable = 'a plain
+|}]
+
+(* ... but not of non-null kinds. *)
+
+type 'a sub_value : value = 'a plain
+
+[%%expect{|
+Line 1, characters 0-36:
+1 | type 'a sub_value : value = 'a plain
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The layout of type "'a plain" is value_or_null
+         because of the definition of plain at line 1, characters 0-57.
+       But the layout of type "'a plain" must be a sublayout of value
+         because of the definition of sub_value at line 1, characters 0-36.
+|}]
+
+(* A kind constraint on the type parameter strengthens the with-bound, so
+   the declaration's kind can cross an axis without mentioning ['a]. *)
+
+type ('a : value mod portable) constrained_param : value_or_null mod portable =
+  | Constrained_some of 'a
+  | Constrained_none
+[@@or_null]
+
+[%%expect{|
+type ('a : value mod portable) constrained_param =
+    Constrained_some of 'a
+  | Constrained_none [@@or_null]
+|}]
+
+(* Custom [@@or_null] variants without a type parameter cross according to
+   their payload. *)
+
+type mono = Mono_none | Mono_some of int [@@or_null]
+
+let cross_mono (x : mono @ contended) = (x : _ @ uncontended)
+
+[%%expect{|
+type mono = Mono_none | Mono_some of int [@@or_null]
+val cross_mono : mono @ contended -> mono = <fun>
+|}]
+
+(* ... and a monomorphic payload that doesn't cross blocks the crossing. *)
+
+type mono_ref = Mono_ref_none | Mono_ref_some of int ref [@@or_null]
+
+let bad_cross_mono (x : mono_ref @ contended) = (x : _ @ uncontended)
+
+[%%expect{|
+type mono_ref = Mono_ref_none | Mono_ref_some of int ref [@@or_null]
+Line 3, characters 49-50:
+3 | let bad_cross_mono (x : mono_ref @ contended) = (x : _ @ uncontended)
+                                                     ^
+Error: This value is "contended" but is expected to be "uncontended".
+|}]
+
+(* An [@@unboxed] wrapper carrying a modality as the payload: the wrapper's
+   modality provides the crossing. *)
+
+type portable_box = { portable_field : (unit -> unit) @@ portable }
+[@@unboxed]
+
+type fn_or_null = Fn_none | Fn_some of portable_box [@@or_null]
+
+let cross_fn (x : fn_or_null @ nonportable) = (x : _ @ portable)
+
+[%%expect{|
+type portable_box = { portable_field : unit -> unit @@ portable; } [@@unboxed]
+type fn_or_null = Fn_none | Fn_some of portable_box [@@or_null]
+val cross_fn : fn_or_null -> fn_or_null = <fun>
+|}]
+
+(* ... and the reverse nesting: a custom [@@or_null] as the field of an
+   [@@unboxed] wrapper carrying a modality. *)
+
+type fn_or_null_plain =
+  | Plain_fn_none
+  | Plain_fn_some of (unit -> unit)
+[@@or_null]
+
+type wrapped_or_null = { wrapped_field : fn_or_null_plain @@ portable }
+[@@unboxed]
+
+let cross_wrapped (x : wrapped_or_null @ nonportable) = (x : _ @ portable)
+
+[%%expect{|
+type fn_or_null_plain = Plain_fn_none | Plain_fn_some of (unit -> unit) [@@or_null]
+type wrapped_or_null = { wrapped_field : fn_or_null_plain @@ portable; } [@@unboxed]
+val cross_wrapped : wrapped_or_null -> wrapped_or_null = <fun>
+|}]
+
 type probe_result : value =
   | Probe_none
   | Probe_some of int

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -266,6 +266,110 @@ Error: The kind of type "nonportable_payload" is
          because of the annotation on the declaration of the type nonportable_payload.
 |}]
 
+(* A custom [@@or_null] type gets the same kind as the builtin ['a or_null]:
+   it crosses everything modulo a with-bound on its payload. *)
+
+type 'a crosses_like_or_null
+  : value_or_null mod many forkable portable contended unyielding with 'a =
+  | Cross_some of 'a
+  | Cross_none
+[@@or_null]
+
+[%%expect{|
+Lines 1-5, characters 0-11:
+1 | type 'a crosses_like_or_null
+2 |   : value_or_null mod many forkable portable contended unyielding with 'a =
+3 |   | Cross_some of 'a
+4 |   | Cross_none
+5 | [@@or_null]
+Error: The kind of type "crosses_like_or_null" is value_or_null
+         because an [@@or_null] type gets its kind by applying or_null to its
+         payload kind.
+       But the kind of type "crosses_like_or_null" must be a subkind of
+           value_or_null
+             mod forkable unyielding many portable contended
+             with 'a
+         because of the annotation on the declaration of the type crosses_like_or_null.
+|}]
+
+(* [int crosses_like_or_null] crosses contention, like [int or_null]. *)
+
+let cross_contention (x : int crosses_like_or_null @ contended) =
+  (x : _ @ uncontended)
+
+[%%expect{|
+Line 1, characters 30-50:
+1 | let cross_contention (x : int crosses_like_or_null @ contended) =
+                                  ^^^^^^^^^^^^^^^^^^^^
+Error: Unbound type constructor "crosses_like_or_null"
+|}]
+
+(* But the crossing depends on the payload: [int ref crosses_like_or_null]
+   does not cross contention. *)
+
+let bad_cross_contention (x : int ref crosses_like_or_null @ contended) =
+  (x : _ @ uncontended)
+
+[%%expect{|
+Line 1, characters 38-58:
+1 | let bad_cross_contention (x : int ref crosses_like_or_null @ contended) =
+                                          ^^^^^^^^^^^^^^^^^^^^
+Error: Unbound type constructor "crosses_like_or_null"
+|}]
+
+(* A payload under a modality contributes its with-bound under that modality:
+   ['a @@ contended] makes the type cross contention regardless of 'a. *)
+
+type 'a contended_payload =
+  | Contended_none
+  | Contended_some of 'a @@ contended
+[@@or_null]
+
+[%%expect{|
+type 'a contended_payload =
+    Contended_none
+  | Contended_some of 'a @@ contended [@@or_null]
+|}]
+
+let cross_contention_modality (x : int ref contended_payload @ contended) =
+  (x : _ @ uncontended)
+
+[%%expect{|
+val cross_contention_modality :
+  int ref contended_payload @ contended -> int ref contended_payload = <fun>
+|}]
+
+(* The precise kind is available for signature inclusion. *)
+
+module M_crosses : sig
+  type 'a t : value_or_null mod many portable contended with 'a
+end = struct
+  type 'a t = Mk_some of 'a | Mk_none [@@or_null]
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type 'a t = Mk_some of 'a | Mk_none [@@or_null]
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type 'a t = Mk_some of 'a | Mk_none [@@or_null] end
+       is not included in
+         sig
+           type 'a t : value_or_null mod many portable contended with 'a
+         end
+       Type declarations do not match:
+         type 'a t = Mk_some of 'a | Mk_none [@@or_null]
+       is not included in
+         type 'a t : value_or_null mod many portable contended with 'a
+       The kind of the first is value_or_null
+         because of the definition of t at line 4, characters 2-49.
+       But the kind of the first must be a subkind of
+           value_or_null mod many portable contended with 'a
+         because of the definition of t at line 2, characters 2-63.
+|}]
+
 type probe_result : value =
   | Probe_none
   | Probe_some of int

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2722,15 +2722,22 @@ let apply_or_null_r env jkind =
   | None ->
     Misc.fatal_error "or_null applied to a type without a scannable layout"
 
-let for_or_null_variant env ~payload_type ~modality jkind =
-  match apply_or_null_l env jkind with
+let for_or_null_variant env ~payload_type ~modality ~payload_jkind =
+  match apply_or_null_l env payload_jkind with
   | Error () -> Error ()
   | Ok jkind ->
     (* A value of the type is either null, which mode-crosses everything the
        builtin ['a or_null]'s null does, or the payload under its modality.
        So the type gets the builtin's mod-bounds together with a with-bound
        on the payload, like [or_null_jkind] in [Predef]; only the layout
-       (computed by [apply_or_null_l] above) comes from the payload's kind. *)
+       (computed by [apply_or_null_l] above) comes from the payload's kind.
+
+       We drop the payload kind's own mod- and with-bounds rather than keep
+       them: they describe the payload's mode-crossing, and the with-bound on
+       [payload_type] added below already accounts for that, at least as
+       precisely (the payload kind may be a conservative bound, e.g. [value]
+       for a type parameter, while normalizing the with-bound sees the
+       instantiated payload type). *)
     let mod_bounds =
       Const.Builtin.value_or_null_mod_everything.jkind.mod_bounds
     in

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2722,6 +2722,25 @@ let apply_or_null_r env jkind =
   | None ->
     Misc.fatal_error "or_null applied to a type without a scannable layout"
 
+let for_or_null_variant env ~payload_type ~modality jkind =
+  match apply_or_null_l env jkind with
+  | Error () -> Error ()
+  | Ok jkind ->
+    (* A value of the type is either null, which mode-crosses everything the
+       builtin ['a or_null]'s null does, or the payload under its modality.
+       So the type gets the builtin's mod-bounds together with a with-bound
+       on the payload, like [or_null_jkind] in [Predef]; only the layout
+       (computed by [apply_or_null_l] above) comes from the payload's kind. *)
+    let mod_bounds =
+      Const.Builtin.value_or_null_mod_everything.jkind.mod_bounds
+    in
+    Ok
+      ({ jkind with
+         jkind = { jkind.jkind with mod_bounds; with_bounds = No_with_bounds }
+       }
+      |> add_with_bounds ~modality ~type_expr:payload_type
+      |> mark_best)
+
 let get_annotation jk = jk.annotation
 
 let decompose_product env jk =
@@ -3026,9 +3045,9 @@ module Format_history = struct
         !printtyp_path parent_path layout_or_kind
     | Or_null_payload _parent_path ->
       fprintf ppf
-        "an [@@@@or_null] type gets its %s by applying or_null to its@ payload \
-         %s"
-        layout_or_kind layout_or_kind
+        "an [@@@@or_null] type gets the %s of or_null@ applied to its payload \
+         type"
+        layout_or_kind
     | Recmod_fun_arg ->
       fprintf ppf
         "it's the type of the first argument to a function in a recursive \

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -520,6 +520,20 @@ val for_boxed_variant :
   Types.constructor_declaration list ->
   Types.jkind_l
 
+(** Choose an appropriate jkind for a user-defined [@@or_null] variant (a
+    [Variant_with_null]), given the jkind of its payload [payload_type]. Like
+    the builtin ['a or_null], the result has the builtin's mod-bounds (crossing
+    everything) with the payload added as a with-bound under [modality]; its
+    layout is the payload's layout adjusted by [apply_or_null_l]. Returns
+    [Error ()] if the payload's kind is maybe-null or has no known scannable
+    layout. *)
+val for_or_null_variant :
+  Env.t ->
+  payload_type:Types.type_expr ->
+  modality:Mode.Modality.Const.t ->
+  Types.jkind_l ->
+  (Types.jkind_l, unit) result
+
 (** Choose an appropriate jkind for a boxed tuple type. *)
 val for_boxed_tuple : (string option * Types.type_expr) list -> Types.jkind_l
 

--- a/typing/jkind.mli
+++ b/typing/jkind.mli
@@ -521,17 +521,20 @@ val for_boxed_variant :
   Types.jkind_l
 
 (** Choose an appropriate jkind for a user-defined [@@or_null] variant (a
-    [Variant_with_null]), given the jkind of its payload [payload_type]. Like
-    the builtin ['a or_null], the result has the builtin's mod-bounds (crossing
-    everything) with the payload added as a with-bound under [modality]; its
-    layout is the payload's layout adjusted by [apply_or_null_l]. Returns
-    [Error ()] if the payload's kind is maybe-null or has no known scannable
-    layout. *)
+    [Variant_with_null]), given [payload_jkind], the inferred jkind of its
+    payload [payload_type]. Like the builtin ['a or_null], the result has the
+    builtin's mod-bounds (crossing everything except staticity) with the payload
+    added as a with-bound under [modality]; its layout is the payload's layout
+    adjusted by [apply_or_null_l]. Both the input and the output are [jkind_l]
+    because both are inferred, actual kinds of types (the payload's and the
+    declaration's), not requirements imposed on them. The result is marked best.
+    Returns [Error ()] if the payload's kind is maybe-null or has no known
+    scannable layout. *)
 val for_or_null_variant :
   Env.t ->
   payload_type:Types.type_expr ->
   modality:Mode.Modality.Const.t ->
-  Types.jkind_l ->
+  payload_jkind:Types.jkind_l ->
   (Types.jkind_l, unit) result
 
 (** Choose an appropriate jkind for a boxed tuple type. *)

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2528,7 +2528,8 @@ let rec update_decl_jkind env dpath decl =
             cstrs
         in
         begin match
-          Jkind.for_or_null_variant env ~payload_type:ty ~modality jkind
+          Jkind.for_or_null_variant env ~payload_type:ty ~modality
+            ~payload_jkind:jkind
         with
         | Ok type_jkind ->
           let type_jkind =

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -2528,8 +2528,7 @@ let rec update_decl_jkind env dpath decl =
             cstrs
         in
         begin match
-          Jkind.apply_modality_l modality jkind
-          |> Jkind.apply_or_null_l env
+          Jkind.for_or_null_variant env ~payload_type:ty ~modality jkind
         with
         | Ok type_jkind ->
           let type_jkind =


### PR DESCRIPTION
A custom `[@@or_null]` variant gets its kind by eagerly substituting the payload's kind and flipping nullability, so `type 'a t = Yep of 'a | Nope [@@or_null]` gets bare `value_or_null` and crosses no modes, while the builtin `'a or_null` is `value_or_null mod everything with 'a`. As a result, annotating the declaration with the builtin's kind was rejected, and `int t` could not cross contention even though `int or_null` can.

The two have the same representation (null is the immediate null, the payload is unchanged), so the builtin's kind is sound and best here too. The new `Jkind.for_or_null_variant` keeps the layout from `apply_or_null_l` (nullability and separability unchanged), takes the builtin's mod-bounds, and adds the payload as a `with`-bound under its modality, mirroring `or_null_jkind` in `predef.ml`.

One deliberate change: a payload under a constant staticity modality no longer yields a staticity-crossing kind, matching the builtin and boxed variants.

Tests cover the annotated declaration, crossing at `int` and non-crossing at `int ref`, a `@@ contended` payload, and signature inclusion.
