### PR TITLE
Add `zero_alloc_` expression keyword

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -264,7 +264,7 @@ let iter_on_occurrences
       | Texp_letmodule _ | Texp_letexception _ | Texp_assert _ | Texp_lazy _
       | Texp_object _ | Texp_pack _ | Texp_letop _ | Texp_unreachable
       | Texp_list_comprehension _ | Texp_array_comprehension _ | Texp_probe _
-      | Texp_probe_is_enabled _ | Texp_exclave _
+      | Texp_probe_is_enabled _ | Texp_exclave _ | Texp_zero_alloc _
       (* CR-someday let_mutable: maybe iterate on mutvar? *)
       | Texp_mutvar _ | Texp_setmutvar _
       | Texp_open _ | Texp_src_pos | Texp_overwrite _

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1420,6 +1420,10 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
     let l = transl_exp ~scopes layout e in
     if Config.stack_allocation then Lexclave l
     else l
+  | Texp_zero_alloc e ->
+    (* CR dkalinichenko: verify the zero_alloc property of [e] using the
+       backend checker; for now, [zero_alloc_] is erased. *)
+    transl_exp ~scopes layout e
   | Texp_src_pos ->
       let pos = e.exp_loc.loc_start in
       let pos_fname = Clflags.prepend_directory pos.pos_fname in

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -4015,6 +4015,9 @@ and quote_expression_desc ~scopes ~transl stage e : Exp_desc.t =
     | Texp_overwrite _ ->
       fatal_errorf "Translquote [at %a]: Texp_overwrite" Location.print_loc
         (to_location loc)
+    | Texp_zero_alloc _ ->
+      fatal_errorf "Translquote [at %a]: Texp_zero_alloc" Location.print_loc
+        (to_location loc)
     | Texp_hole _ ->
       fatal_errorf "Translquote [at %a]: Texp_hole" Location.print_loc
         (to_location loc)

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -285,6 +285,7 @@ module Exp = struct
   let extension ?loc ?attrs a = mk ?loc ?attrs (Pexp_extension a)
   let unreachable ?loc ?attrs () = mk ?loc ?attrs Pexp_unreachable
   let stack ?loc ?attrs e = mk ?loc ?attrs (Pexp_stack e)
+  let zero_alloc ?loc ?attrs e = mk ?loc ?attrs (Pexp_zero_alloc e)
   let comprehension ?loc ?attrs e = mk ?loc ?attrs (Pexp_comprehension e)
   let overwrite ?loc ?attrs a b = mk ?loc ?attrs (Pexp_overwrite (a, b))
   let quote ?loc ?attrs a = mk ?loc ?attrs (Pexp_quote a)

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -234,6 +234,7 @@ module Exp:
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> expression
     val unreachable: ?loc:loc -> ?attrs:attrs -> unit -> expression
     val stack : ?loc:loc -> ?attrs:attrs -> expression -> expression
+    val zero_alloc : ?loc:loc -> ?attrs:attrs -> expression -> expression
     val comprehension :
       ?loc:loc -> ?attrs:attrs -> comprehension_expression -> expression
     val quote : ?loc:loc -> ?attrs:attrs -> expression -> expression

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -576,6 +576,7 @@ module E = struct
     | Pexp_extension x -> sub.extension sub x
     | Pexp_unreachable -> ()
     | Pexp_stack e -> sub.expr sub e
+    | Pexp_zero_alloc e -> sub.expr sub e
     | Pexp_comprehension e -> iter_comp_exp sub e
     | Pexp_overwrite (e1, e2) -> sub.expr sub e1; sub.expr sub e2
     | Pexp_quote e -> sub.expr sub e

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -662,6 +662,7 @@ module E = struct
     | Pexp_extension x -> extension ~loc ~attrs (sub.extension sub x)
     | Pexp_unreachable -> unreachable ~loc ~attrs ()
     | Pexp_stack e -> stack ~loc ~attrs (sub.expr sub e)
+    | Pexp_zero_alloc e -> zero_alloc ~loc ~attrs (sub.expr sub e)
     | Pexp_comprehension c -> comprehension ~loc ~attrs (map_cexp sub c)
     | Pexp_overwrite (e1, e2) -> overwrite ~loc ~attrs (sub.expr sub e1) (sub.expr sub e2)
     | Pexp_quote e -> quote ~loc ~attrs (sub.expr sub e)

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -329,6 +329,7 @@ let rec add_expr bv exp =
       end
   | Pexp_extension e -> handle_extension e
   | Pexp_stack e -> add_expr bv e
+  | Pexp_zero_alloc e -> add_expr bv e
   | Pexp_overwrite (e1, e2) -> add_expr bv e1; add_expr bv e2
   | Pexp_quote e -> add_expr bv e
   | Pexp_splice e -> add_expr bv e

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -113,6 +113,7 @@ let all_keywords =
     "when", WHEN, always;
     "while", WHILE, always;
     "with", WITH, always;
+    "zero_alloc_", ZERO_ALLOC, oxcaml;
 
     "lor", INFIXOP3("lor"), always; (* Should be INFIXOP2 *)
     "lxor", INFIXOP3("lxor"), always; (* Should be INFIXOP2 *)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -1125,6 +1125,7 @@ let maybe_pmod_constraint mode expr =
 %token SIG                    "sig"
 %token LAYOUT                 "layout_"
 %token STACK                  "stack_"
+%token ZERO_ALLOC             "zero_alloc_"
 %token STAR                   "*"
 %token <string * Location.t * string option>
        STRING                 "\"hello\"" (* just an example *)
@@ -2893,6 +2894,8 @@ fun_expr:
      { mkexp_constraint ~loc:$sloc ~exp ~cty:None ~modes:[mode] }
   | EXCLAVE seq_expr
      { mkexp_exclave ~loc:$sloc ~kwd_loc:($loc($1)) $2 }
+  | ZERO_ALLOC seq_expr
+     { mkexp ~loc:$sloc (Pexp_zero_alloc $2) }
 ;
 %inline expr:
   | or_function(fun_expr) { $1 }

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -552,6 +552,9 @@ and expression_desc =
   | Pexp_extension of extension  (** [[%id]] *)
   | Pexp_unreachable  (** [.] *)
   | Pexp_stack of expression (** stack_ exp *)
+  | Pexp_zero_alloc of expression
+      (** [zero_alloc_ exp]: the allocation axis of [exp] is not checked;
+          the zero_alloc property is verified by the backend instead. *)
   | Pexp_comprehension of comprehension_expression
     (** [[? BODY ...CLAUSES... ?]], where:
           - [?] is either [""] (list), [:] (immutable array), or [|] (array).

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -553,8 +553,9 @@ and expression_desc =
   | Pexp_unreachable  (** [.] *)
   | Pexp_stack of expression (** stack_ exp *)
   | Pexp_zero_alloc of expression
-      (** [zero_alloc_ exp]: the allocation axis of [exp] is not checked;
-          the zero_alloc property is verified by the backend instead. *)
+      (* CR dkalinichenko: [zero_alloc_ exp]: the allocation axis of [exp]
+         is not checked; the zero_alloc property is verified by the backend
+         instead. *)
   | Pexp_comprehension of comprehension_expression
     (** [[? BODY ...CLAUSES... ?]], where:
           - [?] is either [""] (list), [:] (immutable array), or [|] (array).

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1017,7 +1017,7 @@ and expression ctxt f x =
       (attributes ctxt) x.pexp_attributes
   else match x.pexp_desc with
     | Pexp_function _ | Pexp_match _ | Pexp_try _ | Pexp_sequence _
-    | Pexp_newtype _
+    | Pexp_newtype _ | Pexp_zero_alloc _
       when ctxt.pipe || ctxt.semi ->
         paren true (expression reset_ctxt) f x
     | Pexp_ifthenelse _ | Pexp_sequence _ when ctxt.ifthenelse ->

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -1118,6 +1118,8 @@ and expression ctxt f x =
     | Pexp_stack e ->
         (* Similar to the common case of [Pexp_apply] *)
         pp f "@[<hov2>stack_@ %a@]" (expression2 reset_ctxt)  e
+    | Pexp_zero_alloc e ->
+        pp f "@[<2>zero_alloc_ %a@]" (expression ctxt) e
     | Pexp_construct (li, Some eo)
       when not (is_simple_construct (view_expr x))-> (* Not efficient FIXME*)
         (match view_expr x with

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -498,6 +498,9 @@ and expression i ppf x =
       payload i ppf arg
   | Pexp_unreachable ->
       line i ppf "Pexp_unreachable"
+  | Pexp_zero_alloc e ->
+      line i ppf "Pexp_zero_alloc\n";
+      expression i ppf e
   | Pexp_stack e ->
       line i ppf "Pexp_stack\n";
       expression i ppf e

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -516,6 +516,9 @@ and expression i ppf x =
       payload i ppf arg
   | Pexp_unreachable ->
       line i ppf "Pexp_unreachable"
+  | Pexp_zero_alloc e ->
+      line i ppf "Pexp_zero_alloc\n";
+      expression i ppf e
   | Pexp_stack e ->
       line i ppf "Pexp_stack\n";
       expression i ppf e

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -829,6 +829,12 @@ let f x y = zero_alloc_ (x, y)
 val f : 'a -> 'b -> 'a * 'b = <fun>
 |}]
 
+let g r = (zero_alloc_ incr r); !r
+
+[%%expect{|
+val g : int ref -> int = <fun>
+|}]
+
 
 type t = { a : int }
 let f a =

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -820,6 +820,16 @@ Error: This value is "local"
          Hint: Use exclave_ to return a local value.
 |}]
 
+(**************)
+(* zero_alloc *)
+
+let f x y = zero_alloc_ (x, y)
+
+[%%expect{|
+val f : 'a -> 'b -> 'a * 'b = <fun>
+|}]
+
+
 type t = { a : int }
 let f a =
   let y = stack_ { a } in

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -591,23 +591,11 @@ val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
    optional-argument wrapping). *)
 let (alloc_optional_arg @ noalloc_strict) ?a () = a
 [%%expect{|
-Line 1, characters 45-51:
-1 | let (alloc_optional_arg @ noalloc_strict) ?a () = a
-                                                 ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 42-51
-         which is expected to be "noalloc_strict".
+val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
 |}]
 let (alloc_optional_arg @ noalloc) ?a () = a
 [%%expect{|
-Line 1, characters 38-44:
-1 | let (alloc_optional_arg @ noalloc) ?a () = a
-                                          ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 35-44
-         which is expected to be "noalloc".
+val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
 |}]
 
 (* Building a closure that captures a variable allocates. *)
@@ -616,20 +604,20 @@ let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
 Line 1, characters 49-60:
 1 | let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
                                                      ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-60
