### PR TITLE
typing: add expected [staticity] to Texp_ident

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -56,7 +56,8 @@ type texp_ident_identifier = ident_kind * unique_use
 let mkTexp_ident ?id:(kind, unique_use = Id_value, aliased_many_use)
     (path, lid, desc) =
   let mode = Mode.Value.(disallow_right legacy) in
-  Texp_ident { path; lid; desc; kind; unique_use; mode }
+  let staticity = Mode.Staticity.(disallow_left legacy) in
+  Texp_ident { path; lid; desc; kind; unique_use; staticity; mode }
 
 type nonrec apply_arg = apply_arg
 

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1262,6 +1262,7 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                            lid = mknoloc (Longident.Lident (Ident.name id));
                            desc = vd; kind = Id_value;
                            unique_use = aliased_many_use;
+                           staticity = Mode.Staticity.(disallow_left legacy);
                            mode = Mode.Value.(disallow_right legacy) };
               exp_loc = Location.none; exp_extra = [];
               exp_type = Ctype.instance vd.val_type;
@@ -1473,6 +1474,8 @@ and class_expr_aux cl_num val_env met_env virt self_scope scl =
                              lid = mknoloc (Longident.Lident (Ident.name id));
                              desc = vd; kind = Id_value;
                              unique_use = aliased_many_use;
+                             staticity =
+                               Mode.Staticity.(disallow_left legacy);
                              mode = Mode.Value.(disallow_right legacy) };
                 exp_loc = Location.none; exp_extra = [];
                 exp_type = ty;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -585,6 +585,9 @@ let as_single_mode {mode; tuple_modes; _} =
       Value.meet (mode :: l)
   | None -> mode
 
+let proj_staticity mode =
+  Staticity.disallow_left (Value.proj_monadic Staticity mode)
+
 let mode_morph f expected_mode =
   let mode = as_single_mode expected_mode in
   let mode = f mode |> Mode.Value.disallow_left in
@@ -6969,11 +6972,15 @@ and type_expect_
             in
             Texp_ident { path; lid; desc; kind;
               unique_use = unique_use ~loc ~env actual_mode
-                (as_single_mode expected_mode); mode = actual_mode }
+                (as_single_mode expected_mode);
+              staticity = proj_staticity (as_single_mode expected_mode);
+              mode = actual_mode }
         | _ ->
             Texp_ident { path; lid; desc; kind;
               unique_use = unique_use ~loc ~env actual_mode
-                (as_single_mode expected_mode); mode = actual_mode }
+                (as_single_mode expected_mode);
+              staticity = proj_staticity (as_single_mode expected_mode);
+              mode = actual_mode }
       in
       let exp = rue {
         exp_desc; exp_loc = loc; exp_extra = [];
@@ -10140,6 +10147,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
          Texp_ident { path = Path.Pident id;
                       lid = mknoloc (Longident.Lident name);
                       desc; kind = Id_value; unique_use = uu;
+                      staticity = proj_staticity mode;
                       mode = Value.disallow_right mode }}
       in
       let eta_mode, _ = Value.newvar_below (alloc_as_value marg) in

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -283,6 +283,7 @@ and expression_desc =
         desc : Types.value_description;
         kind : ident_kind;
         unique_use : unique_use;
+        staticity : Mode.Staticity.r;
         mode : Mode.Value.l }
   | Texp_apply_layout of expression * Jkind_types.Sort.var list
   | Texp_constant of constant

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -468,6 +468,7 @@ and expression_desc =
         desc : Types.value_description;
         kind : ident_kind;
         unique_use : unique_use;
+        staticity : Mode.Staticity.r;
         mode : Mode.Value.l }
         (** x
             M.x


### PR DESCRIPTION
Add a `staticity : Mode.Staticity.r` field to `Texp_ident` recording the expected staticity of the identifier, projected from the expected mode.

This allows `transl` to zap such staticity to ceil (towards `Dynamic`) which allows `Pgetglobal(_, Dynamic)` instead of `Pgetglobal(_, Static)` - the former doesn't load comp-time data from cmx and is thus faster.