### PR TITLE
Remove support for mutable strings in Flambda2

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -528,8 +528,8 @@ module Acc = struct
       | Immutable_int8_array _ | Immutable_int16_array _
       | Immutable_int32_array _ | Immutable_int64_array _
       | Immutable_nativeint_array _ | Immutable_vec128_array _
-      | Immutable_vec256_array _ | Immutable_vec512_array _ | Mutable_string _
-      | Immutable_string _ ->
+      | Immutable_vec256_array _ | Immutable_vec512_array _ | Immutable_string _
+        ->
         Unknown Flambda_kind.value
     in
     let symbol_approximations =

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -161,7 +161,6 @@ type static_data =
   | Immutable_vec512_array of
       Vector_types.Vec512.Bit_pattern.bits or_variable list
   | Empty_array of empty_array_kind
-  | Mutable_string of { initial_value : string }
   | Immutable_string of string
 
 type static_data_binding =

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -643,8 +643,6 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
             (SC.immutable_vec512_array
                (List.map (or_variable vec512 env) elements))
         | Empty_array array_kind -> static_const (SC.empty_array array_kind)
-        | Mutable_string { initial_value = s } ->
-          static_const (SC.mutable_string ~initial_value:s)
         | Immutable_string s -> static_const (SC.immutable_string s))
       | Set_of_closures { bindings; elements } ->
         let fun_decls =

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -2925,18 +2925,6 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT COMMA TIL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET SYMBOL EQUAL KWD_MUTABLE TILDE
-##
-## Ends in an error in state: 420.
-##
-## static_data -> KWD_MUTABLE . STRING [ KWD_WITH KWD_IN KWD_AND ]
-##
-## The known suffix of the stack is as follows:
-## KWD_MUTABLE
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 ##
 ## Ends in an error in state: 424.

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -869,7 +869,6 @@ static_data:
     RBRACKPIPE
     { Immutable_vec512_array is }
   | STATIC_CONST_EMPTY_ARRAY kind=empty_array_kind { Empty_array kind }
-  | KWD_MUTABLE; s = STRING { Mutable_string { initial_value = s } }
   | s = STRING { Immutable_string s }
 ;
 

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -308,7 +308,6 @@ let static_const env (sc : Static_const.t) : Fexpr.static_data =
   | Immutable_vec512_array elements ->
     Immutable_vec512_array (List.map (or_variable vec512 env) elements)
   | Empty_array array_kind -> Empty_array array_kind
-  | Mutable_string { initial_value } -> Mutable_string { initial_value }
   | Immutable_string s -> Immutable_string s
 
 let inlining_state (is : Inlining_state.t) : Fexpr.inlining_state option =

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -470,8 +470,6 @@ let static_data ppf : static_data -> unit = function
       elements
   | Empty_array kind ->
     Format.fprintf ppf "Empty_array%a" (empty_array_kind ~space:Before) kind
-  | Mutable_string { initial_value = s } ->
-    Format.fprintf ppf "mutable \"%s\"" (s |> String.escaped)
   | Immutable_string s -> Format.fprintf ppf "\"%s\"" (s |> String.escaped)
 
 let static_data_binding ppf { symbol = s; defining_expr = sp } =

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -665,7 +665,7 @@ let rewrite_static_const (env : env) ~(bound_to : Symbol.t) (sc : SC.t) =
   | Immutable_vec512_array fields ->
     SC.immutable_vec512_array
       (rewrite_or_variables Vector_types.Vec512.Bit_pattern.zero env fields)
-  | Empty_array _ | Mutable_string _ | Immutable_string _ -> sc
+  | Empty_array _ | Immutable_string _ -> sc
 
 let rebuild_named_default_case env (named : Named.t) =
   let[@local] rewrite_field_access ?(mut : Mutability.t = Immutable) base field

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -320,7 +320,7 @@ let traverse_block_like_static_const denv acc symbol
   | Immutable_int16_array _ | Immutable_int32_array _ | Immutable_int64_array _
   | Immutable_nativeint_array _ | Immutable_vec128_array _
   | Immutable_vec256_array _ | Immutable_vec512_array _ | Empty_array _
