### PR TITLE
Fixes for mode constraints in quotes

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2762,6 +2762,17 @@ let assert_no_jkinds jkind =
           Location.print_loc pjka_loc)
     jkind
 
+(* wildcard annotations *)
+let newvar () = Ctype.newvar (Jkind.Builtin.any ~why:Dummy_jkind)
+
+let newcorevar env loc =
+  { ctyp_desc = Ttyp_var (None, None);
+    ctyp_type = newvar ();
+    ctyp_env = env;
+    ctyp_loc = to_location loc;
+    ctyp_attributes = []
+  }
+
 (* Approximate the [core_type] for type annotation from a given [type_expr].
    Used for annotating the results of type inspections in quotes. *)
 let type_for_annotation ~env ~loc typ =
@@ -2901,6 +2912,7 @@ and quote_pat_extra ~env ~scopes loc pat_lam extra =
   let extra, _, _ = extra in
   match extra with
   | Tpat_constraint (ty, ms) ->
+    let ty = Option.value ~default:(newcorevar env loc) ty in
     Pat.constraint_ loc pat_lam
       (quote_core_type ~scopes ty)
       (quote_modes loc ms)
@@ -3331,6 +3343,7 @@ and fun_param_binding ~scopes ~transl stage loc param frest =
   in
   let idents = pat_bound_idents pat in
   let pat_quoted = quote_value_pattern ~scopes pat in
+  (* This is now redundant with [quote_value_pattern] *)
   let pat_quoted =
     if any_modes param.fp_mode
     then
@@ -3385,6 +3398,7 @@ and quote_function ~scopes ~transl stage loc fn extras =
       match fn.body with
       | Tfunction_body exp ->
         let exp_quoted = quote_expression ~scopes ~transl stage exp in
+        (* This is now redundant with [quote_expression] *)
         let exp_quoted =
           if any_modes fn.ret_mode
           then
@@ -3579,16 +3593,6 @@ and quote_expression_extra ~env ~scopes _stage extra lambda =
          (type_constraint_of_ambiguity loc env ambiguity)
   | Texp_inspected_type (Polymorphic_parameter poly_param) ->
     (* unused dummy for [core_type.ctyp_type] *)
-    let newvar () = Ctype.newvar (Jkind.Builtin.any ~why:Dummy_jkind) in
-    (* wildcard annotation *)
-    let newcorevar () =
-      { ctyp_desc = Ttyp_var (None, None);
-        ctyp_type = newvar ();
-        ctyp_env = env;
-        ctyp_loc = to_location loc;
-        ctyp_attributes = []
-      }
-    in
     let cty =
       match poly_param with
       | Method (met, ty) ->
@@ -3614,7 +3618,7 @@ and quote_expression_extra ~env ~scopes _stage extra lambda =
                     (match sch with
                     | Some sch ->
                       type_for_annotation ~env ~loc:(to_location loc) sch
-                    | None -> newcorevar ()),
+                    | None -> newcorevar env loc),
                     Typemode.transl_alloc_mode [],
                     spine,
                     Typemode.transl_alloc_mode [] );
@@ -3623,7 +3627,7 @@ and quote_expression_extra ~env ~scopes _stage extra lambda =
               ctyp_loc = to_location loc;
               ctyp_attributes = []
             })
