### PR TITLE
Quick check for Allocation mode axis

### DIFF
--- a/oxcaml/tests/quickcheck-allocation/.gitignore
+++ b/oxcaml/tests/quickcheck-allocation/.gitignore
@@ -1,0 +1,1 @@
+witnesses

--- a/oxcaml/tests/quickcheck-allocation/README.md
+++ b/oxcaml/tests/quickcheck-allocation/README.md
@@ -22,8 +22,9 @@ Flags:
   `-count 1 -seed <seed>`
 - `-mode soundness|completeness` -- generation bias (default `soundness`):
   `soundness` favors programs the frontend should accept (immediates,
-  `exclave_`), hunting FE-accept & BE-reject bugs; `completeness` favors
-  non-allocating computation the frontend may conservatively reject
+  `exclave_`, closures, partial application, optional arguments), hunting
+  FE-accept & BE-reject bugs; `completeness` favors non-allocating
+  computation the frontend may conservatively reject
 - `-out DIR` -- save witness .ml files to DIR (created if missing): every
   soundness suspect, plus the first-seen witness of each distinct
   frontend-rejection cause. File names embed the seed

--- a/oxcaml/tests/quickcheck-allocation/README.md
+++ b/oxcaml/tests/quickcheck-allocation/README.md
@@ -8,24 +8,51 @@ Property-based tester for the frontend `Allocation` mode axis, using the backend
 Requires a built compiler. From the repo root:
 
 ```sh
-dune build @oxcaml/tests/quickcheck-allocation/quickcheck
+COMP=$PWD/_build/install/main/bin/ocamlopt.opt
+
+dune exec oxcaml/tests/quickcheck-allocation/main.exe -- $COMP \
+  -count 200 -seed 0 -mode soundness
 ```
 
-This builds `main.exe` and runs the fuzz loop against the just-built
-`ocamlopt.opt`. It is behind its own alias, so `make test` never runs it.
+Flags:
 
-Run directly for more control (`<ocamlopt>` = path to the built `ocamlopt.opt`):
+- `-count N` -- number of programs to try (default 200)
+- `-seed S` -- starting PRNG seed (default 0); round `k` uses seed `S + k`, so
+  runs are reproducible and a single case can be re-run with
+  `-count 1 -seed <seed>`
+- `-mode soundness|completeness` -- generation bias (default `soundness`):
+  `soundness` favors programs the frontend should accept (immediates,
+  `exclave_`), hunting FE-accept & BE-reject bugs; `completeness` favors
+  non-allocating computation the frontend may conservatively reject
+
+Pass the compiler as an absolute path (it is invoked via the shell). The fuzz
+loop can also be run via its alias, which uses the just-built `ocamlopt.opt`
+and the default flags:
 
 ```sh
-dune exec oxcaml/tests/quickcheck-allocation/main.exe -- <ocamlopt> -count 200 -seed 0
+dune build @oxcaml/tests/quickcheck-allocation/quickcheck --force
 ```
 
-Flags: `-count N` (programs to try), `-seed S` (starting PRNG seed).
+(`--force` because dune caches the successful run; without it a second build
+does nothing.) The alias is not part of `make test`.
 
 ## Output
 
-A per-quadrant tally, a list of soundness suspects (FE-accept & BE-reject), and
-a frequency-ranked table of precision-gap causes (FE-reject & BE-pass).
+A tally line, e.g.:
+
+```
+agree(noalloc)=22 suspects=0 fe_rejects=38 gen_errors=0
+```
+
+- `agree(noalloc)` -- FE accepted and the backend `zero_alloc` check passed
+- `suspects` -- FE accepted but the backend rejected: potential soundness bugs.
+  Each is printed in full below the tally (seed, program, backend error)
+- `fe_rejects` -- FE rejected: completeness candidates, printed as a
+  frequency-ranked table of rejection causes (the frontend-improvement
+  backlog). Since the program carries both annotations, a rejected program
+  does not compile, so the backend cannot confirm these
+- `gen_errors` -- compile failures unrelated to either check, i.e. generator
+  bugs; should be 0
 
 ## Editor / ocamllsp tip
 

--- a/oxcaml/tests/quickcheck-allocation/README.md
+++ b/oxcaml/tests/quickcheck-allocation/README.md
@@ -24,6 +24,12 @@ Flags:
   `soundness` favors programs the frontend should accept (immediates,
   `exclave_`), hunting FE-accept & BE-reject bugs; `completeness` favors
   non-allocating computation the frontend may conservatively reject
+- `-out DIR` -- save witness .ml files to DIR (created if missing): every
+  soundness suspect, plus the first-seen witness of each distinct
+  frontend-rejection cause. File names embed the seed
+  (`suspect_seed0042.ml`, `fe_reject_seed0007.ml`). Without this flag,
+  nothing is saved: programs live in temp files only for the duration of
+  their compiles, and results exist only on stdout
 
 Pass the compiler as an absolute path (it is invoked via the shell). The fuzz
 loop can also be run via its alias, which uses the just-built `ocamlopt.opt`

--- a/oxcaml/tests/quickcheck-allocation/README.md
+++ b/oxcaml/tests/quickcheck-allocation/README.md
@@ -1,0 +1,37 @@
+# quickcheck-allocation
+
+Property-based tester for the frontend `Allocation` mode axis, using the backend
+`zero_alloc` analysis as an oracle.
+
+## Build & run
+
+Requires a built compiler. From the repo root:
+
+```sh
+dune build @oxcaml/tests/quickcheck-allocation/quickcheck
+```
+
+This builds `main.exe` and runs the fuzz loop against the just-built
+`ocamlopt.opt`. It is behind its own alias, so `make test` never runs it.
+
+Run directly for more control (`<ocamlopt>` = path to the built `ocamlopt.opt`):
+
+```sh
+dune exec oxcaml/tests/quickcheck-allocation/main.exe -- <ocamlopt> -count 200 -seed 0
+```
+
+Flags: `-count N` (programs to try), `-seed S` (starting PRNG seed).
+
+## Output
+
+A per-quadrant tally, a list of soundness suspects (FE-accept & BE-reject), and
+a frequency-ranked table of precision-gap causes (FE-reject & BE-pass).
+
+## Editor / ocamllsp tip
+
+If ocamllsp shows spurious errors (e.g. `Unbound module`), rebuild in the
+`default` context and restart the language server:
+
+```sh
+dune build _build/default/oxcaml/tests/quickcheck-allocation/main.exe
+```

--- a/oxcaml/tests/quickcheck-allocation/dune
+++ b/oxcaml/tests/quickcheck-allocation/dune
@@ -1,0 +1,29 @@
+; QuickCheck tester for the Allocation mode axis.
+;
+; The fuzz loop is a standalone executable behind the @quickcheck alias so it
+; never runs as part of `make test`. Run it on demand with:
+;
+;   dune build @oxcaml/tests/quickcheck-allocation/quickcheck
+;
+; (Later, minimized witnesses under seeds/ become compile-and-diff runtest
+; rules; those DO ride along in `make test`.)
+
+; No enabled_if on the executable: it must be enabled in the boot ("default")
+; context so ocamllsp/Merlin, which uses that context, can resolve the modules.
+; No library dependencies (stdlib only): the boot compiler cannot build unix/str
+; from this repo's sources, so depending on them would break the LSP.
+
+(executable
+ (name main)
+ (modules gen oracle shrink fuzzer main))
+
+; The fuzz loop, however, must run against the freshly-built "main" compiler
+; (the boot compiler lacks the Allocation axis), so the alias is gated to it.
+
+(rule
+ (alias quickcheck)
+ (enabled_if
+  (= %{context_name} "main"))
+ (deps main.exe)
+ (action
+  (run ./main.exe %{bin:ocamlopt.opt} -count 200)))

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.ml
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.ml
@@ -1,0 +1,115 @@
+module Suspect = struct
+  type t =
+    { seed : int;
+      sample : Gen.Sample.t
+    }
+
+  let to_string { seed; sample } =
+    Printf.sprintf "seed=%d\n%s" seed (Gen.Sample.to_string sample)
+end
+
+module Gap = struct
+  type t =
+    { seed : int;
+      cause : string;
+      sample : Gen.Sample.t
+    }
+end
+
+module Stats = struct
+  type t =
+    { mutable agree_noalloc : int;
+      mutable agree_alloc : int;
+      mutable gen_errors : int;
+      suspects : Suspect.t Queue.t;
+      gaps : Gap.t Queue.t
+    }
+
+  let create () =
+    { agree_noalloc = 0;
+      agree_alloc = 0;
+      gen_errors = 0;
+      suspects = Queue.create ();
+      gaps = Queue.create ()
+    }
+
+  let agree_noalloc t = t.agree_noalloc
+
+  let agree_alloc t = t.agree_alloc
+
+  let gen_errors t = t.gen_errors
+
+  let suspects t = List.of_seq (Queue.to_seq t.suspects)
+
+  let gaps t = List.of_seq (Queue.to_seq t.gaps)
+
+  let record t ~seed ~(sample : Gen.Sample.t) ~frontend ~backend =
+    match Oracle.classify ~frontend ~backend with
+    | Error _ -> t.gen_errors <- t.gen_errors + 1
+    | Ok Oracle.Quadrant.Agree_noalloc -> t.agree_noalloc <- t.agree_noalloc + 1
+    | Ok Oracle.Quadrant.Agree_alloc -> t.agree_alloc <- t.agree_alloc + 1
+    | Ok Oracle.Quadrant.Soundness_suspect ->
+      Queue.add { Suspect.seed; sample } t.suspects
+    | Ok Oracle.Quadrant.Precision_gap ->
+      let cause = Oracle.Verdict.cause frontend in
+      Queue.add { Gap.seed; cause; sample } t.gaps
+end
+
+let write_source path contents =
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc
+
+let cleanup mlfile =
+  let base = Filename.remove_extension mlfile in
+  List.iter
+    (fun ext -> try Sys.remove (base ^ ext) with _ -> ())
+    [".ml"; ".cmi"; ".cmo"; ".cmx"; ".cmt"; ".cmti"; ".o"]
+
+let run_one stats ~compiler ~seed ~mode =
+  let sample = Gen.generate ~mode ~seed in
+  let fe = Filename.temp_file "qc_fe" ".ml" in
+  let be = Filename.temp_file "qc_be" ".ml" in
+  write_source fe sample.Gen.Sample.fe_source;
+  write_source be sample.Gen.Sample.be_source;
+  let frontend = Oracle.run_frontend ~compiler ~file:fe in
+  let backend = Oracle.run_backend ~compiler ~file:be in
+  Stats.record stats ~seed ~sample ~frontend ~backend;
+  cleanup fe;
+  cleanup be
+
+let run ~compiler ~count ~seed0 ~mode =
+  let stats = Stats.create () in
+  for k = 0 to count - 1 do
+    let seed = seed0 + k in
+    run_one stats ~compiler ~seed ~mode
+  done;
+  stats
+
+let report stats =
+  let suspects = Stats.suspects stats in
+  let gaps = Stats.gaps stats in
+  Printf.printf
+    "agree(noalloc)=%d agree(alloc)=%d suspects=%d gaps=%d gen_errors=%d\n"
+    (Stats.agree_noalloc stats)
+    (Stats.agree_alloc stats) (List.length suspects) (List.length gaps)
+    (Stats.gen_errors stats);
+  if suspects <> []
+  then (
+    print_endline "\nsoundness suspects (FE-accept & BE-reject):";
+    List.iter (fun s -> print_endline (Suspect.to_string s)) suspects);
+  if gaps <> []
+  then (
+    let tbl = Hashtbl.create 16 in
+    List.iter
+      (fun { Gap.cause; _ } ->
+        let n = try Hashtbl.find tbl cause with Not_found -> 0 in
+        Hashtbl.replace tbl cause (n + 1))
+      gaps;
+    let ranked =
+      List.sort
+        (fun (_, a) (_, b) -> compare b a)
+        (Hashtbl.fold (fun c n acc -> (c, n) :: acc) tbl [])
+    in
+    print_endline "\nprecision-gap causes (ranked):";
+    List.iter (fun (c, n) -> Printf.printf "  %4d  %s\n" n c) ranked)

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.ml
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.ml
@@ -81,6 +81,48 @@ let run ~compiler ~count ~seed0 ~mode =
   done;
   stats
 
