### PR TITLE
Refactor quoting predefined names

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2356,7 +2356,14 @@ let quote_constructor loc env (constr : Data_types.constructor_description) =
     | Extension (Path.Pdot (p, name)) ->
       Identifier.Constructor.dot loc (module_for_path loc env p) name
       |> persistent
-    | Extension (Path.Pident id) -> Ident.name id |> local
+    | Extension (Path.Pident id) ->
+      let name = Ident.name id in
+      if
+        List.exists
+          (fun (name', _) -> String.equal name name')
+          Predef.builtin_exns
+      then Identifier.Constructor.builtin loc name |> persistent
+      else local name
     | Extension _ ->
       fatal_errorf "Translquote [at %a]: Papply in extension constructor."
         Location.print_loc (to_location loc)
@@ -2370,7 +2377,7 @@ let quote_constructor loc env (constr : Data_types.constructor_description) =
         if
           List.exists
             (fun (name', _) -> String.equal name name')
-            (Predef.builtin_exns @ Predef.builtin_constrs)
+            Predef.builtin_constrs
         then Identifier.Constructor.builtin loc name |> persistent
         else local name
       | Some (Path.Pdot (p, _)) ->

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -693,69 +693,7 @@ module Identifier : sig
 
     val var : Debuginfo.Scoped_location.t -> Var.Type_constr.t -> Loc.t -> t'
 
-    val int : t'
-
-    val char : t'
-
-    val string : t'
-
-    val bytes : t'
-
-    val float : t'
-
-    val float32 : t'
-
-    val bool : t'
-
-    val unit : t'
-
-    val exn : t'
-
-    val array : t'
-
-    val iarray : t'
-
-    val list : t'
-
-    val option : t'
-
-    val nativeint : t'
-
-    val int32 : t'
-
-    val int64 : t'
-
-    val lazy_t : t'
-
-    val extension_constructor : t'
-
-    val floatarray : t'
-
-    val lexing_position : t'
-
-    val expr : t'
-
-    val eval : t'
-
-    val unboxed_float : t'
-
-    val unboxed_nativeint : t'
-
-    val unboxed_int32 : t'
-
-    val unboxed_int64 : t'
-
-    val int8x16 : t'
-
-    val int16x8 : t'
-
-    val int32x4 : t'
-
-    val int64x2 : t'
-
-    val float32x4 : t'
-
-    val float64x2 : t'
+    val builtin : Debuginfo.Scoped_location.t -> string -> t'
   end
 
   module Module_type : sig
@@ -888,69 +826,7 @@ end = struct
     let var loc a1 a2 =
       apply2 "Identifier.Type" "var" loc (extract a1) (extract a2)
 
-    let int = use "Identifier.Type" "int"
-
-    let char = use "Identifier.Type" "char"
-
-    let string = use "Identifier.Type" "string"
-
-    let bytes = use "Identifier.Type" "bytes"
-
-    let float = use "Identifier.Type" "float"
-
-    let float32 = use "Identifier.Type" "float32"
-
-    let bool = use "Identifier.Type" "bool"
-
-    let unit = use "Identifier.Type" "unit"
-
-    let exn = use "Identifier.Type" "exn"
-
-    let array = use "Identifier.Type" "array"
-
-    let iarray = use "Identifier.Type" "iarray"
-
-    let list = use "Identifier.Type" "list"
-
-    let option = use "Identifier.Type" "option"
-
-    let nativeint = use "Identifier.Type" "nativeint"
-
-    let int32 = use "Identifier.Type" "int32"
-
-    let int64 = use "Identifier.Type" "int64"
-
-    let lazy_t = use "Identifier.Type" "lazy_t"
-
-    let extension_constructor = use "Identifier.Type" "extension_constructor"
-
-    let floatarray = use "Identifier.Type" "floatarray"
-
-    let lexing_position = use "Identifier.Type" "lexing_position"
-
-    let expr = use "Identifier.Type" "expr"
-
-    let eval = use "Identifier.Type" "eval"
-
-    let unboxed_float = use "Identifier.Type" "unboxed_float"
-
-    let unboxed_nativeint = use "Identifier.Type" "unboxed_nativeint"
-
-    let unboxed_int32 = use "Identifier.Type" "unboxed_int32"
-
-    let unboxed_int64 = use "Identifier.Type" "unboxed_int64"
-
-    let int8x16 = use "Identifier.Type" "int8x16"
-
-    let int16x8 = use "Identifier.Type" "int16x8"
-
-    let int32x4 = use "Identifier.Type" "int32x4"
-
-    let int64x2 = use "Identifier.Type" "int64x2"
-
-    let float32x4 = use "Identifier.Type" "float32x4"
-
-    let float64x2 = use "Identifier.Type" "float64x2"
+    let builtin loc a1 = apply1 "Identifier.Type" "builtin" loc (string ~loc a1)
   end
 
   module Module_type = struct
@@ -2459,44 +2335,17 @@ let type_for_path_opt loc env = function
     let+ t =
       match Hashtbl.find_opt vars_env.env_tys id with
       | Some t -> Identifier.Type.var loc t (quote_loc loc) |> Option.some
-      | None -> (
-        match Ident.name id with
-        | "int" -> Some Identifier.Type.int
-        | "char" -> Some Identifier.Type.char
-        | "string" -> Some Identifier.Type.string
-        | "bytes" -> Some Identifier.Type.bytes
-        | "float" -> Some Identifier.Type.float
-        | "float32" -> Some Identifier.Type.float32
-        | "bool" -> Some Identifier.Type.bool
-        | "unit" -> Some Identifier.Type.unit
-        | "exn" -> Some Identifier.Type.exn
-        | "array" -> Some Identifier.Type.array
-        | "iarray" -> Some Identifier.Type.iarray
-        | "list" -> Some Identifier.Type.list
-        | "option" -> Some Identifier.Type.option
-        | "nativeint" -> Some Identifier.Type.nativeint
-        | "int32" -> Some Identifier.Type.int32
-        | "int64" -> Some Identifier.Type.int64
-        | "lazy_t" -> Some Identifier.Type.lazy_t
-        | "extension_constructor" -> Some Identifier.Type.extension_constructor
-        | "floatarray" -> Some Identifier.Type.floatarray
-        | "lexing_position" -> Some Identifier.Type.lexing_position
-        | "expr" -> Some Identifier.Type.expr
-        | "eval" -> Some Identifier.Type.eval
-        | "float#" -> Some Identifier.Type.unboxed_float
-        | "nativeint#" -> Some Identifier.Type.unboxed_nativeint
-        | "int32#" -> Some Identifier.Type.unboxed_int32
-        | "int64#" -> Some Identifier.Type.unboxed_int64
-        | "nativeint_u" -> Some Identifier.Type.unboxed_nativeint
-        | "int32_u" -> Some Identifier.Type.unboxed_int32
-        | "int64_u" -> Some Identifier.Type.unboxed_int64
-        | "int8x16" -> Some Identifier.Type.int8x16
-        | "int16x8" -> Some Identifier.Type.int16x8
-        | "int32x4" -> Some Identifier.Type.int32x4
-        | "int64x2" -> Some Identifier.Type.int64x2
-        | "float32x4" -> Some Identifier.Type.float32x4
-        | "float64x2" -> Some Identifier.Type.float64x2
-        | _ -> None)
+      | None ->
+        (* CR-someday jbachurski: I am fairly sure we can retire this check as
+           it is redundant with what the environment already does. However,
+           we can keep it if it does not get in the way. *)
+        let name = Ident.name id in
+        if
+          List.exists
+            (fun (name', _) -> String.equal name name')
+            Predef.builtin_type_constrs
+        then Some (Identifier.Type.builtin loc name)
+        else None
     in
     Identifier.Type.wrap t
   | Path.Pdot (p, s) ->

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2420,9 +2420,11 @@ let quote_arg_label loc = function
        Labelled, Nolabel and Optional"
       Location.print_loc (to_location loc)
 
-let module_for_path loc env path =
+let ( let+ ) f x = Option.map x f
+
+let module_for_path_opt loc env path =
   Env.add_required_global_for_quote path env;
-  let rec module_for_path path =
+  let rec go path =
     match path with
     | Path.Pident id ->
       (match Hashtbl.find_opt vars_env.env_mod id with
@@ -2434,85 +2436,96 @@ let module_for_path loc env path =
             (* We must be in a [Toplevel_lock_for_directive] if we are quoting
              a non-global module. *)
             Ident.name id |> Identifier.Module.toplevel_module loc))
-      |> Identifier.Module.wrap
+      |> Identifier.Module.wrap |> Option.some
     | Path.Pdot (p, s) ->
-      Identifier.Module.dot loc (module_for_path p) s |> Identifier.Module.wrap
-    | _ -> raise Exit
+      let+ m = go p in
+      Identifier.Module.dot loc m s |> Identifier.Module.wrap
+    | _ -> None
   in
-  module_for_path path
+  go path
 
-let module_type_for_path loc env = function
+let module_type_for_path_opt loc env = function
   | Path.Pident id ->
-    Module_type.of_string loc (Ident.name id) |> Module_type.wrap
+    Module_type.of_string loc (Ident.name id) |> Module_type.wrap |> Option.some
   | Path.Pdot (p, s) ->
+    let+ m = module_for_path_opt loc env p in
     Module_type.ident loc
-      (Identifier.Module_type.dot loc (module_for_path loc env p) s
-      |> Identifier.Module_type.wrap)
+      (Identifier.Module_type.dot loc m s |> Identifier.Module_type.wrap)
     |> Module_type.wrap
-  | _ -> raise Exit
+  | _ -> None
 
-let type_for_path loc env = function
+let type_for_path_opt loc env = function
   | Path.Pident id ->
-    (match Hashtbl.find_opt vars_env.env_tys id with
-      | Some t -> Identifier.Type.var loc t (quote_loc loc)
+    let+ t =
+      match Hashtbl.find_opt vars_env.env_tys id with
+      | Some t -> Identifier.Type.var loc t (quote_loc loc) |> Option.some
       | None -> (
         match Ident.name id with
-        | "int" -> Identifier.Type.int
-        | "char" -> Identifier.Type.char
-        | "string" -> Identifier.Type.string
-        | "bytes" -> Identifier.Type.bytes
-        | "float" -> Identifier.Type.float
-        | "float32" -> Identifier.Type.float32
-        | "bool" -> Identifier.Type.bool
-        | "unit" -> Identifier.Type.unit
-        | "exn" -> Identifier.Type.exn
-        | "array" -> Identifier.Type.array
-        | "iarray" -> Identifier.Type.iarray
-        | "list" -> Identifier.Type.list
-        | "option" -> Identifier.Type.option
-        | "nativeint" -> Identifier.Type.nativeint
-        | "int32" -> Identifier.Type.int32
-        | "int64" -> Identifier.Type.int64
-        | "lazy_t" -> Identifier.Type.lazy_t
-        | "extension_constructor" -> Identifier.Type.extension_constructor
-        | "floatarray" -> Identifier.Type.floatarray
-        | "lexing_position" -> Identifier.Type.lexing_position
-        | "expr" -> Identifier.Type.expr
-        | "eval" -> Identifier.Type.eval
-        | "float#" -> Identifier.Type.unboxed_float
-        | "nativeint#" -> Identifier.Type.unboxed_nativeint
-        | "int32#" -> Identifier.Type.unboxed_int32
-        | "int64#" -> Identifier.Type.unboxed_int64
-        | "nativeint_u" -> Identifier.Type.unboxed_nativeint
-        | "int32_u" -> Identifier.Type.unboxed_int32
-        | "int64_u" -> Identifier.Type.unboxed_int64
-        | "int8x16" -> Identifier.Type.int8x16
-        | "int16x8" -> Identifier.Type.int16x8
-        | "int32x4" -> Identifier.Type.int32x4
-        | "int64x2" -> Identifier.Type.int64x2
-        | "float32x4" -> Identifier.Type.float32x4
-        | "float64x2" -> Identifier.Type.float64x2
-        | _ -> raise Exit))
-    |> Identifier.Type.wrap
+        | "int" -> Some Identifier.Type.int
+        | "char" -> Some Identifier.Type.char
+        | "string" -> Some Identifier.Type.string
+        | "bytes" -> Some Identifier.Type.bytes
+        | "float" -> Some Identifier.Type.float
+        | "float32" -> Some Identifier.Type.float32
+        | "bool" -> Some Identifier.Type.bool
+        | "unit" -> Some Identifier.Type.unit
+        | "exn" -> Some Identifier.Type.exn
+        | "array" -> Some Identifier.Type.array
+        | "iarray" -> Some Identifier.Type.iarray
+        | "list" -> Some Identifier.Type.list
+        | "option" -> Some Identifier.Type.option
+        | "nativeint" -> Some Identifier.Type.nativeint
+        | "int32" -> Some Identifier.Type.int32
+        | "int64" -> Some Identifier.Type.int64
+        | "lazy_t" -> Some Identifier.Type.lazy_t
+        | "extension_constructor" -> Some Identifier.Type.extension_constructor
+        | "floatarray" -> Some Identifier.Type.floatarray
+        | "lexing_position" -> Some Identifier.Type.lexing_position
+        | "expr" -> Some Identifier.Type.expr
+        | "eval" -> Some Identifier.Type.eval
+        | "float#" -> Some Identifier.Type.unboxed_float
+        | "nativeint#" -> Some Identifier.Type.unboxed_nativeint
+        | "int32#" -> Some Identifier.Type.unboxed_int32
+        | "int64#" -> Some Identifier.Type.unboxed_int64
+        | "nativeint_u" -> Some Identifier.Type.unboxed_nativeint
+        | "int32_u" -> Some Identifier.Type.unboxed_int32
+        | "int64_u" -> Some Identifier.Type.unboxed_int64
+        | "int8x16" -> Some Identifier.Type.int8x16
+        | "int16x8" -> Some Identifier.Type.int16x8
+        | "int32x4" -> Some Identifier.Type.int32x4
+        | "int64x2" -> Some Identifier.Type.int64x2
+        | "float32x4" -> Some Identifier.Type.float32x4
+        | "float64x2" -> Some Identifier.Type.float64x2
+        | _ -> None)
+    in
+    Identifier.Type.wrap t
   | Path.Pdot (p, s) ->
-    Identifier.Type.dot loc (module_for_path loc env p) s
-    |> Identifier.Type.wrap
-  | _ -> raise Exit
+    let+ m = module_for_path_opt loc env p in
+    Identifier.Type.dot loc m s |> Identifier.Type.wrap
+  | _ -> None
 
-let type_constr_for_path loc env path arity =
-  Type.constr loc
-    (type_for_path loc env path)
-    (List.init arity (fun _ -> Type.var loc None |> Type.wrap))
-  |> Type.wrap
-
-let value_for_path loc env = function
+let value_for_path_opt loc env = function
   | Path.Pdot (p, s) ->
-    Identifier.Value.dot loc (module_for_path loc env p) s
-    |> Identifier.Value.wrap
-  | _ -> raise Exit
+    let+ m = module_for_path_opt loc env p in
+    Identifier.Value.dot loc m s |> Identifier.Value.wrap
+  | _ -> None
 
-let value_for_path_opt loc env p =
-  match value_for_path loc env p with res -> Some res | exception Exit -> None
+let try_path kind path_for_kind_opt loc env path =
+  match path_for_kind_opt loc env path with
+  | Some x -> x
+  | None ->
+    fatal_errorf
+      "Translquote [at %a]: cannot quote %s %s - this is either unsupported or \
+       a bug"
+      Location.print_loc (to_location loc) kind (Path.name path)
+
+let module_for_path loc env path =
+  try_path "module" module_for_path_opt loc env path
+
+let module_type_for_path loc env path =
+  try_path "module" module_type_for_path_opt loc env path
+
+let type_for_path loc env path = try_path "type" type_for_path_opt loc env path
 
 let quote_value_ident_path loc env path =
   match value_for_path_opt loc env path with
@@ -2539,6 +2552,12 @@ let quote_value_ident_path_as_exp loc env path =
 let type_path env ty =
   let desc = Types.get_desc (Ctype.expand_head_opt env ty) in
   match desc with Tconstr (p, _, _) -> Some p | _ -> None
+
+let type_constr_for_path loc env path arity =
+  Type.constr loc
+    (type_for_path loc env path)
+    (List.init arity (fun _ -> Type.var loc None |> Type.wrap))
+  |> Type.wrap
 
 let quote_record_field loc env (lbl_desc : _ Data_types.gen_label_description) =
   match type_path env lbl_desc.lbl_res with

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -719,45 +719,7 @@ module Identifier : sig
 
     val dot : Debuginfo.Scoped_location.t -> Module.t -> string -> t'
 
-    val false_ : t'
-
-    val true_ : t'
-
-    val void : t'
-
-    val nil : t'
-
-    val cons : t'
-
-    val none : t'
-
-    val some : t'
-
-    val match_failure : t'
-
-    val out_of_memory : t'
-
-    val out_of_fibers : t'
-
-    val invalid_argument : t'
-
-    val failure : t'
-
-    val not_found : t'
-
-    val sys_error : t'
-
-    val end_of_file : t'
-
-    val division_by_zero : t'
-
-    val stack_overflow : t'
-
-    val sys_blocked_io : t'
-
-    val assert_failure : t'
-
-    val undefined_recursive_module : t'
+    val builtin : Debuginfo.Scoped_location.t -> string -> t'
   end
 
   module Field : sig
@@ -854,46 +816,8 @@ end = struct
     let dot loc a1 a2 =
       apply2 "Identifier.Constructor" "dot" loc (extract a1) (string ~loc a2)
 
-    let false_ = use "Identifier.Constructor" "false_"
-
-    let true_ = use "Identifier.Constructor" "true_"
-
-    let void = use "Identifier.Constructor" "void"
-
-    let nil = use "Identifier.Constructor" "nil"
-
-    let cons = use "Identifier.Constructor" "cons"
-
-    let none = use "Identifier.Constructor" "none"
-
-    let some = use "Identifier.Constructor" "some"
-
-    let match_failure = use "Identifier.Constructor" "match_failure"
-
-    let out_of_memory = use "Identifier.Constructor" "out_of_memory"
-
-    let out_of_fibers = use "Identifier.Constructor" "out_of_fibers"
-
-    let invalid_argument = use "Identifier.Constructor" "invalid_argument"
-
-    let failure = use "Identifier.Constructor" "failure"
-
-    let not_found = use "Identifier.Constructor" "not_found"
-
-    let sys_error = use "Identifier.Constructor" "sys_error"
-
-    let end_of_file = use "Identifier.Constructor" "end_of_file"
-
-    let division_by_zero = use "Identifier.Constructor" "division_by_zero"
-
-    let stack_overflow = use "Identifier.Constructor" "stack_overflow"
-
-    let sys_blocked_io = use "Identifier.Constructor" "sys_blocked_io"
-
-    let assert_failure = use "Identifier.Constructor" "assert_failure"
-
-    let undefined_recursive_module =
-      use "Identifier.Constructor" "undefined_recursive_module"
+    let builtin loc a1 =
+      apply1 "Identifier.Constructor" "builtin" loc (string ~loc a1)
   end
 
   module Field = struct
@@ -2439,30 +2363,14 @@ let quote_constructor loc env (constr : Data_types.constructor_description) =
          | None ->
            fatal_errorf "Translquote [at %a]: no global path for constructor"
              Location.print_loc (to_location loc)
-         | Some (Path.Pident _) -> (
-           match constr.cstr_name with
-           | "false" -> Identifier.Constructor.false_
-           | "true" -> Identifier.Constructor.true_
-           | "()" -> Identifier.Constructor.void
-           | "[]" -> Identifier.Constructor.nil
-           | "::" -> Identifier.Constructor.cons
-           | "None" -> Identifier.Constructor.none
-           | "Some" -> Identifier.Constructor.some
-           | "Match_failure" -> Identifier.Constructor.match_failure
-           | "Out_of_memory" -> Identifier.Constructor.out_of_memory
-           | "Out_of_fibers" -> Identifier.Constructor.out_of_fibers
-           | "Invalid_argument" -> Identifier.Constructor.invalid_argument
-           | "Failure" -> Identifier.Constructor.failure
-           | "Not_found" -> Identifier.Constructor.not_found
-           | "Sys_error" -> Identifier.Constructor.sys_error
-           | "End_of_file" -> Identifier.Constructor.end_of_file
-           | "Division_by_zero" -> Identifier.Constructor.division_by_zero
-           | "Stack_overflow" -> Identifier.Constructor.stack_overflow
-           | "Sys_blocked_io" -> Identifier.Constructor.sys_blocked_io
-           | "Assert_failure" -> Identifier.Constructor.assert_failure
-           | "Undefined_recursive_module" ->
-             Identifier.Constructor.undefined_recursive_module
-           | name -> raise (Non_builtin name))
+         | Some (Path.Pident _) ->
+           let name = constr.cstr_name in
+           if
+             List.exists
+               (fun (name', _) -> String.equal name name')
+               (Predef.builtin_exns @ Predef.builtin_constrs)
+           then Identifier.Constructor.builtin loc name
+           else raise (Non_builtin name)
          | Some (Path.Pdot (p, _)) ->
            Identifier.Constructor.dot loc
              (module_for_path loc env p)

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2352,6 +2352,10 @@ let quote_constructor loc env (constr : Data_types.constructor_description) =
   let persistent id =
     id |> Identifier.Constructor.wrap |> Constructor.ident loc
   in
+  (* CR-someday jbachurski: Similarly to [type_for_path], I'm fairly sure
+     checking for builtin names is redundant. Secondly, I'm not sure
+     why these code paths are split between [Extension] and the rest,
+     nor certain that the [type_path] check is helpful. *)
   (match constr.cstr_tag with
     | Extension (Path.Pdot (p, name)) ->
       Identifier.Constructor.dot loc (module_for_path loc env p) name

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2348,39 +2348,40 @@ let quote_record_field loc env (lbl_desc : _ Data_types.gen_label_description) =
       Location.print_loc (to_location loc)
 
 let quote_constructor loc env (constr : Data_types.constructor_description) =
-  let exception Non_builtin of string in
-  (try
-     Identifier.Constructor.wrap
-       (match constr.cstr_tag with
-       | Extension (Path.Pdot (p, name)) ->
-         Identifier.Constructor.dot loc (module_for_path loc env p) name
-       | Extension (Path.Pident name) -> raise (Non_builtin (Ident.name name))
-       | Extension _ ->
-         fatal_errorf "Translquote [at %a]: Papply in extension constructor."
-           Location.print_loc (to_location loc)
-       | Ordinary _ | Null -> (
-         match type_path env constr.cstr_res with
-         | None ->
-           fatal_errorf "Translquote [at %a]: no global path for constructor"
-             Location.print_loc (to_location loc)
-         | Some (Path.Pident _) ->
-           let name = constr.cstr_name in
-           if
-             List.exists
-               (fun (name', _) -> String.equal name name')
-               (Predef.builtin_exns @ Predef.builtin_constrs)
-           then Identifier.Constructor.builtin loc name
-           else raise (Non_builtin name)
-         | Some (Path.Pdot (p, _)) ->
-           Identifier.Constructor.dot loc
-             (module_for_path loc env p)
-             constr.cstr_name
-         | _ ->
-           fatal_errorf
-             "Translquote [at %a]: unsupported constructor type detected."
-             Location.print_loc (to_location loc)))
-     |> Constructor.ident loc
-   with Non_builtin name -> Constructor.of_string loc name)
+  let local id = Constructor.of_string loc id in
+  let persistent id =
+    id |> Identifier.Constructor.wrap |> Constructor.ident loc
+  in
+  (match constr.cstr_tag with
+    | Extension (Path.Pdot (p, name)) ->
+      Identifier.Constructor.dot loc (module_for_path loc env p) name
+      |> persistent
+    | Extension (Path.Pident id) -> Ident.name id |> local
+    | Extension _ ->
+      fatal_errorf "Translquote [at %a]: Papply in extension constructor."
+        Location.print_loc (to_location loc)
+    | Ordinary _ | Null -> (
+      match type_path env constr.cstr_res with
+      | None ->
+        fatal_errorf "Translquote [at %a]: no global path for constructor"
+          Location.print_loc (to_location loc)
+      | Some (Path.Pident _) ->
+        let name = constr.cstr_name in
+        if
+          List.exists
+            (fun (name', _) -> String.equal name name')
+            (Predef.builtin_exns @ Predef.builtin_constrs)
+        then Identifier.Constructor.builtin loc name |> persistent
+        else local name
+      | Some (Path.Pdot (p, _)) ->
+        Identifier.Constructor.dot loc
+          (module_for_path loc env p)
+          constr.cstr_name
+        |> persistent
+      | _ ->
+        fatal_errorf
+          "Translquote [at %a]: unsupported constructor type detected."
+          Location.print_loc (to_location loc)))
   |> Constructor.wrap
 
 let rec quote_modtype_path_of_lid loc = function

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2220,8 +2220,6 @@ let quote_arg_label loc = function
        Labelled, Nolabel and Optional"
       Location.print_loc (to_location loc)
 
-let ( let+ ) f x = Option.map x f
-
 let module_for_path_opt loc env path =
   Env.add_required_global_for_quote path env;
   let rec go path =
@@ -2238,8 +2236,9 @@ let module_for_path_opt loc env path =
             Ident.name id |> Identifier.Module.toplevel_module loc))
       |> Identifier.Module.wrap |> Option.some
     | Path.Pdot (p, s) ->
-      let+ m = go p in
-      Identifier.Module.dot loc m s |> Identifier.Module.wrap
+      go p
+      |> Option.map (fun m ->
+          Identifier.Module.dot loc m s |> Identifier.Module.wrap)
     | _ -> None
   in
   go path
@@ -2248,16 +2247,16 @@ let module_type_for_path_opt loc env = function
   | Path.Pident id ->
     Module_type.of_string loc (Ident.name id) |> Module_type.wrap |> Option.some
   | Path.Pdot (p, s) ->
-    let+ m = module_for_path_opt loc env p in
-    Module_type.ident loc
-      (Identifier.Module_type.dot loc m s |> Identifier.Module_type.wrap)
-    |> Module_type.wrap
+    module_for_path_opt loc env p
+    |> Option.map (fun m ->
+        Module_type.ident loc
+          (Identifier.Module_type.dot loc m s |> Identifier.Module_type.wrap)
+        |> Module_type.wrap)
   | _ -> None
 
 let type_for_path_opt loc env = function
   | Path.Pident id ->
-    let+ t =
-      match Hashtbl.find_opt vars_env.env_tys id with
+    (match Hashtbl.find_opt vars_env.env_tys id with
       | Some t -> Identifier.Type.var loc t (quote_loc loc) |> Option.some
       | None ->
         (* CR-someday jbachurski: I am fairly sure we can retire this check as
@@ -2269,18 +2268,18 @@ let type_for_path_opt loc env = function
             (fun (name', _) -> String.equal name name')
             Predef.builtin_type_constrs
         then Some (Identifier.Type.builtin loc name)
-        else None
-    in
-    Identifier.Type.wrap t
+        else None)
+    |> Option.map Identifier.Type.wrap
   | Path.Pdot (p, s) ->
-    let+ m = module_for_path_opt loc env p in
-    Identifier.Type.dot loc m s |> Identifier.Type.wrap
+    module_for_path_opt loc env p
+    |> Option.map (fun m -> Identifier.Type.dot loc m s |> Identifier.Type.wrap)
   | _ -> None
 
 let value_for_path_opt loc env = function
   | Path.Pdot (p, s) ->
-    let+ m = module_for_path_opt loc env p in
-    Identifier.Value.dot loc m s |> Identifier.Value.wrap
+    module_for_path_opt loc env p
+    |> Option.map (fun m ->
+        Identifier.Value.dot loc m s |> Identifier.Value.wrap)
   | _ -> None
 
 let try_path kind path_for_kind_opt loc env path =

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1013,69 +1013,7 @@ module Identifier = struct
 
     let var v l = mk (TVar (v, l))
 
-    let int = TBuiltin "int" |> mk
-
-    let char = TBuiltin "char" |> mk
-
-    let string = TBuiltin "string" |> mk
-
-    let bytes = TBuiltin "bytes" |> mk
-
-    let float = TBuiltin "float" |> mk
-
-    let float32 = TBuiltin "float32" |> mk
-
-    let bool = TBuiltin "bool" |> mk
-
-    let unit = TBuiltin "unit" |> mk
-
-    let exn = TBuiltin "exn" |> mk
-
-    let array = TBuiltin "array" |> mk
-
-    let iarray = TBuiltin "iarray" |> mk
-
-    let list = TBuiltin "list" |> mk
-
-    let option = TBuiltin "option" |> mk
-
-    let nativeint = TBuiltin "nativeint" |> mk
-
-    let int32 = TBuiltin "int32" |> mk
-
-    let int64 = TBuiltin "int64" |> mk
-
-    let lazy_t = TBuiltin "lazy_t" |> mk
-
-    let extension_constructor = TBuiltin "extension_constructor" |> mk
-
-    let floatarray = TBuiltin "floatarray" |> mk
-
-    let lexing_position = TBuiltin "lexing_position" |> mk
-
-    let expr = TBuiltin "expr" |> mk
-
-    let eval = TBuiltin "eval" |> mk
-
-    let unboxed_float = TBuiltin "float#" |> mk
-
-    let unboxed_nativeint = TBuiltin "nativeint#" |> mk
-
-    let unboxed_int32 = TBuiltin "int32#" |> mk
-
-    let unboxed_int64 = TBuiltin "int64#" |> mk
-
-    let int8x16 = TBuiltin "int8x16" |> mk
-
-    let int16x8 = TBuiltin "int16x8" |> mk
-
-    let int32x4 = TBuiltin "int32x4" |> mk
-
-    let int64x2 = TBuiltin "int64x2" |> mk
-
-    let float32x4 = TBuiltin "float32x4" |> mk
-
-    let float64x2 = TBuiltin "float64x2" |> mk
+    let builtin name = TBuiltin name |> mk
   end
 
   module Module_type = struct

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1037,45 +1037,7 @@ module Identifier = struct
       let+ t = t in
       CDot (t, s)
 
-    let false_ = CBuiltin "false" |> mk
-
-    let true_ = CBuiltin "true" |> mk
-
-    let void = CBuiltin "()" |> mk
-
-    let nil = CBuiltin "[]" |> mk
-
-    let cons = CBuiltin "::" |> mk
-
-    let none = CBuiltin "None" |> mk
-
-    let some = CBuiltin "Some" |> mk
-
-    let match_failure = CBuiltin "Match_failure" |> mk
-
-    let out_of_memory = CBuiltin "Out_of_memory" |> mk
-
-    let out_of_fibers = CBuiltin "Out_of_fibers" |> mk
-
-    let invalid_argument = CBuiltin "Invalid_argument" |> mk
-
-    let failure = CBuiltin "Failure" |> mk
-
-    let not_found = CBuiltin "Not_found" |> mk
-
-    let sys_error = CBuiltin "Sys_error" |> mk
-
-    let end_of_file = CBuiltin "End_of_file" |> mk
-
-    let division_by_zero = CBuiltin "Division_by_zero" |> mk
-
-    let stack_overflow = CBuiltin "Stack_overflow" |> mk
-
-    let sys_blocked_io = CBuiltin "Sys_blocked_io" |> mk
-
-    let assert_failure = CBuiltin "Assert_failure" |> mk
-
-    let undefined_recursive_module = CBuiltin "Undefined_recursive_module" |> mk
+    let builtin name = CBuiltin name |> mk
   end
 
   module Field = struct

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -150,45 +150,7 @@ module Identifier : sig
 
     val dot : Module.t -> string -> t
 
-    val false_ : t
-
-    val true_ : t
-
-    val void : t
-
-    val nil : t
-
-    val cons : t
-
-    val none : t
-
-    val some : t
-
-    val match_failure : t
-
-    val out_of_memory : t
-
-    val out_of_fibers : t
-
-    val invalid_argument : t
-
-    val failure : t
-
-    val not_found : t
-
-    val sys_error : t
-
-    val end_of_file : t
-
-    val division_by_zero : t
-
-    val stack_overflow : t
-
-    val sys_blocked_io : t
-
-    val assert_failure : t
-
-    val undefined_recursive_module : t
+    val builtin : string -> t
   end
 
   module Field : sig

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -136,69 +136,7 @@ module Identifier : sig
 
     val var : Var.Type_constr.t -> Loc.t -> t
 
-    val int : t
-
-    val char : t
-
-    val string : t
-
-    val bytes : t
-
-    val float : t
-
-    val float32 : t
-
-    val bool : t
-
-    val unit : t
-
-    val exn : t
-
-    val array : t
-
-    val iarray : t
-
-    val list : t
-
-    val option : t
-
-    val nativeint : t
-
-    val int32 : t
-
-    val int64 : t
-
-    val lazy_t : t
-
-    val extension_constructor : t
-
-    val floatarray : t
-
-    val lexing_position : t
-
-    val expr : t
-
-    val eval : t
-
-    val unboxed_float : t
-
-    val unboxed_nativeint : t
-
-    val unboxed_int32 : t
-
-    val unboxed_int64 : t
-
-    val int8x16 : t
-
-    val int16x8 : t
-
-    val int32x4 : t
-
-    val int64x2 : t
-
-    val float32x4 : t
-
-    val float64x2 : t
+    val builtin : string -> t
   end
 
   module Module_type : sig

--- a/stdlib/quote.ml
+++ b/stdlib/quote.ml
@@ -40,8 +40,8 @@ module Expr = struct
 
   let bool b =
     let q = match b with
-    | true -> inject_constr Identifier.Constructor.true_
-    | false -> inject_constr Identifier.Constructor.false_
+    | true -> inject_constr (Identifier.Constructor.builtin "true")
+    | false -> inject_constr (Identifier.Constructor.builtin "false")
     in (Obj.magic q : <[bool]> expr)
 
   let inject x = Code.of_exp Loc.unknown (Exp.mk (Exp_desc.constant x) [])

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -386,7 +386,8 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
    We should also support this construct (ticket 6790). *)
 <[ let f : type a. a -> a = fun x -> x in f ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 19-20]: cannot quote type a - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -282,7 +282,7 @@ Error: Unbound type constructor "my_type"
 [%%expect {|
 - : 'a expr = <[Stdlib.raise Stdlib.Out_of_memory]>
 |}];;
-<[ raise Out_of_fibers ]>
+<[ raise Out_of_fibers ]> (* not re-exported by [Stdlib] *)
 [%%expect {|
 - : 'a expr = <[Stdlib.raise Out_of_fibers]>
 |}];;
@@ -326,7 +326,7 @@ Error: Unbound type constructor "my_type"
 [%%expect {|
 - : 'a expr = <[Stdlib.raise (Stdlib.Undefined_recursive_module ("", 0, 0))]>
 |}];;
-<[ raise Continuation_already_taken ]>
+<[ raise Continuation_already_taken ]> (* not re-exported by [Stdlib] *)
 [%%expect {|
 - : 'a expr = <[Stdlib.raise Continuation_already_taken]>
 |}];;
@@ -414,7 +414,8 @@ let e = <[ raise Exit ]> in <[ let exception Exit in $e ]>
 ]>
 |}];;
 (* CR jbachurski: This is wrong -- the inner exn should refer to the
-   global [Stdlib], not the extension. *)
+   global [Stdlib], not the extension.
+   Note [Continuation_already_taken] is not re-exported by [Stdlib] (bug?). *)
 let e = <[ raise Continuation_already_taken ]> in <[ let exception Continuation_already_taken in $e ]>
 [%%expect {|
 - : 'a expr =

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -318,7 +318,14 @@ Uncaught exception: Misc.Fatal_error
 [%%expect {|
 >> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float64x8 - this is either unsupported or a bug
 Uncaught exception: Misc.Fatal_error
+|}];;
 
+<[ fun (x : my_type) -> x ]> (* sanity check *)
+[%%expect {|
+Line 1, characters 12-19:
+1 | <[ fun (x : my_type) -> x ]> (* sanity check *)
+                ^^^^^^^
+Error: Unbound type constructor "my_type"
 |}];;
 
 (* Exceptions *)
@@ -380,6 +387,15 @@ Uncaught exception: Misc.Fatal_error
 - : 'a expr = <[Stdlib.raise Continuation_already_taken]>
 |}];;
 
