### PR TITLE
Clean #includes in the runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,6 +292,7 @@ ocaml/primitives.new
 
 /runtime/domain_state.inc
 /runtime/caml/jumptbl.h
+/runtime/api-testing
 /runtime/caml/m.h
 /runtime/caml/s.h
 /runtime/primitives

--- a/.gitignore
+++ b/.gitignore
@@ -291,6 +291,7 @@ ocaml/primitives.new
 /parsing/camlinternalMenhirLib.mli
 
 /runtime/domain_state.inc
+/runtime/api-testing
 /runtime/caml/m.h
 /runtime/caml/s.h
 /runtime/primitives

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -73,6 +73,11 @@ INSTALL_OCAMLNAT = @install_ocamlnat@
 DEP_CC=@DEP_CC@ -MM
 COMPUTE_DEPS=@compute_deps@
 
+TEST_CXX = @ocamltest_CXX@
+TEST_CXX_CXXFLAGS = @common_cflags@
+TEST_CXX_CPPFLAGS = @common_cppflags@
+CXXFLAGS ?=
+
 # Default flags to use to compile C files
 OC_CFLAGS = @oc_cflags@
 
@@ -90,6 +95,9 @@ OC_CPPFLAGS = $(OC_INCLUDES) @oc_cppflags@
 OC_BYTECODE_CPPFLAGS = $(OC_INCLUDES) @oc_bytecode_cppflags@
 
 OC_NATIVE_CPPFLAGS = $(OC_INCLUDES) @oc_native_cppflags@
+
+EXTRA_WARNINGS_CFLAGS = @cc_extra_warnings@
+EXTRA_WARNINGS_CXXFLAGS = @cxx_extra_warnings@
 
 # Additional link-time options
 # To support dynamic loading of shared libraries (they need to look at

--- a/Makefile.common
+++ b/Makefile.common
@@ -43,6 +43,7 @@ V ?= 0
 ifeq "$(V)" "0"
 
 V_CC         = @$(info $   CC $@)
+V_CXX        = @$(info $   CXX $@)
 V_CCDEPS     = @$(info $   CCDEPS $@)
 V_OCAMLC     = @$(info $   OCAMLC $@)
 V_OCAMLOPT   = @$(info $   OCAMLOPT $@)
@@ -63,6 +64,7 @@ V_ODOC       = @$(info $   ODOC $@)
 else
 
 V_CC         =
+V_CXX        =
 V_CCDEPS     =
 V_OCAMLC     =
 V_OCAMLOPT   =

--- a/Makefile.upstream
+++ b/Makefile.upstream
@@ -1250,6 +1250,82 @@ runtime-all: \
   $(runtime_BYTECODE_STATIC_LIBRARIES) $(runtime_BYTECODE_SHARED_LIBRARIES) \
   $(runtime_PROGRAMS) $(SAK)
 
