### PR TITLE
Sign extend the payload of `Typedtree.Const_untagged_char`

### DIFF
--- a/bytecomp/symtable.ml
+++ b/bytecomp/symtable.ml
@@ -213,9 +213,9 @@ external int_as_pointer : int -> Obj.t = "%int_as_pointer"
 
 let rec transl_const = function
     Const_base(Const_int i)
-  | Const_base(Const_untagged_int i) -> Obj.repr i
-  | Const_base(Const_char c)
-  | Const_base(Const_untagged_char c) -> Obj.repr c
+  | Const_base(Const_untagged_int i)
+  | Const_base(Const_untagged_char i) -> Obj.repr i
+  | Const_base(Const_char c) -> Obj.repr c
   | Const_base(Const_string (s, _, _)) -> Obj.repr s
   | Const_base(Const_float32 f)
   | Const_base(Const_unboxed_float32 f) ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -1211,7 +1211,8 @@ let debug_uid ppf duid =
 let rec struct_const ppf = function
   | Const_base(Const_int n) -> fprintf ppf "%i" n
   | Const_base(Const_char c) -> fprintf ppf "%C" c
-  | Const_base(Const_untagged_char c) -> fprintf ppf "#%C" c
+  | Const_base(Const_untagged_char c) ->
+      fprintf ppf "#%C" (Char.chr (c land 0xff))
   | Const_base(Const_string (s, _, _)) -> fprintf ppf "%S" s
   | Const_immstring s -> fprintf ppf "#%S" s
   | Const_base(Const_float f) -> fprintf ppf "%s" f

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -153,8 +153,7 @@ let rec declare_const acc dbg (const : Lambda.structured_constant) =
     register_const acc dbg (SC.boxed_nativeint (Const c)) "nativeint"
   | Const_base (Const_untagged_char c) ->
     ( acc,
-      reg_width
-        (RWC.naked_int8 (Numeric_types.Int8.unsigned_of_int_exn (Char.code c))),
+      reg_width (RWC.naked_int8 (Numeric_types.Int8.of_int_exn c)),
       "untagged_char" )
   | Const_base (Const_untagged_int c) ->
     ( acc,

--- a/middle_end/flambda2/numbers/numeric_types.ml
+++ b/middle_end/flambda2/numbers/numeric_types.ml
@@ -56,8 +56,6 @@ struct
 
     let max_int64 = Int64.lognot min_int64
 
-    let unsigned_min_int64 = 0L
-
     let unsigned_max_int64 =
       Int64.shift_right_logical Int64.minus_one (64 - num_bits)
 
@@ -65,24 +63,14 @@ struct
       if num_bits = 8
       then (
         assert (Int64.equal min_int64 (-128L));
-        assert (Int64.equal max_int64 127L);
-        assert (Int64.equal unsigned_max_int64 255L))
+        assert (Int64.equal max_int64 127L))
 
     let of_int64_exn i =
       if Int64.compare i min_int64 < 0 || Int64.compare i max_int64 > 0
       then Misc.fatal_errorf "Int%d: %Ld is out of range" num_bits i
       else Int64.to_int i
 
-    let unsigned_of_int64_exn i =
-      if
-        Int64.compare i unsigned_min_int64 < 0
-        || Int64.compare i unsigned_max_int64 > 0
-      then Misc.fatal_errorf "Int%d: %Ld is out of range" num_bits i
-      else Int64.to_int i
-
     let of_int_exn i = of_int64_exn (Int64.of_int i)
-
-    let unsigned_of_int_exn i = unsigned_of_int64_exn (Int64.of_int i)
 
     let of_int i =
       let extra_bits = Sys.int_size - num_bits in

--- a/middle_end/flambda2/numbers/numeric_types.mli
+++ b/middle_end/flambda2/numbers/numeric_types.mli
@@ -39,11 +39,7 @@ module Int8 : sig
 
   val of_int_exn : int -> t
 
