### PR TITLE
Emit DWARF call site information

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -357,6 +357,12 @@ let loc_exn_bucket = rax
 let stack_ptr_dwarf_register_number = 7
 let domainstate_ptr_dwarf_register_number = 14
 
+let extcall_code_size_after_return_address ~alloc:_ ~stack_ofs:_ =
+  (* CR mshinwell: implement this, mirroring the [Lextcall] case of
+     [emit_instr] in emit.ml (more delicate than for arm64, since
+     instructions are of variable length). *)
+  None
+
 (* Registers destroyed by operations *)
 
 let int_regs_destroyed_at_c_call_win64 =

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -388,6 +388,12 @@ let loc_exn_bucket = rax
 let stack_ptr_dwarf_register_number = 7
 let domainstate_ptr_dwarf_register_number = 14
 
+let extcall_code_size_after_return_address ~alloc:_ ~stack_ofs:_ =
+  (* CR mshinwell: implement this, mirroring the [Lextcall] case of
+     [emit_instr] in emit.ml (more delicate than for arm64, since
+     instructions are of variable length). *)
+  None
+
 (* Registers destroyed by operations *)
 
 let int_regs_destroyed_at_c_call_win64 =

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -229,6 +229,17 @@ let stack_ptr_dwarf_register_number = 31
 
 let domainstate_ptr_dwarf_register_number = 28
 
+let extcall_code_size_after_return_address ~alloc ~stack_ofs =
+  (* This must be kept in sync with the [Lextcall] case of [emit_instr] in
+     emit.ml. Note that CFI directives do not generate machine code. *)
+  if Config.runtime5 && stack_ofs > 0
+  then Some 0 (* the BL is the last instruction in the sequence *)
+  else if alloc
+  then Some 0 (* likewise *)
+  else if Config.runtime5
+  then Some 4 (* the instruction restoring the stack pointer follows the BL *)
+  else Some 0
+
 (* Registers destroyed by operations *)
 
 let destroyed_at_c_noalloc_call =

--- a/backend/arm64/proc.ml
+++ b/backend/arm64/proc.ml
@@ -231,6 +231,17 @@ let stack_ptr_dwarf_register_number = 31
 
 let domainstate_ptr_dwarf_register_number = 28
 
+let extcall_code_size_after_return_address ~alloc ~stack_ofs =
+  (* This must be kept in sync with the [Lextcall] case of [emit_instr] in
+     emit.ml. Note that CFI directives do not generate machine code. *)
+  if Config.runtime5 && stack_ofs > 0
+  then Some 0 (* the BL is the last instruction in the sequence *)
+  else if alloc
+  then Some 0 (* likewise *)
+  else if Config.runtime5
+  then Some 4 (* the instruction restoring the stack pointer follows the BL *)
+  else Some 0
+
 (* Registers destroyed by operations *)
 
 let destroyed_at_c_noalloc_call =

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_abstract_instances.mli
@@ -32,6 +32,17 @@ open! Asm_targets
 open! Dwarf_low
 open! Dwarf_high
 
