### PR TITLE
[WIP] Peephole rewrites for arm64

### DIFF
--- a/backend/.ocamlformat-enable
+++ b/backend/.ocamlformat-enable
@@ -115,3 +115,5 @@ x86_dsl.ml
 x86_dsl.mli
 x86_peephole/**/*.ml
 x86_peephole/**/*.mli
+arm64_peephole/**/*.ml
+arm64_peephole/**/*.mli

--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -975,7 +975,7 @@ end
     the same width class. *)
 module LDP_STP_width = struct
   type (_, _) t =
-    | X : ([< `X | `LR], [< `X | `LR]) t
+    | X : ([< `X | `LR | `XZR], [< `X | `LR | `XZR]) t
     | W : ([< `W], [< `W]) t
 end
 

--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -3028,14 +3028,27 @@ module DSL = struct
 
     let clear_emit_instruction () = emit_instruction := None
 
-    let ins (type num a) (name : (num, a) Instruction_name.t)
-        (operands : (num, a) many) =
-      let instr = Instruction.create name ~operands in
+    let emit_existing instr =
       (* Emit to binary emitter if configured *)
       (match !emit_instruction with Some emit -> emit instr | None -> ());
       (* Emit to text if configured *)
       let str = Format.asprintf "\t%a\n" Instruction.print instr in
       match !emit_string with None -> () | Some emit_string -> emit_string str
+
+    let ins (type num a) (name : (num, a) Instruction_name.t)
+        (operands : (num, a) many) =
+      emit_existing (Instruction.create name ~operands)
+
+    let with_redirected_emit ~emit_instruction:capture ~f =
+      let saved_emit_string = !emit_string in
+      let saved_emit_instruction = !emit_instruction in
+      emit_string := None;
+      emit_instruction := Some capture;
+      Fun.protect
+        ~finally:(fun () ->
+          emit_string := saved_emit_string;
+          emit_instruction := saved_emit_instruction)
+        f
 
     type measurement =
       { count : int;

--- a/backend/arm64/ast/ast.ml
+++ b/backend/arm64/ast/ast.ml
@@ -3028,9 +3028,20 @@ module DSL = struct
 
     let clear_emit_instruction () = emit_instruction := None
 
+    let emitted_instruction_count = ref 0
+
+    let emitted_instructions () = !emitted_instruction_count
+
     let emit_existing instr =
+      (* [emit_string] is always set during final emission, and unset during the
+         measuring and buffering passes ([with_measuring] and
+         [with_redirected_emit] below), so it distinguishes instructions
+         actually emitted from ones merely measured or buffered. *)
+      if Option.is_some !emit_string then incr emitted_instruction_count;
       (* Emit to binary emitter if configured *)
-      (match !emit_instruction with Some emit -> emit instr | None -> ());
+      (match !emit_instruction with
+      | Some emit -> emit instr
+      | None -> ());
       (* Emit to text if configured *)
       let str = Format.asprintf "\t%a\n" Instruction.print instr in
       match !emit_string with None -> () | Some emit_string -> emit_string str

--- a/backend/arm64/ast/ast.mli
+++ b/backend/arm64/ast/ast.mli
@@ -564,7 +564,7 @@ end
     the same width class. *)
 module LDP_STP_width : sig
   type (_, _) t =
-    | X : ([< `X | `LR], [< `X | `LR]) t
+    | X : ([< `X | `LR | `XZR], [< `X | `LR | `XZR]) t
     | W : ([< `W], [< `W]) t
 end
 

--- a/backend/arm64/ast/ast.mli
+++ b/backend/arm64/ast/ast.mli
@@ -1870,6 +1870,16 @@ module DSL : sig
         conditional branches. *)
     val with_measuring : f:(unit -> unit) -> measurement
 
+    (** Pass a previously-built instruction to the emission callbacks, exactly
+        as [ins] does for a newly-built one. *)
+    val emit_existing : Instruction.t -> unit
+
+    (** Execute [f] with text emission disabled and instructions redirected to
+        [emit_instruction], restoring the previous callbacks afterwards. Used to
+        buffer a function body for peephole optimization. *)
+    val with_redirected_emit :
+      emit_instruction:(Instruction.t -> unit) -> f:(unit -> 'a) -> 'a
+
     val ins1 : (singleton, 'a) Instruction_name.t -> 'a Operand.t -> unit
 
     val ins2 :

--- a/backend/arm64/ast/ast.mli
+++ b/backend/arm64/ast/ast.mli
@@ -1854,6 +1854,11 @@ module DSL : sig
     (** Clear the binary emission callback. *)
     val clear_emit_instruction : unit -> unit
 
+    (** Number of instructions actually emitted so far (excluding the measuring
+        and buffering passes). Monotonically increasing; callers interested in a
+        particular region should take deltas. *)
+    val emitted_instructions : unit -> int
+
     (** Passes the instruction to the function provided to [set_emit_string].
         Also passes to [set_emit_instruction] callback if set. (Can't directly
         reference [Emitaux] due to a circular dependency.) *)

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -2266,7 +2266,7 @@ let record_for_expect_asm ~name ~debug_info ~body =
 
 (* Emission of a function declaration *)
 
-let fundecl fundecl =
+let emit_fundecl fundecl =
   let fun_end_label, fundecl =
     match Emitaux.Dwarf_helpers.record_dwarf_for_fundecl fundecl with
     | None -> None, fundecl
@@ -2359,6 +2359,16 @@ let fundecl fundecl =
   D.type_symbol ~ty:Function fun_sym;
   D.size fun_sym;
   emit_literals env
+
+let fundecl fundecl =
+  let start_count = A.emitted_instructions () in
+  let counter_f () =
+    Profile.Counters.set "emitted_instructions"
+      (A.emitted_instructions () - start_count)
+      (Profile.Counters.create ())
+  in
+  Profile.record_call_with_counters ~accumulate:true ~counter_f "arm64_emit"
+    (fun () -> emit_fundecl fundecl)
 
 (* Emission of data *)
 

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -37,6 +37,7 @@ module Simd_int_cmp = Ast.Simd_int_cmp
 module Branch_cond = Ast.Branch_cond
 module A = Ast.DSL.Acc
 module D = Asm_targets.Asm_directives
+module DLL = Doubly_linked_list
 module H = Dsl_helpers
 module I = Ast.Instruction_name
 module L = Asm_targets.Asm_label
@@ -2116,6 +2117,153 @@ let rec emit_all env i =
     emit_instr env i;
     emit_all env i.next)
 
+(* The sink that directives from [D] are written to. [begin_assembly] installs
+   the real sink (binary emitter and text output); [fundecl] temporarily
+   redirects it to a buffer when the peephole optimizer or expect_asm tests are
+   active. *)
+let directive_sink : (D.Directive.t -> unit) ref =
+  ref (fun (_ : D.Directive.t) ->
+      Misc.fatal_error "Arm64 emitter: directive sink not initialised")
+
+(* These callbacks are just instrumentation for expect_asm tests. *)
+let expect_asm_callbacks = ref []
+
+let asm_collected_for_expect_asm = ref []
+
+let register_expect_asm_callback f =
+  (* Reset label counter to make assembly more predictable. *)
+  Label.reset ();
+  expect_asm_callbacks := f :: !expect_asm_callbacks
+
+let invoke_expect_asm_callbacks () =
+  let output =
+    "\n" ^ String.concat "\n" (List.rev !asm_collected_for_expect_asm)
+  in
+  let callbacks = !expect_asm_callbacks in
+  expect_asm_callbacks := [];
+  asm_collected_for_expect_asm := [];
+  List.iter (fun f -> f output) callbacks
+
+(* Format a buffered function body for expect_asm tests, mirroring
+   [X86_gas.format_asm_for_expect_asm]: labels defined in the body are
+   renumbered sequentially so that the output does not depend on label numbering
+   elsewhere in the unit, only instructions and labels are printed, and tabs are
+   converted to spaces. References to labels defined outside the body (e.g. GC
+   jump pads, which are emitted after the function body) are left as-is; they
+   are deterministic because [register_expect_asm_callback] resets the label
+   counter. *)
+let format_asm_for_expect_asm ~name
+    ~(body : Arm64_peephole.Peephole_utils.asm_line DLL.t) =
+  let module PU = Arm64_peephole.Peephole_utils in
+  let tab_stops = [| 2; 8 |] in
+  let tabs_to_spaces s =
+    let result = Buffer.create (String.length s) in
+    let col = ref 0 in
+    let tab_index = ref 0 in
+    String.iter
+      (fun c ->
+        if Char.equal c '\t' && !tab_index < Array.length tab_stops
+        then (
+          let target_col = tab_stops.(!tab_index) in
+          let spaces = max 1 (target_col - !col) in
+          for _ = 1 to spaces do
+            Buffer.add_char result ' '
+          done;
+          col := !col + spaces;
+          incr tab_index)
+        else (
+          Buffer.add_char result c;
+          incr col))
+      s;
+    Buffer.contents result
+  in
+  let label_map : (string, L.t) Hashtbl.t = Hashtbl.create 16 in
+  let next_id = ref 0 in
+  DLL.iter body ~f:(fun line ->
+      match[@warning "-4"] line with
+      | PU.Directive (New_label (Label l, _)) ->
+        Hashtbl.add label_map (L.encode l) (L.create_int (L.section l) !next_id);
+        incr next_id
+      | _ -> ());
+  let rewrite_label l =
+    match Hashtbl.find_opt label_map (L.encode l) with
+    | None -> l
+    | Some new_label -> new_label
+  in
+  (* Label references inside instructions (branch targets, [adr], ...) are
+     rewritten textually on the printed line: an exact-token replacement, where
+     a token may not be followed by an identifier character (so that e.g.
+     renumbering [.L1] does not corrupt [.L10]). *)
+  let is_ident_char c =
+    match c with
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '$' -> true
+    | _ -> false
+  in
+  let replace_token s old_tok new_tok =
+    let result = Buffer.create (String.length s) in
+    let len = String.length s in
+    let old_len = String.length old_tok in
+    let i = ref 0 in
+    while !i < len do
+      if
+        !i + old_len <= len
+        && String.equal (String.sub s !i old_len) old_tok
+        && (!i + old_len = len || not (is_ident_char s.[!i + old_len]))
+      then (
+        Buffer.add_string result new_tok;
+        i := !i + old_len)
+      else (
+        Buffer.add_char result s.[!i];
+        incr i)
+    done;
+    Buffer.contents result
+  in
+  let rewrite_label_references s =
+    Hashtbl.fold
+      (fun old_str new_label s -> replace_token s old_str (L.encode new_label))
+      label_map s
+  in
+  let buf = Buffer.create 1024 in
+  Buffer.add_string buf (name ^ ":\n");
+  DLL.iter body ~f:(fun line ->
+      match line with
+      | PU.Ins ins ->
+        let text = Format.asprintf "\t%a" Ast.Instruction.print ins in
+        Buffer.add_string buf (tabs_to_spaces (rewrite_label_references text));
+        Buffer.add_char buf '\n'
+      | PU.Directive d ->
+        let should_output =
+          match[@warning "-4"] d with New_label _ -> true | _ -> false
+        in
+        if should_output
+        then (
+          let line_buf = Buffer.create 128 in
+          D.Directive.print line_buf (D.Directive.map_new_label rewrite_label d);
+          Buffer.add_string buf (tabs_to_spaces (Buffer.contents line_buf));
+          Buffer.add_char buf '\n'));
+  Buffer.contents buf
+
+let record_for_expect_asm ~name ~debug_info ~body =
+  if
+    (not (List.is_empty !expect_asm_callbacks))
+    && (not (String.ends_with ~suffix:"__entry" name))
+    && not (String.starts_with ~prefix:"caml_curry" name)
+  then
+    let name =
+      match Debuginfo.to_items debug_info with
+      | item :: _ ->
+        (* CR-someday ttebbi: We could assign disambiguating names for multiple
+           anonymous functions *)
+        Debuginfo.Scoped_location.string_of_scopes ~include_zero_alloc:false
+          item.dinfo_scopes
+        (* Remove the module name introduced by the toplevel eval loop. *)
+        |> Misc.Stdlib.String.split_first_exn ~split_on:'.'
+        |> snd
+      | [] -> name
+    in
+    let output = format_asm_for_expect_asm ~name ~body in
+    asm_collected_for_expect_asm := output :: !asm_collected_for_expect_asm
+
 (* Emission of a function declaration *)
 
 let fundecl fundecl =
@@ -2146,7 +2294,42 @@ let fundecl fundecl =
   emit_debug_info fundecl.fun_dbg;
   D.cfi_startproc ();
   let num_call_gc_sites = relax_branches env fundecl.fun_body in
-  emit_all env fundecl.fun_body;
+  let expect_asm = not (List.is_empty !expect_asm_callbacks) in
+  if !Oxcaml_flags.arm64_peephole_optimize || expect_asm
+  then (
+    (* Capture the function body (instructions from [A], directives and labels
+       from [D]) into a buffer, run the peephole optimizer over it, then flush:
+       replay each line through the original sinks, in order. The out-of-line
+       blocks below (GC calls, local realloc, stack realloc) are not captured,
+       mirroring amd64 where the peephole runs before they are emitted; each of
+       them starts with a label, which is a hard barrier for the rewrite rules
+       anyway. All rules shrink or keep code size and never create, move or
+       delete labels, so the branch displacements computed by [relax_branches]
+       above remain valid upper bounds. *)
+    let buffer : Arm64_peephole.Peephole_utils.asm_line DLL.t =
+      DLL.make_empty ()
+    in
+    let saved_directive_sink = !directive_sink in
+    (directive_sink
+       := fun d ->
+            DLL.add_end buffer (Arm64_peephole.Peephole_utils.Directive d));
+    Fun.protect
+      ~finally:(fun () -> directive_sink := saved_directive_sink)
+      (fun () ->
+        A.with_redirected_emit
+          ~emit_instruction:(fun i ->
+            DLL.add_end buffer (Arm64_peephole.Peephole_utils.Ins i))
+          ~f:(fun () -> emit_all env fundecl.fun_body));
+    if !Oxcaml_flags.arm64_peephole_optimize
+    then Arm64_peephole.Peephole_optimize.optimize buffer;
+    if expect_asm
+    then
+      record_for_expect_asm ~name:fundecl.fun_name ~debug_info:fundecl.fun_dbg
+        ~body:buffer;
+    DLL.iter buffer ~f:(function
+      | Arm64_peephole.Peephole_utils.Ins i -> A.emit_existing i
+      | Arm64_peephole.Peephole_utils.Directive d -> !directive_sink d))
+  else emit_all env fundecl.fun_body;
   List.iter emit_call_gc (Env.call_gc_sites env);
   List.iter emit_local_realloc (Env.local_realloc_sites env);
   emit_stack_realloc env;
@@ -2205,15 +2388,18 @@ let begin_assembly _unix =
      set *)
   let binary_emitter_callback = Binary_emitter_helpers.begin_emission () in
   let asm_line_buffer = Buffer.create 200 in
