### PR TITLE
Allow load/store of atomic fields in mixed blocks

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -955,7 +955,25 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Pget_header _ -> unary (Ccall "caml_get_header")
     | Pobj_dup -> unary (Ccall "caml_obj_dup")
     | Patomic_load_field _ -> binary (Ccall "caml_atomic_load_field")
+    | Patomic_load_mixed_field { index; shape = _ } -> (
+      match args with
+      | [record] ->
+        (* In bytecode, mixed record fields aren't reordered, so the shape
+             index [index] is also a field index at runtime. *)
+        Prim
+          ( Ccall "caml_atomic_load_field",
+            [comp_expr record; Const (Const_base (Const_int index))] )
+      | _ -> wrong_arity ~expected:1)
     | Patomic_set_field _ -> ternary (Ccall "caml_atomic_set_field")
+    | Patomic_set_mixed_field { index; shape = _ } -> (
+      match args with
+      | [record; value] ->
+        let record = comp_expr record in
+        let value = comp_expr value in
+        Prim
+          ( Ccall "caml_atomic_set_field",
+            [record; Const (Const_base (Const_int index)); value] )
+      | _ -> wrong_arity ~expected:2)
     | Patomic_exchange_field _ -> ternary (Ccall "caml_atomic_exchange_field")
     | Patomic_compare_exchange_field _ ->
       n_ary ~arity:4 (Ccall "caml_atomic_compare_exchange_field")

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -373,7 +373,15 @@ type primitive =
   | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load_field of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_load_mixed_field of {
+    index : int;
+    shape : mixed_block_shape;
+  }
   | Patomic_set_field of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_set_mixed_field of {
+    index : int;
+    shape : mixed_block_shape;
+  }
   | Patomic_exchange_field of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_compare_exchange_field of
     {immediate_or_pointer : immediate_or_pointer}
@@ -2784,7 +2792,9 @@ let primitive_may_allocate : primitive -> locality_mode option = function
     Some alloc_heap
   | Pcpu_relax -> if Config.poll_insertion then None else Some alloc_heap
   | Patomic_load_field _
+  | Patomic_load_mixed_field _
   | Patomic_set_field _
+  | Patomic_set_mixed_field _
   | Patomic_exchange_field _
   | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _
@@ -2977,7 +2987,8 @@ let primitive_can_raise prim =
   | Patomic_exchange_field _ | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _ | Patomic_fetch_add_field  | Patomic_add_field
   | Patomic_sub_field  | Patomic_land_field | Patomic_lor_field
-  | Patomic_lxor_field  | Patomic_load_field _ | Patomic_set_field _ -> false
+  | Patomic_lxor_field  | Patomic_load_field _ | Patomic_load_mixed_field _
+  | Patomic_set_field _ | Patomic_set_mixed_field _ -> false
   | Pwith_stack | Pwith_stack_preemptible
   | Pperform | Pcontinue | Pdiscontinue
   | Pdiscontinue_with_backtrace
@@ -3070,6 +3081,27 @@ let extern_repr_involves_unboxed_products extern_repr =
     Misc.fatal_error "extern_repr_involves_unboxed_products: unexpected univar"
   | Same_as_ocaml_repr (Genvar _) ->
     Misc.fatal_error "extern_repr_involves_unboxed_products: unexpected genvar"
+
+let strip_locality_mode shape =
+  let rec strip_elt elt =
+    match elt with
+    | Float_boxed _ -> Float_boxed ()
+    | Product elts -> Product (Array.map strip_elt elts)
+    | Value vk -> Value vk
+    | Float64 -> Float64
+    | Float32 -> Float32
+    | Bits8 -> Bits8
+    | Bits16 -> Bits16
+    | Bits32 -> Bits32
+    | Bits64 -> Bits64
+    | Vec128 -> Vec128
+    | Vec256 -> Vec256
+    | Vec512 -> Vec512
+    | Word -> Word
+    | Untagged_immediate -> Untagged_immediate
+    | Splice_variable id -> Splice_variable id
+  in
+  Array.map strip_elt shape
 
 let rec layout_of_scannable_kinds kinds =
   Punboxed_product (List.map layout_of_scannable_kind kinds)
@@ -3427,7 +3459,9 @@ let primitive_result_layout (p : primitive) =
     layout_int_or_null
   | Patomic_load_field { immediate_or_pointer = Pointer } ->
     layout_any_value
-  | Patomic_set_field _ -> layout_unit
+  | Patomic_load_mixed_field { index ; shape } ->
+    layout_of_mixed_block_shape shape ~path:[index]
+  | Patomic_set_field _ | Patomic_set_mixed_field _ -> layout_unit
   | Patomic_exchange_field { immediate_or_pointer = Immediate } ->
     layout_int_or_null
   | Patomic_exchange_field { immediate_or_pointer = Pointer } ->

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -379,8 +379,8 @@ type primitive =
   | Patomic_load_field of { immediate_or_pointer : immediate_or_pointer }
   | Patomic_load_mixed_field of {
     index : int;
-    (** The field being accessed. This is an index into [shape], not a field
-        index. See [Pmixedfield] for more details. *)
+    (** The field being accessed. Like [Pmixedfield]'s path, this is an index
+        into [shape] -- not a field index. *)
     shape : mixed_block_shape;
   }
   | Patomic_set_field of { immediate_or_pointer : immediate_or_pointer }

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -377,7 +377,17 @@ type primitive =
   (* Atomic operations. Note that these operations must not be used on fields of
      all-float blocks. *)
   | Patomic_load_field of { immediate_or_pointer : immediate_or_pointer }
+  | Patomic_load_mixed_field of {
+    index : int;
+    (** The field being accessed. This is an index into [shape], not a field
+        index. See [Pmixedfield] for more details. *)
+    shape : mixed_block_shape;
+  }
   | Patomic_set_field of { immediate_or_pointer : immediate_or_pointer }
+  | Patomic_set_mixed_field of {
+    index : int;
+    shape : mixed_block_shape;
+  }
   | Patomic_exchange_field of { immediate_or_pointer : immediate_or_pointer }
   | Patomic_compare_exchange_field of
     { immediate_or_pointer : immediate_or_pointer }
@@ -695,6 +705,9 @@ val layout_of_extern_repr : extern_repr -> layout
 val element_layout_of_array_kind : array_kind -> layout
 
 val extern_repr_involves_unboxed_products : extern_repr -> bool
+
+val strip_locality_mode :
+  mixed_block_shape_with_locality_mode -> mixed_block_shape
 
 type structured_constant =
     Const_base of constant

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -845,10 +845,18 @@ let primitive ppf = function
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_load_field_imm"
         | Pointer -> fprintf ppf "atomic_load_field_ptr")
+  | Patomic_load_mixed_field { index ; shape } ->
+      fprintf ppf "atomic_load_mixed_field %a %a"
+        pp_print_int index
+        (mixed_block_shape (fun _ () -> ())) shape
   | Patomic_set_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_set_field_imm"
         | Pointer -> fprintf ppf "atomic_set_field_ptr")
