### PR TITLE
Split the reaper into stages for LTO

### DIFF
--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -207,8 +207,24 @@ let flambda_to_flambda0 : type m.
         then (
           let flambda, free_names, all_code, slot_offsets, final_typing_env =
             Profile.record_call ~accumulate:true "reaper" (fun () ->
-                Flambda2_reaper.Reaper.run ~machine_width ~cmx_loader ~all_code
-                  ~final_typing_env flambda)
+                (* These two branches are exactly the same but spelt
+                   differently. In the future, LTO support will split pre- and
+                   post- traverse work between separate processes. *)
+                if Flambda_features.support_lto ()
+                then
+                  let traverse_result =
+                    Flambda2_reaper.Reaper.Staged.traverse flambda
+                  in
+                  let solved_dep =
+                    Flambda2_reaper.Reaper.Staged.solve traverse_result
+                  in
+                  let unit_metadata = Flambda_unit.metadata flambda in
+                  Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
+                    ~traverse_result ~solved_dep ~machine_width ~cmx_loader
+                    ~all_code ~final_typing_env
+                else
+                  Flambda2_reaper.Reaper.run ~machine_width ~cmx_loader
+                    ~all_code ~final_typing_env flambda)
           in
           print_flambda "reaper" (Flambda_features.dump_reaper ()) ppf flambda;
           print_fexpr "reaper"

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -212,15 +212,13 @@ let flambda_to_flambda0 : type m.
                    post- traverse work between separate processes. *)
                 if Flambda_features.support_lto ()
                 then
-                  let traverse_result =
+                  let deps, traverse_rebuild =
                     Flambda2_reaper.Reaper.Staged.traverse flambda
                   in
-                  let solved_dep =
-                    Flambda2_reaper.Reaper.Staged.solve traverse_result.deps
-                  in
+                  let solved_dep = Flambda2_reaper.Reaper.Staged.solve deps in
                   let unit_metadata = Flambda_unit.metadata flambda in
                   Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata
-                    ~traverse_result ~solved_dep ~machine_width ~cmx_loader
+                    ~traverse_rebuild ~solved_dep ~machine_width ~cmx_loader
                     ~all_code ~final_typing_env
                 else
                   Flambda2_reaper.Reaper.run ~machine_width ~cmx_loader

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -216,7 +216,7 @@ let flambda_to_flambda0 : type m.
                     Flambda2_reaper.Reaper.Staged.traverse flambda
                   in
                   let solved_dep =
-                    Flambda2_reaper.Reaper.Staged.solve traverse_result
+                    Flambda2_reaper.Reaper.Staged.solve traverse_result.deps
                   in
                   let unit_metadata = Flambda_unit.metadata flambda in
                   Flambda2_reaper.Reaper.Staged.rebuild ~unit_metadata

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -13,63 +13,82 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Staged = struct
+  let traverse = Traverse.run
+
+  let solve Traverse.{ deps; _ } =
+    let solved_dep =
+      Profile.record_call ~accumulate:true "solver" (fun () ->
+          Analysis.fixpoint deps)
+    in
+    let () =
+      if Flambda_features.debug_reaper "print-solved"
+      then (
+        Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
+        Dot_printer.print_solved_dep solved_dep deps)
+    in
+    solved_dep
+
+  let rebuild ~unit_metadata ~traverse_result ~solved_dep ~machine_width
+      ~cmx_loader ~all_code ~final_typing_env =
+    let load_code = Flambda_cmx.get_imported_code cmx_loader in
+    let get_code_metadata code_id =
+      Code_or_metadata.code_metadata
+        (match Exported_code.find all_code code_id with
+        | Some code -> code
+        | None -> Exported_code.find_exn (load_code ()) code_id)
+    in
+    let Traverse.
+          { toplevel_expr;
+            code;
+            ordered_code_ids;
+            deps = _;
+            kinds;
+            fixed_arity_continuations;
+            continuation_info;
+            code_deps;
+            all_sets_of_closures
+          } =
+      traverse_result
+    in
+    let types_rewrite_context =
+      Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
+    in
+    let { Rebuild.body;
+          free_names;
+          all_code;
+          code_ids_to_remember;
+          slot_offsets
+        } =
+      Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
+        ~fixed_arity_continuations ~continuation_info ~final_typing_env
+        ~types_rewrite_context kinds solved_dep get_code_metadata toplevel_expr
+        code
+    in
+    let all_code =
+      Exported_code.add_code
+        ~keep_code:(fun code_id -> Code_id.Set.mem code_id code_ids_to_remember)
+        all_code
+        (Exported_code.mark_as_imported
+           (Flambda_cmx.get_imported_code cmx_loader ()))
+    in
+    let final_typing_env =
+      Option.map
+        (Types_rewriter.rewrite_typing_env types_rewrite_context
+           ~unit_symbol:(Flambda_unit.Metadata.module_symbol unit_metadata))
+        final_typing_env
+    in
+    ( Flambda_unit.of_metadata_and_body unit_metadata body,
+      free_names,
+      all_code,
+      slot_offsets,
+      final_typing_env )
+end
+
 let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
     (unit : Flambda_unit.t) =