+  (directive_sink
+     := fun d ->
+          (* Emit to binary emitter if enabled *)
+          binary_emitter_callback d;
+          (* Emit to text *)
+          Buffer.clear asm_line_buffer;
+          D.Directive.print asm_line_buffer d;
+          Buffer.add_string asm_line_buffer "\n";
+          Emitaux.emit_buffer asm_line_buffer);
   D.initialize ~big_endian:Arch.big_endian
     ~emit_assembly_comments:!Oxcaml_flags.dasm_comments ~emit:(fun d ->
-      (* Emit to binary emitter if enabled *)
-      binary_emitter_callback d;
-      (* Emit to text *)
-      Buffer.clear asm_line_buffer;
-      D.Directive.print asm_line_buffer d;
-      Buffer.add_string asm_line_buffer "\n";
-      Emitaux.emit_buffer asm_line_buffer);
+      !directive_sink d);
   D.file ~file_num:None ~file_name:"";
   (* PR#7037 *)
   let data_begin = Cmm_helpers.make_symbol "data_begin" in
@@ -2236,9 +2422,6 @@ let begin_assembly _unix =
     D.align ~fill:Nop ~bytes:8);
   let code_end = Cmm_helpers.make_symbol "code_end" in
   Emitaux.Dwarf_helpers.begin_dwarf ~code_begin ~code_end ~file_emitter
-
-(* Not implemented for arm64 *)
-let register_expect_asm_callback (_ : string -> unit) = ()
 
 let end_assembly () =
   let code_end = Cmm_helpers.make_symbol "code_end" in
@@ -2304,5 +2487,6 @@ let end_assembly () =
   then Emitaux.Dwarf_helpers.emit_dwarf ();
   Probe_emission.emit_probe_notes ~add_def_symbol:(fun _ -> ());
   D.mark_stack_non_executable ();
+  invoke_expect_asm_callbacks ();
   (* Finalize binary emitter if enabled *)
   Binary_emitter_helpers.end_emission ()

--- a/backend/arm64/emit.ml
+++ b/backend/arm64/emit.ml
@@ -1404,15 +1404,32 @@ let emit_instr env i =
   | Lprologue ->
     assert (Env.prologue_required env);
     let n = Env.frame_size env in