+<[ raise My_exception ]> (* sanity check *)
+[%%expect {|
+Line 1, characters 9-21:
+1 | <[ raise My_exception ]> (* sanity check *)
+             ^^^^^^^^^^^^
+Error: This variant expression is expected to have type "exn"
+       There is no constructor "My_exception" within type "exn"
+|}];;
+
 (* Constructors *)
 
 <[ false ]>
@@ -417,6 +433,14 @@ Uncaught exception: Misc.Fatal_error
 <[ This () ]>
 [%%expect {|
 - : <[unit or_null]> expr = <[This ()]>
+|}];;
+
+<[ My_constructor () ]> (* sanity check *)
+[%%expect {|
+Line 1, characters 3-17:
+1 | <[ My_constructor () ]> (* sanity check *)
+       ^^^^^^^^^^^^^^
+Error: Unbound constructor "My_constructor"
 |}];;
 
 (** Shadowing builtins in quotes **)

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -43,12 +43,14 @@
 |}];;
 <[ fun (x : _ eff) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-17]: cannot quote type eff - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : _ continuation) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-26]: cannot quote type continuation - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : _ array) -> x ]>
@@ -69,12 +71,14 @@ Uncaught exception: Stdlib.Exit
 |}];;
 <[ fun (x : int8) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-16]: cannot quote type int8 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int16) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-17]: cannot quote type int16 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int32) -> x ]>