-         which is expected to be "noalloc_strict".
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 let (alloc_closure @ noalloc) (a : int) = fun () -> a
 [%%expect{|
 Line 1, characters 42-53:
 1 | let (alloc_closure @ noalloc) (a : int) = fun () -> a
                                               ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 30-53
-         which is expected to be "noalloc".
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 
 (* The same closure, but [stack_]-marked. *)
@@ -715,24 +703,14 @@ val alloc_tuple : unit -> int * int @ local = <fun>
 let (alloc_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
 [%%expect{|
-Line 2, characters 58-63:
-2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
-                                                              ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 2, characters 6-63
-         which is expected to be "noalloc_strict".
+val alloc_partial_app :
+  (int -> int -> int -> int) @ noalloc_strict -> int -> int = <fun>
 |}]
 let (alloc_partial_app @ noalloc)
       (f : (int -> int -> int -> int) @ noalloc) = f 1 2
 [%%expect{|
-Line 2, characters 51-56:
-2 |       (f : (int -> int -> int -> int) @ noalloc) = f 1 2
-                                                       ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 2, characters 6-56
-         which is expected to be "noalloc".
+val alloc_partial_app : (int -> int -> int -> int) @ noalloc -> int -> int =
+  <fun>
 |}]
 
 (* [stack_] on a partial application is rejected: it is an application, not a
@@ -744,10 +722,7 @@ let (stack_partial_app @ noalloc_strict)
 Line 2, characters 74-81:
 2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
                                                                               ^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 2, characters 6-81
-         which is expected to be "noalloc_strict".
+Error: This expression is not an allocation site.
 |}]
 
 (* Partial application whose result is a function hidden behind a
@@ -761,13 +736,8 @@ let (alloc_partial_app_abbrev @ noalloc_strict)
       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
 [%%expect{|
 type myfun = int -> int
-Line 3, characters 53-58:
-3 |       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
-                                                         ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 6-58
-         which is expected to be "noalloc_strict".
+val alloc_partial_app_abbrev :
+  (int -> int -> myfun) @ noalloc_strict -> myfun = <fun>
 |}]
 
 (* A function [f] with mixed arguments: optional [a], mandatory [b], optional
@@ -796,9 +766,9 @@ let (call_one_opt_one_mand @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
   f ~a:1 2
 [%%expect{|
-Line 3, characters 2-10:
+Line 3, characters 7-8:
 3 |   f ~a:1 2
-      ^^^^^^^^
+           ^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 2-3, characters 6-10
@@ -812,9 +782,9 @@ let (call_one_opt_one_mand @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int)) =
   f ~a:1 2
 [%%expect{|
-Line 3, characters 2-10:
+Line 3, characters 7-8:
 3 |   f ~a:1 2
-      ^^^^^^^^
+           ^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 2-3, characters 6-10
@@ -1508,9 +1478,9 @@ let stack_inner_partial_application
   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
   ()
 [%%expect{|
-Line 3, characters 48-62:
+Line 3, characters 51-59:
 3 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
-                                                    ^^^^^^^^^^^^^^
+                                                       ^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at line 3, characters 27-62
@@ -1674,24 +1644,15 @@ Line 1, characters 32-51:
 Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
-(** Test 5.10:
 
-    CR shsong: a curried multi-argument function cannot be [noalloc]/
-    [noalloc_strict].
+(** Test 6: Muti-argument function (currying) and partial application *)
 
-    Writing [let f x y = x] desugars to [fun x -> (fun y -> x)]. Applying [f] to
-    one argument builds the inner closure [fun y -> x], preventing [f] from
-    begin [noalloc]/[noalloc_strict]. *)
+(** Test 6.1: a curried multi-argument function can be [noalloc]/
+  [noalloc_strict], but the inner closure (its codomain) must be [local]. *)
 
 let (f @ noalloc_strict) x y = x
 [%%expect{|
-Line 10, characters 27-32:
-10 | let (f @ noalloc_strict) x y = x
-                                ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 10, characters 25-32
-         which is expected to be "noalloc_strict".
+val f : 'a -> ('b -> 'a) @ local = <fun>
 |}]
 
 let (f_explicit @ noalloc_strict) x = fun y -> x
@@ -1699,61 +1660,125 @@ let (f_explicit @ noalloc_strict) x = fun y -> x
 Line 1, characters 38-48:
 1 | let (f_explicit @ noalloc_strict) x = fun y -> x
                                           ^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-48
-         which is expected to be "noalloc_strict".
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
 |}]
 
-let (f_n @ noalloc) x y = x
+let (f_explicit_exclave @ noalloc_strict) x = exclave_ fun y -> x
 [%%expect{|
-Line 1, characters 22-27:
-1 | let (f_n @ noalloc) x y = x
-                          ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 20-27
-         which is expected to be "noalloc".
+val f_explicit_exclave : 'a -> ('b -> 'a) @ local = <fun>
 |}]
 
-(* Contrast: a single-argument function builds no inner closure and so is
-   accepted at [noalloc_strict]. *)
+let (f @ noalloc) x y = x
+[%%expect{|
+val f : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+let (f_explicit @ noalloc) x = fun y -> x
+[%%expect{|
+Line 1, characters 31-41:
+1 | let (f_explicit @ noalloc) x = fun y -> x
+                                   ^^^^^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+|}]
+
+let (f_explicit_exclave @ noalloc) x = exclave_ fun y -> x
+[%%expect{|
+val f_explicit_exclave : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* Contrast: a single-argument function builds no inner closure.
+  Its return type is not a closure, so it can be global. *)
 let (g @ noalloc_strict) x = x
 [%%expect{|
 val g : 'a -> 'a = <fun>
 |}]
 
-let (f_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
+let (g @ noalloc) x = x
 [%%expect{|
-Line 1, characters 46-58:
-1 | let (f_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
-                                                  ^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 33-58
-         which is expected to be "noalloc_strict".
-|}]
-
-(* The exemption extends down the whole curry chain: a three-argument function
-   is accepted, with a [local] codomain at each step. *)
-let (f3 @ noalloc_strict) x y z = x
-[%%expect{|
+val g : 'a -> 'a = <fun>
 |}]
 
 (* Soundness: the returned closure is pinned [local], so it cannot escape to a
-   [global] (heap) position -- using [f] where a [global] codomain is expected
-   is rejected. *)
+  [global] (heap) position -- using [f] where a [global] codomain is expected
+  is rejected. *)
+let (f @ noalloc_strict) x y = x
 let escapes = (f : _ -> (_ -> _) @ global)
 [%%expect{|
+val f : 'a -> ('b -> 'a) @ local = <fun>
+Line 2, characters 15-16:
+2 | let escapes = (f : _ -> (_ -> _) @ global)
+                   ^
+Error: The value "f" has type "'a -> ('b -> 'a) @ local"
+       but an expression was expected of type "'c -> 'd -> 'e"
+|}]
+
+(* The local requirement is passed down the whole curry chain:
+  a three-argument function is accepted, with [local] mode at each layer of
+  codomain. Although [local] for inner layers is not printed, we have the
+  following sanity checks to validate this. *)
+let (f3 @ noalloc_strict) x y z = x
+[%%expect{|
+val f3 : 'a -> ('b -> 'c -> 'a) @ local = <fun>
+|}]
+
+(* Sanity check: [c' -> 'a] above is local and cannot be returned *)
+let g () = f3 0 1
+[%%expect{|
+Line 1, characters 11-17:
+1 | let g () = f3 0 1
+               ^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+Hint: This is a partial application
+      Adding 1 more argument will make the value non-local
+|}]
+
+(* Sanity check: Prove local constraints on inner steps with coercions.
+  Requiring the inner arrow ([_ -> _], the result of [f3 x y]) to be
+  [local] is accepted. *)
+let f3_inner_local = (f3 : _ -> ((_ -> (_ -> _) @ local)) @ local)
+[%%expect{|
+val f3_inner_local : 'a -> ('b -> 'c -> 'a) @ local = <fun>
+|}]
+
+(* Sanity check: Conversely, requiring that same inner arrow to be [global]
+  is rejected: it is really [local]. This is the definitive evidence that
+  the propagation reaches the inner step; the missing [@ local] in the
+  printed signature above is only a type-printer elision. *)
+let f3_inner_not_global = (f3 : _ -> ((_ -> (_ -> _) @ global)) @ local)
+[%%expect{|
+Line 1, characters 27-29:
+1 | let f3_inner_not_global = (f3 : _ -> ((_ -> (_ -> _) @ global)) @ local)
+                               ^^
+Error: The value "f3" has type "'a -> ('b -> 'c -> 'a) @ local"
+       but an expression was expected of type
+         "'a -> ('d -> ('e -> 'f)) @ local"
+       Type "'b -> ('c -> 'a) @ local" is not compatible with type
+         "'d -> 'e -> 'f"
 |}]
 
 (* Soundness: a genuine allocation in the body (here a tuple) is still counted;
    only the curried intermediate closures are exempt. *)
 let (f_body_alloc @ noalloc_strict) x y = (x, y)
 [%%expect{|
+Line 1, characters 42-48:
+1 | let (f_body_alloc @ noalloc_strict) x y = (x, y)
+                                              ^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 36-48
+         which is expected to be "noalloc_strict".
 |}]
 
-(** Test 5.11: forcing the codomain of a [noalloc] curried function to [local]
+(** Test 6.2: forcing the codomain of a [noalloc] curried function to [local]
     interacts with an explicit codomain areality annotation. Because the
     codomain arrow is forced to [local], an explicit [@ global] on it conflicts,
     while an explicit [@ local] agrees (and the function is accepted). *)
@@ -1762,22 +1787,208 @@ let (f_body_alloc @ noalloc_strict) x y = (x, y)
    [@ global] on the returned arrow. *)
 let (f : int -> (int -> int) @ global) @ noalloc_strict = fun x y -> x
 [%%expect{|
+Line 8, characters 64-70:
+8 | let (f : int -> (int -> int) @ global) @ noalloc_strict = fun x y -> x
+                                                                    ^^^^^^
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Contrast: without the [noalloc_strict] annotation the codomain is NOT forced,
    so the same [@ global] arrow is accepted. *)
 let (f : int -> (int -> int) @ global) = fun x y -> x
 [%%expect{|
+val f : int -> int -> int = <fun>
 |}]
 
 (* Annotating the codomain [@ local] agrees with the forcing, so the function
    is accepted. *)
 let (f : int -> (int -> int) @ local) @ noalloc_strict = fun x y -> x
 [%%expect{|
+val f : int -> (int -> int) @ local = <fun>
 |}]
 
+(* Sanity check: [f 0] is local *)
+let g () = f 0
+[%%expect{|
+Line 1, characters 11-14:
+1 | let g () = f 0
+               ^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+Hint: This is a partial application
+      Adding 1 more argument will make the value non-local
+|}]
 
-(** Test 6: Misc *)
+(** Test 6.3: propagation of [strictly_local_closure] to inner layers.
+
+    A closure built inside a [noalloc_strict] / [noalloc] function (if
+    the information is known when type check the closure) is forced to be
+    [local] and on stack. It is also exempted from the allocation check.
+    We probe each syntactic position for a nested closure.
+
+    Reading the results:
+    - Acceptance (a [val ... = <fun>] with a [@ local] codomain) means the flag
+      reached that position: the closure was exempted.
+    - "The allocation is "alloc" ... expected to be "noalloc_strict"" means the
+      flag did NOT reach that position (a propagation gap): the closure counts as
+      a heap allocation and forces the enclosing function.
+
+    [exclave_] is used as a uniform wrapper so a returned [local] closure is
+    allowed to escape its region; it does NOT by itself skip the allocation
+    lock-walk (that is what [strictly_local_closure] does), so acceptance below
+    genuinely reflects propagation -- see the control at the end of Part B. *)
+
+(* --- Part A: positions that DO receive the flag (closure exempted) --- *)
+
+(* Inner function parameter / curried closure (no [exclave_] needed). *)
+let (p_curried @ noalloc_strict) x y = x
+[%%expect{|
+val p_curried : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* Function body / return via [exclave_]. *)
+let (p_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
+[%%expect{|
+val p_exclave : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* Mode annotation on the returned closure ([mode_morph]/[type_expect_mode]). We
+   annotate a NON-locality axis ([contended]) on purpose: the [contended] in the
+   result shows the annotation itself took effect (so the [mode_morph] path is
+   exercised), while the [@ local] codomain is enforced by annotating the outer
+   closure p_mode_annot with [@ noalloc_strict]. *)
+let (p_mode_annot @ noalloc_strict) x = exclave_ (fun y -> x : _ @ contended)
+[%%expect{|
+val p_mode_annot : 'a -> ('b -> 'a) @ local contended = <fun>
+|}]
+
+(* Type constraint on the returned closure ([type_argument] reuses the expected
+   mode). *)
+let (p_constraint @ noalloc_strict) x = exclave_ ((fun y -> x) : _ -> _)
+[%%expect{|
+val p_constraint : 'a -> ('b -> 'a) @ local = <fun>
+|}]
+
+(* [if] branches (reuse the expected mode). *)
+let (p_if @ noalloc_strict) b x =
+  exclave_ (if b then (fun y -> x) else (fun y -> x))
+[%%expect{|
+val p_if : bool -> ('a -> 'b -> 'a) @ local = <fun>
+|}]
+
+(* [match] branches (reuse the expected mode). *)
+let (p_match @ noalloc_strict) o x =
+  exclave_ (match o with Some _ -> (fun y -> x) | None -> (fun y -> x))
+[%%expect{|
+val p_match : 'a option -> ('b -> 'c -> 'b) @ local = <fun>
+|}]
+
+(* Record field via a modality ([mode_is_contained_by]); the record block is
+   [stack_]-allocated so the field closure is the only thing exercising the
+   propagation. *)
+type box = { g : unit -> int }
+[%%expect{|
+type box = { g : unit -> int; }
+|}]
+let (p_record @ noalloc_strict) (x : int) = exclave_ stack_ { g = (fun () -> x) }
+[%%expect{|
+val p_record : int -> box @ local = <fun>
+|}]
+
+(* --- Part B: positions that do NOT yet receive the flag (propagation gaps) --- *)
+
+(* [let]-binding RHS: [pat_modes] rebuilds the RHS mode with [mode_default] and
+   drops the flag. The closure is treated as a heap allocation. *)
+let (g_let @ noalloc_strict) (x : int) =
+  let h = fun () -> x in
+  h ()
+[%%expect{|
+Line 2, characters 10-21:
+2 |   let h = fun () -> x in
+              ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-3, characters 29-6
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Application argument: [mode_argument] returns [mode_default] without the
+   flag, so the argument closure is not exempted. [use] and [g_arg] are wrapped
+   in an outer function so [use] stays a local [noalloc_strict] value -- a
+   top-level [use] would instead be exported at [alloc] and trip the capture rule
+   first. The only allocation here is the argument closure [fun () -> x], which
+   is what the error correctly points at. *)
+let g_app_arg () =
+  let (use @ noalloc_strict) (g : unit -> int) = g () in
+  let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
+  ()
+[%%expect{|
+Line 3, characters 47-60:
+3 |   let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
+                                                   ^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 31-60
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Region body ([for]/[while]/comprehension): [mode_region] rebuilds the body
+   mode with [mode_default] and drops the flag. *)
+let (g_region @ noalloc_strict) (x : int) =
+  for _i = 0 to 0 do
+    let _g = fun () -> x in ()
+  done
+[%%expect{|
+Line 3, characters 13-24:
+3 |     let _g = fun () -> x in ()
+                 ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-4, characters 32-6
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Let-binding operator (letop): the [let*] body is a continuation closure typed
+   at legacy via [mode_return] in [type_binding_op] (the [mode_return Value.legacy]
+   there), so it does not receive the flag. In practice the failure surfaces even
+   earlier: the [let*] operator is itself an [alloc] value, so referencing it
+   inside a [noalloc_strict] function trips the capture rule first. Either way,
+   [let*] does not currently compose with [noalloc_strict]. *)
+let ( let* ) o f = match o with None -> None | Some x -> f x
+[%%expect{|
+val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
+|}]
+let (g_letop @ noalloc_strict) (x : int) =
+  let* _ = Some 0 in
+  fun () -> x
+[%%expect{|
+Line 2, characters 2-6:
+2 |   let* _ = Some 0 in
+      ^^^^
+Error: The value "( let* )" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at lines 1-3, characters 31-13
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Control: [exclave_] does NOT rescue a gap position -- it forces [local] but
+   does not skip the lock-walk, so the [let]-RHS closure still errors. This
+   confirms the acceptances in Part A are due to [strictly_local_closure]
+   propagation, not to [exclave_]. *)
+let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
+[%%expect{|
+Line 1, characters 67-78:
+1 | let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
+                                                                       ^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 1, characters 37-84
+         which is expected to be "noalloc_strict".
+|}]
+
+(** Test 7: Misc *)
 
 type record_t = { x : float; y : float }
 [%%expect{|

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -604,20 +604,14 @@ let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
 Line 1, characters 49-60:
 1 | let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
                                                      ^^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_closure @ noalloc) (a : int) = fun () -> a
 [%%expect{|
 Line 1, characters 42-53:
 1 | let (alloc_closure @ noalloc) (a : int) = fun () -> a
                                               ^^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* The same closure, but [stack_]-marked. *)
@@ -1223,10 +1217,9 @@ let (layers3_ss @ noalloc_strict) (a : int) =
   in
   g
 [%%expect{|
-Lines 13-15, characters 27-5:
-13 | ...........................() =
+Line 14, characters 34-40:
 14 |     let (h @ noalloc_strict) () = Just a in
-15 |     h
+                                       ^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 12-17, characters 34-3
@@ -1241,10 +1234,9 @@ let (layers3_n @ noalloc) (a : int) =
   in
   g
 [%%expect{|
-Lines 2-4, characters 20-5:
-2 | ....................() =
+Line 3, characters 27-33:
 3 |     let (h @ noalloc) () = Just a in
-4 |     h
+                               ^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 26-3
@@ -1260,9 +1252,9 @@ let layers_middle (a : int) =
   in
   g
 [%%expect{|
-Line 3, characters 10-21:
+Line 3, characters 15-21:
 3 |     let h () = Just a in
-              ^^^^^^^^^^^
+                   ^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 2-4, characters 27-5
@@ -1660,10 +1652,7 @@ let (f_explicit @ noalloc_strict) x = fun y -> x
 Line 1, characters 38-48:
 1 | let (f_explicit @ noalloc_strict) x = fun y -> x
                                           ^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let (f_explicit_exclave @ noalloc_strict) x = exclave_ fun y -> x
@@ -1681,10 +1670,7 @@ let (f_explicit @ noalloc) x = fun y -> x
 Line 1, characters 31-41:
 1 | let (f_explicit @ noalloc) x = fun y -> x
                                    ^^^^^^^^^^
-Error: This value is "local"
-       but is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let (f_explicit_exclave @ noalloc) x = exclave_ fun y -> x
@@ -1821,26 +1807,11 @@ Hint: This is a partial application
       Adding 1 more argument will make the value non-local
 |}]
 
-(** Test 6.3: propagation of [strictly_local_closure] to inner layers.
-
-    A closure built inside a [noalloc_strict] / [noalloc] function (if
-    the information is known when type check the closure) is forced to be
-    [local] and on stack. It is also exempted from the allocation check.
+(** Test 6.3: A closure built inside a [noalloc_strict] / [noalloc] function
+    (if the information is known when type check the function) is forced to
+    be [local] and on stack. It is also exempted from the allocation check.
     We probe each syntactic position for a nested closure.
-
-    Reading the results:
-    - Acceptance (a [val ... = <fun>] with a [@ local] codomain) means the flag
-      reached that position: the closure was exempted.
-    - "The allocation is "alloc" ... expected to be "noalloc_strict"" means the
-      flag did NOT reach that position (a propagation gap): the closure counts as
-      a heap allocation and forces the enclosing function.
-
-    [exclave_] is used as a uniform wrapper so a returned [local] closure is
-    allowed to escape its region; it does NOT by itself skip the allocation
-    lock-walk (that is what [strictly_local_closure] does), so acceptance below
-    genuinely reflects propagation -- see the control at the end of Part B. *)
-
-(* --- Part A: positions that DO receive the flag (closure exempted) --- *)
+*)
 
 (* Inner function parameter / curried closure (no [exclave_] needed). *)
 let (p_curried @ noalloc_strict) x y = x
@@ -1854,10 +1825,11 @@ let (p_exclave @ noalloc_strict) x = exclave_ (fun y -> x)
 val p_exclave : 'a -> ('b -> 'a) @ local = <fun>
 |}]
 
-(* Mode annotation on the returned closure ([mode_morph]/[type_expect_mode]). We
-   annotate a NON-locality axis ([contended]) on purpose: the [contended] in the
-   result shows the annotation itself took effect (so the [mode_morph] path is
-   exercised), while the [@ local] codomain is enforced by annotating the outer
+(* Closure created inside mode annotation on the returned closure
+   ([mode_morph]/[type_expect_mode]). We annotate a NON-locality axis
+   ([contended]) on purpose: the [contended] in the result shows the
+   annotation itself took effect (so the [mode_morph] path is exercised),
+   while the [@ local] codomain is enforced by annotating the outer
    closure p_mode_annot with [@ noalloc_strict]. *)
 let (p_mode_annot @ noalloc_strict) x = exclave_ (fun y -> x : _ @ contended)
 [%%expect{|
@@ -1897,29 +1869,20 @@ let (p_record @ noalloc_strict) (x : int) = exclave_ stack_ { g = (fun () -> x) 
 val p_record : int -> box @ local = <fun>
 |}]
 
-(* --- Part B: positions that do NOT yet receive the flag (propagation gaps) --- *)
-
-(* [let]-binding RHS: [pat_modes] rebuilds the RHS mode with [mode_default] and
-   drops the flag. The closure is treated as a heap allocation. *)
+(* [let]-binding RHS. *)
 let (g_let @ noalloc_strict) (x : int) =
   let h = fun () -> x in
   h ()
 [%%expect{|
-Line 2, characters 10-21:
-2 |   let h = fun () -> x in
-              ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-3, characters 29-6
-         which is expected to be "noalloc_strict".
+Line 3, characters 2-3:
+3 |   h ()
+      ^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is the function in a tail call.
 |}]
 
-(* Application argument: [mode_argument] returns [mode_default] without the
-   flag, so the argument closure is not exempted. [use] and [g_arg] are wrapped
-   in an outer function so [use] stays a local [noalloc_strict] value -- a
-   top-level [use] would instead be exported at [alloc] and trip the capture rule
-   first. The only allocation here is the argument closure [fun () -> x], which
-   is what the error correctly points at. *)
+(* Application argument. *)
 let g_app_arg () =
   let (use @ noalloc_strict) (g : unit -> int) = g () in
   let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
@@ -1928,34 +1891,25 @@ let g_app_arg () =
 Line 3, characters 47-60:
 3 |   let (g_arg @ noalloc_strict) (x : int) = use (fun () -> x) in
                                                    ^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 31-60
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* Region body ([for]/[while]/comprehension): [mode_region] rebuilds the body
-   mode with [mode_default] and drops the flag. *)
+(* Region body ([for]/[while]/comprehension). *)
 let (g_region @ noalloc_strict) (x : int) =
   for _i = 0 to 0 do
     let _g = fun () -> x in ()
   done
 [%%expect{|
-Line 3, characters 13-24:
-3 |     let _g = fun () -> x in ()
-                 ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-4, characters 32-6
-         which is expected to be "noalloc_strict".
+val g_region : int -> unit = <fun>
 |}]
 
-(* Let-binding operator (letop): the [let*] body is a continuation closure typed
-   at legacy via [mode_return] in [type_binding_op] (the [mode_return Value.legacy]
-   there), so it does not receive the flag. In practice the failure surfaces even
-   earlier: the [let*] operator is itself an [alloc] value, so referencing it
-   inside a [noalloc_strict] function trips the capture rule first. Either way,
-   [let*] does not currently compose with [noalloc_strict]. *)
+(* Special case: Let-binding operator (letop): the [let*] body is a continuation
+   closure typed at legacy via [mode_return] in [type_binding_op]
+   (the [mode_return Value.legacy] there), so we cannot make it local.
+   In practice the failure surfaces even earlier: the [let*] operator is itself
+   an [alloc] value, so referencing it inside a [noalloc_strict] function trips
+   the capture rule first. Either way, [let*] does not currently compose with
+   [noalloc_strict]. *)
 let ( let* ) o f = match o with None -> None | Some x -> f x
 [%%expect{|
 val ( let* ) : 'a option -> ('a -> 'b option) -> 'b option = <fun>
@@ -1970,21 +1924,6 @@ Line 2, characters 2-6:
 Error: The value "( let* )" is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 1-3, characters 31-13
-         which is expected to be "noalloc_strict".
-|}]
-
-(* Control: [exclave_] does NOT rescue a gap position -- it forces [local] but
-   does not skip the lock-walk, so the [let]-RHS closure still errors. This
-   confirms the acceptances in Part A are due to [strictly_local_closure]
-   propagation, not to [exclave_]. *)
-let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
-[%%expect{|
-Line 1, characters 67-78:
-1 | let (g_let_exclave @ noalloc_strict) (x : int) = exclave_ (let h = fun () -> x in h)
-                                                                       ^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-84
          which is expected to be "noalloc_strict".
 |}]
 
@@ -2098,9 +2037,9 @@ let (secretly_allocates @ noalloc) () =
   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
   whitewashed ()
 [%%expect{|
-Line 2, characters 30-58:
+Line 2, characters 40-58:
 2 |   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                            ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-3, characters 35-16
@@ -2114,9 +2053,9 @@ let (secretly_allocates' @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-Line 3, characters 30-60:
+Line 3, characters 41-59:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                             ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 36-17
@@ -2130,9 +2069,9 @@ let (secretly_allocates @ noalloc) () = exclave_
  | None -> stack_ { x = 1.; y = 2. }
  | Some f -> f ()
 [%%expect{|
-Line 3, characters 30-60:
+Line 3, characters 41-59:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                             ^^^^^^^^^^^^^^^^^^
 Error: The allocation is "alloc"
        but is expected to be "noalloc"
          because it is used inside the function at lines 1-6, characters 35-17

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -2146,14 +2146,24 @@ Error: The allocation is "alloc"
 |}]
 
 
-(** Test 8: the [zero_alloc_] escape hatch. The allocation axis is not
-    checked inside [zero_alloc_ e]; the zero_alloc property of [e] is
-    instead verified by the backend checker. *)
+(** Test 8: the [zero_alloc_] escape hatch. [zero_alloc_ e] rolls the
+    enclosing noalloc obligations back for the extent of [e]: uses of values
+    and allocations inside neither constrain nor are constrained by
+    enclosing functions on the allocation axis; the zero_alloc property of
+    [e] is instead verified by the backend checker. Leaving the region is a
+    capture by the enclosing function, so the value [e] produces must
+    satisfy the enclosing noalloc obligation: function-free data crosses
+    the allocation axis and flows out freely, while functions and other
+    allocation carriers must be provably noalloc to re-enter. *)
 
-(* An [alloc] value can be returned where [noalloc_strict] is expected. *)
+(* The result value cannot launder its allocation mode: an [alloc] value
+   does not satisfy a [noalloc_strict] expectation through the wrapper. *)
 let za_direct (x : t @ alloc) : _ @ noalloc_strict = zero_alloc_ x
 [%%expect{|
-val za_direct : t -> t @ noalloc_strict = <fun>
+Line 13, characters 65-66:
+13 | let za_direct (x : t @ alloc) : _ @ noalloc_strict = zero_alloc_ x
+                                                                      ^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
 (* Allocations inside a [noalloc_strict] / [noalloc] closure are allowed. *)
@@ -2167,12 +2177,53 @@ let (za_alloc_n @ noalloc) () = zero_alloc_ { x = 1.; y = 2. }
 val za_alloc_n : unit -> record_t = <fun>
 |}]
 
-(* An [alloc] function can be called inside the region. *)
+(* An [alloc] function can be called inside the region; its result flows
+   out normally. *)
 let alloc_fun () = { x = 1.; y = 2. }
 let (za_call @ noalloc_strict) () = zero_alloc_ (alloc_fun ())
 [%%expect{|
 val alloc_fun : unit -> record_t = <fun>
 val za_call : unit -> record_t = <fun>
+|}]
+
+(* ... but the [alloc] function itself cannot leave the region. *)
+let (za_smuggle_result @ noalloc_strict) () = zero_alloc_ alloc_fun
+[%%expect{|
+Line 1, characters 58-67:
+1 | let (za_smuggle_result @ noalloc_strict) () = zero_alloc_ alloc_fun
+                                                              ^^^^^^^^^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
+|}]
+
+(* Nor can it leave through mutable storage. *)
+let (za_smuggle_ref @ noalloc_strict) () =
+  let mutable (r @ alloc) = None in
+  zero_alloc_ (r <- Some alloc_fun);
+  (match r with
+  | None -> assert false
+  | Some f -> f ());
+  ()
+[%%expect{|
+Lines 4-6, characters 2-19:
+4 | ..(match r with
+5 |   | None -> assert false
+6 |   | Some f -> f ()).
+Warning 10 [non-unit-statement]: this expression should have type unit.
+
+val za_smuggle_ref : unit -> unit = <fun>
+|}]
+
+(* Nor wrapped in a closure built inside the region. *)
+let (za_smuggle_closure @ noalloc_strict) () =
+  zero_alloc_ (fun () -> alloc_fun ())
+[%%expect{|
+Line 2, characters 25-34:
+2 |   zero_alloc_ (fun () -> alloc_fun ())
+                             ^^^^^^^^^
+Error: The value "alloc_fun" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 14-38
+         which is expected to be "noalloc_strict".
 |}]
 
 (* A closure defined inside the region is still checked. *)
@@ -2226,6 +2277,40 @@ let za_exempt (h : (unit -> record_t) @ alloc) =
   f
 [%%expect{|
 val za_exempt : (unit -> record_t) -> unit -> record_t = <fun>
+|}]
+
+(* An inner region's exit is checked against the closure it re-enters:
+   [int ref] is function-free data, crosses the allocation axis, and so
+   flows out of the inner region into the [noalloc_strict] closure [g]
+   (exactly as g could capture an [alloc] int ref). *)
+let za_nested_intervening () =
+  zero_alloc_ (let (g @ noalloc_strict) () = zero_alloc_ (ref 0) in g ())
+[%%expect{|
+Line 2, characters 57-64:
+2 |   zero_alloc_ (let (g @ noalloc_strict) () = zero_alloc_ (ref 0) in g ())
+                                                             ^^^^^^^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
+|}]
+
+(* ... but an allocation carrier may not re-enter [g], even though the
+   lookup of [alloc_fun] itself is exempted by the regions. *)
+let za_nested_smuggle () =
+  zero_alloc_ (let (g @ noalloc_strict) () = zero_alloc_ alloc_fun in g ())
+[%%expect{|
+Line 2, characters 57-66:
+2 |   zero_alloc_ (let (g @ noalloc_strict) () = zero_alloc_ alloc_fun in g ())
+                                                             ^^^^^^^^^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
+|}]
+
+(* [zero_alloc_] does not relax other axes. *)
+let za_other_axis (g : (unit -> unit) @ stateful portable) : _ @ stateless =
+  zero_alloc_ g
+[%%expect{|
+Line 2, characters 14-15:
+2 |   zero_alloc_ g
+                  ^
+Error: This value is "stateful" but is expected to be "stateless".
 |}]
 
 (* [zero_alloc_] is transparent for type inference. *)

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -585,10 +585,12 @@ let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
 val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
 |}]
 
-(* CR shsong: Currently it may also because multi-argument function
-    always allocates. Revisit this in the next PR. *)
-(* A function that takes an optional argument allocates (to handle the
-   optional-argument wrapping). *)
+
+(* A function that takes an optional argument can still be noalloc.
+  Calling the function without providing the optional argument does not
+  trigger allocation.
+  Calling the function with providing the optional argument triggers
+  allocation, which is successfully detected. *)
 let (alloc_optional_arg @ noalloc_strict) ?a () = a
 [%%expect{|
 val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
@@ -598,7 +600,52 @@ let (alloc_optional_arg @ noalloc) ?a () = a
 val alloc_optional_arg : ?a:'a -> (unit -> 'a option) @ local = <fun>
 |}]
 
-(* Building a closure that captures a variable allocates. *)
+let test_missing_arg () =
+  let (f @ noalloc_strict) ?a () = a in
+  let (g @ noalloc_strict) () = f () in
+  g ()
+[%%expect{|
+val test_missing_arg : unit -> 'a option = <fun>
+|}]
+
+let test_passing_arg () =
+  let (f @ noalloc_strict) ?a () = a in
+  let (g @ noalloc_strict) () = f ~a:1 () in
+  g ()
+[%%expect{|
+Line 3, characters 37-38:
+3 |   let (g @ noalloc_strict) () = f ~a:1 () in
+                                         ^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 27-41
+         which is expected to be "noalloc_strict".
+|}]
+
+let test_missing_arg () =
+  let (f @ noalloc_strict) ?(a=0) () = a in
+  let (g @ noalloc_strict) () = f () in
+  g ()
+[%%expect{|
+val test_missing_arg : unit -> int = <fun>
+|}]
+
+let test_passing_arg () =
+  let (f @ noalloc_strict) ?(a=0) () = a in
+  let (g @ noalloc_strict) () = f ~a:1 () in
+  g ()
+[%%expect{|
+Line 3, characters 37-38:
+3 |   let (g @ noalloc_strict) () = f ~a:1 () in
+                                         ^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 3, characters 27-41
+         which is expected to be "noalloc_strict".
+|}]
+
+(* Building a closure inside a noalloc function forcing the closure
+  to be local. *)
 let (alloc_closure @ noalloc_strict) (a : int) = fun () -> a
 [%%expect{|
 Line 1, characters 49-60:
@@ -614,12 +661,12 @@ Line 1, characters 42-53:
 Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same closure, but [stack_]-marked. *)
-let (alloc_closure @ noalloc_strict) (a : int) = exclave_ stack_ (fun () -> a)
+(* The same closure, but [exclave_]-marked. *)
+let (alloc_closure @ noalloc_strict) (a : int) = exclave_ (fun () -> a)
 [%%expect{|
 val alloc_closure : int -> (unit -> int) @ local = <fun>
 |}]
-let (alloc_closure @ noalloc) (a : int) = exclave_ stack_ (fun () -> a)
+let (alloc_closure @ noalloc) (a : int) = exclave_ (fun () -> a)
 [%%expect{|
 val alloc_closure : int -> (unit -> int) @ local = <fun>
 |}]
@@ -690,10 +737,9 @@ let (alloc_tuple @ noalloc) () = exclave_ stack_ (1, 2)
 val alloc_tuple : unit -> int * int @ local = <fun>
 |}]
 
-(* Partial application allocates a closure.
-   We receive [f] as a parameter (rather than defining a multi-argument
-   function, whose curried closures would themselves be flagged)
-   so the only allocation here is the partial-application closure. *)
+(* We do not check partial application to detect potential allocation triggered
+  by it. Instead, we guarantee that if a function is noalloc, then
+  calling it with partial application does not trigger any heap allocation. *)
 let (alloc_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = f 1 2
 [%%expect{|
@@ -708,8 +754,7 @@ val alloc_partial_app : (int -> int -> int -> int) @ noalloc -> int -> int =
 |}]
 
 (* [stack_] on a partial application is rejected: it is an application, not a
-   recognized allocation form. [f] is received as a parameter to avoid the
-   currying closures of a multi-argument definition. *)
+   recognized allocation form. *)
 let (stack_partial_app @ noalloc_strict)
       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
 [%%expect{|
@@ -720,11 +765,7 @@ Error: This expression is not an allocation site.
 |}]
 
 (* Partial application whose result is a function hidden behind a
-   type abbreviation ([myfun = int -> int]). Here [f 1 2] is a partial
-   application returning [myfun], so it allocates a closure. The detection uses
-   [get_desc (expand_head env ty_ret)]: [expand_head] unfolds [myfun] to
-   [int -> int] and the [Tarrow] is seen, so the allocation IS currently
-   caught. *)
+   type abbreviation ([myfun = int -> int]). *)
 type myfun = int -> int
 let (alloc_partial_app_abbrev @ noalloc_strict)
       (f : (int -> int -> myfun) @ noalloc_strict) = f 1 2
@@ -734,16 +775,18 @@ val alloc_partial_app_abbrev :
   (int -> int -> myfun) @ noalloc_strict -> myfun = <fun>
 |}]
 
-(* A function [f] with mixed arguments: optional [a], mandatory [b], optional
-   [c], mandatory [d], optional [e], mandatory [g]. It ends in a mandatory
-   argument [g], so it can be fully applied. It is received as a parameter so
-   referencing it (in function position) does not itself trigger the capture
-   rule; the only allocations come from how it is called. *)
+(* At function call site, we only detect allocation by passing an optional
+  argument, but do not detect potential allocation by partial application.
+
+  A function [f] with mixed arguments: optional [a], mandatory [b], optional
+  [c], mandatory [d], optional [e], mandatory [g]. It ends in a mandatory
+  argument [g], so it can be fully applied. It is received as a parameter so
+  referencing it (in function position) does not itself trigger the capture
+  rule; the only allocations come from how it is called. *)
 
 (* Case 1: call with all mandatory args ([b], [d], [g]); all optionals are
-   omitted, so they default to [None] (constant constructors, no [Some]
-   wrapping). The call is fully applied (not partial), so it allocates nothing
-   and is accepted. *)
+  omitted, so they default to [None] (constant constructors, no [Some]
+  wrapping). Furthermore, [f] is fully applied. Thus, it is accepted. *)
 let (call_all_mandatory @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
   f 1 2 3
@@ -752,10 +795,24 @@ val call_all_mandatory :
   (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int) -> int = <fun>
 |}]
 
-(* Case 2: call with one optional ([~a:1]) and one mandatory ([b]). The mandatory
-   args [d] and [g] are still missing, so this is a partial application, which
-   allocates a closure and is rejected. (The provided [~a:1] would additionally
-   be wrapped in [Some], but the partial-application check fires first.) *)
+(* Case 2: call with two mandatory args ([b], [d]); all optionals are
+  omitted, so they default to [None] (constant constructors, no [Some]
+  wrapping). One mandatory arg is missing. Note that [call_two_mand]
+  does not allocate as long as [f] is noalloc, since our typing rule
+  guarantee that noalloc function does not allocate even when partially
+  applied. Thus, call_two_mand can be noalloc. *)
+let (call_two_mand @ noalloc_strict)
+      (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
+  f 1 2
+[%%expect{|
+val call_two_mand :
+  (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int) ->
+  ?e:int -> int -> int = <fun>
+|}]
+
+(* Case 3: call with one optional ([~a:1]) and one mandatory ([b]). The provided
+  [~a:1] would be wrapped in [Some], which triggers allocation. Thus, it is
+  rejected. *)
 let (call_one_opt_one_mand @ noalloc_strict)
       (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int -> int)) =
   f ~a:1 2
@@ -768,23 +825,6 @@ Error: The allocation is "alloc"
          because it is used inside the function at lines 2-3, characters 6-10
          which is expected to be "noalloc_strict".
 |}]
-
-(* Case 3: call a function whose last agument is optional argument and
-   all mandatory arguments are applied. Since the last argument is optional
-   the result still allocates. *)
-let (call_one_opt_one_mand @ noalloc_strict)
-      (f : (?a:int -> int -> ?c:int -> int -> ?e:int -> int)) =
-  f ~a:1 2
-[%%expect{|
-Line 3, characters 7-8:
-3 |   f ~a:1 2
-           ^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-3, characters 6-10
-         which is expected to be "noalloc_strict".
-|}]
-
 
 (* A lazy block allocates on the heap *)
 let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
@@ -1576,67 +1616,6 @@ Error: This value is "local" because it is "stack_"-allocated.
 |}]
 
 
-(** Test 5.9: annotating the codomain of the arrow with [@ noalloc_strict]
-    constrains the mode of the application result. With
-    [foo : int -> t @ noalloc_strict], applying [M.foo 1] yields a
-    [noalloc_strict] value (and likewise [M.foo_int 1]). Note the codomain mode
-    [@ noalloc_strict] must precede the [@@ noalloc_strict] modality; writing it
-    as [(t @ noalloc_strict) @@ ...] is a syntax error. *)
-
-module M : sig
-  type t
-  val foo : int -> t @ noalloc_strict @@ noalloc_strict
-
-  type int_t
-  val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
-  val foo_int_default : int -> int_t @@ noalloc_strict
-end = struct
-  type t = (int -> unit) -> unit
-  let g0 : t = fun g -> g 0
-  let foo (_ : int) = g0
-
-  type int_t = int
-  let foo_int x = x
-  let foo_int_default x = x
-end
-[%%expect{|
-module M :
-  sig
-    type t
-    val foo : int -> t @ noalloc_strict @@ noalloc_strict
-    type int_t
-    val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
-    val foo_int_default : int -> int_t @@ noalloc_strict
-  end @@ stateless noalloc_strict
-|}]
-
-(* CR shsong: Error expected -- [M.foo 1] is a partial application,
-    which causes allocation. The current partial application detection
-    cannot detect whether an abstract type is an arrow type. *)
-let apply_one () = (M.foo 1 : _ @ noalloc_strict)
-[%%expect{|
-val apply_one : unit -> M.t = <fun>
-|}]
-
-let apply_zero () = (M.foo : _ @ noalloc_strict)
-[%%expect{|
-val apply_zero : unit -> int -> M.t @ noalloc_strict = <fun>
-|}]
-
-let apply_foo_int () = (M.foo_int 1 : _ @ noalloc_strict)
-[%%expect{|
-val apply_foo_int : unit -> M.int_t = <fun>
-|}]
-
-let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
-[%%expect{|
-Line 1, characters 32-51:
-1 | let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
-                                    ^^^^^^^^^^^^^^^^^^^
-Error: This value is "alloc" but is expected to be "noalloc_strict".
-|}]
-
-
 (** Test 6: Muti-argument function (currying) and partial application *)
 
 (** Test 6.1: a curried multi-argument function can be [noalloc]/
@@ -1925,6 +1904,60 @@ Error: The value "( let* )" is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at lines 1-3, characters 31-13
          which is expected to be "noalloc_strict".
+|}]
+
+(** Test 6.4: Misc test regarding abstract type
+
+    CR shsong: Chek whether backend guarantee that foo does not allocate for the
+    returned global closure g0. *)
+module M : sig
+  type t
+  val foo : int -> t @ noalloc_strict @@ noalloc_strict
+
+  type int_t
+  val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
+  val foo_int_default : int -> int_t @@ noalloc_strict
+end = struct
+  type t = (int -> unit) -> unit
+  let g0 : t = fun g -> g 0
+  let foo (_ : int) = g0
+
+  type int_t = int
+  let foo_int x = x
+  let foo_int_default x = x
+end
+[%%expect{|
+module M :
+  sig
+    type t
+    val foo : int -> t @ noalloc_strict @@ noalloc_strict
+    type int_t
+    val foo_int : int -> int_t @ noalloc_strict @@ noalloc_strict
+    val foo_int_default : int -> int_t @@ noalloc_strict
+  end @@ stateless noalloc_strict
+|}]
+
+let apply_one () = (M.foo 1 : _ @ noalloc_strict)
+[%%expect{|
+val apply_one : unit -> M.t = <fun>
+|}]
+
+let apply_zero () = (M.foo : _ @ noalloc_strict)
+[%%expect{|
+val apply_zero : unit -> int -> M.t @ noalloc_strict = <fun>
+|}]
+
+let apply_foo_int () = (M.foo_int 1 : _ @ noalloc_strict)
+[%%expect{|
+val apply_foo_int : unit -> M.int_t = <fun>
+|}]
+
+let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
+[%%expect{|
+Line 1, characters 32-51:
+1 | let apply_foo_int_default () = (M.foo_int_default 1 : _ @ noalloc_strict)
+                                    ^^^^^^^^^^^^^^^^^^^
+Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
 (** Test 7: Misc *)

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1734,6 +1734,49 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
+(* The exemption extends down the whole curry chain: a three-argument function
+   is accepted, with a [local] codomain at each step. *)
+let (f3 @ noalloc_strict) x y z = x
+[%%expect{|
+|}]
+
+(* Soundness: the returned closure is pinned [local], so it cannot escape to a
+   [global] (heap) position -- using [f] where a [global] codomain is expected
+   is rejected. *)
+let escapes = (f : _ -> (_ -> _) @ global)
+[%%expect{|
+|}]
+
+(* Soundness: a genuine allocation in the body (here a tuple) is still counted;
+   only the curried intermediate closures are exempt. *)
+let (f_body_alloc @ noalloc_strict) x y = (x, y)
+[%%expect{|
+|}]
+
+(** Test 5.11: forcing the codomain of a [noalloc] curried function to [local]
+    interacts with an explicit codomain areality annotation. Because the
+    codomain arrow is forced to [local], an explicit [@ global] on it conflicts,
+    while an explicit [@ local] agrees (and the function is accepted). *)
+
+(* The codomain is forced to [local], which conflicts with the explicit
+   [@ global] on the returned arrow. *)
+let (f : int -> (int -> int) @ global) @ noalloc_strict = fun x y -> x
+[%%expect{|
+|}]
+
+(* Contrast: without the [noalloc_strict] annotation the codomain is NOT forced,
+   so the same [@ global] arrow is accepted. *)
+let (f : int -> (int -> int) @ global) = fun x y -> x
+[%%expect{|
+|}]
+
+(* Annotating the codomain [@ local] agrees with the forcing, so the function
+   is accepted. *)
+let (f : int -> (int -> int) @ local) @ noalloc_strict = fun x y -> x
+[%%expect{|
+|}]
+
+
 (** Test 6: Misc *)
 
 type record_t = { x : float; y : float }

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -2285,9 +2285,14 @@ val za_exempt : (unit -> record_t) -> unit -> record_t = <fun>
    [int ref] is function-free data, crosses the allocation axis, and so
    flows out of the inner region into the [noalloc_strict] closure [g]
    (exactly as g could capture an [alloc] int ref). *)
+(* CR dkalinichenko: under [-principal] the type of [ref 0] is not yet
+   resolved when the exit check runs, so it does not cross the
+   allocation axis and the exit is rejected. *)
 let za_nested_intervening () =
   zero_alloc_ (let (g @ noalloc_strict) () = zero_alloc_ (ref 0) in g ())
 [%%expect{|
+val za_nested_intervening : unit -> int ref = <fun>
+|}, Principal{|
 Line 2, characters 57-64:
 2 |   zero_alloc_ (let (g @ noalloc_strict) () = zero_alloc_ (ref 0) in g ())
                                                              ^^^^^^^
@@ -2315,13 +2320,27 @@ Line 2, characters 14-15:
 Error: This value is "stateful" but is expected to be "stateless".
 |}]
 
-(* CR dkalinichenko: [zero_alloc_] is transparent for type inference. *)
+(* CR dkalinichenko: [zero_alloc_] is transparent for type inference; in
+   particular the value restriction still applies. *)
 let za_infer = zero_alloc_ (ref [])
 let () = za_infer := [1]
 let za_contents = !za_infer
 [%%expect{|
-val za_infer : 'a list ref = {contents = []}
-val za_contents : 'a list = [<poly>]
+val za_infer : '_weak1 list ref = {contents = []}
+val za_contents : int list = [1]
+|}]
+
+(* [zero_alloc_] is transparent to the ignored-partial-application
+   warning. *)
+let za_partial (r : int ref) = (zero_alloc_ List.map succ); !r
+[%%expect{|
+Line 1, characters 44-57:
+1 | let za_partial (r : int ref) = (zero_alloc_ List.map succ); !r
+                                                ^^^^^^^^^^^^^
+Warning 5 [ignored-partial-application]: this function application is partial,
+  maybe some arguments are missing.
+
+val za_partial : int ref -> int = <fun>
 |}]
 
 (* CR dkalinichenko: [zero_alloc_] under quotation. *)

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -2191,7 +2191,7 @@ Error: The allocation is "alloc"
 (* The keyword binds loosely: the whole sequence to its right is inside
    the region. *)
 let (za_seq @ noalloc_strict) (r : int ref) =
-  zero_alloc_ (incr r; { x = 1.; y = 2. })
+  zero_alloc_ incr r; { x = 1.; y = 2. }
 [%%expect{|
 val za_seq : int ref -> record_t = <fun>
 |}]
@@ -2209,6 +2209,25 @@ let (za_nested @ noalloc_strict) () =
 val za_nested : unit -> record_t = <fun>
 |}]
 
+(* Nested regions with an intervening noalloc closure: the inner region
+   escapes the inner closure's allocation checks. *)
+let (za_nested_deep @ noalloc_strict) () =
+  zero_alloc_
+    (let (g @ noalloc_strict) () = zero_alloc_ { x = 1.; y = 2. } in
+     g ())
+[%%expect{|
+val za_nested_deep : unit -> record_t = <fun>
+|}]
+
+(* A captured [alloc] function may be called inside the region, even
+   though the capture would otherwise force the closure to be [alloc]. *)
+let za_exempt (h : (unit -> record_t) @ alloc) =
+  let (f @ noalloc_strict) () = zero_alloc_ (h ()) in
+  f
+[%%expect{|
+val za_exempt : (unit -> record_t) -> unit -> record_t = <fun>
+|}]
+
 (* [zero_alloc_] is transparent for type inference. *)
 let za_infer = zero_alloc_ (ref [])
 let () = za_infer := [1]
@@ -2224,7 +2243,9 @@ val za_contents : 'a list = [<poly>]
 
 let za_quoted = <[ fun () -> zero_alloc_ (1, 2) ]>
 [%%expect{|
->> Fatal error: Translquote [at Line 1, characters 29-47]: Texp_zero_alloc
-Uncaught exception: Misc.Fatal_error
-
+Line 1, characters 29-47:
+1 | let za_quoted = <[ fun () -> zero_alloc_ (1, 2) ]>
+                                 ^^^^^^^^^^^^^^^^^^
+Error: The "zero_alloc_" construct is not supported inside quoted expressions,
+       as seen at line 1, characters 29-47.
 |}]

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -2166,7 +2166,8 @@ Line 13, characters 65-66:
 Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
-(* Allocations inside a [noalloc_strict] / [noalloc] closure are allowed. *)
+(* CR dkalinichenko: Allocations inside a [noalloc_strict] / [noalloc]
+   closure are allowed. *)
 let (za_alloc_ss @ noalloc_strict) () = zero_alloc_ { x = 1.; y = 2. }
 [%%expect{|
 val za_alloc_ss : unit -> record_t = <fun>
@@ -2226,7 +2227,7 @@ Error: The value "alloc_fun" is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
-(* A closure defined inside the region is still checked. *)
+(* CR dkalinichenko: A closure defined inside the region is still checked. *)
 let (za_nested_closure @ noalloc_strict) () =
   zero_alloc_ (let (g @ noalloc_strict) () = { x = 1.; y = 2. } in g ())
 [%%expect{|
@@ -2239,21 +2240,22 @@ Error: The allocation is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
-(* The keyword binds loosely: the whole sequence to its right is inside
-   the region. *)
+(* CR dkalinichenko: The keyword binds loosely: the whole sequence to
+   its right is inside the region. *)
 let (za_seq @ noalloc_strict) (r : int ref) =
   zero_alloc_ incr r; { x = 1.; y = 2. }
 [%%expect{|
 val za_seq : int ref -> record_t = <fun>
 |}]
 
-(* [zero_alloc_] is a no-op in a context that already allows allocation. *)
+(* CR dkalinichenko: [zero_alloc_] is a no-op in a context that already
+   allows allocation. *)
 let za_noop () = zero_alloc_ { x = 1.; y = 2. }
 [%%expect{|
 val za_noop : unit -> record_t = <fun>
 |}]
 
-(* Nested regions. *)
+(* CR dkalinichenko: Nested regions. *)
 let (za_nested @ noalloc_strict) () =
   zero_alloc_ (zero_alloc_ { x = 1.; y = 2. })
 [%%expect{|
@@ -2313,7 +2315,7 @@ Line 2, characters 14-15:
 Error: This value is "stateful" but is expected to be "stateless".
 |}]
 
-(* [zero_alloc_] is transparent for type inference. *)
+(* CR dkalinichenko: [zero_alloc_] is transparent for type inference. *)
 let za_infer = zero_alloc_ (ref [])
 let () = za_infer := [1]
 let za_contents = !za_infer
@@ -2322,7 +2324,7 @@ val za_infer : 'a list ref = {contents = []}
 val za_contents : 'a list = [<poly>]
 |}]
 
-(* [zero_alloc_] under quotation. *)
+(* CR dkalinichenko: [zero_alloc_] under quotation. *)
 
 #syntax quotations on
 

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -2205,13 +2205,13 @@ let (za_smuggle_ref @ noalloc_strict) () =
   | Some f -> f ());
   ()
 [%%expect{|
-Lines 4-6, characters 2-19:
-4 | ..(match r with
-5 |   | None -> assert false
-6 |   | Some f -> f ()).
-Warning 10 [non-unit-statement]: this expression should have type unit.
-
-val za_smuggle_ref : unit -> unit = <fun>
+Line 3, characters 25-34:
+3 |   zero_alloc_ (r <- Some alloc_fun);
+                             ^^^^^^^^^
+Error: This value is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is contained (via constructor "Some") in the value at line 3, characters 20-34
+         which is expected to be "noalloc_strict".
 |}]
 
 (* Nor wrapped in a closure built inside the region. *)

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags+="-extension mode_alpha -extension comprehensions";
+ flags+="-extension mode_alpha -extension comprehensions -extension runtime_metaprogramming";
  expect;
 *)
 
@@ -2143,4 +2143,88 @@ Error: The allocation is "alloc"
        but is expected to be "noalloc_strict"
          because it is used inside the function at line 1, characters 32-50
          which is expected to be "noalloc_strict".
+|}]
+
+
+(** Test 8: the [zero_alloc_] escape hatch. The allocation axis is not
+    checked inside [zero_alloc_ e]; the zero_alloc property of [e] is
+    instead verified by the backend checker. *)
+
+(* An [alloc] value can be returned where [noalloc_strict] is expected. *)
+let za_direct (x : t @ alloc) : _ @ noalloc_strict = zero_alloc_ x
+[%%expect{|
+val za_direct : t -> t @ noalloc_strict = <fun>
+|}]
+
+(* Allocations inside a [noalloc_strict] / [noalloc] closure are allowed. *)
+let (za_alloc_ss @ noalloc_strict) () = zero_alloc_ { x = 1.; y = 2. }
+[%%expect{|
+val za_alloc_ss : unit -> record_t = <fun>
+|}]
+
+let (za_alloc_n @ noalloc) () = zero_alloc_ { x = 1.; y = 2. }
+[%%expect{|
+val za_alloc_n : unit -> record_t = <fun>
+|}]
+
+(* An [alloc] function can be called inside the region. *)
+let alloc_fun () = { x = 1.; y = 2. }
+let (za_call @ noalloc_strict) () = zero_alloc_ (alloc_fun ())
+[%%expect{|
+val alloc_fun : unit -> record_t = <fun>
+val za_call : unit -> record_t = <fun>
+|}]
+
+(* A closure defined inside the region is still checked. *)
+let (za_nested_closure @ noalloc_strict) () =
+  zero_alloc_ (let (g @ noalloc_strict) () = { x = 1.; y = 2. } in g ())
+[%%expect{|
+Line 2, characters 45-63:
+2 |   zero_alloc_ (let (g @ noalloc_strict) () = { x = 1.; y = 2. } in g ())
+                                                 ^^^^^^^^^^^^^^^^^^
+Error: The allocation is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 40-63
+         which is expected to be "noalloc_strict".
+|}]
+
+(* The keyword binds loosely: the whole sequence to its right is inside
+   the region. *)
+let (za_seq @ noalloc_strict) (r : int ref) =
+  zero_alloc_ (incr r; { x = 1.; y = 2. })
+[%%expect{|
+val za_seq : int ref -> record_t = <fun>
+|}]
+
+(* [zero_alloc_] is a no-op in a context that already allows allocation. *)
+let za_noop () = zero_alloc_ { x = 1.; y = 2. }
+[%%expect{|
+val za_noop : unit -> record_t = <fun>
+|}]
+
+(* Nested regions. *)
+let (za_nested @ noalloc_strict) () =
+  zero_alloc_ (zero_alloc_ { x = 1.; y = 2. })
+[%%expect{|
+val za_nested : unit -> record_t = <fun>
+|}]
+
+(* [zero_alloc_] is transparent for type inference. *)
+let za_infer = zero_alloc_ (ref [])
+let () = za_infer := [1]
+let za_contents = !za_infer
+[%%expect{|
+val za_infer : 'a list ref = {contents = []}
+val za_contents : 'a list = [<poly>]
+|}]
+
+(* [zero_alloc_] under quotation. *)
+
+#syntax quotations on
+
+let za_quoted = <[ fun () -> zero_alloc_ (1, 2) ]>
+[%%expect{|
+>> Fatal error: Translquote [at Line 1, characters 29-47]: Texp_zero_alloc
+Uncaught exception: Misc.Fatal_error
+
 |}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3140,7 +3140,7 @@ let add_region_lock env = add_lock Region_lock env
 
 let add_exclave_lock env = add_lock Exclave_lock env
 
-let add_zero_alloc_lock ~loc:_ env = add_lock Zero_alloc_lock env
+let add_zero_alloc_lock env = add_lock Zero_alloc_lock env
 
 let add_unboxed_lock env = add_lock Unboxed_lock env
 
@@ -3806,7 +3806,6 @@ let unboxed_type ~errors ~env ~loc ty_and_lid =
    everything up to and including the last such lock, and [inner] is the
    locks pushed inside the innermost [zero_alloc_] region. *)
 let split_at_last_zero_alloc_lock locks =
-  (* Printf.eprintf "ZA locks: %d\n" (List.length locks); *)
   let rec go acc found = function
     | [] -> found
     | (Zero_alloc_lock as l) :: rest ->
@@ -3834,10 +3833,11 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
   match split_at_last_zero_alloc_lock locks with
   | None -> List.fold_left walk_one mode locks
   | Some (outer, inner) ->
-      (* CR dkalinichenko: Mask the allocation axis while walking the locks outside the [zero_alloc_] region:
-         the region neither constrains enclosing closures on that axis, nor is
-         constrained by them. The axis is then restored, so that the locks
-         inside the region still apply. *)
+      (* CR dkalinichenko: Mask the allocation axis while walking the
+         locks outside the [zero_alloc_] region: the region neither
+         constrains enclosing closures on that axis, nor is constrained
+         by them. The axis is then restored, so that the locks inside
+         the region still apply. *)
       let masked =
         Mode.Value.meet_const_with Allocation
           Mode.Allocation.Const.Noalloc_strict mode

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -843,6 +843,7 @@ type no_open_quotations_context =
   | Layout_polymorphism_qt
   | Tconst_pat_qt of Longident.t
   | Class_type_qt
+  | Zero_alloc_qt
 
 let print_structure_components_reason ppf = function
   | Project -> Format_doc.fprintf ppf "have any components"
@@ -3805,12 +3806,13 @@ let unboxed_type ~errors ~env ~loc ty_and_lid =
    [inner] is the locks pushed inside the innermost [zero_alloc_] region. *)
 let split_at_last_zero_alloc_lock locks =
   (* Printf.eprintf "ZA locks: %d\n" (List.length locks); *)
-  let rec go acc = function
-    | [] -> None
-    | (Zero_alloc_lock as l) :: rest -> Some (List.rev (l :: acc), rest)
-    | l :: rest -> go (l :: acc) rest
+  let rec go acc found = function
+    | [] -> found
+    | (Zero_alloc_lock as l) :: rest ->
+        go (l :: acc) (Some (List.rev (l :: acc), rest)) rest
+    | l :: rest -> go (l :: acc) found rest
   in
-  go [] locks
+  go [] None locks
 
 let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
   let walk_one vmode lock =
@@ -3840,6 +3842,11 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
           Mode.Allocation.Const.Noalloc_strict mode
       in
       let vmode = List.fold_left walk_one masked outer in
+      (* CR dkalinichenko: restoring the allocation axis here also
+         discards the [closure_noalloc_mode] marking that forces
+         allocations in enclosing noalloc closures to be local. Revisit
+         once the [Closure_noalloc_lock] detection (currently too
+         conservative) is fixed. *)
       let vmode =
         Mode.Value.join
           [ vmode;
@@ -5222,6 +5229,8 @@ let print_unsupported_quotation ppf =
         (Format.asprintf "%a" Pprintast.longident tconst)
   | Class_type_qt ->
       fprintf ppf "Using class type annotations"
+  | Zero_alloc_qt ->
+      fprintf ppf "The %a construct" (Style.inline_code) "zero_alloc_"
 
 let print_unbound_in_quotation ppf =
   function

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3879,9 +3879,7 @@ let walk_locks_for_legacy_construct ~env pp =
    use site outwards; a [Zero_alloc_lock] means the current context is
    itself inside a [zero_alloc_] region (whose own exit performs this
    check), so there is no obligation here. *)
-let enclosing_noalloc_ceiling env =
-  let locks = IdTbl.get_all_locks env.values in
-  let _stage_locks, locks = partition_locks locks in
+let noalloc_ceiling_of_locks locks =
   let rec go = function
     | [] -> Mode.Allocation.alloc
     | Zero_alloc_lock :: _ -> Mode.Allocation.alloc
@@ -3889,6 +3887,11 @@ let enclosing_noalloc_ceiling env =
     | _ :: rest -> go rest
   in
   Mode.Allocation.disallow_left (go (List.rev locks))
+
+let enclosing_noalloc_ceiling env =
+  let locks = IdTbl.get_all_locks env.values in
+  let _stage_locks, locks = partition_locks locks in
+  noalloc_ceiling_of_locks locks
 
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
@@ -3916,6 +3919,14 @@ let walk_locks_for_allocation ~env pp =
   a write).
 *)
 let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
+  let declaration_ceiling =
+    lazy
+      (let all = IdTbl.get_all_locks env.values in
+       let _stage_locks, all = partition_locks all in
+       let outer_len = List.length all - List.length locks in
+       noalloc_ceiling_of_locks
+         (List.filteri (fun i _ -> i < outer_len) all))
+  in
   let mode =
     m0
     |> mutable_mode |> Mode.Value.disallow_left
@@ -3937,9 +3948,13 @@ let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
           to be [local]. If [m0] is [local], that would trigger type error
           elsewhere, so what we return here doesn't matter. *)
           mode |> Mode.value_to_alloc_r2l |> Mode.alloc_as_value
-      | Const_closure_lock (true, _, _) | Closure_noalloc_lock
-      | Zero_alloc_lock ->
+      | Const_closure_lock (true, _, _) | Closure_noalloc_lock ->
           mode
+      | Zero_alloc_lock ->
+          Mode.Value.meet
+            [mode;
+             Mode.Value.max_with_comonadic Allocation
+               (Lazy.force declaration_ceiling)]
       | Const_closure_lock (false, pp, _) | Closure_lock (pp, _) ->
           may_lookup_error errors loc env
             (Mutable_value_used_in_closure pp)

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3800,10 +3800,11 @@ let unboxed_type ~errors ~env ~loc ty_and_lid =
     [None] when the function is used on modules and classes.
 
     [pp] is the pinpoint used in errors. *)
-(* [locks] is ordered from the definition site (outermost) to the use site
-   (innermost). If there is a [Zero_alloc_lock], returns [Some (outer, inner)]
-   where [outer] is everything up to and including the last such lock, and
-   [inner] is the locks pushed inside the innermost [zero_alloc_] region. *)
+(* CR dkalinichenko: [locks] is ordered from the definition site
+   (outermost) to the use site (innermost). If there is a
+   [Zero_alloc_lock], returns [Some (outer, inner)] where [outer] is
+   everything up to and including the last such lock, and [inner] is the
+   locks pushed inside the innermost [zero_alloc_] region. *)
 let split_at_last_zero_alloc_lock locks =
   (* Printf.eprintf "ZA locks: %d\n" (List.length locks); *)
   let rec go acc found = function
@@ -3833,7 +3834,7 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
   match split_at_last_zero_alloc_lock locks with
   | None -> List.fold_left walk_one mode locks
   | Some (outer, inner) ->
-      (* Mask the allocation axis while walking the locks outside the [zero_alloc_] region:
+      (* CR dkalinichenko: Mask the allocation axis while walking the locks outside the [zero_alloc_] region:
          the region neither constrains enclosing closures on that axis, nor is
          constrained by them. The axis is then restored, so that the locks
          inside the region still apply. *)
@@ -3871,13 +3872,13 @@ let walk_locks_with_mode_constraint ~env pp ~mode =
 let walk_locks_for_legacy_construct ~env pp =
   ignore (walk_locks_with_mode_constraint ~env pp ~mode:Mode.Value.legacy)
 
-(* The allocation ceiling demanded of values entering the current context
-   from a [zero_alloc_] region: leaving the region is a capture by the
-   enclosing function, so the region result must satisfy the innermost
-   enclosing noalloc obligation. Locks are scanned from the use site
-   outwards; a [Zero_alloc_lock] means the current context is itself inside
-   a [zero_alloc_] region (whose own exit performs this check), so there is
-   no obligation here. *)
+(* CR dkalinichenko: The allocation ceiling demanded of values entering
+   the current context from a [zero_alloc_] region: leaving the region is
+   a capture by the enclosing function, so the region result must satisfy
+   the innermost enclosing noalloc obligation. Locks are scanned from the
+   use site outwards; a [Zero_alloc_lock] means the current context is
+   itself inside a [zero_alloc_] region (whose own exit performs this
+   check), so there is no obligation here. *)
 let enclosing_noalloc_ceiling env =
   let locks = IdTbl.get_all_locks env.values in
   let _stage_locks, locks = partition_locks locks in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -180,6 +180,7 @@ type lock =
   | Closure_noalloc_lock
   | Region_lock
   | Exclave_lock
+  | Zero_alloc_lock
   | Unboxed_lock (* to prevent capture of terms with non-value types *)
 
 type lock_or_stage =
@@ -3138,6 +3139,8 @@ let add_region_lock env = add_lock Region_lock env
 
 let add_exclave_lock env = add_lock Exclave_lock env
 
+let add_zero_alloc_lock ~loc:_ env = add_lock Zero_alloc_lock env
+
 let add_unboxed_lock env = add_lock Unboxed_lock env
 
 let enter_quotation env =
@@ -3796,22 +3799,54 @@ let unboxed_type ~errors ~env ~loc ty_and_lid =
     [None] when the function is used on modules and classes.
 
     [pp] is the pinpoint used in errors. *)
+(* [locks] is ordered from the definition site (outermost) to the use site
+   (innermost). If there is a [Zero_alloc_lock], returns [Some (outer, inner)]
+   where [outer] is everything up to and including the last such lock, and
+   [inner] is the locks pushed inside the innermost [zero_alloc_] region. *)
+let split_at_last_zero_alloc_lock locks =
+  (* Printf.eprintf "ZA locks: %d\n" (List.length locks); *)
+  let rec go acc = function
+    | [] -> None
+    | (Zero_alloc_lock as l) :: rest -> Some (List.rev (l :: acc), rest)
+    | l :: rest -> go (l :: acc) rest
+  in
+  go [] locks
+
 let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
-  List.fold_left
-    (fun vmode lock ->
-      match lock with
-      | Region_lock -> region_mode vmode
-      | Const_closure_lock (_, closure_context, comonadic) ->
-          const_closure_mode pp vmode closure_context comonadic
-      | Closure_lock (closure_context, comonadic) ->
-          closure_mode pp vmode closure_context comonadic
-      | Closure_noalloc_lock -> closure_noalloc_mode pp vmode
-      | Exclave_lock ->
-          exclave_mode ~errors ~env ~pp vmode
-      | Unboxed_lock ->
-          unboxed_type ~errors ~env ~loc:(fst pp) ty_and_lid;
-          vmode
-    ) mode locks
+  let walk_one vmode lock =
+    match lock with
+    | Region_lock -> region_mode vmode
+    | Const_closure_lock (_, closure_context, comonadic) ->
+        const_closure_mode pp vmode closure_context comonadic
+    | Closure_lock (closure_context, comonadic) ->
+        closure_mode pp vmode closure_context comonadic
+    | Closure_noalloc_lock -> closure_noalloc_mode pp vmode
+    | Exclave_lock ->
+        exclave_mode ~errors ~env ~pp vmode
+    | Zero_alloc_lock -> vmode
+    | Unboxed_lock ->
+        unboxed_type ~errors ~env ~loc:(fst pp) ty_and_lid;
+        vmode
+  in
+  match split_at_last_zero_alloc_lock locks with
+  | None -> List.fold_left walk_one mode locks
+  | Some (outer, inner) ->
+      (* Mask the allocation axis while walking the locks outside the [zero_alloc_] region:
+         the region neither constrains enclosing closures on that axis, nor is
+         constrained by them. The axis is then restored, so that the locks
+         inside the region still apply. *)
+      let masked =
+        Mode.Value.meet_const_with Allocation
+          Mode.Allocation.Const.Noalloc_strict mode
+      in
+      let vmode = List.fold_left walk_one masked outer in
+      let vmode =
+        Mode.Value.join
+          [ vmode;
+            Mode.Value.min_with_comonadic Allocation
+              (Mode.Value.proj_comonadic Allocation mode) ]
+      in
+      List.fold_left walk_one vmode inner
 
 (** Constrains every enclosing closure lock with the given minimum mode. *)
 let walk_locks_with_mode_constraint ~env pp ~mode =
@@ -3876,7 +3911,8 @@ let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
           to be [local]. If [m0] is [local], that would trigger type error
           elsewhere, so what we return here doesn't matter. *)
           mode |> Mode.value_to_alloc_r2l |> Mode.alloc_as_value
-      | Const_closure_lock (true, _, _) | Closure_noalloc_lock ->
+      | Const_closure_lock (true, _, _) | Closure_noalloc_lock
+      | Zero_alloc_lock ->
           mode
       | Const_closure_lock (false, pp, _) | Closure_lock (pp, _) ->
           may_lookup_error errors loc env

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -177,6 +177,7 @@ type lock =
   | Const_closure_lock of bool * Mode.Hint.pinpoint *
       Mode.Value.Comonadic.Const.t
   | Closure_lock of Mode.Hint.pinpoint * Mode.Value.Comonadic.r
+  | Closure_noalloc_lock
   | Region_lock
   | Exclave_lock
   | Unboxed_lock (* to prevent capture of terms with non-value types *)
@@ -3131,6 +3132,8 @@ let add_closure_lock closure_context comonadic env =
   in
   add_lock lock env
 
+let add_closure_noalloc_lock env = add_lock Closure_noalloc_lock env
+
 let add_region_lock env = add_lock Region_lock env
 
 let add_exclave_lock env = add_lock Exclave_lock env
@@ -3732,6 +3735,14 @@ let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
   in
   {Mode.monadic; comonadic}
 
+let closure_noalloc_mode (pp : Mode.Hint.pinpoint) vmode =
+  let _, pp_desc = pp in
+  match pp_desc with
+  | Mode.Hint.Allocation true ->
+    Mode.Value.meet_const_with Allocation Mode.Allocation.Const.Noalloc_strict
+      vmode
+  | _ -> vmode
+
 let const_closure_mode pp {Mode.monadic; comonadic}
   closure_context comonadic0 =
   Mode.Value.Comonadic.(submode_err pp comonadic
@@ -3794,6 +3805,7 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
           const_closure_mode pp vmode closure_context comonadic
       | Closure_lock (closure_context, comonadic) ->
           closure_mode pp vmode closure_context comonadic
+      | Closure_noalloc_lock -> closure_noalloc_mode pp vmode
       | Exclave_lock ->
           exclave_mode ~errors ~env ~pp vmode
       | Unboxed_lock ->
@@ -3805,10 +3817,9 @@ let walk_locks ~errors ~env ~pp mode ty_and_lid locks =
 let walk_locks_with_mode_constraint ~env pp ~mode =
   let locks = IdTbl.get_all_locks env.values in
   let _stage_locks, locks = partition_locks locks in
-  ignore
-    (walk_locks ~errors:true ~env ~pp
-       (Mode.Value.disallow_right mode) None locks
-      : Mode.Value.l)
+  (walk_locks ~errors:true ~env ~pp
+      (Mode.Value.disallow_right mode) None locks
+    : Mode.Value.l)
 
 (** Registers a use of a construct that is at legacy comonadic modes,
     constraining every enclosing closure lock as if a legacy value defined at
@@ -3816,7 +3827,7 @@ let walk_locks_with_mode_constraint ~env pp ~mode =
     effect handlers) that force enclosing functions to be nonportable and
     stateful. *)
 let walk_locks_for_legacy_construct ~env pp =
-  walk_locks_with_mode_constraint ~env pp ~mode:Mode.Value.legacy
+  ignore (walk_locks_with_mode_constraint ~env pp ~mode:Mode.Value.legacy)
 
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
@@ -3824,8 +3835,17 @@ let walk_locks_for_legacy_construct ~env pp =
 (* CR shsong: currently it only considers noalloc_strict and alloc,
     need to customize this to support noalloc later *)
 let walk_locks_for_allocation ~env pp =
-  walk_locks_with_mode_constraint ~env pp
-    ~mode:(Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc)
+  let post_mode =
+    walk_locks_with_mode_constraint ~env pp
+      ~mode:(Mode.Value.min_with_comonadic Allocation Mode.Allocation.alloc)
+  in
+  match
+    Mode.Allocation.submode
+      (Mode.Value.proj_comonadic Allocation post_mode)
+      Mode.Allocation.noalloc
+  with
+  | Ok () -> true
+  | Error _ -> false
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
   and [locks] which is the locks between the declaration and the usage (either
@@ -3856,7 +3876,7 @@ let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
           to be [local]. If [m0] is [local], that would trigger type error
           elsewhere, so what we return here doesn't matter. *)
           mode |> Mode.value_to_alloc_r2l |> Mode.alloc_as_value
-      | Const_closure_lock (true, _, _) ->
+      | Const_closure_lock (true, _, _) | Closure_noalloc_lock ->
           mode
       | Const_closure_lock (false, pp, _) | Closure_lock (pp, _) ->
           may_lookup_error errors loc env

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3879,7 +3879,9 @@ let walk_locks_for_legacy_construct ~env pp =
    use site outwards; a [Zero_alloc_lock] means the current context is
    itself inside a [zero_alloc_] region (whose own exit performs this
    check), so there is no obligation here. *)
-let noalloc_ceiling_of_locks locks =
+let enclosing_noalloc_ceiling env =
+  let locks = IdTbl.get_all_locks env.values in
+  let _stage_locks, locks = partition_locks locks in
   let rec go = function
     | [] -> Mode.Allocation.alloc
     | Zero_alloc_lock :: _ -> Mode.Allocation.alloc
@@ -3887,11 +3889,6 @@ let noalloc_ceiling_of_locks locks =
     | _ :: rest -> go rest
   in
   Mode.Allocation.disallow_left (go (List.rev locks))
-
-let enclosing_noalloc_ceiling env =
-  let locks = IdTbl.get_all_locks env.values in
-  let _stage_locks, locks = partition_locks locks in
-  noalloc_ceiling_of_locks locks
 
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
@@ -3918,15 +3915,7 @@ let walk_locks_for_allocation ~env pp =
 - Returns the expected mode of the new value at the usage site (if the usage is
   a write).
 *)
-let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
-  let declaration_ceiling =
-    lazy
-      (let all = IdTbl.get_all_locks env.values in
-       let _stage_locks, all = partition_locks all in
-       let outer_len = List.length all - List.length locks in
-       noalloc_ceiling_of_locks
-         (List.filteri (fun i _ -> i < outer_len) all))
-  in
+let walk_locks_for_mutable_mode ~errors ~loc ~env ~region_ceiling locks m0 =
   let mode =
     m0
     |> mutable_mode |> Mode.Value.disallow_left
@@ -3953,8 +3942,7 @@ let walk_locks_for_mutable_mode ~errors ~loc ~env locks m0 =
       | Zero_alloc_lock ->
           Mode.Value.meet
             [mode;
-             Mode.Value.max_with_comonadic Allocation
-               (Lazy.force declaration_ceiling)]
+             Mode.Value.max_with_comonadic Allocation region_ceiling]
       | Const_closure_lock (false, pp, _) | Closure_lock (pp, _) ->
           may_lookup_error errors loc env
             (Mutable_value_used_in_closure pp)
@@ -3966,9 +3954,10 @@ let lookup_ident_value ~errors ~use ~loc name env =
   | Ok (path, locks, Val_bound vda) ->
       let stage_locks, locks = partition_locks locks in
       begin match vda with
-      | {vda_description={val_kind=Val_mut (m0, _); _}; _} ->
+      | {vda_description={val_kind=Val_mut (m0, _, region_ceiling); _}; _} ->
           m0
-          |> walk_locks_for_mutable_mode ~errors ~loc ~env locks
+          |> walk_locks_for_mutable_mode ~errors ~loc ~env ~region_ceiling
+               locks
           |> ignore
       | _ -> () end;
       check_cross_quotation ~errors ~loc_use:loc
@@ -4878,11 +4867,12 @@ let lookup_settable_variable ?(use=true) ~loc name env =
           use_value ~use ~loc path vda;
           Instance_variable
             (path, mut, cl_num, Subst.Lazy.force_type_expr desc.val_type)
-      | Val_mut (m0, sort), Pident id ->
+      | Val_mut (m0, sort, region_ceiling), Pident id ->
           let val_type = Subst.Lazy.force_type_expr desc.val_type in
           let mode =
             m0
-            |> walk_locks_for_mutable_mode ~errors:true ~loc ~env locks
+            |> walk_locks_for_mutable_mode ~errors:true ~loc ~env
+                 ~region_ceiling locks
             |> Mode.Modality.Const.apply_right
                 Typemode.let_mutable_modalities
           in

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3871,6 +3871,24 @@ let walk_locks_with_mode_constraint ~env pp ~mode =
 let walk_locks_for_legacy_construct ~env pp =
   ignore (walk_locks_with_mode_constraint ~env pp ~mode:Mode.Value.legacy)
 
+(* The allocation ceiling demanded of values entering the current context
+   from a [zero_alloc_] region: leaving the region is a capture by the
+   enclosing function, so the region result must satisfy the innermost
+   enclosing noalloc obligation. Locks are scanned from the use site
+   outwards; a [Zero_alloc_lock] means the current context is itself inside
+   a [zero_alloc_] region (whose own exit performs this check), so there is
+   no obligation here. *)
+let enclosing_noalloc_ceiling env =
+  let locks = IdTbl.get_all_locks env.values in
+  let _stage_locks, locks = partition_locks locks in
+  let rec go = function
+    | [] -> Mode.Allocation.alloc
+    | Zero_alloc_lock :: _ -> Mode.Allocation.alloc
+    | Closure_noalloc_lock :: _ -> Mode.Allocation.noalloc_strict
+    | _ :: rest -> go rest
+  in
+  Mode.Allocation.disallow_left (go (List.rev locks))
+
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
     alloc (rather than noalloc_strict) *)

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -602,6 +602,12 @@ val add_exclave_lock : t -> t
 (** Add a lock recording entry into a [zero_alloc_] expression: the allocation
     axis is unconstrained across this lock in both directions. *)
 val add_zero_alloc_lock : loc:Location.t -> t -> t
+
+(** The allocation ceiling demanded by the innermost enclosing noalloc
+    function, up to the nearest enclosing [zero_alloc_] region. Values
+    produced by a [zero_alloc_] region must satisfy it to re-enter the
+    enclosing context. [alloc] if there is no such obligation. *)
+val enclosing_noalloc_ceiling : t -> Mode.Allocation.r
 val add_unboxed_lock : t -> t
 val enter_quotation : t -> t
 val enter_splice : loc:Location.t -> t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -329,7 +329,7 @@ val walk_locks_for_legacy_construct : env:t -> Mode.Hint.pinpoint -> unit
 (** Registers a use of an allocation, constraining every enclosing closure lock.
     Used for constructs with allocations that force enclosing functions to be
     alloc (rather than noalloc_strict) *)
-val walk_locks_for_allocation : env:t -> Mode.Hint.pinpoint -> unit
+val walk_locks_for_allocation : env:t -> Mode.Hint.pinpoint -> bool
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
@@ -591,6 +591,9 @@ messages. [ghost = true] means the closure is not a value (such as
 a loop) *)
 val add_const_closure_lock : ?ghost:bool -> Mode.Hint.pinpoint ->
   Mode.Value.Comonadic.Const.t -> t -> t
+
+(** Add a lock recording that the enclosing function is not [alloc]. *)
+val add_closure_noalloc_lock : t -> t
 
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -597,6 +597,10 @@ val add_closure_noalloc_lock : t -> t
 
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t
+
+(** Add a lock recording entry into a [zero_alloc_] expression: the allocation
+    axis is unconstrained across this lock in both directions. *)
+val add_zero_alloc_lock : loc:Location.t -> t -> t
 val add_unboxed_lock : t -> t
 val enter_quotation : t -> t
 val enter_splice : loc:Location.t -> t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -599,14 +599,16 @@ val add_closure_noalloc_lock : t -> t
 val add_region_lock : t -> t
 val add_exclave_lock : t -> t
 
-(** Add a lock recording entry into a [zero_alloc_] expression: the allocation
-    axis is unconstrained across this lock in both directions. *)
+(* CR dkalinichenko: Add a lock recording entry into a [zero_alloc_]
+   expression: the allocation axis is unconstrained across this lock in
+   both directions. *)
 val add_zero_alloc_lock : loc:Location.t -> t -> t
 
-(** The allocation ceiling demanded by the innermost enclosing noalloc
-    function, up to the nearest enclosing [zero_alloc_] region. Values
-    produced by a [zero_alloc_] region must satisfy it to re-enter the
-    enclosing context. [alloc] if there is no such obligation. *)
+(* CR dkalinichenko: The allocation ceiling demanded by the innermost
+   enclosing noalloc function, up to the nearest enclosing [zero_alloc_]
+   region. Values produced by a [zero_alloc_] region must satisfy it to
+   re-enter the enclosing context. [alloc] if there is no such
+   obligation. *)
 val enclosing_noalloc_ceiling : t -> Mode.Allocation.r
 val add_unboxed_lock : t -> t
 val enter_quotation : t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -252,6 +252,7 @@ type no_open_quotations_context =
   | Layout_polymorphism_qt
   | Tconst_pat_qt of Longident.t
   | Class_type_qt
+  | Zero_alloc_qt
 
 type none_in_quotations_context =
   | Constructor

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -602,7 +602,7 @@ val add_exclave_lock : t -> t
 (* CR dkalinichenko: Add a lock recording entry into a [zero_alloc_]
    expression: the allocation axis is unconstrained across this lock in
    both directions. *)
-val add_zero_alloc_lock : loc:Location.t -> t -> t
+val add_zero_alloc_lock : t -> t
 
 (* CR dkalinichenko: The allocation ceiling demanded by the innermost
    enclosing noalloc function, up to the nearest enclosing [zero_alloc_]

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4806,7 +4806,10 @@ module Report = struct
       Some (print_article_noun Consonant "pattern match with effect cases")
     | Effect_try ->
       Some (print_article_noun Consonant "try-with with effect cases")
-    | Allocation -> Some (print_article_noun Vowel "allocation")
+    | Allocation closure ->
+      if closure
+      then Some (print_article_noun Vowel "allocation for closure")
+      else Some (print_article_noun Vowel "allocation")
     | Class -> Some (print_article_noun Consonant "class")
     | Object -> Some (print_article_noun Vowel "object")
     | Loop -> Some (print_article_noun Consonant "loop")
@@ -5957,6 +5960,10 @@ module Allocation = struct
   let legacy = of_const Const.legacy
 
   let zap_to_legacy = zap_to_ceil
+
+  module Guts = struct
+    let get_loose_ceil = Guts.get_loose_ceil
+  end
 end
 
 module type Areality = sig

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -34,7 +34,9 @@ type pinpoint_desc =
   | Structure  (** A structure definition *)
   | Lazy  (** A lazy expression *)
   | Quote  (** A quoted expression *)
-  | Allocation  (** An allocation *)
+  | Allocation of bool
+      (** An allocation, the boolean indicates whether the allocation is for a
+          closure or not *)
   | Expression  (** An arbitrary expression *)
   | Effect_match  (** A pattern match with effect cases *)
   | Effect_try  (** A try-with expression with effect cases *)

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -585,6 +585,13 @@ module type S = sig
     val noalloc : lr
 
     val alloc : lr
+
+    module Guts : sig
+      (** This module exposes some functions that allow callers to inspect modes
+          directly. *)
+
+      val get_loose_ceil : ('l * 'r) t -> Const.t
+    end
   end
 
   type 'a comonadic_with =

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -864,6 +864,9 @@ and expression i ppf x =
   | Texp_exclave (e) ->
       line i ppf "Texp_exclave";
       expression i ppf e;
+  | Texp_zero_alloc (e) ->
+      line i ppf "Texp_zero_alloc";
+      expression i ppf e;
   | Texp_src_pos ->
       line i ppf "Texp_src_pos"
   | Texp_overwrite (e1, e2) ->

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -517,6 +517,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
   | Texp_probe {handler;_} -> sub.expr sub handler
   | Texp_probe_is_enabled _ -> ()
   | Texp_exclave exp -> sub.expr sub exp
+  | Texp_zero_alloc exp -> sub.expr sub exp
   | Texp_src_pos -> ()
   | Texp_overwrite(exp1, exp2) ->
     sub.expr sub exp1;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -739,6 +739,8 @@ let expr sub x =
     | Texp_probe_is_enabled _ as e -> e
     | Texp_exclave exp ->
         Texp_exclave (sub.expr sub exp)
+    | Texp_zero_alloc exp ->
+        Texp_zero_alloc (sub.expr sub exp)
     | Texp_src_pos -> Texp_src_pos
     | Texp_overwrite (exp1, exp2) ->
         Texp_overwrite (sub.expr sub exp1, sub.expr sub exp2)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -3514,7 +3514,9 @@ and type_pat_aux
         | Mutable ->
             let m0 = Value.Comonadic.newvar () in
             let mode = mutvar_mode ~loc ~env:!!penv m0 alloc_mode in
-            let kind = Val_mut (m0, sort) in
+            let kind =
+              Val_mut (m0, sort, Env.enclosing_noalloc_ceiling !!penv)
+            in
             mode, kind
       in
       let pat_desc =
@@ -6924,7 +6926,7 @@ and type_expect_
                          match lid.txt with
                              Longident.Lident txt -> { txt; loc = lid.loc }
                            | _ -> assert false)
-        | Val_mut (_m0, _) -> begin
+        | Val_mut (_m0, _, _) -> begin
             if not (List.is_empty layout_args) then
               Misc.fatal_error "type_expect_: Val_mut with layout args";
             match path with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5275,9 +5275,7 @@ let rec is_nonexpansive exp =
   | Texp_extension_constructor _ ->
     false
   | Texp_exclave e -> is_nonexpansive e
-  (* CR dkalinichenko: A zero-alloc expression cannot create fresh
-     mutable state: *)
-  | Texp_zero_alloc _ -> true
+  | Texp_zero_alloc e -> is_nonexpansive e
   (* The underlying mutation of exp1 can not be observed since we have the only reference
      to it. In fact, a completely valid model for Texp_overwrite would be to ignore exp1
      and just allocate a new cell for exp2: *)
@@ -5470,7 +5468,7 @@ let rec check_captures_comonadic env (exp : expression) =
       match def with
       | Kept _ -> assert false
       | Overridden (_, e) -> check e) fields
-  | Texp_apply_layout (e, _) | Texp_exclave e -> check e
+  | Texp_apply_layout (e, _) | Texp_exclave e | Texp_zero_alloc e -> check e
   | _ -> fail ()
 
 let annotate_recursive_bindings env valbinds =
@@ -5851,7 +5849,7 @@ let check_partial_application ~statement exp =
             | Texp_construct _ | Texp_variant _ | Texp_record _
             | Texp_atomic_loc _
             | Texp_record_unboxed_product _ | Texp_unboxed_field _
-            | Texp_overwrite _ | Texp_hole _ | Texp_zero_alloc _
+            | Texp_overwrite _ | Texp_hole _
             | Texp_field _ | Texp_setfield _ | Texp_array _ | Texp_idx _
             | Texp_list_comprehension _ | Texp_array_comprehension _
             | Texp_while _ | Texp_for _ | Texp_instvar _
@@ -5875,7 +5873,7 @@ let check_partial_application ~statement exp =
             | Texp_let (_, _, e) | Texp_letmutable(_, e)
             | Texp_sequence (_, _, e) | Texp_open (_, e)
             | Texp_letexception (_, e) | Texp_letmodule (_, _, _, _, e)
-            | Texp_exclave e ->
+            | Texp_exclave e | Texp_zero_alloc e ->
                 check e
             | Texp_apply _ | Texp_send _ | Texp_new _ | Texp_letop _ ->
                 Location.prerr_warning exp_loc
@@ -8577,7 +8575,7 @@ and type_expect_
              (Env.enclosing_noalloc_ceiling env))
           expected_mode
       in
