### PR TITLE
Curry mode without using the argument

### DIFF
--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -7691,9 +7691,12 @@ module Crossing = struct
       Mode.subtract_const_unhint c
         (Mode.unhint (Mode.join [Mode.of_const c; m]))
 
-    let apply_right (Modality (Join_const c)) m =
+    let apply_right_unhint (Modality (Join_const c)) m =
       (* The right adjoint of join is a restriction of identity *)
       Mode.join_const_unhint c m
+
+    let apply_right_alloc t m =
+      Monadic.hint ~hint:Crossing (apply_right_unhint t (S.Unhint.unhint m))
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Join_const c)) : a Atom.t
         =
@@ -7722,6 +7725,14 @@ module Crossing = struct
     let print ppf (Modality m) =
       Fmt.fprintf ppf "Modality %a" Modality.Const.print m
   end
+
+  let comonadic_locality_as_regionality comonadic =
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
+
+  let comonadic_regional_to_local comonadic =
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_local))) comonadic
 
   module Comonadic = struct
     module Modality = Modality.Comonadic
@@ -7786,9 +7797,14 @@ module Crossing = struct
 
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
-    let apply_left (Modality (Meet_const c)) m =
+    let apply_left_unhint (Modality (Meet_const c)) m =
       (* The left adjoint of meet is a restriction of identity *)
       Mode.meet_const_unhint c m
+
+    let apply_left_alloc t m =
+      Alloc.Comonadic.hint ~hint:Crossing
+        (comonadic_locality_as_regionality (S.Unhint.unhint m)
+        |> apply_left_unhint t |> comonadic_regional_to_local)
 
     let apply_right (Modality (Meet_const c)) m =
       Mode.imply_const_unhint c (Mode.unhint (Mode.meet [Mode.of_const c; m]))
@@ -7907,7 +7923,7 @@ module Crossing = struct
   let apply_left_unhint t { monadic; comonadic } =
     let monadic = Monadic.apply_left t.monadic monadic in
     let comonadic =
-      Comonadic.apply_left t.comonadic (S.Unhint.unhint comonadic)
+      Comonadic.apply_left_unhint t.comonadic (S.Unhint.unhint comonadic)
     in
     { monadic; comonadic }
 
@@ -7916,7 +7932,9 @@ module Crossing = struct
       (apply_left_unhint t (Value.disallow_right m))
 
   let apply_right_unhint t { monadic; comonadic } =
-    let monadic = Monadic.apply_right t.monadic (S.Unhint.unhint monadic) in
+    let monadic =
+      Monadic.apply_right_unhint t.monadic (S.Unhint.unhint monadic)
+    in
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
@@ -7953,14 +7971,6 @@ module Crossing = struct
     in
     { comonadic; monadic }
 
-  let comonadic_locality_as_regionality comonadic =
-    S.Unhint.apply Value.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
-
-  let comonadic_regional_to_local comonadic =
-    S.Unhint.apply Alloc.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Regional_to_local))) comonadic
-
   let apply_left_alloc t m =
     m |> alloc_as_value |> apply_left_unhint t |> value_to_alloc_r2l_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
@@ -7971,10 +7981,10 @@ module Crossing = struct
 
   let apply_left_right_alloc t m =
     let { monadic; comonadic } = Alloc.unhint m in
-    let monadic = Monadic.apply_right t.monadic monadic in
+    let monadic = Monadic.apply_right_unhint t.monadic monadic in
     let comonadic =
       comonadic |> comonadic_locality_as_regionality
-      |> Comonadic.apply_left t.comonadic
+      |> Comonadic.apply_left_unhint t.comonadic
       |> comonadic_regional_to_local
       (* the left adjoint of [locality_as_regionality]*)
     in

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -749,6 +749,9 @@ module type S = sig
       (** Similar to [comonadic_to_monadic_min] but for constants *)
       val comonadic_to_monadic_min : Comonadic.Const.t -> Monadic.Const.t
 
+      (** Similar to [monadic_to_comonadic_min] but for constants *)
+      val monadic_to_comonadic_min : Monadic.Const.t -> Comonadic.Const.t
+
       (** Prints a constant on any axis. *)
       val print_axis : 'a Axis.t -> Fmt.formatter -> 'a -> unit
     end
@@ -1134,6 +1137,12 @@ module type S = sig
         visibility:Visibility.Const.t Atom.t ->
         staticity:Staticity.Const.t Atom.t ->
         t