-  let load_code = Flambda_cmx.get_imported_code cmx_loader in
-  let get_code_metadata code_id =
-    Code_or_metadata.code_metadata
-      (match Exported_code.find all_code code_id with
-      | Some code -> code
-      | None -> Exported_code.find_exn (load_code ()) code_id)
-  in
-  let Traverse.
-        { toplevel_expr;
-          code;
-          ordered_code_ids;
-          deps;
-          kinds;
-          fixed_arity_continuations;
-          continuation_info;
-          code_deps;
-          all_sets_of_closures
-        } =
-    Traverse.run unit
-  in
-  let solved_dep =
-    Profile.record_call ~accumulate:true "solver" (fun () ->
-        Analysis.fixpoint deps)
-  in
-  let () =
-    if Flambda_features.debug_reaper "print-solved"
-    then (
-      Format.printf "RESULT@ %a@." Unboxing_analysis.pp_result solved_dep;
-      Dot_printer.print_solved_dep solved_dep deps)
-  in
-  let types_rewrite_context =
-    Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
-  in
-  let Rebuild.{ body; free_names; all_code; code_ids_to_remember; slot_offsets }
-      =
-    Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
-      ~fixed_arity_continuations ~continuation_info ~final_typing_env
-      ~types_rewrite_context kinds solved_dep get_code_metadata toplevel_expr
-      code
-  in
-  let all_code =
-    Exported_code.add_code
-      ~keep_code:(fun code_id -> Code_id.Set.mem code_id code_ids_to_remember)
-      all_code
-      (Exported_code.mark_as_imported
-         (Flambda_cmx.get_imported_code cmx_loader ()))
-  in
-  let final_typing_env =
-    Option.map
-      (Types_rewriter.rewrite_typing_env types_rewrite_context
-         ~unit_symbol:(Flambda_unit.module_symbol unit))
-      final_typing_env
-  in
-  ( Flambda_unit.with_body unit body,
-    free_names,
-    all_code,
-    slot_offsets,
-    final_typing_env )
+  let traverse_result = Staged.traverse unit in
+  let solved_dep = Staged.solve traverse_result in
+  let unit_metadata = Flambda_unit.metadata unit in
+  Staged.rebuild ~unit_metadata ~traverse_result ~solved_dep ~machine_width
+    ~cmx_loader ~all_code ~final_typing_env

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -54,12 +54,8 @@ module Staged = struct
     let types_rewrite_context =
       Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
     in
-    let { Rebuild.body;
-          free_names;
-          all_code;
-          code_ids_to_remember;
-          slot_offsets
-        } =
+    let Rebuild.
+          { body; free_names; all_code; code_ids_to_remember; slot_offsets } =
       Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
         ~fixed_arity_continuations ~continuation_info ~final_typing_env
         ~types_rewrite_context kinds solved_dep get_code_metadata toplevel_expr

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -14,7 +14,47 @@
 (**************************************************************************)
 
 module Staged = struct