-  | Mutable_string _ | Immutable_string _ ->
+  | Immutable_string _ ->
     Acc.add_alias acc ~to_:name
       ~from:(Code_id_or_name.name (Env.all_constants denv))
 

--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -303,14 +303,6 @@ let create_empty_array are_rebuilding array_kind =
   then Block_not_rebuilt { free_names = Name_occurrences.empty; cost_metrics }
   else create_normal_non_code ~cost_metrics (SC.empty_array array_kind)
 
-let create_mutable_string are_rebuilding ~initial_value =
-  let cost_metrics =
-    Cost_metrics.from_size (Code_size.of_int (String.length initial_value))
-  in
-  if ART.do_not_rebuild_terms are_rebuilding
-  then Block_not_rebuilt { free_names = Name_occurrences.empty; cost_metrics }
-  else create_normal_non_code ~cost_metrics (SC.mutable_string ~initial_value)
-
 let create_immutable_string are_rebuilding str =
   let cost_metrics =
     Cost_metrics.from_size (Code_size.of_int (String.length str))
@@ -353,8 +345,7 @@ let map_set_of_closures t ~find_code_metadata ~f =
       | Immutable_int32_array _ | Immutable_int64_array _
       | Immutable_nativeint_array _ | Immutable_vec128_array _
       | Immutable_vec256_array _ | Immutable_vec512_array _
-      | Immutable_value_array _ | Empty_array _ | Mutable_string _
-      | Immutable_string _ ->
+      | Immutable_value_array _ | Empty_array _ | Immutable_string _ ->
         t))
   | Block_not_rebuilt _ | Set_of_closures_not_rebuilt _ | Code_not_rebuilt _ ->
     t

--- a/middle_end/flambda2/simplify/rebuilt_static_const.mli
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.mli
@@ -155,8 +155,6 @@ val create_immutable_value_array :
 
 val create_empty_array : Are_rebuilding_terms.t -> Empty_array_kind.t -> t
 
-val create_mutable_string : Are_rebuilding_terms.t -> initial_value:string -> t
-
 val create_immutable_string : Are_rebuilding_terms.t -> string -> t
 
 val map_set_of_closures :

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -281,8 +281,7 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
         array_kind,
       dacc )
   | Immutable_string str ->
-    let machine_width = DE.machine_width (DA.denv dacc) in
-    let ty = T.this_immutable_string str ~machine_width in
+    let ty = T.this_immutable_string str in
     let dacc = bind_result_sym ty in
     ( Rebuilt_static_const.create_immutable_string
         (DA.are_rebuilding_terms dacc)

--- a/middle_end/flambda2/simplify/simplify_static_const.ml
+++ b/middle_end/flambda2/simplify/simplify_static_const.ml
@@ -280,16 +280,6 @@ let simplify_static_const_of_kind_value dacc (static_const : Static_const.t)
         (DA.are_rebuilding_terms dacc)
         array_kind,
       dacc )
-  | Mutable_string { initial_value } ->
-    let machine_width = DE.machine_width (DA.denv dacc) in
-    let str_ty =
-      T.mutable_string ~size:(String.length initial_value) ~machine_width
-    in
-    let dacc = bind_result_sym str_ty in
-    ( Rebuilt_static_const.create_mutable_string
-        (DA.are_rebuilding_terms dacc)
-        ~initial_value,
-      dacc )
   | Immutable_string str ->
     let machine_width = DE.machine_width (DA.denv dacc) in
     let ty = T.this_immutable_string str ~machine_width in

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -273,9 +273,14 @@ let simplify_string_length dacc ~original_term ~arg:_ ~arg_ty:str_ty ~result_var
     if String_info.Set.is_empty str_infos
     then SPR.create_invalid dacc
     else
+      let machine_width = DE.machine_width (DA.denv dacc) in
       let lengths =
-        String_info.Set.elements str_infos
-        |> List.map String_info.size |> Target_ocaml_int.Set.of_list
+        String_info.Set.fold
+          (fun str lengths ->
+            Target_ocaml_int.Set.add
+              (Target_ocaml_int.of_int machine_width (String.length str))
+              lengths)
+          str_infos Target_ocaml_int.Set.empty
       in
       let ty = T.these_naked_immediates lengths in
       let dacc = DA.add_variable dacc result_var ty in