+(* Keep header comments from being terminated early should a cause ever contain
+   "*)". *)
+let comment_safe s =
+  let buf = Buffer.create (String.length s) in
+  String.iteri
+    (fun i c ->
+      if c = ')' && i > 0 && s.[i - 1] = '*'
+      then Buffer.add_string buf " )"
+      else Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+
+let save stats ~dir =
+  if not (Sys.file_exists dir) then Sys.mkdir dir 0o755;
+  let saved = ref 0 in
+  let write name header source =
+    let oc = open_out (Filename.concat dir name) in
+    output_string oc header;
+    output_string oc source;
+    close_out oc;
+    incr saved
+  in
+  List.iter
+    (fun { Suspect.seed; sample; backend_error = _ } ->
+      write
+        (Printf.sprintf "suspect_seed%04d.ml" seed)
+        (Printf.sprintf "(* seed=%d; FE-accept & BE-reject *)\n" seed)
+        (Gen.Sample.to_string sample))
+    (Stats.suspects stats);
+  let seen_causes = Hashtbl.create 16 in
+  List.iter
+    (fun { Gap.seed; cause; sample } ->
+      if not (Hashtbl.mem seen_causes cause)
+      then (
+        Hashtbl.replace seen_causes cause ();
+        write
+          (Printf.sprintf "fe_reject_seed%04d.ml" seed)
+          (Printf.sprintf "(* seed=%d; %s *)\n" seed (comment_safe cause))
+          (Gen.Sample.to_string sample)))
+    (Stats.gaps stats);
+  Printf.printf "\nsaved %d witness files to %s\n" !saved dir
+
 let report stats =
   let suspects = Stats.suspects stats in
   let gaps = Stats.gaps stats in

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.ml
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.ml
@@ -1,11 +1,16 @@
 module Suspect = struct
   type t =
     { seed : int;
-      sample : Gen.Sample.t
+      sample : Gen.Sample.t;
+      backend_error : string
     }
 
-  let to_string { seed; sample } =
-    Printf.sprintf "seed=%d\n%s" seed (Gen.Sample.to_string sample)
+  let to_string { seed; sample; backend_error } =
+    Printf.sprintf
+      "seed=%d\n%sbackend error:\n%s"
+      seed
+      (Gen.Sample.to_string sample)
+      backend_error
 end
 
 module Gap = struct
@@ -19,7 +24,6 @@ end
 module Stats = struct
   type t =
     { mutable agree_noalloc : int;
-      mutable agree_alloc : int;
       mutable gen_errors : int;
       suspects : Suspect.t Queue.t;
       gaps : Gap.t Queue.t
@@ -27,7 +31,6 @@ module Stats = struct
 
   let create () =
     { agree_noalloc = 0;
-      agree_alloc = 0;
       gen_errors = 0;
       suspects = Queue.create ();
       gaps = Queue.create ()
@@ -35,23 +38,19 @@ module Stats = struct
 
   let agree_noalloc t = t.agree_noalloc
 
-  let agree_alloc t = t.agree_alloc
-
   let gen_errors t = t.gen_errors
 
   let suspects t = List.of_seq (Queue.to_seq t.suspects)
 
   let gaps t = List.of_seq (Queue.to_seq t.gaps)
 
-  let record t ~seed ~(sample : Gen.Sample.t) ~frontend ~backend =
-    match Oracle.classify ~frontend ~backend with
+  let record t ~seed ~(sample : Gen.Sample.t) ~outcome =
+    match (outcome : (Oracle.Outcome.t, string) result) with
     | Error _ -> t.gen_errors <- t.gen_errors + 1
-    | Ok Oracle.Quadrant.Agree_noalloc -> t.agree_noalloc <- t.agree_noalloc + 1
-    | Ok Oracle.Quadrant.Agree_alloc -> t.agree_alloc <- t.agree_alloc + 1
-    | Ok Oracle.Quadrant.Soundness_suspect ->
-      Queue.add { Suspect.seed; sample } t.suspects
-    | Ok Oracle.Quadrant.Precision_gap ->
-      let cause = Oracle.Verdict.cause frontend in
+    | Ok Oracle.Outcome.Agree_noalloc -> t.agree_noalloc <- t.agree_noalloc + 1
+    | Ok (Oracle.Outcome.Soundness_suspect { backend_error }) ->
+      Queue.add { Suspect.seed; sample; backend_error } t.suspects
+    | Ok (Oracle.Outcome.Fe_reject { cause }) ->
       Queue.add { Gap.seed; cause; sample } t.gaps
 end
 
@@ -68,15 +67,11 @@ let cleanup mlfile =
 
 let run_one stats ~compiler ~seed ~mode =
   let sample = Gen.generate ~mode ~seed in
-  let fe = Filename.temp_file "qc_fe" ".ml" in
-  let be = Filename.temp_file "qc_be" ".ml" in
-  write_source fe sample.Gen.Sample.fe_source;
-  write_source be sample.Gen.Sample.be_source;
-  let frontend = Oracle.run_frontend ~compiler ~file:fe in
-  let backend = Oracle.run_backend ~compiler ~file:be in
-  Stats.record stats ~seed ~sample ~frontend ~backend;
-  cleanup fe;
-  cleanup be
+  let file = Filename.temp_file "qc_alloc" ".ml" in
+  write_source file sample.Gen.Sample.source;
+  let outcome = Oracle.check ~compiler ~file in
+  Stats.record stats ~seed ~sample ~outcome;
+  cleanup file
 
 let run ~compiler ~count ~seed0 ~mode =
   let stats = Stats.create () in
@@ -90,10 +85,9 @@ let report stats =
   let suspects = Stats.suspects stats in
   let gaps = Stats.gaps stats in
   Printf.printf
-    "agree(noalloc)=%d agree(alloc)=%d suspects=%d gaps=%d gen_errors=%d\n"
+    "agree(noalloc)=%d suspects=%d fe_rejects=%d gen_errors=%d\n"
     (Stats.agree_noalloc stats)
-    (Stats.agree_alloc stats) (List.length suspects) (List.length gaps)
-    (Stats.gen_errors stats);
+    (List.length suspects) (List.length gaps) (Stats.gen_errors stats);
   if suspects <> []
   then (
     print_endline "\nsoundness suspects (FE-accept & BE-reject):";
@@ -111,5 +105,5 @@ let report stats =
         (fun (_, a) (_, b) -> compare b a)
         (Hashtbl.fold (fun c n acc -> (c, n) :: acc) tbl [])
     in
-    print_endline "\nprecision-gap causes (ranked):";
+    print_endline "\nfrontend rejections (completeness candidates, ranked by cause):";
     List.iter (fun (c, n) -> Printf.printf "  %4d  %s\n" n c) ranked)

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.ml
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.ml
@@ -6,9 +6,7 @@ module Suspect = struct
     }
 
   let to_string { seed; sample; backend_error } =
-    Printf.sprintf
-      "seed=%d\n%sbackend error:\n%s"
-      seed
+    Printf.sprintf "seed=%d\n%sbackend error:\n%s" seed
       (Gen.Sample.to_string sample)
       backend_error
 end
@@ -126,8 +124,7 @@ let save stats ~dir =
 let report stats =
   let suspects = Stats.suspects stats in
   let gaps = Stats.gaps stats in
-  Printf.printf
-    "agree(noalloc)=%d suspects=%d fe_rejects=%d gen_errors=%d\n"
+  Printf.printf "agree(noalloc)=%d suspects=%d fe_rejects=%d gen_errors=%d\n"
     (Stats.agree_noalloc stats)
     (List.length suspects) (List.length gaps) (Stats.gen_errors stats);
   if suspects <> []
@@ -147,5 +144,6 @@ let report stats =
         (fun (_, a) (_, b) -> compare b a)
         (Hashtbl.fold (fun c n acc -> (c, n) :: acc) tbl [])
     in
-    print_endline "\nfrontend rejections (completeness candidates, ranked by cause):";
+    print_endline
+      "\nfrontend rejections (completeness candidates, ranked by cause):";
     List.iter (fun (c, n) -> Printf.printf "  %4d  %s\n" n c) ranked)

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.mli
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.mli
@@ -44,3 +44,10 @@ val run :
   compiler:string -> count:int -> seed0:int -> mode:Gen.Mode.t -> Stats.t
 
 val report : Stats.t -> unit
+
+(* Save witness .ml files to [dir] (created if missing): every soundness
+   suspect, and the first-seen witness of each distinct frontend-rejection
+   cause. File names embed the seed (e.g. suspect_seed0042.ml,
+   fe_reject_seed0007.ml), so any witness can be re-run with
+   [-count 1 -seed N]. *)
+val save : Stats.t -> dir:string -> unit

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.mli
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.mli
@@ -48,6 +48,6 @@ val report : Stats.t -> unit
 (* Save witness .ml files to [dir] (created if missing): every soundness
    suspect, and the first-seen witness of each distinct frontend-rejection
    cause. File names embed the seed (e.g. suspect_seed0042.ml,
-   fe_reject_seed0007.ml), so any witness can be re-run with
-   [-count 1 -seed N]. *)
+   fe_reject_seed0007.ml), so any witness can be re-run with [-count 1 -seed
+   N]. *)
 val save : Stats.t -> dir:string -> unit

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.mli
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.mli
@@ -1,0 +1,46 @@
+(* The fuzz loop: generate programs, run the two-oracle check, classify into the
+   four quadrants, and aggregate the results. *)
+
+module Suspect : sig
+  (* A soundness suspect (FE-accept & BE-reject): ambiguous, needs manual
+     triage. *)
+  type t =
+    { seed : int;
+      sample : Gen.Sample.t
+    }
+
+  val to_string : t -> string
+end
+
+module Gap : sig
+  (* A precision gap (FE-reject & BE-pass): trustworthy frontend
+     conservatism. *)
+  type t =
+    { seed : int;
+      cause : string; (* canonical frontend rejection cause, for bucketing *)
+      sample : Gen.Sample.t
+    }
+end
+
+module Stats : sig
+  type t
+
+  val agree_noalloc : t -> int
+
+  val agree_alloc : t -> int
+
+  val gen_errors : t -> int
+
+  (* Both lists are in generation order. *)
+  val suspects : t -> Suspect.t list
+
+  val gaps : t -> Gap.t list
+end
+
+(* Run [count] rounds starting from PRNG seed [seed0] (round [k] uses seed
+   [seed0 + k]), all in generation mode [mode]. [compiler] is the path to the
+   built [ocamlopt.opt]. *)
+val run :
+  compiler:string -> count:int -> seed0:int -> mode:Gen.Mode.t -> Stats.t
+
+val report : Stats.t -> unit

--- a/oxcaml/tests/quickcheck-allocation/fuzzer.mli
+++ b/oxcaml/tests/quickcheck-allocation/fuzzer.mli
@@ -1,20 +1,22 @@
-(* The fuzz loop: generate programs, run the two-oracle check, classify into the
-   four quadrants, and aggregate the results. *)
+(* The fuzz loop: generate programs, run the oracle pipeline, and aggregate the
+   results. *)
 
 module Suspect : sig
   (* A soundness suspect (FE-accept & BE-reject): ambiguous, needs manual
      triage. *)
   type t =
     { seed : int;
-      sample : Gen.Sample.t
+      sample : Gen.Sample.t;
+      backend_error : string
     }
 
   val to_string : t -> string
 end
 
 module Gap : sig
