### PR TITLE
Add Dwarf_operator.size_of_expression

### DIFF
--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.ml
@@ -549,7 +549,13 @@ module Make (M : sig
   val ( >>> ) : param -> result -> (unit -> result) -> result
 end) =
 struct
-  let run param t =
+  (* [size_of_expression] is used for operators that carry expression-block
+     operands (see the forthcoming entry-value operators), whose ULEB128 length
+     prefixes require the byte size of the enclosed expression to be known up
+     front. It is passed as an argument because [size], from which it is built,
+     is itself defined in terms of this traversal (see the bottom of this
+     file). *)
+  let run ~size_of_expression:_ param t =
     let unit_result = M.unit_result () in
     let opcode = M.opcode param in
     let value = M.value param in
@@ -765,8 +771,12 @@ module Emit = Make (struct
   let ( >>> ) _asm_directives () f = f ()
 end)
 
-let print ppf t = Print.run ppf t
+let rec size t = Size.run ~size_of_expression () t
 
-let size t = Size.run () t
+(* The size of a DWARF expression: the sum of the sizes of its operators. *)
+and size_of_expression ops =
+  List.fold_left (fun acc op -> I.add acc (size op)) (I.zero ()) ops
 
-let emit ~asm_directives t = Emit.run asm_directives t
+let print ppf t = Print.run ~size_of_expression ppf t
+
+let emit ~asm_directives t = Emit.run ~size_of_expression asm_directives t

--- a/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
+++ b/backend/debug/dwarf/dwarf_low/dwarf_operator.mli
@@ -209,4 +209,9 @@ type t =
 
 val print : Format.formatter -> t -> unit
 
+(** The size of a DWARF expression: the sum of the sizes of its operators. (See
+    also [Simple_location_description.size], which is expressed in terms of this
+    function.) *)
+val size_of_expression : t list -> Dwarf_int.t
+
 include Dwarf_emittable.S with type t := t

--- a/backend/debug/dwarf/dwarf_low/simple_location_description.ml
+++ b/backend/debug/dwarf/dwarf_low/simple_location_description.ml
@@ -19,10 +19,7 @@ module Operator = Dwarf_operator
 
 type t = Dwarf_operator.t list
 
-let size t =
-  List.fold_left
-    (fun size op -> Dwarf_int.add size (Operator.size op))
-    (Dwarf_int.zero ()) t
+let size t = Operator.size_of_expression t
 
 let emit ~asm_directives t =
   List.iter (fun op -> Operator.emit ~asm_directives op) t


### PR DESCRIPTION
This PR is part of the `dwarf202607` series (24 PRs) adding end-to-end DWARF debugging improvements for code compiled with Flambda 2: phantom lets so the debugger can print optimised-out variables, correct attribution of parameters and variables to inlined frames, and DWARF call site information.

Stacked on #6505: this PR targets that branch, so the diff shown is exactly this PR's own changes. It was split out of #6525 so that the general expression-measuring function can be reviewed on its own.

## Description

New general function `Dwarf_operator.size_of_expression`, giving the size of a DWARF expression (a list of operators) as the sum of the sizes of its operators. `Simple_location_description.size` — previously an identical private fold — is now expressed in terms of it, so there is a single definition of how DWARF expressions are measured.

The immediate consumer is #6525: entry-value operators carry a block operand whose ULEB128 length prefix requires the byte size of the enclosed expression to be computed up front, *inside* the generic print/size/emit traversal. Since `size` (and hence `size_of_expression`) is itself defined in terms of that traversal, this PR also threads `size_of_expression` into the traversal as an argument of `run` (bound as `_` until #6525 uses it) and ties the knot with an ordinary `let rec` at the bottom of the file — so #6525 itself is purely additive.

Behaviour-neutral.

## Verification

- `make -s boot-compiler` passes; `make -s fmt` clean.

## The series

Suggested landing order: the first eleven independent PRs in any order, then the rest in the order below. Stacked PRs target their parent's branch and are retargeted to `main` as parents land.

1. #6503 — Compare dinfo_uid in Debuginfo.Dbg.compare
2. #6504 — Move Is_parameter to middle_end/ and record it in Backend_var.Provenance
3. #6505 — DWARF infrastructure additions in dwarf_low and dwarf_high
4. #6527 — Add Dwarf_operator.size_of_expression ← **this PR**
5. #6525 — Add DWARF entry-value operators
6. #6506 — Strip the platform symbol prefix from DW_AT_linkage_name
7. #6507 — Keep the startup object file when emitting OxCaml DWARF
8. #6508 — Use immutable loads for closure fields in generic apply/curry functions
9. #6509 — Backend debuginfo-quality fixes for spills, reloads and inserted blocks
10. #6510 — Fix stack-offset double count in available_ranges_vars
11. #6511 — Add -ddebug-avail-sets dump flag
12. #6512 — Use Cmm.symbol for phantom defining expressions
13. #6513 — Add Cmm.Cname_for_debugger to name subexpression values for the debugger
14. #6514 — Bound_var and Bound_parameter carry Debuginfo.t and a parameter classification
15. #6515 — Populate real debugging metadata on bound variables and parameters
16. #6516 — Relax phantom-let visibility requirements in Simplify
17. #6528 — Bind my_closure phantom-ly when it is used only at phantom name mode
18. #6517 — Preserve phantom lets through instruction selection, CFG and Linear
19. #6518 — Track constants and field projections in register availability
20. #6519 — Translate Flambda 2 phantom lets to Cmm
21. #6520 — Compute availability ranges for phantom variables
22. #6521 — DWARF emission for variables, parameters and inlined frames
23. #6522 — Emit DWARF call site information
24. #6523 — Enable phantom lets by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)