-          params (newcorevar ())
+          params (newcorevar env loc)
     in
     Exp_desc.constraint_ loc (mk_exp_noattr loc lambda)
       (Type_constraint.constraint_ loc
@@ -3696,7 +3700,7 @@ and quote_expression_desc ~scopes ~transl stage e : Exp_desc.t =
                   (* CR-soon metaprogramming jbachurski: Support modes on
                      recursive let bindings after refactoring this mess. *)
                   assert_no_modes ms;
-                  Some ct
+                  ct
                 | [] -> None
                 | _ ->
                   fatal_errorf

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2738,8 +2738,6 @@ let constrain_pat_with_type loc typ pat =
 let maybe_constrain_pat_with_type loc typ exp =
   match typ with Some typ -> constrain_pat_with_type loc typ exp | None -> exp
 
-let any_modes modes = not (List.is_empty modes.mode_desc)
-
 let assert_no_modes modes =
   List.iter
     (fun mode ->
@@ -3343,16 +3341,6 @@ and fun_param_binding ~scopes ~transl stage loc param frest =
   in
   let idents = pat_bound_idents pat in
   let pat_quoted = quote_value_pattern ~scopes pat in
-  (* This is now redundant with [quote_value_pattern] *)
-  let pat_quoted =
-    if any_modes param.fp_mode
-    then
-      Pat.constraint_ loc pat_quoted
-        (Type.var loc None |> Type.wrap)
-        (quote_modes loc param.fp_mode)
-      |> Pat.wrap
-    else pat_quoted
-  in
   let fun_ =
     if is_module pat
     then
@@ -3398,20 +3386,6 @@ and quote_function ~scopes ~transl stage loc fn extras =
       match fn.body with
       | Tfunction_body exp ->
         let exp_quoted = quote_expression ~scopes ~transl stage exp in
-        (* This is now redundant with [quote_expression] *)
-        let exp_quoted =
-          if any_modes fn.ret_mode
-          then
-            Exp.mk loc
-              (quote_modes loc fn.ret_mode
-              |> Type_constraint.constraint_ loc (Type.var loc None |> Type.wrap)
-              |> Type_constraint.wrap
-              |> Exp_desc.constraint_ loc exp_quoted
-              |> Exp_desc.wrap)
-              []
-            |> Exp.wrap
-          else exp_quoted
-        in
         Function.body loc exp_quoted None
       | Tfunction_cases cases ->
         (* This case should be impossible, since there is no syntax for

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1430,7 +1430,7 @@ Error: Annotating types with kinds
 <[ fun (x @ local unique) @ local unique -> x]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
-<[fun (x : _ @ local unique) -> x]>
+<[fun (x : _ @ local unique) -> (x : _ @ local unique)]>
 |}];;
 
 <[ let (f @ unique portable) (x @ local unique) @ local unique = x in f ]>
@@ -1438,14 +1438,16 @@ Error: Annotating types with kinds
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
 <[
   let f : _ @ unique portable =
-  (fun (x : _ @ local unique) -> x : _ @ unique portable) in f
+  (fun (x : _ @ local unique) -> (x : _ @ local unique) :
+    _ @ unique portable)
+  in f
 ]>
 |}];;
 
 <[ let rec f (x @ local unique) @ local unique = x in f ]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
-<[let rec f = (fun (x : _ @ local unique) -> x) in f]>
+<[let rec f = (fun (x : _ @ local unique) -> (x : _ @ local unique)) in f]>
 |}];;
 
 <[ let rec (f @ unique portable) (x @ local unique) = x in f ]>
@@ -1476,7 +1478,7 @@ Uncaught exception: Misc.Fatal_error
 <[ let local_ f x = x in f "abc" ]>
 [%%expect {|
 - : <[string]> expr =
-<[let f : _ @ local = (fun x -> x : _ @ local) in f "abc"]>
+<[let f : _ @ local = (fun x -> (x : _ @ local) : _ @ local) in f "abc"]>
 |}];;
 
 (* Function definitions -- with type annotations *)
@@ -1516,7 +1518,8 @@ Uncaught exception: Misc.Fatal_error
 
 <[ fun x @ local unique -> x ]>
 [%%expect {|
-- : <[$('a) @ unique -> $('a) @ local unique]> expr = <[fun x -> x]>
+- : <[$('a) @ unique -> $('a) @ local unique]> expr =
+<[fun x -> (x : _ @ local unique)]>
 |}];;
 
 (* Function types *)

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1173,7 +1173,7 @@ let x = <[<[42]>]> in <[ fun () -> <[ $($x) ]> ]>;;
 let x = <[ "foo" ]> in <[ let y = (borrow_ $x) in (fun (a @ local) -> ()) y ]>
 [%%expect{|
 - : <[unit]> expr =
-<[let y = (borrow_ "foo") in (fun ((a : _ @ local) : _ @ local) -> ()) y]>
+<[let y = (borrow_ "foo") in (fun (a : _ @ local) -> ()) y]>
 |}];;
 
 let x = <[ "foo" ]> in <[ let y = (borrow_ x) in (fun (a @ local) -> ()) y ]>