-  (* A precision gap (FE-reject & BE-pass): trustworthy frontend
-     conservatism. *)
+  (* A frontend rejection: a completeness (precision-gap) candidate, bucketed by
+     cause. The backend cannot confirm it, since the rejected program does not
+     compile. *)
   type t =
     { seed : int;
       cause : string; (* canonical frontend rejection cause, for bucketing *)
@@ -26,8 +28,6 @@ module Stats : sig
   type t
 
   val agree_noalloc : t -> int
-
-  val agree_alloc : t -> int
 
   val gen_errors : t -> int
 

--- a/oxcaml/tests/quickcheck-allocation/gen.ml
+++ b/oxcaml/tests/quickcheck-allocation/gen.ml
@@ -6,10 +6,24 @@
    terms, and a pretty-printer. A single program is emitted, carrying both
    annotations on the function under test (see [Sample]).
 
-   Tier A (milestone 2): construction of one layer -- tuples, records (int and
-   float), variants, lists, arrays -- plain vs [exclave_]-wrapped, plus
-   mode-crossing immediates, glued together with integer/float arithmetic,
-   comparisons, [let], and [if].
+   Tier A: construction of one layer -- tuples, records (int and float),
+   variants, lists, arrays -- plain vs [exclave_]-wrapped, plus mode-crossing
+   immediates, glued together with integer/float arithmetic, comparisons, [let],
+   and [if].
+
+   Tier B: closures, captures, and nesting -- arrow types can be [let]-bound and
+   returned, and lambda bodies freely reference enclosing bindings.
+
+   Tier C: application of in-scope functions, partial application, and labeled /
+   optional arguments (optionals both supplied and omitted; labeled and optional
+   parameters may be skipped and supplied later or passed out of order, since
+   they commute). Following the compiler's own representation, types stay
+   curried and binary ([Ty.Arrow], one labeled arrow per parameter) while
+   expressions carry the arity ([Expr.Lam] binds a list of parameters), so the
+   same arrow chain can be realized either as one n-ary function or as nested
+   unary closures -- same type, different allocation behavior. Argument labels
+   live in the type ([Arg_label]) and come from a small shared pool; binder
+   names are separate and always fresh, so shadowing is impossible.
 
    Per DESIGN.md, the generator does not predict allocation (the oracles decide
    ground truth); [Mode] only steers the distribution: [Soundness] biases toward
@@ -47,6 +61,28 @@ let prelude =
    type fr = { fx : float; fy : float }\n\
    type v = A | B of int\n\n"
 
+(* How an argument is passed, mirroring the compiler's [Asttypes.arg_label].
+   Part of the function type: it determines call-site syntax. For [Optional],
+   the arrow's payload type is the type behind the [?] (whether the *binder* has
+   a default is an expression-side property; see [Expr.param_kind]). *)
+module Arg_label = struct
+  type t =
+    | Nolabel (* t1 -> ... call: f e *)
+    | Labelled of string (* ~l:t1 -> ... call: f ~l:e *)
+    | Optional of string (* ?l:t1 -> ... call: f ~l:e, or omitted *)
+
+  let equal a b =
+    match a, b with
+    | Nolabel, Nolabel -> true
+    | Labelled l1, Labelled l2 | Optional l1, Optional l2 -> String.equal l1 l2
+    | (Nolabel | Labelled _ | Optional _), _ -> false
+
+  let to_string = function
+    | Nolabel -> ""
+    | Labelled l -> l ^ ":"
+    | Optional l -> "?" ^ l ^ ":"
+end
+
 module Ty = struct
   type t =
     | Int
@@ -57,6 +93,11 @@ module Ty = struct
     | Record_int (* r *)
     | Record_float (* fr *)
     | Variant (* v *)
+    | Arrow of
+        { label : Arg_label.t;
+          arg : t; (* payload type; for [Optional], the type behind the ? *)
+          ret : t (* possibly another [Arrow]: multi-parameter = a chain *)
+        }
 
   let rec equal t1 t2 =
     match t1, t2 with
@@ -65,8 +106,11 @@ module Ty = struct
       true
     | Pair (a1, b1), Pair (a2, b2) -> equal a1 a2 && equal b1 b2
     | List a, List b | Array a, Array b -> equal a b
+    | Arrow a1, Arrow a2 ->
+      Arg_label.equal a1.label a2.label
+      && equal a1.arg a2.arg && equal a1.ret a2.ret
     | ( ( Int | Float | Pair _ | List _ | Array _ | Record_int | Record_float
-        | Variant ),
+        | Variant | Arrow _ ),
         _ ) ->
       false
 
@@ -79,11 +123,25 @@ module Ty = struct
     | Record_int -> "r"
     | Record_float -> "fr"
     | Variant -> "v"
+    | Arrow { label; arg; ret } ->
+      "(" ^ Arg_label.to_string label ^ to_string arg ^ " -> " ^ to_string ret
+      ^ ")"
 
-  (* Types whose construction could plausibly be wrapped in [exclave_]. This is
-     distribution steering, not an allocation prediction. *)
+  (* The arrow chain of a function type: one (label, payload) per parameter,
+     outermost first, plus the final non-arrow result. *)
+  let rec arrows = function
+    | Arrow { label; arg; ret } ->
+      let params, result = arrows ret in
+      (label, arg) :: params, result
+    | ty -> [], ty
+
+  (* Types whose construction could plausibly be wrapped in [exclave_] (closures
+     are allocated too). This is distribution steering, not an allocation
+     prediction. *)
   let exclave_candidate = function
-    | Pair _ | List _ | Array _ | Record_int | Record_float | Variant -> true
+    | Pair _ | List _ | Array _ | Record_int | Record_float | Variant | Arrow _
+      ->
+      true
     | Int | Float -> false
 end
 
@@ -106,6 +164,38 @@ module Expr = struct
     | Constr_a (* A -- immediate *)
     | Constr_b of t (* B e -- boxed *)
     | Exclave of t (* exclave_ e; only ever placed in tail position *)
+    | Lam of
+        { params : param list;
+              (* n-ary: arity = length params. Function arity is syntactic since
+                 OCaml 5.2, so binding an arrow chain as one n-ary [Lam] (a
+                 single closure) or as nested unary [Lam]s (a closure allocating
+                 an inner closure per partial application) are different
+                 programs of the same type. *)
+          body : t
+        }
+    | App of
+        { f : t;
+          args : (Arg_label.t * t) list
+              (* in parameter order; an [Optional] parameter simply has no entry
+                 when omitted (it is erased when the following positional
+                 argument is applied) *)
+        }
+
+  and param =
+    { var : string;
+          (* binder, always fresh -- never shadows, and independent of the
+             type-side label *)
+      p_ty : Ty.t; (* payload type (matches the corresponding [Ty.Arrow.arg]) *)
+      kind : param_kind
+    }
+
+  and param_kind =
+    | Positional (* (var : t) *)
+    | Labelled of string (* ~label:(var : t) *)
+    | Opt of string * t option
+  (* [Some d]: ?label:(var = (d : t)), binder has type [t] in the body. [None]:
+     ?label:(var : t option) -- NOT generated yet: the binder would have type [t
+     option], which needs option types in [Ty]. *)
 
   (* Fully parenthesized: ugly but unambiguous, and shrinking (milestone 3) is
      the readability story, not the printer. *)
@@ -135,6 +225,29 @@ module Expr = struct
     | Constr_a -> "A"
     | Constr_b e -> "(B " ^ to_string e ^ ")"
     | Exclave e -> "exclave_ " ^ to_string e
