### PR TITLE
Compute availability ranges for phantom variables

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -664,6 +664,13 @@ let addressing_offset_in_bytes
   | Iscaled _, _ -> None
   | Iindexed2scaled _, _ -> None
 
+(* If [addr] is a single base register plus a constant displacement, return that
+   displacement in bytes; otherwise [None].  Used to describe immutable field
+   projections (e.g. closure value slots) for DWARF call site information. *)
+let addressing_displacement_in_bytes = function
+  | Iindexed n -> Some n
+  | Ibased _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _ -> None
+
 let isomorphic_specific_operation op1 op2 =
   match op1, op2 with
   | Ilea a1, Ilea a2 -> equal_addressing_mode_without_displ a1 a2

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -759,6 +759,13 @@ let addressing_offset_in_bytes
   | Iscaled _, _ -> None
   | Iindexed2scaled _, _ -> None
 
+(* If [addr] is a single base register plus a constant displacement, return that
+   displacement in bytes; otherwise [None].  Used to describe immutable field
+   projections (e.g. closure value slots) for DWARF call site information. *)
+let addressing_displacement_in_bytes = function
+  | Iindexed n -> Some n
+  | Ibased _ | Iindexed2 _ | Iscaled _ | Iindexed2scaled _ -> None
+
 let isomorphic_specific_operation op1 op2 =
   match op1, op2 with
   | Ilea a1, Ilea a2 -> equal_addressing_mode_without_displ a1 a2

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -177,3 +177,7 @@ val addressing_offset_in_bytes
   -> 'a array
   -> 'a array
   -> int option
+
+(* If the addressing mode is a single base register plus a constant
+   displacement, return that displacement in bytes; otherwise [None]. *)
+val addressing_displacement_in_bytes : addressing_mode -> int option

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -199,3 +199,7 @@ val addressing_offset_in_bytes
   -> 'a array
   -> 'a array
   -> int option
+
+(* If the addressing mode is a single base register plus a constant
+   displacement, return that displacement in bytes; otherwise [None]. *)
+val addressing_displacement_in_bytes : addressing_mode -> int option

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -387,3 +387,10 @@ let equal_addressing_mode_without_displ (addressing_mode_1: addressing_mode)
 let addressing_offset_in_bytes (_addressing_mode_1: addressing_mode)
       (_addressing_mode_2 : addressing_mode) ~arg_offset_in_bytes:_ _ _ =
   None
+
+(* If [addr] is a single base register plus a constant displacement, return that
+   displacement in bytes; otherwise [None].  Used to describe immutable field
+   projections (e.g. closure value slots) for DWARF call site information. *)
+let addressing_displacement_in_bytes = function
+  | Iindexed v -> Some (Validated_mem_offset.offset v)
+  | Ibased _ -> None

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -400,3 +400,10 @@ let equal_addressing_mode_without_displ (addressing_mode_1: addressing_mode)
 let addressing_offset_in_bytes (_addressing_mode_1: addressing_mode)
       (_addressing_mode_2 : addressing_mode) ~arg_offset_in_bytes:_ _ _ =
   None
+
+(* If [addr] is a single base register plus a constant displacement, return that
+   displacement in bytes; otherwise [None].  Used to describe immutable field
+   projections (e.g. closure value slots) for DWARF call site information. *)
+let addressing_displacement_in_bytes = function
+  | Iindexed v -> Some (Validated_mem_offset.offset v)
+  | Ibased _ -> None

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -145,3 +145,7 @@ val addressing_offset_in_bytes
   -> 'a array
   -> 'a array
   -> int option
+
+(* If the addressing mode is a single base register plus a constant
+   displacement, return that displacement in bytes; otherwise [None]. *)
+val addressing_displacement_in_bytes : addressing_mode -> int option

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -162,3 +162,7 @@ val addressing_offset_in_bytes
   -> 'a array
   -> 'a array
   -> int option
+
+(* If the addressing mode is a single base register plus a constant
+   displacement, return that displacement in bytes; otherwise [None]. *)
+val addressing_displacement_in_bytes : addressing_mode -> int option

--- a/backend/cfg/cfg_available_regs.ml
+++ b/backend/cfg/cfg_available_regs.ml
@@ -135,10 +135,11 @@ module Transfer = struct
       destroyed_at:(a -> Reg.t array) ->
       is_interesting_constructor:(a -> bool) ->
       is_end_region:(a -> bool) ->
+      const_for_result:RD.Holds_value_of.t option ->
       a Cfg.instruction ->
       RAS.t * RAS.t =
    fun ~avail_before ~destroyed_at ~is_interesting_constructor ~is_end_region
