### PR TITLE
Relax phantom-let visibility requirements in Simplify

### DIFF
--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -205,13 +205,21 @@ let rebuild_let simplify_named_result removed_operations ~rewrite_id
               let has_uses =
                 Name_mode.Or_absent.is_present greatest_name_mode
               in
-              (* Phantomise even non-user-visible variables: they may be
-                 intermediates (for example the [my_closure] introduced when
-                 inlining, or temporaries) that are referenced by user-visible
+              (* A deleted binding may be phantomised if it binds a user-visible
+                 variable, or if it has at least one (phantom) use:
+                 non-user-visible intermediates (for example temporaries
+                 introduced when inlining) may be referenced by user-visible
                  phantom lets -- e.g. [Project_value_slot] /
-                 [Project_function_slot] projections -- which would otherwise
-                 resolve to a deleted binding and display garbage. *)
-              let can_phantomise = not is_depth in
+                 [Project_function_slot] projections -- and must not resolve to
+                 a deleted binding. Unreferenced non-user-visible temporaries,
+                 however, do not give rise to phantom lets. *)
+              let can_phantomise =
+                (not is_depth)
+                && (has_uses
+                   || Bound_pattern.exists_all_bound_vars bound_vars
+                        ~f:(fun bound_var ->
+                          Variable.user_visible (VB.var bound_var)))
+              in
               let will_delete_binding =
                 if is_end_region_for_unused_region
                 then true

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -205,12 +205,13 @@ let rebuild_let simplify_named_result removed_operations ~rewrite_id
               let has_uses =
                 Name_mode.Or_absent.is_present greatest_name_mode
               in
-              let can_phantomise =
-                (not is_depth)
-                && Bound_pattern.exists_all_bound_vars bound_vars
-                     ~f:(fun bound_var ->
-                       Variable.user_visible (VB.var bound_var))
-              in
+              (* Phantomise even non-user-visible variables: they may be
+                 intermediates (for example the [my_closure] introduced when
+                 inlining, or temporaries) that are referenced by user-visible
+                 phantom lets -- e.g. [Project_value_slot] /
+                 [Project_function_slot] projections -- which would otherwise
+                 resolve to a deleted binding and display garbage. *)
+              let can_phantomise = not is_depth in
               let will_delete_binding =
                 if is_end_region_for_unused_region
                 then true


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

Stacked on #6515: this PR targets that branch, so the diff shown is exactly this PR's own changes.

## Description

A change to how Simplify decides which deleted bindings become phantom lets. Only observable with `-flambda2-expert-phantom-lets`, which remains **off by default** (flipped at the end of this series). (A companion change, installing a phantom binding for `my_closure` when it is used only phantomly, was split into #6528, stacked on this PR.)

`Simplify_let_expr.rebuild_let`: `can_phantomise` is relaxed from "all bound variables are user-visible" to "not a depth variable, and either binds a user-visible variable or has at least one (phantom) use" (criterion suggested in review). Non-user-visible intermediates (e.g. temporaries introduced by inlining) may be referenced by user-visible phantom lets — such as `Project_value_slot` / `Project_function_slot` projections — and must not resolve to a deleted binding; such phantom occurrences are recorded when the referencing (inner) phantom binding is placed, so they are visible by the time the intermediate's own `Let` is considered on the upwards traversal. Unreferenced non-user-visible temporaries do not give rise to phantom lets.

## Verification

- `make -s boot-compiler` passes.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify ← **this PR**
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