+# If the compiler is configured with --enable-warn-error (which is the default
+# for development builds), then all the installed header files are tested with
+# more warnings enabled. The test also ensures that each header can be included
+# without any other headers.
+ifneq "$(EXTRA_WARNINGS_CFLAGS)" ""
+runtime-all: runtime-header-tests
+runtime-header-tests-if-enabled: runtime-header-tests
+endif
+
+# As with the runtime-header-tests, if a C++ compiler is available, then we also
+# verify that the headers can be included in a C++ program without error.
+ifneq "$(EXTRA_WARNINGS_CXXFLAGS)" ""
+ifneq "$(TEST_CXX)" ""
+runtime-all: runtime-header-cxx-tests
+runtime-header-tests-if-enabled: runtime-header-cxx-tests
+endif
+endif
+
+# Aggregate target for build drivers that do not go through runtime-all
+# (the dune rule in runtime/dune); expands to nothing when the extra
+# warnings are disabled.
+.PHONY: runtime-header-tests-if-enabled
+runtime-header-tests-if-enabled:
+
+# jumptbl.h and opnames.h are generated interpreter code fragments, not
+# headers (upstream stopped generating them in ocaml/ocaml#14488).
+ALL_PUBLIC_HEADER_FILES := $(notdir $(sort $(filter-out \
+  runtime/caml/jumptbl.h runtime/caml/opnames.h, $(wildcard \
+  $(addsuffix /caml/*.h, $(addprefix otherlibs/, $(OTHERLIBS))) \
+  runtime/caml/*.h))))
+
+.PHONY: runtime-header-tests runtime-header-cxx-tests
+runtime-header-tests: \
+  $(addprefix runtime/api-testing/,$(ALL_PUBLIC_HEADER_FILES:.h=.t))
+
+runtime-header-cxx-tests: \
+  $(addprefix runtime/api-testing/,$(ALL_PUBLIC_HEADER_FILES:.h=.tpp))
+
+.PRECIOUS: runtime/api-testing
+runtime/api-testing:
+	$(MKDIR) $@
+
+runtime/api-testing/%.t: runtime/api-testing/%.c.$(O)
+	@touch $@
+
+runtime/api-testing/%.tpp: runtime/api-testing/%.cpp.$(O)
+	@touch $@
+
+runtime/api-testing/%.c.$(O): runtime/api-testing/%.c
+	$(V_CC)$(CC) \
+	  $(OC_CFLAGS) $(EXTRA_WARNINGS_CFLAGS) $(CFLAGS) \
+	  $(OC_CPPFLAGS) \
+	  $(addprefix -I otherlibs/, $(OTHERLIBS)) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
+
+runtime/api-testing/%.c: | runtime/api-testing
+	$(V_GEN){ \
+	  echo '#include <caml/$*.h>'; \
+	  echo '#include <caml/$*.h>'; \
+	  echo 'int answer = 42;'; \
+	} > $@
+
+runtime/api-testing/%.cpp.$(O): runtime/api-testing/%.cpp
+	$(V_CXX)$(TEST_CXX) \
+	  $(TEST_CXX_CXXFLAGS) $(EXTRA_WARNINGS_CXXFLAGS) $(CXXFLAGS) \
+	  $(TEST_CXX_CPPFLAGS) \
+	  -I runtime $(addprefix -I otherlibs/, $(OTHERLIBS)) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
+
+runtime/api-testing/%.cpp: | runtime/api-testing
+	$(V_GEN){ \
+	  echo '#include <caml/$*.h>'; \
+	  echo '#include <caml/$*.h>'; \
+	  echo 'int answer = 42;'; \
+	} > $@
+
 .PHONY: runtime-allopt
 ifeq "$(NATIVE_COMPILER)" "true"
 runtime-allopt: \
@@ -2455,6 +2531,7 @@ distclean: clean
 	rm -f $(addprefix ocamltest/,ocamltest_config.ml ocamltest_unix.ml)
 	$(MAKE) -C otherlibs distclean
 	rm -f $(runtime_CONFIGURED_HEADERS)
+	rm -rf runtime/api-testing
 	$(MAKE) -C stdlib distclean
 	$(MAKE) -C testsuite distclean
 	rm -f tools/*.bak

--- a/Makefile.upstream
+++ b/Makefile.upstream
@@ -1249,6 +1249,82 @@ runtime-all: \
   $(runtime_BYTECODE_STATIC_LIBRARIES) $(runtime_BYTECODE_SHARED_LIBRARIES) \
   $(runtime_PROGRAMS) $(SAK)
 
+# If the compiler is configured with --enable-warn-error (which is the default
+# for development builds), then all the installed header files are tested with
+# more warnings enabled. The test also ensures that each header can be included
+# without any other headers.
+ifneq "$(EXTRA_WARNINGS_CFLAGS)" ""
+runtime-all: runtime-header-tests
+runtime-header-tests-if-enabled: runtime-header-tests
+endif
+
+# As with the runtime-header-tests, if a C++ compiler is available, then we also
+# verify that the headers can be included in a C++ program without error.
+ifneq "$(EXTRA_WARNINGS_CXXFLAGS)" ""
+ifneq "$(TEST_CXX)" ""
+runtime-all: runtime-header-cxx-tests
+runtime-header-tests-if-enabled: runtime-header-cxx-tests
+endif
+endif
+
+# Aggregate target for build drivers that do not go through runtime-all
+# (the dune rule in runtime/dune); expands to nothing when the extra
+# warnings are disabled.
+.PHONY: runtime-header-tests-if-enabled
+runtime-header-tests-if-enabled:
+
+# jumptbl.h and opnames.h are generated interpreter code fragments, not
+# headers (upstream stopped generating them in ocaml/ocaml#14488).
+ALL_PUBLIC_HEADER_FILES := $(notdir $(sort $(filter-out \
+  runtime/caml/jumptbl.h runtime/caml/opnames.h, $(wildcard \
+  $(addsuffix /caml/*.h, $(addprefix otherlibs/, $(OTHERLIBS))) \
+  runtime/caml/*.h))))
+
+.PHONY: runtime-header-tests runtime-header-cxx-tests
+runtime-header-tests: \
+  $(addprefix runtime/api-testing/,$(ALL_PUBLIC_HEADER_FILES:.h=.t))
+
+runtime-header-cxx-tests: \
+  $(addprefix runtime/api-testing/,$(ALL_PUBLIC_HEADER_FILES:.h=.tpp))
+
+.PRECIOUS: runtime/api-testing
+runtime/api-testing:
+	$(MKDIR) $@
+
+runtime/api-testing/%.t: runtime/api-testing/%.c.$(O)
+	@touch $@
+
+runtime/api-testing/%.tpp: runtime/api-testing/%.cpp.$(O)
+	@touch $@
+
+runtime/api-testing/%.c.$(O): runtime/api-testing/%.c
+	$(V_CC)$(CC) \
+	  $(OC_CFLAGS) $(EXTRA_WARNINGS_CFLAGS) $(CFLAGS) \
+	  $(OC_CPPFLAGS) \
+	  $(addprefix -I otherlibs/, $(OTHERLIBS)) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
+
+runtime/api-testing/%.c: | runtime/api-testing
+	$(V_GEN){ \
+	  echo '#include <caml/$*.h>'; \
+	  echo '#include <caml/$*.h>'; \
+	  echo 'int answer = 42;'; \
+	} > $@
+
+runtime/api-testing/%.cpp.$(O): runtime/api-testing/%.cpp
+	$(V_CXX)$(TEST_CXX) \
+	  $(TEST_CXX_CXXFLAGS) $(EXTRA_WARNINGS_CXXFLAGS) $(CXXFLAGS) \
+	  $(TEST_CXX_CPPFLAGS) \
+	  -I runtime $(addprefix -I otherlibs/, $(OTHERLIBS)) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ -c $<
+
+runtime/api-testing/%.cpp: | runtime/api-testing
+	$(V_GEN){ \
+	  echo '#include <caml/$*.h>'; \
+	  echo '#include <caml/$*.h>'; \
+	  echo 'int answer = 42;'; \
+	} > $@
+
 .PHONY: runtime-allopt
 ifeq "$(NATIVE_COMPILER)" "true"
 runtime-allopt: \
@@ -2431,6 +2507,7 @@ distclean: clean
 	rm -f $(addprefix ocamltest/,ocamltest_config.ml ocamltest_unix.ml)
 	$(MAKE) -C otherlibs distclean
 	rm -f $(runtime_CONFIGURED_HEADERS)
+	rm -rf runtime/api-testing
 	$(MAKE) -C stdlib distclean
 	$(MAKE) -C testsuite distclean
 	rm -f tools/*.bak

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -759,3 +759,37 @@ AC_DEFUN([OCAML_OBJCOPY_COMPRESSION_SUPPORT], [
   fi
   rm -f conftest.s
 ])
+
+# It's difficult to use AC_PROG_CXX or AX_CXX_COMPILE_STDCXX conditionally.
+# This macro is only used for ocamltest to call the C++11 compiler if the
+# default C compiler also can build C++.
+AC_DEFUN([OCAML_CXX_COMPILE_STDCXX_11], [
+  AC_MSG_CHECKING([for a C++11 compiler])
+  AC_CACHE_VAL([ocaml_cv_prog_cxx], [
+    AS_CASE(["$ccomp_type"],
+      [cc], [
+        saved_CC="$CC"
+        saved_CFLAGS="$CFLAGS"
+        AS_IF([test x"$CXX" = x],
+          [CC="$CC -xc++"; CFLAGS="$CXXFLAGS"], [CC="$CXX"; CFLAGS="$CXXFLAGS"])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if !defined(__cplusplus) || __cplusplus < 201103L
+#error "No C++11 support"
+/* This extra test is added to ignore C++ support when compiling with musl
+   (where the -xc++ flag will get passed through to gcc, but the headers are
+   not available). */
+#elif defined(__has_include) && !__has_include(<atomic>)
+#error "Missing <atomic> header"
+#endif
+#include <iostream>
+          ]])],
+          [ocaml_cv_prog_cxx="$CC"],
+          [ocaml_cv_prog_cxx=""])
+        CC="$saved_CC"
+        CFLAGS="$saved_CFLAGS"],
+      [msvc], [
+        # cl.exe selects between C and C++ based on the file extension
+        ocaml_cv_prog_cxx="$CC"],
+      [ocaml_cv_prog_cxx=""])])
+  AC_MSG_RESULT([${ocaml_cv_prog_cxx:-none found}])
+  ocamltest_CXX="$ocaml_cv_prog_cxx"])

--- a/configure.ac
+++ b/configure.ac
@@ -356,6 +356,8 @@ AC_SUBST([oc_cflags])
 AC_SUBST([tsan])
 AC_SUBST([tsan_native_runtime_c_sources])
 AC_SUBST([common_cppflags])
+AC_SUBST([cc_extra_warnings])
+AC_SUBST([cxx_extra_warnings])
 AC_SUBST([oc_cppflags])
 AC_SUBST([oc_ldflags])
 AC_SUBST([oc_dll_ldflags])
@@ -394,6 +396,7 @@ AC_SUBST([optional_libraries])
 AC_SUBST([optional_bytecode_tools])
 AC_SUBST([optional_native_tools])
 AC_SUBST([ocamltest_CPP])
+AC_SUBST([ocamltest_CXX])
 AC_SUBST([ocamltest_libunix])
 AC_SUBST([unix_library])
 AC_SUBST([unix_directory])
