### PR TITLE
Keep the startup object file when emitting OxCaml DWARF

### DIFF
--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -65,6 +65,18 @@ let sourcefile_for_dwarf ~named_startup_file filename =
      purposes. *)
   if named_startup_file then filename else ".startup"
 
+(* On macOS the system linker does not copy debug information into executables:
+   instead a "debug map" in the executable points at the object files, from
+   which the debugger reads the debug information directly. When the startup
+   object file contains DWARF information (e.g. for the [caml_apply] and
+   [caml_curry] functions, which debuggers need in order to see through
+   generically-applied calls) it must accordingly be kept, at a predictable
+   location, rather than being a temporary file deleted after linking. *)
+let keep_startup_obj_for_dwarf () =
+  !Clflags.debug
+  && !Dwarf_flags.dwarf_for_startup_file
+  && String.equal Config.system "macosx"
+
 let emit_ocamlrunparam ~ppf_dump =
   Asmgen.compile_phrase ~ppf_dump
     (Cmm.Cdata
@@ -245,7 +257,7 @@ let link_shared_actual unix ml_objfiles output_name ~genfns ~units_tolink
   then
     (* CR gyorsh: restore after workaround. *)
     Emitaux.binary_backend_available := true;
-  remove_file startup_obj
+  if not (keep_startup_obj_for_dwarf ()) then remove_file startup_obj
 
 let link_shared unix ml_objfiles output_name ~genfns ~units_tolink ~ppf_dump =
   Profile.record_call "link_shared" (fun () ->
@@ -408,7 +420,12 @@ let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports
     else Filename.temp_file "camlstartup" ext_asm
   in
   let sourcefile_for_dwarf = sourcefile_for_dwarf ~named_startup_file startup in
-  let startup_obj = Filename.temp_file "camlstartup" ext_obj in
+  let keep_startup_obj = keep_startup_obj_for_dwarf () in
+  let startup_obj =
+    if keep_startup_obj
+    then output_name ^ ".startup" ^ ext_obj
+    else Filename.temp_file "camlstartup" ext_obj
+  in
   let ml_objfiles =
     if not uses_eval
     then ml_objfiles
@@ -473,7 +490,7 @@ let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports
   Misc.try_finally
     (fun () -> call_linker ?dissector_args ml_objfiles startup_obj output_name)
     ~always:(fun () ->
-      remove_file startup_obj;
+      if not keep_startup_obj then remove_file startup_obj;
       cleanup_dissector_temp_dir ())
 
 let link unix linkenv ml_objfiles output_name ~cached_genfns_imports ~genfns

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -102,7 +102,12 @@ let restrict_to_upstream_dwarf = ref (not Config.oxcaml_dwarf)
 (* Currently the maximum number of stack slots, see asmgen.ml *)
 let dwarf_max_function_complexity = ref 50
 
-let dwarf_for_startup_file = ref false
+(* As for [restrict_to_upstream_dwarf], the default tracks whether OxCaml DWARF
+   support is enabled at configure time. DWARF information for the startup file
+   notably covers the [caml_apply] and [caml_curry] functions, which debuggers
+   need in order to see through generically-applied calls (e.g. for call site
+   resolution and entry value computation). *)
+let dwarf_for_startup_file = ref Config.oxcaml_dwarf
 
 let debug_thing thing = List.mem thing !current_debug_settings
 

--- a/dune
+++ b/dune
@@ -804,7 +804,15 @@
  (instrumentation
   (backend bisect_ppx))
  (ocamlopt_flags
-  (:standard -runtime-variant nnp))
+  (:standard
+   -runtime-variant
+   nnp
+   ; Emit DWARF for the startup file of the compiler itself (when OxCaml
+   ; DWARF is enabled via the flags below): debuggers need the call site
+   ; information of the caml_apply and caml_curry functions, which live
+   ; there, in order to see through generically-applied calls.
+   -gstartup
+   (:include %{project_root}/ocamlopt_flags.sexp)))
  (libraries
   memtrace
   flambda2


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

This PR is independent of the rest of the series and can be reviewed and merged on its own.

## Description

On macOS, debug maps point into object files rather than the final executable, so DWARF for `caml_apply` / `caml_curry` in the `camlstartup` file must survive linking (debuggers need it to see through generically-applied calls; later PRs in this series add call-site and entry-value information that lives there).

- `asmcomp/asmlink.ml`: new `keep_startup_obj_for_dwarf`; writes the startup object to a stable `<output>.startup<ext_obj>` path and does not delete it, in both `link_actual` and `link_shared_actual`.
- `dwarf_flags.ml`: `dwarf_for_startup_file` default changes from `false` to `Config.oxcaml_dwarf`, tracking configure-time OxCaml DWARF support (same policy as `restrict_to_upstream_dwarf`).
- Root `dune`: the compiler's own `ocamlopt_flags` gain `-gstartup` (and the standard `ocamlopt_flags.sexp` include, which was missing from the `oxcaml_main_native` executable stanza).

## Notes for reviewers

- Behaviour change on OxCaml-DWARF-enabled configurations only: an extra `<output>.startup.o` file is left next to linked outputs.
- On configurations without OxCaml DWARF, `dwarf_for_startup_file` remains `false` as before.

## Verification

- `make -s boot-compiler` passes.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF ← **this PR**
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



