### PR TITLE
flambda2: Vibe-coded test case for (Claude-confirmed) latent flambda2 bug

### DIFF
--- a/middle_end/flambda2/tests/tools/dune
+++ b/middle_end/flambda2/tests/tools/dune
@@ -2,5 +2,6 @@
   (names fldiff fexprc roundtrip)
   (modes native)
   (libraries
-   ocamlcommon ocamloptcomp
-   flambda2 flambda2_compare flambda2_parser flambda2_terms flambda2_cmx))
+   ocamlcommon ocamloptcomp unix
+   flambda2 flambda2_compare flambda2_parser flambda2_terms flambda2_cmx
+   flambda2_to_cmm))

--- a/middle_end/flambda2/tests/tools/fexprc.ml
+++ b/middle_end/flambda2/tests/tools/fexprc.ml
@@ -24,23 +24,88 @@ let parse_flambda filename =
     Test_utils.dump_error e;
     exit 1
 
+(* Compile all the way to an executable and run it, so that the runtime
+   behaviour of fexpr code can be observed. This exercises To_cmm and the
+   backend, unlike [parse_flambda] above, which stops after Simplify. The
+   program's output goes to fexprc's stdout/stderr (we exec the program), so the
+   check-program-output ocamltest action can compare it to a reference. *)
+let compile_and_run filename =
+  match Parse_flambda.parse_fexpr filename with
+  | Error e ->
+    Test_utils.dump_error e;
+    exit 1
+  | Ok unit ->
+    let unit_info = Parse_flambda.make_unit_info ~filename in
+    let comp_unit = Unit_info.modname unit_info in
+    Env.set_current_unit unit_info;
+    Compilenv.reset unit_info;
+    let fl2 = Fexpr_to_flambda.conv comp_unit unit in
+    check_invariants fl2.unit;
+    let pipeline ~ppf_dump ~prefixname (_ : Lambda.program) =
+      let { Flambda2.flambda; all_code; offsets; reachable_names } =
+        Flambda2.flambda_to_flambda ~ppf_dump ~prefixname
+          ~machine_width:Sixty_four ~code_slot_offsets:fl2.code_slot_offsets
+          fl2.unit
+      in
+      Flambda2_to_cmm.To_cmm.unit flambda ~all_code ~offsets ~reachable_names
+    in
+    let main_module_block_format : Lambda.main_module_block_format =
+      Mb_struct { mb_repr = Module_value_only { field_count = 0 } }
+    in
+    let program : Lambda.program =
+      { compilation_unit = comp_unit;
+        main_module_block_format;
+        arg_block_idx = None;
+        required_globals = Compilation_unit.Set.empty;
+        code = Lambda.lambda_unit
+      }
+    in
+    let prefixname = Filename.chop_extension filename in
+    Asmgen.compile_implementation
+      (module Unix : Compiler_owee.Unix_intf.S)
+      ~pipeline:(Direct_to_cmm pipeline) ~sourcefile:(Some filename) ~prefixname
+      ~ppf_dump:Format.std_formatter program;
+    Compilenv.save_unit_info (prefixname ^ ".cmx") ~main_module_block_format
+      ~arg_descr:None;
+    Compmisc.init_path ();
+    let module Compiler =
+      (val Optcompile.native
+             (module Unix : Compiler_owee.Unix_intf.S)
+             ~flambda2:Flambda2.lambda_to_cmm)
+    in
+    let exe = prefixname ^ ".exe" in
+    Compiler.link ~ppf_dump:Format.err_formatter [prefixname ^ ".cmx"] exe;
+    Format.pp_print_flush Format.std_formatter ();
+    Format.pp_print_flush Format.err_formatter ();
+    flush stdout;
+    flush stderr;
+    Unix.execv exe [| exe |]
+
 module Options = Oxcaml_args.Make_optcomp_options (Oxcaml_args.Default.Optmain)
 
 let _ =
   (* Setting [Clflags.native_code := true] is how we tell the option parsing
      machinery that we are going to use flambda2. *)
   Clflags.native_code := true;
+  let run_mode = ref false in
   let file_action = ref (fun () -> Misc.fatal_error "Missing a flambda file") in
   let defer_file file =
     let ext = Filename.extension file in
     match ext with
-    | ".fl" -> file_action := fun () -> parse_flambda file
+    | ".fl" ->
+      file_action
+        := fun () ->
+             if !run_mode
+             then compile_and_run file
+             else ignore (parse_flambda file : Flambda2.flambda_result)
     | _ -> Misc.fatal_errorf "Unrecognized extension %s" ext
   in
   Compenv.warnings_for_discarded_params := true;
   Compenv.set_extra_params (Some Oxcaml_args.Extra_params.read_param);
   Compenv.readenv Format.err_formatter Before_args;
