### PR TITLE
Unix_for_owee in driver/boot_ocamlopt.ml

### DIFF
--- a/driver/boot_ocamlopt.ml
+++ b/driver/boot_ocamlopt.ml
@@ -10,6 +10,6 @@ module Unix_for_owee = struct
 end
 
 let () =
-  exit (Optmaindriver.main (module Unix_for_owee : Compiler_owee.Unix_intf.S) Sys.argv
-    Format.err_formatter
+  exit (Optmaindriver.main (module Unix_for_owee : Compiler_owee.Unix_intf.S)
+    Sys.argv Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)

--- a/driver/boot_ocamlopt.ml
+++ b/driver/boot_ocamlopt.ml
@@ -1,4 +1,15 @@
+(* Eta-expansion gives [create_process] and [waitpid] the unannotated types
+   required by [Compiler_owee.Unix_intf.S]. *)
+module Unix_for_owee = struct
+  include Unix
+
+  let create_process prog args stdin stdout stderr =
+    Unix.create_process prog args stdin stdout stderr
+
+  let waitpid flags pid = Unix.waitpid flags pid
+end
+
 let () =
-  exit (Optmaindriver.main (module Unix : Compiler_owee.Unix_intf.S) Sys.argv
+  exit (Optmaindriver.main (module Unix_for_owee : Compiler_owee.Unix_intf.S) Sys.argv
     Format.err_formatter
     ~flambda2:Flambda2.lambda_to_cmm)


### PR DESCRIPTION
This was missed in 898c5493b8c686bd7095840c0fb2ed115956c4d6 (#6447) and is necessary when building using OxCaml as a system compiler.