@@ -108,7 +112,8 @@ Uncaught exception: Stdlib.Exit
 |}];;
 <[ fun (x : _ atomic_loc) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-24]: cannot quote type atomic_loc - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : lexing_position) -> x ]>
@@ -129,7 +134,8 @@ Error: Unbound type constructor "code"
 |}];;
 <[ fun (x : _ box) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-17]: cannot quote type box - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : nativeint_u) -> x ]>
@@ -146,42 +152,50 @@ Uncaught exception: Stdlib.Exit
 |}];;
 <[ fun (x : float32_u) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float32_u - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : uint8_u) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type uint8_u - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : uint16_u) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type uint16_u - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : uint32_u) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type uint32_u - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : uint64_u) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type uint64_u - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : _ or_null) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type or_null - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : _ idx_imm) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type idx_imm - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : _ idx_mut) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type idx_mut - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int8x16) -> x ]>
@@ -202,7 +216,8 @@ Uncaught exception: Stdlib.Exit
 |}];;
 <[ fun (x : float16x8) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float16x8 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : float32x4) -> x ]>
@@ -215,72 +230,86 @@ Uncaught exception: Stdlib.Exit
 |}];;
 <[ fun (x : int8x32) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int8x32 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int16x16) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type int16x16 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int32x8) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int32x8 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int64x4) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int64x4 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : float16x16) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-22]: cannot quote type float16x16 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : float32x8) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float32x8 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : float64x4) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float64x4 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int8x64) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int8x64 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int16x32) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type int16x32 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int32x16) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type int32x16 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : int64x8) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int64x8 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : float16x32) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-22]: cannot quote type float16x32 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : float32x16) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-22]: cannot quote type float32x16 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 <[ fun (x : float64x8) -> x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
+>> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float64x8 - this is either unsupported or a bug
+Uncaught exception: Misc.Fatal_error
 
 |}];;
 

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -51,15 +51,12 @@ module type S = sig type exn += Exit end
 |}];;
 <[ fun (x : _ eff) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-17]: cannot quote type eff - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[$('a) eff -> $('a) eff]> expr = <[fun (x : _ eff) -> x]>
 |}];;
 <[ fun (x : _ continuation) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-26]: cannot quote type continuation - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[($('a), $('b)) continuation -> ($('a), $('b)) continuation]> expr =
