### PR TITLE
 Fix [@unboxable] crashing on local parameters if the function is not local-returning 

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -2157,8 +2157,18 @@ let boxing_primitive (k : Function_decl.unboxing_kind) alloc_mode
 let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
     ~unarized_params:params params_arity ~unarized_param_modes:param_modes
     function_slot compute_body return return_continuation unboxed_params
-    unboxed_return unboxed_function_slot =
+    unboxed_return unboxed_function_slot ~needs_region_wrapper =
   let my_closure_duid = Flambda_debug_uid.none in
+  let local_param_region =
+    if needs_region_wrapper
+    then Some (Variable.create "unboxed_param_region" K.region)
+    else None
+  in
+  let current_region =
+    match local_param_region with
+    | None -> my_region
+    | Some region -> Some region
+  in
   let rec box_params params params_arity param_modes params_unboxing body =
     match params, params_arity, param_modes, params_unboxing with
     | [], [], [], [] -> [], [], [], body
@@ -2183,7 +2193,7 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
           let acc, body = body acc in
           let alloc_mode =
             Alloc_mode.For_allocations.from_lambda
-              ~current_alloc_region:my_alloc_region ~current_region:my_region
+              ~current_alloc_region:my_alloc_region ~current_region
               (Alloc_mode.For_types.to_lambda param_mode)
           in
           let param_duid = Flambda_debug_uid.none in
@@ -2231,9 +2241,56 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
   in
   let acc, unboxed_body, result_arity_main_code, unboxed_return_continuation =
     match unboxed_return with
-    | None ->
-      let acc, body = body acc in
-      acc, body, return, return_continuation
+    | None -> (
+      match local_param_region with
+      | None ->
+        let acc, body = body acc in
+        acc, body, return, return_continuation
+      | Some local_param_region ->
+        (* We need to close the region we used for the unboxed parameter before
+           returning from the function, so we need a return wrapper. *)
+        let outer_return_continuation =
+          Continuation.create ~sort:Return ~name:"return" ()
+        in
+        let handler_params =
+          Bound_parameters.create
+            (List.mapi
+               (fun i kind ->
+                 let var =
+                   Variable.create
+                     ("unboxed_param_result" ^ string_of_int i)
+                     (Flambda_kind.With_subkind.kind kind)
+                 in
+                 Bound_parameter.create var kind Flambda_debug_uid.none)
+               (Flambda_arity.unarized_components return))
+        in
+        let handler acc =
+          let acc, apply_cont =
+            Apply_cont_with_acc.create acc outer_return_continuation
+              ~args:
+                (List.map Bound_parameter.simple
+                   (Bound_parameters.to_list handler_params))
+              ~dbg:Debuginfo.none
+          in
+          let acc, apply_cont =
+            Expr_with_acc.create_apply_cont acc apply_cont
+          in
+          Let_with_acc.create acc
+            (Bound_pattern.singleton
+               (Bound_var.create
+                  (Variable.create "unit" K.value)
+                  Flambda_debug_uid.none Name_mode.normal))
+            (Named.create_prim
+               (Flambda_primitive.Unary
+                  (End_region { ghost = false }, Simple.var local_param_region))
+               Debuginfo.none)
+            ~body:apply_cont
+        in
+        let acc, unboxed_body =
+          Let_cont_with_acc.build_non_recursive acc return_continuation
+            ~handler_params ~handler ~body ~is_exn_handler:false ~is_cold:false
+        in
+        acc, unboxed_body, return, outer_return_continuation)
     | Some (k, _) ->
       let vars_with_kinds = variables_for_unboxing "result" k in
       let unboxed_return_continuation =
@@ -2263,6 +2320,21 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
             ~dbg:Debuginfo.none
         in
         let acc, apply_cont = Expr_with_acc.create_apply_cont acc apply_cont in
+        let acc, expr =
+          match local_param_region with
+          | None -> acc, apply_cont
+          | Some local_param_region ->
+            Let_with_acc.create acc
+              (Bound_pattern.singleton
+                 (Bound_var.create
+                    (Variable.create "unit" K.value)
+                    Flambda_debug_uid.none Name_mode.normal))
+              (Named.create_prim
+                 (Flambda_primitive.Unary
+                    (End_region { ghost = false }, Simple.var local_param_region))
+                 Debuginfo.none)
+              ~body:apply_cont
+        in
         let (acc, expr), _ =
           List.fold_left
             (fun ((acc, expr), i) (var, var_duid, _kind) ->
@@ -2275,7 +2347,7 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
                      Debuginfo.none)
                   ~body:expr,
                 Target_ocaml_int.(add (one (Acc.machine_width acc)) i) ))
-            ((acc, apply_cont), Target_ocaml_int.zero (Acc.machine_width acc))
+            ((acc, expr), Target_ocaml_int.zero (Acc.machine_width acc))
             vars_with_kinds
         in
         acc, expr
@@ -2289,6 +2361,19 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
         Flambda_arity.create_singletons
           (List.map (fun (_, _, kind) -> kind) vars_with_kinds),
         unboxed_return_continuation )
