### PR TITLE
Only link relevant compilation units in the dissector

### DIFF
--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -284,6 +284,7 @@ let call_linker ?dissector_args file_list_rev startup_file output_name =
       Build_linker_args.object_files args @ linker_flags, c_lib
     | None ->
       (* Normal mode: combine startup + ml_objfiles + ccobjs + runtime_lib *)
+      let file_list_rev = List.map (fun f -> f.Linkenv.path) file_list_rev in
       let file_list_rev =
         if !Oxcaml_flags.use_cached_generic_functions
         then !Oxcaml_flags.cached_generic_functions_path :: file_list_rev
@@ -397,6 +398,11 @@ let call_linker ?dissector_args file_list_rev startup_file output_name =
 
 (* Main entry point *)
 
+let entry_symbols units =
+  List.map
+    (fun compilation_unit -> Cmm_helpers.entry_symbol_name ~compilation_unit ())
+    units
+
 let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports
     ~genfns ~units_tolink ~uses_eval ~quoted_cmi ~quoted_cmx ~ppf_dump : unit =
   if !Oxcaml_flags.internal_assembler
@@ -423,7 +429,8 @@ let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports
   let ml_objfiles =
     match bundled_cm_obj with
     | None -> ml_objfiles
-    | Some bundled_cm_obj -> bundled_cm_obj :: ml_objfiles
+    | Some bundled_cm_obj ->
+      { Linkenv.path = bundled_cm_obj; units = [] } :: ml_objfiles
   in
   Asmgen.compile_unit unix ~output_prefix:output_name ~asm_filename:startup
     ~keep_asm:!Clflags.keep_startup_file ~obj_filename:startup_obj
@@ -443,11 +450,16 @@ let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports
         else None
       in
       let temp_dir = mk_temp_dir "camldissector" "" in
+      let ml_objfiles_with_symbols =
+        List.map
+          (fun { Linkenv.path; units } -> path, entry_symbols units)
+          ml_objfiles
+      in
       let result =
         Profile.record_call "dissector" (fun () ->
-            Dissector.run ~unix ~temp_dir ~ml_objfiles ~startup_obj
-              ~ccobjs:(List.rev !Clflags.ccobjs) ~runtime_libs:(runtime_lib ())
-              ~cached_genfns)
+            Dissector.run ~unix ~temp_dir ~ml_objfiles:ml_objfiles_with_symbols
+              ~startup_obj ~ccobjs:(List.rev !Clflags.ccobjs)
+              ~runtime_libs:(runtime_lib ()) ~cached_genfns)
       in
       let linker_args = Build_linker_args.build result in
       (* Add EH frame registration object if the dissector generated one. This

--- a/asmcomp/asmlink.ml
+++ b/asmcomp/asmlink.ml
@@ -400,7 +400,9 @@ let call_linker ?dissector_args file_list_rev startup_file output_name =
 
 let entry_symbols units =
   List.map
-    (fun compilation_unit -> Cmm_helpers.entry_symbol_name ~compilation_unit ())
+    (fun compilation_unit ->
+      Cmm_helpers.entry_symbol_name ~compilation_unit ()
+      |> Asm_targets.Asm_symbol.create_global)
     units
 
 let link_actual unix linkenv ml_objfiles output_name ~cached_genfns_imports

--- a/asmcomp/asmlink.mli
+++ b/asmcomp/asmlink.mli
@@ -21,7 +21,7 @@ open Format
 val link :
   (module Compiler_owee.Unix_intf.S) ->
   Linkenv.t ->
-  string list ->
+  Linkenv.objfile_to_link list ->
   string ->
   cached_genfns_imports:Generic_fns.Partition.Set.t ->
   genfns:Generic_fns.Tbl.t ->

--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -122,10 +122,27 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
      ELF64 files and uses int64 arithmetic extensively. *)
   if Sys.word_size <> 64
   then Misc.fatal_error "The dissector requires a 64-bit host architecture";