-    if n > 0 then emit_stack_adjustment (-n);
-    if Env.contains_calls env
+    if n = 16 && Env.contains_calls env && !Oxcaml_flags.arm64_fuse_frame_ops
     then (
-      D.cfi_offset ~reg:(R.gp_encoding R.lr) ~offset:(-8);
-      emit_str_sp_offset O.lr (n - 8))
+      (* Allocate the frame and save lr in a single instruction. lr must stay at
+         the top of the frame ([sp, #8]) to preserve the runtime's frame walking
+         invariant. The zero written to the remaining slot is dead: stack slots
+         are always stored before being read, and the GC only scans slots that
+         the frametable marks live at a call site, which requires a prior
+         store. *)
+      A.ins3 (STP X) O.xzr O.lr (O.mem_pre_pair ~base:R.sp ~offset:(-16));
+      D.cfi_adjust_cfa_offset ~bytes:16;
+      D.cfi_offset ~reg:(R.gp_encoding R.lr) ~offset:(-8))
+    else (
+      if n > 0 then emit_stack_adjustment (-n);
+      if Env.contains_calls env
+      then (
+        D.cfi_offset ~reg:(R.gp_encoding R.lr) ~offset:(-8);
+        emit_str_sp_offset O.lr (n - 8)))
   | Lepilogue_open ->
     let n = Env.frame_size env in
-    if Env.contains_calls env then emit_ldr_sp_offset O.lr (n - 8);
-    if n > 0 then emit_stack_adjustment n
+    if n = 16 && Env.contains_calls env && !Oxcaml_flags.arm64_fuse_frame_ops
+    then (
+      A.ins3 (LDP X) O.xzr O.lr (O.mem_post_pair ~base:R.sp ~offset:16);
+      D.cfi_adjust_cfa_offset ~bytes:(-16))
+    else (
+      if Env.contains_calls env then emit_ldr_sp_offset O.lr (n - 8);
+      if n > 0 then emit_stack_adjustment n)
   | Lepilogue_close ->
     let n = Env.frame_size env in
     if n > 0 then D.cfi_adjust_cfa_offset ~bytes:n

--- a/backend/arm64_peephole/dune
+++ b/backend/arm64_peephole/dune
@@ -1,0 +1,7 @@
+(library
+ (name arm64_peephole)
+ (wrapped true)
+ (ocamlopt_flags
+  (:standard -w +4
+   (:include %{project_root}/ocamlopt_flags.sexp)))
+ (libraries ocamlcommon asm_targets arm64_ast oxcaml_common))

--- a/backend/arm64_peephole/peephole_optimize.ml
+++ b/backend/arm64_peephole/peephole_optimize.ml
@@ -5,11 +5,12 @@ module DLL = Doubly_linked_list
 module R = Peephole_rules
 module U = Peephole_utils
 
-let stats = R.create_peephole_stats ()
-
 (* Main optimization loop. Iterates through the buffered function body, applying
    rewrite rules and respecting hard barriers. *)
 let optimize buffer =
+  (* Fresh stats per call: [Profile] sums the [counter_f] results of successive
+     accumulated calls, so each call must report its own delta. *)
+  let stats = R.create_peephole_stats () in
   let counter_f () = R.peephole_stats_to_counters stats in
   Profile.record_with_counters ~accumulate:true ~counter_f "arm64_peephole"
     (fun () ->

--- a/backend/arm64_peephole/peephole_optimize.ml
+++ b/backend/arm64_peephole/peephole_optimize.ml
@@ -1,0 +1,28 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+module DLL = Doubly_linked_list
+module R = Peephole_rules
+module U = Peephole_utils
+
+let stats = R.create_peephole_stats ()
+
+(* Main optimization loop. Iterates through the buffered function body, applying
+   rewrite rules and respecting hard barriers. *)
+let optimize buffer =
+  let counter_f () = R.peephole_stats_to_counters stats in
+  Profile.record_with_counters ~accumulate:true ~counter_f "arm64_peephole"
+    (fun () ->
+      let rec optimize cell_opt =
+        match cell_opt with
+        | None -> ()
+        | Some cell -> (
+          if U.is_hard_barrier (DLL.value cell)
+          then optimize (DLL.next cell)
+          else
+            match R.apply stats cell with
+            | U.Matched continuation_cell -> optimize continuation_cell
+            | U.No_match -> optimize (DLL.next cell))
+      in
+      optimize (DLL.hd_cell buffer))
+    ()

--- a/backend/arm64_peephole/peephole_optimize.mli
+++ b/backend/arm64_peephole/peephole_optimize.mli
@@ -1,0 +1,5 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Run the peephole optimizer over a buffered function body, walking forward
+    through the list of assembly lines. *)
+val optimize : Peephole_utils.asm_line Doubly_linked_list.t -> unit

--- a/backend/arm64_peephole/peephole_rules.ml
+++ b/backend/arm64_peephole/peephole_rules.ml
@@ -1,0 +1,571 @@
+[@@@ocaml.warning "+a-4-40-41-42"]
+
+open! Int_replace_polymorphic_compare
+open Arm64_ast.Ast
+module DLL = Doubly_linked_list
+module U = Peephole_utils
+module Gp = U.Gp
+
+type peephole_stats =
+  { mutable fuse_str_pairs : int;
+    mutable fuse_ldr_pairs : int;
+    mutable merge_add_immediates : int;
+    mutable remove_redundant_cmp : int;
+    mutable compose_shift_pairs : int
+  }
+
+let create_peephole_stats () =
+  { fuse_str_pairs = 0;
+    fuse_ldr_pairs = 0;
+    merge_add_immediates = 0;
+    remove_redundant_cmp = 0;
+    compose_shift_pairs = 0
+  }
+
+let peephole_stats_to_counters stats =
+  Profile.Counters.create ()
+  |> Profile.Counters.set "arm64_peephole.fuse_str_pairs" stats.fuse_str_pairs
+  |> Profile.Counters.set "arm64_peephole.fuse_ldr_pairs" stats.fuse_ldr_pairs
+  |> Profile.Counters.set "arm64_peephole.merge_add_immediates"
+       stats.merge_add_immediates
+  |> Profile.Counters.set "arm64_peephole.remove_redundant_cmp"
+       stats.remove_redundant_cmp
+  |> Profile.Counters.set "arm64_peephole.compose_shift_pairs"
+       stats.compose_shift_pairs
+
+(* Decoding helpers over the typed AST. Rewrite rules never reuse a matched
+   register or operand in a rebuilt instruction (the GADT existentials make that
+   awkward); they decode operands to plain values here and rebuild concrete
+   operands through the [DSL] smart constructors. *)
+
+let ins_of_cell cell =
+  match DLL.value cell with U.Ins ins -> Some ins | U.Directive _ -> None
+
+let twelve_value (type w) (op : [`Imm of w] Operand.t) : int option =
+  match op with Imm (Twelve value) -> Some value | Imm _ -> None
+
+let six_value (op : [`Imm of [`Six]] Operand.t) : int =
+  match op with Imm (Six value) -> value
+
+let optional_is_none (type a) (op : [`Optional of a option] Operand.t) : bool =
+  match op with Optional None -> true | Optional (Some _) -> false
+
+(* An X-class transfer register, remembering the assembly spelling so that
+   rebuilt instructions use the same one. *)
+type xreg =
+  | Xn of int
+  | Xlr
+
+let decode_xreg (type a) (reg : [`GP of a] Reg.t) : xreg option =
+  match reg.reg_name with
+  | GP X -> Some (Xn reg.index)
+  | GP LR -> Some Xlr
+  | GP (W | WZR | XZR | WSP | SP | FP) -> None
+
+let xreg_gp = function Xn i -> Gp.Reg64 i | Xlr -> Gp.Reg64 30
+
+(* Rewrite rule: fuse two adjacent 64-bit loads (resp. stores) with the same
+   base register and byte offsets differing by exactly 8 into a single [ldp]
+   (resp. [stp]).
+
+   Pattern: str rA, [rB, #k]; str rC, [rB, #k+-8] (and dually for ldr) Rewrite:
+   stp rlo, rhi, [rB, #min(k, k')]
+
+   Safety: - adjacency (no label in between, cf. [U.next_instruction])
+   guarantees that no call or GC point is crossed and that the second
+   instruction has no other predecessor; - the two stores are to the same base
+   with disjoint offsets, so their relative order is not observable; - for
+   loads, the two destinations must differ (such an [ldp] is
+   constrained-unpredictable) and the first destination must not be the base
+   register (the original second load would have used the updated base); - the
+   fused offset must be a multiple of 8 in [-512, 504], the range of the scaled
+   7-bit immediate (also checked by [DSL.mem_offset_pair]). *)
+
+type transfer =
+  { is_load : bool;
+    reg : xreg;
+    base : Gp.t;
+    offset : int
+  }
+
+let decode_transfer (Instruction.I { name; operands }) : transfer option =
+  match name, operands with
+  | LDR, Pair (Reg reg, mem) -> (
+    match decode_xreg reg, U.decode_simple_mem mem with
+    | Some reg, Some (base, offset) ->
+      Some { is_load = true; reg; base; offset }
+    | None, _ | _, None -> None)
+  | STR, Pair (Reg reg, mem) -> (
+    match decode_xreg reg, U.decode_simple_mem mem with
+    | Some reg, Some (base, offset) ->
+      Some { is_load = false; reg; base; offset }
+    | None, _ | _, None -> None)
+  | _, _ -> None
+
+let make_transfer_pair ~is_load ~base ~offset ~lo ~hi : Instruction.t option =
+  let ins name operands = Instruction.I { name; operands } in
+  let mem () = DSL.mem_offset_pair ~base ~offset in
+  match is_load, lo, hi with
+  | false, Xn a, Xn b ->
+    Some (ins (STP X) (Triple (DSL.reg_x a, DSL.reg_x b, mem ())))
+  | false, Xn a, Xlr ->
+    Some (ins (STP X) (Triple (DSL.reg_x a, DSL.lr, mem ())))
+  | false, Xlr, Xn b ->
+    Some (ins (STP X) (Triple (DSL.lr, DSL.reg_x b, mem ())))
+  | false, Xlr, Xlr -> Some (ins (STP X) (Triple (DSL.lr, DSL.lr, mem ())))
+  | true, Xn a, Xn b ->
+    Some (ins (LDP X) (Triple (DSL.reg_x a, DSL.reg_x b, mem ())))
+  | true, Xn a, Xlr -> Some (ins (LDP X) (Triple (DSL.reg_x a, DSL.lr, mem ())))
+  | true, Xlr, Xn b -> Some (ins (LDP X) (Triple (DSL.lr, DSL.reg_x b, mem ())))
+  | true, Xlr, Xlr ->
+    (* Rejected before this point: equal load destinations. *)
+    None
+
+let fuse_memory_pairs stats cell =
+  match Option.bind (ins_of_cell cell) decode_transfer with
+  | None -> U.No_match
+  | Some t1 -> (
+    match U.next_instruction cell with
+    | None -> U.No_match
+    | Some cell2 -> (
+      match Option.bind (ins_of_cell cell2) decode_transfer with
+      | None -> U.No_match
+      | Some t2 -> (
+        let lo, hi = if t1.offset < t2.offset then t1, t2 else t2, t1 in
+        let offset_ok =
+          abs (t1.offset - t2.offset) = 8
+          && lo.offset mod 8 = 0
+          && lo.offset >= -512 && lo.offset <= 504
+        in
+        let load_ok =
+          (not t1.is_load)
+          || (not (Gp.equal (xreg_gp t1.reg) (xreg_gp t2.reg)))
+             && not (Gp.equal (xreg_gp t1.reg) t1.base)
+        in
+        if
+          not
+            (Bool.equal t1.is_load t2.is_load
+            && Gp.equal t1.base t2.base && offset_ok && load_ok)
+        then U.No_match
+        else
+          let fused =
+            match t1.base with
+            | Gp.Reg64 i ->
+              make_transfer_pair ~is_load:t1.is_load ~base:(Reg.reg_x i)
+                ~offset:lo.offset ~lo:lo.reg ~hi:hi.reg
+            | Gp.Sp ->
+              make_transfer_pair ~is_load:t1.is_load ~base:Reg.sp
+                ~offset:lo.offset ~lo:lo.reg ~hi:hi.reg
+            | Gp.Reg32 _ | Gp.Zr64 | Gp.Zr32 ->
+              (* Cannot happen: the base register of an addressing mode is an X
+                 register or [sp]. *)
+              None
+          in
+          match fused with
+          | None -> U.No_match
+          | Some fused ->
+            DLL.set_value cell (U.Ins fused);
+            U.delete_next_instruction_and_locs cell;
+            if t1.is_load
+            then stats.fuse_ldr_pairs <- stats.fuse_ldr_pairs + 1
+            else stats.fuse_str_pairs <- stats.fuse_str_pairs + 1;
+            U.Matched (Some cell))))
+
+(* Rewrite rule: merge two adjacent add/sub-immediates through the same
+   register.
+
+   Pattern: add rd, rn, #k1; add rd, rd, #k2 (and the sub/mixed variants)
+   Rewrite: add rd, rn, #(k1+k2) (or sub, depending on the sign of the sum)
+
+   The destination is restricted to plain [x0]-[x28]: excluding [sp] keeps the
+   rule away from stack adjustments and their paired CFI directives, and
+   excluding [fp]/[lr] (x29/x30) is conservative. The combined immediate must be
+   encodable: 12 bits, optionally shifted left by 12 (the domain of
+   [DSL.imm]). *)
+
+type add_src =
+  | Src_x of int
+  | Src_sp
+  | Src_fp
+
+let decode_add_src (type a) (reg : [`GP of a] Reg.t) : add_src option =
+  match reg.reg_name with
+  | GP X -> Some (Src_x reg.index)
+  | GP (SP | WSP) -> Some Src_sp
+  | GP FP -> Some Src_fp
+  | GP (W | WZR | XZR | LR) -> None
+
+let decode_add_dest (type a) (reg : [`GP of a] Reg.t) : int option =
+  match reg.reg_name with
+  | GP X -> if reg.index <= 28 then Some reg.index else None
+  | GP (W | WZR | XZR | WSP | SP | LR | FP) -> None
+
+type add_imm =
+  { rd : int;
+    src : add_src;
+    value : int (* signed: positive for add, negative for sub *)
+  }
+
+let decode_add_imm (Instruction.I { name; operands }) : add_imm option =
+  let decode ~negate rd rn imm shift =
+    if not (optional_is_none shift)
+    then None
+    else
+      match decode_add_dest rd, decode_add_src rn, twelve_value imm with
+      | Some rd, Some src, Some value ->
+        Some { rd; src; value = (if negate then -value else value) }
+      | None, _, _ | _, None, _ | _, _, None -> None
+  in
+  match name, operands with
+  | ADD_immediate, Quad (Reg rd, Reg rn, imm, shift) ->
+    decode ~negate:false rd rn imm shift
+  | SUB_immediate, Quad (Reg rd, Reg rn, imm, shift) ->
+    decode ~negate:true rd rn imm shift
+  | _, _ -> None
+
+let encodable_imm12 value =
+  value >= 0 && (value <= 0xFFF || (value <= 0xFFF_000 && value land 0xFFF = 0))
+
+let make_add_imm ~rd ~src ~value : Instruction.t option =
+  let ins name operands = Instruction.I { name; operands } in
+  if value >= 0
+  then
+    let imm = DSL.imm value in
+    match src with
+    | Src_x j ->
+      Some
+        (ins ADD_immediate
+           (Quad (DSL.reg_x rd, DSL.reg_x j, imm, DSL.optional_none)))
+    | Src_sp ->
+      Some
+        (ins ADD_immediate
+           (Quad (DSL.reg_x rd, DSL.sp, imm, DSL.optional_none)))
+    | Src_fp ->
+      Some
+        (ins ADD_immediate
+           (Quad (DSL.reg_x rd, DSL.fp, imm, DSL.optional_none)))
+  else
+    let imm = DSL.imm (-value) in
+    match src with
+    | Src_x j ->
+      Some
+        (ins SUB_immediate
+           (Quad (DSL.reg_x rd, DSL.reg_x j, imm, DSL.optional_none)))
+    | Src_sp ->
+      Some
+        (ins SUB_immediate
+           (Quad (DSL.reg_x rd, DSL.sp, imm, DSL.optional_none)))
+    | Src_fp ->
+      (* [SUB_immediate] does not admit an [fp] source operand. *)
+      None
+
+let merge_add_immediates stats cell =
+  match Option.bind (ins_of_cell cell) decode_add_imm with
+  | None -> U.No_match
+  | Some d1 -> (
+    match U.next_instruction cell with
+    | None -> U.No_match
+    | Some cell2 -> (
+      match Option.bind (ins_of_cell cell2) decode_add_imm with
+      | None -> U.No_match
+      | Some d2 -> (
+        let second_reads_and_rewrites_first_dest =
+          match d2.src with
+          | Src_x j -> j = d1.rd && d2.rd = d1.rd
+          | Src_sp | Src_fp -> false
+        in
+        let value = d1.value + d2.value in
+        if
+          not
+            (second_reads_and_rewrites_first_dest && encodable_imm12 (abs value))
+        then U.No_match
+        else
+          match make_add_imm ~rd:d1.rd ~src:d1.src ~value with
+          | None -> U.No_match
+          | Some merged ->
+            DLL.set_value cell (U.Ins merged);
+            U.delete_next_instruction_and_locs cell;
+            stats.merge_add_immediates <- stats.merge_add_immediates + 1;
+            U.Matched (Some cell))))
+
+(* Rewrite rule: remove a compare that is identical to an earlier one, with no
+   intervening write to the flags or to the compared registers.
+
+   Pattern: subs xzr, rn, op; ...; subs xzr, rn, op Rewrite: subs xzr, rn, op;
+   ...
+
+   The scan continues through conditional branches: they read but do not write
+   the flags, and the second compare can only be reached by fall-through because
+   any other entry point would require a label, which stops the scan. The scan
+   stops at any other control flow, at labels and other barrier directives, at
+   memory-ordering instructions, at flag writers, and at any instruction that
+   may write to (a register overlapping) one of the compared registers -- note
+   that a write to [wN] invalidates a compare reading [xN]. *)
+
+type shift_kind =
+  | Sk_lsl
+  | Sk_lsr
+  | Sk_asr
+
+let equal_shift_kind left right =
+  match left, right with
+  | Sk_lsl, Sk_lsl -> true
+  | Sk_lsr, Sk_lsr -> true
+  | Sk_asr, Sk_asr -> true
+  | (Sk_lsl | Sk_lsr | Sk_asr), _ -> false
+
+type cmp_shape =
+  | Cmp_imm of
+      { is64 : bool;
+        rn : Gp.t;
+        value : int;
+        shifted : bool
+      }
+  | Cmp_reg of
+      { rn : Gp.t;
+        rm : Gp.t;
+        shift : (shift_kind * int) option
+      }
+
+let decode_zr (type a) (reg : [`GP of a] Reg.t) : bool option =
+  match reg.reg_name with
+  | GP XZR -> Some true
+  | GP WZR -> Some false
+  | GP (W | X | WSP | SP | LR | FP) -> None
+
+(* Returns [None] if the shift operand cannot be decoded, [Some None] if there
+   is no shift, and [Some (Some _)] for a decoded shift. *)
+let decode_optional_shift (type k)
+    (op : [`Optional of [`Shift of k * [`Six]] option] Operand.t) :
+    (shift_kind * int) option option =
+  match op with
+  | Optional None -> Some None
+  | Optional (Some (Shift { kind; amount })) -> (
+    let kind =
+      match kind with
+      | Operand.Shift.Kind.LSL -> Sk_lsl
+      | Operand.Shift.Kind.LSR -> Sk_lsr
+      | Operand.Shift.Kind.ASR -> Sk_asr
+    in
+    match amount with Six amount -> Some (Some (kind, amount)))
+
+let decode_cmp (Instruction.I { name; operands }) : cmp_shape option =
+  match name, operands with
+  | SUBS_immediate, Quad (Reg zr, Reg rn, imm, shift) -> (
+    match decode_zr zr, twelve_value imm with
+    | Some is64, Some value ->
+      Some
+        (Cmp_imm
+           { is64;
+             rn = Gp.of_reg rn;
+             value;
+             shifted = not (optional_is_none shift)
+           })
+    | None, _ | _, None -> None)
+  | SUBS_shifted_register, Quad (Reg zr, Reg rn, Reg rm, shift) -> (
+    match decode_zr zr with
+    | Some true -> (
+      match decode_optional_shift shift with
+      | None -> None
+      | Some shift ->
+        Some (Cmp_reg { rn = Gp.of_reg rn; rm = Gp.of_reg rm; shift }))
+    | Some false | None -> None)
+  | _, _ -> None
+
+let equal_cmp_shape left right =
+  match left, right with
+  | Cmp_imm l, Cmp_imm r ->
+    Bool.equal l.is64 r.is64 && Gp.equal l.rn r.rn && l.value = r.value
+    && Bool.equal l.shifted r.shifted
+  | Cmp_reg l, Cmp_reg r ->
+    Gp.equal l.rn r.rn && Gp.equal l.rm r.rm
+    && Option.equal
+         (fun (k1, a1) (k2, a2) -> equal_shift_kind k1 k2 && a1 = a2)
+         l.shift r.shift
+  | Cmp_imm _, Cmp_reg _ | Cmp_reg _, Cmp_imm _ -> false
+
+let cmp_reads = function
+  | Cmp_imm { rn; _ } -> [rn]
+  | Cmp_reg { rn; rm; _ } -> [rn; rm]
+
+let find_redundant_cmp shape start_cell =
+  let reads = cmp_reads shape in
+  let rec loop cell_opt =
+    match cell_opt with
+    | None -> None
+    | Some cell -> (
+      match DLL.value cell with
+      | U.Directive d ->
+        if U.directive_is_barrier d then None else loop (DLL.next cell)
+      | U.Ins ins -> (
+        match decode_cmp ins with
+        | Some shape' when equal_cmp_shape shape shape' -> Some cell
+        | Some _ | None ->
+          if U.is_conditional_branch ins
+          then loop (DLL.next cell)
+          else if
+            U.is_hard_barrier (U.Ins ins)
+            || U.writes_flags ins
+            || U.writes_any_gp_reg ins ~regs:reads
+          then None
+          else loop (DLL.next cell)))
+  in
+  loop (DLL.next start_cell)
+
+let remove_redundant_cmp stats cell =
+  match Option.bind (ins_of_cell cell) decode_cmp with
+  | None -> U.No_match
+  | Some shape -> (
+    match find_redundant_cmp shape cell with
+    | None -> U.No_match
+    | Some redundant_cell ->
+      DLL.delete_curr redundant_cell;
+      stats.remove_redundant_cmp <- stats.remove_redundant_cmp + 1;
+      U.Matched (Some cell))
+
+(* Rewrite rule: compose two adjacent 64-bit immediate shifts through the same
+   register into a single instruction.
+
+   The emitter produces shifts as raw [ubfm]/[sbfm]; this rule recognizes the
+   lsl/lsr/asr shapes and rewrites e.g. lsl rd, rn, #a; lsr rd, rd, #b into ubfm
+   rd, rn, #(b-a mod 64), #(63-a) (i.e. ubfx/ubfiz), and lsr rd, rn, #a; lsl rd,
+   rd, #a into an [and] that clears the low [a] bits. Shifts in the same
+   direction add their amounts (an [asr] chain saturates at 63; over-shifted
+   [lsl]/[lsr] chains, which produce zero, are left alone). The intermediate
+   value of [rd] is dead by construction since the second instruction overwrites
+   it and the instructions are adjacent. *)
+
+type shift_op =
+  | Lsl of int
+  | Lsr of int
+  | Asr of int
+
+type shift_ins =
+  { rd : int;
+    rn : int;
+    op : shift_op
+  }
+
+let decode_xn (type a) (reg : [`GP of a] Reg.t) : int option =
+  match reg.reg_name with
+  | GP X -> Some reg.index
+  | GP (W | WZR | XZR | WSP | SP | LR | FP) -> None
+
+let decode_shift_ins (Instruction.I { name; operands }) : shift_ins option =
+  match name, operands with
+  | UBFM, Quad (Reg rd, Reg rn, immr, imms) -> (
+    match decode_xn rd, decode_xn rn with
+    | Some rd, Some rn ->
+      let immr = six_value immr and imms = six_value imms in
+      if imms = 63 && immr >= 1
+      then Some { rd; rn; op = Lsr immr }
+      else if immr = imms + 1 && imms <= 62
+      then Some { rd; rn; op = Lsl (63 - imms) }
+      else None
+    | None, _ | _, None -> None)
+  | SBFM, Quad (Reg rd, Reg rn, immr, imms) -> (
+    match decode_xn rd, decode_xn rn with
+    | Some rd, Some rn ->
+      let immr = six_value immr and imms = six_value imms in
+      if imms = 63 && immr >= 1 then Some { rd; rn; op = Asr immr } else None
+    | None, _ | _, None -> None)
+  | _, _ -> None
+
+type composed_shift =
+  | Comp_ubfm of
+      { immr : int;
+        imms : int
+      }
+  | Comp_sbfm of
+      { immr : int;
+        imms : int
+      }
+  | Comp_clear_low_bits of int
+
+let compose_shift_ops first second =
+  match first, second with
+  | Lsl a, Lsr b ->
+    Some (Comp_ubfm { immr = (b - a + 64) mod 64; imms = 63 - a })
+  | Lsl a, Asr b ->
+    Some (Comp_sbfm { immr = (b - a + 64) mod 64; imms = 63 - a })
+  | (Lsr a | Asr a), Lsl b ->
+    if a = b then Some (Comp_clear_low_bits a) else None
+  | Lsl a, Lsl b ->
+    if a + b <= 63
+    then Some (Comp_ubfm { immr = 64 - (a + b); imms = 63 - (a + b) })
+    else None
+  | Lsr a, (Lsr b | Asr b) ->
+    (* After [lsr #a] with [a >= 1] the top bit is zero, so a following [asr]
+       behaves as [lsr]. *)
+    if a + b <= 63 then Some (Comp_ubfm { immr = a + b; imms = 63 }) else None
+  | Asr a, Asr b -> Some (Comp_sbfm { immr = min (a + b) 63; imms = 63 })
+  | Asr _, Lsr _ ->
+    (* Not expressible as a single [ubfm]/[sbfm]. *)
+    None
+
+let make_composed_shift ~rd ~rn comp : Instruction.t =
+  match comp with
+  | Comp_ubfm { immr; imms } ->
+    Instruction.I
+      { name = UBFM;
+        operands =
+          Quad (DSL.reg_x rd, DSL.reg_x rn, DSL.imm_six immr, DSL.imm_six imms)
+      }
+  | Comp_sbfm { immr; imms } ->
+    Instruction.I
+      { name = SBFM;
+        operands =
+          Quad (DSL.reg_x rd, DSL.reg_x rn, DSL.imm_six immr, DSL.imm_six imms)
+      }
+  | Comp_clear_low_bits bits ->
+    Instruction.I
+      { name = AND_immediate;
+        operands =
+          Triple
+            ( DSL.reg_x rd,
+              DSL.reg_x rn,
+              DSL.bitmask (Nativeint.shift_left (-1n) bits) )
+      }
+
+let compose_shift_pairs stats cell =
+  match Option.bind (ins_of_cell cell) decode_shift_ins with
+  | None -> U.No_match
+  | Some s1 -> (
+    match U.next_instruction cell with
+    | None -> U.No_match
+    | Some cell2 -> (
+      match Option.bind (ins_of_cell cell2) decode_shift_ins with
+      | None -> U.No_match
+      | Some s2 -> (
+        if not (s2.rn = s1.rd && s2.rd = s1.rd)
+        then U.No_match
+        else
+          match compose_shift_ops s1.op s2.op with
+          | None -> U.No_match
+          | Some comp ->
+            DLL.set_value cell
+              (U.Ins (make_composed_shift ~rd:s1.rd ~rn:s1.rn comp));
+            U.delete_next_instruction_and_locs cell;
+            stats.compose_shift_pairs <- stats.compose_shift_pairs + 1;
+            U.Matched (Some cell))))
+
+(* Apply all rewrite rules in sequence using a pipeline. *)
+let apply stats cell =
+  let[@inline always] if_no_match ~enabled f result =
+    match result with
+    | U.Matched _ -> result
+    | U.No_match -> if enabled then f stats cell else U.No_match
+  in
+  U.No_match
+  |> if_no_match
+       ~enabled:!Oxcaml_flags.arm64_peephole_fuse_memory_pairs
+       fuse_memory_pairs
+  |> if_no_match
+       ~enabled:!Oxcaml_flags.arm64_peephole_merge_add_immediates
+       merge_add_immediates
+  |> if_no_match
+       ~enabled:!Oxcaml_flags.arm64_peephole_remove_redundant_cmp
+       remove_redundant_cmp
+  |> if_no_match
+       ~enabled:!Oxcaml_flags.arm64_peephole_compose_shift_pairs
+       compose_shift_pairs

--- a/backend/arm64_peephole/peephole_rules.mli
+++ b/backend/arm64_peephole/peephole_rules.mli
@@ -1,0 +1,17 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module DLL = Doubly_linked_list
+
+(** Statistics for peephole optimizations. *)
+type peephole_stats
+
+val create_peephole_stats : unit -> peephole_stats
+
+val peephole_stats_to_counters : peephole_stats -> Profile.Counters.t
+
+(** Apply all peephole rewrite rules to a cell. Returns [Matched] with a
+    continuation cell if a rule was applied, [No_match] otherwise. *)
+val apply :
+  peephole_stats ->
+  Peephole_utils.asm_line DLL.cell ->
+  Peephole_utils.rule_result

--- a/backend/arm64_peephole/peephole_utils.ml
+++ b/backend/arm64_peephole/peephole_utils.ml
@@ -1,0 +1,226 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open! Int_replace_polymorphic_compare
+open Arm64_ast.Ast
+module DLL = Doubly_linked_list
+
+type asm_line =
+  | Ins of Instruction.t
+  | Directive of Asm_targets.Asm_directives.Directive.t
+
+type rule_result =
+  | No_match
+  | Matched of asm_line DLL.cell option
+
+module Gp = struct
+  type t =
+    | Reg64 of int
+    | Reg32 of int
+    | Zr64
+    | Zr32
+    | Sp
+
+  (* The zero registers and [sp] share the encoding 31, and [lr]/[fp] are stored
+     with a dummy index, so normalization must go through [reg_name] rather than
+     [index] or [Reg.gp_encoding]. *)
+  let of_reg (type a) (reg : [`GP of a] Reg.t) : t =
+    match reg.reg_name with
+    | GP W -> Reg32 reg.index
+    | GP X -> Reg64 reg.index
+    | GP WZR -> Zr32
+    | GP XZR -> Zr64
+    | GP WSP | GP SP -> Sp
+    | GP LR -> Reg64 30
+    | GP FP -> Reg64 29
+
+  let equal left right =
+    match left, right with
+    | Reg64 l, Reg64 r -> l = r
+    | Reg32 l, Reg32 r -> l = r
+    | Zr64, Zr64 -> true
+    | Zr32, Zr32 -> true
+    | Sp, Sp -> true
+    | (Reg64 _ | Reg32 _ | Zr64 | Zr32 | Sp), _ -> false
+
+  (* Whether two register names overlap the same physical register: [wN] and
+     [xN] are the same register, while the zero registers are not physical
+     storage and alias nothing. *)
+  let same_underlying left right =
+    match left, right with
+    | (Reg64 l | Reg32 l), (Reg64 r | Reg32 r) -> l = r
+    | Sp, Sp -> true
+    | (Zr64 | Zr32), _ | _, (Zr64 | Zr32) -> false
+    | Sp, (Reg64 _ | Reg32 _) | (Reg64 _ | Reg32 _), Sp -> false
+end
+
+let directive_is_barrier (d : Asm_targets.Asm_directives.Directive.t) =
+  match d with
+  | New_label _ | Bytes _ | Cfi_startproc | Cfi_endproc | Section _ -> true
+  | Align _ | Cfi_adjust_cfa_offset _ | Cfi_def_cfa_offset _ | Cfi_offset _
+  | Cfi_remember_state | Cfi_restore_state | Cfi_def_cfa_register _ | Comment _
+  | Const _ | Direct_assignment _ | File _ | Global _ | Indirect_symbol _
+  | Loc _ | New_line | Private_extern _ | Size _ | Sleb128 _ | Space _ | Type _
+  | Uleb128 _ | Protected _ | Hidden _ | Weak _ | External _ | Reloc _ ->
+    false
+
+(* Destination registers of an instruction. [Unknown] is the conservative
+   answer, used for control flow (in particular calls, which clobber all
+   caller-saved registers). *)
+type destinations =
+  | Known of Gp.t list
+  | Unknown
+
+type effects =
+  { is_barrier : bool;
+    writes_flags : bool;
+    destinations : destinations
+  }
+
+let gp_regs_of_operand : type o. o Operand.t -> Gp.t list =
+ fun op ->
+  match op with
+  | Reg r -> ( match r.reg_name with GP _ -> [Gp.of_reg r] | Neon _ -> [])
+  | Imm _ | Lsl_by_twelve | Shift _ | Lsl_by_multiple_of_16_bits _
+  | Shift_by_element_width _ | Cond _ | Float_cond _ | Mem _ | Bitmask _
+  | Optional _ | Unit ->
+    []
+
+let dests_of_first_operand : type num ops. (num, ops) many -> Gp.t list =
+ fun operands ->
+  match operands with
+  | Singleton op -> gp_regs_of_operand op
+  | Pair (op, _) -> gp_regs_of_operand op
+  | Triple (op, _, _) -> gp_regs_of_operand op
+  | Quad (op, _, _, _) -> gp_regs_of_operand op
+
+(* Classification of an instruction, as needed by the rewrite rules. The match
+   on the instruction name is deliberately exhaustive so that adding a new
+   instruction to the AST forces a review of its classification here. All
+   instructions except the ones treated specially below have their (only)
+   possible destination as first operand; [dests_of_first_operand] returns the
+   empty list when that operand is not a general-purpose register. *)
+let effects (Instruction.I { name; operands }) : effects =
+  match name with
+  | B | BL | BLR | BR | B_cond _ | CBZ | CBNZ | TBZ | TBNZ | RET ->
+    { is_barrier = true; writes_flags = true; destinations = Unknown }
+  | DMB _ | DSB _ | YIELD ->
+    { is_barrier = true; writes_flags = false; destinations = Known [] }
+  | LDAR ->
+    { is_barrier = true;
+      writes_flags = false;
+      destinations = Known (dests_of_first_operand operands)
+    }
+  | ADDS | SUBS_immediate | SUBS_shifted_register ->
+    { is_barrier = false;
+      writes_flags = true;
+      destinations = Known (dests_of_first_operand operands)
+    }
+  | TST | FCMP ->
+    { is_barrier = false; writes_flags = true; destinations = Known [] }
+  | STR | STRB | STRH | STR_simd_and_fp | STP _ ->
+    (* The first operand of a store is a source, not a destination. *)
+    { is_barrier = false; writes_flags = false; destinations = Known [] }
+  | LDP _ ->
+    let destinations =
+      match operands with
+      | Triple (op1, op2, _) ->
+        Known (gp_regs_of_operand op1 @ gp_regs_of_operand op2)
+    in
+    { is_barrier = false; writes_flags = false; destinations }
+  | ABS_vector | ADDP_vector | ADDV | ADD_immediate | ADD_shifted_register
+  | ADD_vector | ADR | ADRP | AND_immediate | AND_shifted_register | AND_vector
+  | ASRV | CLZ | CM_register _ | CM_zero _ | CNT | CNT_vector | CSEL | CSINC
+  | CTZ | DUP _ | EOR_immediate | EOR_shifted_register | EOR_vector | EXT | FABS
+  | FADD | FADDP_vector | FADD_vector | FCM_register _ | FCM_zero _ | FCSEL
+  | FCVT | FCVTL_vector | FCVTNS | FCVTNS_vector | FCVTN_vector | FCVTZS
+  | FCVTZS_vector | FDIV | FDIV_vector | FMADD | FMAX | FMAX_vector | FMIN
+  | FMIN_vector | FMOV_fp | FMOV_gp_to_fp_32 | FMOV_gp_to_fp_64
+  | FMOV_fp_to_gp_32 | FMOV_fp_to_gp_64 | FMOV_scalar_immediate | FMSUB | FMUL
+  | FMUL_vector | FNEG | FNEG_vector | FNMADD | FNMSUB | FNMUL | FRECPE_vector
+  | FRINT _ | FRINT_vector _ | FRSQRTE_vector | FSQRT | FSQRT_vector | FSUB
+  | FSUB_vector | INS _ | INS_V _ | LDR | LDRB | LDRH | LDRSB | LDRSH | LDRSW
+  | LDR_simd_and_fp | LSLV | LSRV | MADD | MOVI | MOVK | MOVN | MOVZ | MSUB
+  | MUL_vector | MVN_vector | NEG_vector | NOP | ORR_immediate
+  | ORR_shifted_register | ORR_vector | RBIT | REV | REV16 | SBFM | SCVTF
+  | SCVTF_vector | SDIV | SHL | SMAX_vector | SMIN_vector | SMOV _ | SMULH
+  | SMULL2_vector _ | SMULL_vector _ | SQADD_vector | SQSUB_vector | SQXTN _
+  | SQXTN2 _ | SSHL_vector | SSHR | SUB_immediate | SUB_shifted_register
+  | SUB_vector | SXTL _ | UADDLP_vector | UBFM | UDIV | UMAX_vector | UMIN_vector
+  | UMOV _ | UMULH | UMULL2_vector _ | UMULL_vector _ | UQADD_vector
+  | UQSUB_vector | UQXTN _ | UQXTN2 _ | USHL_vector | USHR | UXTL _ | XTN _
+  | XTN2 _ | ZIP1 | ZIP2 ->
+    { is_barrier = false;
+      writes_flags = false;
+      destinations = Known (dests_of_first_operand operands)
+    }
+
+let is_hard_barrier = function
+  | Directive d -> directive_is_barrier d
+  | Ins ins -> (effects ins).is_barrier
+
+let is_conditional_branch (Instruction.I { name; _ }) =
+  match[@warning "-4"] name with
+  | B_cond _ | CBZ | CBNZ | TBZ | TBNZ -> true
+  | _ -> false
+
+let writes_flags ins = (effects ins).writes_flags
+
+let writes_any_gp_reg ins ~regs =
+  match (effects ins).destinations with
+  | Unknown -> true
+  | Known dests ->
+    List.exists
+      (fun dest -> List.exists (fun reg -> Gp.same_underlying dest reg) regs)
+      dests
+
+let next_instruction cell =
+  let rec loop cell_opt =
+    match cell_opt with
+    | None -> None
+    | Some cell -> (
+      match DLL.value cell with
+      | Ins _ -> Some cell
+      | Directive d ->
+        if directive_is_barrier d then None else loop (DLL.next cell))
+  in
+  loop (DLL.next cell)
+
+let decode_simple_mem (op : [`Mem of Addressing_mode.single] Operand.t) :
+    (Gp.t * int) option =
+  match op with
+  | Mem addressing -> (
+    match addressing with
+    | Reg base -> Some (Gp.of_reg base, 0)
+    | Offset_twelve_unsigned_scaled (base, Twelve_unsigned_scaled offset) ->
+      Some (Gp.of_reg base, offset)
+    | Offset_nine_signed_unscaled (base, Nine_signed_unscaled offset) ->
+      Some (Gp.of_reg base, offset)
+    | Offset_sym _ | Literal _ | Pre _ | Post _ -> None)
+
+(* Delete the instruction following [cell] (as found by [next_instruction]), as
+   well as any [Loc] directives sitting before it (they describe the deleted
+   instruction; leaving them in place would attach them to whatever follows). *)
+let delete_next_instruction_and_locs cell =
+  let rec loop cell_opt =
+    match cell_opt with
+    | None ->
+      Misc.fatal_error
+        "Arm64_peephole.delete_next_instruction_and_locs: no next instruction"
+    | Some cell -> (
+      match DLL.value cell with
+      | Ins _ -> DLL.delete_curr cell
+      | Directive d ->
+        if directive_is_barrier d
+        then
+          Misc.fatal_error
+            "Arm64_peephole.delete_next_instruction_and_locs: barrier before \
+             next instruction"
+        else begin
+          let next = DLL.next cell in
+          (match[@warning "-4"] d with
+          | Loc _ -> DLL.delete_curr cell
+          | _ -> ());
+          loop next
+        end)
+  in
+  loop (DLL.next cell)

--- a/backend/arm64_peephole/peephole_utils.ml
+++ b/backend/arm64_peephole/peephole_utils.ml
@@ -117,16 +117,28 @@ let effects (Instruction.I { name; operands }) : effects =
     }
   | TST | FCMP ->
     { is_barrier = false; writes_flags = true; destinations = Known [] }
-  | STR | STRB | STRH | STR_simd_and_fp | STP _ ->
+  | STR | STRB | STRH | STR_simd_and_fp ->
     (* The first operand of a store is a source, not a destination. *)
     { is_barrier = false; writes_flags = false; destinations = Known [] }
-  | LDP _ ->
-    let destinations =
-      match operands with
-      | Triple (op1, op2, _) ->
+  | STP _ -> (
+    match operands with
+    | Triple (_, _, Mem (Offset_pair _)) ->
+      (* The first two operands of a store pair are sources. *)
+      { is_barrier = false; writes_flags = false; destinations = Known [] }
+    | Triple (_, _, Mem (Pre_pair _ | Post_pair _)) ->
+      (* Pre/post-indexed addressing writes the base register back; the base can
+         be sp, which [Gp] does not represent, so be conservative. *)
+      { is_barrier = false; writes_flags = false; destinations = Unknown })
+  | LDP _ -> (
+    match operands with
+    | Triple (op1, op2, Mem (Offset_pair _)) ->
+      let destinations =
         Known (gp_regs_of_operand op1 @ gp_regs_of_operand op2)
-    in
-    { is_barrier = false; writes_flags = false; destinations }
+      in
+      { is_barrier = false; writes_flags = false; destinations }
+    | Triple (_, _, Mem (Pre_pair _ | Post_pair _)) ->
+      (* Base register write-back on top of the two destinations. *)
+      { is_barrier = false; writes_flags = false; destinations = Unknown })
   | ABS_vector | ADDP_vector | ADDV | ADD_immediate | ADD_shifted_register
   | ADD_vector | ADR | ADRP | AND_immediate | AND_shifted_register | AND_vector
   | ASRV | CLZ | CM_register _ | CM_zero _ | CNT | CNT_vector | CSEL | CSINC

--- a/backend/arm64_peephole/peephole_utils.ml
+++ b/backend/arm64_peephole/peephole_utils.ml
@@ -145,10 +145,10 @@ let effects (Instruction.I { name; operands }) : effects =
   | SCVTF_vector | SDIV | SHL | SMAX_vector | SMIN_vector | SMOV _ | SMULH
   | SMULL2_vector _ | SMULL_vector _ | SQADD_vector | SQSUB_vector | SQXTN _
   | SQXTN2 _ | SSHL_vector | SSHR | SUB_immediate | SUB_shifted_register
-  | SUB_vector | SXTL _ | UADDLP_vector | UBFM | UDIV | UMAX_vector | UMIN_vector
-  | UMOV _ | UMULH | UMULL2_vector _ | UMULL_vector _ | UQADD_vector
-  | UQSUB_vector | UQXTN _ | UQXTN2 _ | USHL_vector | USHR | UXTL _ | XTN _
-  | XTN2 _ | ZIP1 | ZIP2 ->
+  | SUB_vector | SXTL _ | UADDLP_vector | UBFM | UDIV | UMAX_vector
+  | UMIN_vector | UMOV _ | UMULH | UMULL2_vector _ | UMULL_vector _
+  | UQADD_vector | UQSUB_vector | UQXTN _ | UQXTN2 _ | USHL_vector | USHR
+  | UXTL _ | XTN _ | XTN2 _ | ZIP1 | ZIP2 ->
     { is_barrier = false;
       writes_flags = false;
       destinations = Known (dests_of_first_operand operands)

--- a/backend/arm64_peephole/peephole_utils.mli
+++ b/backend/arm64_peephole/peephole_utils.mli
@@ -1,0 +1,66 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+open Arm64_ast.Ast
+module DLL = Doubly_linked_list
+
+(** A single line of assembly: either an instruction or a directive (which
+    includes labels). *)
+type asm_line =
+  | Ins of Instruction.t
+  | Directive of Asm_targets.Asm_directives.Directive.t
+
+(** Type for the result of applying a peephole rewrite rule. *)
+type rule_result =
+  | No_match
+  | Matched of asm_line DLL.cell option
+
+module Gp : sig
+  (** Normalized general-purpose register, resolving the different assembly
+      spellings of the same physical register: [lr] normalizes to [Reg64 30] and
+      [fp] to [Reg64 29]. *)
+  type t =
+    | Reg64 of int
+    | Reg32 of int
+    | Zr64
+    | Zr32
+    | Sp
+
+  val of_reg : [`GP of 'a] Reg.t -> t
+
+  (** Exact equality, distinguishing [wN] from [xN]. *)
+  val equal : t -> t -> bool
+
+  (** Whether two register names overlap the same physical register: [wN] and
+      [xN] are the same register, while the zero registers alias nothing. *)
+  val same_underlying : t -> t -> bool
+end
+
+val directive_is_barrier : Asm_targets.Asm_directives.Directive.t -> bool
+
+(** Whether rewrite rules must not look past the given line: labels and a few
+    other directives, control flow, and memory-ordering instructions. *)
+val is_hard_barrier : asm_line -> bool
+
+val is_conditional_branch : Instruction.t -> bool
+
+(** Conservative: [true] for control flow. *)
+val writes_flags : Instruction.t -> bool
+
+(** Whether the instruction may write to (a register overlapping) any of [regs].
+    Conservative: [true] for control flow. *)
+val writes_any_gp_reg : Instruction.t -> regs:Gp.t list -> bool
+
+(** The next instruction cell, looking through non-barrier directives such as
+    [Loc] and CFI directives. Returns [None] if a hard-barrier directive (in
+    particular a label) is reached first. *)
+val next_instruction : asm_line DLL.cell -> asm_line DLL.cell option
+
+(** Decode a base-plus-immediate addressing mode (including the plain
+    base-register form) to the base register and byte offset. Returns [None] for
+    symbolic, literal and pre/post-indexed forms. *)
+val decode_simple_mem :
+  [`Mem of Addressing_mode.single] Operand.t -> (Gp.t * int) option
+
+(** Delete the instruction following the given cell (as found by
+    [next_instruction]), as well as any [Loc] directives before it. *)
+val delete_next_instruction_and_locs : asm_line DLL.cell -> unit

--- a/backend/cfg/cfg_cse.ml
+++ b/backend/cfg/cfg_cse.ml
@@ -72,6 +72,8 @@ module type S = sig
 
   val remove_mutable_load_numbering : numbering -> numbering
 
+  val filter_equations : (rhs -> bool) -> numbering -> numbering
+
   val kill_addr_regs : numbering -> numbering
 end
 
@@ -118,6 +120,11 @@ module Make (Op : Operation) : S with type op = Op.t = struct
     let remove_mutable_loads m =
       { mutable_load_equations = Rhs_map.empty;
         other_equations = m.other_equations
+      }
+
+    let filter keep m =
+      { mutable_load_equations = Rhs_map.filter keep m.mutable_load_equations;
+        other_equations = Rhs_map.filter keep m.other_equations
       }
   end
 
@@ -234,6 +241,10 @@ module Make (Op : Operation) : S with type op = Op.t = struct
 
   let remove_mutable_load_numbering n =
     { n with num_eqs = Equations.remove_mutable_loads n.num_eqs }
+
+  (* Keep only the equations whose right-hand side satisfies [keep]. *)
+  let filter_equations keep n =
+    { n with num_eqs = Equations.filter (fun rhs _ -> keep rhs) n.num_eqs }
 
   (* Forget everything we know about registers of type [Addr]. *)
 
@@ -357,6 +368,19 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
     | End_region | Dls_get | Tls_get | Domain_index ->
       false
 
+  let is_constant_operation : Operation.t -> bool = function
+    | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
+    | Const_vec128 _ | Const_vec256 _ | Const_vec512 _ ->
+      true
+    | Move | Spill | Reload | Opaque | Pause | Stackoffset _ | Load _
+    | Store (_, _, _)
+    | Alloc _ | Poll | Intop _ | Int128op _
+    | Intop_imm (_, _)
+    | Intop_atomic _ | Floatop _ | Csel _ | Static_cast _ | Reinterpret_cast _
+    | Specific _ | Name_for_debugger _ | Probe_is_enabled _ | Begin_region
+    | End_region | Dls_get | Tls_get | Domain_index ->
+      false
+
   let kill_loads (n : numbering) : numbering = remove_mutable_load_numbering n
 
   let cse_instruction :
@@ -469,9 +493,28 @@ module Cse_generic (Target : Cfg_cse_target_intf.S) = struct
          mappings from hardware registers to value numbers, since the callee
          does not preserve these registers. That doesn't leave much usable
          information: checkbounds could be kept, but won't be usable for CSE as
-         one of their arguments is always a memory load. For simplicity, we just
-         forget everything. *)
-      empty_numbering
+         one of their arguments is always a memory load. *)
+      if !Oxcaml_flags.cfg_cse_constants_across_calls
+      then
+        (* Keep equations over expensive constants: pseudoregister values
+           survive the call, so a constant computed before the call can be
+           reused after it, at the price of a possible spill/reload. This is
+           worthwhile for constants whose materialization is dearer than a stack
+           reload, e.g. symbol addresses loaded through the GOT on arm64.
+           Everything else is forgotten, as described above. *)
+        let n1 =
+          filter_equations
+            (fun (op, args) ->
+              Array.length args = 0
+              && is_constant_operation op
+              && not (is_cheap_operation op))
+            numbering
+        in
+        let n2 = kill_addr_regs n1 in
+        set_unknown_regs n2 (Proc.destroyed_at_terminator terminator.desc)
+      else
+        (* For simplicity, we just forget everything. *)
+        empty_numbering
 
   let cse_blocks : State.t -> Cfg.t -> unit =
    fun state cfg ->

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -175,6 +175,17 @@ let mk_cfg_cse_optimize f =
 let mk_no_cfg_cse_optimize f =
   ("-no-cfg-cse-optimize", Arg.Unit f, " Do not apply CSE optimizations to CFG")
 
+let mk_cfg_cse_constants_across_calls f =
+  ( "-cfg-cse-constants-across-calls",
+    Arg.Unit f,
+    " Let CSE reuse expensive constants (e.g. symbol addresses) across \
+     function calls, instead of rematerializing them" )
+
+let mk_no_cfg_cse_constants_across_calls f =
+  ( "-no-cfg-cse-constants-across-calls",
+    Arg.Unit f,
+    " Do not let CSE reuse expensive constants across function calls" )
+
 let mk_cfg_zero_alloc_checker f =
   ("-cfg-zero-alloc-checker", Arg.Unit f, " Apply zero_alloc checker to CFG")
 
@@ -1349,6 +1360,8 @@ module type Oxcaml_options = sig
   val no_arm64_peephole_compose_shift_pairs : unit -> unit
   val arm64_fuse_frame_ops : unit -> unit
   val no_arm64_fuse_frame_ops : unit -> unit
+  val cfg_cse_constants_across_calls : unit -> unit
+  val no_cfg_cse_constants_across_calls : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit
@@ -1548,6 +1561,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_arm64_peephole_compose_shift_pairs;
       mk_arm64_fuse_frame_ops F.arm64_fuse_frame_ops;
       mk_no_arm64_fuse_frame_ops F.no_arm64_fuse_frame_ops;
+      mk_cfg_cse_constants_across_calls F.cfg_cse_constants_across_calls;
+      mk_no_cfg_cse_constants_across_calls F.no_cfg_cse_constants_across_calls;
       mk_cfg_stack_checks F.cfg_stack_checks;
       mk_no_cfg_stack_checks F.no_cfg_stack_checks;
       mk_cfg_stack_checks_threshold F.cfg_stack_checks_threshold;
@@ -1892,6 +1907,13 @@ module Oxcaml_options_impl = struct
 
   let arm64_fuse_frame_ops = set' Oxcaml_flags.arm64_fuse_frame_ops
   let no_arm64_fuse_frame_ops = clear' Oxcaml_flags.arm64_fuse_frame_ops
+
+  let cfg_cse_constants_across_calls =
+    set' Oxcaml_flags.cfg_cse_constants_across_calls
+
+  let no_cfg_cse_constants_across_calls =
+    clear' Oxcaml_flags.cfg_cse_constants_across_calls
+
   let cfg_stack_checks = set' Oxcaml_flags.cfg_stack_checks
   let no_cfg_stack_checks = clear' Oxcaml_flags.cfg_stack_checks
 
@@ -1935,6 +1957,7 @@ module Oxcaml_options_impl = struct
     x86_peephole_optimize ();
     arm64_peephole_optimize ();
     arm64_fuse_frame_ops ();
+    cfg_cse_constants_across_calls ();
     regalloc_param "SPLIT_AROUND_LOOPS:on";
     regalloc_param "AFFINITY:on";
     regalloc_param "BIT_MATRIX_THRESHOLD:8192";
@@ -2493,6 +2516,8 @@ module Extra_params = struct
     | "x86-peephole-optimize" -> set' Oxcaml_flags.x86_peephole_optimize
     | "arm64-peephole-optimize" -> set' Oxcaml_flags.arm64_peephole_optimize
     | "arm64-fuse-frame-ops" -> set' Oxcaml_flags.arm64_fuse_frame_ops
+    | "cfg-cse-constants-across-calls" ->
+        set' Oxcaml_flags.cfg_cse_constants_across_calls
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -128,6 +128,36 @@ let mk_no_x86_peephole_combine_add_rsp f =
     Arg.Unit f,
     " Disable x86 peephole: combine adjacent add rsp" )
 
+let mk_arm64_peephole_optimize f =
+  ( "-arm64-peephole-optimize",
+    Arg.Unit f,
+    " Apply peephole optimizations to arm64" )
+
+let mk_no_arm64_peephole_optimize f =
+  ( "-no-arm64-peephole-optimize",
+    Arg.Unit f,
+    " Do not apply peephole optimizations to arm64" )
+
+let mk_no_arm64_peephole_fuse_memory_pairs f =
+  ( "-no-arm64-peephole-fuse-memory-pairs",
+    Arg.Unit f,
+    " Disable arm64 peephole: fuse adjacent memory transfers into pairs" )
+
+let mk_no_arm64_peephole_merge_add_immediates f =
+  ( "-no-arm64-peephole-merge-add-immediates",
+    Arg.Unit f,
+    " Disable arm64 peephole: merge adjacent add/sub immediates" )
+
+let mk_no_arm64_peephole_remove_redundant_cmp f =
+  ( "-no-arm64-peephole-remove-redundant-cmp",
+    Arg.Unit f,
+    " Disable arm64 peephole: remove redundant cmp" )
+
+let mk_no_arm64_peephole_compose_shift_pairs f =
+  ( "-no-arm64-peephole-compose-shift-pairs",
+    Arg.Unit f,
+    " Disable arm64 peephole: compose adjacent shift pairs" )
+
 let mk_cfg_cse_optimize f =
   ("-cfg-cse-optimize", Arg.Unit f, " Apply CSE optimizations to CFG")
 
@@ -1300,6 +1330,12 @@ module type Oxcaml_options = sig
   val no_x86_peephole_remove_mov_to_dead_register : unit -> unit
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
+  val arm64_peephole_optimize : unit -> unit
+  val no_arm64_peephole_optimize : unit -> unit
+  val no_arm64_peephole_fuse_memory_pairs : unit -> unit
+  val no_arm64_peephole_merge_add_immediates : unit -> unit
+  val no_arm64_peephole_remove_redundant_cmp : unit -> unit
+  val no_arm64_peephole_compose_shift_pairs : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit
@@ -1487,6 +1523,16 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_x86_peephole_remove_redundant_cmp
         F.no_x86_peephole_remove_redundant_cmp;
       mk_no_x86_peephole_combine_add_rsp F.no_x86_peephole_combine_add_rsp;
+      mk_arm64_peephole_optimize F.arm64_peephole_optimize;
+      mk_no_arm64_peephole_optimize F.no_arm64_peephole_optimize;
+      mk_no_arm64_peephole_fuse_memory_pairs
+        F.no_arm64_peephole_fuse_memory_pairs;
+      mk_no_arm64_peephole_merge_add_immediates
+        F.no_arm64_peephole_merge_add_immediates;
+      mk_no_arm64_peephole_remove_redundant_cmp
+        F.no_arm64_peephole_remove_redundant_cmp;
+      mk_no_arm64_peephole_compose_shift_pairs
+        F.no_arm64_peephole_compose_shift_pairs;
       mk_cfg_stack_checks F.cfg_stack_checks;
       mk_no_cfg_stack_checks F.no_cfg_stack_checks;
       mk_cfg_stack_checks_threshold F.cfg_stack_checks_threshold;
@@ -1814,6 +1860,21 @@ module Oxcaml_options_impl = struct
   let no_x86_peephole_combine_add_rsp =
     clear' Oxcaml_flags.x86_peephole_combine_add_rsp
 
+  let arm64_peephole_optimize = set' Oxcaml_flags.arm64_peephole_optimize
+  let no_arm64_peephole_optimize = clear' Oxcaml_flags.arm64_peephole_optimize
+
+  let no_arm64_peephole_fuse_memory_pairs =
+    clear' Oxcaml_flags.arm64_peephole_fuse_memory_pairs
+
+  let no_arm64_peephole_merge_add_immediates =
+    clear' Oxcaml_flags.arm64_peephole_merge_add_immediates
+
+  let no_arm64_peephole_remove_redundant_cmp =
+    clear' Oxcaml_flags.arm64_peephole_remove_redundant_cmp
+
+  let no_arm64_peephole_compose_shift_pairs =
+    clear' Oxcaml_flags.arm64_peephole_compose_shift_pairs
+
   let cfg_stack_checks = set' Oxcaml_flags.cfg_stack_checks
   let no_cfg_stack_checks = clear' Oxcaml_flags.cfg_stack_checks
 
@@ -1855,6 +1916,7 @@ module Oxcaml_options_impl = struct
     cfg_prologue_shrink_wrap ();
     cfg_prologue_validate ();
     x86_peephole_optimize ();
+    arm64_peephole_optimize ();
     regalloc_param "SPLIT_AROUND_LOOPS:on";
     regalloc_param "AFFINITY:on";
     regalloc_param "BIT_MATRIX_THRESHOLD:8192";
@@ -2411,6 +2473,7 @@ module Extra_params = struct
         set_int' Oxcaml_flags.vectorize_max_block_size
     | "cfg-peephole-optimize" -> set' Oxcaml_flags.cfg_peephole_optimize
     | "x86-peephole-optimize" -> set' Oxcaml_flags.x86_peephole_optimize
+    | "arm64-peephole-optimize" -> set' Oxcaml_flags.arm64_peephole_optimize
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -158,6 +158,17 @@ let mk_no_arm64_peephole_compose_shift_pairs f =
     Arg.Unit f,
     " Disable arm64 peephole: compose adjacent shift pairs" )
 
