### PR TITLE
[arm64] runtime: skip the atomic-RMW fences when the RMW runs as an LSE atomic

### DIFF
--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -130,7 +130,12 @@
    default anyway, so all of these fences compile away to nothing
    (They're still useful, though: they serve to inhibit an overeager C
    compiler's optimisations). On ARMv8, actual hardware fences are
-   generated.
+   generated -- except that the atomic read-modify-writes below omit them
+   when the RMW executes as a single LSE atomic, which is itself a full
+   ordering point (see the dispatch helpers before caml_atomic_exchange_field:
+   an LSE RMW is redundant with the fences, but the baseline LL/SC expansion
+   is not; ocaml/ocaml#10972 and
+   https://github.com/sebpop/ocaml-arm64-barrier-proofs).
 */
 
 /* Note [MMMOC]: Mixing the Memory Models of OCaml and C.
@@ -335,6 +340,100 @@ CAMLprim value caml_atomic_load (value ref)
 
 
 /* stores are implemented as exchanges */
+/* AArch64: a seq_cst read-modify-write is a full ordering point -- making the
+   acquire/release fences Note [MM] places around it redundant -- ONLY when it
+   executes as a single LSE atomic (SWPAL / CASAL / LDADDAL / LDCLRAL / LDSETAL
+   / LDEORAL).  The baseline ARMv8.0 LL/SC expansion (LDAXR ... STLXR) is NOT a
+   full ordering point: an STLXR does not order a program-order-later plain
+   store, so the fences are load-bearing there (ocaml/ocaml#10972; herd7 proofs
+   at https://github.com/sebpop/ocaml-arm64-barrier-proofs).
+
+   We therefore issue the RMW as an explicit LSE instruction (skipping the
+   fences) whenever we know one runs, and otherwise keep the fenced C11
+   sequence:
+     - __ARM_FEATURE_ATOMICS defined: the C compiler already emits LSE directly,
+       so plain C11 (no fences) is a full ordering point.
+     - else, on Linux: dispatch at run time on HWCAP_ATOMICS.  When the CPU has
+       LSE we emit the LSE instruction ourselves with inline asm (so the choice
+       does not depend on how the C compiler lowers C11 atomics -- outline vs
+       LL/SC); otherwise we keep the fenced C11 sequence.
+     - otherwise: keep the fenced C11 sequence. */
+#if defined(__aarch64__) && !defined(__ARM_FEATURE_ATOMICS) && defined(__linux__)
+#include <sys/auxv.h>
+#ifndef HWCAP_ATOMICS
+#include <asm/hwcap.h>
+#endif
+#ifndef HWCAP_ATOMICS
+#define HWCAP_ATOMICS (1u << 8)
+#endif
+#define CAML_AARCH64_LSE_RUNTIME_DISPATCH
+
+Caml_inline int caml_aarch64_has_lse(void)
+{
+  static atomic_int cache = -1;
+  int v = atomic_load_explicit(&cache, memory_order_relaxed);
+  if (v < 0) {
+    v = (getauxval(AT_HWCAP) & HWCAP_ATOMICS) != 0;
+    atomic_store_explicit(&cache, v, memory_order_relaxed);
+  }
+  return v;
+}
+
+/* Enable the LSE (armv8.1-a) encodings for the inline asm below, even when the
+   translation unit is built for plain ARMv8.0.  Emitted once, ahead of every
+   LSE instruction. */
+__asm__(".arch_extension lse");
+
+/* Explicit LSE atomics, used only when caml_aarch64_has_lse().  Each is
+   acquire+release (AL), hence a full ordering point, so no surrounding fence is
+   needed.  They return the old value. */
+Caml_inline value caml_lse_swap(atomic_value *p, value v)
+{
+  value old;
+  __asm__ __volatile__("swpal %2, %0, [%1]"
+                       : "=&r" (old) : "r" (p), "r" (v) : "memory");
+  return old;
+}
+Caml_inline value caml_lse_compare_exchange(atomic_value *p, value expected,
+                                            value newv)
+{
+  value witnessed = expected;
+  __asm__ __volatile__("casal %0, %2, [%1]"
+                       : "+&r" (witnessed) : "r" (p), "r" (newv) : "memory");
+  return witnessed;
+}
+Caml_inline value caml_lse_fetch_add(atomic_value *p, value a)
+{
+  value old;
+  __asm__ __volatile__("ldaddal %2, %0, [%1]"
+                       : "=&r" (old) : "r" (p), "r" (a) : "memory");
+  return old;
+}
+Caml_inline value caml_lse_fetch_and(atomic_value *p, value a)
+{
+  /* LDCLR clears the bits set in its operand ([p] &= ~operand), so pass the
+     complement of the AND mask. */
+  value old, clr = ~a;
+  __asm__ __volatile__("ldclral %2, %0, [%1]"
+                       : "=&r" (old) : "r" (p), "r" (clr) : "memory");
+  return old;
+}
+Caml_inline value caml_lse_fetch_or(atomic_value *p, value a)
+{
+  value old;
+  __asm__ __volatile__("ldsetal %2, %0, [%1]"
+                       : "=&r" (old) : "r" (p), "r" (a) : "memory");
+  return old;
+}
+Caml_inline value caml_lse_fetch_xor(atomic_value *p, value a)
+{
+  value old;
+  __asm__ __volatile__("ldeoral %2, %0, [%1]"
+                       : "=&r" (old) : "r" (p), "r" (a) : "memory");
+  return old;
+}
+#endif
+
 CAMLprim value caml_atomic_exchange_field (value obj, value vfield, value v)
 {
   value ret;
@@ -343,10 +442,24 @@ CAMLprim value caml_atomic_exchange_field (value obj, value vfield, value v)
     ret = Field(obj, field);
     Field(obj, field) = v;
   } else {
+    atomic_value *p = &Op_atomic_val(obj)[field];
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    /* LSE swpal is a full ordering point: no fences (Note [MM]). */
+    ret = atomic_exchange(p, v);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      ret = caml_lse_swap(p, v);
+    } else {
+      atomic_thread_fence(memory_order_acquire);
+      ret = atomic_exchange(p, v);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
     /* See Note [MM] above */
     atomic_thread_fence(memory_order_acquire);
-    ret = atomic_exchange(&Op_atomic_val(obj)[field], v);
+    ret = atomic_exchange(p, v);
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
   }
   write_barrier(obj, field, ret, v);
   return ret;
@@ -384,8 +497,22 @@ CAMLprim value caml_atomic_compare_exchange_field (
     }
   } else {
     atomic_value* p = &Op_atomic_val(obj)[field];
-    int cas_ret = atomic_compare_exchange_strong(p, &oldv, newv);
+    int cas_ret;
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    cas_ret = atomic_compare_exchange_strong(p, &oldv, newv);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      value witnessed = caml_lse_compare_exchange(p, oldv, newv);
+      cas_ret = (witnessed == oldv);
+      oldv = witnessed;
+    } else {
+      cas_ret = atomic_compare_exchange_strong(p, &oldv, newv);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
+    cas_ret = atomic_compare_exchange_strong(p, &oldv, newv);
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
     if (cas_ret) {
       write_barrier(obj, field, oldv, newv);
     }
@@ -425,8 +552,20 @@ CAMLprim value caml_atomic_fetch_add_field (value obj, value vfield, value incr)
     /* no write barrier needed, integer write */
   } else {
     atomic_value *p = &Op_atomic_val(obj)[field];
-    ret = atomic_fetch_add(p, 2 * Long_val(incr));
+    value a = 2 * Long_val(incr);
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    ret = atomic_fetch_add(p, a);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      ret = caml_lse_fetch_add(p, a);
+    } else {
+      ret = atomic_fetch_add(p, a);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
+    ret = atomic_fetch_add(p, a);
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
   }
   return ret;
 }