+
+      (** Apply mode crossing on a right monadic [Alloc] fragment. *)
+      val apply_right_alloc :
+        t ->
+        (disallowed * 'r) Alloc.Monadic.t ->
+        (disallowed * 'r) Alloc.Monadic.t
     end
 
     module Comonadic : sig
@@ -1166,6 +1175,12 @@ module type S = sig
       (** Create the mode crossing for a type whose values are always
           constructed at the given mode. *)
       val always_constructed_at : Value.Comonadic.Const.t -> t
+
+      (** Apply mode crossing on a left comonadic [Alloc] fragment. *)
+      val apply_left_alloc :
+        t ->
+        ('l * disallowed) Alloc.Comonadic.t ->
+        ('l * disallowed) Alloc.Comonadic.t
     end
 
     (** The mode crossing capability on all axes, split into monadic and

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -9938,8 +9938,8 @@ and type_function_
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise
-                        (error(loc, env, Uncurried_function_escapes_comonadic e))
+                      raise (error(loc, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
                     Alloc.Comonadic.submode
@@ -9948,8 +9948,8 @@ and type_function_
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise
-                        (error(loc, env, Uncurried_function_escapes_comonadic e))
+                      raise (error(loc, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   More_args
                     { partial_mode =

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -308,7 +308,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
-  | Uncurried_function_escapes of Alloc.error
+  | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -1306,13 +1306,15 @@ let has_poly_constraint spat =
     end
   | _ -> false
 
-(** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
-    fragment is a left mode. *)
-let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
+(** Mode cross a right monadic mode fragment *)
+let alloc_monadic_mode_cross_to_min (crossing : Crossing.t) monadic =
   let monadic = Alloc.Monadic.disallow_left monadic in
+  Crossing.Monadic.apply_right_alloc crossing.monadic monadic
+
+(** Mode cross a left comonadic mode fragment *)
+let alloc_comonadic_mode_cross_to_max (crossing : Crossing.t) comonadic =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
-  let crossing = crossing_of_ty env ty in
-  Crossing.apply_left_right_alloc crossing { monadic; comonadic }
+  Crossing.Comonadic.apply_left_alloc crossing.comonadic comonadic
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
@@ -4940,7 +4942,7 @@ let check_curried_application_complete ~env ~app_loc args =
           raise (error(loc, env, Curried_application_complete (lbl, e, loc_kind)))
       in
       submode (Alloc.partial_apply mode_fun) mode_ret;
-      submode (Alloc.close_over mode_arg) mode_ret;
+      submode (Alloc.partial_apply mode_arg) mode_ret;
       loop has_commuted rest
   in
   loop false args
@@ -6449,7 +6451,8 @@ type split_function_ty =
        needs to be a right mode for making sure
        arguments generate a lower bound for subsequent closures.
        [alloc_mode] tracks the locality component to store in the Typedtree. *)
-    closure_mode: Mode.Alloc.lr;
+    closure_mode: Mode.Alloc.Comonadic.lr;
+    env_mode: Mode.Alloc.Monadic.r;
     alloc_mode: Locality.lr;
     really_poly: bool
   }
@@ -6549,7 +6552,14 @@ let split_function_ty
       end
     end
   in
-  let arg_value_mode = alloc_to_value_l2r arg_mode in
+  let env_monadic =
+    if is_final_val_param
+    then arg_mode.monadic
+    else fst (Alloc.Monadic.newvar_above arg_mode.monadic)
+  in
+  let arg_value_mode =
+    alloc_to_value_l2r { arg_mode with monadic = env_monadic }
+  in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
     match Ctype.type_sort ~why ~fixed:false env ty with
@@ -6560,9 +6570,9 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; closure_mode; ty_arg_mono;
+    alloc_mode; closure_mode=closure_mode.comonadic; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
-    really_poly
+    really_poly; env_mode=(Alloc.Monadic.disallow_left env_monadic)
   }
 
 type type_function_result_param =
@@ -6573,7 +6583,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr;
   }
 
 module Calling_convention_sort : sig
@@ -9816,7 +9826,7 @@ and type_function_
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; closure_mode; really_poly
+            alloc_mode; closure_mode; really_poly; env_mode
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9905,22 +9915,53 @@ and type_function_
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
-                  let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
+                  let crossing = crossing_of_ty env ty_arg in
+                  let arg_mode =
+                    alloc_comonadic_mode_cross_to_max crossing
+                      arg_mode.comonadic
+                  in
+                  let env_mode =
+                    alloc_monadic_mode_cross_to_min crossing env_mode
+                  in
+                  let cls_details : Mode.Hint.closure_details =
+                    { closure = (loc, Function);
+                      closed = (pparam_loc, Pattern) }
+                  in
+                  let hint : _ Hint.morph =
+                    Is_closed_by (Monadic, cls_details)
+                  in
+                  Alloc.Monadic.submode_err (pparam_loc, Pattern)
+                    (Alloc.comonadic_to_monadic_min ~hint fun_closure_mode)
+                    env_mode;
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
+                    Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
+<<<<<<< Merlin:ageorges/close-over-monadic
                       raise (error(loc, env, Uncurried_function_escapes e))
+||||||| Compiler:last-imported
+                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+=======
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
+>>>>>>> Compiler:HEAD
                   end;
                   begin match
-                    Alloc.submode
-                      (Alloc.partial_apply closure_mode)
+                    Alloc.Comonadic.submode
+                      (Alloc.Comonadic.disallow_right closure_mode)
                       fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
+<<<<<<< Merlin:ageorges/close-over-monadic
                       raise (error(loc, env, Uncurried_function_escapes e))
+||||||| Compiler:last-imported
+                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+=======
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
+>>>>>>> Compiler:HEAD
                   end;
                   More_args
                     { partial_mode =
@@ -12589,8 +12630,8 @@ and type_n_ary_function
     in
     let yielding =
       Yielding.join
-        (Alloc.proj_comonadic Yielding
-           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+        (Alloc.Comonadic.proj Yielding
+           (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
          :: param_yieldings)
     in
     re
@@ -14095,19 +14136,21 @@ let report_error ~loc env =
         but was expected to %s which is %a.@]"
         desc (Style.as_inline_code (Alloc.Const.print_axis ax)) actual
         desc_inf (Style.as_inline_code (Alloc.Const.print_axis ax)) expected
-  | Uncurried_function_escapes e -> begin
-      let Mode.Alloc.Error (ax, {left; right}) = Mode.Alloc.to_simple_error e in
+  | Uncurried_function_escapes_comonadic e -> begin
+      let Mode.Alloc.Comonadic.Error (ax, {left; right}) =
+        Mode.Alloc.Comonadic.to_simple_error e
+      in
       match ax with
-      | Comonadic Areality ->
-          Location.errorf ~loc
+      | Areality ->
+        Location.errorf ~loc
             "This function or one of its parameters escape their region@ \
             when it is partially applied."
       | _ ->
-          Location.errorf ~loc
+        Location.errorf ~loc
             "This function when partially applied returns a value which is %a,@ \
               but expected to be %a."
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) left
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) right
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -9683,7 +9683,7 @@ and type_function
         params_contain_gadt = No_gadt;
         fun_alloc_mode =
           Some { alloc_mode = Locality.newvar ();
-                 fun_closure_mode = Alloc.newvar () };
+                 fun_closure_mode = Alloc.Comonadic.newvar () };
         ret_info = Some ret_info;
         calling_convention_sorts = []
       })
@@ -9938,14 +9938,8 @@ and type_function_
                   with
                     | Ok () -> ()
                     | Error e ->
-<<<<<<< Merlin:ageorges/close-over-monadic
-                      raise (error(loc, env, Uncurried_function_escapes e))
-||||||| Compiler:last-imported
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
-=======
-                      raise (Error(loc_fun, env,
-                        Uncurried_function_escapes_comonadic e))
->>>>>>> Compiler:HEAD
+                      raise
+                        (error(loc, env, Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
                     Alloc.Comonadic.submode
@@ -9954,14 +9948,8 @@ and type_function_
                   with
                     | Ok () -> ()
                     | Error e ->
-<<<<<<< Merlin:ageorges/close-over-monadic
-                      raise (error(loc, env, Uncurried_function_escapes e))
-||||||| Compiler:last-imported
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
-=======
-                      raise (Error(loc_fun, env,
-                        Uncurried_function_escapes_comonadic e))
->>>>>>> Compiler:HEAD
+                      raise
+                        (error(loc, env, Uncurried_function_escapes_comonadic e))
                   end;
                   More_args
                     { partial_mode =

--- a/external/merlin/src/ocaml/typing/typecore.mli
+++ b/external/merlin/src/ocaml/typing/typecore.mli
@@ -381,7 +381,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
-  | Uncurried_function_escapes of Mode.Alloc.error
+  | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/external/merlin/tests/test-dirs/function-recovery.t
+++ b/external/merlin/tests/test-dirs/function-recovery.t
@@ -40,7 +40,7 @@
                     None
                   expression (test.ml[3,104+11]..test.ml[3,104+28])
                     Texp_function
-                    alloc_mode id(modevar#1b<0>[global .. local])
+                    alloc_mode id(modevar#1a<0>[global .. local])
                     yielding_mode unyielding
                     return_mode proj_Locality(modevar#17<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
                     []
@@ -256,7 +256,7 @@
                         "kind": "pattern (test.ml[1,0+6]..test.ml[1,0+9])
     Tpat_var \"x\"
     sort '_representable_layout_1
-    value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#7<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+    value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#6<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#a<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
   ",
                         "children": []
                       },

--- a/external/merlin/tests/test-dirs/type-enclosing/underscore-ids.t
+++ b/external/merlin/tests/test-dirs/type-enclosing/underscore-ids.t
@@ -461,7 +461,7 @@ We try several places in the identifier to check the result stability
             Texp_function
             alloc_mode global
             yielding_mode unyielding
-            return_mode proj_Locality(modevar#1d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
+            return_mode proj_Locality(modevar#1e<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,yielding,stateful])
             []
             [
               Nolabel
@@ -469,7 +469,7 @@ We try several places in the identifier to check the result stability
                 pattern (under.ml[2,13+6]..under.ml[2,13+9])
                   Tpat_var \"x\"
                   sort '_representable_layout_1
-                  value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#e<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
+                  value_mode meet(local,once,nonportable,unforkable,yielding,stateful) . local_to_regional_full(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful]);meet(unique,uncontended,read_write,static,imply(unique,uncontended,read_write,static)(modevar#11<0>[aliased,contended,immutable,dynamic .. unique,uncontended,read_write,static]))
                 proj_Locality(modevar#d<0>[global,many,portable,forkable,unyielding,stateless .. local,once,nonportable,unforkable,unyielding,stateful])
                 []
             ]

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -7691,9 +7691,12 @@ module Crossing = struct
       Mode.subtract_const_unhint c
         (Mode.unhint (Mode.join [Mode.of_const c; m]))
 
-    let apply_right (Modality (Join_const c)) m =
+    let apply_right_unhint (Modality (Join_const c)) m =
       (* The right adjoint of join is a restriction of identity *)
       Mode.join_const_unhint c m
+
+    let apply_right_alloc t m =
+      Monadic.hint ~hint:Crossing (apply_right_unhint t (S.Unhint.unhint m))
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Join_const c)) : a Atom.t
         =
@@ -7722,6 +7725,14 @@ module Crossing = struct
     let print ppf (Modality m) =
       Fmt.fprintf ppf "Modality %a" Modality.Const.print m
   end
+
+  let comonadic_locality_as_regionality comonadic =
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
+
+  let comonadic_regional_to_local comonadic =
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_local))) comonadic
 
   module Comonadic = struct
     module Modality = Modality.Comonadic
@@ -7786,9 +7797,14 @@ module Crossing = struct
 
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
-    let apply_left (Modality (Meet_const c)) m =
+    let apply_left_unhint (Modality (Meet_const c)) m =
       (* The left adjoint of meet is a restriction of identity *)
       Mode.meet_const_unhint c m
+
+    let apply_left_alloc t m =
+      Alloc.Comonadic.hint ~hint:Crossing
+        (comonadic_locality_as_regionality (S.Unhint.unhint m)
+        |> apply_left_unhint t |> comonadic_regional_to_local)
 
     let apply_right (Modality (Meet_const c)) m =
       Mode.imply_const_unhint c (Mode.unhint (Mode.meet [Mode.of_const c; m]))
@@ -7907,7 +7923,7 @@ module Crossing = struct
   let apply_left_unhint t { monadic; comonadic } =
     let monadic = Monadic.apply_left t.monadic monadic in
     let comonadic =
-      Comonadic.apply_left t.comonadic (S.Unhint.unhint comonadic)
+      Comonadic.apply_left_unhint t.comonadic (S.Unhint.unhint comonadic)
     in
     { monadic; comonadic }
 
@@ -7916,7 +7932,9 @@ module Crossing = struct
       (apply_left_unhint t (Value.disallow_right m))
 
   let apply_right_unhint t { monadic; comonadic } =
-    let monadic = Monadic.apply_right t.monadic (S.Unhint.unhint monadic) in
+    let monadic =
+      Monadic.apply_right_unhint t.monadic (S.Unhint.unhint monadic)
+    in
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
@@ -7953,14 +7971,6 @@ module Crossing = struct
     in
     { comonadic; monadic }
 
-  let comonadic_locality_as_regionality comonadic =
-    S.Unhint.apply Value.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
-
-  let comonadic_regional_to_local comonadic =
-    S.Unhint.apply Alloc.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Regional_to_local))) comonadic
-
   let apply_left_alloc t m =
     m |> alloc_as_value |> apply_left_unhint t |> value_to_alloc_r2l_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
@@ -7971,10 +7981,10 @@ module Crossing = struct
 
   let apply_left_right_alloc t m =
     let { monadic; comonadic } = Alloc.unhint m in
-    let monadic = Monadic.apply_right t.monadic monadic in
+    let monadic = Monadic.apply_right_unhint t.monadic monadic in
     let comonadic =
       comonadic |> comonadic_locality_as_regionality
-      |> Comonadic.apply_left t.comonadic
+      |> Comonadic.apply_left_unhint t.comonadic
       |> comonadic_regional_to_local
       (* the left adjoint of [locality_as_regionality]*)
     in

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -749,6 +749,9 @@ module type S = sig
       (** Similar to [comonadic_to_monadic_min] but for constants *)
       val comonadic_to_monadic_min : Comonadic.Const.t -> Monadic.Const.t
 
+      (** Similar to [monadic_to_comonadic_min] but for constants *)
+      val monadic_to_comonadic_min : Monadic.Const.t -> Comonadic.Const.t
+
       (** Prints a constant on any axis. *)
       val print_axis : 'a Axis.t -> Fmt.formatter -> 'a -> unit
     end
@@ -1134,6 +1137,12 @@ module type S = sig
         visibility:Visibility.Const.t Atom.t ->
         staticity:Staticity.Const.t Atom.t ->
         t
+
+      (** Apply mode crossing on a right monadic [Alloc] fragment. *)
+      val apply_right_alloc :
+        t ->
+        (disallowed * 'r) Alloc.Monadic.t ->
+        (disallowed * 'r) Alloc.Monadic.t
     end
 
     module Comonadic : sig
@@ -1166,6 +1175,12 @@ module type S = sig
       (** Create the mode crossing for a type whose values are always
           constructed at the given mode. *)
       val always_constructed_at : Value.Comonadic.Const.t -> t
+
+      (** Apply mode crossing on a left comonadic [Alloc] fragment. *)
+      val apply_left_alloc :
+        t ->
+        ('l * disallowed) Alloc.Comonadic.t ->
+        ('l * disallowed) Alloc.Comonadic.t
     end
 
     (** The mode crossing capability on all axes, split into monadic and

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -306,7 +306,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
-  | Uncurried_function_escapes of Alloc.error
+  | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -1190,13 +1190,15 @@ let has_poly_constraint spat =
     end
   | _ -> false
 
-(** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
-    fragment is a left mode. *)
-let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
+(** Mode cross a right monadic mode fragment *)
+let alloc_monadic_mode_cross_to_min (crossing : Crossing.t) monadic =
   let monadic = Alloc.Monadic.disallow_left monadic in
+  Crossing.Monadic.apply_right_alloc crossing.monadic monadic
+
+(** Mode cross a left comonadic mode fragment *)
+let alloc_comonadic_mode_cross_to_max (crossing : Crossing.t) comonadic =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
-  let crossing = crossing_of_ty env ty in
-  Crossing.apply_left_right_alloc crossing { monadic; comonadic }
+  Crossing.Comonadic.apply_left_alloc crossing.comonadic comonadic
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
@@ -4793,7 +4795,7 @@ let check_curried_application_complete ~env ~app_loc args =
           raise (Error(loc, env, Curried_application_complete (lbl, e, loc_kind)))
       in
       submode (Alloc.partial_apply mode_fun) mode_ret;
-      submode (Alloc.close_over mode_arg) mode_ret;
+      submode (Alloc.partial_apply mode_arg) mode_ret;
       loop has_commuted rest
   in
   loop false args
@@ -6289,7 +6291,8 @@ type split_function_ty =
        needs to be a right mode for making sure
        arguments generate a lower bound for subsequent closures.
        [alloc_mode] tracks the locality component to store in the Typedtree. *)
-    closure_mode: Mode.Alloc.lr;
+    closure_mode: Mode.Alloc.Comonadic.lr;
+    env_mode: Mode.Alloc.Monadic.r;
     alloc_mode: Locality.lr;
     really_poly: bool
   }
@@ -6380,7 +6383,14 @@ let split_function_ty
       end
     end
   in
-  let arg_value_mode = alloc_to_value_l2r arg_mode in
+  let env_monadic =
+    if is_final_val_param
+    then arg_mode.monadic
+    else fst (Alloc.Monadic.newvar_above arg_mode.monadic)
+  in
+  let arg_value_mode =
+    alloc_to_value_l2r { arg_mode with monadic = env_monadic }
+  in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
     match Ctype.type_sort ~why ~fixed:false env ty with
@@ -6391,9 +6401,9 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; closure_mode; ty_arg_mono;
+    alloc_mode; closure_mode=closure_mode.comonadic; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
-    really_poly
+    really_poly; env_mode=(Alloc.Monadic.disallow_left env_monadic)
   }
 
 type type_function_result_param =
@@ -6404,7 +6414,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr;
   }
 
 module Calling_convention_sort : sig
@@ -9445,7 +9455,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; closure_mode; really_poly
+            alloc_mode; closure_mode; really_poly; env_mode
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9534,22 +9544,41 @@ and type_function
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
-                  let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
+                  let crossing = crossing_of_ty env ty_arg in
+                  let arg_mode =
+                    alloc_comonadic_mode_cross_to_max crossing
+                      arg_mode.comonadic
+                  in
+                  let env_mode =
+                    alloc_monadic_mode_cross_to_min crossing env_mode
+                  in
+                  let cls_details : Mode.Hint.closure_details =
+                    { closure = (loc, Function);
+                      closed = (pparam_loc, Pattern) }
+                  in
+                  let hint : _ Hint.morph =
+                    Is_closed_by (Monadic, cls_details)
+                  in
+                  Alloc.Monadic.submode_err (pparam_loc, Pattern)
+                    (Alloc.comonadic_to_monadic_min ~hint fun_closure_mode)
+                    env_mode;
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
+                    Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.submode
-                      (Alloc.partial_apply closure_mode)
+                    Alloc.Comonadic.submode
+                      (Alloc.Comonadic.disallow_right closure_mode)
                       fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   More_args
                     { partial_mode =
@@ -12104,8 +12133,8 @@ and type_n_ary_function
     in
     let yielding =
       Yielding.join
-        (Alloc.proj_comonadic Yielding
-           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+        (Alloc.Comonadic.proj Yielding
+           (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
          :: param_yieldings)
     in
     re
@@ -13610,19 +13639,21 @@ let report_error ~loc env =
         but was expected to %s which is %a.@]"
         desc (Style.as_inline_code (Alloc.Const.print_axis ax)) actual
         desc_inf (Style.as_inline_code (Alloc.Const.print_axis ax)) expected
-  | Uncurried_function_escapes e -> begin
-      let Mode.Alloc.Error (ax, {left; right}) = Mode.Alloc.to_simple_error e in
+  | Uncurried_function_escapes_comonadic e -> begin
+      let Mode.Alloc.Comonadic.Error (ax, {left; right}) =
+        Mode.Alloc.Comonadic.to_simple_error e
+      in
       match ax with
-      | Comonadic Areality ->
-          Location.errorf ~loc
+      | Areality ->
+        Location.errorf ~loc
             "This function or one of its parameters escape their region@ \
             when it is partially applied."
       | _ ->
-          Location.errorf ~loc
+        Location.errorf ~loc
             "This function when partially applied returns a value which is %a,@ \
               but expected to be %a."
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) left
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) right
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.mli
@@ -379,7 +379,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
-  | Uncurried_function_escapes of Mode.Alloc.error
+  | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -520,8 +520,6 @@ let f (g @ unique) x =
   g x x [@nontail]
 [%%expect{|
 val f : ('a -> 'a -> 'b) @ unique -> ('a -> 'b) = <fun>
-|}, Principal{|
-val f : ('a -> 'a -> 'b) @ unique -> ('a -> 'b) = <fun>
 |}]
 
 let f (g @ once) x =

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -412,12 +412,32 @@ let _ =
   let f : _ @ unique -> (_ -> _) = fun _ -> fun x -> x in
   f "hello" "world"
 [%%expect{|
-Line 3, characters 2-11:
-3 |   f "hello" "world"
-      ^^^^^^^^^
-Error: This application is complete, but surplus arguments were provided afterwards.
-       When passing or calling once values, extra arguments are passed in a separate application.
-Hint: Try wrapping the marked application in parentheses.
+- : string = "world"
+|}]
+
+let use_unique (x @ unique) = ()
+[%%expect{|
+val use_unique : 'a @ unique -> unit = <fun>
+|}]
+
+let _ =
+  let f : _ @ unique -> (_ -> _) = fun x -> use_unique x; fun x -> x in
+  f "hello" "world"
+[%%expect{|
+- : string = "world"
+|}]
+
+let _ =
+  let f : _ @ unique -> (_ -> _) = fun y -> fun x -> use_unique y; x in
+  f "hello" "world"
+[%%expect{|
+Line 2, characters 64-65:
+2 |   let f : _ @ unique -> (_ -> _) = fun y -> fun x -> use_unique y; x in
+                                                                    ^
+Error: This value is "aliased"
+         because it is used inside the function at line 2, characters 44-68
+         which is expected to be "many".
+       However, the highlighted expression is expected to be "unique".
 |}]
 
 let _ =

--- a/testsuite/tests/typing-modes/currying.ml
+++ b/testsuite/tests/typing-modes/currying.ml
@@ -501,7 +501,7 @@ let f (g @ unique) x =
 [%%expect{|
 val f : ('a -> 'a -> 'b) @ unique -> ('a -> 'b) = <fun>
 |}, Principal{|
-val f : ('a -> 'a -> 'b) @ unique -> 'a -> 'b = <fun>
+val f : ('a -> 'a -> 'b) @ unique -> ('a -> 'b) = <fun>
 |}]
 
 let f (g @ once) x =

--- a/testsuite/tests/typing-modes/modes.ml
+++ b/testsuite/tests/typing-modes/modes.ml
@@ -403,11 +403,15 @@ type r = { mutable x : string; }
 
 let foo ?(local_ x @ unique once = 42) () = ()
 [%%expect{|
+val foo : ?x:int @ local once unique -> (unit -> unit) @ local = <fun>
+|}, Principal{|
 val foo : ?x:int @ local once unique -> unit -> unit = <fun>
 |}]
 
 let foo ?(local_ x : _ @ unique once = 42) () = ()
 [%%expect{|
+val foo : ?x:int @ local once unique -> (unit -> unit) @ local = <fun>
+|}, Principal{|
 val foo : ?x:int @ local once unique -> unit -> unit = <fun>
 |}]
 
@@ -421,11 +425,15 @@ Error: Optional parameters cannot be polymorphic
 
 let foo ?x:(local_ (x,y) @ unique once = (42, 42)) () = ()
 [%%expect{|
+val foo : ?x:int * int @ local once unique -> (unit -> unit) @ local = <fun>
+|}, Principal{|
 val foo : ?x:int * int @ local once unique -> unit -> unit = <fun>
 |}]
 
 let foo ?x:(local_ (x,y) : _ @ unique once = (42, 42)) () = ()
 [%%expect{|
+val foo : ?x:int * int @ local once unique -> (unit -> unit) @ local = <fun>
+|}, Principal{|
 val foo : ?x:int * int @ local once unique -> unit -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -435,37 +435,74 @@ Error: This function when partially applied returns a value which is "nonportabl
        but expected to be "portable".
 |}]
 
-(* closing over uncontended gives nonportable *)
-let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> ()
+(* closing over an uncontended use of a variable gives nonportable *)
+let use_uncontended (x @ uncontended) = ()
 [%%expect{|
-Line 1, characters 67-81:
-1 | let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> ()
-                                                                       ^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "nonportable",
-       but expected to be "portable".
+val use_uncontended : 'a -> unit = <fun>
 |}]
 
-(* closing over shared gives shareable *)
+let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> use_uncontended a
+[%%expect{|
+Line 1, characters 71-72:
+1 | let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> use_uncontended a
+                                                                           ^
+Error: The pattern is "contended"
+         because it is used inside the function at line 1, characters 67-96
+         which is expected to be "portable".
+       However, the pattern highlighted is expected to be "uncontended".
+|}]
+
+(* closing over an uncontended variable without using it can be portable *)
+let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> a
+[%%expect{|
+val foo : unit @ portable -> (unit -> unit) @ portable = <fun>
+|}]
+
+(* closing over shared uses gives shareable *)
+let use_shared (x @ shared) = ()
+[%%expect{|
+val use_shared : 'a @ shared -> unit = <fun>
+|}]
+
+let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> use_shared a
+[%%expect{|
+Line 1, characters 66-67:
+1 | let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> use_shared a
+                                                                      ^
+Error: The pattern is "contended"
+         because it is used inside the function at line 1, characters 62-86
+         which is expected to be "portable".
+       However, the pattern highlighted is expected to be "shared" or "uncontended".
+|}]
+
+(* closing over a shared variable without using it can be portable *)
 let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> ()
 [%%expect{|
-Line 1, characters 62-76:
-1 | let foo : 'a @ shared portable -> (unit -> unit) @ portable = fun a () -> ()
-                                                                  ^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "shareable",
-       but expected to be "portable".
+val foo : 'a @ portable shared -> (unit -> unit) @ portable = <fun>
 |}]
 
-(* closing over corrupted gives corruptible *)
+(* closing over corrupted use gives corruptible *)
+let use_corrupted (x @ corrupted) = ()
+[%%expect{|
+val use_corrupted : 'a @ corrupted -> unit = <fun>
+|}]
+
+let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> use_corrupted a
+[%%expect{|
+Line 1, characters 69-70:
+1 | let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> use_corrupted a
+                                                                         ^
+Error: The pattern is "contended"
+         because it is used inside the function at line 1, characters 65-92
+         which is expected to be "portable".
+       However, the pattern highlighted is expected to be "corrupted" or "uncontended".
+|}]
+
+(* closing over corrupted without using it can be portable *)
 let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> ()
 [%%expect{|
-Line 1, characters 65-79:
-1 | let foo : 'a @ corrupted portable -> (unit -> unit) @ portable = fun a () -> ()
-                                                                     ^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "corruptible",
-       but expected to be "portable".
+val foo : 'a @ portable corrupted -> (unit -> unit) @ portable = <fun>
 |}]
-(* CR modes: These four tests are in principle fine to allow (they don't cause a data
-   race), since a is never used *)
 
 let foo : ('a @ contended portable -> (string -> string) @ portable) @ nonportable contended = fun a b -> best_bytes ()
 (* CR layouts v2.8: arrows should cross contention. Internal ticket 5121. *)

--- a/testsuite/tests/typing-modes/portable-contend.ml
+++ b/testsuite/tests/typing-modes/portable-contend.ml
@@ -453,9 +453,9 @@ Error: The pattern is "contended"
 |}]
 
 (* closing over an uncontended variable without using it can be portable *)
-let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> a
+let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun _ () -> ()
 [%%expect{|
-val foo : unit @ portable -> (unit -> unit) @ portable = <fun>
+val foo : 'a @ portable -> (unit -> unit) @ portable = <fun>
 |}]
 
 (* closing over shared uses gives shareable *)

--- a/testsuite/tests/typing-modes/statefulness-visibility.ml
+++ b/testsuite/tests/typing-modes/statefulness-visibility.ml
@@ -745,31 +745,37 @@ Error: This value is "reading"
 let foo : int Atomic.t @ read_write -> (unit -> int) @ stateless =
     fun a () -> Atomic.exchange a 2
 [%%expect{|
-Line 2, characters 4-35:
+Line 2, characters 8-9:
 2 |     fun a () -> Atomic.exchange a 2
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "stateful",
-       but expected to be "stateless".
+            ^
+Error: The pattern is "immutable"
+         because it is used inside the function at line 2, characters 4-35
+         which is expected to be "stateless".
+       However, the pattern highlighted is expected to be "read_write".
 |}]
 
 let foo : int Atomic.t @ write -> (unit -> unit) @ stateless =
     fun a () -> Atomic.set a 2
 [%%expect{|
-Line 2, characters 4-30:
+Line 2, characters 8-9:
 2 |     fun a () -> Atomic.set a 2
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "writing",
-       but expected to be "stateless".
+            ^
+Error: The pattern is "immutable"
+         because it is used inside the function at line 2, characters 4-30
+         which is expected to be "stateless".
+       However, the pattern highlighted is expected to be "write" or "read_write".
 |}]
 
 let foo : int Atomic.t @ read -> (unit -> int) @ stateless =
     fun a () -> Atomic.get a
 [%%expect{|
-Line 2, characters 4-28:
+Line 2, characters 8-9:
 2 |     fun a () -> Atomic.get a
-        ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "reading",
-       but expected to be "stateless".
+            ^
+Error: The pattern is "immutable"
+         because it is used inside the function at line 2, characters 4-28
+         which is expected to be "stateless".
+       However, the pattern highlighted is expected to be "read" or "read_write".
 |}]
 
 let foo @ stateless =

--- a/testsuite/tests/typing-unique/borrow.ml
+++ b/testsuite/tests/typing-unique/borrow.ml
@@ -17,7 +17,7 @@ let local_aliased_use (local_ a) = ()
 val local_aliased_use : 'a @ local -> unit = <fun>
 |}]
 
-let unique_aliased_use (x @ local unique) (local_ y) = ()
+let unique_aliased_use (x @ local unique) (local_ y) = unique_use x; ()
 [%%expect{|
 val unique_aliased_use : 'a @ local unique -> 'b @ local -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-unique/borrow.ml
+++ b/testsuite/tests/typing-unique/borrow.ml
@@ -17,9 +17,10 @@ let local_aliased_use (local_ a) = ()
 val local_aliased_use : 'a @ local -> unit = <fun>
 |}]
 
-let unique_aliased_use (x @ local unique) (local_ y) = unique_use x; ()
+let unique_aliased_use (x @ local unique) (local_ y) = ()
 [%%expect{|
-val unique_aliased_use : 'a @ local unique -> 'b @ local -> unit = <fun>
+val unique_aliased_use : 'a @ local unique -> ('b @ local -> unit) @ local =
+  <fun>
 |}]
 
 let aliased_unique_use (local_ x) (y @ local unique) = ()

--- a/testsuite/tests/typing-unique/unique.ml
+++ b/testsuite/tests/typing-unique/unique.ml
@@ -368,7 +368,7 @@ val inf6 : 'a @ unique -> 'a = <fun>
 
 let unique_default_args ?(x @ unique = 1.0) () = x
 [%%expect{|
-val unique_default_args : ?x:float @ unique -> unit -> float = <fun>
+val unique_default_args : ?x:float @ unique -> (unit -> float) = <fun>
 |}]
 
 (* Unique Local *)
@@ -507,7 +507,7 @@ type box = { x : int; }
 
 let curry (b1 : box @ unique) (b2 : box @ unique) = ()
 [%%expect{|
-val curry : box @ unique -> box @ unique -> unit = <fun>
+val curry : box @ unique -> (box @ unique -> unit) = <fun>
 |}]
 
 let curry : box @ unique -> box @ unique -> unit = fun b1 b2 -> ()
@@ -515,22 +515,31 @@ let curry : box @ unique -> box @ unique -> unit = fun b1 b2 -> ()
 val curry : box @ unique -> box @ unique -> unit = <fun>
 |}]
 
-let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> ()
+let use_unique (x @ unique) = ()
 [%%expect{|
-Line 1, characters 53-68:
-1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> ()
-                                                         ^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "once",
-       but expected to be "many".
+val use_unique : 'a @ unique -> unit = <fun>
 |}]
 
-let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> ()
+let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> use_unique b1; ()
 [%%expect{|
-Line 1, characters 53-82:
-1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> ()
-                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This function when partially applied returns a value which is "once",
-       but expected to be "many".
+Line 1, characters 57-59:
+1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 b2 -> use_unique b1; ()
+                                                             ^^
+Error: The pattern is "aliased"
+         because it is used inside the function at line 1, characters 53-83
+         which is expected to be "many".
+       However, the pattern highlighted is expected to be "unique".
+|}]
+
+let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> use_unique b1; ()
+[%%expect{|
+Line 1, characters 57-59:
+1 | let curry : box @ unique -> (box @ unique -> unit) = fun b1 -> function | b2 -> use_unique b1; ()
+                                                             ^^
+Error: The pattern is "aliased"
+         because it is used inside the function at line 1, characters 53-97
+         which is expected to be "many".
+       However, the pattern highlighted is expected to be "unique".
 |}]
 
 (* For nested functions, inner functions are not constrained *)

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7691,9 +7691,12 @@ module Crossing = struct
       Mode.subtract_const_unhint c
         (Mode.unhint (Mode.join [Mode.of_const c; m]))
 
-    let apply_right (Modality (Join_const c)) m =
+    let apply_right_unhint (Modality (Join_const c)) m =
       (* The right adjoint of join is a restriction of identity *)
       Mode.join_const_unhint c m
+
+    let apply_right_alloc t m =
+      Monadic.hint ~hint:Crossing (apply_right_unhint t (S.Unhint.unhint m))
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Join_const c)) : a Atom.t
         =
@@ -7722,6 +7725,14 @@ module Crossing = struct
     let print ppf (Modality m) =
       Fmt.fprintf ppf "Modality %a" Modality.Const.print m
   end
+
+  let comonadic_locality_as_regionality comonadic =
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
+
+  let comonadic_regional_to_local comonadic =
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_local))) comonadic
 
   module Comonadic = struct
     module Modality = Modality.Comonadic
