### PR TITLE
Add DWARF entry-value operators

### DIFF
--- a/backend/debug/dwarf/dwarf_high/operator_builder.ml
+++ b/backend/debug/dwarf/dwarf_high/operator_builder.ml
@@ -148,6 +148,14 @@ let implicit_pointer ~offset_in_bytes ~die_label dwarf_version : O.t =
   then DW_op_GNU_implicit_pointer { offset_in_bytes; label = die_label }
   else DW_op_implicit_pointer { offset_in_bytes; label = die_label }
 
+let entry_value_of_register ~dwarf_reg_number dwarf_version : O.t =
+  (* The block operand always consists of a single register location
+     description, built with the standard machinery. *)
+  let block = [register_as_lvalue ~dwarf_reg_number] in
+  if Dwarf_version.compare dwarf_version Dwarf_version.five >= 0
+  then DW_op_entry_value { block }
+  else DW_op_GNU_entry_value { block }
+
 let call ~die_label ~compilation_unit_header_label : O.t =
   DW_op_call4 { label = die_label; compilation_unit_header_label }
 

--- a/backend/debug/dwarf/dwarf_high/operator_builder.mli
+++ b/backend/debug/dwarf/dwarf_high/operator_builder.mli
@@ -59,6 +59,9 @@ val implicit_pointer :
   Dwarf_version.t ->
   Dwarf_operator.t
 
+val entry_value_of_register :
+  dwarf_reg_number:int -> Dwarf_version.t -> Dwarf_operator.t
+
 val call :
   die_label:Asm_label.t ->
   compilation_unit_header_label:Asm_label.t ->

--- a/backend/debug/dwarf/dwarf_high/simple_location_description_lang.ml
+++ b/backend/debug/dwarf/dwarf_high/simple_location_description_lang.ml
@@ -179,6 +179,9 @@ module Rvalue = struct
   let location_from_another_die ~die_label ~compilation_unit_header_label =
     [OB.call ~die_label ~compilation_unit_header_label]
 
+  let entry_value_of_register ~dwarf_reg_number dwarf_version =
+    [OB.entry_value_of_register ~dwarf_reg_number dwarf_version]
+
   let implicit_pointer ~offset_in_bytes ~die_label dwarf_version =
     [OB.implicit_pointer ~offset_in_bytes ~die_label dwarf_version]
 end

--- a/backend/debug/dwarf/dwarf_high/simple_location_description_lang.mli
+++ b/backend/debug/dwarf/dwarf_high/simple_location_description_lang.mli
@@ -179,6 +179,12 @@ module Rvalue : sig
     compilation_unit_header_label:Asm_label.t ->
     normal t
 
+  (** V is the value that the given register held upon entry to the current
+      function. The debugger recovers such values by virtually unwinding to the
+      call site. *)
+  val entry_value_of_register :
+    dwarf_reg_number:int -> Dwarf_version.t -> normal t
+
   (** V is an optimized-out pointer to a value whose contents are given by
       evaluating the location description (which must yield an rvalue) in the
       DIE at the given [die_label].

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
@@ -210,6 +210,8 @@ type t =
       { label : Asm_label.t;
         offset_in_bytes : Targetint.t
       }
+  | DW_op_entry_value of { block : t list }
+  | DW_op_GNU_entry_value of { block : t list }
 
 let opcode_name t =
   match t with
@@ -369,6 +371,8 @@ let opcode_name t =
   | DW_op_bit_piece _ -> "DW_op_bit_piece"
   | DW_op_implicit_pointer _ -> "DW_op_implicit_pointer"
   | DW_op_GNU_implicit_pointer _ -> "DW_op_GNU_implicit_pointer"
+  | DW_op_entry_value _ -> "DW_op_entry_value"
+  | DW_op_GNU_entry_value _ -> "DW_op_GNU_entry_value"
 
 (* DWARF-4 spec section 7.7.1. *)
 let opcode = function
@@ -528,6 +532,8 @@ let opcode = function
   | DW_op_bit_piece _ -> 0x9d
   | DW_op_implicit_pointer _ -> 0xa0
   | DW_op_GNU_implicit_pointer _ -> 0xf2
+  | DW_op_entry_value _ -> 0xa3
+  | DW_op_GNU_entry_value _ -> 0xf3
 
 external caml_string_set32 : bytes -> index:int -> Int32.t -> unit
   = "%caml_string_set32"
@@ -555,7 +561,7 @@ struct
      front. It is passed as an argument because [size], from which it is built,
      is itself defined in terms of this traversal (see the bottom of this
      file). *)