-      let new_env = Env.add_zero_alloc_lock ~loc env in
+      let new_env = Env.add_zero_alloc_lock env in
       let body =
         type_expect ~recarg new_env body_mode sbody ty_expected_explained
       in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5275,7 +5275,8 @@ let rec is_nonexpansive exp =
   | Texp_extension_constructor _ ->
     false
   | Texp_exclave e -> is_nonexpansive e
-  (* A zero-alloc expression cannot create fresh mutable state: *)
+  (* CR dkalinichenko: A zero-alloc expression cannot create fresh
+     mutable state: *)
   | Texp_zero_alloc _ -> true
   (* The underlying mutation of exp1 can not be observed since we have the only reference
      to it. In fact, a completely valid model for Texp_overwrite would be to ignore exp1

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -669,7 +669,7 @@ let mode_zero_alloc expected_mode =
   let crossing =
     Crossing.create ~linearity:false ~portability:false
       ~regionality:false ~uniqueness:false ~contention:false
-      ~statefulness:true ~visibility:false ~forkable:false ~yielding:false
+      ~statefulness:false ~visibility:false ~forkable:false ~yielding:false
       ~staticity:false ~allocation:true
   in
   mode_morph (Crossing.apply_right crossing) expected_mode
@@ -8580,6 +8580,7 @@ and type_expect_
            exp_env = env }
   | Pexp_zero_alloc sbody ->
       Language_extension.assert_enabled ~loc Mode Language_extension.Stable;
