### PR TITLE
Remove unnecessary `caml_modify`s via better value kinds for type variables

### DIFF
--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -709,8 +709,7 @@ let () =
     fun t v -> t.x <- v
   in
   let t = { x = #("s", 1) } in
-  (* CR rtjoa: should be 1; the ['a] word is immediate *)
-  test ~expect_caml_modifies:2
+  test ~expect_caml_modifies:1
     (fun () -> set t #("u", 2); ignore (Sys.opaque_identity t))
 
 (* Same, via a polymorphic record field *)
@@ -721,8 +720,7 @@ let () =
   end in
   let s = Sys.opaque_identity { apply = fun t v -> t.x <- v } in
   let t = { x = #("s", 1) } in
-  (* CR rtjoa: should be 1; the ['b] word is immediate *)
-  test ~expect_caml_modifies:2
+  test ~expect_caml_modifies:1
     (fun () -> s.apply t #("u", 2); ignore (Sys.opaque_identity t))
 
 (* Same, where the parameter is instantiated to an unboxed existential *)
@@ -733,6 +731,5 @@ let () =
   end in
   let[@inline never] set (t : u t) v = t.x <- v in
   let t = { x = #("s", U 1) } in
-  (* CR rtjoa: should be 1; the [u] word is immediate *)
-  test ~expect_caml_modifies:2
+  test ~expect_caml_modifies:1
     (fun () -> set t #("u", U 2); ignore (Sys.opaque_identity t))

--- a/testsuite/tests/typing-layouts-caml-modify/basics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/basics.ml
@@ -698,3 +698,41 @@ let () =
   let r = { p = P #(Int, "a") } in
   test ~expect_caml_modifies:1
     (fun () -> r.p <- P #(Unit, "b"); ignore (Sys.opaque_identity r))
+
+(* Polymorphic write where ['a]'s kind at the use site is more precise than
+   the declared [value] parameter: only the string word needs the barrier *)
+let () =
+  let open struct
+    type 'a t = { mutable x : #(string * 'a) }
+  end in
+  let[@inline never] set : ('a : immediate). 'a t -> #(string * 'a) -> unit =
+    fun t v -> t.x <- v
+  in
+  let t = { x = #("s", 1) } in
+  (* CR rtjoa: should be 1; the ['a] word is immediate *)
+  test ~expect_caml_modifies:2
+    (fun () -> set t #("u", 2); ignore (Sys.opaque_identity t))
+
+(* Same, via a polymorphic record field *)
+let () =
+  let open struct
+    type 'a t = { mutable x : #(string * 'a) }
+    type setter = { apply : ('b : immediate). 'b t -> #(string * 'b) -> unit }
+  end in
+  let s = Sys.opaque_identity { apply = fun t v -> t.x <- v } in
+  let t = { x = #("s", 1) } in
+  (* CR rtjoa: should be 1; the ['b] word is immediate *)
+  test ~expect_caml_modifies:2
+    (fun () -> s.apply t #("u", 2); ignore (Sys.opaque_identity t))
+
+(* Same, where the parameter is instantiated to an unboxed existential *)
+let () =
+  let open struct
+    type 'a t = { mutable x : #(string * 'a) }
+    type u = U : ('a : immediate). 'a -> u [@@unboxed]
+  end in
+  let[@inline never] set (t : u t) v = t.x <- v in
+  let t = { x = #("s", U 1) } in
+  (* CR rtjoa: should be 1; the [u] word is immediate *)
+  test ~expect_caml_modifies:2
+    (fun () -> set t #("u", U 2); ignore (Sys.opaque_identity t))

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -795,6 +795,10 @@ let rec value_kind env ~loc ~visited ~depth ~num_nodes_visited (ty : type_expr)
     if Btype.tvariant_not_immediate row
     then non_nullable Pgenval
     else non_nullable Pintval
+  | Tvar { jkind; _ } | Tunivar { jkind; _ } | Tof_kind jkind ->
+    num_nodes_visited,
+    add_nullability_from_ty env scty
+      (value_kind_of_scannable_jkind env (Jkind.disallow_right jkind))
   | _ ->
     num_nodes_visited,
     add_nullability_from_ty env scty Pgenval


### PR DESCRIPTION
Update `value_kind` to look at the kinds on `Tvar`/`Tunivar`/`Tof_kind`. This reduces the number of `caml_modify` calls in the following program from 2 to 1.
```ocaml
type 'a t = { mutable x : #(string * 'a) }

let[@inline never] set : ('a : immediate). 'a t -> #(string * 'a) -> unit =
  fun t v -> t.x <- v

let () =
  let t = { x = #("s", 1) } in
  set t #("u", 2);
  ignore (Sys.opaque_identity t : _ t)
```

See also the parent PR: https://github.com/oxcaml/oxcaml/pull/6631