### PR TITLE
Conceptually split kind template's env mode and alloc mode

### DIFF
--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1143,8 +1143,8 @@ and lkindtemplate =
   { ktmpl_params: Slambdaident.t list;
     ktmpl_return: layout;
     ktmpl_body: lambda;
-    ktmpl_mode: locality_mode;
     ktmpl_env: (lambda * layout) Ident.Map.t;
+    ktmpl_env_mode: locality_mode;
     ktmpl_loc: scoped_location;
   }
 
@@ -2322,7 +2322,7 @@ let shallow_map ~tail ~non_tail:f lam =
       let new_lfun = map_lfunction f old_lfun in
       if old_lfun == new_lfun then lam else Lfunction new_lfun
   | Lkindtemplate { ktmpl_params; ktmpl_return; ktmpl_body = old_body;
-                    ktmpl_mode; ktmpl_env = old_env; ktmpl_loc } ->
+                    ktmpl_env = old_env; ktmpl_env_mode; ktmpl_loc } ->
       let new_body = f old_body in
       let env_changed = ref false in
       let new_env =
@@ -2340,8 +2340,8 @@ let shallow_map ~tail ~non_tail:f lam =
           ktmpl_params;
           ktmpl_return;
           ktmpl_body = new_body;
-          ktmpl_mode;
           ktmpl_env = new_env;
+          ktmpl_env_mode;
           ktmpl_loc;
         }
   | Llet (str, layout, v, v_duid, old_e1, old_e2) ->
@@ -3506,8 +3506,10 @@ let may_allocate_in_region lam =
   and loop = function
     | Lvar _ | Lmutvar _ | Lconst _ -> ()
 
-    | Lfunction {mode=Alloc_heap} | Lkindtemplate {ktmpl_mode=Alloc_heap} -> ()
-    | Lfunction {mode=Alloc_local} | Lkindtemplate {ktmpl_mode=Alloc_local} ->
+    | Lfunction {mode=Alloc_heap} | Lkindtemplate {ktmpl_env_mode=Alloc_heap} ->
+      ()
+    | Lfunction {mode=Alloc_local} | Lkindtemplate {ktmpl_env_mode=Alloc_local}
+      ->
       raise Exit
 
     | Lapply {ap_mode=Alloc_local}

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1143,6 +1143,7 @@ and lkindtemplate =
   { ktmpl_params: Slambdaident.t list;
     ktmpl_return: layout;
     ktmpl_body: lambda;
+    ktmpl_ret_mode: locality_mode;
     ktmpl_env: (lambda * layout) Ident.Map.t;
     ktmpl_env_mode: locality_mode;
     ktmpl_loc: scoped_location;
@@ -2322,7 +2323,8 @@ let shallow_map ~tail ~non_tail:f lam =
       let new_lfun = map_lfunction f old_lfun in
       if old_lfun == new_lfun then lam else Lfunction new_lfun
   | Lkindtemplate { ktmpl_params; ktmpl_return; ktmpl_body = old_body;
-                    ktmpl_env = old_env; ktmpl_env_mode; ktmpl_loc } ->
+                    ktmpl_ret_mode; ktmpl_env = old_env; ktmpl_env_mode;
+                    ktmpl_loc } ->
       let new_body = f old_body in
       let env_changed = ref false in
       let new_env =
@@ -2340,6 +2342,7 @@ let shallow_map ~tail ~non_tail:f lam =
           ktmpl_params;
           ktmpl_return;
           ktmpl_body = new_body;
