### PR TITLE
Strip the platform symbol prefix from DW_AT_linkage_name

### DIFF
--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -105,12 +105,12 @@ let encode { name; already_encoded } =
 let encode_without_prefix { name; already_encoded } =
   if already_encoded
   then
-    (* Remove the prefix, if any, on a best-effort basis. *)
-    let prefix = symbol_prefix () in
-    let prefix_len = String.length prefix in
-    if prefix_len > 0 && String.starts_with ~prefix name
-    then String.sub name prefix_len (String.length name - prefix_len)
-    else name
+    (* The name was provided in its final assembly form, so it cannot reliably
+       be determined here whether it starts with the platform symbol prefix; it
+       is returned unchanged. Such symbols (currently only section names and
+       relocation targets in the binary emitters) do not flow into DWARF
+       attributes such as [DW_AT_linkage_name]. *)
+    name
   else to_escaped_string ~symbol_prefix:"" name
 
 (* Comparison and hashing are based on the encoded form, so two symbols that

--- a/backend/asm_targets/asm_symbol.ml
+++ b/backend/asm_targets/asm_symbol.ml
@@ -102,6 +102,17 @@ let encode { name; already_encoded } =
     let symbol_prefix = symbol_prefix () in
     to_escaped_string ~symbol_prefix name
 
+let encode_without_prefix { name; already_encoded } =
+  if already_encoded
+  then
+    (* Remove the prefix, if any, on a best-effort basis. *)
+    let prefix = symbol_prefix () in
+    let prefix_len = String.length prefix in
+    if prefix_len > 0 && String.starts_with ~prefix name
+    then String.sub name prefix_len (String.length name - prefix_len)
+    else name
+  else to_escaped_string ~symbol_prefix:"" name
+
 (* Comparison and hashing are based on the encoded form, so two symbols that
    produce the same assembly output are considered equal regardless of how they
    were constructed. *)

--- a/backend/asm_targets/asm_symbol.mli
+++ b/backend/asm_targets/asm_symbol.mli
@@ -58,6 +58,12 @@ val create_without_encoding : visibility:visibility -> string -> t
 
 val encode : t -> string
 
+(** Like [encode], but without the target-specific symbol prefix (e.g. the
+    leading underscore on macOS). This is the form expected in DWARF attributes
+    such as [DW_AT_linkage_name]: debuggers match such names against symbol
+    table entries from which any platform prefix has been stripped. *)
+val encode_without_prefix : t -> string
+
 val to_raw_string : t -> string
 
 val visibility : t -> visibility

--- a/backend/asm_targets/asm_symbol.mli
+++ b/backend/asm_targets/asm_symbol.mli
@@ -61,7 +61,8 @@ val encode : t -> string
 (** Like [encode], but without the target-specific symbol prefix (e.g. the
     leading underscore on macOS). This is the form expected in DWARF attributes
     such as [DW_AT_linkage_name]: debuggers match such names against symbol
-    table entries from which any platform prefix has been stripped. *)
+    table entries from which any platform prefix has been stripped. Names of
+    symbols created with [create_without_encoding] are returned unchanged. *)
 val encode_without_prefix : t -> string
 
 val to_raw_string : t -> string

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.ml
@@ -43,7 +43,8 @@ let add_empty state ~compilation_unit_proto_die ~fun_symbol ~demangled_name =
     Proto_die.create ~parent:(Some compilation_unit_proto_die) ~tag:Subprogram
       ~attribute_values:
         [ DAH.create_name demangled_name;
-          DAH.create_linkage_name ~linkage_name:(Asm_symbol.encode fun_symbol);
+          DAH.create_linkage_name
+            ~linkage_name:(Asm_symbol.encode_without_prefix fun_symbol);
           DAH.create_external ~is_visible_externally:true ]
       ()
   in
@@ -63,7 +64,8 @@ let add_root state ~parent ~demangled_name fun_symbol ~location_attributes =
     match demangled_name with Some name -> [DAH.create_name name] | None -> []
   in
   let attributes =
-    [ DAH.create_linkage_name ~linkage_name:(Asm_symbol.encode fun_symbol);
+    [ DAH.create_linkage_name
+        ~linkage_name:(Asm_symbol.encode_without_prefix fun_symbol);
       DAH.create_external ~is_visible_externally:true ]
     @ name @ location_attributes
   in

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_inlined_frames.ml
@@ -166,7 +166,8 @@ let die_for_inlined_frame state ~compilation_unit_proto_die ~parent
          (in a way which will also work on macOS). In particular it should
          otherwise suffice for backtraces. *)
       [ DAH.create_name demangled_name;
-        DAH.create_linkage_name ~linkage_name:(Asm_symbol.encode fun_symbol);
+        DAH.create_linkage_name
+          ~linkage_name:(Asm_symbol.encode_without_prefix fun_symbol);
         DAH.create_external ~is_visible_externally:true ]
   in
   let block : Debuginfo.item = List.hd (Debuginfo.to_items block) in


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

This PR is independent of the rest of the series and can be reviewed and merged on its own.

## Description

`DW_AT_linkage_name` is expected to contain the symbol-table name with any platform-specific prefix removed; debuggers (e.g. LLDB) strip the leading underscore from Mach-O symbols before matching. On macOS we were emitting the underscore-prefixed form, which broke matching of linkage names against symbols.

- New `Asm_symbol.encode_without_prefix` (best-effort prefix removal for already-encoded symbols; empty `symbol_prefix` otherwise).
- The three `DW_AT_linkage_name` sites (`dwarf_abstract_instances.ml` ×2, `dwarf_inlined_frames.ml` ×1) switch from `Asm_symbol.encode` to `encode_without_prefix`.

Self-contained; no effect on non-DWARF output, and no visible change on platforms whose symbol prefix is empty (e.g. Linux/ELF).

## Verification

- `make -s boot-compiler` passes; `make -s fmt` clean.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name ← **this PR**
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



