### PR TITLE
Fix calling convention specialization to account for GADTs allowing parameter representation to vary across cases

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -719,10 +719,43 @@ and join_constructor_shape shape1 shape2 =
   | Constructor_uniform fields1, Constructor_uniform fields2
     when List.length fields1 = List.length fields2 ->
       Some (Constructor_uniform (List.map2 join_value_kind fields1 fields2))
-  | Constructor_mixed _, Constructor_mixed _
-    when equal_constructor_shape shape1 shape2 ->
-      Some shape1
+  | Constructor_mixed shape1, Constructor_mixed shape2 ->
+      Option.map
+        (fun shape -> Constructor_mixed shape)
+        (join_mixed_block_shape shape1 shape2)
   | (Constructor_uniform _ | Constructor_mixed _), _ -> None
+
+and join_mixed_block_shape shape1 shape2 =
+  if Array.length shape1 <> Array.length shape2 then None
+  else
+    Misc.Stdlib.Array.all_somes
+      (Array.map2 join_mixed_block_element shape1 shape2)
+
+and join_mixed_block_element (m1 : unit mixed_block_element)
+    (m2 : unit mixed_block_element) : unit mixed_block_element option =
+  match m1, m2 with
+  | Value v1, Value v2 -> Some (Value (join_value_kind v1 v2))
+  | Product es1, Product es2 when Array.length es1 = Array.length es2 ->
+      Option.map (fun es -> Product es) (join_mixed_block_shape es1 es2)
+  | Float_boxed (), Float_boxed () -> Some m1
+  | Float64, Float64
+  | Float32, Float32
+  | Bits8, Bits8
+  | Bits16, Bits16
+  | Bits32, Bits32
+  | Bits64, Bits64
+  | Vec128, Vec128
+  | Vec256, Vec256
+  | Vec512, Vec512
+  | Word, Word
+  | Untagged_immediate, Untagged_immediate -> Some m1
+  | Splice_variable id1, Splice_variable id2 when Ident.equal id1 id2 ->
+      Some m1
+  | ( ( Value _ | Float_boxed _ | Float64 | Float32 | Bits8 | Bits16
+      | Bits32 | Bits64 | Vec128 | Vec256 | Vec512 | Word
+      | Untagged_immediate | Product _ | Splice_variable _ ),
+      _ ) ->
+      None
 
 and join_non_consts non_consts1 non_consts2 =
   let sorted = List.sort (fun (tag1, _) (tag2, _) -> Int.compare tag1 tag2) in

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -700,12 +700,49 @@ let join_nullable x y =
   | Non_nullable, Non_nullable -> Non_nullable
   | Nullable, _ | _, Nullable -> Nullable
 