@@ -1201,17 +1204,25 @@ AS_IF(
 AS_CASE([$ocaml_cc_vendor],
   [xlc-*],
     [warn_error_flag=''
+    cc_extra_warnings=''
+    cxx_extra_warnings=''
     cc_warnings='-qflag=i:i'], # all warnings enabled
   [sunc-*],
-    [cc_warnings=""],
+    [cc_extra_warnings=''
+     cxx_extra_warnings=''
+     cc_warnings=""],
   [msvc-*],
     [AS_CASE([$ocaml_cc_vendor],
       [msvc-*-clang-*],
         [cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
          warn_error_flag='-WX'],
       [cc_warnings='-W2'
-       warn_error_flag='-WX -options:strict'])],
+       cc_extra_warnings='-permissive-'
+       warn_error_flag='-WX -options:strict'
+       cxx_extra_warnings="$cc_extra_warnings $warn_error_flag"])],
   [warn_error_flag='-Werror'
+  cc_extra_warnings='-Wextra -Wpedantic -pedantic -std=c11'
+  cxx_extra_warnings='-Werror -Wextra -Wpedantic -pedantic'
   cc_warnings="-Wall -Wno-pragmas -Wint-conversion -Wstrict-prototypes \
 -Wold-style-definition -Wundef"])
 
@@ -1233,7 +1244,8 @@ for flag in '-Wimplicit-fallthrough=5' '-Wimplicit-fallthrough'; do
 done
 
 AS_CASE([$enable_warn_error],
-  [no], [],
+  [no], [cc_extra_warnings=''
+    cxx_extra_warnings=''],
   [*],
     [cc_warnings="$cc_warnings $warn_error_flag"])
 
@@ -3152,7 +3164,8 @@ AS_CASE([$enable_ocamltest,OCAML__DEVELOPMENT_VERSION],
     ocamltest_opt_target=ocamltest.opt
     ocamltest='ocamltest'
     testsuite_tools='testsuite/tools/codegen testsuite/tools/expect'
-    optional_bytecode_tools="$optional_bytecode_tools $testsuite_tools"],
+    optional_bytecode_tools="$optional_bytecode_tools $testsuite_tools"
+    OCAML_CXX_COMPILE_STDCXX_11],
   [build_ocamltest=false
   ocamltest=''])
 

--- a/otherlibs/systhreads/caml/threads.h
+++ b/otherlibs/systhreads/caml/threads.h
@@ -16,6 +16,8 @@
 #ifndef CAML_THREADS_H
 #define CAML_THREADS_H
 
+#include <caml/misc.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/otherlibs/unix/caml/socketaddr.h
+++ b/otherlibs/unix/caml/socketaddr.h
@@ -16,7 +16,7 @@
 #ifndef CAML_SOCKETADDR_H
 #define CAML_SOCKETADDR_H
 
-#include "caml/misc.h"
+#include <caml/mlvalues.h>
 
 #ifdef _WIN32
 

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -17,6 +17,7 @@
 #define CAML_UNIXSUPPORT_H
 
 #include <caml/misc.h>
+#include <caml/mlvalues.h>
 
 #ifdef _WIN32 /* Windows */
 #define WIN32_LEAN_AND_MEAN

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -57,7 +57,7 @@ value caml_addrmap_lookup(struct addrmap* t, value key)
   for (uintnat pos = pos_initial(t, key); ; pos = pos_next(t, pos)) {
     CAMLassert(t->entries[pos].key != ADDRMAP_INVALID_KEY);
     if (t->entries[pos].key == key)
-      return t->entries[pos].value;
+      return t->entries[pos].val;
   }
 }
 
@@ -68,7 +68,7 @@ static void addrmap_alloc(struct addrmap* t, uintnat sz)
   t->size = sz;
   for (uintnat i = 0; i < sz; i++) {
     t->entries[i].key = ADDRMAP_INVALID_KEY;
-    t->entries[i].value = ADDRMAP_NOT_PRESENT;
+    t->entries[i].val = ADDRMAP_NOT_PRESENT;
   }
 }
 
@@ -98,7 +98,7 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
       t->entries[pos].key = key;
     }
     if (t->entries[pos].key == key) {
-      return &t->entries[pos].value;
+      return &t->entries[pos].val;
     }
   }
   /* failed to insert, rehash and try again */
@@ -110,7 +110,7 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
       if (old_table[i].key != ADDRMAP_INVALID_KEY) {
         value* p = caml_addrmap_insert_pos(t, old_table[i].key);
         CAMLassert(*p == ADDRMAP_NOT_PRESENT);
-        *p = old_table[i].value;
+        *p = old_table[i].val;
       }
     }
     caml_stat_free(old_table);

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -48,7 +48,6 @@ CAMLprim value caml_reset_afl_instrumentation(value full)
 #else
 
 #include <unistd.h>
-#include <sys/types.h>
 #include <signal.h>
 #include <sys/shm.h>
 #include <sys/wait.h>

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -25,11 +25,8 @@
 #include <assert.h>
 #include "caml/alloc.h"
 #include "caml/custom.h"
-#include "caml/major_gc.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
-#include "caml/fiber.h"
-#include "caml/domain.h"
 
 CAMLexport value caml_alloc_with_reserved (mlsize_t wosize, tag_t tag,
                                            reserved_t reserved)

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -23,8 +23,6 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/signals.h"
-#include "caml/runtime_events.h"
-#include "caml/custom.h"
 
 static const mlsize_t mlsize_t_max = CAML_UINTNAT_MAX;
 

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -18,7 +18,6 @@
 /* Stack backtrace for uncaught exceptions */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include "caml/alloc.h"
@@ -26,7 +25,6 @@
 #include "caml/backtrace.h"
 #include "caml/backtrace_prim.h"
 #include "caml/fail.h"
-#include "caml/debugger.h"
 #include "caml/startup.h"
 
 /* Start or stop the backtrace machinery */

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -17,7 +17,6 @@
 
 /* Stack backtrace for uncaught exceptions */
 
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,7 +31,6 @@
 
 #include "caml/mlvalues.h"
 #include "caml/alloc.h"
-#include "caml/custom.h"
 #include "caml/io.h"
 #include "caml/instruct.h"
 #include "caml/intext.h"
@@ -41,9 +39,7 @@
 #include "caml/memory.h"
 #include "caml/startup.h"
 #include "caml/fiber.h"
-#include "caml/sys.h"
 #include "caml/backtrace.h"
-#include "caml/fail.h"
 #include "caml/backtrace_prim.h"
 #include "caml/debugger.h"
 

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -20,7 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "caml/alloc.h"
 #include "caml/backtrace.h"
@@ -31,7 +30,6 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/fiber.h"
-#include "caml/fail.h"
 
 /* Returns the next frame descriptor (or NULL if none is available),
    and updates *pc and *sp to point to the following one.  */

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -15,6 +15,8 @@
 #ifndef CAML_ADDRMAP_H
 #define CAML_ADDRMAP_H
 
+#include "config.h"
+#include "misc.h"
 #include "mlvalues.h"
 
 #ifdef __cplusplus

