### PR TITLE
Start leaving breadcrumbs

### DIFF
--- a/dune
+++ b/dune
@@ -149,6 +149,7 @@
  (modules
   ;; UTILS
   arrayset
+  breadcrumbs
   config
   build_path_prefix_map
   misc

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -665,9 +665,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                   (* Some (Const_block(runtime_tag, constants)) *)
                   None
               | Constructor_mixed shape ->
-                  (* CR layouts v5: once all-void records are allowed, handle
-                     constructors with all-void inline records, which are stored
-                     as immediates *)
+                  Breadcrumbs.assume_inline_records_are_blocks;
                   if !Clflags.native_code then
                     let shape = Lambda.transl_mixed_product_shape shape in
                     Some (Const_mixed_block(runtime_tag, shape, constants))
@@ -698,9 +696,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                                Lambda.block_shape_of_value_kinds (Some shape),
                                alloc_mode)
                 | Constructor_mixed shape ->
-                    (* CR layouts v5: once all-void records are allowed, handle
-                       constructors with all-void inline records, which are
-                       stored as immediates *)
+                    Breadcrumbs.assume_inline_records_are_blocks;
                     let shape = Lambda.transl_mixed_product_shape shape in
                     Pmakeblock(runtime_tag, Immutable, Shape shape, alloc_mode)
                 | Constructor_variable ->
@@ -737,9 +733,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                                (Some (Lambda.generic_value :: shape)),
                              alloc_mode)
               | Constructor_mixed shape ->