+let mk_arm64_fuse_frame_ops f =
+  ( "-arm64-fuse-frame-ops",
+    Arg.Unit f,
+    " Fuse the arm64 frame allocation and return-address save/restore into \
+     single stp/ldp instructions where possible" )
+
+let mk_no_arm64_fuse_frame_ops f =
+  ( "-no-arm64-fuse-frame-ops",
+    Arg.Unit f,
+    " Do not fuse the arm64 frame allocation and return-address save/restore" )
+
 let mk_cfg_cse_optimize f =
   ("-cfg-cse-optimize", Arg.Unit f, " Apply CSE optimizations to CFG")
 
@@ -1336,6 +1347,8 @@ module type Oxcaml_options = sig
   val no_arm64_peephole_merge_add_immediates : unit -> unit
   val no_arm64_peephole_remove_redundant_cmp : unit -> unit
   val no_arm64_peephole_compose_shift_pairs : unit -> unit
+  val arm64_fuse_frame_ops : unit -> unit
+  val no_arm64_fuse_frame_ops : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit
@@ -1533,6 +1546,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_arm64_peephole_remove_redundant_cmp;
       mk_no_arm64_peephole_compose_shift_pairs
         F.no_arm64_peephole_compose_shift_pairs;
+      mk_arm64_fuse_frame_ops F.arm64_fuse_frame_ops;
+      mk_no_arm64_fuse_frame_ops F.no_arm64_fuse_frame_ops;
       mk_cfg_stack_checks F.cfg_stack_checks;
       mk_no_cfg_stack_checks F.no_cfg_stack_checks;
       mk_cfg_stack_checks_threshold F.cfg_stack_checks_threshold;