+<[fun (x : (_, _) continuation) -> x]>
 |}];;
 <[ fun (x : _ array) -> x ]>
 [%%expect {|
@@ -79,15 +76,11 @@ Uncaught exception: Misc.Fatal_error
 |}];;
 <[ fun (x : int8) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-16]: cannot quote type int8 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int8 -> int8]> expr = <[fun (x : int8) -> x]>
 |}];;
 <[ fun (x : int16) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-17]: cannot quote type int16 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int16 -> int16]> expr = <[fun (x : int16) -> x]>
 |}];;
 <[ fun (x : int32) -> x ]>
 [%%expect {|
@@ -120,21 +113,17 @@ Uncaught exception: Misc.Fatal_error
 |}];;
 <[ fun (x : _ atomic_loc) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-24]: cannot quote type atomic_loc - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[$('a) atomic_loc -> $('a) atomic_loc]> expr =
+<[fun (x : _ atomic_loc) -> x]>
 |}];;
 <[ fun (x : lexing_position) -> x ]>
 [%%expect {|
 - : <[lexing_position -> lexing_position]> expr =
 <[fun (x : lexing_position) -> x]>
 |}];;
-<[ fun (x : _ code) -> x ]>
+<[ fun (x : _ expr) -> x ]>
 [%%expect {|
-Line 1, characters 14-18:
-1 | <[ fun (x : _ code) -> x ]>
-                  ^^^^
-Error: Unbound type constructor "code"
+- : <[$('a) expr -> $('a) expr]> expr = <[fun (x : _ expr) -> x]>
 |}];;
 <[ fun (x : _ eval) -> x ]>
 [%%expect {|
@@ -142,69 +131,53 @@ Error: Unbound type constructor "code"
 |}];;
 <[ fun (x : _ box) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-17]: cannot quote type box - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[$('a) box -> $('a) box]> expr = <[fun (x : _ box) -> x]>
 |}];;
 <[ fun (x : nativeint_u) -> x ]>
 [%%expect {|
-- : <[nativeint_u -> nativeint_u]> expr = <[fun (x : nativeint#) -> x]>
+- : <[nativeint_u -> nativeint_u]> expr = <[fun (x : nativeint_u) -> x]>
 |}];;
 <[ fun (x : int32_u) -> x ]>
 [%%expect {|
-- : <[int32_u -> int32_u]> expr = <[fun (x : int32#) -> x]>
+- : <[int32_u -> int32_u]> expr = <[fun (x : int32_u) -> x]>
 |}];;
 <[ fun (x : int64_u) -> x ]>
 [%%expect {|
-- : <[int64_u -> int64_u]> expr = <[fun (x : int64#) -> x]>
+- : <[int64_u -> int64_u]> expr = <[fun (x : int64_u) -> x]>
 |}];;
 <[ fun (x : float32_u) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float32_u - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[float32_u -> float32_u]> expr = <[fun (x : float32_u) -> x]>
 |}];;
 <[ fun (x : uint8_u) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type uint8_u - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[uint8_u -> uint8_u]> expr = <[fun (x : uint8_u) -> x]>
 |}];;
 <[ fun (x : uint16_u) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type uint16_u - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[uint16_u -> uint16_u]> expr = <[fun (x : uint16_u) -> x]>
 |}];;
 <[ fun (x : uint32_u) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type uint32_u - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[uint32_u -> uint32_u]> expr = <[fun (x : uint32_u) -> x]>
 |}];;
 <[ fun (x : uint64_u) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type uint64_u - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[uint64_u -> uint64_u]> expr = <[fun (x : uint64_u) -> x]>
 |}];;
 <[ fun (x : _ or_null) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type or_null - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[$('a) or_null -> $('a) or_null]> expr = <[fun (x : _ or_null) -> x]>
 |}];;
 <[ fun (x : _ idx_imm) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type idx_imm - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[($('a), $('b)) idx_imm -> ($('a), $('b)) idx_imm]> expr =
+<[fun (x : (_, _) idx_imm) -> x]>
 |}];;
 <[ fun (x : _ idx_mut) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type idx_mut - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[($('a), $('b)) idx_mut -> ($('a), $('b)) idx_mut]> expr =
+<[fun (x : (_, _) idx_mut) -> x]>
 |}];;
 <[ fun (x : int8x16) -> x ]>
 [%%expect {|
@@ -224,9 +197,7 @@ Uncaught exception: Misc.Fatal_error
 |}];;
 <[ fun (x : float16x8) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float16x8 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[float16x8 -> float16x8]> expr = <[fun (x : float16x8) -> x]>
 |}];;
 <[ fun (x : float32x4) -> x ]>
 [%%expect {|
@@ -238,86 +209,59 @@ Uncaught exception: Misc.Fatal_error
 |}];;
 <[ fun (x : int8x32) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int8x32 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int8x32 -> int8x32]> expr = <[fun (x : int8x32) -> x]>
 |}];;
 <[ fun (x : int16x16) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type int16x16 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int16x16 -> int16x16]> expr = <[fun (x : int16x16) -> x]>
 |}];;
 <[ fun (x : int32x8) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int32x8 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int32x8 -> int32x8]> expr = <[fun (x : int32x8) -> x]>
 |}];;
 <[ fun (x : int64x4) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int64x4 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int64x4 -> int64x4]> expr = <[fun (x : int64x4) -> x]>
 |}];;
 <[ fun (x : float16x16) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-22]: cannot quote type float16x16 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[float16x16 -> float16x16]> expr = <[fun (x : float16x16) -> x]>
 |}];;
 <[ fun (x : float32x8) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float32x8 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[float32x8 -> float32x8]> expr = <[fun (x : float32x8) -> x]>
 |}];;
 <[ fun (x : float64x4) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float64x4 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[float64x4 -> float64x4]> expr = <[fun (x : float64x4) -> x]>
 |}];;
 <[ fun (x : int8x64) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int8x64 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int8x64 -> int8x64]> expr = <[fun (x : int8x64) -> x]>
 |}];;
 <[ fun (x : int16x32) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type int16x32 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int16x32 -> int16x32]> expr = <[fun (x : int16x32) -> x]>
 |}];;
 <[ fun (x : int32x16) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-20]: cannot quote type int32x16 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int32x16 -> int32x16]> expr = <[fun (x : int32x16) -> x]>
 |}];;
 <[ fun (x : int64x8) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-19]: cannot quote type int64x8 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[int64x8 -> int64x8]> expr = <[fun (x : int64x8) -> x]>
 |}];;
 <[ fun (x : float16x32) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-22]: cannot quote type float16x32 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[float16x32 -> float16x32]> expr = <[fun (x : float16x32) -> x]>
 |}];;
 <[ fun (x : float32x16) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-22]: cannot quote type float32x16 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