--- a/runtime/caml/addrmap.h
+++ b/runtime/caml/addrmap.h
@@ -26,7 +26,7 @@ extern "C" {
 /* An addrmap is a value -> value hashmap, where
    the values are blocks */
 
-struct addrmap_entry { value key, value; };
+struct addrmap_entry { value key; value val; };
 struct addrmap {
   struct addrmap_entry* entries;
   uintnat size;
@@ -86,14 +86,14 @@ Caml_inline value caml_addrmap_iter_value(struct addrmap* t,
                                           addrmap_iterator i)
 {
   CAMLassert(caml_addrmap_iter_ok(t, i));
-  return t->entries[i].value;
+  return t->entries[i].val;
 }
 
 Caml_inline value* caml_addrmap_iter_val_pos(struct addrmap* t,
                                              addrmap_iterator i)
 {
   CAMLassert(caml_addrmap_iter_ok(t, i));
-  return &t->entries[i].value;
+  return &t->entries[i].val;
 }
 
 Caml_inline addrmap_iterator caml_addrmap_iterator(struct addrmap* t)

--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -16,8 +16,10 @@
 #ifndef CAML_ALLOC_H
 #define CAML_ALLOC_H
 
+#include "config.h"
 #include "misc.h"
 #include "mlvalues.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -38,6 +38,9 @@ CAMLextern void caml_record_backtraces(int);
 #ifdef CAML_INTERNALS
 
 #include "exec.h"
+#include <stddef.h>
+#include "domain_state.h"
+#include "misc.h"
 
 /* Runtime support for backtrace generation.
  *

--- a/runtime/caml/backtrace_prim.h
+++ b/runtime/caml/backtrace_prim.h
@@ -19,6 +19,8 @@
 #ifdef CAML_INTERNALS
 
 #include "backtrace.h"
+#include "misc.h"
+#include "mlvalues.h"
 
 /* Backtrace generation is split in [backtrace.c] and [backtrace_prim].
  *

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -23,6 +23,8 @@
 
    These macros are here, rather than misc.h, to discourage the potential future
    use of flexible array members! */
+#include <stdint.h>
+#include "misc.h"
 #ifdef __cplusplus
   #if defined(__clang__)
     #define CAML_flexible_array_member_start \

--- a/runtime/caml/blake2.h
+++ b/runtime/caml/blake2.h
@@ -20,6 +20,9 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "misc.h"
 
 #define BLAKE2_BLOCKSIZE 128

--- a/runtime/caml/callback.h
+++ b/runtime/caml/callback.h
@@ -18,6 +18,7 @@
 #ifndef CAML_CALLBACK_H
 #define CAML_CALLBACK_H
 
+#include "misc.h"
 #include "mlvalues.h"
 #include "memory.h"
 

--- a/runtime/caml/compare.h
+++ b/runtime/caml/compare.h
@@ -18,6 +18,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include "misc.h"
+
 CAMLextern int caml_compare_unordered;
 
 #endif /* CAML_INTERNALS */

--- a/runtime/caml/custom.h
+++ b/runtime/caml/custom.h
@@ -17,6 +17,9 @@
 #define CAML_CUSTOM_H
 
 
+#include "config.h"
+#include "misc.h"
+#include "domain_state.h"
 #include "mlvalues.h"
 
 struct custom_fixed_length {

--- a/runtime/caml/debugger.h
+++ b/runtime/caml/debugger.h
@@ -22,6 +22,7 @@
 
 #include "misc.h"
 #include "mlvalues.h"
+#include "config.h"
 
 CAMLextern int caml_debugger_in_use;
 CAMLextern int caml_debugger_fork_mode; /* non-zero for parent */

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "mlvalues.h"
 #include "domain_state.h"
+#include "misc.h"
 
 #ifdef MULTIDOMAIN
 #ifdef ARCH_SIXTYFOUR

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -21,6 +21,7 @@
 #include <stdio.h>
 
 #include "misc.h"
+#include "mlvalues.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -19,6 +19,8 @@
 
 #include "mlvalues.h"
 #include "roots.h"
+#include <stddef.h>
+#include "misc.h"
 
 /* Define a new dynamic value, which is an immediate unique ID. */
 CAMLprim value caml_dynamic_make(value unit);

--- a/runtime/caml/exec.h.in
+++ b/runtime/caml/exec.h.in
@@ -20,6 +20,8 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stdint.h>
+
 /* Executable bytecode files are composed of a number of sections,
    identified by 4-character names.  A table of contents at the
    end of the file lists the section names along with their sizes,

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -22,6 +22,9 @@
 
 #include "misc.h"
 #include "mlvalues.h"
+#include <stdint.h>
+#include "config.h"
+#include "domain_state.h"
 
 #ifdef CAML_INTERNALS
 /* Built-in exceptions. In bytecode, these exceptions are the first fields in

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -27,6 +27,9 @@
 #include "dynamic.h"
 #include "roots.h"
 #include "platform.h"
+#include <stddef.h>
+#include <stdint.h>
+#include "config.h"
 
 struct stack_info;
 

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -20,6 +20,9 @@
 
 #include "roots.h"
 #include "domain.h"
+#include "config.h"
+#include "domain_state.h"
+#include "mlvalues.h"
 
 struct final {
   value fun;

--- a/runtime/caml/float32.h
+++ b/runtime/caml/float32.h
@@ -17,6 +17,7 @@
 #ifndef CAML_FLOAT32_H
 #define CAML_FLOAT32_H
 
+#include "misc.h"
 #include "mlvalues.h"
 
 #define Float32_val(v) (*((float *)Data_custom_val(v)))

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -23,6 +23,8 @@
 
 #include <stdbool.h>
 #include "config.h"
+#include "misc.h"
+#include <stdint.h>
 
 /* The compiler generates a "frame descriptor" for every potential
  * return address. Each loaded module has a block of memory, the

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #include "config.h"
 #include "misc.h"
+#include <stdint.h>
 
 /* The compiler generates a "frame descriptor" for every potential
  * return address. Each loaded module has a block of memory, the

--- a/runtime/caml/gc.h
+++ b/runtime/caml/gc.h
@@ -17,6 +17,7 @@
 #define CAML_GC_H
 
 
+#include "config.h"
 #include "mlvalues.h"
 
 /* This depends on the layout of the header.  See [mlvalues.h]. */

--- a/runtime/caml/gc_ctrl.h
+++ b/runtime/caml/gc_ctrl.h
@@ -19,6 +19,9 @@
 #ifdef CAML_INTERNALS
 
 #include "misc.h"
+#include "mlvalues.h"
+#include "config.h"
+#include "domain_state.h"
 
 CAMLextern atomic_uintnat caml_max_stack_wsize;
 CAMLextern uintnat caml_fiber_wsz;

--- a/runtime/caml/gc_stats.h
+++ b/runtime/caml/gc_stats.h
@@ -19,6 +19,9 @@
 #ifdef CAML_INTERNALS
 
 #include "domain.h"
+#include <stdint.h>
+#include "config.h"
+#include "domain_state.h"
 
 /* The Gc module provides two kind of runtime statistics:
    - Heap stats: statistics about heap memory, see shared_heap.c

--- a/runtime/caml/hash.h
+++ b/runtime/caml/hash.h
@@ -18,7 +18,10 @@
 #ifndef CAML_HASH_H
 #define CAML_HASH_H
 
+#include "config.h"
+#include "misc.h"
 #include "mlvalues.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -22,6 +22,8 @@
 
 #include "mlvalues.h"
 #include "misc.h"
+#include <stdio.h>
+#include "config.h"
 
 extern CAMLthread_local intnat caml_icount;
 void caml_stop_here (void);

--- a/runtime/caml/interp.h
+++ b/runtime/caml/interp.h
@@ -22,6 +22,7 @@
 
 #include "misc.h"
 #include "mlvalues.h"
+#include "config.h"
 
 CAMLextern
 value caml_bytecode_interpreter (code_t prog, asize_t prog_size,

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -23,6 +23,9 @@
 
 #ifdef CAML_INTERNALS
 #include "io.h"
+#include <stddef.h>
+#include <stdint.h>
+#include "config.h"
 
 /* Magic number */
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -21,6 +21,7 @@
 #ifdef CAML_INTERNALS
 
 #include "camlatomic.h"
+#include "config.h"
 #include "misc.h"
 #include "mlvalues.h"
 

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -18,6 +18,11 @@
 
 #ifdef CAML_INTERNALS
 
+#include "config.h"
+#include "domain_state.h"
+#include "misc.h"
+#include "mlvalues.h"
+
 typedef enum {
   Phase_sweep_main,
   Phase_sweep_and_mark_main,

--- a/runtime/caml/major_gc.h
+++ b/runtime/caml/major_gc.h
@@ -19,6 +19,10 @@
 #ifdef CAML_INTERNALS
 
 #include <stdbool.h>
+#include "config.h"
+#include "domain_state.h"
+#include "misc.h"
+#include "mlvalues.h"
 
 typedef enum {
   Phase_sweep_main,

--- a/runtime/caml/md5.h
+++ b/runtime/caml/md5.h
@@ -22,6 +22,9 @@
 
 #include "mlvalues.h"
 #include "io.h"
+#include <stdint.h>
+#include "config.h"
+#include "misc.h"
 
 CAMLextern void caml_md5_block(unsigned char digest[16],
                                void * data, uintnat len);

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -25,9 +25,11 @@
 #include "minor_gc.h"
 #endif /* CAML_INTERNALS */
 #include "domain.h"
+#include "domain_state.h"
 #include "misc.h"
 #include "mlvalues.h"
 #include "signals.h"
+#include "tsan.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/memprof.h
+++ b/runtime/caml/memprof.h
@@ -21,6 +21,9 @@
 #include "config.h"
 #include "mlvalues.h"
 #include "roots.h"
+#include <stddef.h>
+#include "domain_state.h"
+#include "misc.h"
 
 /*** Sample allocations ***/
 

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -94,6 +94,8 @@ CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
 #include <stdbool.h>
+#include "domain_state.h"
+#include "mlvalues.h"
 
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap_no_major_slice_from_stw

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -93,6 +93,8 @@ CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
 #include <stdbool.h>
+#include "domain_state.h"
+#include "mlvalues.h"
 
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
 extern void caml_empty_minor_heap_no_major_slice_from_stw

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -841,6 +841,7 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #define NSEC_PER_SEC  UINT64_C(1000000000)
 
 #include <time.h>
+#include <stdint.h>
 
 Caml_inline struct timespec caml_timespec_of_nsec(uint64_t nsec)
 {

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -880,6 +880,7 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #define NSEC_PER_SEC  UINT64_C(1000000000)
 
 #include <time.h>
+#include <stdint.h>
 
 Caml_inline struct timespec caml_timespec_of_nsec(uint64_t nsec)
 {

--- a/runtime/caml/mlvalues.h
+++ b/runtime/caml/mlvalues.h
@@ -20,6 +20,8 @@
 #include "misc.h"
 #include "camlatomic.h"
 #include "tsan.h"
+#include <stdint.h>
+#include <limits.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -20,6 +20,10 @@
 
 #ifdef CAML_INTERNALS
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include "config.h"
 #include "misc.h"
 #include "memory.h"
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -24,7 +24,10 @@
 #include <pthread.h>
 #include <errno.h>
 #include <string.h>
+#include <stdint.h>
+#include "camlatomic.h"
 #include "config.h"
+#include "misc.h"
 #include "mlvalues.h"
 #include "sys.h"
 #ifdef _MSC_VER

--- a/runtime/caml/prims.h
+++ b/runtime/caml/prims.h
@@ -20,6 +20,9 @@
 
 #ifdef CAML_INTERNALS
 
+#include "mlvalues.h"
+#include "misc.h"
+
 typedef value (*c_primitive)(void);
 
 extern const c_primitive caml_builtin_cprim[];

--- a/runtime/caml/roots.h
+++ b/runtime/caml/roots.h
@@ -20,6 +20,9 @@
 
 #include "misc.h"
 #include "domain.h"
+#include "domain_state.h"
+#include "mlvalues.h"
+#include "tsan.h"
 
 typedef enum {
   SCANNING_ONLY_YOUNG_VALUES = 1, // action is a no-op outside the minor heap

--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -28,7 +28,10 @@
 #ifndef CAML_RUNTIME_EVENTS_H
 #define CAML_RUNTIME_EVENTS_H
 
+#include "misc.h"
 #include "mlvalues.h"
+#include <stdint.h>
+#include "camlatomic.h"
 
 #ifdef CAML_INSTR
 #define CAML_EV_ALLOC(s) caml_ev_alloc(s)

--- a/runtime/caml/shared_heap.h
+++ b/runtime/caml/shared_heap.h
@@ -26,6 +26,8 @@
 #include "gc_stats.h"
 #include "major_gc.h"
 #include "sizeclasses.h"
+#include "domain_state.h"
+#include "mlvalues.h"
 
 CAMLextern atomic_uintnat caml_compactions_count;
 

--- a/runtime/caml/signals.h
+++ b/runtime/caml/signals.h
@@ -16,6 +16,9 @@
 #ifndef CAML_SIGNALS_H
 #define CAML_SIGNALS_H
 
+#include "config.h"
+#include <stddef.h>
+#include "domain_state.h"
 #if defined(CAML_INTERNALS)
 #include <signal.h>
 #endif

--- a/runtime/caml/simd.h
+++ b/runtime/caml/simd.h
@@ -18,6 +18,7 @@
 #define CAML_SIMD_H
 
 // SIMD is only supported on 64-bit targets
+#include "config.h"
 #define Words_per_vec128 2
 #define Words_per_vec256 4
 

--- a/runtime/caml/simd.h
+++ b/runtime/caml/simd.h
@@ -18,6 +18,7 @@
 #define CAML_SIMD_H
 
 // SIMD is only supported on 64-bit targets
+#include "config.h"
 #define Words_per_vec128 2
 #define Words_per_vec256 4
 #define Words_per_vec512 8

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -20,6 +20,9 @@
 
 #ifdef CAML_INTERNALS
 
+#include "mlvalues.h"
+#include "config.h"
+
 /* Macros to access OCaml stacks */
 
 /* An OCaml stack is composed of one or several "chunks", each chunk

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -16,11 +16,14 @@
 #ifndef CAML_STARTUP_H
 #define CAML_STARTUP_H
 
+#include "mlvalues.h"
+
 #ifdef CAML_INTERNALS
 
-#include "mlvalues.h"
 #include "exec.h"
 #include "startup_aux.h"
+#include <stdint.h>
+#include "misc.h"
 
 CAMLextern void caml_startup_code(
            code_t code, asize_t code_size,

--- a/runtime/caml/startup_aux.h
+++ b/runtime/caml/startup_aux.h
@@ -19,6 +19,7 @@
 #ifdef CAML_INTERNALS
 
 #include "config.h"
+#include "misc.h"
 
 extern void caml_init_locale(void);
 extern void caml_free_locale(void);

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -22,6 +22,7 @@
 
 #include "mlvalues.h"
 #include "platform.h"
+#include "misc.h"
 
 /* OCaml mutexes and condition variables can also be manipulated from
    C code with non-raising primitives from caml/platform.h. In this

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -19,6 +19,8 @@
 #ifdef CAML_INTERNALS
 
 #include "misc.h"
+#include "mlvalues.h"
+#include <stddef.h>
 
 CAMLextern char * caml_strerror(int errnum, char * buf, size_t buflen);
 

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -83,6 +83,8 @@ extern void AnnotateHappensAfter(const char *f, int l, void *addr);
 #ifdef CAML_INTERNALS
 
 #include "mlvalues.h"
+#include "config.h"
+#include "misc.h"
 
 struct stack_info;
 

--- a/runtime/caml/weak.h
+++ b/runtime/caml/weak.h
@@ -18,6 +18,8 @@
 #ifndef CAML_WEAK_H
 #define CAML_WEAK_H
 
+#include "config.h"
+#include "camlatomic.h"
 #include "mlvalues.h"
 
 #ifdef __cplusplus

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -23,11 +23,8 @@
 #include "caml/camlatomic.h"
 #include "caml/custom.h"
 #include "caml/fail.h"
-#include "caml/gc_ctrl.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
-#include "caml/shared_heap.h"
-#include "caml/signals.h"
 #include "caml/memprof.h"
 
 static_assert(sizeof(struct custom_operations) == CUSTOM_OPS_STRUCT_SIZE, "");

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -64,9 +64,6 @@ typedef cpuset_t cpu_set_t;
 #include "caml/fail.h"
 #include "caml/fiber.h"
 #include "caml/dynamic.h"
-#include "caml/finalise.h"
-#include "caml/gc_ctrl.h"
-#include "caml/globroots.h"
 #include "caml/intext.h"
 #include "caml/major_gc.h"
 #include "caml/minor_gc.h"
@@ -77,11 +74,8 @@ typedef cpuset_t cpu_set_t;
 #include "caml/platform.h"
 #include "caml/shared_heap.h"
 #include "caml/signals.h"
-#include "caml/startup.h"
 #include "caml/startup_aux.h"
 #include "caml/sync.h"
-#include "caml/weak.h"
-#include "sync_posix.h"
 
 /* Check that the domain_state structure was laid out without padding,
    since the runtime assumes this in computing offsets */

--- a/runtime/dune
+++ b/runtime/dune
@@ -93,6 +93,10 @@
    sak
    (glob_files *.S)
    (glob_files *.c)
+   ../otherlibs/runtime_events/caml/runtime_events_consumer.h
+   ../otherlibs/systhreads/caml/threads.h
+   ../otherlibs/unix/caml/socketaddr.h
+   ../otherlibs/unix/caml/unixsupport.h
  )
  (action
  (no-infer
@@ -100,7 +104,7 @@
      (bash "rm -f sak build_config.h")
      (bash "cd .. && make V=1 -j8 -f Makefile.upstream runtime/libasmrun.a runtime/libasmrund.a runtime/libasmruni.a runtime/libasmrun_pic.a \
     runtime/libasmrun_shared.so runtime/libcamlrun.a runtime/libcamlrund.a runtime/libcamlruni.a runtime/libcamlrun_pic.a \
-    runtime/libcamlrun_shared.so runtime/ocamlrun runtime/ocamlrund runtime/ocamlruni runtime/ld.conf COMPUTE_DEPS=false")))))
+    runtime/libcamlrun_shared.so runtime/ocamlrun runtime/ocamlrund runtime/ocamlruni runtime/ld.conf runtime-header-tests-if-enabled COMPUTE_DEPS=false")))))
 
 (install
   (files

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -18,11 +18,9 @@
 /* Dynamic loading of C primitives. */
 
 #include <stddef.h>
-#include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include "caml/config.h"
 #ifndef _WIN32
 #include <unistd.h>
 #endif

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -35,7 +35,6 @@ intnat caml_globals_inited = 0;
 
 CAMLexport void (*caml_natdynlink_hook)(void* handle, const char* unit) = NULL;
 
-#include <stdio.h>
 #include <string.h>
 #include <limits.h>
 

--- a/runtime/fail_byt.c
+++ b/runtime/fail_byt.c
@@ -19,10 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "caml/alloc.h"
-#include "caml/callback.h"
 #include "caml/fail.h"
-#include "caml/gc.h"
 #include "caml/io.h"
 #include "caml/memory.h"
 #include "caml/misc.h"

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -18,20 +18,15 @@
 /* Raising exceptions from C. */
 
 #include <stdio.h>
-#include <signal.h>
-#include "caml/alloc.h"
 #include "caml/callback.h"
 #include "caml/domain.h"
 #include "caml/fail.h"
 #include "caml/fiber.h"
 #include "caml/io.h"
-#include "caml/gc.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/printexc.h"
 #include "caml/signals.h"
-#include "caml/stack.h"
-#include "caml/roots.h"
 #include "caml/callback.h"
 #include "caml/signals.h"
 #include "caml/tsan.h"

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -34,12 +34,9 @@
 #include "caml/dynamic.h"
 #include "caml/gc_ctrl.h"
 #include "caml/platform.h"
-#include "caml/minor_gc.h"
 #include "caml/misc.h"
 #include "caml/major_gc.h"
 #include "caml/memory.h"
-#include "caml/obj.h"
-#include "caml/startup_aux.h"
 #include "caml/shared_heap.h"
 #ifdef NATIVE_CODE
 #include "caml/stack.h"
@@ -50,7 +47,6 @@
 #endif
 #ifdef __linux__
 /* for gettid */
-#include <sys/types.h>
 #include <sys/syscall.h>
 #endif
 

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -26,10 +26,8 @@
 #endif
 
 #include "caml/codefrag.h"
-#include "caml/debugger.h"
 #include "caml/fix_code.h"
 #include "caml/instruct.h"
-#include "caml/intext.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -24,7 +24,6 @@
 #define _GNU_SOURCE
 
 #include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
@@ -36,8 +35,6 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/misc.h"
-#include "caml/reverse.h"
-#include "caml/fiber.h"
 
 #if defined(HAS_LOCALE) || defined(__MINGW32__)
 

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -20,10 +20,8 @@
 
 #include "caml/platform.h"
 #include "caml/frame_descriptors.h"
-#include "caml/major_gc.h" /* for caml_major_cycles_completed */
 #include "caml/memory.h"
 #include "caml/fail.h"
-#include "caml/shared_heap.h"
 #include <stddef.h>
 
 struct caml_frame_descrs {

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -20,10 +20,8 @@
 
 #include "caml/platform.h"
 #include "caml/frame_descriptors.h"
-#include "caml/major_gc.h" /* for caml_major_cycles_completed */
 #include "caml/memory.h"
 #include "caml/fail.h"
-#include "caml/shared_heap.h"
 #include "caml/backtrace_prim.h"
 #include <stddef.h>
 

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -17,8 +17,6 @@
 
 #include "caml/alloc.h"
 #include "caml/custom.h"
-#include "caml/finalise.h"
-#include "caml/gc.h"
 #include "caml/gc_ctrl.h"
 #include "caml/gc_stats.h"
 #include "caml/major_gc.h"
@@ -34,7 +32,6 @@
 #endif
 #include "caml/domain.h"
 #include "caml/fiber.h"
-#include "caml/globroots.h"
 #include "caml/signals.h"
 #include "caml/startup.h"
 #include "caml/fail.h"

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -17,10 +17,8 @@
 
 #include "caml/gc_stats.h"
 #include "caml/memory.h"
-#include "caml/minor_gc.h"
 #include "caml/platform.h"
 #include "caml/shared_heap.h"
-#include "caml/startup_aux.h"
 
 Caml_inline intnat intnat_max(intnat a, intnat b) {
   return (a > b ? a : b);

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -22,7 +22,6 @@
 
 #include "caml/mlvalues.h"
 #include "caml/custom.h"
-#include "caml/memory.h"
 #include "caml/hash.h"
 #include "caml/fail.h"
 

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -20,11 +20,9 @@
 #ifdef DEBUG
 
 #include <stdio.h>
-#include <string.h>
 #include <ctype.h>
 
 #include "caml/fiber.h"
-#include "caml/domain.h"
 #include "caml/instrtrace.h"
 #include "caml/instruct.h"
 #include "caml/misc.h"

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -17,17 +17,14 @@
 
 /* The bytecode interpreter */
 #include <stdio.h>
-#include "caml/alloc.h"
 #include "caml/backtrace.h"
 #include "caml/callback.h"
-#include "caml/codefrag.h"
 #include "caml/debugger.h"
 #include "caml/fail.h"
 #include "caml/fix_code.h"
 #include "caml/instrtrace.h"
 #include "caml/instruct.h"
 #include "caml/interp.h"
-#include "caml/major_gc.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
@@ -36,8 +33,6 @@
 #include "caml/fiber.h"
 #include "caml/dynamic.h"
 #include "caml/domain.h"
-#include "caml/globroots.h"
-#include "caml/startup.h"
 #include "caml/startup_aux.h"
 
 /* Registers for the abstract machine:

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -15,13 +15,11 @@
 
 #define CAML_INTERNALS
 
-#include <stdio.h>
 #include <string.h>
 #include "caml/alloc.h"
 #include "caml/custom.h"
 #include "caml/fail.h"
 #include "caml/intext.h"
-#include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -22,7 +22,6 @@
 #include <limits.h>
 #include <string.h>
 #include <stdio.h>
-#include <sys/types.h>
 #include <stdbool.h>
 #include "caml/config.h"
 #ifndef _WIN32
@@ -32,7 +31,6 @@
 #include </usr/include/io.h>
 #endif
 #include "caml/alloc.h"
-#include "caml/camlatomic.h"
 #include "caml/custom.h"
 #include "caml/fail.h"
 #include "caml/io.h"

--- a/runtime/lexing.c
+++ b/runtime/lexing.c
@@ -19,7 +19,6 @@
 
 #include "caml/fail.h"
 #include "caml/mlvalues.h"
-#include "caml/fiber.h"
 
 struct lexer_buffer {
   value refill_buff;

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -25,7 +25,6 @@
 #include "caml/codefrag.h"
 #include "caml/domain.h"
 #include "caml/runtime_events.h"
-#include "caml/fail.h"
 #include "caml/fiber.h"
 #include "caml/finalise.h"
 #include "caml/globroots.h"
@@ -39,7 +38,6 @@
 #include "caml/shared_heap.h"
 #include "caml/startup_aux.h"
 #include "caml/weak.h"
-#include "caml/custom.h"
 #include "caml/minor_gc.h"
 
 /* This variable is only written with the world stopped, so it need not be

--- a/runtime/md5.c
+++ b/runtime/md5.c
@@ -22,7 +22,6 @@
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
 #include "caml/io.h"
-#include "caml/reverse.h"
 
 /* MD5 message digest */
 

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -36,7 +36,6 @@
 #include "caml/signals.h"
 #include "caml/shared_heap.h"
 #include "caml/domain.h"
-#include "caml/roots.h"
 #include "caml/alloc.h"
 #include "caml/fiber.h"
 #include "caml/platform.h"

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -27,15 +27,9 @@
 #include "caml/fail.h"
 #include "caml/fiber.h"
 #include "caml/fix_code.h"
-#include "caml/interp.h"
-#include "caml/intext.h"
-#include "caml/major_gc.h"
 #include "caml/memory.h"
-#include "caml/minor_gc.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
-#include "caml/prims.h"
-#include "caml/startup_aux.h"
 #include "caml/instruct.h"
 
 #ifndef NATIVE_CODE

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -27,7 +27,6 @@
 #include "caml/fiber.h"
 #include "caml/finalise.h"
 #include "caml/gc.h"
-#include "caml/gc_ctrl.h"
 #include "caml/globroots.h"
 #include "caml/major_gc.h"
 #include "caml/memory.h"
@@ -40,7 +39,6 @@
 #include "caml/shared_heap.h"
 #include "caml/signals.h"
 #include "caml/sizeclasses.h"
-#include "caml/startup_aux.h"
 #include "caml/weak.h"
 
 struct generic_table CAML_TABLE_STRUCT(char);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -24,9 +24,6 @@
 #include "caml/misc.h"
 #include "caml/memory.h"
 #include "caml/osdeps.h"
-#include "caml/domain.h"
-#include "caml/startup.h"
-#include "caml/startup_aux.h"
 
 _Atomic caml_timing_hook caml_major_slice_begin_hook = (caml_timing_hook)NULL;
 _Atomic caml_timing_hook caml_major_slice_end_hook = (caml_timing_hook)NULL;

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -22,15 +22,10 @@
 #include "caml/camlatomic.h"
 #include "caml/alloc.h"
 #include "caml/fail.h"
-#include "caml/gc.h"
-#include "caml/interp.h"
-#include "caml/major_gc.h"
 #include "caml/memory.h"
-#include "caml/minor_gc.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
-#include "caml/prims.h"
 #include "caml/signals.h"
 
 static int obj_tag (value arg)

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -22,7 +22,6 @@
 #include "caml/config.h"
 #include "caml/mlvalues.h"
 #include "caml/memory.h"
-#include "caml/alloc.h"
 #include "caml/startup.h"
 
 #define ERRCODE 256

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -20,21 +20,17 @@
 #ifndef _WIN32
 #include <unistd.h>
 #endif
-#include <errno.h>
 #include "caml/osdeps.h"
 #include "caml/platform.h"
-#include "caml/fail.h"
 #include "caml/lf_skiplist.h"
 #include "caml/misc.h"
 #include "caml/signals.h"
 #ifdef HAS_SYS_MMAN_H
-#include <sys/mman.h>
 #endif
 #ifdef _WIN32
 #include <windows.h>
 #endif
 
-#include "caml/alloc.h"
 #include "caml/lf_skiplist.h"
 #include "sync_posix.h"
 

--- a/runtime/prng.c
+++ b/runtime/prng.c
@@ -13,7 +13,6 @@
 /*                                                                        */
 /**************************************************************************/
 
-#include <string.h>
 #include "caml/alloc.h"
 #include "caml/bigarray.h"
 #include "caml/mlvalues.h"

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -18,16 +18,8 @@
 /* To walk the memory roots for garbage collection */
 
 #include "caml/finalise.h"
-#include "caml/globroots.h"
-#include "caml/major_gc.h"
-#include "caml/memory.h"
-#include "caml/minor_gc.h"
 #include "caml/misc.h"
-#include "caml/mlvalues.h"
 #include "caml/roots.h"
-#include "caml/major_gc.h"
-#include "caml/shared_heap.h"
-#include "caml/fiber.h"
 
 CAMLexport _Atomic scan_roots_hook caml_scan_roots_hook =
   (scan_roots_hook)NULL;

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -17,7 +17,6 @@
 #include "caml/runtime_events.h"
 #include "caml/alloc.h"
 #include "caml/callback.h"
-#include "caml/custom.h"
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/mlvalues.h"
@@ -27,8 +26,6 @@
 
 #include <fcntl.h>
 #include <stdatomic.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -21,7 +21,6 @@
 #include "caml/addrmap.h"
 #include "caml/custom.h"
 #include "caml/runtime_events.h"
-#include "caml/fail.h"
 #include "caml/fiber.h" /* for verification */
 #include "caml/gc.h"
 #include "caml/globroots.h"

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -32,12 +32,10 @@
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/platform.h"
-#include "caml/roots.h"
 #include "caml/signals.h"
 #include "caml/sys.h"
 #include "caml/memprof.h"
 #include "caml/finalise.h"
-#include "caml/printexc.h"
 #ifdef __linux__
 #include <sys/auxv.h>
 #include <linux/auxvec.h>

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -15,7 +15,6 @@
 
 #define CAML_INTERNALS
 
-#include <unistd.h>
 #define __USE_GNU
 #if !defined(__OpenBSD__)
 #define _GNU_SOURCE
@@ -25,15 +24,10 @@
 /* Signal handling, code specific to the native-code compiler */
 
 #include <signal.h>
-#include <errno.h>
-#include <stdio.h>
-#include "caml/codefrag.h"
 #include "caml/domain.h"
-#include "caml/fail.h"
 #include "caml/fiber.h"
 #include "caml/frame_descriptors.h"
 #include "caml/memory.h"
-#include "caml/osdeps.h"
 #include "caml/signals.h"
 #include "caml/stack.h"
 

--- a/runtime/simd.c
+++ b/runtime/simd.c
@@ -16,7 +16,6 @@
 
 #include <string.h>
 #include "caml/alloc.h"
-#include "caml/custom.h"
 #include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/simd.h"

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -22,11 +22,9 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "caml/backtrace.h"
 #include "caml/memory.h"
 #include "caml/callback.h"
 #include "caml/domain.h"
-#include "caml/major_gc.h"
 #ifndef NATIVE_CODE
 #include "caml/dynlink.h"
 #endif
@@ -34,11 +32,9 @@
 #include "caml/osdeps.h"
 #include "caml/shared_heap.h"
 #include "caml/startup_aux.h"
-#include "caml/prims.h"
 #include "caml/signals.h"
 #include "caml/gc_ctrl.h"
 #include "caml/fiber.h"
-#include "caml/platform.h"
 
 #include <pthread.h>
 #include <sys/resource.h>

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -44,7 +44,6 @@
 #include "caml/fiber.h"
 #include "caml/fix_code.h"
 #include "caml/gc_ctrl.h"
-#include "caml/instrtrace.h"
 #include "caml/interp.h"
 #include "caml/intext.h"
 #include "caml/io.h"

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -17,8 +17,6 @@
 
 /* Start-up code */
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include "caml/alloc.h"
 #include "caml/callback.h"
@@ -28,16 +26,13 @@
 #include "caml/runtime_events.h"
 #include "caml/fiber.h"
 #include "caml/fail.h"
-#include "caml/gc.h"
 #include "caml/gc_ctrl.h"
-#include "caml/intext.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
 #include "caml/printexc.h"
 #include "caml/signals.h"
-#include "caml/stack.h"
 #include "caml/startup_aux.h"
 #include "caml/sys.h"
 #include "caml/globroots.h"

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -18,7 +18,6 @@
 /* Operations on strings */
 
 #include <string.h>
-#include <ctype.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include "caml/alloc.h"

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -17,7 +17,6 @@
 
 #include "caml/alloc.h"
 #include "caml/custom.h"
-#include "caml/domain_state.h"
 #include "caml/fail.h"
 #include "caml/memory.h"
 

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -23,6 +23,9 @@
 #include <pthread.h>
 #include <string.h>
 
+#include "caml/platform.h"
+#include "caml/config.h"
+#include "caml/memory.h"
 #include "caml/sync.h"
 
 #ifdef __linux__

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -19,12 +19,10 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include <sys/types.h>
 #include <sys/stat.h>
 #ifdef _WIN32
 #include <direct.h> /* for _wchdir and _wgetcwd */
@@ -59,9 +57,7 @@
 #include "caml/mlvalues.h"
 #include "caml/osdeps.h"
 #include "caml/signals.h"
-#include "caml/fiber.h"
 #include "caml/sys.h"
-#include "caml/startup.h"
 #include "caml/callback.h"
 #include "caml/startup_aux.h"
 #include "caml/major_gc.h"

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -64,14 +64,10 @@
 #ifdef __linux__
 #include <sys/prctl.h>
 #endif
-#include "caml/fail.h"
 #include "caml/memory.h"
 #include "caml/misc.h"
 #include "caml/osdeps.h"
 #include "caml/signals.h"
-#include "caml/sys.h"
-#include "caml/io.h"
-#include "caml/alloc.h"
 #include "caml/platform.h"
 #include "caml/startup_aux.h"
 

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -22,7 +22,6 @@
 #include <string.h>
 
 #include "caml/alloc.h"
-#include "caml/domain.h"
 #include "caml/fail.h"
 #include "caml/major_gc.h"
 #include "caml/memory.h"


### PR DESCRIPTION
Three commits to improve the hygiene of `#include`s in the runtime:
- Removing unused `#include`s from `.c` files;
- Adding missing `#include`s to `.h` files (on the Include What You Use principle);
- Bring in the CI check from ocaml/ocaml#14498 to ensure `.h` files are self-sufficient.

We can't really remove unused `#include`s from `.h` files as third-party code may depend on their symbols.