### PR TITLE
Backend debuginfo-quality fixes for spills, reloads and inserted blocks

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -416,11 +416,11 @@ let make_instruction ~desc ?(arg = [||]) ?(res = [||]) ?(dbg = Debuginfo.none)
   }
 
 let make_instruction_from_copy (copy : _ instruction) ~desc ~id ?(arg = [||])
-    ?(res = [||]) () =
+    ?(res = [||]) ?dbg () =
   { desc;
     arg;
     res;
-    dbg = copy.dbg;
+    dbg = (match dbg with None -> copy.dbg | Some dbg -> dbg);
     fdo = copy.fdo;
     live = copy.live;
     stack_offset = copy.stack_offset;

--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -468,11 +468,11 @@ let make_instruction ~desc ?(arg = [||]) ?(res = [||]) ?(dbg = Debuginfo.none)
   }
 
 let make_instruction_from_copy (copy : _ instruction) ~desc ~id ?(arg = [||])
-    ?(res = [||]) () =
+    ?(res = [||]) ?dbg () =
   { desc;
     arg;
     res;
-    dbg = copy.dbg;
+    dbg = (match dbg with None -> copy.dbg | Some dbg -> dbg);
     fdo = copy.fdo;
     live = copy.live;
     stack_offset = copy.stack_offset;

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -237,6 +237,7 @@ val make_instruction_from_copy :
   id:InstructionId.t ->
   ?arg:Reg.t array ->
   ?res:Reg.t array ->
+  ?dbg:Debuginfo.t ->
   unit ->
   'b instruction
 

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -286,6 +286,7 @@ val make_instruction_from_copy :
   id:InstructionId.t ->
   ?arg:Reg.t array ->
   ?res:Reg.t array ->
+  ?dbg:Debuginfo.t ->
   unit ->
   'b instruction
 

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -415,10 +415,17 @@ let insert_block :
   let dbg, fdo, live, stack_offset, available_before, available_across =
     match DLL.last body with
     | None ->
-      ( Debuginfo.none,
-        Fdo_info.none,
+      (* The debuginfo (and FDO information) of the predecessor's terminator is
+         propagated to the new block's terminator, so that instructions
+         subsequently inserted into the new block whose debuginfo is derived
+         from that of the terminator (e.g. reloads inserted after a call, cf.
+         [Regalloc_split]) can be attributed to the relevant position in the
+         predecessor. *)
+      ( predecessor_block.terminator.dbg,
+        predecessor_block.terminator.fdo,
         Reg.Set.empty,
         predecessor_block.terminator.stack_offset,
+        (* CR mshinwell: should these be propagated from the predecessor? *)
         Reg_availability_set.Unreachable,
         Reg_availability_set.Unreachable )
     | Some

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -421,10 +421,17 @@ let insert_block :
         phantom_available_before ) =
     match DLL.last body with
     | None ->
-      ( Debuginfo.none,
-        Fdo_info.none,
+      (* The debuginfo (and FDO information) of the predecessor's terminator is
+         propagated to the new block's terminator, so that instructions
+         subsequently inserted into the new block whose debuginfo is derived
+         from that of the terminator (e.g. reloads inserted after a call, cf.
+         [Regalloc_split]) can be attributed to the relevant position in the
+         predecessor. *)
+      ( predecessor_block.terminator.dbg,
+        predecessor_block.terminator.fdo,
         Reg.Set.empty,
         predecessor_block.terminator.stack_offset,
+        (* CR mshinwell: should these be propagated from the predecessor? *)
         Reg_availability_set.Unreachable,
         Reg_availability_set.Unreachable,
         None )

--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -124,12 +124,13 @@ let join_tail ~from ~to_ =
   List.iter (fun from -> transfer ~from ~to_) from;
   add_never_block to_ ~label:(Cmm.new_label ())
 
-let update_exit_terminator ?arg sub_cfg desc =
+let update_exit_terminator ?arg ?dbg sub_cfg desc =
   sub_cfg.exit.terminator
     <- { sub_cfg.exit.terminator with
          desc;
          id = next_instr_id ();
-         arg = Option.value arg ~default:sub_cfg.exit.terminator.arg
+         arg = Option.value arg ~default:sub_cfg.exit.terminator.arg;
+         dbg = Option.value dbg ~default:sub_cfg.exit.terminator.dbg
        }
 
 let mark_as_trap_handler sub_cfg = sub_cfg.entry.is_trap_handler <- true

--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -158,12 +158,13 @@ let join_tail ~from ~to_ =
   List.iter (fun from -> transfer ~from ~to_) from;
   add_never_block to_ ~label:(Cmm.new_label ())
 
-let update_exit_terminator ?arg sub_cfg desc ~phantom_available_before =
+let update_exit_terminator ?arg ?dbg sub_cfg desc ~phantom_available_before =
   sub_cfg.exit.terminator
     <- { sub_cfg.exit.terminator with
          desc;
          id = next_instr_id ();
          arg = Option.value arg ~default:sub_cfg.exit.terminator.arg;
+         dbg = Option.value dbg ~default:sub_cfg.exit.terminator.dbg;
          phantom_available_before
        }
 

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -80,7 +80,8 @@ val join : from:t list -> to_:t -> unit
 
 val join_tail : from:t list -> to_:t -> unit
 
-val update_exit_terminator : ?arg:Reg.t array -> t -> Cfg.terminator -> unit
+val update_exit_terminator :
+  ?arg:Reg.t array -> ?dbg:Debuginfo.t -> t -> Cfg.terminator -> unit
 
 val start_label : t -> Label.t
 

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -117,6 +117,7 @@ val join_tail : from:t list -> to_:t -> unit
 
 val update_exit_terminator :
   ?arg:Reg.t array ->
+  ?dbg:Debuginfo.t ->
   t ->
   Cfg.terminator ->
   phantom_available_before:Backend_var.Set.t option ->

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1012,9 +1012,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           term)
 
   and emit_expr_ifthenelse env sub_cfg bound_name econd _ifso_dbg eif
-      (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t) :
+      (_ifnot_dbg : Debuginfo.t) eelse (dbg : Debuginfo.t) :
       _ Or_never_returns.t =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
     let cond, earg = select_condition econd in
     match emit_expr env sub_cfg earg ~bound_name:None with
     | Never_returns -> Never_returns
@@ -1028,13 +1027,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_true:(Sub_cfg.start_label sub_if)
           ~label_false:(Sub_cfg.start_label sub_else)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg ~dbg;
       Sub_cfg.join ~from:[sub_if; sub_else] ~to_:sub_cfg;
       r
 
   and emit_expr_switch env sub_cfg bound_name esel index ecases
-      (_dbg : Debuginfo.t) : _ Or_never_returns.t =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+      (dbg : Debuginfo.t) : _ Or_never_returns.t =
     match emit_expr env sub_cfg esel ~bound_name:None with
     | Never_returns -> Never_returns
     | Ok rsel ->
@@ -1049,7 +1047,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let term_desc : Cfg.terminator =
         Switch (Array.map (fun idx -> Sub_cfg.start_label subs.(idx)) index)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel ~dbg;
       Sub_cfg.join ~from:(Array.to_list subs) ~to_:sub_cfg;
       r
 
@@ -1305,8 +1303,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | _ -> Misc.fatal_error "Cfg_selectgen.emit_tail")
 
   and emit_tail_ifthenelse env sub_cfg econd (_ifso_dbg : Debuginfo.t) eif
