### PR TITLE
Keep parameter allocation modes in sync when unboxing closures in Reaper

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2276,12 +2276,13 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
     Flambda_arity.create main_code_params_arity,
     main_code_param_modes,
     false,
-    (* first_complex_local_param = 0, but function should never be partially
-       applied anyway *)
-    0,
+    First_complex_local_param.Never_partially_applied,
     result_arity_main_code,
     unboxed_return_continuation,
     my_unboxed_closure )
+
+let first_complex_local_param_of_function_decl decl =
+  First_complex_local_param.Index (Function_decl.first_complex_local_param decl)
 
 let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
     params_arity ~unarized_param_modes:param_modes return result_arity_main_code
@@ -2516,7 +2517,8 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
   let wrapper_code =
     Code.create code_id ~params_and_body:wrapper_params_and_body
       ~free_names_of_params_and_body ~params_arity ~param_modes
-      ~first_complex_local_param:(Function_decl.first_complex_local_param decl)
+      ~first_complex_local_param:
+        (first_complex_local_param_of_function_decl decl)
       ~result_arity:return ~result_types:Unknown
       ~result_mode:(Function_decl.result_mode decl)
       ~stub:true ~inline:Inline_attribute.Default_inline
@@ -2837,7 +2839,7 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
         params_arity,
         unarized_param_modes,
         is_tupled,
-        Function_decl.first_complex_local_param decl,
+        first_complex_local_param_of_function_decl decl,
         return,
         return_continuation,
         my_closure )
@@ -3102,7 +3104,7 @@ let close_functions acc external_env ~current_alloc_region ~current_region
         let metadata =
           Code_metadata.create code_id ~params_arity
             ~first_complex_local_param:
-              (Function_decl.first_complex_local_param decl)
+              (first_complex_local_param_of_function_decl decl)
             ~param_modes ~result_arity ~result_types:Unknown
             ~result_mode:(Function_decl.result_mode decl)
             ~stub:(Function_decl.stub decl) ~inline:Never_inline
@@ -3358,6 +3360,15 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     ~result_arity ~arity ~first_complex_local_param ~result_mode =
   (* In case of partial application, creates a wrapping function from scratch to
      allow inlining and lifting *)
+  let first_complex_local_param =
+    match (first_complex_local_param : First_complex_local_param.t) with
+    | Index index -> index
+    | Never_partially_applied ->
+      Misc.fatal_errorf
+        "Partial application of %a, whose code metadata states that it is \
+         never partially applied"
+        Ident.print apply.func
+  in
   let wrapper_id = Ident.create_local ("partial_" ^ Ident.name apply.func) in
   let wrapper_id_duid = Flambda_debug_uid.none in
   (* CR sspies: In the future, improve the debugging UIDs here if possible. *)

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -795,7 +795,9 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
           (* CR mshinwell: [inlining_decision] should maybe be set properly *)
           Code.create code_id ~params_and_body ~free_names_of_params_and_body
             ~newer_version_of ~params_arity ~param_modes
-            ~first_complex_local_param:(Flambda_arity.num_params params_arity)
+            ~first_complex_local_param:
+              (First_complex_local_param.Index
+                 (Flambda_arity.num_params params_arity))
             ~result_arity ~result_types:Unknown ~result_mode ~stub ~inline
             ~zero_alloc_attribute:Default_zero_alloc
               (* CR gyorsh: should [check] be set properly? *)

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -2363,6 +2363,12 @@ and rebuild_function_params_and_body (env : env) res code_metadata
       in
       Flambda_arity.create (List.map components_for params)
     in
+    let modes =
+      Misc.replicate_list
+        (Alloc_mode.For_types.unknown ())
+        (List.length params_from_closure)
+      @ modes
+    in
     let code_metadata =
       Code_metadata.with_params_arity params_arity
         (Code_metadata.with_param_modes modes code_metadata)

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -2357,6 +2357,12 @@ and rebuild_function_params_and_body (env : env) res code_metadata
       Code_metadata.with_params_arity params_arity
         (Code_metadata.with_param_modes modes code_metadata)
     in