@@ -446,8 +585,20 @@ CAMLprim value caml_atomic_add_field (value obj, value vfield, value incr)
     /* no write barrier needed, integer write */
   } else {
     atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_add(p, 2*Long_val(incr)); /* ignore the result */
+    value a = 2 * Long_val(incr);
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    (void) atomic_fetch_add(p, a);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      (void) caml_lse_fetch_add(p, a);
+    } else {
+      (void) atomic_fetch_add(p, a);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
+    (void) atomic_fetch_add(p, a); /* ignore the result */
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
   }
   return Val_unit;
 }
@@ -467,8 +618,20 @@ CAMLprim value caml_atomic_sub_field (value obj, value vfield, value incr)
     /* no write barrier needed, integer write */
   } else {
     atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_sub(p, 2*Long_val(incr)); /* ignore the result */
+    value a = 2 * Long_val(incr);
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    (void) atomic_fetch_sub(p, a);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      (void) caml_lse_fetch_add(p, -a); /* no LSE sub: add the negated addend */
+    } else {
+      (void) atomic_fetch_sub(p, a);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
+    (void) atomic_fetch_sub(p, a); /* ignore the result */
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
   }
   return Val_unit;
 }
@@ -488,8 +651,19 @@ CAMLprim value caml_atomic_land_field (value obj, value vfield, value incr)
     /* no write barrier needed, integer write */
   } else {
     atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_and(p, incr); /* ignore the result */
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    (void) atomic_fetch_and(p, incr);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      (void) caml_lse_fetch_and(p, incr);
+    } else {
+      (void) atomic_fetch_and(p, incr);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
+    (void) atomic_fetch_and(p, incr); /* ignore the result */
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
   }
   return Val_unit;
 }
