### PR TITLE
Add -ddebug-avail-sets dump flag

### DIFF
--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.ml
@@ -183,6 +183,8 @@ let gdwarf_may_alter_codegen_experimental = ref false
 
 let dwarf_inlined_frames = ref false
 
+let debug_avail_sets = ref false
+
 let default_gdwarf_compression = "zlib"
 
 let gdwarf_compression = ref default_gdwarf_compression

--- a/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
+++ b/backend/debug/dwarf/dwarf_flags/dwarf_flags.mli
@@ -85,6 +85,10 @@ val gdwarf_may_alter_codegen_experimental : bool ref
     variable being set to [true]). *)
 val dwarf_inlined_frames : bool ref
 
+(** Setting this to [true] will print availability sets (both regular and
+    phantom) when dumping CFG and Linear representations. *)
+val debug_avail_sets : bool ref
+
 val default_gdwarf_compression : string
 
 val gdwarf_compression : string ref

--- a/backend/printlinear.ml
+++ b/backend/printlinear.ml
@@ -49,7 +49,7 @@ let instr' ?(print_reg = Printreg.reg) ppf i =
   let regsetaddr = Printreg.regsetaddr' ~print_reg in
   let test = Operation.format_test ~print_reg in
   let operation = Printoperation.operation ~print_reg in
-  (if !Oxcaml_flags.davail
+  (if !Oxcaml_flags.davail || !Dwarf_flags.debug_avail_sets
    then
      let module RAS = Reg_availability_set in
      let ras_is_nonempty (set : RAS.t) =

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -1164,6 +1164,11 @@ let mk_no_dwarf_inlined_frames f =
     Arg.Unit f,
     " Do not emit DWARF inlined frame information" )
 
+let mk_ddebug_avail_sets f =
+  ( "-ddebug-avail-sets",
+    Arg.Unit f,
+    " Print availability sets when dumping CFG and Linear" )
+
 let mk_dwarf_for_startup_file f =
   ( "-gstartup",
     Arg.Unit f,
@@ -2231,6 +2236,7 @@ module type Debugging_options = sig
   val no_restrict_to_upstream_dwarf : unit -> unit
   val dwarf_inlined_frames : unit -> unit
   val no_dwarf_inlined_frames : unit -> unit
+  val ddebug_avail_sets : unit -> unit
   val dwarf_for_startup_file : unit -> unit
   val no_dwarf_for_startup_file : unit -> unit
   val gdwarf_may_alter_codegen : unit -> unit
@@ -2250,6 +2256,7 @@ module Make_debugging_options (F : Debugging_options) = struct
       mk_no_restrict_to_upstream_dwarf F.no_restrict_to_upstream_dwarf;
       mk_dwarf_inlined_frames F.dwarf_inlined_frames;
       mk_no_dwarf_inlined_frames F.no_dwarf_inlined_frames;
+      mk_ddebug_avail_sets F.ddebug_avail_sets;
       mk_dwarf_for_startup_file F.dwarf_for_startup_file;
       mk_no_dwarf_for_startup_file F.no_dwarf_for_startup_file;
       mk_gdwarf_may_alter_codegen F.gdwarf_may_alter_codegen;
@@ -2280,6 +2287,7 @@ module Debugging_options_impl = struct
 
   let dwarf_inlined_frames () = Debugging.dwarf_inlined_frames := true
   let no_dwarf_inlined_frames () = Debugging.dwarf_inlined_frames := false
+  let ddebug_avail_sets () = Debugging.debug_avail_sets := true
   let dwarf_for_startup_file () = Debugging.dwarf_for_startup_file := true
   let no_dwarf_for_startup_file () = Debugging.dwarf_for_startup_file := false
   let gdwarf_may_alter_codegen () = Debugging.gdwarf_may_alter_codegen := true
@@ -2418,6 +2426,7 @@ module Extra_params = struct
         true
     | "dump-inlining-paths" -> set' Oxcaml_flags.dump_inlining_paths
     | "davail" -> set' Oxcaml_flags.davail
+    | "ddebug-avail-sets" -> set' Debugging.debug_avail_sets
     | "dranges" -> set' Oxcaml_flags.dranges
     | "ddebug-invariants" -> set' Dwarf_flags.ddebug_invariants
     | "ddebug-available-regs" -> set' Dwarf_flags.ddebug_available_regs

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -208,6 +208,7 @@ module type Debugging_options = sig
   val no_restrict_to_upstream_dwarf : unit -> unit
   val dwarf_inlined_frames : unit -> unit
   val no_dwarf_inlined_frames : unit -> unit
+  val ddebug_avail_sets : unit -> unit
   val dwarf_for_startup_file : unit -> unit
   val no_dwarf_for_startup_file : unit -> unit
   val gdwarf_may_alter_codegen : unit -> unit


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

This PR is independent of the rest of the series and can be reviewed and merged on its own.

## Description

New `-ddebug-avail-sets` flag causing register availability sets to be printed when dumping Linear (and, once phantom availability exists in a later PR of this series, CFG) representations, independently of `-davail`.

- `dwarf_flags.{ml,mli}`: new `debug_avail_sets : bool ref`.
- `driver/oxcaml_args.{ml,mli}`: `mk_ddebug_avail_sets`, `Debugging_options` plumbing and the `Extra_params` entry.
- `backend/printlinear.ml`: the availability-printing gate widens from `!Oxcaml_flags.davail` to `davail || debug_avail_sets`.

Pure dump-flag plumbing; no effect unless the flag is passed.

## Verification

- `make -s boot-compiler` passes.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag ← **this PR**
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