--- a/middle_end/flambda2/term_basics/string_info.ml
+++ b/middle_end/flambda2/term_basics/string_info.ml
@@ -14,52 +14,23 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type string_contents =
-  | Contents of string
-  | Unknown_or_mutable
-
-type t =
-  { contents : string_contents;
-    size : Target_ocaml_int.t
-  }
-
-let create ~contents ~size = { contents; size }
-
-let contents t = t.contents
-
-let size t = t.size
+type t = string
 
 include Container_types.Make (struct
-  type nonrec t = t
+  type t = string
 
-  let compare t1 t2 =
-    let c =
-      match t1.contents, t2.contents with
-      | Contents s1, Contents s2 -> String.compare s1 s2
-      | Unknown_or_mutable, Unknown_or_mutable -> 0
-      | Contents _, Unknown_or_mutable -> -1
-      | Unknown_or_mutable, Contents _ -> 1
+  let compare = String.compare
+
+  let equal = String.equal
+
+  let hash = String.hash
+
+  let print ppf str =
+    let size = String.length str in
+    let s, dots =
+      let max_size = 10 in
+      let long = size > max_size in
+      if long then String.sub str 0 8, "..." else str, ""
     in
-    if c <> 0 then c else Stdlib.compare t1.size t2.size
-
-  let equal t1 t2 = compare t1 t2 = 0
-
-  let hash t = Hashtbl.hash t
-
-  let print ppf { contents; size } =
-    match contents with
-    | Unknown_or_mutable ->
-      Format.fprintf ppf "(size %a)" Target_ocaml_int.print size
-    | Contents s ->
-      let s, dots =
-        let machine_width =
-          (* This value doesn't matter *)
-          Target_system.Machine_width.Sixty_four
-        in
-        let max_size = Target_ocaml_int.ten machine_width in
-        let long = Target_ocaml_int.compare size max_size > 0 in
-        if long then String.sub s 0 8, "..." else s, ""
-      in
-      Format.fprintf ppf "(size %a) (contents \"%S\"%s)" Target_ocaml_int.print
-        size s dots
+    Format.fprintf ppf "(size %d) (contents \"%S\"%s)" size s dots
 end)

--- a/middle_end/flambda2/term_basics/string_info.mli
+++ b/middle_end/flambda2/term_basics/string_info.mli
@@ -14,17 +14,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type string_contents =
-  | Contents of string
-  | Unknown_or_mutable
-
-type t
-
-(* CR mshinwell: [size] shouldn't be needed when passing [Contents] *)
-val create : contents:string_contents -> size:Target_ocaml_int.t -> t
-
-val contents : t -> string_contents
-
-val size : t -> Target_ocaml_int.t
+type t = string
 
 include Container_types.S with type t := t

--- a/middle_end/flambda2/terms/flambda.ml
+++ b/middle_end/flambda2/terms/flambda.ml
@@ -1502,12 +1502,12 @@ module Named = struct
                  | Boxed_int64 _ | Boxed_vec128 _ | Boxed_vec256 _
                  | Boxed_vec512 _ | Boxed_nativeint _ | Immutable_float_block _
                  | Immutable_float_array _ | Immutable_float32_array _
-                 | Mutable_string _ | Immutable_string _ | Empty_array _
-                 | Immutable_value_array _ | Immutable_int_array _
-                 | Immutable_int8_array _ | Immutable_int16_array _
-                 | Immutable_int32_array _ | Immutable_int64_array _
-                 | Immutable_nativeint_array _ | Immutable_vec128_array _
-                 | Immutable_vec256_array _ | Immutable_vec512_array _ ) ->
+                 | Immutable_string _ | Empty_array _ | Immutable_value_array _
+                 | Immutable_int_array _ | Immutable_int8_array _
+                 | Immutable_int16_array _ | Immutable_int32_array _
+                 | Immutable_int64_array _ | Immutable_nativeint_array _
+                 | Immutable_vec128_array _ | Immutable_vec256_array _
+                 | Immutable_vec512_array _ ) ->
                acc)
            init
 end

--- a/middle_end/flambda2/terms/static_const.ml
+++ b/middle_end/flambda2/terms/static_const.ml
@@ -51,7 +51,6 @@ type t =
       Vector_types.Vec512.Bit_pattern.t Or_variable.t list
   | Immutable_value_array of Simple.With_debuginfo.t list
   | Empty_array of Empty_array_kind.t