@@ -1430,7 +1430,7 @@ Error: Annotating types with kinds
 <[ fun (x @ local unique) @ local unique -> x]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
-<[fun ((x : _ @ local unique) : _ @ local unique) -> (x : _ @ local unique)]>
+<[fun (x : _ @ local unique) -> x]>
 |}];;
 
 <[ let (f @ unique portable) (x @ local unique) @ local unique = x in f ]>
@@ -1438,20 +1438,14 @@ Error: Annotating types with kinds
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
 <[
   let f : _ @ unique portable =
-  (fun ((x : _ @ local unique) : _ @ local unique) -> (x : _ @ local unique)
-    : _ @ unique portable)
-  in f
+  (fun (x : _ @ local unique) -> x : _ @ unique portable) in f
 ]>
 |}];;
 
 <[ let rec f (x @ local unique) @ local unique = x in f ]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
-<[
-  let rec f =
-  (fun ((x : _ @ local unique) : _ @ local unique) -> (x : _ @ local unique))
-  in f
-]>
+<[let rec f = (fun (x : _ @ local unique) -> x) in f]>
 |}];;
 
 <[ let rec (f @ unique portable) (x @ local unique) = x in f ]>
@@ -1489,13 +1483,13 @@ Uncaught exception: Misc.Fatal_error
 <[ let f (x : _ @ local unique) = x in f ]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local]> expr =
-<[let f = (fun ((x : _ @ local unique) : _ @ local unique) -> x) in f]>
+<[let f = (fun (x : _ @ local unique) -> x) in f]>
 |}];;
 
 <[ let f (x : string @ local unique) = x in f ]>
 [%%expect {|
 - : <[string @ local unique -> string @ local]> expr =
-<[let f = (fun ((x : string @ local unique) : _ @ local unique) -> x) in f]>
+<[let f = (fun (x : string @ local unique) -> x) in f]>
 |}];;
 
 <[ let f (x : string @ local unique) : string @ local unique = x in f ]>
@@ -1503,22 +1497,26 @@ Uncaught exception: Misc.Fatal_error
 - : <[string @ local unique -> string @ local unique]> expr =
 <[
   let f =
-  (fun ((x : string @ local unique) : _ @ local unique) -> (((x : string) :
-     _ @ local unique) : _ @ local unique))
-  in f
+  (fun (x : string @ local unique) -> ((x : string) : _ @ local unique)) in
+  f
 ]>
 |}];;
 
 <[ fun (x : _ @ local unique) -> x ]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local]> expr =
-<[fun ((x : _ @ local unique) : _ @ local unique) -> x]>
+<[fun (x : _ @ local unique) -> x]>
 |}];;
 
 <[ fun (x : string @ local unique) -> x ]>
 [%%expect {|
 - : <[string @ local unique -> string @ local]> expr =
-<[fun ((x : string @ local unique) : _ @ local unique) -> x]>
+<[fun (x : string @ local unique) -> x]>
+|}];;
+
+<[ fun x @ local unique -> x ]>
+[%%expect {|
+- : <[$('a) @ unique -> $('a) @ local unique]> expr = <[fun x -> x]>
 |}];;
 
 (* Function types *)

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1173,7 +1173,7 @@ let x = <[<[42]>]> in <[ fun () -> <[ $($x) ]> ]>;;
 let x = <[ "foo" ]> in <[ let y = (borrow_ $x) in (fun (a @ local) -> ()) y ]>
 [%%expect{|
 - : <[unit]> expr =
-<[let y = (borrow_ "foo") in (fun (a : _ @ local) -> ()) y]>
+<[let y = (borrow_ "foo") in (fun ((a : _ @ local) : _ @ local) -> ()) y]>
 |}];;
 
 let x = <[ "foo" ]> in <[ let y = (borrow_ x) in (fun (a @ local) -> ()) y ]>
