### PR TITLE
Allow coercions from `external`s to `[@@zero_alloc] val`s

### DIFF
--- a/external/merlin/src/ocaml/typing/includecore.ml
+++ b/external/merlin/src/ocaml/typing/includecore.ml
@@ -211,6 +211,23 @@ let moregeneral_lpoly env pat_lpoly subj_lpoly ty1 ty2 =
     raise (Dont_match (Layout_poly_coercion
       (Extra_rhs { extra = List.length subj_rest })))
 
+let value_descriptions_zero_alloc
+    (vd1 : Types.value_description)
+    (vd2 : Types.value_description) =
+  let vd1_zero_alloc, prim_coercion_zero_alloc_check =
+    match vd1.val_kind, Zero_alloc.get vd2.val_zero_alloc with
+    | Val_prim p, Check check ->
+      ( Zero_alloc.create_const (Check { check with arity = p.prim_arity }),
+        Some check )
+    | ( (Val_reg _ | Val_mut _ | Val_prim _ | Val_ivar _ | Val_self _ |
+         Val_anc _),
+        (Default_zero_alloc | Ignore_assert_all | Check _ | Assume _) ) ->
+      vd1.val_zero_alloc, None
+  in
+  match Zero_alloc.sub vd1_zero_alloc vd2.val_zero_alloc with
+  | Ok () -> prim_coercion_zero_alloc_check
+  | Error e -> raise (Dont_match (Zero_alloc e))
+
 let value_descriptions ~loc env name
     ~mmodes
     (vd1 : Types.value_description)
@@ -221,10 +238,7 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  begin match Zero_alloc.sub vd1.val_zero_alloc vd2.val_zero_alloc with
-  | Ok () -> ()
-  | Error e -> raise (Dont_match (Zero_alloc e))
-  end;
+  let prim_coercion_zero_alloc_check = value_descriptions_zero_alloc vd1 vd2 in
   let crossing = Ctype.crossing_of_ty env vd2.val_type in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =
@@ -282,6 +296,7 @@ let value_descriptions ~loc env name
            pc_yielding =
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
+           pc_zero_alloc_check = prim_coercion_zero_alloc_check;
            pc_env = env; pc_loc = vd1.Types.val_loc; } in
         Tcoerce_primitive pc
      end

--- a/external/merlin/src/ocaml/typing/typedtree.ml
+++ b/external/merlin/src/ocaml/typing/typedtree.ml
@@ -733,6 +733,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/external/merlin/src/ocaml/typing/typedtree.mli
+++ b/external/merlin/src/ocaml/typing/typedtree.mli
@@ -1163,6 +1163,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/external/merlin/upstream/ocaml_flambda/typing/includecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/includecore.ml
@@ -211,6 +211,23 @@ let moregeneral_lpoly env pat_lpoly subj_lpoly ty1 ty2 =
     raise (Dont_match (Layout_poly_coercion
       (Extra_rhs { extra = List.length subj_rest })))
 
+let value_descriptions_zero_alloc
+    (vd1 : Types.value_description)
+    (vd2 : Types.value_description) =
+  let vd1_zero_alloc, prim_coercion_zero_alloc_check =
+    match vd1.val_kind, Zero_alloc.get vd2.val_zero_alloc with
+    | Val_prim p, Check check ->
+      ( Zero_alloc.create_const (Check { check with arity = p.prim_arity }),
+        Some check )
+    | ( (Val_reg _ | Val_mut _ | Val_prim _ | Val_ivar _ | Val_self _ |
+         Val_anc _),
+        (Default_zero_alloc | Ignore_assert_all | Check _ | Assume _) ) ->
+      vd1.val_zero_alloc, None
+  in
+  match Zero_alloc.sub vd1_zero_alloc vd2.val_zero_alloc with
+  | Ok () -> prim_coercion_zero_alloc_check
+  | Error e -> raise (Dont_match (Zero_alloc e))
+
 let value_descriptions ~loc env name
     ~mmodes
     (vd1 : Types.value_description)
@@ -221,10 +238,7 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  begin match Zero_alloc.sub vd1.val_zero_alloc vd2.val_zero_alloc with
-  | Ok () -> ()
-  | Error e -> raise (Dont_match (Zero_alloc e))
-  end;
+  let prim_coercion_zero_alloc_check = value_descriptions_zero_alloc vd1 vd2 in
   let crossing = Ctype.crossing_of_ty env vd2.val_type in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =
@@ -282,6 +296,7 @@ let value_descriptions ~loc env name
            pc_yielding =
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
+           pc_zero_alloc_check = prim_coercion_zero_alloc_check;
            pc_env = env; pc_loc = vd1.Types.val_loc; } in
         Tcoerce_primitive pc
      end

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.ml
@@ -731,6 +731,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedtree.mli
@@ -1158,6 +1158,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -377,8 +377,13 @@ let rec iter_exn_names f pat =
 let transl_ident loc env ty path desc kind =
   match desc.val_kind, kind with
   | Val_prim p, Id_prim (poly_mode, poly_sort, yielding) ->
+      let zero_alloc =
+        match Zero_alloc.get desc.val_zero_alloc with
+        | Check c -> Some c
+        | Default_zero_alloc | Ignore_assert_all | Assume _ -> None
+      in
       Translprim.transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding
-        ~zero_alloc:(Zero_alloc.get desc.val_zero_alloc) (Some path)
+        ~zero_alloc (Some path)
   | Val_anc _, Id_value ->
       raise(Error(to_location loc, Free_super_var))
   | (Val_reg _ | Val_self _), Id_value ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -378,7 +378,7 @@ let transl_ident loc env ty path desc kind =
   match desc.val_kind, kind with
   | Val_prim p, Id_prim (poly_mode, poly_sort, yielding) ->
       Translprim.transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding
-        (Some path)
+        ~zero_alloc:(Zero_alloc.get desc.val_zero_alloc) (Some path)
   | Val_anc _, Id_value ->
       raise(Error(to_location loc, Free_super_var))
   | (Val_reg _ | Val_self _), Id_value ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -378,7 +378,7 @@ let transl_ident loc env ty path desc kind =
   match desc.val_kind, kind with
   | Val_prim p, Id_prim (poly_mode, poly_sort, yielding) ->
       Translprim.transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding
-        ~zero_alloc:None (Some path)
+        ~zero_alloc_check:None (Some path)
   | Val_anc _, Id_value ->
       raise(Error(to_location loc, Free_super_var))
   | (Val_reg _ | Val_self _), Id_value ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -377,13 +377,8 @@ let rec iter_exn_names f pat =
 let transl_ident loc env ty path desc kind =
   match desc.val_kind, kind with
   | Val_prim p, Id_prim (poly_mode, poly_sort, yielding) ->
-      let zero_alloc =
-        match Zero_alloc.get desc.val_zero_alloc with
-        | Check c -> Some c
-        | Default_zero_alloc | Ignore_assert_all | Assume _ -> None
-      in
       Translprim.transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding
-        ~zero_alloc (Some path)
+        ~zero_alloc:None (Some path)
   | Val_anc _, Id_value ->
       raise(Error(to_location loc, Free_super_var))
   | (Val_reg _ | Val_self _), Id_value ->

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -145,11 +145,12 @@ let rec apply_coercion loc strict restr arg =
           attributes = Lambda.default_param_attribute; mode = alloc_heap}]
         [carg] yielding cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode; pc_poly_sort;
-                        pc_yielding } ->
+                        pc_yielding; pc_zero_alloc } ->
       Translprim.transl_primitive loc pc_desc pc_env pc_type
         ~poly_mode:pc_poly_mode
         ~poly_sort:pc_poly_sort
         ~yielding:pc_yielding
+        ~zero_alloc:pc_zero_alloc
         None
   | Tcoerce_alias (env, path, cc) ->
       let lam = transl_module_path loc env path in
@@ -741,6 +742,7 @@ and transl_structure ~scopes loc
                             ~poly_mode:p.pc_poly_mode
                             ~poly_sort:p.pc_poly_sort
                             ~yielding:p.pc_yielding
+                            ~zero_alloc:p.pc_zero_alloc
                             None
                       | _ -> apply_coercion loc Strict cc (get_field pos))
                     pos_cc_list, loc)

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -145,12 +145,12 @@ let rec apply_coercion loc strict restr arg =
           attributes = Lambda.default_param_attribute; mode = alloc_heap}]
         [carg] yielding cc_res
   | Tcoerce_primitive { pc_desc; pc_env; pc_type; pc_poly_mode; pc_poly_sort;
-                        pc_yielding; pc_zero_alloc } ->
+                        pc_yielding; pc_zero_alloc_check } ->
       Translprim.transl_primitive loc pc_desc pc_env pc_type
         ~poly_mode:pc_poly_mode
         ~poly_sort:pc_poly_sort
         ~yielding:pc_yielding
-        ~zero_alloc:pc_zero_alloc
+        ~zero_alloc_check:pc_zero_alloc_check
         None
   | Tcoerce_alias (env, path, cc) ->
       let lam = transl_module_path loc env path in
@@ -742,7 +742,7 @@ and transl_structure ~scopes loc
                             ~poly_mode:p.pc_poly_mode
                             ~poly_sort:p.pc_poly_sort
                             ~yielding:p.pc_yielding
-                            ~zero_alloc:p.pc_zero_alloc
+                            ~zero_alloc_check:p.pc_zero_alloc_check
                             None
                       | _ -> apply_coercion loc Strict cc (get_field pos))
                     pos_cc_list, loc)

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2445,7 +2445,8 @@ let transl_primitive_common loc ~poly_mode ~poly_sort
   else
     prim
 
-let transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding path =
+let transl_primitive
+      loc p env ty ~poly_mode ~poly_sort ~yielding ~zero_alloc path =
   let prim =
     transl_primitive_common loc
       ~poly_mode ~poly_sort Rc_normal p env ty path []
@@ -2541,12 +2542,24 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding path =
        | Alloc_heap :: args -> count_nlocal args
        | (Alloc_local :: _) as args -> List.length args
      in
-     let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args)
-     in lfunction
+     let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args) in
+     let zero_alloc : Lambda.zero_alloc_attribute =
+       match (zero_alloc : Zero_alloc.const) with
+       | Default_zero_alloc -> Default_zero_alloc
+       | Check { strict; opt; arity = _; loc; custom_error_msg } ->
+         if Builtin_attributes.is_zero_alloc_check_enabled ~opt
+         then Check { strict; loc; custom_error_msg }
+         else Default_zero_alloc
+       | Assume _ | Ignore_assert_all ->
+         Misc.fatal_error
+           "Translprim.transl_primitive: [~zero_alloc] should be default or \
+            stronger"
+     in
+     lfunction
        ~kind:(Curried {nlocal})
        ~params
        ~return
-       ~attr:default_stub_attribute
+       ~attr:{ default_stub_attribute with zero_alloc }
        ~loc
        ~body
        ~mode:alloc_heap

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2446,7 +2446,7 @@ let transl_primitive_common loc ~poly_mode ~poly_sort
     prim
 
 let transl_primitive
-      loc p env ty ~poly_mode ~poly_sort ~yielding ~zero_alloc path =
+      loc p env ty ~poly_mode ~poly_sort ~yielding ~zero_alloc_check path =
   let prim =
     transl_primitive_common loc
       ~poly_mode ~poly_sort Rc_normal p env ty path []
@@ -2544,7 +2544,7 @@ let transl_primitive
      in
      let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args) in
      let zero_alloc : Lambda.zero_alloc_attribute =