@@ -1875,6 +1890,8 @@ module Oxcaml_options_impl = struct
   let no_arm64_peephole_compose_shift_pairs =
     clear' Oxcaml_flags.arm64_peephole_compose_shift_pairs
 
+  let arm64_fuse_frame_ops = set' Oxcaml_flags.arm64_fuse_frame_ops
+  let no_arm64_fuse_frame_ops = clear' Oxcaml_flags.arm64_fuse_frame_ops
   let cfg_stack_checks = set' Oxcaml_flags.cfg_stack_checks
   let no_cfg_stack_checks = clear' Oxcaml_flags.cfg_stack_checks
 
@@ -1917,6 +1934,7 @@ module Oxcaml_options_impl = struct
     cfg_prologue_validate ();
     x86_peephole_optimize ();
     arm64_peephole_optimize ();
+    arm64_fuse_frame_ops ();
     regalloc_param "SPLIT_AROUND_LOOPS:on";
     regalloc_param "AFFINITY:on";
     regalloc_param "BIT_MATRIX_THRESHOLD:8192";
@@ -2474,6 +2492,7 @@ module Extra_params = struct
     | "cfg-peephole-optimize" -> set' Oxcaml_flags.cfg_peephole_optimize
     | "x86-peephole-optimize" -> set' Oxcaml_flags.x86_peephole_optimize
     | "arm64-peephole-optimize" -> set' Oxcaml_flags.arm64_peephole_optimize
