### PR TITLE
Compare dinfo_uid in Debuginfo.Dbg.compare

### DIFF
--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -247,24 +247,51 @@ module Dbg = struct
       | _ :: _, [] -> 1
       | [], _ :: _ -> -1
       | d1 :: ds1, d2 :: ds2 ->
-
-     let c = String.compare d1.dinfo_file d2.dinfo_file in
+       (* The record patterns below list every field explicitly, making it
+          clear which fields participate in the comparison.  The
+          [dinfo_scopes] and [dinfo_function_symbol] fields are deliberately
+          not compared. *)
+       let { dinfo_file = dinfo_file1;
+                            dinfo_line = dinfo_line1;
+                            dinfo_char_start = dinfo_char_start1;
+                            dinfo_char_end = dinfo_char_end1;
+                            dinfo_start_bol = dinfo_start_bol1;
+                            dinfo_end_bol = dinfo_end_bol1;
+                            dinfo_end_line = dinfo_end_line1;
+                            dinfo_scopes = _;
+                            dinfo_uid = dinfo_uid1;
+                            dinfo_function_symbol = _;
+                            dinfo_dir = dinfo_dir1 } = d1
+       in
+       let { dinfo_file = dinfo_file2;
+                            dinfo_line = dinfo_line2;
+                            dinfo_char_start = dinfo_char_start2;
+                            dinfo_char_end = dinfo_char_end2;
+                            dinfo_start_bol = dinfo_start_bol2;
+                            dinfo_end_bol = dinfo_end_bol2;
+                            dinfo_end_line = dinfo_end_line2;
+                            dinfo_scopes = _;
+                            dinfo_uid = dinfo_uid2;
+                            dinfo_function_symbol = _;
+                            dinfo_dir = dinfo_dir2 } = d2
+       in
+       let c = String.compare dinfo_file1 dinfo_file2 in
        if c <> 0 then c else
-       let c = Int.compare d1.dinfo_line d2.dinfo_line in
+       let c = Int.compare dinfo_line1 dinfo_line2 in
        if c <> 0 then c else
-       let c = Int.compare d1.dinfo_char_end d2.dinfo_char_end in
+       let c = Int.compare dinfo_char_end1 dinfo_char_end2 in
        if c <> 0 then c else
-       let c = Int.compare d1.dinfo_char_start d2.dinfo_char_start in
+       let c = Int.compare dinfo_char_start1 dinfo_char_start2 in
        if c <> 0 then c else
-       let c = Int.compare d1.dinfo_start_bol d2.dinfo_start_bol in
+       let c = Int.compare dinfo_start_bol1 dinfo_start_bol2 in
        if c <> 0 then c else
-       let c = Int.compare d1.dinfo_end_bol d2.dinfo_end_bol in
+       let c = Int.compare dinfo_end_bol1 dinfo_end_bol2 in
        if c <> 0 then c else
-       let c = Int.compare d1.dinfo_end_line d2.dinfo_end_line in
+       let c = Int.compare dinfo_end_line1 dinfo_end_line2 in
        if c <> 0 then c else
-       let c = Option.compare String.compare d1.dinfo_dir d2.dinfo_dir in
+       let c = Option.compare String.compare dinfo_dir1 dinfo_dir2 in
        if c <> 0 then c else
-       let c = Option.compare String.compare d1.dinfo_uid d2.dinfo_uid in
+       let c = Option.compare String.compare dinfo_uid1 dinfo_uid2 in
        if c <> 0 then c else
        loop ds1 ds2
     in

--- a/lambda/debuginfo.ml
+++ b/lambda/debuginfo.ml
@@ -264,6 +264,8 @@ module Dbg = struct
        if c <> 0 then c else
        let c = Option.compare String.compare d1.dinfo_dir d2.dinfo_dir in
        if c <> 0 then c else
+       let c = Option.compare String.compare d1.dinfo_uid d2.dinfo_uid in
+       if c <> 0 then c else
        loop ds1 ds2
     in
     loop dbg1 dbg2

--- a/lambda/debuginfo.mli
+++ b/lambda/debuginfo.mli
@@ -137,7 +137,8 @@ val to_structured_mangling_path :
 module Dbg : sig
   type t
 
-  (** [compare] and [hash] ignore [dinfo_scopes] field of item *)
+  (** [compare] and [hash] ignore the [dinfo_scopes] field of item;
+      [compare] additionally ignores [dinfo_function_symbol]. *)
 
   val is_none : t -> bool
 


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

This PR is independent of the rest of the series and can be reviewed and merged on its own.

## Description

`Debuginfo.Dbg.compare_aux` compared every field of a `Debuginfo` item except the pre-existing `dinfo_uid` field, so two items differing only in their uid compared equal. This matters once debug uids are used to key per-inlined-frame information: distinct frames could be conflated by any map or sort keyed on `Dbg.t`.

Fix: compare `dinfo_uid` (via `Option.compare String.compare`), in the same way as `dinfo_dir`.

## Notes for reviewers

- Standalone correctness fix; no behaviour change expected for code that does not populate `dinfo_uid`.
- The development branch also contained a `Debuginfo.remove_outermost_frame` function; it had no consumers anywhere in the tree, so it has been dropped from this PR rather than shipping dead code.

## Verification

- `make -s boot-compiler` passes.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare ← **this PR**
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