-       match (zero_alloc : Zero_alloc.check option) with
+       match (zero_alloc_check : Zero_alloc.check option) with
        | None -> Default_zero_alloc
        | Some { strict; opt; arity = _; loc; custom_error_msg } ->
          if Builtin_attributes.is_zero_alloc_check_enabled ~opt

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2544,16 +2544,12 @@ let transl_primitive
      in
      let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args) in
      let zero_alloc : Lambda.zero_alloc_attribute =
-       match (zero_alloc : Zero_alloc.const) with
-       | Default_zero_alloc -> Default_zero_alloc
-       | Check { strict; opt; arity = _; loc; custom_error_msg } ->
+       match (zero_alloc : Zero_alloc.check option) with
+       | None -> Default_zero_alloc
+       | Some { strict; opt; arity = _; loc; custom_error_msg } ->
          if Builtin_attributes.is_zero_alloc_check_enabled ~opt
          then Check { strict; loc; custom_error_msg }
          else Default_zero_alloc
-       | Assume _ | Ignore_assert_all ->
-         Misc.fatal_error
-           "Translprim.transl_primitive: [~zero_alloc] should be default or \
-            stronger"
      in
      lfunction
        ~kind:(Curried {nlocal})

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2402,7 +2402,8 @@ let transl_primitive_common loc ~poly_mode ~poly_sort
   else
     prim
 
-let transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding path =
+let transl_primitive
+      loc p env ty ~poly_mode ~poly_sort ~yielding ~zero_alloc path =
   let prim =
     transl_primitive_common loc
       ~poly_mode ~poly_sort Rc_normal p env ty path []
@@ -2498,12 +2499,24 @@ let transl_primitive loc p env ty ~poly_mode ~poly_sort ~yielding path =
        | Alloc_heap :: args -> count_nlocal args
        | (Alloc_local :: _) as args -> List.length args
      in
-     let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args)
-     in lfunction
+     let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args) in
+     let zero_alloc : Lambda.zero_alloc_attribute =
+       match (zero_alloc : Zero_alloc.const) with
+       | Default_zero_alloc -> Default_zero_alloc
+       | Check { strict; opt; arity = _; loc; custom_error_msg } ->
+         if Builtin_attributes.is_zero_alloc_check_enabled ~opt
+         then Check { strict; loc; custom_error_msg }
+         else Default_zero_alloc
+       | Assume _ | Ignore_assert_all ->
+         Misc.fatal_error
+           "Translprim.transl_primitive: [~zero_alloc] should be default or \
+            stronger"
+     in
+     lfunction
        ~kind:(Curried {nlocal})
        ~params
        ~return
-       ~attr:default_stub_attribute
+       ~attr:{ default_stub_attribute with zero_alloc }
        ~loc
        ~body
        ~mode:alloc_heap

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2403,7 +2403,7 @@ let transl_primitive_common loc ~poly_mode ~poly_sort
     prim
 
 let transl_primitive
-      loc p env ty ~poly_mode ~poly_sort ~yielding ~zero_alloc path =
+      loc p env ty ~poly_mode ~poly_sort ~yielding ~zero_alloc_check path =
   let prim =
     transl_primitive_common loc
       ~poly_mode ~poly_sort Rc_normal p env ty path []
@@ -2501,7 +2501,7 @@ let transl_primitive
      in
      let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args) in
      let zero_alloc : Lambda.zero_alloc_attribute =
-       match (zero_alloc : Zero_alloc.check option) with
+       match (zero_alloc_check : Zero_alloc.check option) with
        | None -> Default_zero_alloc
        | Some { strict; opt; arity = _; loc; custom_error_msg } ->
          if Builtin_attributes.is_zero_alloc_check_enabled ~opt

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2501,16 +2501,12 @@ let transl_primitive
      in
      let nlocal = count_nlocal (List.map to_locality p.prim_native_repr_args) in
      let zero_alloc : Lambda.zero_alloc_attribute =
-       match (zero_alloc : Zero_alloc.const) with
-       | Default_zero_alloc -> Default_zero_alloc
-       | Check { strict; opt; arity = _; loc; custom_error_msg } ->
+       match (zero_alloc : Zero_alloc.check option) with
+       | None -> Default_zero_alloc
+       | Some { strict; opt; arity = _; loc; custom_error_msg } ->
          if Builtin_attributes.is_zero_alloc_check_enabled ~opt
          then Check { strict; loc; custom_error_msg }
          else Default_zero_alloc
-       | Assume _ | Ignore_assert_all ->
-         Misc.fatal_error
-           "Translprim.transl_primitive: [~zero_alloc] should be default or \
-            stronger"
      in
      lfunction
        ~kind:(Curried {nlocal})

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -38,7 +38,7 @@ val transl_primitive :
   poly_mode:Mode.Locality.l option ->
   poly_sort:Jkind.Sort.t option ->
   yielding:Mode.Yielding.l ->
-  zero_alloc:Zero_alloc.const ->
+  zero_alloc:Zero_alloc.check option ->
   Path.t option ->
   Lambda.lambda
 

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -38,6 +38,7 @@ val transl_primitive :
   poly_mode:Mode.Locality.l option ->
   poly_sort:Jkind.Sort.t option ->
   yielding:Mode.Yielding.l ->
+  zero_alloc:Zero_alloc.const ->
   Path.t option ->
   Lambda.lambda
 

--- a/lambda/translprim.mli
+++ b/lambda/translprim.mli
@@ -38,7 +38,7 @@ val transl_primitive :
   poly_mode:Mode.Locality.l option ->
   poly_sort:Jkind.Sort.t option ->
   yielding:Mode.Yielding.l ->