+    (* We only change the calling convention if the analysis has shown there are
+       no partial applications. *)
+    let code_metadata =
+      Code_metadata.with_first_complex_local_param
+        First_complex_local_param.Never_partially_applied code_metadata
+    in
     let body, res = rebuild_body () in
     let code_metadata = update_size code_metadata body in
     (* Format.eprintf "REBUILD %a FREE %a@." Code_id.print code_id

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -184,7 +184,7 @@ let get_parameters params_decisions =
     [] params_decisions
   |> List.rev
 
-let get_parameters_and_modes params_decisions modes =
+let get_parameters_and_modes params_decisions_and_modes =
   List.fold_left
     (fun acc (param_decision, mode) ->
       match param_decision with
@@ -198,8 +198,7 @@ let get_parameters_and_modes params_decisions modes =
               mode )
             :: acc)
           fields acc) (* CR sspies: Missing debug uid. *)
-    []
-    (List.combine params_decisions modes)
+    [] params_decisions_and_modes
   |> List.rev |> List.split
 
 let get_arity params_decisions =
@@ -1297,12 +1296,10 @@ let rebuild_apply env apply =
             Misc.fatal_errorf
               "Callee is not unboxable in apply %a with unboxed closure"
               Apply.print apply;
-          let callee_fields = get_simple_unboxable env callee in
-          ( Unboxed_fields.fold2_subset_with_kind
-              (fun kind _param callee_field acc ->
-                (Simple.var callee_field, KS.anything kind) :: acc)
-              fields callee_fields [],
-            None )
+          (* The unboxed fields of the closure are passed at the front of the
+             first argument group, in the same order as the parameters
+             introduced in [rebuild_function_params_and_body]. *)
+          get_args_with_kinds env [Unbox fields] [callee], None
       in
       let params_decisions =
         match Code_id.Map.find_opt code_id env.function_params_to_keep with
@@ -2312,46 +2309,39 @@ and rebuild_function_params_and_body (env : env) res code_metadata
         params_decision
         (Bound_parameters.to_list params)
     in
-    let params_decision =
-      Flambda_arity.group_by_parameter
-        (Code_metadata.params_arity code_metadata)
-        params_decision
-    in
-    let params_and_modes =
-      List.map2
-        (fun p -> get_parameters_and_modes p)
-        params_decision
-        (Flambda_arity.group_by_parameter
-           (Code_metadata.params_arity code_metadata)
-           (Code_metadata.param_modes code_metadata))
-    in
-    let params = List.map fst params_and_modes in
-    let modes = List.concat_map snd params_and_modes in
-    let params_from_closure, code_metadata =
+    let my_closure_decision, code_metadata =
       match
         (* TODO move that in the decisions There should be a single record field
            with all the decisions for return params and closure *)
         Analysis.get_unboxed_fields env.uses (Code_id_or_name.var my_closure)
       with
-      | None -> [], code_metadata
+      (* If we're not unboxing we need to "delete" the extra mode we prepend
+         below, ultimately this is a no-op. *)
+      | None -> Delete, code_metadata
       | Some fields ->
-        ( Unboxed_fields.fold_with_kind
-            (fun kind v acc ->
-              Bound_parameter.create v (KS.anything kind) Flambda_debug_uid.none
-              :: acc)
-            (* CR sspies: Missing debug uid. *)
-            fields [],
-          Code_metadata.with_is_my_closure_used false code_metadata )
+        Unbox fields, Code_metadata.with_is_my_closure_used false code_metadata
     in
-    let params =
-      match params with
+    let params_decision_and_modes =
+      Flambda_arity.group_by_parameter
+        (Code_metadata.params_arity code_metadata)
+        (List.combine params_decision (Code_metadata.param_modes code_metadata))
+    in
+    let params_decision_and_modes =
+      match params_decision_and_modes with
       | [] ->
         Misc.fatal_errorf
           "Empty parameter groups when changing calling convention for code id \
            %a"
           Code_id.print code_id
-      | first :: rest -> (params_from_closure @ first) :: rest
+      | first :: rest ->
+        ((my_closure_decision, Alloc_mode.For_types.unknown ()) :: first)
+        :: rest
     in
+    let params_and_modes =
+      List.map get_parameters_and_modes params_decision_and_modes
+    in
+    let params = List.map fst params_and_modes in
+    let modes = List.concat_map snd params_and_modes in
     let params_arity =
       let components_for params =
         Flambda_arity.Component_for_creation.Unboxed_product