-  | Mutable_string of { initial_value : string }
   | Immutable_string of string
 
 let set_of_closures set = Set_of_closures set
@@ -137,8 +136,6 @@ let immutable_value_array fields =
   | _ :: _ -> Immutable_value_array fields
 
 let empty_array kind = Empty_array kind
-
-let mutable_string ~initial_value = Mutable_string { initial_value }
 
 let immutable_string str = Immutable_string str
 
@@ -314,11 +311,6 @@ let [@ocamlformat "disable"] print ppf t =
       Flambda_colours.static_part
       Empty_array_kind.print array_kind
       Flambda_colours.pop
-  | Mutable_string { initial_value = s; } ->
-    fprintf ppf "@[<hov 1>(%tMutable_string%t@ %S)@]"
-      Flambda_colours.static_part
-      Flambda_colours.pop
-      s
   | Immutable_string s ->
     fprintf ppf "@[<hov 1>(%tImmutable_string%t@ %S)@]"
       Flambda_colours.static_part
@@ -423,10 +415,7 @@ include Container_types.Make (struct
       Misc.Stdlib.List.compare Simple.With_debuginfo.compare fields1 fields2
     | Empty_array array_kind1, Empty_array array_kind2 ->
       Empty_array_kind.compare array_kind1 array_kind2
-    | ( Mutable_string { initial_value = s1 },
-        Mutable_string { initial_value = s2 } )
-    | Immutable_string s1, Immutable_string s2 ->
-      String.compare s1 s2
+    | Immutable_string s1, Immutable_string s2 -> String.compare s1 s2
     | Block _, _ -> -1
     | _, Block _ -> 1
     | Set_of_closures _, _ -> -1
@@ -475,8 +464,6 @@ include Container_types.Make (struct
     | _, Immutable_value_array _ -> 1
     | Empty_array _, _ -> -1
     | _, Empty_array _ -> 1
-    | Mutable_string _, _ -> -1
-    | _, Mutable_string _ -> 1
 
   let equal t1 t2 = compare t1 t2 = 0
 
@@ -509,8 +496,7 @@ let free_names t =
   | Boxed_vec128 or_var -> Or_variable.free_names or_var
   | Boxed_vec256 or_var -> Or_variable.free_names or_var
   | Boxed_vec512 or_var -> Or_variable.free_names or_var
-  | Mutable_string { initial_value = _ } | Immutable_string _ | Empty_array _ ->
-    Name_occurrences.empty
+  | Immutable_string _ | Empty_array _ -> Name_occurrences.empty
   | Immutable_float_block fields | Immutable_float_array fields ->
     free_names_for_numeric_fields fields
   | Immutable_float32_array fields -> free_names_for_numeric_fields fields
@@ -574,7 +560,7 @@ let apply_renaming t renaming =
     | Boxed_vec512 or_var ->
       let or_var' = Or_variable.apply_renaming or_var renaming in
       if or_var == or_var' then t else Boxed_vec512 or_var'
-    | Mutable_string { initial_value = _ } | Immutable_string _ -> t
+    | Immutable_string _ -> t
     | Immutable_float_block fields ->
       let fields' = apply_renaming_number_array_fields renaming fields in
       if fields' == fields then t else Immutable_float_block fields'
@@ -655,7 +641,6 @@ let ids_for_export t =
   | Boxed_vec128 (Const _)
   | Boxed_vec256 (Const _)
   | Boxed_vec512 (Const _)
-  | Mutable_string { initial_value = _ }
   | Immutable_string _ ->
     Ids_for_export.empty
   | Immutable_float_block fields -> ids_for_export_number_array_fields fields
@@ -686,7 +671,7 @@ let block_field_kind t i =
   | Immutable_int16_array _ | Immutable_int32_array _ | Immutable_int64_array _
   | Immutable_nativeint_array _ | Immutable_vec128_array _
   | Immutable_vec256_array _ | Immutable_vec512_array _ | Empty_array _
-  | Mutable_string _ | Immutable_string _ ->
+  | Immutable_string _ ->
     Misc.fatal_errorf "Unexpected static const %a in [block_field_kind]" print t
 
 let is_block t =
@@ -698,7 +683,7 @@ let is_block t =
   | Immutable_int16_array _ | Immutable_int32_array _ | Immutable_int64_array _
   | Immutable_nativeint_array _ | Immutable_vec128_array _
   | Immutable_vec256_array _ | Immutable_vec512_array _ | Immutable_string _
-  | Mutable_string _ | Empty_array _ | Immutable_value_array _ ->
+  | Empty_array _ | Immutable_value_array _ ->
     true
   | Set_of_closures _ -> false
 
@@ -712,7 +697,7 @@ let is_set_of_closures t =
   | Immutable_int16_array _ | Immutable_int32_array _ | Immutable_int64_array _
   | Immutable_nativeint_array _ | Immutable_vec128_array _
   | Immutable_vec256_array _ | Immutable_vec512_array _ | Immutable_string _
-  | Mutable_string _ | Empty_array _ | Immutable_value_array _ ->
+  | Empty_array _ | Immutable_value_array _ ->
     false
 
 let is_fully_static t = free_names t |> Name_occurrences.no_variables
@@ -730,7 +715,7 @@ let can_share0 t =
   | Immutable_vec256_array _ | Immutable_vec512_array _
   | Immutable_value_array _ ->
     true
-  | Block (_, (Mutable | Immutable_unique), _, _) | Mutable_string _ -> false
+  | Block (_, (Mutable | Immutable_unique), _, _) -> false
 
 let can_share t = can_share0 t && is_fully_static t
 
@@ -744,7 +729,7 @@ let must_be_set_of_closures t =
   | Immutable_int16_array _ | Immutable_int32_array _ | Immutable_int64_array _
   | Immutable_nativeint_array _ | Immutable_vec128_array _
   | Immutable_vec256_array _ | Immutable_vec512_array _ | Empty_array _
-  | Immutable_value_array _ | Immutable_string _ | Mutable_string _ ->
+  | Immutable_value_array _ | Immutable_string _ ->
     Misc.fatal_errorf "Not a set of closures:@ %a" print t
 
 let match_against_bound_static_pattern t (pat : Bound_static.Pattern.t)
@@ -775,8 +760,7 @@ let match_against_bound_static_pattern t (pat : Bound_static.Pattern.t)
       | Immutable_int32_array _ | Immutable_int64_array _
       | Immutable_nativeint_array _ | Immutable_vec128_array _
       | Immutable_vec256_array _ | Immutable_vec512_array _
-      | Immutable_value_array _ | Empty_array _ | Immutable_string _
-      | Mutable_string _ ),
+      | Immutable_value_array _ | Empty_array _ | Immutable_string _ ),
       Block_like symbol ) ->
     block_like_callback symbol t
   | Set_of_closures _, (Block_like _ | Code _)