+  (* An archive contributes only the members of required compilation units to
+     the link (unlike plain object files, which are always linked wholly); skip
+     archives that contribute none. *)
+  let ml_objfiles =
+    List.filter
+      (fun (file, required_symbols) ->
+        match required_symbols with
+        | _ :: _ -> true
+        | [] ->
+          let is_archive = Filename.check_suffix file ".a" in
+          if is_archive
+          then log "skipping archive with no required units: %s" file;
+          not is_archive)
+      ml_objfiles
+  in
   (* Collect files to analyze for partitioning. C stubs and runtime libraries
      are passthrough (passed directly to final linker, not partially linked). *)
   let files_to_measure =
-    List.map (fun f -> f, MOF.OCaml) ml_objfiles
+    List.map
+      (fun (file, required_symbols) -> file, MOF.OCaml { required_symbols })
+      ml_objfiles
     @ [startup_obj, MOF.Startup]
     @ match cached_genfns with None -> [] | Some f -> [f, MOF.Cached_genfns]
   in

--- a/asmcomp/dissector/dissector.ml
+++ b/asmcomp/dissector/dissector.ml
@@ -122,21 +122,6 @@ let run ~(unix : (module Compiler_owee.Unix_intf.S)) ~temp_dir ~ml_objfiles
      ELF64 files and uses int64 arithmetic extensively. *)
   if Sys.word_size <> 64
   then Misc.fatal_error "The dissector requires a 64-bit host architecture";
-  (* An archive contributes only the members of required compilation units to
-     the link (unlike plain object files, which are always linked wholly); skip
-     archives that contribute none. *)
-  let ml_objfiles =
-    List.filter
-      (fun (file, required_symbols) ->
-        match required_symbols with
-        | _ :: _ -> true
-        | [] ->
-          let is_archive = Filename.check_suffix file ".a" in
-          if is_archive
-          then log "skipping archive with no required units: %s" file;
-          not is_archive)
-      ml_objfiles
-  in
   (* Collect files to analyze for partitioning. C stubs and runtime libraries
      are passthrough (passed directly to final linker, not partially linked). *)
   let files_to_measure =

--- a/asmcomp/dissector/dissector.mli
+++ b/asmcomp/dissector/dissector.mli
@@ -86,7 +86,11 @@ end
 
     @param unix First-class Unix module for file operations
     @param temp_dir Directory for temporary and output files
-    @param ml_objfiles The OCaml object files (.o, .a derived from .cmx, .cmxa)
+    @param ml_objfiles
+      The OCaml object files (.o, .a derived from .cmx, .cmxa), each paired with
+      the entry symbols of the required compilation units it provides (see
+      {!Partial_link.link_one_partition}). Archives that provide no required
+      compilation units are skipped.
     @param startup_obj The startup object file
     @param ccobjs Extra C object files from -cclib (Clflags.ccobjs)
     @param runtime_libs Runtime libraries (from runtime_lib ())
@@ -101,7 +105,7 @@ end
 val run :
   unix:(module Compiler_owee.Unix_intf.S) ->
   temp_dir:string ->
-  ml_objfiles:string list ->
+  ml_objfiles:(string * string list) list ->
   startup_obj:string ->
   ccobjs:string list ->
   runtime_libs:string list ->

--- a/asmcomp/dissector/dissector.mli
+++ b/asmcomp/dissector/dissector.mli
@@ -105,7 +105,7 @@ end
 val run :
   unix:(module Compiler_owee.Unix_intf.S) ->
   temp_dir:string ->
-  ml_objfiles:(string * string list) list ->
+  ml_objfiles:(string * Asm_targets.Asm_symbol.t list) list ->
   startup_obj:string ->
   ccobjs:string list ->
   runtime_libs:string list ->