-
+- : <[float32x16 -> float32x16]> expr = <[fun (x : float32x16) -> x]>
 |}];;
 <[ fun (x : float64x8) -> x ]>
 [%%expect {|
->> Fatal error: Translquote [at Line 1, characters 12-21]: cannot quote type float64x8 - this is either unsupported or a bug
-Uncaught exception: Misc.Fatal_error
+- : <[float64x8 -> float64x8]> expr = <[fun (x : float64x8) -> x]>
 |}];;
 
 <[ fun (x : my_type) -> x ]> (* sanity check *)

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -1,0 +1,383 @@
+(* TEST
+ flags = "-extension simd_alpha -extension runtime_metaprogramming -extension small_numbers -extension layouts";
+ expect;
+*)
+
+#syntax quotations on
+
+(* This test file should be kept up to date with any [ident_*] in [predef.ml]. *)
+
+(* Type constructors *)
+
+<[ fun (x : int) -> x ]>
+[%%expect {|
+- : <[int -> int]> expr = <[fun (x : int) -> x]>
+|}];;
+<[ fun (x : char) -> x ]>
+[%%expect {|
+- : <[char -> char]> expr = <[fun (x : char) -> x]>
+|}];;
+<[ fun (x : bytes) -> x ]>
+[%%expect {|
+- : <[bytes -> bytes]> expr = <[fun (x : bytes) -> x]>
+|}];;
+<[ fun (x : float) -> x ]>
+[%%expect {|
+- : <[float -> float]> expr = <[fun (x : float) -> x]>
+|}];;
+<[ fun (x : float32) -> x ]>
+[%%expect {|
+- : <[float32 -> float32]> expr = <[fun (x : float32) -> x]>
+|}];;
+<[ fun (x : bool) -> x ]>
+[%%expect {|
+- : <[bool -> bool]> expr = <[fun (x : bool) -> x]>
+|}];;
+<[ fun (x : unit) -> x ]>
+[%%expect {|
+- : <[unit -> unit]> expr = <[fun (x : unit) -> x]>
+|}];;
+<[ fun (x : exn) -> x ]>
+[%%expect {|
+- : <[exn -> exn]> expr = <[fun (x : exn) -> x]>
+|}];;
+<[ fun (x : _ eff) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : _ continuation) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : _ array) -> x ]>
+[%%expect {|
+- : <[$('a) array -> $('a) array]> expr = <[fun (x : _ array) -> x]>
+|}];;
+<[ fun (x : _ list) -> x ]>
+[%%expect {|
+- : <[$('a) list -> $('a) list]> expr = <[fun (x : _ list) -> x]>
+|}];;
+<[ fun (x : _ option) -> x ]>
+[%%expect {|
+- : <[$('a) option -> $('a) option]> expr = <[fun (x : _ option) -> x]>
+|}];;
+<[ fun (x : nativeint) -> x ]>
+[%%expect {|
+- : <[nativeint -> nativeint]> expr = <[fun (x : nativeint) -> x]>
+|}];;
+<[ fun (x : int8) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int16) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int32) -> x ]>
+[%%expect {|
+- : <[int32 -> int32]> expr = <[fun (x : int32) -> x]>
+|}];;
+<[ fun (x : int64) -> x ]>
+[%%expect {|
+- : <[int64 -> int64]> expr = <[fun (x : int64) -> x]>
+|}];;
+<[ fun (x : _ lazy_t) -> x ]>
+[%%expect {|
+- : <[$('a) lazy_t -> $('a) lazy_t]> expr = <[fun (x : _ lazy_t) -> x]>
+|}];;
+<[ fun (x : string) -> x ]>
+[%%expect {|
+- : <[string -> string]> expr = <[fun (x : string) -> x]>
+|}];;
+<[ fun (x : extension_constructor) -> x ]>
+[%%expect {|
+- : <[extension_constructor -> extension_constructor]> expr =
+<[fun (x : extension_constructor) -> x]>
+|}];;
+<[ fun (x : floatarray) -> x ]>
+[%%expect {|
+- : <[floatarray -> floatarray]> expr = <[fun (x : floatarray) -> x]>
+|}];;
+<[ fun (x : _ iarray) -> x ]>
+[%%expect {|
+- : <[$('a) iarray -> $('a) iarray]> expr = <[fun (x : _ iarray) -> x]>
+|}];;
+<[ fun (x : _ atomic_loc) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : lexing_position) -> x ]>
+[%%expect {|
+- : <[lexing_position -> lexing_position]> expr =
+<[fun (x : lexing_position) -> x]>
+|}];;
+<[ fun (x : _ code) -> x ]>
+[%%expect {|
+Line 1, characters 14-18:
+1 | <[ fun (x : _ code) -> x ]>
+                  ^^^^
+Error: Unbound type constructor "code"
+|}];;
+<[ fun (x : _ eval) -> x ]>
+[%%expect {|
+- : <[$('a) eval -> $('a) eval]> expr = <[fun (x : _ eval) -> x]>
+|}];;
+<[ fun (x : _ box) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : nativeint_u) -> x ]>
+[%%expect {|
+- : <[nativeint_u -> nativeint_u]> expr = <[fun (x : nativeint#) -> x]>
+|}];;
+<[ fun (x : int32_u) -> x ]>
+[%%expect {|
+- : <[int32_u -> int32_u]> expr = <[fun (x : int32#) -> x]>
+|}];;
+<[ fun (x : int64_u) -> x ]>
+[%%expect {|
+- : <[int64_u -> int64_u]> expr = <[fun (x : int64#) -> x]>
+|}];;
+<[ fun (x : float32_u) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : uint8_u) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : uint16_u) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : uint32_u) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : uint64_u) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : _ or_null) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : _ idx_imm) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : _ idx_mut) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int8x16) -> x ]>
+[%%expect {|
+- : <[int8x16 -> int8x16]> expr = <[fun (x : int8x16) -> x]>
+|}];;
+<[ fun (x : int16x8) -> x ]>
+[%%expect {|
+- : <[int16x8 -> int16x8]> expr = <[fun (x : int16x8) -> x]>
+|}];;
+<[ fun (x : int32x4) -> x ]>
+[%%expect {|
+- : <[int32x4 -> int32x4]> expr = <[fun (x : int32x4) -> x]>
+|}];;
+<[ fun (x : int64x2) -> x ]>
+[%%expect {|
+- : <[int64x2 -> int64x2]> expr = <[fun (x : int64x2) -> x]>
+|}];;
+<[ fun (x : float16x8) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : float32x4) -> x ]>
+[%%expect {|
+- : <[float32x4 -> float32x4]> expr = <[fun (x : float32x4) -> x]>
+|}];;
+<[ fun (x : float64x2) -> x ]>
+[%%expect {|
+- : <[float64x2 -> float64x2]> expr = <[fun (x : float64x2) -> x]>
+|}];;
+<[ fun (x : int8x32) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int16x16) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int32x8) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int64x4) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : float16x16) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : float32x8) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : float64x4) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int8x64) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int16x32) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int32x16) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : int64x8) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : float16x32) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : float32x16) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+<[ fun (x : float64x8) -> x ]>
+[%%expect {|
+Uncaught exception: Stdlib.Exit
+
+|}];;
+
+(* Exceptions *)
+
+<[ raise (Match_failure ("", 0, 0)) ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise (Stdlib.Match_failure ("", 0, 0))]>
+|}];;
+<[ raise Out_of_memory ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Stdlib.Out_of_memory]>
+|}];;
+<[ raise Out_of_fibers ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Out_of_fibers]>
+|}];;
+<[ raise (Invalid_argument "") ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise (Stdlib.Invalid_argument "")]>
+|}];;
+<[ raise (Failure "") ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise (Stdlib.Failure "")]>
+|}];;
+<[ raise Not_found ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Stdlib.Not_found]>
+|}];;
+<[ raise (Sys_error "") ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise (Stdlib.Sys_error "")]>
+|}];;
+<[ raise End_of_file ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Stdlib.End_of_file]>
+|}];;
+<[ raise Division_by_zero ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Stdlib.Division_by_zero]>
+|}];;
+<[ raise Stack_overflow ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Stdlib.Stack_overflow]>
+|}];;
+<[ raise Sys_blocked_io ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Stdlib.Sys_blocked_io]>
+|}];;
+<[ raise (Assert_failure ("", 0, 0)) ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise (Stdlib.Assert_failure ("", 0, 0))]>
+|}];;
+<[ raise (Undefined_recursive_module ("", 0, 0)) ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise (Stdlib.Undefined_recursive_module ("", 0, 0))]>
+|}];;
+<[ raise Continuation_already_taken ]>
+[%%expect {|
+- : 'a expr = <[Stdlib.raise Continuation_already_taken]>
+|}];;
+
+(* Constructors *)
+
+<[ false ]>
+[%%expect {|
+- : <[bool]> expr = <[false]>
+|}];;
+<[ true ]>
+[%%expect {|
+- : <[bool]> expr = <[true]>
+|}];;
+<[ () ]>
+[%%expect {|
+- : <[unit]> expr = <[()]>
+|}];;
+<[ [] ]>
+[%%expect {|
+- : <[$('a) list]> expr = <[[]]>
+|}];;
+<[ (() :: []) ]>
+[%%expect {|
+- : <[unit list]> expr = <[[()]]>
+|}];;
+<[ None ]>
+[%%expect {|
+- : <[$('a) option]> expr = <[None]>
+|}];;
+<[ Some () ]>
+[%%expect {|
+- : <[unit option]> expr = <[Some ()]>
+|}];;
+<[ Null ]>
+[%%expect {|
+- : <[$('a) or_null]> expr = <[Null]>
+|}];;
+<[ This () ]>
+[%%expect {|
+- : <[unit or_null]> expr = <[This ()]>
+|}];;

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -7,6 +7,14 @@
 
 (* This test file should be kept up to date with any [ident_*] in [predef.ml]. *)
 
+module type S = sig type exn += Exit end
+#mark_toplevel_in_quotations;;
+[%%expect {|
+module type S = sig type exn += Exit end
+|}];;
+
+(** Quoting **)
+
 (* Type constructors *)
 
 <[ fun (x : int) -> x ]>
@@ -410,3 +418,43 @@ Uncaught exception: Misc.Fatal_error
 [%%expect {|
 - : <[unit or_null]> expr = <[This ()]>
 |}];;
+
+(** Shadowing builtins in quotes **)
+
+(* Type *)
+(* CR jbachurski: This is wrong -- the [int] in [e] refers to prelude,
+   not the local one.  *)
+let e = <[ fun (x : int) -> x ]> in <[ fun (type int) () -> $e ]>
+[%%expect {|
+- : <[unit -> int -> int]> expr = <[fun (type int) () -> fun (x : int) -> x]>
+|}];;
+(* Exception *)
+let e = <[ raise Exit ]> in <[ let exception Exit in $e ]>
+[%%expect {|
+- : 'a expr = <[let exception Exit in Stdlib.raise Stdlib.Exit]>
+|}];;
+(* We can avoid the following two bugs by banning [let exception],
+   but they seem unlikely enough. *)
+(* CR jbachurski: This is wrong -- the inner [Exit] should refer to the
+   global [Stdlib], not the argument. *)
+<[ fun (module Stdlib : S) -> raise Exit ]>
+[%%expect {|
+- : <[(module S) -> $('a)]> expr =
+<[
+  fun (((module Stdlib) : (module S)) : (module S)) ->
+    Stdlib.raise Stdlib.Exit
+]>
+|}];;
+(* CR jbachurski: This is wrong -- the inner exn should refer to the
+   global [Stdlib], not the extension. *)
+let e = <[ raise Continuation_already_taken ]> in <[ let exception Continuation_already_taken in $e ]>
+[%%expect {|
+- : 'a expr =
+<[
+  let exception Continuation_already_taken in
+    Stdlib.raise Continuation_already_taken
+]>
+|}];;
+
+(* Similar examples to the above could be constructed for locally declared
+   types if we had struct syntax in quotes. *)

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -8,7 +8,7 @@
 (* This test file should be kept up to date with any [ident_*] in [predef.ml]. *)
 
 module type S = sig type exn += Exit end
-#mark_toplevel_in_quotations;;
+#mark_persistent_in_quotations;;
 [%%expect {|
 module type S = sig type exn += Exit end
 |}];;

--- a/testsuite/tests/quotation/builtins.ml
+++ b/testsuite/tests/quotation/builtins.ml
@@ -1,5 +1,5 @@
 (* TEST
- flags = "-extension simd_alpha -extension runtime_metaprogramming -extension small_numbers -extension layouts";
+ flags = "-extension simd_alpha -extension runtime_metaprogramming -extension small_numbers -extension layouts -nopervasives";
  expect;
 *)
 
@@ -274,68 +274,68 @@ Error: Unbound type constructor "my_type"
 
 (* Exceptions *)
 
-<[ raise (Match_failure ("", 0, 0)) ]>
+<[ Stdlib.raise (Match_failure ("", 0, 0)) ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Stdlib.Match_failure ("", 0, 0))]>
+- : 'a expr = <[Stdlib.raise (Match_failure ("", 0, 0))]>
 |}];;
-<[ raise Out_of_memory ]>
+<[ Stdlib.raise Out_of_memory ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Stdlib.Out_of_memory]>
+- : 'a expr = <[Stdlib.raise Out_of_memory]>
 |}];;
-<[ raise Out_of_fibers ]> (* not re-exported by [Stdlib] *)
+<[ Stdlib.raise Out_of_fibers ]> (* not re-exported by [Stdlib] *)
 [%%expect {|
 - : 'a expr = <[Stdlib.raise Out_of_fibers]>
 |}];;
-<[ raise (Invalid_argument "") ]>
+<[ Stdlib.raise (Invalid_argument "") ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Stdlib.Invalid_argument "")]>
+- : 'a expr = <[Stdlib.raise (Invalid_argument "")]>
 |}];;