-  let run ~size_of_expression:_ param t =
+  let rec run ~size_of_expression param t =
     let unit_result = M.unit_result () in
     let opcode = M.opcode param in
     let value = M.value param in
@@ -722,6 +728,15 @@ struct
       let offset_in_bytes = Targetint.to_int64 offset_in_bytes in
       value (V.offset_into_debug_info label) >>> fun () ->
       value (V.sleb128 ~comment:"offset in bytes" offset_in_bytes)
+    | DW_op_entry_value { block } | DW_op_GNU_entry_value { block } ->
+      (* The operand is a ULEB128-length-prefixed block holding a DWARF
+         expression. The operators in the block are printed, sized and emitted
+         using the normal machinery, via the recursive calls to [run]. *)
+      let block_size = size_of_expression block in
+      List.fold_left
+        (fun acc op -> acc >>> fun () -> run ~size_of_expression param op)
+        (value (V.uleb128 ~comment:"block length" (I.to_uint64_exn block_size)))
+        block
 end
 
 module Print = Make (struct

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
@@ -206,6 +206,14 @@ type t =
       { label : Asm_label.t;
         offset_in_bytes : Targetint.t
       }
+  | DW_op_entry_value of { block : t list }
+      (** The DWARF-5 [DW_OP_entry_value] operator. The operand is a block
+          holding a DWARF expression; in the typical case where that expression
+          is a single register location description, the value pushed is the
+          value the given register held upon entry to the current function. *)
+  | DW_op_GNU_entry_value of { block : t list }
+      (** As for [DW_op_entry_value], but using the pre-DWARF-5 GNU extension
+          opcode. *)
 
 val print : Format.formatter -> t -> unit
 

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
@@ -207,10 +207,11 @@ type t =
         offset_in_bytes : Targetint.t
       }
   | DW_op_entry_value of { block : t list }
-      (** The DWARF-5 [DW_OP_entry_value] operator. The operand is a block
-          holding a DWARF expression; in the typical case where that expression
-          is a single register location description, the value pushed is the
-          value the given register held upon entry to the current function. *)
+      (** The DWARF-5 [DW_OP_entry_value] operator. The block operand holds a
+          DWARF expression describing a location (for example a register
+          location description). The operator pushes the value that this
+          location held upon entry to the current function; debuggers typically
+          recover such values by virtually unwinding to the call site. *)
   | DW_op_GNU_entry_value of { block : t list }
       (** As for [DW_op_entry_value], but using the pre-DWARF-5 GNU extension
           opcode. *)


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

Stacked on #6527 (which is in turn stacked on #6505): this PR targets that branch, so the diff shown is exactly this PR's own changes. It was split out of #6505 so that the entry-value machinery can be reviewed separately.

## Description

New operators `DW_op_entry_value` (DWARF-5, opcode 0xa3) and `DW_op_GNU_entry_value` (0xf3, the pre-DWARF-5 GNU extension). The operand is a ULEB128-length-prefixed block holding a DWARF expression, represented as a list of `Dwarf_operator.t` and printed, sized and emitted via the normal operator machinery (the generic traversal recurses into the block).

- The block's ULEB128 length prefix is computed with `Dwarf_operator.size_of_expression`, whose machinery (including its threading into the traversal) was added by #6527 — so this PR is purely additive: the new constructors, their traversal case, and the builders. Arbitrary expressions are supported in blocks.
- `Operator_builder.entry_value_of_register` builds the block with the existing `register_as_lvalue` and dispatches on the DWARF version.
- The location description language gains `Rvalue.entry_value_of_register`.

The block operand holds a DWARF expression describing a location; the operator pushes the value that this location held upon entry to the current function, which the debugger recovers by virtually unwinding to the call site. The form emitted by this series is always a single register location description.

Target-agnostic and behaviour-neutral: the new operators are unused until the DWARF variable/parameter emission (#6521) and call-site (#6522) PRs later in the series.

## Verification

- `make -s boot-compiler` passes; `make -s fmt` clean.
- Split out of #6505 (and the general size function subsequently split into #6527); the emission was reworked to build the block operand using the existing operator machinery rather than hand-encoded bytes.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression
5. #6525 — Add DWARF entry-value operators ← **this PR**
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)