-  let traverse = Traverse.run
+  module TraverseRebuild = struct
+    type t =
+      { toplevel_expr : Rev_expr.t;
+        code : Rev_expr.rev_code Code_id.Map.t;
+        ordered_code_ids : Code_id.t array;
+        kinds : Flambda_kind.t Name.Map.t;
+        fixed_arity_continuations : Continuation.Set.t;
+        continuation_info : Traverse_acc.continuation_info Continuation.Map.t;
+        code_deps : Traverse_acc.code_dep Code_id.Map.t;
+        all_sets_of_closures :
+          (Name.t * Code_id.t Or_unknown.t) Function_slot.Lmap.t list
+      }
+  end
+
+  let traverse unit =
+    let Traverse.
+          { toplevel_expr;
+            code;
+            ordered_code_ids;
+            deps;
+            kinds;
+            fixed_arity_continuations;
+            continuation_info;
+            code_deps;
+            all_sets_of_closures
+          } =
+      Traverse.run unit
+    in
+    let rebuild_data =
+      TraverseRebuild.
+        { toplevel_expr;
+          code;
+          ordered_code_ids;
+          kinds;
+          fixed_arity_continuations;
+          continuation_info;
+          code_deps;
+          all_sets_of_closures
+        }
+    in
+    deps, rebuild_data
 
   let solve deps =
     let solved_dep =
@@ -29,7 +69,7 @@ module Staged = struct
     in
     solved_dep
 
-  let rebuild ~unit_metadata ~traverse_result ~solved_dep ~machine_width
+  let rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
       ~cmx_loader ~all_code ~final_typing_env =
     let load_code = Flambda_cmx.get_imported_code cmx_loader in
     let get_code_metadata code_id =
@@ -38,18 +78,17 @@ module Staged = struct
         | Some code -> code
         | None -> Exported_code.find_exn (load_code ()) code_id)
     in
-    let Traverse.
+    let TraverseRebuild.
           { toplevel_expr;
             code;
             ordered_code_ids;
-            deps = _;
             kinds;
             fixed_arity_continuations;
             continuation_info;
             code_deps;
             all_sets_of_closures
           } =
-      traverse_result
+      traverse_rebuild
     in
     let types_rewrite_context =
       Types_rewriter.prepare_rewrite_context solved_dep all_sets_of_closures
@@ -83,8 +122,8 @@ end
 
 let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
     (unit : Flambda_unit.t) =
-  let traverse_result = Staged.traverse unit in
-  let solved_dep = Staged.solve traverse_result.deps in
+  let deps, traverse_rebuild = Staged.traverse unit in
+  let solved_dep = Staged.solve deps in
   let unit_metadata = Flambda_unit.metadata unit in
-  Staged.rebuild ~unit_metadata ~traverse_result ~solved_dep ~machine_width
+  Staged.rebuild ~unit_metadata ~traverse_rebuild ~solved_dep ~machine_width
     ~cmx_loader ~all_code ~final_typing_env

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -16,7 +16,7 @@
 module Staged = struct
   let traverse = Traverse.run
 
-  let solve Traverse.{ deps; _ } =
+  let solve deps =
     let solved_dep =
       Profile.record_call ~accumulate:true "solver" (fun () ->
           Analysis.fixpoint deps)
@@ -84,7 +84,7 @@ end
 let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
     (unit : Flambda_unit.t) =
   let traverse_result = Staged.traverse unit in
-  let solved_dep = Staged.solve traverse_result in
+  let solved_dep = Staged.solve traverse_result.deps in
   let unit_metadata = Flambda_unit.metadata unit in
   Staged.rebuild ~unit_metadata ~traverse_result ~solved_dep ~machine_width
     ~cmx_loader ~all_code ~final_typing_env

--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -78,7 +78,7 @@ module Staged = struct
            ~unit_symbol:(Flambda_unit.Metadata.module_symbol unit_metadata))
         final_typing_env
     in
