### PR TITLE
Guard unsigned types by the `small_numbers` extension

### DIFF
--- a/testsuite/tests/typing-layouts/unsigned_unboxed_types.ml
+++ b/testsuite/tests/typing-layouts/unsigned_unboxed_types.ml
@@ -10,11 +10,13 @@ type t8 : bits8 mod everything = uint8_u
 type t16 : bits16 mod everything = uint16_u
 type t32 : bits32 mod everything = uint32_u
 type t64 : bits64 mod everything = uint64_u
+type tw : word mod everything = unativeint_u
 [%%expect{|
 type t8 = uint8_u
 type t16 = uint16_u
 type t32 = uint32_u
 type t64 = uint64_u
+type tw = unativeint_u
 |}]
 
 (* They are distinct from the signed types. *)
@@ -55,6 +57,15 @@ Error: The value "x" has type "int64#" but an expression was expected of type
          "uint64_u"
 |}]
 
+let f (x : nativeint#) : unativeint_u = x
+[%%expect{|
+Line 1, characters 40-41:
+1 | let f (x : nativeint#) : unativeint_u = x
+                                            ^
+Error: The value "x" has type "nativeint#" but an expression was expected of type
+         "unativeint_u"
+|}]
+
 (* They can be used as GADT indices and distinguished from the signed
    types. *)
 
@@ -67,6 +78,8 @@ type ('a : any) width =
   | U32 : uint32_u width
   | I64 : int64# width
   | U64 : uint64_u width
+  | IW : nativeint# width
+  | UW : unativeint_u width
 [%%expect{|
 type ('a : any) width =
     I8 : int8# width
@@ -77,6 +90,8 @@ type ('a : any) width =
   | U32 : uint32_u width
   | I64 : int64# width
   | U64 : uint64_u width
+  | IW : nativeint# width
+  | UW : unativeint_u width
 |}]
 
 (* Specifying the index selects between the signed and unsigned
@@ -98,6 +113,12 @@ let unsigned64 (x : uint64_u width) = match x with
   | U64 -> ()
 [%%expect{|
 val unsigned64 : uint64_u width -> unit = <fun>
+|}]
+
+let unsignedw (x : unativeint_u width) = match x with
+  | UW -> ()
+[%%expect{|
+val unsignedw : unativeint_u width -> unit = <fun>
 |}]
 
 (* A constructor of the wrong signedness cannot match at a specified
@@ -123,4 +144,16 @@ Line 2, characters 4-7:
 Error: This pattern matches values of type "uint16_u width"
        but a pattern was expected which matches values of type "int16# width"
        Type "uint16_u" is not compatible with type "int16#"
+|}]
+
+let bad (x : unativeint_u width) = match x with
+  | IW -> ()
+[%%expect{|
+Line 2, characters 4-6:
+2 |   | IW -> ()
+        ^^
+Error: This pattern matches values of type "nativeint# width"
+       but a pattern was expected which matches values of type
+         "unativeint_u width"
+       Type "nativeint#" is not compatible with type "unativeint_u"
 |}]

--- a/testsuite/tests/typing-simd/test_upstream_compatible.ml
+++ b/testsuite/tests/typing-simd/test_upstream_compatible.ml
@@ -17,7 +17,7 @@ Line 1, characters 9-16:
 1 | type t = int16x8;;
              ^^^^^^^
 Error: Unbound type constructor "int16x8"
-Hint:              Did you mean "int64" or "uint16_u"?
+Hint:              Did you mean "int64"?
 |}];;
 
 type t = int32x4;;

--- a/testsuite/tests/typing-small-numbers/test_disabled.ml
+++ b/testsuite/tests/typing-small-numbers/test_disabled.ml
@@ -230,6 +230,51 @@ Error: Unbound type constructor "int16"
 Hint:              Did you mean "int", "int16x8", "int32", "int64" or "int8x16"?
 |}];;
 
+type t = uint8_u;;
+[%%expect{|
+Line 1, characters 9-16:
+1 | type t = uint8_u;;
+             ^^^^^^^
+Error: Unbound type constructor "uint8_u"
+Hint:              Did you mean "int32_u" or "int64_u"?
+|}];;
+
+type t = uint16_u;;
+[%%expect{|
+Line 1, characters 9-17:
+1 | type t = uint16_u;;
+             ^^^^^^^^
+Error: Unbound type constructor "uint16_u"
+Hint:              Did you mean "int16x8", "int32_u" or "int64_u"?
+|}];;
+
+type t = uint32_u;;
+[%%expect{|
+Line 1, characters 9-17:
+1 | type t = uint32_u;;
+             ^^^^^^^^
+Error: Unbound type constructor "uint32_u"
+Hint:              Did you mean "int32_u"?
+|}];;
+
+type t = uint64_u;;
+[%%expect{|
+Line 1, characters 9-17:
+1 | type t = uint64_u;;
+             ^^^^^^^^
+Error: Unbound type constructor "uint64_u"
+Hint:              Did you mean "int64_u"?
+|}];;
+
+type t = unativeint_u;;
+[%%expect{|
+Line 1, characters 9-21:
+1 | type t = unativeint_u;;
+             ^^^^^^^^^^^^
+Error: Unbound type constructor "unativeint_u"
+Hint:              Did you mean "nativeint_u"?
+|}];;
+
 let f () = #'a';;
 [%%expect{|
 Line 1, characters 11-15:

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -66,6 +66,7 @@ type abstract_non_value_type_constr = [
   | `Uint16_u
   | `Uint32_u
   | `Uint64_u
+  | `Unativeint_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -132,10 +133,6 @@ let base_type_constrs : type_constr list = [
   `Nativeint_u;
   `Int32_u;
   `Int64_u;
-  `Uint8_u;
-  `Uint16_u;
-  `Uint32_u;
-  `Uint64_u;
   `Idx_imm;
   `Idx_mut;
 ]
@@ -178,6 +175,11 @@ let small_number_extension_type_constrs : type_constr list = [
   `Float32_u;
   `Int8;
   `Int16;
+  `Uint8_u;
+  `Uint16_u;
+  `Uint32_u;
+  `Uint64_u;
+  `Unativeint_u;
 ]
 
 let metaprogramming_extension_type_constrs : type_constr list = [
@@ -234,6 +236,7 @@ and ident_uint8_u = ident_create "uint8_u"
 and ident_uint16_u = ident_create "uint16_u"
 and ident_uint32_u = ident_create "uint32_u"
 and ident_uint64_u = ident_create "uint64_u"
+and ident_unativeint_u = ident_create "unativeint_u"
 and ident_or_null = ident_create "or_null"
 and ident_idx_imm = ident_create "idx_imm"
 and ident_idx_mut = ident_create "idx_mut"
@@ -297,6 +300,7 @@ let ident_of_type_constr : type_constr -> Ident.t = function
   | `Uint16_u -> ident_uint16_u
   | `Uint32_u -> ident_uint32_u
   | `Uint64_u -> ident_uint64_u
+  | `Unativeint_u -> ident_unativeint_u
   | `Idx_imm -> ident_idx_imm
   | `Idx_mut -> ident_idx_mut
   | `Int8x16 -> ident_int8x16
@@ -355,6 +359,7 @@ and path_uint8_u = Pident ident_uint8_u
 and path_uint16_u = Pident ident_uint16_u
 and path_uint32_u = Pident ident_uint32_u
 and path_uint64_u = Pident ident_uint64_u
+and path_unativeint_u = Pident ident_unativeint_u
 and path_idx_imm = Pident ident_idx_imm
 and path_idx_mut = Pident ident_idx_mut
 and path_code = Pident ident_code
@@ -469,6 +474,7 @@ and type_uint8_u = tconstr path_uint8_u []
 and type_uint16_u = tconstr path_uint16_u []
 and type_uint32_u = tconstr path_uint32_u []
 and type_uint64_u = tconstr path_uint64_u []
+and type_unativeint_u = tconstr path_unativeint_u []
 and type_or_null t = tconstr path_or_null [t]
 and type_idx_imm t1 t2 = tconstr path_idx_imm [t1; t2]
 and type_idx_mut t1 t2 = tconstr path_idx_mut [t1; t2]
@@ -934,6 +940,8 @@ let decl_of_type_constr type_constr =
     decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int32) ()
   | `Uint64_u ->
     decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_int64) ()
+  | `Unativeint_u ->
+    decl0 ~jkind:(builtin Jkind.Const.Builtin.kind_of_unboxed_nativeint) ()
   | `Idx_imm ->
     decl2 ~variance:(Variance.full, Variance.covariant)
        ~param_jkinds:(

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -50,6 +50,7 @@ type abstract_non_value_type_constr = [
   | `Uint16_u
   | `Uint32_u
   | `Uint64_u
+  | `Unativeint_u
   | `Idx_imm
   | `Idx_mut
   | `Int8x16
@@ -136,6 +137,7 @@ val type_uint8_u: type_expr
 val type_uint16_u: type_expr
 val type_uint32_u: type_expr
 val type_uint64_u: type_expr
+val type_unativeint_u: type_expr
 val type_or_null: type_expr -> type_expr
 val type_idx_imm : type_expr -> type_expr -> type_expr
 val type_idx_mut : type_expr -> type_expr -> type_expr
@@ -232,6 +234,7 @@ val path_uint8_u: Path.t
 val path_uint16_u: Path.t
 val path_uint32_u: Path.t
 val path_uint64_u: Path.t
+val path_unativeint_u: Path.t
 val path_or_null: Path.t
 val path_idx_imm: Path.t
 val path_idx_mut: Path.t


### PR DESCRIPTION
The unsigned unboxed integer types are now part of the `small_numbers` extension (which we may want to rename to `more_numbers` at this point).

Also adds `unativeint_u`, which is the unsigned version of `nativeint_u`. 