### PR TITLE
Datalog-based validator for cfg_simplify

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -265,6 +265,29 @@ let fold_body_instructions t ~f ~init =
   let helper _ block acc = DLL.fold_left block.body ~f ~init:acc in
   fold_blocks t ~f:helper ~init
 
+let iter_instructions cfg ~instruction ~terminator =
+  iter_blocks
+    ~f:(fun _label block ->
+      DLL.iter block.body ~f:instruction;
+      terminator block.terminator)
+    cfg
+
+type instruction_iterator = { f : 'a. 'a instruction -> unit } [@@unboxed]
+
+let iter_all_instructions cfg { f } =
+  iter_blocks
+    ~f:(fun _label block ->
+      DLL.iter block.body ~f;
+      f block.terminator)
+    cfg
+
+type 'a instruction_folder = { f : 'b. 'a -> 'b instruction -> 'a } [@@unboxed]
+
+let fold_all_instructions cfg ~f ~init =
+  fold_blocks cfg ~init ~f:(fun _label block acc ->
+      let acc = DLL.fold_left block.body ~f:f.f ~init:acc in
+      f.f acc block.terminator)
+
 let register_predecessors_for_all_blocks (t : t) =
   Label.Tbl.iter
     (fun label block ->

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -176,6 +176,20 @@ val fold_blocks : t -> f:(Label.t -> basic_block -> 'a -> 'a) -> init:'a -> 'a
 val fold_body_instructions :
   t -> f:('a -> basic instruction -> 'a) -> init:'a -> 'a
 
+val iter_instructions :
+  t ->
+  instruction:(basic instruction -> unit) ->
+  terminator:(terminator instruction -> unit) ->
+  unit
+
+type instruction_iterator = { f : 'a. 'a instruction -> unit } [@@unboxed]
+
+val iter_all_instructions : t -> instruction_iterator -> unit
+
+type 'a instruction_folder = { f : 'b. 'a -> 'b instruction -> 'a } [@@unboxed]
+
+val fold_all_instructions : t -> f:'a instruction_folder -> init:'a -> 'a
+
 (* CR-soon xclerc for xclerc: [register_predecessors_for_all_blocks] only adds
    blocks to the predecessor sets, and does not clear the sets beforehand. This
    looks like a mistake; at the very least a named boolean parameter should be

--- a/backend/cfg/cfg_dataflow.mli
+++ b/backend/cfg/cfg_dataflow.mli
@@ -43,14 +43,18 @@ module type Forward_S = sig
 
   (** Perform the dataflow analysis on the passed CFG, returning [OK _] if a
       fix-point has been reached and [Error _] otherwise, where the nested value
-      is a partial map from labels to the domain values at the start of the
-      corresponding blocks. If [Error _] is returned then the contents of the
-      map is not guaranteed to be sound.
+      is a map binding each label of the CFG to the domain value at the start of
+      the corresponding block. The map has an entry for every block: entry
+      points are initially bound to [init], all other blocks to the domain's
+      [bot] value, and blocks never reached by the analysis keep their initial
+      binding. If [Error _] is returned then the contents of the map is not
+      guaranteed to be sound.
 
       A fix-point is not reached if there is still pending work after
-      [max_iteration] (defaulting to [max_int]) have been executed, and
-      iteration being the processing of one element from the working set. The
-      [init] value is the initial value of entry points. *)
+      [max_iteration] (defaulting to [max_int]) have been executed, an iteration
+      being the processing of one element from the working set. The [init] value
+      is the initial value of entry points: the entry block and, if
+      [handlers_are_entry_points] is [true], all trap handler blocks. *)
   val run :
     Cfg.t ->
     ?max_iteration:int ->

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -448,6 +448,13 @@ let compute_dominator_forest : Cfg.t -> doms -> dominator_tree list =
 module Validator : sig
   val validate_idom : Cfg.t -> doms -> unit
 end = struct
+  let debug_print_dom doms =
+    Label.Map.iter
+      (fun label immediate_dominator ->
+        Format.eprintf "%a -> %a@." Label.format label Label.format
+          immediate_dominator)
+      (Label.Tbl.to_map doms)
+
   let calculate_idom (cfg : Cfg.t) : doms =
     let buffer = Buffer.create 4096 in
     let fmt = Format.formatter_of_buffer buffer in
@@ -461,19 +468,24 @@ end = struct
 
   (* CR hwasilewski: add validators for the dominance frontier and forest. *)
   let validate_idom (cfg : Cfg.t) (doms : doms) =
+    (* CR hwasilewski: Note: we assume that cfg has no dead code here. *)
     let z3_doms = calculate_idom cfg in
     let doms_equal =
       Label.Map.equal Label.equal (Label.Tbl.to_map doms)
         (Label.Tbl.to_map z3_doms)
     in
     if not doms_equal
-    then
+    then (
+      Format.eprintf "CFG dominators:@.";
+      debug_print_dom doms;
+      Format.eprintf "Z3 dominators:@.";
+      debug_print_dom z3_doms;
       (* CR hwasilewski for xclerc: cannot import Printcfg here, it causes a
          cyclic dependency. *)
       Misc.fatal_errorf
         "validate_idoms: Dominator validation failed: dominator calculated by \
          Datalog does not agree with the Cfg_dominators, cfg '%s'"
-        cfg.fun_name
+        cfg.fun_name)
 end
 
 let build : Cfg.t -> t =

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -144,6 +144,14 @@ end = struct
             (not (Label.Tbl.mem components label))
             && Label.Set.is_empty block.predecessors
           then raise (Found label));
+      (* CR-someday xclerc for xclerc: this fatals on an isolated unreachable
+         cycle (a dead strongly-connected component in which every block has a
+         predecessor inside the component), so no unvisited block then has an
+         empty predecessor set. Cfg_reducibility tolerates the analogous case;
+         consider a clearer diagnostic, or falling back to an arbitrary
+         unvisited block as the component root. Not known to occur today. Note
+         however, that if all dead block are deleted, this should not happen,
+         and we are guaranteed to have a tree rather than a forest. *)
       Misc.fatal_error "did not find a block with no predecessors"
     with Found label -> label
 
@@ -237,6 +245,14 @@ let compute_doms : Cfg.t -> doms =
   Cfg.iter_blocks cfg ~f:(fun label block ->
       if Label.Set.is_empty block.predecessors
       then Label.Tbl.replace doms label label);
+  (* CR-someday xclerc for xclerc: the entry is seeded as self-dominating only
+     via the no-predecessor rule above, so the assertion below also requires the
+     entry block to have no predecessors. Per the dominance definition the entry
+     is always its own immediate dominator; consider seeding it unconditionally
+     (Label.Tbl.replace doms cfg.entry_label cfg.entry_label) and dropping the
+     assertion, so this stays correct even if the entry ever gained a
+     predecessor (e.g. a Tailcall_self back-edge, which cfg_invariants permits
+     to target the entry block). *)
   (match Label.Tbl.find_opt doms cfg.entry_label with
   | None -> assert false
   | Some label -> assert (Label.equal label cfg.entry_label));
@@ -400,7 +416,7 @@ let invariant_dominator_forest : Cfg.t -> doms -> dominator_tree list -> unit =
   List.iter dominator_forest ~f:(fun dominator_tree ->
       check_parent ~parent:None dominator_tree)
 
-let compute_dominator_forest_naive : Cfg.t -> doms -> dominator_tree list =
+let compute_dominator_forest : Cfg.t -> doms -> dominator_tree list =
  fun cfg doms ->
   let roots = ref [] in
   let children = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
@@ -429,65 +445,48 @@ let compute_dominator_forest_naive : Cfg.t -> doms -> dominator_tree list =
   if debug then invariant_dominator_forest cfg doms res;
   res
 
-let compute_dominator_forest_opt : Cfg.t -> doms -> dominator_tree list =
- fun cfg doms ->
-  let roots = ref [] in
-  let children = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
-  let rec build_tree (label : Label.t) : dominator_tree =
-    let children_labels =
-      match Label.Tbl.find_opt children label with
-      | None -> []
-      | Some labels -> labels
+module Validator : sig
+  val validate_idom : Cfg.t -> doms -> unit
+end = struct
+  let calculate_idom (cfg : Cfg.t) : doms =
+    let buffer = Buffer.create 4096 in
+    let fmt = Format.formatter_of_buffer buffer in
+    let id_gen = Cfg_z3.Id_gen.create cfg in
+    Cfg_z3.fmt_dom_code_begin fmt ~id_gen;
+    Cfg_z3.z3_graph_of_cfg fmt ~cfg ~id_gen;
+    Cfg_z3.fmt_dom_code_end fmt;
+    Format.pp_print_flush fmt ();
+    let z3_output = Buffer.contents buffer |> Cfg_z3.run_z3 in
+    Cfg_z3.parse_doms ~id_gen ~entry_label:cfg.entry_label z3_output
+
+  (* CR hwasilewski: add validators for the dominance frontier and forest. *)
+  let validate_idom (cfg : Cfg.t) (doms : doms) =
+    let z3_doms = calculate_idom cfg in
+    let doms_equal =
+      Label.Map.equal Label.equal (Label.Tbl.to_map doms)
+        (Label.Tbl.to_map z3_doms)
     in
-    { label; children = List.map children_labels ~f:build_tree }
-  in
-  Cfg.iter_blocks cfg ~f:(fun label _block ->
-      match Label.Tbl.find_opt doms label with
-      | None -> assert false
-      | Some immediate_dominator ->
-        if Label.equal label immediate_dominator
-        then roots := label :: !roots
-        else
-          let current =
-            match Label.Tbl.find_opt children immediate_dominator with
-            | None -> []
-            | Some children -> children
-          in
-          Label.Tbl.replace children immediate_dominator (label :: current));
-  let res = List.map !roots ~f:build_tree in
-  if debug then invariant_dominator_forest cfg doms res;
-  res
-
-let sort_forest : dominator_tree list -> dominator_tree list =
- fun trees ->
-  let compare_label left right = Label.compare left.label right.label in
-  List.sort ~cmp:compare_label trees
-
-let rec equal_tree : dominator_tree -> dominator_tree -> bool =
- fun left right ->
-  Label.equal left.label right.label
-  && equal_forest left.children right.children
-
-and equal_forest : dominator_tree list -> dominator_tree list -> bool =
- fun left right ->
-  match sort_forest left, sort_forest right with
-  | [], [] -> true
-  | hd_left :: tl_left, hd_right :: tl_right ->
-    equal_tree hd_left hd_right && equal_forest tl_left tl_right
-  | [], _ :: _ | _ :: _, [] -> false
+    if not doms_equal
+    then
+      (* CR hwasilewski for xclerc: cannot import Printcfg here, it causes a
+         cyclic dependency. *)
+      Misc.fatal_errorf
+        "validate_idoms: Dominator validation failed: dominator calculated by \
+         Datalog does not agree with the Cfg_dominators, cfg '%s'"
+        cfg.fun_name
+end
 
 let build : Cfg.t -> t =
  fun cfg ->
   let doms = compute_doms cfg in
   let dominance_frontiers = compute_dominance_frontiers cfg doms in
-  let dominator_forest_naive = compute_dominator_forest_naive cfg doms in
-  let dominator_forest_opt = compute_dominator_forest_opt cfg doms in
-  assert (equal_forest dominator_forest_naive dominator_forest_opt);
-  { entry_label = cfg.entry_label;
-    doms;
-    dominance_frontiers;
-    dominator_forest = dominator_forest_opt
-  }
+  let dominator_forest = compute_dominator_forest cfg doms in
+  if !Oxcaml_flags.cfg_dominators_validate
+  then
+    Profile.record ~accumulate:true "validate_dominators"
+      (Validator.validate_idom cfg)
+      doms;
+  { entry_label = cfg.entry_label; doms; dominance_frontiers; dominator_forest }
 
 let is_dominating t left right = is_dominating t.doms left right
 

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -458,7 +458,7 @@ end = struct
   let calculate_idom (cfg : Cfg.t) : doms =
     let buffer = Buffer.create 4096 in
     let fmt = Format.formatter_of_buffer buffer in
-    let id_gen = Cfg_z3.Id_gen.create cfg in
+    let id_gen = Cfg_z3.create_label_id_gen cfg in
     Cfg_z3.fmt_dom_code_begin fmt ~id_gen;
     Cfg_z3.z3_graph_of_cfg fmt ~cfg ~id_gen;
     Cfg_z3.fmt_dom_code_end fmt;

--- a/backend/cfg/cfg_dominators.ml
+++ b/backend/cfg/cfg_dominators.ml
@@ -147,11 +147,10 @@ end = struct
       (* CR-someday xclerc for xclerc: this fatals on an isolated unreachable
          cycle (a dead strongly-connected component in which every block has a
          predecessor inside the component), so no unvisited block then has an
-         empty predecessor set. Cfg_reducibility tolerates the analogous case;
-         consider a clearer diagnostic, or falling back to an arbitrary
-         unvisited block as the component root. Not known to occur today. Note
-         however, that if all dead block are deleted, this should not happen,
-         and we are guaranteed to have a tree rather than a forest. *)
+         empty predecessor set. The default now removes all unreachable blocks.
+         Once all callers guarantee this before dominator computation, the
+         pseudo-entry/component handling can be removed and the dominator forest
+         simplified to a single tree. *)
       Misc.fatal_error "did not find a block with no predecessors"
     with Found label -> label
 
@@ -445,49 +444,6 @@ let compute_dominator_forest : Cfg.t -> doms -> dominator_tree list =
   if debug then invariant_dominator_forest cfg doms res;
   res
 