-       instr ->
+       ~const_for_result instr ->
     (* We split the calculation of registers that become unavailable after a
        call into two parts. First: anything that the target marks as destroyed
        by the operation, combined with any registers that will be clobbered by
@@ -212,10 +213,20 @@ module Transfer = struct
     in
     let avail_across = RD_quotient_set.diff avail_before made_unavailable in
     let avail_after =
-      let res = Reg.set_of_array instr.res in
-      RD_quotient_set.union
-        (RD_quotient_set.without_debug_info res)
-        avail_across
+      (* In addition to tracking which registers hold the values of which
+         variables, we also track which registers contain which immediate
+         constants (e.g. for DWARF call site information). *)
+      match const_for_result, instr.res with
+      | Some holds_value_of, [| res |] ->
+        RD_quotient_set.add
+          (RD.create ~reg:res ~holds_value_of ~part_of_value:0
+             ~num_parts_of_value:1 ~which_parameter:None ~provenance:None)
+          avail_across
+      | (Some _ | None), _ ->
+        let res = Reg.set_of_array instr.res in
+        RD_quotient_set.union
+          (RD_quotient_set.without_debug_info res)
+          avail_across
     in
     dprintf "...avail_before %a\n%!" RD_quotient_set.print avail_before;
     dprintf "...avail_across %a\n%!" RD_quotient_set.print avail_across;
@@ -269,8 +280,9 @@ module Transfer = struct
               && RD_quotient_set.mem_reg_by_loc avail_before reg
             then
               let regd =
-                RD.create ~reg ~holds_value_of:ident ~part_of_value
-                  ~num_parts_of_value ~which_parameter ~provenance
+                RD.create ~reg ~holds_value_of:(RD.Holds_value_of.Var ident)
+                  ~part_of_value ~num_parts_of_value ~which_parameter
+                  ~provenance
               in
               avail_after
                 := RD_quotient_set.add regd
@@ -371,9 +383,50 @@ module Transfer = struct
         | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue
         | Stack_check _ ->
           let is_op_end_region = Cfg.is_end_region in
+          let const_for_result : RD.Holds_value_of.t option =
+            match instr.desc with
+            | Op (Const_int i) -> Some (Const_int i)
+            | Op (Const_float f) -> Some (Const_naked_float f)
+            | Op (Const_symbol sym) -> Some (Const_symbol sym)
+            | Op
+                (Load
+                   { memory_chunk = Word_val | Word_int;
+                     addressing_mode;
+                     mutability = Immutable;
+                     is_atomic = false
+                   })
+              when Array.length instr.arg >= 1 -> (
+              (* An immutable, full-word load at a constant displacement from a
+                 register whose held value we can describe (e.g. a closure value
+                 slot loaded from [my_closure]) is a projection: the loaded
+                 value can be recomputed by the debugger, in a caller's context,
+                 as a field of whatever description applies to the base. CR
+                 mshinwell: only full-word value fields are handled here; flat
+                 and unboxed fields (Single/Double, unboxed products, etc.)
+                 require matching the field's machine representation -- TODO. *)
+              match Arch.addressing_displacement_in_bytes addressing_mode with
+              | Some offset when offset >= 0 && offset mod Arch.size_addr = 0
+                -> (
+                match
+                  RD_quotient_set.find_reg_with_same_location_exn avail_before
+                    instr.arg.(0)
+                with
+                | exception Not_found -> None
+                | base_rd -> (
+                  match RD.debug_info base_rd with
+                  | None -> None
+                  | Some base_di ->
+                    Some
+                      (RD.Holds_value_of.Projection
+                         { base = RD.Debug_info.holds_value_of base_di;
+                           field = offset / Arch.size_addr
+                         })))
+              | Some _ | None -> None)
+            | _ -> None
+          in
           common ~avail_before ~destroyed_at:Proc.destroyed_at_basic
             ~is_interesting_constructor:is_op_end_region
-            ~is_end_region:is_op_end_region instr)
+            ~is_end_region:is_op_end_region ~const_for_result instr)
     in
     instr.available_across <- avail_across;
     { avail_before = avail_after }
@@ -410,7 +463,7 @@ module Transfer = struct
                 | Prim { op = External _; label_after = _ } ->
                   false)
             ~is_end_region:(fun _ -> false)
-            term)
+            ~const_for_result:None term)
     in
     term.available_across <- avail_across;
     let avail_before_exn_handler =

