### PR TITLE
Distinct unsigned unboxed integer primitive types

### DIFF
--- a/testsuite/tests/typing-layouts/unsigned_unboxed_types.ml
+++ b/testsuite/tests/typing-layouts/unsigned_unboxed_types.ml
@@ -1,0 +1,126 @@
+(* TEST
+ flags = "-extension small_numbers";
+ expect;
+*)
+
+(* The unboxed unsigned integer types have the same kinds as their signed
+   counterparts. *)
+
+type t8 : bits8 mod everything = uint8_u
+type t16 : bits16 mod everything = uint16_u
+type t32 : bits32 mod everything = uint32_u
+type t64 : bits64 mod everything = uint64_u
+[%%expect{|
+type t8 = uint8_u
+type t16 = uint16_u
+type t32 = uint32_u
+type t64 = uint64_u
+|}]
+
+(* They are distinct from the signed types. *)
+
+let f (x : int8#) : uint8_u = x
+[%%expect{|
+Line 1, characters 30-31:
+1 | let f (x : int8#) : uint8_u = x
+                                  ^
+Error: The value "x" has type "int8#" but an expression was expected of type
+         "uint8_u"
+|}]
+
+let f (x : int16#) : uint16_u = x
+[%%expect{|
+Line 1, characters 32-33:
+1 | let f (x : int16#) : uint16_u = x
+                                    ^
+Error: The value "x" has type "int16#" but an expression was expected of type
+         "uint16_u"
+|}]
+
+let f (x : int32#) : uint32_u = x
+[%%expect{|
+Line 1, characters 32-33:
+1 | let f (x : int32#) : uint32_u = x
+                                    ^
+Error: The value "x" has type "int32#" but an expression was expected of type
+         "uint32_u"
+|}]
+
+let f (x : int64#) : uint64_u = x
+[%%expect{|
+Line 1, characters 32-33:
+1 | let f (x : int64#) : uint64_u = x
+                                    ^
+Error: The value "x" has type "int64#" but an expression was expected of type
+         "uint64_u"
+|}]
+
+(* They can be used as GADT indices and distinguished from the signed
+   types. *)
+
+type ('a : any) width =
+  | I8 : int8# width
+  | U8 : uint8_u width
+  | I16 : int16# width
+  | U16 : uint16_u width
+  | I32 : int32# width
+  | U32 : uint32_u width
+  | I64 : int64# width
+  | U64 : uint64_u width
+[%%expect{|
+type ('a : any) width =
+    I8 : int8# width
+  | U8 : uint8_u width
+  | I16 : int16# width
+  | U16 : uint16_u width
+  | I32 : int32# width
+  | U32 : uint32_u width
+  | I64 : int64# width
+  | U64 : uint64_u width
+|}]
+
+(* Specifying the index selects between the signed and unsigned
+   constructors: the matching constructor alone is exhaustive. *)
+
+let signed8 (x : int8# width) = match x with
+  | I8 -> ()
+[%%expect{|
+val signed8 : int8# width -> unit = <fun>
+|}]
+
+let unsigned8 (x : uint8_u width) = match x with
+  | U8 -> ()
+[%%expect{|
+val unsigned8 : uint8_u width -> unit = <fun>
+|}]
+
+let unsigned64 (x : uint64_u width) = match x with
+  | U64 -> ()
+[%%expect{|
+val unsigned64 : uint64_u width -> unit = <fun>
+|}]
+
+(* A constructor of the wrong signedness cannot match at a specified
+   index. *)
+
+let bad (x : uint8_u width) = match x with
+  | I8 -> ()
+[%%expect{|
+Line 2, characters 4-6:
+2 |   | I8 -> ()
+        ^^
+Error: This pattern matches values of type "int8# width"
+       but a pattern was expected which matches values of type "uint8_u width"
+       Type "int8#" is not compatible with type "uint8_u"
+|}]
+
+let bad (x : int16# width) = match x with
+  | U16 -> ()
+[%%expect{|
+Line 2, characters 4-7:
+2 |   | U16 -> ()
+        ^^^
+Error: This pattern matches values of type "uint16_u width"
+       but a pattern was expected which matches values of type "int16# width"
+       Type "uint16_u" is not compatible with type "int16#"
+|}]

--- a/testsuite/tests/typing-simd/test_upstream_compatible.ml
+++ b/testsuite/tests/typing-simd/test_upstream_compatible.ml
@@ -17,7 +17,7 @@ Line 1, characters 9-16:
 1 | type t = int16x8;;
              ^^^^^^^
 Error: Unbound type constructor "int16x8"
-Hint:              Did you mean "int64"?
+Hint:              Did you mean "int64" or "uint16_u"?
 |}];;
 
 type t = int32x4;;

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -62,6 +62,10 @@ type abstract_non_value_type_constr = [
   | `Int32_u
   | `Int64_u
   | `Float32_u
+  | `Uint8_u
+  | `Uint16_u
+  | `Uint32_u
+  | `Uint64_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -128,6 +132,10 @@ let base_type_constrs : type_constr list = [
   `Nativeint_u;
   `Int32_u;
   `Int64_u;
+  `Uint8_u;
+  `Uint16_u;
+  `Uint32_u;
+  `Uint64_u;
   `Idx_imm;
   `Idx_mut;
 ]
@@ -222,6 +230,10 @@ and ident_nativeint_u = ident_create "nativeint_u"
 and ident_int32_u = ident_create "int32_u"
 and ident_int64_u = ident_create "int64_u"
 and ident_float32_u = ident_create "float32_u"
+and ident_uint8_u = ident_create "uint8_u"
+and ident_uint16_u = ident_create "uint16_u"
+and ident_uint32_u = ident_create "uint32_u"
+and ident_uint64_u = ident_create "uint64_u"
 and ident_or_null = ident_create "or_null"
 and ident_idx_imm = ident_create "idx_imm"
 and ident_idx_mut = ident_create "idx_mut"
@@ -281,6 +293,10 @@ let ident_of_type_constr : type_constr -> Ident.t = function
   | `Int32_u -> ident_int32_u
   | `Int64_u -> ident_int64_u
   | `Float32_u -> ident_float32_u
+  | `Uint8_u -> ident_uint8_u
+  | `Uint16_u -> ident_uint16_u
+  | `Uint32_u -> ident_uint32_u
+  | `Uint64_u -> ident_uint64_u
   | `Idx_imm -> ident_idx_imm
   | `Idx_mut -> ident_idx_mut
   | `Int8x16 -> ident_int8x16
@@ -335,6 +351,10 @@ and path_nativeint_u = Pident ident_nativeint_u
 and path_int32_u = Pident ident_int32_u
 and path_int64_u = Pident ident_int64_u
 and path_float32_u = Pident ident_float32_u
+and path_uint8_u = Pident ident_uint8_u
+and path_uint16_u = Pident ident_uint16_u
+and path_uint32_u = Pident ident_uint32_u
+and path_uint64_u = Pident ident_uint64_u
 and path_idx_imm = Pident ident_idx_imm
 and path_idx_mut = Pident ident_idx_mut
 and path_code = Pident ident_code
@@ -445,6 +465,10 @@ and type_nativeint_u = tconstr path_nativeint_u []
 and type_int32_u = tconstr path_int32_u []
 and type_int64_u = tconstr path_int64_u []
 and type_float32_u = tconstr path_float32_u []
+and type_uint8_u = tconstr path_uint8_u []
+and type_uint16_u = tconstr path_uint16_u []
+and type_uint32_u = tconstr path_uint32_u []
+and type_uint64_u = tconstr path_uint64_u []
 and type_or_null t = tconstr path_or_null [t]
 and type_idx_imm t1 t2 = tconstr path_idx_imm [t1; t2]
 and type_idx_mut t1 t2 = tconstr path_idx_mut [t1; t2]
@@ -899,6 +923,17 @@ let decl_of_type_constr type_constr =
   | `Float32_u ->
     decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_float32)
       ~manifest:(tconstr (Path.unboxed_version path_float32) []) ()
+  (* The unboxed unsigned integer types are abstract: they support no
+     operations and exist only to be distinct from their signed
+     counterparts, e.g. for use as GADT indices. *)
+  | `Uint8_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int8) ()
+  | `Uint16_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int16) ()
+  | `Uint32_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int32) ()
+  | `Uint64_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int64) ()
   | `Idx_imm ->
     decl2 ~variance:(Variance.full, Variance.covariant)
        ~param_jkinds:(

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -46,6 +46,10 @@ type abstract_non_value_type_constr = [
   | `Int32_u
   | `Int64_u
   | `Float32_u
+  | `Uint8_u
+  | `Uint16_u
+  | `Uint32_u
+  | `Uint64_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -128,6 +132,10 @@ val type_nativeint_u: type_expr
 val type_int32_u: type_expr
 val type_int64_u: type_expr
 val type_float32_u: type_expr
+val type_uint8_u: type_expr
+val type_uint16_u: type_expr
+val type_uint32_u: type_expr
+val type_uint64_u: type_expr
 val type_or_null: type_expr -> type_expr
 val type_idx_imm : type_expr -> type_expr -> type_expr
 val type_idx_mut : type_expr -> type_expr -> type_expr
@@ -220,6 +228,10 @@ val path_nativeint_u: Path.t
 val path_int32_u: Path.t
 val path_int64_u: Path.t
 val path_float32_u: Path.t
+val path_uint8_u: Path.t
+val path_uint16_u: Path.t
+val path_uint32_u: Path.t
+val path_uint64_u: Path.t
 val path_or_null: Path.t
 val path_idx_imm: Path.t
 val path_idx_mut: Path.t


### PR DESCRIPTION
Makes `uint{8,16,32,64}_u` primitive types with the same kinds as their signed counterparts. This allows the compiler to distinguish the signed and unsigned types when used as GADT indices. 

The new unsigned types are opaque, and have no builtin operations. Their only runtime use is reinterpreting them to and from the signed types.