@@ -7786,9 +7797,14 @@ module Crossing = struct
 
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
-    let apply_left (Modality (Meet_const c)) m =
+    let apply_left_unhint (Modality (Meet_const c)) m =
       (* The left adjoint of meet is a restriction of identity *)
       Mode.meet_const_unhint c m
+
+    let apply_left_alloc t m =
+      Alloc.Comonadic.hint ~hint:Crossing
+        (comonadic_locality_as_regionality (S.Unhint.unhint m)
+        |> apply_left_unhint t |> comonadic_regional_to_local)
 
     let apply_right (Modality (Meet_const c)) m =
       Mode.imply_const_unhint c (Mode.unhint (Mode.meet [Mode.of_const c; m]))
@@ -7907,7 +7923,7 @@ module Crossing = struct
   let apply_left_unhint t { monadic; comonadic } =
     let monadic = Monadic.apply_left t.monadic monadic in
     let comonadic =
-      Comonadic.apply_left t.comonadic (S.Unhint.unhint comonadic)
+      Comonadic.apply_left_unhint t.comonadic (S.Unhint.unhint comonadic)
     in
     { monadic; comonadic }
 
@@ -7916,7 +7932,9 @@ module Crossing = struct
       (apply_left_unhint t (Value.disallow_right m))
 
   let apply_right_unhint t { monadic; comonadic } =