@@ -2362,12 +2352,6 @@ and rebuild_function_params_and_body (env : env) res code_metadata
              params)
       in
       Flambda_arity.create (List.map components_for params)
-    in
-    let modes =
-      Misc.replicate_list
-        (Alloc_mode.For_types.unknown ())
-        (List.length params_from_closure)
-      @ modes
     in
     let code_metadata =
       Code_metadata.with_params_arity params_arity

--- a/middle_end/flambda2/reaper/types_rewriter.ml
+++ b/middle_end/flambda2/reaper/types_rewriter.ml
@@ -1372,9 +1372,12 @@ let rewrite_result_types context ~old_typing_env ~my_closure:func_my_closure
     with
     | None -> []
     | Some fields ->
-      Unboxed_fields.fold_with_kind
-        (fun kind v acc -> (v, kind) :: acc)
-        fields []
+      (* These are in the same order as the parameters introduced in
+         [Rebuild.rebuild_function_params_and_body]. *)
+      List.rev
+        (Unboxed_fields.fold_with_kind
+           (fun kind v acc -> (v, kind) :: acc)
+           fields [])
   in
   let new_vars, new_env_extension =
     TypesRewrite.rewrite_env_extension_with_extra_variables old_typing_env

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -472,8 +472,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
      of the application. We check here that it is consistent with
      [first_complex_local_param]. *)
   let new_closure_alloc_mode_and_first_complex_local_param : _ Or_bottom.t =
