### PR TITLE
Merge CFG blocks that differ only in debug info

### DIFF
--- a/backend/cfg/cfg_merge_blocks.ml
+++ b/backend/cfg/cfg_merge_blocks.ml
@@ -48,7 +48,11 @@ end = struct
       && Misc.Stdlib.Array.equal equal_reg left_res right_res
       && equal_desc left_desc right_desc
       (* CR-someday xclerc for xclerc: consider definin equal in `Debuginfo` *)
-      && Debuginfo.compare left_dbg right_dbg = 0
+      (* Debug info is allowed to differ (the merged-away paths inherit the
+         representative block's locations), unless the user has asked for
+         debugging to take precedence over code generation. *)
+      && ((not !Dwarf_flags.gdwarf_may_alter_codegen)
+         || Debuginfo.compare left_dbg right_dbg = 0)
 
   let basic_block :
       equal_reg:(Reg.t -> Reg.t -> bool) ->

--- a/testsuite/tests/codegen/functions.ml
+++ b/testsuite/tests/codegen/functions.ml
@@ -123,17 +123,11 @@ f:
 |}]
 
 
-(* CR ttebbi: The two branches end up equivalent and could be merged. *)
 let inline_identical x =
   let f () = x + 1 in
   if x > 0 then let _ = f() in f() else f()
 [%%expect_asm X86_64{|
 inline_identical:
-  cmpq  $1, %rax
-  jle   .L0
-  addq  $2, %rax
-  ret
-.L0:
   addq  $2, %rax
   ret
 |}]

--- a/testsuite/tests/codegen/merge-blocks-dbg.ml
+++ b/testsuite/tests/codegen/merge-blocks-dbg.ml
@@ -1,0 +1,24 @@
+(* TEST
+ flags += " -cfg-merge-blocks";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Both branches of the or-pattern compile to CFG blocks that are identical
+   except for their debug info (the two patterns cover different character
+   ranges on the same line). [Cfg_merge_blocks] must ignore that difference
+   and produce a single return path. *)
+
+type void = unit#
+
+type t =
+  | A of { x : string; y : void }
+  | B of { x : string; y : float }
+
+let get_x (A { x; _ } | B { x; _ }) = x
+[%%expect_asm X86_64{|
+get_x:
+  movzbq -8(%rax), %rbx
+  movq  (%rax), %rax
+  ret
+|}]


### PR DESCRIPTION
Cfg_merge_blocks required instructions' Debuginfo to compare equal, so blocks that were otherwise identical never merged when they came from distinct source ranges, e.g. the branches of an or-pattern:

  type void = unit#

  type t =
    | A of { x : string; y : void }
    | B of { x : string; y : float }

  let get_x (A { x; _ } | B { x; _ }) = x

Only require Debuginfo equality when -gdwarf-may-alter-codegen is set, i.e. when the user has asked for debugging to take precedence over code generation. Otherwise the merged-away paths inherit the representative block's locations.