-    let monadic = Monadic.apply_right t.monadic (S.Unhint.unhint monadic) in
+    let monadic =
+      Monadic.apply_right_unhint t.monadic (S.Unhint.unhint monadic)
+    in
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
@@ -7953,14 +7971,6 @@ module Crossing = struct
     in
     { comonadic; monadic }
 
-  let comonadic_locality_as_regionality comonadic =
-    S.Unhint.apply Value.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
-
-  let comonadic_regional_to_local comonadic =
-    S.Unhint.apply Alloc.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Regional_to_local))) comonadic
-
   let apply_left_alloc t m =
     m |> alloc_as_value |> apply_left_unhint t |> value_to_alloc_r2l_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
@@ -7971,10 +7981,10 @@ module Crossing = struct
 
   let apply_left_right_alloc t m =
     let { monadic; comonadic } = Alloc.unhint m in
-    let monadic = Monadic.apply_right t.monadic monadic in
+    let monadic = Monadic.apply_right_unhint t.monadic monadic in
     let comonadic =
       comonadic |> comonadic_locality_as_regionality
-      |> Comonadic.apply_left t.comonadic
+      |> Comonadic.apply_left_unhint t.comonadic
       |> comonadic_regional_to_local
       (* the left adjoint of [locality_as_regionality]*)
     in

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -7597,9 +7597,12 @@ module Crossing = struct
       Mode.subtract_const_unhint c
         (Mode.unhint (Mode.join [Mode.of_const c; m]))
 