+  | Patomic_set_mixed_field { index ; shape } ->
+      fprintf ppf "atomic_set_mixed_field %a %a"
+        pp_print_int index
+        (mixed_block_shape (fun _ () -> ())) shape
   | Patomic_exchange_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_exchange_field_imm"
@@ -1049,10 +1057,12 @@ let name_of_primitive = function
       (match immediate_or_pointer with
         | Immediate -> "atomic_load_field_imm"
         | Pointer -> "atomic_load_field_ptr")
+  | Patomic_load_mixed_field _ -> "atomic_load_mixed_field"
   | Patomic_set_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> "atomic_set_field_imm"
         | Pointer -> "atomic_set_field_ptr")
+  | Patomic_set_mixed_field _ -> "atomic_set_mixed_field"
   | Patomic_exchange_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> "atomic_exchange_field_imm"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -555,7 +555,8 @@ and fracture_prim lambda prim args loc =
   | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
   | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
   | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
-  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _ | Patomic_set_field _
+  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _
+  | Patomic_load_mixed_field _ | Patomic_set_field _ | Patomic_set_mixed_field _
   | Patomic_exchange_field _ | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _ | Patomic_fetch_add_field | Patomic_add_field
   | Patomic_sub_field | Patomic_land_field | Patomic_lor_field

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -495,7 +495,8 @@ and eval_prim env prim =
   | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
   | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
   | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
-  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _ | Patomic_set_field _
+  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _
+  | Patomic_load_mixed_field _ | Patomic_set_field _ | Patomic_set_mixed_field _
   | Patomic_exchange_field _ | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _ | Patomic_fetch_add_field | Patomic_add_field
   | Patomic_sub_field | Patomic_land_field | Patomic_lor_field

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -917,7 +917,8 @@ let rec choice ctx t =
     | Patomic_compare_set_field _ | Patomic_fetch_add_field
     | Patomic_add_field | Patomic_sub_field | Patomic_land_field
     | Patomic_lor_field | Patomic_lxor_field
-    | Patomic_load_field _ | Patomic_set_field _
+    | Patomic_load_field _ | Patomic_load_mixed_field _
+    | Patomic_set_field _ | Patomic_set_mixed_field _
     | Pcpu_relax
     | Punbox_vector _ | Pbox_vector (_, _)
     | Pjoin_vec256 | Psplit_vec256

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -894,7 +894,14 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                           \ present for float field read")
               shape
           in
-          Some (Pmixedfield ([lbl.lbl_pos], shape, sem), [targ])
+          if Types.is_atomic lbl.lbl_mut then
+            (* Patomic_load_mixed_field doesn't care about locality mode;
+               @@flatten_floats doesn't accept records with atomic fields. *)
+            let shape = strip_locality_mode shape in
+            Some
+              (Patomic_load_mixed_field { index = lbl.lbl_pos; shape }, [targ])
+          else
+            Some (Pmixedfield ([lbl.lbl_pos], shape, sem), [targ])
         | Record_inlined (_, _, Variant_with_null) -> assert false
         | Record_dummy _ ->
           fatal_error "transl_exp0: dummy record representation"
@@ -1008,8 +1015,12 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           let shape = Lambda.transl_mixed_product_shape shape in
           (* Update the shape with details for the modified field. *)
           shape.(lbl.lbl_pos) <- field_shape;
-          Psetmixedfield([lbl.lbl_pos], shape, mode),
-          [arg_lambda; newval_lambda]
+          if Types.is_atomic lbl.lbl_mut then
+            (Patomic_set_mixed_field { index = lbl.lbl_pos; shape },
+            [arg_lambda; newval_lambda])
+          else
+            (Psetmixedfield([lbl.lbl_pos], shape, mode),
+            [arg_lambda; newval_lambda])
         | Record_inlined (_, _, Variant_with_null) -> assert false
         | Record_dummy _ ->
             fatal_error "transl_exp0: unexpected dummy representation"

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -896,7 +896,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
           in
           if Types.is_atomic lbl.lbl_mut then
             (* Patomic_load_mixed_field doesn't care about locality mode;
-               @@flatten_floats doesn't accept records with atomic fields. *)
+               [@@flatten_floats] doesn't accept records with atomic fields. *)
             let shape = strip_locality_mode shape in
             Some
               (Patomic_load_mixed_field { index = lbl.lbl_pos; shape }, [targ])

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2590,7 +2590,8 @@ let lambda_primitive_needs_event_after = function
   | Patomic_compare_set_field _ | Patomic_fetch_add_field
   | Patomic_add_field | Patomic_sub_field
   | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
-  | Patomic_load_field _ | Patomic_set_field _
+  | Patomic_load_field _ | Patomic_load_mixed_field _
+  | Patomic_set_field _ | Patomic_set_mixed_field _
   | Pcpu_relax | Pctconst _ | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Ptls_get

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -435,7 +435,9 @@ let compute_static_size lam =
     | Pbigstring_load_64 _
     | Pint_as_pointer _
     | Patomic_load_field _
+    | Patomic_load_mixed_field _
     | Patomic_set_field _
+    | Patomic_set_mixed_field _
     | Patomic_exchange_field _
     | Patomic_compare_exchange_field _
     | Patomic_compare_set_field _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1306,7 +1306,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
       | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field | Pdls_get
       | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
-      | Patomic_set_field _ | Preinterpret_tagged_int63_as_unboxed_int64
+      | Patomic_load_mixed_field _ | Patomic_set_field _
+      | Patomic_set_mixed_field _ | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _
       | Pscalar _ | Pphys_equal _ | Pcpu_relax ->
         (* Inconsistent with outer match *)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1806,6 +1806,29 @@ let string_or_bytes_checks (size : Flambda_primitive.string_accessor_width)
       ( ~len:(Flambda_primitive.byte_width_of_string_accessor_width size),
         ~align:0 )
 
+let mixed_field_index_and_kind ~machine_width ~prim_name index shape =
+  let shape =
+    Mixed_block_shape.of_mixed_block_elements shape
+      ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
+  in
+  let field_index =
+    match Mixed_block_shape.lookup_path_producing_new_indexes shape [index] with
+    | [index] -> index
+    | _ ->
+      Misc.fatal_errorf "%s: expected exactly one flattened index" prim_name
+  in
+  let field_kind =
+    match (Mixed_block_shape.flattened_reordered_shape shape).(field_index) with
+    | Value vk -> H.block_access_field_kind_of_value_kind vk
+    | Float_boxed _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
+    | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
+      Misc.fatal_errorf "%s: expected mixed block element to be a value"
+        prim_name
+  in
+  let imm = Target_ocaml_int.of_int machine_width field_index in
+  check_non_negative_imm imm prim_name;
+  imm, field_kind
+
 (* Primitive conversion *)
 let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     (prim : L.primitive) (args : Simple.t list list) (dbg : Debuginfo.t)
@@ -3181,12 +3204,30 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
             (convert_block_access_field_kind immediate_or_pointer),
           atomic,
           field ) ]