@@ -509,8 +683,19 @@ CAMLprim value caml_atomic_lor_field (value obj, value vfield, value incr)
     /* no write barrier needed, integer write */
   } else {
     atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_or(p, incr); /* ignore the result */
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    (void) atomic_fetch_or(p, incr);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      (void) caml_lse_fetch_or(p, incr);
+    } else {
+      (void) atomic_fetch_or(p, incr);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
+    (void) atomic_fetch_or(p, incr); /* ignore the result */
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
   }
   return Val_unit;
 }
@@ -530,8 +715,20 @@ CAMLprim value caml_atomic_lxor_field (value obj, value vfield, value incr)
     /* no write barrier needed, integer write */
   } else {
     atomic_value *p = &Op_atomic_val(obj)[field];
-    atomic_fetch_xor(p, 2*Long_val(incr)); /* ignore the result */
+    value a = 2 * Long_val(incr);
+#if defined(__aarch64__) && defined(__ARM_FEATURE_ATOMICS)
+    (void) atomic_fetch_xor(p, a);
+#elif defined(CAML_AARCH64_LSE_RUNTIME_DISPATCH)
+    if (caml_aarch64_has_lse()) {
+      (void) caml_lse_fetch_xor(p, a);
+    } else {
+      (void) atomic_fetch_xor(p, a);
+      atomic_thread_fence(memory_order_release);
+    }
+#else
+    (void) atomic_fetch_xor(p, a); /* ignore the result */
     atomic_thread_fence(memory_order_release); /* generates `dmb ish` on Arm64*/
+#endif
   }
   return Val_unit;
 }