+      Env.check_no_open_quotations loc env Zero_alloc_qt;
       (* [zero_alloc_ e] must be in the tail position of its region; the
          allocation axis of [e] is unconstrained and its zero_alloc property
          is verified by the backend checker instead. *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -662,6 +662,18 @@ let mode_strictly_stack expected_mode =
     with strictly_stack = true
   }
 
+(** Take the expected mode of [zero_alloc_ exp], return the expected mode of
+    [exp]. The allocation axis is relaxed, since the zero_alloc property is
+    verified by the backend instead. *)
+let mode_zero_alloc expected_mode =
+  let crossing =
+    Crossing.create ~linearity:false ~portability:false
+      ~regionality:false ~uniqueness:false ~contention:false
+      ~statefulness:true ~visibility:false ~forkable:false ~yielding:false
+      ~staticity:false ~allocation:true
+  in
+  mode_morph (Crossing.apply_right crossing) expected_mode
+
 let is_not_alloc_mode expected_mode =
   let ceil =
     Allocation.Guts.get_loose_ceil
@@ -5275,6 +5287,8 @@ let rec is_nonexpansive exp =
   | Texp_extension_constructor _ ->
     false
   | Texp_exclave e -> is_nonexpansive e
+  (* A zero-alloc expression cannot create fresh mutable state: *)
+  | Texp_zero_alloc _ -> true
   (* The underlying mutation of exp1 can not be observed since we have the only reference
      to it. In fact, a completely valid model for Texp_overwrite would be to ignore exp1
      and just allocate a new cell for exp2: *)