+  | Patomic_load_mixed_field { index; shape }, [[atomic]] ->
+    let imm, field_kind =
+      mixed_field_index_and_kind ~machine_width
+        ~prim_name:"Patomic_load_mixed_field" index shape
+    in
+    [ Binary
+        (Atomic_load_field field_kind, atomic, H.Simple (Simple.const_int imm))
+    ]
   | Patomic_set_field { immediate_or_pointer }, [[atomic]; [field]; [new_value]]
     ->
     [ Ternary
         ( Atomic_set_field (convert_block_access_field_kind immediate_or_pointer),
           atomic,
           field,
+          new_value ) ]
+  | Patomic_set_mixed_field { index; shape }, [[atomic]; [new_value]] ->
+    let imm, field_kind =
+      mixed_field_index_and_kind ~machine_width
+        ~prim_name:"Patomic_set_mixed_field" index shape
+    in
+    [ Ternary
+        ( Atomic_set_field field_kind,
+          atomic,
+          H.Simple (Simple.const_int imm),
           new_value ) ]
   | ( Patomic_exchange_field { immediate_or_pointer },
       [[atomic]; [field]; [new_value]] ) ->
@@ -3326,7 +3367,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Pobj_dup | Pobj_magic _ | Punbox_vector _ | Punbox_unit
       | Pbox_vector (_, _)
       | Punboxed_product_field _ | Pget_header _ | Pufloatfield _
-      | Patomic_load_field _ | Pmixedfield _
+      | Patomic_load_field _ | Patomic_load_mixed_field _ | Pmixedfield _
       | Preinterpret_unboxed_int64_as_tagged_int63
       | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_boxed_vector_as_tuple _
@@ -3369,7 +3410,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
             | Punspecializedarray_ref _ ),
             _,
             _ )
-      | Patomic_load_field _ | Ppoke _ | Pphys_equal _
+      | Patomic_load_field _ | Patomic_set_mixed_field _ | Ppoke _
+      | Pphys_equal _
       | Pscalar (Binary _)
       | Pget_idx _ | Pset_ptr _ | Pset_ext_ptr _ ),
       ( []

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -493,7 +493,7 @@ and bind_rec_primitive acc exn_cont ~register_const0 (prim : simple_or_prim)
     in
     bind_recs acc exn_cont ~register_const0 p dbg cont
 
-let convert_block_access_field_kind_from_value_kind
+let block_access_field_kind_of_value_kind
     ({ raw_kind; nullable = _ } : L.value_kind) : P.Block_access_field_kind.t =
   match raw_kind with
   | Pintval -> Immediate
@@ -510,7 +510,7 @@ let mixed_block_access_field_kind
     P.Mixed_block_access_field_kind.t =
   match elt with
   | Value value_kind ->
-    Value_prefix (convert_block_access_field_kind_from_value_kind value_kind)
+    Value_prefix (block_access_field_kind_of_value_kind value_kind)
   | ( Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256
     | Vec512 | Word | Untagged_immediate ) as mixed_block_element ->
     Flat_suffix

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -88,6 +88,11 @@ val bind_recs :
   (Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) ->
   Expr_with_acc.t
 
+(** Returns the appropriate [Block_access_field_kind.t] for accessing field
+    element with given value kind. *)
+val block_access_field_kind_of_value_kind :
+  Lambda.value_kind -> Flambda_primitive.Block_access_field_kind.t
+
 (** Returns the appropriate [Block_access_kind.t] for accessing a field of a
     mixed block element. *)
 val block_access_kind_of_mixed_field_element :

--- a/testsuite/tests/atomic-locs/atomic_fields.ml
+++ b/testsuite/tests/atomic-locs/atomic_fields.ml
@@ -169,6 +169,18 @@ Line 1, characters 48-77:
 Error: The record field "regular_field" is not atomic
 |}]
 
+(* Test Label_not_atomic for an unusual record representation *)
+
+type float_record = { mutable f : float } (* Record_float *)
+let test_non_atomic_float_field (r : float_record) = [%atomic.loc r.f]
+[%%expect{|
+type float_record = { mutable f : float; }
+Line 2, characters 53-70:
+2 | let test_non_atomic_float_field (r : float_record) = [%atomic.loc r.f]
+                                                         ^^^^^^^^^^^^^^^^^
+Error: The record field "f" is not atomic
+|}]
+
 (* Test Invalid_atomic_loc_payload errors *)
 
 (* Empty payload *)

