### PR TITLE
Make the dissector robust to manifest-resolved link inputs

### DIFF
--- a/asmcomp/dissector/measure_object_files.ml
+++ b/asmcomp/dissector/measure_object_files.ml
@@ -92,33 +92,21 @@ type file_kind =
   | Elf_object
   | Ar_archive
 
-let elf_magic = "\x7fELF"
-
-let ar_magic = "!<arch>\n"
-
 (* Classify an input file as an ELF relocatable object or an ar archive by its
    leading magic bytes. We must not classify by filename extension: link inputs
    may be resolved through manifest files (see [-I-manifest]) to
    content-addressed paths that carry no meaningful file name. Anything that is
    neither kind is a hard error; silently skipping an input would drop its code
    from the final link. *)
-let classify_file filename =
-  if not (Sys.file_exists filename) then raise (Error (File_not_found filename));
-  let magic =
-    let ic = open_in_bin filename in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        let len = min (String.length ar_magic) (in_channel_length ic) in
-        really_input_string ic len)
-  in
-  if
-    String.length magic >= String.length elf_magic
-    && String.equal (String.sub magic 0 (String.length elf_magic)) elf_magic
+let classify_file filename buf =
+  if Compiler_owee.Owee_elf.is_elf buf
   then Elf_object
-  else if String.equal magic ar_magic
+  else if Compiler_owee.Owee_archive.is_archive buf
   then Ar_archive
-  else raise (Error (Unrecognized_input { filename; magic }))
+  else
+    let magic_len = min 8 (Compiler_owee.Owee_buf.size buf) in
+    let magic = String.init magic_len (fun i -> Char.chr buf.{i}) in
+    raise (Error (Unrecognized_input { filename; magic }))
 
 module File_size = struct
   type t =
@@ -151,38 +139,31 @@ let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
     | None -> Printf.ifprintf stderr fmt
     | Some oc -> Printf.fprintf oc fmt
   in
-  (* Analyze a single .o file, returning (size, has_probes) *)
-  let analyze_object_file filename =
+  (* Map an input file, checking that it exists first. *)
+  let map_input_file filename =
     if not (Sys.file_exists filename)
     then raise (Error (File_not_found filename))
-    else
-      let buf = Compiler_owee.Owee_buf.map_binary (module Unix) filename in
-      analyze_elf_buf buf
+    else Compiler_owee.Owee_buf.map_binary (module Unix) filename
   in