--- a/asmcomp/dissector/dissector.mli
+++ b/asmcomp/dissector/dissector.mli
@@ -89,8 +89,8 @@ end
     @param ml_objfiles
       The OCaml object files (.o, .a derived from .cmx, .cmxa), each paired with
       the entry symbols of the required compilation units it provides (see
-      {!Partial_link.link_one_partition}). Archives that provide no required
-      compilation units are skipped.
+      {!Partial_link.link_one_partition}). An archive contributes only the
+      members of these units to the link.
     @param startup_obj The startup object file
     @param ccobjs Extra C object files from -cclib (Clflags.ccobjs)
     @param runtime_libs Runtime libraries (from runtime_lib ())

--- a/asmcomp/dissector/measure_object_files.ml
+++ b/asmcomp/dissector/measure_object_files.ml
@@ -47,12 +47,12 @@ let () =
     | _ -> None)
 
 type file_origin =
-  | OCaml
+  | OCaml of { required_symbols : string list }
   | Startup
   | Cached_genfns
 
 let string_of_origin = function
-  | OCaml -> "OCaml"
+  | OCaml _ -> "OCaml"
   | Startup -> "Startup"
   | Cached_genfns -> "Cached_genfns"
 
@@ -107,6 +107,11 @@ module File_size = struct
   let has_probes t = t.has_probes
 
   let origin t = t.origin
+
+  let required_symbols t =
+    match t.origin with
+    | OCaml { required_symbols } -> required_symbols
+    | Startup | Cached_genfns -> []
 end
 
 let measure_files (unix : (module Compiler_owee.Unix_intf.S)) ~files =

--- a/asmcomp/dissector/measure_object_files.ml
+++ b/asmcomp/dissector/measure_object_files.ml
@@ -47,7 +47,7 @@ let () =
     | _ -> None)
 
 type file_origin =
-  | OCaml of { required_symbols : string list }
+  | OCaml of { required_symbols : Asm_targets.Asm_symbol.t list }
   | Startup
   | Cached_genfns
 

--- a/asmcomp/dissector/measure_object_files.mli
+++ b/asmcomp/dissector/measure_object_files.mli
@@ -48,7 +48,10 @@ val report_error : Format_doc.formatter -> error -> unit
     Note: Passthrough files (C stubs from -cclib, runtime libraries) are
     separated before measuring and don't use this type. *)
 type file_origin =
-  | OCaml  (** OCaml-compiled code (.o from .cmx, .a from .cmxa) *)
+  | OCaml of { required_symbols : string list }
+      (** OCaml-compiled code (.o from .cmx, .a from .cmxa), with the entry
+          symbols of the required compilation units it provides (see
+          {!Partial_link.link_one_partition}). *)
   | Startup  (** Startup object file *)
   | Cached_genfns  (** Cached generic functions *)
 
@@ -67,6 +70,10 @@ module File_size : sig
 
   (** Returns the origin of the file. *)
   val origin : t -> file_origin