+(** Add an empty abstract instance DIE for the given function symbol (which may
+    correspond to a function in another compilation unit), to be filled in later
+    by [add_root] should the function turn out to be defined in the current
+    unit. *)
+val add_empty :
+  Dwarf_state.t ->
+  compilation_unit_proto_die:Proto_die.t ->
+  fun_symbol:Asm_symbol.t ->
+  demangled_name:string ->
+  Proto_die.t * Asm_symbol.t
+
 (** Add an abstract instance root. *)
 val add_root :
   Dwarf_state.t ->

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_call_sites.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_call_sites.ml
@@ -1,0 +1,618 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2025 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.warning "+a-4-30-40-41-42"]
+
+open! Int_replace_polymorphic_compare
+open! Asm_targets
+open! Dwarf_low
+open! Dwarf_high
+module DAH = Dwarf_attribute_helpers
+module DS = Dwarf_state
+module L = Linear
+module RD = Reg_with_debug_info
+module SLDL = Simple_location_description_lang
+module V = Backend_var
+
+(* CFA-relative offset for a register assigned to a stack slot, mirroring the
+   calculation in [Available_ranges_vars.Subrange_info.create]. Returns [None]
+   for registers in the domainstate area: that area is not preserved during
+   calls (it is for example used to pass excess arguments), so values there
+   cannot reliably be recovered by the debugger whilst the callee (or anything
+   the callee calls) is executing. *)
+let cfa_offset_for_stack_reg (reg : Reg.t) ~stack_offset ~fun_contains_calls
+    ~fun_num_stack_slots =
+  match reg.loc with
+  | Reg _ | Unknown -> None
+  | Stack loc -> (
+    (* [stack_offset] is the dynamic stack adjustment at the call point;
+       [Proc.frame_size] and [Proc.slot_offset] add [Proc.initial_stack_offset]
+       themselves, so it must not be added here as well (see
+       [Available_ranges_vars.Subrange_info.create]). *)
+    let frame_size =
+      Proc.frame_size ~stack_offset ~contains_calls:fun_contains_calls
+        ~num_stack_slots:fun_num_stack_slots
+    in
+    let slot_offset =
+      Proc.slot_offset loc
+        ~stack_class:(Stack_class.of_machtype reg.typ)
+        ~stack_offset ~fun_contains_calls ~fun_num_stack_slots
+    in
+    match slot_offset with
+    | Bytes_relative_to_stack_pointer i ->
+      Some (Stack_reg_offset.Bytes_relative_to_cfa (frame_size - i))
+    | Bytes_relative_to_domainstate_pointer _ -> None)
+
+let single_call_value_attribute simple_location_description =
+  [ DAH.create_single_call_value_location_description
+      (Single_location_description.of_simple_location_description
+         simple_location_description) ]
+
+(* If the value held in [reg] (at the relevant call point) also has a spilled
+   copy, at a CFA-relative stack location -- which, unlike registers and the
+   domainstate area, is preserved during the call -- then return an rvalue
+   describing the contents of such location. *)
+let spilled_copy_rvalue ~(reg : Reg.t) ~avail ~stack_offset ~fun_contains_calls
+    ~fun_num_stack_slots : _ SLDL.Rvalue.t option =
+  match
+    RD.Set_distinguishing_names_and_locations.find_reg_with_same_location_exn
+      avail reg
+  with
+  | exception Not_found -> None
+  | rd -> (
+    match RD.debug_info rd with
+    | None -> None
+    | Some debug_info -> (
+      match RD.Debug_info.holds_value_of debug_info with
+      | Const_int _ | Const_naked_float _ | Const_symbol _ | Projection _ ->
+        (* CR mshinwell: is it useful to return [Some] here instead? *)
+        None
+      | Var var -> (
+        if RD.Debug_info.num_parts_of_value debug_info <> 1
+        then None (* Values split across registers are not handled yet. *)
+        else
+          (* Note that [RD.assigned_to_stack] excludes the domainstate area. *)
+          let spilled_copy =
+            RD.Set_distinguishing_names_and_locations.fold
+              (fun rd' spilled_copy ->
+                match spilled_copy with
+                | Some _ -> spilled_copy
+                | None -> (
+                  if not (RD.assigned_to_stack rd')
+                  then None
+                  else
+                    match RD.debug_info rd' with
+                    | None -> None
+                    | Some debug_info' -> (
+                      match RD.Debug_info.holds_value_of debug_info' with
+                      | Var var'
+                        when V.same var var'
+                             && RD.Debug_info.num_parts_of_value debug_info' = 1
+                        ->
+                        Some rd'
+                      | Var _ | Const_int _ | Const_naked_float _
+                      | Const_symbol _ | Projection _ ->
+                        None)))
+              avail None
+          in
+          match spilled_copy with
+          | None -> None
+          | Some rd' -> (
+            let reg' = RD.reg rd' in
+            match
+              cfa_offset_for_stack_reg reg' ~stack_offset ~fun_contains_calls
+                ~fun_num_stack_slots
+            with
+            | None -> None
+            | Some (Bytes_relative_to_cfa offset_in_bytes) ->
+              if offset_in_bytes mod Arch.size_addr <> 0
+              then None
+              else
+                Some
+                  (SLDL.Rvalue.in_stack_slot
+                     ~offset_in_words:
+                       (Targetint.of_int_exn (offset_in_bytes / Arch.size_addr)))
+            | Some (Bytes_relative_to_domainstate_pointer _) -> None))))
+
+let dwarf_version () =
+  match !Dwarf_flags.gdwarf_version with
+  | Four -> Dwarf_version.four
+  | Five -> Dwarf_version.five
+
+(* If the given variable is a parameter of the function being compiled that
+   arrived in a register -- only parameters are available at the function's
+   entry point, whose availability set is [entry_available] -- then return an
+   rvalue describing the value of the variable as the DWARF "entry value" of
+   that register. Variables at this level are immutable, so such a description
+   is valid at any point in the function. Debuggers recover entry values by
+   virtually unwinding to the caller and consulting the call site information
+   there; in particular such descriptions remain valid at tail call sites, whose
+   enclosing frame has been destroyed by the time the callee executes (recovery
+   then chains through the tail-calling function's own incoming call site
+   information, one frame further up). *)
+let entry_value_rvalue ~(entry_available : Reg_availability_set.t) var :
+    _ SLDL.Rvalue.t option =
+  match entry_available with
+  | Unreachable -> None
+  | Ok entry_avail ->
+    RD.Set_distinguishing_names_and_locations.fold
+      (fun rd entry_value ->
+        match entry_value with
+        | Some _ -> entry_value
+        | None -> (
+          match RD.debug_info rd with
+          | None -> None
+          | Some debug_info -> (
+            match RD.Debug_info.holds_value_of debug_info with
+            | Var var'
+              when V.same var var'
+                   && RD.Debug_info.num_parts_of_value debug_info = 1 -> (
+              let reg = RD.reg rd in
+              match reg.loc with
+              | Reg phys_reg ->
+                let dwarf_reg_number = Regs.dwarf_reg_number reg.typ phys_reg in
+                Some
+                  (SLDL.Rvalue.entry_value_of_register ~dwarf_reg_number
+                     (dwarf_version ()))
+              | Stack _ | Unknown -> None)
+            | Var _ | Const_int _ | Const_naked_float _ | Const_symbol _
+            | Projection _ ->
+              None)))
+      entry_avail None
+
+(* Compute, where possible, a description of the value denoted by
+   [holds_value_of] that is evaluable in the context of the _caller_ of a call
+   (typically after the debugger has virtually unwound to it). The following may
+   be described:
+
+   - constants;
+
+   - spilled copies of the relevant value, at CFA-relative stack locations (such
+   slots, unlike registers and the domainstate area, are preserved during the
+   call), when [reg_for_spilled] gives a register currently holding the value;
+
+   - entry values (see [entry_value_rvalue] above), when the value is a
+   parameter of the calling function;
+
+   - and, recursively, a projection of any of the above: the field of an
+   immutable block (e.g. a closure value slot) whose base is itself describable.
+   This is what makes the arguments of a partial-application wrapper, loaded
+   from its closure and forwarded by a tail call, recoverable: each is a field
+   of the wrapper's closure, which is itself a parameter (hence an entry value).
+
+   For tail calls the caller's frame no longer exists by the time the callee
+   executes, so spilled copies may not be used; only constants, entry values and
+   projections thereof. *)
+let rec rvalue_of_holds_value_of (holds_value_of : RD.Holds_value_of.t)
+    ~reg_for_spilled ~avail ~entry_available ~is_tail ~stack_offset
+    ~fun_contains_calls ~fun_num_stack_slots : _ SLDL.Rvalue.t option =
+  match holds_value_of with
+  | Const_int i ->
+    Some
+      (SLDL.Rvalue.signed_int_const (Targetint.of_int64 (Int64.of_nativeint i)))
+  | Const_naked_float f -> Some (SLDL.Rvalue.float_const f)
+  | Const_symbol sym ->
+    Some (Dwarf_reg_locations.address_of_cmm_symbol_rvalue sym)
+  | Var var -> (
+    (* Spilled copies are preferred to entry values: the debugger can read them
+       directly, without chaining through further call site information. They
+       cannot however be used at tail call sites (the frame containing the
+       spilled copy no longer exists when the callee executes). *)
+    let spilled_copy =
+      match reg_for_spilled with
+      | Some reg when not is_tail ->
+        spilled_copy_rvalue ~reg ~avail ~stack_offset ~fun_contains_calls
+          ~fun_num_stack_slots
+      | Some _ | None -> None
+    in
+    match spilled_copy with
+    | Some _ -> spilled_copy
+    | None -> entry_value_rvalue ~entry_available var)
+  | Projection { base; field } -> (
+    (* The base is described from scratch; there is no single register holding
+       it at the call (and at a tail call a spilled copy would be unusable
+       anyway), so [reg_for_spilled] is dropped. *)
+    match
+      rvalue_of_holds_value_of base ~reg_for_spilled:None ~avail
+        ~entry_available ~is_tail ~stack_offset ~fun_contains_calls
+        ~fun_num_stack_slots
+    with
+    | None -> None
+    | Some base_rvalue ->
+      Some
+        (SLDL.Rvalue.read_field_unguarded ~block:base_rvalue
+           ~field:(Targetint.of_int_exn field)))
+
+(* The [DW_AT_call_value] (GNU: [DW_AT_GNU_call_site_value]) attribute of a call
+   site parameter DIE describes how to compute the value passed for the
+   parameter, as an expression to be evaluated in the context of the _caller_;
+   see [rvalue_of_holds_value_of]. *)
+let call_site_value_attribute ~(arg : Reg.t)
+    ~(available_before : Reg_availability_set.t) ~entry_available ~is_tail
+    ~stack_offset ~fun_contains_calls ~fun_num_stack_slots =
+  match available_before with
+  | Unreachable -> []
+  | Ok avail -> (
+    match
+      RD.Set_distinguishing_names_and_locations.find_reg_with_same_location_exn
+        avail arg
+    with
+    | exception Not_found -> []
+    | rd -> (
+      match RD.debug_info rd with
+      | None -> []
+      | Some debug_info -> (
+        match
+          rvalue_of_holds_value_of
+            (RD.Debug_info.holds_value_of debug_info)
+            ~reg_for_spilled:(Some arg) ~avail ~entry_available ~is_tail
+            ~stack_offset ~fun_contains_calls ~fun_num_stack_slots
+        with
+        | None -> []
+        | Some rvalue ->
+          single_call_value_attribute (SLDL.compile (SLDL.of_rvalue rvalue)))))
+
+let add_call_site_parameter ~call_site_die ~arg_index ~(arg : Reg.t)
+    ~available_before ~entry_available ~is_tail ~stack_offset
+    ~fun_contains_calls ~fun_num_stack_slots =
+  match arg.loc with
+  | Stack _ | Unknown ->
+    (* Excess arguments are passed via the domainstate area; see above. *)
+    ()
+  | Reg _ -> (
+    match
+      call_site_value_attribute ~arg ~available_before ~entry_available ~is_tail
+        ~stack_offset ~fun_contains_calls ~fun_num_stack_slots
+    with
+    | [] ->
+      (* A call site parameter DIE without a means of computing the value passed
+         is of no use to debuggers. *)
+      (* CR mshinwell: does it produce an LLDB warning though? *)
+      ()
+    | value_attribute ->
+      let location_attribute =
+        [ DAH.create_single_location_description
+            (Single_location_description.of_simple_location_description
+               (Dwarf_reg_locations.reg_location_description arg ~offset:None
+                  ~need_rvalue:false)) ]
+      in
+      let tag : Dwarf_tag.t =
+        match !Dwarf_flags.gdwarf_version with
+        | Four -> Dwarf_4 GNU_call_site_parameter
+        | Five -> Call_site_parameter
+      in
+      (* We don't give the name of the parameter since it is complicated to
+         calculate (and there is currently insufficient information to perform
+         the calculation if the callee is in a different compilation unit). *)
+      Proto_die.create_ignore ~sort_priority:arg_index
+        ~parent:(Some call_site_die) ~tag
+        ~attribute_values:(location_attribute @ value_attribute)
+        ())
+
+let add_call_site state ~function_proto_die ~(insn : L.instruction)
+    ~return_label ~return_label_offset_in_bytes ~is_tail ~target_attributes
+    ~(args : Reg.t array) ~entry_available ~stack_offset ~fun_contains_calls
+    ~fun_num_stack_slots =
+  let position_attributes =
+    (* The innermost item of the debuginfo gives the source location of the call
+       itself. *)
+    match List.rev (Debuginfo.to_items insn.dbg) with
+    | [] -> []
+    | { dinfo_file; dinfo_line; dinfo_char_start; _ } :: _ ->
+      [DAH.create_call_file (DS.get_file_num state dinfo_file)]
+      @ (if dinfo_line >= 0 then [DAH.create_call_line dinfo_line] else [])
+      @
+      if dinfo_char_start >= 0
+      then [DAH.create_call_column dinfo_char_start]
+      else []
+  in
+  let pc_attributes =
+    let return_label = Asm_label.create_int Text (Label.to_int return_label) in
+    match !Dwarf_flags.gdwarf_version, return_label_offset_in_bytes with
+    | Four, 0 ->
+      (* In DWARF-4 (GNU extension) call sites, [DW_AT_low_pc] gives the return
+         address. *)
+      [DAH.create_low_pc return_label]
+    | Four, offset ->
+      [ DAH.create_low_pc_with_offset return_label
+          ~offset_in_bytes:(Targetint.of_int_exn offset) ]
+    | Five, 0 -> [DAH.create_call_return_pc return_label]
+    | Five, offset ->
+      [ DAH.create_call_return_pc_with_offset return_label
+          ~offset_in_bytes:(Targetint.of_int_exn offset) ]
+  in
+  let tail_call_attributes =
+    (* The attribute is omitted for non-tail calls, which is interpreted as a
+       value of false. *)
+    if is_tail then [DAH.create_call_tail_call ~is_tail] else []
+  in
+  let tag : Dwarf_tag.t =
+    match !Dwarf_flags.gdwarf_version with
+    | Four -> Dwarf_4 GNU_call_site
+    | Five -> Call_site
+  in
+  let call_site_die =
+    Proto_die.create ~parent:(Some function_proto_die) ~tag
+      ~attribute_values:
+        (target_attributes @ position_attributes @ pc_attributes
+       @ tail_call_attributes)
+      ()
+  in
+  Array.iteri
+    (fun arg_index arg ->
+      add_call_site_parameter ~call_site_die ~arg_index ~arg
+        ~available_before:insn.available_before ~entry_available ~is_tail
+        ~stack_offset ~fun_contains_calls ~fun_num_stack_slots)
+    args
+
+let callee_attributes_from_symbol state ~fun_symbol ~demangled_name =
+  let die_symbol =
+    match
+      Asm_symbol.Tbl.find (DS.function_abstract_instances state) fun_symbol
+    with
+    | _proto_die, die_symbol -> die_symbol
+    | exception Not_found ->
+      (* The callee may be in another compilation unit (or indeed not be an
+         OCaml function at all), or merely not yet seen in this unit; in the
+         latter case the DIE created here will be completed when the definition
+         of the callee is encountered. *)
+      let _proto_die, die_symbol =
+        Dwarf_abstract_instances.add_empty state
+          ~compilation_unit_proto_die:(DS.compilation_unit_proto_die state)
+          ~fun_symbol ~demangled_name
+      in
+      die_symbol
+  in
+  [DAH.create_call_origin ~die_symbol]
+
+let direct_callee_attributes state ~(callee : Cmm.symbol) =
+  callee_attributes_from_symbol state
+    ~fun_symbol:(Asm_symbol.create_global callee.sym_name)
+    ~demangled_name:callee.sym_name
+
+let external_callee_attributes state ~func =
+  callee_attributes_from_symbol state
+    ~fun_symbol:(Asm_symbol.create_global func)
+    ~demangled_name:func
+
+let indirect_callee_attributes ~(callee : Reg.t) ~(args : Reg.t array)
+    ~(available_before : Reg_availability_set.t) ~entry_available ~is_tail
+    ~stack_offset ~fun_contains_calls ~fun_num_stack_slots =
+  let closure_rvalue =
+    (* The code pointer for an OCaml indirect call lies within the closure (more
+       precisely the function slot), which is passed as the final argument. If
+       the closure is statically allocated (a symbol), has a spilled copy
+       surviving the call, or is a parameter of the function being compiled
+       (whose value may be described as the entry value of the register in which
+       it arrived), then the code pointer can be recomputed by the debugger in
+       the context of the caller's frame even after the call. This permits the
+       use of [DW_AT_call_target] rather than the "clobbered" variant: debuggers
+       cannot identify callees, in particular when resolving entry values during
+       virtual unwinding, from clobbered target expressions. (Spilled copies are
+       not usable for tail calls, whose frames no longer exist by the time the
+       callee executes; statically-allocated closures and entry values are
+       always usable.) *)
+    if Array.length args < 1
+    then None
+    else
+      match available_before with
+      | Unreachable -> None
+      | Ok avail -> (
+        let closure = args.(Array.length args - 1) in
+        match closure.loc with
+        | Stack _ | Unknown -> None
+        | Reg _ -> (
+          match
+            RD.Set_distinguishing_names_and_locations
+            .find_reg_with_same_location_exn avail closure
+          with
+          | exception Not_found -> None
+          | rd -> (
+            match RD.debug_info rd with
+            | None -> None
+            | Some debug_info ->
+              (* In particular this describes the function slot of a partial
+                 application invoked by a tail call: it is itself a projection
+                 (a field of the wrapper's closure), and so the callee can be
+                 identified rather than left "clobbered". *)
+              rvalue_of_holds_value_of
+                (RD.Debug_info.holds_value_of debug_info)
+                ~reg_for_spilled:(Some closure) ~avail ~entry_available ~is_tail
+                ~stack_offset ~fun_contains_calls ~fun_num_stack_slots)))
+  in
+  match closure_rvalue with
+  | Some closure ->
+    (* The code pointer that an [Lcall_ind] branches to was loaded from a fixed
+       field of the function slot, chosen when the call was compiled: field 0
+       for single-argument calls (generic applications of one argument, see
+       [Cmm_helpers.apply_or_call_caml_apply], and full applications of
+       single-parameter functions, see [Cmm_helpers.indirect_full_call]); field
+       2 for full applications passing more than one argument
+       ([Cmm_helpers.indirect_full_call], and likewise the [caml_applyN] inline
+       fast path, whose arity guard ensures full application). Generic
+       applications of more than one argument, including overapplications, are
+       direct calls to [caml_applyN] and do not arise here. The closure
+       information word must not be consulted instead: at a field-0 call site
+       the closure may be of any arity (for example a partial application
+       entering [caml_curryN], or a tupled function, whose arity is encoded
+       negatively), yet field 0 is still the code pointer that was called. CR
+       mshinwell: the field selection in [Cmm_helpers.indirect_full_call] and
+       the function slot layout key on the number of source parameters (see
+       [args_ty] in [To_cmm_expr.translate_apply0] and
+       [To_cmm_set_of_closures.get_func_decl_params_arity]), whereas machine
+       arguments are counted here. These differ only for known-arity indirect
+       full applications of functions whose single parameter is unarized to
+       multiple machine registers (an unboxed product): field 2 is selected here
+       where the call site loaded field 0. Fixing this would require propagating
+       the field index from Cmm to Linear. The consequence is only that the
+       debugger will fail to identify the callee for such call sites. *)
+    let num_value_args = Array.length args - 1 in
+    let field = if num_value_args <= 1 then 0 else 2 in
+    [ DAH.create_call_target
+        (Single_location_description.of_simple_location_description
+           (SLDL.compile
+              (SLDL.of_rvalue
+                 (SLDL.Rvalue.read_field_unguarded ~block:closure
+                    ~field:(Targetint.of_int_exn field))))) ]
+  | None -> (
+    match callee.loc with
+    | Reg _ ->
+      (* The register holding the callee's address is clobbered by the call
+         itself (hence "clobbered" in the attribute name). *)
+      [ DAH.create_call_target_clobbered
+          (Single_location_description.of_simple_location_description
+             (Dwarf_reg_locations.reg_location_description callee ~offset:None
+                ~need_rvalue:false)) ]
+    | Stack _ | Unknown -> [])
+
+(* Insert a label immediately after [insn] (which the emitter will define at the
+   return address of the call) and return it. *)
+let insert_label_after (insn : L.instruction) =
+  let label = Cmm.new_label () in
+  let label_insn : L.instruction =
+    { desc = L.Llabel { label; section_name = None };
+      next = insn.next;
+      arg = [||];
+      res = [||];
+      dbg = insn.dbg;
+      fdo = insn.fdo;
+      live = insn.live;
+      available_before = insn.available_before;
+      available_across = insn.available_across;
+      phantom_available_before = insn.phantom_available_before
+    }
+  in
+  insn.next <- label_insn;
+  label
+
+let dwarf state (fundecl : L.fundecl) ~function_proto_die =
+  let fun_contains_calls = fundecl.fun_contains_calls in
+  let fun_num_stack_slots = fundecl.fun_num_stack_slots in
+  (* The availability set at the function's entry point, which determines the
+     registers in which the function's parameters arrived (see
+     [entry_value_rvalue] above). The registers are not associated with the
+     parameters until the [Name_for_debugger] operations at the start of the
+     function's body have been processed, so the availability set is taken from
+     just after any such leading operations (at which point no register has yet
+     been modified). *)
+  let entry_available =
+    let rec after_leading_naming_ops (insn : L.instruction) =
+      match insn.desc with
+      | Lprologue | Llabel _ | Lop (Name_for_debugger _) ->
+        after_leading_naming_ops insn.next
+      | _ -> insn.available_before
+    in
+    after_leading_naming_ops fundecl.fun_body
+  in
+  let described_a_call_site = ref false in
+  let add_call_site insn ~return_label ?(return_label_offset_in_bytes = 0)
+      ?(is_tail = false) ~target_attributes ~args ~stack_offset () =
+    described_a_call_site := true;
+    add_call_site state ~function_proto_die ~insn ~return_label
+      ~return_label_offset_in_bytes ~is_tail ~target_attributes ~args
+      ~entry_available ~stack_offset ~fun_contains_calls ~fun_num_stack_slots
+  in
+  let rec traverse (insn : L.instruction) ~stack_offset =
+    match insn.desc with
+    | Lend -> ()
+    | Lcall_op call_op ->
+      (match call_op with
+      | Lcall_ind ->
+        let callee = insn.arg.(0) in
+        let args = Array.sub insn.arg 1 (Array.length insn.arg - 1) in
+        let return_label = insert_label_after insn in
+        add_call_site insn ~return_label
+          ~target_attributes:
+            (indirect_callee_attributes ~callee ~args
+               ~available_before:insn.available_before ~entry_available
+               ~is_tail:false ~stack_offset ~fun_contains_calls
+               ~fun_num_stack_slots)
+          ~args ~stack_offset ()
+      | Lcall_imm { func } ->
+        let return_label = insert_label_after insn in
+        add_call_site insn ~return_label
+          ~target_attributes:(direct_callee_attributes state ~callee:func)
+          ~args:insn.arg ~stack_offset ()
+      (* For tail calls, parameter values are described using constants and
+         chained entry values; likewise the targets of indirect tail calls (see
+         [call_site_value_attribute] and [indirect_callee_attributes] above). *)
+      | Ltailcall_ind ->
+        let callee = insn.arg.(0) in
+        let args = Array.sub insn.arg 1 (Array.length insn.arg - 1) in
+        let return_label = insert_label_after insn in
+        add_call_site insn ~return_label ~is_tail:true
+          ~target_attributes:
+            (indirect_callee_attributes ~callee ~args
+               ~available_before:insn.available_before ~entry_available
+               ~is_tail:true ~stack_offset ~fun_contains_calls
+               ~fun_num_stack_slots)
+          ~args ~stack_offset ()
+      | Ltailcall_imm { func } ->
+        (* Call site entries are not generated for self tail calls ("tail
+           recursion calls"); see DWARF-5 spec section 3.4.1, page 89, lines
+           19--22. *)
+        if not (String.equal func.sym_name fundecl.fun_name)
+        then
+          let return_label = insert_label_after insn in
+          add_call_site insn ~return_label ~is_tail:true
+            ~target_attributes:(direct_callee_attributes state ~callee:func)
+            ~args:insn.arg ~stack_offset ()
+      | Lextcall { func; alloc; stack_ofs; _ } -> (
+        (* The emitter may generate instructions after the actual call
+           instruction within the sequence for an [Lextcall], in which case the
+           label inserted after the Linear instruction does not lie at the
+           return address; compensate accordingly. *)
+        match Proc.extcall_code_size_after_return_address ~alloc ~stack_ofs with
+        | None -> ()
+        | Some code_size_after_return_address ->
+          let return_label = insert_label_after insn in
+          add_call_site insn ~return_label
+            ~return_label_offset_in_bytes:(-code_size_after_return_address)
+            ~target_attributes:(external_callee_attributes state ~func)
+            ~args:insn.arg ~stack_offset ())
+      | Lprobe _ -> ());
+      traverse insn.next ~stack_offset
+    | Lop op ->
+      let stack_offset =
+        match op with
+        | Stackoffset delta -> stack_offset + delta
+        | _ -> stack_offset
+      in
+      traverse insn.next ~stack_offset
+    | Lpushtrap _ ->
+      traverse insn.next
+        ~stack_offset:(stack_offset + Proc.trap_frame_size_in_bytes)
+    | Lpoptrap _ ->
+      traverse insn.next
+        ~stack_offset:(stack_offset - Proc.trap_frame_size_in_bytes)
+    | Ladjust_stack_offset { delta_bytes } ->
+      traverse insn.next ~stack_offset:(stack_offset + delta_bytes)
+    | Lprologue | Lepilogue_open | Lepilogue_close | Lreloadretaddr | Lreturn
+    | Llabel _ | Lbranch _ | Lcondbranch _ | Lcondbranch3 _ | Lswitch _
+    | Lentertrap | Lraise _ | Lstackcheck _ ->
+      traverse insn.next ~stack_offset
+  in
+  traverse fundecl.fun_body ~stack_offset:0;
+  (* Strictly speaking the "all calls" attribute asserts that every call in the
+     function has a call site entry (DWARF-5 spec section 3.3.1.6), which is not
+     currently the case here: probes, self tail calls and, on architectures
+     where [Proc.extcall_code_size_after_return_address] returns [None],
+     external calls are not described. However LLDB will not parse the call site
+     entries of a function at all unless its subprogram DIE carries this
+     attribute (see [SymbolFileDWARF::CollectCallEdges]), so it is set whenever
+     any call site entry exists. *)
+  if !described_a_call_site
+  then
+    Proto_die.add_or_replace_attribute_value function_proto_die
+      (DAH.create_call_all_calls ())

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_call_sites.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_call_sites.mli
@@ -1,0 +1,30 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Mark Shinwell, Jane Street Europe                     *)
+(*                                                                        *)
+(*   Copyright 2013--2025 Jane Street Group LLC                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Emission of DWARF call site information ([DW_TAG_call_site] and
+    [DW_TAG_call_site_parameter], or their pre-DWARF-5 GNU equivalents).
+    Debuggers use this information to construct call graph edges for optimized
+    code and to recover the values of function parameters by virtual unwinding
+    (DWARF "entry values").
+
+    Note that this function inserts labels into the body of [fundecl] (after
+    call instructions) so that return addresses may be referenced from the DWARF
+    information. It must therefore be called after the available-ranges
+    computations (which renumber labels) and prior to emission of the function's
+    code. *)
+
+open! Dwarf_high
+
+val dwarf :
+  Dwarf_state.t -> Linear.fundecl -> function_proto_die:Proto_die.t -> unit

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -124,6 +124,13 @@ let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
           ~function_proto_die:concrete_instance_proto_die ~proto_dies_for_vars
           ~vars_at_entry ~fun_end_label available_ranges_all_vars)
       ~accumulate:true ());