-  val unsigned_of_int_exn : int -> t
-
   val of_int64_exn : Int64.t -> t
-
-  val unsigned_of_int64_exn : Int64.t -> t
 
   val to_int : t -> int
 
@@ -67,11 +63,7 @@ module Int16 : sig
 
   val of_int_exn : int -> t
 
-  val unsigned_of_int_exn : int -> t
-
   val of_int64_exn : Int64.t -> t
-
-  val unsigned_of_int64_exn : Int64.t -> t
 
   val to_int : t -> int
 

--- a/testsuite/tests/typing-small-numbers/test_matching_native.compilers.reference
+++ b/testsuite/tests/typing-small-numbers/test_matching_native.compilers.reference
@@ -99,4 +99,10 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched: #11S
 
 val five_hundred_partial : int = 500
+external int8_u_of_int : int -> int8# = "%int8#_of_int"
+external char_u_of_int8_u : int8# -> char# = "%identity"
+val char_u_of_code : int -> char# = <fun>
+val f_count_in_hexstring : char# -> int = <fun>
+val f_count_in_0xff : int = 2
+val f_count_in_'xff' : int = 2
 

--- a/testsuite/tests/typing-small-numbers/test_matching_native.ml
+++ b/testsuite/tests/typing-small-numbers/test_matching_native.ml
@@ -1,6 +1,8 @@
 (* TEST
- flambda2;
  {
+   toplevel;
+ }{
+   flambda2;
    toplevel.opt;
  }
 *)
@@ -242,4 +244,19 @@ let forty =
 let five_hundred_partial =
   match #6S with
   | #0S | #1S | #2S | #3S | #4S | #5S | #6S | #7S | #8S | #9S | #10S -> 500
+;;
+
+external int8_u_of_int : int -> int8# = "%int8#_of_int"
+external char_u_of_int8_u : int8# -> char# = "%identity"
+
+let char_u_of_code code = char_u_of_int8_u (int8_u_of_int code)
+
+let[@inline never] f_count_in_hexstring = function
+  | #'\x00' -> 0
+  | #'\xf0' -> 1
+  | #'\xff' -> 2
+  | _ -> failwith "not implemented"
+
+let f_count_in_0xff = f_count_in_hexstring (char_u_of_code 0xff)
+let f_count_in_'xff' = f_count_in_hexstring #'\xff'
 ;;

--- a/typing/parmatch.ml
+++ b/typing/parmatch.ml
@@ -1200,12 +1200,13 @@ let build_other ext env =
               ' ', '~' ; Char.chr 0 , Char.chr 255] d env
       | Constant Const_untagged_char _ ->
           build_exhaustable_constant