-    ( Flambda_unit.of_metadata_and_body unit_metadata body,
+    ( Flambda_unit.create_of_metadata_and_body unit_metadata body,
       free_names,
       all_code,
       slot_offsets,

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -13,6 +13,30 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Staged : sig
+  (** Traverse the compilation unit in preparation for Reaper analysis. *)
+  val traverse : Flambda_unit.t -> Traverse.result
+
+  (** Run Reaper analysis for a compilation unit producing a Reaper solution. *)
+  val solve : Traverse.result -> Unboxing_analysis.result
+
+  (** Use a Reaper solution and traversed compilation unit to rebuild the unit
+      with dead code removed. *)
+  val rebuild :
+    unit_metadata:Flambda_unit.Metadata.t ->
+    traverse_result:Traverse.result ->
+    solved_dep:Unboxing_analysis.result ->
+    machine_width:Target_system.Machine_width.t ->
+    cmx_loader:Flambda_cmx.loader ->
+    all_code:Exported_code.t ->
+    final_typing_env:Typing_env.t option ->
+    Flambda_unit.t
+    * Name_occurrences.t
+    * Exported_code.t
+    * Slot_offsets.t
+    * Typing_env.t option
+end
+
 val run :
   machine_width:Target_system.Machine_width.t ->
   cmx_loader:Flambda_cmx.loader ->

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -18,7 +18,7 @@ module Staged : sig
   val traverse : Flambda_unit.t -> Traverse.result
 
   (** Run Reaper analysis for a compilation unit producing a Reaper solution. *)
-  val solve : Traverse.result -> Unboxing_analysis.result
+  val solve : Global_flow_graph.graph -> Unboxing_analysis.result
 
   (** Use a Reaper solution and traversed compilation unit to rebuild the unit
       with dead code removed. *)

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -14,8 +14,12 @@
 (**************************************************************************)
 
 module Staged : sig
+  module TraverseRebuild : sig
+    type t
+  end
+
   (** Traverse the compilation unit in preparation for Reaper analysis. *)
-  val traverse : Flambda_unit.t -> Traverse.result
+  val traverse : Flambda_unit.t -> Global_flow_graph.graph * TraverseRebuild.t
 
   (** Run Reaper analysis for a compilation unit producing a Reaper solution. *)
   val solve : Global_flow_graph.graph -> Unboxing_analysis.result
@@ -24,7 +28,7 @@ module Staged : sig
       with dead code removed. *)
   val rebuild :
     unit_metadata:Flambda_unit.Metadata.t ->
-    traverse_result:Traverse.result ->
+    traverse_rebuild:TraverseRebuild.t ->
     solved_dep:Unboxing_analysis.result ->
     machine_width:Target_system.Machine_width.t ->
     cmx_loader:Flambda_cmx.loader ->

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -14,56 +14,72 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module Metadata = struct
+  type t =
+    { return_continuation : Continuation.t;
+      exn_continuation : Continuation.t;
+      toplevel_my_region : Variable.t;
+      toplevel_my_ghost_region : Variable.t;
+      toplevel_my_alloc_region : Variable.t;
+      module_symbol : Symbol.t;
+      used_value_slots : Value_slot.Set.t Or_unknown.t
+    }
+
+  let module_symbol t = t.module_symbol
+end
+
 type t =
-  { return_continuation : Continuation.t;
-    exn_continuation : Continuation.t;
-    toplevel_my_region : Variable.t;
-    toplevel_my_ghost_region : Variable.t;
-    toplevel_my_alloc_region : Variable.t;
-    body : Flambda.Expr.t;
-    module_symbol : Symbol.t;
-    used_value_slots : Value_slot.Set.t Or_unknown.t
+  { body : Flambda.Expr.t;
+    metadata : Metadata.t
   }
 
 let create ~return_continuation ~exn_continuation ~toplevel_my_region
     ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~body ~module_symbol
     ~used_value_slots =
-  { return_continuation;
-    exn_continuation;
-    toplevel_my_region;
-    toplevel_my_ghost_region;
-    toplevel_my_alloc_region;
-    body;
-    module_symbol;
-    used_value_slots
+  { body;
+    metadata =
+      { return_continuation;
+        exn_continuation;
+        toplevel_my_region;
+        toplevel_my_ghost_region;
+        toplevel_my_alloc_region;
+        module_symbol;
+        used_value_slots
+      }
   }
 
-let return_continuation t = t.return_continuation
+let of_metadata_and_body metadata body = { body; metadata }
 
-let exn_continuation t = t.exn_continuation
+let metadata t = t.metadata
 
-let toplevel_my_region t = t.toplevel_my_region
+let return_continuation t = t.metadata.return_continuation
 
-let toplevel_my_ghost_region t = t.toplevel_my_ghost_region
+let exn_continuation t = t.metadata.exn_continuation
 
-let toplevel_my_alloc_region t = t.toplevel_my_alloc_region
+let toplevel_my_region t = t.metadata.toplevel_my_region
+
+let toplevel_my_ghost_region t = t.metadata.toplevel_my_ghost_region
+
+let toplevel_my_alloc_region t = t.metadata.toplevel_my_alloc_region
 
 let body t = t.body
 
-let module_symbol t = t.module_symbol
+let module_symbol t = t.metadata.module_symbol
 
-let used_value_slots t = t.used_value_slots
+let used_value_slots t = t.metadata.used_value_slots
 
 let with_used_value_slots t used_value_slots =
-  { t with used_value_slots = Known used_value_slots }
+  { t with
+    metadata = { t.metadata with used_value_slots = Known used_value_slots }
+  }
 
 let with_body t body = { t with body }
 
 let [@ocamlformat "disable"] print ppf
-      { return_continuation; exn_continuation; toplevel_my_region;
-        toplevel_my_ghost_region; toplevel_my_alloc_region; body;
-        module_symbol; used_value_slots;
-      } =
+      { body; metadata = { return_continuation; exn_continuation;
+        toplevel_my_region; toplevel_my_ghost_region;
+        toplevel_my_alloc_region; module_symbol; used_value_slots;
+      } } =
   Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(module_symbol@ %a)@]@ \
         @[<hov 1>(return_continuation@ %a)@]@ \

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -48,7 +48,7 @@ let create ~return_continuation ~exn_continuation ~toplevel_my_region
       }
   }
 