+    | Lam { params; body } ->
+      "(fun "
+      ^ String.concat " " (List.map param_to_string params)
+      ^ " -> " ^ to_string body ^ ")"
+    | App { f; args } ->
+      "(" ^ to_string f ^ " "
+      ^ String.concat " " (List.map arg_to_string args)
+      ^ ")"
+
+  and param_to_string { var; p_ty; kind } =
+    match kind with
+    | Positional -> "(" ^ var ^ " : " ^ Ty.to_string p_ty ^ ")"
+    | Labelled l -> "~" ^ l ^ ":(" ^ var ^ " : " ^ Ty.to_string p_ty ^ ")"
+    | Opt (l, Some d) ->
+      "?" ^ l ^ ":(" ^ var ^ " = (" ^ to_string d ^ " : " ^ Ty.to_string p_ty
+      ^ "))"
+    | Opt (l, None) ->
+      "?" ^ l ^ ":(" ^ var ^ " : " ^ Ty.to_string p_ty ^ " option)"
+
+  and arg_to_string (label, e) =
+    match (label : Arg_label.t) with
+    | Nolabel -> to_string e
+    | Labelled l | Optional l -> "~" ^ l ^ ":" ^ to_string e
 end
 
 (* Generation context: PRNG state and a fresh-name supply. The typed environment
@@ -168,6 +281,51 @@ let small_ty ctx =
   choose ctx
     [(3, fun () -> Ty.Int); (2, fun () -> Ty.Float); (2, fun () -> Ty.Variant)]
 
+(* Function types, for [let]-bound and returned closures (Tiers B and C).
+   Components are leaf types, mirroring [small_ty]'s termination argument.
+   Parameter shapes come from a fixed list that respects the erasability
+   invariant: every [Optional] parameter is followed by a positional one
+   (otherwise it could never be omitted at a call site, and the definition trips
+   warning 16).
+
+   Labels come from a tiny fixed pool, distinct within a chain (duplicate labels
+   in one type would break argument matching) but deliberately shared across
+   function types: a partially-applied remainder with leftover labeled
+   parameters can then equal an independently generated goal type, which is what
+   makes label-skipping candidates reachable at all. Binders are separate from
+   labels, so this reuse cannot cause shadowing. *)
+let fun_ty ctx =
+  let shape =
+    choose ctx
+      [ (3, fun () -> [`P]);
+        (1, fun () -> [`L]);
+        (2, fun () -> [`P; `P]);
+        (1, fun () -> [`L; `P]);
+        (1, fun () -> [`P; `L]);
+        (1, fun () -> [`L; `L]);
+        (2, fun () -> [`O; `P]) ]
+  in
+  let l_idx = ref 0 in
+  let o_idx = ref 0 in
+  let labels =
+    List.map
+      (fun k ->
+        match k with
+        | `P -> Arg_label.Nolabel
+        | `L ->
+          let l = [| "la"; "lb" |].(!l_idx) in
+          incr l_idx;
+          Arg_label.Labelled l
+        | `O ->
+          let l = [| "oa"; "ob" |].(!o_idx) in
+          incr o_idx;
+          Arg_label.Optional l)
+      shape
+  in
+  List.fold_right
+    (fun label ret -> Ty.Arrow { label; arg = small_ty ctx; ret })
+    labels (small_ty ctx)
+
 let goal_ty ctx =
   let pair () = Ty.Pair (small_ty ctx, small_ty ctx) in
   match ctx.mode with
@@ -180,14 +338,18 @@ let goal_ty ctx =
         (2, fun () -> Ty.Record_float);
         (1, fun () -> Ty.Record_int);
         (1, fun () -> Ty.List (small_ty ctx));
-        (1, fun () -> Ty.Array (small_ty ctx)) ]
+        (1, fun () -> Ty.Array (small_ty ctx));
+        (* returning a closure is prime soundness bait: the closure (and its
+           captures) must be allocated *)
+        (2, fun () -> fun_ty ctx) ]
   | Mode.Completeness ->
     choose ctx
       [ (6, fun () -> Ty.Int);
         (2, fun () -> Ty.Float);
         (2, fun () -> Ty.Variant);
         1, pair;
-        (1, fun () -> Ty.List (small_ty ctx)) ]
+        (1, fun () -> Ty.List (small_ty ctx));
+        (1, fun () -> fun_ty ctx) ]
 
 let int_lit ctx = Expr.Int_lit (Random.State.int ctx.rng 13 - 3)
 
@@ -210,9 +372,11 @@ let rec gen_expr ctx env ty fuel =
     Expr.Var x
   in
   let let_in () =
-    (* CR shsong: Here let only allow bind with small_ty; we may need to allow
-       more flexibility here. *)
-    let bound_ty = small_ty ctx in
+    let bound_ty =
+      choose ctx
+        [ (4, fun () -> small_ty ctx);
+          ((if completeness then 1 else 2), fun () -> fun_ty ctx) ]
+    in
     let x = fresh ctx in
     let e1 = gen_expr ctx env bound_ty (fuel - 1) in
     let e2 = gen_expr ctx ((x, bound_ty) :: env) ty (fuel - 1) in
@@ -225,10 +389,114 @@ let rec gen_expr ctx env ty fuel =
     in
     Expr.If (c, gen_expr ctx env ty (fuel - 1), gen_expr ctx env ty (fuel - 1))
   in
+  (* Tier C: apply an in-scope function. Argument matching follows OCaml's
+     rules, so an application may skip parameters and supply them later: -
+     labeled / optional parameters commute: any subset of them may be supplied,
+     in any order relative to the rest; - positional parameters cannot be
+     reordered: the supplied ones must form a prefix of the function's
+     positional parameters; - a skipped [Optional] parameter is erased
+     (defaulted) if a positional argument matching a later parameter is
+     supplied, and otherwise remains in the result type. A candidate is a
+     function variable plus a nonempty parameter subset such that the type
+     remaining after the application equals the goal type; supplying fewer than
+     all parameters is partial application. Subsets are enumerated by bitmask,
+     which is fine while [fun_ty] chains stay short. *)
+  let app_candidates =
+    List.concat_map
+      (fun (x, ty') ->
+        match Ty.arrows ty' with
+        | [], _ -> []
+        | params, result ->
+          let n = List.length params in
+          let indices = List.init n (fun i -> i) in
+          let nth i = List.nth params i in
+          let is_positional i =
+            match fst (nth i) with
+            | Arg_label.Nolabel -> true
+            | Arg_label.Labelled _ | Arg_label.Optional _ -> false
+          in
+          List.filter_map
+            (fun mask ->
+              let in_set i = mask land (1 lsl i) <> 0 in
+              (* no positional parameter may be supplied after a skipped one *)
+              let positionals_form_prefix =
+                let rec ok seen_skipped = function
+                  | [] -> true
+                  | i :: rest ->
+                    if in_set i
+                    then (not seen_skipped) && ok false rest
+                    else ok true rest
+                in
+                ok false (List.filter is_positional indices)
+              in
+              if not positionals_form_prefix
+              then None
+              else begin
+                let erased i =
+                  (match fst (nth i) with
+                    | Arg_label.Optional _ -> not (in_set i)
+                    | Arg_label.Nolabel | Arg_label.Labelled _ -> false)
+                  && List.exists
+                       (fun j -> j > i && in_set j && is_positional j)
+                       indices
+                in
+                let remaining =
+                  List.fold_right
+                    (fun i acc ->
+                      if in_set i || erased i
+                      then acc
+                      else
+                        let label, arg = nth i in
+                        Ty.Arrow { label; arg; ret = acc })
+                    indices result
+                in
+                if Ty.equal remaining ty
+                then
+                  Some
+                    ( x,
+                      List.filter_map
+                        (fun i -> if in_set i then Some (nth i) else None)
+                        indices )
+                else None
+              end)
+            (List.init ((1 lsl n) - 1) (fun m -> m + 1)))
+      env
+  in
+  let apply () =
+    let f, supplied =
+      List.nth app_candidates
+        (Random.State.int ctx.rng (List.length app_candidates))
+    in
+    let args =
+      List.map
+        (fun ((label : Arg_label.t), arg_ty) ->
+          label, gen_expr ctx env arg_ty (fuel - 1))
+        supplied
+    in
+    (* Labeled arguments also commute syntactically: sometimes emit them ahead
+       of the positional ones (the relative order of positional arguments is
+       preserved either way). *)
+    let args =
+      if List.length args > 1 && Random.State.int ctx.rng 2 = 0
+      then begin
+        let labeled, positional =
+          List.partition
+            (fun ((l : Arg_label.t), _) ->
+              match l with Labelled _ | Optional _ -> true | Nolabel -> false)
+            args
+        in
+        labeled @ positional
+      end
+      else args
+    in
+    Expr.App { f = Expr.Var f; args }
+  in
   let generic =
     [ (if vars = [] then 0 else 3), use_var;
       deep 1, let_in;
-      deep (if completeness then 3 else 1), if_ ]
+      deep (if completeness then 3 else 1), if_;
+      ( (if app_candidates = [] then 0 else deep (if completeness then 2 else 3)),
+        apply ) ]
   in
   (* Productions specific to the goal type. *)
   let structural =
@@ -283,6 +551,73 @@ let rec gen_expr ctx env ty fuel =
         ((if completeness then 2 else 4), fun () -> Expr.Constr_a);
         (deep 2, fun () -> Expr.Constr_b (gen_expr ctx env Ty.Int (fuel - 1)))
       ]
+    (* Tier B: lambdas. Bind a prefix of [k] parameters in this [Lam]; k < chain
+       length leaves a function-typed body, i.e. nested closures, while k =
+       chain length is the n-ary single-closure form -- same type, different
+       allocation behavior, so both are generated. Split points where a bound
+       [Optional] parameter is not followed by a bound positional one are
+       excluded (the optional would be unerasable within this syntactic
+       function: warning 16). Parameter binders are fresh and independent of the
+       type-side labels; a default expression may refer to earlier parameters of
+       the same lambda. Not [deep]-gated: like construction, a lambda must be
+       available at exhausted fuel (its body then bottoms out in leaves, since
+       [fun_ty] components are leaf types). *)
+    | Ty.Arrow _ ->
+      [ ( 4,
+          fun () ->
+            let all, _result = Ty.arrows ty in
+            let total = List.length all in
+            let valid k =
+              let prefix = List.filteri (fun i _ -> i < k) all in
+              let rec ok = function
+                | [] -> true
+                | ((l : Arg_label.t), _) :: rest -> (
+                  match l with
+                  | Optional _ ->
+                    List.exists
+                      (fun ((l', _) : Arg_label.t * _) ->
+                        match l' with
+                        | Nolabel -> true
+                        | Labelled _ | Optional _ -> false)
+                      rest
+                    && ok rest
+                  | Nolabel | Labelled _ -> ok rest)
+              in
+              ok prefix
+            in
+            (* k = total is always valid thanks to [fun_ty]'s erasability
+               invariant, so [ks] is never empty. *)
+            let ks = List.filter valid (List.init total (fun i -> i + 1)) in
+            let k = List.nth ks (Random.State.int ctx.rng (List.length ks)) in
+            let prefix = List.filteri (fun i _ -> i < k) all in
+            let rec ret_after k chain =
+              if k = 0
+              then chain
+              else
+                match chain with
+                | Ty.Arrow { ret; _ } -> ret_after (k - 1) ret
+                | _ -> assert false
+            in
+            let rev_params, env' =
+              List.fold_left
+                (fun (params, env) ((label : Arg_label.t), arg_ty) ->
+                  let var = fresh ctx in
+                  let kind =
+                    match label with
+                    | Nolabel -> Expr.Positional
+                    | Labelled l -> Expr.Labelled l
+                    | Optional l ->
+                      (* always with a default for now; see [Expr.param_kind] *)
+                      Expr.Opt (l, Some (gen_expr ctx env arg_ty (fuel - 1)))
+                  in
+                  ( { Expr.var; p_ty = arg_ty; kind } :: params,
+                    (var, arg_ty) :: env ))
+                ([], env) prefix
+            in
+            Expr.Lam
+              { params = List.rev rev_params;
+                body = gen_expr ctx env' (ret_after k ty) (fuel - 1)
+              } ) ]
   in
   choose ctx (generic @ structural)
 

--- a/oxcaml/tests/quickcheck-allocation/gen.ml
+++ b/oxcaml/tests/quickcheck-allocation/gen.ml
@@ -1,10 +1,10 @@
 (* Type-directed program generator. See DESIGN.md, "Generation".
 
-      Structure follows the in-repo precedent of
-   testsuite/tests/comprehensions/quickcheck_lists_arrays_haskell_python.ml: a typed AST
-   ([Expr]), a type-directed generator that only produces well-typed terms, and a
-   pretty-printer. A single program is emitted, carrying both annotations on the
-   function under test (see [Sample]).
+   Structure follows the in-repo precedent of
+   testsuite/tests/comprehensions/quickcheck_lists_arrays_haskell_python.ml: a
+   typed AST ([Expr]), a type-directed generator that only produces well-typed
+   terms, and a pretty-printer. A single program is emitted, carrying both
+   annotations on the function under test (see [Sample]).
 
    Tier A (milestone 2): construction of one layer -- tuples, records (int and
    float), variants, lists, arrays -- plain vs [exclave_]-wrapped, plus
@@ -210,6 +210,8 @@ let rec gen_expr ctx env ty fuel =
     Expr.Var x
   in
   let let_in () =
+    (* CR shsong: Here let only allow bind with small_ty; we may need to allow
+       more flexibility here. *)
     let bound_ty = small_ty ctx in
     let x = fresh ctx in
     let e1 = gen_expr ctx env bound_ty (fuel - 1) in
@@ -300,18 +302,17 @@ let generate ~mode ~seed =
   let env = ["x0", Ty.Int; "x1", Ty.Float] in
   let ty = goal_ty ctx in
   let body = maybe_exclave ctx ty (gen_expr ctx env ty initial_fuel) in
-    (* No return-type annotation is emitted since a plain [: ty] could interact with
-     mode inference. Both annotations go on the same function: [@ noalloc_strict]
-     drives the frontend check (and forces the body's allocations local), and
-     [@zero_alloc strict] makes the backend check exactly that typed program. *)
+  (* No return-type annotation is emitted since a plain [: ty] could interact
+     with mode inference. Both annotations go on the same function: [@
+     noalloc_strict] drives the frontend check (and forces the body's
+     allocations local), and [@zero_alloc strict] makes the backend check
+     exactly that typed program. *)
   let header = Printf.sprintf "(* goal: %s *)\n" (Ty.to_string ty) in
   let body_str = Expr.to_string body in
   let source =
     Printf.sprintf
-      "%s%slet[@zero_alloc strict] (f @ noalloc_strict) (x0 : int) (x1 : float) = %s\n"
-      prelude
-      header
-      body_str
+      "%s%slet[@zero_alloc strict] (f @ noalloc_strict) (x0 : int) (x1 : \
+       float) = %s\n"
+      prelude header body_str
   in
   { Sample.source }
-;;

--- a/oxcaml/tests/quickcheck-allocation/gen.ml
+++ b/oxcaml/tests/quickcheck-allocation/gen.ml
@@ -1,0 +1,43 @@
+module Mode = struct
+  type t =
+    | Soundness
+    | Completeness
+
+  let to_string = function
+    | Soundness -> "soundness"
+    | Completeness -> "completeness"
+
+  let of_string = function
+    | "soundness" -> Some Soundness
+    | "completeness" -> Some Completeness
+    | _ -> None
+end
+
+module Sample = struct
+  type t =
+    { fe_source : string;
+      be_source : string
+    }
+
+  let to_string { fe_source; be_source } =
+    Printf.sprintf "(* frontend *)\n%s(* backend *)\n%s" fe_source be_source
+end
+
+let prelude = ""
+
+(* CR shsong: placeholder generator. Emits a trivial non-allocating identity so
+   the end-to-end oracle path (milestone 1) can be exercised; it always lands in
+   the [Agree_noalloc] quadrant. Replace with real type-directed generation
+   (milestones 2-4): build a well-typed body of a chosen type, tracking a coarse
+   allocation potential to steer toward the [mode]'s target quadrant. *)
+let generate ~mode ~seed =
+  ignore (mode : Mode.t);
+  ignore (seed : int);
+  let body = "x0" in
+  let fe_source =
+    Printf.sprintf "%slet (f @ noalloc_strict) (x0 : int) = %s\n" prelude body
+  in
+  let be_source =
+    Printf.sprintf "%slet[@zero_alloc strict] f (x0 : int) = %s\n" prelude body
+  in
+  { Sample.fe_source; be_source }

--- a/oxcaml/tests/quickcheck-allocation/gen.ml
+++ b/oxcaml/tests/quickcheck-allocation/gen.ml
@@ -1,7 +1,27 @@
+(* Type-directed program generator. See DESIGN.md, "Generation".
+
+      Structure follows the in-repo precedent of
+   testsuite/tests/comprehensions/quickcheck_lists_arrays_haskell_python.ml: a typed AST
+   ([Expr]), a type-directed generator that only produces well-typed terms, and a
+   pretty-printer. A single program is emitted, carrying both annotations on the
+   function under test (see [Sample]).
+
+   Tier A (milestone 2): construction of one layer -- tuples, records (int and
+   float), variants, lists, arrays -- plain vs [exclave_]-wrapped, plus
+   mode-crossing immediates, glued together with integer/float arithmetic,
+   comparisons, [let], and [if].
+
+   Per DESIGN.md, the generator does not predict allocation (the oracles decide
+   ground truth); [Mode] only steers the distribution: [Soundness] biases toward
+   constructs the frontend is likely to accept (immediates, [exclave_]),
+   [Completeness] toward non-allocating computation the frontend may
+   conservatively reject (arithmetic, comparisons, branching). *)
+
 module Mode = struct
   type t =
-    | Soundness
+    | Soundness (* bias toward programs the frontend accepts *)
     | Completeness
+  (* bias toward non-allocating but conservatively-rejected forms *)
 
   let to_string = function
     | Soundness -> "soundness"
@@ -14,30 +34,284 @@ module Mode = struct
 end
 
 module Sample = struct
-  type t =
-    { fe_source : string;
-      be_source : string
-    }
+  type t = { source : string }
 
-  let to_string { fe_source; be_source } =
-    Printf.sprintf "(* frontend *)\n%s(* backend *)\n%s" fe_source be_source
+  let to_string { source } = source
 end
 
-let prelude = ""
+(* Shared type declarations emitted into both files. [r] is an
+   all-immediate-field record, [fr] a float record (flat float layout), [v] a
+   variant with an immediate and a boxed constructor. *)
+let prelude =
+  "type r = { a : int; b : int }\n\
+   type fr = { fx : float; fy : float }\n\
+   type v = A | B of int\n\n"
 
-(* CR shsong: placeholder generator. Emits a trivial non-allocating identity so
-   the end-to-end oracle path (milestone 1) can be exercised; it always lands in
-   the [Agree_noalloc] quadrant. Replace with real type-directed generation
-   (milestones 2-4): build a well-typed body of a chosen type, tracking a coarse
-   allocation potential to steer toward the [mode]'s target quadrant. *)
+module Ty = struct
+  type t =
+    | Int
+    | Float
+    | Pair of t * t
+    | List of t
+    | Array of t
+    | Record_int (* r *)
+    | Record_float (* fr *)
+    | Variant (* v *)
+
+  let rec equal t1 t2 =
+    match t1, t2 with
+    | Int, Int | Float, Float -> true
+    | Record_int, Record_int | Record_float, Record_float | Variant, Variant ->
+      true
+    | Pair (a1, b1), Pair (a2, b2) -> equal a1 a2 && equal b1 b2
+    | List a, List b | Array a, Array b -> equal a b
+    | ( ( Int | Float | Pair _ | List _ | Array _ | Record_int | Record_float
+        | Variant ),
+        _ ) ->
+      false
+
+  let rec to_string = function
+    | Int -> "int"
+    | Float -> "float"
+    | Pair (a, b) -> "(" ^ to_string a ^ " * " ^ to_string b ^ ")"
+    | List t -> to_string t ^ " list"
+    | Array t -> to_string t ^ " array"
+    | Record_int -> "r"
+    | Record_float -> "fr"
+    | Variant -> "v"
+
+  (* Types whose construction could plausibly be wrapped in [exclave_]. This is
+     distribution steering, not an allocation prediction. *)
+  let exclave_candidate = function
+    | Pair _ | List _ | Array _ | Record_int | Record_float | Variant -> true
+    | Int | Float -> false
+end
+
+module Expr = struct
+  type t =
+    | Var of string
+    | Int_lit of int
+    | Float_lit of float
+    | Add of t * t (* int + int *)
+    | Fadd of t * t (* float +. float *)
+    | Leq of t * t (* int <= int, used only as an [If] condition *)
+    | If of t * t * t
+    | Let of string * t * t
+    | Pair of t * t
+    | Nil
+    | Cons of t * t
+    | Array_lit of t list
+    | Record_int of t * t (* { a; b } *)
+    | Record_float of t * t (* { fx; fy } *)
+    | Constr_a (* A -- immediate *)
+    | Constr_b of t (* B e -- boxed *)
+    | Exclave of t (* exclave_ e; only ever placed in tail position *)
+
+  (* Fully parenthesized: ugly but unambiguous, and shrinking (milestone 3) is
+     the readability story, not the printer. *)
+  let rec to_string = function
+    | Var x -> x
+    | Int_lit n ->
+      if n < 0 then "(" ^ string_of_int n ^ ")" else string_of_int n
+    | Float_lit f ->
+      let s = Printf.sprintf "%F" f in
+      if f < 0.0 then "(" ^ s ^ ")" else s
+    | Add (a, b) -> "(" ^ to_string a ^ " + " ^ to_string b ^ ")"
+    | Fadd (a, b) -> "(" ^ to_string a ^ " +. " ^ to_string b ^ ")"
+    | Leq (a, b) -> "(" ^ to_string a ^ " <= " ^ to_string b ^ ")"
+    | If (c, t, e) ->
+      "(if " ^ to_string c ^ " then " ^ to_string t ^ " else " ^ to_string e
+      ^ ")"
+    | Let (x, e1, e2) ->
+      "(let " ^ x ^ " = " ^ to_string e1 ^ " in " ^ to_string e2 ^ ")"
+    | Pair (a, b) -> "(" ^ to_string a ^ ", " ^ to_string b ^ ")"
+    | Nil -> "[]"
+    | Cons (h, t) -> "(" ^ to_string h ^ " :: " ^ to_string t ^ ")"
+    | Array_lit es -> "[| " ^ String.concat "; " (List.map to_string es) ^ " |]"
+    | Record_int (a, b) ->
+      "{ a = " ^ to_string a ^ "; b = " ^ to_string b ^ " }"
+    | Record_float (a, b) ->
+      "{ fx = " ^ to_string a ^ "; fy = " ^ to_string b ^ " }"
+    | Constr_a -> "A"
+    | Constr_b e -> "(B " ^ to_string e ^ ")"
+    | Exclave e -> "exclave_ " ^ to_string e
+end
+
+(* Generation context: PRNG state and a fresh-name supply. The typed environment
+   is threaded functionally so bindings scope correctly. *)
+type ctx =
+  { rng : Random.State.t;
+    mutable next_var : int;
+    mode : Mode.t
+  }
+
+let fresh ctx =
+  let n = ctx.next_var in
+  ctx.next_var <- n + 1;
+  Printf.sprintf "v%d" n
+
+(* Pick among weighted alternatives; entries with weight 0 are disabled. *)
+let choose ctx options =
+  let options = List.filter (fun (w, _) -> w > 0) options in
+  let total = List.fold_left (fun acc (w, _) -> acc + w) 0 options in
+  let rec pick n = function
+    | [] -> assert false
+    | (w, f) :: rest -> if n < w then f () else pick (n - w) rest
+  in
+  pick (Random.State.int ctx.rng total) options
+
+(* Component types for pairs / lists / arrays are leaf types only: Tier A is
+   about one layer of construction, and it also guarantees the generator
+   terminates (composite children generated at exhausted fuel bottom out in
+   literals). *)
+let small_ty ctx =
+  choose ctx
+    [(3, fun () -> Ty.Int); (2, fun () -> Ty.Float); (2, fun () -> Ty.Variant)]
+
+let goal_ty ctx =
+  let pair () = Ty.Pair (small_ty ctx, small_ty ctx) in
+  match ctx.mode with
+  | Mode.Soundness ->
+    choose ctx
+      [ (3, fun () -> Ty.Int);
+        (2, fun () -> Ty.Float);
+        (2, fun () -> Ty.Variant);
+        2, pair;
+        (2, fun () -> Ty.Record_float);
+        (1, fun () -> Ty.Record_int);
+        (1, fun () -> Ty.List (small_ty ctx));
+        (1, fun () -> Ty.Array (small_ty ctx)) ]
+  | Mode.Completeness ->
+    choose ctx
+      [ (6, fun () -> Ty.Int);
+        (2, fun () -> Ty.Float);
+        (2, fun () -> Ty.Variant);
+        1, pair;
+        (1, fun () -> Ty.List (small_ty ctx)) ]
+
+let int_lit ctx = Expr.Int_lit (Random.State.int ctx.rng 13 - 3)
+
+let float_lit ctx =
+  Expr.Float_lit (float_of_int (Random.State.int ctx.rng 13 - 3) *. 0.5)
+
+(* Generate a well-typed expression of type [ty] in environment [env]. Every
+   recursive call decreases [fuel]; once fuel is exhausted only non-recursive
+   productions (and one-layer construction with literal children) remain, so
+   generation terminates. *)
+let rec gen_expr ctx env ty fuel =
+  let completeness =
+    match ctx.mode with Mode.Completeness -> true | Mode.Soundness -> false
+  in
+  let deep w = if fuel > 0 then w else 0 in
+  (* Productions available at every type. *)
+  let vars = List.filter (fun (_, ty') -> Ty.equal ty' ty) env in
+  let use_var () =
+    let x, _ = List.nth vars (Random.State.int ctx.rng (List.length vars)) in
+    Expr.Var x
+  in
+  let let_in () =
+    let bound_ty = small_ty ctx in
+    let x = fresh ctx in
+    let e1 = gen_expr ctx env bound_ty (fuel - 1) in
+    let e2 = gen_expr ctx ((x, bound_ty) :: env) ty (fuel - 1) in
+    Expr.Let (x, e1, e2)
+  in
+  let if_ () =
+    let c =
+      Expr.Leq
+        (gen_expr ctx env Ty.Int (fuel - 1), gen_expr ctx env Ty.Int (fuel - 1))
+    in
+    Expr.If (c, gen_expr ctx env ty (fuel - 1), gen_expr ctx env ty (fuel - 1))
+  in
+  let generic =
+    [ (if vars = [] then 0 else 3), use_var;
+      deep 1, let_in;
+      deep (if completeness then 3 else 1), if_ ]
+  in
+  (* Productions specific to the goal type. *)
+  let structural =
+    match ty with
+    | Ty.Int ->
+      [ (2, fun () -> int_lit ctx);
+        ( deep (if completeness then 4 else 2),
+          fun () ->
+            Expr.Add
+              ( gen_expr ctx env Ty.Int (fuel - 1),
+                gen_expr ctx env Ty.Int (fuel - 1) ) ) ]
+    | Ty.Float ->
+      [ (2, fun () -> float_lit ctx);
+        ( deep 2,
+          fun () ->
+            Expr.Fadd
+              ( gen_expr ctx env Ty.Float (fuel - 1),
+                gen_expr ctx env Ty.Float (fuel - 1) ) ) ]
+    | Ty.Pair (t1, t2) ->
+      [ ( 4,
+          fun () ->
+            Expr.Pair
+              (gen_expr ctx env t1 (fuel - 1), gen_expr ctx env t2 (fuel - 1))
+        ) ]
+    | Ty.List t ->
+      [ (2, fun () -> Expr.Nil);
+        ( deep 3,
+          fun () ->
+            Expr.Cons
+              (gen_expr ctx env t (fuel - 1), gen_expr ctx env ty (fuel - 1)) )
+      ]
+    | Ty.Array t ->
+      [ ( 3,
+          fun () ->
+            let n = Random.State.int ctx.rng 4 in
+            Expr.Array_lit
+              (List.init n (fun _ -> gen_expr ctx env t (fuel - 1))) ) ]
+    | Ty.Record_int ->
+      [ ( 4,
+          fun () ->
+            Expr.Record_int
+              ( gen_expr ctx env Ty.Int (fuel - 1),
+                gen_expr ctx env Ty.Int (fuel - 1) ) ) ]
+    | Ty.Record_float ->
+      [ ( 4,
+          fun () ->
+            Expr.Record_float
+              ( gen_expr ctx env Ty.Float (fuel - 1),
+                gen_expr ctx env Ty.Float (fuel - 1) ) ) ]
+    | Ty.Variant ->
+      [ (* Soundness mode favors the immediate constructor (mode crossing). *)
+        ((if completeness then 2 else 4), fun () -> Expr.Constr_a);
+        (deep 2, fun () -> Expr.Constr_b (gen_expr ctx env Ty.Int (fuel - 1)))
+      ]
+  in
+  choose ctx (generic @ structural)
+
+(* CR: [exclave_] is only placed at the very top of the body (a tail position by
+   construction). Extend to tail positions of [if]/[let] when Tier B lands. *)
+let maybe_exclave ctx ty body =
+  match ctx.mode with
+  | Mode.Soundness
+    when Ty.exclave_candidate ty && Random.State.int ctx.rng 3 = 0 ->
+    Expr.Exclave body
+  | Mode.Soundness | Mode.Completeness -> body
+
+let initial_fuel = 5
+
 let generate ~mode ~seed =
-  ignore (mode : Mode.t);
-  ignore (seed : int);
-  let body = "x0" in
-  let fe_source =
-    Printf.sprintf "%slet (f @ noalloc_strict) (x0 : int) = %s\n" prelude body
+  let ctx = { rng = Random.State.make [| seed |]; next_var = 0; mode } in
+  let env = ["x0", Ty.Int; "x1", Ty.Float] in
+  let ty = goal_ty ctx in
+  let body = maybe_exclave ctx ty (gen_expr ctx env ty initial_fuel) in
+    (* No return-type annotation is emitted since a plain [: ty] could interact with
+     mode inference. Both annotations go on the same function: [@ noalloc_strict]
+     drives the frontend check (and forces the body's allocations local), and
+     [@zero_alloc strict] makes the backend check exactly that typed program. *)
+  let header = Printf.sprintf "(* goal: %s *)\n" (Ty.to_string ty) in
+  let body_str = Expr.to_string body in
+  let source =
+    Printf.sprintf
+      "%s%slet[@zero_alloc strict] (f @ noalloc_strict) (x0 : int) (x1 : float) = %s\n"
+      prelude
+      header
+      body_str
   in
-  let be_source =
-    Printf.sprintf "%slet[@zero_alloc strict] f (x0 : int) = %s\n" prelude body
-  in
-  { Sample.fe_source; be_source }
+  { Sample.source }
+;;

--- a/oxcaml/tests/quickcheck-allocation/gen.ml
+++ b/oxcaml/tests/quickcheck-allocation/gen.ml
@@ -90,6 +90,7 @@ module Ty = struct
     | Pair of t * t
     | List of t
     | Array of t
+    (* CR shsong: need to improve how we generate user-defined types *)
     | Record_int (* r *)
     | Record_float (* fr *)
     | Variant (* v *)
@@ -150,6 +151,7 @@ module Expr = struct
     | Var of string
     | Int_lit of int
     | Float_lit of float
+    (* CR shsong: consider to group bop to one variant *)
     | Add of t * t (* int + int *)
     | Fadd of t * t (* float +. float *)
     | Leq of t * t (* int <= int, used only as an [If] condition *)
@@ -159,6 +161,8 @@ module Expr = struct
     | Nil
     | Cons of t * t
     | Array_lit of t list
+    (* CR shsong: in the following four cases, user defined types are hard-coded
+       again. Improve this. *)
     | Record_int of t * t (* { a; b } *)
     | Record_float of t * t (* { fx; fy } *)
     | Constr_a (* A -- immediate *)
@@ -194,8 +198,10 @@ module Expr = struct
     | Labelled of string (* ~label:(var : t) *)
     | Opt of string * t option
   (* [Some d]: ?label:(var = (d : t)), binder has type [t] in the body. [None]:
-     ?label:(var : t option) -- NOT generated yet: the binder would have type [t
-     option], which needs option types in [Ty]. *)
+     ?label:(var : t option)
+
+     CR shsong: the [None] case is NOT generated yet: the binder would have type
+     [t option], which needs option types in [Ty]. *)
 
   (* Fully parenthesized: ugly but unambiguous, and shrinking (milestone 3) is
      the readability story, not the printer. *)
@@ -322,10 +328,15 @@ let fun_ty ctx =
           Arg_label.Optional l)
       shape
   in
+  (* CR shsong: It seems that currently a function type can only be an 1 or
+     2-ary function returns small_ty. *)
   List.fold_right
     (fun label ret -> Ty.Arrow { label; arg = small_ty ctx; ret })
     labels (small_ty ctx)
 
+(* CR shsong: We should allow more flexibility of generated type here: 1. Avoid
+   having small_ty, i.e., allow other types in pair, list, array, and function
+   return type; 2. Allow more kinds of variant and record types. *)
 let goal_ty ctx =
   let pair () = Ty.Pair (small_ty ctx, small_ty ctx) in
   match ctx.mode with
@@ -372,6 +383,8 @@ let rec gen_expr ctx env ty fuel =
     Expr.Var x
   in
   let let_in () =
+    (* CR shsong: bound_ty cannot be user-defined type here like a record or a
+       variant. *)
     let bound_ty =
       choose ctx
         [ (4, fun () -> small_ty ctx);

--- a/oxcaml/tests/quickcheck-allocation/gen.mli
+++ b/oxcaml/tests/quickcheck-allocation/gen.mli
@@ -11,10 +11,12 @@ module Mode : sig
 end
 
 module Sample : sig
-  type t =
-    { fe_source : string;
-      be_source : string
-    }
+  (* A single program carrying both annotations on each function under test:
+     [@ noalloc_strict] drives the frontend Allocation-axis check, and
+     [@zero_alloc strict] enables the backend check. Both checks must see the same
+     program because the mode annotation changes inference (it forces every allocation
+     in the function to be local). *)
+  type t = { source : string }
 
   val to_string : t -> string
 end

--- a/oxcaml/tests/quickcheck-allocation/gen.mli
+++ b/oxcaml/tests/quickcheck-allocation/gen.mli
@@ -11,10 +11,10 @@ module Mode : sig
 end
 
 module Sample : sig
-  (* A single program carrying both annotations on each function under test:
-     [@ noalloc_strict] drives the frontend Allocation-axis check, and
-     [@zero_alloc strict] enables the backend check. Both checks must see the same
-     program because the mode annotation changes inference (it forces every allocation
+  (* A single program carrying both annotations on each function under test: [@
+     noalloc_strict] drives the frontend Allocation-axis check, and [@zero_alloc
+     strict] enables the backend check. Both checks must see the same program
+     because the mode annotation changes inference (it forces every allocation
      in the function to be local). *)
   type t = { source : string }
 

--- a/oxcaml/tests/quickcheck-allocation/gen.mli
+++ b/oxcaml/tests/quickcheck-allocation/gen.mli
@@ -1,0 +1,22 @@
+(* Type-directed program generator. *)
+
+module Mode : sig
+  type t =
+    | Soundness
+    | Completeness
+
+  val to_string : t -> string
+
+  val of_string : string -> t option
+end
+
+module Sample : sig
+  type t =
+    { fe_source : string;
+      be_source : string
+    }
+
+  val to_string : t -> string
+end
+
+val generate : mode:Mode.t -> seed:int -> Sample.t

--- a/oxcaml/tests/quickcheck-allocation/main.ml
+++ b/oxcaml/tests/quickcheck-allocation/main.ml
@@ -1,0 +1,45 @@
+(* Entry point: parse arguments and hand off to [Fuzzer]. Usage:
+
+   main.exe <ocamlopt-path> [-count N] [-seed S] *)
+
+let count = ref 200
+let seed0 = ref 0
+let compiler = ref ""
+let mode = ref Gen.Mode.Soundness
+
+let usage_msg =
+  "main.exe <ocamlopt-path> [-count N] [-seed S] [-mode soundness|completeness]"
+;;
+
+let speclist =
+  [ ( "-count"
+    , Arg.Set_int count
+    , Printf.sprintf "N  number of programs to try (default %d)" !count )
+  ; "-seed", Arg.Set_int seed0, Printf.sprintf "S  starting PRNG seed (default %d)" !seed0
+  ; ( "-mode"
+    , Arg.Symbol
+        ( [ "soundness"; "completeness" ]
+        , fun s ->
+            match Gen.Mode.of_string s with
+            | Some m -> mode := m
+            | None -> raise (Arg.Bad (Printf.sprintf "unknown mode %S" s)) )
+    , Printf.sprintf "  hunting mode (default %s)" (Gen.Mode.to_string !mode) )
+  ]
+;;
+
+let anon_arg s =
+  if !compiler = ""
+  then compiler := s
+  else raise (Arg.Bad (Printf.sprintf "unexpected extra argument %S" s))
+;;
+
+let () =
+  Arg.parse speclist anon_arg usage_msg;
+  if !compiler = ""
+  then (
+    prerr_endline "error: missing <ocamlopt-path>";
+    Arg.usage speclist usage_msg;
+    exit 2);
+  let stats = Fuzzer.run ~compiler:!compiler ~count:!count ~seed0:!seed0 ~mode:!mode in
+  Fuzzer.report stats
+;;

--- a/oxcaml/tests/quickcheck-allocation/main.ml
+++ b/oxcaml/tests/quickcheck-allocation/main.ml
@@ -3,40 +3,43 @@
    main.exe <ocamlopt-path> [-count N] [-seed S] [-mode M] [-out DIR] *)
 
 let count = ref 200
+
 let seed0 = ref 0
+
 let compiler = ref ""
+
 let mode = ref Gen.Mode.Soundness
+
 let out_dir = ref ""
 
 let usage_msg =
-  "main.exe <ocamlopt-path> [-count N] [-seed S] [-mode soundness|completeness] \
-   [-out DIR]"
-;;
+  "main.exe <ocamlopt-path> [-count N] [-seed S] [-mode \
+   soundness|completeness] [-out DIR]"
 
 let speclist =
-  [ ( "-count"
-    , Arg.Set_int count
-    , Printf.sprintf "N  number of programs to try (default %d)" !count )
-  ; "-seed", Arg.Set_int seed0, Printf.sprintf "S  starting PRNG seed (default %d)" !seed0
-  ; ( "-mode"
-    , Arg.Symbol
-        ( [ "soundness"; "completeness" ]
-        , fun s ->
+  [ ( "-count",
+      Arg.Set_int count,
+      Printf.sprintf "N  number of programs to try (default %d)" !count );
+    ( "-seed",
+      Arg.Set_int seed0,
+      Printf.sprintf "S  starting PRNG seed (default %d)" !seed0 );
+    ( "-mode",
+      Arg.Symbol
+        ( ["soundness"; "completeness"],
+          fun s ->
             match Gen.Mode.of_string s with
             | Some m -> mode := m
-            | None -> raise (Arg.Bad (Printf.sprintf "unknown mode %S" s)) )
-    , Printf.sprintf "  hunting mode (default %s)" (Gen.Mode.to_string !mode) )
-  ; ( "-out"
-    , Arg.Set_string out_dir
-    , "DIR  save witness .ml files (all suspects; one per rejection cause) to DIR" )
-  ]
-;;
+            | None -> raise (Arg.Bad (Printf.sprintf "unknown mode %S" s)) ),
+      Printf.sprintf "  hunting mode (default %s)" (Gen.Mode.to_string !mode) );
+    ( "-out",
+      Arg.Set_string out_dir,
+      "DIR  save witness .ml files (all suspects; one per rejection cause) to \
+       DIR" ) ]
 
 let anon_arg s =
   if !compiler = ""
   then compiler := s
   else raise (Arg.Bad (Printf.sprintf "unexpected extra argument %S" s))
-;;
 
 let () =
   Arg.parse speclist anon_arg usage_msg;
@@ -45,7 +48,8 @@ let () =
     prerr_endline "error: missing <ocamlopt-path>";
     Arg.usage speclist usage_msg;
     exit 2);
-  let stats = Fuzzer.run ~compiler:!compiler ~count:!count ~seed0:!seed0 ~mode:!mode in
+  let stats =
+    Fuzzer.run ~compiler:!compiler ~count:!count ~seed0:!seed0 ~mode:!mode
+  in
   Fuzzer.report stats;
   if !out_dir <> "" then Fuzzer.save stats ~dir:!out_dir
-;;

--- a/oxcaml/tests/quickcheck-allocation/main.ml
+++ b/oxcaml/tests/quickcheck-allocation/main.ml
@@ -1,14 +1,16 @@
 (* Entry point: parse arguments and hand off to [Fuzzer]. Usage:
 
-   main.exe <ocamlopt-path> [-count N] [-seed S] *)
+   main.exe <ocamlopt-path> [-count N] [-seed S] [-mode M] [-out DIR] *)
 
 let count = ref 200
 let seed0 = ref 0
 let compiler = ref ""
 let mode = ref Gen.Mode.Soundness
+let out_dir = ref ""
 
 let usage_msg =
-  "main.exe <ocamlopt-path> [-count N] [-seed S] [-mode soundness|completeness]"
+  "main.exe <ocamlopt-path> [-count N] [-seed S] [-mode soundness|completeness] \
+   [-out DIR]"
 ;;
 
 let speclist =
@@ -24,6 +26,9 @@ let speclist =
             | Some m -> mode := m
             | None -> raise (Arg.Bad (Printf.sprintf "unknown mode %S" s)) )
     , Printf.sprintf "  hunting mode (default %s)" (Gen.Mode.to_string !mode) )
+  ; ( "-out"
+    , Arg.Set_string out_dir
+    , "DIR  save witness .ml files (all suspects; one per rejection cause) to DIR" )
   ]
 ;;
 
@@ -41,5 +46,6 @@ let () =
     Arg.usage speclist usage_msg;
     exit 2);
   let stats = Fuzzer.run ~compiler:!compiler ~count:!count ~seed0:!seed0 ~mode:!mode in
-  Fuzzer.report stats
+  Fuzzer.report stats;
+  if !out_dir <> "" then Fuzzer.save stats ~dir:!out_dir
 ;;

--- a/oxcaml/tests/quickcheck-allocation/main.mli
+++ b/oxcaml/tests/quickcheck-allocation/main.mli
@@ -1,0 +1,1 @@
+(* Deliberately empty: [main.ml] is the executable entry point and exports nothing. *)

--- a/oxcaml/tests/quickcheck-allocation/main.mli
+++ b/oxcaml/tests/quickcheck-allocation/main.mli
@@ -1,1 +1,2 @@
-(* Deliberately empty: [main.ml] is the executable entry point and exports nothing. *)
+(* Deliberately empty: [main.ml] is the executable entry point and exports
+   nothing. *)

--- a/oxcaml/tests/quickcheck-allocation/oracle.ml
+++ b/oxcaml/tests/quickcheck-allocation/oracle.ml
@@ -31,9 +31,9 @@ module Outcome = struct
   type t =
     | Agree_noalloc (* FE accepts, BE passes -- agree *)
     | Soundness_suspect of { backend_error : string }
-        (* FE accepts, BE rejects -- ambiguous, triage *)
+      (* FE accepts, BE rejects -- ambiguous, triage *)
     | Fe_reject of { cause : string }
-        (* FE rejects -- possible precision gap; not confirmable by the backend *)
+  (* FE rejects -- possible precision gap; not confirmable by the backend *)
 end
 
 (* Run [compiler] with [args], returning (exit_code, captured_stderr). stdout is
@@ -128,9 +128,9 @@ let check ~compiler ~file =
   | Verdict.Reject _ as frontend ->
     (* The program does not typecheck, so the backend check cannot run on it. *)
     Ok (Outcome.Fe_reject { cause = Verdict.cause frontend })
-  | Verdict.Accept ->
-    (match run_backend ~compiler ~file with
-     | Verdict.Gen_error e -> Error e
-     | Verdict.Accept -> Ok Outcome.Agree_noalloc
-     | Verdict.Reject backend_error ->
-       Ok (Outcome.Soundness_suspect { backend_error }))
+  | Verdict.Accept -> (
+    match run_backend ~compiler ~file with
+    | Verdict.Gen_error e -> Error e
+    | Verdict.Accept -> Ok Outcome.Agree_noalloc
+    | Verdict.Reject backend_error ->
+      Ok (Outcome.Soundness_suspect { backend_error }))

--- a/oxcaml/tests/quickcheck-allocation/oracle.ml
+++ b/oxcaml/tests/quickcheck-allocation/oracle.ml
@@ -1,0 +1,105 @@
+module Verdict = struct
+  type t =
+    | Accept (* the check succeeded (exit 0) *)
+    | Reject of
+        string (* the check failed as expected; payload = captured stderr *)
+    | Gen_error of string (* compile failed for an unrelated reason *)
+
+  (* Helper to extract canonical "cause" of a frontend rejection, for
+     deduplicating precision gaps into a ranked backlog. For now: the first line
+     beginning with "Error:".
+
+     CR shsong: refine to normalize locations / extract the offending value
+     name. *)
+  let first_error_line msg =
+    let is_error l = String.length l >= 6 && String.sub l 0 6 = "Error:" in
+    let rec find = function
+      | [] -> "unknown"
+      | l :: rest ->
+        let l = String.trim l in
+        if is_error l then l else find rest
+    in
+    find (String.split_on_char '\n' msg)
+
+  let cause v =
+    match v with
+    | Reject msg -> first_error_line msg
+    | Accept | Gen_error _ -> "unknown"
+end
+
+module Quadrant = struct
+  type t =
+    | Agree_noalloc (* FE accept, BE pass *)
+    | Agree_alloc (* FE reject, BE reject *)
+    | Soundness_suspect (* FE accept, BE reject -- ambiguous, triage *)
+    | Precision_gap (* FE reject, BE pass -- trustworthy frontend gap *)
+end
+
+(* Run [compiler] with [args], returning (exit_code, captured_stderr). stdout is
+   discarded; the checks we care about report on stderr. Uses [Sys.command] (via
+   /bin/sh) rather than the [unix] library so the tool builds with the stdlib
+   alone -- the boot compiler used for the LSP cannot build [unix] from this
+   repo's sources. [compiler] and every arg are shell-quoted, so an absolute
+   [compiler] path is required (a bare name would be resolved by the shell's
+   PATH). *)
+let run_compiler compiler args =
+  let stderr_file = Filename.temp_file "qc_alloc" ".stderr" in
+  let cmd =
+    Printf.sprintf "%s %s > /dev/null 2> %s" (Filename.quote compiler)
+      (String.concat " " (List.map Filename.quote args))
+      (Filename.quote stderr_file)
+  in
+  (* [Sys.command] returns the shell's exit status, i.e. the compiler's exit
+     code (or 128 + signal if it was killed). *)
+  let code = Sys.command cmd in
+  let ic = open_in_bin stderr_file in
+  let text = really_input_string ic (in_channel_length ic) in
+  close_in ic;
+  (try Sys.remove stderr_file with _ -> ());
+  code, text
+
+let frontend_flags =
+  [ "-c";
+    "-stop-after";
+    "typing";
+    "-extension";
+    "mode_alpha";
+    "-color";
+    "never";
+    "-error-style";
+    "short" ]
+
+(* Low optimization level on purpose: keeps BE-pass close to the naive lowering
+   so precision gaps are attributable to fixable frontend conservatism. *)
+let backend_flags =
+  [ "-c";
+    "-O0";
+    "-zero-alloc-check";
+    "default";
+    "-color";
+    "never";
+    "-error-style";
+    "short" ]
+
+let run_frontend ~compiler ~file =
+  let code, text = run_compiler compiler (frontend_flags @ [file]) in
+  (* CR shsong: a syntactically bad body would also give nonzero here; such
+     cases are caught by the backend returning [Gen_error] and are dropped in
+     [classify]. Refine to inspect [text] for the mode-error signature if
+     needed. *)
+  if code = 0 then Verdict.Accept else Verdict.Reject text
+
+let run_backend ~compiler ~file =
+  let code, text = run_compiler compiler (backend_flags @ [file]) in
+  match code with
+  | 0 -> Verdict.Accept
+  | 2 -> Verdict.Reject text
+  | _ -> Verdict.Gen_error text
+
+let classify ~frontend ~backend =
+  match frontend, backend with
+  | Verdict.Gen_error e, _ | _, Verdict.Gen_error e -> Error e
+  | Verdict.Accept, Verdict.Accept -> Ok Quadrant.Agree_noalloc
+  | Verdict.Reject _, Verdict.Reject _ -> Ok Quadrant.Agree_alloc
+  | Verdict.Accept, Verdict.Reject _ -> Ok Quadrant.Soundness_suspect
+  | Verdict.Reject _, Verdict.Accept -> Ok Quadrant.Precision_gap

--- a/oxcaml/tests/quickcheck-allocation/oracle.ml
+++ b/oxcaml/tests/quickcheck-allocation/oracle.ml
@@ -27,12 +27,13 @@ module Verdict = struct
     | Accept | Gen_error _ -> "unknown"
 end
 
-module Quadrant = struct
+module Outcome = struct
   type t =
-    | Agree_noalloc (* FE accept, BE pass *)
-    | Agree_alloc (* FE reject, BE reject *)
-    | Soundness_suspect (* FE accept, BE reject -- ambiguous, triage *)
-    | Precision_gap (* FE reject, BE pass -- trustworthy frontend gap *)
+    | Agree_noalloc (* FE accepts, BE passes -- agree *)
+    | Soundness_suspect of { backend_error : string }
+        (* FE accepts, BE rejects -- ambiguous, triage *)
+    | Fe_reject of { cause : string }
+        (* FE rejects -- possible precision gap; not confirmable by the backend *)
 end
 
 (* Run [compiler] with [args], returning (exit_code, captured_stderr). stdout is
@@ -69,18 +70,38 @@ let frontend_flags =
     "-error-style";
     "short" ]
 
-(* Low optimization level on purpose: keeps BE-pass close to the naive lowering
-   so precision gaps are attributable to fixable frontend conservatism. *)
+(* No -O flag: the default is the lowest optimization level (this compiler has
+   no -O0/-O1; only -O2/-O3 raise it). Keeping it low keeps BE-pass close to the
+   naive lowering, so precision gaps are attributable to fixable frontend
+   conservatism rather than to allocations flambda would optimize away.
+
+   The mode extension is needed here too: the backend run compiles the same
+   doubly-annotated source, which contains mode syntax. *)
 let backend_flags =
   [ "-c";
-    "-O0";
     "-zero-alloc-check";
     "default";
+    "-extension";
+    "mode_alpha";
     "-color";
     "never";
     "-error-style";
     "short" ]
 
+(* Does [text] contain [needle]? Substring search, stdlib only. *)
+let contains ~needle text =
+  let n = String.length text and k = String.length needle in
+  let rec loop i =
+    if i + k > n
+    then false
+    else if String.sub text i k = needle
+    then true
+    else loop (i + 1)
+  in
+  loop 0
+
+(* CR shsong: Frontend should distinguish allocation error from other error such
+   as local/global errors. *)
 let run_frontend ~compiler ~file =
   let code, text = run_compiler compiler (frontend_flags @ [file]) in
   (* CR shsong: a syntactically bad body would also give nonzero here; such
@@ -91,15 +112,25 @@ let run_frontend ~compiler ~file =
 
 let run_backend ~compiler ~file =
   let code, text = run_compiler compiler (backend_flags @ [file]) in
-  match code with
-  | 0 -> Verdict.Accept
-  | 2 -> Verdict.Reject text
-  | _ -> Verdict.Gen_error text
+  (* Exit 2 is OCaml's generic error code, not only a zero_alloc failure (e.g.
+     an unknown flag or a malformed body also exits 2). A genuine rejection must
+     carry the zero_alloc checker's signature; anything else is an unrelated
+     compile failure, i.e. a generator bug. *)
+  if code = 0
+  then Verdict.Accept
+  else if code = 2 && contains ~needle:"Annotation check for zero_alloc" text
+  then Verdict.Reject text
+  else Verdict.Gen_error text
 
-let classify ~frontend ~backend =
-  match frontend, backend with
-  | Verdict.Gen_error e, _ | _, Verdict.Gen_error e -> Error e
-  | Verdict.Accept, Verdict.Accept -> Ok Quadrant.Agree_noalloc
-  | Verdict.Reject _, Verdict.Reject _ -> Ok Quadrant.Agree_alloc
-  | Verdict.Accept, Verdict.Reject _ -> Ok Quadrant.Soundness_suspect
-  | Verdict.Reject _, Verdict.Accept -> Ok Quadrant.Precision_gap
+let check ~compiler ~file =
+  match run_frontend ~compiler ~file with
+  | Verdict.Gen_error e -> Error e
+  | Verdict.Reject _ as frontend ->
+    (* The program does not typecheck, so the backend check cannot run on it. *)
+    Ok (Outcome.Fe_reject { cause = Verdict.cause frontend })
+  | Verdict.Accept ->
+    (match run_backend ~compiler ~file with
+     | Verdict.Gen_error e -> Error e
+     | Verdict.Accept -> Ok Outcome.Agree_noalloc
+     | Verdict.Reject backend_error ->
+       Ok (Outcome.Soundness_suspect { backend_error }))

--- a/oxcaml/tests/quickcheck-allocation/oracle.mli
+++ b/oxcaml/tests/quickcheck-allocation/oracle.mli
@@ -1,8 +1,9 @@
-(* Oracle: run the frontend Allocation-mode check and the backend zero_alloc check on a
-   single doubly-annotated program, and classify the outcome. The same file is used for
-   both checks so that both analyses see the same typed program (the [@ noalloc_strict]
-   mode annotation changes inference by forcing the function's allocations local, so a
-   source without it would be a different program). *)
+(* Oracle: run the frontend Allocation-mode check and the backend zero_alloc
+   check on a single doubly-annotated program, and classify the outcome. The
+   same file is used for both checks so that both analyses see the same typed
+   program (the [@ noalloc_strict] mode annotation changes inference by forcing
+   the function's allocations local, so a source without it would be a different
+   program). *)
 
 module Verdict : sig
   type t =
@@ -15,16 +16,17 @@ module Verdict : sig
 end
 
 module Outcome : sig
-  (* Because the program carries both annotations, a frontend rejection is a type
-     error: the program does not compile, so the backend check cannot run on it. There
-     is no FE-reject & BE-pass quadrant anymore; frontend rejections are completeness
-     candidates, bucketed by cause. *)
+  (* Because the program carries both annotations, a frontend rejection is a
+     type error: the program does not compile, so the backend check cannot run
+     on it. There is no FE-reject & BE-pass quadrant anymore; frontend
+     rejections are completeness candidates, bucketed by cause. *)
   type t =
     | Agree_noalloc (* FE accepts, BE passes -- agree *)
     | Soundness_suspect of { backend_error : string }
-        (* FE accepts, BE rejects -- ambiguous (backend may be imprecise), triage *)
+      (* FE accepts, BE rejects -- ambiguous (backend may be imprecise),
+         triage *)
     | Fe_reject of { cause : string }
-        (* FE rejects -- possible precision gap; not confirmable by the backend *)
+  (* FE rejects -- possible precision gap; not confirmable by the backend *)
 end
 
 (* [compiler] must be an absolute path to the built [ocamlopt.opt]; it is
@@ -34,7 +36,8 @@ val run_frontend : compiler:string -> file:string -> Verdict.t
 
 val run_backend : compiler:string -> file:string -> Verdict.t
 
-(* The full oracle pipeline on one source file: the frontend typing check first, then
-   the backend zero_alloc check only if the frontend accepts. [Error] means a check
-   failed for a reason unrelated to the property under test, i.e. a generator bug. *)
+(* The full oracle pipeline on one source file: the frontend typing check first,
+   then the backend zero_alloc check only if the frontend accepts. [Error] means
+   a check failed for a reason unrelated to the property under test, i.e. a
+   generator bug. *)
 val check : compiler:string -> file:string -> (Outcome.t, string) result

--- a/oxcaml/tests/quickcheck-allocation/oracle.mli
+++ b/oxcaml/tests/quickcheck-allocation/oracle.mli
@@ -1,3 +1,9 @@
+(* Oracle: run the frontend Allocation-mode check and the backend zero_alloc check on a
+   single doubly-annotated program, and classify the outcome. The same file is used for
+   both checks so that both analyses see the same typed program (the [@ noalloc_strict]
+   mode annotation changes inference by forcing the function's allocations local, so a
+   source without it would be a different program). *)
+
 module Verdict : sig
   type t =
     | Accept (* the check succeeded (exit 0) *)
@@ -8,12 +14,17 @@ module Verdict : sig
   val cause : t -> string
 end
 
-module Quadrant : sig
+module Outcome : sig
+  (* Because the program carries both annotations, a frontend rejection is a type
+     error: the program does not compile, so the backend check cannot run on it. There
+     is no FE-reject & BE-pass quadrant anymore; frontend rejections are completeness
+     candidates, bucketed by cause. *)
   type t =
-    | Agree_noalloc (* FE accept, BE pass *)
-    | Agree_alloc (* FE reject, BE reject *)
-    | Soundness_suspect (* FE accept, BE reject -- ambiguous, triage *)
-    | Precision_gap (* FE reject, BE pass -- trustworthy frontend gap *)
+    | Agree_noalloc (* FE accepts, BE passes -- agree *)
+    | Soundness_suspect of { backend_error : string }
+        (* FE accepts, BE rejects -- ambiguous (backend may be imprecise), triage *)
+    | Fe_reject of { cause : string }
+        (* FE rejects -- possible precision gap; not confirmable by the backend *)
 end
 
 (* [compiler] must be an absolute path to the built [ocamlopt.opt]; it is
@@ -23,5 +34,7 @@ val run_frontend : compiler:string -> file:string -> Verdict.t
 
 val run_backend : compiler:string -> file:string -> Verdict.t
 
-val classify :
-  frontend:Verdict.t -> backend:Verdict.t -> (Quadrant.t, string) result
+(* The full oracle pipeline on one source file: the frontend typing check first, then
+   the backend zero_alloc check only if the frontend accepts. [Error] means a check
+   failed for a reason unrelated to the property under test, i.e. a generator bug. *)
+val check : compiler:string -> file:string -> (Outcome.t, string) result

--- a/oxcaml/tests/quickcheck-allocation/oracle.mli
+++ b/oxcaml/tests/quickcheck-allocation/oracle.mli
@@ -1,0 +1,27 @@
+module Verdict : sig
+  type t =
+    | Accept (* the check succeeded (exit 0) *)
+    | Reject of
+        string (* the check failed as expected; payload = captured stderr *)
+    | Gen_error of string (* compile failed for an unrelated reason *)
+
+  val cause : t -> string
+end
+
+module Quadrant : sig
+  type t =
+    | Agree_noalloc (* FE accept, BE pass *)
+    | Agree_alloc (* FE reject, BE reject *)
+    | Soundness_suspect (* FE accept, BE reject -- ambiguous, triage *)
+    | Precision_gap (* FE reject, BE pass -- trustworthy frontend gap *)
+end
+
+(* [compiler] must be an absolute path to the built [ocamlopt.opt]; it is
+   invoked via the shell, so a bare name would be resolved by the shell's
+   PATH. *)
+val run_frontend : compiler:string -> file:string -> Verdict.t
+
+val run_backend : compiler:string -> file:string -> Verdict.t
+
+val classify :
+  frontend:Verdict.t -> backend:Verdict.t -> (Quadrant.t, string) result

--- a/oxcaml/tests/quickcheck-allocation/shrink.ml
+++ b/oxcaml/tests/quickcheck-allocation/shrink.ml
@@ -1,0 +1,8 @@
+(* Type-preserving shrinker.
+
+   [candidates sample] returns smaller well-typed variants of [sample]. The
+   driver re-runs the oracle on each and keeps one only if it stays in the same
+   quadrant, iterating to a fixpoint.
+
+   CR shsong: not yet implemented. *)
+let candidates (_sample : Gen.Sample.t) : Gen.Sample.t list = []

--- a/oxcaml/tests/quickcheck-allocation/shrink.mli
+++ b/oxcaml/tests/quickcheck-allocation/shrink.mli
@@ -1,0 +1,6 @@
+(* Type-preserving shrinker. *)
+
+(* [candidates sample] returns smaller well-typed variants of [sample]. The
+   driver re-runs the oracle on each and keeps one only if it stays in the same
+   quadrant, iterating to a fixpoint. *)
+val candidates : Gen.Sample.t -> Gen.Sample.t list


### PR DESCRIPTION
A simple tester that uses `[zero_alloc]` backend analysis as an oracle to test Allocation mode analysis.


Testing
-------
Manual test (assume a compiler is already built at `$COMP`): the generated test can be viewed in `oxcaml/tests/quickcheck-allocation/witnesses`
```sh
COMP=$PWD/_build/install/main/bin/ocamlopt.opt

dune exec oxcaml/tests/quickcheck-allocation/main.exe -- $COMP -count 200 -seed 0 -mode soundness  -out oxcaml/tests/quickcheck-allocation/witnesses
```