+          ktmpl_ret_mode;
           ktmpl_env = new_env;
           ktmpl_env_mode;
           ktmpl_loc;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1017,6 +1017,7 @@ and lkindtemplate =
   { ktmpl_params: Slambdaident.t list;
     ktmpl_return: layout;
     ktmpl_body: lambda;
+    ktmpl_ret_mode: locality_mode;
     ktmpl_env: (lambda * layout) Ident.Map.t;
     ktmpl_env_mode: locality_mode;
     ktmpl_loc: scoped_location;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1017,8 +1017,8 @@ and lkindtemplate =
   { ktmpl_params: Slambdaident.t list;
     ktmpl_return: layout;
     ktmpl_body: lambda;
-    ktmpl_mode: locality_mode;
     ktmpl_env: (lambda * layout) Ident.Map.t;
+    ktmpl_env_mode: locality_mode;
     ktmpl_loc: scoped_location;
   }
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4832,8 +4832,8 @@ let for_let ~scopes ~arg_sort ~return_layout loc param mutable_flag pat body =
       { ktmpl_params = kind_params;
         ktmpl_return = return;
         ktmpl_body = Lambda.rename fresh_vars param;
-        ktmpl_mode = env_alloc_mode;
         ktmpl_env = env;
+        ktmpl_env_mode = env_alloc_mode;
         ktmpl_loc = Scoped_location.of_location ~scopes loc;
       }
     in

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -4802,10 +4802,14 @@ let for_let ~scopes ~arg_sort ~return_layout loc param mutable_flag pat body =
       (* This eliminates a useless variable (and stack slot in bytecode)
          for "let _ = ...". See #6865. *)
       Lsequence (param, body)
-  | Tpat_fun_layout { id; uid = duid; lpoly; env_alloc_mode; _ }
+  | Tpat_fun_layout { id; uid = duid; sort; mode; lpoly; env_alloc_mode; _ }
       when not (List.is_empty (Lpoly.get_exn lpoly)) ->
     assert (mutable_flag == Asttypes.Immutable);
-    let return = Typeopt.layout pat.pat_env pat.pat_loc arg_sort pat.pat_type in
+    let sort = Jkind.Sort.default_for_transl_and_get sort in
+    let return = Typeopt.layout pat.pat_env pat.pat_loc sort pat.pat_type in
+    let mode = Mode.value_to_alloc_r2l mode in
+    let locality = Mode.Alloc.proj_comonadic Areality mode in
+    let ret_mode = Translmode.transl_locality_mode_l locality in
     let kind_params =
       List.map Slambdaident.of_sort_var (Lpoly.get_exn lpoly)
     in
@@ -4829,15 +4833,17 @@ let for_let ~scopes ~arg_sort ~return_layout loc param mutable_flag pat body =
         free_vars
     in
     let f =
-      { ktmpl_params = kind_params;
-        ktmpl_return = return;
-        ktmpl_body = Lambda.rename fresh_vars param;
-        ktmpl_env = env;
-        ktmpl_env_mode = env_alloc_mode;
-        ktmpl_loc = Scoped_location.of_location ~scopes loc;
-      }
+      Lkindtemplate
+        { ktmpl_params = kind_params;
+          ktmpl_return = return;
+          ktmpl_body = Lambda.rename fresh_vars param;
+          ktmpl_ret_mode = ret_mode;
+          ktmpl_env = env;
+          ktmpl_env_mode = env_alloc_mode;
+          ktmpl_loc = Scoped_location.of_location ~scopes loc;
+        }
     in
-    Llet (Strict, layout_block, id, duid, Lkindtemplate f, body)
+    Llet (Strict, layout_block, id, duid, f, body)
   | Tpat_var { id; uid = duid; _ }
   | Tpat_alias { pattern = { pat_desc = Tpat_any }; id; uid = duid; _ }
   | Tpat_fun_layout { id; uid = duid; _ } ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -1445,8 +1445,8 @@ let rec lam ppf = function
       fprintf ppf "@[<2>(exclave@ %a)@]" lam expr
   | Lsplice (_, slambda) ->
       fprintf ppf "$%a" slam slambda
-  | Lkindtemplate {ktmpl_params; ktmpl_return; ktmpl_body; ktmpl_mode;
-                   ktmpl_env; ktmpl_loc = _} ->
+  | Lkindtemplate {ktmpl_params; ktmpl_return; ktmpl_body; ktmpl_env;
+                   ktmpl_env_mode; ktmpl_loc = _} ->
       let pr_env ppf env =
         fprintf ppf "{@[";
         Ident.Map.iter
@@ -1463,11 +1463,10 @@ let rec lam ppf = function
       let pr_params ppf params =
         List.iter (fun l -> fprintf ppf "%a@ " Slambdaident.print l) params
       in
-      fprintf ppf "@[<2>(ktemplate%s@ %a@ %a%a%a)@]"
-        (locality_kind ktmpl_mode)
+      fprintf ppf "@[<2>(ktemplate@ %a@ %a%a%a)@]"
         pr_env ktmpl_env
         pr_params ktmpl_params
-        return_kind (ktmpl_mode, ktmpl_return)
+        return_kind (ktmpl_env_mode, ktmpl_return)
         lam ktmpl_body
   | Lkindinstantiate {kinst_func; kinst_args; kinst_result_layout = _;
                       kinst_mode = _; kinst_loc = _} ->

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -1445,10 +1445,10 @@ let rec lam ppf = function
       fprintf ppf "@[<2>(exclave@ %a)@]" lam expr
   | Lsplice (_, slambda) ->
       fprintf ppf "$%a" slam slambda
-  | Lkindtemplate {ktmpl_params; ktmpl_return; ktmpl_body; ktmpl_env;
-                   ktmpl_env_mode; ktmpl_loc = _} ->
+  | Lkindtemplate {ktmpl_params; ktmpl_return; ktmpl_body; ktmpl_ret_mode;
+                   ktmpl_env; ktmpl_env_mode; ktmpl_loc = _} ->
       let pr_env ppf env =
-        fprintf ppf "{@[";
+        fprintf ppf "@[{";
         Ident.Map.iter
           (fun id (l, layout) ->
             match l with
@@ -1458,15 +1458,16 @@ let rec lam ppf = function
               fprintf ppf "@,%a=%a%a;"
                 Ident.print id layout_annotation layout lam l)
           env;
-        fprintf ppf "@]}"
+        fprintf ppf "}@]"
       in
       let pr_params ppf params =
         List.iter (fun l -> fprintf ppf "%a@ " Slambdaident.print l) params
       in
-      fprintf ppf "@[<2>(ktemplate@ %a@ %a%a%a)@]"
+      fprintf ppf "@[<2>(ktemplate@ %a%a@ %a%a%a)@]"
+        locality_mode ktmpl_env_mode
         pr_env ktmpl_env
         pr_params ktmpl_params
-        return_kind (ktmpl_env_mode, ktmpl_return)
+        return_kind (ktmpl_ret_mode, ktmpl_return)
         lam ktmpl_body
   | Lkindinstantiate {kinst_func; kinst_args; kinst_result_layout = _;
                       kinst_mode = _; kinst_loc = _} ->

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -359,6 +359,8 @@ let rec fracture_lam lambda : slambda =
               debug_uid = debug_uid_none;
               layout = layout_block;
               attributes = default_param_attribute;
+              (* The env parameter can be local because we immediately
+                 destructure it. *)
               mode = alloc_local
             }
           in
@@ -388,7 +390,10 @@ let rec fracture_lam lambda : slambda =
                 lfunction
                   ~kind:(Curried { nlocal = 1 })
                   ~params:[closure_param] ~return:ktmpl_return ~body
-                  ~attr:default_function_attribute ~loc:ktmpl_loc
+                  ~attr:default_function_attribute
+                  ~loc:ktmpl_loc
+                    (* This closure has no free variables and will always be
+                     statically allocated. alloc_heap is an safe choice. *)
                   ~mode:alloc_heap ~ret_mode:ktmpl_ret_mode
             })
     in

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -335,8 +335,8 @@ let rec fracture_lam lambda : slambda =
       { ktmpl_params;
         ktmpl_return;
         ktmpl_body;
-        ktmpl_mode;
         ktmpl_env;
+        ktmpl_env_mode;
         ktmpl_loc
       } ->
     let env = Ident.Map.to_list ktmpl_env in