-  zero_alloc:Zero_alloc.check option ->
+  zero_alloc_check:Zero_alloc.check option ->
   Path.t option ->
   Lambda.lambda
 

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
@@ -1,0 +1,180 @@
+(* TEST
+   (* Compile [stubs.cmxs] to use with [expect.opt] *)
+   readonly_files = "stubs.c";
+   setup-ocamlopt.opt-build-env;
+   program = "stubs.cmxs";
+   flags = "-shared";
+   all_modules = "stubs.c";
+   ocamlopt.opt;
+   src = "stubs.cmxs";
+   dst = "${test_build_directory_prefix}/";
+   copy;
+
+   flags = "stubs.cmxs";
+   expect.opt;
+*)
+
+module Nonallocating_primitive : sig
+  val add : int8# -> int8# -> int8# [@@zero_alloc]
+end = struct
+  external add : int8# -> int8# -> int8# = "%int8#_add"
+end
+[%%expect {|
+module Nonallocating_primitive :
+  sig val add : int8# -> int8# -> int8# [@@zero_alloc] end
+|}]
+
+module Allocating_primitive : sig
+  val add : int32 -> int32 -> int32 [@@zero_alloc]
+end = struct
+  external add : int32 -> int32 -> int32 = "%int32_add"
+end
+[%%expect {|
+Line 2, characters 39-49:
+2 |   val add : int32 -> int32 -> int32 [@@zero_alloc]
+                                           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP2.Allocating_primitive.(partial) (camlTOP2__fn[:4,2--55]_2_1_code).
+Line 4, characters 2-55:
+4 |   external add : int32 -> int32 -> int32 = "%int32_add"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes for boxed_int32
+|}]
+
+module Allocating_c_stub : sig
+  val add : float -> float -> float [@@zero_alloc]
+end = struct
+  external add : float -> float -> float = "caml_add_float"
+end
+[%%expect {|
+Line 2, characters 39-49:
+2 |   val add : float -> float -> float [@@zero_alloc]
+                                           ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP3.Allocating_c_stub.(partial) (camlTOP3__fn[:4,2--59]_4_2_code).
+Line 4, characters 2-59:
+4 |   external add : float -> float -> float = "caml_add_float"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: called function may allocate (external call to caml_add_float)
+|}]
+
+module Non_allocating_c_stubs : sig
+  val to_int : float -> int [@@zero_alloc]
+  val add : float -> float -> float [@@zero_alloc]
+end = struct
+  external to_int : float -> int = "caml_int_of_float" [@@noalloc]
+  external add : float -> float -> float = "caml_add_float" [@@noalloc]
+  (* Notice [caml_add_float] does allocate. [[@@noalloc]] does not actually
+     check *)
+end
+[%%expect {|
+module Non_allocating_c_stubs :
+  sig
+    val to_int : float -> int [@@zero_alloc]
+    val add : float -> float -> float [@@zero_alloc]
+  end
+|}]
+
+module Non_allocating_builtin : sig
+  val select : bool -> int32 -> int32 -> int32 [@@zero_alloc]
+end = struct
+  external select : bool -> int32 -> int32 -> int32 = "caml_csel_value" [@@builtin]
+end
+[%%expect {|
+module Non_allocating_builtin :
+  sig val select : bool -> int32 -> int32 -> int32 [@@zero_alloc] end
+|}]
+
+module Allocating_builtin : sig
+  val float_to_int64 : float32 -> int64 [@@zero_alloc]
+end = struct
+  external float_to_int64 : float32 -> int64 =
+    "" "caml_float32_to_int64" [@@builtin] [@@unboxed] [@@noalloc]
+end
+[%%expect {|
+Line 2, characters 43-53:
+2 |   val float_to_int64 : float32 -> int64 [@@zero_alloc]
+                                               ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP6.Allocating_builtin.(partial) (camlTOP6__fn[:4,2--113]_12_6_code).
+Lines 4-5, characters 2-66:
+4 | ..external float_to_int64 : float32 -> int64 =
+5 |     "" "caml_float32_to_int64" [@@builtin] [@@unboxed] [@@noalloc]
+Error: allocation of 24 bytes for boxed_int64
+|}]
+
+module Primitive_made_non_allocating_with_coercion : sig
+  val array_get :
+    ('a : value mod non_float). 'a array -> int -> 'a [@@zero_alloc]
+end = struct
+  external array_get : 'a array -> int -> 'a = "%array_safe_get"
+  (* [array_get] allocates, but after ['a] is restricted to be [non_float],
+     [array_get] never allocates. *)
+end
+[%%expect {|
+module Primitive_made_non_allocating_with_coercion :
+  sig
+    val array_get : ('a : value non_float). 'a array -> int -> 'a
+      [@@zero_alloc]
+  end
+|}]
+
+module Overapplied_primitive : sig
+  val select_and_apply : ('a -> 'b) array -> int -> 'a -> 'b [@@zero_alloc]
+end = struct
+  external select_and_apply : 'a array -> int -> 'a = "%array_safe_get"
+end
+[%%expect {|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   external select_and_apply : 'a array -> int -> 'a = "%array_safe_get"
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           external select_and_apply : 'a array -> int -> 'a
+             = "%array_safe_get"
+         end
+       is not included in
+         sig
+           val select_and_apply : ('a -> 'b) array -> int -> 'a -> 'b
+             [@@zero_alloc]
+         end
+       Values do not match:
+         external select_and_apply : 'a array -> int -> 'a
+           = "%array_safe_get"
+       is not included in
+         val select_and_apply : ('a -> 'b) array -> int -> 'a -> 'b
+           [@@zero_alloc]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}]
+
+module Underapplied_primitive : sig
+  type 'a t = int -> 'a
+  val make : 'a array -> 'a t [@@zero_alloc]
+end = struct
+  type 'a t = int -> 'a
+  external make : 'a array -> int -> 'a = "%array_safe_get"
+end
+[%%expect {|
+Lines 4-7, characters 6-3:
+4 | ......struct
+5 |   type 'a t = int -> 'a
+6 |   external make : 'a array -> int -> 'a = "%array_safe_get"
+7 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig
+           type 'a t = int -> 'a
+           external make : 'a array -> int -> 'a = "%array_safe_get"
+         end
+       is not included in
+         sig
+           type 'a t = int -> 'a
+           val make : 'a array -> 'a t [@@zero_alloc]
+         end
+       Values do not match:
+         external make : 'a array -> int -> 'a = "%array_safe_get"
+       is not included in
+         val make : 'a array -> 'a t [@@zero_alloc]
+       The former provides a weaker "zero_alloc" guarantee than the latter.
+       Hint: Add a "zero_alloc" attribute to the implementation.
+|}]

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
@@ -101,35 +101,30 @@ Error: allocation of 24 bytes for boxed_int64
 |}]
 
 module Primitive_could_be_made_non_allocating_with_constraint : sig
-  val array_get : 'a array -> int -> 'a [@@zero_alloc]
+  val equal : 'a -> 'a -> bool [@@zero_alloc]
 end = struct
-  external array_get : 'a array -> int -> 'a = "%array_safe_get"
+  external equal : 'a -> 'a -> bool = "%equal"
 end
 [%%expect {|
-Line 2, characters 43-53:
-2 |   val array_get : 'a array -> int -> 'a [@@zero_alloc]
-                                               ^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function TOP7.Primitive_could_be_made_non_allocating_with_constraint.(partial) (camlTOP7__fn[:4,2--64]_14_7_code).
-Line 4, characters 2-64:
-4 |   external array_get : 'a array -> int -> 'a = "%array_safe_get"
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: allocation of 16 bytes for float
+Line 2, characters 34-44:
+2 |   val equal : 'a -> 'a -> bool [@@zero_alloc]
+                                      ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP7.Primitive_could_be_made_non_allocating_with_constraint.(partial) (camlTOP7__fn[:4,2--46]_14_7_code).
+Line 4, characters 2-46:
+4 |   external equal : 'a -> 'a -> bool = "%equal"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: called function may allocate (external call to caml_equal)
 |}]
 
 module Primitive_made_non_allocating_with_constraint : sig
-  val array_get :
-    ('a : value mod non_float). 'a array -> int -> 'a [@@zero_alloc]
+  val equal : ('a : immediate). 'a -> 'a -> bool [@@zero_alloc]
 end = struct
-  external array_get : 'a array -> int -> 'a = "%array_safe_get"
-  (* [array_get] allocates, but after ['a] is restricted to be [non_float],
-     [array_get] never allocates. *)
+  external equal : 'a -> 'a -> bool = "%equal"
+  (* Polymorphic equality allocates, but only if ['a] is a pointer *)
 end
 [%%expect {|
 module Primitive_made_non_allocating_with_constraint :
-  sig
-    val array_get : ('a : value non_float). 'a array -> int -> 'a
-      [@@zero_alloc]
-  end
+  sig val equal : ('a : immediate). 'a -> 'a -> bool [@@zero_alloc] end
 |}]
 
 module Overapplied_primitive : sig

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
@@ -100,7 +100,23 @@ Lines 4-5, characters 2-66:
 Error: allocation of 24 bytes for boxed_int64
 |}]
 
-module Primitive_made_non_allocating_with_coercion : sig
+module Primitive_could_be_made_non_allocating_with_constraint : sig
+  val array_get : 'a array -> int -> 'a [@@zero_alloc]
+end = struct
+  external array_get : 'a array -> int -> 'a = "%array_safe_get"
+end
+[%%expect {|
+Line 2, characters 43-53:
+2 |   val array_get : 'a array -> int -> 'a [@@zero_alloc]
+                                               ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function TOP7.Primitive_could_be_made_non_allocating_with_constraint.(partial) (camlTOP7__fn[:4,2--64]_14_7_code).
+Line 4, characters 2-64:
+4 |   external array_get : 'a array -> int -> 'a = "%array_safe_get"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 16 bytes for float
+|}]
+
+module Primitive_made_non_allocating_with_constraint : sig
   val array_get :
     ('a : value mod non_float). 'a array -> int -> 'a [@@zero_alloc]
 end = struct
@@ -109,7 +125,7 @@ end = struct
      [array_get] never allocates. *)
 end
 [%%expect {|
-module Primitive_made_non_allocating_with_coercion :
+module Primitive_made_non_allocating_with_constraint :
   sig
     val array_get : ('a : value non_float). 'a array -> int -> 'a
       [@@zero_alloc]
@@ -181,4 +197,14 @@ Error: Signature mismatch:
        When using "zero_alloc" in a signature, the syntactic arity of
        the implementation must match the function type in the interface.
        Here the former is 2 and the latter is 1.
+|}]
+
+module Allocating_primitive_not_checked_with_zero_alloc_opt : sig
+  val add : int32 -> int32 -> int32 [@@zero_alloc opt]
+end = struct
+  external add : int32 -> int32 -> int32 = "%int32_add"
+end
+[%%expect {|
+module Allocating_primitive_not_checked_with_zero_alloc_opt :
+  sig val add : int32 -> int32 -> int32 [@@zero_alloc opt] end
 |}]

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion.ml
@@ -143,8 +143,10 @@ Error: Signature mismatch:
        is not included in
          val select_and_apply : ('a -> 'b) array -> int -> 'a -> 'b
            [@@zero_alloc]
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       zero_alloc arity mismatch:
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
+       Here the former is 2 and the latter is 3.
 |}]
 
 module Underapplied_primitive : sig
@@ -175,6 +177,8 @@ Error: Signature mismatch:
          external make : 'a array -> int -> 'a = "%array_safe_get"
        is not included in
          val make : 'a array -> 'a t [@@zero_alloc]
-       The former provides a weaker "zero_alloc" guarantee than the latter.
-       Hint: Add a "zero_alloc" attribute to the implementation.
+       zero_alloc arity mismatch:
+       When using "zero_alloc" in a signature, the syntactic arity of
+       the implementation must match the function type in the interface.
+       Here the former is 2 and the latter is 1.
 |}]

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.compilers.reference
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.compilers.reference
@@ -1,9 +1,9 @@
-File "primitive_coercion_all.ml", line 17, characters 2-35:
+File "primitive_coercion_zero_alloc_all.ml", line 17, characters 2-35:
 17 |   val add : int32 -> int32 -> int32 (* Should error *)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function Primitive_coercion_all.Allocating_primitive.(partial) (camlPrimitive_coercion_all__fn[primitive_coercion_all.ml:19,2--55]_1_1_code).
+Error: Annotation check for zero_alloc failed on function Primitive_coercion_zero_alloc_all.Allocating_primitive.(partial) (camlPrimitive_coercion_zero_alloc_all__fn[primitive_coercion_zero_alloc_all.ml:19,2--55]_1_1_code).
 
-File "primitive_coercion_all.ml", line 19, characters 2-55:
+File "primitive_coercion_zero_alloc_all.ml", line 19, characters 2-55:
 19 |   external add : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: allocation of 24 bytes for boxed_int32

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.compilers.reference
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.compilers.reference
@@ -1,9 +1,9 @@
-File "primitive_coercion_zero_alloc_all.ml", line 17, characters 2-35:
-17 |   val add : int32 -> int32 -> int32 (* Should error *)
+File "primitive_coercion_zero_alloc_all.ml", line 18, characters 2-35:
+18 |   val add : int32 -> int32 -> int32 (* Should error *)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Annotation check for zero_alloc failed on function Primitive_coercion_zero_alloc_all.Allocating_primitive.(partial) (camlPrimitive_coercion_zero_alloc_all__fn[primitive_coercion_zero_alloc_all.ml:19,2--55]_1_1_code).
+Error: Annotation check for zero_alloc failed on function Primitive_coercion_zero_alloc_all.Allocating_primitive.(partial) (camlPrimitive_coercion_zero_alloc_all__fn_1_1).
 
-File "primitive_coercion_zero_alloc_all.ml", line 19, characters 2-55:
-19 |   external add : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+File "primitive_coercion_zero_alloc_all.ml", line 20, characters 2-55:
+20 |   external add : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: allocation of 24 bytes for boxed_int32

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.compilers.reference
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.compilers.reference
@@ -1,0 +1,9 @@
+File "primitive_coercion_all.ml", line 17, characters 2-35:
+17 |   val add : int32 -> int32 -> int32 (* Should error *)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function Primitive_coercion_all.Allocating_primitive.(partial) (camlPrimitive_coercion_all__fn[primitive_coercion_all.ml:19,2--55]_1_1_code).
+
+File "primitive_coercion_all.ml", line 19, characters 2-55:
+19 |   external add : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes for boxed_int32

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.ml
@@ -1,0 +1,32 @@
+(* TEST
+ setup-ocamlopt.opt-build-env;
+ ocamlopt_opt_exit_status = "2";
+ ocamlopt.opt;
+ check-ocamlopt.opt-output;
+*)
+
+[@@@zero_alloc all]
+
+module Nonallocating_primitive : sig
+  val add : int8# -> int8# -> int8#
+end = struct
+  external add : int8# -> int8# -> int8# = "%int8#_add"
+end
+
+module Allocating_primitive : sig
+  val add : int32 -> int32 -> int32 (* Should error *)
+end = struct
+  external add : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+end
+
+module Zero_alloc_ignore : sig
+  val add : int32 -> int32 -> int32 [@@zero_alloc ignore]
+end = struct
+  external add : int32 -> int32 -> int32 = "%int32_add"
+end
+
+module Uncoerced_primitive : sig
+  external add : int32 -> int32 -> int32 = "%int32_add"
+end = struct
+  external add : int32 -> int32 -> int32 = "%int32_add"
+end

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all.ml
@@ -1,5 +1,6 @@
 (* TEST
  setup-ocamlopt.opt-build-env;
+ flags = "-flambda2-expert-shorten-symbol-names";
  ocamlopt_opt_exit_status = "2";
  ocamlopt.opt;
  check-ocamlopt.opt-output;

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.compilers.reference
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.compilers.reference
@@ -1,7 +1,7 @@
 File "primitive_coercion_zero_alloc_all_in_mli.mli", line 5, characters 0-35:
-Error: Annotation check for zero_alloc failed on function Primitive_coercion_zero_alloc_all_in_mli.(partial) (camlPrimitive_coercion_zero_alloc_all_in_mli__fn[primitive_coercion_zero_alloc_all_in_mli.ml:10,0--55]_0_0_code).
+Error: Annotation check for zero_alloc failed on function Primitive_coercion_zero_alloc_all_in_mli.(partial) (camlPrimitive_coercion_zero_alloc_all_in_mli__fn_0_0).
 
-File "primitive_coercion_zero_alloc_all_in_mli.ml", line 10, characters 0-55:
-10 | external add32 : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+File "primitive_coercion_zero_alloc_all_in_mli.ml", line 11, characters 0-55:
+11 | external add32 : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: allocation of 24 bytes for boxed_int32

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.compilers.reference
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.compilers.reference
@@ -1,0 +1,7 @@
+File "primitive_coercion_zero_alloc_all_in_mli.mli", line 5, characters 0-35:
+Error: Annotation check for zero_alloc failed on function Primitive_coercion_zero_alloc_all_in_mli.(partial) (camlPrimitive_coercion_zero_alloc_all_in_mli__fn[primitive_coercion_zero_alloc_all_in_mli.ml:10,0--55]_0_0_code).
+
+File "primitive_coercion_zero_alloc_all_in_mli.ml", line 10, characters 0-55:
+10 | external add32 : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes for boxed_int32

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.ml
@@ -1,5 +1,6 @@
 (* TEST
  setup-ocamlopt.opt-build-env;
+ flags = "-flambda2-expert-shorten-symbol-names";
  ocamlopt_opt_exit_status = "2";
  ocamlopt.opt;
  check-ocamlopt.opt-output;

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.ml
@@ -1,0 +1,12 @@
+(* TEST
+ setup-ocamlopt.opt-build-env;
+ ocamlopt_opt_exit_status = "2";
+ ocamlopt.opt;
+ check-ocamlopt.opt-output;
+*)
+
+external add8 : int8# -> int8# -> int8# = "%int8#_add"
+
+external add32 : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+
+external add64 : int64 -> int64 -> int64 = "%int64_add"

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.mli
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_all_in_mli.mli
@@ -1,0 +1,7 @@
+[@@@zero_alloc all]
+
+val add8 : int8# -> int8# -> int8#
+
+val add32 : int32 -> int32 -> int32
+
+external add64 : int64 -> int64 -> int64 = "%int64_add"

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_opt.compilers.reference
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_opt.compilers.reference
@@ -1,0 +1,9 @@
+File "primitive_coercion_zero_alloc_opt.ml", line 16, characters 39-49:
+16 |   val add : int32 -> int32 -> int32 [@@zero_alloc opt] (* Should error *)
+                                            ^^^^^^^^^^
+Error: Annotation check for zero_alloc failed on function Primitive_coercion_zero_alloc_opt.Allocating_primitive.(partial) (camlPrimitive_coercion_zero_alloc_opt__fn_1_1).
+
+File "primitive_coercion_zero_alloc_opt.ml", line 18, characters 2-55:
+18 |   external add : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: allocation of 24 bytes for boxed_int32

--- a/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_opt.ml
+++ b/testsuite/tests/typing-zero-alloc/primitive_coercion_zero_alloc_opt.ml
@@ -1,0 +1,19 @@
+(* TEST
+ setup-ocamlopt.opt-build-env;
+ flags = "-flambda2-expert-shorten-symbol-names -zero-alloc-check opt";
+ ocamlopt_opt_exit_status = "2";
+ ocamlopt.opt;
+ check-ocamlopt.opt-output;
+*)
+
+module Nonallocating_primitive : sig
+  val add : int8# -> int8# -> int8# [@@zero_alloc opt]
+end = struct
+  external add : int8# -> int8# -> int8# = "%int8#_add"
+end
+
+module Allocating_primitive : sig
+  val add : int32 -> int32 -> int32 [@@zero_alloc opt] (* Should error *)
+end = struct
+  external add : int32 -> int32 -> int32 = "%int32_add" (* Should error *)
+end

--- a/testsuite/tests/typing-zero-alloc/stubs.c
+++ b/testsuite/tests/typing-zero-alloc/stubs.c
@@ -1,0 +1,4 @@
+#include <assert.h>
+#define BUILTIN(name) void name() { assert(0); }
+
+BUILTIN(caml_csel_value)

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -290,7 +290,7 @@ let value_descriptions ~loc env name
            pc_yielding =
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
-           pc_zero_alloc = prim_coercion_zero_alloc_check;
+           pc_zero_alloc_check = prim_coercion_zero_alloc_check;
            pc_env = env; pc_loc = vd1.Types.val_loc; } in
         Tcoerce_primitive pc
      end

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -211,16 +211,9 @@ let moregeneral_lpoly env pat_lpoly subj_lpoly ty1 ty2 =
     raise (Dont_match (Layout_poly_coercion
       (Extra_rhs { extra = List.length subj_rest })))
 
-let value_descriptions ~loc env name
-    ~mmodes
+let value_descriptions_zero_alloc
     (vd1 : Types.value_description)
     (vd2 : Types.value_description) =
-  Builtin_attributes.check_alerts_inclusion
-    ~def:vd1.val_loc
-    ~use:vd2.val_loc
-    loc
-    vd1.val_attributes vd2.val_attributes
-    name;
   let vd1_zero_alloc, prim_coercion_zero_alloc_check =
     match vd1.val_kind, Zero_alloc.get vd2.val_zero_alloc with
     | Val_prim p, Check check ->
@@ -231,10 +224,21 @@ let value_descriptions ~loc env name
         (Default_zero_alloc | Ignore_assert_all | Check _ | Assume _) ) ->
       vd1.val_zero_alloc, None
   in
-  begin match Zero_alloc.sub vd1_zero_alloc vd2.val_zero_alloc with
-  | Ok () -> ()
+  match Zero_alloc.sub vd1_zero_alloc vd2.val_zero_alloc with
+  | Ok () -> prim_coercion_zero_alloc_check
   | Error e -> raise (Dont_match (Zero_alloc e))
-  end;
+
+let value_descriptions ~loc env name
+    ~mmodes
+    (vd1 : Types.value_description)
+    (vd2 : Types.value_description) =
+  Builtin_attributes.check_alerts_inclusion
+    ~def:vd1.val_loc
+    ~use:vd2.val_loc
+    loc
+    vd1.val_attributes vd2.val_attributes
+    name;
+  let prim_coercion_zero_alloc_check = value_descriptions_zero_alloc vd1 vd2 in
   let crossing = Ctype.crossing_of_ty env vd2.val_type in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -221,12 +221,12 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  let prim_coercion_zero_alloc : Zero_alloc.const =
+  let prim_coercion_zero_alloc : Zero_alloc.check option =
     match vd1.val_kind, vd2.val_kind, Zero_alloc.get vd2.val_zero_alloc with
-    | Val_prim p1, Val_reg _, Check c when c.arity = p1.prim_arity -> Check c
+    | Val_prim p1, Val_reg _, Check c when c.arity = p1.prim_arity -> Some c
     | _, _, _ ->
       match Zero_alloc.sub vd1.val_zero_alloc vd2.val_zero_alloc with
-      | Ok () -> Default_zero_alloc
+      | Ok () -> None
       | Error e -> raise (Dont_match (Zero_alloc e))
   in
   let crossing = Ctype.crossing_of_ty env vd2.val_type in

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -221,10 +221,14 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  begin match Zero_alloc.sub vd1.val_zero_alloc vd2.val_zero_alloc with
-  | Ok () -> ()
-  | Error e -> raise (Dont_match (Zero_alloc e))
-  end;
+  let prim_coercion_zero_alloc : Zero_alloc.const =
+    match vd1.val_kind, vd2.val_kind, Zero_alloc.get vd2.val_zero_alloc with
+    | Val_prim p1, Val_reg _, Check c when c.arity = p1.prim_arity -> Check c
+    | _, _, _ ->
+      match Zero_alloc.sub vd1.val_zero_alloc vd2.val_zero_alloc with
+      | Ok () -> Default_zero_alloc
+      | Error e -> raise (Dont_match (Zero_alloc e))
+  in
   let crossing = Ctype.crossing_of_ty env vd2.val_type in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =
@@ -282,6 +286,7 @@ let value_descriptions ~loc env name
            pc_yielding =
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
+           pc_zero_alloc = prim_coercion_zero_alloc;
            pc_env = env; pc_loc = vd1.Types.val_loc; } in
         Tcoerce_primitive pc
      end

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -221,14 +221,18 @@ let value_descriptions ~loc env name
     loc
     vd1.val_attributes vd2.val_attributes
     name;
-  let prim_coercion_zero_alloc : Zero_alloc.check option =
-    match vd1.val_kind, vd2.val_kind, Zero_alloc.get vd2.val_zero_alloc with
-    | Val_prim p1, Val_reg _, Check c when c.arity = p1.prim_arity -> Some c
-    | _, _, _ ->
-      match Zero_alloc.sub vd1.val_zero_alloc vd2.val_zero_alloc with
-      | Ok () -> None
-      | Error e -> raise (Dont_match (Zero_alloc e))
+  let vd1_zero_alloc, prim_coercion_zero_alloc_check =
+    match vd1.val_kind, Zero_alloc.get vd2.val_zero_alloc with
+    | Val_prim p, Check check ->
+      ( Zero_alloc.create_const (Check { check with arity = p.prim_arity }),
+        Some check )
+    | _, (Default_zero_alloc | Ignore_assert_all | Check _ | Assume _) ->
+      vd1.val_zero_alloc, None
   in
+  begin match Zero_alloc.sub vd1_zero_alloc vd2.val_zero_alloc with
+  | Ok () -> ()
+  | Error e -> raise (Dont_match (Zero_alloc e))
+  end;
   let crossing = Ctype.crossing_of_ty env vd2.val_type in
   let modalities = vd1.val_modalities, vd2.val_modalities in
   let modes =
@@ -286,7 +290,7 @@ let value_descriptions ~loc env name
            pc_yielding =
              Ctype.prim_params_yielding env vd2.Types.val_type
                ~arity:p1.prim_arity;
-           pc_zero_alloc = prim_coercion_zero_alloc;
+           pc_zero_alloc = prim_coercion_zero_alloc_check;
            pc_env = env; pc_loc = vd1.Types.val_loc; } in
         Tcoerce_primitive pc
      end

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -226,7 +226,9 @@ let value_descriptions ~loc env name
     | Val_prim p, Check check ->
       ( Zero_alloc.create_const (Check { check with arity = p.prim_arity }),
         Some check )
-    | _, (Default_zero_alloc | Ignore_assert_all | Check _ | Assume _) ->
+    | ( (Val_reg _ | Val_mut _ | Val_prim _ | Val_ivar _ | Val_self _ |
+         Val_anc _),
+        (Default_zero_alloc | Ignore_assert_all | Check _ | Assume _) ) ->
       vd1.val_zero_alloc, None
   in
   begin match Zero_alloc.sub vd1_zero_alloc vd2.val_zero_alloc with

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -731,7 +731,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
-    pc_zero_alloc: Zero_alloc.check option;
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -731,7 +731,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
-    pc_zero_alloc: Zero_alloc.const;
+    pc_zero_alloc: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -731,6 +731,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
+    pc_zero_alloc: Zero_alloc.const;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -730,6 +730,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
+    pc_zero_alloc: Zero_alloc.const;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -730,7 +730,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
-    pc_zero_alloc: Zero_alloc.const;
+    pc_zero_alloc: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -730,7 +730,7 @@ and primitive_coercion =
     pc_poly_mode: Mode.Locality.l option;
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
-    pc_zero_alloc: Zero_alloc.check option;
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1158,7 +1158,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
-    pc_zero_alloc: Zero_alloc.const;
+    pc_zero_alloc: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1158,7 +1158,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
-    pc_zero_alloc: Zero_alloc.check option;
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1158,6 +1158,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
+    pc_zero_alloc: Zero_alloc.const;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1133,7 +1133,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
-    pc_zero_alloc: Zero_alloc.const;
+    pc_zero_alloc: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1133,6 +1133,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
+    pc_zero_alloc: Zero_alloc.const;
     pc_env: Env.t;
     pc_loc : Location.t;
   }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1133,7 +1133,7 @@ and primitive_coercion =
     pc_poly_sort: Jkind.Sort.t option;
     pc_yielding: Mode.Yielding.l;
     (** As the [Mode.Yielding.l] in [Id_prim]. *)
-    pc_zero_alloc: Zero_alloc.check option;
+    pc_zero_alloc_check: Zero_alloc.check option;
     pc_env: Env.t;
     pc_loc : Location.t;
   }


### PR DESCRIPTION
This is done by adding a `pc_zero_alloc : Zero_alloc.check option` field to `Tcoerce_primitive`, representing the zero_alloc check that must be performed to ensure the coercion is valid. This field is used in `transl_primitive` similar to how `transl_function` handles zero_alloc.