+
+  (** Returns the required entry symbols of the file's origin; empty for
+      non-OCaml origins. *)
+  val required_symbols : t -> string list
 end
 
 (** [measure_files unix ~files] computes the allocated section size for each

--- a/asmcomp/dissector/measure_object_files.mli
+++ b/asmcomp/dissector/measure_object_files.mli
@@ -48,7 +48,7 @@ val report_error : Format_doc.formatter -> error -> unit
     Note: Passthrough files (C stubs from -cclib, runtime libraries) are
     separated before measuring and don't use this type. *)
 type file_origin =
-  | OCaml of { required_symbols : string list }
+  | OCaml of { required_symbols : Asm_targets.Asm_symbol.t list }
       (** OCaml-compiled code (.o from .cmx, .a from .cmxa), with the entry
           symbols of the required compilation units it provides (see
           {!Partial_link.link_one_partition}). *)
@@ -73,7 +73,7 @@ module File_size : sig
 
   (** Returns the required entry symbols of the file's origin; empty for
       non-OCaml origins. *)
-  val required_symbols : t -> string list
+  val required_symbols : t -> Asm_targets.Asm_symbol.t list
 end
 
 (** [measure_files unix ~files] computes the allocated section size for each

--- a/asmcomp/dissector/partial_link.ml
+++ b/asmcomp/dissector/partial_link.ml
@@ -56,19 +56,23 @@ let () =
 
 let write_response_file ~filename files =
   let oc = open_out filename in
+  (* The linker tokenizes the response file like a shell: whitespace separates
+     arguments, and quotes and backslashes are special. Filenames can contain
+     such characters (unit names may contain '), so they are quoted with
+     [Filename.quote], as [Ccomp.build_response_file] does. *)
   (* The -u flags must precede the files: the linker only extracts an archive
      member if its symbol is undefined when the archive is scanned, and it never
      rescans an archive. *)
   List.iter
     (fun entry ->
       List.iter
-        (fun symbol -> Printf.fprintf oc "-u %s\n" symbol)
+        (fun symbol ->
+          Printf.fprintf oc "-u %s\n" (Asm_targets.Asm_symbol.encode symbol))
         (MOF.File_size.required_symbols entry))
     files;
   List.iter
     (fun entry ->
-      output_string oc (MOF.File_size.filename entry);
-      output_char oc '\n')
+      Printf.fprintf oc "%s\n" (Filename.quote (MOF.File_size.filename entry)))
     files;
   close_out oc
 

--- a/asmcomp/dissector/partial_link.ml
+++ b/asmcomp/dissector/partial_link.ml
@@ -56,6 +56,15 @@ let () =
 
 let write_response_file ~filename files =
   let oc = open_out filename in
+  (* The -u flags must precede the files: the linker only extracts an archive
+     member if its symbol is undefined when the archive is scanned, and it never
+     rescans an archive. *)
+  List.iter
+    (fun entry ->
+      List.iter
+        (fun symbol -> Printf.fprintf oc "-u %s\n" symbol)
+        (MOF.File_size.required_symbols entry))
+    files;
   List.iter
     (fun entry ->
       output_string oc (MOF.File_size.filename entry);
@@ -130,8 +139,7 @@ end = struct
       ~partition_index ~response_file ~output_file =
     (* Config.native_pack_linker is something like "ld -r -o " *)
     let cmd =
-      Printf.sprintf "%s%s --whole-archive @%s --no-whole-archive"
-        Config.native_pack_linker
+      Printf.sprintf "%s%s @%s" Config.native_pack_linker
         (Filename.quote output_file)
         (Filename.quote response_file)
     in

--- a/asmcomp/dissector/partial_link.mli
+++ b/asmcomp/dissector/partial_link.mli
@@ -50,9 +50,15 @@ val report_error : Format_doc.formatter -> error -> unit
 (** [link_one_partition unix ~temp_dir ~partition_index partition] partially
     links [partition] into a single relocatable object file.
 
-    Creates a response file listing the input files, then invokes the linker
-    with:
-    {v   ld --whole-archive @<response_file> --relocatable -o <output.o> v}
+    Creates a response file listing -u flags for the entry symbols of the
+    partition's required compilation units, followed by the input files, then
+    invokes the linker with:
+    {v   ld @<response_file> --relocatable -o <output.o> v}
+
+    The -u flags pull exactly the required members out of archives (instead of
+    --whole-archive pulling all of them). Unlike --require-defined, which only
+    BFD ld supports, -u does not make the link fail if a required unit is
+    missing from the partition.
 
     Returns the linked partition with the path to the output .o file. Raises
     [Error] if the link fails.

--- a/asmcomp/dissector/partition_object_files.ml
+++ b/asmcomp/dissector/partition_object_files.ml
@@ -61,7 +61,7 @@ let default_partition_size =
    cross-partition references. *)
 let must_be_in_main entry =
   match MOF.File_size.origin entry with
-  | OCaml -> false
+  | OCaml _ -> false
   | Startup | Cached_genfns -> true
 
 let log fmt =

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -4492,6 +4492,12 @@ let make_symbol ?compilation_unit name =
   Symbol.for_name compilation_unit name
   |> Symbol.linkage_name |> Linkage_name.to_string
 
+(* The name of the module initialization ("entry") function of a compilation
+   unit. The definition site (To_cmm), the startup file's tables and the
+   dissector's -u linker flags must all agree on this name. *)
+let entry_symbol_name ?compilation_unit () =
+  make_symbol ?compilation_unit "entry"
+
 (* Failure function for closures that should never be called indirectly *)
 
 let fail_if_called_indirectly_function () =
@@ -4568,7 +4574,7 @@ let entry_point namelist =
     List.map
       (fun name ->
         Csymbol_address
-          (global_symbol (make_symbol ~compilation_unit:name "entry")))
+          (global_symbol (entry_symbol_name ~compilation_unit:name ())))
       namelist
   in
   let data = Cdefine_symbol table_symbol :: data in
@@ -4723,7 +4729,7 @@ let unit_deps_table units =
         let name = unit_name cu in
         let name_sym = StringMap.find name name_symbols in
         let entry_sym =
-          global_symbol (make_symbol ~compilation_unit:cu "entry")
+          global_symbol (entry_symbol_name ~compilation_unit:cu ())
         in
         let gc_roots_sym =
           global_symbol (make_symbol ~compilation_unit:cu "gc_roots")

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1163,6 +1163,12 @@ val cmm_arith_size : expression -> int option
 (* CR lmaurer: Return [Linkage_name.t] instead *)
 val make_symbol : ?compilation_unit:Compilation_unit.t -> string -> string
 
+(** Linkage name of the module initialization ("entry") function of the given
+    compilation unit (default: the current unit). The startup file references
+    this symbol for every linked unit, and the dissector passes it to the linker
+    via -u to select the required archive members. *)
+val entry_symbol_name : ?compilation_unit:Compilation_unit.t -> unit -> string
+
 val machtype_of_layout : Lambda.layout -> machtype
 
 val machtype_of_layout_changing_tagged_int_to_val : Lambda.layout -> machtype

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -1166,7 +1166,9 @@ val make_symbol : ?compilation_unit:Compilation_unit.t -> string -> string
 (** Linkage name of the module initialization ("entry") function of the given
     compilation unit (default: the current unit). The startup file references
     this symbol for every linked unit, and the dissector passes it to the linker
-    via -u to select the required archive members. *)
+    via -u to select the required archive members. Object files contain the
+    assembler-encoded form of this name (see [Asm_targets.Asm_symbol.encode]).
+*)
 val entry_symbol_name : ?compilation_unit:Compilation_unit.t -> unit -> string
 
 val machtype_of_layout : Lambda.layout -> machtype

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -130,7 +130,7 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
     then Afl_instrument.instrument_initialiser body (fun () -> dbg)
     else body
   in
-  let entry_name = Cmm_helpers.make_symbol "entry" in
+  let entry_name = Cmm_helpers.entry_symbol_name () in
   let res, entry_sym = R.raw_symbol res ~global:Global entry_name in
   let entry =
     let fun_codegen =

--- a/optcomp/linkenv.ml
+++ b/optcomp/linkenv.ml
@@ -28,6 +28,11 @@ type unit_link_info =
     dynunit : Cmxs_format.dynunit option
   }
 
+type objfile_to_link =
+  { path : string;
+    units : Compilation_unit.t list
+  }
+
 module Cmi_consistbl = Consistbl.Make (CU.Name) (Import_info.Intf.Nonalias.Kind)
 module Cmx_consistbl = Consistbl.Make (CU) (Unit)
 

--- a/optcomp/linkenv.mli
+++ b/optcomp/linkenv.mli
@@ -40,6 +40,14 @@ type unit_link_info =
     dynunit : Cmxs_format.dynunit option
   }
 