@@ -1410,7 +1410,8 @@ Error: Annotating types with kinds
 (* Pattern constraints *)
 <[ let (x @ unique portable) = "abc" in x ]>
 [%%expect {|
-- : <[string]> expr = <[let x = ("abc" : _ @ unique portable) in x]>
+- : <[string]> expr =
+<[let x : _ @ unique portable = ("abc" : _ @ unique portable) in x]>
 |}];;
 
 (* Expression constraints *)
@@ -1425,20 +1426,20 @@ Error: Annotating types with kinds
 - : <[$('a) -> $('a) @ local]> expr = <[fun x -> exclave_ (x : _ @ local)]>
 |}];;
 
-(* Function definitions *)
+(* Function definitions -- without type annotation *)
 <[ fun (x @ local unique) @ local unique -> x]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
-<[fun (x : _ @ local unique) -> (x : _ @ local unique)]>
+<[fun ((x : _ @ local unique) : _ @ local unique) -> (x : _ @ local unique)]>
 |}];;
 
 <[ let (f @ unique portable) (x @ local unique) @ local unique = x in f ]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
 <[
-  let f =
-  (fun (x : _ @ local unique) -> (x : _ @ local unique) :
-    _ @ unique portable)
+  let f : _ @ unique portable =
+  (fun ((x : _ @ local unique) : _ @ local unique) -> (x : _ @ local unique)
+    : _ @ unique portable)
   in f
 ]>
 |}];;
@@ -1446,43 +1447,65 @@ Error: Annotating types with kinds
 <[ let rec f (x @ local unique) @ local unique = x in f ]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local unique]> expr =
-<[let rec f = (fun (x : _ @ local unique) -> (x : _ @ local unique)) in f]>
-|}];;
-
-<[ let rec (f @ unique portable) (x @ local unique) = x in f ]>
-[%%expect {|
-- : <[$('a) @ local unique -> $('a) @ local]> expr =
-<[let rec f = (fun (x : _ @ local unique) -> x : _ @ unique portable) in f]>
-|}];;
-
-<[ let rec (f @ unique portable) (x @ local unique) @ local unique = x in f ]>
-[%%expect {|
-- : <[$('a) @ local unique -> $('a) @ local unique]> expr =
 <[
   let rec f =
-  (fun (x : _ @ local unique) -> (x : _ @ local unique) :
-    _ @ unique portable)
+  (fun ((x : _ @ local unique) : _ @ local unique) -> (x : _ @ local unique))
   in f
 ]>
 |}];;
 
