### PR TITLE
Shuffle the compiler-libs deck slightly

### DIFF
--- a/backend/asm_targets/asm_directives.ml
+++ b/backend/asm_targets/asm_directives.ml
@@ -1280,14 +1280,11 @@ let offset_into_dwarf_section_symbol ?comment:_comment
           (const_sub (const_symbol upper) (const_label lower))
       else
         Misc.fatal_errorf
-          "Don't know how to encode offset from start of section XXX to \
-           undefined symbol %a on macOS (current compilation unit %a, symbol \
-           in compilation unit XXX)"
-          (* Asm_section.print upper_section *) Asm_symbol.print upper
+          "Don't know how to encode offset from start of section %a to \
+           undefined symbol %a on macOS (current compilation unit %a)"
+          Asm_section.print (Asm_section.DWARF section) Asm_symbol.print upper
           (Format_doc.compat Compilation_unit.print)
           (Current_unit.get_cu_exn ())
-          (Format_doc.compat Compilation_unit.print)
-      (* (Asm_symbol.compilation_unit upper) *)
     else const_symbol upper
   in
   match width with

--- a/driver/compmisc.ml
+++ b/driver/compmisc.ml
@@ -99,30 +99,6 @@ let initial_env () =
     ~initially_opened_module
     ~open_implicit_args:(List.rev !Clflags.open_args)
 