-      (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t) =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+      (_ifnot_dbg : Debuginfo.t) eelse (dbg : Debuginfo.t) =
     let cond, earg = select_condition econd in
     match emit_expr env sub_cfg earg ~bound_name:None with
     | Never_returns -> ()
@@ -1319,11 +1316,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_true:(Sub_cfg.start_label sub_if)
           ~label_false:(Sub_cfg.start_label sub_else)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg ~dbg;
       Sub_cfg.join_tail ~from:[sub_if; sub_else] ~to_:sub_cfg
 
-  and emit_tail_switch env sub_cfg esel index ecases (_dbg : Debuginfo.t) =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+  and emit_tail_switch env sub_cfg esel index ecases (dbg : Debuginfo.t) =
     match emit_expr env sub_cfg esel ~bound_name:None with
     | Never_returns -> ()
     | Ok rsel ->
@@ -1335,7 +1331,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         Switch
           (Array.map (fun idx -> Sub_cfg.start_label sub_cases.(idx)) index)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel ~dbg;
       Sub_cfg.join_tail ~from:(Array.to_list sub_cases) ~to_:sub_cfg
 
   and emit_tail_catch env sub_cfg (flag : Cmm.ccatch_flag) handlers e1 =

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1077,9 +1077,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           term)
 
   and emit_expr_ifthenelse env sub_cfg bound_name econd _ifso_dbg eif