-            ~to_int:Char.code
-            ~proj:(function Constant(Const_untagged_char c) -> Char.code c
+            ~to_int:Fun.id
+            ~proj:(function Constant(Const_untagged_char c) -> c
                           | _ -> assert false)
-            ~make:(fun i -> Const_untagged_char (Char.chr i))
-            [ 'a', 'z' ; 'A', 'Z' ; '0', '9' ;
-              ' ', '~' ; Char.chr 0 , Char.chr 255] d env
+            ~make:(fun i -> Const_untagged_char i)
+            [ Char.code 'a', Char.code 'z' ; Char.code 'A', Char.code 'Z' ;
+              Char.code '0', Char.code '9' ; Char.code ' ', Char.code '~' ;
+              0, 0x7f ; -0x80, -1 ] d env
       | Constant Const_int _ ->
           build_other_constant
             (function Constant(Const_int i) -> i | _ -> assert false)

--- a/typing/printpat.ml
+++ b/typing/printpat.ml
@@ -27,7 +27,7 @@ let is_cons = function
 let pretty_const c = match c with
 | Const_int i -> Printf.sprintf "%d" i
 | Const_char c -> Printf.sprintf "%C" c
-| Const_untagged_char c -> Printf.sprintf "#%C" c
+| Const_untagged_char c -> Printf.sprintf "#%C" (Char.chr (c land 0xff))
 | Const_string (s, _, _) -> Printf.sprintf "%S" s
 | Const_float f -> Printf.sprintf "%s" f
 | Const_float32 f -> Printf.sprintf "%s" f

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -72,7 +72,7 @@ let fmt_constant f x =
   | Const_int (i) -> fprintf f "Const_int %d" i
   | Const_char (c) -> fprintf f "Const_char %02x" (Char.code c)
   | Const_untagged_char (c) ->
-      fprintf f "Const_untagged_char %02x" (Char.code c)
+      fprintf f "Const_untagged_char %02x" (c land 0xff)
   | Const_string (s, strloc, None) ->
       fprintf f "Const_string(%S,%a,None)" s fmt_location strloc
   | Const_string (s, strloc, Some delim) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1019,7 +1019,9 @@ let constant_desc
   | Pconst_char c -> Ok (Const_char c)
   | Pconst_untagged_char c ->
       if Language_extension.is_enabled Small_numbers
-      then Ok (Const_untagged_char c)
+      then
+        let extra_bits = Sys.int_size - 8 in
+        Ok (Const_untagged_char ((Char.code c lsl extra_bits) asr extra_bits))
       else Error (Untagged_char_literal c)
   | Pconst_string (s,loc,d) -> Ok (Const_string (s,loc,d))
   | Pconst_float (f,None)-> Ok (Const_float f)
@@ -3666,7 +3668,8 @@ and type_pat_aux
         expand_interval (Char.code c1) (Char.code c2)
           ~make:(fun loc i -> Const.char ~loc (Char.chr i))
       | Const_untagged_char c1, Const_untagged_char c2 ->
-        expand_interval (Char.code c1) (Char.code c2)
+        (* Intervals are specified by character code, as for [char]. *)
+        expand_interval (c1 land 0xff) (c2 land 0xff)
           ~make:(fun loc i -> Const.untagged_char ~loc (Char.chr i))
       | _ ->
         raise (Error (loc, !!penv, Invalid_interval))

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -23,7 +23,7 @@ open Mode
 type constant =
     Const_int of int
   | Const_char of char
-  | Const_untagged_char of char
+  | Const_untagged_char of int
   | Const_string of string * Location.t * string option
   | Const_float of string
   | Const_float32 of string

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -31,7 +31,11 @@ module Uid = Shape.Uid
 type constant =
     Const_int of int
   | Const_char of char
-  | Const_untagged_char of char
+  | Const_untagged_char of int
+    (* The payload is between -128 and 127, inclusive. [int] is used
+       instead of [char] since untagged chars have layout
+       [bits8], which are expected to be sign-extended, and [char] is
+       zero-extended. *)
   | Const_string of string * Location.t * string option
   | Const_float of string
   | Const_float32 of string

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -123,7 +123,8 @@ let rec extract_letop_patterns n pat =
 
 let constant = function
   | Const_char c -> Const.char c
-  | Const_untagged_char c -> Const.mk (Pconst_untagged_char c)
+  | Const_untagged_char c ->
+      Const.mk (Pconst_untagged_char (Char.chr (c land 0xff)))
   | Const_string (s,loc,d) -> Const.string ?quotation_delimiter:d ~loc s
   | Const_int i -> Const.integer (Int.to_string i)
   | Const_int8 i -> Const.integer ~suffix:'s' (Int.to_string i)


### PR DESCRIPTION
Previously, the payload was a `char` and zero-extended. This resulted in a miscompilation when using untagged char literals (see the changed test for an example) since untagged char constants were compared inconsistently. For example, in flambda, they were zero-extended instead of sign-extended to register width, and the matching compiler sorted them in unsigned order but emitted signed comparisons. The easiest way to make sure there are no inconsistencies between sign/zero-extension is to always store constants sign-extended.