### PR TITLE
Keep lambda switches in native compilation

### DIFF
--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -595,6 +595,10 @@ let mk_safer_matching f =
   "-safer-matching", Arg.Unit f,
   " Do not use type information to optimize pattern-matching"
 
+let mk_skip_lambda_switch_compilation f =
+  "-skip-lambda-switch-compilation", Arg.Unit f,
+  " Keep integer switches untouched before the middle-end"
+
 let mk_shared f =
   "-shared", Arg.Unit f, " Produce a dynlinkable plugin"
 
@@ -1178,6 +1182,7 @@ module type Common_options = sig
   val _rectypes : unit -> unit
   val _no_rectypes : unit -> unit
   val _safer_matching : unit -> unit
+  val _skip_lambda_switch_compilation : unit -> unit
   val _short_paths : unit -> unit
   val _strict_sequence : unit -> unit
   val _no_strict_sequence : unit -> unit
@@ -1575,6 +1580,7 @@ struct
     mk_without_runtime F._without_runtime;
     mk_safe_string;
     mk_safer_matching F._safer_matching;
+    mk_skip_lambda_switch_compilation F._skip_lambda_switch_compilation;
     mk_short_paths F._short_paths;
     mk_strict_sequence F._strict_sequence;
     mk_no_strict_sequence F._no_strict_sequence;
@@ -1690,6 +1696,7 @@ struct
     mk_no_rectypes F._no_rectypes;
     mk_safe_string;
     mk_safer_matching F._safer_matching;
+    mk_skip_lambda_switch_compilation F._skip_lambda_switch_compilation;
     mk_short_paths F._short_paths;
     mk_stdin F._stdin;
     mk_strict_sequence F._strict_sequence;
@@ -1869,6 +1876,7 @@ struct
     mk_S F._S;
     mk_safe_string;
     mk_safer_matching F._safer_matching;
+    mk_skip_lambda_switch_compilation F._skip_lambda_switch_compilation;
     mk_shared F._shared;
     mk_short_paths F._short_paths;
     mk_strict_sequence F._strict_sequence;
@@ -2036,6 +2044,7 @@ module Make_opttop_options (F : Opttop_options) = struct
     mk_S F._S;
     mk_safe_string;
     mk_safer_matching F._safer_matching;
+    mk_skip_lambda_switch_compilation F._skip_lambda_switch_compilation;
     mk_short_paths F._short_paths;
     mk_stdin F._stdin;
     mk_strict_sequence F._strict_sequence;
@@ -2189,6 +2198,7 @@ struct
     mk_without_runtime F._without_runtime;
     mk_safe_string;
     mk_safer_matching F._safer_matching;
+    mk_skip_lambda_switch_compilation F._skip_lambda_switch_compilation;
     mk_short_paths F._short_paths;
     mk_strict_sequence F._strict_sequence;
     mk_no_strict_sequence F._no_strict_sequence;
@@ -2427,6 +2437,7 @@ module Default = struct
     let _principal = set principal
     let _rectypes = set recursive_types
     let _safer_matching = set safer_matching
+    let _skip_lambda_switch_compilation = set skip_lambda_switch_compilation
     let _short_paths = clear real_paths
     let _strict_formats = set strict_formats
     let _strict_sequence = set strict_sequence

--- a/driver/main_args.mli
+++ b/driver/main_args.mli
@@ -55,6 +55,7 @@ module type Common_options = sig
   val _rectypes : unit -> unit
   val _no_rectypes : unit -> unit
   val _safer_matching : unit -> unit
+  val _skip_lambda_switch_compilation : unit -> unit
   val _short_paths : unit -> unit
   val _strict_sequence : unit -> unit
   val _no_strict_sequence : unit -> unit

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3290,8 +3290,20 @@ let as_interval fail ?(low = min_int) ?(high = max_int) l =
     | Some act -> as_interval_canfail act ~low ~high l )
 
 let call_switcher kind loc fail arg ?low ?high int_lambda_list =
-  let edges, (cases, actions) = as_interval fail ?low ?high int_lambda_list in
-  Switcher.zyva loc kind edges arg cases actions
+  match low, high, !Clflags.native_code with
+  | Some 0, Some high, true ->
+    let sw : Lambda.lambda_switch =
+      { sw_numconsts = high + 1;
+        sw_consts = int_lambda_list;
+        sw_numblocks = 0;
+        sw_blocks = [];
+        sw_failaction = fail
+      }
+    in
+    Lswitch (arg, sw, loc, kind)
+  | _, _, _ ->
+    let edges, (cases, actions) = as_interval fail ?low ?high int_lambda_list in
+    Switcher.zyva loc kind edges arg cases actions
 
 let rec list_as_pat = function
   | [] -> fatal_error "Matching.list_as_pat"

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3289,9 +3289,12 @@ let as_interval fail ?(low = min_int) ?(high = max_int) l =
     | None -> as_interval_nofail l
     | Some act -> as_interval_canfail act ~low ~high l )
 