-      (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t) :
+      (_ifnot_dbg : Debuginfo.t) eelse (dbg : Debuginfo.t) :
       _ Or_never_returns.t =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
     let cond, earg = select_condition econd in
     match emit_expr env sub_cfg earg ~bound_name:None with
     | Never_returns -> Never_returns
@@ -1094,7 +1093,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_false:(Sub_cfg.start_label sub_else)
       in
       let phantom_available_before = SU.phantom_vars_from_env env in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg ~dbg
         ~phantom_available_before;
       Sub_cfg.join
         ~from:[join_branch rif sub_if; join_branch relse sub_else]
@@ -1102,8 +1101,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       r
 
   and emit_expr_switch env sub_cfg bound_name esel index ecases
-      (_dbg : Debuginfo.t) : _ Or_never_returns.t =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+      (dbg : Debuginfo.t) : _ Or_never_returns.t =
     match emit_expr env sub_cfg esel ~bound_name:None with
     | Never_returns -> Never_returns
     | Ok rsel ->
@@ -1119,7 +1117,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         Switch (Array.map (fun idx -> Sub_cfg.start_label subs.(idx)) index)
       in
       let phantom_available_before = SU.phantom_vars_from_env env in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel ~dbg
         ~phantom_available_before;
       Sub_cfg.join
         ~from:
@@ -1386,8 +1384,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | _ -> Misc.fatal_error "Cfg_selectgen.emit_tail")
 
   and emit_tail_ifthenelse env sub_cfg econd (_ifso_dbg : Debuginfo.t) eif
-      (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t) =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+      (_ifnot_dbg : Debuginfo.t) eelse (dbg : Debuginfo.t) =
     let cond, earg = select_condition econd in
     match emit_expr env sub_cfg earg ~bound_name:None with
     | Never_returns -> ()
@@ -1400,12 +1397,11 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_true:(Sub_cfg.start_label sub_if)
           ~label_false:(Sub_cfg.start_label sub_else)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg ~dbg
         ~phantom_available_before:(SU.phantom_vars_from_env env);
       Sub_cfg.join_tail ~from:[sub_if; sub_else] ~to_:sub_cfg
 
-  and emit_tail_switch env sub_cfg esel index ecases (_dbg : Debuginfo.t) =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+  and emit_tail_switch env sub_cfg esel index ecases (dbg : Debuginfo.t) =
     match emit_expr env sub_cfg esel ~bound_name:None with
     | Never_returns -> ()
     | Ok rsel ->
@@ -1417,7 +1413,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         Switch
           (Array.map (fun idx -> Sub_cfg.start_label sub_cases.(idx)) index)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel ~dbg
         ~phantom_available_before:(SU.phantom_vars_from_env env);
       Sub_cfg.join_tail ~from:(Array.to_list sub_cases) ~to_:sub_cfg
 

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -254,9 +254,17 @@ let insert_spills_in_block :
       (* See comment before Insert_skipping_name_for_debugger *)
       Insert_skipping_name_for_debugger.insert_after cell instr ~reg)
     ~copy_default:
+      (* The terminator is the destruction point that has necessitated the
+         spill, making its debug and FDO information the natural choice for a
+         spill that is not associated with any instruction in the block's body.
+         Such a spill is inserted at the beginning of the block, however, so the
+         other fields (in particular the stack offset) must come from the first
+         instruction of the block, since they may differ from those of the
+         terminator. *)
       (match DLL.hd block.body with
       | None -> dummy_instr_of_terminator block.terminator
-      | Some hd -> hd)
+      | Some hd ->
+        { hd with dbg = block.terminator.dbg; fdo = block.terminator.fdo })
     ~add_default:(fun list instr reg ->
       (* See comment before Insert_skipping_name_for_debugger *)
       Insert_skipping_name_for_debugger.add_begin list instr ~reg)
@@ -309,10 +317,39 @@ let make_reload : type a. a make_operation =
     ~id:(InstructionId.get_and_incr instr_id)
     ~copy ~from:stack_reg ~to_:new_reg
 