--- a/backend/debug/available_ranges_all_vars.ml
+++ b/backend/debug/available_ranges_all_vars.ml
@@ -1,0 +1,184 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Mark Shinwell, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2014--2025 Jane Street Group LLC                             *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module ARV = Available_ranges_vars
+module ARPV = Available_ranges_phantom_vars
+module L = Linear
+module V = Backend_var
+
+module Subrange_info = struct
+  type t =
+    | Non_phantom of
+        { reg : Reg.t;
+          offset : Stack_reg_offset.t option
+        }
+    | Phantom of L.phantom_defining_expr
+end
+
+module Subrange = struct
+  type t =
+    | Non_phantom of ARV.Subrange.t
+    | Phantom of L.phantom_defining_expr * ARPV.Subrange.t
+
+  let info = function
+    | Non_phantom subrange ->
+      let reg = ARV.Subrange_info.reg (ARV.Subrange.info subrange) in
+      let offset = ARV.Subrange_info.offset (ARV.Subrange.info subrange) in
+      Subrange_info.Non_phantom { reg; offset }
+    | Phantom (defining_expr, _subrange) -> Subrange_info.Phantom defining_expr
+
+  let start_pos = function
+    | Non_phantom subrange -> ARV.Subrange.start_pos subrange
+    | Phantom (_defining_expr, subrange) -> ARPV.Subrange.start_pos subrange
+
+  let start_pos_offset = function
+    | Non_phantom subrange -> ARV.Subrange.start_pos_offset subrange
+    | Phantom (_defining_expr, subrange) ->
+      ARPV.Subrange.start_pos_offset subrange
+
+  let end_pos = function
+    | Non_phantom subrange -> ARV.Subrange.end_pos subrange
+    | Phantom (_defining_expr, subrange) -> ARPV.Subrange.end_pos subrange
+
+  let end_pos_offset = function
+    | Non_phantom subrange -> ARV.Subrange.end_pos_offset subrange
+    | Phantom (_defining_expr, subrange) ->
+      ARPV.Subrange.end_pos_offset subrange
+end
+
+module Range_info = struct
+  type phantom_defining_expr =
+    | Non_phantom
+    | Phantom of L.phantom_defining_expr
+
+  type t =
+    { provenance : V.Provenance.t option;
+      debuginfo : Debuginfo.t;
+      is_parameter : Is_parameter.t;
+      phantom_defining_expr : phantom_defining_expr
+    }
+
+  let provenance t = t.provenance
+
+  let debuginfo t = t.debuginfo
+
+  let is_parameter t = t.is_parameter
+
+  let phantom_defining_expr t = t.phantom_defining_expr
+end
+
+module Range = struct
+  type t =
+    | Non_phantom of ARV.Range.t
+    | Phantom of ARPV.Range.t
+
+  let info = function
+    | Non_phantom range ->
+      let range_info = ARV.Range.info range in
+      { Range_info.provenance = ARV.Range_info.provenance range_info;
+        debuginfo = Debuginfo.none;
+        (* TODO: Get from fundecl *)
+        is_parameter = ARV.Range_info.is_parameter range_info;
+        phantom_defining_expr = Non_phantom
+      }
+    | Phantom range ->
+      let range_info = ARPV.Range.info range in
+      { Range_info.provenance = ARPV.Range_info.provenance range_info;
+        debuginfo = Debuginfo.none;
+        (* TODO: Get from fundecl *)
+        is_parameter = ARPV.Range_info.is_parameter range_info;
+        phantom_defining_expr =
+          Phantom (ARPV.Range_info.defining_expr range_info)
+      }
+
+  let extremities = function
+    | Non_phantom range -> (
+      match ARV.Range.estimate_lowest_address range with
+      | None -> None
+      | Some (label, _offset) ->
+        (* Find the last label by folding through subranges *)
+        let last_label =
+          ARV.Range.fold range ~init:label ~f:(fun _acc subrange ->
+              ARV.Subrange.end_pos subrange)
+        in
+        Some (label, last_label))
+    | Phantom range -> (
+      match ARPV.Range.estimate_lowest_address range with
+      | None -> None
+      | Some (label, _offset) ->
+        let last_label =
+          ARPV.Range.fold range ~init:label ~f:(fun _acc subrange ->
+              ARPV.Subrange.end_pos subrange)
+        in
+        Some (label, last_label))
+
+  let fold t ~init ~f =
+    match t with
+    | Non_phantom range ->
+      ARV.Range.fold range ~init ~f:(fun acc subrange ->
+          f acc (Subrange.Non_phantom subrange))
+    | Phantom range ->
+      let defining_expr =
+        ARPV.Range_info.defining_expr (ARPV.Range.info range)
+      in
+      ARPV.Range.fold range ~init ~f:(fun acc subrange ->
+          f acc (Subrange.Phantom (defining_expr, subrange)))
+end
+
+type t =
+  { non_phantom : ARV.t;
+    phantom : ARPV.t (* TODO: Add static phantom variables *)
+  }
+
+let empty = { non_phantom = ARV.empty; phantom = ARPV.empty }
+
+let create ~available_ranges_vars ~available_ranges_phantom_vars
+    (_fundecl : L.fundecl) =
+  { non_phantom = available_ranges_vars;
+    phantom = available_ranges_phantom_vars
+  }
+
+let iter t ~f =
+  ARV.iter t.non_phantom ~f:(fun var range -> f var (Range.Non_phantom range));
+  ARPV.iter t.phantom ~f:(fun var range -> f var (Range.Phantom range))
+
+let find t var =
+  match ARV.find t.non_phantom var with
+  | range -> Some (Range.Non_phantom range)
+  | exception Not_found -> (
+    match ARPV.find t.phantom var with
+    | range -> Some (Range.Phantom range)
+    | exception Not_found -> None)
+
+let fold t ~init ~f =
+  let acc =
+    ARV.fold t.non_phantom ~init ~f:(fun acc var range ->
+        f acc var (Range.Non_phantom range))
+  in
+  ARPV.fold t.phantom ~init:acc ~f:(fun acc var range ->
+      f acc var (Range.Phantom range))

--- a/backend/debug/available_ranges_all_vars.mli
+++ b/backend/debug/available_ranges_all_vars.mli
@@ -1,0 +1,95 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Mark Shinwell, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2014--2025 Jane Street Group LLC                             *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Unified interface to [Available_ranges_vars] and
+    [Available_ranges_phantom_vars] for a consumer. *)
+
+module Subrange_info : sig
+  type t = private
+    | Non_phantom of
+        { reg : Reg.t;
+          offset : Stack_reg_offset.t option
+        }
+    | Phantom of Linear.phantom_defining_expr
+end
+
+module Subrange : sig
+  type t
+
+  val info : t -> Subrange_info.t
+
+  val start_pos : t -> Linear.label
+
+  val start_pos_offset : t -> int
+
+  val end_pos : t -> Linear.label
+
+  val end_pos_offset : t -> int
+end
+
+module Range_info : sig
+  type t
+
+  val provenance : t -> Backend_var.Provenance.t option
+
+  val debuginfo : t -> Debuginfo.t
+
+  val is_parameter : t -> Is_parameter.t
+
+  type phantom_defining_expr = private
+    | Non_phantom
+    | Phantom of Linear.phantom_defining_expr
+
+  val phantom_defining_expr : t -> phantom_defining_expr
+end
+
+module Range : sig
+  type t
+
+  val info : t -> Range_info.t
+
+  val extremities : t -> (Linear.label * Linear.label) option
+
+  val fold : t -> init:'a -> f:('a -> Subrange.t -> 'a) -> 'a
+end
+
+type t
+
+val empty : t
+
+val create :
+  available_ranges_vars:Available_ranges_vars.t ->
+  available_ranges_phantom_vars:Available_ranges_phantom_vars.t ->
+  Linear.fundecl ->
+  t
+
+val iter : t -> f:(Backend_var.t -> Range.t -> unit) -> unit
+
+val find : t -> Backend_var.t -> Range.t option
+
+val fold : t -> init:'a -> f:('a -> Backend_var.t -> Range.t -> 'a) -> 'a

