### PR TITLE
Fix stack-offset double count in Available_ranges_vars

### DIFF
--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -57,7 +57,9 @@ module Vars = struct
     type t = { stack_offset : int }
 
     let create () =
-      { (* This does not include the [Proc.initial_stack_offset] (see below). *)
+      { (* Only the dynamic stack adjustment (pushtraps, [Lstackoffset]); the
+           [Proc.initial_stack_offset] is added by [Proc.frame_size] and
+           [Proc.slot_offset] when [Subrange_info.create] consults them. *)
         stack_offset = 0
       }
 
@@ -101,13 +103,14 @@ module Vars = struct
 
     let create reg subrange_state ~fun_contains_calls ~fun_num_stack_slots =
       let reg = RD.reg reg in
-      let initial_stack_offset =
-        Proc.initial_stack_offset ~contains_calls:fun_contains_calls
-          ~num_stack_slots:fun_num_stack_slots
-      in
-      let stack_offset =
-        Subrange_state.stack_offset subrange_state + initial_stack_offset
-      in
+      (* [Proc.frame_size] and [Proc.slot_offset] below already account for
+         [Proc.initial_stack_offset], so [stack_offset] must be only the dynamic
+         adjustment (pushtraps, [Lstackoffset]) at this program point -- exactly
+         what the emitter passes to those functions. Adding the initial offset
+         here as well double-counts it, which after 16-byte frame alignment
+         yields a CFA offset that is wrong by the alignment padding whenever the
+         initial offset is not itself a multiple of 16. *)
+      let stack_offset = Subrange_state.stack_offset subrange_state in
       let offset =
         match reg.loc with
         | Stack loc ->


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

This PR is independent of the rest of the series and can be reviewed and merged on its own.

## Description

`Proc.frame_size` and `Proc.slot_offset` already account for `Proc.initial_stack_offset`, so `Subrange_info.create` (in `backend/debug/available_ranges_vars.ml`) must pass only the *dynamic* stack adjustment (pushtraps, `Lstackoffset`) at the relevant program point — exactly what the emitter passes to those functions.

Adding `Proc.initial_stack_offset` again double-counted it. After 16-byte frame alignment this produced CFA-relative variable offsets that were wrong by the alignment padding whenever the initial offset was not itself a multiple of 16 — i.e. the debugger read stack variables from the wrong slot in such frames.

## Notes for reviewers

- Two hunks in one file: the arithmetic fix plus a clarifying comment on `Subrange_state.create`.
- Only affects OxCaml DWARF variable location lists; no codegen change.

## Verification

- `make -s boot-compiler` passes.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars ← **this PR**
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