-(* CR dkalinichenko: we could have a finer-grained join here,
-   but I don't think the complexity is worth it. *)
-let join_value_kind_non_null x y =
-  if equal_value_kind_non_null x y then x else Pgenval
+let rec join_value_kind_non_null x y =
+  if equal_value_kind_non_null x y then x
+  else
+    match x, y with
+    | Pvariant { consts = consts1; non_consts = non_consts1 },
+      Pvariant { consts = consts2; non_consts = non_consts2 } -> begin
+        match join_non_consts non_consts1 non_consts2 with
+        | Some non_consts ->
+            let consts = List.sort_uniq Int.compare (consts1 @ consts2) in
+            Pvariant { consts; non_consts }
+        | None -> Pgenval
+      end
+    | _, _ -> Pgenval
 
-let join_value_kind x y =
+and join_constructor_shape shape1 shape2 =
+  match shape1, shape2 with
+  | Constructor_uniform fields1, Constructor_uniform fields2
+    when List.length fields1 = List.length fields2 ->
+      Some (Constructor_uniform (List.map2 join_value_kind fields1 fields2))
+  | Constructor_mixed _, Constructor_mixed _
+    when equal_constructor_shape shape1 shape2 ->
+      Some shape1
+  | (Constructor_uniform _ | Constructor_mixed _), _ -> None
+
+and join_non_consts non_consts1 non_consts2 =
+  let sorted = List.sort (fun (tag1, _) (tag2, _) -> Int.compare tag1 tag2) in
+  let rec merge l1 l2 =
+    match l1, l2 with
+    | [], l | l, [] -> Some l
+    | (tag1, shape1) :: rest1, (tag2, shape2) :: rest2 ->
+        if tag1 < tag2 then
+          Option.map (fun l -> (tag1, shape1) :: l) (merge rest1 l2)
+        else if tag2 < tag1 then
+          Option.map (fun l -> (tag2, shape2) :: l) (merge l1 rest2)
+        else
+          match join_constructor_shape shape1 shape2 with
+          | Some shape ->
+              Option.map (fun l -> (tag1, shape) :: l) (merge rest1 rest2)
+          | None -> None
+  in
+  merge (sorted non_consts1) (sorted non_consts2)
+
+and join_value_kind x y =
   { raw_kind = join_value_kind_non_null x.raw_kind y.raw_kind;
     nullable = join_nullable x.nullable y.nullable;
   }

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -695,6 +695,21 @@ and equal_constructor_shape x y =
       equal_mixed_block_shape shape1 shape2
   | (Constructor_uniform _ | Constructor_mixed _), _ -> false
 
+let join_nullable x y =
+  match x, y with
+  | Non_nullable, Non_nullable -> Non_nullable
+  | Nullable, _ | _, Nullable -> Nullable
+
+(* CR dkalinichenko: we could have a finer-grained join here,
+   but I don't think the complexity is worth it. *)
+let join_value_kind_non_null x y =
+  if equal_value_kind_non_null x y then x else Pgenval
+
+let join_value_kind x y =
+  { raw_kind = join_value_kind_non_null x.raw_kind y.raw_kind;
+    nullable = join_nullable x.nullable y.nullable;
+  }
+
 let block_shape_of_value_kinds (vks : value_kind list option) : block_shape =
   match vks with
   | None -> All_value
@@ -729,6 +744,29 @@ let equal_layout x y =
   | Ptop, Ptop -> true
   | Pbottom, Pbottom -> true
   | _, _ -> false
+
+let rec join_layout x y =
+  match x, y with
+  | Pbottom, l | l, Pbottom -> l
+  | Ptop, _ | _, Ptop -> Ptop
+  | Pvalue kind1, Pvalue kind2 -> Pvalue (join_value_kind kind1 kind2)
+  | Punboxed_product layouts1, Punboxed_product layouts2
+    when List.length layouts1 = List.length layouts2 ->
+      Punboxed_product (List.map2 join_layout layouts1 layouts2)
+  | Punboxed_float f1, Punboxed_float f2
+    when Primitive.equal_unboxed_float f1 f2 ->
+      x
+  | Punboxed_or_untagged_integer i1, Punboxed_or_untagged_integer i2
+    when Primitive.equal_unboxed_or_untagged_integer i1 i2 ->
+      x
+  | Punboxed_vector v1, Punboxed_vector v2
+    when Primitive.equal_unboxed_vector v1 v2 ->
+      x
+  | Psplicevar id1, Psplicevar id2 when Ident.equal id1 id2 -> x
+  | ( ( Pvalue _ | Punboxed_float _ | Punboxed_or_untagged_integer _
+      | Punboxed_vector _ | Punboxed_product _ | Psplicevar _ ),
+      _ ) ->
+      Misc.fatal_error "Lambda.join_layout: layouts of different sorts"
 
 let rec equal_ignorable_product_element_kind k1 k2 =
   match k1, k2 with

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -656,6 +656,11 @@ val equal_raise_kind : raise_kind -> raise_kind -> bool
 
 val equal_value_kind : value_kind -> value_kind -> bool
 
+val join_value_kind : value_kind -> value_kind -> value_kind
+
+(** Join of two layouts, must be of the same kind. *)
+val join_layout : layout -> layout -> layout
+
 val equal_layout : layout -> layout -> bool
 
 val print_boxed_vector : Format.formatter -> boxed_vector -> unit

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -47,6 +47,16 @@ let use_dup_for_constant_mutable_arrays_bigger_than = 4
 let layout_exp sort e = layout e.exp_env e.exp_loc sort e.exp_type
 let layout_pat sort p = layout p.pat_env p.pat_loc sort p.pat_type
 
+let join_layout_of_cases sort cases =
+  match cases with
+  | [] -> None
+  | { c_lhs; _ } :: rest ->
+      Some
+        (List.fold_left
+           (fun acc { c_lhs; _ } ->
+             Lambda.join_layout acc (layout_pat sort c_lhs))
+           (layout_pat sort c_lhs) rest)
+
 let field_offset_for_label lbl repres =
   match repres with
   | Record_boxed
@@ -1741,33 +1751,49 @@ and transl_tupled_function
   match eligible_cases with
   | Some
       (cases, partial,
-       ({ pat_desc = Tpat_tuple pl } as arg_pat), arg_mode, arg_sort)
+       { pat_desc = Tpat_tuple pl }, arg_mode, arg_sort)
     when is_alloc_heap mode
       && is_alloc_heap (transl_alloc_mode_l arg_mode)
       && !Clflags.native_code
       && List.length pl <= (Lambda.max_arity ()) ->
       begin try
-        let arg_layout = layout_pat arg_sort arg_pat in
         let size = List.length pl in
         let pats_expr_list =
           List.map
             (fun {c_lhs; c_guard; c_rhs} ->
               (Matching.flatten_pattern size c_lhs, c_guard, c_rhs))
             cases in
-        let kinds =
+        let tuple_value_kinds arg_layout =
           match arg_layout with
           | Pvalue {
               nullable = Non_nullable;
               raw_kind = Pvariant { consts = [];
-                               non_consts = [0, Constructor_uniform kinds] }} ->
+                               non_consts = [0, Constructor_uniform kinds] }}
+            when List.length kinds = size ->
               (* CR layouts v5: to change when we have non-value tuple
                  elements. *)