+(** An object file or archive to pass to the linker, together with the
+    compilation units it contributes to the link (for an archive, only the units
+    of its required members). *)
+type objfile_to_link =
+  { path : string;
+    units : Compilation_unit.t list
+  }
+
 (** Values of type [t] are mutable structures. *)
 type t
 

--- a/optcomp/optcomp_intf.ml
+++ b/optcomp/optcomp_intf.ml
@@ -64,7 +64,7 @@ module type Backend = sig
 
   val link :
     Linkenv.t ->
-    string list ->
+    Linkenv.objfile_to_link list ->
     string ->
     cached_genfns_imports:Generic_fns.Partition.Set.t ->
     genfns:Generic_fns.Tbl.t ->

--- a/optcomp/optlink.ml
+++ b/optcomp/optlink.ml
@@ -202,7 +202,8 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
           (Linkenv.Error
              (Requires_metaprogramming_without_flag resolved_pathname));
       ( resolved_pathname :: full_paths,
-        object_pathname :: object_pathnames,
+        { Linkenv.path = object_pathname; units = info.ui_defines }
+        :: object_pathnames,
         unit :: tolink,
         cached_genfns_imports )
     | Library (resolved_pathname, infos) ->
@@ -224,7 +225,7 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         raise
           (Linkenv.Error
              (Requires_metaprogramming_without_flag resolved_pathname));