+  if not !Dwarf_flags.restrict_to_upstream_dwarf
+  then
+    Profile.record "dwarf_call_sites"
+      (fun () ->
+        Dwarf_call_sites.dwarf state fundecl
+          ~function_proto_die:concrete_instance_proto_die)
+      ~accumulate:true ();
   (* CR mshinwell: When cross-referencing of DIEs across files is necessary we
      need to be careful about symbol table size. let name = Printf.sprintf
      "__concrete_instance_%s" fun_name in Proto_die.set_name

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_concrete_instances.ml
@@ -111,6 +111,13 @@ let for_fundecl ~get_file_id ~value_type_proto_die state (fundecl : L.fundecl)
           ~function_symbol:start_sym
           ~function_proto_die:concrete_instance_proto_die available_ranges_vars)
       ~accumulate:true ());
+  if not !Clflags.restrict_to_upstream_dwarf
+  then
+    Profile.record "dwarf_call_sites"
+      (fun () ->
+        Dwarf_call_sites.dwarf state fundecl
+          ~function_proto_die:concrete_instance_proto_die)
+      ~accumulate:true ();
   (* CR mshinwell: When cross-referencing of DIEs across files is necessary we
      need to be careful about symbol table size. let name = Printf.sprintf
      "__concrete_instance_%s" fun_name in Proto_die.set_name

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_reg_locations.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_reg_locations.ml
@@ -74,3 +74,19 @@ let reg_location_description (reg : Reg.t) ~(offset : Stack_reg_offset.t option)
                  ~domainstate_ptr_dwarf_register_number)))
   in
   SLDL.compile sldl