-              List.map (fun vk -> Pvalue vk) kinds
-          | _ ->
+              Some kinds
+          | _ -> None
+        in
+        let value_kinds_of_case { c_lhs; _ } =
+          match tuple_value_kinds (layout_pat arg_sort c_lhs) with
+          | Some kinds -> kinds
+          | None ->
               Misc.fatal_error
                 "Translcore.transl_tupled_function: \
                  Argument should be a tuple, but couldn't get the kinds"
         in
+        let value_kinds =
+          match cases with
+          | [] -> raise Matching.Cannot_flatten
+          | first :: rest ->
+              List.fold_left
+                (fun acc case ->
+                  List.map2 Lambda.join_value_kind acc
+                    (value_kinds_of_case case))
+                (value_kinds_of_case first) rest
+        in
+        let kinds = List.map (fun vk -> Pvalue vk) value_kinds in
         let tparams =
           List.map (fun kind -> {
                 name = Ident.create_local "param";
@@ -1872,9 +1898,9 @@ and transl_curried_function ~scopes loc repr params body
       ->
         let fc_arg_sort = Jkind.Sort.default_for_transl_and_get fc_arg_sort in
         let arg_layout =
-          match fc_cases with
-          | { c_lhs } :: _ -> layout_pat fc_arg_sort c_lhs
-          | [] ->
+          match join_layout_of_cases fc_arg_sort fc_cases with
+          | Some arg_layout -> arg_layout
+          | None ->
               (* ppxes can generate empty function cases, which compiles to
                  a function that always raises Match_failure. We try less
                  hard to calculate a detailed layout that the middle-end can

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1788,8 +1788,7 @@ and transl_tupled_function
           | Pvalue {
               nullable = Non_nullable;
               raw_kind = Pvariant { consts = [];
-                               non_consts = [0, Constructor_uniform kinds] }}
-            when List.length kinds = size ->
+                               non_consts = [0, Constructor_uniform kinds] }} ->
               (* CR layouts v5: to change when we have non-value tuple
                  elements. *)
               Some kinds

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1794,26 +1794,16 @@ and transl_tupled_function
               Some kinds
           | _ -> None
         in
-        let value_kinds_of_case { c_lhs; _ } =
-          match tuple_value_kinds (layout_pat arg_sort c_lhs) with
+        let value_kinds =
+          match
+            Option.bind (join_layout_of_cases arg_sort cases)
+              tuple_value_kinds
+          with
           | Some kinds -> kinds
           | None ->
               Misc.fatal_error
                 "Translcore.transl_tupled_function: \
                  Argument should be a tuple, but couldn't get the kinds"
-        in
-        let value_kinds =
-          let first_kinds = value_kinds_of_case first_case in
-          (* Only a GADT match makes the cases' types differ; otherwise
-             the first case's value kinds are already the join. *)
-          if cases_contain_gadt cases
-          then
-            List.fold_left
-              (fun acc case ->
-                List.map2 Lambda.join_value_kind acc
-                  (value_kinds_of_case case))
-              first_kinds rest_cases
-          else first_kinds
         in
         let kinds = List.map (fun vk -> Pvalue vk) value_kinds in
         let tparams =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1750,17 +1750,17 @@ and transl_tupled_function
     match params, body with
     | [],
       Tfunction_cases
-        { fc_cases = { c_lhs; _ } :: _ as cases;
+        { fc_cases = first_case :: rest_cases;
           fc_partial; fc_arg_mode; fc_arg_sort } ->
         let fc_arg_sort = Jkind.Sort.default_for_transl_and_get fc_arg_sort in
-        Some (cases, fc_partial, c_lhs, fc_arg_mode, fc_arg_sort)
+        Some (first_case, rest_cases, fc_partial, fc_arg_mode, fc_arg_sort)
     | [{ fp_kind = Tparam_pat pat; fp_partial; fp_mode; fp_sort }],
       Tfunction_body body ->
         let fp_sort = Jkind.Sort.default_for_transl_and_get fp_sort in
         let case =
           { c_lhs = pat; c_cont = None; c_guard = None; c_rhs = body }
         in
-        Some ([ case ], fp_partial, pat, fp_mode.mode_modes, fp_sort)
+        Some (case, [], fp_partial, fp_mode.mode_modes, fp_sort)
     | _ -> None
   in
   (* Cases can be eligible for flattening if they belong to the only param
@@ -1769,13 +1769,14 @@ and transl_tupled_function
      thought it through. *)
   match eligible_cases with
   | Some
-      (cases, partial,
-       { pat_desc = Tpat_tuple pl }, arg_mode, arg_sort)
+      (({ c_lhs = { pat_desc = Tpat_tuple pl } } as first_case),
+       rest_cases, partial, arg_mode, arg_sort)
     when is_alloc_heap mode
       && is_alloc_heap (transl_alloc_mode_l arg_mode)
       && !Clflags.native_code
       && List.length pl <= (Lambda.max_arity ()) ->
       begin try
+        let cases = first_case :: rest_cases in
         let size = List.length pl in
         let pats_expr_list =
           List.map
@@ -1803,20 +1804,17 @@ and transl_tupled_function
                  Argument should be a tuple, but couldn't get the kinds"
         in
         let value_kinds =
-          match cases with
-          | [] -> raise Matching.Cannot_flatten
-          | first :: rest ->
-              let first_kinds = value_kinds_of_case first in
-              (* Only a GADT match makes the cases' types differ; otherwise
-                 the first case's value kinds are already the join. *)
-              if cases_contain_gadt cases
-              then
-                List.fold_left
-                  (fun acc case ->
-                    List.map2 Lambda.join_value_kind acc
-                      (value_kinds_of_case case))
-                  first_kinds rest
-              else first_kinds
+          let first_kinds = value_kinds_of_case first_case in
+          (* Only a GADT match makes the cases' types differ; otherwise
+             the first case's value kinds are already the join. *)
+          if cases_contain_gadt cases
+          then
+            List.fold_left
+              (fun acc case ->
+                List.map2 Lambda.join_value_kind acc
+                  (value_kinds_of_case case))
+              first_kinds rest_cases
+          else first_kinds
         in
         let kinds = List.map (fun vk -> Pvalue vk) value_kinds in
         let tparams =

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -47,15 +47,34 @@ let use_dup_for_constant_mutable_arrays_bigger_than = 4
 let layout_exp sort e = layout e.exp_env e.exp_loc sort e.exp_type
 let layout_pat sort p = layout p.pat_env p.pat_loc sort p.pat_type
 
+(* Mirrors [Typecore.contains_gadt]: [cstr_generalized] is the criterion the
+   type checker uses to decide when a match adds GADT equations. *)
+let pat_contains_gadt pat =
+  exists_pattern
+    (fun p ->
+      match p.pat_desc with
+      | Tpat_construct (_, cd, _, _, _) -> cd.cstr_generalized
+      | _ -> false)
+    pat
+
+let cases_contain_gadt cases =
+  List.exists (fun { c_lhs; _ } -> pat_contains_gadt c_lhs) cases
+
 let join_layout_of_cases sort cases =
   match cases with
   | [] -> None
   | { c_lhs; _ } :: rest ->
-      Some
-        (List.fold_left
-           (fun acc { c_lhs; _ } ->
-             Lambda.join_layout acc (layout_pat sort c_lhs))
-           (layout_pat sort c_lhs) rest)
+      let first_layout = layout_pat sort c_lhs in
+      (* Only a GADT match makes the cases' types differ; otherwise the first
+         case's layout is already the join. *)
+      if cases_contain_gadt cases
+      then
+        Some
+          (List.fold_left
+             (fun acc { c_lhs; _ } ->
+               Lambda.join_layout acc (layout_pat sort c_lhs))
+             first_layout rest)
+      else Some first_layout
 
 let field_offset_for_label lbl repres =
   match repres with
@@ -1787,11 +1806,17 @@ and transl_tupled_function
           match cases with
           | [] -> raise Matching.Cannot_flatten
           | first :: rest ->
-              List.fold_left
-                (fun acc case ->
-                  List.map2 Lambda.join_value_kind acc
-                    (value_kinds_of_case case))
-                (value_kinds_of_case first) rest
+              let first_kinds = value_kinds_of_case first in
+              (* Only a GADT match makes the cases' types differ; otherwise
+                 the first case's value kinds are already the join. *)
+              if cases_contain_gadt cases
+              then
+                List.fold_left
+                  (fun acc case ->
+                    List.map2 Lambda.join_value_kind acc
+                      (value_kinds_of_case case))
+                  first_kinds rest
+              else first_kinds
         in
         let kinds = List.map (fun vk -> Pvalue vk) value_kinds in
         let tparams =

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_widening.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_widening.ml
@@ -1,0 +1,73 @@
+(* TEST
+ flags = "-w -8";
+ {
+   (* Pre-fix, [g6] below segfaults in native code (the [Int6] call
+      projects through the [Block6] branch's tuple kind). Pin the
+      crash here; the [Update tests] commit removes it once the fix lands. *)
+   exit_status = "-11";
+   native;
+ }{
+   bytecode;
+ }
+*)
+
+(* Regression tests: an argument matched by a multi-case GADT match used to
+   get its value kind from the first branch's equations, miscompiling callers
+   that pick another constructor. *)
+
+(* Regression test: total match unpacking a tuple, unarized *)
+type 'a rep6 = Block6 : (int * int) rep6 | Int6 : int rep6
+
+let[@inline never] g6 b =
+  let[@local] f : type a. a rep6 * a -> int = function
+    | Block6, (a, _b) -> a
+    | Int6, x -> x
+  in
+  if b then f (Block6, (1, 2)) else f (Int6, Sys.opaque_identity 0)
+
+let () =
+  assert (g6 true = 1);
+  assert (g6 false = 0)
+
+(* Regression test: total match unpacking a tuple,
+   not unarized due to the extra argument. *)
+type 'a rep9 = Block9 : (int * int) rep9 | Int9 : int rep9
+
+let[@inline never] g9 b =
+  let[@local] f : type a. unit -> a rep9 * a -> int = fun () -> function
+    | Block9, (a, _b) -> a
+    | Int9, x -> x
+  in
+  if b then f () (Block9, (1, 2)) else f () (Int9, Sys.opaque_identity 0)
+
+let () =
+  assert (g9 true = 1);
+  assert (g9 false = 0)
+
+(* Regression test: total match unpacking a tuple,
+   not unarized due to [as _t]. *)
+type 'a rep10 = Int10 : int rep10 | Float10 : float rep10
+
+let[@inline never] g10 b =
+  let[@local] f : type a. a rep10 * a -> float = function
+    | (Float10, x) as _t -> x +. 1.0
+    | Int10, z -> float_of_int z
+  in
+  if b then f (Float10, Sys.opaque_identity 3.5)
+  else f (Int10, Sys.opaque_identity 7)
+
+let () =
+  assert (g10 true = 4.5);
+  assert (g10 false = 7.0)
+
+(* Regression test: total match unpacking a tuple whose branch kinds
+   disagree, compiled with the tupled calling convention. *)
+type 'a rep12 = Block12 : (int * int) rep12 | Int12 : int rep12
+
+let[@inline never] f12 : type a. a rep12 * a -> int = function
+  | Block12, (a, _b) -> a
+  | Int12, x -> x
+
+let () =
+  assert (f12 (Block12, (1, 2)) = 1);
+  assert (f12 (Int12, Sys.opaque_identity 0) = 0)

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_widening.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_widening.ml
@@ -1,10 +1,6 @@
 (* TEST
  flags = "-w -8";
  {
-   (* Pre-fix, [g6] below segfaults in native code (the [Int6] call
-      projects through the [Block6] branch's tuple kind). Pin the
-      crash here; the [Update tests] commit removes it once the fix lands. *)
-   exit_status = "-11";
    native;
  }{
    bytecode;

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
@@ -66,14 +66,7 @@ let n : type a. a rep * a -> int = function
 [%%expect{|
 (let
   (n =
-     (function {nlocal = 0}
-       param[value<
-              (consts ())
-               (non_consts ([0: value<int>,
-                             value<
-                              (consts ())
-                               (non_consts ([0: value<int>, value<int>]))>]))>]
-       : int
+     (function {nlocal = 0} param : int
        (if (field_imm 0 param) (field_imm 1 param)
          (field_imm 0 (field_imm 1 param)))))
   (apply (field_imm 1 (global Toploop!)) "n" n))

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
@@ -1,0 +1,81 @@
+(* TEST
+ flags = "-w -8 -dlambda -dno-unique-ids";
+ expect;
+*)
+
+(* Lambda tests tracking the value kinds of function parameters whose type
+   is constrained by a GADT constructor match. *)
+
+type 'a rep = Block : (int * int) rep | Int : int rep
+[%%expect{|
+0
+type 'a rep = Block : (int * int) rep | Int : int rep
+|}]
+
+(* Control: no GADT narrowing involved. The parameter's kind must stay
+   precise. *)
+let fst2 (p : int * int) = match p with a, _b -> a
+[%%expect{|
+(let
+  (fst2 =
+     (function {nlocal = 0}
+       p[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>] : int
+       (field_imm 0 p)))
+  (apply (field_imm 1 (global Toploop!)) "fst2" fst2))
+val fst2 : int * int -> int = <fun>
+|}]
+
+(* Control: a non-GADT constructor pattern does not narrow the type; the
+   kind of [o] must stay precise either way. *)
+let get (o : int option) = match o with Some x -> x | None -> 0
+[%%expect{|
+(let
+  (get =
+     (function {nlocal = 0} o[value<(consts (0)) (non_consts ([0: ?]))>]
+       : int (if o (field_imm 0 o) 0)))
+  (apply (field_imm 1 (global Toploop!)) "get" get))
+val get : int option -> int = <fun>
+|}]
+
+(* Sound: a total multi-case GADT match; the parameter's kind is the join of
+   the branches' kinds, which here agree exactly. *)
+type _ ab = A : int ab | B : bool ab
+
+let m : type a. a ab * a -> int = function
+  | A, x -> x
+  | B, b -> if b then 1 else 0
+[%%expect{|
+0
+type _ ab = A : int ab | B : bool ab
+(let
+  (m =
+     (function {nlocal = 0}
+       param[value<(consts ()) (non_consts ([0: value<int>, value<int>]))>]
+       : int
+       (if (field_imm 0 param) (if (field_imm 1 param) 1 0)
+         (field_imm 1 param))))
+  (apply (field_imm 1 (global Toploop!)) "m" m))
+val m : 'a ab * 'a -> int = <fun>
+|}]
+
+(* Sound: a total multi-case GADT match whose branch kinds disagree; the
+   join widens the parameter's kind to a generic value. *)
+let n : type a. a rep * a -> int = function
+  | Block, (a, _b) -> a
+  | Int, x -> x
+[%%expect{|
+(let
+  (n =
+     (function {nlocal = 0}
+       param[value<
+              (consts ())
+               (non_consts ([0: value<int>,
+                             value<
+                              (consts ())
+                               (non_consts ([0: value<int>, value<int>]))>]))>]
+       : int
+       (if (field_imm 0 param) (field_imm 1 param)
+         (field_imm 0 (field_imm 1 param)))))
+  (apply (field_imm 1 (global Toploop!)) "n" n))
+val n : 'a rep * 'a -> int = <fun>
+|}]

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
@@ -73,3 +73,61 @@ let n : type a. a rep * a -> int = function
   (apply (field_imm 1 (global Toploop!)) "n" n))
 val n : 'a rep * 'a -> int = <fun>
 |}]
+
+(* Sound: the disagreeing component is a mixed block whose scannable field is
+   [int] (an immediate) in one branch and [string] (a pointer) in the other.
+   Both are scannable, so the join keeps the mixed shape -- including its
+   [float#] flat suffix -- and widens only that scannable slot. *)
+type im = { vi : int; d : float# }
+type sm = { vs : string; e : float# }
+type _ rep2 = RI : im rep2 | RS : sm rep2
+
+let mixed : type a. a rep2 * a -> int = function
+  | RI, x -> x.vi
+  | RS, x -> String.length x.vs
+[%%expect{|
+0
+type im = { vi : int; d : float#; }
+0
+type sm = { vs : string; e : float#; }
+0
+type _ rep2 = RI : im rep2 | RS : sm rep2
+(let
+  (mixed =
+     (function {nlocal = 0}
+       param[value<(consts ()) (non_consts ([0: value<int>, *]))>] : int
+       (if (field_imm 0 param)
+         (string.length (mixedfield 0  (*,float64) (field_imm 1 param)))
+         (mixedfield 0  (value<int>,float64) (field_imm 1 param)))))
+  (apply (field_imm 1 (global Toploop!)) "mixed" mixed))
+val mixed : 'a rep2 * 'a -> int = <fun>
+|}]
+
+(* Sound: two mixed blocks whose flat suffixes disagree ([float#] versus
+   [float32#]) cannot be joined -- their representations differ -- so the
+   whole component widens to a generic value even though the scannable
+   prefixes agree. *)
+type fa = { fx : int; fd : float# }
+type fb = { gx : int; ge : float32# }
+type _ rep3 = RF : fa rep3 | RG : fb rep3
+
+let mixed_flat : type a. a rep3 * a -> int = function
+  | RF, x -> x.fx
+  | RG, x -> x.gx
+[%%expect{|
+0
+type fa = { fx : int; fd : float#; }
+0
+type fb = { gx : int; ge : float32#; }
+0
+type _ rep3 = RF : fa rep3 | RG : fb rep3
+(let
+  (mixed_flat =
+     (function {nlocal = 0}
+       param[value<(consts ()) (non_consts ([0: value<int>, *]))>] : int
+       (if (field_imm 0 param)
+         (mixedfield 0  (value<int>,float32) (field_imm 1 param))
+         (mixedfield 0  (value<int>,float64) (field_imm 1 param)))))
+  (apply (field_imm 1 (global Toploop!)) "mixed_flat" mixed_flat))
+val mixed_flat : 'a rep3 * 'a -> int = <fun>
+|}]

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
@@ -59,14 +59,15 @@ val m : 'a ab * 'a -> int = <fun>
 |}]
 
 (* Sound: a total multi-case GADT match whose branch kinds disagree; the
-   join widens the parameter's kind to a generic value. *)
+   join keeps the tuple shape and widens only the disagreeing component. *)
 let n : type a. a rep * a -> int = function
   | Block, (a, _b) -> a
   | Int, x -> x
 [%%expect{|
 (let
   (n =
-     (function {nlocal = 0} param : int
+     (function {nlocal = 0}
+       param[value<(consts ()) (non_consts ([0: value<int>, *]))>] : int
        (if (field_imm 0 param) (field_imm 1 param)
          (field_imm 0 (field_imm 1 param)))))
   (apply (field_imm 1 (global Toploop!)) "n" n))

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_value_kinds.ml
@@ -95,7 +95,12 @@ type _ rep2 = RI : im rep2 | RS : sm rep2
 (let
   (mixed =
      (function {nlocal = 0}
-       param[value<(consts ()) (non_consts ([0: value<int>, *]))>] : int
+       param[value<
+              (consts ())
+               (non_consts ([0: value<int>,
+                             value<
+                              (consts ()) (non_consts ([0: *, float64]))>]))>]
+       : int
        (if (field_imm 0 param)
          (string.length (mixedfield 0  (*,float64) (field_imm 1 param)))
          (mixedfield 0  (value<int>,float64) (field_imm 1 param)))))


### PR DESCRIPTION
When computing the value kind for a function parameter pattern, `transl_tupled_function`/`transl_curried_function` currently use the first case only. However, this is unsound - for example, in `transl_tupled_function`, if one component of the tuple matches on a GADT, other parts of the tuple could vary in their value kind across cases.

As a result, this program segfaults, as we tuplify `f` based solely on the case matching `Block6`.
```ocaml
type 'a rep6 = Block6 : (int * int) rep6 | Int6 : int rep6

let[@inline never] g6 b =
  let[@local] f : type a. a rep6 * a -> int = function
    | Block6, (a, _b) -> a
    | Int6, x -> x
  in
  if b then f (Block6, (1, 2)) else f (Int6, Sys.opaque_identity 0)

let () =
  assert (g6 true = 1);
  assert (g6 false = 0)
```

To fix this, we join the layouts across all cases (h/t @dkalinichenko-js) when there is a GADT match.

Followed by https://github.com/oxcaml/oxcaml/pull/6356.