--- a/backend/debug/available_ranges_phantom_vars.ml
+++ b/backend/debug/available_ranges_phantom_vars.ml
@@ -1,0 +1,226 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Mark Shinwell, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2014--2025 Jane Street Group LLC                             *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+module L = Linear
+module V = Backend_var
+
+module Phantom_vars = struct
+  module Key = struct
+    type t = V.t
+
+    type key = t
+
+    module Raw_set = V.Set
+
+    module Set = struct
+      type t =
+        | Ok of Raw_set.t
+        | Unreachable
+
+      let of_list keys = Ok (Raw_set.of_list keys)
+
+      let union s1 s2 =
+        match s1, s2 with
+        | Unreachable, x | x, Unreachable -> x
+        | Ok s1, Ok s2 -> Ok (Raw_set.union s1 s2)
+
+      let inter s1 s2 =
+        match s1, s2 with
+        | Unreachable, _ | _, Unreachable -> Unreachable
+        | Ok s1, Ok s2 -> Ok (Raw_set.inter s1 s2)
+
+      let diff s1 s2 =
+        match s1, s2 with
+        | Unreachable, _ -> Unreachable
+        | s1, Unreachable -> s1
+        | Ok s1, Ok s2 -> Ok (Raw_set.diff s1 s2)
+
+      let fold f t init =
+        match t with Unreachable -> init | Ok s -> Raw_set.fold f s init
+
+      let print ppf = function
+        | Unreachable -> Format.fprintf ppf "unreachable"
+        | Ok s -> V.Set.print ppf s
+    end
+
+    module Map = V.Map
+
+    let print = V.print
+
+    let all_parents _t = []
+  end
+
+  module Index = V
+
+  module Subrange_state : Compute_ranges_intf.S_subrange_state = struct
+    type t = unit
+
+    let create () = ()
+
+    let advance_over_instruction _ _ = ()
+  end
+
+  module Subrange_info :
+    Compute_ranges_intf.S_subrange_info
+      with type key := Key.t
+      with type subrange_state := Subrange_state.t = struct
+    type t = unit
+
+    let create _var _subrange_state ~fun_contains_calls:_ ~fun_num_stack_slots:_
+        =
+      ()
+
+    let print _ppf () = ()
+  end
+
+  module Range_info : sig
+    include
+      Compute_ranges_intf.S_range_info
+        with type key := Key.t
+        with type index := Index.t
+
+    val provenance : t -> V.Provenance.t option
+
+    val is_parameter : t -> Is_parameter.t
+
+    val defining_expr : t -> L.phantom_defining_expr
+  end = struct
+    type t =
+      { provenance : V.Provenance.t option;
+        is_parameter : Is_parameter.t;
+        defining_expr : L.phantom_defining_expr
+      }
+
+    let create (fundecl : L.fundecl) var ~start_insn:_ =
+      match V.Map.find var fundecl.fun_phantom_lets with
+      | exception Not_found ->
+        Misc.fatal_errorf
+          "Available_ranges_phantom_vars.Range_info.create: phantom variable \
+           occurs in [phantom_available_before] but not in [fun_phantom_lets]: \
+           %a"
+          V.print var
+      | provenance, defining_expr ->
+        (* Static phantom variables are sent via a different path (see
+           [Available_ranges_all_vars]) since they are always available. *)
+        (* TODO: implement is_static check when Backend_var.Provenance supports
+           it *)
+        let is_parameter =
+          match provenance with
+          | None -> Is_parameter.local
+          | Some prov -> V.Provenance.is_parameter prov
+        in
+        let t = { provenance; is_parameter; defining_expr } in
+        Some (var, t)
+
+    let provenance t = t.provenance
+
+    let is_parameter t = t.is_parameter
+
+    let defining_expr t = t.defining_expr
+
+    let print ppf t =
+      Format.fprintf ppf "phantom_var(is_param=%a)" Is_parameter.print
+        t.is_parameter
+  end
+
+  let item_inlining_tags_equal (item1 : Debuginfo.item) (item2 : Debuginfo.item)
+      =
+    Option.equal String.equal item1.dinfo_uid item2.dinfo_uid
+    && Option.equal String.equal item1.dinfo_function_symbol
+         item2.dinfo_function_symbol
+
+  (* Tests whether [insn_dbg] identifies a program point within the inlined
+     frame given by [location] (or within some frame inlined inside it). Items
+     are compared solely on their inlining tags (uid and function symbol), as
+     for [Inlined_frame_ranges.Key.compare]: the lines/columns of corresponding
+     items will typically differ (e.g. [location] may carry the declaration site
+     of an inlined function's parameter whereas [insn_dbg] carries some location
+     within the inlined body). *)
+  let dbg_lies_within_inlining_context ~(location : Debuginfo.t)
+      ~(insn_dbg : Debuginfo.t) =
+    let rec loop (location : Debuginfo.item list)
+        (insn_dbg : Debuginfo.item list) =
+      match location, insn_dbg with
+      | [], _ -> true
+      | _ :: _, [] -> false
+      | loc_item :: location, dbg_item :: insn_dbg ->
+        item_inlining_tags_equal loc_item dbg_item && loop location insn_dbg
+    in
+    loop (Debuginfo.to_items location) (Debuginfo.to_items insn_dbg)
+
+  let location_has_inlining_tags (location : Debuginfo.t) =
+    List.exists
+      (fun (item : Debuginfo.item) ->
+        Option.is_some item.dinfo_uid
+        || Option.is_some item.dinfo_function_symbol)
+      (Debuginfo.to_items location)
+
+  (* A phantom variable bound inside an inlined frame is only made available
+     across the instructions of that frame (as determined by the [Debuginfo.t]
+     values on the instructions), even though the variable's lexical scope
+     extends to the end of the enclosing function's body. This keeps the
+     variable's range inside the PC ranges of the corresponding
+     DW_TAG_inlined_subroutine DIE, which are likewise derived only from the
+     instructions' [Debuginfo.t] values (see [Inlined_frame_ranges]); the
+     debugger can only show the variable when such a frame is selected, so
+     nothing visible is lost. Phantom variables not bound inside any inlined
+     frame remain available throughout their scopes. *)
+  let var_in_scope (fundecl : L.fundecl) (insn : L.instruction) var =
+    match V.Map.find var fundecl.fun_phantom_lets with
+    | exception Not_found ->
+      (* This will cause a fatal error in [Range_info.create]. *)
+      true
+    | None, _defining_expr -> true
+    | Some provenance, _defining_expr ->
+      let location = V.Provenance.location provenance in
+      (not (location_has_inlining_tags location))
+      || dbg_lies_within_inlining_context ~location ~insn_dbg:insn.dbg
+
+  let available_before (fundecl : L.fundecl) (insn : L.instruction) =
+    match insn.phantom_available_before with
+    | None -> None
+    | Some set ->
+      Some
+        (Key.Set.of_list
+           (List.filter (var_in_scope fundecl insn) (V.Set.elements set)))
+
+  let available_across fundecl insn =
+    (* Phantom variable availability never changes during the execution of a
+       [Linear] instruction. *)
+    available_before fundecl insn
+end
+
+module Impl = Compute_ranges.Make (Phantom_vars)
+include Impl
+
+let create = Impl.create
+
+module Key = Phantom_vars.Key
+module Subrange_state = Phantom_vars.Subrange_state
+module Subrange_info = Phantom_vars.Subrange_info
+module Range_info = Phantom_vars.Range_info