-module Validator : sig
-  val validate_idom : Cfg.t -> doms -> unit
-end = struct
-  let debug_print_dom doms =
-    Label.Map.iter
-      (fun label immediate_dominator ->
-        Format.eprintf "%a -> %a@." Label.format label Label.format
-          immediate_dominator)
-      (Label.Tbl.to_map doms)
-
-  let calculate_idom (cfg : Cfg.t) : doms =
-    let buffer = Buffer.create 4096 in
-    let fmt = Format.formatter_of_buffer buffer in
-    let id_gen = Cfg_z3.create_label_id_gen cfg in
-    Cfg_z3.fmt_dom_code_begin fmt ~id_gen;
-    Cfg_z3.z3_graph_of_cfg fmt ~cfg ~id_gen;
-    Cfg_z3.fmt_dom_code_end fmt;
-    Format.pp_print_flush fmt ();
-    let z3_output = Buffer.contents buffer |> Cfg_z3.run_z3 in
-    Cfg_z3.parse_doms ~id_gen ~entry_label:cfg.entry_label z3_output
-
-  (* CR hwasilewski: add validators for the dominance frontier and forest. *)
-  let validate_idom (cfg : Cfg.t) (doms : doms) =
-    (* CR hwasilewski: Note: we assume that cfg has no dead code here. *)
-    let z3_doms = calculate_idom cfg in
-    let doms_equal =
-      Label.Map.equal Label.equal (Label.Tbl.to_map doms)
-        (Label.Tbl.to_map z3_doms)
-    in
-    if not doms_equal
-    then (
-      Format.eprintf "CFG dominators:@.";
-      debug_print_dom doms;
-      Format.eprintf "Z3 dominators:@.";
-      debug_print_dom z3_doms;
-      (* CR hwasilewski for xclerc: cannot import Printcfg here, it causes a
-         cyclic dependency. *)
-      Misc.fatal_errorf
-        "validate_idoms: Dominator validation failed: dominator calculated by \
-         Datalog does not agree with the Cfg_dominators, cfg '%s'"
-        cfg.fun_name)
-end
-
 let build : Cfg.t -> t =
  fun cfg ->
   let doms = compute_doms cfg in
@@ -496,7 +452,7 @@ let build : Cfg.t -> t =
   if !Oxcaml_flags.cfg_dominators_validate
   then
     Profile.record ~accumulate:true "validate_dominators"
-      (Validator.validate_idom cfg)
+      (Cfg_dominators_validate.validate_idom cfg)
       doms;
   { entry_label = cfg.entry_label; doms; dominance_frontiers; dominator_forest }
 

--- a/backend/cfg/cfg_dominators_validate.ml
+++ b/backend/cfg/cfg_dominators_validate.ml
@@ -1,0 +1,200 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+type doms = Label.t Label.Tbl.t
+
+let fmt_dom_code_begin fmt ~id_gen =
+  let width = Cfg_z3.Label_id_gen.width id_gen in
+  Format.fprintf fmt
+    {|
+(set-option :fp.engine datalog)
+
+(define-sort node () (_ BitVec %d))
+
+(declare-rel edge (node node))
+(declare-rel is-node (node))
+(declare-rel entry (node))
+(declare-rel reachable (node))
+(declare-rel not-dom (node node))
+(declare-rel dom (node node))
+(declare-rel not-idom (node node))
+(declare-rel idom (node node))
+
+(declare-var a node)
+(declare-var b node)
+(declare-var c node)
+
+(rule (=> (entry a) (reachable a)))
+(rule (=> (and (reachable a) (edge a b))
+          (reachable b)))
+
+(rule (=> (and (is-node a) (entry b) (distinct a b))
+          (not-dom b a)))
+
+(rule (=> (and (edge b c) (not-dom b a) (distinct a c))
+          (not-dom c a)))
+
+(rule (=> (and (reachable a) (reachable b) (not (not-dom b a)))
+          (dom b a)))
+
+(rule (=> (and (dom a b) (dom a c) (dom b c) (distinct a b) (distinct b c))
+          (not-idom a c)))
+
+(rule (=> (and (dom a b) (distinct a b) (not (not-idom a b)))
+          (idom a b)))
+|}
+    width
+
+let fmt_dom_code_end fmt =
+  Format.pp_print_string fmt
+    {|
+(echo "BEGIN_IDOM")
+(query idom :print-answer true)
+(echo "END_IDOM")
+|}
+
+let lines_between ~begin_marker ~end_marker output =
+  let rec drop_until_marker = function
+    | [] -> Misc.fatal_errorf "Marker %S not found in Z3 output" begin_marker
+    | line :: lines ->
+      if String.equal (String.trim line) begin_marker
+      then lines
+      else drop_until_marker lines
+  in
+  let rec take_until_marker acc = function
+    | [] -> Misc.fatal_errorf "Marker %S not found in Z3 output" end_marker
+    | line :: lines ->
+      if String.equal (String.trim line) end_marker
+      then List.rev acc
+      else take_until_marker (line :: acc) lines
+  in
+  output |> String.split_on_char '\n' |> drop_until_marker
+  |> take_until_marker []
+
+let is_binary_digit = function
+  | '0' | '1' -> true
+  | '2' .. '9' | 'a' .. 'f' | 'A' .. 'F' | _ -> false
+
+let bitvector_tokens line =
+  let length = String.length line in
+  let rec find_end is_digit index =
+    if index < length && is_digit line.[index]
+    then find_end is_digit (index + 1)
+    else index
+  in
+  let rec loop index tokens =
+    if index + 2 > length
+    then List.rev tokens
+    else if
+      Char.equal line.[index] '#'
+      && (Char.equal line.[index + 1] 'x' || Char.equal line.[index + 1] 'b')
+    then
+      let is_digit =
+        if Char.equal line.[index + 1] 'x'
+        then Char.Ascii.is_hex_digit
+        else is_binary_digit
+      in
+      let end_index = find_end is_digit (index + 2) in
+      if end_index = index + 2
+      then loop (index + 1) tokens
+      else
+        let token = String.sub line index (end_index - index) in
+        loop end_index (token :: tokens)
+    else loop (index + 1) tokens
+  in
+  loop 0 []
+
+let int_of_bitvector token =
+  let length = String.length token in
+  if length <= 2 || not (Char.equal token.[0] '#')
+  then Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token;
+  let prefix =
+    match token.[1] with
+    | 'x' -> "0x"
+    | 'b' -> "0b"
+    | _ -> Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token
+  in
+  let digits = String.sub token 2 (length - 2) in
+  match int_of_string_opt (prefix ^ digits) with
+  | Some value -> value
+  | None -> Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token
+
+let parse_idom_pairs output =
+  let lines =
+    lines_between ~begin_marker:"BEGIN_IDOM" ~end_marker:"END_IDOM" output
+    |> List.filter_map (fun line ->
+        let line = String.trim line in
+        if String.equal line "" then None else Some line)
+  in
+  match lines with
+  | [] -> Misc.fatal_error "Missing IDOM query result in Z3 output"
+  | "unsat" :: _ -> []
+  | "sat" :: answer_lines ->
+    List.fold_left
+      (fun pairs line ->
+        match bitvector_tokens line with
+        | [] -> pairs
+        | [node; immediate_dominator] ->
+          (int_of_bitvector node, int_of_bitvector immediate_dominator) :: pairs
+        | tokens ->
+          Misc.fatal_errorf
+            "Unexpected bitvectors in IDOM answer line %S: expected 2, got %d"
+            line (List.length tokens))
+      [] answer_lines
+    |> List.rev
+  | result :: _ ->
+    Misc.fatal_errorf "Unexpected IDOM query result from Z3: %S" result
+
+let parse_doms ~(id_gen : Cfg_z3.Label_id_gen.t) ~entry_label output =
+  let doms = Label.Tbl.create (Cfg_z3.Label_id_gen.length id_gen) in
+  Label.Tbl.add doms entry_label entry_label;
+  parse_idom_pairs output
+  |> List.iter (fun (node_id, immediate_dominator_id) ->
+      let node = Cfg_z3.Label_id_gen.key_of_id_exn id_gen node_id in
+      let immediate_dominator =
+        Cfg_z3.Label_id_gen.key_of_id_exn id_gen immediate_dominator_id
+      in
+      if Label.Tbl.mem doms node
+      then
+        Misc.fatal_errorf "Z3 returned multiple IDOMs for label %a" Label.format
+          node;
+      Label.Tbl.add doms node immediate_dominator);
+  doms
+
+let debug_print_dom doms =
+  Label.Map.iter
+    (fun label immediate_dominator ->
+      Format.eprintf "%a -> %a@." Label.format label Label.format
+        immediate_dominator)
+    (Label.Tbl.to_map doms)
+
+let calculate_idom (cfg : Cfg.t) : doms =
+  let buffer = Buffer.create 4096 in
+  let fmt = Format.formatter_of_buffer buffer in
+  let id_gen = Cfg_z3.create_label_id_gen cfg in
+  fmt_dom_code_begin fmt ~id_gen;
+  Cfg_z3.z3_graph_of_cfg fmt ~cfg ~id_gen;
+  fmt_dom_code_end fmt;
+  Format.pp_print_flush fmt ();
+  let z3_output = Buffer.contents buffer |> Cfg_z3.run_z3 in
+  parse_doms ~id_gen ~entry_label:cfg.entry_label z3_output
+
+(* CR hwasilewski: add validators for the dominance frontier and forest. *)
+let validate_idom (cfg : Cfg.t) (doms : doms) =
+  (* CR hwasilewski: Note: we assume that cfg has no dead code here. *)
+  let z3_doms = calculate_idom cfg in
+  let doms_equal =
+    Label.Map.equal Label.equal (Label.Tbl.to_map doms)
+      (Label.Tbl.to_map z3_doms)
+  in
+  if not doms_equal
+  then (
+    Format.eprintf "CFG dominators:@.";
+    debug_print_dom doms;
+    Format.eprintf "Z3 dominators:@.";
+    debug_print_dom z3_doms;
+    (* CR hwasilewski for xclerc: cannot import Printcfg here, it causes a
+       cyclic dependency. *)
+    Misc.fatal_errorf
+      "validate_idoms: Dominator validation failed: dominator calculated by \
+       Datalog does not agree with the Cfg_dominators, cfg '%s'"
+      cfg.fun_name)

--- a/backend/cfg/cfg_dominators_validate.mli
+++ b/backend/cfg/cfg_dominators_validate.mli
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+val validate_idom : Cfg.t -> Label.t Label.Tbl.t -> unit

--- a/backend/cfg/cfg_invariants.ml
+++ b/backend/cfg/cfg_invariants.ml
@@ -137,6 +137,27 @@ let check_tailrec_position t =
            followingsuccessors:@.%a@."
           Label.print tailrec_label Label.Set.print successors
 
+let check_entry_predecessors t =
+  (* The only expected edges into the entry block are self tail calls, which can
+     occur when the tailrec entry point is the entry block itself. Passes such
+     as [Cfg_simplify.Merge_straightline_blocks] rely on the absence of other
+     kinds of edges into the entry block: they may delete a block whose unique
+     predecessor jumps to it, and the entry block must never be deleted. *)
+  let entry_block = Cfg.get_block_exn t.cfg t.cfg.entry_label in
+  List.iter
+    (fun predecessor ->
+      let pred_block = Cfg.get_block_exn t.cfg predecessor in
+      match pred_block.terminator.desc with
+      | Tailcall_self _ -> ()
+      | Never | Always _ | Parity_test _ | Truth_test _ | Float_test _
+      | Int_test _ | Switch _ | Return | Raise _ | Tailcall_func _
+      | Call_no_return _ | Call _ | Prim _ | Invalid _ ->
+        report t
+          "Block %a is a predecessor of the entry block, but its terminator is \
+           not a self tail call"
+          Label.print predecessor)
+    (Cfg.predecessor_labels entry_block)
+
 let check_terminator_arity t label block =
   let term = block.Cfg.terminator in
   let args = term.arg in
@@ -580,6 +601,7 @@ let run ppf cfg_with_layout =
   in
   check_layout t layout;
   Cfg.iter_blocks ~f:(check_block t) cfg;
+  check_entry_predecessors t;
   check_tailrec_position t;
   let cfg_with_infos = Cfg_with_infos.make cfg_with_layout in
   check_reducibility t cfg_with_infos;