-  (* Analyze an archive (.a) file, returning (size, has_probes, member_names) *)
-  let analyze_archive_file filename =
-    if not (Sys.file_exists filename)
-    then raise (Error (File_not_found filename))
-    else
-      let buf = Compiler_owee.Owee_buf.map_binary (module Unix) filename in
-      let archive, members = Compiler_owee.Owee_archive.read buf in
-      let size, has_probes, member_names =
-        List.fold_left
-          (fun (acc_size, acc_probes, acc_names) member ->
-            let name = member.Compiler_owee.Owee_archive.name in
-            if Filename.check_suffix name ".o"
-            then
-              let member_buf =
-                Compiler_owee.Owee_archive.member_body archive member
-              in
-              let size, has_probes = analyze_elf_buf member_buf in
-              ( Int64.add acc_size size,
-                acc_probes || has_probes,
-                name :: acc_names )
-            else acc_size, acc_probes, acc_names)
-          (0L, false, []) members
-      in
-      size, has_probes, List.rev member_names
+  (* Analyze an archive (.a) buffer, returning (size, has_probes,
+     member_names) *)
+  let analyze_archive_buf buf =
+    let archive, members = Compiler_owee.Owee_archive.read buf in
+    let size, has_probes, member_names =
+      List.fold_left
+        (fun (acc_size, acc_probes, acc_names) member ->
+          let name = member.Compiler_owee.Owee_archive.name in
+          if Filename.check_suffix name ".o"
+          then
+            let member_buf =
+              Compiler_owee.Owee_archive.member_body archive member
+            in
+            let size, has_probes = analyze_elf_buf member_buf in
+            Int64.add acc_size size, acc_probes || has_probes, name :: acc_names
+          else acc_size, acc_probes, acc_names)
+        (0L, false, []) members
+    in
+    size, has_probes, List.rev member_names
   in
   (* Track which files we've already analyzed to avoid double-counting *)
   let analyzed = String.Tbl.create 256 in
@@ -203,15 +184,16 @@ let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
       [])
     else (
       String.Tbl.add analyzed filename ();
-      match classify_file filename with
+      let buf = map_input_file filename in
+      match classify_file filename buf with
       | Elf_object ->
-        let size, has_probes = analyze_object_file filename in
+        let size, has_probes = analyze_elf_buf buf in
         log "%sInput: %s (%s)\n" indent filename (string_of_origin origin);
         log "%s  -> %s (%Ld bytes, has_probes=%b)\n" indent filename size
           has_probes;
         [{ File_size.filename; size; has_probes; origin }]
       | Ar_archive ->
-        let size, has_probes, member_names = analyze_archive_file filename in
+        let size, has_probes, member_names = analyze_archive_buf buf in
         log "%sInput: %s (%s)\n" indent filename (string_of_origin origin);
         log "%s  -> %s (%Ld bytes, has_probes=%b)\n" indent filename size
           has_probes;

--- a/asmcomp/dissector/measure_object_files.ml
+++ b/asmcomp/dissector/measure_object_files.ml
@@ -31,15 +31,23 @@ module String = Misc.Stdlib.String
 
 type error =
   | File_not_found of string
-  | Duplicate_file of string
+  | Unrecognized_input of
+      { filename : string;
+        magic : string
+      }
 
 exception Error of error
 
 let report_error ppf = function
   | File_not_found filename ->
     Format_doc.fprintf ppf "Dissector: file not found: %s" filename
-  | Duplicate_file filename ->
-    Format_doc.fprintf ppf "Dissector: duplicate file in link: %s" filename
+  | Unrecognized_input { filename; magic } ->
+    Format_doc.fprintf ppf
+      "Dissector: input file %s is neither an ELF object file nor an ar \
+       archive (leading bytes: %S). Refusing to continue, since skipping a \
+       link input would silently drop its code from the final executable or \
+       shared object."
+      filename magic
 
 let () =
   Location.register_error_of_exn (function
@@ -80,17 +88,37 @@ let analyze_elf_buf buf =
 (* Check if a string is a linker option (starts with '-') rather than a file *)
 let is_linker_option s = String.length s > 0 && String.get s 0 = '-'
 
-(* Check for duplicate files in the input list, ignoring linker options *)
-let check_for_duplicates files =
-  let seen = String.Tbl.create 256 in
-  List.iter
-    (fun file ->
-      if is_linker_option file
-      then ()
-      else if String.Tbl.mem seen file
-      then raise (Error (Duplicate_file file))
-      else String.Tbl.add seen file ())
-    files
+type file_kind =
+  | Elf_object
+  | Ar_archive
+
+let elf_magic = "\x7fELF"
+
+let ar_magic = "!<arch>\n"
+
+(* Classify an input file as an ELF relocatable object or an ar archive by its
+   leading magic bytes. We must not classify by filename extension: link inputs
+   may be resolved through manifest files (see [-I-manifest]) to
+   content-addressed paths that carry no meaningful file name. Anything that is
+   neither kind is a hard error; silently skipping an input would drop its code
+   from the final link. *)
+let classify_file filename =
+  if not (Sys.file_exists filename) then raise (Error (File_not_found filename));
+  let magic =
+    let ic = open_in_bin filename in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let len = min (String.length ar_magic) (in_channel_length ic) in
+        really_input_string ic len)
+  in
+  if
+    String.length magic >= String.length elf_magic
+    && String.equal (String.sub magic 0 (String.length elf_magic)) elf_magic
+  then Elf_object
+  else if String.equal magic ar_magic
+  then Ar_archive
+  else raise (Error (Unrecognized_input { filename; magic }))
 
 module File_size = struct
   type t =
@@ -110,8 +138,11 @@ module File_size = struct
 end
 
 let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
-  (* Check for duplicates in the input list first (extract just filenames) *)
-  check_for_duplicates (List.map fst files);
+  (* Note that duplicate entries in [files] are deduplicated (via [analyzed]
+     below) rather than rejected. Beyond the same file legitimately being listed
+     twice, distinct libraries can resolve to the same content-addressed path
+     when their companion archives are byte-identical (e.g. empty archives), see
+     [-I-manifest]. Measuring (and linking) such a file once is correct. *)
   let module Unix = (val unix) in
   (* Open output file if -ddissector-inputs is set *)
   let out_channel = Option.map open_out !Clflags.ddissector_inputs in
@@ -155,9 +186,10 @@ let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
   in
   (* Track which files we've already analyzed to avoid double-counting *)
   let analyzed = String.Tbl.create 256 in
-  (* Analyze a single file based on its extension, return list of file_size
-     records. Linker options (starting with '-') are ignored. The origin is
-     propagated to the resulting entries. *)
+  (* Analyze a single file based on its leading magic bytes (see
+     [classify_file]), return list of file_size records. Linker options
+     (starting with '-') are ignored. The origin is propagated to the resulting
+     entries. *)
   let analyze_one ~indent (filename, origin) =
     if is_linker_option filename
     then (
@@ -171,25 +203,20 @@ let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
       [])
     else (
       String.Tbl.add analyzed filename ();
-      if Filename.check_suffix filename ".o"
-      then (
+      match classify_file filename with
+      | Elf_object ->
         let size, has_probes = analyze_object_file filename in
         log "%sInput: %s (%s)\n" indent filename (string_of_origin origin);
         log "%s  -> %s (%Ld bytes, has_probes=%b)\n" indent filename size
           has_probes;
-        [{ File_size.filename; size; has_probes; origin }])
-      else if Filename.check_suffix filename ".a"
-      then (
+        [{ File_size.filename; size; has_probes; origin }]
+      | Ar_archive ->
         let size, has_probes, member_names = analyze_archive_file filename in
         log "%sInput: %s (%s)\n" indent filename (string_of_origin origin);
         log "%s  -> %s (%Ld bytes, has_probes=%b)\n" indent filename size
           has_probes;
         log "%s  Members: %s\n" indent (String.concat ", " member_names);
         [{ File_size.filename; size; has_probes; origin }])
-      else (
-        log "%sInput: %s (%s) [unknown extension, skipped]\n" indent filename
-          (string_of_origin origin);
-        []))
   in
   let result = List.concat_map (analyze_one ~indent:"") files in
   Gc.compact ();

--- a/asmcomp/dissector/measure_object_files.ml
+++ b/asmcomp/dissector/measure_object_files.ml
@@ -44,9 +44,7 @@ let report_error ppf = function
   | Unrecognized_input { filename; magic } ->
     Format_doc.fprintf ppf
       "Dissector: input file %s is neither an ELF object file nor an ar \
-       archive (leading bytes: %S). Refusing to continue, since skipping a \
-       link input would silently drop its code from the final executable or \
-       shared object."
+       archive (leading bytes: %S)"
       filename magic
 
 let () =
@@ -92,12 +90,8 @@ type file_kind =
   | Elf_object
   | Ar_archive
 
-(* Classify an input file as an ELF relocatable object or an ar archive by its
-   leading magic bytes. We must not classify by filename extension: link inputs
-   may be resolved through manifest files (see [-I-manifest]) to
-   content-addressed paths that carry no meaningful file name. Anything that is
-   neither kind is a hard error; silently skipping an input would drop its code
-   from the final link. *)
+(* Classify by magic bytes rather than file name: manifest-resolved link inputs
+   (see [-I-manifest]) may live at content-addressed paths. *)
 let classify_file filename buf =
   if Compiler_owee.Owee_elf.is_elf buf
   then Elf_object
@@ -126,11 +120,9 @@ module File_size = struct
 end
 
 let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
-  (* Note that duplicate entries in [files] are deduplicated (via [analyzed]
-     below) rather than rejected. Beyond the same file legitimately being listed
-     twice, distinct libraries can resolve to the same content-addressed path
-     when their companion archives are byte-identical (e.g. empty archives), see
-     [-I-manifest]. Measuring (and linking) such a file once is correct. *)
+  (* Duplicate entries in [files] are deduplicated (via [analyzed] below): in a
+     content-addressed store, byte-identical inputs (e.g. empty archives from
+     distinct libraries) share a single path. *)
   let module Unix = (val unix) in
   (* Open output file if -ddissector-inputs is set *)
   let out_channel = Option.map open_out !Clflags.ddissector_inputs in
@@ -145,6 +137,8 @@ let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
     then raise (Error (File_not_found filename))
     else Compiler_owee.Owee_buf.map_binary (module Unix) filename
   in
+  (* Analyze an object (.o) buffer, returning (size, has_probes) *)
+  let analyze_object_buf buf = analyze_elf_buf buf in
   (* Analyze an archive (.a) buffer, returning (size, has_probes,
      member_names) *)
   let analyze_archive_buf buf =
@@ -187,7 +181,7 @@ let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =
       let buf = map_input_file filename in
       match classify_file filename buf with
       | Elf_object ->
-        let size, has_probes = analyze_elf_buf buf in
+        let size, has_probes = analyze_object_buf buf in
         log "%sInput: %s (%s)\n" indent filename (string_of_origin origin);
         log "%s  -> %s (%Ld bytes, has_probes=%b)\n" indent filename size
           has_probes;

--- a/asmcomp/dissector/measure_object_files.mli
+++ b/asmcomp/dissector/measure_object_files.mli
@@ -38,13 +38,7 @@ type error =
   | Unrecognized_input of
       { filename : string;
         magic : string
-      }
-      (** The file is neither an ELF relocatable object nor an ar archive.
-          Inputs are classified by their leading magic bytes rather than by
-          filename extension, because build systems may supply link inputs via
-          manifest files (see [-I-manifest]) that resolve to content-addressed
-          paths without meaningful file names. Silently skipping such a file
-          would drop its code from the final link, so this is a hard error. *)
+      }  (** The file is neither an ELF relocatable object nor an ar archive. *)
 
 (** Exception wrapper for measurement errors. *)
 exception Error of error

--- a/asmcomp/dissector/measure_object_files.mli
+++ b/asmcomp/dissector/measure_object_files.mli
@@ -35,7 +35,16 @@
 (** Errors that can occur when measuring object files. *)
 type error =
   | File_not_found of string
-  | Duplicate_file of string
+  | Unrecognized_input of
+      { filename : string;
+        magic : string
+      }
+      (** The file is neither an ELF relocatable object nor an ar archive.
+          Inputs are classified by their leading magic bytes rather than by
+          filename extension, because build systems may supply link inputs via
+          manifest files (see [-I-manifest]) that resolve to content-addressed
+          paths without meaningful file names. Silently skipping such a file
+          would drop its code from the final link, so this is a hard error. *)
 
 (** Exception wrapper for measurement errors. *)
 exception Error of error

--- a/external/owee/owee_archive.ml
+++ b/external/owee/owee_archive.ml
@@ -36,6 +36,15 @@ let archive_magic = "!<arch>\n"
 
 let archive_magic_size = 8
 
+let is_archive buf =
+  size buf >= archive_magic_size
+  &&
+  let matches = ref true in
+  String.iteri
+    (fun i c -> if buf.{i} <> Char.code c then matches := false)
+    archive_magic;
+  !matches
+
 let header_size = 60
 
 let header_terminator = "`\n"

--- a/external/owee/owee_archive.ml
+++ b/external/owee/owee_archive.ml
@@ -38,12 +38,9 @@ let archive_magic_size = 8
 
 let is_archive buf =
   size buf >= archive_magic_size
-  &&
-  let matches = ref true in
-  String.iteri
-    (fun i c -> if buf.{i} <> Char.code c then matches := false)
-    archive_magic;
-  !matches
+  && String.equal
+       (Read.fixed_string (cursor buf) archive_magic_size)
+       archive_magic
 
 let header_size = 60
 

--- a/external/owee/owee_archive.mli
+++ b/external/owee/owee_archive.mli
@@ -64,6 +64,11 @@ type member = private
 (** Alias for [member] for clarity when referring to header metadata. *)
 type member_header = member
 
+(** [is_archive buf] tells whether [buf] starts with the ar archive magic
+    string. It validates nothing else about the contents (use [read] for that)
+    and never raises. *)
+val is_archive : Owee_buf.t -> bool
+
 (** [read buf] reads an ar archive from the given buffer. Returns the archive
     handle and a list of members. The buffer should contain the entire archive
     (e.g., via memory mapping).

--- a/external/owee/owee_elf.ml
+++ b/external/owee/owee_elf.ml
@@ -2,16 +2,21 @@
 
 open Owee_buf
 
+let magic = "\x7fELF"
+
+let magic_matches buffer ~at =
+  buffer.{at + 0} = Char.code magic.[0]
+  && buffer.{at + 1} = Char.code magic.[1]
+  && buffer.{at + 2} = Char.code magic.[2]
+  && buffer.{at + 3} = Char.code magic.[3]
+
+let is_elf buffer =
+  size buffer >= String.length magic && magic_matches buffer ~at:0
+
 let read_magic t =
   ensure t 4 "Magic number truncated";
   let { buffer; position } = t in
-  let valid =
-    buffer.{position + 0} = 0x7f
-    && buffer.{position + 1} = Char.code 'E'
-    && buffer.{position + 2} = Char.code 'L'
-    && buffer.{position + 3} = Char.code 'F'
-  in
-  if not valid
+  if not (magic_matches buffer ~at:position)
   then
     invalid_format
       (Printf.sprintf "No ELF magic number (found %02x %02x %02x %02x)"

--- a/external/owee/owee_elf.mli
+++ b/external/owee/owee_elf.mli
@@ -139,6 +139,11 @@ val make_symtab_shndx_section :
   sh_link:u32 ->
   section
 
+(** [is_elf buf] tells whether [buf] starts with the ELF magic number. It
+    validates nothing else about the contents (use [read_elf] for that) and
+    never raises. *)
+val is_elf : Owee_buf.t -> bool
+
 (** From a buffer pointing to an ELF image, [read_elf] decodes the header and
     section table. *)
 val read_elf : Owee_buf.t -> header * section array

--- a/testsuite/tests/manifests-link/link.sh
+++ b/testsuite/tests/manifests-link/link.sh
@@ -135,4 +135,22 @@ MANIFEST
     cat negative_kind.err >&2
     exit 1
   fi
+
+  # Same for a zero-length input, which additionally exercises mapping an
+  # empty file.
+  : > cas/blob_empty_file
+  sed 's|^file mylib\.a .*|file mylib.a cas/blob_empty_file|' manifest.txt \
+    > manifest_empty_kind.txt
+  if compile "$@" -dissector -I-manifest manifest_empty_kind.txt \
+       helper.$EXT mylib.$LIBEXT empty.$LIBEXT empty2.$LIBEXT link_manifest.$EXT \
+       -o should_fail_empty.exe 2> negative_empty.err; then
+    echo "ERROR: dissected link unexpectedly succeeded with an empty mylib.a" >&2
+    exit 1
+  fi
+  if ! grep -q "neither an ELF object file nor an ar archive" negative_empty.err
+  then
+    echo "ERROR: expected an unrecognized-input error for an empty file, got:" >&2
+    cat negative_empty.err >&2
+    exit 1
+  fi
 fi

--- a/testsuite/tests/manifests-link/link.sh
+++ b/testsuite/tests/manifests-link/link.sh
@@ -116,9 +116,10 @@ MANIFEST
 
   # Every manifest-resolved object blob must be measured, and nothing may be
   # skipped (except re-analyzing the shared blob).
-  for blob in cas/blob_helper_o cas/blob_main_o cas/blob_mylib_a \
-      cas/blob_shared_empty_a; do
-    if ! grep -Eq "^Input: $blob \([A-Za-z_]+\)\$" dissector.inputs; then
+  # Resolved paths are absolute: $MANIFEST_FILES_ROOT/cas/<blob>.
+  for blob in blob_helper_o blob_main_o blob_mylib_a blob_shared_empty_a; do
+    if ! grep -Eq "^Input: [^ ]*/cas/$blob \([A-Za-z_]+\)\$" dissector.inputs
+    then
       echo "ERROR: the dissector did not measure $blob:" >&2
       cat dissector.inputs >&2
       exit 1

--- a/testsuite/tests/manifests-link/link.sh
+++ b/testsuite/tests/manifests-link/link.sh
@@ -91,3 +91,48 @@ if [ "$EXT" = "cmx" ]; then
     exit 1
   fi
 fi
+
+if [ "$EXT" = "cmx" ] && [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]; then
+  # The dissector (-dissector) inserts an extra link-time pass that reads
+  # every link input; it must classify inputs by their content (magic bytes),
+  # not their file names, to work with manifest-resolved blob paths.
+  #
+  # Also give a second empty archive a '.a' companion sharing one blob with
+  # the first, as happens in a content-addressed store (identical files, one
+  # path). The dissector must tolerate the repeated path instead of rejecting
+  # it as a duplicate input.
+  compile -a -o empty2.$LIBEXT
+  mv empty2.$LIBEXT cas/blob_empty2
+  printf '!<arch>\n' > cas/blob_shared_empty_a
+  cat >> manifest.txt <<MANIFEST
+file empty2.$LIBEXT cas/blob_empty2
+file empty.a cas/blob_shared_empty_a
+file empty2.a cas/blob_shared_empty_a
+MANIFEST
+
+  compile "$@" -dissector -I-manifest manifest.txt \
+    helper.$EXT mylib.$LIBEXT empty.$LIBEXT empty2.$LIBEXT link_manifest.$EXT \
+    -o dissected.exe
+  ./link_manifest.exe > expected.out
+  ./dissected.exe > dissected.out
+  diff expected.out dissected.out
+
+  # Negative test: a link input that is neither an ELF object nor an ar
+  # archive must be a hard error; silently skipping it would drop its code
+  # from the final link.
+  echo "this is not an object file" > cas/blob_text
+  sed 's|^file mylib\.a .*|file mylib.a cas/blob_text|' manifest.txt \
+    > manifest_bad_kind.txt
+  if compile "$@" -dissector -I-manifest manifest_bad_kind.txt \
+       helper.$EXT mylib.$LIBEXT empty.$LIBEXT empty2.$LIBEXT link_manifest.$EXT \
+       -o should_fail_kind.exe 2> negative_kind.err; then
+    echo "ERROR: dissected link unexpectedly succeeded with a bogus mylib.a" >&2
+    exit 1
+  fi
+  if ! grep -q "neither an ELF object file nor an ar archive" negative_kind.err
+  then
+    echo "ERROR: expected an unrecognized-input error, got:" >&2
+    cat negative_kind.err >&2
+    exit 1
+  fi
+fi

--- a/testsuite/tests/manifests-link/link.sh
+++ b/testsuite/tests/manifests-link/link.sh
@@ -93,14 +93,10 @@ if [ "$EXT" = "cmx" ]; then
 fi
 
 if [ "$EXT" = "cmx" ] && [ "$(uname -s)" = "Linux" ] && [ "$(uname -m)" = "x86_64" ]; then
-  # The dissector (-dissector) inserts an extra link-time pass that reads
-  # every link input; it must classify inputs by their content (magic bytes),
-  # not their file names, to work with manifest-resolved blob paths.
-  #
-  # Also give a second empty archive a '.a' companion sharing one blob with
-  # the first, as happens in a content-addressed store (identical files, one
-  # path). The dissector must tolerate the repeated path instead of rejecting
-  # it as a duplicate input.
+  # The dissector reads every link input, so it must classify them by content
+  # rather than by file name. The second empty archive gets a '.a' companion
+  # sharing one blob with the first (as in a content-addressed store); the
+  # dissector must tolerate the repeated path.
   compile -a -o empty2.$LIBEXT
   mv empty2.$LIBEXT cas/blob_empty2
   printf '!<arch>\n' > cas/blob_shared_empty_a
@@ -110,16 +106,31 @@ file empty.a cas/blob_shared_empty_a
 file empty2.a cas/blob_shared_empty_a
 MANIFEST
 
-  compile "$@" -dissector -I-manifest manifest.txt \
+  compile "$@" -dissector -ddissector-inputs dissector.inputs \
+    -I-manifest manifest.txt \
     helper.$EXT mylib.$LIBEXT empty.$LIBEXT empty2.$LIBEXT link_manifest.$EXT \
     -o dissected.exe
   ./link_manifest.exe > expected.out
   ./dissected.exe > dissected.out
   diff expected.out dissected.out
 
-  # Negative test: a link input that is neither an ELF object nor an ar
-  # archive must be a hard error; silently skipping it would drop its code
-  # from the final link.
+  # Every manifest-resolved object blob must be measured, and nothing may be
+  # skipped (except re-analyzing the shared blob).
+  for blob in cas/blob_helper_o cas/blob_main_o cas/blob_mylib_a \
+      cas/blob_shared_empty_a; do
+    if ! grep -Eq "^Input: $blob \([A-Za-z_]+\)\$" dissector.inputs; then
+      echo "ERROR: the dissector did not measure $blob:" >&2
+      cat dissector.inputs >&2
+      exit 1
+    fi
+  done
+  if grep "skipped" dissector.inputs | grep -qv "already analyzed"; then
+    echo "ERROR: the dissector skipped a link input:" >&2
+    cat dissector.inputs >&2
+    exit 1
+  fi
+
+  # A link input that is neither an ELF object nor an ar archive is an error.
   echo "this is not an object file" > cas/blob_text
   sed 's|^file mylib\.a .*|file mylib.a cas/blob_text|' manifest.txt \
     > manifest_bad_kind.txt

--- a/testsuite/tests/manifests-link/link_manifest.ml
+++ b/testsuite/tests/manifests-link/link_manifest.ml
@@ -53,7 +53,14 @@
    simulated content-addressed store (extensionless blob names), writes a
    manifest, and links the program by bare names only. It also checks that a
    missing '.a' entry is an error for a non-empty archive, and is accepted for
-   an empty archive. *)
+   an empty archive.
+
+   On Linux/x86-64, link.sh additionally links the program with -dissector:
+   the dissector reads every link input, so it must classify them by content
+   rather than by file name, tolerate distinct inputs resolving to the same
+   content-addressed path (byte-identical archives), and reject inputs that
+   are neither ELF objects nor ar archives instead of silently skipping
+   them. *)
 
 let () =
   print_endline (Helper.greeting ());


### PR DESCRIPTION
Based on #6468.

The `-dissector` pass classified link inputs by filename extension and silently skipped anything unrecognized, which resulted in dropping essentially all OCaml code from the link when manifests are used. As the linker doesn't complain about missing shared objects, the result was a silently broken `.so` file. The dissector also rejected duplicate input paths, which content-addressed store sometimes legitimately produce (for example, byte-identical empty archives resolve to one path).

Fix: classify inputs by magic bytes (ELF vs ar), hard-error on anything unrecognizable instead of skipping it, and deduplicate repeated paths. The manifests-link test now also exercises `-dissector` on Linux/x86-64.