--- a/backend/debug/available_ranges_phantom_vars.mli
+++ b/backend/debug/available_ranges_phantom_vars.mli
@@ -1,0 +1,82 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ *                       Mark Shinwell, Jane Street                           *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2014--2025 Jane Street Group LLC                             *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** Like [Available_ranges_vars], but with phantom variables associated to
+    subranges, rather than normal (non-phantom) variables.
+
+    Phantom variables correspond to variables that once bound computations that
+    have now been optimised out. *)
+
+module Key : Compute_ranges_intf.S_key with type t = Backend_var.t
+
+module Subrange_state : sig
+  type t
+
+  val create : unit -> t
+
+  val advance_over_instruction : t -> Linear.instruction -> t
+end
+
+module Subrange_info : sig
+  type t
+
+  val create :
+    Backend_var.t ->
+    Subrange_state.t ->
+    fun_contains_calls:bool ->
+    fun_num_stack_slots:int Stack_class.Tbl.t ->
+    t
+
+  val print : Format.formatter -> t -> unit
+end
+
+module Range_info : sig
+  type t
+
+  val create :
+    Linear.fundecl ->
+    Backend_var.t ->
+    start_insn:Linear.instruction ->
+    (Backend_var.t * t) option
+
+  val provenance : t -> Backend_var.Provenance.t option
+
+  val is_parameter : t -> Is_parameter.t
+
+  val defining_expr : t -> Linear.phantom_defining_expr
+
+  val print : Format.formatter -> t -> unit
+end
+
+include
+  Compute_ranges_intf.S
+    with module Index := Backend_var
+    with module Key := Key
+    with module Subrange_state := Subrange_state
+    with module Subrange_info := Subrange_info
+    with module Range_info := Range_info

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -57,7 +57,9 @@ module Vars = struct
     type t = { stack_offset : int }
 
     let create () =
-      { (* This does not include the [Proc.initial_stack_offset] (see below). *)
+      { (* Only the dynamic stack adjustment (pushtraps, [Lstackoffset]); the
+           [Proc.initial_stack_offset] is added by [Proc.frame_size] and
+           [Proc.slot_offset] when [Subrange_info.create] consults them. *)
         stack_offset = 0
       }
 
@@ -101,13 +103,14 @@ module Vars = struct
 
     let create reg subrange_state ~fun_contains_calls ~fun_num_stack_slots =
       let reg = RD.reg reg in
-      let initial_stack_offset =
-        Proc.initial_stack_offset ~contains_calls:fun_contains_calls
-          ~num_stack_slots:fun_num_stack_slots
-      in
-      let stack_offset =
-        Subrange_state.stack_offset subrange_state + initial_stack_offset
-      in
+      (* [Proc.frame_size] and [Proc.slot_offset] below already account for
+         [Proc.initial_stack_offset], so [stack_offset] must be only the dynamic
+         adjustment (pushtraps, [Lstackoffset]) at this program point -- exactly
+         what the emitter passes to those functions. Adding the initial offset
+         here as well double-counts it, which after 16-byte frame alignment
+         yields a CFA offset that is wrong by the alignment padding whenever the
+         initial offset is not itself a multiple of 16. *)
+      let stack_offset = Subrange_state.stack_offset subrange_state in
       let offset =
         match reg.loc with
         | Stack loc ->

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -167,12 +167,17 @@ module Vars = struct
     let create _fundecl reg ~start_insn:_ =
       match RD.debug_info reg with
       | None -> None
-      | Some debug_info ->
-        let var = RD.Debug_info.holds_value_of debug_info in
-        let provenance = RD.Debug_info.provenance debug_info in
-        let is_parameter = RD.Debug_info.is_parameter debug_info in
-        let t = { provenance; is_parameter } in
-        Some (var, t)
+      | Some debug_info -> (
+        match RD.Debug_info.holds_value_of debug_info with
+        | Const_int _ | Const_naked_float _ | Const_symbol _ | Projection _ ->
+          (* Constants and projections are tracked for call site information
+             only; they do not give rise to available ranges for variables. *)
+          None
+        | Var var ->
+          let provenance = RD.Debug_info.provenance debug_info in
+          let is_parameter = RD.Debug_info.is_parameter debug_info in
+          let t = { provenance; is_parameter } in
+          Some (var, t))
 
     let provenance t = t.provenance
 

--- a/backend/debug/available_ranges_vars.ml
+++ b/backend/debug/available_ranges_vars.ml
@@ -194,10 +194,10 @@ module Vars = struct
   let availability_set_to_key_set (avail : Reg_availability_set.t) =
     Reg_availability_set.canonicalise avail
 
-  let available_before (insn : L.instruction) =
+  let available_before (_fundecl : L.fundecl) (insn : L.instruction) =
     Some (availability_set_to_key_set insn.available_before)
 
-  let available_across (insn : L.instruction) =
+  let available_across (_fundecl : L.fundecl) (insn : L.instruction) =
     Some (availability_set_to_key_set insn.available_across)
 end
 

--- a/backend/debug/compute_ranges.ml
+++ b/backend/debug/compute_ranges.ml
@@ -228,6 +228,9 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
      (d) [key] is in [S.available_before insn] and it is also in it is in
      [S.available_across insn]. The existing range remains open. *)
 