-    let apply_right (Modality (Join_const c)) m =
+    let apply_right_unhint (Modality (Join_const c)) m =
       (* The right adjoint of join is a restriction of identity *)
       Mode.join_const_unhint c m
+
+    let apply_right_alloc t m =
+      Monadic.hint ~hint:Crossing (apply_right_unhint t (S.Unhint.unhint m))
 
     let proj (type a) (ax : a Mode.Axis.t) (Modality (Join_const c)) : a Atom.t
         =
@@ -7628,6 +7631,14 @@ module Crossing = struct
     let print ppf (Modality m) =
       Fmt.fprintf ppf "Modality %a" Modality.Const.print m
   end
+
+  let comonadic_locality_as_regionality comonadic =
+    S.Unhint.apply Value.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
+
+  let comonadic_regional_to_local comonadic =
+    S.Unhint.apply Alloc.Comonadic.Obj.obj
+      (Simple (Core (Locality_full Regional_to_local))) comonadic
 
   module Comonadic = struct
     module Modality = Modality.Comonadic
@@ -7692,9 +7703,14 @@ module Crossing = struct
 
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
-    let apply_left (Modality (Meet_const c)) m =
+    let apply_left_unhint (Modality (Meet_const c)) m =
       (* The left adjoint of meet is a restriction of identity *)
       Mode.meet_const_unhint c m
