### PR TITLE
Remove unnecessary `caml_modify` for existential immediate types in mixed blocks

### DIFF
--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -672,3 +672,29 @@ let () =
   test ~expect_caml_modifies:1
     (fun () -> f t #{ x = 3; y = "b" };
                ignore (Sys.opaque_identity t))
+
+(* Unboxed GADT: the existential component's immediacy is only visible in the
+   declared [immediate & immediate] field shape *)
+let () =
+  let open struct
+    type ('a : immediate) t' : immediate = Int : int t' | Unit : unit t'
+    type t : immediate & immediate = T : #('a t' * 'a) -> t [@@unboxed]
+    type holder = { mutable t : t }
+  end in
+  let r = { t = T #(Int, 1) } in
+  test ~expect_caml_modifies:0
+    (fun () -> r.t <- T #(Unit, ()); ignore (Sys.opaque_identity r));
+  let[@inline never] set r v = r.t <- v in
+  test ~expect_caml_modifies:0
+    (fun () -> set r (T #(Int, 2)); ignore (Sys.opaque_identity r))
+
+(* Same shape but with a genuinely pointer-carrying component *)
+let () =
+  let open struct
+    type ('a : immediate) t' : immediate = Int : int t' | Unit : unit t'
+    type p : immediate & value = P : #('a t' * string) -> p [@@unboxed]
+    type holder = { mutable p : p }
+  end in
+  let r = { p = P #(Int, "a") } in
+  test ~expect_caml_modifies:1
+    (fun () -> r.p <- P #(Unit, "b"); ignore (Sys.opaque_identity r))

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -804,17 +804,28 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
   : int * unit Lambda.mixed_block_element =
   match field with
   | Scannable { separability } ->
+    let pointerness = pointerness_of_separability separability in
     begin match ty with
     | Some ty ->
       let num_nodes_visited, kind =
         value_kind env ~loc ~visited ~depth ~num_nodes_visited ty
       in
+      (* The declared shape's separability can be more precise than what
+         [value_kind] computes here (e.g. for existential type variables), so
+         take the better of the two. *)
+      (* CR-someday rtjoa: The most precise thing would be a real meet of
+         value kinds, which could e.g. improve upon a [Pintval] with a
+         [Pvariant], keeping only the [Pvariant]'s constant constructors. *)
+      let kind =
+        match pointerness, kind.raw_kind with
+        | Immediate, Pgenval -> { kind with raw_kind = Pintval }
+        | Immediate, _ | Pointer, _ -> kind
+      in
       num_nodes_visited, Value kind
     | None ->
-      let raw_kind =
-        value_kind_of_pointerness (pointerness_of_separability separability)
-      in
-      num_nodes_visited, Value { generic_value with raw_kind }
+      num_nodes_visited,
+      Value
+        { generic_value with raw_kind = value_kind_of_pointerness pointerness }
     (* CR layouts v7.1: assess whether it is important for performance to
        support deep value_kinds here *)
     end

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -813,8 +813,8 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
       (* The declared shape's separability can be more precise than what
          [value_kind] computes here (e.g. for existential type variables), so
          take the better of the two. *)
-      (* CR-someday rtjoa: The most precise thing would be a real meet of value
-         kinds (e.g. a pointerness of [Immediate] could remove the non-constant
+      (* CR layouts: The most precise thing would be a real meet of value kinds
+         (e.g. a pointerness of [Immediate] could remove the non-constant
          constructors from [Pvariant _]) *)
       let kind =
         match pointerness, kind.raw_kind with

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -813,9 +813,9 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
       (* The declared shape's separability can be more precise than what
          [value_kind] computes here (e.g. for existential type variables), so
          take the better of the two. *)
-      (* CR-someday rtjoa: The most precise thing would be a real meet of
-         value kinds, which could e.g. improve upon a [Pintval] with a
-         [Pvariant], keeping only the [Pvariant]'s constant constructors. *)
+      (* CR-someday rtjoa: The most precise thing would be a real meet of value
+         kinds (e.g. a pointerness of [Immediate] could remove the non-constant
+         constructors from [Pvariant _]) *)
       let kind =
         match pointerness, kind.raw_kind with
         | Immediate, Pgenval -> { kind with raw_kind = Pintval }


### PR DESCRIPTION
In `value_kind_mixed_block_field`, when we have a type of the field available, we compute the value kind from that type rather than the mixed block shape. However, this can result in a *less precise* value kind for an existential type variable under a GADT constructor, as `value_kind` doesn't look at the kinds of type variables (which is often fine when non-existential type variables substituted).

This results in an extra `caml_modify` for the following program, as we compute `Pgenval` for `'a`:

```ocaml
type ('a:immediate) t' : immediate = Int : int t' | Unit : unit t'
type t : immediate & immediate = T : #('a t' * 'a) -> t [@@unboxed]
type x = { mutable t : t }

let f x = x.t <- T #(Int, 1)
```

There are two ways to improve this information:
1. When `value_kind_mixed_block_field` has a type, look at *both* the mixed block shape and the type's value kind, taking the better of the two.
2. Teach `value_kind` to look at the kind of `Tvar`/`Tof_kind`s.

We should do both, as neither subsumes the other. This PR starts with just (1). (2) is done by https://github.com/oxcaml/oxcaml/pull/6633.