-  Clflags.add_arguments __LOC__ (Arch.command_line_options @ Options.list);
+  Clflags.add_arguments __LOC__
+    (("-run", Arg.Set run_mode, " Compile to an executable and run it")
+    :: (Arch.command_line_options @ Options.list));
   Clflags.Opt_flag_handler.set Oxcaml_flags.opt_flag_handler;
   Compenv.parse_arguments (ref Sys.argv) defer_file "fexprc";
   Location.read_clflags_from_env ();

--- a/testsuite/tests/flambda2/static_boxed_int64_var_payload.fl
+++ b/testsuite/tests/flambda2/static_boxed_int64_var_payload.fl
@@ -1,0 +1,142 @@
+(* TEST
+ flambda2;
+ setup-simple-build-env;
+ ocamlopt_flags = "-run";
+ fexpr;
+*)
+
+(* KNOWN-FAILURE test for a To_cmm bug with statically-allocated boxed numbers
+   whose payload is an [Or_variable.Var] (found by the Flambda 2 formalism
+   effort).
+
+   [To_cmm_static.static_boxed_number] emits the deferred update for a static
+   [Boxed_int32]/[Boxed_int64]/[Boxed_nativeint]/[Boxed_float32] with a
+   variable payload at field index 0 of the block. These four are custom
+   blocks: word 0 is the custom_operations pointer and the payload lives at
+   offset 8. The update therefore clobbers the ops pointer (with the boxed
+   value of the variable) and never writes the payload, which keeps its
+   default value 0. ([Boxed_float] is unaffected: its payload really is at
+   field 0.)
+
+   No production pass currently creates [Var] payloads for these four kinds
+   (lifting always produces [Const]), so the bug is latent in ordinary
+   compilation, but it is reachable through fexpr, as this test demonstrates.
+
+   The reference file INTENTIONALLY records the current buggy behaviour
+   ("payload=0" followed by the MISMATCH line). Once the bug is fixed, this
+   test will start failing; update the reference to the correct output:
+
+     payload=42
+     caml_compare=0
+
+   The program binds a static boxed int64 symbol [b] whose payload is the
+   variable [xv] (an opaque boxed 42L), reads the payload back through an
+   opaque copy of [b], and prints it. Only if the payload matches the input
+   (i.e. only once the bug is fixed) does it call [caml_compare] on [b] and
+   the boxed input, which exercises the custom_operations pointer; in the
+   buggy case that pointer is clobbered, so following it could crash. *)
+
+let $fmt = "%d" in
+let $msg_payload = "payload=" in
+let $msg_mismatch = "MISMATCH: deferred update did not write the payload" in
+let $msg_cmp = "caml_compare=" in
+let $c = 42L in
+let xv = %opaque ($c) in
+let $b = xv : int64 boxed in
+let bv = %opaque ($b) in
+let p = %unbox_num.`int64` (bv) in
+let x = %unbox_num.`int64` (xv) in
+(apply ccall &toplevel.alloc_region
+   ($`*extern*`.caml_ml_open_descriptor_out : val -> val)
+   (1)
+   -> k_ch * error
+ where k_ch (ch) =
+   let len1 = %string_length ($msg_payload) in
+   let len1t = %tag_imm (len1) in
+   (apply ccall &toplevel.alloc_region
+      ($`*extern*`.caml_ml_output : val * val * val * val -> val)
+      (ch, $msg_payload, 0, len1t)
+      -> k1 * error
+    where k1 (u1) =
+      (apply ccall &toplevel.alloc_region
+         ($`*extern*`.caml_int64_format : val * val -> val)
+         ($fmt, bv)
+         -> k2 * error
+       where k2 (s2) =
+         let len2 = %string_length (s2) in
+         let len2t = %tag_imm (len2) in
+         (apply ccall &toplevel.alloc_region
+            ($`*extern*`.caml_ml_output : val * val * val * val -> val)
+            (ch, s2, 0, len2t)
+            -> k3 * error
+          where k3 (u3) =
+            (apply ccall &toplevel.alloc_region
+               ($`*extern*`.caml_ml_output_char : val * val -> val)
+               (ch, 10)
+               -> k4 * error
+             where k4 (u4) =
+               let eq = %int_comp.`int64`.eq (p, x) in
+               (switch eq
+                | 0 -> k_bad
+                | 1 -> k_good
+                where k_bad =
+                  let len5 = %string_length ($msg_mismatch) in
+                  let len5t = %tag_imm (len5) in
+                  (apply ccall &toplevel.alloc_region
+                     ($`*extern*`.caml_ml_output : val * val * val * val -> val)
+                     (ch, $msg_mismatch, 0, len5t)
+                     -> k5 * error
+                   where k5 (u5) =
+                     cont k_nl
+                  )
+                where k_good =
+                  let len6 = %string_length ($msg_cmp) in
+                  let len6t = %tag_imm (len6) in
+                  (apply ccall &toplevel.alloc_region
+                     ($`*extern*`.caml_ml_output : val * val * val * val -> val)
+                     (ch, $msg_cmp, 0, len6t)
+                     -> k6 * error
+                   where k6 (u6) =
+                     (apply ccall &toplevel.alloc_region
+                        ($`*extern*`.caml_compare : val * val -> val)
+                        (bv, xv)
+                        -> k7 * error
+                      where k7 (r7) =
+                        (apply ccall &toplevel.alloc_region
+                           ($`*extern*`.caml_format_int : val * val -> val)
+                           ($fmt, r7)
+                           -> k8 * error
+                         where k8 (s8) =
+                           let len8 = %string_length (s8) in
+                           let len8t = %tag_imm (len8) in
+                           (apply ccall &toplevel.alloc_region
+                              ($`*extern*`.caml_ml_output : val * val * val * val -> val)
+                              (ch, s8, 0, len8t)
+                              -> k9 * error
+                            where k9 (u9) =
+                              cont k_nl
+                           )
+                        )
+                     )
+                  )
+                where k_nl =
+                  (apply ccall &toplevel.alloc_region
+                     ($`*extern*`.caml_ml_output_char : val * val -> val)
+                     (ch, 10)
+                     -> k10 * error
+                   where k10 (u10) =
+                     (apply ccall &toplevel.alloc_region
+                        ($`*extern*`.caml_ml_flush : val -> val)
+                        (ch)
+                        -> k11 * error
+                      where k11 (u11) =
+                        let $camlStatic_boxed_int64_var_payload = Block 0 () in
+                        cont done ($camlStatic_boxed_int64_var_payload)
+                     )
+                  )
+               )
+            )
+         )
+      )
+   )
+)