--- a/backend/cfg/cfg_liveness_validate.ml
+++ b/backend/cfg/cfg_liveness_validate.ml
@@ -1,0 +1,164 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module DLL = Oxcaml_utils.Doubly_linked_list
+
+let fmt_liveness_code_begin fmt instr_id_gen reg_id_gen =
+  Format.fprintf fmt
+    {|
+(set-option :fp.engine datalog)
+
+(define-sort instr () (_ BitVec %d))
+(define-sort reg () (_ BitVec %d))
+
+(declare-rel next (instr instr))
+(declare-rel arg (instr reg))
+(declare-rel res (instr reg))
+(declare-rel exn-next (instr instr))
+(declare-rel exn-bucket (reg))
+(declare-rel expected-before (instr reg))
+(declare-rel expected-across (instr reg))
+(declare-rel tailcall-self (instr))
+
+(declare-rel before (instr reg))
+(declare-rel across (instr reg))
+(declare-rel not-removable (instr))
+(declare-rel bad ())
+
+(declare-var i0 instr)
+(declare-var i1 instr)
+(declare-var r reg)
+
+(rule (=> (and (res i0 r) (next i0 i1) (before i1 r)) (not-removable i0)))
+
+(rule (=> (and (next i0 i1) (before i1 r)
+               (not (res i0 r))
+               (not (tailcall-self i0)))
+          (across i0 r)))
+
+(rule (=> (and (exn-next i0 i1) (before i1 r) (not (exn-bucket r))) (across i0 r)))
+
+(rule (=> (across i0 r) (before i0 r)))
+(rule (=> (and (not-removable i0) (arg i0 r)) (before i0 r)))
+
+(rule (=> (and (not (expected-before i0 r)) (before i0 r)) bad))
+(rule (=> (and (expected-before i0 r) (not (before i0 r))) bad))
+
+(rule (=> (and (not (expected-across i0 r)) (across i0 r)) bad))
+(rule (=> (and (expected-across i0 r) (not (across i0 r))) bad))
+|}
+    (Cfg_z3.Instruction_id_gen.width instr_id_gen)
+    (Cfg_z3.Reg_id_gen.width reg_id_gen)
+
+let fmt_liveness_code_end fmt = Format.pp_print_string fmt "(query bad)"
+
+let iter_instruction_edges (cfg : Cfg.t)
+    ~(f : id:InstructionId.t -> succ_id:InstructionId.t -> unit) =
+  Cfg.iter_blocks cfg ~f:(fun _label block ->
+      let (_ : InstructionId.t) =
+        DLL.fold_right block.body
+          ~f:(fun
+              (instruction : Cfg.basic Cfg.instruction) succ_instruction_id ->
+            f ~id:instruction.id ~succ_id:succ_instruction_id;
+            instruction.id)
+          ~init:block.terminator.id
+      in
+      Cfg.successor_labels ~normal:true ~exn:false block
+      |> Label.Set.iter (fun succ_label ->
+          let succ_block = Cfg.get_block_exn cfg succ_label in
+          f ~id:block.terminator.id
+            ~succ_id:(Cfg.first_instruction_id succ_block)))
+
+let iter_exn_edges (cfg : Cfg.t)
+    ~(f : id:InstructionId.t -> succ_id:InstructionId.t -> unit) =
+  Cfg.iter_blocks cfg ~f:(fun _label block ->
+      Cfg.successor_labels ~normal:false ~exn:true block
+      |> Label.Set.iter (fun succ_label ->
+          let succ_block = Cfg.get_block_exn cfg succ_label in
+          f ~id:block.terminator.id
+            ~succ_id:(Cfg.first_instruction_id succ_block)))
+
+let fmt_instruction_arg_res fmt cfg ~get_instr_id ~get_reg_id =
+  Cfg.iter_all_instructions cfg
+    { f =
+        (fun instruction ->
+          Array.iter
+            (fun reg ->
+              Cfg_z3.fmt_fact fmt "arg"
+                [get_instr_id instruction.id; get_reg_id reg])
+            instruction.arg;
+          Array.iter
+            (fun reg ->
+              Cfg_z3.fmt_fact fmt "res"
+                [get_instr_id instruction.id; get_reg_id reg])
+            instruction.res)
+    }
+
+let fmt_not_removable fmt cfg ~get_instr_id =
+  let emit instruction_id =
+    Cfg_z3.fmt_fact fmt "not-removable" [get_instr_id instruction_id]
+  in
+  Cfg.iter_instructions cfg
+    ~instruction:(fun instruction ->
+      if not (Cfg.is_pure_basic instruction.desc) then emit instruction.id)
+    ~terminator:(fun instruction -> emit instruction.id)
+
+let fmt_tailcalls fmt cfg ~get_instr_id =
+  Cfg.iter_instructions cfg ~instruction:ignore
+    ~terminator:(fun (terminator : Cfg.terminator Cfg.instruction) ->
+      match terminator.desc with
+      | Tailcall_self _ ->
+        Cfg_z3.fmt_fact fmt "tailcall-self" [get_instr_id terminator.id]
+      | Never -> assert false
+      | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+      | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _
+      | Call _ | Prim _ | Invalid _ ->
+        ())
+
+let validate_liveness cfg (liveness : Cfg_liveness.domain InstructionId.Tbl.t) =
+  let buffer = Buffer.create 4096 in
+  let fmt = Format.formatter_of_buffer buffer in
+  let instr_id_gen = Cfg_z3.create_instruction_id_gen cfg in
+  let reg_id_gen = Cfg_z3.create_reg_id_gen cfg in
+  fmt_liveness_code_begin fmt instr_id_gen reg_id_gen;
+  let get_instr_id key = Cfg_z3.Instruction_id_gen.get_id instr_id_gen ~key in
+  let get_reg_id key = Cfg_z3.Reg_id_gen.get_id reg_id_gen ~key in
+  (* Emit which instructions are definitely non-removable (i.e impure,
+     terminators). *)
+  fmt_not_removable fmt cfg ~get_instr_id;
+  (* Emit which terminators are tailcalls, so their liveness analysis can be
+     special-cased *)
+  fmt_tailcalls fmt cfg ~get_instr_id;
+  (* Emit information about the instructions' successors. *)
+  iter_instruction_edges cfg ~f:(fun ~id ~succ_id ->
+      Cfg_z3.fmt_fact fmt "next" [get_instr_id id; get_instr_id succ_id]);
+  (* Emit instructions' exception successors. *)
+  iter_exn_edges cfg ~f:(fun ~id ~succ_id ->
+      Cfg_z3.fmt_fact fmt "exn-next" [get_instr_id id; get_instr_id succ_id]);
+  (* Emit arg, res register sets *)
+  fmt_instruction_arg_res fmt cfg ~get_instr_id ~get_reg_id;
+  (* Emit which register is the exception bucket. *)
+  Cfg_z3.fmt_fact fmt "exn-bucket" [get_reg_id Proc.loc_exn_bucket];
+  (* Emit what are the expected liveness analysis results. *)
+  InstructionId.Tbl.iter
+    (fun instr_id (domain : Cfg_liveness.domain) ->
+      Reg.Set.iter
+        (fun reg ->
+          Cfg_z3.fmt_fact fmt "expected-before"
+            [get_instr_id instr_id; get_reg_id reg])
+        domain.before;
+      Reg.Set.iter
+        (fun reg ->
+          Cfg_z3.fmt_fact fmt "expected-across"
+            [get_instr_id instr_id; get_reg_id reg])
+        domain.across)
+    liveness;
+  fmt_liveness_code_end fmt;
+  Format.pp_print_flush fmt ();
+  let z3_output = Buffer.contents buffer |> Cfg_z3.run_z3 |> String.trim in
+  if not (String.equal z3_output "unsat")
+  then
+    Misc.fatal_errorf
+      (* CR hwasilewski: improve debug prints *)
+      "validate_liveness: validation failed, mismatch found between expected \
+       and actual liveness analysis. Z3 code:@.%s@."
+      (Buffer.contents buffer)

--- a/backend/cfg/cfg_liveness_validate.mli
+++ b/backend/cfg/cfg_liveness_validate.mli
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+val validate_liveness : Cfg.t -> Cfg_liveness.domain InstructionId.Tbl.t -> unit

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -50,10 +50,6 @@ end = struct
 (declare-var a node)
 (declare-var b node)
 
-(rule (=> (edge a b) (is-node a)))
-(rule (=> (edge a b) (is-node b)))
-(rule (=> (entry a) (is-node a)))
-
 (rule (=> (entry a) (reachable a)))
 (rule (=> (and (reachable a) (edge a b)) (reachable b)))
 (rule (=> (and (not (reachable a)) (is-node a)) (unreachable a)))
@@ -147,10 +143,6 @@ end = struct
           block.terminator <- { block.terminator with desc = Cfg_intf.S.Never };
           block.exn <- None)
         unreachable_labels;
-      if !Oxcaml_flags.cfg_eliminate_dead_code_validate
-      then
-        Profile.record ~accumulate:true "validate_reachability"
-          Validator.validate_reachability cfg;
       unreachable_labels
 end
 
@@ -352,4 +344,9 @@ let run cfg_with_layout =
      second round of dead code elimination. *)
   Eliminate_dead_code.run cfg_with_layout |> acc;
   Cfg_with_layout.remove_blocks cfg_with_layout !dead_labels;
+  if !Oxcaml_flags.cfg_eliminate_dead_code_validate
+  then
+    Profile.record ~accumulate:true "validate_reachability"
+      Validator.validate_reachability
+      (Cfg_with_layout.cfg cfg_with_layout);
   cfg_with_layout

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -34,25 +34,7 @@ module Validator : sig
   val validate_reachability : Cfg.t -> unit
 end = struct
   let z3_code_of_cfg (cfg : Cfg.t) =
-    let width =
-      match Label.Tbl.length cfg.blocks with
-      | 0 | 1 -> 1
-      | num_blocks -> 1 + Misc.log2 (num_blocks - 1)
-    in
-    let next_id = ref 0 in
-    let id_table = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
-    let get_id label =
-      let id_number =
-        match Label.Tbl.find_opt id_table label with
-        | Some id -> id
-        | None ->
-          let id = !next_id in
-          incr next_id;
-          Label.Tbl.add id_table label id;
-          id
-      in
-      Printf.sprintf "(_ bv%d %d)" id_number width
-    in
+    let id_gen = Cfg_z3.Id_gen.create cfg in
     let buffer = Buffer.create 4096 in
     let fmt = Format.formatter_of_buffer buffer in
     Format.fprintf fmt
@@ -76,45 +58,15 @@ end = struct
 (rule (=> (and (reachable a) (edge a b)) (reachable b)))
 (rule (=> (and (not (reachable a)) (is-node a)) (unreachable a)))
 |}
-      width;
-    Label.Tbl.iter
-      (fun label (value : Cfg.basic_block) ->
-        let id = get_id label in
-        if not (Cfg.is_never_terminator value.terminator.desc)
-        then Format.fprintf fmt "(rule (is-node %s))\n" id;
-        Cfg.successor_labels ~exn:true ~normal:true value
-        |> Label.Set.iter (fun succ_label ->
-            let succ_id = get_id succ_label in
-            Format.fprintf fmt "(rule (edge %s %s))\n" id succ_id))
-      cfg.blocks;
-    Format.fprintf fmt "(rule (entry %s))" (get_id cfg.entry_label);
+      (Cfg_z3.Id_gen.width id_gen);
+    Cfg_z3.z3_graph_of_cfg fmt ~cfg ~id_gen;
     Format.fprintf fmt "\n%s" "(query unreachable)";
     Format.pp_print_flush fmt ();
     Buffer.contents buffer
 
-  let run_z3 code =
-    let with_temp_file suffix f =
-      let filename = Filename.temp_file "oxcaml-z3-" suffix in
-      Misc.try_finally
-        (fun () -> f filename)
-        ~always:(fun () -> Misc.remove_file filename)
-    in
-    with_temp_file ".smt2" @@ fun input_file ->
-    with_temp_file ".out" @@ fun output_file ->
-    Out_channel.with_open_text input_file (fun out_channel ->
-        Out_channel.output_string out_channel code);
-    let command =
-      Filename.quote_command "z3" ["-smt2"; input_file] ~stderr:output_file
-        ~stdout:output_file
-    in
-    let ret = Ccomp.command command in
-    if ret <> 0 then Misc.fatal_errorf "Z3 failed with return code %d" ret;
-    let output = In_channel.with_open_text output_file In_channel.input_all in
-    output
-
   let validate_reachability (cfg : Cfg.t) =
     let z3_code = z3_code_of_cfg cfg in
-    let z3_output = run_z3 z3_code |> String.trim in
+    let z3_output = Cfg_z3.run_z3 z3_code |> String.trim in
     if not (String.equal z3_output "unsat")
     then
       Misc.fatal_errorf

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -71,6 +71,92 @@ end = struct
 
   module Dataflow = Cfg_dataflow.Forward (Domain) (Transfer)
 
+  let z3_code_of_cfg (cfg : Cfg.t) =
+    let width =
+      match Label.Tbl.length cfg.blocks with
+      | 0 | 1 -> 1
+      | num_blocks -> 1 + Misc.log2 (num_blocks - 1)
+    in
+    let next_id = ref 0 in
+    let id_table = Label.Tbl.create (Label.Tbl.length cfg.blocks) in
+    let get_id label =
+      let id_number =
+        match Label.Tbl.find_opt id_table label with
+        | Some id -> id
+        | None ->
+          let id = !next_id in
+          incr next_id;
+          Label.Tbl.add id_table label id;
+          id
+      in
+      Printf.sprintf "(_ bv%d %d)" id_number width
+    in
+    let buffer = Buffer.create 4096 in
+    let fmt = Format.formatter_of_buffer buffer in
+    Format.fprintf fmt
+      {|
+(set-option :fp.engine datalog)
+
+(define-sort node () (_ BitVec %d))
+(declare-rel entry (node))
+(declare-rel edge (node node))
+(declare-rel is-node (node))
+(declare-rel reachable (node))
+(declare-rel unreachable (node))
+(declare-var a node)
+(declare-var b node)
+
+(rule (=> (edge a b) (is-node a)))
+(rule (=> (edge a b) (is-node b)))
+(rule (=> (entry a) (is-node a)))
+
+(rule (=> (entry a) (reachable a)))
+(rule (=> (and (reachable a) (edge a b)) (reachable b)))
+(rule (=> (and (not (reachable a)) (is-node a)) (unreachable a)))
+|}
+      width;
+    Label.Tbl.iter
+      (fun label (value : Cfg.basic_block) ->
+        let id = get_id label in
+        if not (Cfg.is_never_terminator value.terminator.desc)
+        then Format.fprintf fmt "(rule (is-node %s))\n" id;
+        Cfg.successor_labels ~exn:true ~normal:true value
+        |> Label.Set.to_list
+        |> List.iter (fun succ_label ->
+            let succ_id = get_id succ_label in
+            Format.fprintf fmt "(rule (edge %s %s))\n" id succ_id))
+      cfg.blocks;
+    Format.fprintf fmt "(rule (entry %s))" (get_id cfg.entry_label);
+    Format.fprintf fmt "\n%s" "(query unreachable)";
+    Format.pp_print_flush fmt ();
+    Buffer.contents buffer
+
+  let run_z3 code =
+    let with_temp_file suffix f =
+      let filename = Filename.temp_file "oxcaml-z3-" suffix in
+      Misc.try_finally
+        (fun () -> f filename)
+        ~always:(fun () -> Misc.remove_file filename)
+    in
+    with_temp_file ".smt2" @@ fun input_file ->
+    with_temp_file ".out" @@ fun output_file ->
+    Out_channel.with_open_text input_file (fun out_channel ->
+        Out_channel.output_string out_channel code);
+    let command =
+      Filename.quote_command "z3" ["-smt2"; input_file] ~stderr:output_file
+        ~stdout:output_file
+    in
+    let ret = Ccomp.command command in
+    let output = In_channel.with_open_text output_file In_channel.input_all in
+    if ret <> 0 then Misc.fatal_errorf "Z3 failed with return code %d" ret;
+    output
+
+  let validate_reachability (cfg : Cfg.t) =
+    let z3_code = z3_code_of_cfg cfg in
+    let z3_output = run_z3 z3_code |> String.trim in
+    if not (String.equal z3_output "unsat")
+    then Misc.fatal_errorf "unreachable blocks found in cfg: %s" cfg.fun_name
+
   let run : Cfg_with_layout.t -> Label.Set.t =
    fun cfg_with_layout ->
     let cfg = Cfg_with_layout.cfg cfg_with_layout in
