### PR TITLE
codegen: use x86 TEST instead of CMP when materializing booleans

### DIFF
--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2267,16 +2267,22 @@ let emit_instr ~first ~last ~fallthrough i =
       I.movzx al (res i 0)
     end
   | Lop (Intop_imm (Icomp cmp, n)) ->
+    let emit_cmp () =
+      match cmp, n with
+      | (Ceq | Cne), 0 -> output_test_zero i.arg.(0)
+      | (Ceq | Cne | Clt | Cgt | Cle | Cge | Cult | Cugt | Cule | Cuge), _ ->
+        I.cmp (int n) (arg i 0)
+    in
     if
       Reg.is_reg i.res.(0)
       && not (Reg.equal_location i.res.(0).loc i.arg.(0).loc)
     then begin
       I.xor (res32 i 0) (res32 i 0);
-      I.cmp (int n) (arg i 0);
+      emit_cmp ();
       I.set (cond cmp) (res8 i 0)
     end
     else begin
-      I.cmp (int n) (arg i 0);
+      emit_cmp ();
       I.set (cond cmp) al;
       I.movzx al (res i 0)
     end

--- a/testsuite/tests/codegen/or_null.ml
+++ b/testsuite/tests/codegen/or_null.ml
@@ -14,7 +14,7 @@ let is_null (x : int or_null) =
   match x with Null -> true | This _ -> false
 [%%expect_asm X86_64{|
 is_null:
-  cmpq  $0, %rax
+  testq %rax, %rax
   sete  %al
   movzbq %al, %rax
   leaq  1(%rax,%rax), %rax
@@ -25,7 +25,7 @@ let is_this (x : int or_null) =
   match x with Null -> false | This _ -> true
 [%%expect_asm X86_64{|
 is_this:
-  cmpq  $0, %rax
+  testq %rax, %rax
   setne %al
   movzbq %al, %rax
   leaq  1(%rax,%rax), %rax
@@ -59,7 +59,7 @@ equal_int:
   testq %rax, %rax
   jne   .L0
   xorl  %eax, %eax
-  cmpq  $0, %rbx
+  testq %rbx, %rbx
   sete  %al
   leaq  1(%rax,%rax), %rax
   ret


### PR DESCRIPTION
Using `test` instead of `cmp` for comparisons to 0 saves one byte of instruction encoding size.