+
+let address_of_cmm_symbol_rvalue (sym : Cmm.symbol) =
+  match sym.sym_global with
+  | Global ->
+    SLDL.Rvalue.const_symbol (Asm_targets.Asm_symbol.create_global sym.sym_name)
+  | Local ->
+    (* Local symbols are defined as assembler-temporary labels rather than
+       linker symbols, and must be referenced as such. (In particular, any
+       relocation against such a symbol arising in a debug section would never
+       be applied: the symbol is absent from the object file's symbol table, and
+       on macOS the linker does not process debug sections in any event.) The
+       assembler resolves label references itself, causing the relevant
+       addresses to be quoted directly in the DWARF. *)
+    SLDL.Rvalue.address_of_label
+      (Asm_targets.Asm_label.create_label_for_local_symbol Data
+         (Asm_targets.Asm_symbol.create_local sym.sym_name))

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_reg_locations.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_reg_locations.mli
@@ -14,6 +14,7 @@
 
 (** Construction of DWARF location descriptions for registers. *)
 
+open! Dwarf_high
 open! Dwarf_low
 
 val reg_location_description :
@@ -21,3 +22,12 @@ val reg_location_description :
   offset:Stack_reg_offset.t option ->
   need_rvalue:bool ->
   Simple_location_description.t
