### PR TITLE
Fix "make promote" with Dune 3.23.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ _compare/config.status: ocaml/config.status
 
 .PHONY: promote
 promote:
-	$(dune) promote $(ws_main)
+	$(dune) promotion apply $(ws_main)
 
 .PHONY: fmt
 fmt: $(dune_config_targets)


### PR DESCRIPTION
`make promote` ran `dune promote`, but in Dune 3.23 that has become `dune promotion apply`.