@@ -788,8 +772,7 @@ let match_against_bound_static_pattern t (pat : Bound_static.Pattern.t)
       | Immutable_int32_array _ | Immutable_int64_array _
       | Immutable_nativeint_array _ | Immutable_vec128_array _
       | Immutable_vec256_array _ | Immutable_vec512_array _
-      | Immutable_value_array _ | Empty_array _ | Immutable_string _
-      | Mutable_string _ ),
+      | Immutable_value_array _ | Empty_array _ | Immutable_string _ ),
       (Set_of_closures _ | Code _) ) ->
     Misc.fatal_errorf "Mismatch on variety of [Static_const]:@ %a@ =@ %a"
       Bound_static.Pattern.print pat print t

--- a/middle_end/flambda2/terms/static_const.mli
+++ b/middle_end/flambda2/terms/static_const.mli
@@ -64,7 +64,6 @@ type t = private
           representation (currently using custom blocks) from regular arrays of
           values. This affects all operations, most importantly the computation
           of the length of the array. *)
-  | Mutable_string of { initial_value : string }
   | Immutable_string of string
 
 include Container_types.S with type t := t
@@ -155,8 +154,6 @@ val immutable_vec512_array :
 val immutable_value_array : Simple.With_debuginfo.t list -> t
 
 val empty_array : Empty_array_kind.t -> t
-
-val mutable_string : initial_value:string -> t
 
 val immutable_string : string -> t
 

