### PR TITLE
Add support for atomic block indices

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -738,37 +738,65 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         let element_size = Prim (Lsrint, [word_size; tagged_immediate 3]) in
         Sequence (comp_expr arg, element_size)
       | [] | _ :: _ :: _ -> wrong_arity ~expected:1)
-    | Pget_idx (layout, _) ->
+    | Pget_idx (layout, mut) ->
+      let prim =
+        match Lambda.access_atomicity mut with
+        | Nonatomic -> Ccall "caml_get_idx_bytecode"
+        | Atomic -> Ccall "caml_get_idx_atomic_bytecode"
+      in
       let elt = Lambda.mixed_block_element_of_layout layout in
-      copy_mixed_block_element elt (binary (Ccall "caml_get_idx_bytecode"))
-    | Pset_idx (layout, _) -> (
+      copy_mixed_block_element elt (binary prim)
+    | Pset_idx (layout, _, atomicity) -> (
       let elt = Lambda.mixed_block_element_of_layout layout in
       match args with
       | [arr; idx; value] ->
+        let prim =
+          match atomicity with
+          | Nonatomic -> Ccall "caml_set_idx_bytecode"
+          | Atomic -> Ccall "caml_set_idx_atomic_bytecode"
+        in
         let copied_value = copy_mixed_block_element elt (comp_expr value) in
-        Prim
-          ( Ccall "caml_set_idx_bytecode",
-            [comp_expr arr; comp_expr idx; copied_value] )
+        Prim (prim, [comp_expr arr; comp_expr idx; copied_value])
       | _ -> wrong_arity ~expected:3)
-    | Pget_ptr (layout, _) ->
+    | Pget_ptr (layout, mut) ->
+      let prim =
+        match Lambda.access_atomicity mut with
+        | Nonatomic -> Ccall "caml_get_ptr_bytecode"
+        | Atomic -> Ccall "caml_get_ptr_atomic_bytecode"
+      in
       let elt = Lambda.mixed_block_element_of_layout layout in
-      copy_mixed_block_element elt (unary (Ccall "caml_get_ptr_bytecode"))
-    | Pset_ptr (layout, _) -> (
+      copy_mixed_block_element elt (unary prim)
+    | Pset_ptr (layout, _, atomicity) -> (
       let elt = Lambda.mixed_block_element_of_layout layout in
       match args with
       | [ptr; value] ->
+        let prim =
+          match atomicity with
+          | Nonatomic -> Ccall "caml_set_ptr_bytecode"
+          | Atomic -> Ccall "caml_set_ptr_atomic_bytecode"
+        in
         let copied_value = copy_mixed_block_element elt (comp_expr value) in
-        Prim (Ccall "caml_set_ptr_bytecode", [comp_expr ptr; copied_value])
+        Prim (prim, [comp_expr ptr; copied_value])
       | _ -> wrong_arity ~expected:2)
-    | Pget_ext_ptr (layout, _) ->
+    | Pget_ext_ptr (layout, mut) ->
+      let prim =
+        match Lambda.access_atomicity mut with
+        | Nonatomic -> Ccall "caml_get_ext_ptr_bytecode"
+        | Atomic -> Ccall "caml_get_ext_ptr_atomic_bytecode"
+      in
       let elt = Lambda.mixed_block_element_of_layout layout in
-      copy_mixed_block_element elt (unary (Ccall "caml_get_ext_ptr_bytecode"))
-    | Pset_ext_ptr (layout, _) -> (
+      copy_mixed_block_element elt (unary prim)
+    | Pset_ext_ptr (layout, _, atomicity) -> (
       let elt = Lambda.mixed_block_element_of_layout layout in
       match args with
       | [ptr; value] ->
+        let prim =
+          match atomicity with
+          | Nonatomic -> Ccall "caml_set_ext_ptr_bytecode"
+          | Atomic -> Ccall "caml_set_ext_ptr_atomic_bytecode"
+        in
         let copied_value = copy_mixed_block_element elt (comp_expr value) in
-        Prim (Ccall "caml_set_ext_ptr_bytecode", [comp_expr ptr; copied_value])
+        Prim (prim, [comp_expr ptr; copied_value])
       | _ -> wrong_arity ~expected:2)
     | Pmake_idx_field pos ->
       Const (Const_block (0, [Const_base (Const_int pos)]))

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -953,7 +953,25 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Pget_header _ -> unary (Ccall "caml_get_header")
     | Pobj_dup -> unary (Ccall "caml_obj_dup")
     | Patomic_load_field _ -> binary (Ccall "caml_atomic_load_field")
+    | Patomic_load_mixed_field { index; shape = _ } -> (
+      match args with
+      | [record] ->
+        (* In bytecode, mixed record fields aren't reordered, so the shape
+             index [index] is also a field index at runtime. *)
+        Prim
+          ( Ccall "caml_atomic_load_field",
+            [comp_expr record; Const (Const_base (Const_int index))] )
+      | _ -> wrong_arity ~expected:1)
     | Patomic_set_field _ -> ternary (Ccall "caml_atomic_set_field")
+    | Patomic_set_mixed_field { index; shape = _ } -> (
+      match args with
+      | [record; value] ->
+        let record = comp_expr record in
+        let value = comp_expr value in
+        Prim
+          ( Ccall "caml_atomic_set_field",
+            [record; Const (Const_base (Const_int index)); value] )
+      | _ -> wrong_arity ~expected:2)
     | Patomic_exchange_field _ -> ternary (Ccall "caml_atomic_exchange_field")
     | Patomic_compare_exchange_field _ ->
       n_ary ~arity:4 (Ccall "caml_atomic_compare_exchange_field")

--- a/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
+++ b/jane/doc/extensions/_03-unboxed-types/03-block-indices.md
@@ -43,9 +43,10 @@ The language feature includes these predefined types:
 ```ocaml
 type ('a, 'b : any) idx_imm : bits64
 type ('a, 'b : any) idx_mut : bits64
+type ('a, 'b : any) idx_atomic : bits64
 ```
 
-Given `('a, 'b) idx_imm` or `('a, 'b) idx_mut`, we refer to `'a` as the "base
+Given an `('a, 'b) idx_imm` (or other index type), we refer to `'a` as the "base
 type" and `'b` as the "element type." A block index thus represents the position
 of an element type within the base type. For example,
 `(.q.#y) : (line, int) idx_imm` in the example above represents the position of
@@ -66,23 +67,22 @@ Block accesses take the following forms:
 Unboxed accesses take the following forms:
 - Unboxed record field: `.#bar`
 
-If the block access is mutable (mutable record fields and mutable block
-indices), then an `idx_mut` is created, and if the block access is immutable
-(immutable record fields and immutable block indices), then an `idx_imm` is
-created.
+The type of the index that gets created is determined by the kind of block access:
+- If the block access is atomic (atomic record fields), then an `idx_atomic` is created.
+- If the block access is mutable (mutable record fields and mutable block indices), then an `idx_mut` is created.
+- If the block access is immutable (immutable record fields and immutable block indices), then an `idx_imm` is created.
 
-**Array indices.** Array indices are created via functions in
-`Stdlib_stable`, rather than syntax:
+**Array indices.** Array indices are created via functions in `Stdlib_stable`:
 - `Idx_mut.unsafe_create_into_array : int -> ('a array, 'a) idx_mut`
 - `Idx_imm.unsafe_create_into_iarray : int -> ('a iarray, 'a) idx_imm`
+- Atomic array indices are not currently supported.
 
 These functions are marked `unsafe` because they cannot check array bounds, so
 using the index later could perform an unchecked out-of-bounds access.
 
-**Using indices.** Naturally, block indices can be used to read and write
-within blocks. This can be done via the `Idx_imm.get`, `Idx_mut.get`, and
-`Idx_mut.set` functions in [`Stdlib_stable`](https://github.com/oxcaml/oxcaml/blob/main/otherlibs/stdlib_stable
-).
+**Using indices.** Block indices can be used to read and write values within blocks.
+[`Stdlib_stable`](https://github.com/oxcaml/oxcaml/blob/main/otherlibs/stdlib_stable)
+exposes `get` and `set` functions for `idx_imm`, `idx_mut`, and `idx_atomic`.
 
 _A key advantage of block indices is that these accessor functions are
 polymorphic in both the base type and element type._ Index reading roughly
@@ -94,6 +94,8 @@ signature `'a -> ('a, 'b) idx -> 'b -> unit`.
 access so that indices can be _deepened_. For example, given
 `idx : ('a, pt#) idx_imm`, one may obtain
 `(.idx_imm(idx).#y) : ('a, int) idx_imm`.
+
+Deepening atomic indices is not currently supported.
 
 # Example use cases
 
@@ -144,7 +146,7 @@ let drop_last_to_y_axis (s : line Stack.t) =
 4. Indices to structures with non-default modalities are not supported.
    Specifically, the composition of modalities of the accesses of an `idx_imm`
    must have the identity modality, while the composition of modalities of the
-   accesses of an `idx_mut` must the the modality
+   accesses of an `idx_mut` must have the modality
    `global many aliased unyielding`.
 
 # Representation of block indices

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -371,7 +371,15 @@ type primitive =
   | Pint_as_pointer of locality_mode
   (* Atomic operations *)
   | Patomic_load_field of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_load_mixed_field of {
+    index : int;
+    shape : mixed_block_shape;
+  }
   | Patomic_set_field of {immediate_or_pointer : immediate_or_pointer}
+  | Patomic_set_mixed_field of {
+    index : int;
+    shape : mixed_block_shape;
+  }
   | Patomic_exchange_field of {immediate_or_pointer : immediate_or_pointer}
   | Patomic_compare_exchange_field of
     {immediate_or_pointer : immediate_or_pointer}
@@ -2578,7 +2586,9 @@ let primitive_may_allocate : primitive -> locality_mode option = function
     Some alloc_heap
   | Pcpu_relax -> if Config.poll_insertion then None else Some alloc_heap
   | Patomic_load_field _
+  | Patomic_load_mixed_field _
   | Patomic_set_field _
+  | Patomic_set_mixed_field _
   | Patomic_exchange_field _
   | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _
@@ -2771,7 +2781,8 @@ let primitive_can_raise prim =
   | Patomic_exchange_field _ | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _ | Patomic_fetch_add_field  | Patomic_add_field
   | Patomic_sub_field  | Patomic_land_field | Patomic_lor_field
-  | Patomic_lxor_field  | Patomic_load_field _ | Patomic_set_field _ -> false
+  | Patomic_lxor_field  | Patomic_load_field _ | Patomic_load_mixed_field _
+  | Patomic_set_field _ | Patomic_set_mixed_field _ -> false
   | Pwith_stack | Pwith_stack_preemptible
   | Pperform | Pcontinue | Pdiscontinue
   | Pdiscontinue_with_backtrace
@@ -2864,6 +2875,27 @@ let extern_repr_involves_unboxed_products extern_repr =
     Misc.fatal_error "extern_repr_involves_unboxed_products: unexpected univar"
   | Same_as_ocaml_repr (Genvar _) ->
     Misc.fatal_error "extern_repr_involves_unboxed_products: unexpected genvar"
+
+let strip_locality_mode shape =
+  let rec strip_elt elt =
+    match elt with
+    | Float_boxed _ -> Float_boxed ()
+    | Product elts -> Product (Array.map strip_elt elts)
+    | Value vk -> Value vk
+    | Float64 -> Float64
+    | Float32 -> Float32
+    | Bits8 -> Bits8
+    | Bits16 -> Bits16
+    | Bits32 -> Bits32
+    | Bits64 -> Bits64
+    | Vec128 -> Vec128
+    | Vec256 -> Vec256
+    | Vec512 -> Vec512
+    | Word -> Word
+    | Untagged_immediate -> Untagged_immediate
+    | Splice_variable id -> Splice_variable id
+  in
+  Array.map strip_elt shape
 
 let rec layout_of_scannable_kinds kinds =
   Punboxed_product (List.map layout_of_scannable_kind kinds)
@@ -3221,7 +3253,9 @@ let primitive_result_layout (p : primitive) =
     layout_int_or_null
   | Patomic_load_field { immediate_or_pointer = Pointer } ->
     layout_any_value
-  | Patomic_set_field _ -> layout_unit
+  | Patomic_load_mixed_field { index ; shape } ->
+    layout_of_mixed_block_shape shape ~path:[index]
+  | Patomic_set_field _ | Patomic_set_mixed_field _ -> layout_unit
   | Patomic_exchange_field { immediate_or_pointer = Immediate } ->
     layout_int_or_null
   | Patomic_exchange_field { immediate_or_pointer = Pointer } ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -52,6 +52,14 @@ type has_initializer =
   | With_initializer
   | Uninitialized
 
+type atomicity = Asttypes.atomic_flag
+
+type access_mutability = Immutable | Mutable | Atomic
+
+let access_atomicity : access_mutability -> atomicity = function
+  | Immutable | Mutable -> Nonatomic
+  | Atomic -> Atomic
+
 include (struct
 
   type locality_mode =
@@ -419,12 +427,12 @@ type primitive =
   (* Poll for runtime actions *)
   | Ppoll
   | Pcpu_relax
-  | Pget_idx of layout * Asttypes.mutable_flag
-  | Pset_idx of layout * modify_mode
-  | Pget_ptr of layout * Asttypes.mutable_flag
-  | Pset_ptr of layout * modify_mode
-  | Pget_ext_ptr of layout * Asttypes.mutable_flag
-  | Pset_ext_ptr of layout * modify_mode
+  | Pget_idx of layout * access_mutability
+  | Pset_idx of layout * modify_mode * atomicity
+  | Pget_ptr of layout * access_mutability
+  | Pset_ptr of layout * modify_mode * atomicity
+  | Pget_ext_ptr of layout * access_mutability
+  | Pset_ext_ptr of layout * modify_mode * atomicity
 
 and extern_repr =
   | Same_as_ocaml_repr of Jkind.Sort.Const.t

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -51,6 +51,17 @@ type modify_mode = private
   | Modify_heap
   | Modify_maybe_stack
 
+type atomicity = Asttypes.atomic_flag
+
+type access_mutability =
+  | Immutable
+  | Mutable
+  (** Nonatomic access of mutable data. *)
+  | Atomic
+  (** Atomic access of mutable data. *)
+
+val access_atomicity : access_mutability -> atomicity
+
 val alloc_heap : locality_mode
 
 (* Actually [Alloc_heap] if [Config.stack_allocation] is [false] *)
@@ -433,14 +444,14 @@ type primitive =
   | Ppoll
   (* Arch-specific pause. Without poll insertion, also acts as a [Ppoll]. *)
   | Pcpu_relax
-  | Pget_idx of layout * Asttypes.mutable_flag
-  | Pset_idx of layout * modify_mode
-  | Pget_ptr of layout * Asttypes.mutable_flag
-  | Pset_ptr of layout * modify_mode
+  | Pget_idx of layout * access_mutability
+  | Pset_idx of layout * modify_mode * atomicity
+  | Pget_ptr of layout * access_mutability
+  | Pset_ptr of layout * modify_mode * atomicity
   (* External pointer primitives: like [Pget_ptr]/[Pset_ptr] but take only the
      offset and behave as if the base were null. *)
-  | Pget_ext_ptr of layout * Asttypes.mutable_flag
-  | Pset_ext_ptr of layout * modify_mode
+  | Pget_ext_ptr of layout * access_mutability
+  | Pset_ext_ptr of layout * modify_mode * atomicity
 
 (** This is the same as [Primitive.native_repr] but with [Repr_poly]
     compiled away. *)

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -365,7 +365,17 @@ type primitive =
   (* Atomic operations. Note that these operations must not be used on fields of
      all-float blocks. *)
   | Patomic_load_field of { immediate_or_pointer : immediate_or_pointer }
+  | Patomic_load_mixed_field of {
+    index : int;
+    (** The field being accessed. This is an index into [shape], not a field
+        index. See [Pmixedfield] for more details. *)
+    shape : mixed_block_shape;
+  }
   | Patomic_set_field of { immediate_or_pointer : immediate_or_pointer }
+  | Patomic_set_mixed_field of {
+    index : int;
+    shape : mixed_block_shape;
+  }
   | Patomic_exchange_field of { immediate_or_pointer : immediate_or_pointer }
   | Patomic_compare_exchange_field of
     { immediate_or_pointer : immediate_or_pointer }
@@ -678,6 +688,9 @@ val layout_of_extern_repr : extern_repr -> layout
 val element_layout_of_array_kind : array_kind -> layout
 
 val extern_repr_involves_unboxed_products : extern_repr -> bool
+
+val strip_locality_mode :
+  mixed_block_shape_with_locality_mode -> mixed_block_shape
 
 type structured_constant =
     Const_base of constant

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -367,8 +367,8 @@ type primitive =
   | Patomic_load_field of { immediate_or_pointer : immediate_or_pointer }
   | Patomic_load_mixed_field of {
     index : int;
-    (** The field being accessed. This is an index into [shape], not a field
-        index. See [Pmixedfield] for more details. *)
+    (** The field being accessed. Like [Pmixedfield]'s path, this is an index
+        into [shape] -- not a field index. *)
     shape : mixed_block_shape;
   }
   | Patomic_set_field of { immediate_or_pointer : immediate_or_pointer }

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -2736,7 +2736,8 @@ let get_expr_args_array ~scopes kind head { arg; mut; _ } rem =
          array pattern, once that's available *)
       let ref_kind = Lambda.(array_ref_kind alloc_heap kind) in
       let result_layout = element_layout_of_array_kind kind in
-      let am_mut = if Types.is_mutable am then Mutable else Immutable in
+      let am_mut: mutable_flag =
+        if Types.is_mutable am then Mutable else Immutable in
       { arg = Lprim
           (Parrayrefu (ref_kind, Ptagged_int_index, am_mut),
            [ arg; Lconst (Const_base (Const_int pos)) ],

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -98,7 +98,7 @@ let array_kind = function
     "ignorableproduct " ^ ignorable_product_element_kinds kinds
   | Punspecializedarray -> "unspecialized"
 
-let array_mut = function
+let array_mut (mut: mutable_flag) = match mut with
   | Mutable -> "array"
   | Immutable | Immutable_unique -> "iarray"
 
@@ -907,15 +907,25 @@ let primitive ppf = function
   | Ppoke layout ->
       fprintf ppf "(poke@ %a)"
         peek_or_poke layout
+  | Pget_idx (l, Atomic) ->
+      fprintf ppf "(get_idx_atomic@ %a)"
+        layout l
   | Pget_idx (l, Mutable) ->
       fprintf ppf "(get_idx@ %a)"
         layout l
   | Pget_idx (l, Immutable) ->
       fprintf ppf "(get_idx_imm@ %a)"
         layout l
-  | Pset_idx (l, mode) ->
+  | Pset_idx (l, mode, Atomic) ->
+      fprintf ppf "(set_idx_atomic%s@ %a)"
+        (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
+        layout l
+  | Pset_idx (l, mode, Nonatomic) ->
       fprintf ppf "(set_idx%s@ %a)"
         (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
+        layout l
+  | Pget_ptr (l, Atomic) ->
+      fprintf ppf "(get_ptr_atomic@ %a)"
         layout l
   | Pget_ptr (l, Mutable) ->
       fprintf ppf "(get_ptr@ %a)"
@@ -923,9 +933,16 @@ let primitive ppf = function
   | Pget_ptr (l, Immutable) ->
       fprintf ppf "(get_ptr_imm@ %a)"
         layout l
-  | Pset_ptr (l, mode) ->
+  | Pset_ptr (l, mode, Atomic) ->
+      fprintf ppf "(set_ptr_atomic%s@ %a)"
+        (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
+        layout l
+  | Pset_ptr (l, mode, Nonatomic) ->
       fprintf ppf "(set_ptr%s@ %a)"
         (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
+        layout l
+  | Pget_ext_ptr (l, Atomic) ->
+      fprintf ppf "(get_ext_ptr_atomic@ %a)"
         layout l
   | Pget_ext_ptr (l, Mutable) ->
       fprintf ppf "(get_ext_ptr@ %a)"
@@ -933,7 +950,11 @@ let primitive ppf = function
   | Pget_ext_ptr (l, Immutable) ->
       fprintf ppf "(get_ext_ptr_imm@ %a)"
         layout l
-  | Pset_ext_ptr (l, mode) ->
+  | Pset_ext_ptr (l, mode, Atomic) ->
+      fprintf ppf "(set_ext_ptr_atomic%s@ %a)"
+        (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
+        layout l
+  | Pset_ext_ptr (l, mode, Nonatomic) ->
       fprintf ppf "(set_ext_ptr%s@ %a)"
         (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
         layout l

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -845,10 +845,18 @@ let primitive ppf = function
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_load_field_imm"
         | Pointer -> fprintf ppf "atomic_load_field_ptr")
+  | Patomic_load_mixed_field { index ; shape } ->
+      fprintf ppf "atomic_load_mixed_field %a %a"
+        pp_print_int index
+        (mixed_block_shape (fun _ () -> ())) shape
   | Patomic_set_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_set_field_imm"
         | Pointer -> fprintf ppf "atomic_set_field_ptr")
+  | Patomic_set_mixed_field { index ; shape } ->
+      fprintf ppf "atomic_set_mixed_field %a %a"
+        pp_print_int index
+        (mixed_block_shape (fun _ () -> ())) shape
   | Patomic_exchange_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> fprintf ppf "atomic_exchange_field_imm"
@@ -1049,10 +1057,12 @@ let name_of_primitive = function
       (match immediate_or_pointer with
         | Immediate -> "atomic_load_field_imm"
         | Pointer -> "atomic_load_field_ptr")
+  | Patomic_load_mixed_field _ -> "atomic_load_mixed_field"
   | Patomic_set_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> "atomic_set_field_imm"
         | Pointer -> "atomic_set_field_ptr")
+  | Patomic_set_mixed_field _ -> "atomic_set_mixed_field"
   | Patomic_exchange_field {immediate_or_pointer} ->
       (match immediate_or_pointer with
         | Immediate -> "atomic_exchange_field_imm"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -429,7 +429,8 @@ and fracture_prim lambda prim args loc =
   | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
   | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
   | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
-  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _ | Patomic_set_field _
+  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _
+  | Patomic_load_mixed_field _ | Patomic_set_field _ | Patomic_set_mixed_field _
   | Patomic_exchange_field _ | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _ | Patomic_fetch_add_field | Patomic_add_field
   | Patomic_sub_field | Patomic_land_field | Patomic_lor_field

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -491,7 +491,8 @@ and eval_prim env prim =
   | Punboxed_float32_array_set_vec _ | Puntagged_int8_array_set_vec _
   | Puntagged_int16_array_set_vec _ | Punboxed_int32_array_set_vec _
   | Punboxed_int64_array_set_vec _ | Punboxed_nativeint_array_set_vec _
-  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _ | Patomic_set_field _
+  | Pctconst _ | Pint_as_pointer _ | Patomic_load_field _
+  | Patomic_load_mixed_field _ | Patomic_set_field _ | Patomic_set_mixed_field _
   | Patomic_exchange_field _ | Patomic_compare_exchange_field _
   | Patomic_compare_set_field _ | Patomic_fetch_add_field | Patomic_add_field
   | Patomic_sub_field | Patomic_land_field | Patomic_lor_field

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -445,21 +445,27 @@ and eval_prim env prim =
   | Pget_idx (old_layout, mut) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pget_idx (new_layout, mut)
-  | Pset_idx (old_layout, mode) ->
+  | Pset_idx (old_layout, mode, atomicity) ->
     let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout then prim else Pset_idx (new_layout, mode)
+    if new_layout == old_layout
+    then prim
+    else Pset_idx (new_layout, mode, atomicity)
   | Pget_ptr (old_layout, mut) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pget_ptr (new_layout, mut)
-  | Pset_ptr (old_layout, mode) ->
+  | Pset_ptr (old_layout, mode, atomicity) ->
     let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout then prim else Pset_ptr (new_layout, mode)
+    if new_layout == old_layout
+    then prim
+    else Pset_ptr (new_layout, mode, atomicity)
   | Pget_ext_ptr (old_layout, mut) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pget_ext_ptr (new_layout, mut)
-  | Pset_ext_ptr (old_layout, mode) ->
+  | Pset_ext_ptr (old_layout, mode, atomicity) ->
     let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout then prim else Pset_ext_ptr (new_layout, mode)
+    if new_layout == old_layout
+    then prim
+    else Pset_ext_ptr (new_layout, mode, atomicity)
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Pgetpredef _
   | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakelazyblock _ | Pfield _
   | Pfield_computed _ | Psetfield _ | Psetfield_computed _ | Pfloatfield _
@@ -534,11 +540,11 @@ let assert_primitive_contains_no_splices (prim : Lambda.primitive) =
   | Popaque layout | Pobj_magic layout ->
     assert_layout_contains_no_splices layout
   | Pget_idx (layout, _)
-  | Pset_idx (layout, _)
+  | Pset_idx (layout, _, _)
   | Pget_ptr (layout, _)
-  | Pset_ptr (layout, _)
+  | Pset_ptr (layout, _, _)
   | Pget_ext_ptr (layout, _)
-  | Pset_ext_ptr (layout, _) ->
+  | Pset_ext_ptr (layout, _, _) ->
     assert_layout_contains_no_splices layout
   | Pmake_unboxed_product layouts | Punboxed_product_field (_, layouts) ->
     List.iter assert_layout_contains_no_splices layouts

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -917,7 +917,8 @@ let rec choice ctx t =
     | Patomic_compare_set_field _ | Patomic_fetch_add_field
     | Patomic_add_field | Patomic_sub_field | Patomic_land_field
     | Patomic_lor_field | Patomic_lxor_field
-    | Patomic_load_field _ | Patomic_set_field _
+    | Patomic_load_field _ | Patomic_load_mixed_field _
+    | Patomic_set_field _ | Patomic_set_mixed_field _
     | Pcpu_relax
     | Punbox_vector _ | Pbox_vector (_, _)
     | Pjoin_vec256 | Psplit_vec256

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -823,7 +823,7 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
           in
           if Types.is_atomic lbl.lbl_mut then
             (* Patomic_load_mixed_field doesn't care about locality mode;
-               @@flatten_floats doesn't accept records with atomic fields. *)
+               [@@flatten_floats] doesn't accept records with atomic fields. *)
             let shape = strip_locality_mode shape in
             Some
               (Patomic_load_mixed_field { index = lbl.lbl_pos; shape }, [targ])

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -2384,7 +2384,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
       else Immutable in
     let lam =
       try
-        if mut = Mutable then raise Not_constant;
+        if mut = (Mutable : mutable_flag) then raise Not_constant;
         let cl = List.map extract_constant ll in
         match repres with
         | Record_boxed -> Lconst(Const_block(0, cl))

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -821,7 +821,14 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
                           \ present for float field read")
               shape
           in
-          Some (Pmixedfield ([lbl.lbl_pos], shape, sem), [targ])
+          if Types.is_atomic lbl.lbl_mut then
+            (* Patomic_load_mixed_field doesn't care about locality mode;
+               @@flatten_floats doesn't accept records with atomic fields. *)
+            let shape = strip_locality_mode shape in
+            Some
+              (Patomic_load_mixed_field { index = lbl.lbl_pos; shape }, [targ])
+          else
+            Some (Pmixedfield ([lbl.lbl_pos], shape, sem), [targ])
         | Record_inlined (_, _, Variant_with_null) -> assert false
         | Record_dummy _ ->
           fatal_error "transl_exp0: dummy record representation"
@@ -932,8 +939,12 @@ and transl_exp0 ~in_new_scope ~scopes layout e =
           let shape = Lambda.transl_mixed_product_shape shape in
           (* Update the shape with details for the modified field. *)
           shape.(lbl.lbl_pos) <- field_shape;
-          Psetmixedfield([lbl.lbl_pos], shape, mode),
-          [arg_lambda; newval_lambda]
+          if Types.is_atomic lbl.lbl_mut then
+            (Patomic_set_mixed_field { index = lbl.lbl_pos; shape },
+            [arg_lambda; newval_lambda])
+          else
+            (Psetmixedfield([lbl.lbl_pos], shape, mode),
+            [arg_lambda; newval_lambda])
         | Record_inlined (_, _, Variant_with_null) -> assert false
         | Record_dummy _ ->
             fatal_error "transl_exp0: unexpected dummy representation"

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2582,7 +2582,8 @@ let lambda_primitive_needs_event_after = function
   | Patomic_compare_set_field _ | Patomic_fetch_add_field
   | Patomic_add_field | Patomic_sub_field
   | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
-  | Patomic_load_field _ | Patomic_set_field _
+  | Patomic_load_field _ | Patomic_load_mixed_field _
+  | Patomic_set_field _ | Patomic_set_mixed_field _
   | Pcpu_relax | Pctconst _ | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Ptls_get

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1182,9 +1182,14 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
          (just above), it's also safe to use this one. Marking the primitive as
          [Mutable] just restricts the optimizations that can be performed. *)
       Primitive(Pget_idx (layout, Mutable), 2)
+    | "%get_idx_atomic" ->
+      Primitive(Pget_idx (layout, Atomic), 2)
     | "%set_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
-      Primitive(Pset_idx (layout, get_first_arg_mode ()), 3)
+      Primitive(Pset_idx (layout, get_first_arg_mode (), Nonatomic), 3)
+    | "%set_idx_atomic" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Primitive(Pset_idx (layout, get_first_arg_mode (), Atomic), 3)
     | "%unsafe_array_idx" ->
       Primitive(Pmake_idx_array
         (Punspecializedarray, Ptagged_int_index,
@@ -1225,14 +1230,14 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       Primitive(Pget_ptr (layout, Mutable), 1)
     | "%unsafe_set_ptr" ->
       let layout = List.nth (get_arg_layouts ()) 1 in
-      Primitive(Pset_ptr (layout, get_first_arg_mode ()), 2)
+      Primitive(Pset_ptr (layout, get_first_arg_mode (), Nonatomic), 2)
     | "%unsafe_get_ext_ptr_imm" ->
       Primitive(Pget_ext_ptr (layout, Immutable), 1)
     | "%unsafe_get_ext_ptr" ->
       Primitive(Pget_ext_ptr (layout, Mutable), 1)
     | "%unsafe_set_ext_ptr" ->
       let layout = List.nth (get_arg_layouts ()) 1 in
-      Primitive(Pset_ext_ptr (layout, get_first_arg_mode ()), 2)
+      Primitive(Pset_ext_ptr (layout, get_first_arg_mode (), Nonatomic), 2)
     | "%peek" -> Peek None
     | "%poke" -> Poke None
     | s when String.length s > 0 && s.[0] = '%' ->
@@ -1893,15 +1898,15 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     (match fst (maybe_pointer_type env v) with
     | Pointer -> None
     | Immediate -> Some (Atomic (op, kind, Immediate)))
-  | Primitive (Pset_idx (_, m), arity), (_ :: _ :: p3 :: _) ->
+  | Primitive (Pset_idx (_, m, a), arity), (_ :: _ :: p3 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p3 in
-    Some (Primitive (Pset_idx (l, m), arity))
-  | Primitive (Pset_ptr (_, m), arity), (_ :: p2 :: _) ->
+    Some (Primitive (Pset_idx (l, m, a), arity))
+  | Primitive (Pset_ptr (_, m, a), arity), (_ :: p2 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p2 in
-    Some (Primitive (Pset_ptr (l, m), arity))
-  | Primitive (Pset_ext_ptr (_, m), arity), (_ :: p2 :: _) ->
+    Some (Primitive (Pset_ptr (l, m, a), arity))
+  | Primitive (Pset_ext_ptr (_, m, a), arity), (_ :: p2 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p2 in
-    Some (Primitive (Pset_ext_ptr (l, m), arity))
+    Some (Primitive (Pset_ext_ptr (l, m, a), arity))
   | Primitive (Pmake_idx_array (_, ik, _mbe, path), arity), _ ->
     let loc = to_location loc in
     let err () =

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -432,7 +432,9 @@ let compute_static_size lam =
     | Pbigstring_load_64 _
     | Pint_as_pointer _
     | Patomic_load_field _
+    | Patomic_load_mixed_field _
     | Patomic_set_field _
+    | Patomic_set_mixed_field _
     | Patomic_exchange_field _
     | Patomic_compare_exchange_field _
     | Patomic_compare_set_field _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1309,7 +1309,8 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
       | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field | Pdls_get
       | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
-      | Patomic_set_field _ | Preinterpret_tagged_int63_as_unboxed_int64
+      | Patomic_load_mixed_field _ | Patomic_set_field _
+      | Patomic_set_mixed_field _ | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _
       | Pscalar _ | Pphys_equal _ | Pcpu_relax ->
         (* Inconsistent with outer match *)

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -3288,7 +3288,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Ppoke layout, [[ptr]; [new_value]] ->
     let kind = standard_int_or_float_of_peek_or_poke layout in
     [Binary (Poke kind, ptr, new_value)]
-  | Pget_idx (layout, mut), [[ptr]; [idx]] | Pget_ptr (layout, mut), [[ptr; idx]]
+  | Pget_idx (layout, mut), [[ptr]; [idx]]
+  | Pget_ptr (layout, mut), [[ptr; idx]]
     ->
     needs_64_bit_target prim dbg;
     let offsets = block_index_access_offsets ~machine_width layout idx in
@@ -3308,11 +3309,19 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       "Closure_convertion.convert_primitive: The argument to Pget_ptr should \
        be an unboxed product of length 2"
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
-  | Pset_idx (layout, mode), [[ptr]; [idx]; new_values] ->
+  | Pset_idx (layout, mode, atomicity), [[ptr]; [idx]; new_values] ->
     needs_64_bit_target prim dbg;
+    begin match atomicity with
+    | Nonatomic -> ()
+    | Atomic -> Misc.fatal_error "unimplemented!"
+    end;
     write_offset Into_block layout mode ~machine_width ~ptr ~idx ~new_values
-  | Pset_ptr (layout, mode), [[ptr; idx]; new_values] ->
+  | Pset_ptr (layout, mode, atomicity), [[ptr; idx]; new_values] ->
     needs_64_bit_target prim dbg;
+    begin match atomicity with
+    | Nonatomic -> ()
+    | Atomic -> Misc.fatal_error "unimplemented!"
+    end;
     write_offset Into_block_or_off_heap layout mode ~machine_width ~ptr ~idx
       ~new_values
   | Pset_ptr _, [([] | [_] | _ :: _ :: _ :: _); _] ->
@@ -3335,8 +3344,12 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         kinds offsets
     in
     [H.maybe_create_unboxed_product reads]
-  | Pset_ext_ptr (layout, mode), [[idx]; new_values] ->
+  | Pset_ext_ptr (layout, mode, atomicity), [[idx]; new_values] ->
     needs_64_bit_target prim dbg;
+    begin match atomicity with
+    | Nonatomic -> ()
+    | Atomic -> Misc.fatal_error "unimplemented!"
+    end;
     let null_base = H.Simple (Simple.const Reg_width_const.const_null) in
     write_offset Into_block_or_off_heap layout mode ~machine_width
       ~ptr:null_base ~idx ~new_values

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1806,6 +1806,29 @@ let string_or_bytes_checks (size : Flambda_primitive.string_accessor_width)
       ( ~len:(Flambda_primitive.byte_width_of_string_accessor_width size),
         ~align:0 )
 
+let mixed_field_index_and_kind ~machine_width ~prim_name index shape =
+  let shape =
+    Mixed_block_shape.of_mixed_block_elements shape
+      ~print_locality:(fun ppf () -> Format.fprintf ppf "()")
+  in
+  let field_index =
+    match Mixed_block_shape.lookup_path_producing_new_indexes shape [index] with
+    | [index] -> index
+    | _ ->
+      Misc.fatal_errorf "%s: expected exactly one flattened index" prim_name
+  in
+  let field_kind =
+    match (Mixed_block_shape.flattened_reordered_shape shape).(field_index) with
+    | Value vk -> H.block_access_field_kind_of_value_kind vk
+    | Float_boxed _ | Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64
+    | Vec128 | Vec256 | Vec512 | Word | Untagged_immediate ->
+      Misc.fatal_errorf "%s: expected mixed block element to be a value"
+        prim_name
+  in
+  let imm = Target_ocaml_int.of_int machine_width field_index in
+  check_non_negative_imm imm prim_name;
+  imm, field_kind
+
 (* Primitive conversion *)
 let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     (prim : L.primitive) (args : Simple.t list list) (dbg : Debuginfo.t)
@@ -3173,12 +3196,30 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
             (convert_block_access_field_kind immediate_or_pointer),
           atomic,
           field ) ]
+  | Patomic_load_mixed_field { index; shape }, [[atomic]] ->
+    let imm, field_kind =
+      mixed_field_index_and_kind ~machine_width
+        ~prim_name:"Patomic_load_mixed_field" index shape
+    in
+    [ Binary
+        (Atomic_load_field field_kind, atomic, H.Simple (Simple.const_int imm))
+    ]
   | Patomic_set_field { immediate_or_pointer }, [[atomic]; [field]; [new_value]]
     ->
     [ Ternary
         ( Atomic_set_field (convert_block_access_field_kind immediate_or_pointer),
           atomic,
           field,
+          new_value ) ]
+  | Patomic_set_mixed_field { index; shape }, [[atomic]; [new_value]] ->
+    let imm, field_kind =
+      mixed_field_index_and_kind ~machine_width
+        ~prim_name:"Patomic_set_mixed_field" index shape
+    in
+    [ Ternary
+        ( Atomic_set_field field_kind,
+          atomic,
+          H.Simple (Simple.const_int imm),
           new_value ) ]
   | ( Patomic_exchange_field { immediate_or_pointer },
       [[atomic]; [field]; [new_value]] ) ->
@@ -3318,7 +3359,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Pobj_dup | Pobj_magic _ | Punbox_vector _ | Punbox_unit
       | Pbox_vector (_, _)
       | Punboxed_product_field _ | Pget_header _ | Pufloatfield _
-      | Patomic_load_field _ | Pmixedfield _
+      | Patomic_load_field _ | Patomic_load_mixed_field _ | Pmixedfield _
       | Preinterpret_unboxed_int64_as_tagged_int63
       | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_boxed_vector_as_tuple _
@@ -3361,7 +3402,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
             | Punspecializedarray_ref _ ),
             _,
             _ )
-      | Patomic_load_field _ | Ppoke _ | Pphys_equal _
+      | Patomic_load_field _ | Patomic_set_mixed_field _ | Ppoke _
+      | Pphys_equal _
       | Pscalar (Binary _)
       | Pget_idx _ | Pset_ptr _ | Pset_ext_ptr _ ),
       ( []

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1777,25 +1777,18 @@ let block_index_access_offsets ~machine_width layout idx =
     in
     snd (List.fold_left_map f MPB.zero (L.mixed_block_element_leaves mbe))
 
-let write_offset write_offset_kind layout mode ~machine_width ~ptr ~idx
-    ~new_values =
-  let mode = Alloc_mode.For_assignments.from_lambda mode in
-  let offsets = block_index_access_offsets ~machine_width layout idx in
-  let kinds =
-    Flambda_arity.unarize
-      (Flambda_arity.from_lambda_list [layout] ~machine_width)
+(* [block_index_access_offests] produces untagged byte offsets, but
+   [Atomic_load_field] and [Atomic_set_field] expect a tagged word index. *)
+let tagged_field_index_of_offset ~machine_width offset : H.simple_or_prim =
+  let log2_size_addr =
+    H.simple_untagged_int ~machine_width
+      (Misc.log2 (Target_system.Machine_width.size_in_bytes machine_width))
   in
-  let writes =
-    Misc.Stdlib.List.map3
-      (fun kind offset new_value ->
-        H.Ternary
-          ( Write_offset (write_offset_kind, kind, mode),
-            ptr,
-            Prim offset,
-            new_value ))
-      kinds offsets new_values
+  let index =
+    H.Binary (Int_shift (Naked_int64, Lsr), Prim offset, log2_size_addr)
   in
-  [H.Sequence writes]
+  Prim
+    (Unary (Num_conv { src = Naked_int64; dst = Tagged_immediate }, Prim index))
 
 let string_or_bytes_checks (size : Flambda_primitive.string_accessor_width)
     unsafe =
@@ -1839,6 +1832,88 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     List.map (List.map (fun arg : H.simple_or_prim -> Simple arg)) args
   in
   let size_int = Target_system.Machine_width.size_in_bytes machine_width in
+  let convert_pget_indirect layout (mut : Lambda.access_mutability) ~ptr ~idx :
+      H.expr_primitive list =
+    needs_64_bit_target prim dbg;
+    let offsets = block_index_access_offsets ~machine_width layout idx in
+    let kinds =
+      Flambda_arity.unarize
+        (Flambda_arity.from_lambda_list [layout] ~machine_width)
+    in
+    begin match Lambda.access_atomicity mut with
+    | Nonatomic ->
+      let mut =
+        match mut with
+        | Immutable -> Asttypes.Immutable
+        | Mutable -> Asttypes.Mutable
+        | Atomic ->
+          Misc.fatal_error "convert_pget_indirect: expected nonatomic access"
+      in
+      let reads =
+        List.map2
+          (fun kind offset ->
+            H.Binary (Read_offset (kind, mut), ptr, Prim offset))
+          kinds offsets
+      in
+      [H.maybe_create_unboxed_product reads]
+    | Atomic ->
+      if List.length offsets <> 1
+      then
+        Misc.fatal_error
+          "convert_pget_indirect: expected single element for atomic op";
+      let full_kind = List.hd kinds in
+      if not (K.is_value (K.With_subkind.kind full_kind))
+      then
+        (* defensive check: field index computation assumes data is
+           word-sized *)
+        Misc.fatal_error "convert_pget_indirect: expected value for atomic op";
+      let field_kind = P.Block_access_field_kind.from_kind full_kind in
+      let offset = List.hd offsets in
+      let field = tagged_field_index_of_offset ~machine_width offset in
+      [Binary (Atomic_load_field field_kind, ptr, field)]
+    end
+  in
+  let convert_pset_indirect write_offset_kind layout mode
+      (atomicity : Lambda.atomicity) ~ptr ~idx ~new_values :
+      H.expr_primitive list =
+    needs_64_bit_target prim dbg;
+    let mode = Alloc_mode.For_assignments.from_lambda mode in
+    let offsets = block_index_access_offsets ~machine_width layout idx in
+    let kinds =
+      Flambda_arity.unarize
+        (Flambda_arity.from_lambda_list [layout] ~machine_width)
+    in
+    begin match atomicity with
+    | Nonatomic ->
+      let writes =
+        Misc.Stdlib.List.map3
+          (fun kind offset new_value ->
+            H.Ternary
+              ( Write_offset (write_offset_kind, kind, mode),
+                ptr,
+                Prim offset,
+                new_value ))
+          kinds offsets new_values
+      in
+      [H.Sequence writes]
+    | Atomic ->
+      if List.length offsets <> 1
+      then
+        Misc.fatal_error
+          "convert_pset_indirect: expected single element for atomic op";
+      let full_kind = List.hd kinds in
+      if not (K.is_value (K.With_subkind.kind full_kind))
+      then
+        (* defensive check: field index computation assumes data is
+           word-sized *)
+        Misc.fatal_error "convert_pget_indirect: expected value for atomic op";
+      let field_kind = P.Block_access_field_kind.from_kind full_kind in
+      let offset = List.hd offsets in
+      let field = tagged_field_index_of_offset ~machine_width offset in
+      let new_value = List.hd new_values in
+      [Ternary (Atomic_set_field field_kind, ptr, field, new_value)]
+    end
+  in
   match prim, args with
   | Pphys_equal eq, [[arg1]; [arg2]] ->
     let eq : P.equality_comparison = match eq with Eq -> Eq | Noteq -> Neq in
@@ -3288,41 +3363,18 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Ppoke layout, [[ptr]; [new_value]] ->
     let kind = standard_int_or_float_of_peek_or_poke layout in
     [Binary (Poke kind, ptr, new_value)]
-  | Pget_idx (layout, mut), [[ptr]; [idx]]
-  | Pget_ptr (layout, mut), [[ptr; idx]]
+  | Pget_idx (layout, mut), [[ptr]; [idx]] | Pget_ptr (layout, mut), [[ptr; idx]]
     ->
-    needs_64_bit_target prim dbg;
-    let offsets = block_index_access_offsets ~machine_width layout idx in
-    let kinds =
-      Flambda_arity.unarize
-        (Flambda_arity.from_lambda_list [layout] ~machine_width)
-    in
-    let reads =
-      List.map2
-        (fun kind offset ->
-          H.Binary (Read_offset (kind, mut), ptr, Prim offset))
-        kinds offsets
-    in
-    [H.maybe_create_unboxed_product reads]
+    convert_pget_indirect layout mut ~ptr ~idx
   | Pget_ptr _, [([] | [_] | _ :: _ :: _ :: _)] ->
     Misc.fatal_errorf
       "Closure_convertion.convert_primitive: The argument to Pget_ptr should \
        be an unboxed product of length 2"
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
   | Pset_idx (layout, mode, atomicity), [[ptr]; [idx]; new_values] ->
-    needs_64_bit_target prim dbg;
-    begin match atomicity with
-    | Nonatomic -> ()
-    | Atomic -> Misc.fatal_error "unimplemented!"
-    end;
-    write_offset Into_block layout mode ~machine_width ~ptr ~idx ~new_values
+    convert_pset_indirect Into_block layout mode atomicity ~ptr ~idx ~new_values
   | Pset_ptr (layout, mode, atomicity), [[ptr; idx]; new_values] ->
-    needs_64_bit_target prim dbg;
-    begin match atomicity with
-    | Nonatomic -> ()
-    | Atomic -> Misc.fatal_error "unimplemented!"
-    end;
-    write_offset Into_block_or_off_heap layout mode ~machine_width ~ptr ~idx
+    convert_pset_indirect Into_block_or_off_heap layout mode atomicity ~ptr ~idx
       ~new_values
   | Pset_ptr _, [([] | [_] | _ :: _ :: _ :: _); _] ->
     Misc.fatal_errorf
@@ -3330,28 +3382,11 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
        should be an unboxed product of length 2"
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
   | Pget_ext_ptr (layout, mut), [[idx]] ->
-    needs_64_bit_target prim dbg;
     let null_base = H.Simple (Simple.const Reg_width_const.const_null) in
-    let offsets = block_index_access_offsets ~machine_width layout idx in
-    let kinds =
-      Flambda_arity.unarize
-        (Flambda_arity.from_lambda_list [layout] ~machine_width)
-    in
-    let reads =
-      List.map2
-        (fun kind offset ->
-          H.Binary (Read_offset (kind, mut), null_base, Prim offset))
-        kinds offsets
-    in
-    [H.maybe_create_unboxed_product reads]
+    convert_pget_indirect layout mut ~ptr:null_base ~idx
   | Pset_ext_ptr (layout, mode, atomicity), [[idx]; new_values] ->
-    needs_64_bit_target prim dbg;
-    begin match atomicity with
-    | Nonatomic -> ()
-    | Atomic -> Misc.fatal_error "unimplemented!"
-    end;
     let null_base = H.Simple (Simple.const Reg_width_const.const_null) in
-    write_offset Into_block_or_off_heap layout mode ~machine_width
+    convert_pset_indirect Into_block_or_off_heap layout mode atomicity
       ~ptr:null_base ~idx ~new_values
   | (Praise _ | Pccall _), _ ->
     Misc.fatal_errorf

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -493,7 +493,7 @@ and bind_rec_primitive acc exn_cont ~register_const0 (prim : simple_or_prim)
     in
     bind_recs acc exn_cont ~register_const0 p dbg cont
 
-let convert_block_access_field_kind_from_value_kind
+let block_access_field_kind_of_value_kind
     ({ raw_kind; nullable = _ } : L.value_kind) : P.Block_access_field_kind.t =
   match raw_kind with
   | Pintval -> Immediate
@@ -510,7 +510,7 @@ let mixed_block_access_field_kind
     P.Mixed_block_access_field_kind.t =
   match elt with
   | Value value_kind ->
-    Value_prefix (convert_block_access_field_kind_from_value_kind value_kind)
+    Value_prefix (block_access_field_kind_of_value_kind value_kind)
   | ( Float64 | Float32 | Bits8 | Bits16 | Bits32 | Bits64 | Vec128 | Vec256
     | Vec512 | Word | Untagged_immediate ) as mixed_block_element ->
     Flat_suffix

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.mli
@@ -88,6 +88,11 @@ val bind_recs :
   (Acc.t -> Flambda.Named.t list -> Expr_with_acc.t) ->
   Expr_with_acc.t
 
+(** Returns the appropriate [Block_access_field_kind.t] for accessing field
+    element with given value kind. *)
+val block_access_field_kind_of_value_kind :
+  Lambda.value_kind -> Flambda_primitive.Block_access_field_kind.t
+
 (** Returns the appropriate [Block_access_kind.t] for accessing a field of a
     mixed block element. *)
 val block_access_kind_of_mixed_field_element :

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -543,6 +543,18 @@ module Block_access_field_kind = struct
     | Immediate -> Format.pp_print_string ppf "Immediate"
 
   let compare = Stdlib.compare
+
+  let from_kind kind =
+    match K.With_subkind.non_null_value_subkind kind with
+    | Tagged_immediate -> Immediate
+    | Anything | Boxed_float32 | Boxed_float | Boxed_int32 | Boxed_int64
+    | Boxed_nativeint | Boxed_vec128 | Boxed_vec256 | Boxed_vec512 | Variant _
+    | Float_block _ | Float_array | Immediate_array | Value_array
+    | Generic_array | Unboxed_float32_array | Untagged_int_array
+    | Untagged_int8_array | Untagged_int16_array | Unboxed_int32_array
+    | Unboxed_int64_array | Unboxed_nativeint_array | Unboxed_vec128_array
+    | Unboxed_vec256_array | Unboxed_vec512_array | Unboxed_product_array ->
+      Any_value
 end
 
 module Mixed_block_access_field_kind = struct

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -208,6 +208,8 @@ module Block_access_field_kind : sig
   val print : Format.formatter -> t -> unit
 
   val compare : t -> t -> int
+
+  val from_kind : Flambda_kind.With_subkind.full_kind -> t
 end
 
 module Mixed_block_access_field_kind : sig

--- a/otherlibs/stdlib_stable/idx_atomic.ml
+++ b/otherlibs/stdlib_stable/idx_atomic.ml
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                 Joe Kerrigan, Jane Street, New York                    *)
 (*                                                                        *)
-(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)

--- a/otherlibs/stdlib_stable/idx_atomic.ml
+++ b/otherlibs/stdlib_stable/idx_atomic.ml
@@ -1,0 +1,30 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                 Joe Kerrigan, Jane Street, New York                    *)
+(*                                                                        *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+[@@@ocaml.flambda_o3]
+
+type ('a : value_or_null, 'b : any) t : bits64 mod everything =
+  ('a, 'b) idx_atomic
+
+external get
+  : ('a : value_or_null) ('b : any).
+  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> ('b[@local_opt])
+  = "%get_idx_atomic"
+[@@layout_poly]
+
+external set
+  : ('a : value_or_null) ('b : any).
+  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> 'b -> unit
+  = "%set_idx_atomic"
+[@@layout_poly]

--- a/otherlibs/stdlib_stable/idx_atomic.mli
+++ b/otherlibs/stdlib_stable/idx_atomic.mli
@@ -1,0 +1,37 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                 Joe Kerrigan, Jane Street, New York                    *)
+(*                                                                        *)
+(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Atomic indices into blocks. *)
+
+(** An alias for the type of atomic indices into blocks. *)
+type ('a : value_or_null, 'b : any) t : bits64 mod everything =
+  ('a, 'b) idx_atomic
+
+(** [get a i] uses the index [i] to access [a]. *)
+external get
+  : ('a : value_or_null) ('b : any).
+  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> ('b[@local_opt])
+  = "%get_idx_atomic"
+[@@layout_poly]
+
+(** [set a i v] uses the index [i] to set [a] to [v].
+
+    It can take [a] locally and [v] globally because mutable indices (e.g. to
+    array elements or mutable record fields) can only be created to elements
+    with the [global] modality. *)
+external set
+  : ('a : value_or_null) ('b : any).
+  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> 'b -> unit
+  = "%set_idx_atomic"
+[@@layout_poly]

--- a/otherlibs/stdlib_stable/idx_atomic.mli
+++ b/otherlibs/stdlib_stable/idx_atomic.mli
@@ -4,7 +4,7 @@
 (*                                                                        *)
 (*                 Joe Kerrigan, Jane Street, New York                    *)
 (*                                                                        *)
-(*   Copyright 2024 Jane Street Group LLC                                 *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
 (*                                                                        *)
 (*   All rights reserved.  This file is distributed under the terms of    *)
 (*   the GNU Lesser General Public License version 2.1, with the          *)
@@ -18,14 +18,14 @@
 type ('a : value_or_null, 'b : any) t : bits64 mod everything =
   ('a, 'b) idx_atomic
 
-(** [get a i] uses the index [i] to access [a]. *)
+(** [get a i] uses the index [i] to access [a] atomically. *)
 external get
   : ('a : value_or_null) ('b : any).
   ('a[@local_opt]) -> ('a, 'b) idx_atomic -> ('b[@local_opt])
   = "%get_idx_atomic"
 [@@layout_poly]
 
-(** [set a i v] uses the index [i] to set [a] to [v].
+(** [set a i v] uses the index [i] to set [a] to [v] atomically.
 
     It can take [a] locally and [v] globally because mutable indices (e.g. to
     array elements or mutable record fields) can only be created to elements

--- a/otherlibs/stdlib_stable/stdlib_stable.ml
+++ b/otherlibs/stdlib_stable/stdlib_stable.ml
@@ -4,6 +4,7 @@ module Float32 = Float32
 module Float32_u = Float32_u
 module Idx_imm = Idx_imm
 module Idx_mut = Idx_mut
+module Idx_atomic = Idx_atomic
 module Int = Int
 module Int_u = Int_u
 module Int8 = Int8

--- a/otherlibs/stdlib_stable/stdlib_stable.mli
+++ b/otherlibs/stdlib_stable/stdlib_stable.mli
@@ -4,6 +4,7 @@ module Float32 = Float32
 module Float32_u = Float32_u
 module Idx_imm = Idx_imm
 module Idx_mut = Idx_mut
+module Idx_atomic = Idx_atomic
 module Int = Int
 module Int_u = Int_u
 module Int8 = Int8

--- a/parsing/parse.ml
+++ b/parsing/parse.ml
@@ -205,6 +205,10 @@ let prepare_error err =
          @{<hint>Hint@}: If you really want a mutable function variable, \
          use the de-sugared syntax:\n  %a"
          Style.inline_code "let mutable f = fun x -> .."
+  | Block_access_idx_atomic loc ->
+      Location.errorf ~loc
+        "Syntax error: %a block accesses are not supported."
+        Style.inline_code ".idx_atomic"
   | Block_access_bad_paren loc ->
       Location.errorf ~loc
         "Syntax error: A parenthesis here can only follow %a or %a."

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -3128,6 +3128,8 @@ block_access:
       match $2 with
       | "idx_imm" -> Baccess_block (Immutable, i)
       | "idx_mut" -> Baccess_block (Mutable, i)
+      | "idx_atomic" ->
+         raise Syntaxerr.(Error(Block_access_idx_atomic(make_loc $loc(_p))))
       | _ ->
         raise Syntaxerr.(Error(Block_access_bad_paren(make_loc $loc(_p))))
     }

--- a/parsing/syntaxerr.ml
+++ b/parsing/syntaxerr.ml
@@ -39,6 +39,7 @@ type error =
   | Let_mutable_not_allowed_at_structure_level of Location.t
   | Let_mutable_not_allowed_in_class_definition of Location.t
   | Let_mutable_not_allowed_with_function_bindings of Location.t
+  | Block_access_idx_atomic of Location.t
   | Block_access_bad_paren of Location.t
 
 exception Error of error
@@ -60,6 +61,7 @@ let location_of_error = function
   | Let_mutable_not_allowed_at_structure_level l -> l
   | Let_mutable_not_allowed_in_class_definition l -> l
   | Let_mutable_not_allowed_with_function_bindings l -> l
+  | Block_access_idx_atomic l -> l
   | Block_access_bad_paren l -> l
 
 

--- a/parsing/syntaxerr.mli
+++ b/parsing/syntaxerr.mli
@@ -44,6 +44,7 @@ type error =
   | Let_mutable_not_allowed_at_structure_level of Location.t
   | Let_mutable_not_allowed_in_class_definition of Location.t
   | Let_mutable_not_allowed_with_function_bindings of Location.t
+  | Block_access_idx_atomic of Location.t
   | Block_access_bad_paren of Location.t
 
 exception Error of error

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -1120,6 +1120,14 @@ CAMLprim value caml_get_idx_bytecode(value base, value idx)
   CAMLreturn (res);
 }
 
+CAMLprim value caml_get_idx_atomic_bytecode(value base, value idx) {
+  CAMLparam2 (base, idx);
+  CAMLassert (Tag_val(idx) == 0);
+  CAMLassert (Wosize_val(idx) == 1); // Nested atomic accesses not supported
+  CAMLassert (Tag_val(base) != Double_array_tag);
+  CAMLreturn (caml_atomic_load_field(base, Field(idx, 0)));
+}
+
 CAMLprim value caml_set_idx_bytecode(value base, value idx, value v)
 {
   CAMLparam3 (base, idx, v);
@@ -1143,12 +1151,30 @@ CAMLprim value caml_set_idx_bytecode(value base, value idx, value v)
   CAMLreturn (Val_unit);
 }
 
+CAMLprim value caml_set_idx_atomic_bytecode(value base, value idx, value v)
+{
+  CAMLparam2 (base, idx);
+  CAMLassert (Tag_val(idx) == 0);
+  CAMLassert (Wosize_val(idx) == 1); // Nested atomic accesses not supported
+  CAMLassert (Tag_val(base) != Double_array_tag);
+  caml_atomic_exchange_field(base, Field(idx, 0), v);
+  CAMLreturn (Val_unit);
+}
+
 CAMLprim value caml_get_ptr_bytecode(value ptr)
 {
   value base = Field(ptr, 0);
   if (Is_null(base))
     caml_failwith("External ptrs are unimplemented on bytecode");
   return caml_get_idx_bytecode(base, Field(ptr, 1));
+}
+
+CAMLprim value caml_get_ptr_atomic_bytecode(value ptr)
+{
+  value base = Field(ptr, 0);
+  if (Is_null(base))
+    caml_failwith("External ptrs are unimplemented on bytecode");
+  return caml_get_idx_atomic_bytecode(base, Field(ptr, 1));
 }
 
 CAMLprim value caml_set_ptr_bytecode(value ptr, value v)
@@ -1159,13 +1185,33 @@ CAMLprim value caml_set_ptr_bytecode(value ptr, value v)
   return caml_set_idx_bytecode(base, Field(ptr, 1), v);
 }
 
+CAMLprim value caml_set_ptr_atomic_bytecode(value ptr, value v)
+{
+  value base = Field(ptr, 0);
+  if (Is_null(base))
+    caml_failwith("External ptrs are unimplemented on bytecode");
+  return caml_set_idx_atomic_bytecode(base, Field(ptr, 1), v);
+}
+
 CAMLprim value caml_get_ext_ptr_bytecode(value idx)
 {
   caml_failwith("External ptr primitives are unimplemented on bytecode");
   return Val_unit;
 }
 
+CAMLprim value caml_get_ext_ptr_atomic_bytecode(value idx)
+{
+  caml_failwith("External ptr primitives are unimplemented on bytecode");
+  return Val_unit;
+}
+
 CAMLprim value caml_set_ext_ptr_bytecode(value idx, value v)
+{
+  caml_failwith("External ptr primitives are unimplemented on bytecode");
+  return Val_unit;
+}
+
+CAMLprim value caml_set_ext_ptr_atomic_bytecode(value idx, value v)
 {
   caml_failwith("External ptr primitives are unimplemented on bytecode");
   return Val_unit;

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -46,6 +46,8 @@ CAMLextern void caml_free_dependent_memory (value v, mlsize_t bsz);
 CAMLextern void caml_modify (volatile value *, value);
 CAMLextern void caml_modify_local (value obj, intnat i, value val);
 CAMLextern void caml_initialize (volatile value *, value);
+CAMLextern value caml_atomic_load_field (value, value);
+CAMLprim value caml_atomic_exchange_field (value, value, value);
 CAMLextern value caml_atomic_cas_field (value, value, value, value);
 CAMLextern value caml_check_urgent_gc (value);
 

--- a/testsuite/tests/atomic-locs/atomic_fields.ml
+++ b/testsuite/tests/atomic-locs/atomic_fields.ml
@@ -169,6 +169,18 @@ Line 1, characters 48-77:
 Error: The record field "regular_field" is not atomic
 |}]
 
+(* Test Label_not_atomic for an unusual record representation *)
+
+type float_record = { mutable f : float } (* Record_float *)
+let test_non_atomic_float_field (r : float_record) = [%atomic.loc r.f]
+[%%expect{|
+type float_record = { mutable f : float; }
+Line 2, characters 53-70:
+2 | let test_non_atomic_float_field (r : float_record) = [%atomic.loc r.f]
+                                                         ^^^^^^^^^^^^^^^^^
+Error: The record field "f" is not atomic
+|}]
+
 (* Test Invalid_atomic_loc_payload errors *)
 
 (* Empty payload *)

--- a/testsuite/tests/atomic-locs/mixed_field_access.ml
+++ b/testsuite/tests/atomic-locs/mixed_field_access.ml
@@ -1,0 +1,156 @@
+(* TEST
+ include stdlib_upstream_compatible;
+ flambda2;
+ {
+   native;
+ } {
+   bytecode;
+ }
+*)
+
+module Int64_u = struct
+  include Stdlib_upstream_compatible.Int64_u
+end
+
+module Mixed_record = struct
+  (* the value field comes first, so flambda2 reordering is a noop *)
+  type t = { mutable atomic : int [@atomic]; mutable nonatomic : int64# }
+
+  let () =
+    Printf.printf "== Mixed record (no reordering) ==\n";
+    let t = { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_reorder = struct
+  (* flambda2 will reorder so [atomic] comes before [nonatomic] *)
+  type t = { mutable nonatomic : int64#; mutable atomic : int [@atomic] }
+
+  let () =
+    Printf.printf "== Mixed record (reordering) ==\n";
+    let t = { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_inline_record = struct
+  (* use an inline record *)
+  type t = A of { mutable atomic : int [@atomic]; mutable nonatomic : int64# }
+
+  let () =
+    Printf.printf "== Mixed inline record (no reordering) ==\n";
+    let (A t) = A { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_inline_record_reorder = struct
+  type t = A of { mutable nonatomic : int64#; mutable atomic : int [@atomic] }
+
+  let () =
+    Printf.printf "== Mixed inline record (reordering) ==\n";
+    let (A t) = A { atomic = 42; nonatomic = #13L } in
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- 43; Printf.printf "set t.atomic <- 43\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %d\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_nonimmediate = struct
+  (* atomic field is not an immediate *)
+  type t = { mutable atomic : string [@atomic]; mutable nonatomic : int64# }
+
+  let () =
+    Printf.printf "== Mixed record with non-immediate (no reordering) ==\n";
+    let t = { atomic = "hello"; nonatomic = #13L } in
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- "world"; Printf.printf "set t.atomic <- \"world\"\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_nonimmediate_reorder = struct
+  type t = { mutable nonatomic : int64#; mutable atomic : string [@atomic]; }
+
+  let () =
+    Printf.printf "== Mixed record with non-immediate (reordering) ==\n";
+    let t = { atomic = "hello"; nonatomic = #13L } in
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.atomic <- "world"; Printf.printf "set t.atomic <- \"world\"\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic: %s\n" t.atomic;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+end
+
+module Mixed_record_sandwich = struct
+  (* a non-value field sandwiched between two atomic value fields *)
+  type t =
+    { mutable atomic1 : int [@atomic];
+      mutable nonatomic : int64#;
+      mutable atomic2 : string [@atomic]
+    }
+
+  let () =
+    Printf.printf "== Mixed record (sandwiched non-value field) ==\n";
+    let t = { atomic1 = 42; nonatomic = #13L; atomic2 = "hello" } in
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2;
+
+    t.atomic1 <- 43; Printf.printf "set t.atomic1 <- 43\n";
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2;
+
+    t.nonatomic <- #14L; Printf.printf "set t.nonatomic <- 14\n";
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2;
+
+    t.atomic2 <- "world"; Printf.printf "set t.atomic2 <- \"world\"\n";
+    Printf.printf "t.atomic1: %d\n" t.atomic1;
+    Printf.printf "t.nonatomic: %Ld\n" (Int64_u.to_int64 t.nonatomic);
+    Printf.printf "t.atomic2: %s\n" t.atomic2
+end

--- a/testsuite/tests/atomic-locs/mixed_field_access.reference
+++ b/testsuite/tests/atomic-locs/mixed_field_access.reference
@@ -1,0 +1,70 @@
+== Mixed record (no reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed record (reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed inline record (no reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed inline record (reordering) ==
+t.atomic: 42
+t.nonatomic: 13
+set t.atomic <- 43
+t.atomic: 43
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: 43
+t.nonatomic: 14
+== Mixed record with non-immediate (no reordering) ==
+t.atomic: hello
+t.nonatomic: 13
+set t.atomic <- "world"
+t.atomic: world
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: world
+t.nonatomic: 14
+== Mixed record with non-immediate (reordering) ==
+t.atomic: hello
+t.nonatomic: 13
+set t.atomic <- "world"
+t.atomic: world
+t.nonatomic: 13
+set t.nonatomic <- 14
+t.atomic: world
+t.nonatomic: 14
+== Mixed record (sandwiched non-value field) ==
+t.atomic1: 42
+t.nonatomic: 13
+t.atomic2: hello
+set t.atomic1 <- 43
+t.atomic1: 43
+t.nonatomic: 13
+t.atomic2: hello
+set t.nonatomic <- 14
+t.atomic1: 43
+t.nonatomic: 14
+t.atomic2: hello
+set t.atomic2 <- "world"
+t.atomic1: 43
+t.nonatomic: 14
+t.atomic2: world

--- a/testsuite/tests/atomic-locs/mixed_records.ml
+++ b/testsuite/tests/atomic-locs/mixed_records.ml
@@ -152,34 +152,63 @@ module Pattern_matching_wildcard :
   end
 |}]
 
-(* Defining atomic fields in a mixed block is permitted. *)
-module Mixed_blocks_ok = struct
+(* Atomic fields are permitted in mixed blocks. *)
+module Mixed_record_atomics = struct
   type t = {
-    padding : #(int * int * int);
-    mutable field : int [@atomic]
+    mutable a : int [@atomic];
+    mutable b : int64#
   }
-end
 
+  let access t =
+    let _ = t.a in
+    let _ = t.b in
+    t.a <- 42;
+    t.b <- #42L
+end
 [%%expect{|
-module Mixed_blocks_ok :
+module Mixed_record_atomics :
   sig
-    type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
+    type t = { mutable a : int [@atomic]; mutable b : int64#; }
+    val access : t -> unit
   end
 |}]
 
-(* Test access of nonatomic fields in mixed record with atomic fields *)
-type t = { i : int64#; mutable a : int [@atomic]; mutable b : int }
-[%%expect {|
-type t = { i : int64#; mutable a : int [@atomic]; mutable b : int; }
+(* Atomic fields are permitted in mixed inline records. *)
+module Mixed_inline_record_atomics = struct
+  type t = A of {
+    mutable a : int [@atomic];
+    mutable b : int64#
+  }
+
+  let access (A t) =
+    let _ = t.a in
+    let _ = t.b in
+    t.a <- 42;
+    t.b <- #42L
+end
+[%%expect{|
+module Mixed_inline_record_atomics :
+  sig
+    type t = A of { mutable a : int [@atomic]; mutable b : int64#; }
+    val access : t -> unit
+  end
 |}]
 
-let ok_project (t : t) = t.b
-[%%expect {|
-val ok_project : t -> int = <fun>
+(* We forbid taking atomic.loc of fields from mixed records. *)
+let forbidden (t : Mixed_record_atomics.t) = [%atomic.loc t.a]
+[%%expect{|
+Line 1, characters 45-62:
+1 | let forbidden (t : Mixed_record_atomics.t) = [%atomic.loc t.a]
+                                                 ^^^^^^^^^^^^^^^^^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "a") is forbidden.
 |}]
-let ok_set (t : t) = t.b <- 42
-[%%expect {|
-val ok_set : t -> unit = <fun>
+
+let forbidden_inline (A t : Mixed_inline_record_atomics.t) = [%atomic.loc t.a]
+[%%expect{|
+Line 1, characters 61-78:
+1 | let forbidden_inline (A t : Mixed_inline_record_atomics.t) = [%atomic.loc t.a]
+                                                                 ^^^^^^^^^^^^^^^^^
+Error: Use of "[%atomic.loc]" with mixed record fields (here "a") is forbidden.
 |}]
 
 (* Test mixed record atomic fields with non-value layouts *)
@@ -213,6 +242,16 @@ end
 Line 4, characters 4-31:
 4 |     mutable field : u [@atomic]
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Atomic record fields must have layout value.
+|}]
+
+module Mixed_inline_record_non_value_atomic = struct
+  type t = A of { mutable f : float# [@atomic]; g : int64# }
+end
+[%%expect{|
+Line 2, characters 18-47:
+2 |   type t = A of { mutable f : float# [@atomic]; g : int64# }
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Atomic record fields must have layout value.
 |}]
 
@@ -257,11 +296,11 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-Line 5, characters 31-32:
-5 |   let allowed t = { t with y = t.y }
-                                   ^
-Error: Accessing atomic fields (here "y") of mixed records is not yet
-       supported.
+module Functional_update_copy_ok :
+  sig
+    type t = { x : int64#; mutable y : int [@atomic]; }
+    val allowed : t -> t
+  end
 |}]
 
 module Functional_update_multi_error = struct
@@ -301,9 +340,13 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-Line 4, characters 31-32:
-4 |   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
-                                   ^
-Error: Accessing atomic fields (here "y") of mixed records is not yet
-       supported.
+module Functional_update_multi_copy_ok :
+  sig
+    type t = {
+      x : int64#;
+      mutable y : int [@atomic];
+      mutable z : int [@atomic];
+    }
+    val allowed : t -> t
+  end
 |}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -201,51 +201,52 @@ type ('a : any) t = { a : 'a; mutable f: int [@atomic]}
 type ('a : any) t = { a : 'a; mutable f : int [@atomic]; }
 |}];;
 
-let ok_project (t: int t) = t.f
+let project (t: int t) = t.f
+[%%expect{|
+(let (project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : int t -> int = <fun>
+|}];;
+
+let mixed_project (t: int64# t) = t.f
 [%%expect{|
 (let
-  (ok_project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
-  (apply (field_imm 1 (global Toploop!)) "ok_project" ok_project))
-val ok_project : int t -> int = <fun>
+  (mixed_project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (bits64,value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_project" mixed_project))
+val mixed_project : int64# t -> int = <fun>
 |}];;
 
-let wrong_project (t: int64# t) = t.f
+let set (t: int t) = t.f <- 42
 [%%expect{|
-Line 1, characters 34-35:
-1 | let wrong_project (t: int64# t) = t.f
-                                      ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(let (set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : int t -> unit = <fun>
 |}];;
 
-let ok_set (t: int t) = t.f <- 42
+let mixed_set (t: int64# t) = t.f <- 42
 [%%expect{|
-(let (ok_set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
-  (apply (field_imm 1 (global Toploop!)) "ok_set" ok_set))
-val ok_set : int t -> unit = <fun>
+(let
+  (mixed_set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (bits64,value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_set" mixed_set))
+val mixed_set : int64# t -> unit = <fun>
 |}];;
 
-let wrong_set (t: int64# t) = t.f <- 42
+let loc (t: int t) = [%atomic.loc t.f]
 [%%expect{|
-Line 1, characters 30-39:
-1 | let wrong_set (t: int64# t) = t.f <- 42
-                                  ^^^^^^^^^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
-|}];;
-
-let ok_loc (t: int t) = [%atomic.loc t.f]
-[%%expect{|
-(let (ok_loc = (function {nlocal = 0} t (makeblock 0 (*,value<int>) t 1)))
-  (apply (field_imm 1 (global Toploop!)) "ok_loc" ok_loc))
-val ok_loc : int t -> int atomic_loc = <fun>
+(let (loc = (function {nlocal = 0} t (makeblock 0 (*,value<int>) t 1)))
+  (apply (field_imm 1 (global Toploop!)) "loc" loc))
+val loc : int t -> int atomic_loc = <fun>
 |}];;
 
 let wrong_loc (t: int64# t) = [%atomic.loc t.f];
 [%%expect{|
-Line 1, characters 43-44:
+Line 1, characters 30-47:
 1 | let wrong_loc (t: int64# t) = [%atomic.loc t.f];
-                                               ^
+                                  ^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "f") is forbidden.
 |}];;
 
@@ -307,37 +308,38 @@ type ('a : any) t = A of { a : 'a; mutable f: int [@atomic]}
 type ('a : any) t = A of { a : 'a; mutable f : int [@atomic]; }
 |}];;
 
-let ok_project (t: int t) = match t with A r -> r.f
+let project (t: int t) = match t with A r -> r.f
+[%%expect{|
+(let (project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : int t -> int = <fun>
+|}];;
+
+let mixed_project (t: int64# t) = match t with A r -> r.f
 [%%expect{|
 (let
-  (ok_project = (function {nlocal = 0} t : int (atomic_load_field_imm t 1)))
-  (apply (field_imm 1 (global Toploop!)) "ok_project" ok_project))
-val ok_project : int t -> int = <fun>
+  (mixed_project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (bits64,value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_project" mixed_project))
+val mixed_project : int64# t -> int = <fun>
 |}];;
 
-let wrong_project (t: int64# t) = match t with A r -> r.f
+let set (t: int t) = match t with A r -> r.f <- 42
 [%%expect{|
-Line 1, characters 54-55:
-1 | let wrong_project (t: int64# t) = match t with A r -> r.f
-                                                          ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(let (set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : int t -> unit = <fun>
 |}];;
 
-let ok_set (t: int t) = match t with A r -> r.f <- 42
+let mixed_set (t: int64# t) = match t with A r -> r.f <- 42
 [%%expect{|
-(let (ok_set = (function {nlocal = 0} t : int (atomic_set_field_imm t 1 42)))
-  (apply (field_imm 1 (global Toploop!)) "ok_set" ok_set))
-val ok_set : int t -> unit = <fun>
-|}];;
-
-let wrong_set (t: int64# t) = match t with A r -> r.f <- 42
-[%%expect{|
-Line 1, characters 50-59:
-1 | let wrong_set (t: int64# t) = match t with A r -> r.f <- 42
-                                                      ^^^^^^^^^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(let
+  (mixed_set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (bits64,value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "mixed_set" mixed_set))
+val mixed_set : int64# t -> unit = <fun>
 |}];;
 
 let ok_loc (t: int t) = match t with A r -> [%atomic.loc r.f]
@@ -349,9 +351,9 @@ val ok_loc : int t -> int atomic_loc = <fun>
 
 let wrong_loc (t: int64# t) = match t with A r -> [%atomic.loc r.f]
 [%%expect{|
-Line 1, characters 63-64:
+Line 1, characters 50-67:
 1 | let wrong_loc (t: int64# t) = match t with A r -> [%atomic.loc r.f]
-                                                                   ^
+                                                      ^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "f") is forbidden.
 |}];;
 
@@ -372,7 +374,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic float field
   which prevents the float record optimization.
   The fields of this record will be boxed instead of being
   represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/471"
+(apply (field_imm 1 (global Toploop!)) "Float_records/470"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -592,7 +594,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/534"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/533"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))
@@ -633,7 +635,7 @@ module Functional_update_ok = struct
   let allowed t = { t with y = 42 }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/550"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/549"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -653,7 +655,7 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/558"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/557"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -687,7 +689,7 @@ module Functional_update_multi_ok = struct
   let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/574"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/573"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -711,7 +713,7 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/583"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/582"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -740,32 +742,38 @@ end
 
 let project (t : Mixed_blocks.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/614" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/587" (makeblock 0))
 module Mixed_blocks :
   sig
     type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
   end
-Line 8, characters 35-36:
-8 | let project (t : Mixed_blocks.t) = t.field
-                                       ^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (product  (value_or_null<int>,value_or_null<
+                                                                  int>,
+         value_or_null<int>),value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : Mixed_blocks.t -> int = <fun>
 |}]
 
 let set (t: Mixed_blocks.t) = t.field <- 42
 [%%expect{|
-Line 1, characters 30-43:
-1 | let set (t: Mixed_blocks.t) = t.field <- 42
-                                  ^^^^^^^^^^^^^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (product  (value_or_null<int>,value_or_null<
+                                                                 int>,
+         value_or_null<int>),value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : Mixed_blocks.t -> unit = <fun>
 |}]
 
 let loc (t: Mixed_blocks.t) = [%atomic.loc t.field]
 [%%expect{|
-Line 1, characters 43-44:
+Line 1, characters 30-51:
 1 | let loc (t: Mixed_blocks.t) = [%atomic.loc t.field]
-                                               ^
+                                  ^^^^^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
@@ -778,32 +786,36 @@ end
 
 let project (t : Mixed_blocks_2.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/627" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/597" (makeblock 0))
 module Mixed_blocks_2 :
   sig
     type t = { mutable field : int [@atomic]; padding : #(int * int * int); }
   end
-Line 8, characters 37-38:
-8 | let project (t : Mixed_blocks_2.t) = t.field
-                                         ^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 0  (value<int>,product  (value_or_null<int>,
+         value_or_null<int>,value_or_null<int>)) t)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : Mixed_blocks_2.t -> int = <fun>
 |}]
 
 let set (t: Mixed_blocks_2.t) = t.field <- 42
 [%%expect{|
-Line 1, characters 32-45:
-1 | let set (t: Mixed_blocks_2.t) = t.field <- 42
-                                    ^^^^^^^^^^^^^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 0  (value<int>,product  (value_or_null<int>,
+         value_or_null<int>,value_or_null<int>)) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : Mixed_blocks_2.t -> unit = <fun>
 |}]
 
 let loc (t: Mixed_blocks_2.t) = [%atomic.loc t.field]
 [%%expect{|
-Line 1, characters 45-46:
+Line 1, characters 32-53:
 1 | let loc (t: Mixed_blocks_2.t) = [%atomic.loc t.field]
-                                                 ^
+                                    ^^^^^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
@@ -820,7 +832,7 @@ module Mixed_blocks_rec = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/643" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/610" (makeblock 0))
 module Mixed_blocks_rec :
   sig
     type t = { padding : u; mutable field : int [@atomic]; }
@@ -830,25 +842,29 @@ module Mixed_blocks_rec :
 
 let project (t : Mixed_blocks_rec.t) = t.field
 [%%expect{|
-Line 1, characters 39-40:
-1 | let project (t : Mixed_blocks_rec.t) = t.field
-                                           ^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (project =
+     (function {nlocal = 0} t : int
+       (atomic_load_mixed_field 1  (product  (untagged_immediate,float64),
+         value<int>) t)))
+  (apply (field_imm 1 (global Toploop!)) "project" project))
+val project : Mixed_blocks_rec.t -> int = <fun>
 |}]
 let set (t: Mixed_blocks_rec.t) = t.field <- 42
 [%%expect{|
-Line 1, characters 34-47:
-1 | let set (t: Mixed_blocks_rec.t) = t.field <- 42
-                                      ^^^^^^^^^^^^^
-Error: Accessing atomic fields (here "field") of mixed records is not yet
-       supported.
+(let
+  (set =
+     (function {nlocal = 0} t : int
+       (atomic_set_mixed_field 1  (product  (untagged_immediate,float64),
+         value<int>) t 42)))
+  (apply (field_imm 1 (global Toploop!)) "set" set))
+val set : Mixed_blocks_rec.t -> unit = <fun>
 |}]
 let loc (t: Mixed_blocks_rec.t) = [%atomic.loc t.field]
 [%%expect{|
-Line 1, characters 47-48:
+Line 1, characters 34-55:
 1 | let loc (t: Mixed_blocks_rec.t) = [%atomic.loc t.field]
-                                                   ^
+                                      ^^^^^^^^^^^^^^^^^^^^^
 Error: Use of "[%atomic.loc]" with mixed record fields (here "field") is forbidden.
 |}]
 
@@ -924,11 +940,17 @@ module Atomic_float_with_float_hash = struct
 end
 
 [%%expect{|
-Line 4, characters 21-22:
-4 |   let disallowed t = t.f
-                         ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/636"
+  (let
+    (disallowed =
+       (function {nlocal = 0} t : float
+         (atomic_load_mixed_field 0  (*,float64) t)))
+    (makeblock 0 disallowed)))
+module Atomic_float_with_float_hash :
+  sig
+    type t = { mutable f : float [@atomic]; u : float#; }
+    val disallowed : t -> float
+  end
 |}]
 
 module Inline_record_atomic_in_mixed = struct
@@ -939,9 +961,15 @@ module Inline_record_atomic_in_mixed = struct
 end
 
 [%%expect{|
-Line 5, characters 11-12:
-5 |   | A r -> r.f
-               ^
-Error: Accessing atomic fields (here "f") of mixed records is not yet
-       supported.
+(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/645"
+  (let
+    (disallowed =
+       (function {nlocal = 0} t : int
+         (atomic_load_mixed_field 0  (value<int>,untagged_immediate) t)))
+    (makeblock 0 disallowed)))
+module Inline_record_atomic_in_mixed :
+  sig
+    type t = A of { mutable f : int [@atomic]; u : int#; }
+    val disallowed : t -> int
+  end
 |}]

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -728,60 +728,6 @@ module Functional_update_multi_copy_ok :
     val allowed : t -> t
   end
 |}]
-(* Pattern matching follows the same rules in mixed blocks. *)
-module Pattern_matching = struct
-  type t = { x : int64#; mutable y : int [@atomic] }
-
-  let forbidden { x; y } = x + y
-end
-[%%expect{|
-Line 4, characters 16-24:
-4 |   let forbidden { x; y } = x + y
-                    ^^^^^^^^
-Error: Atomic fields (here "y") are forbidden in patterns,
-       as it is difficult to reason about when the atomic read
-       will happen during pattern matching: the field may be read
-       zero, one or several times depending on the patterns around it.
-|}]
-
-(* ... except for wildcards, to allow exhaustive record patterns. *)
-module Pattern_matching_wildcard = struct
-  type t = { x : int64#; mutable y : int [@atomic] }
-
-  [@@@warning "+missing-record-field-pattern"]
-  let warning { x } = x
-
-  let allowed { x; y = _ } = x
-  let also_allowed { x; _ } = x
-end
-[%%expect{|
-Line 5, characters 14-19:
-5 |   let warning { x } = x
-                  ^^^^^
-Warning 9 [missing-record-field-pattern]: the following labels are not bound
-  in this record pattern: "y".
-  Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/607"
-  (let
-    (warning =
-       (function {nlocal = 0} param : unboxed_int64
-         (mixedfield 0  (bits64,value_or_null<int>) param))
-     allowed =
-       (function {nlocal = 0} param : unboxed_int64
-         (mixedfield 0  (bits64,value_or_null<int>) param))
-     also_allowed =
-       (function {nlocal = 0} param : unboxed_int64
-         (mixedfield 0  (bits64,value_or_null<int>) param)))
-    (makeblock 0 warning allowed also_allowed)))
-
-module Pattern_matching_wildcard :
-  sig
-    type t = { x : int64#; mutable y : int [@atomic]; }
-    val warning : t -> int64#
-    val allowed : t -> int64#
-    val also_allowed : t -> int64#
-  end
-|}]
 
 (* Test atomic record fields in mixed blocks *)
 

--- a/testsuite/tests/records-and-block-indices/idx_atomic.ml
+++ b/testsuite/tests/records-and-block-indices/idx_atomic.ml
@@ -1,0 +1,94 @@
+(* TEST
+ include stdlib_stable;
+ include stdlib_upstream_compatible;
+ flambda2;
+ {
+   bytecode;
+ } {
+   native;
+ }
+*)
+
+open Stdlib_stable
+open Stdlib_upstream_compatible
+
+(* test reading/writing atomic fields using block indices *)
+
+module Basic = struct
+  type t = { mutable x: int [@atomic]; mutable y: string [@atomic] }
+
+  let () =
+    Printf.printf "== Basic idx_atomic ==\n";
+    let t = { x = 1; y = "two" } in
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    Printf.printf "(.x) <- 3\n"; Idx_atomic.set t (.x) 3;
+    Printf.printf "(.y) <- \"four\"\n"; Idx_atomic.set t (.y) "four";
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    ()
+end
+
+(* test reading/writing unboxed singleton record *)
+
+module UnboxedSingleton = struct
+  type inner = { y: int }
+  type outer = { mutable x: inner# [@atomic] }
+
+  let () =
+    Printf.printf "== idx_atomic with unboxed singleton ==\n";
+    let t = { x = #{ y = 1 } } in
+    Printf.printf "(.x.#y) = %d\n" (Idx_atomic.get t (.x.#y));
+    Printf.printf "(.x.#y) <- 2\n"; Idx_atomic.set t (.x.#y) 2;
+    Printf.printf "(.x.#y) = %d\n" (Idx_atomic.get t (.x.#y));
+    ()
+end
+
+(* test reading/writing from mixed record *)
+
+module Mixed = struct
+  type t = { x: int64#; mutable y: string [@atomic]; z: int64# }
+
+  let () =
+    Printf.printf "== Basic idx_atomic (mixed record) ==\n";
+    let t = { x = #42L; y = "two"; z = #67L } in
+    Printf.printf "(.x) = %Ld\n" (Int64_u.to_int64 t.x);
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    Printf.printf "(.z) = %Ld\n" (Int64_u.to_int64 t.z);
+    Printf.printf "(.y) <- \"three\"\n"; Idx_atomic.set t (.y) "three";
+    Printf.printf "(.x) = %Ld\n" (Int64_u.to_int64 t.x);
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    Printf.printf "(.z) = %Ld\n" (Int64_u.to_int64 t.z);
+end
+
+(* test reading/writing from all-float record *)
+
+module Float = struct
+  [@@@warning "-214"]
+  type t = { x: float; mutable y: float [@atomic] }
+
+  let () =
+    Printf.printf "== Basic idx_atomic (float record) ==\n";
+    let t = { x = 2.0; y = 4.0 } in
+    Printf.printf "(.x) = %f\n" t.x;
+    Printf.printf "(.y) = %f\n" (Idx_atomic.get t (.y));
+    Printf.printf "(.y) <- 6.0\n"; Idx_atomic.set t (.y) 6.0;
+    Printf.printf "(.x) = %f\n" t.x;
+    Printf.printf "(.y) = %f\n" (Idx_atomic.get t (.y));
+    ()
+end
+
+(* test reading/writing from record with void fields *)
+
+module Void = struct
+  [@@@warning "-214"]
+  type t = { x: unit#; mutable y: string [@atomic]; z: unit# }
+
+  let () =
+    Printf.printf "== Basic idx_atomic (void record) ==\n";
+    let t = { x = #(); y = "hello"; z = #() } in
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    Printf.printf "(.y) <- \"world\"\n"; Idx_atomic.set t (.y) "world";
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    ()
+end

--- a/testsuite/tests/records-and-block-indices/idx_atomic.reference
+++ b/testsuite/tests/records-and-block-indices/idx_atomic.reference
@@ -1,0 +1,29 @@
+== Basic idx_atomic ==
+(.x) = 1
+(.y) = two
+(.x) <- 3
+(.y) <- "four"
+(.x) = 3
+(.y) = four
+== idx_atomic with unboxed singleton ==
+(.x.#y) = 1
+(.x.#y) <- 2
+(.x.#y) = 2
+== Basic idx_atomic (mixed record) ==
+(.x) = 42
+(.y) = two
+(.z) = 67
+(.y) <- "three"
+(.x) = 42
+(.y) = three
+(.z) = 67
+== Basic idx_atomic (float record) ==
+(.x) = 2.000000
+(.y) = 4.000000
+(.y) <- 6.0
+(.x) = 2.000000
+(.y) = 6.000000
+== Basic idx_atomic (void record) ==
+(.y) = hello
+(.y) <- "world"
+(.y) = world

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -522,14 +522,45 @@ val idx_mut : ('a, 'b) idx_mut -> ('a, 'b) idx_mut = <fun>
 
 (*****************************************)
 (* Block indices to atomic record fields *)
-type atomic = { mutable i : int [@atomic] }
-let bad () = (.i)
+type atomic = { mutable i : int [@atomic]; mutable j : int [@atomic] }
+
+let idx_atomic_i = (.i)
 [%%expect{|
-type atomic = { mutable i : int [@atomic]; }
-Line 2, characters 13-17:
-2 | let bad () = (.i)
-                 ^^^^
-Error: Block indices do not yet support [@atomic] record fields.
+type atomic = { mutable i : int [@atomic]; mutable j : int [@atomic]; }
+val idx_atomic_i : (atomic, int) idx_atomic = <abstr>
+|}]
+
+let idx_atomic_j = (.j)
+[%%expect{|
+val idx_atomic_j : (atomic, int) idx_atomic = <abstr>
+|}]
+
+(* Block indices to unboxed singleton record *)
+type inner = { y: int }
+type outer = { mutable x: inner# [@atomic] }
+
+let unbox_idx_atomic = (.x.#y)
+[%%expect{|
+type inner = { y : int; }
+type outer = { mutable x : inner# [@atomic]; }
+val unbox_idx_atomic : (outer, int) idx_atomic = <abstr>
+|}]
+
+(* Block indices to mixed record *)
+type t = { x: int64#; mutable y: string [@atomic]; z: int64# }
+
+let mixed_idx_atomic = (.y)
+[%%expect{|
+type t = { x : int64#; mutable y : string [@atomic]; z : int64#; }
+val mixed_idx_atomic : (t, string) idx_atomic = <abstr>
+|}]
+
+(* Block indices to all-float record *)
+type floats = { x: float; mutable y: float [@atomic] } [@@warning "-214"]
+let float_idx_atomic = (.y)
+[%%expect{|
+type floats = { x : float; mutable y : float [@atomic]; }
+val float_idx_atomic : (floats, float) idx_atomic = <abstr>
 |}]
 
 (**************)

--- a/testsuite/tests/typing-layouts-block-indices/parsing_idx_atomic.compilers.reference
+++ b/testsuite/tests/typing-layouts-block-indices/parsing_idx_atomic.compilers.reference
@@ -1,0 +1,4 @@
+File "parsing_idx_atomic.ml", line 8, characters 20-21:
+8 | let _ = (.idx_atomic(0))
+                        ^
+Error: Syntax error: .idx_atomic block accesses are not supported.

--- a/testsuite/tests/typing-layouts-block-indices/parsing_idx_atomic.ml
+++ b/testsuite/tests/typing-layouts-block-indices/parsing_idx_atomic.ml
@@ -1,0 +1,8 @@
+(* TEST
+   setup-ocamlc.byte-build-env;
+   ocamlc_byte_exit_status = "2";
+   ocamlc.byte;
+   check-ocamlc.byte-output;
+*)
+
+let _ = (.idx_atomic(0))

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -223,18 +223,31 @@ type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
 
 let () =
   let t = { imm = 1; ptr = "two"} in
-  test_atomic_exchange_field ~expected:1 (fun () ->
+  test_atomic_exchange_field ~expected:0 (fun () ->
     t.imm <- 3;
+    ignore (Sys.opaque_identity t)
+  )
+
+let () =
+  let t = { imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:1 (fun () ->
     t.ptr <- "four";
     ignore (Sys.opaque_identity t)
   )
 
 (* Patomic_set_mixed_field skips runtime call for immediates. *)
 type mixed = { f : int64#; mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+
+let () =
+  let m = { f = #42L; imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:0 (fun () ->
+    m.imm <- 3;
+    ignore (Sys.opaque_identity m)
+  )
+
 let () =
   let m = { f = #42L; imm = 1; ptr = "two"} in
   test_atomic_exchange_field ~expected:1 (fun () ->
-    m.imm <- 3;
     m.ptr <- "four";
     ignore (Sys.opaque_identity m)
   )

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -1,4 +1,5 @@
 (* TEST
+ include stdlib_stable;
  modules = "replace_caml_atomic.c";
  {
    not-macos;
@@ -28,6 +29,8 @@
    native;
  }
 *)
+
+open Stdlib_stable
 
 (* CR-someday mslater: this should also work on arm once atomics are builtins *)
 
@@ -219,35 +222,69 @@ let test_atomic_exchange_field = gen_test ~fn:"atomic_exchange_field"
                               ~reset_fn_calls:atomic_exchange_field_reset
 
 (* Patomic_set_field skips runtime call for immediates. *)
-type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+module Set_field = struct
+  type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
 
-let () =
-  let t = { imm = 1; ptr = "two"} in
-  test_atomic_exchange_field ~expected:0 (fun () ->
-    t.imm <- 3;
-    ignore (Sys.opaque_identity t)
-  )
-
-let () =
-  let t = { imm = 1; ptr = "two"} in
-  test_atomic_exchange_field ~expected:1 (fun () ->
-    t.ptr <- "four";
-    ignore (Sys.opaque_identity t)
-  )
+  let () =
+    let t = { imm = 1; ptr = "two"} in
+    test_atomic_exchange_field ~expected:0 (fun () ->
+      t.imm <- 3;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_exchange_field ~expected:1 (fun () ->
+      t.ptr <- "four";
+      ignore (Sys.opaque_identity t)
+    )
+end
 
 (* Patomic_set_mixed_field skips runtime call for immediates. *)
-type mixed = { f : int64#; mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+module Set_field_mixed = struct
+  type t = { f : int64#; mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
 
-let () =
-  let m = { f = #42L; imm = 1; ptr = "two"} in
-  test_atomic_exchange_field ~expected:0 (fun () ->
-    m.imm <- 3;
-    ignore (Sys.opaque_identity m)
-  )
+  let () =
+    let t = { f = #42L; imm = 1; ptr = "two"} in
+    test_atomic_exchange_field ~expected:0 (fun () ->
+      t.imm <- 3;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_exchange_field ~expected:1 (fun () ->
+      t.ptr <- "four";
+      ignore (Sys.opaque_identity t)
+    )
+end
 
-let () =
-  let m = { f = #42L; imm = 1; ptr = "two"} in
-  test_atomic_exchange_field ~expected:1 (fun () ->
-    m.ptr <- "four";
-    ignore (Sys.opaque_identity m)
-  )
+(* Idx_atomic.set skips runtime call for immediates. *)
+module Set_idx_atomic = struct
+  type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+
+  let () =
+    let t = { imm = 1; ptr = "two"} in
+    test_atomic_exchange_field ~expected:0 (fun () ->
+      let idx = (.imm) in
+      Idx_atomic.set t idx 3;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_exchange_field ~expected:1 (fun () ->
+      let idx = (.ptr) in
+      Idx_atomic.set t idx "four";
+      ignore (Sys.opaque_identity t)
+    )
+end
+
+(* Idx_atomic.set on mixed field skips runtime call for immediates. *)
+module Set_idx_atomic_mixed = struct
+  type t = { f : int64#; mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+
+  let () =
+    let t = { f = #42L; imm = 1; ptr = "two"} in
+    test_atomic_exchange_field ~expected:0 (fun () ->
+      let idx = (.imm) in
+      Idx_atomic.set t idx 3;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_exchange_field ~expected:1 (fun () ->
+      let idx = (.ptr) in
+      Idx_atomic.set t idx "four";
+      ignore (Sys.opaque_identity t)
+    )
+end

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -34,6 +34,83 @@
 (* This test verifies that immediate atomics do not call runtime wrapper functions
    in native amd64 builds. *)
 
+external total_atomic_calls : unit -> int = "total_atomic_calls"
+external total_atomic_reset : unit -> unit = "total_atomic_reset"
+
+external atomic_load_calls : unit -> int = "atomic_load_calls"
+external atomic_load_field_calls : unit -> int = "atomic_load_field_calls"
+external atomic_exchange_calls : unit -> int = "atomic_exchange_calls"
+external atomic_exchange_field_calls : unit -> int = "atomic_exchange_field_calls"
+external atomic_set_calls : unit -> int = "atomic_set_calls"
+external atomic_set_field_calls : unit -> int = "atomic_set_field_calls"
+external atomic_compare_exchange_calls : unit -> int = "atomic_compare_exchange_calls"
+external atomic_compare_exchange_field_calls : unit -> int = "atomic_compare_exchange_field_calls"
+external atomic_cas_calls : unit -> int = "atomic_cas_calls"
+external atomic_cas_field_calls : unit -> int = "atomic_cas_field_calls"
+external atomic_fetch_add_calls : unit -> int = "atomic_fetch_add_calls"
+external atomic_fetch_add_field_calls : unit -> int = "atomic_fetch_add_field_calls"
+external atomic_add_calls : unit -> int = "atomic_add_calls"
+external atomic_add_field_calls : unit -> int = "atomic_add_field_calls"
+external atomic_sub_calls : unit -> int = "atomic_sub_calls"
+external atomic_sub_field_calls : unit -> int = "atomic_sub_field_calls"
+external atomic_land_calls : unit -> int = "atomic_land_calls"
+external atomic_land_field_calls : unit -> int = "atomic_land_field_calls"
+external atomic_lor_calls : unit -> int = "atomic_lor_calls"
+external atomic_lor_field_calls : unit -> int = "atomic_lor_field_calls"
+external atomic_lxor_calls : unit -> int = "atomic_lxor_calls"
+external atomic_lxor_field_calls : unit -> int = "atomic_lxor_field_calls"
+
+external atomic_load_reset : unit -> unit = "atomic_load_reset"
+external atomic_load_field_reset : unit -> unit = "atomic_load_field_reset"
+external atomic_exchange_reset : unit -> unit = "atomic_exchange_reset"
+external atomic_exchange_field_reset : unit -> unit = "atomic_exchange_field_reset"
+external atomic_set_reset : unit -> unit = "atomic_set_reset"
+external atomic_set_field_reset : unit -> unit = "atomic_set_field_reset"
+external atomic_compare_exchange_reset : unit -> unit = "atomic_compare_exchange_reset"
+external atomic_compare_exchange_field_reset : unit -> unit = "atomic_compare_exchange_field_reset"
+external atomic_cas_reset : unit -> unit = "atomic_cas_reset"
+external atomic_cas_field_reset : unit -> unit = "atomic_cas_field_reset"
+external atomic_fetch_add_reset : unit -> unit = "atomic_fetch_add_reset"
+external atomic_fetch_add_field_reset : unit -> unit = "atomic_fetch_add_field_reset"
+external atomic_add_reset : unit -> unit = "atomic_add_reset"
+external atomic_add_field_reset : unit -> unit = "atomic_add_field_reset"
+external atomic_sub_reset : unit -> unit = "atomic_sub_reset"
+external atomic_sub_field_reset : unit -> unit = "atomic_sub_field_reset"
+external atomic_land_reset : unit -> unit = "atomic_land_reset"
+external atomic_land_field_reset : unit -> unit = "atomic_land_field_reset"
+external atomic_lor_reset : unit -> unit = "atomic_lor_reset"
+external atomic_lor_field_reset : unit -> unit = "atomic_lor_field_reset"
+external atomic_lxor_reset : unit -> unit = "atomic_lxor_reset"
+external atomic_lxor_field_reset : unit -> unit = "atomic_lxor_field_reset"
+
+(* Reset all atomic counters. Initializing stdlib modules (like Format) can
+   invoke atomic operations. *)
+
+let () =
+  total_atomic_reset ();
+  atomic_load_reset ();
+  atomic_load_field_reset ();
+  atomic_exchange_reset ();
+  atomic_exchange_field_reset ();
+  atomic_set_reset ();
+  atomic_set_field_reset ();
+  atomic_compare_exchange_reset ();
+  atomic_compare_exchange_field_reset ();
+  atomic_cas_reset ();
+  atomic_cas_field_reset ();
+  atomic_fetch_add_reset ();
+  atomic_fetch_add_field_reset ();
+  atomic_add_reset ();
+  atomic_add_field_reset ();
+  atomic_sub_reset ();
+  atomic_sub_field_reset ();
+  atomic_land_reset ();
+  atomic_land_field_reset ();
+  atomic_lor_reset ();
+  atomic_lor_field_reset ();
+  atomic_lxor_reset ();
+  atomic_lxor_field_reset ()
+
 let a = Atomic.make 0
 let _ = Atomic.get a
 let _ = Atomic.set a 1
@@ -91,29 +168,6 @@ let _ = atomic_logand_field a 0 1
 let _ = atomic_logor_field a 0 1
 let _ = atomic_logxor_field a 0 1
 
-external atomic_load_calls : unit -> int = "atomic_load_calls"
-external atomic_load_field_calls : unit -> int = "atomic_load_field_calls"
-external atomic_exchange_calls : unit -> int = "atomic_exchange_calls"
-external atomic_exchange_field_calls : unit -> int = "atomic_exchange_field_calls"
-external atomic_set_calls : unit -> int = "atomic_set_calls"
-external atomic_set_field_calls : unit -> int = "atomic_set_field_calls"
-external atomic_compare_exchange_calls : unit -> int = "atomic_compare_exchange_calls"
-external atomic_compare_exchange_field_calls : unit -> int = "atomic_compare_exchange_field_calls"
-external atomic_cas_calls : unit -> int = "atomic_cas_calls"
-external atomic_cas_field_calls : unit -> int = "atomic_cas_field_calls"
-external atomic_fetch_add_calls : unit -> int = "atomic_fetch_add_calls"
-external atomic_fetch_add_field_calls : unit -> int = "atomic_fetch_add_field_calls"
-external atomic_add_calls : unit -> int = "atomic_add_calls"
-external atomic_add_field_calls : unit -> int = "atomic_add_field_calls"
-external atomic_sub_calls : unit -> int = "atomic_sub_calls"
-external atomic_sub_field_calls : unit -> int = "atomic_sub_field_calls"
-external atomic_land_calls : unit -> int = "atomic_land_calls"
-external atomic_land_field_calls : unit -> int = "atomic_land_field_calls"
-external atomic_lor_calls : unit -> int = "atomic_lor_calls"
-external atomic_lor_field_calls : unit -> int = "atomic_lor_field_calls"
-external atomic_lxor_calls : unit -> int = "atomic_lxor_calls"
-external atomic_lxor_field_calls : unit -> int = "atomic_lxor_field_calls"
-
 let () = assert (atomic_load_calls () = 0)
 let () = assert (atomic_load_field_calls () = 0)
 let () = assert (atomic_exchange_calls () = 0)
@@ -136,3 +190,51 @@ let () = assert (atomic_lor_calls () = 0)
 let () = assert (atomic_lor_field_calls () = 0)
 let () = assert (atomic_lxor_calls () = 0)
 let () = assert (atomic_lxor_field_calls () = 0)
+
+(* Test individual atomic operations. *)
+
+(* build a test function for a particular atomic call *)
+let gen_test ~fn ~fn_calls ~reset_fn_calls =
+  let test ~(call_pos : [%call_pos]) ~expected f =
+    total_atomic_reset ();
+    reset_fn_calls ();
+    f ();
+    let actual_fn = fn_calls () in
+    let actual_total = total_atomic_calls () in
+    if not (expected = actual_fn) then
+      failwith @@
+        Format.sprintf
+          "On line %d, expected %d calls to %s, but saw %d"
+          call_pos.pos_lnum expected fn actual_fn;
+    if not (expected = actual_total) then
+      failwith @@
+        Format.sprintf
+          "On line %d, expected %d total atomic calls, but saw %d"
+          call_pos.pos_lnum expected actual_total;
+  in
+  test
+
+let test_atomic_exchange_field = gen_test ~fn:"atomic_exchange_field"
+                              ~fn_calls:atomic_exchange_field_calls
+                              ~reset_fn_calls:atomic_exchange_field_reset
+
+(* Patomic_set_field skips runtime call for immediates. *)
+type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+
+let () =
+  let t = { imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:1 (fun () ->
+    t.imm <- 3;
+    t.ptr <- "four";
+    ignore (Sys.opaque_identity t)
+  )
+
+(* Patomic_set_mixed_field skips runtime call for immediates. *)
+type mixed = { f : int64#; mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
+let () =
+  let m = { f = #42L; imm = 1; ptr = "two"} in
+  test_atomic_exchange_field ~expected:1 (fun () ->
+    m.imm <- 3;
+    m.ptr <- "four";
+    ignore (Sys.opaque_identity m)
+  )

--- a/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
+++ b/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
@@ -27,7 +27,7 @@ CAMLprim value total_atomic_reset()
   CAMLprim void __wrap_caml_##name(arg_tys)    \
   {                                            \
     called_##name++;                           \
-    called_total_atomic++;                       \
+    called_total_atomic++;                     \
     __real_caml_##name(args);                  \
   }
 

--- a/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
+++ b/testsuite/tests/typing-layouts-caml-modify/replace_caml_atomic.c
@@ -1,5 +1,16 @@
 #include <caml/mlvalues.h>
 
+static int called_total_atomic = 0;
+CAMLprim value total_atomic_calls()
+{
+  return Val_int(called_total_atomic);
+}
+CAMLprim value total_atomic_reset()
+{
+  called_total_atomic = 0;
+  return Val_unit;
+}
+
 #define P(...) __VA_ARGS__
 #define TRACK(name, arg_tys, args)             \
   static int called_##name = 0;                \
@@ -7,10 +18,16 @@
   {                                            \
     return Val_int(called_##name);             \
   }                                            \
+  CAMLprim value name##_reset()                \
+  {                                            \
+    called_##name = 0;                         \
+    return Val_unit;                           \
+  }                                            \
   CAMLextern void __real_caml_##name(arg_tys); \
   CAMLprim void __wrap_caml_##name(arg_tys)    \
   {                                            \
     called_##name++;                           \
+    called_total_atomic++;                       \
     __real_caml_##name(args);                  \
   }
 

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -64,6 +64,7 @@ type abstract_non_value_type_constr = [
   | `Float32_u
   | `Idx_imm
   | `Idx_mut
+  | `Idx_atomic
   | `Int8x16
   | `Int16x8
   | `Int32x4
@@ -130,6 +131,7 @@ let base_type_constrs : type_constr list = [
   `Int64_u;
   `Idx_imm;
   `Idx_mut;
+  `Idx_atomic;
 ]
 
 let or_null_extension_type_constrs : type_constr list = [
@@ -225,6 +227,7 @@ and ident_float32_u = ident_create "float32_u"
 and ident_or_null = ident_create "or_null"
 and ident_idx_imm = ident_create "idx_imm"
 and ident_idx_mut = ident_create "idx_mut"
+and ident_idx_atomic = ident_create "idx_atomic"
 
 and ident_int8x16 = ident_create "int8x16"
 and ident_int16x8 = ident_create "int16x8"
@@ -283,6 +286,7 @@ let ident_of_type_constr : type_constr -> Ident.t = function
   | `Float32_u -> ident_float32_u
   | `Idx_imm -> ident_idx_imm
   | `Idx_mut -> ident_idx_mut
+  | `Idx_atomic -> ident_idx_atomic
   | `Int8x16 -> ident_int8x16
   | `Int16x8 -> ident_int16x8
   | `Int32x4 -> ident_int32x4
@@ -337,6 +341,7 @@ and path_int64_u = Pident ident_int64_u
 and path_float32_u = Pident ident_float32_u
 and path_idx_imm = Pident ident_idx_imm
 and path_idx_mut = Pident ident_idx_mut
+and path_idx_atomic = Pident ident_idx_atomic
 and path_code = Pident ident_code
 and path_eval = Pident ident_eval
 and path_box = Pident ident_box
@@ -448,6 +453,7 @@ and type_float32_u = tconstr path_float32_u []
 and type_or_null t = tconstr path_or_null [t]
 and type_idx_imm t1 t2 = tconstr path_idx_imm [t1; t2]
 and type_idx_mut t1 t2 = tconstr path_idx_mut [t1; t2]
+and type_idx_atomic t1 t2 = tconstr path_idx_atomic [t1; t2]
 
 and type_int8x16 = tconstr path_int8x16 []
 and type_int16x8 = tconstr path_int16x8 []
@@ -924,6 +930,21 @@ let decl_of_type_constr type_constr =
          }),
          Jkind.Builtin.any ~why:(Type_argument {
            parent_path = Path.Pident ident_idx_mut;
+           position = 2;
+           arity = 2;
+         }))
+       ~jkind:(builtin2 Jkind.Const.Builtin.kind_of_idx)
+       ()
+  | `Idx_atomic ->
+    decl2 ~variance:(Variance.full, Variance.full)
+       ~param_jkinds:(
+         Jkind.Builtin.value_or_null ~why:(Type_argument {
+           parent_path = Path.Pident ident_idx_atomic;
+           position = 1;
+           arity = 2;
+         }),
+         Jkind.Builtin.any ~why:(Type_argument {
+           parent_path = Path.Pident ident_idx_atomic;
            position = 2;
            arity = 2;
          }))

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -48,6 +48,7 @@ type abstract_non_value_type_constr = [
   | `Float32_u
   | `Idx_imm
   | `Idx_mut
+  | `Idx_atomic
   | `Int8x16
   | `Int16x8
   | `Int32x4
@@ -131,6 +132,7 @@ val type_float32_u: type_expr
 val type_or_null: type_expr -> type_expr
 val type_idx_imm : type_expr -> type_expr -> type_expr
 val type_idx_mut : type_expr -> type_expr -> type_expr
+val type_idx_atomic : type_expr -> type_expr -> type_expr
 
 val type_int8x16: type_expr
 val type_int16x8: type_expr
@@ -223,6 +225,7 @@ val path_float32_u: Path.t
 val path_or_null: Path.t
 val path_idx_imm: Path.t
 val path_idx_mut: Path.t
+val path_idx_atomic: Path.t
 
 val path_int8x16: Path.t
 val path_int16x8: Path.t

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -945,7 +945,20 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.bits64);
         any
       ]
+    | "%get_idx_atomic" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        any
+      ]
     | "%set_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        any;
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%set_idx_atomic" ->
       check [
         is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.bits64);

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7724,14 +7724,14 @@ and type_expect_
       match ba with
       | Baccess_field (_, { lbl_mut = Immutable; _ }, _)
       | Baccess_block (Immutable, _) ->
-        false
+        Immutable
       | Baccess_field
           (_, { lbl_mut = Mutable { mode = _; atomic = Nonatomic }; _ }, _)
       | Baccess_block (Mutable, _) ->
-        true
+        Mutable { mode = Mode.Value.Comonadic.legacy; atomic = Nonatomic }
       | Baccess_field
           (_, { lbl_mut = Mutable { mode = _; atomic = Atomic }; _ }, _) ->
-        raise (Error(loc, env, Block_index_atomic_unsupported))
+        Mutable { mode = Mode.Value.Comonadic.legacy; atomic = Atomic }
     in
     let (el_ty, modality), uas =
       List.fold_left_map
@@ -7750,18 +7750,24 @@ and type_expect_
         (el_ty, modality)
         uas
     in
-    let expected_modality = Typemode.idx_expected_modalities ~mut in
+    let expected_modality =
+      Typemode.idx_expected_modalities ~mut:(Types.is_mutable mut)
+    in
     begin
       match Modality.Const.equate modality expected_modality with
       | Ok () -> ()
       | Error err ->
-        raise (Error(loc, env, Block_index_modality_mismatch { mut; err }))
+        raise (Error(
+          loc, env,
+          Block_index_modality_mismatch { mut = Types.is_mutable mut; err }
+        ))
     end;
-    let ty =
-      if mut then
+    let ty = match mut with
+      | Immutable -> Predef.type_idx_imm base_ty el_ty
+      | Mutable { atomic = Nonatomic; mode = _ } ->
         Predef.type_idx_mut base_ty el_ty
-      else
-        Predef.type_idx_imm base_ty el_ty
+      | Mutable { atomic = Atomic; mode = _ } ->
+        Predef.type_idx_atomic base_ty el_ty
     in
     with_explanation (fun () ->
       unify_exp_types loc env ty (generic_instance ty_expected));

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -247,7 +247,6 @@ type error =
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
-  | Mixed_record_atomic_access of Longident.t
   | Mixed_record_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string
@@ -1310,43 +1309,22 @@ let check_project_mutability ~loc ~env mut_name mutability mode =
   if Types.is_mutable mutability then
     submode ~loc ~env mode (mode_project_mutable mut_name)
 
-(* Does this record representation permit atomic field usage? *)
-let allows_atomic_field_usage = function
-  | Record_boxed -> true
-  | Record_inlined (_tag, ctor_repres, _variant_repres) -> (
-      match ctor_repres with
-      | Constructor_uniform_value -> true
-      | Constructor_mixed _ -> false
-      (* At this point, we should know the constructor representation. *)
-      | Constructor_variable -> false)
-  (* Reads/writes of atomic record fields are currently only supported for
-     labels whose logical offset matches the physical field position. To support
-     mixed records, we will add atomic primitives to lambda that consider mixed
-     block field reordering. *)
-  | Record_mixed _ -> false
-  (* The remaining cases should be unreachable. *)
-  (* [@@unboxed] already prohibits mutable (and therefore atomic) fields. *)
+let check_atomic_loc ~loc ~env record_repres mutability lid =
+  if not (Types.is_atomic mutability) then
+    raise (Error (loc, env, Label_not_atomic lid));
+  match record_repres with
+  | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) -> ()
+  | Record_mixed _ | Record_inlined (_, Constructor_mixed _, _) ->
+      raise (Error (loc, env, Mixed_record_atomic_loc lid))
+  (* We should know constructor representation at this point. *)
+  | Record_inlined (_, Constructor_variable, _)
+  (* [@@unboxed] prohibits mutable (and therefore atomic) fields. *)
   | Record_unboxed
-  (* [@atomic] fields disable the float record optimization. *)
+  (* [@atomic] fields disable float record optimization. *)
   | Record_float | Record_ufloat
-  (* At this point, we should know the record representation. *)
+  (* We should know record representation at this point. *)
   | Record_dummy _ | Record_variable ->
-      false
-
-(* CR-soon jkerrigan: simplify after we allow access of atomic fields in mixed
-   records. *)
-type atomic_field_use = Access | Loc
-
-(* Raises if we try to use an atomic field from a mixed record. *)
-let check_atomic_field_usage ~usage ~loc ~env record_repres mutability lid =
-  if Types.is_atomic mutability && not (allows_atomic_field_usage record_repres)
-  then
-    let err =
-      match usage with
-      | Access -> Mixed_record_atomic_access lid
-      | Loc -> Mixed_record_atomic_loc lid
-    in
-    raise (Error (loc, env, err))
+      Misc.fatal_error "check_atomic_loc: unexpected record representation"
 
 (* Represents information about an array type inferred using type-directed
    disambiguation. *)
@@ -7498,8 +7476,6 @@ and type_expect_
       in
       check_project_mutability ~loc:record.exp_loc ~env
         (Record_field label.lbl_name) label.lbl_mut mode;
-      check_atomic_field_usage ~usage:Access ~loc:record.exp_loc ~env
-        record_repres label.lbl_mut lid.txt;
       let is_contained_by : Mode.Hint.is_contained_by =
         { containing = Record (label.lbl_name, Modality);
           container = (record.exp_loc, Expression) }
@@ -7629,8 +7605,6 @@ and type_expect_
           ~why:Field_assignment
           ~containing_type:ty_record
       in
-      check_atomic_field_usage ~usage:Access ~loc ~env record_repres
-        label.lbl_mut lid.txt;
       rue {
         exp_desc = Texp_setfield {
           record;
@@ -8534,11 +8508,8 @@ and type_expect_
             solve_Pexp_field ~label_usage:Env.Mutation loc env sexp srecord
               Legacy lid
           in
-          check_atomic_field_usage ~usage:Loc ~loc:record.exp_loc ~env
-            record_repres label.lbl_mut lid.txt;
           Env.mark_label_used Env.Projection label.lbl_uid;
-          if (not (Types.is_atomic label.lbl_mut))
-          then raise (Error (loc, env, Label_not_atomic lid.txt));
+          check_atomic_loc ~loc ~env record_repres label.lbl_mut lid.txt;
           let alloc_mode, argument_mode =
             register_allocation ~loc expected_mode
           in
@@ -13009,11 +12980,6 @@ let report_error ~loc env =
          of an atomic field, do so explicitly:@ %a"
         Style.inline_code l
         Style.inline_code ("{ t with " ^ l ^ " = t." ^ l ^ " }")
-  | Mixed_record_atomic_access lid ->
-      Location.errorf ~loc
-        "Accessing atomic fields (here %a) of mixed records is not yet@ \
-         supported."
-        quoted_longident lid
   | Mixed_record_atomic_loc lid ->
       Location.errorf ~loc
         "Use of %a with mixed record fields (here %a) is forbidden."

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -297,7 +297,6 @@ type error =
   | Label_not_atomic of Longident.t
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
-  | Mixed_record_atomic_access of Longident.t
   | Mixed_record_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -431,7 +431,7 @@ let array_type_kind ~elt_ty env loc ty =
         }))
     end
 
-let array_type_mut env ty =
+let array_type_mut env ty : Lambda.mutable_flag =
   match scrape_poly env ty with
   | Some (Tconstr(p, [_], _)) when Path.same p Predef.path_iarray -> Immutable
   | _ -> Mutable


### PR DESCRIPTION
Currently, one cannot take the block index of an atomic record field:

```
type t = { mutable x : int [@atomic] }
let i = (.x)
```

```
2 | let i = (.x)
            ^^^^
Error: Block indices do not yet support [@atomic] record fields.
```

This PR introduces `atomic_idx`, a predef type representing an index to an
atomic record field. Users can create an atomic index using the usual block
access syntax. They can read and write the underlying data atomically using
`Idx_atomic.get` and `Idx_atomic.set` in `Stdlib_stable`.

Some considerations:

- We support creating atomic indices to any atomic field in both boxed and mixed
  records. Note that atomic non-value fields remain unsupported.
  - This includes singleton unboxed records, which have kind `value` and
    are allowed to be atomic:

```
type inner = { y: int }
type outer = { mutable x: inner# [@atomic] }

let idx : (outer, inner) idx_atomic = (.x.#y)
```

- We do not support atomic index deepening. This is because fields with unboxed
  types cannot be atomic, with the just-discussed exception of singleton
  unboxed records.

## Testing
- Typing tests for `idx_atomic`.
- `caml_modify`-style tests that ensure we skip runtime calls when setting
immediates atomically.
- Native/bytecode tests reading/writing atomic fields through their indices.

Note that I did **not** update `records-and-block-indices/test_generation.ml` to
randomly generate `idx_atomic` tests. The existing test generation code relies
on certain language features (pattern matches, functional updates) that work
differently (or not at all) for atomic record fields. Like `idx_imm` (which is
also not exercised in the randomly generated tests),
`idx_atomic` shares much of its implementation with `idx_mut`, which is covered.
I think the manual testing in `idx_atomic.ml` but am happy to discuss with reviewers.