+(* Computes the default copy instruction for reloads at the beginning of [block]
+   that are not associated with any instruction in the block's body. Such
+   reloads exist because of a destruction point at the end of a predecessor; the
+   debug and FDO information of that destruction point (e.g. a call) is the
+   natural choice. The relevant terminator is found by walking the
+   unique-predecessor chain while the terminators encountered have no debuginfo,
+   since the block may be separated from the destruction point by empty blocks
+   inserted on destruction (or critical) edges. Only the debug and FDO
+   information is taken from that terminator: the other fields (in particular
+   the stack offset) come from the block's own terminator, as they may differ
+   from those of the predecessors' terminators. *)
+let default_copy_for_reloads : Cfg.t -> Cfg.basic_block -> Instruction.t =
+ fun cfg block ->
+  let rec find_dbg_source (block : Cfg.basic_block) fuel =
+    if (not (Debuginfo.is_none block.terminator.dbg)) || fuel <= 0
+    then block.terminator
+    else
+      match Label.Set.elements block.predecessors with
+      | [predecessor_label] ->
+        find_dbg_source (Cfg.get_block_exn cfg predecessor_label) (pred fuel)
+      | [] | _ :: _ -> block.terminator
+  in
+  let dbg_source = find_dbg_source block 3 in
+  { (dummy_instr_of_terminator block.terminator) with
+    dbg = dbg_source.dbg;
+    fdo = dbg_source.fdo
+  }
+
 (* Inserts the reloads in a block, as late as possible (i.e. immediately before
    the register is first read), to reduce live ranges. *)
 let insert_reloads_in_block :
     State.t ->
+    cfg:Cfg.t ->
     instr_id:InstructionId.sequence ->
     block_subst:Substitution.t ->
     stack_subst:Substitution.t ->
@@ -320,7 +357,7 @@ let insert_reloads_in_block :
     Instruction.t DLL.cell option ->
     Reg.Set.t ->
     unit =
- fun state ~instr_id ~block_subst ~stack_subst block cell
+ fun state ~cfg ~instr_id ~block_subst ~stack_subst block cell
      live_at_definition_point ->
   insert_spills_or_reloads_in_block state ~instr_id
     ~make_spill_or_reload:make_reload ~occur_check
@@ -332,7 +369,7 @@ let insert_reloads_in_block :
          Reg_availability_set.canonicalise), so it's probably not necessary to
          add a Name_for_debugger on the reloaded one. *)
       DLL.insert_before cell instr)
-    ~copy_default:(dummy_instr_of_terminator block.terminator)
+    ~copy_default:(default_copy_for_reloads cfg block)
     ~add_default:(fun list instr _reg ->
       (* Same reasoning as for insert above *)
       DLL.add_end list instr)
@@ -350,11 +387,12 @@ let insert_reloads :
   Label.Map.iter
     (fun label live_at_definition_point ->
       if debug then log "block %a" Label.format label;
+      let cfg = Cfg_with_infos.cfg cfg_with_infos in
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
-      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id in
+      let instr_id = cfg.next_instruction_id in
       let block_subst = Substitution.for_label substs label in
-      insert_reloads_in_block state ~instr_id ~block_subst ~stack_subst block
-        (DLL.hd_cell block.body) live_at_definition_point)
+      insert_reloads_in_block state ~cfg ~instr_id ~block_subst ~stack_subst
+        block (DLL.hd_cell block.body) live_at_definition_point)
     (State.definitions_at_beginning state);
   if debug then dedent ()
 

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -260,6 +260,25 @@ module Move = struct
     | Load -> Operation.Reload
     | Store -> Operation.Spill
 
+  (* Spills and reloads are bookkeeping, not code lowered from the source of the
+     function identified by the debuginfo of [copy]. If such debuginfo were used
+     unaltered for spill and reload instructions, then in the case where such
+     debuginfo indicated the body of an inlined function, the instructions would
+     be attributed to that inlined function (e.g. by a profiler reading the
+     DWARF line table), which could be confusing: for example reloads, of a
+     caller's variables after a call, being attributed to an inlined callee.
+     Instead only the outermost frame of the debuginfo is kept, attributing such
+     instructions to the enclosing (non-inlined) function. This is consistent
+     with [Inlined_frame_ranges], which excludes spills and reloads from the
+     DWARF address ranges of all inlined frames. *)
+  let dbg_for_move (move : t) (copy : _ Cfg.instruction) : Debuginfo.t =
+    match move with
+    | Plain -> copy.dbg
+    | Load | Store -> (
+      match Debuginfo.to_items copy.dbg with
+      | [] | [_] -> copy.dbg
+      | outermost :: _ :: _ -> Debuginfo.of_items [outermost])
+
   let make_instr :
       t ->
       id:InstructionId.t ->