-let set_from_env flag Clflags.{ parse; usage; env_var } =
-  try
-    match parse (Sys.getenv env_var) with
-    | None ->
-        Location.prerr_warning Location.none
-          (Warnings.Bad_env_variable (env_var, usage))
-    | Some x -> match !flag with
-      | None -> flag := Some x
-      | Some _ -> ()
-  with
-    Not_found -> ()
-
-let read_clflags_from_env () =
-  set_from_env Clflags.color Clflags.color_reader;
-  let no_color () = (* See https://no-color.org/ *)
-    match Sys.getenv_opt "NO_COLOR" with
-    | None | Some "" -> false
-    | _ -> true
-  in
-  if Option.is_none !Clflags.color && no_color () then
-    Clflags.color := Some Misc.Color.Never;
-  set_from_env Clflags.error_style Clflags.error_style_reader;
-  ()
-
 let directory_exists dir =
   Sys.file_exists dir && Sys.is_directory dir
 

--- a/driver/compmisc.mli
+++ b/driver/compmisc.mli
@@ -18,10 +18,6 @@ val init_path :
 val init_parameters : unit -> unit
 val initial_env : unit -> Env.t
 
-(* Support for flags that can also be set from an environment variable *)
-val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
-val read_clflags_from_env : unit -> unit
-
 val with_ppf_file :
   file_prefix:string -> file_extension:string -> (Format.formatter -> 'a) -> 'a
 

--- a/driver/jsmaindriver.ml
+++ b/driver/jsmaindriver.ml
@@ -47,7 +47,7 @@ let main argv ppf =
     Compenv.readenv ppf Before_args;
     Clflags.Opt_flag_handler.set Oxcaml_flags.opt_flag_handler;
     Compenv.parse_arguments (ref argv) Compenv.anonymous program;
-    Compmisc.read_clflags_from_env ();
+    Location.read_clflags_from_env ();
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
     try

--- a/driver/maindriver.ml
+++ b/driver/maindriver.ml
@@ -28,7 +28,7 @@ let main argv ppf =
   match
     Compenv.readenv ppf Before_args;
     Compenv.parse_arguments (ref argv) Compenv.anonymous program;
-    Compmisc.read_clflags_from_env ();
+    Location.read_clflags_from_env ();
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
     begin try

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -60,7 +60,7 @@ let main unix argv ppf ~flambda2 =
         (use 'ocamlopt -depend -help' for details)"];
     Clflags.Opt_flag_handler.set Oxcaml_flags.opt_flag_handler;
     Compenv.parse_arguments (ref argv) Compenv.anonymous "ocamlopt";
-    Compmisc.read_clflags_from_env ();
+    Location.read_clflags_from_env ();
     (* Set platform-appropriate DWARF fission default when oxcaml-dwarf is
        enabled *)
     if Config.oxcaml_dwarf &&

--- a/middle_end/flambda2/tests/tools/fexprc.ml
+++ b/middle_end/flambda2/tests/tools/fexprc.ml
@@ -43,5 +43,5 @@ let _ =
   Clflags.add_arguments __LOC__ (Arch.command_line_options @ Options.list);
   Clflags.Opt_flag_handler.set Oxcaml_flags.opt_flag_handler;
   Compenv.parse_arguments (ref Sys.argv) defer_file "fexprc";
-  Compmisc.read_clflags_from_env ();
+  Location.read_clflags_from_env ();
   !file_action ()

--- a/ocamltest/options.ml
+++ b/ocamltest/options.ml
@@ -120,7 +120,7 @@ let usage = "Usage: ocamltest [options] <files...>"
 
 let () =
   Arg.parse (Arg.align commandline_options) (add_to_list files_to_test) usage;
-  Compmisc.read_clflags_from_env ();
+  Location.read_clflags_from_env ();
   Misc.Style.setup !Clflags.color;
   ()
 

--- a/parsing/location.ml
+++ b/parsing/location.ml
@@ -1118,6 +1118,29 @@ let deprecated_script_alert program =
   in
   prerr_alert none alert
 
+let set_from_env flag Clflags.{ parse; usage; env_var } =
+  try
+    match parse (Sys.getenv env_var) with
+    | None ->
+        prerr_warning none (Warnings.Bad_env_variable (env_var, usage))
+    | Some x -> match !flag with
+      | None -> flag := Some x
+      | Some _ -> ()
+  with
+    Not_found -> ()
+
+let read_clflags_from_env () =
+  set_from_env Clflags.color Clflags.color_reader;
+  let no_color () = (* See https://no-color.org/ *)
+    match Sys.getenv_opt "NO_COLOR" with
+    | None | Some "" -> false
+    | _ -> true
+  in
+  if Option.is_none !Clflags.color && no_color () then
+    Clflags.color := Some Misc.Color.Never;
+  set_from_env Clflags.error_style Clflags.error_style_reader;
+  ()
+
 (******************************************************************************)
 (* Reporting errors on exceptions *)
 

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -297,6 +297,10 @@ type report_printer = {
     existing ones.
 *)
 
+(* Support for flags that can also be set from an environment variable *)
+val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
+val read_clflags_from_env : unit -> unit
+
 (** {2 Report printers used in the compiler} *)
 
 val batch_mode_printer: report_printer

--- a/parsing/location.mli
+++ b/parsing/location.mli
@@ -298,6 +298,8 @@ type report_printer = {
 *)
 
 (* Support for flags that can also be set from an environment variable *)
+(* TODO This is not the natural home for these functions, but Clflags cannot
+        depend on Location *)
 val set_from_env : 'a option ref -> 'a Clflags.env_reader -> unit
 val read_clflags_from_env : unit -> unit
 

--- a/toplevel/byte/topmain.ml
+++ b/toplevel/byte/topmain.ml
@@ -160,7 +160,7 @@ let input_argument name =
                               (Array.length !argv - !current)
       in
       Compenv.readenv ppf Before_link;
-      Compmisc.read_clflags_from_env ();
+      Location.read_clflags_from_env ();
       if Toploop.prepare ppf ~input:name () &&
          Toploop.run_script ppf name newargs
       then raise (Compenv.Exit_with_status 0)
@@ -197,7 +197,7 @@ let main () =
   Clflags.add_arguments __LOC__ Options.list;
   Compenv.parse_arguments ~current argv file_argument program;
   Compenv.readenv ppf Before_link;
-  Compmisc.read_clflags_from_env ();
+  Location.read_clflags_from_env ();
   if not (Toploop.prepare ppf ()) then raise (Compenv.Exit_with_status 2);
   Compmisc.init_path ();
   Toploop.loop Format.std_formatter

--- a/toplevel/native/topmain.ml
+++ b/toplevel/native/topmain.ml
@@ -56,7 +56,7 @@ let input_argument (name : Opttoploop.input) =
     let newargs = Array.sub !argv !Arg.current
                               (Array.length !argv - !Arg.current)
       in
-      Compmisc.read_clflags_from_env ();
+      Location.read_clflags_from_env ();
       if Opttoploop.prepare ppf ~input:name () &&
          Opttoploop.run_script ppf filename newargs
       then raise (Exit_with_status 0)
@@ -106,7 +106,7 @@ let main () =
     | Arg.Help msg -> Format.fprintf Format.std_formatter "%s%!" msg;
                       raise (Exit_with_status 0)
   end;
-  Compmisc.read_clflags_from_env ();
+  Location.read_clflags_from_env ();
   if not (Opttoploop.prepare ppf ()) then raise (Exit_with_status 2);
   Compmisc.init_path ();
   Opttoploop.loop Format.std_formatter

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -243,15 +243,7 @@ let tvariant_not_immediate row =
       | _ -> false)
     (row_fields row)
 
-let hash_variant s =
-  let accu = ref 0 in
-  for i = 0 to String.length s - 1 do
-    accu := 223 * !accu + Char.code s.[i]
-  done;
-  (* reduce to 31 bits *)
-  accu := !accu land (1 lsl 31 - 1);
-  (* make it signed for 64 bits architectures *)
-  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
+let hash_variant = Misc.hash_variant
 
 let proxy ty =
   match get_desc ty with

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -15,29 +15,28 @@
 
 (* Command-line parameters *)
 
-module Int_arg_helper = Arg_helper.Make (struct
-  module Key = struct
+(* Stripped down version of Numbers, as its dependencies are a lot of code *)
+module Numbers = struct
+  module Int = struct
     type t = int
-    let of_string = int_of_string
     module Map = Map.Make(Stdlib.Int)
-  end
-
-  module Value = struct
-    type t = int
     let of_string = int_of_string
   end
-end)
-module Float_arg_helper = Arg_helper.Make (struct
-  module Key = struct
-    type t = int
-    let of_string = int_of_string
-    module Map = Map.Make(Stdlib.Int)
-  end
-
-  module Value = struct
+  module Float = struct
     type t = float
     let of_string = float_of_string
   end
+end
+
+module Int_arg_helper = Arg_helper.Make (struct
+  module Key = Numbers.Int
+
+  module Value = Numbers.Int
+end)
+module Float_arg_helper = Arg_helper.Make (struct
+  module Key = Numbers.Int
+
+  module Value = Numbers.Float
 end)
 
 type open_arg =

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -17,23 +17,25 @@
 
 module Int_arg_helper = Arg_helper.Make (struct
   module Key = struct
-    include Numbers.Int
+    type t = int
     let of_string = int_of_string
+    module Map = Map.Make(Stdlib.Int)
   end
 
   module Value = struct
-    include Numbers.Int
+    type t = int
     let of_string = int_of_string
   end
 end)
 module Float_arg_helper = Arg_helper.Make (struct
   module Key = struct
-    include Numbers.Int
+    type t = int
     let of_string = int_of_string
+    module Map = Map.Make(Stdlib.Int)
   end
 
   module Value = struct
-    include Numbers.Float
+    type t = float
     let of_string = float_of_string
   end
 end)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1004,6 +1004,17 @@ let create_hashtable size init =
   List.iter (fun (key, data) -> Hashtbl.add tbl key data) init;
   tbl
 
+(* This would be better in Obj, but we'd need upstream to do the same *)
+let hash_variant s =
+  let accu = ref 0 in
+  for i = 0 to String.length s - 1 do
+    accu := 223 * !accu + Char.code s.[i]
+  done;
+  (* reduce to 31 bits *)
+  accu := !accu land (1 lsl 31 - 1);
+  (* make it signed for 64 bits architectures *)
+  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
+
 (* File copy *)
 
 let copy_file ic oc =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -114,6 +114,7 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
        (** Create a hashtable with the given initial size and fills it
            with the given bindings. *)
 
+(* TODO Move this to Obj when the system compiler includes ocaml/ocaml/#14939 *)
 val hash_variant: string -> int
         (** Hash function for variant tags *)
 

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -114,6 +114,9 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
        (** Create a hashtable with the given initial size and fills it
            with the given bindings. *)
 
+val hash_variant: string -> int
+        (** Hash function for variant tags *)
+
 (** {1 Extensions to the standard library} *)
 
 module Stdlib : sig


### PR DESCRIPTION
This moves three functions, in ascending order of impact on linking sizes:
- `Clflags` depends on `Numbers` and `Identifiable`, which in `-O3` links a non-trivial amount of code. I don't think the code suffers too much snipping that dependency.
- `Btype.hash_variant`. I think this should really live in `Obj`, but we'd have to coordinate that with upstream, so for now I propose putting it in the `Misc` kitchen sink.
- `Compmisc` also depends on `Env` which is painful for ppxlib, which needs to call `Compmisc.read_clflags_from_env`. The linking story means that all ppx drivers pull in the entire type-checker with it. The problem is where to put it, because `Location` depends on `Clflags` and `read_cflags_from_env` needs `Location`. It's not the first function to be inappropriately placed in `Location`, so I'm open to better suggestions (we could split `Compmisc`, I guess).

Note that this PR strictly moves functions and then updates callsites - no actual changes.