-      let object_pathnames =
+      let object_pathnames units_of_lib =
         match
           find_companion_object_file ~requested_filename ~resolved_pathname
             ~artifact_ext:Backend.ext_flambda_lib ~object_ext:Backend.ext_lib
@@ -238,9 +239,12 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
             List.is_empty infos.lib_units
             && not (Sys.file_exists object_pathname)
           then object_pathnames
-          else object_pathname :: object_pathnames
+          else
+            let units = List.concat_map (fun u -> u.defines) units_of_lib in
+            { Linkenv.path = object_pathname; units } :: object_pathnames
         | Resolved_via_manifest_and_found_in_load_path object_pathname ->
-          object_pathname :: object_pathnames
+          let units = List.concat_map (fun u -> u.defines) units_of_lib in
+          { Linkenv.path = object_pathname; units } :: object_pathnames
         | Resolved_via_manifest_but_not_found_in_load_path object_filename ->
           (* The archive was resolved through a manifest with no entry for the
              corresponding [.a]/[.lib] file. This is only legitimate when the
@@ -255,11 +259,10 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
                     { object_filename; requested_filename }))
       in
       (* [resolved_pathname] is always returned irrespective of the
-         [object_pathnames] calculation above and the units calculation below:
-         the aim is to know the full set of files which were provided on the
-         command line. *)
-      ( resolved_pathname :: full_paths,
-        object_pathnames,
+         [object_pathnames] calculation above and the [units_of_lib] calculation
+         below: the aim is to know the full set of files which were provided on
+         the command line. *)
+      let units_of_lib =
         List.fold_right
           (fun info reqd ->
             let li_name = CU.name info.li_name in
@@ -319,7 +322,11 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
               Linkenv.check_consistency linkenv ~unit [||] [||];
               unit :: reqd)
             else reqd)
-          infos.lib_units tolink,
+          infos.lib_units []
+      in
+      ( resolved_pathname :: full_paths,
+        object_pathnames units_of_lib,
+        units_of_lib @ tolink,
         cached_genfns_imports )
 
   (* Second pass: generate the startup file and link it with everything else *)
@@ -344,8 +351,9 @@ module Make (Backend : Optcomp_intf.Backend) : S = struct
         in
         Clflags.ccobjs := !Clflags.ccobjs @ Linkenv.lib_ccobjs linkenv;
         Clflags.all_ccopts := Linkenv.lib_ccopts linkenv @ !Clflags.all_ccopts;
