### PR TITLE
Noalloc force local no stack

### DIFF
--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -423,28 +423,22 @@ let (alloc_record @ noalloc_strict) () = { x = 1.; y = 2. }
 Line 1, characters 41-59:
 1 | let (alloc_record @ noalloc_strict) () = { x = 1.; y = 2. }
                                              ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-59
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_record @ noalloc) () = { x = 1.; y = 2. }
 [%%expect{|
 Line 1, characters 34-52:
 1 | let (alloc_record @ noalloc) () = { x = 1.; y = 2. }
                                       ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 29-52
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same record allocation, but [stack_]-marked. *)
-let (alloc_record @ noalloc_strict) () = exclave_ stack_ { x = 1.; y = 2. }
+(* The same record allocation, but [exclave_]-marked. *)
+let (alloc_record @ noalloc_strict) () = exclave_ { x = 1.; y = 2. }
 [%%expect{|
 val alloc_record : unit -> record_t5 @ local = <fun>
 |}]
-let (alloc_record @ noalloc) () = exclave_ stack_ { x = 1.; y = 2. }
+let (alloc_record @ noalloc) () = exclave_ { x = 1.; y = 2. }
 [%%expect{|
 val alloc_record : unit -> record_t5 @ local = <fun>
 |}]
@@ -456,28 +450,22 @@ let (alloc_variant @ noalloc_strict) (a : int) = Just a
 Line 1, characters 49-55:
 1 | let (alloc_variant @ noalloc_strict) (a : int) = Just a
                                                      ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 37-55
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_variant @ noalloc) (a : int) = Just a
 [%%expect{|
 Line 1, characters 42-48:
 1 | let (alloc_variant @ noalloc) (a : int) = Just a
                                               ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 30-48
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same variant allocation, but [stack_]-marked. *)
-let (alloc_variant @ noalloc_strict) (a : int) = exclave_ stack_ (Just a)
+(* The same variant allocation, but [exclave_]-marked. *)
+let (alloc_variant @ noalloc_strict) (a : int) = exclave_ (Just a)
 [%%expect{|
 val alloc_variant : int -> int variant_t5 @ local = <fun>
 |}]
-let (alloc_variant @ noalloc) (a : int) = exclave_ stack_ (Just a)
+let (alloc_variant @ noalloc) (a : int) = exclave_ (Just a)
 [%%expect{|
 val alloc_variant : int -> int variant_t5 @ local = <fun>
 |}]
@@ -488,28 +476,22 @@ let (alloc_list @ noalloc_strict) (a : int) = [a]
 Line 1, characters 46-49:
 1 | let (alloc_list @ noalloc_strict) (a : int) = [a]
                                                   ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-49
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_list @ noalloc) (a : int) = [a]
 [%%expect{|
 Line 1, characters 39-42:
 1 | let (alloc_list @ noalloc) (a : int) = [a]
                                            ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 27-42
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same list cell, but [stack_]-marked. *)
-let (alloc_list @ noalloc_strict) (a : int) = exclave_ stack_ [a]
+(* The same list cell, but [exclave_]-marked. *)
+let (alloc_list @ noalloc_strict) (a : int) = exclave_ [a]
 [%%expect{|
 val alloc_list : int -> int list @ local = <fun>
 |}]
-let (alloc_list @ noalloc) (a : int) = exclave_ stack_ [a]
+let (alloc_list @ noalloc) (a : int) = exclave_ [a]
 [%%expect{|
 val alloc_list : int -> int list @ local = <fun>
 |}]
@@ -520,28 +502,22 @@ let (alloc_array @ noalloc_strict) (a : int) = [| a |]
 Line 1, characters 47-54:
 1 | let (alloc_array @ noalloc_strict) (a : int) = [| a |]
                                                    ^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 35-54
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_array @ noalloc) (a : int) = [| a |]
 [%%expect{|
 Line 1, characters 40-47:
 1 | let (alloc_array @ noalloc) (a : int) = [| a |]
                                             ^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 28-47
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same array, but [stack_]-marked. *)
-let (alloc_array @ noalloc_strict) (a : int) = exclave_ stack_ [| a |]
+(* The same array, but [exclave_]-marked. *)
+let (alloc_array @ noalloc_strict) (a : int) = exclave_ [| a |]
 [%%expect{|
 val alloc_array : int -> int array @ local = <fun>
 |}]
-let (alloc_array @ noalloc) (a : int) = exclave_ stack_ [| a |]
+let (alloc_array @ noalloc) (a : int) = exclave_ [| a |]
 [%%expect{|
 val alloc_array : int -> int array @ local = <fun>
 |}]
@@ -559,28 +535,22 @@ let (alloc_polyvariant @ noalloc_strict) (a : int) = `Tag a
 Line 1, characters 53-59:
 1 | let (alloc_polyvariant @ noalloc_strict) (a : int) = `Tag a
                                                          ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 41-59
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_polyvariant @ noalloc) (a : int) = `Tag a
 [%%expect{|
 Line 1, characters 46-52:
 1 | let (alloc_polyvariant @ noalloc) (a : int) = `Tag a
                                                   ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 34-52
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same polymorphic variant, but [stack_]-marked. *)
-let (alloc_polyvariant @ noalloc_strict) (a : int) = exclave_ stack_ (`Tag a)
+(* The same polymorphic variant, but [exclave_]-marked. *)
+let (alloc_polyvariant @ noalloc_strict) (a : int) = exclave_ (`Tag a)
 [%%expect{|
 val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
 |}]