--- a/testsuite/tests/lib-atomic/test_atomic_parallel.ml
+++ b/testsuite/tests/lib-atomic/test_atomic_parallel.ml
@@ -1,0 +1,90 @@
+(* TEST
+   multicore;
+   native;
+   bytecode;
+*)
+
+(* Stress the atomic read-modify-write primitives (fetch_and_add, exchange,
+   compare_and_set) concurrently across domains, and check results that only
+   come out right if their acquire/release ordering is preserved.  A broken
+   ordering shows up as lost updates or a torn publication. *)
+
+let ndom = max 2 (min 8 (Domain.recommended_domain_count ()))
+
+let spawn_all f =
+  let ds = Array.init ndom (fun i -> Domain.spawn (fun () -> f i)) in
+  Array.iter Domain.join ds
+
+(* fetch_and_add: every increment must be counted exactly once. *)
+let test_fetch_add () =
+  let n = 100_000 in
+  let c = Atomic.make 0 in
+  spawn_all (fun _ -> for _ = 1 to n do ignore (Atomic.fetch_and_add c 1) done);
+  assert (Atomic.get c = ndom * n)
+
+(* exchange as a test-and-set spinlock guarding a non-atomic counter:
+   the plain [incr] is only safe because the exchange orders the critical
+   section; a broken ordering loses updates. *)
+let test_exchange_lock () =
+  let n = 20_000 in
+  let lock = Atomic.make 0 in
+  let counter = ref 0 in
+  spawn_all (fun _ ->
+    for _ = 1 to n do
+      while Atomic.exchange lock 1 <> 0 do Domain.cpu_relax () done;
+      incr counter;
+      ignore (Atomic.exchange lock 0)
+    done);
+  assert (!counter = ndom * n)
+
+(* Treiber stack via compare_and_set: concurrent pushes then a sequential
+   drain.  Both the node count and the value sum must match, which needs each
+   pushed node to be published correctly by the CAS. *)
+type 'a lst = Nil | Cons of 'a * 'a lst
+let test_cas_stack () =
+  let per = 20_000 in
+  let top = Atomic.make Nil in
+  spawn_all (fun d ->
+    let v = d + 1 in
+    for _ = 1 to per do
+      let rec push () =
+        let old = Atomic.get top in
+        if not (Atomic.compare_and_set top old (Cons (v, old))) then push ()
+      in push ()
+    done);
+  let count = ref 0 and sum = ref 0 in
+  let rec drain () = match Atomic.get top with
+    | Nil -> ()
+    | Cons (v, next) as old ->
+      if Atomic.compare_and_set top old next
+      then (incr count; sum := !sum + v; drain ()) else drain ()
+  in drain ();
+  assert (!count = ndom * per);
+  assert (!sum = per * (ndom * (ndom + 1) / 2))
+
+(* Publication: the producer fills a multi-word payload (non-atomic) then
+   publishes with Atomic.exchange (release); the consumer waits on the flag
+   with Atomic.get (acquire) and checks every word.  A broken release/acquire
+   lets the consumer see a torn/stale payload. *)
+let test_publication () =
+  let width = 32 and rounds = 50_000 in
+  let payload = Array.make width 0 in
+  let flag = Atomic.make 0 and ack = Atomic.make 0 in
+  let consumer = Domain.spawn (fun () ->
+    for r = 1 to rounds do
+      while Atomic.get flag <> r do Domain.cpu_relax () done;
+      for i = 0 to width - 1 do assert (Array.unsafe_get payload i = r) done;
+      ignore (Atomic.exchange ack r)
+    done) in
+  for r = 1 to rounds do
+    for i = 0 to width - 1 do Array.unsafe_set payload i r done;
+    ignore (Atomic.exchange flag r);
+    while Atomic.get ack <> r do Domain.cpu_relax () done
+  done;
+  Domain.join consumer
+
+let () =
+  test_fetch_add ();
+  test_exchange_lock ();
+  test_cas_stack ();
+  test_publication ()


### PR DESCRIPTION
On AArch64 the acquire/release fences Note [MM] places around the atomic
    read-modify-writes (caml_atomic_exchange / compare_exchange / fetch_add / add /
    sub / land / lor / lxor) are redundant only when the RMW executes as a single
    LSE atomic (SWPAL / CASAL / LDADDAL / LDCLRAL / LDSETAL / LDEORAL), which is a
    full ordering point (Arm's acquire/release are RCsc).  The baseline ARMv8.0
    LL/SC expansion (LDAXR ... STLXR) is not -- STLXR does not order a
    program-order-later plain store -- so the trailing fence is load-bearing there
    (ocaml/ocaml#10972).

We therefore issue the RMW as an explicit LSE instruction, skipping the fences,
    exactly when we know one runs: __ARM_FEATURE_ATOMICS at compile time, or a
    cached getauxval(AT_HWCAP) & HWCAP_ATOMICS check on Linux that emits the LSE
    instruction via inline asm (so the choice does not depend on how the C compiler
    lowers C11 atomics).  Otherwise the fenced C11 sequence is kept, as on all other
    targets.  land uses LDCLRAL of the bit-complement (no LSE AND); sub uses LDADDAL
    of the negated addend (no LSE sub); both stay acquire+release.

Verified with herd7 against the Arm AArch64 memory model:
    https://github.com/sebpop/ocaml-arm64-barrier-proofs
    Builds clean on NVIDIA Vera (arm64); libasmrun.a carries the LSE instructions.