+let skip_lambda_switch_compilation () =
+  !Clflags.skip_lambda_switch_compilation
+
 let call_switcher kind loc fail arg ?low ?high int_lambda_list =
-  match low, high, !Clflags.native_code with
-  | Some 0, Some high, true ->
+  match skip_lambda_switch_compilation (), low, high, !Clflags.native_code with
+  | true, Some 0, Some high, true ->
     let sw : Lambda.lambda_switch =
       { sw_numconsts = high + 1;
         sw_consts = int_lambda_list;
@@ -3301,7 +3304,7 @@ let call_switcher kind loc fail arg ?low ?high int_lambda_list =
       }
     in
     Lswitch (arg, sw, loc, kind)
-  | _, _, _ ->
+  | _, _, _, _ ->
     let edges, (cases, actions) = as_interval fail ?low ?high int_lambda_list in
     Switcher.zyva loc kind edges arg cases actions
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3295,15 +3295,19 @@ let skip_lambda_switch_compilation () =
 let call_switcher kind loc fail arg ?low ?high int_lambda_list =
   match skip_lambda_switch_compilation (), low, high, !Clflags.native_code with
   | true, Some 0, Some high, true ->
-    let sw : Lambda.lambda_switch =
-      { sw_numconsts = high + 1;
-        sw_consts = int_lambda_list;
-        sw_numblocks = 0;
-        sw_blocks = [];
-        sw_failaction = fail
-      }
-    in
-    Lswitch (arg, sw, loc, kind)
+    begin match high, int_lambda_list with
+    | 0, [ 0, lam ] -> lam (* No branch *)
+    | _ , _ ->
+      let sw : Lambda.lambda_switch =
+        { sw_numconsts = high + 1;
+          sw_consts = int_lambda_list;
+          sw_numblocks = 0;
+          sw_blocks = [];
+          sw_failaction = fail
+        }
+      in
+      Lswitch (arg, sw, loc, kind)
+    end
   | _, _, _, _ ->
     let edges, (cases, actions) = as_interval fail ?low ?high int_lambda_list in
     Switcher.zyva loc kind edges arg cases actions

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -135,6 +135,7 @@ and classic = ref false                 (* -nolabels *)
 and nopervasives = ref false            (* -nopervasives *)
 and match_context_rows = ref 32         (* -match-context-rows *)
 and safer_matching = ref false          (* -safer-matching *)
+and skip_lambda_switch_compilation = ref false
 and preprocessor = ref(None : string option) (* -pp *)
 and all_ppx = ref ([] : string list)        (* -ppx *)
 let absname = ref false                 (* -absname *)

--- a/utils/clflags.mli
+++ b/utils/clflags.mli
@@ -122,6 +122,7 @@ val classic : bool ref
 val nopervasives : bool ref
 val match_context_rows : int ref
 val safer_matching : bool ref
+val skip_lambda_switch_compilation : bool ref
 type open_arg =
   | Open of string
   | Open_cmi of string


### PR DESCRIPTION
The code in `matching.ml` that handles integer switches calls into `switch.ml` to generate efficient test trees.
This interferes with the rest of the backend, which will see complex arithmetic expressions and tests instead of the simple original switch. When optimisations do not trigger, `switch.ml` is still called anyway as part of he translation to Cmm.

So this PR gets rid of (some of) the calls to `switch.ml`, in the cases where we can easily generate a meaningful `Lswitch` constructor.

This changes the output of a number of tests, many of them in a harmless way (some stamps change), but a few of them in meaningful ways.
In particular, some of the raw outputs (before simplification) look a bit worse, but in a harmless way (simplification will take care of the extra continuation/primitives). Some of them look clearly better (typically `codegen/variants.ml` looks definitely better, but it may mean that the test itself has become meaningless). A few of them look a bit worse because we translate patterns like `match c with 'a' -> ... | _ -> ...` using a naked equality comparison instead of a tagged disequality comparison (neither of them is strictly better at the moment, so some outputs change in a good way and some in a bad way).
And there is a clear gain on `flambda2/examples/variant_unboxing.ml`, but I haven't investigated why exactly.