-let (alloc_polyvariant @ noalloc) (a : int) = exclave_ stack_ (`Tag a)
+let (alloc_polyvariant @ noalloc) (a : int) = exclave_ (`Tag a)
 [%%expect{|
 val alloc_polyvariant : int -> [> `Tag of int ] @ local = <fun>
 |}]
@@ -616,10 +586,7 @@ let test_passing_arg () =
 Line 3, characters 37-38:
 3 |   let (g @ noalloc_strict) () = f ~a:1 () in
                                          ^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 27-41
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let test_missing_arg () =
@@ -638,10 +605,7 @@ let test_passing_arg () =
 Line 3, characters 37-38:
 3 |   let (g @ noalloc_strict) () = f ~a:1 () in
                                          ^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 27-41
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Building a closure inside a noalloc function forcing the closure
@@ -677,28 +641,22 @@ let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = r.x
 Line 1, characters 60-63:
 1 | let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = r.x
                                                                 ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 42-63
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_float_boxing @ noalloc) (r : record_t5) = r.x
 [%%expect{|
 Line 1, characters 53-56:
 1 | let (alloc_float_boxing @ noalloc) (r : record_t5) = r.x
                                                          ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 35-56
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same float boxing, but [stack_]-marked. *)
-let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = exclave_ stack_ r.x
+(* The same float boxing, but [exclave_]-marked. *)
+let (alloc_float_boxing @ noalloc_strict) (r : record_t5) = exclave_ r.x
 [%%expect{|
 val alloc_float_boxing : record_t5 -> float @ local = <fun>
 |}]
-let (alloc_float_boxing @ noalloc) (r : record_t5) = exclave_ stack_ r.x
+let (alloc_float_boxing @ noalloc) (r : record_t5) = exclave_ r.x
 [%%expect{|
 val alloc_float_boxing : record_t5 -> float @ local = <fun>
 |}]
@@ -711,28 +669,22 @@ let (alloc_tuple @ noalloc_strict) () = (1, 2)
 Line 1, characters 40-46:
 1 | let (alloc_tuple @ noalloc_strict) () = (1, 2)
                                             ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 35-46
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_tuple @ noalloc) () = (1, 2)
 [%%expect{|
 Line 1, characters 33-39:
 1 | let (alloc_tuple @ noalloc) () = (1, 2)
                                      ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 28-39
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same tuple, but [stack_]-marked. *)
-let (alloc_tuple @ noalloc_strict) () = exclave_ stack_ (1, 2)
+(* The same tuple, but [exclave_]-marked. *)
+let (alloc_tuple @ noalloc_strict) () = exclave_ (1, 2)
 [%%expect{|
 val alloc_tuple : unit -> int * int @ local = <fun>
 |}]
-let (alloc_tuple @ noalloc) () = exclave_ stack_ (1, 2)
+let (alloc_tuple @ noalloc) () = exclave_ (1, 2)
 [%%expect{|
 val alloc_tuple : unit -> int * int @ local = <fun>
 |}]
@@ -751,17 +703,6 @@ let (alloc_partial_app @ noalloc)
 [%%expect{|
 val alloc_partial_app : (int -> int -> int -> int) @ noalloc -> int -> int =
   <fun>
-|}]
-
-(* [stack_] on a partial application is rejected: it is an application, not a
-   recognized allocation form. *)
-let (stack_partial_app @ noalloc_strict)
-      (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
-[%%expect{|
-Line 2, characters 74-81:
-2 |       (f : (int -> int -> int -> int) @ noalloc_strict) = exclave_ stack_ (f 1 2)
-                                                                              ^^^^^^^
-Error: This expression is not an allocation site.
 |}]
 
 (* Partial application whose result is a function hidden behind a
@@ -820,10 +761,7 @@ let (call_one_opt_one_mand @ noalloc_strict)
 Line 3, characters 7-8:
 3 |   f ~a:1 2
            ^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-3, characters 6-10
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* A lazy block allocates on the heap *)
@@ -832,20 +770,14 @@ let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
 Line 1, characters 46-52:
 1 | let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
                                                   ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-52
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_lazy @ noalloc) (a : int) = lazy a
 [%%expect{|
 Line 1, characters 39-45:
 1 | let (alloc_lazy @ noalloc) (a : int) = lazy a
                                            ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 27-45
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* [stack_] does not support lazy expressions. *)
@@ -854,10 +786,7 @@ let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
 Line 1, characters 62-70:
 1 | let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
                                                                   ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-70
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 
@@ -867,20 +796,14 @@ let (alloc_object @ noalloc_strict) () = object method m = 1 end
 Line 1, characters 41-64:
 1 | let (alloc_object @ noalloc_strict) () = object method m = 1 end
                                              ^^^^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-64
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_object @ noalloc) () = object method m = 1 end
 [%%expect{|
 Line 1, characters 34-57:
 1 | let (alloc_object @ noalloc) () = object method m = 1 end
                                       ^^^^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 29-57
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* [stack_] does not support objects; here the object's method closure is
@@ -891,10 +814,7 @@ let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 en
 Line 1, characters 57-82:
 1 | let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-82
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* An object with no allocating method (here only a value field) still
@@ -904,10 +824,7 @@ let (obj_no_alloc_method @ noalloc_strict) () = object val x = 0 end
 Line 1, characters 48-68:
 1 | let (obj_no_alloc_method @ noalloc_strict) () = object val x = 0 end
                                                     ^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 43-68
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 
@@ -923,20 +840,14 @@ let (alloc_first_class_module @ noalloc_strict) () = (module Empty : S)
 Line 1, characters 61-66:
 1 | let (alloc_first_class_module @ noalloc_strict) () = (module Empty : S)
                                                                  ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 48-71
-         which is expected to be "noalloc_strict".
+Error: Module cannot be "local".
 |}]
 let (alloc_first_class_module @ noalloc) () = (module Empty : S)
 [%%expect{|
 Line 1, characters 54-59:
 1 | let (alloc_first_class_module @ noalloc) () = (module Empty : S)
                                                           ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 41-64
-         which is expected to be "noalloc".
+Error: Module cannot be "local".
 |}]
 
 (* [stack_] does not support first-class modules. *)
@@ -945,10 +856,7 @@ let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Emp
 Line 1, characters 77-82:
 1 | let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
                                                                                  ^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 48-87
-         which is expected to be "noalloc_strict".
+Error: Module cannot be "local".
 |}]
 
 
@@ -1034,28 +942,22 @@ let (alloc_exception @ noalloc_strict) (a : string) = Failure a
 Line 1, characters 54-63:
 1 | let (alloc_exception @ noalloc_strict) (a : string) = Failure a
                                                           ^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 39-63
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_exception @ noalloc) (a : string) = Failure a
 [%%expect{|
 Line 1, characters 47-56:
 1 | let (alloc_exception @ noalloc) (a : string) = Failure a
                                                    ^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 32-56
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* The same exception construction, but [stack_]-marked. *)
-let (alloc_exception @ noalloc_strict) (a : string) = exclave_ stack_ (Failure a)
+(* The same exception construction, but [exclave_]-marked. *)
+let (alloc_exception @ noalloc_strict) (a : string) = exclave_ (Failure a)
 [%%expect{|
 val alloc_exception : string -> exn @ local = <fun>
 |}]
-let (alloc_exception @ noalloc) (a : string) = exclave_ stack_ (Failure a)
+let (alloc_exception @ noalloc) (a : string) = exclave_ (Failure a)
 [%%expect{|
 val alloc_exception : string -> exn @ local = <fun>
 |}]
@@ -1072,10 +974,7 @@ let (alloc_atomic_loc @ noalloc_strict) (r : atomic_record) =
 Line 2, characters 2-20:
 2 |   [%atomic.loc r.af]
       ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-2, characters 40-20
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_atomic_loc @ noalloc) (r : atomic_record) =
   [%atomic.loc r.af]
@@ -1083,13 +982,9 @@ let (alloc_atomic_loc @ noalloc) (r : atomic_record) =
 Line 2, characters 2-20:
 2 |   [%atomic.loc r.af]
       ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at lines 1-2, characters 33-20
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
-(* CR-soon shsong: check currying-related behavior later *)
 (* Coercing a function with an optional argument to a plain arrow eta-expands
    it, allocating a closure. We receive both functions as parameters (in a
    tuple to avoid currying closures) so the only allocation is the coercion
@@ -1102,10 +997,7 @@ let (alloc_fun_coerce @ noalloc_strict)
 Line 4, characters 8-11:
 4 |   apply opt
             ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-4, characters 6-11
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_fun_coerce @ noalloc)
       ((apply, opt) :
@@ -1115,10 +1007,7 @@ let (alloc_fun_coerce @ noalloc)
 Line 4, characters 8-11:
 4 |   apply opt
             ^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at lines 2-4, characters 6-11
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* A list/array comprehension allocates its result *)
@@ -1127,20 +1016,14 @@ let (alloc_list_comprehension @ noalloc_strict) () = [ x for x = 1 to 10 ]
 Line 1, characters 53-74:
 1 | let (alloc_list_comprehension @ noalloc_strict) () = [ x for x = 1 to 10 ]
                                                          ^^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 48-74
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_list_comprehension @ noalloc) () = [ x for x = 1 to 10 ]
 [%%expect{|
 Line 1, characters 46-67:
 1 | let (alloc_list_comprehension @ noalloc) () = [ x for x = 1 to 10 ]
                                                   ^^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at line 1, characters 41-67
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* [stack_] does not support comprehensions. *)
@@ -1149,10 +1032,7 @@ let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to
 Line 1, characters 64-85:
 1 | let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
                                                                     ^^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 43-85
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Only the first case below is a genuine bug introduced by routing the
@@ -1232,10 +1112,7 @@ let (use_format @ noalloc_strict) () : (_, _, _) format = "%d"
 Line 1, characters 58-62:
 1 | let (use_format @ noalloc_strict) () : (_, _, _) format = "%d"
                                                               ^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 34-62
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 
@@ -1260,10 +1137,7 @@ let (layers3_ss @ noalloc_strict) (a : int) =
 Line 14, characters 34-40:
 14 |     let (h @ noalloc_strict) () = Just a in
                                        ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 12-17, characters 34-3
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* The same nesting, all layers [noalloc]. *)
@@ -1277,10 +1151,7 @@ let (layers3_n @ noalloc) (a : int) =
 Line 3, characters 27-33:
 3 |     let (h @ noalloc) () = Just a in
                                ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at lines 1-6, characters 26-3
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Annotating only the middle layer still errors: building the closure [h]
@@ -1295,10 +1166,7 @@ let layers_middle (a : int) =
 Line 3, characters 15-21:
 3 |     let h () = Just a in
                    ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-4, characters 27-5
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Annotating only the innermost layer still errors: [Just a] forces [h]. *)
@@ -1312,10 +1180,7 @@ let layers_inner (a : int) =
 Line 3, characters 34-40:
 3 |     let (h @ noalloc_strict) () = Just a in
                                       ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 29-40
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (** Test 5.3: [stack_] negative cases *)
@@ -1331,16 +1196,35 @@ Error: This expression is not an allocation site.
 |}]
 
 (** Test 5.4: [stack_] nested cases. *)
+
+(* Many tests below (Tests 5.4-5.7) rely on the following trick. If a function is
+   known to be noalloc when its body is type-checked, all inner allocations are
+   forced to be local (on the stack) and the allocation check is exempted -- which
+   would mask the very effect of [local_]/[exclave_]/[stack_] we want to observe.
+   So we do NOT annotate the function under test as noalloc directly; instead we
+   constrain it to be noalloc indirectly, by referencing it inside a separate
+   [require_noalloc @ noalloc_strict] function. That constraint arrives only after
+   the body has been type-checked, so inner allocations are not force-made local
+   and their genuine allocation behavior is observed. *)
+
 (* Nested: an inner allocation that is not itself [stack_]-marked still
    allocates on the heap, even when an enclosing allocation is [stack_]-marked. *)
-let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
+let f () =
+  let stack_nested (a : int) = exclave_ stack_ (Just (Just a)) in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_nested in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-Line 1, characters 70-78:
-1 | let (stack_nested @ noalloc_strict) (a : int) = exclave_ stack_ (Just (Just a))
-                                                                          ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-79
+Line 18, characters 12-24:
+18 |     let _ = stack_nested in ()
+                 ^^^^^^^^^^^^
+Error: The value "stack_nested" is "alloc"
+         because it closes over the allocation at line 16, characters 53-61
+         which is "alloc".
+       However, the value "stack_nested" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at lines 17-18, characters 41-30
          which is expected to be "noalloc_strict".
 |}]
 
@@ -1350,16 +1234,27 @@ Error: The allocation is "alloc"
    is another way (besides plain nesting above) for a heap allocation to sit
    inside a [stack_] one. *)
 type 'a global_field_rec = { gf : 'a @@ global; rest : int }
-let (stack_global_field @ noalloc_strict) (a : int) =
-  exclave_ stack_ { gf = Just a; rest = a }
 [%%expect{|
 type 'a global_field_rec = { gf : 'a @@ global; rest : int; }
-Line 3, characters 25-31:
-3 |   exclave_ stack_ { gf = Just a; rest = a }
-                             ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-3, characters 42-43
+|}]
+let f () =
+  let stack_global_field (a : int) =
+    exclave_ stack_ { gf = Just a; rest = a }
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_global_field in ()
+  in
+  let _ = require_noalloc () in
+  ()
+[%%expect{|
+Line 6, characters 12-30:
+6 |     let _ = stack_global_field in ()
+                ^^^^^^^^^^^^^^^^^^
+Error: The value "stack_global_field" is "alloc"
+         because it closes over the allocation at line 3, characters 27-33
+         which is "alloc".
+       However, the value "stack_global_field" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at lines 5-6, characters 41-36
          which is expected to be "noalloc_strict".
 |}]
 
@@ -1380,47 +1275,77 @@ Error: The allocation is "alloc"
       so these still error (see [exclave_not_exempt]/[local_not_exempt]). *)
 
 (* [exclave_] alone (no [stack_]) does not exempt the allocation. *)
-let (exclave_not_exempt @ noalloc_strict) (a : int) = exclave_ (Just a)
+let f () =
+  let exclave_not_exempt (a : int) = exclave_ (Just a) in
+  let (require_noalloc @ noalloc_strict) () =
+    let _  = exclave_not_exempt in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-Line 17, characters 63-71:
-17 | let (exclave_not_exempt @ noalloc_strict) (a : int) = exclave_ (Just a)
-                                                                    ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 17, characters 42-71
+Line 20, characters 13-31:
+20 |     let _  = exclave_not_exempt in ()
+                  ^^^^^^^^^^^^^^^^^^
+Error: The value "exclave_not_exempt" is "alloc"
+         because it closes over the allocation at line 18, characters 46-54
+         which is "alloc".
+       However, the value "exclave_not_exempt" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at lines 19-20, characters 41-37
          which is expected to be "noalloc_strict".
 |}]
 
-(* [local_] alone (no [stack_]) does not exempt the allocation. *)
-let (local_not_exempt @ noalloc_strict) (a : int) =
-  let _x = local_ (Just a) in
+(* CR shsong: currently, [local_] does not exempt the allocation. *)
+let f () =
+  let local_not_exempt (a : int) =
+    let _x = local_ (Just a) in
+    ()
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _  = local_not_exempt in ()
+  in
+  let _ = require_noalloc () in
   ()
 [%%expect{|
-Line 2, characters 18-26:
-2 |   let _x = local_ (Just a) in
-                      ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-3, characters 40-4
+Line 7, characters 13-29:
+7 |     let _  = local_not_exempt in ()
+                 ^^^^^^^^^^^^^^^^
+Error: The value "local_not_exempt" is "alloc"
+         because it closes over the allocation at line 3, characters 20-28
+         which is "alloc".
+       However, the value "local_not_exempt" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at lines 6-7, characters 41-35
          which is expected to be "noalloc_strict".
 |}]
 
 (* For contrast, the same allocation wrapped in [stack_] (sets [strictly_stack])
    is exempt and accepted. *)
-let (stack_is_exempt @ noalloc_strict) (a : int) = exclave_ stack_ (Just a)
+let f () =
+  let stack_is_exempt (a : int) = exclave_ stack_ (Just a) in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_is_exempt in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-val stack_is_exempt : int -> int variant_t5 @ local = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 (* The decisive case: a [stack_] in a plain [let] binding (no [exclave_]/[local_]
    around it) has [strictly_stack = true] but [strictly_local = false]. It is
    correctly accepted. Gating the walk on [strictly_local] would reject it, which
    is why [strictly_stack] is required rather than reusing [strictly_local]. *)
-let (stack_in_let @ noalloc_strict) (a : int) =
-  let _x = stack_ (Just a) in
+let f () =
+  let stack_in_let (a : int) =
+    let _x = stack_ (Just a) in
+    ()
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_in_let in ()
+  in
+  let _ = require_noalloc () in
   ()
 [%%expect{|
-val stack_in_let : int -> unit = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 
@@ -1435,44 +1360,79 @@ val stack_in_let : int -> unit = <fun>
 (* A type annotation goes through [Pexp_constraint] -> [type_expect_mode]
    -> [mode_coerce], which should not resets [strictly_stack] on the
    inner allocation, i.e., the inner allocation is still on stack. *)
-let (stack_through_type_annot @ noalloc_strict) (a : int) =
-  exclave_ stack_ ((Just a : int variant_t5))
+let f () =
+  let stack_through_type_annot (a : int) =
+    exclave_ stack_ ((Just a : int variant_t5))
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_through_type_annot in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-val stack_through_type_annot : int -> int variant_t5 @ local = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 (* Same via a mode annotation. *)
-let (stack_through_mode_annot @ noalloc_strict) (a : int) =
-  exclave_ stack_ ((Just a : _ @ local))
+let f () =
+  let stack_through_mode_annot (a : int) =
+    exclave_ stack_ ((Just a : _ @ local))
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_through_mode_annot in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-val stack_through_mode_annot : int -> int variant_t5 @ local = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 (* A coercion [:>] does NOT reset [strictly_stack]: the [stack_]
    operand stays exempt and is correctly accepted. *)
-let (stack_through_coercion @ noalloc_strict) (a : int) =
-  exclave_ stack_ ((Just a :> int variant_t5))
+let f () =
+  let stack_through_coercion (a : int) =
+    exclave_ stack_ ((Just a :> int variant_t5))
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_through_coercion in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-val stack_through_coercion : int -> int variant_t5 @ local = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 (* An attribute on the allocation is also fine. *)
-let (stack_through_attribute @ noalloc_strict) (a : int) =
-  exclave_ stack_ ((Just a)[@inline])
+let f () =
+  let stack_through_attribute (a : int) =
+    exclave_ stack_ ((Just a)[@inline])
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_through_attribute in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-val stack_through_attribute : int -> int variant_t5 @ local = <fun>
+val f : unit -> unit = <fun>
 |}]
 
 (* [let open ... in] is also transparent, but here [stack_]
    fails to even recognize the allocation site -- the [Pexp_stack]
    allocation-site detection does not see through [Pexp_open] (this is a
    detection gap, not the [strictly_stack] reset issue). *)
-let (stack_through_open @ noalloc_strict) (a : int) =
-  exclave_ stack_ (let open Stdlib in Just a)
+let f () =
+  let stack_through_open (a : int) =
+    exclave_ stack_ (let open Stdlib in Just a)
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_through_open in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-Line 2, characters 18-45:
-2 |   exclave_ stack_ (let open Stdlib in Just a)
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 3, characters 20-47:
+3 |     exclave_ stack_ (let open Stdlib in Just a)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression is not an allocation site.
 |}]
 
@@ -1486,77 +1446,119 @@ Error: This expression is not an allocation site.
     components, record fields, function bodies) or because [mode_morph] resets
     [strictly_stack] for children (lazy thunk body, partial-application args). *)
 
-(* a new allocation captured as an argument of a function application *)
-let stack_inner_function_application
-      (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
-  let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2 3) in
+(* a new allocation captured as an argument of a function application.
+   With the indirect trick (no force-local), the outer [stack_] operand -- a full
+   application returning [int] -- is reached first and rejected as not an
+   allocation site, before the inner [Just a] is examined. *)
+let f () =
+  let stack_inner_function_application
+        (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
+    exclave_ stack_ (g (Just a) 2 3)
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_inner_function_application in ()
+  in
+  let _ = require_noalloc () in
   ()
 [%%expect{|
-Line 13, characters 51-59:
-13 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2 3) in
-                                                        ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 13, characters 27-64
-         which is expected to be "noalloc_strict".
+Line 17, characters 20-36:
+17 |     exclave_ stack_ (g (Just a) 2 3)
+                         ^^^^^^^^^^^^^^^^
+Error: This expression is not an allocation site.
 |}]
 
 (* CR shsong: function partial application triggers allocation, and is not
     considered to be on the stack even though it is annotated with [stack_].
     Revisit this in the next PR. *)
-(* a new allocation captured as an argument of a partial application *)
-let stack_inner_partial_application
-      (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
-  let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
+(* a new allocation captured as an argument of a partial application. With the
+   indirect trick (no force-local), the outer [stack_] operand -- a partial
+   application closure -- is reached first and rejected as not an allocation site
+   ([Pexp_stack] does not recognize partial applications), before the inner
+   [Just a] is examined. *)
+let f () =
+  let stack_inner_partial_application
+        (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
+    exclave_ stack_ (g (Just a) 2)
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_inner_partial_application in ()
+  in
+  let _ = require_noalloc () in
   ()
 [%%expect{|
-Line 3, characters 51-59:
-3 |   let (f @ noalloc_strict) () = exclave_ stack_ (g (Just a) 2) in
-                                                       ^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 3, characters 27-62
-         which is expected to be "noalloc_strict".
+Line 4, characters 20-34:
+4 |     exclave_ stack_ (g (Just a) 2)
+                        ^^^^^^^^^^^^^^
+Error: This expression is not an allocation site.
 |}]
 
 (* a tuple component is a new allocation *)
-let (stack_inner_tuple @ noalloc_strict) (a : int) =
-  exclave_ stack_ (Just a, Just a)
+let f () =
+  let stack_inner_tuple (a : int) =
+    exclave_ stack_ (Just a, Just a)
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_inner_tuple in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-Line 2, characters 19-25:
-2 |   exclave_ stack_ (Just a, Just a)
-                       ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-2, characters 41-34
+Line 6, characters 12-29:
+6 |     let _ = stack_inner_tuple in ()
+                ^^^^^^^^^^^^^^^^^
+Error: The value "stack_inner_tuple" is "alloc"
+         because it closes over the allocation at line 3, characters 21-27
+         which is "alloc".
+       However, the value "stack_inner_tuple" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at lines 5-6, characters 41-35
          which is expected to be "noalloc_strict".
 |}]
 
 (* a record field is a new allocation *)
 type stack_inner_rec = { sf1 : int variant_t5; sf2 : int }
-let (stack_inner_field @ noalloc_strict) (a : int) =
-  exclave_ stack_ { sf1 = Just a; sf2 = a }
 [%%expect{|
 type stack_inner_rec = { sf1 : int variant_t5; sf2 : int; }
-Line 3, characters 26-32:
-3 |   exclave_ stack_ { sf1 = Just a; sf2 = a }
-                              ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 2-3, characters 41-43
+|}]
+let f () =
+  let stack_inner_field (a : int) =
+    exclave_ stack_ { sf1 = Just a; sf2 = a }
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_inner_field in ()
+  in
+  let _ = require_noalloc () in
+  ()
+[%%expect{|
+Line 6, characters 12-29:
+6 |     let _ = stack_inner_field in ()
+                ^^^^^^^^^^^^^^^^^
+Error: The value "stack_inner_field" is "alloc"
+         because it closes over the allocation at line 3, characters 28-34
+         which is "alloc".
+       However, the value "stack_inner_field" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at lines 5-6, characters 41-35
          which is expected to be "noalloc_strict".
 |}]
 
 (* a function body has a new allocation *)
-let (stack_inner_funbody @ noalloc_strict) (a : int) =
-  exclave_ stack_ (fun () -> Just a)
+let f () =
+  let stack_inner_funbody (a : int) =
+    exclave_ stack_ (fun () -> Just a)
+  in
+  let (require_noalloc @ noalloc_strict) () =
+    let _ = stack_inner_funbody in ()
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-Line 2, characters 29-35:
-2 |   exclave_ stack_ (fun () -> Just a)
-                                 ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at lines 1-2, characters 43-36
+Line 6, characters 12-31:
+6 |     let _ = stack_inner_funbody in ()
+                ^^^^^^^^^^^^^^^^^^^
+Error: The value "stack_inner_funbody" is "alloc"
+         because it closes over the allocation at line 3, characters 31-37
+         which is "alloc".
+       However, the value "stack_inner_funbody" highlighted is expected to be "noalloc_strict"
+         because it is used inside the function at lines 5-6, characters 41-37
          which is expected to be "noalloc_strict".
 |}]
 
@@ -1778,10 +1780,7 @@ let (f_body_alloc @ noalloc_strict) x y = (x, y)
 Line 1, characters 42-48:
 1 | let (f_body_alloc @ noalloc_strict) x y = (x, y)
                                               ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 36-48
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (** Test 6.2: forcing the codomain of a [noalloc] curried function to [local]
@@ -2028,7 +2027,7 @@ Line 6, characters 3-4:
 6 |   (f : _ @ noalloc_strict)
        ^
 Error: This value is "alloc"
-         because it closes over the allocation for closure at line 3, characters 29-55
+         because it closes over the allocation at line 3, characters 29-55
          which is "alloc".
        However, the highlighted expression is expected to be "noalloc_strict".
 |}]
@@ -2068,10 +2067,7 @@ end
 Line 2, characters 34-54:
 2 |     let (f @ noalloc_strict) () = { x = 3.0; y = 4.0 }
                                       ^^^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 2, characters 29-54
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* Parameter is not captured *)
@@ -2157,10 +2153,7 @@ let (secretly_allocates @ noalloc) () =
 Line 2, characters 40-58:
 2 |   let (whitewashed @ alloc) = fun () -> { x = 1.; y = 2. } in
                                             ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at lines 1-3, characters 35-16
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let (secretly_allocates' @ noalloc) () = exclave_
@@ -2173,10 +2166,7 @@ let (secretly_allocates' @ noalloc) () = exclave_
 Line 3, characters 41-59:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
                                              ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at lines 1-6, characters 36-17
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 let (secretly_allocates @ noalloc) () = exclave_
@@ -2189,10 +2179,7 @@ let (secretly_allocates @ noalloc) () = exclave_
 Line 3, characters 41-59:
 3 |  (escape_hatch <- stack_ Some (fun () -> { x = 1.; y = 2. })) [@zero_alloc];
                                              ^^^^^^^^^^^^^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc"
-         because it is used inside the function at lines 1-6, characters 35-17
-         which is expected to be "noalloc".
+Error: This value is "local" but is expected to be "global".
 |}]
 
 (* [Pexp_lazy] (typecore.ml) must call [walk_locks_for_allocation] for the lazy
@@ -2223,8 +2210,5 @@ let (lz_in_fn @ noalloc_strict) (x : int) = lazy x
 Line 1, characters 44-50:
 1 | let (lz_in_fn @ noalloc_strict) (x : int) = lazy x
                                                 ^^^^^^
-Error: The allocation is "alloc"
-       but is expected to be "noalloc_strict"
-         because it is used inside the function at line 1, characters 32-50
-         which is expected to be "noalloc_strict".
+Error: This value is "local" but is expected to be "global".
 |}]

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -401,14 +401,13 @@ Error: This value is "alloc" but is expected to be "noalloc_strict".
 |}]
 
 
-(** Test 5.1: Allocation mode identifies all allocations and forces the proper
-    mode. For each kind of allocation the typechecker can see, we test a
-    [noalloc_strict] and a [noalloc] enclosing function side by side, and -- for
-    the allocations that [stack_] supports -- a [stack_]-marked pair as well. An
-    allocation currently forces the enclosing function to [alloc], which is
-    above both [noalloc] and [noalloc_strict], so the detected cases error for
-    both. For allocations that are moved to the stack by [stack_], no error
-    is expected. *)
+(** Test 5.1: When a function is anntoated with [noalloc_strict]/[noalloc],
+    Allocation mode identifies all allocations in the function and force them
+    to be local. *)
+(* CR shsong: Currently [noalloc_strict]/[noalloc] has the same requirement,
+    both force all allocations to be local, so test results for them should be
+    the same. We will add more tests to test difference between them after we
+    make [noalloc] ignore allocation on exception branches. *)
 
 type record_t5 = { x : float; y : float }
 type 'a variant_t5 = Nothing | Just of 'a
@@ -764,66 +763,147 @@ Line 3, characters 7-8:
 Error: This value is "local" but is expected to be "global".
 |}]
 
-(* A lazy block allocates on the heap *)
-let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
+(* A partial application that omits an earlier labeled argument (here [~x], while
+    the later [~y] is given) forces the compiler to abstract over the omitted
+    parameter, allocating a closure in
+    [type_omitted_parameters_and_build_result_type].
+
+    This is a special case for closure allocation at partial application where we
+    force the closure allocation to be local at callee's call site, since
+    the compiler explicitly register allocation for it.
+    However, for other closure allocation at partial application, noalloc forces
+    the allocation to be local at the callee's definition site, since whether
+    there would be allocation at the call site might be unknown at typing stage. *)
+let partial_application_omit_earlier_arg (h : (x:int -> y:int -> int)) =
+  let (require_noalloc @ noalloc_strict) () =
+    (h ~y:1)
+  in
+  let _ = require_noalloc () in
+  ()
 [%%expect{|
-Line 1, characters 46-52:
-1 | let (alloc_lazy @ noalloc_strict) (a : int) = lazy a
-                                                  ^^^^^^
+Line 3, characters 4-12:
+3 |     (h ~y:1)
+        ^^^^^^^^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+Hint: This is a partial application
+      Adding 1 more argument will make the value non-local
+|}]
+
+let partial_application_omit_earlier_arg (h : (x:int -> y:int -> int)) =
+  let (require_noalloc @ noalloc_strict) () = exclave_
+    (h ~y:1)
+  in
+  let _ = require_noalloc () in
+  ()
+[%%expect{|
+Line 5, characters 10-28:
+5 |   let _ = require_noalloc () in
+              ^^^^^^^^^^^^^^^^^^
+Warning 5 [ignored-partial-application]: this function application is partial,
+  maybe some arguments are missing.
+
+val partial_application_omit_earlier_arg :
+  (x:int -> y:int -> int) @ noalloc_strict -> unit = <fun>
+|}]
+
+(* A lazy block always allocates on the heap and cannot be made [local]. *)
+let (alloc_lazy @ noalloc_strict) (a : int) = let _ = lazy a in ()
+[%%expect{|
+Line 1, characters 54-60:
+1 | let (alloc_lazy @ noalloc_strict) (a : int) = let _ = lazy a in ()
+                                                          ^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
-let (alloc_lazy @ noalloc) (a : int) = lazy a
+let (alloc_lazy @ noalloc) (a : int) =  let _ = lazy a in ()
 [%%expect{|
-Line 1, characters 39-45:
-1 | let (alloc_lazy @ noalloc) (a : int) = lazy a
-                                           ^^^^^^
+Line 1, characters 48-54:
+1 | let (alloc_lazy @ noalloc) (a : int) =  let _ = lazy a in ()
+                                                    ^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
-(* [stack_] does not support lazy expressions. *)
-let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
+let (alloc_lazy @ noalloc) (a : int) = exclave_ (lazy a)
 [%%expect{|
-Line 1, characters 62-70:
-1 | let (stack_lazy @ noalloc_strict) (a : int) = exclave_ stack_ (lazy a)
-                                                                  ^^^^^^^^
+Line 1, characters 48-56:
+1 | let (alloc_lazy @ noalloc) (a : int) = exclave_ (lazy a)
+                                                    ^^^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
-
-(* An object allocates. *)
-let (alloc_object @ noalloc_strict) () = object method m = 1 end
+(* An object always allocates on the heap and cannot be made [local]. *)
+let (alloc_object @ noalloc_strict) () =
+  let _ = object method m = 1 end in ()
 [%%expect{|
-Line 1, characters 41-64:
-1 | let (alloc_object @ noalloc_strict) () = object method m = 1 end
-                                             ^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 10-33:
+2 |   let _ = object method m = 1 end in ()
+              ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
-let (alloc_object @ noalloc) () = object method m = 1 end
+let (alloc_object @ noalloc) () =
+  let _ = object method m = 1 end in ()
 [%%expect{|
-Line 1, characters 34-57:
-1 | let (alloc_object @ noalloc) () = object method m = 1 end
-                                      ^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 10-33:
+2 |   let _ = object method m = 1 end in ()
+              ^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
-(* [stack_] does not support objects; here the object's method closure is
-   itself a detected allocation, so the allocation-axis error fires on the
-   method body before the unsupported-[stack_] check is reached. *)
-let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
+let (stack_object @ noalloc_strict) () = exclave_ (object method m = 1 end)
 [%%expect{|
-Line 1, characters 57-82:
-1 | let (stack_object @ noalloc_strict) () = exclave_ stack_ (object method m = 1 end)
-                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 50-75:
+1 | let (stack_object @ noalloc_strict) () = exclave_ (object method m = 1 end)
+                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
 (* An object with no allocating method (here only a value field) still
    allocates the object block itself. *)
-let (obj_no_alloc_method @ noalloc_strict) () = object val x = 0 end
+let (obj_no_alloc_method @ noalloc_strict) () =
+  let _ = object val x = 0 end in ()
 [%%expect{|
-Line 1, characters 48-68:
-1 | let (obj_no_alloc_method @ noalloc_strict) () = object val x = 0 end
-                                                    ^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 10-30:
+2 |   let _ = object val x = 0 end in ()
+              ^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let (obj_no_alloc_method @ noalloc) () =
+  let _ = object val x = 0 end in ()
+[%%expect{|
+Line 2, characters 10-30:
+2 |   let _ = object val x = 0 end in ()
+              ^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+let (obj_no_alloc_method @ noalloc_strict) () = exclave_ object val x = 0 end
+[%%expect{|
+Line 1, characters 57-77:
+1 | let (obj_no_alloc_method @ noalloc_strict) () = exclave_ object val x = 0 end
+                                                             ^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
+
+(* A functional-update override [{< ... >}] copies [self], which allocates.
+   Like an [object] block, the copy is registered as an allocation, so it is
+   forced [local] inside a noalloc function; since the object copy needs
+   [global], it is rejected. *)
+let f () =
+  object (self)
+    val y = 0
+    method bump =
+      let (require_noalloc @ noalloc_strict) () =
+        let _ = {< y = 1 >} in ()
+      in
+      require_noalloc ()
+  end
+[%%expect{|
+Line 6, characters 16-27:
+6 |         let _ = {< y = 1 >} in ()
+                    ^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
@@ -835,27 +915,18 @@ module Empty : S = struct end
 module type S = sig end
 module Empty : S @@ stateless noalloc_strict
 |}]
-let (alloc_first_class_module @ noalloc_strict) () = (module Empty : S)
+let (alloc_first_class_module @ noalloc_strict) () = let _ = (module Empty : S) in ()
 [%%expect{|
-Line 1, characters 61-66:
-1 | let (alloc_first_class_module @ noalloc_strict) () = (module Empty : S)
-                                                                 ^^^^^
+Line 1, characters 69-74:
+1 | let (alloc_first_class_module @ noalloc_strict) () = let _ = (module Empty : S) in ()
+                                                                         ^^^^^
 Error: Module cannot be "local".
 |}]
-let (alloc_first_class_module @ noalloc) () = (module Empty : S)
+let (alloc_first_class_module @ noalloc) () = let _ = (module Empty : S) in ()
 [%%expect{|
-Line 1, characters 54-59:
-1 | let (alloc_first_class_module @ noalloc) () = (module Empty : S)
-                                                          ^^^^^
-Error: Module cannot be "local".
-|}]
-
-(* [stack_] does not support first-class modules. *)
-let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
-[%%expect{|
-Line 1, characters 77-82:
-1 | let (stack_first_class_module @ noalloc_strict) () = exclave_ stack_ (module Empty : S)
-                                                                                 ^^^^^
+Line 1, characters 62-67:
+1 | let (alloc_first_class_module @ noalloc) () = let _ = (module Empty : S) in ()
+                                                                  ^^^^^
 Error: Module cannot be "local".
 |}]
 
@@ -985,6 +1056,17 @@ Line 2, characters 2-20:
 Error: This value is "local" but is expected to be "global".
 |}]
 
+let (alloc_atomic_loc @ noalloc_strict) (r : atomic_record) = exclave_
+  [%atomic.loc r.af]
+[%%expect{|
+val alloc_atomic_loc : atomic_record -> string atomic_loc @ local = <fun>
+|}]
+let (alloc_atomic_loc @ noalloc) (r : atomic_record) = exclave_
+  [%atomic.loc r.af]
+[%%expect{|
+val alloc_atomic_loc : atomic_record -> string atomic_loc @ local = <fun>
+|}]
+
 (* Coercing a function with an optional argument to a plain arrow eta-expands
    it, allocating a closure. We receive both functions as parameters (in a
    tuple to avoid currying closures) so the only allocation is the coercion
@@ -992,59 +1074,52 @@ Error: This value is "local" but is expected to be "global".
 let (alloc_fun_coerce @ noalloc_strict)
       ((apply, opt) :
          (((unit -> int) -> int) * (?x:int -> unit -> int)) @ noalloc_strict) =
-  apply opt
+  let _ = apply opt in ()
 [%%expect{|
-Line 4, characters 8-11:
-4 |   apply opt
-            ^^^
+Line 4, characters 16-19:
+4 |   let _ = apply opt in ()
+                    ^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 let (alloc_fun_coerce @ noalloc)
       ((apply, opt) :
          (((unit -> int) -> int) * (?x:int -> unit -> int)) @ noalloc) =
-  apply opt
+  let _ = apply opt in ()
 [%%expect{|
-Line 4, characters 8-11:
-4 |   apply opt
-            ^^^
+Line 4, characters 16-19:
+4 |   let _ = apply opt in ()
+                    ^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
 (* A list/array comprehension allocates its result *)
-let (alloc_list_comprehension @ noalloc_strict) () = [ x for x = 1 to 10 ]
+let (alloc_list_comprehension @ noalloc_strict) () = let _ = [ x for x = 1 to 10 ] in ()
 [%%expect{|
-Line 1, characters 53-74:
-1 | let (alloc_list_comprehension @ noalloc_strict) () = [ x for x = 1 to 10 ]
-                                                         ^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 61-82:
+1 | let (alloc_list_comprehension @ noalloc_strict) () = let _ = [ x for x = 1 to 10 ] in ()
+                                                                 ^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
-let (alloc_list_comprehension @ noalloc) () = [ x for x = 1 to 10 ]
+let (alloc_list_comprehension @ noalloc) () = let _ = [ x for x = 1 to 10 ] in ()
 [%%expect{|
-Line 1, characters 46-67:
-1 | let (alloc_list_comprehension @ noalloc) () = [ x for x = 1 to 10 ]
-                                                  ^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "local" but is expected to be "global".
-|}]
-
-(* [stack_] does not support comprehensions. *)
-let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
-[%%expect{|
-Line 1, characters 64-85:
-1 | let (stack_comprehension @ noalloc_strict) () = exclave_ stack_ [ x for x = 1 to 10 ]
-                                                                    ^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 54-75:
+1 | let (alloc_list_comprehension @ noalloc) () = let _ = [ x for x = 1 to 10 ] in ()
+                                                          ^^^^^^^^^^^^^^^^^^^^^
 Error: This value is "local" but is expected to be "global".
 |}]
 
-(* Only the first case below is a genuine bug introduced by routing the
-   lock-walk through [register_allocation_mode]. The others turned out NOT to be
-   problems and are kept for contrast. *)
+let (stack_comprehension @ noalloc_strict) () = exclave_ [ x for x = 1 to 10 ]
+[%%expect{|
+Line 1, characters 57-78:
+1 | let (stack_comprehension @ noalloc_strict) () = exclave_ [ x for x = 1 to 10 ]
+                                                             ^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "local" but is expected to be "global".
+|}]
 
-(* CR shsong (false positive): array indexing uses the [%array_safe_get]
-   primitive, whose result is [@local_opt] (Prim_poly). It does NOT allocate, but
-   the Prim_poly registration in [type_ident] goes through
-   [register_allocation_mode], which now walks locks, so it is wrongly rejected
-   -- note the error is "The allocation is alloc". It should be accepted once the
-   Prim_poly site is exempted from walking. *)
+(* CR shsong: these case might be handled too conservatively since referecing a
+  primitive/operator as a value is captured and always considered as [alloc]. *)
+(* array indexing uses the [%array_safe_get] primitive, whose result is
+    [@local_opt] (Prim_poly). It does NOT allocate. *)
 let array_get_prim_poly (a : int array) (i : int) =
   let (f @ noalloc_strict) () = a.(i) in
   f ()
@@ -1058,12 +1133,8 @@ Error: The value "Array.get" is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
-(* NOT the Prim_poly bug: referencing a primitive/operator as a value is rejected
-   by the pre-existing capture rule (primitives are [alloc] by default) -- note
-   "The value ... is alloc", not "The allocation is alloc". Same conservative
-   behavior as the external/arithmetic tests above; independent of Prim_poly.
-   ([my_id]/[!] do not allocate, but referencing the value is conservatively
-   treated as [alloc].) *)
+(* [my_id] do not allocate, but referencing the value is conservatively
+   treated as [alloc]. *)
 external my_id : ('a[@local_opt]) -> ('a[@local_opt]) = "%identity"
 let (prim_value_captured @ noalloc_strict) (x : int) = my_id x
 [%%expect{|
@@ -1076,6 +1147,9 @@ Error: The value "my_id" is "alloc"
          because it is used inside the function at line 2, characters 43-62
          which is expected to be "noalloc_strict".
 |}]
+
+(* [!] does not allocate, but referencing the value is conservatively
+   treated as [alloc]. *)
 let (deref_value_captured @ noalloc_strict) (r : int ref) = !r
 [%%expect{|
 Line 1, characters 60-61:
@@ -1181,440 +1255,6 @@ Line 3, characters 34-40:
 3 |     let (h @ noalloc_strict) () = Just a in
                                       ^^^^^^
 Error: This value is "local" but is expected to be "global".
-|}]
-
-(** Test 5.3: [stack_] negative cases *)
-
-(* [stack_] on a non-allocation (a plain value) is rejected: it is not an
-   allocation. *)
-let (stack_non_alloc @ noalloc_strict) (a : int) = exclave_ stack_ a
-[%%expect{|
-Line 5, characters 67-68:
-5 | let (stack_non_alloc @ noalloc_strict) (a : int) = exclave_ stack_ a
-                                                                       ^
-Error: This expression is not an allocation site.
-|}]
-
-(** Test 5.4: [stack_] nested cases. *)
-
-(* Many tests below (Tests 5.4-5.7) rely on the following trick. If a function is
-   known to be noalloc when its body is type-checked, all inner allocations are
-   forced to be local (on the stack) and the allocation check is exempted -- which
-   would mask the very effect of [local_]/[exclave_]/[stack_] we want to observe.
-   So we do NOT annotate the function under test as noalloc directly; instead we
-   constrain it to be noalloc indirectly, by referencing it inside a separate
-   [require_noalloc @ noalloc_strict] function. That constraint arrives only after
-   the body has been type-checked, so inner allocations are not force-made local
-   and their genuine allocation behavior is observed. *)
-
-(* Nested: an inner allocation that is not itself [stack_]-marked still
-   allocates on the heap, even when an enclosing allocation is [stack_]-marked. *)
-let f () =
-  let stack_nested (a : int) = exclave_ stack_ (Just (Just a)) in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_nested in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 18, characters 12-24:
-18 |     let _ = stack_nested in ()
-                 ^^^^^^^^^^^^
-Error: The value "stack_nested" is "alloc"
-         because it closes over the allocation at line 16, characters 53-61
-         which is "alloc".
-       However, the value "stack_nested" highlighted is expected to be "noalloc_strict"
-         because it is used inside the function at lines 17-18, characters 41-30
-         which is expected to be "noalloc_strict".
-|}]
-
-(* A [@@ global] field forces its value onto the heap even when the enclosing
-   record is [stack_]-allocated: the record block is exempt, but the global
-   field value [Just a] is a genuine heap allocation and is still rejected. This
-   is another way (besides plain nesting above) for a heap allocation to sit
-   inside a [stack_] one. *)
-type 'a global_field_rec = { gf : 'a @@ global; rest : int }
-[%%expect{|
-type 'a global_field_rec = { gf : 'a @@ global; rest : int; }
-|}]
-let f () =
-  let stack_global_field (a : int) =
-    exclave_ stack_ { gf = Just a; rest = a }
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_global_field in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 6, characters 12-30:
-6 |     let _ = stack_global_field in ()
-                ^^^^^^^^^^^^^^^^^^
-Error: The value "stack_global_field" is "alloc"
-         because it closes over the allocation at line 3, characters 27-33
-         which is "alloc".
-       However, the value "stack_global_field" highlighted is expected to be "noalloc_strict"
-         because it is used inside the function at lines 5-6, characters 41-36
-         which is expected to be "noalloc_strict".
-|}]
-
-
-(** Test 5.5: the allocation axis is exempted only by [stack_]
-    ([expected_mode.strictly_stack]), not by [local_]/[exclave_]
-    ([expected_mode.strictly_local]). The two flags are independent, so they are
-    NOT interchangeable:
-
-    - [strictly_stack] is set ONLY by the direct operand of [stack_], the
-      explicit, checked stack-allocation form. It can be [true] while
-      [strictly_local] is [false] -- e.g. a [stack_] in a plain [let] binding,
-      not under any [exclave_]/[local_]. Gating the walk on [strictly_local]
-      would WRONGLY REJECT such a legitimate [stack_] (see [stack_in_let]).
-    - [strictly_local] is set by [local_]/[exclave_], which only constrain the
-      *mode* to [local]. The current implementation does not treat them as
-      exempt (it conservatively requires the explicit, checked [stack_] marker),
-      so these still error (see [exclave_not_exempt]/[local_not_exempt]). *)
-
-(* [exclave_] alone (no [stack_]) does not exempt the allocation. *)
-let f () =
-  let exclave_not_exempt (a : int) = exclave_ (Just a) in
-  let (require_noalloc @ noalloc_strict) () =
-    let _  = exclave_not_exempt in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 20, characters 13-31:
-20 |     let _  = exclave_not_exempt in ()
-                  ^^^^^^^^^^^^^^^^^^
-Error: The value "exclave_not_exempt" is "alloc"
-         because it closes over the allocation at line 18, characters 46-54
-         which is "alloc".
-       However, the value "exclave_not_exempt" highlighted is expected to be "noalloc_strict"
-         because it is used inside the function at lines 19-20, characters 41-37
-         which is expected to be "noalloc_strict".
-|}]
-
-(* CR shsong: currently, [local_] does not exempt the allocation. *)
-let f () =
-  let local_not_exempt (a : int) =
-    let _x = local_ (Just a) in
-    ()
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _  = local_not_exempt in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 7, characters 13-29:
-7 |     let _  = local_not_exempt in ()
-                 ^^^^^^^^^^^^^^^^
-Error: The value "local_not_exempt" is "alloc"
-         because it closes over the allocation at line 3, characters 20-28
-         which is "alloc".
-       However, the value "local_not_exempt" highlighted is expected to be "noalloc_strict"
-         because it is used inside the function at lines 6-7, characters 41-35
-         which is expected to be "noalloc_strict".
-|}]
-
-(* For contrast, the same allocation wrapped in [stack_] (sets [strictly_stack])
-   is exempt and accepted. *)
-let f () =
-  let stack_is_exempt (a : int) = exclave_ stack_ (Just a) in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_is_exempt in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-val f : unit -> unit = <fun>
-|}]
-
-(* The decisive case: a [stack_] in a plain [let] binding (no [exclave_]/[local_]
-   around it) has [strictly_stack = true] but [strictly_local = false]. It is
-   correctly accepted. Gating the walk on [strictly_local] would reject it, which
-   is why [strictly_stack] is required rather than reusing [strictly_local]. *)
-let f () =
-  let stack_in_let (a : int) =
-    let _x = stack_ (Just a) in
-    ()
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_in_let in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-val f : unit -> unit = <fun>
-|}]
-
-
-(** Test 5.6: a transparent wrapper around the [stack_] operand should not defeat
-    the [stack_] exemption.
-
-    [stack_] sets [strictly_stack] on its operand.
-    Although we do not want [strictly_stack = true] for children allocations,
-    we should not use [mode_morph]/[mode_coerce] to reset [strictly_stack] for
-    children (while keeping [strictly_local]). *)
-
-(* A type annotation goes through [Pexp_constraint] -> [type_expect_mode]
-   -> [mode_coerce], which should not resets [strictly_stack] on the
-   inner allocation, i.e., the inner allocation is still on stack. *)
-let f () =
-  let stack_through_type_annot (a : int) =
-    exclave_ stack_ ((Just a : int variant_t5))
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_through_type_annot in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-val f : unit -> unit = <fun>
-|}]
-
-(* Same via a mode annotation. *)
-let f () =
-  let stack_through_mode_annot (a : int) =
-    exclave_ stack_ ((Just a : _ @ local))
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_through_mode_annot in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-val f : unit -> unit = <fun>
-|}]
-
-(* A coercion [:>] does NOT reset [strictly_stack]: the [stack_]
-   operand stays exempt and is correctly accepted. *)
-let f () =
-  let stack_through_coercion (a : int) =
-    exclave_ stack_ ((Just a :> int variant_t5))
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_through_coercion in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-val f : unit -> unit = <fun>
-|}]
-
-(* An attribute on the allocation is also fine. *)
-let f () =
-  let stack_through_attribute (a : int) =
-    exclave_ stack_ ((Just a)[@inline])
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_through_attribute in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-val f : unit -> unit = <fun>
-|}]
-
-(* [let open ... in] is also transparent, but here [stack_]
-   fails to even recognize the allocation site -- the [Pexp_stack]
-   allocation-site detection does not see through [Pexp_open] (this is a
-   detection gap, not the [strictly_stack] reset issue). *)
-let f () =
-  let stack_through_open (a : int) =
-    exclave_ stack_ (let open Stdlib in Just a)
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_through_open in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 3, characters 20-47:
-3 |     exclave_ stack_ (let open Stdlib in Just a)
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This expression is not an allocation site.
-|}]
-
-
-(** Test 5.7: a genuinely NEW inner allocation under a [stack_] outer is still
-    flagged. Unlike a transparent wrapper (Test 5.6), these inner expressions
-    introduce their own allocation, so the [stack_] exemption must NOT reach
-    them. It does not: [stack_] only marks its top operand, and every inner
-    allocation below is registered with [strictly_stack = false] -- either
-    because its mode is built by [mode_default] (constructor args, tuple
-    components, record fields, function bodies) or because [mode_morph] resets
-    [strictly_stack] for children (lazy thunk body, partial-application args). *)
-
-(* a new allocation captured as an argument of a function application.
-   With the indirect trick (no force-local), the outer [stack_] operand -- a full
-   application returning [int] -- is reached first and rejected as not an
-   allocation site, before the inner [Just a] is examined. *)
-let f () =
-  let stack_inner_function_application
-        (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
-    exclave_ stack_ (g (Just a) 2 3)
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_inner_function_application in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 17, characters 20-36:
-17 |     exclave_ stack_ (g (Just a) 2 3)
-                         ^^^^^^^^^^^^^^^^
-Error: This expression is not an allocation site.
-|}]
-
-(* CR shsong: function partial application triggers allocation, and is not
-    considered to be on the stack even though it is annotated with [stack_].
-    Revisit this in the next PR. *)
-(* a new allocation captured as an argument of a partial application. With the
-   indirect trick (no force-local), the outer [stack_] operand -- a partial
-   application closure -- is reached first and rejected as not an allocation site
-   ([Pexp_stack] does not recognize partial applications), before the inner
-   [Just a] is examined. *)
-let f () =
-  let stack_inner_partial_application
-        (g : (int variant_t5 -> int -> int -> int) @ noalloc_strict) (a : int) =
-    exclave_ stack_ (g (Just a) 2)
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_inner_partial_application in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 4, characters 20-34:
-4 |     exclave_ stack_ (g (Just a) 2)
-                        ^^^^^^^^^^^^^^
-Error: This expression is not an allocation site.
-|}]
-
-(* a tuple component is a new allocation *)
-let f () =
-  let stack_inner_tuple (a : int) =
-    exclave_ stack_ (Just a, Just a)
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_inner_tuple in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 6, characters 12-29:
-6 |     let _ = stack_inner_tuple in ()
-                ^^^^^^^^^^^^^^^^^
-Error: The value "stack_inner_tuple" is "alloc"
-         because it closes over the allocation at line 3, characters 21-27
-         which is "alloc".
-       However, the value "stack_inner_tuple" highlighted is expected to be "noalloc_strict"
-         because it is used inside the function at lines 5-6, characters 41-35
-         which is expected to be "noalloc_strict".
-|}]
-
-(* a record field is a new allocation *)
-type stack_inner_rec = { sf1 : int variant_t5; sf2 : int }
-[%%expect{|
-type stack_inner_rec = { sf1 : int variant_t5; sf2 : int; }
-|}]
-let f () =
-  let stack_inner_field (a : int) =
-    exclave_ stack_ { sf1 = Just a; sf2 = a }
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_inner_field in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 6, characters 12-29:
-6 |     let _ = stack_inner_field in ()
-                ^^^^^^^^^^^^^^^^^
-Error: The value "stack_inner_field" is "alloc"
-         because it closes over the allocation at line 3, characters 28-34
-         which is "alloc".
-       However, the value "stack_inner_field" highlighted is expected to be "noalloc_strict"
-         because it is used inside the function at lines 5-6, characters 41-35
-         which is expected to be "noalloc_strict".
-|}]
-
-(* a function body has a new allocation *)
-let f () =
-  let stack_inner_funbody (a : int) =
-    exclave_ stack_ (fun () -> Just a)
-  in
-  let (require_noalloc @ noalloc_strict) () =
-    let _ = stack_inner_funbody in ()
-  in
-  let _ = require_noalloc () in
-  ()
-[%%expect{|
-Line 6, characters 12-31:
-6 |     let _ = stack_inner_funbody in ()
-                ^^^^^^^^^^^^^^^^^^^
-Error: The value "stack_inner_funbody" is "alloc"
-         because it closes over the allocation at line 3, characters 31-37
-         which is "alloc".
-       However, the value "stack_inner_funbody" highlighted is expected to be "noalloc_strict"
-         because it is used inside the function at lines 5-6, characters 41-37
-         which is expected to be "noalloc_strict".
-|}]
-
-
-(** Test 5.8: regression guard for making [stack_] set [strictly_local].
-
-    A [stack_] closure placed where a [global] value is required must report a
-    clean locality error, NOT crash. If the [Pexp_stack] handler is changed to
-    [mode_strictly_stack expected_mode |> mode_strictly_local], then
-    [split_function_ty] forces the closure areality with [Locality.submode_exn]
-    (line ~6237). That submode genuinely fails here (the closure must be global),
-    and the [_exn] form raises [Invalid_argument "result is Error _"] -- a
-    compiler crash -- instead of the graceful error below. With the handler left
-    as [mode_strictly_stack] only, all four error cleanly. *)
-
-(* stack_ closure stored in a ref (ref contents must be global) *)
-let stack_clo_in_ref = ref (stack_ (fun x -> x))
-[%%expect{|
-Line 13, characters 27-48:
-13 | let stack_clo_in_ref = ref (stack_ (fun x -> x))
-                                ^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "local" because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "global".
-|}]
-
-(* stack_ closure as the function in a tail call *)
-let stack_clo_tailcall () = (stack_ (fun x -> x)) 42
-[%%expect{|
-Line 1, characters 28-49:
-1 | let stack_clo_tailcall () = (stack_ (fun x -> x)) 42
-                                ^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "local" because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "local" to the parent region or "global"
-         because it is the function in a tail call.
-|}]
-
-(* stack_ multi-argument closure stored in a ref *)
-let stack_clo_multiarg () = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a))
-[%%expect{|
-Line 1, characters 32-72:
-1 | let stack_clo_multiarg () = ref (stack_ (fun x y -> x : 'a -> 'a -> 'a))
-                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "local" because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "global".
-|}]
-
-(* stack_ closure returned where a global function is expected *)
-let stack_clo_global_return () : int -> int = stack_ (fun x -> x)
-[%%expect{|
-Line 1, characters 46-65:
-1 | let stack_clo_global_return () : int -> int = stack_ (fun x -> x)
-                                                  ^^^^^^^^^^^^^^^^^^^
-Error: This value is "local" because it is "stack_"-allocated.
-       However, the highlighted expression is expected to be "local" to the parent region or "global"
-         because it is a function return value.
-         Hint: Use exclave_ to return a local value.
 |}]
 
 
@@ -1876,14 +1516,12 @@ let (p_match @ noalloc_strict) o x =
 val p_match : 'a option -> ('b -> 'c -> 'b) @ local = <fun>
 |}]
 
-(* Record field via a modality ([mode_is_contained_by]); the record block is
-   [stack_]-allocated so the field closure is the only thing exercising the
-   propagation. *)
+(* Record field via a modality ([mode_is_contained_by]). *)
 type box = { g : unit -> int }
 [%%expect{|
 type box = { g : unit -> int; }
 |}]
-let (p_record @ noalloc_strict) (x : int) = exclave_ stack_ { g = (fun () -> x) }
+let (p_record @ noalloc_strict) (x : int) = exclave_ { g = (fun () -> x) }
 [%%expect{|
 val p_record : int -> box @ local = <fun>
 |}]

--- a/testsuite/tests/typing-modes/zero_alloc.ml
+++ b/testsuite/tests/typing-modes/zero_alloc.ml
@@ -1133,6 +1133,63 @@ Error: The value "Array.get" is "alloc"
          which is expected to be "noalloc_strict".
 |}]
 
+(* [Prim_poly] result ([@local_opt]): [%makemutable] allocates. *)
+external mk_poly : 'a -> ('a ref[@local_opt]) = "%makemutable"
+let (prim_poly_result @ noalloc_strict) (x : int) = mk_poly x
+[%%expect{|
+external mk_poly : 'a -> ('a ref [@local_opt]) = "%makemutable"
+Line 2, characters 52-59:
+2 | let (prim_poly_result @ noalloc_strict) (x : int) = mk_poly x
+                                                        ^^^^^^^
+Error: The value "mk_poly" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 40-61
+         which is expected to be "noalloc_strict".
+|}]
+
+(* [Prim_global] result: [%makemutable] allocates on the heap. *)
+external mk_global : 'a -> 'a ref = "%makemutable"
+let (prim_global_result @ noalloc_strict) (x : int) = mk_global x
+[%%expect{|
+external mk_global : 'a -> 'a ref = "%makemutable"
+Line 2, characters 54-63:
+2 | let (prim_global_result @ noalloc_strict) (x : int) = mk_global x
+                                                          ^^^^^^^^^
+Error: The value "mk_global" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 42-65
+         which is expected to be "noalloc_strict".
+|}]
+
+(* [Prim_global] result with a [Prim_poly] argument: [%makemutable] allocates
+   on the heap. *)
+external mk_polyarg : ('a[@local_opt]) -> 'a ref = "%makemutable"
+let (prim_global_result_poly_arg @ noalloc_strict) (x : int) = mk_polyarg x
+[%%expect{|
+external mk_polyarg : ('a [@local_opt]) -> 'a ref = "%makemutable"
+Line 2, characters 63-73:
+2 | let (prim_global_result_poly_arg @ noalloc_strict) (x : int) = mk_polyarg x
+                                                                   ^^^^^^^^^^
+Error: The value "mk_polyarg" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 51-75
+         which is expected to be "noalloc_strict".
+|}]
+
+(* [Prim_local] result: [%makemutable] allocates on the stack. *)
+external mk_local : 'a -> local_ 'a ref = "%makemutable"
+let (prim_local_result @ noalloc_strict) (x : int) = mk_local x
+[%%expect{|
+external mk_local : 'a -> 'a ref @ local = "%makemutable"
+Line 2, characters 53-61:
+2 | let (prim_local_result @ noalloc_strict) (x : int) = mk_local x
+                                                         ^^^^^^^^
+Error: The value "mk_local" is "alloc"
+       but is expected to be "noalloc_strict"
+         because it is used inside the function at line 2, characters 41-63
+         which is expected to be "noalloc_strict".
+|}]
+
 (* [my_id] do not allocate, but referencing the value is conservatively
    treated as [alloc]. *)
 external my_id : ('a[@local_opt]) -> ('a[@local_opt]) = "%identity"

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3738,7 +3738,7 @@ let closure_mode pp {Mode.monadic; comonadic} closure_context comonadic0 =
 let closure_noalloc_mode (pp : Mode.Hint.pinpoint) vmode =
   let _, pp_desc = pp in
   match pp_desc with
-  | Mode.Hint.Allocation true ->
+  | Mode.Hint.Allocation ->
     Mode.Value.meet_const_with Allocation Mode.Allocation.Const.Noalloc_strict
       vmode
   | _ -> vmode

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4806,10 +4806,7 @@ module Report = struct
       Some (print_article_noun Consonant "pattern match with effect cases")
     | Effect_try ->
       Some (print_article_noun Consonant "try-with with effect cases")
-    | Allocation closure ->
-      if closure
-      then Some (print_article_noun Vowel "allocation for closure")
-      else Some (print_article_noun Vowel "allocation")
+    | Allocation -> Some (print_article_noun Vowel "allocation")
     | Class -> Some (print_article_noun Consonant "class")
     | Object -> Some (print_article_noun Vowel "object")
     | Loop -> Some (print_article_noun Consonant "loop")

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -34,9 +34,7 @@ type pinpoint_desc =
   | Structure  (** A structure definition *)
   | Lazy  (** A lazy expression *)
   | Quote  (** A quoted expression *)
-  | Allocation of bool
-      (** An allocation, the boolean indicates whether the allocation is for a
-          closure or not *)
+  | Allocation  (** An allocation *)
   | Expression  (** An arbitrary expression *)
   | Effect_match  (** A pattern match with effect cases *)
   | Effect_try  (** A try-with expression with effect cases *)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7993,6 +7993,11 @@ and type_expect_
       let (cl_path, cl_decl, cl_mode) =
         Env.lookup_class ~loc:cl.loc cl.txt env
       in
+      (* Allocation axis: [new] allocates the object on the heap. This
+         registration is currently redundant -- [Env.lookup_class] above
+         already walks the locks and forces enclosing closures to [alloc] --
+         but we register it anyway so every allocation site is covered. *)
+      register_allocation_mode ~env ~loc Alloc.legacy;
       Value.submode_exn ~pp:(cl.loc, Ident {category = Class; lid = cl.txt})
         cl_mode Value.legacy;
       let pm = position_and_mode env expected_mode sexp in
@@ -9067,6 +9072,9 @@ and type_ident env ?(recarg=Rejected) lid =
   associative, the order of which we apply those join does not matter.
   *)
   (* CR modes: codify the above per-axis argument. *)
+  (* CR shsong: the allocation axis is treated conservatively here -- any value
+     referenced at [alloc] (in particular every primitive) forces the enclosing
+     closures to [alloc], even when no allocation actually happens. *)
   let actual_mode =
     Env.walk_locks ~env ~loc:lid.loc lid.txt ~item:Value (Some desc.val_type)
       (mode, locks)
@@ -9093,19 +9101,31 @@ and type_ident env ?(recarg=Rejected) lid =
   end;
   let layout_args, val_type, kind =
     match desc.val_kind with
+    (* Allocation axis: only [Val_prim] can allocate merely by being referenced
+       (the primitive's result). We register an allocation whenever one may
+       happen, not only for poly results as an optimization hint. *)
+    (* CR shsong: this check is currently masked by [walk_locks] above, which
+       already treats every primitive as [alloc]. *)
     | Val_prim prim ->
        if not @@ Lpoly.is_empty_exn desc.val_lpoly then
          Misc.fatal_error "type_ident: Val_prim with non-empty val_lpoly";
        let ty, mode, _, sort = instance_prim env prim desc.val_type in
        let ty = instance ty in
        begin match prim.prim_native_repr_res, mode with
-       (* if the locality of returned value of the primitive is poly
-          we then register allocation for further optimization *)
+       (* Poly result: register an allocation at the result's locality. *)
        | (Prim_poly, _), Some mode ->
-          (* CR shsong: Can this be local? *)
            register_allocation_mode ~env ~loc:lid.loc
              (Alloc.max_with_comonadic Areality mode)
-       | _ -> ()
+       | (Prim_poly, _), None ->
+           (* Unreachable: a poly result implies [mode = Some]. Conservatively
+              register a heap allocation rather than silently skip it. *)
+           register_allocation_mode ~env ~loc:lid.loc Alloc.legacy
+       (* Global result: register a heap allocation. *)
+       | (Prim_global, _), _ ->
+           register_allocation_mode ~env ~loc:lid.loc Alloc.legacy
+       (* Local result: a stack allocation, which does not count on the
+          allocation axis. *)
+       | (Prim_local, _), _ -> ()
        end;
        [], ty, Id_prim (Option.map Locality.disallow_right mode, sort)
     | _ ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -446,16 +446,6 @@ type expected_mode =
     field and [mode]: this field being [true] while [mode] being [global] is
     sensible, but not very useful as it will fail all expressions. *)
 
-    strictly_stack : bool;
-    (** True iff this expression is the direct operand of [stack_].
-    Suppresses the allocation-axis lock-walk for its top allocation. *)
-
-    (* CR shsong: An alternative design is to unify strictly_local and
-    strictly_stack. Specifically, we want to set strictly_local when
-    [stack_] keyword is used, so that we can use strictly_local and remove
-    strictly_stack. However, if we do that, there would be uncaught exception
-    in Test 5h in test typing-modes/zero_alloc.ml. We will review this later. *)
-
     alloc_annot : Allocation.Const.t option;
     (** [Some c] iff the function was directly annotated with the allocation
     mode [c] on its binding (e.g. [let (f @ noalloc) x = ...]). *)
@@ -542,7 +532,6 @@ let mode_default mode =
   { position = RNontail;
     mode = Value.disallow_left mode;
     strictly_local = false;
-    strictly_stack = false;
     alloc_annot = None;
     tuple_modes = None }
 
@@ -660,11 +649,6 @@ let mode_exclave expected_mode =
 let mode_strictly_local expected_mode =
   { expected_mode
     with strictly_local = true
-  }
-
-let mode_strictly_stack expected_mode =
-  { expected_mode
-    with strictly_stack = true
   }
 
 let mode_alloc_annot expected_mode alloc_annot =
@@ -823,30 +807,29 @@ let allocations : Alloc.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
-let register_allocation_mode ~env ~loc ?(stack = false) alloc_mode =
+let register_allocation_mode ~env ~loc alloc_mode =
   (* [stack_]-marked allocations are stack-allocated and so do not count
      towards the allocation axis; only heap allocations walk the locks. *)
-  if not stack then
-    let is_local =
-      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation)
-    in
-    if is_local then
-      (match
-        Value.submode ~pp:(loc, Function)
-          (Value.min_with_comonadic Areality Regionality.local)
-          (alloc_as_value alloc_mode)
-      with
-      | Ok () -> ()
-      | Error failure_reason ->
-        let error = Submode_failed(failure_reason, Other) in
-        raise (Error (loc, env, error)));
+  let is_local =
+    Env.walk_locks_for_allocation ~env (loc, Hint.Allocation)
+  in
+  if is_local then
+    (match
+      Value.submode ~pp:(loc, Function)
+        (Value.min_with_comonadic Areality Regionality.local)
+        (alloc_as_value alloc_mode)
+    with
+    | Ok () -> ()
+    | Error failure_reason ->
+      let error = Submode_failed(failure_reason, Other) in
+      raise (Error (loc, env, error)));
   let alloc_mode = Alloc.disallow_left alloc_mode in
   allocations := alloc_mode :: !allocations
 
-let register_allocation_value_mode ~env ~loc ?(stack = false)
+let register_allocation_value_mode ~env ~loc
     ?(desc  = (Unknown : Mode.Hint.allocation_desc)) mode =
   let alloc_mode = value_to_alloc_r2g mode in
-  register_allocation_mode ~env ~loc ~stack alloc_mode;
+  register_allocation_mode ~env ~loc alloc_mode;
   (* We must apply each morphism separately so that their hints correspond to
      the correct morphism *)
   let mode =
@@ -861,13 +844,13 @@ let register_allocation_value_mode ~env ~loc ?(stack = false)
    parameter function needs to be made global if its partial application
    to one argument must be global. As a result, a function gets an
    [Alloc.lr] allocation mode that can be further constrained. *)
-let register_closure_allocation ~env ?(stack = false) (mode : Value.r) ~loc
+let register_closure_allocation ~env (mode : Value.r) ~loc
     : Alloc.lr * Value.r =
   let allocation : Hint.allocation = {loc; txt = Unknown} in
   let (alloc_mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode ~env ~loc ~stack (Alloc.disallow_left alloc_mode);
+  register_allocation_mode ~env ~loc (Alloc.disallow_left alloc_mode);
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
   in
@@ -878,7 +861,7 @@ let register_closure_allocation ~env ?(stack = false) (mode : Value.r) ~loc
     of potential subcomponents. *)
 let register_allocation ~env ~loc ?desc (expected_mode : expected_mode) =
   let alloc_mode, mode =
-    register_allocation_value_mode ~env ~loc ~stack:expected_mode.strictly_stack
+    register_allocation_value_mode ~env ~loc
       ?desc (as_single_mode expected_mode)
   in
   alloc_mode, mode_default mode
@@ -6243,8 +6226,7 @@ let split_function_ty
     ~mode_annots ~ret_mode_annots ~in_function ~is_first_val_param ~is_final_val_param
   =
   let alloc_mode, closed_over_mode =
-    register_closure_allocation ~env ~stack:expected_mode.strictly_stack ~loc
-      (as_single_mode expected_mode)
+    register_closure_allocation ~env ~loc (as_single_mode expected_mode)
   in
   if expected_mode.strictly_local then
     Locality.submode_exn ~pp:(loc, Function) Locality.local
@@ -8057,6 +8039,8 @@ and type_expect_
         exp_env = env }
   | Pexp_override lst ->
       submode ~loc ~env Value.legacy expected_mode;
+      (* Allocation axis check: [{< ... >}] copies [self], which allocates *)
+      register_allocation_mode ~env ~loc Alloc.legacy;
       let _ =
        List.fold_right
         (fun (lab, _) l ->
@@ -8570,8 +8554,7 @@ and type_expect_
   | Pexp_stack e ->
       (* Allocation axis: suppress the axis lock-walk at the registration
           site *)
-      let expected_stack_mode = mode_strictly_stack expected_mode in
-      let exp = type_expect env expected_stack_mode e ty_expected_explained in
+      let exp = type_expect env expected_mode e ty_expected_explained in
       let unsupported category =
         raise (Error (exp.exp_loc, env, Unsupported_stack_allocation category))
       in
@@ -9119,6 +9102,7 @@ and type_ident env ?(recarg=Rejected) lid =
        (* if the locality of returned value of the primitive is poly
           we then register allocation for further optimization *)
        | (Prim_poly, _), Some mode ->
+          (* CR shsong: Can this be local? *)
            register_allocation_mode ~env ~loc:lid.loc
              (Alloc.max_with_comonadic Areality mode)
        | _ -> ()
@@ -10380,8 +10364,7 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
     (fun l -> raise (Error (loc, env, Repeated_tuple_exp_label l)))
     (Misc.repeated_label sexpl);
   let alloc_mode, value_mode =
-    register_allocation_value_mode ~env ~loc
-      ~stack:expected_mode.strictly_stack expected_mode.mode
+    register_allocation_value_mode ~env ~loc expected_mode.mode
   in
   let argument_mode =
     value_mode
@@ -10412,8 +10395,7 @@ and type_tuple ~overwrite ~loc ~env ~(expected_mode : expected_mode) ~ty_expecte
           should be an type error. Here, we give the sound mode anyway. *)
         let tuple_modes =
           List.map (fun (mode, _) ->
-            snd (register_allocation_value_mode ~env ~loc
-                   ~stack:expected_mode.strictly_stack mode)) tuple_modes
+            snd (register_allocation_value_mode ~env ~loc mode)) tuple_modes
         in
         let argument_mode = Value.meet (argument_mode :: tuple_modes) in
         List.init arity (fun _ -> argument_mode)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -823,15 +823,14 @@ let allocations : Alloc.r list ref = Local_store.s_ref []
 
 let reset_allocations () = allocations := []
 
-let register_allocation_mode ~env ~loc
-    ?(stack = false) ?(closure = false) alloc_mode =
+let register_allocation_mode ~env ~loc ?(stack = false) alloc_mode =
   (* [stack_]-marked allocations are stack-allocated and so do not count
      towards the allocation axis; only heap allocations walk the locks. *)
   if not stack then
-    let local_closure =
-      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation closure)
+    let is_local =
+      Env.walk_locks_for_allocation ~env (loc, Hint.Allocation)
     in
-    if local_closure then
+    if is_local then
       (match
         Value.submode ~pp:(loc, Function)
           (Value.min_with_comonadic Areality Regionality.local)
@@ -868,8 +867,7 @@ let register_closure_allocation ~env ?(stack = false) (mode : Value.r) ~loc
   let (alloc_mode : Alloc.lr), _ =
     Alloc.newvar_below (value_to_alloc_r2g ~allocation mode)
   in
-  register_allocation_mode ~env ~loc ~stack ~closure:true
-    (Alloc.disallow_left alloc_mode);
+  register_allocation_mode ~env ~loc ~stack (Alloc.disallow_left alloc_mode);
   let closed_over_mode =
     alloc_as_value ~allocation (Alloc.disallow_left alloc_mode)
   in
@@ -8593,7 +8591,7 @@ and type_expect_
             Alloc.(of_const ~hint_comonadic:Stack_expression
               { Const.min with areality = Local })
           in
-          Alloc.submode_err (exp.exp_loc, Allocation false) local alloc_mode
+          Alloc.submode_err (exp.exp_loc, Allocation) local alloc_mode
         end
       | Texp_list_comprehension _ -> unsupported List_comprehension
       | Texp_array_comprehension _ -> unsupported Array_comprehension

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -103,6 +103,7 @@ type error =
       old_source_file : Misc.filepath;
     }
   | Duplicate_parameter_name of Global_module.Parameter_name.t
+  | Cannot_be_local
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -116,8 +117,11 @@ let new_mode_var_from_annots (m : Alloc.Const.Option.t) =
   mode
 
 let register_allocation ~env ~loc : Alloc.lr * Value.lr =
-  ignore
-    (Env.walk_locks_for_allocation ~env (loc, Hint.Allocation false) : bool);
+  let is_local =
+    Env.walk_locks_for_allocation ~env (loc, Hint.Allocation)
+  in
+  if is_local then
+    raise (Error (loc, env, Cannot_be_local));
   let upper_bound =
     Alloc.of_const
       ~hint_comonadic:Module_allocated_on_heap
@@ -5149,6 +5153,8 @@ let report_error ~loc _env = function
       Location.errorf ~loc
         "This instance has multiple arguments with the name %a."
         (Style.as_inline_code Global_module.Parameter_name.print) name
+  | Cannot_be_local ->
+      Location.errorf ~loc "Module cannot be \"local\"."
 
 let report_error env ~loc err =
   Printtyp.wrap_printing_env ~error:true env

--- a/typing/typemod.mli
+++ b/typing/typemod.mli
@@ -175,6 +175,7 @@ type error =
       old_source_file: Misc.filepath;
     }
   | Duplicate_parameter_name of Global_module.Parameter_name.t
+  | Cannot_be_local
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error


### PR DESCRIPTION
We expect user to always have explicit `[noalloc_strict]`/`[noalloc]` annotation (rather than relying on mode solving), to avoid tricky dependency between different mode axes solving.

-  A function annotated by `[noalloc_strict]`/`[noalloc]` forces all allocation inside the function to be local. If the allocation cannot be local, a type error will be reported.
- We do not rely on `[stack_]` annotation to imply that an allocation will be on stack and can be exempted from Allocation mode axis check.
- Add missing register_allocation for a few cases


Testing
-------
- Clean up tests in `testsuite/tests/typing-modes/zero_alloc.ml`
- Add a few tests to demonstrate the consequence of missing register_allocation in those cases (one case leads to soundness issues)