-<[ raise (Failure "") ]>
+<[ Stdlib.raise (Failure "") ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Stdlib.Failure "")]>
+- : 'a expr = <[Stdlib.raise (Failure "")]>
 |}];;
-<[ raise Not_found ]>
+<[ Stdlib.raise Not_found ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Stdlib.Not_found]>
+- : 'a expr = <[Stdlib.raise Not_found]>
 |}];;
-<[ raise (Sys_error "") ]>
+<[ Stdlib.raise (Sys_error "") ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Stdlib.Sys_error "")]>
+- : 'a expr = <[Stdlib.raise (Sys_error "")]>
 |}];;
-<[ raise End_of_file ]>
+<[ Stdlib.raise End_of_file ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Stdlib.End_of_file]>
+- : 'a expr = <[Stdlib.raise End_of_file]>
 |}];;
-<[ raise Division_by_zero ]>
+<[ Stdlib.raise Division_by_zero ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Stdlib.Division_by_zero]>
+- : 'a expr = <[Stdlib.raise Division_by_zero]>
 |}];;
-<[ raise Stack_overflow ]>
+<[ Stdlib.raise Stack_overflow ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Stdlib.Stack_overflow]>
+- : 'a expr = <[Stdlib.raise Stack_overflow]>
 |}];;