+<[ let rec (f @ unique portable) (x @ local unique) = x in f ]>
+[%%expect {|
+>> Fatal error: Translquote [at Line 1, characters 16-22]:
+no support for mode annotations in this position.
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+<[ let rec (f @ unique portable) (x @ local unique) @ local unique = x in f ]>
+[%%expect {|
+>> Fatal error: Translquote [at Line 1, characters 16-22]:
+no support for mode annotations in this position.
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
+<[ let rec (f @ unique portable)
+              (x : string @ local unique) : string @ local unique = x in f ]>
+[%%expect {|
+>> Fatal error: Translquote [at Line 1, characters 16-22]:
+no support for mode annotations in this position.
+Uncaught exception: Misc.Fatal_error
+
+|}];;
+
 <[ let local_ f x = x in f "abc" ]>
 [%%expect {|
-- : <[string]> expr = <[let f = (fun x -> x : _ @ local) in f "abc"]>
+- : <[string]> expr =
+<[let f : _ @ local = (fun x -> x : _ @ local) in f "abc"]>
 |}];;
 
-<[ let rec f (x : _ @ local unique) = x in f ]>
+(* Function definitions -- with type annotations *)
+<[ let f (x : _ @ local unique) = x in f ]>
 [%%expect {|
 - : <[$('a) @ local unique -> $('a) @ local]> expr =
-<[let rec f = (fun ((x : _ @ local unique) : _ @ local unique) -> x) in f]>
+<[let f = (fun ((x : _ @ local unique) : _ @ local unique) -> x) in f]>
 |}];;
 
-<[ let rec f (x : string @ local unique) = x in f ]>
+<[ let f (x : string @ local unique) = x in f ]>
 [%%expect {|
 - : <[string @ local unique -> string @ local]> expr =
+<[let f = (fun ((x : string @ local unique) : _ @ local unique) -> x) in f]>
+|}];;
+
+<[ let f (x : string @ local unique) : string @ local unique = x in f ]>
+[%%expect {|
+- : <[string @ local unique -> string @ local unique]> expr =
 <[
-  let rec f = (fun ((x : string @ local unique) : _ @ local unique) -> x) in
-  f
+  let f =
+  (fun ((x : string @ local unique) : _ @ local unique) -> (((x : string) :
+     _ @ local unique) : _ @ local unique))
+  in f
 ]>
 |}];;
 

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -1471,6 +1471,33 @@ Error: Annotating types with kinds
 - : <[string]> expr = <[let f = (fun x -> x : _ @ local) in f "abc"]>
 |}];;
 
+<[ let rec f (x : _ @ local unique) = x in f ]>
+[%%expect {|
+- : <[$('a) @ local unique -> $('a) @ local]> expr =
+<[let rec f = (fun ((x : _ @ local unique) : _ @ local unique) -> x) in f]>
+|}];;
+
+<[ let rec f (x : string @ local unique) = x in f ]>
+[%%expect {|
+- : <[string @ local unique -> string @ local]> expr =
+<[
+  let rec f = (fun ((x : string @ local unique) : _ @ local unique) -> x) in
+  f
+]>
+|}];;
+
+<[ fun (x : _ @ local unique) -> x ]>
+[%%expect {|
+- : <[$('a) @ local unique -> $('a) @ local]> expr =
+<[fun ((x : _ @ local unique) : _ @ local unique) -> x]>
+|}];;
+
+<[ fun (x : string @ local unique) -> x ]>
+[%%expect {|
+- : <[string @ local unique -> string @ local]> expr =
+<[fun ((x : string @ local unique) : _ @ local unique) -> x]>
+|}];;
+
 (* Function types *)
 <[ fun (f : _ @ local unique -> _ @ local unique) -> f]>
 [%%expect {|

--- a/testsuite/tests/quotation/typing/moding.ml
+++ b/testsuite/tests/quotation/typing/moding.ml
@@ -122,7 +122,7 @@ Error: This value is "local"
 (* Unique result *)
 <[ let x @ unique = M.x_unique () in x ]>
 [%%expect {|
-- : <[M.t]> expr = <[let x = (M.x_unique () : _ @ unique) in x]>
+- : <[M.t]> expr = <[let x : _ @ unique = (M.x_unique () : _ @ unique) in x]>
 |}];;
 
 (* Once result *)
@@ -139,7 +139,7 @@ Error: This value is "once"
 (* Portable result *)
 <[ let x @ portable = M.x in x ]>
 [%%expect {|
-- : <[M.t]> expr = <[let x = (M.x : _ @ portable) in x]>
+- : <[M.t]> expr = <[let x : _ @ portable = (M.x : _ @ portable) in x]>
 |}];;
 
 (* Contended result *)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -567,7 +567,7 @@ and pattern_extra i ppf (extra_pat, loc, attrs) =
   | Tpat_constraint (cty, m) ->
      line i ppf "Tpat_extra_constraint\n";
      attributes i ppf attrs;
-     core_type i ppf cty;
+     option i core_type ppf cty;
      alloc_modes i ppf m;
   | Tpat_type (id, _) ->
      line i ppf "Tpat_extra_type %a\n" fmt_path id;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -280,7 +280,7 @@ let pat_extra sub (e, loc, attrs) =
   | Tpat_type (_, lid) -> iter_loc_lid sub lid
   | Tpat_unpack -> ()
   | Tpat_open (_, lid, env) -> iter_loc_lid sub lid; sub.env sub env
-  | Tpat_constraint (ct, ma) -> sub.typ sub ct; sub.modes sub ma
+  | Tpat_constraint (ct, ma) -> Option.iter (sub.typ sub) ct; sub.modes sub ma
   | Tpat_inspected_type (Label_disambiguation _) -> ()
   | Tpat_inspected_type (Polymorphic_parameter (Param _)) -> ()
   | Tpat_inspected_type (Module_pack _) -> ()

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -337,7 +337,7 @@ let pat_extra sub = function
   | Tpat_open (path,lid,env) ->
       Tpat_open (path, map_loc_lid sub lid, sub.env sub env)
   | Tpat_constraint (ct, ma) ->
-    Tpat_constraint (sub.typ sub ct, sub.modes sub ma)
+    Tpat_constraint (Option.map (sub.typ sub) ct, sub.modes sub ma)
   | Tpat_inspected_type (Label_disambiguation _) as d -> d
   | Tpat_inspected_type (Polymorphic_parameter (Param _)) as d -> d
   | Tpat_inspected_type (Module_pack _) as d -> d

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -9509,27 +9509,27 @@ and type_function
       in
       match body with
       | Pfunction_body body ->
+          let body_loc = body.pexp_loc in
           let body =
             match ret_type_constraint with
             | None -> type_expect env expected_mode body (mk_expected ty_expected)
             | Some constraint_ ->
-            let body_loc = body.pexp_loc in
-            let body, exp_type, exp_extra =
-              type_constraint_expect (expression_constraint body)
-                env expected_mode body_loc ~loc_arg:body_loc
-                type_mode.mode_modes constraint_ ty_expected
-            in
-            let texp_mode =
-              match type_mode.mode_desc with
-              | [] -> []
-              | _ :: _ ->
-                [ (Texp_mode type_mode, body_loc, []) ]
-            in
-            { body with
-                exp_extra =
-                  texp_mode @ (exp_extra, body_loc, []) :: body.exp_extra;
-                exp_type;
-            }
+              let body, exp_type, exp_extra =
+                type_constraint_expect (expression_constraint body)
+                  env expected_mode body_loc ~loc_arg:body_loc
+                  type_mode.mode_modes constraint_ ty_expected
+              in
+              { body with
+                  exp_extra = (exp_extra, body_loc, []) :: body.exp_extra;
+                  exp_type;
+              }
+          in
+          let body =
+            match type_mode.mode_desc with
+            | [] -> body
+            | _ :: _ ->
+              let extra = Texp_mode type_mode, body_loc, [] in
+              { body with exp_extra = extra :: body.exp_extra }
           in
           body.exp_type, Tfunction_body body, None, None
       | Pfunction_cases (cases, _, attributes) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -1824,10 +1824,10 @@ let rec build_as_type_and_mode (env : Env.t) p ~mode =
 
 and build_as_type_and_mode_extra env p ~mode : _ -> _ * _ = function
   | [] -> build_as_type_aux env p ~mode
-  | ((Tpat_type _ | Tpat_open _ | Tpat_unpack |
+  | ((Tpat_type _ | Tpat_open _ | Tpat_unpack | Tpat_constraint (None, _) |
       Tpat_inspected_type _), _, _) :: rest ->
       build_as_type_and_mode_extra env p rest ~mode
-  | (Tpat_constraint ({ctyp_type = ty; _}, _), _, _) :: rest ->
+  | (Tpat_constraint (Some {ctyp_type = ty; _}, _), _, _) :: rest ->
       (* If the type constraint is ground, then this is the best type
          we can return, so just return an instance (cf. #12313) *)
       if closed_type_expr ty then instance ty, mode else
@@ -3984,25 +3984,26 @@ and type_pat_aux
         pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_constraint(sp_constrained, sty, ms) ->
       (* Pretend separate = true *)
-      begin match sty with
-      | Some sty ->
-        let type_modes = Typemode.transl_alloc_mode ms in
-        let cty, ty, expected_ty' =
-          solve_Ppat_constraint tps loc !!penv type_modes.mode_modes sty
-            expected_ty
-        in
-        let p =
-          type_pat ~alloc_mode tps category sp_constrained expected_ty' sort
-        in
-        let extra =
-          Tpat_constraint (cty, type_modes),
-          loc,
-          sp_constrained.ppat_attributes
-        in
-        { p with pat_type = ty; pat_extra = extra::p.pat_extra }
-      | None ->
+      let type_modes = Typemode.transl_alloc_mode ms in
+      let cty, ty, expected_ty =
+        match sty with
+        | Some sty ->
+          let cty, ty, expected_ty' =
+            solve_Ppat_constraint tps loc !!penv type_modes.mode_modes sty
+              expected_ty
+          in
+          Some cty, Some ty, expected_ty'
+        | None ->
+          None, None, expected_ty
+      in
+      let p =
         type_pat ~alloc_mode tps category sp_constrained expected_ty sort
-      end
+      in
+      let pat_type = match ty with Some ty -> ty | None -> p.pat_type in
+      let extra =
+        Tpat_constraint (cty, type_modes), loc, sp_constrained.ppat_attributes
+      in
+      { p with pat_type; pat_extra = extra :: p.pat_extra }
   | Ppat_type lid ->
       Env.check_no_open_quotations sp.ppat_loc !!penv
         (Env.Tconst_pat_qt lid.txt);

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -5921,7 +5921,7 @@ let check_partial_application ~statement exp =
 let pattern_needs_partial_application_check p =
   let rec check : type a. a general_pattern -> bool = fun p ->
     not (List.exists
-          (function (Tpat_constraint (_, _), _, _) -> true | _ -> false)
+          (function (Tpat_constraint (Some _, _), _, _) -> true | _ -> false)
           p.pat_extra) &&
     match p.pat_desc with
     | Tpat_any -> true

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -174,7 +174,7 @@ and 'a pattern_data =
    }
 
 and pat_extra =
-  | Tpat_constraint of core_type * Mode.Alloc.Const.t modes
+  | Tpat_constraint of core_type option * Mode.Alloc.Const.t modes
   | Tpat_type of Path.t * Longident.t loc
   | Tpat_open of Path.t * Longident.t loc * Env.t
   | Tpat_unpack

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -196,7 +196,7 @@ and 'a pattern_data =
    }
 
 and pat_extra =
-  | Tpat_constraint of core_type * Mode.Alloc.Const.t modes
+  | Tpat_constraint of core_type option * Mode.Alloc.Const.t modes
         (** P : T          { pat_desc = P
                            ; pat_extra = (Tpat_constraint T, _, _) :: ... }
          *)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -358,7 +358,7 @@ let pattern : type k . _ -> k T.general_pattern -> _ = fun sub pat ->
     | { pat_extra= (Tpat_constraint (ct, modes), _, _attrs) :: rem; _ } ->
         let modes = Typemode.untransl_mode modes in
         Ppat_constraint (sub.pat sub { pat with pat_extra=rem },
-                         Some (sub.typ sub ct), modes)
+                         Option.map (sub.typ sub) ct, modes)
     | { pat_extra = (Tpat_open (_path, lid, _env), _, _attrs) :: rem; _ } ->
         Ppat_open (lid, sub.pat sub { pat with pat_extra=rem })
     | _ ->


### PR DESCRIPTION
Moves away some hacky logic for mode constraints in `Translquote`, replacing it with better handling in `Typedtree`. 

### Fixed bugs

* Mode constraints on variables in let-bindings were silently dropped. On recursive let-bindings they now fatal error properly
  * For recursive let-bindings, the user can still move the mode annotation on the function to the body position.
* Mode constraints on parameters with type annotations were duplicated (which is actually a syntax error).

### Changes to `Typedtree`

The better handling in `Typedtree` amounts to:
* Making `core_type` `option`al in `Tpat_constraint`, consistently with how it is in `Ppat_constraint`. 
* Adding a `Texp_mode` in a possible case (yet accidentally omitted possibly due to confusing indentation).

### Reviewer notes

* In `Translquote` I added more places where I add wildcard type constraints along with the mode constraints instead of avoiding them entirely (i.e. `term : _ @ m` instead of `expr : @ m` or `pat @ m`). It is known these type-check differently (see https://github.com/oxcaml/oxcaml/pull/5602), but I think only with respect to type inspections, which we should handle separately.
* It should be sufficient to verify that the quotes printed in `build_quotation.ml` parse as expected -- they should mean the same thing as what was written in quotes. It's okay if they end up redundant as long as they are valid.