+
+    let apply_left_alloc t m =
+      Alloc.Comonadic.hint ~hint:Crossing
+        (comonadic_locality_as_regionality (S.Unhint.unhint m)
+        |> apply_left_unhint t |> comonadic_regional_to_local)
 
     let apply_right (Modality (Meet_const c)) m =
       Mode.imply_const_unhint c (Mode.unhint (Mode.meet [Mode.of_const c; m]))
@@ -7813,7 +7829,7 @@ module Crossing = struct
   let apply_left_unhint t { monadic; comonadic } =
     let monadic = Monadic.apply_left t.monadic monadic in
     let comonadic =
-      Comonadic.apply_left t.comonadic (S.Unhint.unhint comonadic)
+      Comonadic.apply_left_unhint t.comonadic (S.Unhint.unhint comonadic)
     in
     { monadic; comonadic }
 
@@ -7822,7 +7838,9 @@ module Crossing = struct
       (apply_left_unhint t (Value.disallow_right m))
 
   let apply_right_unhint t { monadic; comonadic } =
-    let monadic = Monadic.apply_right t.monadic (S.Unhint.unhint monadic) in
+    let monadic =
+      Monadic.apply_right_unhint t.monadic (S.Unhint.unhint monadic)
+    in
     let comonadic = Comonadic.apply_right t.comonadic comonadic in
     { monadic; comonadic }
 
@@ -7859,14 +7877,6 @@ module Crossing = struct
     in
     { comonadic; monadic }
 
-  let comonadic_locality_as_regionality comonadic =
-    S.Unhint.apply Value.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Locality_as_regionality))) comonadic
-
-  let comonadic_regional_to_local comonadic =
-    S.Unhint.apply Alloc.Comonadic.Obj.obj
-      (Simple (Core (Locality_full Regional_to_local))) comonadic
-
   let apply_left_alloc t m =
     m |> alloc_as_value |> apply_left_unhint t |> value_to_alloc_r2l_unhint
     |> Alloc.hint ~comonadic:Crossing ~monadic:Crossing
@@ -7877,10 +7887,10 @@ module Crossing = struct
 
   let apply_left_right_alloc t m =
     let { monadic; comonadic } = Alloc.unhint m in
-    let monadic = Monadic.apply_right t.monadic monadic in
+    let monadic = Monadic.apply_right_unhint t.monadic monadic in
     let comonadic =
       comonadic |> comonadic_locality_as_regionality
-      |> Comonadic.apply_left t.comonadic
+      |> Comonadic.apply_left_unhint t.comonadic
       |> comonadic_regional_to_local
       (* the left adjoint of [locality_as_regionality]*)
     in

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -749,6 +749,9 @@ module type S = sig
       (** Similar to [comonadic_to_monadic_min] but for constants *)
       val comonadic_to_monadic_min : Comonadic.Const.t -> Monadic.Const.t
 
+      (** Similar to [monadic_to_comonadic_min] but for constants *)
+      val monadic_to_comonadic_min : Monadic.Const.t -> Comonadic.Const.t
+
       (** Prints a constant on any axis. *)
       val print_axis : 'a Axis.t -> Fmt.formatter -> 'a -> unit
     end
@@ -1134,6 +1137,12 @@ module type S = sig
         visibility:Visibility.Const.t Atom.t ->
         staticity:Staticity.Const.t Atom.t ->
         t