+    | "arm64-fuse-frame-ops" -> set' Oxcaml_flags.arm64_fuse_frame_ops
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -54,6 +54,8 @@ module type Oxcaml_options = sig
   val no_arm64_peephole_merge_add_immediates : unit -> unit
   val no_arm64_peephole_remove_redundant_cmp : unit -> unit
   val no_arm64_peephole_compose_shift_pairs : unit -> unit
+  val arm64_fuse_frame_ops : unit -> unit
+  val no_arm64_fuse_frame_ops : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -56,6 +56,8 @@ module type Oxcaml_options = sig
   val no_arm64_peephole_compose_shift_pairs : unit -> unit
   val arm64_fuse_frame_ops : unit -> unit
   val no_arm64_fuse_frame_ops : unit -> unit
+  val cfg_cse_constants_across_calls : unit -> unit
+  val no_cfg_cse_constants_across_calls : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -48,6 +48,12 @@ module type Oxcaml_options = sig
   val no_x86_peephole_remove_mov_to_dead_register : unit -> unit
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
+  val arm64_peephole_optimize : unit -> unit
+  val no_arm64_peephole_optimize : unit -> unit
+  val no_arm64_peephole_fuse_memory_pairs : unit -> unit
+  val no_arm64_peephole_merge_add_immediates : unit -> unit
+  val no_arm64_peephole_remove_redundant_cmp : unit -> unit
+  val no_arm64_peephole_compose_shift_pairs : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -35,6 +35,12 @@ let x86_peephole_remove_mov_to_dead_register = ref true
 let x86_peephole_remove_redundant_cmp = ref true
 let x86_peephole_combine_add_rsp = ref true
 
+let arm64_peephole_optimize = ref false (* -[no-]arm64-peephole-optimize *)
+let arm64_peephole_fuse_memory_pairs = ref true
+let arm64_peephole_merge_add_immediates = ref true
+let arm64_peephole_remove_redundant_cmp = ref true
+let arm64_peephole_compose_shift_pairs = ref true
+
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -43,6 +43,9 @@ let arm64_peephole_compose_shift_pairs = ref true
 
 let arm64_fuse_frame_ops = ref false    (* -[no-]arm64-fuse-frame-ops *)
 
+let cfg_cse_constants_across_calls = ref false
+                                (* -[no-]cfg-cse-constants-across-calls *)
+
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -41,6 +41,8 @@ let arm64_peephole_merge_add_immediates = ref true
 let arm64_peephole_remove_redundant_cmp = ref true
 let arm64_peephole_compose_shift_pairs = ref true
 
+let arm64_fuse_frame_ops = ref false    (* -[no-]arm64-fuse-frame-ops *)
+
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -41,6 +41,7 @@ val arm64_peephole_fuse_memory_pairs : bool ref
 val arm64_peephole_merge_add_immediates : bool ref
 val arm64_peephole_remove_redundant_cmp : bool ref
 val arm64_peephole_compose_shift_pairs : bool ref
+val arm64_fuse_frame_ops : bool ref
 
 val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -36,6 +36,12 @@ val x86_peephole_remove_mov_to_dead_register : bool ref
 val x86_peephole_remove_redundant_cmp : bool ref
 val x86_peephole_combine_add_rsp : bool ref
 
+val arm64_peephole_optimize : bool ref
+val arm64_peephole_fuse_memory_pairs : bool ref
+val arm64_peephole_merge_add_immediates : bool ref
+val arm64_peephole_remove_redundant_cmp : bool ref
+val arm64_peephole_compose_shift_pairs : bool ref
+
 val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref
 

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -42,6 +42,7 @@ val arm64_peephole_merge_add_immediates : bool ref
 val arm64_peephole_remove_redundant_cmp : bool ref
 val arm64_peephole_compose_shift_pairs : bool ref
 val arm64_fuse_frame_ops : bool ref
+val cfg_cse_constants_across_calls : bool ref
 
 val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref

--- a/dune
+++ b/dune
@@ -750,6 +750,7 @@
   compiler_owee
   gc_timings
   arm64_ast
+  arm64_peephole
   dwarf_low
   dwarf_high
   binary_emitter_intf))
@@ -856,6 +857,7 @@
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.a}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.a}
    %{dep:oxcaml_common.a}
+   %{dep:backend/arm64_peephole/arm64_peephole.a}
    %{dep:middle_end/flambda2/import/flambda2_import.a}
    %{dep:middle_end/flambda2/ui/flambda2_ui.a}
    %{dep:middle_end/flambda2/algorithms/flambda2_algorithms.a}
@@ -897,6 +899,7 @@
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.cma}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.cma}
    %{dep:oxcaml_common.cma}
+   %{dep:backend/arm64_peephole/arm64_peephole.cma}
    %{dep:middle_end/flambda2/import/flambda2_import.cma}
    %{dep:middle_end/flambda2/ui/flambda2_ui.cma}
    %{dep:middle_end/flambda2/algorithms/flambda2_algorithms.cma}
@@ -938,6 +941,7 @@
    %{dep:backend/debug/dwarf/dwarf_low/dwarf_low.cmxa}
    %{dep:backend/debug/dwarf/dwarf_high/dwarf_high.cmxa}
    %{dep:oxcaml_common.cmxa}
+   %{dep:backend/arm64_peephole/arm64_peephole.cmxa}
    %{dep:middle_end/flambda2/import/flambda2_import.cmxa}
    %{dep:middle_end/flambda2/ui/flambda2_ui.cmxa}
    %{dep:middle_end/flambda2/algorithms/flambda2_algorithms.cmxa}