-        Backend.link_shared ml_objfiles output_name ~ppf_dump ~genfns
-          ~units_tolink)
+        Backend.link_shared
+          (List.map (fun f -> f.Linkenv.path) ml_objfiles)
+          output_name ~ppf_dump ~genfns ~units_tolink)
 
   (* Main entry point *)
 

--- a/oxcaml/tests/dissector/dune
+++ b/oxcaml/tests/dissector/dune
@@ -41,6 +41,16 @@
  (action (run ./generate_large_modules.exe mylib_b)))
 
 (rule
+ (target mylib_unused.ml)
+ (deps generate_large_modules.exe)
+ (action (run ./generate_large_modules.exe mylib_unused)))
+
+(rule
+ (target unusedlib.ml)
+ (deps generate_large_modules.exe)
+ (action (run ./generate_large_modules.exe unusedlib)))
+
+(rule
  (target cmxa_main.ml)
  (deps generate_large_modules.exe)
  (action (run ./generate_large_modules.exe cmxa_main)))
@@ -521,6 +531,18 @@
  (action
   (run %{bin:ocamlopt.opt} -c mylib_b.ml)))
 
+; mylib_unused is part of the archive but never referenced, so the dissector
+; must not link it into the executable
+(rule
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{architecture} "amd64")
+       (= %{system} "linux")))
+ (targets mylib_unused.cmi mylib_unused.cmx mylib_unused.o)
+ (deps mylib_unused.ml)
+ (action
+  (run %{bin:ocamlopt.opt} -c %{deps})))
+
 ; Create the .cmxa archive
 (rule
  (enabled_if
@@ -528,21 +550,47 @@
        (= %{architecture} "amd64")
        (= %{system} "linux")))
  (targets mylib.cmxa mylib.a)
- (deps mylib_a.cmx mylib_a.o mylib_b.cmx mylib_b.o)
+ (deps mylib_a.cmx mylib_a.o mylib_b.cmx mylib_b.o mylib_unused.cmx
+       mylib_unused.o)
  (action
-  (run %{bin:ocamlopt.opt} -a mylib_a.cmx mylib_b.cmx -o mylib.cmxa)))
+  (run %{bin:ocamlopt.opt} -a mylib_a.cmx mylib_b.cmx mylib_unused.cmx
+       -o mylib.cmxa)))
 
-; Link with dissector using the .cmxa archive
+; unusedlib is an archive none of whose units are referenced, so the dissector
+; must skip the whole archive
+(rule
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{architecture} "amd64")
+       (= %{system} "linux")))
+ (targets unusedlib.cmi unusedlib.cmx unusedlib.o)
+ (deps unusedlib.ml)
+ (action
+  (run %{bin:ocamlopt.opt} -c %{deps})))
+
+(rule
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{architecture} "amd64")
+       (= %{system} "linux")))
+ (targets unusedlib.cmxa unusedlib.a)
+ (deps unusedlib.cmx unusedlib.o)
+ (action
+  (run %{bin:ocamlopt.opt} -a unusedlib.cmx -o unusedlib.cmxa)))
+
+; Link with dissector using the .cmxa archives
 (rule
  (enabled_if
   (and (= %{context_name} "main")
        (= %{architecture} "amd64")
        (= %{system} "linux")))
  (target cmxa_test.exe)
- (deps mylib.cmxa mylib.a mylib_a.cmi mylib_a.cmx mylib_b.cmi mylib_b.cmx cmxa_main.ml)
+ (deps mylib.cmxa mylib.a mylib_a.cmi mylib_a.cmx mylib_b.cmi mylib_b.cmx
+       mylib_unused.cmi mylib_unused.cmx unusedlib.cmxa unusedlib.a
+       unusedlib.cmi unusedlib.cmx cmxa_main.ml)
  (action
   (run %{bin:ocamlopt.opt} -dissector -dissector-partition-size 0.005
-       mylib.cmxa cmxa_main.ml -o %{target})))
+       mylib.cmxa unusedlib.cmxa cmxa_main.ml -o %{target})))
 
 (rule
  (enabled_if
@@ -573,6 +621,22 @@
  (action (progn
   (with-stdout-to cmxa_sections.txt (run readelf -S cmxa_test.exe))
   (bash "grep -q 'caml.p1' cmxa_sections.txt || (echo 'ERROR: no multiple partitions'; exit 1)"))))
+
+; Verify the unused archive member and the unused archive were not linked into
+; cmxa_test.exe (the dissector links only the required compilation units, like
+; a normal link)
+(rule
+ (alias runtest)
+ (enabled_if
+  (and (= %{context_name} "main")
+       (= %{architecture} "amd64")
+       (= %{system} "linux")))
+ (deps cmxa_test.exe)
+ (action (progn
+  (with-stdout-to cmxa_symbols.txt (run nm cmxa_test.exe))
+  (bash "grep -q 'Mylib_a' cmxa_symbols.txt || (echo 'ERROR: Mylib_a symbols missing'; exit 1)")
+  (bash "! grep -q 'Mylib_unused' cmxa_symbols.txt || (echo 'ERROR: unused unit Mylib_unused was linked'; exit 1)")
+  (bash "! grep -q 'Unusedlib' cmxa_symbols.txt || (echo 'ERROR: unused archive Unusedlib was linked'; exit 1)"))))
 
 ; Test 4: Linker flags (-cclib) should not be treated as files
 (rule

--- a/oxcaml/tests/dissector/dune
+++ b/oxcaml/tests/dissector/dune
@@ -557,7 +557,7 @@
        -o mylib.cmxa)))
 
 ; unusedlib is an archive none of whose units are referenced, so the dissector