@@ -103,6 +189,7 @@ end = struct
           block.terminator <- { block.terminator with desc = Cfg_intf.S.Never };
           block.exn <- None)
         unreachable_labels;
+      Profile.record "validate_reachability" validate_reachability cfg;
       unreachable_labels
 end
 

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -207,7 +207,7 @@ module Merge_straightline_blocks : sig
   val run : Cfg_with_layout.t -> Label.Set.t
 end = struct
   (* Two blocks `b1` and `b2` can be merged if:
-   * - `b1` is not the entry block;
+   * - neither `b1` nor `b2` is the entry block;
    * - `b1` has only one non-exceptional successor, `b2`;
    * - `b1` cannot raise;
    * - `b2` has only one predecessor, `b1`;
@@ -246,6 +246,9 @@ end = struct
             let b2_predecessors = Cfg.predecessor_labels b2_block in
             if
               (not (Label.equal b1_label cfg.entry_label))
+              (* the merge deletes `b2`, and the entry block must never be
+                 deleted (`cfg.entry_label` would be left dangling) *)
+              && (not (Label.equal b2_label cfg.entry_label))
               && (not (Label.equal b1_label b2_label))
               && List.compare_length_with b2_predecessors 1 = 0
               && Cfg.is_pure_terminator b1_block.terminator.desc
@@ -296,6 +299,9 @@ let run cfg_with_layout =
      [Eliminate_fallthrough_blocks] because merging blocks creates more
      opportunities for terminator simplification. *)
   Simplify_terminator.run (Cfg_with_layout.cfg cfg_with_layout);
+  (* [Simplify_terminator] can change successor sets, e.g. by short-circuiting
+     jumps to empty blocks, possibly making some blocks unreachable: hence the
+     second round of dead code elimination. *)
   Eliminate_dead_code.run cfg_with_layout |> acc;
   Cfg_with_layout.remove_blocks cfg_with_layout !dead_labels;
   cfg_with_layout

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -30,47 +30,9 @@ module C = Cfg
 module CL = Cfg_with_layout
 module DLL = Oxcaml_utils.Doubly_linked_list
 
-module Eliminate_dead_code : sig
-  val run : Cfg_with_layout.t -> Label.Set.t
+module Validator : sig
+  val validate_reachability : Cfg.t -> unit
 end = struct
-  module Domain = struct
-    type t =
-      | Reachable
-      | Unreachable
-
-    let bot = Unreachable
-
-    let less_equal left right =
-      match left, right with
-      | Reachable, Reachable -> true
-      | Reachable, Unreachable -> false
-      | Unreachable, Reachable -> true
-      | Unreachable, Unreachable -> true
-
-    let join left right =
-      match left, right with
-      | Reachable, (Reachable | Unreachable) | Unreachable, Reachable ->
-        Reachable
-      | Unreachable, Unreachable -> Unreachable
-  end
-
-  module Transfer = struct
-    type domain = Domain.t
-
-    type context = unit
-
-    type image =
-      { normal : domain;
-        exceptional : domain
-      }
-
-    let basic value _ _ = value
-
-    let terminator value _ _ = { normal = value; exceptional = value }
-  end
-
-  module Dataflow = Cfg_dataflow.Forward (Domain) (Transfer)
-
   let z3_code_of_cfg (cfg : Cfg.t) =
     let width =
       match Label.Tbl.length cfg.blocks with
@@ -121,8 +83,7 @@ end = struct
         if not (Cfg.is_never_terminator value.terminator.desc)
         then Format.fprintf fmt "(rule (is-node %s))\n" id;
         Cfg.successor_labels ~exn:true ~normal:true value
-        |> Label.Set.to_list
-        |> List.iter (fun succ_label ->
+        |> Label.Set.iter (fun succ_label ->
             let succ_id = get_id succ_label in
             Format.fprintf fmt "(rule (edge %s %s))\n" id succ_id))
       cfg.blocks;
@@ -147,15 +108,60 @@ end = struct
         ~stdout:output_file
     in
     let ret = Ccomp.command command in
-    let output = In_channel.with_open_text output_file In_channel.input_all in
     if ret <> 0 then Misc.fatal_errorf "Z3 failed with return code %d" ret;
+    let output = In_channel.with_open_text output_file In_channel.input_all in
     output
 
   let validate_reachability (cfg : Cfg.t) =
     let z3_code = z3_code_of_cfg cfg in
     let z3_output = run_z3 z3_code |> String.trim in
     if not (String.equal z3_output "unsat")
-    then Misc.fatal_errorf "unreachable blocks found in cfg: %s" cfg.fun_name
+    then
+      Misc.fatal_errorf
+        "validate_reachability: unreachable blocks found in cfg '%s'@.%a"
+        cfg.fun_name Printcfg.cfg cfg
+end
+
+module Eliminate_dead_code : sig
+  val run : Cfg_with_layout.t -> Label.Set.t
+end = struct
+  module Domain = struct
+    type t =
+      | Reachable
+      | Unreachable
+
+    let bot = Unreachable
+
+    let less_equal left right =
+      match left, right with
+      | Reachable, Reachable -> true
+      | Reachable, Unreachable -> false
+      | Unreachable, Reachable -> true
+      | Unreachable, Unreachable -> true
+
+    let join left right =
+      match left, right with
+      | Reachable, (Reachable | Unreachable) | Unreachable, Reachable ->
+        Reachable
+      | Unreachable, Unreachable -> Unreachable
+  end
+
+  module Transfer = struct
+    type domain = Domain.t
+
+    type context = unit
+
+    type image =
+      { normal : domain;
+        exceptional : domain
+      }
+
+    let basic value _ _ = value
+
+    let terminator value _ _ = { normal = value; exceptional = value }
+  end
+
+  module Dataflow = Cfg_dataflow.Forward (Domain) (Transfer)
 
   let run : Cfg_with_layout.t -> Label.Set.t =
    fun cfg_with_layout ->
@@ -189,7 +195,10 @@ end = struct
           block.terminator <- { block.terminator with desc = Cfg_intf.S.Never };
           block.exn <- None)
         unreachable_labels;
-      Profile.record "validate_reachability" validate_reachability cfg;
+      if !Oxcaml_flags.cfg_eliminate_dead_code_validate
+      then
+        Profile.record ~accumulate:true "validate_reachability"
+          Validator.validate_reachability cfg;
       unreachable_labels
 end
 

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -34,7 +34,7 @@ module Validator : sig
   val validate_reachability : Cfg.t -> unit
 end = struct
   let z3_code_of_cfg (cfg : Cfg.t) =
-    let id_gen = Cfg_z3.Id_gen.create cfg in
+    let id_gen = Cfg_z3.create_label_id_gen cfg in
     let buffer = Buffer.create 4096 in
     let fmt = Format.formatter_of_buffer buffer in
     Format.fprintf fmt
@@ -54,7 +54,7 @@ end = struct
 (rule (=> (and (reachable a) (edge a b)) (reachable b)))
 (rule (=> (and (not (reachable a)) (is-node a)) (unreachable a)))
 |}
-      (Cfg_z3.Id_gen.width id_gen);
+      (Cfg_z3.Label_id_gen.width id_gen);
     Cfg_z3.z3_graph_of_cfg fmt ~cfg ~id_gen;
     Format.fprintf fmt "\n%s" "(query unreachable)";
     Format.pp_print_flush fmt ();

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -66,8 +66,9 @@ end = struct
     if not (String.equal z3_output "unsat")
     then
       Misc.fatal_errorf
-        "validate_reachability: unreachable blocks found in cfg '%s'@.%a"
-        cfg.fun_name Printcfg.cfg cfg
+        "validate_reachability: unreachable blocks found in cfg '%s'. Z3 \
+         output:@.%s@.CFG:@.%a"
+        cfg.fun_name z3_output Printcfg.cfg cfg
 end
 
 module Eliminate_dead_code : sig

--- a/backend/cfg/cfg_with_infos.ml
+++ b/backend/cfg/cfg_with_infos.ml
@@ -1,8 +1,127 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
 open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
+module DLL = Oxcaml_utils.Doubly_linked_list
 
 type liveness = Cfg_liveness.Liveness.domain InstructionId.Tbl.t