--- a/testsuite/tests/flambda2/static_boxed_int64_var_payload.reference
+++ b/testsuite/tests/flambda2/static_boxed_int64_var_payload.reference
@@ -1,0 +1,2 @@
+payload=0
+MISMATCH: deferred update did not write the payload


### PR DESCRIPTION
(Original title from Claude: flambda2: add known-failure test for static boxed-number Var-payload …)

…update bug

to_cmm emits the deferred static update for a statically-allocated boxed number whose payload is an [Or_variable.Var] at field index 0 of the block ([To_cmm_static.static_boxed_number] passes [~index:0] to [To_cmm_shared.make_update]). For [Boxed_int32], [Boxed_int64], [Boxed_nativeint] and [Boxed_float32] the static block is a custom block: word 0 is the custom_operations pointer and the payload lives at byte offset 8 (see [emit_int32_constant] etc. in cmm_helpers.ml). The update therefore clobbers the custom_operations pointer and never writes the payload, which keeps its default value 0. ([Boxed_float] and the boxed vector kinds keep their payload at field 0, so they do not have the addressing problem.)

There is a second inconsistency: Simplify
([Simplify_static_const.simplify_static_const_of_kind_value]) requires the [Var] payload to have kind [Value], i.e. to be the boxed value itself, while [make_update] stores the variable's Cmm value raw under a naked-number update kind - so even at the correct offset the update would store the pointer to the boxed value rather than the unboxed payload.

The bug is latent in production: no pass creates [Var] payloads for boxed numbers (lifting reification only produces [Const]; closure conversion only produces [Var] payloads inside float records). It is, however, reachable through the fexpr parser, which accepts [Var] payloads for all boxed kinds, and it is then observable at runtime, as this test demonstrates.

Predicted and observed behaviour agree: the payload of the static boxed int64 reads back 0 (never written), and word 0 is overwritten with the pointer to the boxed input value, so invoking polymorphic operations on the symbol would follow a garbage custom_operations pointer. The generated Cmm (via -dcmm) shows the static data and the misdirected store:

  (data int 3071 "b": addr G:"caml_int64_ops" int 0)
  ...
  (let xv (opaque L:"c") (store int(init) L:"b" xv) ...)

i.e. the store targets L:"b" + 0 (the caml_int64_ops word) instead of L:"b" + 8, and stores the boxed pointer rather than the unboxed payload.

Since no committed harness could run fexpr code, this patch gives fexprc a [-run] flag that continues past Simplify through To_cmm and Asmgen, links the resulting .cmx into an executable and execs it, so the program's runtime output is captured as fexprc's output and can be compared by the existing check-program-output action of the ocamltest [fexpr] test.

The test is committed as a KNOWN FAILURE: its .reference file intentionally records the current buggy output ("payload=0" plus a MISMATCH line). The witness only performs the polymorphic-compare step (which dereferences the custom_operations pointer) if the payload read back correctly, to avoid crashing on the clobbered pointer while the bug is present. When the bug is fixed, this test will start failing and the reference should be updated to the correct output:

  payload=42
  caml_compare=0

Fix pointer: the four affected calls in to_cmm_static.ml need to address field 1 rather than field 0 for these custom-block kinds, and the update path needs to agree with Simplify on the [Var] convention: either the variable is the boxed value (then unbox before storing) or it is the naked payload (then fix Simplify's kind check).

Found by the flambda2 formalism effort (finding KF-040); the formalism documents live on a separate branch.