### PR TITLE
Rename `code` to `expr` internally in `Predef`

### DIFF
--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -429,7 +429,7 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 tree_of_lazy depth obj ty_arg
 
               | Tconstr (path, [_], _)
-                when Path.same path Predef.path_code ->
+                when Path.same path Predef.path_expr ->
                 Oval_code (O.obj obj : CamlinternalQuote.Code.t)
 
               | _ ->

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -50,7 +50,7 @@ type abstract_type_constr = [
   | `Iarray
   | `Atomic_loc
   | `Lexing_position
-  | `Code
+  | `Expr
   | `Eval
   | `Box
   | `Float32
@@ -181,7 +181,7 @@ let small_number_extension_type_constrs : type_constr list = [
 ]
 
 let metaprogramming_extension_type_constrs : type_constr list = [
-  `Code;
+  `Expr;
   `Eval;
 ]
 
@@ -220,9 +220,7 @@ and ident_floatarray = ident_create "floatarray"
 and ident_iarray = ident_create "iarray"
 and ident_atomic_loc = ident_create "atomic_loc"
 and ident_lexing_position = ident_create "lexing_position"
-(* CR metaprogramming aivaskovic: there is a question about naming;
-   keep `expr` for now instead of `code` *)
-and ident_code = ident_create "expr"
+and ident_expr = ident_create "expr"
 and ident_eval = ident_create "eval"
 and ident_box = ident_create "box"
 
@@ -283,7 +281,7 @@ let ident_of_type_constr : type_constr -> Ident.t = function
   | `Iarray -> ident_iarray
   | `Atomic_loc -> ident_atomic_loc
   | `Lexing_position -> ident_lexing_position
-  | `Code -> ident_code
+  | `Expr -> ident_expr
   | `Eval -> ident_eval
   | `Box -> ident_box
   | `Float32 -> ident_float32
@@ -357,7 +355,7 @@ and path_uint32_u = Pident ident_uint32_u
 and path_uint64_u = Pident ident_uint64_u
 and path_idx_imm = Pident ident_idx_imm
 and path_idx_mut = Pident ident_idx_mut
-and path_code = Pident ident_code
+and path_expr = Pident ident_expr
 and path_eval = Pident ident_eval
 and path_box = Pident ident_box
 
@@ -448,7 +446,7 @@ and type_floatarray = tconstr path_floatarray []
 and type_iarray t = tconstr path_iarray [t]
 and type_atomic_loc t = tconstr path_atomic_loc [t]
 and type_lexing_position = tconstr path_lexing_position []
-and type_code t = tconstr path_code [t]
+and type_expr t = tconstr path_expr [t]
 
 and type_unboxed_unit = tconstr path_unboxed_unit []
 and type_unboxed_bool = tconstr path_unboxed_bool []
@@ -995,7 +993,7 @@ let decl_of_type_constr type_constr =
          of_builtin Const.Builtin.immutable_data
            ~why:(Primitive ident_lexing_position))
        ()
-  | `Code ->
+  | `Expr ->
     decl1
        ~variance:Variance.covariant
        ~separability:Separability.Ind

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -34,7 +34,7 @@ type abstract_type_constr = [
   | `Iarray
   | `Atomic_loc
   | `Lexing_position
-  | `Code
+  | `Expr
   | `Eval
   | `Box
   | `Float32
@@ -116,7 +116,7 @@ val type_extension_constructor:type_expr
 val type_floatarray:type_expr
 val type_lexing_position:type_expr
 val type_atomic_loc:type_expr -> type_expr
-val type_code: type_expr -> type_expr
+val type_expr: type_expr -> type_expr
 val type_unboxed_unit: type_expr
 val type_unboxed_bool: type_expr
 val type_unboxed_float:type_expr
@@ -209,7 +209,7 @@ val path_extension_constructor: Path.t
 val path_floatarray: Path.t
 val path_continuation: Path.t
 val path_lexing_position: Path.t
-val path_code: Path.t
+val path_expr: Path.t
 val path_eval: Path.t
 val path_box: Path.t
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8727,7 +8727,7 @@ and type_expect_
         |> Env.add_closure_lock (loc, Quote) expected_comonadic_mode
       in
       let ty = newgenvar (Jkind.Builtin.any ~why:Inside_quote) in
-      let expr_ty = Predef.type_code (newgenty (Tquote ty)) in
+      let expr_ty = Predef.type_expr (newgenty (Tquote ty)) in
       with_explanation (fun () ->
         unify_exp_types loc env expr_ty (generic_instance ty_expected));
       (* If we are checking staged modes in the metaprogram,
@@ -8762,7 +8762,7 @@ and type_expect_
       if not magic_staged_modes then
         submode ~loc ~env ~reason:Other mode_splice expected_mode;
       let new_env = Env.enter_splice ~loc env in
-      let ty = Predef.type_code (newgenty (Tquote ty_expected)) in
+      let ty = Predef.type_expr (newgenty (Tquote ty_expected)) in
       let arg = type_expect new_env mode_spliced exp (mk_expected ty) in
       re {
         exp_desc = Texp_antiquotation arg;

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -247,7 +247,7 @@ let classify ~classify_product env ty layout : _ classification =
              | `Float64x8
              )
         -> Addr
-      | Some (`Lexing_position | `Code | `Eval | `Box)
+      | Some (`Lexing_position | `Expr | `Eval | `Box)
       | Some (#Predef.data_type_constr | #Predef.abstract_non_value_type_constr)
       | None ->
         try


### PR DESCRIPTION
Gets rid of the inconsistency in `Predef` where `expr` is referred to as `code`. Removes a stale CR as I'm pretty sure we're staying with `expr` (and even if we aren't we can just fix this later).

I was going to rename `CamlinternalQuote.Code`, too, but that is its own can of worms. I don't really follow why `Code.t` isn't just `Exp.t` (it only differs by the presence of an unused `_loc`...). 
There's also `Code.Closed.t` which is not used properly anyway (and which I'll fix in a next PR).