+
+module Validator : sig
+  val validate_liveness :
+    Cfg.t -> Cfg_liveness.domain InstructionId.Tbl.t -> unit
+end = struct
+  let iter_instruction_edges (cfg : Cfg.t)
+      ~(f : id:InstructionId.t -> succ_id:InstructionId.t -> unit) =
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+        let (_ : InstructionId.t) =
+          DLL.fold_right block.body
+            ~f:(fun
+                (instruction : Cfg.basic Cfg.instruction) succ_instruction_id ->
+              f ~id:instruction.id ~succ_id:succ_instruction_id;
+              instruction.id)
+            ~init:block.terminator.id
+        in
+        Cfg.successor_labels ~normal:true ~exn:false block
+        |> Label.Set.iter (fun succ_label ->
+            let succ_block = Cfg.get_block_exn cfg succ_label in
+            f ~id:block.terminator.id
+              ~succ_id:(Cfg.first_instruction_id succ_block)))
+
+  let iter_exn_edges (cfg : Cfg.t)
+      ~(f : id:InstructionId.t -> succ_id:InstructionId.t -> unit) =
+    Cfg.iter_blocks cfg ~f:(fun _label block ->
+        Cfg.successor_labels ~normal:false ~exn:true block
+        |> Label.Set.iter (fun succ_label ->
+            let succ_block = Cfg.get_block_exn cfg succ_label in
+            f ~id:block.terminator.id
+              ~succ_id:(Cfg.first_instruction_id succ_block)))
+
+  let fmt_instruction_arg_res fmt cfg ~get_instr_id ~get_reg_id =
+    Cfg.iter_all_instructions cfg
+      { f =
+          (fun instruction ->
+            Array.iter
+              (fun reg ->
+                Cfg_z3.fmt_fact fmt "arg"
+                  [get_instr_id instruction.id; get_reg_id reg])
+              instruction.arg;
+            Array.iter
+              (fun reg ->
+                Cfg_z3.fmt_fact fmt "res"
+                  [get_instr_id instruction.id; get_reg_id reg])
+              instruction.res)
+      }
+
+  let fmt_not_removable fmt cfg ~get_instr_id =
+    let emit instruction_id =
+      Cfg_z3.fmt_fact fmt "not-removable" [get_instr_id instruction_id]
+    in
+    Cfg.iter_instructions cfg
+      ~instruction:(fun instruction ->
+        if not (Cfg.is_pure_basic instruction.desc) then emit instruction.id)
+      ~terminator:(fun instruction -> emit instruction.id)
+
+  let fmt_tailcalls fmt cfg ~get_instr_id =
+    Cfg.iter_instructions cfg ~instruction:ignore
+      ~terminator:(fun (terminator : Cfg.terminator Cfg.instruction) ->
+        match terminator.desc with
+        | Tailcall_self _ ->
+          Cfg_z3.fmt_fact fmt "tailcall-self" [get_instr_id terminator.id]
+        | Never -> assert false
+        | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
+        | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _
+        | Call _ | Prim _ | Invalid _ ->
+          ())
+
+  let validate_liveness cfg (liveness : Cfg_liveness.domain InstructionId.Tbl.t)
+      =
+    let buffer = Buffer.create 4096 in
+    let fmt = Format.formatter_of_buffer buffer in
+    let instr_id_gen = Cfg_z3.create_instruction_id_gen cfg in
+    let reg_id_gen = Cfg_z3.create_reg_id_gen cfg in
+    Cfg_z3.fmt_liveness_code_begin fmt instr_id_gen reg_id_gen;
+    let get_instr_id key = Cfg_z3.Instruction_id_gen.get_id instr_id_gen ~key in
+    let get_reg_id key = Cfg_z3.Reg_id_gen.get_id reg_id_gen ~key in
+    (* Emit which instructions are definitely non-removable (i.e impure,
+       terminators). *)
+    fmt_not_removable fmt cfg ~get_instr_id;
+    (* Emit which terminators are tailcalls, so their liveness analysis can be
+       special-cased *)
+    fmt_tailcalls fmt cfg ~get_instr_id;
+    (* Emit information about the instructions' successors. *)
+    iter_instruction_edges cfg ~f:(fun ~id ~succ_id ->
+        Cfg_z3.fmt_fact fmt "next" [get_instr_id id; get_instr_id succ_id]);
+    (* Emit instructions' exception successors. *)
+    iter_exn_edges cfg ~f:(fun ~id ~succ_id ->
+        Cfg_z3.fmt_fact fmt "exn-next" [get_instr_id id; get_instr_id succ_id]);
+    (* Emit arg, res register sets *)
+    fmt_instruction_arg_res fmt cfg ~get_instr_id ~get_reg_id;
+    (* Emit which register is the exception bucket. *)
+    Cfg_z3.fmt_fact fmt "exn-bucket" [get_reg_id Proc.loc_exn_bucket];
+    (* Emit what are the expected liveness analysis results. *)
+    InstructionId.Tbl.iter
+      (fun instr_id (domain : Cfg_liveness.domain) ->
+        Reg.Set.iter
+          (fun reg ->
+            Cfg_z3.fmt_fact fmt "expected-before"
+              [get_instr_id instr_id; get_reg_id reg])
+          domain.before;
+        Reg.Set.iter
+          (fun reg ->
+            Cfg_z3.fmt_fact fmt "expected-across"
+              [get_instr_id instr_id; get_reg_id reg])
+          domain.across)
+      liveness;
+    Cfg_z3.fmt_liveness_code_end fmt;
+    Format.pp_print_flush fmt ();
+    let z3_output = Buffer.contents buffer |> Cfg_z3.run_z3 |> String.trim in
+    if not (String.equal z3_output "unsat")
+    then
+      Misc.fatal_errorf
+        (* CR hwasilewski: improve debug prints *)
+        "validate_liveness: validation failed, mismatch found between expected \
+         and actual liveness analysis. Z3 code:@.%s@."
+        (Buffer.contents buffer)
+end
 
 let liveness_analysis : Cfg_with_layout.t -> liveness =
  fun cfg_with_layout ->
@@ -11,7 +130,13 @@ let liveness_analysis : Cfg_with_layout.t -> liveness =
   match
     Cfg_liveness.Liveness.run cfg ~init ~map:Cfg_liveness.Liveness.Instr ()
   with
-  | Ok liveness -> liveness
+  | Ok liveness ->
+    if !Oxcaml_flags.cfg_liveness_validate
+    then
+      Profile.record ~accumulate:true "validate_liveness"
+        (Validator.validate_liveness cfg)
+        liveness;
+    liveness
   | Aborted _ -> .
   | Max_iterations_reached ->
     Misc.fatal_errorf "Unable to compute liveness from CFG for function %s@."

--- a/backend/cfg/cfg_with_infos.ml
+++ b/backend/cfg/cfg_with_infos.ml
@@ -1,127 +1,8 @@
 [@@@ocaml.warning "+a-40-41-42"]
 
 open! Int_replace_polymorphic_compare [@@ocaml.warning "-66"]
-module DLL = Oxcaml_utils.Doubly_linked_list
 
 type liveness = Cfg_liveness.Liveness.domain InstructionId.Tbl.t
-
-module Validator : sig
-  val validate_liveness :
-    Cfg.t -> Cfg_liveness.domain InstructionId.Tbl.t -> unit
-end = struct
-  let iter_instruction_edges (cfg : Cfg.t)
-      ~(f : id:InstructionId.t -> succ_id:InstructionId.t -> unit) =
-    Cfg.iter_blocks cfg ~f:(fun _label block ->
-        let (_ : InstructionId.t) =
-          DLL.fold_right block.body
-            ~f:(fun
-                (instruction : Cfg.basic Cfg.instruction) succ_instruction_id ->
-              f ~id:instruction.id ~succ_id:succ_instruction_id;
-              instruction.id)
-            ~init:block.terminator.id
-        in
-        Cfg.successor_labels ~normal:true ~exn:false block
-        |> Label.Set.iter (fun succ_label ->
-            let succ_block = Cfg.get_block_exn cfg succ_label in
-            f ~id:block.terminator.id
-              ~succ_id:(Cfg.first_instruction_id succ_block)))
-
-  let iter_exn_edges (cfg : Cfg.t)
-      ~(f : id:InstructionId.t -> succ_id:InstructionId.t -> unit) =
-    Cfg.iter_blocks cfg ~f:(fun _label block ->
-        Cfg.successor_labels ~normal:false ~exn:true block
-        |> Label.Set.iter (fun succ_label ->
-            let succ_block = Cfg.get_block_exn cfg succ_label in
-            f ~id:block.terminator.id
-              ~succ_id:(Cfg.first_instruction_id succ_block)))
-
-  let fmt_instruction_arg_res fmt cfg ~get_instr_id ~get_reg_id =
-    Cfg.iter_all_instructions cfg
-      { f =
-          (fun instruction ->
-            Array.iter
-              (fun reg ->
-                Cfg_z3.fmt_fact fmt "arg"
-                  [get_instr_id instruction.id; get_reg_id reg])
-              instruction.arg;
-            Array.iter
-              (fun reg ->
-                Cfg_z3.fmt_fact fmt "res"
-                  [get_instr_id instruction.id; get_reg_id reg])
-              instruction.res)
-      }
-
-  let fmt_not_removable fmt cfg ~get_instr_id =
-    let emit instruction_id =
-      Cfg_z3.fmt_fact fmt "not-removable" [get_instr_id instruction_id]
-    in
-    Cfg.iter_instructions cfg
-      ~instruction:(fun instruction ->
-        if not (Cfg.is_pure_basic instruction.desc) then emit instruction.id)
-      ~terminator:(fun instruction -> emit instruction.id)
-
-  let fmt_tailcalls fmt cfg ~get_instr_id =
-    Cfg.iter_instructions cfg ~instruction:ignore
-      ~terminator:(fun (terminator : Cfg.terminator Cfg.instruction) ->
-        match terminator.desc with
-        | Tailcall_self _ ->
-          Cfg_z3.fmt_fact fmt "tailcall-self" [get_instr_id terminator.id]
-        | Never -> assert false
-        | Always _ | Parity_test _ | Truth_test _ | Float_test _ | Int_test _
-        | Switch _ | Return | Raise _ | Tailcall_func _ | Call_no_return _
-        | Call _ | Prim _ | Invalid _ ->
-          ())
-
-  let validate_liveness cfg (liveness : Cfg_liveness.domain InstructionId.Tbl.t)
-      =
-    let buffer = Buffer.create 4096 in
-    let fmt = Format.formatter_of_buffer buffer in
-    let instr_id_gen = Cfg_z3.create_instruction_id_gen cfg in
-    let reg_id_gen = Cfg_z3.create_reg_id_gen cfg in
-    Cfg_z3.fmt_liveness_code_begin fmt instr_id_gen reg_id_gen;
-    let get_instr_id key = Cfg_z3.Instruction_id_gen.get_id instr_id_gen ~key in
-    let get_reg_id key = Cfg_z3.Reg_id_gen.get_id reg_id_gen ~key in
-    (* Emit which instructions are definitely non-removable (i.e impure,
-       terminators). *)
-    fmt_not_removable fmt cfg ~get_instr_id;
-    (* Emit which terminators are tailcalls, so their liveness analysis can be
-       special-cased *)
-    fmt_tailcalls fmt cfg ~get_instr_id;
-    (* Emit information about the instructions' successors. *)
-    iter_instruction_edges cfg ~f:(fun ~id ~succ_id ->
-        Cfg_z3.fmt_fact fmt "next" [get_instr_id id; get_instr_id succ_id]);
-    (* Emit instructions' exception successors. *)
-    iter_exn_edges cfg ~f:(fun ~id ~succ_id ->
-        Cfg_z3.fmt_fact fmt "exn-next" [get_instr_id id; get_instr_id succ_id]);
-    (* Emit arg, res register sets *)
-    fmt_instruction_arg_res fmt cfg ~get_instr_id ~get_reg_id;
-    (* Emit which register is the exception bucket. *)
-    Cfg_z3.fmt_fact fmt "exn-bucket" [get_reg_id Proc.loc_exn_bucket];
-    (* Emit what are the expected liveness analysis results. *)
-    InstructionId.Tbl.iter
-      (fun instr_id (domain : Cfg_liveness.domain) ->
-        Reg.Set.iter
-          (fun reg ->
-            Cfg_z3.fmt_fact fmt "expected-before"
-              [get_instr_id instr_id; get_reg_id reg])
-          domain.before;
-        Reg.Set.iter
-          (fun reg ->
-            Cfg_z3.fmt_fact fmt "expected-across"
-              [get_instr_id instr_id; get_reg_id reg])
-          domain.across)
-      liveness;
-    Cfg_z3.fmt_liveness_code_end fmt;
-    Format.pp_print_flush fmt ();
-    let z3_output = Buffer.contents buffer |> Cfg_z3.run_z3 |> String.trim in
-    if not (String.equal z3_output "unsat")
-    then
-      Misc.fatal_errorf
-        (* CR hwasilewski: improve debug prints *)
-        "validate_liveness: validation failed, mismatch found between expected \
-         and actual liveness analysis. Z3 code:@.%s@."
-        (Buffer.contents buffer)
-end
 
 let liveness_analysis : Cfg_with_layout.t -> liveness =
  fun cfg_with_layout ->
@@ -134,7 +15,7 @@ let liveness_analysis : Cfg_with_layout.t -> liveness =
     if !Oxcaml_flags.cfg_liveness_validate
     then
       Profile.record ~accumulate:true "validate_liveness"
-        (Validator.validate_liveness cfg)
+        (Cfg_liveness_validate.validate_liveness cfg)
         liveness;
     liveness
   | Aborted _ -> .

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -1,0 +1,242 @@
+let run_z3 code =
+  let with_temp_file suffix f =
+    let filename = Filename.temp_file "oxcaml-z3-" suffix in
+    Misc.try_finally
+      (fun () -> f filename)
+      ~always:(fun () -> Misc.remove_file filename)
+  in
+  with_temp_file ".smt2" @@ fun input_file ->
+  with_temp_file ".out" @@ fun output_file ->
+  Out_channel.with_open_text input_file (fun out_channel ->
+      Out_channel.output_string out_channel code);
+  let command =
+    Filename.quote_command "z3" ["-smt2"; input_file] ~stderr:output_file
+      ~stdout:output_file
+  in
+  let ret = Ccomp.command command in
+  if ret <> 0 then Misc.fatal_errorf "Z3 failed with return code %d" ret;
+  let output = In_channel.with_open_text output_file In_channel.input_all in
+  output
+
+module Id_gen = struct
+  type t =
+    { id_table : int Label.Tbl.t;
+      labels_by_id : Label.t array;
+      width : int
+    }
+
+  let bitwidth_of_count count =
+    match count with 0 | 1 -> 1 | num_blocks -> 1 + Misc.log2 (num_blocks - 1)
+
+  let create (cfg : Cfg.t) =
+    let labels_by_id = cfg.blocks |> Label.Tbl.to_seq_keys |> Array.of_seq in
+    Array.sort Label.compare labels_by_id;
+    (* CR hwasilewski for xclerc: do we want this sort? not required but
+       provides determins across runs, i.e if we compile the same cfg (with the
+       same labels) it will have the same z3 IDs. Not sure there is much gain
+       from this. *)
+    let block_count = Array.length labels_by_id in
+    let id_table = Label.Tbl.create block_count in
+    Array.iteri (fun id label -> Label.Tbl.add id_table label id) labels_by_id;
+    { id_table; labels_by_id; width = bitwidth_of_count block_count }
+
+  let width t = t.width
+
+  let get_id { id_table; width; labels_by_id = _ } ~label =
+    let id_number =
+      match Label.Tbl.find_opt id_table label with
+      | Some id -> id
+      | None ->
+        Misc.fatal_errorf "No Z3 id assigned to CFG label %a" Label.format label
+    in
+    Printf.sprintf "(_ bv%d %d)" id_number width
+
+  let label_of_id t id =
+    if id < 0 || id >= Array.length t.labels_by_id
+    then Misc.fatal_errorf "Invalid Z3 node ID %d" id;
+    t.labels_by_id.(id)
+end
+
+let z3_graph_of_cfg fmt ~(cfg : Cfg.t) ~(id_gen : Id_gen.t) =
+  Format.fprintf fmt "(rule (entry %s))"
+    (Id_gen.get_id id_gen ~label:cfg.entry_label);
+  Label.Tbl.iter
+    (fun label (value : Cfg.basic_block) ->
+      let id = Id_gen.get_id id_gen ~label in
+      if not (Cfg.is_never_terminator value.terminator.desc)
+      then Format.fprintf fmt "(rule (is-node %s))\n" id;
+      Cfg.successor_labels ~exn:true ~normal:true value
+      |> Label.Set.iter (fun succ_label ->
+          let succ_id = Id_gen.get_id id_gen ~label:succ_label in
+          Format.fprintf fmt "(rule (edge %s %s))\n" id succ_id))
+    cfg.blocks
+
+let fmt_dom_code_begin fmt ~id_gen =
+  let width = Id_gen.width id_gen in
+  Format.fprintf fmt
+    {|
+(define-sort node () (_ BitVec %d))
+
+(declare-rel edge (node node))
+(declare-rel is-node (node))
+(declare-rel entry (node))
+(declare-rel reachable (node))
+(declare-rel not-dom (node node))
+(declare-rel dom (node node))
+(declare-rel strict-dom (node node))
+(declare-rel not-idom (node node))
+(declare-rel idom (node node))
+(declare-rel df (node node))
+
+(declare-var a node)
+(declare-var b node)
+(declare-var c node)
+
+(rule (=> (edge a b) (is-node a)))
+(rule (=> (edge a b) (is-node b)))
+(rule (=> (entry a) (is-node a)))
+
+(rule (=> (entry a) (reachable a)))
+(rule (=> (and (reachable a) (edge a b))
+          (reachable b)))
+
+(rule (=> (and (is-node a) (entry b) (distinct a b))
+          (not-dom b a)))
+
+(rule (=> (and (edge b c) (not-dom b a) (distinct a c))
+          (not-dom c a)))
+
+(rule (=> (and (reachable a) (reachable b) (not (not-dom b a)))
+          (dom b a)))
+
+(rule (=> (and (dom a b) (dom a c) (dom b c) (distinct a b) (distinct b c))
+          (not-idom a c)))
+
+(rule (=> (and (dom a b) (distinct a b) (not (not-idom a b)))
+          (idom a b)))
+
+(rule (=> (and (dom b a) (distinct a b)) (strict-dom b a)))
+(rule (=> (and (edge b c) (dom b a) (not (strict-dom c a))) (df a c)))
+|}
+    width
+
+let fmt_dom_code_end fmt =
+  Format.pp_print_string fmt
+    {|
+(echo "BEGIN_IDOM")
+(query idom :print-answer true)
+(echo "END_IDOM")
+(echo "BEGIN_DF")
+(query df :print-answer true)
+(echo "END_DF")
+|}
+
+(* CR hwasilewski for xclerc: here begins the parsing code written by GPT, I
+   haven't really read it *)
+let lines_between ~begin_marker ~end_marker output =
+  let rec drop_until_marker = function
+    | [] -> Misc.fatal_errorf "Marker %S not found in Z3 output" begin_marker
+    | line :: lines ->
+      if String.equal (String.trim line) begin_marker
+      then lines
+      else drop_until_marker lines
+  in
+  let rec take_until_marker acc = function
+    | [] -> Misc.fatal_errorf "Marker %S not found in Z3 output" end_marker
+    | line :: lines ->
+      if String.equal (String.trim line) end_marker
+      then List.rev acc
+      else take_until_marker (line :: acc) lines
+  in
+  output |> String.split_on_char '\n' |> drop_until_marker
+  |> take_until_marker []
+
+let is_binary_digit = function
+  | '0' | '1' -> true
+  | '2' .. '9' | 'a' .. 'f' | 'A' .. 'F' | _ -> false
+
+let bitvector_tokens line =
+  let length = String.length line in
+  let rec find_end is_digit index =
+    if index < length && is_digit line.[index]
+    then find_end is_digit (index + 1)
+    else index
+  in
+  let rec loop index tokens =
+    if index + 2 > length
+    then List.rev tokens
+    else if
+      Char.equal line.[index] '#'
+      && (Char.equal line.[index + 1] 'x' || Char.equal line.[index + 1] 'b')
+    then
+      let is_digit =
+        if Char.equal line.[index + 1] 'x'
+        then Char.Ascii.is_hex_digit
+        else is_binary_digit
+      in
+      let end_index = find_end is_digit (index + 2) in
+      if end_index = index + 2
+      then loop (index + 1) tokens
+      else
+        let token = String.sub line index (end_index - index) in
+        loop end_index (token :: tokens)
+    else loop (index + 1) tokens
+  in
+  loop 0 []
+
+let int_of_bitvector token =
+  let length = String.length token in
+  if length <= 2 || not (Char.equal token.[0] '#')
+  then Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token;
+  let prefix =
+    match token.[1] with
+    | 'x' -> "0x"
+    | 'b' -> "0b"
+    | _ -> Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token
+  in
+  let digits = String.sub token 2 (length - 2) in
+  match int_of_string_opt (prefix ^ digits) with
+  | Some value -> value
+  | None -> Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token
+
+let parse_idom_pairs output =
+  let lines =
+    lines_between ~begin_marker:"BEGIN_IDOM" ~end_marker:"END_IDOM" output
+    |> List.filter_map (fun line ->
+        let line = String.trim line in
+        if String.equal line "" then None else Some line)
+  in
+  match lines with
+  | [] -> Misc.fatal_error "Missing IDOM query result in Z3 output"
+  | "unsat" :: _ -> []
+  | "sat" :: answer_lines ->
+    List.fold_left
+      (fun pairs line ->
+        match bitvector_tokens line with
+        | [] -> pairs
+        | [node; immediate_dominator] ->
+          (int_of_bitvector node, int_of_bitvector immediate_dominator) :: pairs
+        | tokens ->
+          Misc.fatal_errorf
+            "Unexpected bitvectors in IDOM answer line %S: expected 2, got %d"
+            line (List.length tokens))
+      [] answer_lines
+    |> List.rev
+  | result :: _ ->
+    Misc.fatal_errorf "Unexpected IDOM query result from Z3: %S" result
+
+let parse_doms ~(id_gen : Id_gen.t) ~entry_label output =
+  let doms = Label.Tbl.create (Array.length id_gen.labels_by_id) in
+  Label.Tbl.add doms entry_label entry_label;
+  parse_idom_pairs output
+  |> List.iter (fun (node_id, immediate_dominator_id) ->
+      let node = Id_gen.label_of_id id_gen node_id in
+      let immediate_dominator =
+        Id_gen.label_of_id id_gen immediate_dominator_id
+      in
+      if Label.Tbl.mem doms node
+      then
+        Misc.fatal_errorf "Z3 returned multiple IDOMs for label %a" Label.format
+          node;
+      Label.Tbl.add doms node immediate_dominator);
+  doms

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -14,8 +14,10 @@ let run_z3 code =
       ~stdout:output_file
   in
   let ret = Ccomp.command command in
-  if ret <> 0 then Misc.fatal_errorf "Z3 failed with return code %d" ret;
   let output = In_channel.with_open_text output_file In_channel.input_all in
+  if ret <> 0
+  then
+    Misc.fatal_errorf "Z3 failed with return code %d. Output: @.%s" ret output;
   output
 
 module Id_gen = struct
@@ -63,8 +65,7 @@ let z3_graph_of_cfg fmt ~(cfg : Cfg.t) ~(id_gen : Id_gen.t) =
   Label.Tbl.iter
     (fun label (value : Cfg.basic_block) ->
       let id = Id_gen.get_id id_gen ~label in
-      if not (Cfg.is_never_terminator value.terminator.desc)
-      then Format.fprintf fmt "(rule (is-node %s))\n" id;
+      Format.fprintf fmt "(rule (is-node %s))\n" id;
       Cfg.successor_labels ~exn:true ~normal:true value
       |> Label.Set.iter (fun succ_label ->
           let succ_id = Id_gen.get_id id_gen ~label:succ_label in
@@ -91,10 +92,6 @@ let fmt_dom_code_begin fmt ~id_gen =
 (declare-var a node)
 (declare-var b node)
 (declare-var c node)
-
-(rule (=> (edge a b) (is-node a)))
-(rule (=> (edge a b) (is-node b)))
-(rule (=> (entry a) (is-node a)))
 
 (rule (=> (entry a) (reachable a)))
 (rule (=> (and (reachable a) (edge a b))

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -1,3 +1,5 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
 let run_z3 code =
   let with_temp_file suffix f =
     let filename = Filename.temp_file "oxcaml-z3-" suffix in
@@ -38,6 +40,8 @@ module type Id_gen_S = sig
 
   val width : t -> int
 
+  val length : t -> int
+
   val key_of_id_exn : t -> int -> key
 end
 
@@ -71,6 +75,8 @@ module Make_id_gen (Key : Id_key) = struct
     { id_table; keys_by_id; width = bitwidth_of_count key_count }
 
   let width t = t.width
+
+  let length t = Array.length t.keys_by_id
 
   let get_id { id_table; width; keys_by_id = _ } ~key =
     let id_number =
@@ -136,216 +142,3 @@ let z3_graph_of_cfg fmt ~(cfg : Cfg.t) ~(id_gen : Label_id_gen.t) =
           let succ_id = Label_id_gen.get_id id_gen ~key:succ_label in
           fmt_fact fmt "edge" [id; succ_id]))
     cfg.blocks
-
-let fmt_dom_code_begin fmt ~id_gen =
-  let width = Label_id_gen.width id_gen in
-  Format.fprintf fmt
-    {|
-(define-sort node () (_ BitVec %d))
-
-(declare-rel edge (node node))
-(declare-rel is-node (node))
-(declare-rel entry (node))
-(declare-rel reachable (node))
-(declare-rel not-dom (node node))
-(declare-rel dom (node node))
-(declare-rel strict-dom (node node))
-(declare-rel not-idom (node node))
-(declare-rel idom (node node))
-(declare-rel df (node node))
-
-(declare-var a node)
-(declare-var b node)
-(declare-var c node)
-
-(rule (=> (entry a) (reachable a)))
-(rule (=> (and (reachable a) (edge a b))
-          (reachable b)))
-
-(rule (=> (and (is-node a) (entry b) (distinct a b))
-          (not-dom b a)))
-
-(rule (=> (and (edge b c) (not-dom b a) (distinct a c))
-          (not-dom c a)))
-
-(rule (=> (and (reachable a) (reachable b) (not (not-dom b a)))
-          (dom b a)))
-
-(rule (=> (and (dom a b) (dom a c) (dom b c) (distinct a b) (distinct b c))
-          (not-idom a c)))
-
-(rule (=> (and (dom a b) (distinct a b) (not (not-idom a b)))
-          (idom a b)))
-
-(rule (=> (and (dom b a) (distinct a b)) (strict-dom b a)))
-(rule (=> (and (edge b c) (dom b a) (not (strict-dom c a))) (df a c)))
-|}
-    width
-
-let fmt_dom_code_end fmt =
-  Format.pp_print_string fmt
-    {|
-(echo "BEGIN_IDOM")
-(query idom :print-answer true)
-(echo "END_IDOM")
-(echo "BEGIN_DF")
-(query df :print-answer true)
-(echo "END_DF")
-|}
-
-let fmt_liveness_code_begin fmt instr_id_gen reg_id_gen =
-  Format.fprintf fmt
-    {|
-(define-sort instr () (_ BitVec %d))
-(define-sort reg () (_ BitVec %d))
-
-(declare-rel next (instr instr))
-(declare-rel arg (instr reg))
-(declare-rel res (instr reg))
-(declare-rel exn-next (instr instr))
-(declare-rel exn-bucket (reg))
-(declare-rel expected-before (instr reg))
-(declare-rel expected-across (instr reg))
-(declare-rel tailcall-self (instr))
-
-(declare-rel before (instr reg))
-(declare-rel across (instr reg))
-(declare-rel not-removable (instr))
-(declare-rel bad ())
-
-(declare-var i0 instr)
-(declare-var i1 instr)
-(declare-var r reg)
-
-(rule (=> (and (res i0 r) (next i0 i1) (before i1 r)) (not-removable i0)))
-
-(rule (=> (and (next i0 i1) (before i1 r)
-               (not (res i0 r))
-               (not (tailcall-self i0)))
-          (across i0 r)))
-
-(rule (=> (and (exn-next i0 i1) (before i1 r) (not (exn-bucket r))) (across i0 r)))
-
-(rule (=> (across i0 r) (before i0 r)))
-(rule (=> (and (not-removable i0) (arg i0 r)) (before i0 r)))
-
-(rule (=> (and (not (expected-before i0 r)) (before i0 r)) bad))
-(rule (=> (and (expected-before i0 r) (not (before i0 r))) bad))
-
-(rule (=> (and (not (expected-across i0 r)) (across i0 r)) bad))
-(rule (=> (and (expected-across i0 r) (not (across i0 r))) bad))
-|}
-    (Instruction_id_gen.width instr_id_gen)
-    (Reg_id_gen.width reg_id_gen)
-
-let fmt_liveness_code_end fmt = Format.pp_print_string fmt "(query bad)"
-
-(* CR hwasilewski for xclerc: here begins the parsing code written by GPT, I
-   haven't really read it *)
-let lines_between ~begin_marker ~end_marker output =
-  let rec drop_until_marker = function
-    | [] -> Misc.fatal_errorf "Marker %S not found in Z3 output" begin_marker
-    | line :: lines ->
-      if String.equal (String.trim line) begin_marker
-      then lines
-      else drop_until_marker lines
-  in
-  let rec take_until_marker acc = function
-    | [] -> Misc.fatal_errorf "Marker %S not found in Z3 output" end_marker
-    | line :: lines ->
-      if String.equal (String.trim line) end_marker
-      then List.rev acc
-      else take_until_marker (line :: acc) lines
-  in
-  output |> String.split_on_char '\n' |> drop_until_marker
-  |> take_until_marker []
-
-let is_binary_digit = function
-  | '0' | '1' -> true
-  | '2' .. '9' | 'a' .. 'f' | 'A' .. 'F' | _ -> false
-
-let bitvector_tokens line =
-  let length = String.length line in
-  let rec find_end is_digit index =
-    if index < length && is_digit line.[index]
-    then find_end is_digit (index + 1)
-    else index
-  in
-  let rec loop index tokens =
-    if index + 2 > length
-    then List.rev tokens
-    else if
-      Char.equal line.[index] '#'
-      && (Char.equal line.[index + 1] 'x' || Char.equal line.[index + 1] 'b')
-    then
-      let is_digit =
-        if Char.equal line.[index + 1] 'x'
-        then Char.Ascii.is_hex_digit
-        else is_binary_digit
-      in
-      let end_index = find_end is_digit (index + 2) in
-      if end_index = index + 2
-      then loop (index + 1) tokens
-      else
-        let token = String.sub line index (end_index - index) in
-        loop end_index (token :: tokens)
-    else loop (index + 1) tokens
-  in
-  loop 0 []
-
-let int_of_bitvector token =
-  let length = String.length token in
-  if length <= 2 || not (Char.equal token.[0] '#')
-  then Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token;
-  let prefix =
-    match token.[1] with
-    | 'x' -> "0x"
-    | 'b' -> "0b"
-    | _ -> Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token
-  in
-  let digits = String.sub token 2 (length - 2) in
-  match int_of_string_opt (prefix ^ digits) with
-  | Some value -> value
-  | None -> Misc.fatal_errorf "Invalid bitvector in Z3 output: %S" token
-
-let parse_idom_pairs output =
-  let lines =
-    lines_between ~begin_marker:"BEGIN_IDOM" ~end_marker:"END_IDOM" output
-    |> List.filter_map (fun line ->
-        let line = String.trim line in
-        if String.equal line "" then None else Some line)
-  in
-  match lines with
-  | [] -> Misc.fatal_error "Missing IDOM query result in Z3 output"
-  | "unsat" :: _ -> []
-  | "sat" :: answer_lines ->
-    List.fold_left
-      (fun pairs line ->
-        match bitvector_tokens line with
-        | [] -> pairs
-        | [node; immediate_dominator] ->
-          (int_of_bitvector node, int_of_bitvector immediate_dominator) :: pairs
-        | tokens ->
-          Misc.fatal_errorf
-            "Unexpected bitvectors in IDOM answer line %S: expected 2, got %d"
-            line (List.length tokens))
-      [] answer_lines
-    |> List.rev
-  | result :: _ ->
-    Misc.fatal_errorf "Unexpected IDOM query result from Z3: %S" result
-
-let parse_doms ~(id_gen : Label_id_gen.t) ~entry_label output =
-  let doms = Label.Tbl.create (Array.length id_gen.keys_by_id) in
-  Label.Tbl.add doms entry_label entry_label;
-  parse_idom_pairs output
-  |> List.iter (fun (node_id, immediate_dominator_id) ->
-      let node = Label_id_gen.key_of_id_exn id_gen node_id in
-      let immediate_dominator =
-        Label_id_gen.key_of_id_exn id_gen immediate_dominator_id
-      in
-      if Label.Tbl.mem doms node
-      then
-        Misc.fatal_errorf "Z3 returned multiple IDOMs for label %a" Label.format
-          node;
-      Label.Tbl.add doms node immediate_dominator);
-  doms

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -17,63 +17,128 @@ let run_z3 code =
   let output = In_channel.with_open_text output_file In_channel.input_all in
   if ret <> 0
   then
-    Misc.fatal_errorf "Z3 failed with return code %d. Output: @.%s" ret output;
+    Misc.fatal_errorf "Z3 failed with return code %d. Input: @.%s@.Output: @.%s"
+      ret code output;
   output
 
-module Id_gen = struct
+let fmt_fact fmt relation arguments =
+  let fmt_argument fmt argument = Format.fprintf fmt " %s" argument in
+  Format.fprintf fmt "(rule (%s%a))@." relation
+    (Format.pp_print_list fmt_argument)
+    arguments
+
+module type Id_gen_S = sig
+  type key
+
+  type t
+
+  val create : key list -> t
+
+  val get_id : t -> key:key -> string
+
+  val width : t -> int
+
+  val key_of_id_exn : t -> int -> key
+end
+
+module type Id_key = sig
+  type t
+
+  val compare : t -> t -> int
+
+  val format : Format.formatter -> t -> unit
+
+  module Tbl : Hashtbl.S with type key = t
+end
+
+module Make_id_gen (Key : Id_key) = struct
+  type key = Key.t
+
   type t =
-    { id_table : int Label.Tbl.t;
-      labels_by_id : Label.t array;
+    { id_table : int Key.Tbl.t;
+      keys_by_id : key array;
       width : int
     }
 
   let bitwidth_of_count count =
     match count with 0 | 1 -> 1 | num_blocks -> 1 + Misc.log2 (num_blocks - 1)
 
-  let create (cfg : Cfg.t) =
-    let labels_by_id = cfg.blocks |> Label.Tbl.to_seq_keys |> Array.of_seq in
-    Array.sort Label.compare labels_by_id;
-    (* CR hwasilewski for xclerc: do we want this sort? not required but
-       provides determins across runs, i.e if we compile the same cfg (with the
-       same labels) it will have the same z3 IDs. Not sure there is much gain
-       from this. *)
-    let block_count = Array.length labels_by_id in
-    let id_table = Label.Tbl.create block_count in
-    Array.iteri (fun id label -> Label.Tbl.add id_table label id) labels_by_id;
-    { id_table; labels_by_id; width = bitwidth_of_count block_count }
+  let create (keys : key list) =
+    let keys_by_id = keys |> List.sort_uniq Key.compare |> Array.of_list in
+    let key_count = Array.length keys_by_id in
+    let id_table = Key.Tbl.create key_count in
+    Array.iteri (fun id key -> Key.Tbl.add id_table key id) keys_by_id;
+    { id_table; keys_by_id; width = bitwidth_of_count key_count }
 
   let width t = t.width
 
-  let get_id { id_table; width; labels_by_id = _ } ~label =
+  let get_id { id_table; width; keys_by_id = _ } ~key =
     let id_number =
-      match Label.Tbl.find_opt id_table label with
+      match Key.Tbl.find_opt id_table key with
       | Some id -> id
-      | None ->
-        Misc.fatal_errorf "No Z3 id assigned to CFG label %a" Label.format label
+      | None -> Misc.fatal_errorf "No Z3 id assigned to %a" Key.format key
     in
     Printf.sprintf "(_ bv%d %d)" id_number width
 
-  let label_of_id t id =
-    if id < 0 || id >= Array.length t.labels_by_id
+  let key_of_id_exn t id =
+    if id < 0 || id >= Array.length t.keys_by_id
     then Misc.fatal_errorf "Invalid Z3 node ID %d" id;
-    t.labels_by_id.(id)
+    t.keys_by_id.(id)
 end
 
-let z3_graph_of_cfg fmt ~(cfg : Cfg.t) ~(id_gen : Id_gen.t) =
-  Format.fprintf fmt "(rule (entry %s))"
-    (Id_gen.get_id id_gen ~label:cfg.entry_label);
+module Label_id_gen = Make_id_gen (Label)
+module Instruction_id_gen = Make_id_gen (InstructionId)
+
+module Reg_id_gen = Make_id_gen (struct
+  type t = Reg.t
+
+  let compare = Reg.compare
+
+  let format = Printreg.reg
+
+  module Tbl = Reg.Tbl
+end)
+
+let create_label_id_gen (cfg : Cfg.t) =
+  cfg.blocks |> Label.Tbl.to_seq_keys |> List.of_seq |> Label_id_gen.create
+
+let create_instruction_id_gen (cfg : Cfg.t) =
+  Cfg.fold_all_instructions cfg ~init:[]
+    ~f:
+      { f =
+          (fun instruction_ids instruction ->
+            instruction.Cfg.id :: instruction_ids)
+      }
+  |> Instruction_id_gen.create
+
+let create_reg_id_gen (cfg : Cfg.t) =
+  let add_instruction_regs : type a.
+      Reg.t list -> a Cfg.instruction -> Reg.t list =
+   fun regs instruction ->
+    let add_regs regs regs_to_add =
+      Array.fold_left (fun regs reg -> reg :: regs) regs regs_to_add
+    in
+    let regs = add_regs regs instruction.arg in
+    add_regs regs instruction.res
+  in
+  let init_regs = Proc.loc_exn_bucket :: Array.to_list cfg.fun_args in
+  Cfg.fold_all_instructions cfg ~init:init_regs ~f:{ f = add_instruction_regs }
+  |> Reg_id_gen.create
+
+let z3_graph_of_cfg fmt ~(cfg : Cfg.t) ~(id_gen : Label_id_gen.t) =
+  fmt_fact fmt "entry" [Label_id_gen.get_id id_gen ~key:cfg.entry_label];
   Label.Tbl.iter
     (fun label (value : Cfg.basic_block) ->
-      let id = Id_gen.get_id id_gen ~label in
-      Format.fprintf fmt "(rule (is-node %s))\n" id;
+      let id = Label_id_gen.get_id id_gen ~key:label in
+      fmt_fact fmt "is-node" [id];
       Cfg.successor_labels ~exn:true ~normal:true value
       |> Label.Set.iter (fun succ_label ->
-          let succ_id = Id_gen.get_id id_gen ~label:succ_label in
-          Format.fprintf fmt "(rule (edge %s %s))\n" id succ_id))
+          let succ_id = Label_id_gen.get_id id_gen ~key:succ_label in
+          fmt_fact fmt "edge" [id; succ_id]))
     cfg.blocks
 
 let fmt_dom_code_begin fmt ~id_gen =
-  let width = Id_gen.width id_gen in
+  let width = Label_id_gen.width id_gen in
   Format.fprintf fmt
     {|
 (define-sort node () (_ BitVec %d))
@@ -127,6 +192,53 @@ let fmt_dom_code_end fmt =
 (query df :print-answer true)
 (echo "END_DF")
 |}
+
+let fmt_liveness_code_begin fmt instr_id_gen reg_id_gen =
+  Format.fprintf fmt
+    {|
+(define-sort instr () (_ BitVec %d))
+(define-sort reg () (_ BitVec %d))
+
+(declare-rel next (instr instr))
+(declare-rel arg (instr reg))
+(declare-rel res (instr reg))
+(declare-rel exn-next (instr instr))
+(declare-rel exn-bucket (reg))
+(declare-rel expected-before (instr reg))
+(declare-rel expected-across (instr reg))
+(declare-rel tailcall-self (instr))
+
+(declare-rel before (instr reg))
+(declare-rel across (instr reg))
+(declare-rel not-removable (instr))
+(declare-rel bad ())
+
+(declare-var i0 instr)
+(declare-var i1 instr)
+(declare-var r reg)
+
+(rule (=> (and (res i0 r) (next i0 i1) (before i1 r)) (not-removable i0)))
+
+(rule (=> (and (next i0 i1) (before i1 r)
+               (not (res i0 r))
+               (not (tailcall-self i0)))
+          (across i0 r)))
+
+(rule (=> (and (exn-next i0 i1) (before i1 r) (not (exn-bucket r))) (across i0 r)))
+
+(rule (=> (across i0 r) (before i0 r)))
+(rule (=> (and (not-removable i0) (arg i0 r)) (before i0 r)))
+
+(rule (=> (and (not (expected-before i0 r)) (before i0 r)) bad))
+(rule (=> (and (expected-before i0 r) (not (before i0 r))) bad))
+
+(rule (=> (and (not (expected-across i0 r)) (across i0 r)) bad))
+(rule (=> (and (expected-across i0 r) (not (across i0 r))) bad))
+|}
+    (Instruction_id_gen.width instr_id_gen)
+    (Reg_id_gen.width reg_id_gen)
+
+let fmt_liveness_code_end fmt = Format.pp_print_string fmt "(query bad)"
 
 (* CR hwasilewski for xclerc: here begins the parsing code written by GPT, I
    haven't really read it *)
@@ -222,14 +334,14 @@ let parse_idom_pairs output =
   | result :: _ ->
     Misc.fatal_errorf "Unexpected IDOM query result from Z3: %S" result
 
-let parse_doms ~(id_gen : Id_gen.t) ~entry_label output =
-  let doms = Label.Tbl.create (Array.length id_gen.labels_by_id) in
+let parse_doms ~(id_gen : Label_id_gen.t) ~entry_label output =
+  let doms = Label.Tbl.create (Array.length id_gen.keys_by_id) in
   Label.Tbl.add doms entry_label entry_label;
   parse_idom_pairs output
   |> List.iter (fun (node_id, immediate_dominator_id) ->
-      let node = Id_gen.label_of_id id_gen node_id in
+      let node = Label_id_gen.key_of_id_exn id_gen node_id in
       let immediate_dominator =
-        Id_gen.label_of_id id_gen immediate_dominator_id
+        Label_id_gen.key_of_id_exn id_gen immediate_dominator_id
       in
       if Label.Tbl.mem doms node
       then

--- a/backend/cfg/cfg_z3.mli
+++ b/backend/cfg/cfg_z3.mli
@@ -1,0 +1,20 @@
+val run_z3 : string -> string
+
+module Id_gen : sig
+  type t
+  val create : Cfg.t -> t
+  val get_id : t -> label:Label.t -> string
+  val width : t -> int
+  val label_of_id : t -> int -> Label.t
+end
+
+val z3_graph_of_cfg : Format.formatter -> cfg:Cfg.t -> id_gen:Id_gen.t -> unit
+
+val fmt_dom_code_begin : Format.formatter -> id_gen:Id_gen.t -> unit
+val fmt_dom_code_end : Format.formatter -> unit
+
+val parse_doms :
+  id_gen:Id_gen.t ->
+  entry_label:Label.t ->
+  string ->
+  Label.t Label.Tbl.t

--- a/backend/cfg/cfg_z3.mli
+++ b/backend/cfg/cfg_z3.mli
@@ -1,3 +1,5 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
 val run_z3 : string -> string
 
 val fmt_fact : Format.formatter -> string -> string list -> unit
@@ -23,6 +25,8 @@ module type Id_gen_S = sig
 
   val width : t -> int
 
+  val length : t -> int
+
   val key_of_id_exn : t -> int -> key
 end
 
@@ -42,15 +46,3 @@ val create_reg_id_gen : Cfg.t -> Reg_id_gen.t
 
 val z3_graph_of_cfg :
   Format.formatter -> cfg:Cfg.t -> id_gen:Label_id_gen.t -> unit
-
-val fmt_dom_code_begin : Format.formatter -> id_gen:Label_id_gen.t -> unit
-
-val fmt_dom_code_end : Format.formatter -> unit
-
-val fmt_liveness_code_begin :
-  Format.formatter -> Instruction_id_gen.t -> Reg_id_gen.t -> unit
-
-val fmt_liveness_code_end : Format.formatter -> unit
-
-val parse_doms :
-  id_gen:Label_id_gen.t -> entry_label:Label.t -> string -> Label.t Label.Tbl.t

--- a/backend/cfg/cfg_z3.mli
+++ b/backend/cfg/cfg_z3.mli
@@ -1,20 +1,56 @@
 val run_z3 : string -> string
 
-module Id_gen : sig
+val fmt_fact : Format.formatter -> string -> string list -> unit
+
+module type Id_key = sig
   type t
-  val create : Cfg.t -> t
-  val get_id : t -> label:Label.t -> string
-  val width : t -> int
-  val label_of_id : t -> int -> Label.t
+
+  val compare : t -> t -> int
+
+  val format : Format.formatter -> t -> unit
+
+  module Tbl : Hashtbl.S with type key = t
 end
 
-val z3_graph_of_cfg : Format.formatter -> cfg:Cfg.t -> id_gen:Id_gen.t -> unit
+module type Id_gen_S = sig
+  type key
 
-val fmt_dom_code_begin : Format.formatter -> id_gen:Id_gen.t -> unit
+  type t
+
+  val create : key list -> t
+
+  val get_id : t -> key:key -> string
+
+  val width : t -> int
+
+  val key_of_id_exn : t -> int -> key
+end
+
+module Make_id_gen (Key : Id_key) : Id_gen_S with type key = Key.t
+
+module Label_id_gen : Id_gen_S with type key = Label.t
+
+module Instruction_id_gen : Id_gen_S with type key = InstructionId.t
+
+module Reg_id_gen : Id_gen_S with type key = Reg.t
+
+val create_label_id_gen : Cfg.t -> Label_id_gen.t
+
+val create_instruction_id_gen : Cfg.t -> Instruction_id_gen.t
+
+val create_reg_id_gen : Cfg.t -> Reg_id_gen.t
+
+val z3_graph_of_cfg :
+  Format.formatter -> cfg:Cfg.t -> id_gen:Label_id_gen.t -> unit
+
+val fmt_dom_code_begin : Format.formatter -> id_gen:Label_id_gen.t -> unit
+
 val fmt_dom_code_end : Format.formatter -> unit
 
+val fmt_liveness_code_begin :
+  Format.formatter -> Instruction_id_gen.t -> Reg_id_gen.t -> unit
+
+val fmt_liveness_code_end : Format.formatter -> unit
+
 val parse_doms :
-  id_gen:Id_gen.t ->
-  entry_label:Label.t ->
-  string ->
-  Label.t Label.Tbl.t
+  id_gen:Label_id_gen.t -> entry_label:Label.t -> string -> Label.t Label.Tbl.t

--- a/backend/cfg/simplify_terminator.mli
+++ b/backend/cfg/simplify_terminator.mli
@@ -23,11 +23,25 @@
  * SOFTWARE.                                                                      *
  *                                                                                *
  **********************************************************************************)
-(** Merge successors that go to the same label and simplify their conditions.
-    Modifies the terminators in place. Does not merge blocks. *)
+(** Simplify the terminators of blocks: merge successors that go to the same
+    label, simplify conditions whose value is statically known, and
+    short-circuit jumps to empty blocks. Modifies the terminators in place. Does
+    not merge blocks.
+
+    Simplification can change the set of successor labels of a block, and can
+    hence make other blocks unreachable. [run] re-registers the predecessors of
+    all blocks whenever that may have happened, so that predecessor sets are
+    consistent with successor sets when it returns. *)
 
 [@@@ocaml.warning "+a-40-41-42"]
 
+(** [block cfg b] simplifies the terminator of [b], and returns [true] when the
+    simplification may have changed the set of successor labels of [b]. In that
+    case it is the caller's responsibility to make predecessor sets consistent
+    again, e.g. via [Cfg.register_predecessors_for_all_blocks] (after first
+    clearing the predecessor sets, since that function only ever adds elements).
+    If it returns [false], successor sets are unchanged, even though the
+    terminator may have been rewritten. *)
 val block : Cfg.t -> Cfg.basic_block -> bool
 
 val run : Cfg.t -> unit

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -167,6 +167,16 @@ let mk_no_cfg_eliminate_dead_trap_handlers f =
     Arg.Unit f,
     " Do not eliminate dead trap handlers" )
 
+let mk_cfg_eliminate_dead_code_validate f =
+  ( "-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Validate the eliminate dead code pass" )
+
+let mk_no_cfg_eliminate_dead_code_validate f =
+  ( "-no-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Do not validate the eliminate dead code pass" )
+
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
 
@@ -1287,6 +1297,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1473,6 +1485,9 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_eliminate_dead_trap_handlers F.cfg_eliminate_dead_trap_handlers;
       mk_no_cfg_eliminate_dead_trap_handlers
         F.no_cfg_eliminate_dead_trap_handlers;
+      mk_cfg_eliminate_dead_code_validate F.cfg_eliminate_dead_code_validate;
+      mk_no_cfg_eliminate_dead_code_validate
+        F.no_cfg_eliminate_dead_code_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1805,6 +1820,12 @@ module Oxcaml_options_impl = struct
 
   let no_cfg_eliminate_dead_trap_handlers =
     clear' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+
+  let cfg_eliminate_dead_code_validate =
+    set' Oxcaml_flags.cfg_eliminate_dead_code_validate
+
+  let no_cfg_eliminate_dead_code_validate =
+    clear' Oxcaml_flags.cfg_eliminate_dead_code_validate
 
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
@@ -2369,6 +2390,8 @@ module Extra_params = struct
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+    | "cfg-eliminate-dead-code-validate" ->
+        set' Oxcaml_flags.cfg_eliminate_dead_code_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -177,6 +177,16 @@ let mk_no_cfg_eliminate_dead_code_validate f =
     Arg.Unit f,
     " Do not validate the eliminate dead code pass" )
 
+let mk_cfg_dominators_validate f =
+  ( "-cfg-dominators-validate",
+    Arg.Unit f,
+    " Validate CFG dominators using Z3" )
+
+let mk_no_cfg_dominators_validate f =
+  ( "-no-cfg-dominators-validate",
+    Arg.Unit f,
+    " Do not validate CFG dominators using Z3" )
+
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
 
@@ -1299,6 +1309,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
   val cfg_eliminate_dead_code_validate : unit -> unit
   val no_cfg_eliminate_dead_code_validate : unit -> unit
+  val cfg_dominators_validate : unit -> unit
+  val no_cfg_dominators_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1488,6 +1500,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_eliminate_dead_code_validate F.cfg_eliminate_dead_code_validate;
       mk_no_cfg_eliminate_dead_code_validate
         F.no_cfg_eliminate_dead_code_validate;
+      mk_cfg_dominators_validate F.cfg_dominators_validate;
+      mk_no_cfg_dominators_validate F.no_cfg_dominators_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1826,6 +1840,9 @@ module Oxcaml_options_impl = struct
 
   let no_cfg_eliminate_dead_code_validate =
     clear' Oxcaml_flags.cfg_eliminate_dead_code_validate
+
+  let cfg_dominators_validate = set' Oxcaml_flags.cfg_dominators_validate
+  let no_cfg_dominators_validate = clear' Oxcaml_flags.cfg_dominators_validate
 
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
@@ -2392,6 +2409,7 @@ module Extra_params = struct
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
     | "cfg-eliminate-dead-code-validate" ->
         set' Oxcaml_flags.cfg_eliminate_dead_code_validate
+    | "cfg-dominators-validate" -> set' Oxcaml_flags.cfg_dominators_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -178,14 +178,20 @@ let mk_no_cfg_eliminate_dead_code_validate f =
     " Do not validate the eliminate dead code pass" )
 
 let mk_cfg_dominators_validate f =
-  ( "-cfg-dominators-validate",
-    Arg.Unit f,
-    " Validate CFG dominators using Z3" )
+  ("-cfg-dominators-validate", Arg.Unit f, " Validate CFG dominators using Z3")
 
 let mk_no_cfg_dominators_validate f =
   ( "-no-cfg-dominators-validate",
     Arg.Unit f,
     " Do not validate CFG dominators using Z3" )
+
+let mk_cfg_liveness_validate f =
+  ("-cfg-liveness-validate", Arg.Unit f, " Validate CFG liveness using Z3")
+
+let mk_no_cfg_liveness_validate f =
+  ( "-no-cfg-liveness-validate",
+    Arg.Unit f,
+    " Do not validate CFG liveness using Z3" )
 
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
@@ -1311,6 +1317,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_dominators_validate : unit -> unit
   val no_cfg_dominators_validate : unit -> unit
+  val cfg_liveness_validate : unit -> unit
+  val no_cfg_liveness_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1502,6 +1510,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_cfg_eliminate_dead_code_validate;
       mk_cfg_dominators_validate F.cfg_dominators_validate;
       mk_no_cfg_dominators_validate F.no_cfg_dominators_validate;
+      mk_cfg_liveness_validate F.cfg_liveness_validate;
+      mk_no_cfg_liveness_validate F.no_cfg_liveness_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1843,7 +1853,8 @@ module Oxcaml_options_impl = struct
 
   let cfg_dominators_validate = set' Oxcaml_flags.cfg_dominators_validate
   let no_cfg_dominators_validate = clear' Oxcaml_flags.cfg_dominators_validate
-
+  let cfg_liveness_validate = set' Oxcaml_flags.cfg_liveness_validate
+  let no_cfg_liveness_validate = clear' Oxcaml_flags.cfg_liveness_validate
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
   let cfg_prologue_shrink_wrap = set' Oxcaml_flags.cfg_prologue_shrink_wrap
@@ -2410,6 +2421,7 @@ module Extra_params = struct
     | "cfg-eliminate-dead-code-validate" ->
         set' Oxcaml_flags.cfg_eliminate_dead_code_validate
     | "cfg-dominators-validate" -> set' Oxcaml_flags.cfg_dominators_validate
+    | "cfg-liveness-validate" -> set' Oxcaml_flags.cfg_liveness_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -53,6 +53,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -55,6 +55,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
   val cfg_eliminate_dead_code_validate : unit -> unit
   val no_cfg_eliminate_dead_code_validate : unit -> unit
+  val cfg_dominators_validate : unit -> unit
+  val no_cfg_dominators_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -57,6 +57,8 @@ module type Oxcaml_options = sig
   val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_dominators_validate : unit -> unit
   val no_cfg_dominators_validate : unit -> unit
+  val cfg_liveness_validate : unit -> unit
+  val no_cfg_liveness_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -40,6 +40,7 @@ let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-handlers *)
 let cfg_eliminate_dead_code_validate = ref false  (* -cfg-eliminate-dead-code-validate *)
+let cfg_dominators_validate = ref false  (* -cfg-dominators-validate *)
 
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -39,6 +39,7 @@ let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-handlers *)
+let cfg_eliminate_dead_code_validate = ref false  (* -cfg-eliminate-dead-code-validate *)
 
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -38,9 +38,14 @@ let x86_peephole_combine_add_rsp = ref true
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
-let cfg_eliminate_dead_trap_handlers = ref false  (* -cfg-eliminate-dead-trap-handlers *)
-let cfg_eliminate_dead_code_validate = ref false  (* -cfg-eliminate-dead-code-validate *)
+let cfg_eliminate_dead_trap_handlers = ref false
+(* -cfg-eliminate-dead-trap-handlers *)
+
+let cfg_eliminate_dead_code_validate = ref false
+(* -cfg-eliminate-dead-code-validate *)
+
 let cfg_dominators_validate = ref false  (* -cfg-dominators-validate *)
+let cfg_liveness_validate = ref false  (* -cfg-liveness-validate *)
 
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -41,6 +41,7 @@ val cfg_stack_checks_threshold : int ref
 
 val cfg_eliminate_dead_trap_handlers : bool ref
 val cfg_eliminate_dead_code_validate : bool ref
+val cfg_dominators_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -40,6 +40,7 @@ val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref
 
 val cfg_eliminate_dead_trap_handlers : bool ref
+val cfg_eliminate_dead_code_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -42,6 +42,7 @@ val cfg_stack_checks_threshold : int ref
 val cfg_eliminate_dead_trap_handlers : bool ref
 val cfg_eliminate_dead_code_validate : bool ref
 val cfg_dominators_validate : bool ref
+val cfg_liveness_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/dune
+++ b/dune
@@ -660,6 +660,7 @@
   cfg_stack_checks
   cfg_polling
   cfg_simplify
+  cfg_z3
   cfg_prologue
   cfg_merge_blocks
   extra_debug

--- a/dune
+++ b/dune
@@ -652,7 +652,9 @@
   cfg_dataflow
   cfg_deadcode
   cfg_liveness
+  cfg_liveness_validate
   cfg_dominators
+  cfg_dominators_validate
   cfg_loop_infos
   cfg_to_linear_desc
   cfg_cse


### PR DESCRIPTION
I introduce a simple Z3 Datalog-based validator for the `Eliminate_dead_code` pass from cfg_simplify. It was tested not to have false negatives by running the compiler with the validator on the compiler itself. When unreachable nodes existed (checked by passing `-no-cfg-eliminate-dead-trap-handlers`) the validator noticed this as expected.