+
+      (** Apply mode crossing on a right monadic [Alloc] fragment. *)
+      val apply_right_alloc :
+        t ->
+        (disallowed * 'r) Alloc.Monadic.t ->
+        (disallowed * 'r) Alloc.Monadic.t
     end
 
     module Comonadic : sig
@@ -1166,6 +1175,12 @@ module type S = sig
       (** Create the mode crossing for a type whose values are always
           constructed at the given mode. *)
       val always_constructed_at : Value.Comonadic.Const.t -> t
+
+      (** Apply mode crossing on a left comonadic [Alloc] fragment. *)
+      val apply_left_alloc :
+        t ->
+        ('l * disallowed) Alloc.Comonadic.t ->
+        ('l * disallowed) Alloc.Comonadic.t
     end
 
     (** The mode crossing capability on all axes, split into monadic and

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -739,6 +739,9 @@ module type S = sig
       (** Similar to [comonadic_to_monadic_min] but for constants *)
       val comonadic_to_monadic_min : Comonadic.Const.t -> Monadic.Const.t
 
+      (** Similar to [monadic_to_comonadic_min] but for constants *)
+      val monadic_to_comonadic_min : Monadic.Const.t -> Comonadic.Const.t
+
       (** Prints a constant on any axis. *)
       val print_axis : 'a Axis.t -> Fmt.formatter -> 'a -> unit
     end
@@ -1112,6 +1115,12 @@ module type S = sig
         visibility:Visibility.Const.t Atom.t ->
         staticity:Staticity.Const.t Atom.t ->
         t
+
+      (** Apply mode crossing on a right monadic [Alloc] fragment. *)
+      val apply_right_alloc :
+        t ->
+        (disallowed * 'r) Alloc.Monadic.t ->
+        (disallowed * 'r) Alloc.Monadic.t
     end
 
     module Comonadic : sig
@@ -1144,6 +1153,12 @@ module type S = sig
       (** Create the mode crossing for a type whose values are always
           constructed at the given mode. *)
       val always_constructed_at : Value.Comonadic.Const.t -> t
+
+      (** Apply mode crossing on a left comonadic [Alloc] fragment. *)
+      val apply_left_alloc :
+        t ->
+        ('l * disallowed) Alloc.Comonadic.t ->
+        ('l * disallowed) Alloc.Comonadic.t
     end
 
     (** The mode crossing capability on all axes, split into monadic and

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1191,15 +1191,13 @@ let has_poly_constraint spat =
   | _ -> false
 
 (** Mode cross a right monadic mode fragment *)
-let alloc_monadic_mode_cross_to_min env ty monadic =
+let alloc_monadic_mode_cross_to_min (crossing : Crossing.t) monadic =
   let monadic = Alloc.Monadic.disallow_left monadic in
-  let crossing = crossing_of_ty env ty in
   Crossing.Monadic.apply_right_alloc crossing.monadic monadic
 
 (** Mode cross a left comonadic mode fragment *)
-let alloc_comonadic_mode_cross_to_max env ty comonadic =
+let alloc_comonadic_mode_cross_to_max (crossing : Crossing.t) comonadic =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
-  let crossing = crossing_of_ty env ty in
   Crossing.Comonadic.apply_left_alloc crossing.comonadic comonadic
 
 (** Mode cross a right mode *)
@@ -6385,8 +6383,10 @@ let split_function_ty
       end
     end
   in
-  let env_mode, _ = Alloc.newvar_above arg_mode in
-  let arg_value_mode = alloc_to_value_l2r env_mode in
+  let env_monadic, _ = Alloc.Monadic.newvar_above arg_mode.monadic in
+  let arg_value_mode =
+    alloc_to_value_l2r { arg_mode with monadic = env_monadic }
+  in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
     match Ctype.type_sort ~why ~fixed:false env ty with
@@ -6399,7 +6399,7 @@ let split_function_ty
   { filtered_arrow; arg_sort; ret_sort;
     alloc_mode; closure_mode=closure_mode.comonadic; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
-    really_poly; env_mode=(Alloc.Monadic.disallow_left env_mode.monadic)
+    really_poly; env_mode=(Alloc.Monadic.disallow_left env_monadic)
   }
 
 type type_function_result_param =
@@ -9540,12 +9540,13 @@ and type_function
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
+                  let crossing = crossing_of_ty env ty_arg in
                   let arg_mode =
-                    alloc_comonadic_mode_cross_to_max env ty_arg
+                    alloc_comonadic_mode_cross_to_max crossing
                       arg_mode.comonadic
                   in
                   let env_mode =
-                    alloc_monadic_mode_cross_to_min env ty_arg env_mode
+                    alloc_monadic_mode_cross_to_min crossing env_mode
                   in
                   let cls_details : Mode.Hint.closure_details =
                     { closure = (loc, Function);

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6383,7 +6383,11 @@ let split_function_ty
       end
     end
   in
-  let env_monadic, _ = Alloc.Monadic.newvar_above arg_mode.monadic in
+  let env_monadic =
+    if is_final_val_param
+    then arg_mode.monadic
+    else fst (Alloc.Monadic.newvar_above arg_mode.monadic)
+  in
   let arg_value_mode =
     alloc_to_value_l2r { arg_mode with monadic = env_monadic }
   in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4795,7 +4795,7 @@ let check_curried_application_complete ~env ~app_loc args =
           raise (Error(loc, env, Curried_application_complete (lbl, e, loc_kind)))
       in
       submode (Alloc.partial_apply mode_fun) mode_ret;
-      submode (Alloc.close_over mode_arg) mode_ret;
+      submode (Alloc.partial_apply mode_arg) mode_ret;
       loop has_commuted rest
   in
   loop false args

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -306,7 +306,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
-  | Uncurried_function_escapes of Alloc.error
+  | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -1190,13 +1190,17 @@ let has_poly_constraint spat =
     end
   | _ -> false
 
-(** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
-    fragment is a left mode. *)
-let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
+(** Mode cross a right monadic mode fragment *)
+let alloc_monadic_mode_cross_to_min env ty monadic =
   let monadic = Alloc.Monadic.disallow_left monadic in
+  let crossing = crossing_of_ty env ty in
+  Crossing.Monadic.apply_right_alloc crossing.monadic monadic
+
+(** Mode cross a left comonadic mode fragment *)
+let alloc_comonadic_mode_cross_to_max env ty comonadic =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
   let crossing = crossing_of_ty env ty in
-  Crossing.apply_left_right_alloc crossing { monadic; comonadic }
+  Crossing.Comonadic.apply_left_alloc crossing.comonadic comonadic
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
@@ -6289,7 +6293,8 @@ type split_function_ty =
        needs to be a right mode for making sure
        arguments generate a lower bound for subsequent closures.
        [alloc_mode] tracks the locality component to store in the Typedtree. *)
-    closure_mode: Mode.Alloc.lr;
+    closure_mode: Mode.Alloc.Comonadic.lr;
+    env_mode: Mode.Alloc.Monadic.r;
     alloc_mode: Locality.lr;
     really_poly: bool
   }
@@ -6380,7 +6385,8 @@ let split_function_ty
       end
     end
   in
-  let arg_value_mode = alloc_to_value_l2r arg_mode in
+  let env_mode, _ = Alloc.newvar_above arg_mode in
+  let arg_value_mode = alloc_to_value_l2r env_mode in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
     match Ctype.type_sort ~why ~fixed:false env ty with
@@ -6391,9 +6397,9 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; closure_mode; ty_arg_mono;
+    alloc_mode; closure_mode=closure_mode.comonadic; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
-    really_poly
+    really_poly; env_mode=(Alloc.Monadic.disallow_left env_mode.monadic)
   }
 
 type type_function_result_param =
@@ -6404,7 +6410,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr;
   }
 
 module Calling_convention_sort : sig
@@ -9445,7 +9451,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; closure_mode; really_poly
+            alloc_mode; closure_mode; really_poly; env_mode
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9534,22 +9540,40 @@ and type_function
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
-                  let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
+                  let arg_mode =
+                    alloc_comonadic_mode_cross_to_max env ty_arg
+                      arg_mode.comonadic
+                  in
+                  let env_mode =
+                    alloc_monadic_mode_cross_to_min env ty_arg env_mode
+                  in
+                  let cls_details : Mode.Hint.closure_details =
+                    { closure = (loc, Function);
+                      closed = (pparam_loc, Pattern) }
+                  in
+                  let hint : _ Hint.morph =
+                    Is_closed_by (Monadic, cls_details)
+                  in
+                  Alloc.Monadic.submode_err (pparam_loc, Pattern)
+                    (Alloc.comonadic_to_monadic_min ~hint fun_closure_mode)
+                    env_mode;
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
+                    Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.submode
-                      (Alloc.partial_apply closure_mode)
+                    Alloc.Comonadic.submode
+                      (Alloc.Comonadic.disallow_right closure_mode)
                       fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   More_args
                     { partial_mode =
@@ -12104,8 +12128,8 @@ and type_n_ary_function
     in
     let yielding =
       Yielding.join
-        (Alloc.proj_comonadic Yielding
-           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+        (Alloc.Comonadic.proj Yielding
+           (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
          :: param_yieldings)
     in
     re
@@ -13610,19 +13634,21 @@ let report_error ~loc env =
         but was expected to %s which is %a.@]"
         desc (Style.as_inline_code (Alloc.Const.print_axis ax)) actual
         desc_inf (Style.as_inline_code (Alloc.Const.print_axis ax)) expected
-  | Uncurried_function_escapes e -> begin
-      let Mode.Alloc.Error (ax, {left; right}) = Mode.Alloc.to_simple_error e in
+  | Uncurried_function_escapes_comonadic e -> begin
+      let Mode.Alloc.Comonadic.Error (ax, {left; right}) =
+        Mode.Alloc.Comonadic.to_simple_error e
+      in
       match ax with
-      | Comonadic Areality ->
-          Location.errorf ~loc
+      | Areality ->
+        Location.errorf ~loc
             "This function or one of its parameters escape their region@ \
             when it is partially applied."
       | _ ->
-          Location.errorf ~loc
+        Location.errorf ~loc
             "This function when partially applied returns a value which is %a,@ \
               but expected to be %a."
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) left
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) right
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6351,7 +6351,11 @@ let split_function_ty
       end
     end
   in
-  let env_monadic, _ = Alloc.Monadic.newvar_above arg_mode.monadic in
+  let env_monadic =
+    if is_final_val_param
+    then arg_mode.monadic
+    else fst (Alloc.Monadic.newvar_above arg_mode.monadic)
+  in
   let arg_value_mode =
     alloc_to_value_l2r { arg_mode with monadic = env_monadic }
   in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1186,15 +1186,13 @@ let has_poly_constraint spat =
   | _ -> false
 
 (** Mode cross a right monadic mode fragment *)
-let alloc_monadic_mode_cross_to_min env ty monadic =
+let alloc_monadic_mode_cross_to_min (crossing : Crossing.t) monadic =
   let monadic = Alloc.Monadic.disallow_left monadic in
-  let crossing = crossing_of_ty env ty in
   Crossing.Monadic.apply_right_alloc crossing.monadic monadic
 
 (** Mode cross a left comonadic mode fragment *)
-let alloc_comonadic_mode_cross_to_max env ty comonadic =
+let alloc_comonadic_mode_cross_to_max (crossing : Crossing.t) comonadic =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
-  let crossing = crossing_of_ty env ty in
   Crossing.Comonadic.apply_left_alloc crossing.comonadic comonadic
 
 (** Mode cross a right mode *)
@@ -6353,8 +6351,10 @@ let split_function_ty
       end
     end
   in
-  let env_mode, _ = Alloc.newvar_above arg_mode in
-  let arg_value_mode = alloc_to_value_l2r env_mode in
+  let env_monadic, _ = Alloc.Monadic.newvar_above arg_mode.monadic in
+  let arg_value_mode =
+    alloc_to_value_l2r { arg_mode with monadic = env_monadic }
+  in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
     match Ctype.type_sort ~why ~fixed:false env ty with
@@ -6367,7 +6367,7 @@ let split_function_ty
   { filtered_arrow; arg_sort; ret_sort;
     alloc_mode; closure_mode=closure_mode.comonadic; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
-    really_poly; env_mode=(Alloc.Monadic.disallow_left env_mode.monadic)
+    really_poly; env_mode=(Alloc.Monadic.disallow_left env_monadic)
   }
 
 type type_function_result_param =
@@ -9411,12 +9411,13 @@ and type_function
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
+                  let crossing = crossing_of_ty env ty_arg in
                   let arg_mode =
-                    alloc_comonadic_mode_cross_to_max env ty_arg
+                    alloc_comonadic_mode_cross_to_max crossing
                       arg_mode.comonadic
                   in
                   let env_mode =
-                    alloc_monadic_mode_cross_to_min env ty_arg env_mode
+                    alloc_monadic_mode_cross_to_min crossing env_mode
                   in
                   let cls_details : Mode.Hint.closure_details =
                     { closure = (loc, Function);

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -305,7 +305,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Alloc.equate_error
-  | Uncurried_function_escapes of Alloc.error
+  | Uncurried_function_escapes_comonadic of Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]
@@ -1185,13 +1185,17 @@ let has_poly_constraint spat =
     end
   | _ -> false
 
-(** Mode cross a mode whose monadic fragment is a right mode, and whose comonadic
-    fragment is a left mode. *)
-let alloc_mode_cross_to_max_min env ty { monadic; comonadic } =
+(** Mode cross a right monadic mode fragment *)
+let alloc_monadic_mode_cross_to_min env ty monadic =
   let monadic = Alloc.Monadic.disallow_left monadic in
+  let crossing = crossing_of_ty env ty in
+  Crossing.Monadic.apply_right_alloc crossing.monadic monadic
+
+(** Mode cross a left comonadic mode fragment *)
+let alloc_comonadic_mode_cross_to_max env ty comonadic =
   let comonadic = Alloc.Comonadic.disallow_right comonadic in
   let crossing = crossing_of_ty env ty in
-  Crossing.apply_left_right_alloc crossing { monadic; comonadic }
+  Crossing.Comonadic.apply_left_alloc crossing.comonadic comonadic
 
 (** Mode cross a right mode *)
 (* This is very similar to Ctype.mode_cross_right. Any bugs here are likely bugs
@@ -6257,7 +6261,8 @@ type split_function_ty =
        needs to be a right mode for making sure
        arguments generate a lower bound for subsequent closures.
        [alloc_mode] tracks the locality component to store in the Typedtree. *)
-    closure_mode: Mode.Alloc.lr;
+    closure_mode: Mode.Alloc.Comonadic.lr;
+    env_mode: Mode.Alloc.Monadic.r;
     alloc_mode: Locality.lr;
     really_poly: bool
   }
@@ -6348,7 +6353,8 @@ let split_function_ty
       end
     end
   in
-  let arg_value_mode = alloc_to_value_l2r arg_mode in
+  let env_mode, _ = Alloc.newvar_above arg_mode in
+  let arg_value_mode = alloc_to_value_l2r env_mode in
   let expected_pat_mode = simple_pat_mode arg_value_mode in
   let type_sort ~why ty =
     match Ctype.type_sort ~why ~fixed:false env ty with
@@ -6359,9 +6365,9 @@ let split_function_ty
   let ret_sort = type_sort ~why:Function_result ty_ret in
   env,
   { filtered_arrow; arg_sort; ret_sort;
-    alloc_mode; closure_mode; ty_arg_mono;
+    alloc_mode; closure_mode=closure_mode.comonadic; ty_arg_mono;
     expected_inner_mode; expected_pat_mode;
-    really_poly
+    really_poly; env_mode=(Alloc.Monadic.disallow_left env_mode.monadic)
   }
 
 type type_function_result_param =
@@ -6372,7 +6378,7 @@ type type_function_result_param =
 
 type fun_alloc_mode =
   { alloc_mode: Locality.lr;
-    fun_closure_mode: Mode.Alloc.lr;
+    fun_closure_mode: Mode.Alloc.Comonadic.lr;
   }
 
 (* The result of calling [type_function]. For the outer call to
@@ -9317,7 +9323,7 @@ and type_function
           { filtered_arrow = { ty_arg; arg_mode; ty_ret; ret_mode };
             arg_sort; ret_sort;
             ty_arg_mono; expected_pat_mode; expected_inner_mode;
-            alloc_mode; closure_mode; really_poly
+            alloc_mode; closure_mode; really_poly; env_mode
           } =
         split_function_ty env expected_mode ty_expected loc
           ~is_first_val_param:first ~is_final_val_param
@@ -9405,22 +9411,40 @@ and type_function
                      uses the [arg_mode.comonadic] as a left mode, and
                      [arg_mode.monadic] as a right mode, hence they need to be
                      mode-crossed differently. *)
-                  let arg_mode = alloc_mode_cross_to_max_min env ty_arg arg_mode in
+                  let arg_mode =
+                    alloc_comonadic_mode_cross_to_max env ty_arg
+                      arg_mode.comonadic
+                  in
+                  let env_mode =
+                    alloc_monadic_mode_cross_to_min env ty_arg env_mode
+                  in
+                  let cls_details : Mode.Hint.closure_details =
+                    { closure = (loc, Function);
+                      closed = (pparam_loc, Pattern) }
+                  in
+                  let hint : _ Hint.morph =
+                    Is_closed_by (Monadic, cls_details)
+                  in
+                  Alloc.Monadic.submode_err (pparam_loc, Pattern)
+                    (Alloc.comonadic_to_monadic_min ~hint fun_closure_mode)
+                    env_mode;
                   begin match
-                    Alloc.submode (Alloc.close_over arg_mode) fun_closure_mode
+                    Alloc.Comonadic.submode arg_mode fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   begin match
-                    Alloc.submode
-                      (Alloc.partial_apply closure_mode)
+                    Alloc.Comonadic.submode
+                      (Alloc.Comonadic.disallow_right closure_mode)
                       fun_closure_mode
                   with
                     | Ok () -> ()
                     | Error e ->
-                      raise (Error(loc_fun, env, Uncurried_function_escapes e))
+                      raise (Error(loc_fun, env,
+                        Uncurried_function_escapes_comonadic e))
                   end;
                   More_args
                     { partial_mode =
@@ -11926,8 +11950,8 @@ and type_n_ary_function
     in
     let yielding =
       Yielding.join
-        (Alloc.proj_comonadic Yielding
-           (Alloc.disallow_right fun_alloc_mode.fun_closure_mode)
+        (Alloc.Comonadic.proj Yielding
+           (Alloc.Comonadic.disallow_right fun_alloc_mode.fun_closure_mode)
          :: param_yieldings)
     in
     re
@@ -13425,19 +13449,21 @@ let report_error ~loc env =
         but was expected to %s which is %a.@]"
         desc (Style.as_inline_code (Alloc.Const.print_axis ax)) actual
         desc_inf (Style.as_inline_code (Alloc.Const.print_axis ax)) expected
-  | Uncurried_function_escapes e -> begin
-      let Mode.Alloc.Error (ax, {left; right}) = Mode.Alloc.to_simple_error e in
+  | Uncurried_function_escapes_comonadic e -> begin
+      let Mode.Alloc.Comonadic.Error (ax, {left; right}) =
+        Mode.Alloc.Comonadic.to_simple_error e
+      in
       match ax with
-      | Comonadic Areality ->
-          Location.errorf ~loc
+      | Areality ->
+        Location.errorf ~loc
             "This function or one of its parameters escape their region@ \
             when it is partially applied."
       | _ ->
-          Location.errorf ~loc
+        Location.errorf ~loc
             "This function when partially applied returns a value which is %a,@ \
               but expected to be %a."
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) left
-            (Style.as_inline_code (Alloc.Const.print_axis ax)) right
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) left
+            (Style.as_inline_code (Alloc.Const.print_axis (Comonadic ax))) right
     end
   | Bad_tail_annotation err ->
       Location.errorf ~loc

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -379,7 +379,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
-  | Uncurried_function_escapes of Mode.Alloc.error
+  | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -351,7 +351,7 @@ type error =
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
   | Mode_mismatch of mode_mismatch_kind * Mode.Alloc.equate_error
-  | Uncurried_function_escapes of Mode.Alloc.error
+  | Uncurried_function_escapes_comonadic of Mode.Alloc.Comonadic.error
   | Function_returns_local
   | Tail_call_local_returning
   | Bad_tail_annotation of [`Conflict|`Not_a_tailcall]


### PR DESCRIPTION
Previously, in a curried function `fun a () -> ...` , the parameter `a` 's full mode was fed into `close_over`, so an argument's monadic mode (e.g.  `unique`,  `uncontended`,  `read_write`) forced the inner closure to a its dual mode (in this case `once`, `nonportable`, `stateful`) *even when  a  was never used in the body of the function*.

This is sound but restrictive. This PR imposes a constraint on the monadic part of a curry mode based on uses of the argument.

 As a result, we get: 
```
(* Accepted now (was rejected before): [a] is uncontended but never used, 
    so the closure can still be portable. *) 
  let foo : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> ()

(* Still rejected: [a] is actually used uncontendedly inside the closure.
    The error now points at the pattern [a] instead of the whole function. *)                                                                                                                                                                                 
  let use_uncontended (x @ uncontended) = ()

  let bar : 'a @ uncontended portable -> (unit -> unit) @ portable = fun a () -> use_uncontended a
```

Various test files have been updated to reflect this change. In particular, `typing-modes/portable-contend.ml` contains new relevant tests to showcase the above cases.