@@ -5431,6 +5445,7 @@ let rec maybe_computation exp =
   | Texp_probe _
   | Texp_probe_is_enabled _
   | Texp_exclave _
+  | Texp_zero_alloc _
   | Texp_src_pos
   | Texp_overwrite _
   | Texp_antiquotation _
@@ -5847,7 +5862,7 @@ let check_partial_application ~statement exp =
             | Texp_construct _ | Texp_variant _ | Texp_record _
             | Texp_atomic_loc _
             | Texp_record_unboxed_product _ | Texp_unboxed_field _
-            | Texp_overwrite _ | Texp_hole _
+            | Texp_overwrite _ | Texp_hole _ | Texp_zero_alloc _
             | Texp_field _ | Texp_setfield _ | Texp_array _ | Texp_idx _
             | Texp_list_comprehension _ | Texp_array_comprehension _
             | Texp_while _ | Texp_for _ | Texp_instvar _
@@ -8563,6 +8578,22 @@ and type_expect_
            exp_type = instance ty_expected;
            exp_attributes = sexp.pexp_attributes;
            exp_env = env }
+  | Pexp_zero_alloc sbody ->
+      Language_extension.assert_enabled ~loc Mode Language_extension.Stable;
+      (* [zero_alloc_ e] must be in the tail position of its region; the
+         allocation axis of [e] is unconstrained and its zero_alloc property
+         is verified by the backend checker instead. *)
+      let body_mode = mode_zero_alloc expected_mode in
+      let new_env = Env.add_zero_alloc_lock ~loc env in
+      let body =
+        type_expect ~recarg new_env body_mode sbody ty_expected_explained
+      in
+      { exp_desc = Texp_zero_alloc body;
+        exp_loc = loc;
+        exp_extra = [];
+        exp_type = body.exp_type;
+        exp_attributes = sexp.pexp_attributes;
+        exp_env = env }
   | Pexp_stack e ->
       (* Allocation axis: suppress the axis lock-walk at the registration
           site *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -662,18 +662,6 @@ let mode_strictly_stack expected_mode =
     with strictly_stack = true
   }
 