--- a/middle_end/flambda2/to_cmm/to_cmm_static.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_static.ml
@@ -629,7 +629,6 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
     let header = C.black_block_header 0 0 in
     let block = C.emit_block sym header [] in
     env, R.set_data res block, updates
-  | Block_like s, Mutable_string { initial_value = str }
   | Block_like s, Immutable_string str ->
     let data = C.emit_string_constant (R.symbol res s) str in
     env, R.update_data res data, updates
@@ -646,8 +645,7 @@ let static_const0 env res ~updates (bound_static : Bound_static.Pattern.t)
       | Immutable_int32_array _ | Immutable_int64_array _
       | Immutable_nativeint_array _ | Immutable_vec128_array _
       | Immutable_vec256_array _ | Immutable_vec512_array _
-      | Immutable_value_array _ | Empty_array _ | Mutable_string _
-      | Immutable_string _ ) ) ->
+      | Immutable_value_array _ | Empty_array _ | Immutable_string _ ) ) ->
     Misc.fatal_errorf
       "Block-like constants cannot be bound by [Code] or [Set_of_closures] \
        bindings:@ %a"

--- a/middle_end/flambda2/to_jsir/to_jsir_static_const.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_static_const.ml
@@ -232,9 +232,6 @@ let block_like ~env ~res symbol (const : Static_const.t) =
        maybe it's still worth fixing in the future just for uniformity. *)
     bind_expr_to_symbol ~env ~res symbol
       (Prim (Extern "caml_array_make", [Pc (Int Targetint.zero); Pc Null]))
-  | Mutable_string { initial_value } ->
-    ignore initial_value;
-    static_const_not_supported const
   | Immutable_string value ->
     bind_expr_to_symbol ~env ~res symbol (Constant (String value))
 

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -588,11 +588,7 @@ val variant :
   Alloc_mode.For_types.t ->
   t
 
-val this_immutable_string :
-  string -> machine_width:Target_system.Machine_width.t -> t
-
-val mutable_string :
-  size:int -> machine_width:Target_system.Machine_width.t -> t
+val this_immutable_string : string -> t
 
 val exactly_this_closure :
   Function_slot.t ->

--- a/middle_end/flambda2/types/grammar/type_grammar.ml
+++ b/middle_end/flambda2/types/grammar/type_grammar.ml
@@ -4366,20 +4366,8 @@ let boxed_vec256_alias_to ~naked_vec256 =
 let boxed_vec512_alias_to ~naked_vec512 =
   box_vec512 (Naked_vec512 (TD.create_equals (Simple.var naked_vec512)))
 
-let this_immutable_string str ~machine_width =
-  let size = Target_ocaml_int.of_int machine_width (String.length str) in
-  let string_info =
-    String_info.Set.singleton
-      (String_info.create ~contents:(Contents str) ~size)
-  in
-  non_null_value (String string_info)
-
-let mutable_string ~size ~machine_width =
-  let size = Target_ocaml_int.of_int machine_width size in
-  let string_info =
-    String_info.Set.singleton
-      (String_info.create ~contents:Unknown_or_mutable ~size)
-  in
+let this_immutable_string str =
+  let string_info = String_info.Set.singleton str in
   non_null_value (String string_info)
 
 let array_of_length ~element_kind ~length alloc_mode =

--- a/middle_end/flambda2/types/grammar/type_grammar.mli
+++ b/middle_end/flambda2/types/grammar/type_grammar.mli
@@ -431,11 +431,7 @@ val mutable_block : Alloc_mode.For_types.t -> t
 val create_closures : Alloc_mode.For_types.t -> row_like_for_closures -> t
 
 (** Note this assumes the allocation mode is [Heap] *)
-val this_immutable_string :
-  string -> machine_width:Target_system.Machine_width.t -> t
-
-val mutable_string :
-  size:int -> machine_width:Target_system.Machine_width.t -> t
+val this_immutable_string : string -> t
 
 val array_of_length :
   element_kind:Flambda_kind.With_subkind.t Or_unknown_or_bottom.t ->


### PR DESCRIPTION
Since support for unsafe strings was removed, there is no way to create mutable strings anymore. This PR simplifies Flambda2 a little bit by removing support for these.