-    if num_non_unarized_args <= first_complex_local_param
-    then
+    match (first_complex_local_param : First_complex_local_param.t) with
+    | Index index when num_non_unarized_args <= index ->
       (* At this point, we *have* to allocate the closure on the heap, even if
          the alloc_mode of the application was local. Indeed, consider a
          three-argument function, of type [string -> string -> string ->
@@ -492,11 +492,17 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
       in
       Ok
         ( Alloc_mode.For_applications.heap ~alloc_region,
-          first_complex_local_param - num_non_unarized_args )
-    else
+          First_complex_local_param.Index (index - num_non_unarized_args) )
+    | Index _ -> (
       match Apply_expr.alloc_mode apply with
       | Heap _ -> (* This can happen in dead GADT match cases. *) Bottom
-      | Local _ as apply_alloc_mode -> Ok (apply_alloc_mode, 0)
+      | Local _ as apply_alloc_mode ->
+        Ok (apply_alloc_mode, First_complex_local_param.Index 0))
+    | Never_partially_applied ->
+      Misc.fatal_errorf
+        "Partial application of %a, whose code metadata states that it is \
+         never partially applied"
+        Apply.print apply
   in
   let expr, dacc =
     match new_closure_alloc_mode_and_first_complex_local_param with

--- a/middle_end/flambda2/terms/code_metadata.ml
+++ b/middle_end/flambda2/terms/code_metadata.ml
@@ -19,7 +19,7 @@ type t =
     newer_version_of : Code_id.t option;
     params_arity : [`Complex] Flambda_arity.t;
     param_modes : Alloc_mode.For_types.t list;
-    first_complex_local_param : int;
+    first_complex_local_param : First_complex_local_param.t;
     (* Note: first_complex_local_param cannot be computed from param_modes,
        because it might be 0 if the closure itself has to be allocated locally,
        for instance as a result of a partial application. *)
@@ -142,7 +142,7 @@ type 'a create_type =
   newer_version_of:Code_id.t option ->
   params_arity:[`Complex] Flambda_arity.t ->
   param_modes:Alloc_mode.For_types.t list ->
-  first_complex_local_param:int ->
+  first_complex_local_param:First_complex_local_param.t ->
   result_arity:[`Unarized] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   result_mode:Lambda.locality_mode ->
@@ -182,13 +182,14 @@ let createk k code_id ~newer_version_of ~params_arity ~param_modes
     ()
   | true, (Always_inline | Unroll _) ->
     Misc.fatal_error "Stubs may not be annotated as [Always_inline] or [Unroll]");
-  if
-    first_complex_local_param < 0
-    || first_complex_local_param > Flambda_arity.num_params params_arity
-  then
-    Misc.fatal_errorf
-      "Illegal first_complex_local_param=%d for params arity: %a"
-      first_complex_local_param Flambda_arity.print params_arity;
+  (match (first_complex_local_param : First_complex_local_param.t) with
+  | Never_partially_applied -> ()
+  | Index index ->
+    if index < 0 || index > Flambda_arity.num_params params_arity
+    then
+      Misc.fatal_errorf
+        "Illegal first_complex_local_param=%d for params arity: %a" index
+        Flambda_arity.print params_arity);
   if
     List.compare_length_with param_modes
       (Flambda_arity.cardinal_unarized params_arity)
@@ -245,6 +246,9 @@ let with_params_arity params_arity t = { t with params_arity }
 
 let with_param_modes param_modes t = { t with param_modes }
 
+let with_first_complex_local_param first_complex_local_param t =
+  { t with first_complex_local_param }
+
 let with_is_tupled is_tupled t = { t with is_tupled }
 
 let with_result_types result_types t = { t with result_types }
@@ -291,7 +295,7 @@ let [@ocamlformat "disable"] print ppf
       @[<hov 1>%t(is_opaque@ %b)%t@]@ \
       @[<hov 1>%t(params_arity@ %t%a%t)%t@]@ \
       @[<hov 1>%t(param_modes@ %t(%a)%t)%t@]@ \
-      @[<hov 1>(first_complex_local_param@ %d)@]@ \
+      @[<hov 1>(first_complex_local_param@ %a)@]@ \
       @[<hov 1>%t(result_arity@ %t%a%t)%t@]@ \
       @[<hov 1>(result_types@ @[<hov 1>(%a)@])@]@ \
       @[<hov 1>(result_mode@ %s)@]@ \
@@ -366,7 +370,7 @@ let [@ocamlformat "disable"] print ppf
     then Flambda_colours.elide
     else Flambda_colours.none)
     Flambda_colours.pop
-    first_complex_local_param
+    First_complex_local_param.print first_complex_local_param
     (if Flambda_arity.is_one_param_of_kind_value result_arity
     then Flambda_colours.elide
     else Flambda_colours.none)
@@ -603,7 +607,8 @@ let approx_equal
   && (Option.equal Code_id.equal) newer_version_of1 newer_version_of2
   && Flambda_arity.equal_ignoring_subkinds params_arity1 params_arity2
   && List.equal Alloc_mode.For_types.equal param_modes1 param_modes2
-  && Int.equal first_complex_local_param1 first_complex_local_param2
+  && First_complex_local_param.equal first_complex_local_param1
+       first_complex_local_param2
   && Flambda_arity.equal_ignoring_subkinds result_arity1 result_arity2
   && Lambda.eq_locality_mode result_mode1 result_mode2
   && Bool.equal stub1 stub2

--- a/middle_end/flambda2/terms/code_metadata.mli
+++ b/middle_end/flambda2/terms/code_metadata.mli
@@ -38,7 +38,7 @@ module type Code_metadata_accessors_result_type = sig
   (* Zero-indexed position of the first local param, to be able to determine the
      allocation modes of partial applications. If there is no local parameter,
      equal to the number of (complex) parameters. *)
-  val first_complex_local_param : 'a t -> int
+  val first_complex_local_param : 'a t -> First_complex_local_param.t
 
   val result_arity : 'a t -> [`Unarized] Flambda_arity.t
 
@@ -97,7 +97,7 @@ type 'a create_type =
   newer_version_of:Code_id.t option ->
   params_arity:[`Complex] Flambda_arity.t ->
   param_modes:Alloc_mode.For_types.t list ->
-  first_complex_local_param:int ->
+  first_complex_local_param:First_complex_local_param.t ->
   result_arity:[`Unarized] Flambda_arity.t ->
   result_types:Result_types.t Or_unknown_or_bottom.t ->
   result_mode:Lambda.locality_mode ->
@@ -139,6 +139,8 @@ val with_result_arity : [`Unarized] Flambda_arity.t -> t -> t
 val with_params_arity : [`Complex] Flambda_arity.t -> t -> t
 
 val with_param_modes : Alloc_mode.For_types.t list -> t -> t
+
+val with_first_complex_local_param : First_complex_local_param.t -> t -> t
 
 val with_is_tupled : bool -> t -> t
 

--- a/middle_end/flambda2/terms/first_complex_local_param.ml
+++ b/middle_end/flambda2/terms/first_complex_local_param.ml
@@ -1,0 +1,41 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+type t =
+  | Index of int
+  | Never_partially_applied
+
+let print ppf = function
+  | Index index -> Format.fprintf ppf "%d" index
+  | Never_partially_applied ->
+    Format.pp_print_string ppf "Never_partially_applied"
+
+let equal t1 t2 =
+  match t1, t2 with
+  | Index index1, Index index2 -> Int.equal index1 index2
+  | Never_partially_applied, Never_partially_applied -> true
+  | (Index _ | Never_partially_applied), _ -> false

--- a/middle_end/flambda2/terms/first_complex_local_param.mli
+++ b/middle_end/flambda2/terms/first_complex_local_param.mli
@@ -1,0 +1,41 @@
+(******************************************************************************
+ *                                  OxCaml                                    *
+ * -------------------------------------------------------------------------- *
+ *                               MIT License                                  *
+ *                                                                            *
+ * Copyright (c) 2026 Jane Street Group LLC                                   *
+ * opensource-contacts@janestreet.com                                         *
+ *                                                                            *
+ * Permission is hereby granted, free of charge, to any person obtaining a    *
+ * copy of this software and associated documentation files (the "Software"), *
+ * to deal in the Software without restriction, including without limitation  *
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,   *
+ * and/or sell copies of the Software, and to permit persons to whom the      *
+ * Software is furnished to do so, subject to the following conditions:       *
+ *                                                                            *
+ * The above copyright notice and this permission notice shall be included    *
+ * in all copies or substantial portions of the Software.                     *
+ *                                                                            *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    *
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    *
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        *
+ * DEALINGS IN THE SOFTWARE.                                                  *
+ ******************************************************************************)
+
+(** When partially applying a function, the index of the first complex parameter
+    that's locally allocated (if there are no locally allocated complex
+    parameters, just the total number of global parameters).
+
+    When a function is never partially applied, we might change its calling
+    convention, and then we stop tracking this index (hence this variant type).
+*)
+type t =
+  | Index of int
+  | Never_partially_applied
+
+val print : Format.formatter -> t -> unit
+
+val equal : t -> t -> bool

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -64,8 +64,15 @@ let get_func_decl_params_arity t code_id =
     then Lambda.Tupled
     else
       let nlocal =