+  in
+  let acc, unboxed_body =
+    match local_param_region with
+    | None -> acc, unboxed_body
+    | Some local_param_region ->
+      Let_with_acc.create acc
+        (Bound_pattern.singleton
+           (Bound_var.create local_param_region Flambda_debug_uid.none
+              Name_mode.normal))
+        (Named.create_prim
+           (Flambda_primitive.Variadic (Begin_region { ghost = false }, []))
+           Debuginfo.none)
+        ~body:unboxed_body
   in
   let my_unboxed_closure = Variable.create "my_unboxed_closure" K.value in
   let acc, unboxed_body =
@@ -2881,11 +2966,15 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
         return_continuation,
         my_closure )
     | Unboxed_calling_convention
-        (unboxed_params, unboxed_return, unboxed_function_slot) ->
+        { params_unboxing;
+          return_unboxing;
+          unboxed_function_slot;
+          needs_region_wrapper
+        } ->
       compute_body_of_unboxed_function acc my_region alloc_region my_closure
         ~unarized_params params_arity ~unarized_param_modes function_slot
-        compute_body return return_continuation unboxed_params unboxed_return
-        unboxed_function_slot
+        compute_body return return_continuation params_unboxing return_unboxing
+        unboxed_function_slot ~needs_region_wrapper
   in
   let contains_subfunctions = Acc.seen_a_function acc in
   let cost_metrics = Acc.cost_metrics acc in
@@ -2997,14 +3086,18 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
     | Normal_calling_convention ->
       main_code, by_function_slot, function_code_ids, acc
     | Unboxed_calling_convention
-        (unboxed_params, unboxed_return, unboxed_function_slot) ->
+        { params_unboxing;
+          return_unboxing;
+          unboxed_function_slot;
+          needs_region_wrapper = _
+        } ->
       make_unboxed_function_wrapper acc function_slot ~unarized_params
         params_arity ~unarized_param_modes return result_arity_main_code code_id
         main_code_id decl loc external_env recursive
         contains_no_escaping_local_allocs cost_metrics dbg is_tupled
         inlining_decision absolute_history relative_history main_code
-        by_function_slot function_code_ids unboxed_function_slot unboxed_params
-        unboxed_return
+        by_function_slot function_code_ids unboxed_function_slot params_unboxing
+        return_unboxing
   in
   let approx =
     let code = Code_or_metadata.create code in

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -777,9 +777,11 @@ module Function_decls = struct
     type calling_convention =
       | Normal_calling_convention
       | Unboxed_calling_convention of