-<[ raise Sys_blocked_io ]>
+<[ Stdlib.raise Sys_blocked_io ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Stdlib.Sys_blocked_io]>
+- : 'a expr = <[Stdlib.raise Sys_blocked_io]>
 |}];;
-<[ raise (Assert_failure ("", 0, 0)) ]>
+<[ Stdlib.raise (Assert_failure ("", 0, 0)) ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Stdlib.Assert_failure ("", 0, 0))]>
+- : 'a expr = <[Stdlib.raise (Assert_failure ("", 0, 0))]>
 |}];;
-<[ raise (Undefined_recursive_module ("", 0, 0)) ]>
+<[ Stdlib.raise (Undefined_recursive_module ("", 0, 0)) ]>
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Stdlib.Undefined_recursive_module ("", 0, 0))]>
+- : 'a expr = <[Stdlib.raise (Undefined_recursive_module ("", 0, 0))]>
 |}];;
-<[ raise Continuation_already_taken ]> (* not re-exported by [Stdlib] *)
+<[ Stdlib.raise Continuation_already_taken ]> (* not re-exported by [Stdlib] *)
 [%%expect {|
 - : 'a expr = <[Stdlib.raise Continuation_already_taken]>
 |}];;
 
-<[ raise My_exception ]> (* sanity check *)
+<[ Stdlib.raise My_exception ]> (* sanity check *)
 [%%expect {|
-Line 1, characters 9-21:
-1 | <[ raise My_exception ]> (* sanity check *)
-             ^^^^^^^^^^^^
+Line 1, characters 16-28:
+1 | <[ Stdlib.raise My_exception ]> (* sanity check *)
+                    ^^^^^^^^^^^^
 Error: This variant expression is expected to have type "exn"
        There is no constructor "My_exception" within type "exn"
 |}];;