--- a/testsuite/tests/atomic-locs/mixed_field_access.ml
+++ b/testsuite/tests/atomic-locs/mixed_field_access.ml
@@ -1,0 +1,156 @@
+(* TEST
+ include stdlib_upstream_compatible;
+ flambda2;
+ {
+   native;
+ } {
+   bytecode;
+ }
+*)
+
+module Int64_u = struct
+  include Stdlib_upstream_compatible.Int64_u
+end
+
+module Mixed_record = struct
+  (* the value field comes first, so flambda2 reordering is a noop *)
+  type t = { mutable atomic : int [@atomic]; mutable nonatomic : int64# }
+
+  let () =
+    Printf.printf "== Mixed record (no reordering) ==\n";
+    let t = { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_reorder = struct
+  (* flambda2 will reorder so [atomic] comes before [nonatomic] *)
+  type t = { mutable nonatomic : int64#; mutable atomic : int [@atomic] }
+
+  let () =
+    Printf.printf "== Mixed record (reordering) ==\n";
+    let t = { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_inline_record = struct
+  (* use an inline record *)
+  type t = A of { mutable atomic : int [@atomic]; mutable nonatomic : int64# }
+
+  let () =
+    Printf.printf "== Mixed inline record (no reordering) ==\n";
+    let (A t) = A { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_inline_record_reorder = struct
+  type t = A of { mutable nonatomic : int64#; mutable atomic : int [@atomic] }
+
+  let () =
+    Printf.printf "== Mixed inline record (reordering) ==\n";
+    let (A t) = A { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_nonimmediate = struct
+  (* atomic field is not an immediate *)
+  type t = { mutable atomic : string [@atomic]; mutable nonatomic : int64# }
+
+  let () =
+    Printf.printf "== Mixed record with non-immediate (no reordering) ==\n";
+    let t = { atomic = "hello"; nonatomic = #13L } in
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- "world"; Printf.printf "set t.atomic <- \"world\"\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_nonimmediate_reorder = struct
+  type t = { mutable nonatomic : int64#; mutable atomic : string [@atomic]; }
+
+  let () =
+    Printf.printf "== Mixed record with non-immediate (reordering) ==\n";
+    let t = { atomic = "hello"; nonatomic = #13L } in
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- "world"; Printf.printf "set t.atomic <- \"world\"\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_sandwich = struct
+  (* a non-value field sandwiched between two atomic value fields *)
+  type t =
+    { mutable atomic1 : int [@atomic];
+      mutable nonatomic : int64#;
+      mutable atomic2 : string [@atomic]
+    }
+
+  let () =
+    Printf.printf "== Mixed record (sandwiched non-value field) ==\n";
+    let t = { atomic1 = 42; nonatomic = #13L; atomic2 = "hello" } in
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2;
+
+    t.atomic1 <- 43; Printf.printf "set t.atomic1 <- 43\n";
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2;
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2;
+
+    t.atomic2 <- "world"; Printf.printf "set t.atomic2 <- \"world\"\n";
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2
+end

--- a/testsuite/tests/atomic-locs/mixed_field_access.reference
+++ b/testsuite/tests/atomic-locs/mixed_field_access.reference
@@ -1,0 +1,70 @@
+== Mixed record (no reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed record (reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed inline record (no reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed inline record (reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed record with non-immediate (no reordering) ==
+t.atomic: hello
+t.nonatomic: 13
+set t.atomic <- "world"
+t.atomic: world
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: world
+t.nonatomic: 14
+== Mixed record with non-immediate (reordering) ==
+t.atomic: hello
+t.nonatomic: 13
+set t.atomic <- "world"
+t.atomic: world
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: world
+t.nonatomic: 14
+== Mixed record (sandwiched non-value field) ==
+t.atomic1: 42
+t.nonatomic: 13
+t.atomic2: hello
+set t.atomic1 <- 43
+t.atomic1: 43
+t.nonatomic: 13
+t.atomic2: hello
+set t.nonatomic <- 14
+t.atomic1: 43
+t.nonatomic: 14
+t.atomic2: hello
+set t.atomic2 <- "world"
+t.atomic1: 43
+t.nonatomic: 14
+t.atomic2: world

--- a/testsuite/tests/atomic-locs/mixed_records.ml
+++ b/testsuite/tests/atomic-locs/mixed_records.ml
@@ -152,34 +152,63 @@ module Pattern_matching_wildcard :
   end
 |}]
 
-(* Defining atomic fields in a mixed block is permitted. *)
-module Mixed_blocks_ok = struct
+(* Atomic fields are permitted in mixed blocks. *)
+module Mixed_record_atomics = struct
   type t = {
-    padding : #(int * int * int);
-    mutable field : int [@atomic]
+    mutable a : int [@atomic];
+    mutable b : int64#
   }
-end
 
+  let access t =
+    let _ = t.a in
+    let _ = t.b in
+    t.a <- 42;
+    t.b <- #42L
+end
 [%%expect{|
-module Mixed_blocks_ok :
+module Mixed_record_atomics :
   sig
-    type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
+    type t = { mutable a : int [@atomic]; mutable b : int64#; }
+    val access : t -> unit
   end
 |}]
 
-(* Test access of nonatomic fields in mixed record with atomic fields *)
-type t = { i : int64#; mutable a : int [@atomic]; mutable b : int }
-[%%expect {|
-type t = { i : int64#; mutable a : int [@atomic]; mutable b : int; }
+(* Atomic fields are permitted in mixed inline records. *)
+module Mixed_inline_record_atomics = struct
+  type t = A of {
+    mutable a : int [@atomic];
+    mutable b : int64#
+  }
+
+  let access (A t) =
+    let _ = t.a in
+    let _ = t.b in
+    t.a <- 42;
+    t.b <- #42L
+end
+[%%expect{|
+module Mixed_inline_record_atomics :
+  sig
+    type t = A of { mutable a : int [@atomic]; mutable b : int64#; }
+    val access : t -> unit
+  end
 |}]
 
-let ok_project (t : t) = t.b
-[%%expect {|
-val ok_project : t -> int = <fun>
+(* We forbid taking atomic.loc of fields from mixed records. *)
+let forbidden (t : Mixed_record_atomics.t) = [%atomic.loc t.a]
+[%%expect{|
+Line 1, characters 45-62:
+1 | let forbidden (t : Mixed_record_atomics.t) = [%atomic.loc t.a]
+                                                 ^^^^^^^^^^^^^^^^^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "a") is forbidden.
 |}]
-let ok_set (t : t) = t.b <- 42
-[%%expect {|
-val ok_set : t -> unit = <fun>
+
+let forbidden_inline (A t : Mixed_inline_record_atomics.t) = [%atomic.loc t.a]
+[%%expect{|
+Line 1, characters 61-78:
+1 | let forbidden_inline (A t : Mixed_inline_record_atomics.t) = [%atomic.loc t.a]
+                                                                 ^^^^^^^^^^^^^^^^^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "a") is forbidden.
 |}]
 
 (* Test mixed record atomic fields with non-value layouts *)
@@ -213,6 +242,16 @@ end
 Line 4, characters 4-31:
 4 |     mutable field : u [@atomic]
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields must have layout value.
+|}]
+
+module Mixed_inline_record_non_value_atomic = struct
+  type t = A of { mutable f : float# [@atomic]; g : int64# }
+end
+[%%expect{|
+Line 2, characters 18-47:
+2 |   type t = A of { mutable f : float# [@atomic]; g : int64# }
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Atomic record fields must have layout value.
 |}]
 
@@ -257,11 +296,11 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-Line 5, characters 31-32:
-5 |   let allowed t = { t with y = t.y }
-                                   ^
-Error: Accessing atomic fields (here "y") of mixed records is not yet
-       supported.
+module Functional_update_copy_ok :
+  sig
+    type t = { x : int64#; mutable y : int [@atomic]; }
+    val allowed : t -> t
+  end
 |}]
 
 module Functional_update_multi_error = struct
@@ -301,9 +340,13 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-Line 4, characters 31-32:
-4 |   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
-                                   ^
-Error: Accessing atomic fields (here "y") of mixed records is not yet
-       supported.
+module Functional_update_multi_copy_ok :
+  sig
+    type t = {
+      x : int64#;
+      mutable y : int [@atomic];
+      mutable z : int [@atomic];
+    }
+    val allowed : t -> t
+  end
 |}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -201,51 +201,52 @@ type ('a : any) t = { a : 'a; mutable f: int [@atomic]}
 type ('a : any) t = { a : 'a; mutable f : int [@atomic]; }
 |}];;
 
-let ok_project (t: int t) = t.f
+let project (t: int t) = t.f
+[%%expect{|
+(let (project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : int t -> int = <fun>
+|}];;
+
+let mixed_project (t: int64# t) = t.f
 [%%expect{|
 (let
-  (ok_project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
-  (apply (field_imm 1 (global Toploop!)) "ok_project" ok_project))
-val ok_project : int t -> int = <fun>
+  (mixed_project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (bits64,value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_project" mixed_project))
+val mixed_project : int64# t -> int = <fun>
 |}];;
 
-let wrong_project (t: int64# t) = t.f
+let set (t: int t) = t.f <- 42
 [%%expect{|
-Line 1, characters 34-35:
-1 | let wrong_project (t: int64# t) = t.f
-                                      ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(let (set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : int t -> unit = <fun>
 |}];;
 
-let ok_set (t: int t) = t.f <- 42
+let mixed_set (t: int64# t) = t.f <- 42
 [%%expect{|
-(let (ok_set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
-  (apply (field_imm 1 (global Toploop!)) "ok_set" ok_set))
-val ok_set : int t -> unit = <fun>
+(let
+  (mixed_set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (bits64,value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_set" mixed_set))
+val mixed_set : int64# t -> unit = <fun>
 |}];;
 
-let wrong_set (t: int64# t) = t.f <- 42
+let loc (t: int t) = [%atomic.loc t.f]
 [%%expect{|
-Line 1, characters 30-39:
-1 | let wrong_set (t: int64# t) = t.f <- 42
-                                  ^^^^^^^^^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
-|}];;
-
-let ok_loc (t: int t) = [%atomic.loc t.f]
-[%%expect{|
-(let (ok_loc = (function {nlocal = 0} t (makeblock 0 (*,value<int>) t 1)))
-  (apply (field_imm 1 (global Toploop!)) "ok_loc" ok_loc))
-val ok_loc : int t -> int atomic_loc = <fun>
+(let (loc = (function {nlocal = 0} t (makeblock 0 (*,value<int>) t 1)))
+  (apply (field_imm 1 (global Toploop!)) "loc" loc))
+val loc : int t -> int atomic_loc = <fun>
 |}];;
 
 let wrong_loc (t: int64# t) = [%atomic.loc t.f];
 [%%expect{|
-Line 1, characters 43-44:
+Line 1, characters 30-47:
 1 | let wrong_loc (t: int64# t) = [%atomic.loc t.f];
-                                               ^
+                                  ^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "f") is forbidden.
 |}];;
 
@@ -307,37 +308,38 @@ type ('a : any) t = A of { a : 'a; mutable f: int [@atomic]}
 type ('a : any) t = A of { a : 'a; mutable f : int [@atomic]; }
 |}];;
 
-let ok_project (t: int t) = match t with A r -> r.f
+let project (t: int t) = match t with A r -> r.f
+[%%expect{|
+(let (project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : int t -> int = <fun>
+|}];;
+
+let mixed_project (t: int64# t) = match t with A r -> r.f
 [%%expect{|
 (let
-  (ok_project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
-  (apply (field_imm 1 (global Toploop!)) "ok_project" ok_project))
-val ok_project : int t -> int = <fun>
+  (mixed_project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (bits64,value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_project" mixed_project))
+val mixed_project : int64# t -> int = <fun>
 |}];;
 
-let wrong_project (t: int64# t) = match t with A r -> r.f
+let set (t: int t) = match t with A r -> r.f <- 42
 [%%expect{|
-Line 1, characters 54-55:
-1 | let wrong_project (t: int64# t) = match t with A r -> r.f
-                                                          ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(let (set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : int t -> unit = <fun>
 |}];;
 
-let ok_set (t: int t) = match t with A r -> r.f <- 42
+let mixed_set (t: int64# t) = match t with A r -> r.f <- 42
 [%%expect{|
-(let (ok_set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
-  (apply (field_imm 1 (global Toploop!)) "ok_set" ok_set))
-val ok_set : int t -> unit = <fun>
-|}];;
-
-let wrong_set (t: int64# t) = match t with A r -> r.f <- 42
-[%%expect{|
-Line 1, characters 50-59:
-1 | let wrong_set (t: int64# t) = match t with A r -> r.f <- 42
-                                                      ^^^^^^^^^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(let
+  (mixed_set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (bits64,value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_set" mixed_set))
+val mixed_set : int64# t -> unit = <fun>
 |}];;
 
 let ok_loc (t: int t) = match t with A r -> [%atomic.loc r.f]
@@ -349,9 +351,9 @@ val ok_loc : int t -> int atomic_loc = <fun>
 
 let wrong_loc (t: int64# t) = match t with A r -> [%atomic.loc r.f]
 [%%expect{|
-Line 1, characters 63-64:
+Line 1, characters 50-67:
 1 | let wrong_loc (t: int64# t) = match t with A r -> [%atomic.loc r.f]
-                                                                   ^
+                                                      ^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "f") is forbidden.
 |}];;
 
@@ -372,7 +374,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic float field
   which prevents the float record optimization.
   The fields of this record will be boxed instead of being
   represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/471"
+(apply (field_imm 1 (global Toploop!)) "Float_records/470"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -592,7 +594,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/534"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/533"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))
@@ -633,7 +635,7 @@ module Functional_update_ok = struct
   let allowed t = { t with y = 42 }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/550"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/549"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -653,7 +655,7 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/558"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/557"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -687,7 +689,7 @@ module Functional_update_multi_ok = struct
   let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/574"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/573"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -711,7 +713,7 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/583"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/582"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -740,32 +742,38 @@ end
 
 let project (t : Mixed_blocks.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/614" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/587" (makeblock 0))
 module Mixed_blocks :
   sig
     type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
   end
-Line 8, characters 35-36:
-8 | let project (t : Mixed_blocks.t) = t.field
-                                       ^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (product  (value_or_null<int>,value_or_null<
+                                                                  int>,
+         value_or_null<int>),value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : Mixed_blocks.t -> int = <fun>
 |}]
 
 let set (t: Mixed_blocks.t) = t.field <- 42
 [%%expect{|
-Line 1, characters 30-43:
-1 | let set (t: Mixed_blocks.t) = t.field <- 42
-                                  ^^^^^^^^^^^^^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (product  (value_or_null<int>,value_or_null<
+                                                                 int>,
+         value_or_null<int>),value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : Mixed_blocks.t -> unit = <fun>
 |}]
 
 let loc (t: Mixed_blocks.t) = [%atomic.loc t.field]
 [%%expect{|
-Line 1, characters 43-44:
+Line 1, characters 30-51:
 1 | let loc (t: Mixed_blocks.t) = [%atomic.loc t.field]
-                                               ^
+                                  ^^^^^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
@@ -778,32 +786,36 @@ end
 
 let project (t : Mixed_blocks_2.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/627" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/597" (makeblock 0))
 module Mixed_blocks_2 :
   sig
     type t = { mutable field : int [@atomic]; padding : #(int * int * int); }
   end
-Line 8, characters 37-38:
-8 | let project (t : Mixed_blocks_2.t) = t.field
-                                         ^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 0  (value<int>,product  (value_or_null<int>,
+         value_or_null<int>,value_or_null<int>)) t)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : Mixed_blocks_2.t -> int = <fun>
 |}]
 
 let set (t: Mixed_blocks_2.t) = t.field <- 42
 [%%expect{|
-Line 1, characters 32-45:
-1 | let set (t: Mixed_blocks_2.t) = t.field <- 42
-                                    ^^^^^^^^^^^^^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 0  (value<int>,product  (value_or_null<int>,
+         value_or_null<int>,value_or_null<int>)) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : Mixed_blocks_2.t -> unit = <fun>
 |}]
 
 let loc (t: Mixed_blocks_2.t) = [%atomic.loc t.field]
 [%%expect{|
-Line 1, characters 45-46:
+Line 1, characters 32-53:
 1 | let loc (t: Mixed_blocks_2.t) = [%atomic.loc t.field]
-                                                 ^
+                                    ^^^^^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
@@ -820,7 +832,7 @@ module Mixed_blocks_rec = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/643" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/610" (makeblock 0))
 module Mixed_blocks_rec :
   sig
     type t = { padding : u; mutable field : int [@atomic]; }
@@ -830,25 +842,29 @@ module Mixed_blocks_rec :
 
 let project (t : Mixed_blocks_rec.t) = t.field
 [%%expect{|
-Line 1, characters 39-40:
-1 | let project (t : Mixed_blocks_rec.t) = t.field
-                                           ^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (product  (untagged_immediate,float64),
+         value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : Mixed_blocks_rec.t -> int = <fun>
 |}]
 let set (t: Mixed_blocks_rec.t) = t.field <- 42
 [%%expect{|
-Line 1, characters 34-47:
-1 | let set (t: Mixed_blocks_rec.t) = t.field <- 42
-                                      ^^^^^^^^^^^^^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (product  (untagged_immediate,float64),
+         value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : Mixed_blocks_rec.t -> unit = <fun>
 |}]
 let loc (t: Mixed_blocks_rec.t) = [%atomic.loc t.field]
 [%%expect{|
-Line 1, characters 47-48:
+Line 1, characters 34-55:
 1 | let loc (t: Mixed_blocks_rec.t) = [%atomic.loc t.field]
-                                                   ^
+                                      ^^^^^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
@@ -924,11 +940,17 @@ module Atomic_float_with_float_hash = struct
 end
 
 [%%expect{|
-Line 4, characters 21-22:
-4 |   let disallowed t = t.f
-                         ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/636"
+  (let
+    (disallowed =
+       (function {nlocal = 0} t : float
+         (atomic_load_mixed_field 0  (*,float64) t)))
+    (makeblock 0 disallowed)))
+module Atomic_float_with_float_hash :
+  sig
+    type t = { mutable f : float [@atomic]; u : float#; }
+    val disallowed : t -> float
+  end
 |}]
 
 module Inline_record_atomic_in_mixed = struct
@@ -939,9 +961,15 @@ module Inline_record_atomic_in_mixed = struct
 end
 
 [%%expect{|
-Line 5, characters 11-12:
-5 |   | A r -> r.f
-               ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/645"
+  (let
+    (disallowed =
+       (function {nlocal = 0} t : int
+         (atomic_load_mixed_field 0  (value<int>,untagged_immediate) t)))
+    (makeblock 0 disallowed)))
+module Inline_record_atomic_in_mixed :
+  sig
+    type t = A of { mutable f : int [@atomic]; u : int#; }
+    val disallowed : t -> int
+  end
 |}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -728,60 +728,6 @@ module Functional_update_multi_copy_ok :
     val allowed : t -> t
   end
 |}]
-(* Pattern matching follows the same rules in mixed blocks. *)
-module Pattern_matching = struct
-  type t = { x : int64#; mutable y : int [@atomic] }
-
-  let forbidden { x; y } = x + y
-end
-[%%expect{|
-Line 4, characters 16-24:
-4 |   let forbidden { x; y } = x + y
-                    ^^^^^^^^
-Error: Atomic fields (here "y") are forbidden in patterns,
-       as it is difficult to reason about when the atomic read
-       will happen during pattern matching: the field may be read
-       zero, one or several times depending on the patterns around it.
-|}]
-
-(* ... except for wildcards, to allow exhaustive record patterns. *)
-module Pattern_matching_wildcard = struct
-  type t = { x : int64#; mutable y : int [@atomic] }
-
-  [@@@warning "+missing-record-field-pattern"]
-  let warning { x } = x
-
-  let allowed { x; y = _ } = x
-  let also_allowed { x; _ } = x
-end
-[%%expect{|
-Line 5, characters 14-19:
-5 |   let warning { x } = x
-                  ^^^^^
-Warning 9 [missing-record-field-pattern]: the following labels are not bound
-  in this record pattern: "y".
-  Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/607"
-  (let
-    (warning =
-       (function {nlocal = 0} param : unboxed_int64
-         (mixedfield 0  (bits64,value_or_null<int>) param))
-     allowed =
-       (function {nlocal = 0} param : unboxed_int64
-         (mixedfield 0  (bits64,value_or_null<int>) param))
-     also_allowed =
-       (function {nlocal = 0} param : unboxed_int64
-         (mixedfield 0  (bits64,value_or_null<int>) param)))
-    (makeblock 0 warning allowed also_allowed)))
-
-module Pattern_matching_wildcard :
-  sig
-    type t = { x : int64#; mutable y : int [@atomic]; }
-    val warning : t -> int64#
-    val allowed : t -> int64#
-    val also_allowed : t -> int64#
-  end
-|}]
 
 (* Test atomic record fields in mixed blocks *)
 

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -223,18 +223,31 @@ type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
 
 let () =
   let t = { imm = 1; ptr = "two"} in
-  test_atomic_exchange_field ~expected:1 (fun () ->
+  test_atomic_exchange_field ~expected:0 (fun () ->
     t.imm <- 3;
+    ignore (Sys.opaque_identity t)
+  )
+
+let () =
+  let t = { imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:1 (fun () ->
     t.ptr <- "four";
     ignore (Sys.opaque_identity t)
   )
 
 (* Patomic_set_mixed_field skips runtime call for immediates. *)
 type mixed = { f : int64#; mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+
+let () =
+  let m = { f = #42L; imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:0 (fun () ->
+    m.imm <- 3;
+    ignore (Sys.opaque_identity m)
+  )
+
 let () =
   let m = { f = #42L; imm = 1; ptr = "two"} in
   test_atomic_exchange_field ~expected:1 (fun () ->
-    m.imm <- 3;
     m.ptr <- "four";
     ignore (Sys.opaque_identity m)
   )

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -34,6 +34,83 @@
 (* This test verifies that immediate atomics do not call runtime wrapper functions
    in native amd64 builds. *)
 
+external total_atomic_calls : unit -> int = "total_atomic_calls"
+external total_atomic_reset : unit -> unit = "total_atomic_reset"
+
+external atomic_load_calls : unit -> int = "atomic_load_calls"
+external atomic_load_field_calls : unit -> int = "atomic_load_field_calls"
+external atomic_exchange_calls : unit -> int = "atomic_exchange_calls"
+external atomic_exchange_field_calls : unit -> int = "atomic_exchange_field_calls"
+external atomic_set_calls : unit -> int = "atomic_set_calls"
+external atomic_set_field_calls : unit -> int = "atomic_set_field_calls"
+external atomic_compare_exchange_calls : unit -> int = "atomic_compare_exchange_calls"
+external atomic_compare_exchange_field_calls : unit -> int = "atomic_compare_exchange_field_calls"
+external atomic_cas_calls : unit -> int = "atomic_cas_calls"
+external atomic_cas_field_calls : unit -> int = "atomic_cas_field_calls"
+external atomic_fetch_add_calls : unit -> int = "atomic_fetch_add_calls"
+external atomic_fetch_add_field_calls : unit -> int = "atomic_fetch_add_field_calls"
+external atomic_add_calls : unit -> int = "atomic_add_calls"
+external atomic_add_field_calls : unit -> int = "atomic_add_field_calls"
+external atomic_sub_calls : unit -> int = "atomic_sub_calls"
+external atomic_sub_field_calls : unit -> int = "atomic_sub_field_calls"
+external atomic_land_calls : unit -> int = "atomic_land_calls"
+external atomic_land_field_calls : unit -> int = "atomic_land_field_calls"
+external atomic_lor_calls : unit -> int = "atomic_lor_calls"
+external atomic_lor_field_calls : unit -> int = "atomic_lor_field_calls"
+external atomic_lxor_calls : unit -> int = "atomic_lxor_calls"
+external atomic_lxor_field_calls : unit -> int = "atomic_lxor_field_calls"
+
+external atomic_load_reset : unit -> unit = "atomic_load_reset"
+external atomic_load_field_reset : unit -> unit = "atomic_load_field_reset"
+external atomic_exchange_reset : unit -> unit = "atomic_exchange_reset"
+external atomic_exchange_field_reset : unit -> unit = "atomic_exchange_field_reset"
+external atomic_set_reset : unit -> unit = "atomic_set_reset"
+external atomic_set_field_reset : unit -> unit = "atomic_set_field_reset"
+external atomic_compare_exchange_reset : unit -> unit = "atomic_compare_exchange_reset"
+external atomic_compare_exchange_field_reset : unit -> unit = "atomic_compare_exchange_field_reset"
+external atomic_cas_reset : unit -> unit = "atomic_cas_reset"
+external atomic_cas_field_reset : unit -> unit = "atomic_cas_field_reset"
+external atomic_fetch_add_reset : unit -> unit = "atomic_fetch_add_reset"
+external atomic_fetch_add_field_reset : unit -> unit = "atomic_fetch_add_field_reset"
+external atomic_add_reset : unit -> unit = "atomic_add_reset"
+external atomic_add_field_reset : unit -> unit = "atomic_add_field_reset"
+external atomic_sub_reset : unit -> unit = "atomic_sub_reset"
+external atomic_sub_field_reset : unit -> unit = "atomic_sub_field_reset"
+external atomic_land_reset : unit -> unit = "atomic_land_reset"
+external atomic_land_field_reset : unit -> unit = "atomic_land_field_reset"
+external atomic_lor_reset : unit -> unit = "atomic_lor_reset"
+external atomic_lor_field_reset : unit -> unit = "atomic_lor_field_reset"
+external atomic_lxor_reset : unit -> unit = "atomic_lxor_reset"
+external atomic_lxor_field_reset : unit -> unit = "atomic_lxor_field_reset"
+
+(* Reset all atomic counters. Initializing stdlib modules (like Format) can
+   invoke atomic operations. *)
+
+let () =
+  total_atomic_reset ();
+  atomic_load_reset ();
+  atomic_load_field_reset ();
+  atomic_exchange_reset ();
+  atomic_exchange_field_reset ();
+  atomic_set_reset ();
+  atomic_set_field_reset ();
+  atomic_compare_exchange_reset ();
+  atomic_compare_exchange_field_reset ();
+  atomic_cas_reset ();
+  atomic_cas_field_reset ();
+  atomic_fetch_add_reset ();
+  atomic_fetch_add_field_reset ();
+  atomic_add_reset ();
+  atomic_add_field_reset ();
+  atomic_sub_reset ();
+  atomic_sub_field_reset ();
+  atomic_land_reset ();
+  atomic_land_field_reset ();
+  atomic_lor_reset ();
+  atomic_lor_field_reset ();
+  atomic_lxor_reset ();
+  atomic_lxor_field_reset ()
+
 let a = Atomic.make 0
 let _ = Atomic.get a
 let _ = Atomic.set a 1
@@ -91,29 +168,6 @@ let _ = atomic_logand_field a 0 1
 let _ = atomic_logor_field a 0 1
 let _ = atomic_logxor_field a 0 1
 
-external atomic_load_calls : unit -> int = "atomic_load_calls"
-external atomic_load_field_calls : unit -> int = "atomic_load_field_calls"
-external atomic_exchange_calls : unit -> int = "atomic_exchange_calls"
-external atomic_exchange_field_calls : unit -> int = "atomic_exchange_field_calls"
-external atomic_set_calls : unit -> int = "atomic_set_calls"
-external atomic_set_field_calls : unit -> int = "atomic_set_field_calls"
-external atomic_compare_exchange_calls : unit -> int = "atomic_compare_exchange_calls"
-external atomic_compare_exchange_field_calls : unit -> int = "atomic_compare_exchange_field_calls"
-external atomic_cas_calls : unit -> int = "atomic_cas_calls"
-external atomic_cas_field_calls : unit -> int = "atomic_cas_field_calls"
-external atomic_fetch_add_calls : unit -> int = "atomic_fetch_add_calls"
-external atomic_fetch_add_field_calls : unit -> int = "atomic_fetch_add_field_calls"
-external atomic_add_calls : unit -> int = "atomic_add_calls"
-external atomic_add_field_calls : unit -> int = "atomic_add_field_calls"
-external atomic_sub_calls : unit -> int = "atomic_sub_calls"
-external atomic_sub_field_calls : unit -> int = "atomic_sub_field_calls"
-external atomic_land_calls : unit -> int = "atomic_land_calls"
-external atomic_land_field_calls : unit -> int = "atomic_land_field_calls"
-external atomic_lor_calls : unit -> int = "atomic_lor_calls"
-external atomic_lor_field_calls : unit -> int = "atomic_lor_field_calls"
-external atomic_lxor_calls : unit -> int = "atomic_lxor_calls"
-external atomic_lxor_field_calls : unit -> int = "atomic_lxor_field_calls"
-
 let () = assert (atomic_load_calls () = 0)
 let () = assert (atomic_load_field_calls () = 0)
 let () = assert (atomic_exchange_calls () = 0)
@@ -136,3 +190,51 @@ let () = assert (atomic_lor_calls () = 0)
 let () = assert (atomic_lor_field_calls () = 0)
 let () = assert (atomic_lxor_calls () = 0)
 let () = assert (atomic_lxor_field_calls () = 0)
+
+(* Test individual atomic operations. *)
+
+(* build a test function for a particular atomic call *)
+let gen_test ~fn ~fn_calls ~reset_fn_calls =
+  let test ~(call_pos : [%call_pos]) ~expected f =
+    total_atomic_reset ();
+    reset_fn_calls ();
+    f ();
+    let actual_fn = fn_calls () in
+    let actual_total = total_atomic_calls () in
+    if not (expected = actual_fn) then
+      failwith @@
+        Format.sprintf
+          "On line %d, expected %d calls to %s, but saw %d"
+          call_pos.pos_lnum expected fn actual_fn;
+    if not (expected = actual_total) then
+      failwith @@
+        Format.sprintf
+          "On line %d, expected %d total atomic calls, but saw %d"
+          call_pos.pos_lnum expected actual_total;
+  in
+  test
+
+let test_atomic_exchange_field = gen_test ~fn:"atomic_exchange_field"
+                              ~fn_calls:atomic_exchange_field_calls
+                              ~reset_fn_calls:atomic_exchange_field_reset
+
+(* Patomic_set_field skips runtime call for immediates. *)
+type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+
+let () =
+  let t = { imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:1 (fun () ->
+    t.imm <- 3;
+    t.ptr <- "four";
+    ignore (Sys.opaque_identity t)
+  )
+
+(* Patomic_set_mixed_field skips runtime call for immediates. *)
+type mixed = { f : int64#; mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+let () =
+  let m = { f = #42L; imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:1 (fun () ->
+    m.imm <- 3;
+    m.ptr <- "four";
+    ignore (Sys.opaque_identity m)
+  )

--- a/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
+++ b/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
@@ -27,7 +27,7 @@ CAMLprim value total_atomic_reset()
   CAMLprim void __wrap_caml_##name(arg_tys)    \
   {                                            \
     called_##name++;                           \
-    called_total_atomic++;                       \
+    called_total_atomic++;                     \
     __real_caml_##name(args);                  \
   }
 

--- a/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
+++ b/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
@@ -1,5 +1,16 @@
 #include <caml/mlvalues.h>
 
+static int called_total_atomic = 0;
+CAMLprim value total_atomic_calls()
+{
+  return Val_int(called_total_atomic);
+}
+CAMLprim value total_atomic_reset()
+{
+  called_total_atomic = 0;
+  return Val_unit;
+}
+
 #define P(...) __VA_ARGS__
 #define TRACK(name, arg_tys, args)             \
   static int called_##name = 0;                \
@@ -7,10 +18,16 @@
   {                                            \
     return Val_int(called_##name);             \
   }                                            \
+  CAMLprim value name##_reset()                \
+  {                                            \
+    called_##name = 0;                         \
+    return Val_unit;                           \
+  }                                            \
   CAMLextern void __real_caml_##name(arg_tys); \
   CAMLprim void __wrap_caml_##name(arg_tys)    \
   {                                            \
     called_##name++;                           \
+    called_total_atomic++;                       \
     __real_caml_##name(args);                  \
   }
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -259,7 +259,6 @@ type error =
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
-  | Mixed_record_atomic_access of Longident.t
   | Mixed_record_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string
@@ -1325,43 +1324,22 @@ let check_project_mutability ~loc ~env mut_name mutability mode =
   if Types.is_mutable mutability then
     submode ~loc ~env mode (mode_project_mutable mut_name)
 
-(* Does this record representation permit atomic field usage? *)
-let allows_atomic_field_usage = function
-  | Record_boxed -> true
-  | Record_inlined (_tag, ctor_repres, _variant_repres) -> (
-      match ctor_repres with
-      | Constructor_uniform_value -> true
-      | Constructor_mixed _ -> false
-      (* At this point, we should know the constructor representation. *)
-      | Constructor_variable -> false)
-  (* Reads/writes of atomic record fields are currently only supported for
-     labels whose logical offset matches the physical field position. To support
-     mixed records, we will add atomic primitives to lambda that consider mixed
-     block field reordering. *)
-  | Record_mixed _ -> false
-  (* The remaining cases should be unreachable. *)
-  (* [@@unboxed] already prohibits mutable (and therefore atomic) fields. *)
+let check_atomic_loc ~loc ~env record_repres mutability lid =
+  if not (Types.is_atomic mutability) then
+    raise (Error (loc, env, Label_not_atomic lid));
+  match record_repres with
+  | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) -> ()
+  | Record_mixed _ | Record_inlined (_, Constructor_mixed _, _) ->
+      raise (Error (loc, env, Mixed_record_atomic_loc lid))
+  (* We should know constructor representation at this point. *)
+  | Record_inlined (_, Constructor_variable, _)
+  (* [@@unboxed] prohibits mutable (and therefore atomic) fields. *)
   | Record_unboxed
-  (* [@atomic] fields disable the float record optimization. *)
+  (* [@atomic] fields disable float record optimization. *)
   | Record_float | Record_ufloat
-  (* At this point, we should know the record representation. *)
+  (* We should know record representation at this point. *)
   | Record_dummy _ | Record_variable ->
-      false
-
-(* CR-soon jkerrigan: simplify after we allow access of atomic fields in mixed
-   records. *)
-type atomic_field_use = Access | Loc
-
-(* Raises if we try to use an atomic field from a mixed record. *)
-let check_atomic_field_usage ~usage ~loc ~env record_repres mutability lid =
-  if Types.is_atomic mutability && not (allows_atomic_field_usage record_repres)
-  then
-    let err =
-      match usage with
-      | Access -> Mixed_record_atomic_access lid
-      | Loc -> Mixed_record_atomic_loc lid
-    in
-    raise (Error (loc, env, err))
+      Misc.fatal_error "check_atomic_loc: unexpected record representation"
 
 (* Represents information about an array type inferred using type-directed
    disambiguation. *)
@@ -7514,8 +7492,6 @@ and type_expect_
       in
       check_project_mutability ~loc:record.exp_loc ~env
         (Record_field label.lbl_name) label.lbl_mut mode;
-      check_atomic_field_usage ~usage:Access ~loc:record.exp_loc ~env
-        record_repres label.lbl_mut lid.txt;
       let is_contained_by : Mode.Hint.is_contained_by =
         { containing = Record (label.lbl_name, Modality);
           container = (record.exp_loc, Expression) }
@@ -7645,8 +7621,6 @@ and type_expect_
           ~why:Field_assignment
           ~containing_type:ty_record
       in
-      check_atomic_field_usage ~usage:Access ~loc ~env record_repres
-        label.lbl_mut lid.txt;
       rue {
         exp_desc = Texp_setfield {
           record;
@@ -8550,11 +8524,8 @@ and type_expect_
             solve_Pexp_field ~label_usage:Env.Mutation loc env sexp srecord
               Legacy lid
           in
-          check_atomic_field_usage ~usage:Loc ~loc:record.exp_loc ~env
-            record_repres label.lbl_mut lid.txt;
           Env.mark_label_used Env.Projection label.lbl_uid;
-          if (not (Types.is_atomic label.lbl_mut))
-          then raise (Error (loc, env, Label_not_atomic lid.txt));
+          check_atomic_loc ~loc ~env record_repres label.lbl_mut lid.txt;
           let alloc_mode, argument_mode =
             register_allocation ~loc expected_mode
           in
@@ -13084,11 +13055,6 @@ let report_error ~loc env =
          of an atomic field, do so explicitly:@ %a"
         Style.inline_code l
         Style.inline_code ("{ t with " ^ l ^ " = t." ^ l ^ " }")
-  | Mixed_record_atomic_access lid ->
-      Location.errorf ~loc
-        "Accessing atomic fields (here %a) of mixed records is not yet@ \
-         supported."
-        quoted_longident lid
   | Mixed_record_atomic_loc lid ->
       Location.errorf ~loc
         "Use of %a with mixed record fields (here %a) is forbidden."

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -303,7 +303,6 @@ type error =
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
-  | Mixed_record_atomic_access of Longident.t
   | Mixed_record_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string


### PR DESCRIPTION
Currently, atomic fields are permitted in mixed blocks, but you can't really use
them. Attempting to load from or store to an atomic field gives an error:

```
  4 |   let disallowed t = t.f
                           ^
  Error: Accessing atomic fields (here "f") of mixed records is not yet
         supported.
```

This PR adds support for loading/storing atomic fields of mixed records.
Taking the `[%atomic.loc]` of such a field is still forbidden.

We translate loads/stores of mixed record atomic fields to new primitives,
`Patomic_load_mixed_field` and `Patomic_set_mixed_field`, which closely resemble
`Pmixedfield` and `Psetmixedfield`.

Add several tests, and tweak the 'caml-modify' tests for atomics to support
positives tests for runtime atomic calls.