+
+(** An rvalue whose value is the address of the given symbol, referencing the
+    symbol in the manner required by its visibility. (In particular, local
+    symbols are defined as assembler-temporary labels, not linker symbols, and
+    must be referenced as such.) *)
+val address_of_cmm_symbol_rvalue :
+  Cmm.symbol ->
+  Simple_location_description_lang.normal
+  Simple_location_description_lang.rvalue

--- a/backend/proc.mli
+++ b/backend/proc.mli
@@ -109,6 +109,16 @@ val stack_ptr_dwarf_register_number : int
 (** The DWARF register number corresponding to the domainstate pointer. *)
 val domainstate_ptr_dwarf_register_number : int
 
+(** For an external call ([Linear.Lextcall]), the number of bytes of machine
+    code that the emitter generates after the return address of the actual call
+    instruction within the sequence emitted for the external call. (In other
+    words, how many bytes must be subtracted from the address of the instruction
+    following the sequence in order to obtain the return address.) Returns
+    [None] if this is not known for the current architecture, in which case
+    DWARF call site information will not be generated for external calls. *)
+val extcall_code_size_after_return_address :
+  alloc:bool -> stack_ofs:int -> int option
+
 (* Calling the assembler *)
 val assemble_file : string -> string -> int
 

--- a/dune
+++ b/dune
@@ -712,6 +712,7 @@
   ;; build it as part of that library.
   dwarf
   dwarf_abstract_instances
