### PR TITLE
Normalize bound-identifier stamps when saving a .cmi

### DIFF
--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -17,7 +17,7 @@ module Atomic = struct
   end
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Atomic/293"
+(apply (field_imm 1 (global Toploop!)) "Atomic/329"
   (let (Loc = (makeblock 0)) (makeblock 0 Loc)))
 module Atomic :
   sig
@@ -55,7 +55,7 @@ module Basic = struct
     Atomic.Loc.compare_and_set (get_loc r) oldv newv
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Basic/331"
+(apply (field_imm 1 (global Toploop!)) "Basic/367"
   (let
     (get = (function {nlocal = 0} r (atomic_load_field_ptr r 1))
      get_imm = (function {nlocal = 0} r : int (atomic_load_field_imm r 1))
@@ -189,7 +189,7 @@ end : sig
   type t = { mutable x : int [@atomic] }
 end)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Ok/361" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Ok/408" (makeblock 0))
 module Ok : sig type t = { mutable x : int [@atomic]; } end
 |}];;
 
@@ -258,7 +258,7 @@ module Inline_record = struct
   let test : t -> int = fun (A r) -> r.x
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record/402"
+(apply (field_imm 1 (global Toploop!)) "Inline_record/452"
   (let
     (test =
        (function {nlocal = 0} param : int (atomic_load_field_imm param 0)))
@@ -280,7 +280,7 @@ module Extension_with_inline_record = struct
   let () = assert (test (A { x = 42 }) = 42)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/410"
+(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/464"
   (let
     (A =
        (makeblock_unique 248 "Extension_with_inline_record.A"
@@ -374,7 +374,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic float field
   which prevents the float record optimization.
   The fields of this record will be boxed instead of being
   represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/470"
+(apply (field_imm 1 (global Toploop!)) "Float_records/529"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -594,7 +594,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/533"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/622"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))
@@ -635,7 +635,7 @@ module Functional_update_ok = struct
   let allowed t = { t with y = 42 }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/549"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/642"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -655,7 +655,7 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/557"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/654"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -689,7 +689,7 @@ module Functional_update_multi_ok = struct
   let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/573"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/674"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -713,7 +713,7 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/582"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/689"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -742,7 +742,7 @@ end
 
 let project (t : Mixed_blocks.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/587" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/700" (makeblock 0))
 module Mixed_blocks :
   sig
     type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
@@ -786,7 +786,7 @@ end
 
 let project (t : Mixed_blocks_2.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/597" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/714" (makeblock 0))
 module Mixed_blocks_2 :
   sig
     type t = { mutable field : int [@atomic]; padding : #(int * int * int); }
@@ -832,7 +832,7 @@ module Mixed_blocks_rec = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/610" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/731" (makeblock 0))
 module Mixed_blocks_rec :
   sig
     type t = { padding : u; mutable field : int [@atomic]; }
@@ -940,7 +940,7 @@ module Atomic_float_with_float_hash = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/636"
+(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/765"
   (let
     (disallowed =
        (function {nlocal = 0} t : float
@@ -961,7 +961,7 @@ module Inline_record_atomic_in_mixed = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/645"
+(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/778"
   (let
     (disallowed =
        (function {nlocal = 0} t : int

--- a/testsuite/tests/cmi-stamp-normalization/bar.mli
+++ b/testsuite/tests/cmi-stamp-normalization/bar.mli
@@ -1,0 +1,3 @@
+type t = Foo.t
+
+val y : t

--- a/testsuite/tests/cmi-stamp-normalization/bar.mli
+++ b/testsuite/tests/cmi-stamp-normalization/bar.mli
@@ -1,3 +1,7 @@
 type t = Foo.t
 
+type r = { lbl : t }
+
+type v = A | B of r
+
 val y : t

--- a/testsuite/tests/cmi-stamp-normalization/baz.ml
+++ b/testsuite/tests/cmi-stamp-normalization/baz.ml
@@ -1,0 +1,3 @@
+type t = A | B
+
+let x = A

--- a/testsuite/tests/cmi-stamp-normalization/foo.ml
+++ b/testsuite/tests/cmi-stamp-normalization/foo.ml
@@ -1,0 +1,7 @@
+type t = int
+
+let a = 1
+let b = 2
+let c = 3
+let d = 4
+let e = 5

--- a/testsuite/tests/cmi-stamp-normalization/test.ml
+++ b/testsuite/tests/cmi-stamp-normalization/test.ml
@@ -42,5 +42,5 @@ bound_ident_stamps "ocamlc.byte/bar.cmi"
 ;;
 [%%expect {|
 val bound_ident_stamps : string -> string list = <fun>
-- : string list = ["t_288"; "y_289"]
+- : string list = ["t_1"; "y_2"]
 |}]

--- a/testsuite/tests/cmi-stamp-normalization/test.ml
+++ b/testsuite/tests/cmi-stamp-normalization/test.ml
@@ -1,0 +1,46 @@
+(* TEST
+ readonly_files = "foo.ml bar.mli";
+ include ocamlcommon;
+ flags = "-I ${ocamlsrcdir}/utils -I ${ocamlsrcdir}/parsing \
+          -I ${ocamlsrcdir}/typing -I ${ocamlsrcdir}/file_formats";
+ setup-ocamlc.byte-build-env;
+ module = "foo.ml";
+ ocamlc.byte;
+ module = "bar.mli";
+ ocamlc.byte;
+ expect;
+*)
+
+(* [Bar] refers to [Foo.t], yet its bound identifiers are stamped 1, 2, ...
+   regardless of how many declarations [Foo] has: ident stamps are normalized
+   when the signature is written to the [.cmi], so they no longer leak the
+   global [Ident.currentstamp] counter (which is perturbed by loading [Foo]).
+   ([bar.cmi] was built by the preceding steps into the [ocamlc.byte]
+   subdirectory of the [expect] working directory.) *)
+
+let bound_ident_stamps cmi_file =
+  let cmi = Cmi_format.read_cmi cmi_file in
+  let sg, _ = cmi.Cmi_format.cmi_sign in
+  List.map
+    (fun (item : Types.signature_item) ->
+      let id =
+        match item with
+        | Sig_value (id, _, _) -> id
+        | Sig_type (id, _, _, _) -> id
+        | Sig_typext (id, _, _, _) -> id
+        | Sig_module (id, _, _, _, _) -> id
+        | Sig_modtype (id, _, _) -> id
+        | Sig_class (id, _, _, _) -> id
+        | Sig_class_type (id, _, _, _) -> id
+        | Sig_jkind (id, _, _) -> id
+      in
+      Ident.unique_name id)
+    sg
+;;
+
+bound_ident_stamps "ocamlc.byte/bar.cmi"
+;;
+[%%expect {|
+val bound_ident_stamps : string -> string list = <fun>
+- : string list = ["t_288"; "y_289"]
+|}]

--- a/testsuite/tests/cmi-stamp-normalization/test.ml
+++ b/testsuite/tests/cmi-stamp-normalization/test.ml
@@ -1,13 +1,23 @@
 (* TEST
- readonly_files = "foo.ml bar.mli";
+ readonly_files = "foo.ml baz.ml bar.mli";
  include ocamlcommon;
  flags = "-I ${ocamlsrcdir}/utils -I ${ocamlsrcdir}/parsing \
           -I ${ocamlsrcdir}/typing -I ${ocamlsrcdir}/file_formats";
  setup-ocamlc.byte-build-env;
  module = "foo.ml";
  ocamlc.byte;
+ module = "baz.ml";
+ ocamlc.byte;
  module = "bar.mli";
  ocamlc.byte;
+ src = "bar.cmi";
+ dst = "bar_orig.cmi";
+ copy;
+ flags = "-open Baz";
+ module = "bar.mli";
+ ocamlc.byte;
+ flags = "-I ${ocamlsrcdir}/utils -I ${ocamlsrcdir}/parsing \
+          -I ${ocamlsrcdir}/typing -I ${ocamlsrcdir}/file_formats";
  expect;
 *)
 
@@ -15,7 +25,14 @@
    regardless of how many declarations [Foo] has: ident stamps are normalized
    when the signature is written to the [.cmi], so they no longer leak the
    global [Ident.currentstamp] counter (which is perturbed by loading [Foo]).
-   ([bar.cmi] was built by the preceding steps into the [ocamlc.byte]
+
+   [bar.mli] is compiled twice: the first [.cmi] is preserved as
+   [bar_orig.cmi], then the same source is recompiled with [-open Baz], which
+   loads an extra dependency ([baz.cmi]) that the first compilation never
+   loads, perturbing the stamp counter differently. Without normalization the
+   two [.cmi]s would carry different stamps; with it they are identical.
+
+   (Both [.cmi]s were built by the preceding steps into the [ocamlc.byte]
    subdirectory of the [expect] working directory.) *)
 
 let bound_ident_stamps cmi_file =
@@ -38,9 +55,16 @@ let bound_ident_stamps cmi_file =
     sg
 ;;
 
-bound_ident_stamps "ocamlc.byte/bar.cmi"
+bound_ident_stamps "ocamlc.byte/bar_orig.cmi"
 ;;
 [%%expect {|
 val bound_ident_stamps : string -> string list = <fun>
-- : string list = ["t_1"; "y_2"]
+- : string list = ["t_1"; "r_2"; "v_3"; "y_4"]
+|}]
+
+;;
+bound_ident_stamps "ocamlc.byte/bar.cmi"
+;;
+[%%expect {|
+- : string list = ["t_1"; "r_2"; "v_3"; "y_4"]
 |}]

--- a/testsuite/tests/cmi-stamp-normalization/test.ml
+++ b/testsuite/tests/cmi-stamp-normalization/test.ml
@@ -35,36 +35,55 @@
    (Both [.cmi]s were built by the preceding steps into the [ocamlc.byte]
    subdirectory of the [expect] working directory.) *)
 
+let label_ids (lbls : Types.label_declaration list) =
+  List.map (fun (l : Types.label_declaration) -> l.ld_id) lbls
+
+let decl_ids (decl : Types.type_declaration) =
+  match decl.type_kind with
+  | Type_record (lbls, _, _) | Type_record_unboxed_product (lbls, _, _) ->
+      label_ids lbls
+  | Type_variant (cstrs, _, _) ->
+      List.concat_map
+        (fun (c : Types.constructor_declaration) ->
+          c.cd_id ::
+          (match c.cd_args with
+           | Cstr_record lbls -> label_ids lbls
+           | Cstr_tuple _ -> []))
+        cstrs
+  | Type_abstract _ | Type_open -> []
+
 let bound_ident_stamps cmi_file =
   let cmi = Cmi_format.read_cmi cmi_file in
   let sg, _ = cmi.Cmi_format.cmi_sign in
-  List.map
+  List.concat_map
     (fun (item : Types.signature_item) ->
-      let id =
+      let ids =
         match item with
-        | Sig_value (id, _, _) -> id
-        | Sig_type (id, _, _, _) -> id
-        | Sig_typext (id, _, _, _) -> id
-        | Sig_module (id, _, _, _, _) -> id
-        | Sig_modtype (id, _, _) -> id
-        | Sig_class (id, _, _, _) -> id
-        | Sig_class_type (id, _, _, _) -> id
-        | Sig_jkind (id, _, _) -> id
+        | Sig_value (id, _, _) -> [id]
+        | Sig_type (id, decl, _, _) -> id :: decl_ids decl
+        | Sig_typext (id, _, _, _) -> [id]
+        | Sig_module (id, _, _, _, _) -> [id]
+        | Sig_modtype (id, _, _) -> [id]
+        | Sig_class (id, _, _, _) -> [id]
+        | Sig_class_type (id, _, _, _) -> [id]
+        | Sig_jkind (id, _, _) -> [id]
       in
-      Ident.unique_name id)
+      List.map Ident.unique_name ids)
     sg
 ;;
 
 bound_ident_stamps "ocamlc.byte/bar_orig.cmi"
 ;;
 [%%expect {|
+val label_ids : Types.label_declaration list -> Ident.t list = <fun>
+val decl_ids : Types.type_declaration -> Ident.t list = <fun>
 val bound_ident_stamps : string -> string list = <fun>
-- : string list = ["t_1"; "r_2"; "v_3"; "y_4"]
+- : string list = ["t_1"; "r_2"; "lbl_8"; "v_3"; "A_5"; "B_6"; "y_4"]
 |}]
 
 ;;
 bound_ident_stamps "ocamlc.byte/bar.cmi"
 ;;
 [%%expect {|
-- : string list = ["t_1"; "r_2"; "v_3"; "y_4"]
+- : string list = ["t_1"; "r_2"; "lbl_8"; "v_3"; "A_5"; "B_6"; "y_4"]
 |}]

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.no-flat-float-array.reference
@@ -15,16 +15,16 @@ let code loopify(never) size(49) newer_version_of(sum_0)
       let prim_1 = %untag_imm (for_stop) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, 0)
-         where rec k2 (for_counter_naked : int64, r_442_unboxed0) =
+         where rec k2 (for_counter_naked : int64, r_478_unboxed0) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let Parrayrefu = %array_load.mut (Pfield, i) in
            ((let prim_3 = %is_int (Parrayrefu) in
              switch prim_3
                | 0 -> k4
-               | 1 -> k3 (r_442_unboxed0)
+               | 1 -> k3 (r_478_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (r_442_unboxed0, 1) in
+                 let int_add = %int_barith.add (r_478_unboxed0, 1) in
                  cont k3 (int_add))
               where k3 (return_val0) =
                 let for_next_naked =

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -15,16 +15,16 @@ let code loopify(never) size(52) newer_version_of(sum_0)
       let prim_1 = %untag_imm (for_stop) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, 0)
-         where rec k2 (for_counter_naked : int64, r_442_unboxed0) =
+         where rec k2 (for_counter_naked : int64, r_478_unboxed0) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let ifnot_result = %array_load.mut (Pfield, i) in
            ((let prim_3 = %is_int (ifnot_result) in
              switch prim_3
                | 0 -> k4
-               | 1 -> k3 (r_442_unboxed0)
+               | 1 -> k3 (r_478_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (r_442_unboxed0, 1) in
+                 let int_add = %int_barith.add (r_478_unboxed0, 1) in
                  cont k3 (int_add))
               where k3 (return_val0) =
                 let for_next_naked =

--- a/testsuite/tests/tool-ocamlc-stop-after/stop_after_lambda.compilers.reference
+++ b/testsuite/tests/tool-ocamlc-stop-after/stop_after_lambda.compilers.reference
@@ -1,1 +1,1 @@
-(let (*match*/7 =[value<int>] ( 1)) (makeblock 0))
+(let (*match*/6 =[value<int>] ( 1)) (makeblock 0))

--- a/testsuite/tests/typedtree/module_presence.ml
+++ b/testsuite/tests/typedtree/module_presence.ml
@@ -8,7 +8,7 @@ module X = struct end
 [
   structure_item
     Tstr_module (Present)
-    X/290
+    X/326
       module_expr
         Tmod_structure
         []
@@ -22,7 +22,7 @@ module X = struct end [@foo]
 [
   structure_item
     Tstr_module (Present)
-    X/291
+    X/327
       module_expr
         attribute "foo"
           []
@@ -38,9 +38,9 @@ module Y = X
 [
   structure_item
     Tstr_module (Absent)
-    Y/292
+    Y/328
       module_expr
-        Tmod_ident "X/291"
+        Tmod_ident "X/327"
 ]
 
 module Y = X
@@ -50,15 +50,15 @@ module type T = sig module Y = X end
 [%%expect{|
 [
   structure_item
-    Tstr_modtype "T/294"
+    Tstr_modtype "T/330"
       module_type
         Tmty_signature
         [
           signature_item
             Tsig_module (Absent)
-            Y/293
+            Y/329
               module_type
-                Tmty_alias "X/291"
+                Tmty_alias "X/327"
         ]
         join_const(unique,uncontended,read_write,static);meet_const(local,once,nonportable,unforkable,yielding,stateful)
         []

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -57,7 +57,7 @@ end = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "X/367"
+(apply (field_imm 1 (global Toploop!)) "X/403"
   (let
     (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
        [0: "first" 1]
@@ -80,7 +80,7 @@ let () =
 
 [%%expect{|
 (let
-  (X =? (apply (field_imm 0 (global Toploop!)) "X/367")
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/403")
    *match* =[value<int>]
      (let (xs =[value<addrarray>] (caml_array_make 4 (field_imm 0 X)))
        (seq (array.set[addr indexed by int] xs 1 (field_imm 1 X))

--- a/testsuite/tests/typing-modes/yielding_lambda.ml
+++ b/testsuite/tests/typing-modes/yielding_lambda.ml
@@ -13,7 +13,7 @@ end
 let[@inline never] yield (_ : Yielding.t @ yielding) = ()
 let[@inline never] add x y = x + y
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Yielding/296"
+(apply (field_imm 1 (global Toploop!)) "Yielding/332"
   (let (with_ = (function {nlocal = 0} f never_inline (apply[yielding] f 0)))
     (makeblock 0 with_)))
 module Yielding : sig type t val with_ : (t @ yielding -> 'r) -> 'r end
@@ -41,7 +41,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -59,7 +59,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -76,7 +76,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -93,7 +93,7 @@ let (_ : int) = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (seq (apply add 2 2) (apply[yielding] yield y) (applynontail add 4 4)))))
@@ -119,7 +119,7 @@ end = struct
   ;;
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "List/398"
+(apply (field_imm 1 (global Toploop!)) "List/438"
   (letrec
     (map
        (function {nlocal = 2} f[L]
@@ -183,8 +183,8 @@ let f (l : int list) =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   List =? (apply (field_imm 0 (global Toploop!)) "List/398")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   List =? (apply (field_imm 0 (global Toploop!)) "List/438")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    f =
      (function {nlocal = 0}
        l[value<
@@ -227,8 +227,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   List =? (apply (field_imm 0 (global Toploop!)) "List/398")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   List =? (apply (field_imm 0 (global Toploop!)) "List/438")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -483,7 +483,7 @@ let (_ : int) =
   end
 ;;
 [%%expect{|
-(let (Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296"))
+(let (Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (let
@@ -530,7 +530,7 @@ let (_ : int) =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (let
@@ -573,7 +573,7 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -608,17 +608,17 @@ module F (X : sig val n : int end) = struct let m = X.n + 1 end
 module N = struct let n = 41 end
 module R = F(N)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "F/689"
+(apply (field_imm 1 (global Toploop!)) "F/857"
   (function {nlocal = 0} X is_a_functor never_loop
     (let (m =[value<int>] (%int_add (field_imm 0 X) 1)) (makeblock 0 m))))
 module F : functor (X : sig val n : int end) -> sig val m : int end
-(apply (field_imm 1 (global Toploop!)) "N/694"
+(apply (field_imm 1 (global Toploop!)) "N/862"
   (let (n =[value<int>] 41) (makeblock 0 n)))
 module N : sig val n : int end
 (let
-  (N =? (apply (field_imm 0 (global Toploop!)) "N/694")
-   F =? (apply (field_imm 0 (global Toploop!)) "F/689"))
-  (apply (field_imm 1 (global Toploop!)) "R/696" (apply F N)))
+  (N =? (apply (field_imm 0 (global Toploop!)) "N/862")
+   F =? (apply (field_imm 0 (global Toploop!)) "F/857"))
+  (apply (field_imm 1 (global Toploop!)) "R/864" (apply F N)))
 module R : sig val m : int end
 |}]
 
@@ -629,7 +629,7 @@ module Yf (X : sig val f : unit -> unit end @ yielding) = struct
   let g () = X.f ()
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Yf/702"
+(apply (field_imm 1 (global Toploop!)) "Yf/870"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -647,8 +647,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/702")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/870")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -674,13 +674,13 @@ let h () =
   let module R = Yf (M) in
   R.g ()
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "M/715"
+(apply (field_imm 1 (global Toploop!)) "M/883"
   (let (f = (function {nlocal = 0} param[value<int>] : int 0))
     (makeblock 0 f)))
 module M : sig val f : unit -> unit end
 (let
-  (M =? (apply (field_imm 0 (global Toploop!)) "M/715")
-   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/702")
+  (M =? (apply (field_imm 0 (global Toploop!)) "M/883")
+   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/870")
    h =
      (function {nlocal = 0} param[value<int>] : int
        (let (R = (apply Yf M)) (apply[yielding] (field_imm 0 R) 0))))
@@ -697,7 +697,7 @@ let () =
     let module R = Uf (struct let f () = yield y end) in
     R.g ())
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Uf/726"
+(apply (field_imm 1 (global Toploop!)) "Uf/894"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -736,8 +736,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   M =? (apply (field_imm 0 (global Toploop!)) "M/715")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   M =? (apply (field_imm 0 (global Toploop!)) "M/883")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -767,7 +767,7 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -877,15 +877,15 @@ class d = object inherit c as super method n = super#m end
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!)) (opaque [0: #"m"])
            c_init))))
-  (apply (field_imm 1 (global Toploop!)) "c/788" c))
+  (apply (field_imm 1 (global Toploop!)) "c/956" c))
 class c : object method m : int end
 (let
-  (c =? (apply (field_imm 0 (global Toploop!)) "c/788")
+  (c =? (apply (field_imm 0 (global Toploop!)) "c/956")
    mk = (function {nlocal = 0} param[value<int>] (apply (field_mut 0 c) 0)))
   (apply (field_imm 1 (global Toploop!)) "mk" mk))
 val mk : unit -> c = <fun>
 (let
-  (c =? (apply (field_imm 0 (global Toploop!)) "c/788")
+  (c =? (apply (field_imm 0 (global Toploop!)) "c/956")
    shared =a (opaque [0: #"m"])
    shared =a (opaque [0: #"n" #"m"])
    d =?
@@ -921,7 +921,7 @@ val mk : unit -> c = <fun>
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!))
            (opaque [0: #"m" #"n"]) d_init))))
-  (apply (field_imm 1 (global Toploop!)) "d/816" d))
+  (apply (field_imm 1 (global Toploop!)) "d/984" d))
 class d : object method m : int method n : int end
 |}]
 
@@ -975,12 +975,12 @@ end
 [%%expect{|
 0
 module type S = sig type t val x : t end
-(apply (field_imm 1 (global Toploop!)) "F/864"
+(apply (field_imm 1 (global Toploop!)) "F/1032"
   (function {nlocal = 0} M is_a_functor never_loop
     (let (y = (field_imm 0 M)) (makeblock 0 y))))
 module F : functor (M : S) -> sig val y : M.t end
-(let (F =? (apply (field_imm 0 (global Toploop!)) "F/864"))
-  (apply (field_imm 1 (global Toploop!)) "M/872"
+(let (F =? (apply (field_imm 0 (global Toploop!)) "F/1032"))
+  (apply (field_imm 1 (global Toploop!)) "M/1040"
     (let (x =[value<int>] 42 include = (apply F (makeblock 0 x)))
       (makeblock 0 x (field_imm 0 include)))))
 module M : sig type t = int val x : int val y : int end
@@ -1000,7 +1000,7 @@ let () =
     end in
     M.g ())
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Gf/879"
+(apply (field_imm 1 (global Toploop!)) "Gf/1047"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -1012,8 +1012,8 @@ module Gf :
     sig val g : unit -> unit end @ yielding
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Gf =? (apply (field_imm 0 (global Toploop!)) "Gf/879")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296")
+   Gf =? (apply (field_imm 0 (global Toploop!)) "Gf/1047")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int

--- a/testsuite/tests/typing-modes/yielding_lambda.ml
+++ b/testsuite/tests/typing-modes/yielding_lambda.ml
@@ -1084,7 +1084,7 @@ let (_ : int) = Yielding.with_ (fun y -> o#uses y)
 [%%expect{|
 (let
   (o =? (apply (field_imm 0 (global Toploop!)) "o")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int (send[yielding] o -844262836 y))))
 - : int = 0
@@ -1124,6 +1124,6 @@ end
                       class)))))))
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!)) shared c2_init))))
-  (apply (field_imm 1 (global Toploop!)) "c2/928" c2))
+  (apply (field_imm 1 (global Toploop!)) "c2/1096" c2))
 class c2 : object method call_m : int method m : int -> int end
 |}]

--- a/typing/ident.ml
+++ b/typing/ident.ml
@@ -72,13 +72,16 @@ let name = function
   | Predef { name; _ } -> name
   | Global_with_args g -> global_name g
 
-let rename = function
+let rename_with_stamp stamp = function
   | Local { name; stamp = _ }
   | Scoped { name; stamp = _; scope = _ } ->
-      incr currentstamp;
-      Local { name; stamp = !currentstamp }
+      Local { name; stamp }
   | id ->
       Misc.fatal_errorf "Ident.rename %s" (name id)
+
+let rename id =
+  incr currentstamp;
+  rename_with_stamp !currentstamp id
 
 let unique_name = function
   | Local { name; stamp }

--- a/typing/ident.mli
+++ b/typing/ident.mli
@@ -49,6 +49,9 @@ val rename: t -> t
             stamp, and no scope.
             @raise [Fatal_error] if called on a persistent / predef ident. *)
 
+val rename_with_stamp: int -> t -> t
+        (** Like {!rename}, but with the given stamp rather than a fresh one. *)
+
 val name: t -> string
 val unique_name: t -> string
 val canonical_name: t -> string

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -41,7 +41,8 @@ type additional_action =
   | Prepare_for_saving of
       { prepare_jkind : 'l 'r. Location.t -> ('l * 'r) jkind -> ('l * 'r) jkind;
         prepare_mode : Mode.Alloc.lr -> Mode.Alloc.lr;
-        prepare_modality : Mode.Modality.t -> Mode.Modality.t
+        prepare_modality : Mode.Modality.t -> Mode.Modality.t;
+        prepare_ident : Ident.t -> Ident.t
       }
     (* The [prepare_jkind] function should be applied to all jkinds when
        saving; this commons them up, truncates their histories, and runs
@@ -49,7 +50,10 @@ type additional_action =
 
        The [prepare_mode]/[prepare_modality] functions should be applied to all
        modes/modalities when saving; this ensures the saved file doesn't contain
-       mode variables. *)
+       mode variables.
+
+       The [prepare_ident] function is applied to bound identifiers when saving,
+       giving them deterministic stamps so the saved [.cmi] is reproducible. *)
   | Duplicate_variables
   | No_action
 
@@ -307,7 +311,13 @@ let with_additional_action =
         let prepare_modality modality =
           Mode.Modality.(modality |> to_const_exn|> of_const)
         in
-        Prepare_for_saving { prepare_jkind; prepare_mode; prepare_modality },
+        let bound_ident_stamp = ref 0 in
+        let prepare_ident id =
+          incr bound_ident_stamp;
+          Ident.rename_with_stamp !bound_ident_stamp id
+        in
+        Prepare_for_saving
+          { prepare_jkind; prepare_mode; prepare_modality; prepare_ident },
         Saving (Hashtbl.create 17)
   in
   { s with
@@ -1093,12 +1103,17 @@ end
 module Lazy_types = Types.Make_wrapped(Wrap)
 open Lazy_types
 
+let rename_ident s id =
+  match s.additional_action with
+  | Prepare_for_saving { prepare_ident; _ } -> prepare_ident id
+  | Duplicate_variables | No_action -> Ident.rename id
+
 let rename_bound_idents scoping s sg =
   let rename =
     let open Ident in
     match scoping with
     | Keep -> (fun id -> create_scoped ~scope:(scope id) (name id))
-    | Make_local -> Ident.rename
+    | Make_local -> rename_ident s
     | Rescope scope -> (fun id -> create_scoped ~scope (name id))
   in
   let rec rename_bound_idents s sg = function
@@ -1137,7 +1152,7 @@ let rename_bound_idents scoping s sg =
           rest
     | Sig_value(id, vd, vis) :: rest ->
         (* scope doesn't matter for value identifiers. *)
-        let id' = Ident.rename id in
+        let id' = rename_ident s id in
         rename_bound_idents s (Sig_value(id', vd, vis) :: sg) rest
     | Sig_typext(id, ec, es, vis) :: rest ->
         let id' = rename id in
@@ -1253,7 +1268,7 @@ and subst_lazy_modtype scoping s = function
       Mty_functor(Named (None, (subst_lazy_modtype scoping s) arg, marg),
                    subst_lazy_modtype scoping s res, mres)
   | Mty_functor(Named (Some id, arg, marg), res, mres) ->
-      let id' = Ident.rename id in
+      let id' = rename_ident s id in
       Mty_functor(Named (Some id', (subst_lazy_modtype scoping s) arg, marg),
                   subst_lazy_modtype scoping (add_module id (Pident id') s)
                     res,

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -272,9 +272,6 @@ let with_additional_action =
      attempt to do this based on filename caused spurious "inconsistent
      assumption" errors that couldn't immediately be solved. Revisit
      with a better approach.
-
-     We'll need to revisit the Note [Preparing_for_saving always the same]
-     once we do this tailoring.
   *)
   let (additional_action, sort_var_mapping) : additional_action * sort_map =
     match config with
@@ -1348,13 +1345,9 @@ and compose s1 s2 =
             | Duplicate_variables, (Prepare_for_saving _ as prepare)
                 -> prepare
 
-            (* Note [Preparing_for_saving always the same]
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-               The function we put in [Prepare_for_saving] is always the same,
-               so we can take either.
-            *)
-            | (Prepare_for_saving _ as prepare1), Prepare_for_saving _
-                -> prepare1
+            | Prepare_for_saving _, Prepare_for_saving _ ->
+              fatal_error
+                "compose: composing Prepare_for_saving and Prepare_for_saving"
           end;
           sort_var_mapping = begin
             match s1.sort_var_mapping, s2.sort_var_mapping with

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -803,9 +803,23 @@ let type_expr s ty =
   let loc = Option.value s.loc ~default:Location.none in
   For_copy.with_scope (fun copy_scope -> typexp copy_scope s loc ty)
 
+(* For idents that are guaranteed to be local/scoped, such as bound
+   signature items and functor parameters. *)
+let rename_ident s id =
+  match s.additional_action with
+  | Prepare_for_saving { prepare_ident; _ } -> prepare_ident id
+  | Duplicate_variables | No_action -> Ident.rename id
+
+(* For constructor/label idents, which may be predef (e.g. the constructors
+   of [bool] or [or_null], whose declarations can appear in a substituted
+   signature). Predef and global idents are kept: they cannot be renamed,
+   and they carry no volatile stamp. *)
+let rename_decl_ident s id =
+  if Ident.is_global_or_predef id then id else rename_ident s id
+
 let label_declaration copy_scope s l =
   {
-    ld_id = l.ld_id;
+    ld_id = rename_decl_ident s l.ld_id;
     ld_mutable = l.ld_mutable;
     ld_modalities = l.ld_modalities;
     ld_sort = l.ld_sort;
@@ -831,7 +845,7 @@ let constructor_arguments copy_scope s = function
 
 let constructor_declaration copy_scope s c =
   {
-    cd_id = c.cd_id;
+    cd_id = rename_decl_ident s c.cd_id;
     cd_args = constructor_arguments copy_scope s c.cd_args;
     cd_res = Option.map (typexp copy_scope s c.cd_loc) c.cd_res;
     cd_loc = loc s c.cd_loc;
@@ -1099,11 +1113,6 @@ end
 
 module Lazy_types = Types.Make_wrapped(Wrap)
 open Lazy_types
-
-let rename_ident s id =
-  match s.additional_action with
-  | Prepare_for_saving { prepare_ident; _ } -> prepare_ident id
-  | Duplicate_variables | No_action -> Ident.rename id
 
 let rename_bound_idents scoping s sg =
   let rename =


### PR DESCRIPTION
The signature in a `cmi` contains `Ident.t` that are currently based on a global stamp counter, which is how many identifiers happened to be allocated while compiling it — which is perturbed by things such as loading its dependencies. This makes the byte representation of the signature volatile even if the signature "morally" stays the same. This defeats content-based build cutoff and cascading spurious recompilations.

This PR makes the signature in a `cmi` less volatile, by restamping the `Ident.t` when the signature is saved.

- [x] check performance degeneration