### PR TITLE
Use Cmm.symbol for phantom defining expressions

### DIFF
--- a/backend/cmm.ml
+++ b/backend/cmm.ml
@@ -291,9 +291,28 @@ type coeffects =
   | No_coeffects
   | Has_coeffects
 
+type is_global =
+  | Global
+  | Local
+
+let equal_is_global g g' =
+  match g, g' with
+  | Local, Local | Global, Global -> true
+  | Local, Global | Global, Local -> false
+
+type symbol =
+  { sym_name : string;
+    sym_global : is_global
+  }
+
+let equal_symbol { sym_name = left_sym_name; sym_global = left_sym_global }
+    { sym_name = right_sym_name; sym_global = right_sym_global } =
+  String.equal left_sym_name right_sym_name
+  && equal_is_global left_sym_global right_sym_global
+
 type phantom_defining_expr =
   | Cphantom_const_int of Targetint.t
-  | Cphantom_const_symbol of string
+  | Cphantom_const_symbol of symbol
   | Cphantom_var of Backend_var.t
   | Cphantom_offset_var of
       { var : Backend_var.t;
@@ -304,7 +323,7 @@ type phantom_defining_expr =
         field : int
       }
   | Cphantom_read_symbol_field of
-      { sym : string;
+      { sym : symbol;
         field : int
       }
   | Cphantom_block of
@@ -514,25 +533,6 @@ type alloc_dbginfo = alloc_dbginfo_item list
 
 let equal_alloc_dbginfo left right =
   List.equal equal_alloc_dbginfo_item left right
-
-type is_global =
-  | Global
-  | Local
-
-let equal_is_global g g' =
-  match g, g' with
-  | Local, Local | Global, Global -> true
-  | Local, Global | Global, Local -> false
-
-type symbol =
-  { sym_name : string;
-    sym_global : is_global
-  }
-
-let equal_symbol { sym_name = left_sym_name; sym_global = left_sym_global }
-    { sym_name = right_sym_name; sym_global = right_sym_global } =
-  String.equal left_sym_name right_sym_name
-  && equal_is_global left_sym_global right_sym_global
 
 type operation =
   | Capply of

--- a/backend/cmm.mli
+++ b/backend/cmm.mli
@@ -191,6 +191,31 @@ type coeffects =
   | No_coeffects
   | Has_coeffects
 
+type is_global =
+  | Global
+  | Local
+
+val equal_is_global : is_global -> is_global -> bool
+
+(* Symbols are marked with whether they are local or global, at both definition
+   and use sites.
+
+   Symbols defined as [Local] may only be referenced within the same file, and
+   all such references must also be [Local].
+
+   Symbols defined as [Global] may be referenced from other files. References
+   from other files must be [Global], but references from the same file may be
+   [Local].
+
+   (Marking symbols in this way speeds up linking, as many references can then
+   be resolved early) *)
+type symbol =
+  { sym_name : string;
+    sym_global : is_global
+  }
+
+val equal_symbol : symbol -> symbol -> bool
+
 type phantom_defining_expr =
   (* CR-soon mshinwell: Convert this to [Targetint.OCaml.t] (or whatever the
      representation of "target-width OCaml integers of type [int]" becomes when
@@ -199,7 +224,7 @@ type phantom_defining_expr =
       (** The phantom-let-bound variable is a constant integer. The argument
           must be the tagged representation of an integer within the range of
           type [int] on the target. (Analogously to [Cconst_int].) *)
-  | Cphantom_const_symbol of string
+  | Cphantom_const_symbol of symbol
       (** The phantom-let-bound variable is an alias for a symbol. *)
   | Cphantom_var of Backend_var.t
       (** The phantom-let-bound variable is an alias for another variable. The
@@ -218,7 +243,7 @@ type phantom_defining_expr =
           number of words to the pointer contained in the given identifier, then
           dereferencing. *)
   | Cphantom_read_symbol_field of
-      { sym : string;
+      { sym : symbol;
         field : int
       }
       (** As for [Uphantom_read_var_field], but with the pointer specified by a
@@ -390,31 +415,6 @@ val equal_alloc_dbginfo_item : alloc_dbginfo_item -> alloc_dbginfo_item -> bool
 type alloc_dbginfo = alloc_dbginfo_item list
 
 val equal_alloc_dbginfo : alloc_dbginfo -> alloc_dbginfo -> bool
-
-type is_global =
-  | Global
-  | Local
-
-val equal_is_global : is_global -> is_global -> bool
-
-(* Symbols are marked with whether they are local or global, at both definition
-   and use sites.
-
-   Symbols defined as [Local] may only be referenced within the same file, and
-   all such references must also be [Local].
-
-   Symbols defined as [Global] may be referenced from other files. References
-   from other files must be [Global], but references from the same file may be
-   [Local].
-
-   (Marking symbols in this way speeds up linking, as many references can then
-   be resolved early) *)
-type symbol =
-  { sym_name : string;
-    sym_global : is_global
-  }
-
-val equal_symbol : symbol -> symbol -> bool
 
 type operation =
   | Capply of

--- a/backend/printcmm.ml
+++ b/backend/printcmm.ml
@@ -180,14 +180,14 @@ let atomic_op = function
 let phantom_defining_expr ppf defining_expr =
   match defining_expr with
   | Cphantom_const_int i -> Targetint.print ppf i
-  | Cphantom_const_symbol sym -> Format.pp_print_string ppf sym
+  | Cphantom_const_symbol sym -> Format.pp_print_string ppf sym.sym_name
   | Cphantom_var var -> V.print ppf var
   | Cphantom_offset_var { var; offset_in_words } ->
     Format.fprintf ppf "%a+(%d)" V.print var offset_in_words
   | Cphantom_read_field { var; field } ->
     Format.fprintf ppf "%a[%d]" V.print var field
   | Cphantom_read_symbol_field { sym; field } ->
-    Format.fprintf ppf "%s[%d]" sym field
+    Format.fprintf ppf "%s[%d]" sym.sym_name field
   | Cphantom_block { tag; fields } ->
     Format.fprintf ppf "[%d: " tag;
     List.iter (fun field -> Format.fprintf ppf "%a; " V.print field) fields;


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

This PR is independent of the rest of the series and can be reviewed and merged on its own.

## Description

`Cphantom_const_symbol` and `Cphantom_read_symbol_field` now carry a `Cmm.symbol` (name plus `Global`/`Local` visibility) rather than a bare `string`, so DWARF emission (later in this series) can know whether a symbol referenced from a phantom value is local to the compilation unit — which matters for how its address may be described (e.g. label-based addresses on macOS, where local symbols may not have relocations).

- `backend/cmm.{ml,mli}`: the `is_global` / `symbol` type definitions and their equality functions move **unchanged** above `phantom_defining_expr`; the two constructors change type.
- `backend/printcmm.ml`: print `sym.sym_name`.

## Notes for reviewers

- Behaviour-neutral: nothing produces these constructors yet (verified by grep at base — the only consumer is `printcmm.ml`). The Flambda 2 translation that produces them arrives in a later PR of this series.
- The `cmm.{ml,mli}` diff looks bigger than it is because of the pure relocation of the type definitions.

## Verification

- `make -s boot-compiler` passes.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions ← **this PR**
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