-          unboxing_kind option list
-          * unboxing_return_kind option
-          * Function_slot.t
+          { params_unboxing : unboxing_kind option list;
+            return_unboxing : unboxing_return_kind option;
+            unboxed_function_slot : Function_slot.t;
+            needs_region_wrapper : bool
+          }
 
     type t =
       { let_rec_ident : Ident.t;

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -346,9 +346,11 @@ module Function_decls : sig
     type calling_convention =
       | Normal_calling_convention
       | Unboxed_calling_convention of
-          unboxing_kind option list
-          * unboxing_return_kind option
-          * Function_slot.t
+          { params_unboxing : unboxing_kind option list;
+            return_unboxing : unboxing_return_kind option;
+            unboxed_function_slot : Function_slot.t;
+            needs_region_wrapper : bool
+          }
 
     type t
 

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1503,7 +1503,7 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
           ~name:(Ident.name fid ^ "_unboxed")
           ~is_always_immediate:false Flambda_kind.value
       in
-      let unboxed_return =
+      let return_unboxing =
         match unboxing_kind return, attr.unbox_return with
         | Some kind, Some mode -> Some (kind, mode)
         | _, _ -> None
@@ -1513,7 +1513,7 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
         then unboxing_kind param.layout
         else None
       in
-      let unboxed_params =
+      let params_unboxing =
         List.concat
           (List.map2
              (fun param kinds ->
@@ -1524,15 +1524,35 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
                  Misc.fatal_error "Trying to unbox an unboxed product.")
              params unarized_per_param)
       in
+      (* If an unboxable parameter is locally-allocated, but this function is
+         [not_alloc_stack], we need to introduce a wrapper after the return to
+         close the local region introduced for the parameter. We can't allocate
+         the parameter on the heap instead, because the parameter might contain
+         pointers to locally-allocated blocks, for instance if it is a block
+         itself. *)
+      let needs_region_wrapper =
+        Lambda.is_not_alloc_stack ret_mode
+        && List.exists
+             (fun (param : Lambda.lparam) ->
+               param.attributes.unbox_param && Lambda.is_local_mode param.mode)
+             params
+      in
       Unboxed_calling_convention
-        (unboxed_params, unboxed_return, unboxed_function_slot)
+        { params_unboxing;
+          return_unboxing;
+          unboxed_function_slot;
+          needs_region_wrapper
+        }
   in
   let body_cont =
     match calling_convention with
-    | Normal_calling_convention | Unboxed_calling_convention (_, None, _) ->
+    | Normal_calling_convention
+    | Unboxed_calling_convention
+        { return_unboxing = None; needs_region_wrapper = false; _ } ->
       Continuation.create ~sort:Return ()
-    | Unboxed_calling_convention (_, Some _, _) ->
-      Continuation.create ~sort:Normal_or_exn ~name:"boxed_return" ()
+    | Unboxed_calling_convention { needs_region_wrapper = true; _ }
+    | Unboxed_calling_convention { return_unboxing = Some _; _ } ->
+      Continuation.create ~sort:Normal_or_exn ~name:"return_wrapper" ()
   in
   let body_exn_cont = Continuation.create () in
   let free_idents_of_body =

--- a/testsuite/tests/flambda2/unboxable_local_param.ml
+++ b/testsuite/tests/flambda2/unboxable_local_param.ml
@@ -1,0 +1,11 @@
+(* TEST
+ stack-allocation;
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ unset OCAMLPARAM;
+ ocamlopt.byte with dump-raw;
+ check-fexpr-dump;
+*)
+
+let f : float @ local -> unit = fun (_x[@unboxable]) -> ()
+let[@unboxable] g : float @ local -> float = fun (_x[@unboxable]) -> 0.

--- a/testsuite/tests/flambda2/unboxable_local_param.raw.reference
+++ b/testsuite/tests/flambda2/unboxable_local_param.raw.reference
@@ -1,0 +1,77 @@
+(let code size(10)
+       f_1 (_x_unboxed : float)
+         my_unboxed_closure &my_alloc_region my_depth
+         -> return * k1
+         : imm tagged =
+   let my_closure =
+     %project_function_slot.[f_unboxed].[f] (my_unboxed_closure)
+   in
+   let unboxed_param_region = %begin_region () in
+   (let _x =
+      %box_num.`float`.my_alloc_region.local[unboxed_param_region]
+        (_x_unboxed)
+    in
+    let next_depth = rec_info (succ my_depth) in
+    cont return_wrapper (0))
+     where return_wrapper (unboxed_param_result0 : imm tagged) =
+       let `unit` = %end_region (unboxed_param_region) in
+       cont return (unboxed_param_result0)
+ in
+ let code loopify(never) size(10) stub
+       f_1_1 (_x : float boxed)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : imm tagged =
+   let _x_unboxed = %unbox_num.`float` (_x) in
+   let f_unboxed = %project_function_slot.[f].[f_unboxed] (my_closure) in
+   apply direct(f_1 &my_alloc_region)
+     (f_unboxed : _ -> imm tagged) (_x_unboxed) -> k1 * k2
+ in
+ let $camlUnboxable_local_param__float_0 = 0x0p+0 in
+ let code size(11)
+       g_3 (_x_unboxed : float)
+         my_unboxed_closure &my_alloc_region my_depth
+         -> unboxed_return * k1
+         : float =
+   let my_closure =
+     %project_function_slot.[g_unboxed].[g] (my_unboxed_closure)
+   in
+   let unboxed_param_region = %begin_region () in
+   (let _x =
+      %box_num.`float`.my_alloc_region.local[unboxed_param_region]
+        (_x_unboxed)
+    in
+    let next_depth = rec_info (succ my_depth) in
+    cont return_wrapper ($camlUnboxable_local_param__float_0))
+     where return_wrapper (boxed_result : float boxed) =
+       let result_unboxed = %unbox_num.`float` (boxed_result) in
+       let `unit` = %end_region (unboxed_param_region) in
+       cont unboxed_return (result_unboxed)
+ in
+ let code loopify(never) size(11) stub
+       g_3_1 (_x : float boxed)
+         my_closure &my_alloc_region my_depth
+         -> k1 * k2
+         : float boxed =
+   (let _x_unboxed = %unbox_num.`float` (_x) in
+    let g_unboxed = %project_function_slot.[g].[g_unboxed] (my_closure) in
+    apply direct(g_3 &my_alloc_region)
+      (g_unboxed : _ -> float) (_x_unboxed) -> k3 * k2)
+     where k3 (unboxed_return : float) =
+       let boxed_return = %box_num.`float`.my_alloc_region (unboxed_return)
+       in
+       cont k1 (boxed_return)
+ in
+ let f = closure f_1_1 @f &toplevel.alloc_region
+ and generated = closure f_1 @f_unboxed &toplevel.alloc_region
+ in
+ let g = closure g_3_1 @g &toplevel.alloc_region
+ and generated_1 = closure g_3 @g_unboxed &toplevel.alloc_region
+ in
+ let Pmakeblock = %block.[`0`].`toplevel` (f, g) in
+ cont k (Pmakeblock))
+  where k define_root_symbol (module_block) =
+    let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
+    let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in
+    let $camlUnboxable_local_param = Block 0 (field_0, field_1) in
+    cont done ($camlUnboxable_local_param)


### PR DESCRIPTION
On top of #6558. Previously, `let f : float @ local -> unit = fun (_x[@unboxable]) -> ()` would crash the compiler because it introduced a local boxing primitive for `x`, which would correspond to no region.