-(** Take the expected mode of [zero_alloc_ exp], return the expected mode of
-    [exp]. The allocation axis is relaxed, since the zero_alloc property is
-    verified by the backend instead. *)
-let mode_zero_alloc expected_mode =
-  let crossing =
-    Crossing.create ~linearity:false ~portability:false
-      ~regionality:false ~uniqueness:false ~contention:false
-      ~statefulness:false ~visibility:false ~forkable:false ~yielding:false
-      ~staticity:false ~allocation:true
-  in
-  mode_morph (Crossing.apply_right crossing) expected_mode
-
 let is_not_alloc_mode expected_mode =
   let ceil =
     Allocation.Guts.get_loose_ceil
@@ -8581,10 +8569,13 @@ and type_expect_
   | Pexp_zero_alloc sbody ->
       Language_extension.assert_enabled ~loc Mode Language_extension.Stable;
       Env.check_no_open_quotations loc env Zero_alloc_qt;
-      (* [zero_alloc_ e] must be in the tail position of its region; the
-         allocation axis of [e] is unconstrained and its zero_alloc property
-         is verified by the backend checker instead. *)
-      let body_mode = mode_zero_alloc expected_mode in
+      (* CR dkalinichenko: explain *)
+      let body_mode =
+        mode_coerce
+          (Value.max_with_comonadic Allocation
+             (Env.enclosing_noalloc_ceiling env))
+          expected_mode
+      in
       let new_env = Env.add_zero_alloc_lock ~loc env in
       let body =
         type_expect ~recarg new_env body_mode sbody ty_expected_explained

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -662,6 +662,13 @@ let mode_strictly_stack expected_mode =
     with strictly_stack = true
   }
 