@@ -1029,6 +1033,9 @@
   (glob_files
    backend/arm64/ast/.arm64_ast.objs/byte/*.{cmi,cmo,cmt,cmti})
   (glob_files backend/arm64/ast/.arm64_ast.objs/native/*.cmx)
+  (glob_files
+   backend/arm64_peephole/.arm64_peephole.objs/byte/*.{cmi,cmo,cmt,cmti})
+  (glob_files backend/arm64_peephole/.arm64_peephole.objs/native/*.cmx)
   (glob_files
    backend/arm64/binary_emitter/.arm64_binary_emitter.objs/byte/*.{cmi,cmo,cmt,cmti})
   (glob_files

--- a/oxcaml/tests/backend/arm64_peephole/dune
+++ b/oxcaml/tests/backend/arm64_peephole/dune
@@ -1,0 +1,4 @@
+(tests
+ (names test)
+ (libraries arm64_peephole arm64_ast asm_targets ocamlcommon oxcaml_common)
+ (modules test))

--- a/oxcaml/tests/backend/arm64_peephole/test.expected
+++ b/oxcaml/tests/backend/arm64_peephole/test.expected
@@ -1,0 +1,393 @@
+==== str pair, ascending offsets (allocation-init shape)
+---- before
+	str	x1, [x0, #-8]
+	str	x2, [x0, #0]
+---- after
+	stp	x1, x2, [x0, #-8]
+==== ldr pair, descending sp offsets (reload shape)
+---- before
+	ldr	x0, [sp, #16]
+	ldr	x1, [sp, #8]
+---- after
+	ldp	x1, x0, [sp, #8]
+==== run of four stores fuses pairwise
+---- before
+	str	x1, [x0, #0]
+	str	x2, [x0, #8]
+	str	x3, [x0, #16]
+	str	x4, [x0, #24]
+---- after
+	stp	x1, x2, [x0, #0]
+	stp	x3, x4, [x0, #16]
+==== loc between the pair is dropped with the second instruction
+---- before
+	.loc	1	1	0
+	str	x1, [x0, #0]
+	.loc	1	2	0
+	str	x2, [x0, #8]
+---- after
+	.loc	1	1	0
+	stp	x1, x2, [x0, #0]
+==== str pair involving lr
+---- before
+	str	x1, [sp, #0]
+	str	lr, [sp, #8]
+---- after
+	stp	x1, lr, [sp, #0]
+==== no fuse: label between
+---- before
+	str	x1, [x0, #0]
+.L100:
+	str	x2, [x0, #8]
+---- after
+	str	x1, [x0, #0]
+.L100:
+	str	x2, [x0, #8]
+==== no fuse: offset gap of 16
+---- before
+	str	x1, [x0, #0]
+	str	x2, [x0, #16]
+---- after
+	str	x1, [x0, #0]
+	str	x2, [x0, #16]
+==== boundary: fused offset 504 is in range
+---- before
+	str	x1, [x0, #504]
+	str	x2, [x0, #512]
+---- after
+	stp	x1, x2, [x0, #504]
+==== no fuse: fused offset 512 is out of range
+---- before
+	str	x1, [x0, #512]
+	str	x2, [x0, #520]
+---- after
+	str	x1, [x0, #512]
+	str	x2, [x0, #520]
+==== no fuse: unaligned offsets
+---- before
+	str	x1, [x0, #4]
+	str	x2, [x0, #12]
+---- after
+	str	x1, [x0, #4]
+	str	x2, [x0, #12]
+==== no fuse: w registers
+---- before
+	str	w1, [x0, #0]
+	str	w2, [x0, #8]
+---- after
+	str	w1, [x0, #0]
+	str	w2, [x0, #8]
+==== no fuse: pre-indexed addressing
+---- before
+	str	x1, [x0, #0]!
+	str	x2, [x0, #8]
+---- after
+	str	x1, [x0, #0]!
+	str	x2, [x0, #8]
+==== no fuse: different bases
+---- before
+	str	x1, [x0, #0]
+	str	x2, [x3, #8]
+---- after
+	str	x1, [x0, #0]
+	str	x2, [x3, #8]
+==== no fuse: first load destination is the base
+---- before
+	ldr	x0, [x0, #0]
+	ldr	x1, [x0, #8]
+---- after
+	ldr	x0, [x0, #0]
+	ldr	x1, [x0, #8]
+==== fuse: second load destination is the base
+---- before
+	ldr	x1, [x0, #0]
+	ldr	x0, [x0, #8]
+---- after
+	ldp	x1, x0, [x0, #0]
+==== no fuse: equal load destinations
+---- before
+	ldr	x1, [x0, #0]
+	ldr	x1, [x0, #8]
+---- after
+	ldr	x1, [x0, #0]
+	ldr	x1, [x0, #8]
+==== add/add merge (comballoc shape)
+---- before
+	add	x2, x27, #8
+	add	x2, x2, #16
+---- after
+	add	x2, x27, #24
+==== chain of three adds folds fully
+---- before
+	add	x2, x27, #8
+	add	x2, x2, #16
+	add	x2, x2, #32
+---- after
+	add	x2, x27, #56
+==== add/sub merge with negative net
+---- before
+	add	x2, x27, #8
+	sub	x2, x2, #24
+---- after
+	sub	x2, x27, #16
+==== add/sub merge with zero net
+---- before
+	add	x2, x27, #8
+	sub	x2, x2, #8
+---- after
+	add	x2, x27, #0
+==== add with sp source
+---- before
+	add	x2, sp, #8
+	add	x2, x2, #8
+---- after
+	add	x2, sp, #16
+==== add with fp source and positive net
+---- before
+	add	x2, fp, #8
+	add	x2, x2, #8
+---- after
+	add	x2, fp, #16
+==== no merge: fp source with negative net (no sub fp form)
+---- before
+	add	x2, fp, #8
+	sub	x2, x2, #24
+---- after
+	add	x2, fp, #8
+	sub	x2, x2, #24
+==== merge: combined immediate 4096 encodable as shifted
+---- before
+	add	x2, x27, #4095
+	add	x2, x2, #1
+---- after
+	add	x2, x27, #4096
+==== no merge: combined immediate 4097 not encodable
+---- before
+	add	x2, x27, #4095
+	add	x2, x2, #2
+---- after
+	add	x2, x27, #4095
+	add	x2, x2, #2
+==== no merge: second source is not the first destination
+---- before
+	add	x2, x27, #8
+	add	x3, x3, #16
+---- after
+	add	x2, x27, #8
+	add	x3, x3, #16
+==== no merge: destinations differ
+---- before
+	add	x2, x27, #8
+	add	x3, x2, #16
+---- after
+	add	x2, x27, #8
+	add	x3, x2, #16
+==== no merge: label between (gc-return label shape)
+---- before
+	add	x2, x27, #8
+.L101:
+	add	x2, x2, #16
+---- after
+	add	x2, x27, #8
+.L101:
+	add	x2, x2, #16
+==== no merge: destination is sp
+---- before
+	add	sp, sp, #16
+	add	sp, sp, #16
+---- after
+	add	sp, sp, #16
+	add	sp, sp, #16
+==== redundant immediate compare across b.cond and store
+---- before
+	subs	xzr, x0, #1
+	b.ne	.L900
+	orr	x1, xzr, #3
+	str	x1, [sp, #64]
+	subs	xzr, x0, #1
+---- after
+	subs	xzr, x0, #1
+	b.ne	.L900
+	orr	x1, xzr, #3
+	str	x1, [sp, #64]
+==== redundant register compare
+---- before
+	subs	xzr, x0, x1
+	orr	x2, xzr, #7
+	subs	xzr, x0, x1
+---- after
+	subs	xzr, x0, x1
+	orr	x2, xzr, #7
+==== two redundant compares are both removed
+---- before
+	subs	xzr, x0, #1
+	orr	x1, xzr, #3
+	subs	xzr, x0, #1
+	orr	x2, xzr, #7
+	subs	xzr, x0, #1
+---- after
+	subs	xzr, x0, #1
+	orr	x1, xzr, #3
+	orr	x2, xzr, #7
+==== no removal: compared register written in between
+---- before
+	subs	xzr, x0, #1
+	add	x0, x0, #8
+	subs	xzr, x0, #1
+---- after
+	subs	xzr, x0, #1
+	add	x0, x0, #8
+	subs	xzr, x0, #1
+==== no removal: w0 written between compares on x0 (aliasing)
+---- before
+	subs	xzr, x0, #1
+	movz	w0, #5, lsl #0
+	subs	xzr, x0, #1
+---- after
+	subs	xzr, x0, #1
+	movz	w0, #5, lsl #0
+	subs	xzr, x0, #1
+==== no removal: flag writer in between
+---- before
+	subs	xzr, x0, #1
+	adds	x1, x2, #0
+	subs	xzr, x0, #1
+---- after
+	subs	xzr, x0, #1
+	adds	x1, x2, #0
+	subs	xzr, x0, #1
+==== no removal: label in between
+---- before
+	subs	xzr, x0, #1
+.L102:
+	subs	xzr, x0, #1
+---- after
+	subs	xzr, x0, #1
+.L102:
+	subs	xzr, x0, #1
+==== no removal: call in between
+---- before
+	subs	xzr, x0, #1
+	bl	.L901
+	subs	xzr, x0, #1
+---- after
+	subs	xzr, x0, #1
+	bl	.L901
+	subs	xzr, x0, #1
+==== no removal: width mismatch
+---- before
+	subs	wzr, w0, #1
+	orr	x1, xzr, #3
+	subs	xzr, x0, #1
+---- after
+	subs	wzr, w0, #1
+	orr	x1, xzr, #3
+	subs	xzr, x0, #1
+==== no removal: different immediate
+---- before
+	subs	xzr, x0, #1
+	orr	x1, xzr, #3
+	subs	xzr, x0, #3
+---- after
+	subs	xzr, x0, #1
+	orr	x1, xzr, #3
+	subs	xzr, x0, #3
+==== lsl 8 then lsr 18 (string-length shape)
+---- before
+	ubfm	x2, x2, #56, #55
+	ubfm	x2, x2, #18, #63
+---- after
+	ubfm	x2, x2, #10, #55
+==== lsl 8 then lsr 17 (mixed-block shape)
+---- before
+	ubfm	x2, x2, #56, #55
+	ubfm	x2, x2, #17, #63
+---- after
+	ubfm	x2, x2, #9, #55
+==== lsl 31 then asr 32
+---- before
+	ubfm	x2, x2, #33, #32
+	sbfm	x2, x2, #32, #63
+---- after
+	sbfm	x2, x2, #1, #32
+==== lsr 18 then lsl 18 becomes a mask
+---- before
+	ubfm	x2, x2, #18, #63
+	ubfm	x2, x2, #46, #45
+---- after
+	and	x2, x2, #-262144
+==== lsl 3 then lsl 4 add up
+---- before
+	ubfm	x2, x2, #61, #60
+	ubfm	x2, x2, #60, #59
+---- after
+	ubfm	x2, x2, #57, #56
+==== lsr 3 then lsr 4 add up
+---- before
+	ubfm	x2, x2, #3, #63
+	ubfm	x2, x2, #4, #63
+---- after
+	ubfm	x2, x2, #7, #63
+==== asr chain saturates at 63
+---- before
+	sbfm	x2, x2, #40, #63
+	sbfm	x2, x2, #40, #63
+---- after
+	sbfm	x2, x2, #63, #63
+==== first shift may have a distinct source
+---- before
+	ubfm	x2, x1, #56, #55
+	ubfm	x2, x2, #18, #63
+---- after
+	ubfm	x2, x1, #10, #55
+==== no compose: lsr then lsl with different amounts
+---- before
+	ubfm	x2, x2, #18, #63
+	ubfm	x2, x2, #61, #60
+---- after
+	ubfm	x2, x2, #18, #63
+	ubfm	x2, x2, #61, #60
+==== no compose: different registers
+---- before
+	ubfm	x2, x2, #56, #55
+	ubfm	x3, x3, #18, #63
+---- after
+	ubfm	x2, x2, #56, #55
+	ubfm	x3, x3, #18, #63
+==== no compose: unclassifiable bitfield move (uxtb shape)
+---- before
+	ubfm	x2, x2, #0, #7
+	ubfm	x2, x2, #18, #63
+---- after
+	ubfm	x2, x2, #0, #7
+	ubfm	x2, x2, #18, #63
+==== no compose: over-shifted lsl chain
+---- before
+	ubfm	x2, x2, #24, #23
+	ubfm	x2, x2, #34, #33
+---- after
+	ubfm	x2, x2, #24, #23
+	ubfm	x2, x2, #34, #33
+==== no compose: w-width shifts
+---- before
+	ubfm	w2, w2, #18, #63
+	ubfm	w2, w2, #18, #63
+---- after
+	ubfm	w2, w2, #18, #63
+	ubfm	w2, w2, #18, #63
+==== no compose: label between
+---- before
+	ubfm	x2, x2, #56, #55
+.L103:
+	ubfm	x2, x2, #18, #63
+---- after
+	ubfm	x2, x2, #56, #55
+.L103:
+	ubfm	x2, x2, #18, #63
+==== rule disabled by its flag
+---- before
+	str	x1, [x0, #0]
+	str	x2, [x0, #8]
+---- after
+	str	x1, [x0, #0]
+	str	x2, [x0, #8]

--- a/oxcaml/tests/backend/arm64_peephole/test.ml
+++ b/oxcaml/tests/backend/arm64_peephole/test.ml
@@ -1,0 +1,401 @@
+(* Tests for the arm64 assembly-level peephole optimizer. Each case builds a
+   stream of instructions and directives (as the emitter would), runs the
+   optimizer over it, and prints the stream before and after. *)
+
+[@@@ocaml.warning "+a-40-41-42"]
+
+open Arm64_ast.Ast
+module D = Asm_targets.Asm_directives
+module DLL = Doubly_linked_list
+module U = Arm64_peephole.Peephole_utils
+
+let current : U.asm_line DLL.t ref = ref (DLL.make_empty ())
+
+(* Route directives (labels, [.loc], ...) into the current stream, exactly as
+   the emitter routes them into its per-function buffer. *)
+let () =
+  D.initialize ~big_endian:false ~emit_assembly_comments:false ~emit:(fun d ->
+      DLL.add_end !current (U.Directive d));
+  (* [define_label] requires a current section; the [Section] directive goes to
+     the scratch stream above and is discarded. *)
+  D.switch_to_section Asm_targets.Asm_section.Text;
+  current := DLL.make_empty ()
+
+let ins name operands =
+  DLL.add_end !current (U.Ins (Instruction.I { name; operands }))
+
+let label n = D.define_label (Asm_targets.Asm_label.create_int Text n)
+
+let loc ~line = D.loc ~file_num:1 ~line ~col:0 ()
+
+let label_target n =
+  DSL.symbol
+    (Symbol.create_label Same_section_and_unit
+       (Asm_targets.Asm_label.create_int Text n))
+
+let mem ~base ~offset =
+  match DSL.mem_offset ~base ~scale:8 ~offset with
+  | Ok operand -> operand
+  | Offset_out_of_range ->
+    failwith (Printf.sprintf "unencodable test offset %d" offset)
+
+(* Shift aliases, encoded as the emitter encodes them (cf.
+   [Acc.ins_lsl_immediate] and friends). *)
+let lsl_ ~rd ~rn ~amount =
+  ins UBFM
+    (Quad
+       ( DSL.reg_x rd,
+         DSL.reg_x rn,
+         DSL.imm_six ((64 - amount) mod 64),
+         DSL.imm_six (63 - amount) ))
+
+let lsr_ ~rd ~rn ~amount =
+  ins UBFM
+    (Quad (DSL.reg_x rd, DSL.reg_x rn, DSL.imm_six amount, DSL.imm_six 63))
+
+let asr_ ~rd ~rn ~amount =
+  ins SBFM
+    (Quad (DSL.reg_x rd, DSL.reg_x rn, DSL.imm_six amount, DSL.imm_six 63))
+
+let add_imm ~rd ~rn ~imm =
+  ins ADD_immediate (Quad (rd, rn, DSL.imm imm, DSL.optional_none))
+
+let sub_imm ~rd ~rn ~imm =
+  ins SUB_immediate (Quad (rd, rn, DSL.imm imm, DSL.optional_none))
+
+let cmp_imm ~zr ~rn ~imm =
+  ins SUBS_immediate (Quad (zr, rn, DSL.imm imm, DSL.optional_none))
+
+let cmp_reg ~rn ~rm =
+  ins SUBS_shifted_register (Quad (DSL.xzr, rn, rm, DSL.optional_none))
+
+let print_stream stream =
+  DLL.iter stream ~f:(function
+    | U.Ins i -> Format.printf "\t%a@." Instruction.print i
+    | U.Directive d ->
+      let buffer = Buffer.create 80 in
+      D.Directive.print buffer d;
+      Format.printf "%s@." (Buffer.contents buffer))
+
+let run_test name build =
+  let stream = DLL.make_empty () in
+  current := stream;
+  build ();
+  Format.printf "==== %s@." name;
+  Format.printf "---- before@.";
+  print_stream stream;
+  Arm64_peephole.Peephole_optimize.optimize stream;
+  Format.printf "---- after@.";
+  print_stream stream
+
+(* ---- fuse_memory_pairs ---- *)
+
+let () =
+  run_test "str pair, ascending offsets (allocation-init shape)" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:(-8)));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:0)))
+
+let () =
+  run_test "ldr pair, descending sp offsets (reload shape)" (fun () ->
+      ins LDR (Pair (DSL.reg_x 0, mem ~base:Reg.sp ~offset:16));
+      ins LDR (Pair (DSL.reg_x 1, mem ~base:Reg.sp ~offset:8)))
+
+let () =
+  run_test "run of four stores fuses pairwise" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:8));
+      ins STR (Pair (DSL.reg_x 3, mem ~base:(Reg.reg_x 0) ~offset:16));
+      ins STR (Pair (DSL.reg_x 4, mem ~base:(Reg.reg_x 0) ~offset:24)))
+
+let () =
+  run_test "loc between the pair is dropped with the second instruction"
+    (fun () ->
+      loc ~line:1;
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      loc ~line:2;
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:8)))
+
+let () =
+  run_test "str pair involving lr" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:Reg.sp ~offset:0));
+      ins STR (Pair (DSL.lr, mem ~base:Reg.sp ~offset:8)))
+
+let () =
+  run_test "no fuse: label between" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      label 100;
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:8)))
+
+let () =
+  run_test "no fuse: offset gap of 16" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:16)))
+
+let () =
+  run_test "boundary: fused offset 504 is in range" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:504));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:512)))
+
+let () =
+  run_test "no fuse: fused offset 512 is out of range" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:512));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:520)))
+
+let () =
+  run_test "no fuse: unaligned offsets" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:4));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:12)))
+
+let () =
+  run_test "no fuse: w registers" (fun () ->
+      ins STR (Pair (DSL.reg_w 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      ins STR (Pair (DSL.reg_w 2, mem ~base:(Reg.reg_x 0) ~offset:8)))
+
+let () =
+  run_test "no fuse: pre-indexed addressing" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, DSL.mem_pre ~base:(Reg.reg_x 0) ~offset:0));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:8)))
+
+let () =
+  run_test "no fuse: different bases" (fun () ->
+      ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 3) ~offset:8)))
+
+let () =
+  run_test "no fuse: first load destination is the base" (fun () ->
+      ins LDR (Pair (DSL.reg_x 0, mem ~base:(Reg.reg_x 0) ~offset:0));
+      ins LDR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:8)))
+
+let () =
+  run_test "fuse: second load destination is the base" (fun () ->
+      ins LDR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      ins LDR (Pair (DSL.reg_x 0, mem ~base:(Reg.reg_x 0) ~offset:8)))
+
+let () =
+  run_test "no fuse: equal load destinations" (fun () ->
+      ins LDR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+      ins LDR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:8)))
+
+(* ---- merge_add_immediates ---- *)
+
+let () =
+  run_test "add/add merge (comballoc shape)" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:8;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:16)
+
+let () =
+  run_test "chain of three adds folds fully" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:8;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:16;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:32)
+
+let () =
+  run_test "add/sub merge with negative net" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:8;
+      sub_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:24)
+
+let () =
+  run_test "add/sub merge with zero net" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:8;
+      sub_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:8)
+
+let () =
+  run_test "add with sp source" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:DSL.sp ~imm:8;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:8)
+
+let () =
+  run_test "add with fp source and positive net" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:DSL.fp ~imm:8;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:8)
+
+let () =
+  run_test "no merge: fp source with negative net (no sub fp form)" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:DSL.fp ~imm:8;
+      sub_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:24)
+
+let () =
+  run_test "merge: combined immediate 4096 encodable as shifted" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:4095;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:1)
+
+let () =
+  run_test "no merge: combined immediate 4097 not encodable" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:4095;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:2)
+
+let () =
+  run_test "no merge: second source is not the first destination" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:8;
+      add_imm ~rd:(DSL.reg_x 3) ~rn:(DSL.reg_x 3) ~imm:16)
+
+let () =
+  run_test "no merge: destinations differ" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:8;
+      add_imm ~rd:(DSL.reg_x 3) ~rn:(DSL.reg_x 2) ~imm:16)
+
+let () =
+  run_test "no merge: label between (gc-return label shape)" (fun () ->
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 27) ~imm:8;
+      label 101;
+      add_imm ~rd:(DSL.reg_x 2) ~rn:(DSL.reg_x 2) ~imm:16)
+
+let () =
+  run_test "no merge: destination is sp" (fun () ->
+      ins ADD_immediate (Quad (DSL.sp, DSL.sp, DSL.imm 16, DSL.optional_none));
+      ins ADD_immediate (Quad (DSL.sp, DSL.sp, DSL.imm 16, DSL.optional_none)))
+
+(* ---- remove_redundant_cmp ---- *)
+
+let () =
+  run_test "redundant immediate compare across b.cond and store" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      ins (B_cond (Int NE)) (Singleton (label_target 900));
+      ins ORR_immediate (Triple (DSL.reg_x 1, DSL.xzr, DSL.bitmask 3n));
+      ins STR (Pair (DSL.reg_x 1, mem ~base:Reg.sp ~offset:64));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "redundant register compare" (fun () ->
+      cmp_reg ~rn:(DSL.reg_x 0) ~rm:(DSL.reg_x 1);
+      ins ORR_immediate (Triple (DSL.reg_x 2, DSL.xzr, DSL.bitmask 7n));
+      cmp_reg ~rn:(DSL.reg_x 0) ~rm:(DSL.reg_x 1))
+
+let () =
+  run_test "two redundant compares are both removed" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      ins ORR_immediate (Triple (DSL.reg_x 1, DSL.xzr, DSL.bitmask 3n));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      ins ORR_immediate (Triple (DSL.reg_x 2, DSL.xzr, DSL.bitmask 7n));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "no removal: compared register written in between" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      add_imm ~rd:(DSL.reg_x 0) ~rn:(DSL.reg_x 0) ~imm:8;
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "no removal: w0 written between compares on x0 (aliasing)" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      ins MOVZ
+        (Triple
+           ( DSL.reg_w 0,
+             DSL.imm_sixteen 5,
+             DSL.optional_lsl_by_multiple_of_16_bits_w 0 ));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "no removal: flag writer in between" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      ins ADDS (Quad (DSL.reg_x 1, DSL.reg_x 2, DSL.imm 0, DSL.optional_none));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "no removal: label in between" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      label 102;
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "no removal: call in between" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      ins BL (Singleton (label_target 901));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "no removal: width mismatch" (fun () ->
+      ins SUBS_immediate
+        (Quad (DSL.wzr, DSL.reg_w 0, DSL.imm 1, DSL.optional_none));
+      ins ORR_immediate (Triple (DSL.reg_x 1, DSL.xzr, DSL.bitmask 3n));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1)
+
+let () =
+  run_test "no removal: different immediate" (fun () ->
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:1;
+      ins ORR_immediate (Triple (DSL.reg_x 1, DSL.xzr, DSL.bitmask 3n));
+      cmp_imm ~zr:DSL.xzr ~rn:(DSL.reg_x 0) ~imm:3)
+
+(* ---- compose_shift_pairs ---- *)
+
+let () =
+  run_test "lsl 8 then lsr 18 (string-length shape)" (fun () ->
+      lsl_ ~rd:2 ~rn:2 ~amount:8;
+      lsr_ ~rd:2 ~rn:2 ~amount:18)
+
+let () =
+  run_test "lsl 8 then lsr 17 (mixed-block shape)" (fun () ->
+      lsl_ ~rd:2 ~rn:2 ~amount:8;
+      lsr_ ~rd:2 ~rn:2 ~amount:17)
+
+let () =
+  run_test "lsl 31 then asr 32" (fun () ->
+      lsl_ ~rd:2 ~rn:2 ~amount:31;
+      asr_ ~rd:2 ~rn:2 ~amount:32)
+
+let () =
+  run_test "lsr 18 then lsl 18 becomes a mask" (fun () ->
+      lsr_ ~rd:2 ~rn:2 ~amount:18;
+      lsl_ ~rd:2 ~rn:2 ~amount:18)
+
+let () =
+  run_test "lsl 3 then lsl 4 add up" (fun () ->
+      lsl_ ~rd:2 ~rn:2 ~amount:3;
+      lsl_ ~rd:2 ~rn:2 ~amount:4)
+
+let () =
+  run_test "lsr 3 then lsr 4 add up" (fun () ->
+      lsr_ ~rd:2 ~rn:2 ~amount:3;
+      lsr_ ~rd:2 ~rn:2 ~amount:4)
+
+let () =
+  run_test "asr chain saturates at 63" (fun () ->
+      asr_ ~rd:2 ~rn:2 ~amount:40;
+      asr_ ~rd:2 ~rn:2 ~amount:40)
+
+let () =
+  run_test "first shift may have a distinct source" (fun () ->
+      lsl_ ~rd:2 ~rn:1 ~amount:8;
+      lsr_ ~rd:2 ~rn:2 ~amount:18)
+
+let () =
+  run_test "no compose: lsr then lsl with different amounts" (fun () ->
+      lsr_ ~rd:2 ~rn:2 ~amount:18;
+      lsl_ ~rd:2 ~rn:2 ~amount:3)
+
+let () =
+  run_test "no compose: different registers" (fun () ->
+      lsl_ ~rd:2 ~rn:2 ~amount:8;
+      lsr_ ~rd:3 ~rn:3 ~amount:18)
+
+let () =
+  run_test "no compose: unclassifiable bitfield move (uxtb shape)" (fun () ->
+      ins UBFM (Quad (DSL.reg_x 2, DSL.reg_x 2, DSL.imm_six 0, DSL.imm_six 7));
+      lsr_ ~rd:2 ~rn:2 ~amount:18)
+
+let () =
+  run_test "no compose: over-shifted lsl chain" (fun () ->
+      lsl_ ~rd:2 ~rn:2 ~amount:40;
+      lsl_ ~rd:2 ~rn:2 ~amount:30)
+
+let () =
+  run_test "no compose: w-width shifts" (fun () ->
+      ins UBFM (Quad (DSL.reg_w 2, DSL.reg_w 2, DSL.imm_six 18, DSL.imm_six 63));
+      ins UBFM (Quad (DSL.reg_w 2, DSL.reg_w 2, DSL.imm_six 18, DSL.imm_six 63)))
+
+let () =
+  run_test "no compose: label between" (fun () ->
+      lsl_ ~rd:2 ~rn:2 ~amount:8;
+      label 103;
+      lsr_ ~rd:2 ~rn:2 ~amount:18)
+
+(* ---- driver / flags ---- *)
+
+let () =
+  Oxcaml_flags.arm64_peephole_fuse_memory_pairs := false;
+  Fun.protect
+    ~finally:(fun () -> Oxcaml_flags.arm64_peephole_fuse_memory_pairs := true)
+    (fun () ->
+      run_test "rule disabled by its flag" (fun () ->
+          ins STR (Pair (DSL.reg_x 1, mem ~base:(Reg.reg_x 0) ~offset:0));
+          ins STR (Pair (DSL.reg_x 2, mem ~base:(Reg.reg_x 0) ~offset:8))))

--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -22,7 +22,7 @@ type string_constant =
   ; tag : string
   }
 
-type expectation_filter = Principal | X86_64 | Raw | Simplify | Reaper
+type expectation_filter = Principal | X86_64 | ARM64 | Raw | Simplify | Reaper
 
 type expectation_kind = Expect_toplevel | Expect_asm | Expect_fexpr
 
@@ -53,6 +53,7 @@ type correction =
 let filter_of_string = function
   | "Principal" -> Some Principal
   | "X86_64" -> Some X86_64
+  | "ARM64" -> Some ARM64
   | "Raw" -> Some Raw
   | "Simplify" -> Some Simplify
   | "Reaper" -> Some Reaper
@@ -61,6 +62,7 @@ let filter_of_string = function
 let string_of_filter = function
   | Principal -> "Principal"
   | X86_64 -> "X86_64"
+  | ARM64 -> "ARM64"
   | Raw -> "Raw"
   | Simplify -> "Simplify"
   | Reaper -> "Reaper"
@@ -138,12 +140,12 @@ let match_expect_extension (ext : Parsetree.extension) =
       (filters, txt)
     in
     let is_arch_filter = function
-      | X86_64 -> true
+      | X86_64 | ARM64 -> true
       | Principal | Raw | Simplify | Reaper -> false
     in
     let is_pass_filter = function
       | Raw | Simplify | Reaper -> true
-      | Principal | X86_64 -> false
+      | Principal | X86_64 | ARM64 -> false
     in
     let validate_expect_toplevel entries =
       (* Valid formats:
@@ -308,14 +310,15 @@ let parse_contents ~fname contents =
 let current_arch_filter () =
   match Target_system.architecture () with
   | X86_64 -> Some X86_64
-  | AArch64 | IA32 | ARM | POWER | Z | Riscv -> None
+  | AArch64 -> Some ARM64
+  | IA32 | ARM | POWER | Z | Riscv -> None
 
 (* For [%%expect]:
    - {|...|} alone: used for both principal and non-principal
    - {|...|}, Principal{|...|}: first for non-principal, second for principal
 
    For [%%expect_asm]:
-   - All entries must have architecture tags (X86_64)
+   - All entries must have architecture tags (X86_64, ARM64)
 *)
 let eval_expectation expectation ~output =
   let to_update = match expectation.kind with
@@ -457,7 +460,7 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
         | Raw -> read_dump_file "raw"
         | Simplify -> read_dump_file "simplify"
         | Reaper -> read_dump_file "reaper"
-        | Principal | X86_64 -> "")
+        | Principal | X86_64 | ARM64 -> "")
     |> String.concat ~sep:"\n"
     |> (^) "\n"
   in

--- a/testsuite/tests/codegen/arm64_frame_pairs.ml
+++ b/testsuite/tests/codegen/arm64_frame_pairs.ml
@@ -1,0 +1,36 @@
+(* TEST
+ flags += " -O3";
+ flags += " -arm64-fuse-frame-ops";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Tests for fused arm64 frame allocation (-arm64-fuse-frame-ops). The
+   expected assembly blocks below are only checked on arm64 hosts; promote
+   them there with [make promote-one TEST=codegen/arm64_frame_pairs.ml]. *)
+
+(* A function that makes a non-tail call with no values live across it needs
+   a 16-byte frame (just the saved return address). The prologue should be a
+   single [stp xzr, x30, [sp, #-16]!] and the epilogue a single
+   [ldp xzr, x30, [sp], #16]. *)
+let[@inline never] callee x = x + 1
+
+let small_frame x = callee x + 1
+[%%expect_asm ARM64 {|
+|}]
+
+(* The fused epilogue must also appear before a tail call ([b], not [ret]). *)
+let epilogue_before_tail_call x =
+  let y = callee x in
+  callee y
+[%%expect_asm ARM64 {|
+|}]
+
+(* Values live across the call force spill slots, growing the frame beyond
+   16 bytes; the prologue/epilogue must then keep the two-instruction
+   sequences. *)
+let big_frame a b c =
+  let x = callee a in
+  x + b + c
+[%%expect_asm ARM64 {|
+|}]

--- a/testsuite/tests/codegen/arm64_peephole.ml
+++ b/testsuite/tests/codegen/arm64_peephole.ml
@@ -1,0 +1,49 @@
+(* TEST
+ flags += " -O3";
+ flags += " -arm64-peephole-optimize";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Tests for the arm64 assembly-level peephole optimizer
+   (backend/arm64_peephole). The expected assembly blocks below are only
+   checked on arm64 hosts; promote them there with
+   [make promote-one TEST=codegen/arm64_peephole.ml]. *)
+
+(* Field initialization of the allocated block should use [stp] rather than
+   one [str] per field (rule: fuse_memory_pairs). *)
+type t =
+  { a : int;
+    b : int;
+    c : int;
+    d : int
+  }
+
+let make_record a b c d = { a; b; c; d }
+[%%expect_asm ARM64 {|
+|}]
+
+(* Comballoc gives the second allocation its address as
+   [add rd, x27, #8; add rd, rd, #k]; the two adds should be merged
+   (rule: merge_add_immediates), and the field initializations should use
+   [stp] (rule: fuse_memory_pairs). *)
+let make_two_pairs x y = (x, y), (y, x)
+[%%expect_asm ARM64 {|
+|}]
+
+(* The string length computation is [lsl #8; lsr #17] on the header (for
+   byte-sized elements, followed by a subtraction involving the last byte);
+   the two shifts should be composed into a single [ubfm]
+   (rule: compose_shift_pairs). *)
+let string_length s = String.length s
+[%%expect_asm ARM64 {|
+|}]
+
+(* The second comparison of [x] against the same constant is redundant: the
+   store in between does not affect the flags
+   (rule: remove_redundant_cmp). *)
+let redundant_compare x r =
+  if x = 1 then r := 3;
+  if x = 1 then 5 else 7
+[%%expect_asm ARM64 {|
+|}]

--- a/testsuite/tests/codegen/cse_constants_across_calls.ml
+++ b/testsuite/tests/codegen/cse_constants_across_calls.ml
@@ -1,0 +1,36 @@
+(* TEST
+ flags += " -O3";
+ flags += " -cfg-cse-constants-across-calls";
+ only-default-codegen;
+ expect.opt;
+*)
+
+(* Tests for CSE of expensive constants across calls
+   (-cfg-cse-constants-across-calls). On arm64 a symbol materialization is
+   an adrp/ldr pair through the GOT; reusing the value computed before a
+   call replaces each later pair with a single stack reload. The expected
+   assembly blocks below are only checked on arm64 hosts; promote them
+   there with [make promote-one TEST=codegen/cse_constants_across_calls.ml]. *)
+
+let counter = ref 0
+
+let[@inline never] callee x = x + 1
+
+(* [counter]'s address should be materialized once, before the call, and
+   reused after it: a single adrp/ldr pair for the whole function. *)
+let across_one_call () =
+  counter := !counter + 1;
+  ignore (callee 0 : int);
+  counter := !counter + 2
+[%%expect_asm ARM64 {|
+|}]
+
+(* The reuse should extend across several calls in sequence. *)
+let across_two_calls () =
+  counter := !counter + 1;
+  ignore (callee 0 : int);
+  counter := !counter + 2;
+  ignore (callee 0 : int);
+  counter := !counter + 3
+[%%expect_asm ARM64 {|
+|}]


### PR DESCRIPTION
This needs a bit of work (and 22ed65f9063d1571582b51b437669f1da363345f is
actually not architecture-specific), but
the numbers look good:

- about -6.7% instructions are removed;
- about -3.6% assembler lines are removed;
- assembler files are -2.7% smaller overall; 

when all rules introduced by this pull request
are enabled.