-                  (* CR layouts v5: once all-void records are allowed, handle
-                     constructors with all-void inline records, which are stored
-                     as immediates *)
+                  Breadcrumbs.assume_inline_records_are_blocks;
                   let shape = Lambda.transl_mixed_product_shape shape in
                   let shape =
                     (* This corresponds to the poly variant hash.  This will
@@ -859,10 +853,8 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
             fatal_error
               "Mixed inlined records not supported for extensible variants"
         | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
-          (* CR layouts v5: once all-void records are allowed, handle
-             constructors with all-void inline records, which are stored as
-             immediates *)
         | Record_mixed shape ->
+          Breadcrumbs.assume_inline_records_are_blocks;
           let shape =
             Lambda.transl_mixed_product_shape_for_read
               ~get_value_kind:(fun i ->
@@ -985,10 +977,8 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
             fatal_error
               "Mixed inlined records not supported for extensible variants"
         | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
-          (* CR layouts v5: once all-void records are allowed, handle
-             constructors with all-void inline records, which are stored as
-             immediates *)
         | Record_mixed shape ->
+          Breadcrumbs.assume_inline_records_are_blocks;
           let field_shape =
             Typeopt.transl_mixed_block_element newval.exp_env newval.exp_loc
               newval.exp_type shape.(lbl.lbl_pos)
@@ -2356,10 +2346,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                 fatal_error
                   "Mixed inlined records not supported for extensible variants"
             | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
-                (* CR layouts v5: once all-void records are allowed, handle
-                  constructors with all-void inline records, which are stored as
-                  immediates *)
             | Record_mixed shape ->
+                Breadcrumbs.assume_inline_records_are_blocks;
                 let field_shape =
                   Typeopt.transl_mixed_block_element expr.exp_env expr.exp_loc
                     expr.exp_type shape.(lbl.lbl_pos)
@@ -2437,10 +2425,8 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                     Pfloatfield (i, sem, alloc_heap)
                  | Record_ufloat -> Pufloatfield (i, sem)
                  | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
-                   (* CR layouts v5: once all-void records are allowed, handle
-                      constructors with all-void inline records, which are
-                      stored as immediates *)
                  | Record_mixed shape ->
+                   Breadcrumbs.assume_inline_records_are_blocks;
                    let shape =
                      Lambda.transl_mixed_product_shape_for_read
                        ~get_value_kind:(fun i ->
@@ -2575,9 +2561,7 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             Lprim (Pmakeblock (0, mut, Shape shape, Option.get mode), ll, loc)
         | Record_inlined (Ordinary { runtime_tag },
                           Constructor_mixed shape, Variant_boxed _) ->
-            (* CR layouts v5: once all-void records are allowed, handle
-              constructors with all-void inline records, which are stored as
-              immediates *)
+            Breadcrumbs.assume_inline_records_are_blocks;
             let shape = Lambda.transl_mixed_product_shape shape in
             Lprim (Pmakeblock (runtime_tag, mut, Shape shape, Option.get mode),
                    ll, loc)

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -665,7 +665,9 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                   (* Some (Const_block(runtime_tag, constants)) *)
                   None
               | Constructor_mixed shape ->
-                  Breadcrumbs.assume_inline_records_are_blocks;
+                  (* CR layouts v5: once all-void records are allowed, handle
+                     constructors with all-void inline records, which are stored
+                     as immediates *)
                   if !Clflags.native_code then
                     let shape = Lambda.transl_mixed_product_shape shape in
                     Some (Const_mixed_block(runtime_tag, shape, constants))
@@ -696,7 +698,9 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                                Lambda.block_shape_of_value_kinds (Some shape),
                                alloc_mode)
                 | Constructor_mixed shape ->
-                    Breadcrumbs.assume_inline_records_are_blocks;
+                    (* CR layouts v5: once all-void records are allowed, handle
+                       constructors with all-void inline records, which are
+                       stored as immediates *)
                     let shape = Lambda.transl_mixed_product_shape shape in
                     Pmakeblock(runtime_tag, Immutable, Shape shape, alloc_mode)
                 | Constructor_variable ->
@@ -733,7 +737,9 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                                (Some (Lambda.generic_value :: shape)),
                              alloc_mode)
               | Constructor_mixed shape ->
-                  Breadcrumbs.assume_inline_records_are_blocks;
+                  (* CR layouts v5: once all-void records are allowed, handle
+                     constructors with all-void inline records, which are stored
+                     as immediates *)
                   let shape = Lambda.transl_mixed_product_shape shape in
                   let shape =
                     (* This corresponds to the poly variant hash.  This will
@@ -853,8 +859,10 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
             fatal_error
               "Mixed inlined records not supported for extensible variants"
         | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+          (* CR layouts v5: once all-void records are allowed, handle
+             constructors with all-void inline records, which are stored as
+             immediates *)
         | Record_mixed shape ->
-          Breadcrumbs.assume_inline_records_are_blocks;
           let shape =
             Lambda.transl_mixed_product_shape_for_read
               ~get_value_kind:(fun i ->
@@ -977,8 +985,10 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
             fatal_error
               "Mixed inlined records not supported for extensible variants"
         | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+          (* CR layouts v5: once all-void records are allowed, handle
+             constructors with all-void inline records, which are stored as
+             immediates *)
         | Record_mixed shape ->
-          Breadcrumbs.assume_inline_records_are_blocks;
           let field_shape =
             Typeopt.transl_mixed_block_element newval.exp_env newval.exp_loc
               newval.exp_type shape.(lbl.lbl_pos)
@@ -2346,8 +2356,10 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                 fatal_error
                   "Mixed inlined records not supported for extensible variants"
             | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+                (* CR layouts v5: once all-void records are allowed, handle
+                  constructors with all-void inline records, which are stored as
+                  immediates *)
             | Record_mixed shape ->
-                Breadcrumbs.assume_inline_records_are_blocks;
                 let field_shape =
                   Typeopt.transl_mixed_block_element expr.exp_env expr.exp_loc
                     expr.exp_type shape.(lbl.lbl_pos)
@@ -2425,8 +2437,10 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
                     Pfloatfield (i, sem, alloc_heap)
                  | Record_ufloat -> Pufloatfield (i, sem)
                  | Record_inlined (_, Constructor_mixed shape, Variant_boxed _)
+                   (* CR layouts v5: once all-void records are allowed, handle
+                      constructors with all-void inline records, which are
+                      stored as immediates *)
                  | Record_mixed shape ->
-                   Breadcrumbs.assume_inline_records_are_blocks;
                    let shape =
                      Lambda.transl_mixed_product_shape_for_read
                        ~get_value_kind:(fun i ->
@@ -2561,7 +2575,9 @@ and transl_record ~scopes loc env mode fields repres opt_init_expr =
             Lprim (Pmakeblock (0, mut, Shape shape, Option.get mode), ll, loc)
         | Record_inlined (Ordinary { runtime_tag },
                           Constructor_mixed shape, Variant_boxed _) ->
-            Breadcrumbs.assume_inline_records_are_blocks;
+            (* CR layouts v5: once all-void records are allowed, handle
+              constructors with all-void inline records, which are stored as
+              immediates *)
             let shape = Lambda.transl_mixed_product_shape shape in
             Lprim (Pmakeblock (runtime_tag, mut, Shape shape, Option.get mode),
                    ll, loc)

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -138,6 +138,7 @@
   value_rec_types
   btype
   lazy_backtrack
+  breadcrumbs
   type_shape
   zero_alloc_utils
   diffing
@@ -268,6 +269,8 @@
 (copy_files ../../utils/linkage_name.ml)
 
 (copy_files ../../utils/lazy_backtrack.ml)
+
+(copy_files ../../utils/breadcrumbs.ml)
 
 (copy_files ../../utils/zero_alloc_utils.ml)
 
@@ -473,6 +476,8 @@
 (copy_files ../../utils/linkage_name.mli)
 
 (copy_files ../../utils/lazy_backtrack.mli)
+
+(copy_files ../../utils/breadcrumbs.mli)
 
 (copy_files ../../utils/zero_alloc_utils.mli)
 
@@ -725,6 +730,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Printast.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Syntaxerr.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Lazy_backtrack.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Breadcrumbs.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Zero_alloc_utils.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Diffing.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Diffing_with_keys.cmo
@@ -857,6 +863,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lexer.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Path.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Lazy_backtrack.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Breadcrumbs.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Zero_alloc_utils.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Diffing.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Diffing_with_keys.cmx

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -1,5 +1,6 @@
 (* TEST
-    flags = "-extension layouts_alpha -no-ikinds";
+    flags = "-extension layouts_alpha -no-ikinds -I ${ocamlsrcdir}/utils";
+    include ocamlcommon;
     expect;
 *)
 
@@ -342,7 +343,9 @@ module M : sig
 end = struct
   type 'a t = 'a
 end
-(* CR layouts v2.8: This should get accepted. But we should wait until we have kind_of *)
+let () =
+  (* This should get accepted. But we should wait until we have kind_of *)
+  Breadcrumbs.until_kind_of
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
@@ -1,5 +1,6 @@
 (* TEST
-    flags = "-extension layouts_alpha";
+    flags = "-extension layouts_alpha -I ${ocamlsrcdir}/utils";
+    include ocamlcommon;
     expect;
 *)
 
@@ -336,7 +337,9 @@ module M : sig
 end = struct
   type 'a t = 'a
 end
-(* CR layouts v2.8: This should get accepted. But we should wait until we have kind_of *)
+let () =
+  (* This should get accepted. But we should wait until we have kind_of *)
+  Breadcrumbs.until_kind_of
 [%%expect {|
 Lines 3-5, characters 6-3:
 3 | ......struct

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8667,10 +8667,13 @@ let check_decl_jkind env decl jkind =
   let type_equal = type_equal env in
   let type_jkind_purely = type_jkind_purely env in
   let context = mk_jkind_context_always_principal env in
-  (* CR layouts v2.8: When we have [layout_of], this logic should move to the
-     place where [type_jkind] is set. But for now, it has to be here, because we
-     want this in module inclusion but not other places (because substitutions
-     won't improve the layout). Internal ticket 2912. *)
+  let () =
+    (* When we have [layout_of], this logic should move to the place where
+       [type_jkind] is set. But for now, it has to be here, because we want this
+       in module inclusion but not other places (because substitutions won't
+       improve the layout). *)
+    Breadcrumbs.until_kind_of
+  in
   (* CR layouts v2.8: This improvement ignores types with both [@@unboxed]
      and [@@unsafe_allow_any_mode_crossing], because the stdlib didn't build
      otherwise. But we really shouldn't allow mixing those two features, and

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -2386,7 +2386,8 @@ let for_unboxed_record_with_updates lbls =
   Builtin.product ~why:Unboxed_record tys_modalities layouts
 
 let for_abbreviation ~type_jkind_purely ~modality ty =
-  (* CR layouts v2.8: This should really use layout_of. Internal ticket 2912. *)
+  (* This should really use [layout_of] *)
+  Breadcrumbs.until_kind_of;
   let jkind = type_jkind_purely ty in
   let with_bounds_types =
     let relevant_axes = Mod_bounds.relevant_axes_of_modality ~modality in

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -1410,8 +1410,9 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
         lbls
     in
     let rep = Types.Record_unboxed_product in
-    (* CR layouts v11: update type_jkind once we have [layout_of] layouts *)
     let jkind =
+      (* Update this once we have [layout_of] layouts *)
+      Breadcrumbs.until_kind_of;
       Jkind.Builtin.product_of_any ~why:Unboxed_record (List.length lbls)
     in
     let kind =
@@ -3196,14 +3197,17 @@ type step_result =
   | Is_cyclic
 let check_unboxed_recursion ~abs_env env loc path0 ty0 to_check =
   let contained_parameters tyl layout =
-    (* A type whose layout has [any] could contain all its parameters.
-       CR layouts v11: update this function for [layout_of] layouts. *)
+    (* A type whose layout has [any] could contain all its parameters. *)
     let rec has_any : Jkind_types.Layout.Const.t -> bool = function
       | Any _ -> true
       | Base _ -> false
       | Product l -> List.exists has_any l
       | Univar _ -> Misc.fatal_error "Unboxed_recursion: univar"
       | Genvar _ -> Misc.fatal_error "Unboxed_recursion: genvar"
+    in
+    let () =
+      (* A type with layout [layout_of 'a] could contain ['a]. *)
+      Breadcrumbs.until_kind_of
     in
     if has_any layout then tyl else []
   in

--- a/utils/.ocamlformat-enable
+++ b/utils/.ocamlformat-enable
@@ -20,3 +20,5 @@ structured_mangling.ml
 structured_mangling.mli
 opt_fuel.ml
 opt_fuel.mli
+breadcrumbs.ml
+breadcrumbs.mli

--- a/utils/breadcrumbs.ml
+++ b/utils/breadcrumbs.ml
@@ -1,0 +1,3 @@
+let until_kind_of = ()
+
+let assume_inline_records_are_blocks = ()

--- a/utils/breadcrumbs.ml
+++ b/utils/breadcrumbs.ml
@@ -1,3 +1,1 @@
 let until_kind_of = ()
-
-let assume_inline_records_are_blocks = ()

--- a/utils/breadcrumbs.mli
+++ b/utils/breadcrumbs.mli
@@ -15,15 +15,3 @@
     Some users of this breadcrumb may really care about [layout_of], but we
     expect these features to arrive ~together. *)
 val until_kind_of : unit
-
-(** Currently, all inline records are blocks. We plan to break this once we have
-    all-void inline records (internal ticket 4654) plus [inherit] (internal
-    ticket 7361).
-    {[
-      type t = A of { inherit u : unit# }
-    ]}
-
-    Tangentially, note that all-void constructors can be immediates with the
-    attribute [@immediate_all_void_constructor]. We plan to replace uses of
-    these constructors with [inherit] as well. *)
-val assume_inline_records_are_blocks : unit

--- a/utils/breadcrumbs.mli
+++ b/utils/breadcrumbs.mli
@@ -1,0 +1,29 @@
+(** Breadcrumbs mark assumptions we plan to revisit.
+
+    Code depending on these assumptions should destruct these values. Then, upon
+    breaking an assumption, delete the breadcrumb to be forced by the compiler
+    to update its dependencies.
+
+    Breadcrumbs can also be depended on in tests; grep [testsuite/] for
+    examples. *)
+
+(** Mark to revisit once we have [kind_of] (internal ticket 2912), e.g.
+    {[
+      type ('a : any) t : (kind_of 'a) & (kind_of 'a) = #('a * 'a)
+    ]}
+
+    Some users of this breadcrumb may really care about [layout_of], but we
+    expect these features to arrive ~together. *)
+val until_kind_of : unit
+
+(** Currently, all inline records are blocks. We plan to break this once we have
+    all-void inline records (internal ticket 4654) plus [inherit] (internal
+    ticket 7361).
+    {[
+      type t = A of { inherit u : unit# }
+    ]}
+
+    Tangentially, note that all-void constructors can be immediates with the
+    attribute [@immediate_all_void_constructor]. We plan to replace uses of
+    these constructors with [inherit] as well. *)
+val assume_inline_records_are_blocks : unit

--- a/utils/breadcrumbs.mli
+++ b/utils/breadcrumbs.mli
@@ -1,13 +1,28 @@
 (** Breadcrumbs mark assumptions we plan to revisit.
 
     Code depending on these assumptions should destruct these values. Then, upon
-    breaking an assumption, delete the breadcrumb to be forced by the compiler
-    to update its dependencies.
+    breaking an assumption, delete the breadcrumb, and the compiler will force
+    its references to be updated.
 
     Breadcrumbs can also be depended on in tests; grep [testsuite/] for
-    examples. *)
+    examples.
 
-(** Mark to revisit once we have [kind_of] (internal ticket 2912), e.g.
+    When considering adding new breadcrumbs, be judicious! Often, it's best to
+    structure the code such that the future change will be caught by a type
+    error anyway. For example, future constructors added to a variant are
+    naturally handled by the match exhaustiveness check, and
+    invariants/assumptions can often be localized to a new module's
+    implementation.
+
+    Some cases in which breadcrumbs *can* be the right choice are:
+    - When we have non-local invariants (which, of course, should be avoided
+      anyway).
+    - When we will want to *produce* different data in the future while
+      consuming the same data.
+    - When we expect a test to update with some future feature, and want to
+      ensure that we come back to check that it does. *)
+
+(** Marks code to revisit once we have [kind_of] (internal ticket 2912), e.g.
     {[
       type ('a : any) t : (kind_of 'a) & (kind_of 'a) = #('a * 'a)
     ]}


### PR DESCRIPTION
Add a `Breadcrumbs` module.

Breadcrumbs mark assumptions we plan to revisit. Code depending on these assumptions should destruct these values. Then, upon breaking an assumption, delete the breadcrumb to be forced by the compiler to update its dependencies.

Breadcrumbs can also be depended on in tests, e.g., if we expect their output to update with a future change.

This PR adds one breadcrumb to start, `Breadcrumbs.until_kind_of`, documented in `utils/breadcrumbs.mli`.