@@ -358,7 +358,7 @@ let rec fracture_lam lambda : slambda =
               debug_uid = debug_uid_none;
               layout = layout_block;
               attributes = default_param_attribute;
-              mode = ktmpl_mode
+              mode = ktmpl_env_mode
             }
           in
           let _, body =
@@ -388,13 +388,13 @@ let rec fracture_lam lambda : slambda =
                   ~kind:
                     (Curried
                        { nlocal =
-                           (match ktmpl_mode with
+                           (match ktmpl_env_mode with
                            | Alloc_heap -> 0
                            | Alloc_local -> 1)
                        })
                   ~params:[closure_param] ~return:ktmpl_return ~body
                   ~attr:default_function_attribute ~loc:ktmpl_loc
-                  ~mode:ktmpl_mode ~ret_mode:ktmpl_mode
+                  ~mode:alloc_heap ~ret_mode:ktmpl_env_mode
             })
     in
     let free_var_capture =
@@ -411,7 +411,8 @@ let rec fracture_lam lambda : slambda =
               };
           sval_runtime =
             Lprim
-              ( Pmakeblock (0, Immutable, Shape free_vars_shape_unit, ktmpl_mode),
+              ( Pmakeblock
+                  (0, Immutable, Shape free_vars_shape_unit, ktmpl_env_mode),
                 free_var_capture,
                 ktmpl_loc )
         }

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -335,6 +335,7 @@ let rec fracture_lam lambda : slambda =
       { ktmpl_params;
         ktmpl_return;
         ktmpl_body;
+        ktmpl_ret_mode;
         ktmpl_env;
         ktmpl_env_mode;
         ktmpl_loc
@@ -358,7 +359,7 @@ let rec fracture_lam lambda : slambda =
               debug_uid = debug_uid_none;
               layout = layout_block;
               attributes = default_param_attribute;
-              mode = ktmpl_env_mode
+              mode = alloc_local
             }
           in
           let _, body =
@@ -385,16 +386,10 @@ let rec fracture_lam lambda : slambda =
             { sval_comptime = body_c;
               sval_runtime =
                 lfunction
-                  ~kind:
-                    (Curried
-                       { nlocal =
-                           (match ktmpl_env_mode with
-                           | Alloc_heap -> 0
-                           | Alloc_local -> 1)
-                       })
+                  ~kind:(Curried { nlocal = 1 })
                   ~params:[closure_param] ~return:ktmpl_return ~body
                   ~attr:default_function_attribute ~loc:ktmpl_loc
-                  ~mode:alloc_heap ~ret_mode:ktmpl_env_mode
+                  ~mode:alloc_heap ~ret_mode:ktmpl_ret_mode
             })
     in
     let free_var_capture =


### PR DESCRIPTION
It also makes the alloc mode always heap now, as it's safe and they won't actually be allocated (eventually) as they're always closed and never actually passed around as first-class values.

This is necessary for #5877.