+let is_not_alloc_mode expected_mode =
+  let ceil =
+    Allocation.Guts.get_loose_ceil
+      (Value.proj_comonadic Allocation expected_mode.mode)
+  in
+  not (Allocation.Const.le Allocation.Const.max ceil)
+
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
 
@@ -815,11 +822,24 @@ let allocations : Alloc.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
-let register_allocation_mode ~env ~loc ?(stack = false) alloc_mode =
+let register_allocation_mode ~env ~loc
+    ?(stack = false) ?(closure = false) alloc_mode =
   (* [stack_]-marked allocations are stack-allocated and so do not count
      towards the allocation axis; only heap allocations walk the locks. *)
   if not stack then
-    Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+    let local_closure =
+      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation closure)
+    in
+    if local_closure then
+      (match
+        Value.submode ~pp:(loc, Function)
+          (Value.min_with_comonadic Areality Regionality.local)
+          (alloc_as_value alloc_mode)
+      with
+      | Ok () -> ()
+      | Error failure_reason ->
+        let error = Submode_failed(failure_reason, Other) in
+        raise (Error (loc, env, error)));
   let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
@@ -847,7 +867,8 @@ let register_closure_allocation ~env ?(stack = false) (mode : Value.r) ~loc
   let (alloc_mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode ~env ~loc ~stack (Alloc.disallow_left alloc_mode);
+  register_allocation_mode ~env ~loc ~stack ~closure:true
+    (Alloc.disallow_left alloc_mode);
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
   in
@@ -4938,30 +4959,13 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
   loop ty_fun0 mode_fun rev_args sargs
 
 (* See Note [Type-checking applications] for an overview *)
-let collect_apply_args env loc funct ignore_labels ty_fun ty_fun0 mode_fun sargs
+let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs
       ret_tvar =
   let warned = ref false in
   let rec loop ty_fun ty_fun0 mode_fun rev_args sargs =
-    if sargs = [] then begin
-      (* Allocation axis check: partial application of a function returns
-         an arrow type and allocates *)
-      let ty_fun' = expand_head env ty_fun in
-      let ty_fun_is_arrow =
-        match get_desc ty_fun' with Tarrow _ -> true | _ -> false
-      in
-      (* CR shsong: this check for partial application is not strong enough
-          to guarantee soundness. Especially for the case where the partial
-          application's return type is an abstract type and is actually a
-          function. *)
-      (* CR shsong: Alternative design: only register_allocation_mode if
-          partial_app = is_partial_apply untyped_args (where untyped_args
-          are in the return value) is false, since if partial_app is true,
-          there are Omitted args and the code walks the locks already *)
-      if ty_fun_is_arrow then
-        register_allocation_mode ~env ~loc Alloc.legacy;
+    if sargs = [] then
       collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
         ret_tvar
-    end
     else
     let ty_fun' = expand_head env ty_fun in
     let lv = get_level ty_fun' in
@@ -6239,11 +6243,11 @@ let split_function_ty
     env (expected_mode : expected_mode) ty_expected loc ~arg_label ~has_poly
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
-  let alloc_mode, closed_over_mode =
+    let alloc_mode, closed_over_mode =
     register_closure_allocation ~env ~stack:expected_mode.strictly_stack ~loc
       (as_single_mode expected_mode)
   in
-  if expected_mode.strictly_local then
+    if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
       (Alloc.proj_comonadic Areality alloc_mode);
   let { ty = ty_fun; explanation }, loc_fun = in_function in
@@ -6278,6 +6282,11 @@ let split_function_ty
     match is_first_val_param with
     | false -> env
     | true ->
+        let env =
+          if is_not_alloc_mode expected_mode
+          then Env.add_closure_noalloc_lock env
+          else env
+        in
         let env =
           Env.add_closure_lock
             (loc, Function)
@@ -8578,7 +8587,7 @@ and type_expect_
             Alloc.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
           in
-          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
+          Alloc.submode_err (exp.exp_loc, Allocation false) local alloc_mode
         end
       | Texp_list_comprehension _ -> unsupported List_comprehension
       | Texp_array_comprehension _ -> unsupported Array_comprehension
@@ -10320,7 +10329,7 @@ and type_application env app_loc expected_mode position_and_mode
             (fun (label, e) -> Typetexp.transl_label_from_expr label e) sargs
           in
           let ty_ret, mode_ret, untyped_args =
-            collect_apply_args env app_loc funct ignore_labels ty (instance ty)
+            collect_apply_args env funct ignore_labels ty (instance ty)
               (value_to_alloc_r2l funct_mode) sargs ret_tvar
           in
           (* example: [collect_apply_args] returns

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -408,6 +408,7 @@ and expression_desc =
   | Texp_probe of { name:string; handler:expression; enabled_at_init:bool; }
   | Texp_probe_is_enabled of { name:string }
   | Texp_exclave of expression
+  | Texp_zero_alloc of expression
   | Texp_src_pos
   | Texp_overwrite of expression * expression
   | Texp_hole of unique_use
@@ -1604,6 +1605,7 @@ let rec fold_antiquote_exp f  acc exp =
   | Texp_probe {handler;_} -> fold_antiquote_exp f acc handler
   | Texp_probe_is_enabled _ -> acc
   | Texp_exclave exp -> fold_antiquote_exp f acc exp
+  | Texp_zero_alloc exp -> fold_antiquote_exp f acc exp
   | Texp_src_pos -> acc
   | Texp_overwrite (exp1, exp2) ->
       let acc = fold_antiquote_exp f acc exp1 in

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -712,6 +712,7 @@ and expression_desc =
   | Texp_probe of { name:string; handler:expression; enabled_at_init:bool }
   | Texp_probe_is_enabled of { name:string }
   | Texp_exclave of expression
+  | Texp_zero_alloc of expression (** zero_alloc_ exp *)
   | Texp_src_pos
     (* A source position value which has been automatically inferred, either
        as a result of [%call_pos] occuring in an expression, or omission of a

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -116,7 +116,8 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   mode
 
 let register_allocation ~env ~loc : Alloc.lr * Value.lr =
-  Env.walk_locks_for_allocation ~env (loc, Hint.Allocation);
+  ignore
+    (Env.walk_locks_for_allocation ~env (loc, Hint.Allocation false) : bool);
   let upper_bound =
     Alloc.of_const
       ~hint_comonadic:Module_allocated_on_heap

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -317,7 +317,8 @@ module Vars = Misc.Stdlib.String.Map
 
 type value_kind =
     Val_reg of Jkind_types.Sort.t       (* Regular value *)
-  | Val_mut of Mode.Value.Comonadic.lr * Jkind_types.Sort.t
+  | Val_mut of
+      Mode.Value.Comonadic.lr * Jkind_types.Sort.t * Mode.Allocation.r
                                         (* Mutable value *)
   | Val_prim of Primitive.description   (* Primitive *)
   | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -727,7 +727,8 @@ module Vars  : Map.S with type key = string
 
 type value_kind =
     Val_reg of Jkind_types.Sort.t       (* Regular value *)
-  | Val_mut of Mode.Value.Comonadic.lr * Jkind_types.Sort.t
+  | Val_mut of
+      Mode.Value.Comonadic.lr * Jkind_types.Sort.t * Mode.Allocation.r
                                         (* Mutable variable *)
   | Val_prim of Primitive.description   (* Primitive *)
   | Val_ivar of mutable_flag * string   (* Instance variable (mutable ?) *)

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2652,6 +2652,7 @@ let rec check_uniqueness_exp_desc ~borrows ~overwrite (ienv : Ienv.t) ~loc :
   | Texp_probe { handler } -> check_uniqueness_exp ~overwrite:None ienv handler
   | Texp_probe_is_enabled _ -> UF.unused
   | Texp_exclave e -> check_uniqueness_exp ~overwrite:None ienv e
+  | Texp_zero_alloc e -> check_uniqueness_exp ~overwrite:None ienv e
   | Texp_src_pos -> UF.unused
   | Texp_overwrite (e1, e2) ->
     let value, uf = check_uniqueness_exp_as_value ienv e1 in

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -836,6 +836,7 @@ let expression sub exp =
         pexp_attributes = [];
       }, [Nolabel, sub.expr sub exp])
     | Texp_src_pos -> Pexp_extension ({ txt = "src_pos"; loc }, PStr [])
+    | Texp_zero_alloc exp -> (sub.expr sub exp).pexp_desc
     | Texp_overwrite (exp1, exp2) ->
         Pexp_overwrite(sub.expr sub exp1, sub.expr sub exp2)
     | Texp_hole _ -> Pexp_hole

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -836,7 +836,7 @@ let expression sub exp =
         pexp_attributes = [];
       }, [Nolabel, sub.expr sub exp])
     | Texp_src_pos -> Pexp_extension ({ txt = "src_pos"; loc }, PStr [])