+  (* CR mshinwell: can cases such as 2(b) actually happen - it seems like
+     [available_across] should be a subset of [available_before]? *)
+
   type action =
     | Open_one_byte_subrange
     | Open_subrange
@@ -309,10 +312,11 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
     |> handle case_2b Close_subrange
     |> handle case_2c Close_subrange_one_byte_after
 
-  let actions_at_instruction ~ppf_dump ~(insn : L.instruction)
-      ~(prev_insn : L.instruction option) ~known_available_after_prev_insn =
-    let available_before = S.available_before insn in
-    let available_across = S.available_across insn in
+  let actions_at_instruction ~ppf_dump ~(fundecl : L.fundecl)
+      ~(insn : L.instruction) ~(prev_insn : L.instruction option)
+      ~known_available_after_prev_insn =
+    let available_before = S.available_before fundecl insn in
+    let available_across = S.available_across fundecl insn in
     if !Oxcaml_flags.dranges
     then
       Format.fprintf ppf_dump "canonicalised available_before:@ %a\n"
@@ -425,7 +429,7 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
         let known_available_after_prev_insn =
           KM.bindings currently_open_subranges |> List.map fst |> KS.of_list
         in
-        actions_at_instruction ~ppf_dump ~insn ~prev_insn
+        actions_at_instruction ~ppf_dump ~fundecl ~insn ~prev_insn
           ~known_available_after_prev_insn
     in
     (* Apply actions *)
@@ -499,7 +503,7 @@ module Make (S : Compute_ranges_intf.S_functor) = struct
               (fun (key, _datum) -> key)
               (KM.bindings currently_open_subranges))
        in
-       match S.available_across insn with
+       match S.available_across fundecl insn with
        | None | Some Unreachable -> ()
        | Some (Ok _ as should_be_open) -> (
          match KS.diff should_be_open currently_open_subranges with

--- a/backend/debug/compute_ranges_intf.ml
+++ b/backend/debug/compute_ranges_intf.ml
@@ -165,13 +165,19 @@ module type S_functor = sig
       with type subrange_state := Subrange_state.t
 
   (** How to retrieve from an instruction those keys that are available
-      immediately before the instruction starts executing. *)
-  val available_before : L.instruction -> Key.Set.t option
+      immediately before the instruction starts executing. The [fundecl] is
+      provided so implementations can consult per-function context (such as
+      [fun_phantom_lets]) when computing keys. *)
+  val available_before : L.fundecl -> L.instruction -> Key.Set.t option
 
   (** How to retrieve from an instruction those keys that are available between
       the points at which the instruction reads its arguments and writes its
-      results. *)
-  val available_across : L.instruction -> Key.Set.t option
+      results. There is no separate "phantom available across" field on
+      instructions: implementations that combine [phantom_available_before] into
+      their key sets should treat the phantom-derived contribution as identical
+      for [available_before] and [available_across] (equivalently, "phantom
+      available after [prev]" equals "phantom available before [next]"). *)
+  val available_across : L.fundecl -> L.instruction -> Key.Set.t option
 end
 
 (** This module type is the result type of the [Compute_ranges.Make] functor.

--- a/backend/debug/inlined_frame_ranges.ml
+++ b/backend/debug/inlined_frame_ranges.ml
@@ -159,27 +159,71 @@ module Inlined_frames = struct
     let print ppf () = Format.pp_print_string ppf "()"
   end
 
-  let available_before (insn : L.instruction) =
-    let get_parents (dbg : Debuginfo.item list) : Debuginfo.t list =
-      match List.rev dbg with
-      | [] | [_] -> []
-      | _ :: parents ->
-        let rec loop (t : Debuginfo.item list) =
-          match t with
-          | [] -> []
-          | _ :: tl -> Debuginfo.of_items (List.rev t) :: loop tl
-        in
-        loop parents
-    in
-    let insn_dbg = Debuginfo.to_items insn.dbg in
-    match insn_dbg with
-    | [] -> None
+  (* Given a non-empty Debuginfo.t, return the list of all non-empty prefixes:
+     the value itself and each of its parents (the path with progressively fewer
+     deeper frames). *)
+  let dbg_and_parents dbg =
+    let items = Debuginfo.to_items dbg in
+    match items with
+    | [] -> []
     | _ :: _ ->
-      Some (Key.Set.Ok (Key.Raw_set.of_list (insn.dbg :: get_parents insn_dbg)))
+      let rec parents (t : Debuginfo.item list) =
+        match List.rev t with
+        | [] | [_] -> []
+        | _ :: rest ->
+          let prefix = List.rev rest in
+          Debuginfo.of_items prefix :: parents prefix
+      in
+      dbg :: parents items
 
-  let available_across insn =
+  let is_spill_or_reload (insn : L.instruction) =
+    match insn.desc with
+    | Lop (Spill | Reload) -> true
+    | Lprologue | Lepilogue_open | Lepilogue_close | Lend | Lop _ | Lcall_op _
+    | Lreloadretaddr | Lreturn | Llabel _ | Lbranch _ | Lcondbranch _
+    | Lcondbranch3 _ | Lswitch _ | Lentertrap | Ladjust_stack_offset _
+    | Lpushtrap _ | Lpoptrap _ | Lraise _ | Lstackcheck _ ->
+      false
+  [@@ocaml.warning "-4"]
+
+  let available_before (_fundecl : L.fundecl) (insn : L.instruction) =
+    (* Inlined-frame keys are derived solely from the instruction's own [dbg]
+       (and all of its parents): an instruction physically located inside an
+       inlined frame keeps that frame alive. Since each instruction identifies
+       exactly one frame at each inlining depth, the ranges of sibling frames
+       may interleave but can never overlap, as required by the DWARF
+       specification for DW_TAG_inlined_subroutine DIEs.
+
+       In particular, the ranges are _not_ extended to cover the scopes of
+       phantom variables bound in inlined frames: such scopes extend to the end
+       of the enclosing function's body and would cause sibling frames' ranges
+       to overlap. (The consequence is that a fully optimized-out inlined
+       function, none of whose instructions remain, gets no
+       DW_TAG_inlined_subroutine DIE; the phantom lets corresponding to its
+       parameters are correspondingly restricted -- see
+       [Available_ranges_phantom_vars].)
+
+       Spill and reload instructions are register-allocator bookkeeping, not
+       code lowered from any inlined body; typically they preserve the
+       _enclosing_ function's state across a call to which the surrounding
+       debuginfo relates. They are treated as belonging to no inlined frame (an
+       empty key set, closing any open ranges), so that the address ranges of
+       inlined frames never cover them. This matters in particular for reloads
+       of the enclosing function's variables after a call within an inlined
+       body: such reloads must not be attributed to the inlined function (e.g.
+       by a profiler). Note that returning [None] would not suffice, since that
+       would leave existing open ranges untouched. *)
+    if is_spill_or_reload insn
+    then Some (Key.Set.Ok Key.Raw_set.empty)
+    else
+      match Debuginfo.to_items insn.dbg with
+      | [] -> None
+      | _ :: _ ->
+        Some (Key.Set.Ok (Key.Raw_set.of_list (dbg_and_parents insn.dbg)))
+
+  let available_across fundecl insn =
     (* A single [Linear] instruction never spans inlined frames. *)
-    available_before insn
+    available_before fundecl insn
 
   let must_restart_ranges_upon_any_change () = false
 end

--- a/backend/debug/reg_availability_set.ml
+++ b/backend/debug/reg_availability_set.ml
@@ -101,25 +101,31 @@ let canonicalise availability =
         match RD.debug_info reg with
         | None -> ()
         | Some debug_info -> (
-          let name = RD.Debug_info.holds_value_of debug_info in
-          if not (V.is_global_or_predef name)
-          then
-            match V.Tbl.find regs_by_ident name with
-            | exception Not_found -> V.Tbl.add regs_by_ident name reg
-            | (reg' : RD.t) -> (
-              (* We prefer registers that are assigned to the stack since they
-                 probably give longer available ranges (less likely to be
-                 clobbered). *)
-              match RD.location reg, RD.location reg' with
-              | Reg _, Stack _
-              | Reg _, Reg _
-              | Stack _, Stack _
-              | _, Unknown
-              | Unknown, _ ->
-                ()
-              | Stack _, Reg _ ->
-                V.Tbl.remove regs_by_ident name;
-                V.Tbl.add regs_by_ident name reg)))
+          match RD.Debug_info.holds_value_of debug_info with
+          | Const_int _ | Const_naked_float _ | Const_symbol _ | Projection _ ->
+            (* Constants and projections are tracked for call site information
+               only; they do not give rise to canonical locations for
+               variables. *)
+            ()
+          | Var name -> (
+            if not (V.is_global_or_predef name)
+            then
+              match V.Tbl.find regs_by_ident name with
+              | exception Not_found -> V.Tbl.add regs_by_ident name reg
+              | (reg' : RD.t) -> (
+                (* We prefer registers that are assigned to the stack since they
+                   probably give longer available ranges (less likely to be
+                   clobbered). *)
+                match RD.location reg, RD.location reg' with
+                | Reg _, Stack _
+                | Reg _, Reg _
+                | Stack _, Stack _
+                | _, Unknown
+                | Unknown, _ ->
+                  ()
+                | Stack _, Reg _ ->
+                  V.Tbl.remove regs_by_ident name;
+                  V.Tbl.add regs_by_ident name reg))))
       availability;
     let result =
       V.Tbl.fold

