### PR TITLE
Avoid ambiguous use of the phrase "top-level" in metaprogramming

### DIFF
--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -63,7 +63,7 @@ end
 module Exc : sig exception E end
 |}];;
 
-#mark_toplevel_in_quotations;;
+#mark_persistent_in_quotations;;
 
 (* Tests *)
 
@@ -531,7 +531,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 ]>
 |}];;
 
-(* Non-top-level functor *)
+(* Non-persistent functor *)
 module Make = Set.Make;;
 <[ let module M = Make(Int) in M.singleton 100 |> M.elements ]>;;
 [%%expect {|
@@ -544,7 +544,7 @@ Error: Identifier "Make" is used at line 2, characters 18-22,
        it is introduced at file "_none_", line 1, outside any quotations.
 |}];;
 
-(* Non-top-level functor argument *)
+(* Non-persistent functor argument *)
 module Int' = Int;;
 <[ let module M = Set.Make(Int') in M.singleton 100 |> M.elements ]>;;
 [%%expect {|

--- a/testsuite/tests/quotation/mark_toplevel.ml
+++ b/testsuite/tests/quotation/mark_toplevel.ml
@@ -3,8 +3,8 @@
  expect;
 *)
 
-(* Test the [#mark_toplevel_in_quotations] directive,
-   intended for making names available as top-level in quotation tests. *)
+(* Test the [#mark_persistent_in_quotations] directive,
+   intended for making names available as persistent in quotation tests. *)
 
 #syntax quotations on
 
@@ -13,7 +13,7 @@ type t = int
 [%%expect {|
 type t = int
 |}];;
-(* Fails, as [t] is not top-level *)
+(* Fails, as [t] is not persistent *)
 let (x : <[t]> expr) = <[42]>
 [%%expect {|
 Line 1, characters 11-12:
@@ -23,9 +23,9 @@ Error: Identifier "t" is used at line 1, characters 11-12,
        inside a quotation (<[ ... ]>);
        it is introduced at line 1, characters 0-12, outside any quotations.
 |}];;
-#mark_toplevel_in_quotations;;
+#mark_persistent_in_quotations;;
 
-(* [t] is now considered top-level *)
+(* [t] is now considered persistent *)
 let (x : <[t]> expr) = <[42]>
 [%%expect {|
 val x : <[t]> expr = <[42]>
@@ -64,7 +64,7 @@ Error: Identifier "M" is used at line 1, characters 14-15,
        inside a quotation (<[ ... ]>);
        it is introduced at file "_none_", line 1, outside any quotations.
 |}];;
-#mark_toplevel_in_quotations;;
+#mark_persistent_in_quotations;;
 
 let id (x : <[M.t]> expr) = x
 [%%expect {|
@@ -105,7 +105,7 @@ Error: Constructor "X" used at line 1, characters 11-12
        "X" is not defined inside a quotation (<[ ... ]>).
 Hint: Constructor "X" is defined outside any quotations.
 |}];;
-#mark_toplevel_in_quotations;;
+#mark_persistent_in_quotations;;
 
 let r = <[ { x = 42 } ]>
 [%%expect {|

--- a/testsuite/tests/quotation/typing/eval/annotated.ml
+++ b/testsuite/tests/quotation/typing/eval/annotated.ml
@@ -18,7 +18,7 @@ type nonrec 'a eval' = 'a eval
 val eval : 'a expr @ once -> 'a eval = <fun>
 type nonrec 'a eval' = 'a eval
 |}]
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 
 (* The [eval] argument is annotated at introduction, and its result is typed *)
 let f (e : <[int list]> expr) : int list = eval e

--- a/testsuite/tests/quotation/typing/eval/reductions.ml
+++ b/testsuite/tests/quotation/typing/eval/reductions.ml
@@ -96,7 +96,7 @@ let f (x : <[($('a), $('b)) Either.t]> expr)
 val f : <[($('a), $('b)) Either.t]> expr -> ('a eval, 'b eval) Either.t =
   <fun>
 |}]
-(* non-top-level type constructor -- locally abstract type *)
+(* non-persistent type constructor -- locally abstract type *)
 let _ = <[ fun (type t) (x : t) -> $(eval <[ x ]>) ]>
 [%%expect {|
 Line 1, characters 36-50:
@@ -324,13 +324,13 @@ val f :
   <[(module Map.OrderedType with type t = $('a)) -> unit]> expr ->
   (module Map.OrderedType with type t = 'a eval) -> unit = <fun>
 |}]
-(* non-top-level package type -- generative functor *)
+(* non-persistent package type -- generative functor *)
 module S () = struct
   module type T = sig
     type s
   end
 end
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 let _ = <[
   (* It is illegal to write [S()] in a type, so we have an intermediate [Z]. *)
   let module Z = S () in
@@ -505,7 +505,7 @@ end
 module QuoteKinded : sig type t end
 module QuoteKindedParam : sig type 'a t end
 |}]
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 
 (* CR quoted-kinds jbachurski: None of the types on [x] should reduce and hence all tests
    with annotated results should error. *)

--- a/testsuite/tests/quotation/typing/inspection/pack_splice_in_constraint.ml
+++ b/testsuite/tests/quotation/typing/inspection/pack_splice_in_constraint.ml
@@ -11,7 +11,7 @@ module type S = sig
   val x : t
   val i : int
 end
-#mark_toplevel_in_quotations;;
+#mark_persistent_in_quotations;;
 [%%expect {|
 type t
 module type S = sig type t val x : t val i : int end

--- a/testsuite/tests/quotation/typing/magic_staged_modes.ml
+++ b/testsuite/tests/quotation/typing/magic_staged_modes.ml
@@ -14,7 +14,7 @@ end = struct
   let of_local _ = <[()]>
   let of_global _ = <[()]>
 end
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 [%%expect{|
 module M :
   sig

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -33,7 +33,7 @@ module M :
     val send : 'a @ portable -> unit
   end
 |}]
-#mark_toplevel_in_quotations;;
+#mark_persistent_in_quotations;;
 
 (** Splicing non-legacy expressions **)
 

--- a/testsuite/tests/quotation/typing/quotes_splices/gadt.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/gadt.ml
@@ -14,7 +14,7 @@ end
 [%%expect {|
 module M : sig type t type t' end
 |}]
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 
 let sorry0 =
         fun (f : (_ Type.eq -> _ @ once)) -> f (Obj.magic Type.Equal) |> Obj.magic_many
@@ -142,8 +142,8 @@ val maybe_non_negative : <[int]> t -> bool = <fun>
    In cases when it's significant that [S_min =/= S_subj] or [S_max =/= S_subj],
    we extend the notation to [S_proof ~~> x ~~> S_subj] for x in {S_min, S_max}.
 
-   For [t] we use either a locally abstract type or the top-level [M.t],
-   and for [s] we usually use a simple top-level type: [int] or [bool]. *)
+   For [t] we use either a locally abstract type or the persistent [M.t],
+   and for [s] we usually use a simple persistent type: [int] or [bool]. *)
 
 (* Evidence stays in the same stage -- should always succeed:
    [S_proof = S_min] and [T_proof = T_subj] *)
@@ -251,7 +251,7 @@ let _ = <[ fun (type t) (Equal : (t, bool) Type.eq) (x : t) ->
       ]>
 ]>
 |}]
-(* 1 ~~> 3 ~~> 1  @  1 <=> 1  with top-level [M.t] *)
+(* 1 ~~> 3 ~~> 1  @  1 <=> 1  with persistent [M.t] *)
 let _ = <[ fun (Equal : (M.t, bool) Type.eq) (x : M.t) ->
     <[ Obj.magic_many <[ $($(
       match x with

--- a/testsuite/tests/quotation/typing/quotes_splices/mcomp.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/mcomp.ml
@@ -70,7 +70,7 @@ module Inst2 : sig type t end
 module NonInst2 : sig type 'a t end
 module A : sig type _ t = | type _ t' = | end
 |}]
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 
 (* Flexible: type variables under quotes/splices *)
 
@@ -94,7 +94,7 @@ module F :
     type _ r1 = { x : <[$(int) -> unit]> expr; }
   end
 |}]
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 
 (* One side flexible and under splices *)
 (* $t ~ s  when t flexible *)

--- a/testsuite/tests/quotation/typing/quotes_splices/unify.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/unify.ml
@@ -65,7 +65,7 @@ module NonInst2 : sig type 'a t end
 (* Note that [generalize] type schemes have their quantified variables
    normalised to stage 0 (i.e. all of these would become ['a -> 'a]).
    This means in all tests with directly quoted variables we will eventually
-   remove the quotes, as we cannot have top-level splices.
+   remove the quotes, as we cannot have initial-stage splices.
    However, unification should happen before this. *)
 
 (* <['a]> ~ unit *)

--- a/testsuite/tests/quotation/typing/quotes_splices/unify.ml
+++ b/testsuite/tests/quotation/typing/quotes_splices/unify.ml
@@ -56,7 +56,7 @@ module NonInst1 : sig type 'a t type 'a t' end
 module Inst2 : sig type t end
 module NonInst2 : sig type 'a t end
 |}]
-#mark_toplevel_in_quotations
+#mark_persistent_in_quotations
 
 
 (** [unify]ing a variable under quotes/splices -- flexibility checks **)

--- a/toplevel/topdirs.ml
+++ b/toplevel/topdirs.ml
@@ -184,9 +184,9 @@ let _ = add_directive "mod_use" (Directive_string (with_error_fmt dir_mod_use))
              wraps the contents in a module.";
     }
 
-let _ = add_directive "mark_toplevel_in_quotations"
+let _ = add_directive "mark_persistent_in_quotations"
     (Directive_none (fun () ->
-      toplevel_env := Ctype.mark_toplevel_in_quotations !toplevel_env))
+      toplevel_env := Ctype.mark_persistent_in_quotations !toplevel_env))
     {
       section = section_meta;
       doc = "Mark all names in the current environment as available \

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -196,11 +196,11 @@ let create_scope () =
 
 let wrap_end_def f = Misc.try_finally f ~always:end_def
 
-let mark_toplevel_in_quotations env =
+let mark_persistent_in_quotations env =
   let scope = !current_level in
   (* Create a new scope to make sure we only capture what came before *)
   let _ = create_scope () in
-  Env.mark_toplevel_in_quotations ~scope env
+  Env.mark_persistent_in_quotations ~scope env
 
 (* [with_local_level_gen] handles both the scoping structure of levels
    and automatic generalization through pools (cf. btype.ml) *)
@@ -2419,11 +2419,11 @@ let try_expand_safe env ty =
    [t = <[t' qeval^n]>^m] for natural [n], integer [m] and type expression [t'].
    If [n > 0], then [t'] is irreducible, and has to be one of the following:
    * Type variable,
-   * Type constructor that is not top-level,
+   * Type constructor that is not persistent,
    * Quote-kinded type. *)
 
 (* Perform one of the following head-position beta reductions via rewrites:
-   * Reduce a quoted-eval through a concrete (top-level) type constructor.
+   * Reduce a quoted-eval through a concrete (persistent) type constructor.
    * Cancel a quote-splice pair.
    * Simplify a [Tbox] over a type with a unboxed version. *)
 let rec try_reduce_once env t =
@@ -2455,8 +2455,8 @@ let rec try_reduce_once env t =
   | _ -> raise Cannot_expand
 
 and try_reduce_quote_eval env t =
-  let path_must_be_toplevel env path =
-    if not (Env.path_is_toplevel_in_quotations env path) then
+  let path_must_be_persistent env path =
+    if not (Env.path_is_persistent_in_quotations env path) then
       raise Cannot_expand
   in
   let try_reduce_poly env t = if is_Tpoly t then try_reduce_once env t else t in
@@ -2479,7 +2479,7 @@ and try_reduce_quote_eval env t =
     Tunboxed_tuple (List.map (fun (l, t) -> (l, new_quote_eval_ty t)) tl)
   (* [<[(t1, t2) typ]> eval]  ==>  [(<[t1]> eval, <[t2]> eval) typ] *)
   | Tconstr (p, tl, a) ->
-    path_must_be_toplevel env p;
+    path_must_be_persistent env p;
     Tconstr (p, List.map new_quote_eval_ty tl, a)
   (* [<[ < .. > ]> eval]  ==>  [< <[..]> eval >] *)
   | Tobject (t, ct) ->
@@ -2488,7 +2488,7 @@ and try_reduce_quote_eval env t =
          will [raise Cannot_expand]. [Cannot_expand] propagates to here
          so the [Tobject] does not reduce at all.
          Alternatively, the object type has a private row type given by
-         a [Tconstr], in which case we will reduce if it is top-level.
+         a [Tconstr], in which case we will reduce if it is persistent.
        - If the object type is closed, its final element is a [Tnil] and
          the entire [Tobject] will reduce just fine. *)
     (* CR metaprogramming jbachurski: As for [Tvariant], it would be nicer
@@ -2498,7 +2498,7 @@ and try_reduce_quote_eval env t =
       ref (
         Option.map
           (fun (p, tl) ->
-            path_must_be_toplevel env p;
+            path_must_be_persistent env p;
             p, List.map new_quote_eval_ty tl)
           !ct))
   (* [<[ < a: t, .. > ]> eval] ==> [<a : <[t]> eval, <[..]> eval >] *)
@@ -2549,7 +2549,7 @@ and try_reduce_quote_eval env t =
   (*  [<[ module S with type typ = t ]> eval]
       ==> [module S with type typ = <[t]> eval] *)
   | Tpackage { pack_path; pack_cstrs } ->
-    path_must_be_toplevel env pack_path;
+    path_must_be_persistent env pack_path;
     Tpackage { pack_path;
                pack_cstrs =
                  List.map (fun (n, t) -> n, new_quote_eval_ty t) pack_cstrs }

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -479,7 +479,7 @@ let without_assume_injective uenv f =
   | Pattern r -> f (Pattern { r with assume_injective = false })
 
 (* In type checking, we only use [decr_stage] when we observe a spliced type.
-   [Env.enter_splice] only fails when the splice would be top-level. Hence,
+   [Env.enter_splice] only fails when the splice would be initial-stage. Hence,
    no legitimate errors will ever be raised there and we can omit the [loc].
 
    For sanity, we have an extra assertion here. It fails when we [decr_stage]
@@ -515,7 +515,7 @@ let iter_type_expr_with_stages f env ty =
    The right way to address this is to track the stage in errors. With that
    done, this function can be removed, and some GADT-related errors improve.
    This is tracked by ticket 6726. *)
-let contains_toplevel_splice stage ty =
+let contains_initial_stage_splice stage ty =
   let visited = ref TypeSet.empty in
   let rec loop acc ty =
     if TypeSet.mem ty !visited then false else begin
@@ -4052,12 +4052,12 @@ let rec has_cached_expansion p abbrev =
    but still might be nice. *)
 
 let expand_type env ty =
-  (* If the type contains top-level splices, then we enter some far-away future
-     stage where all splices are valid. *)
-  (* CR metaprogramming jbachurski: Remove [contains_toplevel_splice] and
+  (* If the type contains initial-stage splices, then we enter some future stage
+     where all splices are valid. *)
+  (* CR metaprogramming jbachurski: Remove [contains_initial_stage_splice] and
      track the stage in errors so we don't need this. *)
   let env =
-    if contains_toplevel_splice (Env.stage env :> int) ty
+    if contains_initial_stage_splice (Env.stage env :> int) ty
     then Env.enter_future env
     else env
   in

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -84,7 +84,7 @@ val restore_global_level: int -> unit
 
 val create_scope : unit -> int
 
-val mark_toplevel_in_quotations : Env.t -> Env.t
+val mark_persistent_in_quotations : Env.t -> Env.t
 
 val newty: type_desc -> type_expr
 val new_scoped_ty: int -> type_desc -> type_expr

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -148,7 +148,7 @@ val merge_row_fields:
 val filter_row_fields:
         bool -> (label * row_field) list -> (label * row_field) list
 
-val contains_toplevel_splice: int -> type_expr -> bool
+val contains_initial_stage_splice: int -> type_expr -> bool
 val iter_type_expr_with_stages:
         (Env.t -> type_expr -> unit) -> Env.t -> type_expr -> unit
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -899,7 +899,7 @@ type error =
   | Illegal_value_name of Location.t * string
   | Lookup_error of Location.t * t * lookup_error
   | Incomplete_instantiation of { unset_param : Global_module.Parameter_name.t }
-  | Toplevel_splice of Location.t
+  | Initial_stage_splice of Location.t
   | Unsupported_inside_quotation of Location.t * no_open_quotations_context
 
 exception Error of error
@@ -3104,7 +3104,7 @@ let enter_quotation env =
 
 let enter_splice ~loc env =
   if env.stage = 0 then
-    raise (Error (Toplevel_splice loc));
+    raise (Error (Initial_stage_splice loc));
   add_stage_lock Splice_lock {env with stage = env.stage - 1}
 
 let enter_future env =
@@ -5466,7 +5466,7 @@ let report_error_doc = function
         "@[<hov>Not enough instance arguments: \
            the parameter@ %a@ is required.@]"
         Global_module.Parameter_name.print unset_param
-  | Toplevel_splice loc ->
+  | Initial_stage_splice loc ->
       Location.errorf ~loc
         "@[<hov>Splices ($) are not allowed in the initial stage,@ \
          as encountered at %a.@,\

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -681,7 +681,7 @@ type t = {
   implicit_jkinds: jkind_lr loc String.Map.t;
   flags: int;
   stage: stage;
-  toplevel_scope: int
+  persistent_scope: int
 }
 
 and module_components =
@@ -986,7 +986,7 @@ let empty = {
   functor_args = Ident.empty;
   jkinds = IdTbl.empty;
   stage = 0;
-  toplevel_scope = Ident.lowest_scope
+  persistent_scope = Ident.lowest_scope
  }
 
 let path_at_current_stage env path = { StagedPath.stage = env.stage; path }
@@ -3111,8 +3111,8 @@ let enter_future env =
   (* Reuse a very large number *)
   { env with stage = Ident.highest_scope }
 
-let mark_toplevel_in_quotations ~scope env =
-  { env with toplevel_scope = scope }
+let mark_persistent_in_quotations ~scope env =
+  { env with persistent_scope = scope }
 
 let check_no_open_quotations loc env context =
   if env.stage = 0
@@ -3470,11 +3470,11 @@ let may_lookup_error report_errors loc env err =
   if report_errors then lookup_error loc env err
   else raise Not_found
 
-let path_is_toplevel_in_quotations env path =
-  Path.scope path <= env.toplevel_scope
+let path_is_persistent_in_quotations env path =
+  Path.scope path <= env.persistent_scope
 
 let does_not_cross_quotation env path locks =
-  if path_is_toplevel_in_quotations env path
+  if path_is_persistent_in_quotations env path
   then Ok ()
   else
     (match stage_locks_offset locks with
@@ -3503,8 +3503,7 @@ let locks_for_pers_mod ~loc_use ~loc_def env path =
   let stage_locks, locks =
     partition_locks (IdTbl.get_all_locks env.modules)
   in
-  (* Tripwire: persistent paths are toplevel-scoped, so this should never
-     fire. *)
+  (* This should never fire -- [path] points to a persistent module. *)
   assert_does_not_cross_quotation env ~loc_use ~loc_def path stage_locks;
   locks
 
@@ -4262,7 +4261,7 @@ let add_components slot root env0 comps (locks : locks) =
     implicit_jkinds = env0.implicit_jkinds;
     flags = env0.flags;
     stage = env0.stage;
-    toplevel_scope = env0.toplevel_scope;
+    persistent_scope = env0.persistent_scope;
   }
 
 let open_signature_by_path path env0 =

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -691,7 +691,7 @@ type error =
   | Illegal_value_name of Location.t * string
   | Lookup_error of Location.t * t * lookup_error
   | Incomplete_instantiation of { unset_param : Global_module.Parameter_name.t; }
-  | Toplevel_splice of Location.t
+  | Initial_stage_splice of Location.t
   | Unsupported_inside_quotation of Location.t * no_open_quotations_context
 
 exception Error of error

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -597,8 +597,8 @@ val check_no_open_quotations :
   Location.t -> t -> no_open_quotations_context -> unit
 val stage : t -> stage
 
-val mark_toplevel_in_quotations : scope:int -> t -> t
-val path_is_toplevel_in_quotations : t -> Path.t -> bool
+val mark_persistent_in_quotations : scope:int -> t -> t
+val path_is_persistent_in_quotations : t -> Path.t -> bool
 
 (* Initialize the cache of in-core module interfaces. *)
 val reset_cache: preserve_persistent_env:bool -> unit

--- a/typing/errortrace_report.ml
+++ b/typing/errortrace_report.ml
@@ -121,10 +121,10 @@ let is_unit_arg env ty =
   let ty, vars = Btype.tpoly_get_poly ty in
   if vars <> [] then false
   else begin
-    (* CR metaprogramming jbachurski: Remove [contains_toplevel_splice] and
+    (* CR metaprogramming jbachurski: Remove [contains_initial_stage_splice] and
        track the stage in errors so we don't need this. See ticket 6726. *)
     let env =
-      if Ctype.contains_toplevel_splice (Env.stage env :> int) ty
+      if Ctype.contains_initial_stage_splice (Env.stage env :> int) ty
       then Env.enter_future env
       else env
     in

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1772,7 +1772,7 @@ let tree_of_typexp mode ty =
   (* CR metaprogramming jbachurski: Remove this [Env.enter_future] hack once
      errors track their stage, as we should usually print at stage 0.
      See ticket 6726. *)
-  if Ctype.contains_toplevel_splice (Env.stage !printing_env :> int) ty
+  if Ctype.contains_initial_stage_splice (Env.stage !printing_env :> int) ty
   then
     wrap_printing_env_unguarded
       (Env.enter_future !printing_env)


### PR DESCRIPTION
This is a naming nit that's held up for a while: the term "toplevel" is overloaded (usually it refers to top-level bindings: the `let x = e` form), especially with metaprogramming. 
At least for the purposes of eval we care about paths that are accessible at all stages -- we currently call these toplevel paths. Right now, this is just for paths pointing to _persistent modules_, hence _persistent paths_ is probably a better name.
Toplevel paths is an unfortunate name -- one might imagine they mean exactly the paths which refer to toplevel bindings, while we want the opposite.
I also made naming for initial-stage splices consistent (errors would stay they are "initial-stage", but the implementation called them "top-level" too). IMO this is a good idea for similar reasons.