@@ -270,7 +289,7 @@ module Move = struct
    fun move ~id ~copy ~from ~to_ ->
     Cfg.make_instruction_from_copy copy
       ~desc:(Cfg.Op (op_of_move move))
-      ~arg:[| from |] ~res:[| to_ |] ~id ()
+      ~arg:[| from |] ~res:[| to_ |] ~id ~dbg:(dbg_for_move move copy) ()
 
   let to_string = function Plain -> "move" | Load -> "load" | Store -> "store"
 end

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -259,6 +259,25 @@ module Move = struct
     | Load -> Operation.Reload
     | Store -> Operation.Spill
 
+  (* Spills and reloads are bookkeeping, not code lowered from the source of the
+     function identified by the debuginfo of [copy]. If such debuginfo were used
+     unaltered for spill and reload instructions, then in the case where such
+     debuginfo indicated the body of an inlined function, the instructions would
+     be attributed to that inlined function (e.g. by a profiler reading the
+     DWARF line table), which could be confusing: for example reloads, of a
+     caller's variables after a call, being attributed to an inlined callee.
+     Instead only the outermost frame of the debuginfo is kept, attributing such
+     instructions to the enclosing (non-inlined) function. This is consistent
+     with [Inlined_frame_ranges], which excludes spills and reloads from the
+     DWARF address ranges of all inlined frames. *)
+  let dbg_for_move (move : t) (copy : _ Cfg.instruction) : Debuginfo.t =
+    match move with
+    | Plain -> copy.dbg
+    | Load | Store -> (
+      match Debuginfo.to_items copy.dbg with
+      | [] | [_] -> copy.dbg
+      | outermost :: _ :: _ -> Debuginfo.of_items [outermost])
+
   let make_instr :
       t ->
       id:InstructionId.t ->
@@ -269,7 +288,7 @@ module Move = struct
    fun move ~id ~copy ~from ~to_ ->
     Cfg.make_instruction_from_copy copy
       ~desc:(Cfg.Op (op_of_move move))
-      ~arg:[| from |] ~res:[| to_ |] ~id ()
+      ~arg:[| from |] ~res:[| to_ |] ~id ~dbg:(dbg_for_move move copy) ()
 
   let to_string = function Plain -> "move" | Load -> "load" | Store -> "store"
 end


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

This PR is independent of the rest of the series and can be reviewed and merged on its own.

## Description

Several independent fixes improving the accuracy of per-instruction debugging information in the backend. None of these change generated code — only the `dbg`/`fdo` metadata attached to instructions.

- **Spill/reload attribution:** spill and reload moves take only the *outermost* item of the debuginfo of the instruction that necessitated them (`Regalloc_utils.Move.dbg_for_move`, using the pre-existing `Debuginfo.of_items`). Previously a reload of a caller's variable after a call could be attributed to an *inlined callee* by profilers/debuggers reading the line table. Consistent with `Inlined_frame_ranges`, which excludes spills/reloads from inlined-frame address ranges.
- **Block-start spills** (`regalloc_split.ml`): take dbg/fdo from the block terminator (the destruction point), while keeping other fields (notably stack offset) from the first body instruction.
- **Block-start reloads** (`regalloc_split.ml`): new `default_copy_for_reloads` walks the unique-predecessor chain (fuel 3) past empty split-edge blocks to find the destruction point's real debuginfo.
- **Inserted empty blocks** (`cfg_with_layout.ml insert_block`): take dbg/fdo from the predecessor's terminator instead of `Debuginfo.none`.
- **Selection terminators** (`cfg_selectgen.ml`): ifthenelse/switch terminators now carry the Cmm expression's debuginfo, resolving the `CR-someday xclerc` comments about unused `_dbg` parameters. Supported by a new `?dbg` on `Sub_cfg.update_exit_terminator` and `Cfg.make_instruction_from_copy`.

## Notes for reviewers

- Independent of the phantom-lets work later in this series; extracted at hunk level from files that later PRs also touch.

## Verification

- `make -s boot-compiler` passes; `make -s fmt` clean.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks ← **this PR**
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