-; must skip the whole archive
+; must not link any of its members into the executable
 (rule
  (enabled_if
   (and (= %{context_name} "main")

--- a/oxcaml/tests/dissector/generate_large_modules.ml
+++ b/oxcaml/tests/dissector/generate_large_modules.ml
@@ -285,6 +285,24 @@ let generate_mylib_b () =
   Buffer.add_string buf (generate_functions 10001 num_functions);
   Buffer.contents buf
 
+let generate_mylib_unused () =
+  {|(* Generated mylib_unused - do not edit *)
+(* Not referenced by cmxa_main: the dissector must not link it *)
+
+let unused_marker () = 12345
+
+let unused_data = [| 1; 2; 3; 4; 5 |]
+|}
+
+let generate_unusedlib () =
+  {|(* Generated unusedlib - do not edit *)
+(* An archive whose units are all unreferenced: the dissector must skip it *)
+
+let unusedlib_marker () = 54321
+
+let unusedlib_data = [| 6; 7; 8; 9; 10 |]
+|}
+
 let generate_cmxa_main () =
   {|(* Generated cmxa main - do not edit *)
 
@@ -321,10 +339,12 @@ let () =
   | ["gen_main"] -> output_file "gen_main.ml" (generate_main ())
   | ["mylib_a"] -> output_file "mylib_a.ml" (generate_mylib_a ())
   | ["mylib_b"] -> output_file "mylib_b.ml" (generate_mylib_b ())
+  | ["mylib_unused"] -> output_file "mylib_unused.ml" (generate_mylib_unused ())
+  | ["unusedlib"] -> output_file "unusedlib.ml" (generate_unusedlib ())
   | ["cmxa_main"] -> output_file "cmxa_main.ml" (generate_cmxa_main ())
   | _ ->
     Printf.eprintf
       "Usage: %s \
-       <gen_module_a|gen_module_b|gen_module_c|gen_main|mylib_a|mylib_b|cmxa_main>\n"
+       <gen_module_a|gen_module_b|gen_module_c|gen_main|mylib_a|mylib_b|mylib_unused|unusedlib|cmxa_main>\n"
       Sys.argv.(0);
     exit 1


### PR DESCRIPTION
Building on top of #6447, this PR changes the link step in the dissector to only link the compilation units that are used by changing the linker invocation.