-let of_metadata_and_body metadata body = { body; metadata }
+let create_of_metadata_and_body metadata body = { body; metadata }
 
 let metadata t = t.metadata
 

--- a/middle_end/flambda2/terms/flambda_unit.mli
+++ b/middle_end/flambda2/terms/flambda_unit.mli
@@ -16,6 +16,12 @@
 
 (** The Flambda representation of a single compilation unit's code. *)
 
+module Metadata : sig
+  type t
+
+  val module_symbol : t -> Symbol.t
+end
+
 type t
 
 val print : Format.formatter -> t -> unit
@@ -30,6 +36,10 @@ val create :
   module_symbol:Symbol.t ->
   used_value_slots:Value_slot.Set.t Or_unknown.t ->
   t
+
+val of_metadata_and_body : Metadata.t -> Flambda.Expr.t -> t
+
+val metadata : t -> Metadata.t
 
 val return_continuation : t -> Continuation.t
 

--- a/middle_end/flambda2/terms/flambda_unit.mli
+++ b/middle_end/flambda2/terms/flambda_unit.mli
@@ -37,7 +37,7 @@ val create :
   used_value_slots:Value_slot.Set.t Or_unknown.t ->
   t
 
-val of_metadata_and_body : Metadata.t -> Flambda.Expr.t -> t
+val create_of_metadata_and_body : Metadata.t -> Flambda.Expr.t -> t
 
 val metadata : t -> Metadata.t
 


### PR DESCRIPTION
Refactor the reaper into traverse, solve and rebuild stages, as these will eventually be run in separate processes for LTO.

To minimise the amount of data being stored, this also introduces a refactor of `flambda_unit`, splitting its metadata fields into a separate struct. 