@@ -397,26 +397,28 @@ let e = <[ fun (x : int) -> x ]> in <[ fun (type int) () -> $e ]>
 - : <[unit -> int -> int]> expr = <[fun (type int) () -> fun (x : int) -> x]>
 |}];;
 (* Exception *)
-let e = <[ raise Exit ]> in <[ let exception Exit in $e ]>
+let e = <[ Stdlib.raise (Failure "") ]> in
+<[ let exception Failure of string in $e ]>
 [%%expect {|
-- : 'a expr = <[let exception Exit in Stdlib.raise Stdlib.Exit]>
+- : 'a expr = <[let exception Failure in Stdlib.raise (Failure "")]>
 |}];;
 (* We can avoid the following two bugs by banning [let exception],
    but they seem unlikely enough. *)
 (* CR jbachurski: This is wrong -- the inner [Exit] should refer to the
    global [Stdlib], not the argument. *)
-<[ fun (module Stdlib : S) -> raise Exit ]>
+let e = Stdlib.Obj.magic_many <[ Stdlib.raise (Failure "") ]> in
+<[ fun (module Stdlib : S) -> $e ]>
 [%%expect {|
 - : <[(module S) -> $('a)]> expr =
 <[
   fun (((module Stdlib) : (module S)) : (module S)) ->
-    Stdlib.raise Stdlib.Exit
+    Stdlib.raise (Failure "")
 ]>
 |}];;
 (* CR jbachurski: This is wrong -- the inner exn should refer to the
    global [Stdlib], not the extension.
    Note [Continuation_already_taken] is not re-exported by [Stdlib] (bug?). *)
-let e = <[ raise Continuation_already_taken ]> in <[ let exception Continuation_already_taken in $e ]>
+let e = <[ Stdlib.raise Continuation_already_taken ]> in <[ let exception Continuation_already_taken in $e ]>
 [%%expect {|
 - : 'a expr =
 <[

--- a/testsuite/tests/quotation/typing/inspection/pack_splice_in_constraint.ml
+++ b/testsuite/tests/quotation/typing/inspection/pack_splice_in_constraint.ml
@@ -5,7 +5,9 @@
 
 #syntax quotations on
 
-type t
+module T = struct
+  type t
+end
 module type S = sig
   type t
   val x : t
@@ -13,15 +15,18 @@ module type S = sig
 end
 #mark_persistent_in_quotations;;
 [%%expect {|
-type t
+module T : sig type t end
 module type S = sig type t val x : t val i : int end
 |}]
 
 (* Obviously fine, nothing is spliced *)
-let _ = <[ fun (module M : S with type t = t) -> M.x ]>
+let _ = <[ fun (module M : S with type t = T.t) -> M.x ]>
 [%%expect {|
-Uncaught exception: Stdlib.Exit
-
+- : <[(module S with type t = T.t) -> T.t]> expr =
+<[
+  fun (((module M) : (module S with type t = T.t)) : (module
+    S with type t = T.t)) -> M.x
+]>
 |}]
 
 (* Not fine -- there's a wildcard, which is a type variable under the hood,
@@ -39,7 +44,7 @@ Error: The type of this packed module contains variables:
    the below should fail with an error like the above to be consistent. *)
 (* CR metaprogramming jbachurski: This should fail gracefully.
    See ticket 7081. *)
-let _ = <[ fun (module M : S with type t = $t) -> M.x ]>
+let _ = <[ fun (module M : S with type t = $T.t) -> M.x ]>
 [%%expect {|
 >> Fatal error: Translquote [at line 1, characters 23-24]:
 Splices cannot appear in type annotations inserted in quotations
@@ -48,7 +53,7 @@ Uncaught exception: Misc.Fatal_error
 
 |}]
 
-let _ = <[ <[ fun (module M : S with type t = $t) -> M.x ]> ]>
+let _ = <[ <[ fun (module M : S with type t = $T.t) -> M.x ]> ]>
 [%%expect {|
 >> Fatal error: Translquote [at line 1, characters 26-27]:
 Splices cannot appear in type annotations inserted in quotations

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -1252,3 +1252,8 @@ let builtin_values =
   List.map (fun id -> (Ident.name id, id)) all_predef_exns
 
 let builtin_idents = List.rev !builtin_idents
+
+let builtin_type_constrs =
+  List.map
+    (fun t -> let id = ident_of_type_constr t in (Ident.name id, id))
+    all_type_constrs

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -580,6 +580,18 @@ and ident_some = ident_create "Some"
 and ident_null = ident_create "Null"
 and ident_this = ident_create "This"
 
+let all_predef_constrs = [
+  ident_false;
+  ident_true;
+  ident_void;
+  ident_nil;
+  ident_cons;
+  ident_none;
+  ident_some;
+  ident_null;
+  ident_this;
+]
+
 let option_argument_sort = Jkind_types.Sort.Const.scannable
 let option_argument_jkind = Jkind.Builtin.value_or_null ~why:(
   Type_argument {parent_path = path_option; position = 1; arity = 1})
@@ -1248,8 +1260,13 @@ let add_runtime_metaprogramming_types add_type env =
     add_type (ident_of_type_constr tconstr) (decl_of_type_constr tconstr) env
   ) env metaprogramming_extension_type_constrs
 
-let builtin_values =
+let builtin_exns =
   List.map (fun id -> (Ident.name id, id)) all_predef_exns
+
+let builtin_constrs =
+  List.map (fun id -> (Ident.name id, id)) all_predef_constrs
+
+let builtin_values = builtin_exns
 
 let builtin_idents = List.rev !builtin_idents
 

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -372,6 +372,8 @@ val or_null_jkind : Types.type_expr -> Types.jkind_l
 
 val builtin_values: (string * Ident.t) list
 val builtin_idents: (string * Ident.t) list
+val builtin_exns: (string * Ident.t) list
+val builtin_constrs: (string * Ident.t) list
 val builtin_type_constrs: (string * Ident.t) list
 
 (** All predefined exceptions, exposed as [Ident.t] for flambda (for

--- a/typing/predef.mli
+++ b/typing/predef.mli
@@ -368,10 +368,11 @@ val or_null_kind : type_expr -> ('a, 'b, constructor_declaration) type_kind
 (* CR layouts v3.5: remove this when users can define null constructors. *)
 val or_null_jkind : Types.type_expr -> Types.jkind_l
 
-(* To initialize linker tables *)
+(* To initialize linker tables and for [Translquote] *)
 
 val builtin_values: (string * Ident.t) list
 val builtin_idents: (string * Ident.t) list
+val builtin_type_constrs: (string * Ident.t) list
 
 (** All predefined exceptions, exposed as [Ident.t] for flambda (for
     building value approximations).


### PR DESCRIPTION
`camlinternalQuote` til now was structured to only list names it deemed builtin and exported. I see no reason not to just allow quoting arbitrary strings as names of builtins -- the compiler knows best what it allowed to type-check. 
To keep the same level of sanity-checking I re-used (and added some more) lists of builtin identifiers in `Predef`. 

(However, I'm not convinced these sanity-checks are necessary -- the environment should already check everything for us -- so I think we could get rid of these in the future if they ever get in the way again.)

See first commit for tests with all the bad output this PR fixes. There were just a lot of random names missing (like `bool#` from a bug report) and I see no reason to cultivate copies of the list of predefined names.

I also added some tests a the drive-by, showing that we can inappropriately shadow builtin names in quotes and break references to them. This seems pretty difficult to do accidentally but it's a bug nevertheless.