-    | Texp_zero_alloc exp -> (sub.expr sub exp).pexp_desc
+    | Texp_zero_alloc exp -> Pexp_zero_alloc (sub.expr sub exp)
     | Texp_overwrite (exp1, exp2) ->
         Pexp_overwrite(sub.expr sub exp1, sub.expr sub exp2)
     | Texp_hole _ -> Pexp_hole

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -171,7 +171,8 @@ let classify_expression : Typedtree.expression -> sd =
     | Texp_letmodule (None, _, _, _, e)
     | Texp_sequence (_, _, e)
     | Texp_letexception (_, e)
-    | Texp_exclave e ->
+    | Texp_exclave e
+    | Texp_zero_alloc e ->
         classify_expression env e
 
     | Texp_construct (_, {cstr_repr = Variant_unboxed}, _, [_, e], _) ->
@@ -1094,6 +1095,7 @@ let rec expression : Typedtree.expression -> term_judg =
       expression handler << Dereference
     | Texp_probe_is_enabled _ -> empty
     | Texp_exclave e -> expression e
+    | Texp_zero_alloc e -> expression e
     | Texp_src_pos -> empty
     | Texp_overwrite (exp1, exp2) ->
       (* This is untested, since we currently mark Texp_overwrite as Dynamic and


### PR DESCRIPTION
`zero_alloc_ e` is an escape hatch for the allocation mode axis: the frontend does not check the allocation axis inside `e`; the zero_alloc property of `e` is instead deferred to the backend checker (not yet wired up; `Texp_zero_alloc` is currently erased in Translcore).

The keyword parses like `exclave_` (loosely, over seq_expr), is represented as `Pexp_zero_alloc` / `Texp_zero_alloc`, and is gated on the `mode` extension. Inside the region, the allocation axis of the expected mode is relaxed, and a new `Zero_alloc_lock` masks the allocation axis against enclosing closure locks in both directions, while locks pushed inside the region still apply.