+  dwarf_call_sites
   dwarf_compilation_unit
   dwarf_concrete_instances
   dwarf_inlined_frames

--- a/dune
+++ b/dune
@@ -725,6 +725,7 @@
   ;; build it as part of that library.
   dwarf
   dwarf_abstract_instances
+  dwarf_call_sites
   dwarf_compilation_unit
   dwarf_concrete_instances
   dwarf_inlined_frames


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

Stacked on #6521: this PR targets that branch, so the diff shown is exactly this PR's own changes.

## Description

New `Dwarf_call_sites` pass (~650 lines) walking Linear bodies matching `Lcall_op` variants while tracking the stack offset, emitting `DW_TAG_call_site` / `DW_TAG_call_site_parameter` DIEs (GNU variants for DWARF-4), with `DW_AT_call_return_pc` labels inserted after call instructions (`insert_label_after`) and `DW_AT_call_all_calls` on the function DIE.

Argument values are recovered via `Reg_with_debug_info.Holds_value_of` (#6518): constants, spilled copies, entry values (#6521 machinery) and projections such as closure value slots — letting debuggers reconstruct a callee's parameter values by virtual unwinding.

New `Proc.extcall_code_size_after_return_address` describes how many bytes the emitter places after an external call's return address:

- **arm64**: implemented, kept in sync with the `Lextcall` case of `emit_instr` in `emit.ml`.
- **amd64**: returns `None` (with a CR) — **extcall call sites are silently absent on amd64 for now** (variable-length instructions make this more delicate).

## Review flags

- A substantial `CR mshinwell` discusses function-slot field-0 vs field-2 callee identification.
- Self tail calls are skipped.
- The amd64 extcall gap above.

## Verification

- `make -s boot-compiler` passes; `make -s fmt` clean.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information ← **this PR**
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



