### PR TITLE
fix(flambda2-types): Only recover relations that hold globally

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1218,6 +1218,8 @@ module Joined_envs : sig
 
   val keys : t -> Index.Set.t
 
+  val exists_in_all_joined_envs : t -> _ Index.Map.t -> bool
+
   (** Returns the aliases of a variable in all the environments where it exists.
 
       The provided variable {b must} be defined in the current compilation unit.
@@ -1260,6 +1262,9 @@ end = struct
     | Some (_, { current; _ }) -> current
 
   let keys t = Index.Map.keys (envs_and_equations t)
+
+  let exists_in_all_joined_envs t m =
+    Index.Map.subset_domain (envs_and_equations t) m
 
   let get_canonical_simple_ignoring_name_mode typing_env simple =
     Simple_in_one_joined_env.create
@@ -1624,7 +1629,26 @@ let add_to_inverse_relations inverse_relations name relation ~scrutinee =
     (Name.Map.singleton name
        (TG.Relation.Map.singleton relation (Name.Set.singleton scrutinee)))
 
-let recover_inverse_relations inverse_relations name ty =
+let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
+    ty =
+  (* We can only recover inverse relations if the type we are recovering from is
+     valid in all the joined environments.
+
+     If we have a type [x : Variant (is_int = y)] for [x], but [x] only exists
+     in a subset of the joined environments, then the equation [y = %get_tag x]
+     is only valid in those environments -- in particular, if [y] exists in more
+     environments than [x], it is unsound to include that equation in the target
+     environment.
+
+     We avoid this situation by only recovering relations if the type we are
+     recovering from exists in all the joined environments -- this ensures that
+     the variables mentioned in the type cannot exist in more environments than
+     the type itself.
+
+     CR-someday bclement: We could be more precise here by recovering relations
+     if they are valid in all the environments where the involved variables are
+     defined, but it is not clear if that would actually be useful. *)
+  assert exists_in_all_joined_envs;
   match TG.descr ty with
   | Value (Ok (No_alias { is_null = Not_null; non_null = Ok head })) -> (
     match head with
@@ -1734,8 +1758,17 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
       with
       | Unknown, t -> types_in_target_env, inverse_relations, t
       | Known ty, t ->
+        let exists_in_all_joined_envs =
+          Joined_envs.exists_in_all_joined_envs t.joined_envs types
+        in
         let ty, inverse_relations =
-          recover_inverse_relations inverse_relations (name :> Name.t) ty
+          if exists_in_all_joined_envs
+          then
+            recover_inverse_relations ~exists_in_all_joined_envs
+              inverse_relations
+              (name :> Name.t)
+              ty
+          else ty, inverse_relations
         in
         let ty = Type_in_target_env.create ty in
         ( Name_in_target_env.Map.add name ty types_in_target_env,

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1635,7 +1635,7 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
      valid in all the joined environments.
 
      If we have a type [x : Variant (is_int = y)] for [x], but [x] only exists
-     in a subset of the joined environments, then the equation [y = %get_tag x]
+     in a subset of the joined environments, then the equation [y = %is_int x]
      is only valid in those environments -- in particular, if [y] exists in more
      environments than [x], it is unsound to include that equation in the target
      environment.

--- a/testsuite/tests/flambda2/n_way_join_recover_relations.ml
+++ b/testsuite/tests/flambda2/n_way_join_recover_relations.ml
@@ -1,0 +1,48 @@
+(* TEST
+   ocamlopt_flags += " -flambda2-join-points -flambda2-join-algorithm=n-way";
+   flambda2;
+   native;
+ *)
+
+type t =
+  | A of unit
+  | B of unit
+  | C of unit
+
+type tag = T0 | T1 | T2
+
+let[@inline never] g (action : t) =
+  let[@local] kend () =
+    match action with
+    | C _ -> 0
+    | B _ | A _ -> 1
+  in
+  let[@local] kmid tag =
+    (* Here we know that [tag = %get_tag action]. *)
+    let[@local] kjoin _x =
+      (* Here we propagate the first field of [x] from [isint0], which has
+         [tag] as an [is_int] variable, from which we used to incorrectly
+         deduce that [tag] was equal to [%is_int x]. *)
+      kend ()
+    in
+    let[@local] isint0 x =
+      (* Here we discover that [tag] is also the [%is_int] of the
+         first field of [x], and since it is equal to the [%is_int] of a value,
+         it can't be equal to [2] (which is true!). *)
+      kjoin x
+    in
+    match tag with
+    | T0 ->
+      isint0 (Some (Some ()))
+    | T1 ->
+      isint0 (Some None)
+    | T2 ->
+      kjoin None
+  in
+  match action with
+  | A _ -> kmid T0
+  | B _ -> kmid T1
+  | C _ -> kmid T2
+
+let () =
+  assert (Sys.opaque_identity g (C ()) == 0)


### PR DESCRIPTION
In #4394 we introduced a `recover_inverse_relations` functions to reconstruct inverse relations (i.e. equations of the form `y = %get_tag x`) from direct relations (i.e. equations that state "`x` is a variant with tag `y`").

Introducing these inverse relations means that whenever we inspect `y` (e.g. by performing a match in `y`, or otherwise refining its type), the equation must hold. Hence, to be valid in the target environment, the equation must hold in all the joined environments where `y` exists, which can include more environments than the environments where `x` exists (i.e. environments where the type for `x` is valid -- note that since the type of `x` mentions `y`, `y` is either defined or guarded by an env extension in all the environments where `x` is defined).

This patch ensures the above condition by only recovering such inverse relations if the type for `x` we are recovering them from is valid in *all* the joined environments (in which case it is not possible for `y` to exist in more environments than `x`).