--- a/backend/debug/reg_with_debug_info.ml
+++ b/backend/debug/reg_with_debug_info.ml
@@ -17,9 +17,69 @@
 open! Int_replace_polymorphic_compare
 module V = Backend_var
 
+module Holds_value_of = struct
+  type t =
+    | Var of V.t
+    (* CR mshinwell: There are more numeric cases to add here *)
+    | Const_int of nativeint
+    | Const_naked_float of Int64.t
+    | Const_symbol of Cmm.symbol
+    | Projection of
+        { base : t;
+          field : int
+              (* Field index, in words, of an immutable load from [base] (e.g. a
+                 closure value slot). The value can be described to a debugger,
+                 in the context of a caller, as a projection from whatever
+                 caller-evaluable description applies to [base]. *)
+        }
+
+  let compare_symbol (sym1 : Cmm.symbol) (sym2 : Cmm.symbol) =
+    let c = String.compare sym1.sym_name sym2.sym_name in
+    if c <> 0
+    then c
+    else
+      match sym1.sym_global, sym2.sym_global with
+      | Global, Global | Local, Local -> 0
+      | Global, Local -> -1
+      | Local, Global -> 1
+
+  let rank = function
+    | Var _ -> 0
+    | Const_int _ -> 1
+    | Const_naked_float _ -> 2
+    | Const_symbol _ -> 3
+    | Projection _ -> 4
+
+  let rec compare t1 t2 =
+    match t1, t2 with
+    | Var var1, Var var2 -> V.compare var1 var2
+    | Const_int i1, Const_int i2 -> Nativeint.compare i1 i2
+    | Const_naked_float f1, Const_naked_float f2 -> Int64.compare f1 f2
+    | Const_symbol sym1, Const_symbol sym2 -> compare_symbol sym1 sym2
+    | ( Projection { base = base1; field = field1 },
+        Projection { base = base2; field = field2 } ) ->
+      let c = Int.compare field1 field2 in
+      if c <> 0 then c else compare base1 base2
+    | ( ( Var _ | Const_int _ | Const_naked_float _ | Const_symbol _
+        | Projection _ ),
+        _ ) ->
+      Int.compare (rank t1) (rank t2)
+
+  let equal t1 t2 = compare t1 t2 = 0
+
+  let rec print ppf t =
+    match t with
+    | Var var -> V.print ppf var
+    | Const_int i -> Format.fprintf ppf "%nd" i
+    | Const_naked_float f -> Format.fprintf ppf "0x%Lx" f
+    | Const_symbol sym -> Format.pp_print_string ppf sym.sym_name
+    | Projection { base; field } ->
+      Format.fprintf ppf "%a.(%d)" print base field
+end
+
 module Debug_info = struct
   type t =