-        Flambda_arity.num_params (Code_metadata.params_arity info)
-        - Code_metadata.first_complex_local_param info
+        match
+          (Code_metadata.first_complex_local_param info
+            : First_complex_local_param.t)
+        with
+        | Index index ->
+          Flambda_arity.num_params (Code_metadata.params_arity info) - index
+        | Never_partially_applied ->
+          (* This value should never be observed. *)
+          0
       in
       Lambda.Curried { nlocal }
   in

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
@@ -12,7 +12,7 @@ let $camlArguments_for_unboxed_closure__id_6 =
 in
 let code inline(never) loopify(never) size(7) newer_version_of(u_4)
       u_4_1
-        (u_into_my_closure_field_g_field_x, u_into_my_closure_field_g_field_y)
+        (u_into_my_closure_field_g_field_y, u_into_my_closure_field_g_field_x)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
@@ -58,7 +58,7 @@ let code loopify(never) size(13) newer_version_of(f_0)
   let u_into_u_field_g_field_x = g_into_g_field_x in
   let u_into_u_field_g_field_y = g_into_g_field_y in
   apply direct(u_4_1 &my_alloc_region)
-     (u_into_u_field_g_field_x, u_into_u_field_g_field_y) -> k2 * k1
+     (u_into_u_field_g_field_y, u_into_u_field_g_field_x) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       (apply direct(g_1_1 &my_alloc_region) inlined(never)
          


### PR DESCRIPTION
When Reaper unboxes closures, it adds closed over values to the parameter list. There is a parallel list of allocation modes for the parameters, and currently that doesn't get updated correspondingly: this PR fixes that.

This doesn't seem to cause any issues at the moment because the modes aren't used later, but it caused a crash when running Reaper twice to explore LTO. Here's an example of code where that happened:

```ocaml
let f x =
  let[@inline never] [@local never] g () = x in
  g () + g ()
```

This change sets the allocation mode of the new parameters to the same as that of the closure itself, I am not sure if this is correct though.