-    { holds_value_of : V.t;
+    { holds_value_of : Holds_value_of.t;
       part_of_value : int;
       num_parts_of_value : int;
       (* CR mshinwell: use [Is_parameter] *)
@@ -44,7 +104,7 @@ module Debug_info = struct
         } =
       t2
     in
-    let c = V.compare holds_value_of1 holds_value_of2 in
+    let c = Holds_value_of.compare holds_value_of1 holds_value_of2 in
     if c <> 0
     then c
     else
@@ -78,7 +138,7 @@ module Debug_info = struct
   let provenance t = t.provenance
 
   let print ppf t =
-    Format.fprintf ppf "%a" V.print t.holds_value_of;
+    Format.fprintf ppf "%a" Holds_value_of.print t.holds_value_of;
     if not (t.part_of_value = 0 && t.num_parts_of_value = 1)
     then Format.fprintf ppf "(%d/%d)" t.part_of_value t.num_parts_of_value;
     match t.which_parameter with
@@ -112,6 +172,13 @@ let create ~reg ~holds_value_of ~part_of_value ~num_parts_of_value
   assert (num_parts_of_value >= 1);
   assert (part_of_value >= 0 && part_of_value < num_parts_of_value);
   assert (match which_parameter with None -> true | Some index -> index >= 0);
+  assert (
+    match (holds_value_of : Holds_value_of.t) with
+    | Var _ -> true
+    | Const_int _ | Const_naked_float _ | Const_symbol _ | Projection _ ->
+      (* Constants and projections do not relate to parameters and have no
+         provenance. *)
+      Option.is_none which_parameter && Option.is_none provenance);
   let debug_info : Debug_info.t =
     { holds_value_of;
       part_of_value;

--- a/backend/debug/reg_with_debug_info.mli
+++ b/backend/debug/reg_with_debug_info.mli
@@ -15,6 +15,34 @@
 (** Registers equipped with information used for generating debugging
     information. *)
 
+module Holds_value_of : sig
+  (** What value a register holds: either (part of) the value of a variable, or
+      a constant. The constant cases arise for example when a register holding
+      an immediate is an argument to a function call: the constant may then be
+      quoted in DWARF call site information, permitting the recovery of the
+      values of the callee's parameters by virtual unwinding (DWARF "entry
+      values"). *)
+  type t =
+    | Var of Backend_var.t
+    | Const_int of nativeint
+    | Const_naked_float of Int64.t
+    | Const_symbol of Cmm.symbol
+    | Projection of
+        { base : t;
+          field : int
+              (* Field index, in words, of an immutable load from [base] (e.g. a
+                 closure value slot): the value can be described to a debugger,
+                 in the context of a caller, as a projection from whatever
+                 caller-evaluable description applies to [base]. *)
+        }
+
+  val compare : t -> t -> int
+
+  val equal : t -> t -> bool
+
+  val print : Format.formatter -> t -> unit
+end
+
 module Debug_info : sig
   type t
 
@@ -22,8 +50,9 @@ module Debug_info : sig
 
   val equal : t -> t -> bool
 
-  (** The identifier that the register holds (part of) the value of. *)
-  val holds_value_of : t -> Backend_var.t
+  (** The identifier or constant that the register holds (part of) the value of.
+  *)
+  val holds_value_of : t -> Holds_value_of.t
 
   val part_of_value : t -> int
 
@@ -44,7 +73,7 @@ type reg_with_debug_info = t
 
 val create :
   reg:Reg.t ->
-  holds_value_of:Backend_var.t ->
+  holds_value_of:Holds_value_of.t ->
   part_of_value:int ->
   num_parts_of_value:int ->
   which_parameter:int option ->

--- a/dune
+++ b/dune
@@ -699,6 +699,8 @@
   cfg_format
   ;; backend/debug/
   available_ranges_vars
+  available_ranges_phantom_vars
+  available_ranges_all_vars
   compute_ranges
   compute_ranges_intf
   inlined_frame_ranges

--- a/dune
+++ b/dune
@@ -713,6 +713,8 @@
   cfg_format
   ;; backend/debug/
   available_ranges_vars
+  available_ranges_phantom_vars
+  available_ranges_all_vars
   compute_ranges
   compute_ranges_intf
   inlined_frame_ranges


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

Stacked on #6517 (this PR targets that branch) and additionally merges #6518, so please review only the final, non-merge commit.

## Description

Turns the Linear-level phantom information (#6517) into DWARF-ready ranges:

- `compute_ranges` / `compute_ranges_intf` thread the Linear `fundecl` into `available_before`/`available_across`, so subrange computations can consult `fun_phantom_lets`.
- **New** `Available_ranges_phantom_vars`: ranges keyed on phantom variables, derived from `phantom_available_before`. Each range is clipped to its defining inlined frame by comparing `dinfo_uid`/`dinfo_function_symbol`, so a phantom variable does not appear in scope outside the frame that defines it.
- **New** `Available_ranges_all_vars`: unifying wrapper presenting ordinary and phantom variable ranges through one interface for DWARF emission (next PR).
- `inlined_frame_ranges.ml`: `dbg_and_parents`; spill/reload instructions close inlined-frame ranges (`is_spill_or_reload`) — they are bookkeeping of the enclosing function (cf. the spill/reload debuginfo PR earlier in the series).
- Root `dune`: register the two new modules.

## TODOs kept visible

- `Available_ranges_all_vars.Range_info.debuginfo` currently returns `Debuginfo.none`.
- Static phantom variables are not yet handled.

## Verification

- `make -s boot-compiler` passes; `make -s fmt` clean.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables ← **this PR**
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



