### PR TITLE
Variant subtype declarations (type t :> u)

### DIFF
--- a/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/complex_shape.ml
@@ -535,7 +535,7 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
     try
       let constructors =
         List.map
-          (fun { S.name; kind = _; args; constr_uid = _ } ->
+          (fun { S.name; kind = _; args; constr_uid = _; cstr_tag } ->
             (* We first compute complex shapes for the fields. Then we unarize
                using the mixed block helpers defined above. *)
             let is_tuple_constructor =
@@ -559,12 +559,14 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
             if is_tuple_constructor
             then
               (* We clear the field names for tuple constructors. *)
-              RS.constructor_with_tuple_arg ~name
+              RS.constructor_with_tuple_arg ~name ~tag:cstr_tag
                 ~args:
                   (List.map
                      (RS.map_mixed_block_field_label (fun _ -> ()))
                      constr_args)
-            else RS.constructor_with_record_arg ~name ~args:constr_args)
+            else
+              RS.constructor_with_record_arg ~name ~tag:cstr_tag
+                ~args:constr_args)
           constructors
       in
       runtime (RS.variant constructors)
@@ -577,8 +579,8 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
   | Poly_variant constructors, (None | Some (Base Scannable)) -> (
     try
       let constructors =
-        List.map
-          (fun { S.pv_constr_name; pv_constr_args } ->
+        List.mapi
+          (fun i { S.pv_constr_name; pv_constr_args } ->
             let source_level_fields =
               List.map
                 (fun arg ->
@@ -593,7 +595,10 @@ let rec type_shape_to_complex_shape_exn ~cache ~rec_env (type_shape : Shape.t)
             let constr_args =
               lay_out_into_mixed_block_exn ~source_level_fields
             in
-            RS.constructor_with_tuple_arg ~name:pv_constr_name
+            (* Polymorphic variant discriminants are hashes of the constructor
+               names, computed in [Dwarf_type]; the tag here is just a
+               deterministic index and is not used for dispatch. *)
+            RS.constructor_with_tuple_arg ~name:pv_constr_name ~tag:i
               ~args:
                 (List.map
                    (RS.map_mixed_block_field_label (fun _ -> ()))

--- a/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/dwarf_type.ml
@@ -400,8 +400,8 @@ let create_attribute_unboxed_record_die ~reference ~parent_proto_die ?name
     ()
 
 let create_simple_variant_die ~reference ~parent_proto_die ?name
-    simple_constructors =
-  Debugging_the_compiler.add_enum ~reference simple_constructors;
+    (simple_constructors : (string * int) list) =
+  Debugging_the_compiler.add_enum ~reference (List.map fst simple_constructors);
   let enum =
     Proto_die.create ~reference ~parent:(Some parent_proto_die)
       ~tag:Dwarf_tag.Enumeration_type
@@ -410,11 +410,11 @@ let create_simple_variant_die ~reference ~parent_proto_die ?name
         |> attribute_list_with_optional_name name)
       ()
   in
-  List.iteri
-    (fun i constructor ->
+  List.iter
+    (fun (constructor, tag) ->
       Proto_die.create_ignore ~parent:(Some enum) ~tag:Dwarf_tag.Enumerator
         ~attribute_values:
-          [ DAH.create_const_value ~value:(Int64.of_int ((2 * i) + 1));
+          [ DAH.create_const_value ~value:(Int64.of_int ((2 * tag) + 1));
             DAH.create_name constructor ]
         ())
     simple_constructors
@@ -488,14 +488,15 @@ let create_attribute_unboxed_variant_die ~reference ~parent_proto_die ?name
   done
 
 let create_complex_variant_die ~reference ~parent_proto_die ?name
-    ~simple_constructors
+    ~(simple_constructors : (string * int) list)
     ~(complex_constructors :
-       (string * (string option * Proto_die.reference * RL.t) list) list) () =
+       (string * int * (string option * Proto_die.reference * RL.t) list) list)
+    () =
   let complex_constructors_names =
-    List.map (fun (name, _) -> name) complex_constructors
+    List.map (fun (name, _, _) -> name) complex_constructors
   in
   Debugging_the_compiler.add_enum ~reference
-    (simple_constructors @ complex_constructors_names);
+    (List.map fst simple_constructors @ complex_constructors_names);
   let value_size = Arch.size_addr in
   let variant_part_immediate_or_pointer =
     let int_or_ptr_structure =
@@ -560,13 +561,13 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
     in
     Debugging_the_compiler.add_enum
       ~reference:(Proto_die.reference enum_die)
-      simple_constructors;
-    List.iteri
-      (fun i name ->
+      (List.map fst simple_constructors);
+    List.iter
+      (fun (name, tag) ->
         Proto_die.create_ignore ~parent:(Some enum_die)
           ~tag:Dwarf_tag.Enumerator
           ~attribute_values:
-            [ DAH.create_const_value ~value:(Int64.of_int i);
+            [ DAH.create_const_value ~value:(Int64.of_int tag);
               DAH.create_name name ]
           ())
       simple_constructors;
@@ -641,12 +642,14 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
           ~attribute_values:[DAH.create_byte_size_exn ~byte_size:1]
           ()
       in
-      List.iteri
-        (fun i (name, _) ->
+      (* These enum values are the runtime tags of the blocks; they must stay
+         consistent with the [discr_value]s of the variants below. *)
+      List.iter
+        (fun (name, tag, _) ->
           Proto_die.create_ignore ~parent:(Some enum_die)
             ~tag:Dwarf_tag.Enumerator
             ~attribute_values:
-              [ DAH.create_const_value ~value:(Int64.of_int i);
+              [ DAH.create_const_value ~value:(Int64.of_int tag);
                 DAH.create_name name ]
             ())
         complex_constructors;
@@ -662,12 +665,12 @@ let create_complex_variant_die ~reference ~parent_proto_die ?name
         (DAH.create_discr
            ~proto_die_reference:(Proto_die.reference discriminant))
     in
-    List.iteri
-      (fun i (constructor_name, fields) ->
+    List.iter
+      (fun (constructor_name, tag, fields) ->
         let subvariant =
           Proto_die.create ~parent:(Some variant_part_pointer)
             ~tag:Dwarf_tag.Variant
-            ~attribute_values:[DAH.create_discr_value ~value:(Int64.of_int i)]
+            ~attribute_values:[DAH.create_discr_value ~value:(Int64.of_int tag)]
             ()
         in
         Debugging_the_compiler.add
@@ -1260,14 +1263,15 @@ let partition_constructors constructors ~f =
   List.partition_map
     (fun (constr : RS.constructor) ->
       let constr_name = RS.constructor_name constr in
+      let tag = RS.constructor_tag constr in
       let args = RS.constructor_args constr in
       match args with
-      | [] -> Left constr_name
+      | [] -> Left (constr_name, tag)
       | _ :: _ ->
         let args =
           List.map (fun { RS.label; field_type } -> f label field_type) args
         in
-        Right (constr_name, args))
+        Right (constr_name, tag, args))
     constructors
 
 (* CR sspies: We have to be careful here, because LLDB currently disambiguates
@@ -1358,6 +1362,12 @@ and runtime_shape_to_dwarf_die_memo ~reference ?name (t : RS.t)
     let simple_constructors, complex_constructors =
       partition_constructors constructors ~f:(fun _label field_type ->
           die field_type)
+    in
+    (* Polymorphic variants dispatch on hashes of the constructor names rather
+       than on the tags. *)
+    let simple_constructors = List.map fst simple_constructors in
+    let complex_constructors =
+      List.map (fun (name, _tag, args) -> name, args) complex_constructors
     in
     create_poly_variant_dwarf_die ~reference ~parent_proto_die ?name
       ~simple_constructors ~complex_constructors ()

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.ml
@@ -210,10 +210,12 @@ and 'label mixed_block_field =
 and constructor =
   | Constructor_with_tuple_arg of
       { name : string;
+        tag : int;
         args : unit mixed_block_field list
       }
   | Constructor_with_record_arg of
       { name : string;
+        tag : int;
         args : string mixed_block_field list
       }
 
@@ -407,10 +409,12 @@ let hash_mixed_block_field (type label) (hash_label : label -> int)
   Hashtbl.hash (hash field_type, hash_label label)
 
 let hash_constructor = function
-  | Constructor_with_tuple_arg { name; args } ->
-    Hashtbl.hash (0, name, List.map (hash_mixed_block_field (fun () -> 0)) args)
-  | Constructor_with_record_arg { name; args } ->
-    Hashtbl.hash (1, name, List.map (hash_mixed_block_field Hashtbl.hash) args)
+  | Constructor_with_tuple_arg { name; tag; args } ->
+    Hashtbl.hash
+      (0, name, tag, List.map (hash_mixed_block_field (fun () -> 0)) args)
+  | Constructor_with_record_arg { name; tag; args } ->
+    Hashtbl.hash
+      (1, name, tag, List.map (hash_mixed_block_field Hashtbl.hash) args)
 
 let hash_array_kind = function
   | Regular s -> Hashtbl.hash (0, hash s)
@@ -474,11 +478,11 @@ let tuple args =
       Hashtbl.hash (hash_tuple, hash_tuple_kind Tuple_boxed, List.map hash args)
   }
 
-let constructor_with_tuple_arg ~name ~args =
-  Constructor_with_tuple_arg { name; args }
+let constructor_with_tuple_arg ~name ~tag ~args =
+  Constructor_with_tuple_arg { name; tag; args }
 
-let constructor_with_record_arg ~name ~args =
-  Constructor_with_record_arg { name; args }
+let constructor_with_record_arg ~name ~tag ~args =
+  Constructor_with_record_arg { name; tag; args }
 
 let variant constructors =
   let desc = Variant { constructors; kind = Variant_boxed } in
@@ -510,11 +514,13 @@ let variant_attribute_unboxed ~constructor_name
     | None ->
       Constructor_with_tuple_arg
         { name = constructor_name;
+          tag = 0;
           args = [{ field_type = constructor_arg.field_type; label = () }]
         }
     | Some label ->
       Constructor_with_record_arg
         { name = constructor_name;
+          tag = 0;
           args = [{ field_type = constructor_arg.field_type; label }]
         }
   in
@@ -810,12 +816,15 @@ and equal_record_field { field_type = type1; label = label1 }
 
 and equal_constructor c1 c2 =
   match c1, c2 with
-  | ( Constructor_with_tuple_arg { name = name1; args = args1 },
-      Constructor_with_tuple_arg { name = name2; args = args2 } ) ->
-    String.equal name1 name2 && List.equal equal_tuple_field args1 args2
-  | ( Constructor_with_record_arg { name = name1; args = args1 },
-      Constructor_with_record_arg { name = name2; args = args2 } ) ->
-    String.equal name1 name2 && List.equal equal_record_field args1 args2
+  | ( Constructor_with_tuple_arg { name = name1; tag = tag1; args = args1 },
+      Constructor_with_tuple_arg { name = name2; tag = tag2; args = args2 } ) ->
+    String.equal name1 name2 && Int.equal tag1 tag2
+    && List.equal equal_tuple_field args1 args2
+  | ( Constructor_with_record_arg { name = name1; tag = tag1; args = args1 },
+      Constructor_with_record_arg { name = name2; tag = tag2; args = args2 } )
+    ->
+    String.equal name1 name2 && Int.equal tag1 tag2
+    && List.equal equal_record_field args1 args2
   | Constructor_with_tuple_arg _, Constructor_with_record_arg _ -> false
   | Constructor_with_record_arg _, Constructor_with_tuple_arg _ -> false
 
@@ -855,6 +864,10 @@ and equal_predef p1 p2 =
 let constructor_name = function
   | Constructor_with_tuple_arg { name; _ } -> name
   | Constructor_with_record_arg { name; _ } -> name
+
+let constructor_tag = function
+  | Constructor_with_tuple_arg { tag; _ } -> tag
+  | Constructor_with_record_arg { tag; _ } -> tag
 
 let constructor_args = function
   | Constructor_with_tuple_arg { args; _ } ->

--- a/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
+++ b/backend/debug/dwarf/dwarf_ocaml/runtime_shape.mli
@@ -147,10 +147,12 @@ and 'label mixed_block_field = private
 and constructor = private
   | Constructor_with_tuple_arg of
       { name : string;
+        tag : int;
         args : unit mixed_block_field list
       }
   | Constructor_with_record_arg of
       { name : string;
+        tag : int;
         args : string mixed_block_field list
       }
 
@@ -234,17 +236,20 @@ val map_mixed_block_field_label :
     Note that in [args], the order matters for the runtime memory layout. Ensure
     fields are in the correct order (i.e., values occur before non-values). *)
 val constructor_with_tuple_arg :
-  name:string -> args:unit mixed_block_field list -> constructor
+  name:string -> tag:int -> args:unit mixed_block_field list -> constructor
 
 (** Create a constructor with record-style arguments for use in variants.
 
     Note that in [args], the order matters for the runtime memory layout. Ensure
     fields are in the correct order (i.e., values occur before non-values). *)
 val constructor_with_record_arg :
-  name:string -> args:string mixed_block_field list -> constructor
+  name:string -> tag:int -> args:string mixed_block_field list -> constructor
 
 (** Get the name of a constructor. *)
 val constructor_name : constructor -> string
+
+(** Get the runtime tag of a constructor. *)
+val constructor_tag : constructor -> int
 
 (** Get the arguments of a constructor as a list of fields with optional labels.
     Tuple-style constructors have [None] labels, record-style constructors have

--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -523,6 +523,8 @@ let mk_constructor_description cstr_name =
     cstr_tag = Ordinary { src_index = 0; runtime_tag = 0 };
     cstr_consts = 0;
     cstr_nonconsts = 0;
+    cstr_const_span = 0;
+    cstr_nonconst_span = 0;
     cstr_generalized = false;
     cstr_private = Public;
     cstr_loc = Location.none;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -1029,9 +1029,11 @@ and lambda_apply =
   }
 
 and lambda_switch =
-  { sw_numconsts: int;                  (* Number of integer cases *)
+  { sw_numconsts: int;                  (* 1 + the largest possible immediate
+                                           value of the scrutinee *)
     sw_consts: (int * lambda) list;     (* Integer cases *)
-    sw_numblocks: int;                  (* Number of tag block cases *)
+    sw_numblocks: int;                  (* 1 + the largest possible block
+                                           tag of the scrutinee *)
     sw_blocks: (int * lambda) list;     (* Tag block cases *)
     sw_failaction : lambda option}      (* Action to take if failure *)
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3748,7 +3748,8 @@ let combine_regular_constructor value_kind loc arg cstr partial
         act
     | _ -> (
         match
-          (cstr.cstr_consts, cstr.cstr_nonconsts, consts, nonconsts, null)
+          (cstr.cstr_const_span, cstr.cstr_nonconst_span,
+           consts, nonconsts, null)
         with
         | 1, 1, [ (0, act1) ], [ (0, act2) ], None
           when not (Clflags.is_flambda2 ()) ->
@@ -3805,9 +3806,9 @@ let combine_regular_constructor value_kind loc arg cstr partial
             | None ->
                 (* In the general case, emit a switch. *)
                 let sw =
-                  { sw_numconsts = cstr.cstr_consts;
+                  { sw_numconsts = cstr.cstr_const_span;
                     sw_consts = consts;
-                    sw_numblocks = cstr.cstr_nonconsts;
+                    sw_numblocks = cstr.cstr_nonconst_span;
                     sw_blocks = nonconsts;
                     sw_failaction = fail_opt
                   }

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -613,6 +613,7 @@ module Type = struct
       ?(kind = Ptype_abstract)
       ?(priv = Public)
       ?manifest
+      ?supertype
       ?jkind_annotation
       name =
     {
@@ -622,6 +623,7 @@ module Type = struct
      ptype_kind = kind;
      ptype_private = priv;
      ptype_manifest = manifest;
+     ptype_supertype = supertype;
      ptype_attributes = add_text_attrs text (add_docs_attrs docs attrs);
      ptype_jkind_annotation = jkind_annotation;
      ptype_loc = loc;

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -261,7 +261,7 @@ module Type:
       ?params:(core_type * (variance * injectivity)) list ->
       ?cstrs:(core_type * core_type * loc) list ->
       ?kind:type_kind -> ?priv:private_flag -> ?manifest:core_type ->
-      ?jkind_annotation:jkind_annotation ->
+      ?supertype:core_type -> ?jkind_annotation:jkind_annotation ->
       str ->
       type_declaration
 

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -181,6 +181,7 @@ module T = struct
        ptype_kind;
        ptype_private = _;
        ptype_manifest;
+       ptype_supertype;
        ptype_attributes;
        ptype_jkind_annotation;
        ptype_loc} =
@@ -191,6 +192,7 @@ module T = struct
       ptype_cstrs;
     sub.type_kind sub ptype_kind;
     iter_opt (sub.typ sub) ptype_manifest;
+    iter_opt (sub.typ sub) ptype_supertype;
     sub.location sub ptype_loc;
     sub.attributes sub ptype_attributes;
     Option.iter (sub.jkind_annotation sub) ptype_jkind_annotation

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -231,6 +231,7 @@ module T = struct
        ptype_kind;
        ptype_private;
        ptype_manifest;
+       ptype_supertype;
        ptype_attributes;
        ptype_jkind_annotation;
        ptype_loc} =
@@ -247,6 +248,7 @@ module T = struct
                 ptype_cstrs)
       ~kind:(sub.type_kind sub ptype_kind)
       ?manifest:(map_opt (sub.typ sub) ptype_manifest)
+      ?supertype:(map_opt (sub.typ sub) ptype_supertype)
       ~docs:Docstrings.empty_docs
       ?jkind_annotation:ptype_jkind_annotation
 

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -170,6 +170,7 @@ let add_type_declaration bv td =
     (fun (ty1, ty2, _) -> add_type bv ty1; add_type bv ty2)
     td.ptype_cstrs;
   add_opt add_type bv td.ptype_manifest;
+  add_opt add_type bv td.ptype_supertype;
   let add_tkind = function
     Ptype_abstract -> ()
   | Ptype_variant cstrs ->

--- a/parsing/language_extension.ml
+++ b/parsing/language_extension.ml
@@ -75,6 +75,7 @@ let get_level_ops : type a. a t -> (module Extension_level with type t = a) =
   | Let_mutable -> (module Unit)
   | Layout_poly -> (module Maturity)
   | Runtime_metaprogramming -> (module Unit)
+  | Subtypes -> (module Unit)
 
 (* We'll do this in a more principled way later. *)
 (* CR layouts: Note that layouts is only "mostly" erasable, because of annoying
@@ -88,7 +89,7 @@ let is_erasable : type a. a t -> bool = function
   | Mode | Unique | Overwriting | Layouts | Layout_poly -> true
   | Comprehensions | Include_functor | Polymorphic_parameters | Immutable_arrays
   | Module_strengthening | SIMD | Small_numbers | Instances | Let_mutable
-  | Runtime_metaprogramming ->
+  | Runtime_metaprogramming | Subtypes ->
     false
 
 let maturity_of_unique_for_drf = Stable
@@ -114,6 +115,7 @@ module Exist_pair = struct
     | Pair (Let_mutable, ()) -> Stable
     | Pair (Layout_poly, m) -> m
     | Pair (Runtime_metaprogramming, ()) -> Beta
+    | Pair (Subtypes, ()) -> Alpha
 
   let is_erasable : t -> bool = function Pair (ext, _) -> is_erasable ext
 
@@ -129,7 +131,7 @@ module Exist_pair = struct
     | Pair
         ( (( Comprehensions | Include_functor | Polymorphic_parameters
            | Immutable_arrays | Module_strengthening | Instances | Overwriting
-           | Let_mutable | Runtime_metaprogramming ) as ext),
+           | Let_mutable | Runtime_metaprogramming | Subtypes ) as ext),
           _ ) ->
       to_string ext
 
@@ -165,6 +167,7 @@ module Exist_pair = struct
     | "layout_poly_alpha" -> Some (Pair (Layout_poly, Alpha))
     | "layout_poly_beta" -> Some (Pair (Layout_poly, Beta))
     | "runtime_metaprogramming" -> Some (Pair (Runtime_metaprogramming, ()))
+    | "subtypes" -> Some (Pair (Subtypes, ()))
     | _ -> None
 end
 
@@ -187,7 +190,8 @@ let all_extensions =
     Pack Instances;
     Pack Let_mutable;
     Pack Layout_poly;
-    Pack Runtime_metaprogramming ]
+    Pack Runtime_metaprogramming;
+    Pack Subtypes ]
 
 (**********************************)
 (* string conversions *)
@@ -228,10 +232,11 @@ let equal_t (type a b) (a : a t) (b : b t) : (a, b) Misc.eq option =
   | Let_mutable, Let_mutable -> Some Refl
   | Layout_poly, Layout_poly -> Some Refl
   | Runtime_metaprogramming, Runtime_metaprogramming -> Some Refl
+  | Subtypes, Subtypes -> Some Refl
   | ( ( Comprehensions | Mode | Unique | Overwriting | Include_functor
       | Polymorphic_parameters | Immutable_arrays | Module_strengthening
       | Layouts | SIMD | Small_numbers | Instances | Let_mutable | Layout_poly
-      | Runtime_metaprogramming ),
+      | Runtime_metaprogramming | Subtypes ),
       _ ) ->
     None
 

--- a/parsing/language_extension.mli
+++ b/parsing/language_extension.mli
@@ -32,6 +32,7 @@ type 'a t = 'a Language_extension_kernel.t =
   | Let_mutable : unit t
   | Layout_poly : maturity t
   | Runtime_metaprogramming : unit t
+  | Subtypes : unit t
 
 (** Require that an extension is enabled for at least the provided level, or
     else throw an exception at the provided location saying otherwise. *)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4022,17 +4022,17 @@ generic_type_declaration(flag, kind):
   params = type_parameters
   id = mkrhs(LIDENT)
   jkind_annotation = jkind_constraint?
-  kind_priv_manifest = kind
+  kind_priv_manifest_supertype = kind
   cstrs = constraints
   attrs2 = post_item_attributes
     {
-      let (kind, priv, manifest) = kind_priv_manifest in
+      let (kind, priv, manifest, supertype) = kind_priv_manifest_supertype in
       let docs = symbol_docs $sloc in
       let attrs = attrs1 @ attrs2 in
       let loc = make_loc $sloc in
       (flag, ext),
-      Type.mk id ~params ~cstrs ~kind ~priv ?manifest ~attrs ~loc ~docs
-        ?jkind_annotation
+      Type.mk id ~params ~cstrs ~kind ~priv ?manifest ?supertype ~attrs ~loc
+        ~docs ?jkind_annotation
     }
 ;
 %inline generic_and_type_declaration(kind):
@@ -4041,17 +4041,17 @@ generic_type_declaration(flag, kind):
   params = type_parameters
   id = mkrhs(LIDENT)
   jkind_annotation = jkind_constraint?
-  kind_priv_manifest = kind
+  kind_priv_manifest_supertype = kind
   cstrs = constraints
   attrs2 = post_item_attributes
     {
-      let (kind, priv, manifest) = kind_priv_manifest in
+      let (kind, priv, manifest, supertype) = kind_priv_manifest_supertype in
       let docs = symbol_docs $sloc in
       let attrs = attrs1 @ attrs2 in
       let loc = make_loc $sloc in
       let text = symbol_text $symbolstartpos in
-      Type.mk id ~params ~cstrs ~kind ~priv ?manifest ~attrs ~loc ~docs ~text
-        ?jkind_annotation
+      Type.mk id ~params ~cstrs ~kind ~priv ?manifest ?supertype ~attrs ~loc
+        ~docs ~text ?jkind_annotation
     }
 ;
 %inline constraints:
@@ -4087,15 +4087,20 @@ nonempty_type_kind:
   ioption(terminated(core_type, EQUAL))
     { $1 }
 ;
+%inline type_supertype:
+  ioption(preceded(COLONGREATER, core_type))
+    { $1 }
+;
 type_kind:
-    /*empty*/
-      { (Ptype_abstract, Public, None) }
-  | EQUAL nonempty_type_kind
-      { $2 }
+    sup = type_supertype
+      { (Ptype_abstract, Public, None, sup) }
+  | sup = type_supertype
+    EQUAL nonempty_type_kind
+      { let (kind, priv, manifest) = $3 in (kind, priv, manifest, sup) }
 ;
 %inline type_subst_kind:
     COLONEQUAL nonempty_type_kind
-      { $2 }
+      { let (kind, priv, manifest) = $2 in (kind, priv, manifest, None) }
 ;
 type_parameters:
     /* empty */

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -750,7 +750,7 @@ and type_declaration =
      ptype_kind: type_kind;
      ptype_private: private_flag;  (** for [= private ...] *)
      ptype_manifest: core_type option;  (** represents [= T] *)
-     ptype_supertype: core_type option;  (** represents [<: T] *)
+     ptype_supertype: core_type option;  (** represents [:> T] *)
      ptype_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      ptype_jkind_annotation: jkind_annotation option; (** for [: jkind] *)
      ptype_loc: Location.t;

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -750,6 +750,7 @@ and type_declaration =
      ptype_kind: type_kind;
      ptype_private: private_flag;  (** for [= private ...] *)
      ptype_manifest: core_type option;  (** represents [= T] *)
+     ptype_supertype: core_type option;  (** represents [<: T] *)
      ptype_attributes: attributes;  (** [... [\@\@id1] [\@\@id2]] *)
      ptype_jkind_annotation: jkind_annotation option; (** for [: jkind] *)
      ptype_loc: Location.t;

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -2136,11 +2136,16 @@ and type_def_list ctxt f (rf, exported, l) =
       | Some jkind ->
           Format.dprintf " : %a" (jkind_annotation ctxt) jkind
     in
-    pp f "@[<2>%s %a%a%a%t%s%a@]%a" kwd
+    let subtype =
+      match x.ptype_supertype with
+      | None -> Format.dprintf ""
+      | Some ty -> Format.dprintf " <: %a" (core_type ctxt) ty
+    in
+    pp f "@[<2>%s %a%a%a%t%t%s%a@]%a" kwd
       nonrec_flag rf
       type_params x.ptype_params
       ident_of_name x.ptype_name.txt
-      layout_annot eq
+      layout_annot subtype eq
       (type_declaration ctxt) x
       (item_attributes ctxt) x.ptype_attributes
   in

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -2139,7 +2139,7 @@ and type_def_list ctxt f (rf, exported, l) =
     let subtype =
       match x.ptype_supertype with
       | None -> Format.dprintf ""
-      | Some ty -> Format.dprintf " <: %a" (core_type ctxt) ty
+      | Some ty -> Format.dprintf " :> %a" (core_type ctxt) ty
     in
     pp f "@[<2>%s %a%a%a%t%t%s%a@]%a" kwd
       nonrec_flag rf

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -656,6 +656,8 @@ and type_declaration i ppf x =
   line i ppf "ptype_private = %a\n" fmt_private_flag x.ptype_private;
   line i ppf "ptype_manifest =\n";
   option (i+1) core_type ppf x.ptype_manifest;
+  line i ppf "ptype_supertype =\n";
+  option (i+1) core_type ppf x.ptype_supertype;
   line i ppf "ptype_jkind_annotation =\n";
   option (i+1) jkind_annotation ppf x.ptype_jkind_annotation
 

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -679,7 +679,9 @@ and type_declaration i ppf x =
   type_kind (i+1) ppf x.ptype_kind;
   line i ppf "ptype_private = %a\n" fmt_private_flag x.ptype_private;
   line i ppf "ptype_manifest =\n";
-  option (i+1) core_type ppf x.ptype_manifest
+  option (i+1) core_type ppf x.ptype_manifest;
+  line i ppf "ptype_supertype =\n";
+  option (i+1) core_type ppf x.ptype_supertype
   )
 
 and jkind_declaration i ppf

--- a/testsuite/tests/language-extensions/pprintast_unconditional.ml
+++ b/testsuite/tests/language-extensions/pprintast_unconditional.ml
@@ -88,6 +88,7 @@ module Example = struct
                          ; ptype_kind = Ptype_abstract
                          ; ptype_private = Public
                          ; ptype_manifest = Some core_type
+                         ; ptype_supertype = None
                          ; ptype_attributes = []
                          ; ptype_loc = loc
                          ; ptype_jkind_annotation =

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -58,6 +58,8 @@ Ptop_def
                   ]
                 Ptyp_constr "int" (//toplevel//[2,1+9]..[2,1+12])
                 []
+          ptype_supertype =
+            None
           ptype_jkind_annotation =
             None
       ]
@@ -162,6 +164,8 @@ Ptop_def
                   ptype_private = Public
                   ptype_manifest =
                     None
+                  ptype_supertype =
+                    None
                   ptype_jkind_annotation =
                     None
               ]
@@ -192,6 +196,8 @@ Ptop_def
                     core_type (//toplevel//[2,1+34]..[2,1+37])
                       Ptyp_constr "int" (//toplevel//[2,1+34]..[2,1+37])
                       []
+                ptype_supertype =
+                  None
                 ptype_jkind_annotation =
                   None
           ]
@@ -221,6 +227,8 @@ Ptop_def
                     core_type (//toplevel//[2,1+35]..[2,1+38])
                       Ptyp_constr "int" (//toplevel//[2,1+35]..[2,1+38])
                       []
+                ptype_supertype =
+                  None
                 ptype_jkind_annotation =
                   None
           ]

--- a/testsuite/tests/parsing/attributes.compilers.reference
+++ b/testsuite/tests/parsing/attributes.compilers.reference
@@ -90,6 +90,8 @@
         ptype_private = Public
         ptype_manifest =
           None
+        ptype_supertype =
+          None
         ptype_jkind_annotation =
           None
     ]
@@ -133,6 +135,8 @@
                     ]
                 ptype_private = Public
                 ptype_manifest =
+                  None
+                ptype_supertype =
                   None
                 ptype_jkind_annotation =
                   None
@@ -202,6 +206,8 @@
                         core_type (attributes.ml[39,498+58]..[39,498+61])
                           Ptyp_constr "M.t" (attributes.ml[39,498+58]..[39,498+61])
                           []
+                    ptype_supertype =
+                      None
                     ptype_jkind_annotation =
                       None
               ]
@@ -231,6 +237,8 @@
                   Ptype_abstract
                 ptype_private = Public
                 ptype_manifest =
+                  None
+                ptype_supertype =
                   None
                 ptype_jkind_annotation =
                   None
@@ -275,6 +283,8 @@
                     core_type (attributes.ml[53,681+34]..[53,681+37])
                       Ptyp_constr "int" (attributes.ml[53,681+34]..[53,681+37])
                       []
+                ptype_supertype =
+                  None
                 ptype_jkind_annotation =
                   None
           ]

--- a/testsuite/tests/parsing/extensions.compilers.reference
+++ b/testsuite/tests/parsing/extensions.compilers.reference
@@ -116,6 +116,8 @@
                       core_type (extensions.ml[13,251+41]..[13,251+42])
                         Ptyp_constr "t" (extensions.ml[13,251+41]..[13,251+42])
                         []
+                  ptype_supertype =
+                    None
                   ptype_jkind_annotation =
                     None
               ]
@@ -284,6 +286,8 @@
                           core_type (extensions.ml[23,534+35]..[23,534+36])
                             Ptyp_constr "t" (extensions.ml[23,534+35]..[23,534+36])
                             []
+                      ptype_supertype =
+                        None
                       ptype_jkind_annotation =
                         None
                 ]
@@ -325,6 +329,8 @@
                       core_type (extensions.ml[25,606+20]..[25,606+21])
                         Ptyp_constr "t" (extensions.ml[25,606+20]..[25,606+21])
                         []
+                  ptype_supertype =
+                    None
                   ptype_jkind_annotation =
                     None
               ]

--- a/testsuite/tests/parsing/hash_ambiguity.compilers.reference
+++ b/testsuite/tests/parsing/hash_ambiguity.compilers.reference
@@ -43,6 +43,8 @@
                     Ptyp_constr "int" (hash_ambiguity.ml[9,169+12]..[9,169+15])
                     []
                 ]
+        ptype_supertype =
+          None
         ptype_jkind_annotation =
           None
     ]
@@ -76,6 +78,8 @@
             ]
         ptype_private = Public
         ptype_manifest =
+          None
+        ptype_supertype =
           None
         ptype_jkind_annotation =
           None
@@ -114,6 +118,8 @@
             ]
         ptype_private = Public
         ptype_manifest =
+          None
+        ptype_supertype =
           None
         ptype_jkind_annotation =
           None

--- a/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
+++ b/testsuite/tests/parsing/shortcut_ext_attr.compilers.reference
@@ -531,6 +531,8 @@
                 Ptyp_package
                   package_type "M" (shortcut_ext_attr.ml[61,1304+20]..[61,1304+21])
                   []
+        ptype_supertype =
+          None
         ptype_jkind_annotation =
           None
     ]
@@ -622,6 +624,8 @@
                 core_type (shortcut_ext_attr.ml[79,1615+19]..[79,1615+22])
                   Ptyp_constr "int" (shortcut_ext_attr.ml[79,1615+19]..[79,1615+22])
                   []
+            ptype_supertype =
+              None
             ptype_jkind_annotation =
               None
           type_declaration "t" (shortcut_ext_attr.ml[80,1638+10]..[80,1638+11]) (shortcut_ext_attr.ml[80,1638+0]..[80,1638+17])
@@ -639,6 +643,8 @@
                 core_type (shortcut_ext_attr.ml[80,1638+14]..[80,1638+17])
                   Ptyp_constr "int" (shortcut_ext_attr.ml[80,1638+14]..[80,1638+17])
                   []
+            ptype_supertype =
+              None
             ptype_jkind_annotation =
               None
         ]
@@ -856,6 +862,8 @@
                         core_type (shortcut_ext_attr.ml[101,2020+21]..[101,2020+24])
                           Ptyp_constr "int" (shortcut_ext_attr.ml[101,2020+21]..[101,2020+24])
                           []
+                    ptype_supertype =
+                      None
                     ptype_jkind_annotation =
                       None
                   type_declaration "t'" (shortcut_ext_attr.ml[102,2045+12]..[102,2045+14]) (shortcut_ext_attr.ml[102,2045+2]..[102,2045+20])
@@ -873,6 +881,8 @@
                         core_type (shortcut_ext_attr.ml[102,2045+17]..[102,2045+20])
                           Ptyp_constr "int" (shortcut_ext_attr.ml[102,2045+17]..[102,2045+20])
                           []
+                    ptype_supertype =
+                      None
                     ptype_jkind_annotation =
                       None
                 ]

--- a/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
+++ b/testsuite/tests/typing-layouts-products/parsing_ambiguous_product.compilers.reference
@@ -12,6 +12,8 @@
         ptype_private = Public
         ptype_manifest =
           None
+        ptype_supertype =
+          None
         ptype_jkind_annotation =
           Some
             jkind (parsing_ambiguous_product.ml[12,327+10]..[12,327+49])
@@ -42,6 +44,8 @@
         ptype_private = Public
         ptype_manifest =
           None
+        ptype_supertype =
+          None
         ptype_jkind_annotation =
           Some
             jkind (parsing_ambiguous_product.ml[14,380+10]..[14,380+45])
@@ -71,6 +75,8 @@
           Ptype_abstract
         ptype_private = Public
         ptype_manifest =
+          None
+        ptype_supertype =
           None
         ptype_jkind_annotation =
           Some

--- a/testsuite/tests/typing-subtypes/errors.ml
+++ b/testsuite/tests/typing-subtypes/errors.ml
@@ -1,0 +1,230 @@
+(* TEST
+ flags = "-extension subtypes";
+ expect;
+*)
+
+(* Prerequisite: a boxed variant type to use as a supertype. *)
+type letter = A | B | C | D | E
+[%%expect{|
+type letter = A | B | C | D | E
+|}]
+
+(* An alias of a variant type cannot be a supertype (no alias chasing). *)
+type l2 = letter
+type w :> l2 = A
+[%%expect{|
+type l2 = letter
+Line 2, characters 0-16:
+2 | type w :> l2 = A
+    ^^^^^^^^^^^^^^^^
+Error: The supertype "l2" is not a variant type.
+       Only a type declared as a variant can be a supertype.
+|}]
+
+(* An arrow type cannot be a supertype. *)
+type w :> (int -> int) = A
+[%%expect{|
+Line 1, characters 0-26:
+1 | type w :> (int -> int) = A
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The supertype "int -> int" is not a variant type.
+       Only a type declared as a variant can be a supertype.
+|}]
+
+(* An extensible variant cannot be a supertype. *)
+type ext = ..
+type w :> ext = A
+[%%expect{|
+type ext = ..
+Line 2, characters 0-17:
+2 | type w :> ext = A
+    ^^^^^^^^^^^^^^^^^
+Error: The supertype "ext" is not a variant type.
+       Only a type declared as a variant can be a supertype.
+|}]
+
+(* An extensible kind cannot declare a supertype. *)
+type w2 :> letter = ..
+[%%expect{|
+Line 1, characters 0-22:
+1 | type w2 :> letter = ..
+    ^^^^^^^^^^^^^^^^^^^^^^
+Error: Only variant types can declare a supertype.
+|}]
+
+(* A subtype cannot be [@@unboxed] (here the unboxed attribute itself is
+   ill-formed, since the constructor is constant). *)
+type u :> letter = A [@@unboxed]
+[%%expect{|
+Line 1, characters 0-32:
+1 | type u :> letter = A [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type cannot be unboxed because its constructor has no argument.
+|}]
+
+(* An [@@unboxed] variant cannot be a supertype: only boxed variants have
+   the tags a subtype inherits. *)
+type ubx = U of int [@@unboxed]
+type w :> ubx = U of int
+[%%expect{|
+type ubx = U of int [@@unboxed]
+Line 2, characters 0-24:
+2 | type w :> ubx = U of int
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The supertype "ubx" is not a variant type.
+       Only a type declared as a variant can be a supertype.
+|}]
+
+(* Constructor argument types must equal the supertype's. *)
+type args = X of int | Y of string
+type w :> args = X of string
+[%%expect{|
+type args = X of int | Y of string
+Line 2, characters 0-28:
+2 | type w :> args = X of string
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "args"
+       Constructors do not match:
+         "X of int"
+       is not the same as:
+         "X of string"
+       The type "int" is not equal to the type "string"
+|}]
+
+(* Constructor arity must equal the supertype's. *)
+type w :> args = Y of string * string
+[%%expect{|
+Line 1, characters 0-37:
+1 | type w :> args = Y of string * string
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "args"
+       Constructors do not match:
+         "Y of string"
+       is not the same as:
+         "Y of string * string"
+       They have different arities.
+|}]
+
+(* Constructors must appear in the supertype's relative order. *)
+type w :> letter = E | A
+[%%expect{|
+Line 1, characters 0-24:
+1 | type w :> letter = E | A
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "letter"
+       1. Constructors have different names, "A" and "E".
+       2. Constructors have different names, "B" and "A".
+|}]
+
+(* A tuple argument cannot match the supertype's inline record. *)
+type ir = R of { x : int } | S
+type w :> ir = R of int
+[%%expect{|
+type ir = R of { x : int; } | S
+Line 2, characters 0-23:
+2 | type w :> ir = R of int
+    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "ir"
+       Constructors do not match:
+         "R of { x : int; }"
+       is not the same as:
+         "R of int"
+       The original uses inline records and this doesn't.
+|}]
+
+(* A mutable inline-record payload is fine when literally equal. *)
+type ir2 = M of { mutable x : int } | N
+type w :> ir2 = M of { mutable x : int }
+[%%expect{|
+type ir2 = M of { mutable x : int; } | N
+type w :> ir2 = M of { mutable x : int; }
+|}]
+
+(* Recursive occurrences must match the supertype literally: [K of w]
+   does not match [K of rt]. *)
+type rt = K of rt | L
+type w :> rt = K of w
+[%%expect{|
+type rt = K of rt | L
+Line 2, characters 0-21:
+2 | type w :> rt = K of w
+    ^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "rt"
+       Constructors do not match:
+         "K of rt"
+       is not the same as:
+         "K of w"
+       The type "rt" is not equal to the type "w"
+|}]
+
+(* ... but the literal form [K of rt] is accepted. *)
+type w2 :> rt = K of rt
+[%%expect{|
+type w2 :> rt = K of rt
+|}]
+
+(* GADT syntax: the subtype constructor's result type is the subtype
+   itself, which differs from the supertype's result type. *)
+type g = G : int -> g
+type w :> g = G : int -> w
+[%%expect{|
+type g = G : int -> g
+Line 2, characters 0-26:
+2 | type w :> g = G : int -> w
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "g"
+       Constructors do not match:
+         "G : int -> g"
+       is not the same as:
+         "G : int -> w"
+       The type "g" is not equal to the type "w"
+|}]
+
+(* GADT result type naming the supertype: best guess is that the usual
+   GADT return-type check rejects it (recording actual behavior). *)
+type w2 :> g = G : int -> g
+[%%expect{|
+Line 1, characters 26-27:
+1 | type w2 :> g = G : int -> g
+                              ^
+Error: Constraints are not satisfied in this type.
+       Type "g" should be an instance of "w2"
+|}]
+
+(* A private variant supertype's constructors may not be re-exposed by a
+   public subtype. *)
+type priv = private P | Q
+type w :> priv = P
+[%%expect{|
+type priv = private P | Q
+Line 2, characters 0-18:
+2 | type w :> priv = P
+    ^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "priv"
+       Private variant constructor(s) would be revealed.
+|}]
+
+(* A manifest, a supertype, and an explicit definition may be combined:
+   both the manifest and the supertype are checked against the
+   definition. *)
+type vowel :> letter = A | E
+type both :> letter = vowel = A | E
+[%%expect{|
+type vowel :> letter = A | E
+type both :> letter = vowel = A | E
+|}]
+
+(* An [@@unboxed] subtype that drops a constructor must be rejected: its
+   value is the bare payload, so the free coercion would reinterpret an
+   immediate as a boxed block (segfault / type confusion otherwise). *)
+type ubx_drop = P of int | Q
+type w :> ubx_drop = P of int [@@unboxed]
+[%%expect{|
+type ubx_drop = P of int | Q
+Line 2, characters 0-41:
+2 | type w :> ubx_drop = P of int [@@unboxed]
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: A variant type with a supertype must use the default (boxed)
+       representation. A type with an unboxed or special representation
+       cannot be a subtype.
+|}]

--- a/testsuite/tests/typing-subtypes/extension_off.ml
+++ b/testsuite/tests/typing-subtypes/extension_off.ml
@@ -1,0 +1,22 @@
+(* TEST
+ expect;
+*)
+
+(* Ordinary variant declarations work without the extension *)
+
+type letter = A | B
+
+[%%expect{|
+type letter = A | B
+|}]
+
+(* A supertype annotation requires the "subtypes" extension *)
+
+type v :> letter = A
+
+[%%expect{|
+Line 1, characters 10-16:
+1 | type v :> letter = A
+              ^^^^^^
+Error: The extension "subtypes" is disabled and cannot be used
+|}]

--- a/testsuite/tests/typing-subtypes/modules.ml
+++ b/testsuite/tests/typing-subtypes/modules.ml
@@ -1,0 +1,318 @@
+(* TEST
+ flags = "-extension subtypes";
+ expect;
+*)
+
+(* Signature inclusion, with-constraints, and functors for variant
+   subtype declarations *)
+
+type letter = A | B | C | D | E
+type vowel :> letter = A | E
+type consonant :> letter = B | C | D
+
+[%%expect{|
+type letter = A | B | C | D | E
+type vowel :> letter = A | E
+type consonant :> letter = B | C | D
+|}]
+
+(* Sig and impl both declare the same supertype: accepted *)
+module M1 : sig
+  type t :> letter = A | E
+end = struct
+  type t :> letter = A | E
+end
+
+[%%expect{|
+module M1 : sig type t :> letter = A | E end
+|}]
+
+(* Sig declares a supertype but the impl doesn't: rejected *)
+module M2 : sig
+  type t :> letter = A | E
+end = struct
+  type t = A | E
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t = A | E
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A | E end
+       is not included in
+         sig type t :> letter = A | E end
+       Type declarations do not match:
+         type t = A | E
+       is not included in
+         type t :> letter = A | E
+       The second declaration has a supertype and the first does not.
+|}]
+
+(* Impl declares a supertype but the sig shows plain constructors:
+   rejected, because the runtime tags differ *)
+module M3 : sig
+  type t = A | E
+end = struct
+  type t :> letter = A | E
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t :> letter = A | E
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t :> letter = A | E end
+       is not included in
+         sig type t = A | E end
+       Type declarations do not match:
+         type t :> letter = A | E
+       is not included in
+         type t = A | E
+       Constructor "E" has a different runtime representation:
+       its tag is 4 in the first declaration
+       but 1 in the second declaration.
+|}]
+
+(* Impl declares a supertype, sig fully abstract: accepted *)
+module M4 : sig
+  type t
+end = struct
+  type t :> letter = A | E
+end
+
+[%%expect{|
+module M4 : sig type t end
+|}]
+
+(* Abstract sig with a supertype, impl concrete with the same
+   supertype: accepted *)
+module M5 : sig
+  type t :> letter
+end = struct
+  type t :> letter = A | E
+end
+
+[%%expect{|
+module M5 : sig type t :> letter end
+|}]
+
+(* Coercion still works through the abstract supertype *)
+let f (x : M5.t) = (x : M5.t :> letter)
+
+[%%expect{|
+val f : M5.t -> letter = <fun>
+|}]
+
+(* Abstract sig with a supertype, justified by the impl's manifest:
+   accepted *)
+module M6 : sig
+  type t :> letter
+end = struct
+  type t = vowel
+end
+
+[%%expect{|
+module M6 : sig type t :> letter end
+|}]
+
+(* Chain-weakening: impl's supertype consonant is itself a subtype of
+   the sig's supertype letter. Not yet supported: rejected *)
+module M7 : sig
+  type t :> letter
+end = struct
+  type t :> consonant = C
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t :> consonant = C
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t :> consonant = C end
+       is not included in
+         sig type t :> letter end
+       Type declarations do not match:
+         type t :> consonant = C
+       is not included in
+         type t :> letter
+       Their supertypes differ:
+       The type "consonant" is not equal to the type "letter"
+       Hint: signature inclusion requires the two supertypes to be equal.
+|}]
+
+(* Supertype mismatch in the other direction: rejected *)
+module M8 : sig
+  type t :> consonant
+end = struct
+  type t :> letter = B
+end
+
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   type t :> letter = B
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t :> letter = B end
+       is not included in
+         sig type t :> consonant end
+       Type declarations do not match:
+         type t :> letter = B
+       is not included in
+         type t :> consonant
+       Their supertypes differ:
+       The type "letter" is not equal to the type "consonant"
+       Hint: signature inclusion requires the two supertypes to be equal.
+|}]
+
+(* With-constraint on a concrete type keeps the supertype *)
+module type S = sig
+  type t :> letter = A | E
+  val x : t
+end
+
+[%%expect{|
+module type S = sig type t :> letter = A | E val x : t end
+|}]
+
+module type S2 = S with type t = vowel
+
+[%%expect{|
+module type S2 = sig type t :> letter = vowel = A | E val x : t end
+|}]
+
+(* An abstract impl doesn't match S2's concrete type... *)
+module M9 : S2 = struct
+  type t = vowel
+  let x = A
+end
+
+[%%expect{|
+Lines 1-4, characters 17-3:
+1 | .................struct
+2 |   type t = vowel
+3 |   let x = A
+4 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = vowel val x : vowel end
+       is not included in
+         S2
+       Type declarations do not match:
+         type t = vowel
+       is not included in
+         type t :> letter = vowel = A | E
+       The first is abstract, but the second is a variant.
+|}]
+
+(* ...but a manifest re-export does, the supertype being justified by
+   the manifest *)
+module M9b : S2 = struct
+  type t = vowel = A | E
+  let x = A
+end
+
+[%%expect{|
+module M9b : S2
+|}]
+
+(* With-constraint on an abstract type with a supertype: accepted via
+   manifest justification *)
+module type T0 = sig
+  type t :> letter
+end
+
+[%%expect{|
+module type T0 = sig type t :> letter end
+|}]
+
+module type T1 = T0 with type t = vowel
+
+[%%expect{|
+module type T1 = sig type t = vowel end
+|}]
+
+(* Destructive substitution removes the declaration, supertype and
+   all *)
+module type T2 = T0 with type t := vowel
+
+[%%expect{|
+module type T2 = sig end
+|}]
+
+(* A functor can coerce through its parameter's declared supertype *)
+module F (X : T0) = struct
+  let up (x : X.t) = (x : X.t :> letter)
+end
+
+[%%expect{|
+module F : functor (X : T0) -> sig val up : X.t -> letter end
+|}]
+
+(* Application whose argument justifies the supertype by a manifest *)
+module App = F (struct type t = vowel end)
+
+[%%expect{|
+module App : sig val up : vowel -> letter end
+|}]
+
+(* Functor over an inline signature with a supertype *)
+module G (X : sig type t :> letter end) = struct
+  let f (x : X.t) = (x : X.t :> letter)
+end
+
+[%%expect{|
+module G :
+  functor (X : sig type t :> letter end) -> sig val f : X.t -> letter end
+|}]
+
+(* Application whose argument declares the supertype itself; the
+   argument is bound to a name so X.t is expressible in the result *)
+module Arg = struct
+  type t :> letter = A
+end
+
+[%%expect{|
+module Arg : sig type t :> letter = A end
+|}]
+
+module R = G (Arg)
+
+[%%expect{|
+module R : sig val f : Arg.t -> letter end
+|}]
+
+(* Manifest justification is followed only one level: an implementation
+   whose manifest is a *transitive* subtype of the signature's supertype
+   (semicircular_consonant :> consonant :> letter) is not accepted, because
+   semicircular_consonant's own supertype is consonant, not letter. *)
+type semicircular_consonant :> consonant = C
+module M10 : sig type t :> letter end = struct
+  type t = semicircular_consonant
+end
+
+[%%expect{|
+type semicircular_consonant :> consonant = C
+Lines 2-4, characters 40-3:
+2 | ........................................struct
+3 |   type t = semicircular_consonant
+4 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = semicircular_consonant end
+       is not included in
+         sig type t :> letter end
+       Type declarations do not match:
+         type t = semicircular_consonant
+       is not included in
+         type t :> letter
+       The second declaration has a supertype and the first does not.
+|}]

--- a/testsuite/tests/typing-subtypes/params.ml
+++ b/testsuite/tests/typing-subtypes/params.ml
@@ -1,0 +1,165 @@
+(* TEST
+ flags = "-extension subtypes";
+ expect;
+*)
+
+(* Parameterized supertype: the subtype keeps the parameter and inherits
+   sparse tags (N keeps its block tag 1 from s). *)
+type 'a s = L of 'a | M | N of 'a * int
+
+type 'a t :> 'a s = L of 'a | N of 'a * int
+
+[%%expect{|
+type 'a s = L of 'a | M | N of 'a * int
+type 'a t :> 'a s = L of 'a | N of 'a * int
+|}]
+
+(* Coercion with the parameter instantiated. *)
+let f (x : int t) = (x : int t :> int s)
+
+[%%expect{|
+val f : int t -> int s = <fun>
+|}]
+
+(* Coercion must respect the instantiation: int t is not a subtype of
+   string s. *)
+let g x = (x : int t :> string s)
+
+[%%expect{|
+Line 1, characters 10-33:
+1 | let g x = (x : int t :> string s)
+              ^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "int t" is not a subtype of "string s"
+       Type "int" is not a subtype of "string"
+|}]
+
+(* Arity mismatch: a 1-ary subtype of a 0-ary supertype. *)
+type letter = A | B | C | D | E
+
+type 'a w :> letter = A
+
+[%%expect{|
+type letter = A | B | C | D | E
+Line 3, characters 0-23:
+3 | type 'a w :> letter = A
+    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "letter"
+       They have different arities.
+|}]
+
+(* A parameterized supertype for the remaining cases. *)
+type 'a pair = Fst of 'a | Snd of string
+
+[%%expect{|
+type 'a pair = Fst of 'a | Snd of string
+|}]
+
+(* Instantiated supertype: a 0-ary subtype of int pair. The supertype's
+   arguments must be exactly the declaration's parameters, so this is an
+   arity mismatch. *)
+type w2 :> int pair = Fst of int
+
+[%%expect{|
+Line 1, characters 0-32:
+1 | type w2 :> int pair = Fst of int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "int pair"
+       They have different arities.
+|}]
+
+(* The parameter may go unused in the kept constructors. *)
+type 'a keep :> 'a pair = Snd of string
+
+[%%expect{|
+type 'a keep :> 'a pair = Snd of string
+|}]
+
+(* Param swap: the supertype's arguments must be the declaration's
+   parameters in order, as for manifest re-exports, so instantiating the
+   supertype at swapped parameters is rejected (recording actual
+   behavior). *)
+type ('a, 'b) two = AA of 'a | BB of 'b
+
+type ('a, 'b) tw :> ('b, 'a) two = AA of 'b
+
+[%%expect{|
+type ('a, 'b) two = AA of 'a | BB of 'b
+Line 3, characters 0-43:
+3 | type ('a, 'b) tw :> ('b, 'a) two = AA of 'b
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('b, 'a) two"
+       Their parameters differ:
+       The type "'b" is not equal to the type "'a"
+|}]
+
+(* Param swap with a wrong constructor type: also rejected (the parameter
+   check fires first). *)
+type ('a, 'b) tw2 :> ('b, 'a) two = AA of 'a
+
+[%%expect{|
+Line 1, characters 0-44:
+1 | type ('a, 'b) tw2 :> ('b, 'a) two = AA of 'a
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type
+         "('b, 'a) two"
+       Their parameters differ:
+       The type "'b" is not equal to the type "'a"
+|}]
+
+(* Constraint interplay: constraining the parameter specializes the
+   supertype, which no longer matches the supertype's own parameters
+   (recording actual behavior; the manifest analogue is also rejected). *)
+type 'a c :> 'a pair = Fst of 'a constraint 'a = int
+
+[%%expect{|
+Line 1, characters 0-52:
+1 | type 'a c :> 'a pair = Fst of 'a constraint 'a = int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "int pair"
+       Their parameters differ:
+       The type "'a" is not equal to the type "int"
+|}]
+
+(* Coercion transitivity through a parameterized chain. *)
+type 'a mid :> 'a s = L of 'a
+
+type 'a bot :> 'a mid = L of 'a
+
+[%%expect{|
+type 'a mid :> 'a s = L of 'a
+type 'a bot :> 'a mid = L of 'a
+|}]
+
+let h (x : int bot) = (x : int bot :> int s)
+
+[%%expect{|
+val h : int bot -> int s = <fun>
+|}]
+
+(* A parameterized subtype matches through a module boundary: its supertype
+   is copied along with the fresh instance parameters. *)
+module Mp : sig type 'a t :> 'a s = L of 'a | N of 'a * int end = struct
+  type 'a t :> 'a s = L of 'a | N of 'a * int
+end
+
+[%%expect{|
+module Mp : sig type 'a t :> 'a s = L of 'a | N of 'a * int end
+|}]
+
+(* An abstract declaration's supertype must be applied to its own
+   parameters; otherwise the signature is unimplementable (and can diverge
+   under -rectypes). *)
+type 'a box = Box of 'a
+module type Sbad = sig
+  type 'a bad :> ('a bad) box
+end
+
+[%%expect{|
+type 'a box = Box of 'a
+Line 3, characters 2-29:
+3 |   type 'a bad :> ('a bad) box
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The supertype "'a bad box" must be applied to the parameters of this
+       type declaration.
+|}]

--- a/testsuite/tests/typing-subtypes/recursion.ml
+++ b/testsuite/tests/typing-subtypes/recursion.ml
@@ -1,0 +1,190 @@
+(* TEST
+ flags = "-extension subtypes";
+ expect;
+*)
+
+type letter = A | B | C | D | E
+
+[%%expect{|
+type letter = A | B | C | D | E
+|}]
+
+(* A type cannot be its own supertype. *)
+
+type t :> t = A
+
+[%%expect{|
+Line 1, characters 0-15:
+1 | type t :> t = A
+    ^^^^^^^^^^^^^^^
+Error: The supertype "t" must be defined before this declaration;
+       it cannot be part of the same recursive group.
+|}]
+
+(* The supertype cannot be in the same recursive group, even when it is
+   declared first. *)
+
+type a = A | B
+and b :> a = A
+
+[%%expect{|
+Line 2, characters 0-14:
+2 | and b :> a = A
+    ^^^^^^^^^^^^^^
+Error: The supertype "a" must be defined before this declaration;
+       it cannot be part of the same recursive group.
+|}]
+
+(* ... nor when it is declared second. *)
+
+type b2 :> a2 = A
+and a2 = A | B
+
+[%%expect{|
+Line 1, characters 0-17:
+1 | type b2 :> a2 = A
+    ^^^^^^^^^^^^^^^^^
+Error: The supertype "a2" must be defined before this declaration;
+       it cannot be part of the same recursive group.
+|}]
+
+(* Mutual supertypes are rejected. *)
+
+type u :> v = A
+and v :> u = A
+
+[%%expect{|
+Line 1, characters 0-15:
+1 | type u :> v = A
+    ^^^^^^^^^^^^^^^
+Error: The supertype "v" must be defined before this declaration;
+       it cannot be part of the same recursive group.
+|}]
+
+(* An abstract declaration whose supertype is in the same group is
+   rejected too. *)
+
+type p :> q
+and q = A | B
+
+[%%expect{|
+Line 1, characters 0-11:
+1 | type p :> q
+    ^^^^^^^^^^^
+Error: The supertype "q" must be defined before this declaration;
+       it cannot be part of the same recursive group.
+|}]
+
+(* Same for mutually abstract declarations in a signature. *)
+
+module type S = sig
+  type p :> q
+  and q :> p
+end
+
+[%%expect{|
+Line 2, characters 2-13:
+2 |   type p :> q
+      ^^^^^^^^^^^
+Error: The supertype "q/2" must be defined before this declaration;
+       it cannot be part of the same recursive group.
+|}]
+
+(* A previously defined supertype may be shared by several members of one
+   recursive group: the supertype itself is outside the group. *)
+
+type a3 = A | B
+
+type b3 :> a3 = A
+and c3 :> a3 = B
+
+[%%expect{|
+type a3 = A | B
+type b3 :> a3 = A
+and c3 :> a3 = B
+|}]
+
+(* c3's B inherits a3's tag for B (tag 1), so the coercion typechecks. *)
+
+let c3_to_a3 x = (x : c3 :> a3)
+
+[%%expect{|
+val c3_to_a3 : c3 -> a3 = <fun>
+|}]
+
+(* A subtype may itself serve as a supertype later, forming a chain. *)
+
+type v :> a3 = A
+
+type w :> v = A
+
+[%%expect{|
+type v :> a3 = A
+type w :> v = A
+|}]
+
+(* Coercions are accepted along the chain, transitively. *)
+
+let w_to_v x = (x : w :> v)
+let w_to_a3 x = (x : w :> a3)
+
+[%%expect{|
+val w_to_v : w -> v = <fun>
+val w_to_a3 : w -> a3 = <fun>
+|}]
+
+(* Coercing down the chain is rejected. *)
+
+let a3_to_w x = (x : a3 :> w)
+
+[%%expect{|
+Line 1, characters 16-29:
+1 | let a3_to_w x = (x : a3 :> w)
+                    ^^^^^^^^^^^^^
+Error: Type "a3" is not a subtype of "w"
+|}]
+
+(* Recursive-module smoke test: the supertype is defined outside the
+   module recursion. This records current behavior; the supertype is
+   expected to survive signature matching. *)
+
+module rec M : sig
+  type t :> letter
+  val x : t
+end = struct
+  type t :> letter = A
+  let x = A
+end
+
+[%%expect{|
+module rec M : sig type t :> letter val x : t end
+|}]
+
+let m_to_letter x = (x : M.t :> letter)
+
+[%%expect{|
+val m_to_letter : M.t -> letter = <fun>
+|}]
+
+(* A supertype/manifest knot built through a recursive module and a
+   with-constraint must not hang the typechecker: a failing coercion on the
+   knotted type reports an ordinary "not a subtype" error. *)
+
+module type Sc = sig
+  type v = A
+  type t :> v = A
+end
+module rec Mc : (Sc with type v = Mc.t) = struct
+  type v = Mc.t = A
+  type t :> v = A
+end
+let mc_bad (x : Mc.t) = (x : Mc.t :> string)
+
+[%%expect{|
+module type Sc = sig type v = A type t :> v = A end
+module rec Mc : sig type v = Mc.t = A type t :> v = A end
+Line 9, characters 24-44:
+9 | let mc_bad (x : Mc.t) = (x : Mc.t :> string)
+                            ^^^^^^^^^^^^^^^^^^^^
+Error: Type "Mc.t" is not a subtype of "string"
+|}]

--- a/testsuite/tests/typing-subtypes/reexport.ml
+++ b/testsuite/tests/typing-subtypes/reexport.ml
@@ -1,0 +1,92 @@
+(* TEST
+ flags = "-extension subtypes";
+ expect;
+*)
+
+type letter = A | B | C | D | E
+type vowel :> letter = A | E
+
+[%%expect{|
+type letter = A | B | C | D | E
+type vowel :> letter = A | E
+|}]
+
+(* Manifest re-export of a subtype keeps its inherited (sparse) tags *)
+
+type v2 = vowel = A | E
+
+[%%expect{|
+type v2 = vowel = A | E
+|}]
+
+(* A dense variant with the same constructors is fine on its own... *)
+
+type v3 = A | E
+
+[%%expect{|
+type v3 = A | E
+|}]
+
+(* ...but a fresh dense variant cannot implement a re-export of the
+   subtype *)
+
+module M : sig type t = vowel = A | E end = struct type t = A | E end
+
+[%%expect{|
+Line 1, characters 44-69:
+1 | module M : sig type t = vowel = A | E end = struct type t = A | E end
+                                                ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t = A | E end
+       is not included in
+         sig type t = vowel = A | E end
+       Type declarations do not match:
+         type t = A | E
+       is not included in
+         type t = vowel = A | E
+       The type "t" is not equal to the type "vowel"
+|}]
+
+(* A signature exposing dense constructors does not match a subtype
+   implementation: the runtime tags disagree *)
+
+module N : sig type t = A | E end = struct type t :> letter = A | E end
+
+[%%expect{|
+Line 1, characters 36-71:
+1 | module N : sig type t = A | E end = struct type t :> letter = A | E end
+                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig type t :> letter = A | E end
+       is not included in
+         sig type t = A | E end
+       Type declarations do not match:
+         type t :> letter = A | E
+       is not included in
+         type t = A | E
+       Constructor "E" has a different runtime representation:
+       its tag is 4 in the first declaration
+       but 1 in the second declaration.
+|}]
+
+(* Coercion through the re-export: v2 expands to vowel, whose declaration
+   has the supertype *)
+
+let f (x : v2) = (x : v2 :> letter)
+
+[%%expect{|
+val f : v2 -> letter = <fun>
+|}]
+
+(* The supertype may be named through a re-export alias: the subtype's own
+   manifest (vowel) must not be forced equal to the alias (letter2). *)
+
+type letter2 = letter = A | B | C | D | E
+type vowel2 :> letter2 = vowel = A | E
+
+[%%expect{|
+type letter2 = letter = A | B | C | D | E
+type vowel2 :> letter2 = vowel = A | E
+|}]

--- a/testsuite/tests/typing-subtypes/variants.ml
+++ b/testsuite/tests/typing-subtypes/variants.ml
@@ -1,0 +1,79 @@
+(* TEST
+ (* XXX Should need an extension here *)
+ expect;
+*)
+
+type letter = A | B | C | D | E
+
+type vowel :> letter = A | E
+
+type consonant :> letter = B | C | D
+
+type semicircular_consonant :> consonant = C
+
+type semicircular_vowel :> vowel = |
+
+[%%expect{|
+type letter = A | B | C | D | E
+type vowel :> letter = A | E
+type consonant :> letter = B | C | D
+type semicircular_consonant :> consonant = C
+type semicircular_vowel :> vowel = |
+|}]
+
+type wrong :> letter = A | B | Banana
+
+[%%expect{|
+That's not a subtype, dude.
+|}]
+
+type wrong :> string = int
+
+[%%expect{|
+Come on, man. This is serious.
+|}]
+
+type wrong :> string = A
+
+[%%expect{|
+WTF??
+|}]
+
+type wrong :> letter = { i : int }
+
+[%%expect{|
+I thought you wanted to do something together.
+|}]
+
+type r = { a : int; }
+
+[%%expect {|
+type r = { a : int; }
+|}]
+
+type wrong :> r = A | B
+
+[%%expect{|
+Why don't you take anything seriously anymore?
+|}]
+
+type wrong :> r = { a : int; b : float }
+
+[%%expect{|
+I'm leaving.
+|}]
+
+let consonant_is_letter c = (c : consonant :> letter)
+
+let semicircular_consonant_is_letter c = (c : semicircular_consonant :> letter)
+
+[%%expect{|
+val consonant_is_letter : consonant -> letter = <fun>
+val semicircular_consonant_is_letter : semicircular_consonant -> letter = <fun>
+|}]
+
+let wrong l = (l : letter :> consonant)
+
+[%%expect{|
+I mean it. I'm leaving.
+|}]

--- a/testsuite/tests/typing-subtypes/variants.ml
+++ b/testsuite/tests/typing-subtypes/variants.ml
@@ -1,5 +1,5 @@
 (* TEST
- (* XXX Should need an extension here *)
+ flags = "-extension subtypes";
  expect;
 *)
 
@@ -24,25 +24,39 @@ type semicircular_vowel :> vowel = |
 type wrong :> letter = A | B | Banana
 
 [%%expect{|
-That's not a subtype, dude.
+Line 1, characters 0-37:
+1 | type wrong :> letter = A | B | Banana
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This variant or record definition does not match that of type "letter"
+       Constructors have different names, "C" and "Banana".
 |}]
 
 type wrong :> string = int
 
 [%%expect{|
-Come on, man. This is serious.
+Line 1, characters 0-26:
+1 | type wrong :> string = int
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: A type declaration cannot have both a type equation and a supertype.
 |}]
 
 type wrong :> string = A
 
 [%%expect{|
-WTF??
+Line 1, characters 0-24:
+1 | type wrong :> string = A
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The supertype "string" is not a variant type.
+       Only a type declared as a variant can be a supertype.
 |}]
 
 type wrong :> letter = { i : int }
 
 [%%expect{|
-I thought you wanted to do something together.
+Line 1, characters 0-34:
+1 | type wrong :> letter = { i : int }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Only variant types can declare a supertype.
 |}]
 
 type r = { a : int; }
@@ -54,13 +68,21 @@ type r = { a : int; }
 type wrong :> r = A | B
 
 [%%expect{|
-Why don't you take anything seriously anymore?
+Line 1, characters 0-23:
+1 | type wrong :> r = A | B
+    ^^^^^^^^^^^^^^^^^^^^^^^
+Error: The supertype "r" is not a variant type.
+       Only a type declared as a variant can be a supertype.
 |}]
 
 type wrong :> r = { a : int; b : float }
 
 [%%expect{|
-I'm leaving.
+Line 1, characters 0-40:
+1 | type wrong :> r = { a : int; b : float }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The supertype "r" is not a variant type.
+       Only a type declared as a variant can be a supertype.
 |}]
 
 let consonant_is_letter c = (c : consonant :> letter)
@@ -69,11 +91,15 @@ let semicircular_consonant_is_letter c = (c : semicircular_consonant :> letter)
 
 [%%expect{|
 val consonant_is_letter : consonant -> letter = <fun>
-val semicircular_consonant_is_letter : semicircular_consonant -> letter = <fun>
+val semicircular_consonant_is_letter : semicircular_consonant -> letter =
+  <fun>
 |}]
 
 let wrong l = (l : letter :> consonant)
 
 [%%expect{|
-I mean it. I'm leaving.
+Line 1, characters 14-39:
+1 | let wrong l = (l : letter :> consonant)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "letter" is not a subtype of "consonant"
 |}]

--- a/testsuite/tests/typing-subtypes/variants_runtime.ml
+++ b/testsuite/tests/typing-subtypes/variants_runtime.ml
@@ -1,0 +1,188 @@
+(* TEST
+ flags = "-extension subtypes";
+*)
+
+(* Runtime behavior of variant subtypes: coercions are no-ops, constructors
+   inherit the supertype's (possibly sparse) tags, and pattern matching
+   compiles correctly on sparse tag sets. *)
+
+type letter = A | B | C | D | E
+type vowel :> letter = A | E
+type consonant :> letter = B | C | D
+type semicircular_consonant :> consonant = C
+
+type shape = Pt | Ln of int | Sq of int * int | Cr of { r : int } | Dot
+type round :> shape = Ln of int | Cr of { r : int } | Dot
+
+let check name b =
+  print_string name;
+  print_string (if b then ": OK" else ": FAIL");
+  print_newline ()
+
+(* Coercion preserves identity *)
+let () =
+  let v : vowel = E in
+  check "coerce identity" ((v : vowel :> letter) = (E : letter))
+
+(* Transitive coercion through a chain of subtypes *)
+let () =
+  let c : semicircular_consonant = C in
+  check "transitive coerce"
+    ((c : semicircular_consonant :> letter) = (C : letter))
+
+(* Total match on vowel values (sparse constant tags 0 and 4) *)
+let vowel_name (v : vowel) = match v with A -> "A" | E -> "E"
+
+let () =
+  List.iter
+    (fun v ->
+      print_string "vowel match: ";
+      print_string (vowel_name v);
+      print_newline ())
+    ([A; E] : vowel list)
+
+(* Total match on round values, extracting payloads: block tags are
+   sparse (Ln = 0, Cr = 2) and so are constant tags (Dot = 1) *)
+let round_value (x : round) =
+  match x with Ln n -> n | Cr { r } -> r | Dot -> -1
+
+let () = check "round Ln" (round_value (Ln 5) = 5)
+let () = check "round Cr" (round_value (Cr { r = 7 }) = 7)
+let () = check "round Dot" (round_value Dot = -1)
+
+(* Coerced block constructor compares equal to the supertype's *)
+let () =
+  check "coerce block equal"
+    (((Ln 5 : round) : round :> shape) = (Ln 5 : shape))
+
+(* Structural compare sees the inherited tags: E (4) > A (0) *)
+let () = check "compare vowel" (compare (E : vowel) (A : vowel) > 0)
+
+(* Inherited runtime representations, observed via Obj *)
+let () = check "repr vowel E" ((Obj.magic (E : vowel) : int) = 4)
+let () = check "repr round Dot" ((Obj.magic (Dot : round) : int) = 1)
+let () = check "tag round Cr" (Obj.tag (Obj.repr (Cr { r = 1 } : round)) = 2)
+
+(* Marshalling round-trip of a block constructor with a sparse tag *)
+let () =
+  let s = Marshal.to_string (Ln 5 : round) [] in
+  check "marshal round-trip" ((Marshal.from_string s 0 : round) = Ln 5)
+
+(* A big supertype, so subtypes can have many constructors with sparse
+   tags *)
+type big =
+  | K00 | K01 | K02 | K03 | K04 | K05 | K06 | K07 | K08 | K09
+  | K10 | K11 | K12 | K13 | K14 | K15 | K16 | K17 | K18 | K19
+  | K20 | K21 | K22 | K23 | K24 | K25 | K26 | K27 | K28 | K29
+  | K30 | K31 | K32 | K33 | K34 | K35 | K36 | K37 | K38 | K39
+  | V0 of int
+  | V1 of int
+
+type bigsub :> big = K00 | K05 | K37 | V1 of int
+
+(* Partial matches with defaults on a small, very sparse subtype *)
+let f (x : bigsub) = match x with K00 -> 0 | _ -> 1
+
+let () =
+  List.iter
+    (fun x ->
+      print_string "bigsub f: ";
+      print_int (f x);
+      print_newline ())
+    ([K00; K05; K37; V1 3] : bigsub list)
+
+let g (x : bigsub) = match x with K05 -> 5 | K37 -> 37 | _ -> -1
+
+let () =
+  List.iter
+    (fun x ->
+      print_string "bigsub g: ";
+      print_int (g x);
+      print_newline ())
+    ([K00; K05; K37; V1 9] : bigsub list)
+
+(* A subtype with 34 constructors, so a one-armed match leaves >= 32
+   constructors for the wildcard: exercises the switch-compilation
+   default-action path on sparse inherited tags *)
+type bigsub2 :> big =
+  | K00 | K01 | K02 | K04 | K05 | K06 | K08 | K09
+  | K10 | K11 | K12 | K14 | K15 | K16 | K17 | K18 | K19
+  | K20 | K22 | K23 | K24 | K25 | K26 | K27 | K28
+  | K30 | K31 | K32 | K33 | K34 | K36 | K37 | K38 | K39
+
+let h (x : bigsub2) = match x with K00 -> true | _ -> false
+
+let () = check "bigsub2 h K00" (h K00)
+let () = check "bigsub2 h K04" (not (h K04))
+let () = check "bigsub2 h K39" (not (h K39))
+
+(* Payloads of various shapes in a sparse-tagged subtype: a float, a mixed
+   block (int + float), and a mutable inline record. PInt (block tag 0) is
+   dropped, so the kept block tags 1/2/3 are sparse. *)
+type payload =
+  | PInt of int
+  | PFloat of float
+  | PMixed of { i : int; f : float }
+  | PMut of { mutable m : int }
+  | PNone
+
+type psub :> payload =
+  | PFloat of float
+  | PMixed of { i : int; f : float }
+  | PMut of { mutable m : int }
+  | PNone
+
+let () =
+  check "psub PFloat tag" (Obj.tag (Obj.repr (PFloat 1.0 : psub)) = 1);
+  check "psub PMixed tag"
+    (Obj.tag (Obj.repr (PMixed { i = 1; f = 2.0 } : psub)) = 2);
+  check "psub PMut tag" (Obj.tag (Obj.repr (PMut { m = 1 } : psub)) = 3);
+  check "psub PNone repr" ((Obj.magic (PNone : psub) : int) = 0)
+
+let psub_show (x : psub) =
+  match x with
+  | PFloat f -> "F" ^ string_of_float f
+  | PMixed { i; f } -> "M" ^ string_of_int i ^ "/" ^ string_of_float f
+  | PMut { m } -> "R" ^ string_of_int m
+  | PNone -> "N"
+
+let () =
+  List.iter
+    (fun x ->
+      print_string "psub: "; print_string (psub_show x); print_newline ())
+    ([PFloat 3.5; PMixed { i = 2; f = 1.5 }; PMut { m = 10 }; PNone]
+     : psub list)
+
+(* Coercion is a no-op for float and mixed-block payloads too *)
+let () =
+  check "coerce float payload"
+    (((PFloat 3.5 : psub) : psub :> payload) = (PFloat 3.5 : payload));
+  check "coerce mixed payload"
+    (match ((PMixed { i = 2; f = 1.5 } : psub) : psub :> payload) with
+     | PMixed { i; f } -> i = 2 && f = 1.5
+     | _ -> false)
+
+(* Mutating a mutable payload is visible through the coerced view (the
+   coercion shares the block) *)
+let () =
+  let r = (PMut { m = 0 } : psub) in
+  (match r with PMut s -> s.m <- 42 | _ -> ());
+  check "mutate payload"
+    (match (r : psub :> payload) with PMut { m } -> m = 42 | _ -> false)
+
+(* More direct tag-value assertions on sparse inherited tags *)
+let () =
+  check "repr vowel A" ((Obj.magic (A : vowel) : int) = 0);
+  check "tag round Ln" (Obj.tag (Obj.repr (Ln 5 : round)) = 0);
+  check "repr bigsub K05" ((Obj.magic (K05 : bigsub) : int) = 5);
+  check "repr bigsub K37" ((Obj.magic (K37 : bigsub) : int) = 37);
+  check "tag bigsub V1" (Obj.tag (Obj.repr (V1 3 : bigsub)) = 1)
+
+(* Parameterized subtype: kept block constructors keep their tags (L = 0,
+   N = 1; the dropped constant M would be const tag 0) *)
+type 'a s = L of 'a | M | N of 'a * int
+type 'a t :> 'a s = L of 'a | N of 'a * int
+
+let () =
+  check "tag param L" (Obj.tag (Obj.repr (L 0 : int t)) = 0);
+  check "tag param N" (Obj.tag (Obj.repr (N (0, 0) : int t)) = 1)

--- a/testsuite/tests/typing-subtypes/variants_runtime.reference
+++ b/testsuite/tests/typing-subtypes/variants_runtime.reference
@@ -1,0 +1,42 @@
+coerce identity: OK
+transitive coerce: OK
+vowel match: A
+vowel match: E
+round Ln: OK
+round Cr: OK
+round Dot: OK
+coerce block equal: OK
+compare vowel: OK
+repr vowel E: OK
+repr round Dot: OK
+tag round Cr: OK
+marshal round-trip: OK
+bigsub f: 0
+bigsub f: 1
+bigsub f: 1
+bigsub f: 1
+bigsub g: -1
+bigsub g: 5
+bigsub g: 37
+bigsub g: -1
+bigsub2 h K00: OK
+bigsub2 h K04: OK
+bigsub2 h K39: OK
+psub PFloat tag: OK
+psub PMixed tag: OK
+psub PMut tag: OK
+psub PNone repr: OK
+psub: F3.5
+psub: M2/1.5
+psub: R10
+psub: N
+coerce float payload: OK
+coerce mixed payload: OK
+mutate payload: OK
+repr vowel A: OK
+tag round Ln: OK
+repr bigsub K05: OK
+repr bigsub K37: OK
+tag bigsub V1: OK
+tag param L: OK
+tag param N: OK

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -467,6 +467,7 @@ let type_iterators_without_type_expr =
   and it_type_declaration it td =
     List.iter (it.it_type_expr it) td.type_params;
     Option.iter (it.it_type_expr it) td.type_manifest;
+    Option.iter (it.it_type_expr it) td.type_supertype;
     Option.iter (it.it_type_declaration it) td.type_unboxed_version;
     it.it_type_kind it td.type_kind
   and it_extension_constructor it td =

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -1601,6 +1601,7 @@ let new_local_type ?(loc = Location.none) ?manifest_and_scope origin jkind =
     type_ikind = Types.ikinds_todo "new_local_type";
     type_private = Public;
     type_manifest = manifest;
+    type_supertype = None;
     type_variance = [];
     type_separability = [];
     type_is_newtype = true;
@@ -2348,6 +2349,18 @@ let safe_abbrev env ty =
       Btype.backtrack snap;
       cleanup_abbrev ();
       false
+
+let find_supertype env ty =
+  let path, args = match get_desc ty with
+    | Tconstr (path, args, _) -> path, args
+    | _ -> assert false
+  in
+  (* XXX Deal with args *)
+  ignore args;
+  match Env.find_type path env with
+  | { type_supertype = Some sup; _ } -> sup
+  | { type_supertype = None; _ }
+  | exception Not_found -> assert false
 
 let rec try_expand_once_gen expand_abbrev env ty =
   match get_desc ty with
@@ -3661,6 +3674,14 @@ let generic_private_abbrev env path =
        type_private = Private;
        type_manifest = Some body} ->
          get_level body = generic_level
+    | _ -> false
+  with Not_found -> false
+
+let has_generic_supertype env path =
+  try
+    match Env.find_type path env with
+      {type_supertype = Some sup} ->
+        get_level sup = generic_level
     | _ -> false
   with Not_found -> false
 
@@ -7800,6 +7821,9 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tconstr(p1, _, _), _)
       when generic_private_abbrev env p1 && safe_abbrev_opt env t1 ->
         subtype_rec env trace (expand_abbrev_opt env t1) t2 cstrs
+    | (Tconstr(p1, _, _), _)
+      when has_generic_supertype env p1 ->
+        subtype_rec env trace (find_supertype env t1) t2 cstrs
 (*  | (_, Tconstr(p2, _, _)) when generic_private_abbrev false env p2 ->
         subtype_rec env trace t1 (expand_abbrev_opt env t2) cstrs *)
     | (Tobject (f1, _), Tobject (f2, _))
@@ -8405,6 +8429,20 @@ let rec nondep_type_decl env mid is_covariant decl =
                 Private
             with Nondep_cannot_erase _ ->
               None, decl.type_private
+    (* XXX Just copying code blindly here. Need to understand and probably
+       refactor with above. *)
+    in
+    let st, priv =
+      match decl.type_supertype with
+      | None -> None, priv
+      | Some ty ->
+          try Some (nondep_type_rec env mid ty), priv
+          with Nondep_cannot_erase _ when is_covariant ->
+            clear_hash ();
+            try Some (nondep_type_rec ~expand_private:true env mid ty),
+                Private
+            with Nondep_cannot_erase _ ->
+              None, priv
     and jkind =
       let jkind = nondep_jkind_base env mid decl.type_jkind in
       try Jkind.map_type_expr (nondep_type_rec env mid) jkind
@@ -8432,6 +8470,7 @@ let rec nondep_type_decl env mid is_covariant decl =
       type_jkind = jkind;
       type_ikind = Types.ikinds_todo "nondep_type_decl";
       type_manifest = tm;
+      type_supertype = st;
       type_private = priv;
       type_variance = decl.type_variance;
       type_separability = decl.type_separability;

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -893,6 +893,10 @@ let closed_type_decl decl =
       None    -> ()
     | Some ty -> close_type mark ty
     end;
+    begin match decl.type_supertype with
+      None    -> ()
+    | Some ty -> close_type mark ty
+    end;
     None
   with Non_closed (ty, _) ->
     Some ty
@@ -1730,6 +1734,7 @@ let instance_declaration decl =
         decl with
         type_params = List.map copy decl.type_params;
         type_manifest = Option.map copy decl.type_manifest;
+        type_supertype = Option.map copy decl.type_supertype;
         type_kind = map_kind copy decl.type_kind;
         type_jkind = Jkind.map_type_expr copy decl.type_jkind;
         type_unboxed_version = Option.map instance decl.type_unboxed_version;
@@ -2350,17 +2355,23 @@ let safe_abbrev env ty =
       cleanup_abbrev ();
       false
 
+(* Instantiate the declared supertype of [ty] (a [Tconstr]) at [ty]'s type
+   arguments. The result consists of fresh nodes, so unifying with it cannot
+   corrupt the declaration. Termination of repeated expansion relies on
+   supertype chains being well-founded, which [Typedecl.check_supertype]
+   enforces (a supertype must be a previously defined type). *)
 let find_supertype env ty =
-  let path, args = match get_desc ty with
-    | Tconstr (path, args, _) -> path, args
-    | _ -> assert false
-  in
-  (* XXX Deal with args *)
-  ignore args;
-  match Env.find_type path env with
-  | { type_supertype = Some sup; _ } -> sup
-  | { type_supertype = None; _ }
-  | exception Not_found -> assert false
+  match get_desc ty with
+  | Tconstr (path, args, _) -> begin
+      match Env.find_type path env with
+      | { type_supertype = Some sup; type_params; _ } -> begin
+          match apply env type_params sup args with
+          | sup -> Some sup
+          | exception Cannot_apply -> None
+        end
+      | { type_supertype = None; _ } | exception Not_found -> None
+    end
+  | _ -> None
 
 let rec try_expand_once_gen expand_abbrev env ty =
   match get_desc ty with
@@ -7735,6 +7746,14 @@ let enlarge_type env ty =
 
 let subtypes = TypePairs.create 17
 
+(* Supertype paths currently being expanded on the active [subtype_rec] chain.
+   Unlike abbreviations, [find_supertype] returns freshly instantiated nodes
+   each time, so the physical-node cycle guard [subtypes] never catches a
+   supertype/manifest knot (constructible via recursive modules). A path can
+   only recur along one expansion chain if the supertypes form a cycle, which
+   declaration order otherwise forbids; treat a repeat as "not a subtype". *)
+let subtype_expanding = ref Path.Set.empty
+
 let subtype_error ~env ~trace ~unification_trace =
   raise (Subtype (Subtype.error
                     ~trace:(expand_subtype_trace env (List.rev trace))
@@ -7822,8 +7841,17 @@ let rec subtype_rec env trace t1 t2 cstrs =
       when generic_private_abbrev env p1 && safe_abbrev_opt env t1 ->
         subtype_rec env trace (expand_abbrev_opt env t1) t2 cstrs
     | (Tconstr(p1, _, _), _)
-      when has_generic_supertype env p1 ->
-        subtype_rec env trace (find_supertype env t1) t2 cstrs
+      when has_generic_supertype env p1
+           && not (Path.Set.mem p1 !subtype_expanding) ->
+        begin match find_supertype env t1 with
+        | Some sup ->
+            let saved = !subtype_expanding in
+            subtype_expanding := Path.Set.add p1 saved;
+            let cstrs = subtype_rec env trace sup t2 cstrs in
+            subtype_expanding := saved;
+            cstrs
+        | None -> (trace, t1, t2, !univar_pairs)::cstrs
+        end
 (*  | (_, Tconstr(p2, _, _)) when generic_private_abbrev false env p2 ->
         subtype_rec env trace t1 (expand_abbrev_opt env t2) cstrs *)
     | (Tobject (f1, _), Tobject (f2, _))
@@ -8022,6 +8050,7 @@ and subtype_row env trace row1 row2 cstrs =
 
 let subtype env ty1 ty2 =
   TypePairs.clear subtypes;
+  subtype_expanding := Path.Set.empty;
   with_univar_pairs [] (fun () ->
     (* Build constraint set. *)
     let cstrs =
@@ -8429,20 +8458,15 @@ let rec nondep_type_decl env mid is_covariant decl =
                 Private
             with Nondep_cannot_erase _ ->
               None, decl.type_private
-    (* XXX Just copying code blindly here. Need to understand and probably
-       refactor with above. *)
-    in
-    let st, priv =
+    and st =
+      (* A supertype only enables coercions, so unlike a manifest it can
+         simply be dropped: doing so is sound and, since it plays no role in
+         type identity, requires no privacy adjustment. *)
       match decl.type_supertype with
-      | None -> None, priv
+      | None -> None
       | Some ty ->
-          try Some (nondep_type_rec env mid ty), priv
-          with Nondep_cannot_erase _ when is_covariant ->
-            clear_hash ();
-            try Some (nondep_type_rec ~expand_private:true env mid ty),
-                Private
-            with Nondep_cannot_erase _ ->
-              None, priv
+          (try Some (nondep_type_rec env mid ty)
+           with Nondep_cannot_erase _ when is_covariant -> None)
     and jkind =
       let jkind = nondep_jkind_base env mid decl.type_jkind in
       try Jkind.map_type_expr (nondep_type_rec env mid) jkind

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -476,6 +476,10 @@ val match_class_declarations:
 
 val enlarge_type: Env.t -> type_expr -> type_expr * bool
         (* Make a type larger, flag is true if some pruning had to be done *)
+val find_supertype: Env.t -> type_expr -> type_expr option
+        (* If [ty] is a [Tconstr] whose declaration has a supertype, that
+           supertype instantiated at [ty]'s arguments (fresh nodes); else
+           [None]. *)
 val subtype: Env.t -> type_expr -> type_expr -> unit -> unit
         (* [subtype env t1 t2] checks that [t1] is a subtype of [t2].
            It accumulates the constraints the type variables must

--- a/typing/data_types.ml
+++ b/typing/data_types.ml
@@ -35,6 +35,12 @@ type constructor_description =
        the null pointer) *)
     cstr_consts: int;                   (* Number of constant constructors *)
     cstr_nonconsts: int;                (* Number of non-const constructors *)
+    cstr_const_span: int;
+    (* 1 + largest constant-constructor tag; equals [cstr_consts] except
+       when constructors inherit sparse tags from a supertype *)
+    cstr_nonconst_span: int;
+    (* 1 + largest non-constant-constructor tag; equals [cstr_nonconsts]
+       except when constructors inherit sparse tags from a supertype *)
     cstr_generalized: bool;             (* Constrained return type? *)
     cstr_private: private_flag;         (* Read-only constructor? *)
     cstr_loc: Location.t;

--- a/typing/data_types.mli
+++ b/typing/data_types.mli
@@ -32,6 +32,12 @@ type constructor_description =
     cstr_constant: bool;                (* True if all args are void *)
     cstr_consts: int;                   (* Number of constant constructors *)
     cstr_nonconsts: int;                (* Number of non-const constructors *)
+    cstr_const_span: int;
+    (* 1 + largest constant-constructor tag; equals [cstr_consts] except
+       when constructors inherit sparse tags from a supertype *)
+    cstr_nonconst_span: int;
+    (* 1 + largest non-constant-constructor tag; equals [cstr_nonconsts]
+       except when constructors inherit sparse tags from a supertype *)
     cstr_generalized: bool;             (* Constrained return type? *)
     cstr_private: private_flag;         (* Read-only constructor? *)
     cstr_loc: Location.t;

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -158,7 +158,10 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       | Cstr_tuple [{ ca_sort = Some sort }]
       | Cstr_record [{ ld_sort = Some sort }] ->
         [| Cstr_layout_known
-             { tag = 0; shape = Constructor_uniform_value; sorts = [| sort |] } |],
+             { tag = 0;
+               shape = Constructor_uniform_value;
+               sorts = [| sort |]
+             } |],
         true
       | Cstr_tuple [{ ca_sort = None }]
       | Cstr_record [{ ld_sort = None }] ->
@@ -212,6 +215,26 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
          is_const)
       cstr_layouts
   in
+  (* 1 + largest tag per class; can exceed the counts when constructors
+     inherit sparse tags from a supertype *)
+  let const_span, nonconst_span =
+    match rep with
+    | Variant_boxed _ ->
+        let const_span = ref 0 and nonconst_span = ref 0 in
+        Array.iteri
+          (fun i layout ->
+             let tag = cstr_layout_tag layout in
+             let span =
+               if cstr_constant.(i) then const_span else nonconst_span
+             in
+             if tag + 1 > !span then span := tag + 1)
+          cstr_layouts;
+        !const_span, !nonconst_span
+    | Variant_unboxed | Variant_with_null ->
+        (* All tags are 0, so the spans equal the counts *)
+        !num_consts, !num_nonconsts
+    | Variant_extensible -> assert false
+  in
   let describe_constructor (src_index, acc)
         {cd_id; cd_args; cd_res; cd_loc; cd_attributes; cd_uid} =
     let cstr_name = Ident.name cd_id in
@@ -258,6 +281,8 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
         cstr_constant;
         cstr_consts = !num_consts;
         cstr_nonconsts = !num_nonconsts;
+        cstr_const_span = const_span;
+        cstr_nonconst_span = nonconst_span;
         cstr_generalized = cd_res <> None;
         cstr_private = decl.type_private;
         cstr_loc = cd_loc;
@@ -293,6 +318,8 @@ let extension_descr ~current_unit path_ext ext =
       cstr_constant = ext.ext_constant;
       cstr_consts = -1;
       cstr_nonconsts = -1;
+      cstr_const_span = -1;
+      cstr_nonconst_span = -1;
       cstr_private = ext.ext_private;
       cstr_generalized = ext.ext_ret_type <> None;
       cstr_loc = ext.ext_loc;

--- a/typing/datarepr.ml
+++ b/typing/datarepr.ml
@@ -87,6 +87,7 @@ let constructor_args ~current_unit priv cd_args cd_res path rep =
           type_ikind = Types.ikinds_todo "datarepr boxed record";
           type_private = priv;
           type_manifest = None;
+          type_supertype = None;
           type_variance = Variance.unknown_signature ~injective:true ~arity;
           type_separability = Types.Separability.default_signature ~arity;
           type_is_newtype = false;
@@ -157,11 +158,11 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       | Cstr_tuple [{ ca_sort = Some sort }]
       | Cstr_record [{ ld_sort = Some sort }] ->
         [| Cstr_layout_known
-             { shape = Constructor_uniform_value; sorts = [| sort |] } |],
+             { tag = 0; shape = Constructor_uniform_value; sorts = [| sort |] } |],
         true
       | Cstr_tuple [{ ca_sort = None }]
       | Cstr_record [{ ld_sort = None }] ->
-        [| Cstr_layout_variable |], true
+        [| Cstr_layout_variable { tag = 0 } |], true
       | Cstr_tuple ([] | _ :: _) | Cstr_record ([] | _ :: _) ->
         Misc.fatal_error "Multiple arguments in [@@unboxed] variant"
       end
@@ -169,21 +170,22 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       Misc.fatal_error "Multiple or 0 constructors in [@@unboxed] variant"
     | Variant_with_null, _ ->
       let layout cstr =
+        let tag = 0 in
         match classify_variant_with_null_constructor cstr with
         | Variant_with_null_nullary ->
           Cstr_layout_known
-            { shape = Constructor_uniform_value; sorts = [| |] }
+            { tag; shape = Constructor_uniform_value; sorts = [| |] }
         | Variant_with_null_payload
             { payload_arg = { ca_sort = Some sort; _ }; _ } ->
           Cstr_layout_known
-            { shape = Constructor_uniform_value; sorts = [| sort |] }
+            { tag; shape = Constructor_uniform_value; sorts = [| sort |] }
         | Variant_with_null_payload
             { payload_arg = { ca_sort = None; _ }; _ } ->
           (* Sort may be [None] during the recursive-decl temp-env phase
              (see Note [Default jkinds in transl_declaration] in typedecl.ml);
              the temp-env descriptors are not consumed, and the real ones are
              recomputed after [update_decls_jkind] fills the sorts. *)
-          Cstr_layout_variable
+          Cstr_layout_variable { tag }
       in
       Array.of_list (List.map layout cstrs), false
   in
@@ -193,7 +195,7 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       (fun layout ->
          let all_void =
            match layout with
-           | Cstr_layout_variable ->
+           | Cstr_layout_variable _ ->
              (* Someday we'll want to let a constructor be constant iff the type
                 argument is void (after all, [unit# option] is [bool]), but
                 we're not there yet. For now, assume [Some #()] (so to speak) is
@@ -210,7 +212,7 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
          is_const)
       cstr_layouts
   in
-  let describe_constructor (src_index, const_tag, nonconst_tag, acc)
+  let describe_constructor (src_index, acc)
         {cd_id; cd_args; cd_res; cd_loc; cd_attributes; cd_uid} =
     let cstr_name = Ident.name cd_id in
     let cstr_res =
@@ -218,17 +220,12 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
       | Some ty_res' -> ty_res'
       | None -> ty_res
     in
-    let cstr_shape =
+    let runtime_tag, cstr_shape =
       match cstr_layouts.(src_index) with
-      | Cstr_layout_known { shape; _ } -> Some shape
-      | Cstr_layout_variable -> None
+      | Cstr_layout_known { tag; shape; _ } -> tag, Some shape
+      | Cstr_layout_variable { tag } -> tag, None
     in
     let cstr_constant = cstr_constant.(src_index) in
-    let runtime_tag, const_tag, nonconst_tag =
-      if cstr_constant
-      then const_tag, 1 + const_tag, nonconst_tag
-      else nonconst_tag, const_tag, 1 + nonconst_tag
-    in
     let cstr_tag =
       match rep with
       | Variant_with_null ->
@@ -268,9 +265,9 @@ let constructor_descrs ~current_unit ty_path decl cstrs rep =
         cstr_inlined;
         cstr_uid = cd_uid;
       } in
-    (src_index+1, const_tag, nonconst_tag, (cd_id, cstr) :: acc)
+    (src_index+1, (cd_id, cstr) :: acc)
   in
-  let (_,_,_,cstrs) = List.fold_left describe_constructor (0,0,0,[]) cstrs in
+  let (_,cstrs) = List.fold_left describe_constructor (0,[]) cstrs in
   List.rev cstrs
 
 let extension_descr ~current_unit path_ext ext =

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -1607,6 +1607,7 @@ and find_type_unboxed_version path env seen =
              "env unboxed Tbox manifest path=%a" Path.print path);
       type_private = decl.type_private;
       type_manifest = Some inner;
+      type_supertype = None;
       type_variance = decl.type_variance;
       type_separability =
         Types.Separability.default_signature ~arity:decl.type_arity;
@@ -1655,6 +1656,7 @@ and find_type_unboxed_version path env seen =
           (Format_doc.asprintf "env unboxed alias path=%a" Path.print path);
       type_private = decl.type_private;
       type_manifest = Some man;
+      type_supertype = None;
       type_variance = decl.type_variance;
       (* Variance is the same as the boxed version *)
       type_separability;

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -1284,7 +1284,7 @@ module Variant_diffing = struct
     =
     let shape_of_layout = function
       | Cstr_layout_known { shape; _ } -> Some shape
-      | Cstr_layout_variable -> None
+      | Cstr_layout_variable _ -> None
     in
     let shapes1, shapes2 =
       match rep1, rep2 with
@@ -1594,8 +1594,8 @@ let type_declarations_consistency env decl1 decl2 =
     | None -> None
 
 (* See Note [Contravariance of type parameter jkinds]. *)
-let type_declarations ?(equality = false) ~loc env ~mark name
-      decl1 path decl2 =
+let type_declarations ?(equality = false) ?(allow_supertype = false) ~loc env
+      ~mark name decl1 path decl2 =
   Builtin_attributes.check_alerts_inclusion
     ~def:decl1.type_loc
     ~use:decl2.type_loc
@@ -1701,14 +1701,28 @@ let type_declarations ?(equality = false) ~loc env ~mark name
           mark usage cstrs1;
           if equality then mark Env.Exported cstrs2
         end;
+        let variant_diff =
+          Variant_diffing.compare_with_representation ~loc env
+            decl1.type_params
+            decl2.type_params
+            cstrs1
+            cstrs2
+            rep1
+            rep2
+        in
+        let variant_diff =
+          match variant_diff with
+          | Some (Variant_mismatch changes) when allow_supertype ->
+              (* If everything is a deletion, we're good *)
+              let is_deletion : variant_change -> bool = function
+                | Delete _ -> true
+                | _ -> false
+              in
+              if List.for_all is_deletion changes then None else variant_diff
+          | Some _ | None -> None
+        in
         Misc.Stdlib.Option.first_some
-          (Variant_diffing.compare_with_representation ~loc env
-              decl1.type_params
-              decl2.type_params
-              cstrs1
-              cstrs2
-              rep1
-              rep2)
+          variant_diff
           (fun () -> compare_unsafe_mode_crossing ~env umc1 umc2)
       end
     | (Type_record(labels1,rep1,umc1), Type_record(labels2,rep2,umc2)) -> begin

--- a/typing/includecore.ml
+++ b/typing/includecore.ml
@@ -412,6 +412,9 @@ type type_mismatch =
   | Variance
   | Record_mismatch of record_mismatch
   | Variant_mismatch of variant_change list
+  | Constructor_tag of { name : string; tag1 : int; tag2 : int }
+  | Supertype_only_on of position
+  | Supertype_mismatch of Errortrace.equality_error
   | Unboxed_representation of position * attributes
   | Extensible_representation of position
   | With_null_representation of position
@@ -819,6 +822,25 @@ let report_type_mismatch first second decl env ppf err =
       report_record_mismatch first second decl env ppf err
   | Variant_mismatch err ->
       report_patch pp_variant_diff first second decl env ppf err
+  | Constructor_tag { name; tag1; tag2 } ->
+      pr "Constructor %a has a different runtime representation:@ \
+          its tag is %d in %s %s@ but %d in %s %s."
+        Style.inline_code name tag1 first decl tag2 second decl
+  | Supertype_only_on ord ->
+      pr "%s %s has a supertype and %s does not."
+        (String.capitalize_ascii (choose ord first second)) decl
+        (choose_other ord first second)
+  | Supertype_mismatch err ->
+      pr "Their supertypes differ:@,";
+      report_type_inequality env ppf err;
+      (* CR-someday lmaurer: because inclusion requires the supertypes to be
+         equal, a subtype member of a [module type of ...] cannot currently
+         be relaxed by a plain [with type]; it takes a destructive
+         substitution with another subtype of the same supertype. Once
+         [with type t :> u] is supported this hint can point there; for now
+         the workaround is too situational to spell out in every mismatch. *)
+      pr "@ @[<2>Hint: signature inclusion requires the two supertypes to be@ \
+          equal.@]"
   | Unboxed_representation (ord, attrs) ->
       pr "Their internal representations differ:@ %s %s %s."
          (choose ord first second) decl
@@ -1308,9 +1330,32 @@ module Variant_diffing = struct
       | [cstr] -> cstr.Types.cd_attributes
       | _ -> []
     in
+    let tag_mismatch cstr_layouts1 cstr_layouts2 =
+      (* Runtime tags are part of the representation: structurally equal
+         declarations can still disagree once constructors inherit tags from
+         a supertype. Reaching here means the structural diff already found
+         the constructors equal and in order, so the layout arrays are
+         aligned with [cstrs1]/[cstrs2] and with each other; a parallel scan
+         suffices. *)
+      let n = Array.length cstr_layouts1 in
+      if Array.length cstr_layouts2 <> n then None
+      else
+        let rec loop i =
+          if i >= n then None
+          else
+            let tag1 = cstr_layout_tag cstr_layouts1.(i) in
+            let tag2 = cstr_layout_tag cstr_layouts2.(i) in
+            if tag1 <> tag2 then
+              let name = Ident.name (List.nth cstrs1 i).Types.cd_id in
+              Some (Constructor_tag { name; tag1; tag2 })
+            else loop (i + 1)
+        in
+        loop 0
+    in
     match err, rep1, rep2 with
+    | None, Variant_boxed cstr_layouts1, Variant_boxed cstr_layouts2 ->
+        tag_mismatch cstr_layouts1 cstr_layouts2
     | None, Variant_unboxed, Variant_unboxed
-    | None, Variant_boxed _, Variant_boxed _
     | None, Variant_extensible, Variant_extensible
     | None, Variant_with_null, Variant_with_null -> None
     | Some err, _, _ ->
@@ -1640,7 +1685,14 @@ let type_declarations ?(equality = false) ?(allow_supertype = false) ~loc env
       | () -> None
   in
   if err <> None then err else
-  let err = match (decl1.type_manifest, decl2.type_manifest) with
+  (* Under [allow_supertype] (the subtype-coherence check) [decl2] is the
+     subtype and [decl1] its supertype; [decl2]'s manifest is a re-export
+     target, not a claim of equality with [decl1], so comparing manifests
+     here would spuriously reject valid re-exports (the constructor and tag
+     comparison below is what matters). *)
+  let err =
+    if allow_supertype then None
+    else match (decl1.type_manifest, decl2.type_manifest) with
       (_, None) -> None
     | (Some ty1, Some ty2) ->
          type_manifest env ty1 ty2 decl2.type_private decl2.type_kind
@@ -1651,6 +1703,38 @@ let type_declarations ?(equality = false) ?(allow_supertype = false) ~loc env
         match Ctype.equal env false [ty1] [ty2] with
         | exception Ctype.Equality err -> Some (Manifest err)
         | () -> None
+  in
+  if err <> None then err else
+  (* A declared supertype determines the constructors' runtime tags, so if
+     the second declaration has one, the first must have an equal one. (The
+     reverse needs no check here: if the second declaration exposes
+     constructors, differing tags are caught below; if it is abstract,
+     forgetting the supertype is sound.) Skipped for [allow_supertype]: there
+     [decl2]'s supertype is the relation being established against [decl1],
+     not an interface to match. *)
+  let err =
+    if allow_supertype then None
+    else match decl1.type_supertype, decl2.type_supertype with
+      | _, None -> None
+      | Some ty1, Some ty2 ->
+          begin match Ctype.equal env false [ty1] [ty2] with
+          | exception Ctype.Equality err -> Some (Supertype_mismatch err)
+          | () -> None
+          end
+      | None, Some ty2 ->
+          (* An equation can also justify the claim: [type t = m] matches
+             [type t :> s] when [m]'s own declaration has supertype [s].
+             (CR-someday lmaurer: Follow chains of supertypes.) *)
+          let justified =
+            match Option.bind decl1.type_manifest (Ctype.find_supertype env)
+            with
+            | None -> false
+            | Some s1 ->
+                match Ctype.equal env false [s1] [ty2] with
+                | exception Ctype.Equality _ -> false
+                | () -> true
+          in
+          if justified then None else Some (Supertype_only_on Second)
   in
   if err <> None then err else
   let mark_and_compare_records record_form labels1 rep1 labels2 rep2 =
@@ -1713,13 +1797,20 @@ let type_declarations ?(equality = false) ?(allow_supertype = false) ~loc env
         let variant_diff =
           match variant_diff with
           | Some (Variant_mismatch changes) when allow_supertype ->
-              (* If everything is a deletion, we're good *)
+              (* A subtype may omit constructors of its supertype, so
+                 deletions are fine (and not worth reporting); anything else
+                 is an error. *)
               let is_deletion : variant_change -> bool = function
                 | Delete _ -> true
                 | _ -> false
               in
-              if List.for_all is_deletion changes then None else variant_diff
-          | Some _ | None -> None
+              begin match
+                List.filter (fun c -> not (is_deletion c)) changes
+              with
+              | [] -> None
+              | changes -> Some (Variant_mismatch changes)
+              end
+          | (Some _ | None) as variant_diff -> variant_diff
         in
         Misc.Stdlib.Option.first_some
           variant_diff

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -199,6 +199,7 @@ val value_descriptions:
 
 val type_declarations:
   ?equality:bool ->
+  ?allow_supertype:bool ->
   loc:Location.t ->
   Env.t -> mark:bool -> string ->
   type_declaration -> Path.t -> type_declaration -> type_mismatch option

--- a/typing/includecore.mli
+++ b/typing/includecore.mli
@@ -140,6 +140,9 @@ type type_mismatch =
   | Variance
   | Record_mismatch of record_mismatch
   | Variant_mismatch of variant_change list
+  | Constructor_tag of { name : string; tag1 : int; tag2 : int }
+  | Supertype_only_on of position
+  | Supertype_mismatch of Errortrace.equality_error
   | Unboxed_representation of position * attributes
   | Extensible_representation of position
   | With_null_representation of position

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -985,7 +985,7 @@ and print_out_type_decl kwd ppf td =
   in
   let print_supertype ppf =
     function
-      Some ty -> fprintf ppf " <:@ %a" !out_type ty
+      Some ty -> fprintf ppf " :>@ %a" !out_type ty
     | None -> ()
   in
   let print_manifest ppf =

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -983,14 +983,20 @@ and print_out_type_decl kwd ppf td =
           td.otype_params
           print_lident td.otype_name
   in
+  let print_supertype ppf =
+    function
+      Some ty -> fprintf ppf " <:@ %a" !out_type ty
+    | None -> ()
+  in
   let print_manifest ppf =
     function
       Otyp_manifest (ty, _) -> fprintf ppf " =@ %a" !out_type ty
     | _ -> ()
   in
   let print_name_params ppf =
-    fprintf ppf "%s %t%a%a" kwd type_defined
+    fprintf ppf "%s %t%a%a%a" kwd type_defined
       print_out_jkind_annot td.otype_jkind
+      print_supertype td.otype_supertype
       print_manifest td.otype_type
   in
   let ty =

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1950,6 +1950,7 @@ let prepare_decl id decl =
         prepare_type ty;
         Some ty
   in
+  Option.iter prepare_type decl.type_supertype;
   begin match decl.type_kind with
   | Type_abstract _ -> ()
   | Type_variant (cstrs, _rep,_umc) ->
@@ -2076,6 +2077,9 @@ let tree_of_type_decl id decl =
         None,
         false
   in
+  let otype_supertype =
+    Option.map (tree_of_typexp Type) decl.type_supertype
+  in
   (* The algorithm for setting [lay] here is described as Case (C1) in
      Note [When to print jkind annotations] *)
   let is_value =
@@ -2099,6 +2103,7 @@ let tree_of_type_decl id decl =
   { otype_name = name;
     otype_params = args;
     otype_type = ty;
+    otype_supertype;
     otype_private = priv;
     otype_jkind;
     otype_unboxed = unboxed;
@@ -2517,6 +2522,7 @@ let dummy =
     type_ikind = Types.ikinds_todo "print dummy";
     type_private = Public;
     type_manifest = None;
+    type_supertype = None;
     type_variance = [];
     type_separability = [];
     type_is_newtype = false;

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -215,6 +215,7 @@ and out_type_decl =
   { otype_name: string;
     otype_params: out_type_param list;
     otype_type: out_type;
+    otype_supertype: out_type option;
     otype_private: Asttypes.private_flag;
 
     (* Some <=> we should print this annotation;

--- a/typing/predef.ml
+++ b/typing/predef.ml
@@ -625,6 +625,7 @@ let decl_of_type_constr tconstr =
           type_loc = Location.none;
           type_private = Asttypes.Public;
           type_manifest = None;
+          type_supertype = None;
           type_variance = [];
           type_separability = [];
           type_is_newtype = false;
@@ -645,6 +646,7 @@ let decl_of_type_constr tconstr =
      type_loc = Location.none;
      type_private = Asttypes.Public;
      type_manifest = None;
+     type_supertype = None;
      type_variance = [];
      type_separability = [];
      type_is_newtype = false;
@@ -700,6 +702,10 @@ let decl_of_type_constr tconstr =
     let array_of_list_map_option f l =
       Misc.Stdlib.List.map_option f l |> Option.map Array.of_list
     in
+    (* There aren't any built-in types with all-void constructors so we can
+       assume that it's easy to know which tag counter to use. *)
+    let consts = ref 0 in
+    let non_consts = ref 0 in
     let mk_elt { cd_args } =
       let sorts = match cd_args with
         | Cstr_tuple args ->
@@ -707,10 +713,16 @@ let decl_of_type_constr tconstr =
         | Cstr_record lbls ->
           array_of_list_map_option (fun { ld_sort } -> ld_sort) lbls
       in
+      let post_incr r = let value = !r in incr r; value in
+      let tag = match cd_args with
+        | Cstr_tuple [] -> post_incr consts
+        | Cstr_tuple (_ :: _)
+        | Cstr_record _ -> post_incr non_consts
+      in
       match sorts with
       | Some sorts ->
-        Cstr_layout_known { shape = Constructor_uniform_value; sorts }
-      | None -> Cstr_layout_variable
+        Cstr_layout_known { tag; shape = Constructor_uniform_value; sorts }
+      | None -> Cstr_layout_variable { tag }
     in
     Type_variant (
       constrs,

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -240,7 +240,7 @@ let variant_representation i ppf = let open Types in function
     line i ppf "Variant_boxed %a\n"
       (array (i+1) (fun _ ppf l ->
          match (l : Types.cstr_layout) with
-         | Cstr_layout_variable ->
+         | Cstr_layout_variable _ ->
            line (i+1) ppf "Cstr_layout_variable\n"
          | Cstr_layout_known { sorts; _ } ->
            sort_array (i+1) ppf sorts))

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -924,6 +924,8 @@ and type_declaration i ppf x =
   line i ppf "ptype_private = %a\n" fmt_private_flag x.typ_private;
   line i ppf "ptype_manifest =\n";
   option (i+1) core_type ppf x.typ_manifest;
+  line i ppf "ptype_supertype =\n";
+  option (i+1) core_type ppf x.typ_supertype;
 
 and type_kind i ppf x =
   match x with

--- a/typing/shape.ml
+++ b/typing/shape.ml
@@ -564,6 +564,7 @@ and 'a complex_constructors = 'a complex_constructor list
 and 'a complex_constructor =
   { name : string;
     constr_uid: Uid.t option;
+    cstr_tag: int;
     kind : constructor_representation;
     args : 'a complex_constructor_argument list
   }
@@ -583,14 +584,14 @@ let poly_variant_constructors_map f pvs =
     (fun pv -> { pv with pv_constr_args = List.map f pv.pv_constr_args })
     pvs
 
-let complex_constructor_map f { name; constr_uid; kind; args } =
+let complex_constructor_map f { name; constr_uid; cstr_tag; kind; args } =
   let args =
     List.map
       (fun { field_name; field_uid; field_value } ->
         { field_name; field_uid; field_value = f field_value })
       args
   in
-  { name; constr_uid; kind; args }
+  { name; constr_uid; cstr_tag; kind; args }
 
 let complex_constructors_map f = List.map (complex_constructor_map f)
 
@@ -601,9 +602,10 @@ let equal_complex_constructor_arguments eq
   eq field_value1 field_value2
 
 let equal_complex_constructor eq
-    { name = name1; kind = kind1; args = args1 }
-    { name = name2; kind = kind2; args = args2 } =
+    { name = name1; cstr_tag = tag1; kind = kind1; args = args1 }
+    { name = name2; cstr_tag = tag2; kind = kind2; args = args2 } =
   String.equal name1 name2 &&
+  Int.equal tag1 tag2 &&
   Misc.Stdlib.Array.equal Layout.equal kind1 kind2 &&
   List.equal (equal_complex_constructor_arguments eq) args1 args2
 

--- a/typing/shape.mli
+++ b/typing/shape.mli
@@ -316,6 +316,9 @@ and 'a complex_constructors = 'a complex_constructor list
 and 'a complex_constructor =
   { name : string;
     constr_uid: Uid.t option;
+    cstr_tag: int;
+    (** The runtime tag of the constructor.  Tags may be sparse: a subtype
+        inherits the tags of the same-named constructors of its supertype. *)
     kind : constructor_representation;
     args : 'a complex_constructor_argument list
   }

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -872,6 +872,8 @@ let rec type_declaration' copy_scope s decl =
           None -> None
         | Some ty -> Some(typexp copy_scope s decl.type_loc ty)
       end;
+    type_supertype =
+      Option.map (typexp copy_scope s decl.type_loc) decl.type_supertype;
     type_jkind = jkind copy_scope s decl.type_loc decl.type_jkind;
     type_ikind = (
       (* Preserve constructor ikinds via [s.types] (path rename or identity-env

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -236,6 +236,7 @@ let type_declaration sub x =
     x.typ_cstrs;
   sub.type_kind sub x.typ_kind;
   Option.iter (sub.typ sub) x.typ_manifest;
+  Option.iter (sub.typ sub) x.typ_supertype;
   List.iter (fun (c, _) -> sub.typ sub c) x.typ_params
 
 let type_declarations sub (_, list) = List.iter (sub.type_declaration sub) list

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -273,10 +273,11 @@ let type_declaration sub x =
   in
   let typ_kind = sub.type_kind sub x.typ_kind in
   let typ_manifest = Option.map (sub.typ sub) x.typ_manifest in
+  let typ_supertype = Option.map (sub.typ sub) x.typ_supertype in
   let typ_params = List.map (tuple2 (sub.typ sub) id) x.typ_params in
   let typ_attributes = sub.attributes sub x.typ_attributes in
-  {x with typ_loc; typ_name; typ_cstrs; typ_kind; typ_manifest; typ_params;
-          typ_attributes}
+  {x with typ_loc; typ_name; typ_cstrs; typ_kind; typ_manifest;
+          typ_supertype; typ_params; typ_attributes}
 
 let type_declarations sub (rec_flag, list) =
   (rec_flag, List.map (sub.type_declaration sub) list)

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -444,7 +444,7 @@ module Type_decl_shape = struct
           list
     in
     match (arg_layout : Types.cstr_layout), args with
-    | Cstr_layout_known { shape = constructor_repr; _ }, Some args ->
+    | Cstr_layout_known { tag; shape = constructor_repr; _ }, Some args ->
       let constructor_repr =
         match (constructor_repr : Types.constructor_representation) with
         | Constructor_mixed shapes ->
@@ -486,6 +486,7 @@ module Type_decl_shape = struct
       Some
         { Shape.name;
           constr_uid = Some cstr_args.cd_uid;
+          cstr_tag = tag;
           kind = constructor_repr;
           args
         }
@@ -678,7 +679,7 @@ module Type_decl_shape = struct
         constrs
     | Variant constructors ->
       List.for_all
-        (fun { name = _; constr_uid = _; kind = _; args } ->
+        (fun { name = _; constr_uid = _; cstr_tag = _; kind = _; args } ->
           List.for_all
             (fun { field_name = _; field_uid = _; field_value = sh, _ } ->
               is_closed_type_shape sh)

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -489,7 +489,7 @@ module Type_decl_shape = struct
           kind = constructor_repr;
           args
         }
-    | Cstr_layout_known _, None | Cstr_layout_variable, _ -> None
+    | Cstr_layout_known _, None | Cstr_layout_variable _, _ -> None
 
   let is_empty_constructor_list (cstr_args : Types.constructor_declaration) =
     match cstr_args.cd_args with

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1632,6 +1632,7 @@ let temp_abbrev loc id arity uid =
        type_ikind = Types.ikinds_todo "typeclass temp_abbrev";
        type_private = Public;
        type_manifest = Some ty;
+       type_supertype = None;
        type_variance = Variance.unknown_signature ~injective:false ~arity;
        type_separability = Types.Separability.default_signature ~arity;
        type_is_newtype = false;
@@ -1866,6 +1867,7 @@ let class_infos define_class kind
      type_ikind = Types.ikinds_todo "typeclass temp_abbrev";
      type_private = Public;
      type_manifest = Some obj_ty;
+     type_supertype = None;
      type_variance = Variance.unknown_signature ~injective:false ~arity;
      type_separability = Types.Separability.default_signature ~arity;
      type_is_newtype = false;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -390,6 +390,7 @@ in
       type_ikind;
       type_private = sdecl.ptype_private;
       type_manifest = unboxed_type_manifest;
+      type_supertype = None;
       type_variance = Variance.unknown_signature ~injective:false ~arity;
       type_separability = Types.Separability.default_signature ~arity;
       type_is_newtype = false;
@@ -409,6 +410,7 @@ in
       type_ikind;
       type_private = sdecl.ptype_private;
       type_manifest;
+      type_supertype = None;
       type_variance = Variance.unknown_signature ~injective:false ~arity;
       type_separability = Types.Separability.default_signature ~arity;
       type_is_newtype = false;
@@ -1002,13 +1004,19 @@ let transl_declaration env sdecl (id, uid) =
         Some jkind, annot
     | None -> None, None
   in
-  let (tman, man) = match sdecl.ptype_manifest with
+  let transl_simple_type_opt_in_decl sty =
+    match sty with
       None -> None, None
     | Some sty ->
       let no_row = not (is_fixed_type sdecl) in
-      let cty = transl_simple_type ~new_var_jkind:Any env ~closed:no_row Mode.Alloc.Const.legacy sty in
+      let cty =
+        transl_simple_type ~new_var_jkind:Any env ~closed:no_row
+          Mode.Alloc.Const.legacy sty
+      in
       Some cty, Some cty.ctyp_type
   in
+  let (tman, man) = transl_simple_type_opt_in_decl sdecl.ptype_manifest in
+  let (tsup, sup) = transl_simple_type_opt_in_decl sdecl.ptype_supertype in
   (* jkind_default is the jkind to use for now as the type_jkind when there
      is no annotation and no manifest.
      See Note [Default jkinds in transl_declaration].
@@ -1130,7 +1138,7 @@ let transl_declaration env sdecl (id, uid) =
                         | Cstr_record _ -> [| Jkind.Sort.Const.scannable |]
                       in
                       Cstr_layout_known
-                        { shape = Constructor_uniform_value; sorts })
+                        { tag = -1; shape = Constructor_uniform_value; sorts })
                    (Array.of_list cstrs)
                ),
                Jkind.for_non_float ~why:Boxed_variant
@@ -1225,6 +1233,7 @@ let transl_declaration env sdecl (id, uid) =
         type_ikind = Types.ikinds_todo "update_decl_jkind initial";
         type_private = sdecl.ptype_private;
         type_manifest = man;
+        type_supertype = sup;
         type_variance = Variance.unknown_signature ~injective:false ~arity;
         type_separability = Types.Separability.default_signature ~arity;
         type_is_newtype = false;
@@ -1267,6 +1276,7 @@ let transl_declaration env sdecl (id, uid) =
         typ_cstrs = cstrs;
         typ_loc = sdecl.ptype_loc;
         typ_manifest = tman;
+        typ_supertype = tsup;
         typ_kind = tkind;
         typ_private = sdecl.ptype_private;
         typ_attributes = sdecl.ptype_attributes;
@@ -1417,6 +1427,13 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
              simplifies things. *)
           None
     in
+    let type_supertype =
+      (* CR-someday lmaurer: We could conceivably have unboxed subtypes, with
+         the exciting (?) property that being an unboxed subtype could change
+         the type's layout (adding more registers, say). But for now we only
+         have declared subtypes among things of layout [value]. *)
+      None
+    in
     Some
       {
         type_params = decl.type_params;
@@ -1426,6 +1443,7 @@ let derive_unboxed_version env path_in_group_has_unboxed_version decl =
         type_ikind = Types.ikinds_todo "derive_unboxed_versions";
         type_private = decl.type_private;
         type_manifest;
+        type_supertype;
         type_variance =
           Variance.unknown_signature ~injective:false ~arity:decl.type_arity;
         type_separability =
@@ -1732,7 +1750,17 @@ let narrow_to_manifest_jkind env loc path decl =
    need to check that the equation refers to a type of the same kind
    with the same constructors and labels. *)
 let check_kind_coherence env loc dpath decl =
-  match decl.type_kind, decl.type_manifest with
+  let manifest_or_supertype, ~is_manifest =
+    match decl.type_manifest, decl.type_supertype with
+    | Some _, Some _ ->
+      (* XXX Should be non-fatal *)
+      Misc.fatal_errorf "Can't combine manifest and supertype: %a"
+        (Format_doc.compat Path.print) dpath
+    | Some man, None -> Some man, ~is_manifest:true
+    | None, Some sup -> Some sup, ~is_manifest:false
+    | None, None -> None, ~is_manifest:false
+  in
+  match decl.type_kind, manifest_or_supertype with
   | (Type_variant _ | Type_record _ | Type_record_unboxed_product _
     | Type_open),
     Some ty ->
@@ -1759,6 +1787,7 @@ let check_kind_coherence env loc dpath decl =
                     assert false
               in
               Includecore.type_declarations ~loc ~equality:true env
+                ~allow_supertype:(not is_manifest)
                 ~mark:true
                 (Path.last path)
                 decl'
@@ -2521,10 +2550,16 @@ let rec update_decl_jkind env dpath decl =
       end
     | cstrs, Variant_boxed cstr_layouts ->
       let cstrs =
+        let consts = ref 0 in
+        let non_consts = ref 0 in
         List.mapi (fun idx cstr ->
-          let cd_args, _all_void, jkinds, arg_sorts =
+          let cd_args, all_void, jkinds, arg_sorts =
             update_constructor_arguments_sorts env cstr.Types.cd_loc
               cstr.Types.cd_args
+          in
+          let post_incr r = let value = !r in incr r; value in
+          let tag =
+            if all_void then post_incr consts else post_incr non_consts
           in
           let cstr_repr =
             update_constructor_representation env cd_args jkinds
@@ -2534,12 +2569,12 @@ let rec update_decl_jkind env dpath decl =
           let () =
             match cstr_repr, arg_sorts with
             | Ok shape, Some sorts ->
-                cstr_layouts.(idx) <- Cstr_layout_known { shape; sorts }
+                cstr_layouts.(idx) <- Cstr_layout_known { tag; shape; sorts }
             | Ok _, None ->
                 Misc.fatal_error "Representation but no arg sorts?"
             | _, _ ->
                 assert_any_args_support loc;
-                cstr_layouts.(idx) <- Cstr_layout_variable
+                cstr_layouts.(idx) <- Cstr_layout_variable { tag }
           in
           let cstr = { cstr with Types.cd_args } in
           cstr
@@ -4792,6 +4827,15 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       in
       cty, cty.ctyp_type
   in
+  let (tsup, sup) = match sdecl.ptype_supertype with
+      None -> None, None
+    | Some sty ->
+      let cty =
+        transl_simple_type ~new_var_jkind:Any env ~closed:no_row
+          Mode.Alloc.Const.legacy sty
+      in
+      Some cty, Some cty.ctyp_type
+  in
   (* In the second part, we check the consistency between the two
      declarations and compute a "merged" declaration; we now need to
      work in the larger signature environment [sig_env], because
@@ -4830,6 +4874,10 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       begin match Env.find_type path sig_env with
       | { type_unboxed_version = Some decl ; _ } ->
         let man = Ctype.newconstr (Path.unboxed_version path) args in
+        let sup =
+          (* CR-someday lmaurer: See comment in [derive_unboxed_version] *)
+          None
+        in
         let type_kind =
           match sig_decl.type_unboxed_version, arity_ok with
           | Some { type_kind ; _ }, true -> type_kind
@@ -4849,6 +4897,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
              Types.ikinds_todo reason);
           type_private = priv;
           type_manifest = Some man;
+          type_supertype = sup;
           type_variance = [];
           type_separability = Types.Separability.default_signature ~arity;
           type_is_newtype = false;
@@ -4888,6 +4937,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
          Types.ikinds_todo reason);
       type_private = priv;
       type_manifest = Some man;
+      type_supertype = sup;
       type_variance = [];
       type_separability = Types.Separability.default_signature ~arity;
       type_is_newtype = false;
@@ -4929,6 +4979,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       type_ikind = new_sig_decl.type_ikind;
       type_private = new_sig_decl.type_private;
       type_manifest = new_sig_decl.type_manifest;
+      type_supertype = new_sig_decl.type_supertype;
       type_unboxed_default = new_sig_decl.type_unboxed_default;
       type_is_newtype = new_sig_decl.type_is_newtype;
       type_expansion_scope = new_sig_decl.type_expansion_scope;
@@ -4972,6 +5023,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     typ_cstrs = constraints;
     typ_loc = loc;
     typ_manifest = Some tman;
+    typ_supertype = tsup;
     typ_kind = Ttype_abstract;
     typ_private = sdecl.ptype_private;
     typ_attributes = sdecl.ptype_attributes;
@@ -4994,6 +5046,7 @@ let transl_package_constraint ~loc ty =
     type_ikind = Types.ikinds_todo "transl_package_constraint";
     type_private = Public;
     type_manifest = Some ty;
+    type_supertype = None;
     type_variance = [];
     type_separability = [];
     type_is_newtype = false;
@@ -5019,6 +5072,7 @@ let abstract_type_decl ~injective ~jkind ~params =
       type_ikind = Types.ikinds_todo "abstract_type_decl";
       type_private = Public;
       type_manifest = None;
+      type_supertype = None;
       type_variance = Variance.unknown_signature ~injective ~arity;
       type_separability = Types.Separability.default_signature ~arity;
       type_is_newtype = false;
@@ -5036,6 +5090,7 @@ let abstract_type_decl ~injective ~jkind ~params =
           type_ikind = Types.ikinds_todo "abstract_type_decl unboxed";
           type_private = Public;
           type_manifest = None;
+          type_supertype = None;
           type_variance = Variance.unknown_signature ~injective ~arity;
           type_separability = Types.Separability.default_signature ~arity;
           type_is_newtype = false;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -158,6 +158,13 @@ type error =
   | Misplaced_flatten_floats
   | Recursive_jkind_definition of Path.t * Env.t * reaching_kind_path
   | Bad_represent_as_float_array_attribute
+  | Manifest_and_supertype
+  | Supertype_not_a_variant of type_expr
+  | Supertype_in_recursive_group of type_expr
+  | Supertype_on_non_variant
+  | Supertype_not_boxed
+  | Supertype_bad_parameters of type_expr
+  | Supertype_in_with_constraint
 
 open Typedtree
 
@@ -1016,6 +1023,10 @@ let transl_declaration env sdecl (id, uid) =
       Some cty, Some cty.ctyp_type
   in
   let (tman, man) = transl_simple_type_opt_in_decl sdecl.ptype_manifest in
+  Option.iter
+    (fun sty ->
+      Language_extension.assert_enabled ~loc:sty.ptyp_loc Subtypes ())
+    sdecl.ptype_supertype;
   let (tsup, sup) = transl_simple_type_opt_in_decl sdecl.ptype_supertype in
   (* jkind_default is the jkind to use for now as the type_jkind when there
      is no annotation and no manifest.
@@ -1745,75 +1756,151 @@ let narrow_to_manifest_jkind env loc path decl =
     in
     { decl with type_jkind = manifest_jkind; type_ikind }
 
+(* Check that a supertype is legal: it must be (headed by) a previously
+   defined boxed variant type, and only a variant (or abstract) type may
+   declare one. Run for every kind, including abstract: an abstract
+   declaration's supertype still licenses coercions, so it must be validated
+   even though there is no kind to compare it against. *)
+let check_supertype env loc ~group_ids dpath decl =
+  match decl.type_supertype with
+  | None -> ()
+  | Some sup ->
+    begin match decl.type_manifest, decl.type_kind with
+    | Some _, Type_abstract _ ->
+      (* With an explicit variant definition, an equation and a supertype can
+         both be checked against it, but a bare equation gives no way to
+         justify the supertype. *)
+      (* CR-someday lmaurer: We intend to support combining a supertype with
+         a bare equation, e.g. [type t :> letter = vowel], by checking that
+         the equated type is (transitively) a subtype of the supertype. *)
+      raise (Error (loc, Manifest_and_supertype))
+    | _, _ -> ()
+    end;
+    begin match get_desc sup with
+    | Tconstr (path, args, _) ->
+      let in_group =
+        Path.same path dpath
+        || (match path with
+            | Path.Pident id -> Ident.Set.mem id group_ids
+            | _ -> false)
+      in
+      (* Requiring the supertype to be previously defined keeps supertype
+         chains well-founded, which [Ctype.subtype_rec] relies on for
+         termination, and guarantees its constructor tags are final when
+         [update_decl_jkind] inherits them. *)
+      if in_group then
+        raise (Error (loc, Supertype_in_recursive_group sup));
+      begin match Env.find_type path env with
+      | { type_kind = Type_variant (_, Variant_boxed _, _); _ } -> ()
+      | _ -> raise (Error (loc, Supertype_not_a_variant sup))
+      | exception Not_found ->
+        raise (Error (loc, Unavailable_type_constructor path))
+      end;
+      (* Constrain this declaration's own kind against the supertype:
+         - An abstract declaration skips [check_kind_coherence]'s comparison,
+           so enforce here that the supertype is applied to this declaration's
+           own parameters (as a manifest would be); otherwise e.g.
+           [type 'a s :> ('a s) t] yields an unimplementable signature and,
+           under [-rectypes], divergence.
+           CR-someday lmaurer: for concrete kinds this same invariant is
+           enforced by [check_kind_coherence] via [Includecore.Arity];
+           unifying the two would give one diagnostic.
+         - The coercion is a no-op, so the subtype must share the supertype's
+           boxed representation; an [@@unboxed] (or otherwise special) variant
+           has no such representation (its value is its bare payload), so it
+           is not a subtype of anything, and tag inheritance
+           ([update_decl_jkind]) only runs for the boxed branch anyway. *)
+      begin match decl.type_kind with
+      | Type_abstract _ ->
+        if List.length args <> decl.type_arity
+        || (match Ctype.equal env false args decl.type_params with
+            | () -> false
+            | exception Ctype.Equality _ -> true)
+        then raise (Error (loc, Supertype_bad_parameters sup))
+      | Type_variant (_, Variant_boxed _, _) -> ()
+      | Type_variant (_, (Variant_unboxed | Variant_with_null
+                         | Variant_extensible), _) ->
+        raise (Error (loc, Supertype_not_boxed))
+      | Type_record _ | Type_record_unboxed_product _ | Type_open ->
+        raise (Error (loc, Supertype_on_non_variant))
+      end
+    | _ -> raise (Error (loc, Supertype_not_a_variant sup))
+    end
+
 (* Check that the type expression (if present) is compatible with the kind.
    If both a variant/record definition and a type equation are given,
    need to check that the equation refers to a type of the same kind
-   with the same constructors and labels. *)
-let check_kind_coherence env loc dpath decl =
-  let manifest_or_supertype, ~is_manifest =
-    match decl.type_manifest, decl.type_supertype with
-    | Some _, Some _ ->
-      (* XXX Should be non-fatal *)
-      Misc.fatal_errorf "Can't combine manifest and supertype: %a"
-        (Format_doc.compat Path.print) dpath
-    | Some man, None -> Some man, ~is_manifest:true
-    | None, Some sup -> Some sup, ~is_manifest:false
-    | None, None -> None, ~is_manifest:false
-  in
-  match decl.type_kind, manifest_or_supertype with
-  | (Type_variant _ | Type_record _ | Type_record_unboxed_product _
-    | Type_open),
-    Some ty ->
-    begin match get_desc ty with
-    | Tconstr(path, args, _) ->
-      begin
-      try
-        let decl' = Env.find_type path env in
-        let err =
-          if List.length args <> List.length decl.type_params
-          then Some Includecore.Arity
-          else begin
-            match Ctype.equal env false args decl.type_params with
-            | exception Ctype.Equality err ->
-                Some (Includecore.Constraint err)
-            | () ->
-              let subst =
-                Subst.Unsafe.add_type_path dpath path Subst.identity in
-              let decl =
-                match Subst.Unsafe.type_declaration subst decl with
-                | Ok decl -> decl
-                | Error (Fcm_type_substituted_away _) ->
-                      (* no module type substitution in [subst] *)
-                    assert false
-              in
-              Includecore.type_declarations ~loc ~equality:true env
-                ~allow_supertype:(not is_manifest)
-                ~mark:true
-                (Path.last path)
-                decl'
-                dpath
-                decl
-          end
-        in
-        if err <> None then
-          raise (Error(loc, Definition_mismatch (ty, env, err)))
-      with Not_found ->
-        raise(Error(loc, Unavailable_type_constructor path))
+   with the same constructors and labels. Similarly, a variant definition
+   with a supertype must declare a subset of the supertype's constructors,
+   with equal argument types and inherited tags. *)
+let check_kind_coherence env loc ~group_ids dpath decl =
+  check_supertype env loc ~group_ids dpath decl;
+  let check_against ~is_manifest ty =
+    match decl.type_kind with
+    | Type_abstract _ -> ()
+    | Type_variant _ | Type_record _ | Type_record_unboxed_product _
+    | Type_open ->
+      begin match get_desc ty with
+      | Tconstr(path, args, _) ->
+        begin
+        try
+          let decl' = Env.find_type path env in
+          let err =
+            if List.length args <> List.length decl.type_params
+            then Some Includecore.Arity
+            else begin
+              match Ctype.equal env false args decl.type_params with
+              | exception Ctype.Equality err ->
+                  Some (Includecore.Constraint err)
+              | () ->
+                let decl =
+                  if not is_manifest then
+                    (* Unlike a manifest, a supertype is not an equation, so
+                       recursive occurrences of [dpath] must match literally.
+                       (Substituting would e.g. equate [A of {mutable x : t}]
+                       with the supertype's [A of {mutable x : s}], making
+                       the zero-cost coercion unsound.) *)
+                    decl
+                  else begin
+                    let subst =
+                      Subst.Unsafe.add_type_path dpath path Subst.identity in
+                    match Subst.Unsafe.type_declaration subst decl with
+                    | Ok decl -> decl
+                    | Error (Fcm_type_substituted_away _) ->
+                          (* no module type substitution in [subst] *)
+                        assert false
+                  end
+                in
+                Includecore.type_declarations ~loc ~equality:true env
+                  ~allow_supertype:(not is_manifest)
+                  ~mark:true
+                  (Path.last path)
+                  decl'
+                  dpath
+                  decl
+            end
+          in
+          if err <> None then
+            raise (Error(loc, Definition_mismatch (ty, env, err)))
+        with Not_found ->
+          raise(Error(loc, Unavailable_type_constructor path))
+        end
+      | _ -> raise (Error(loc, Definition_mismatch (ty, env, None)))
       end
-    | _ -> raise (Error(loc, Definition_mismatch (ty, env, None)))
-    end
-  | _ -> ()
+  in
+  Option.iter (check_against ~is_manifest:true) decl.type_manifest;
+  Option.iter (check_against ~is_manifest:false) decl.type_supertype
 
-let check_coherence env loc dpath decl =
-  check_kind_coherence env loc dpath decl;
+let check_coherence ?(group_ids = Ident.Set.empty) env loc dpath decl =
+  check_kind_coherence env loc ~group_ids dpath decl;
   match decl.type_unboxed_version with
   | Some decl' ->
-    check_kind_coherence env loc (Path.unboxed_version dpath) decl'
+    check_kind_coherence env loc ~group_ids (Path.unboxed_version dpath) decl'
   | None -> ()
 
-let check_abbrev env sdecl (id, decl) =
+let check_abbrev env ~group_ids sdecl (id, decl) =
   let path = Path.Pident id in
-  check_coherence env sdecl.ptype_loc path decl;
+  check_coherence ~group_ids env sdecl.ptype_loc path decl;
   (id, narrow_to_manifest_jkind env sdecl.ptype_loc path decl)
 
 let all_void_sort_option sort =
@@ -2549,6 +2636,39 @@ let rec update_decl_jkind env dpath decl =
           assert false
       end
     | cstrs, Variant_boxed cstr_layouts ->
+      (* If the declaration has a supertype (or re-exports a variant type via
+         its manifest), each constructor keeps the runtime tag of the
+         same-named constructor of that type, so that subtype values need no
+         conversion. The resulting tags may be sparse. Otherwise, constant and
+         non-constant constructors are numbered separately, in order.
+
+         When no tag can be inherited (unknown or non-variant head, missing
+         constructor, or a type from the same recursive group whose own tags
+         aren't assigned yet), fall back to numbering: [check_kind_coherence]
+         rejects all such declarations before the tags are consumed. *)
+      let inherited_tags =
+        let head =
+          match decl.type_supertype, decl.type_manifest with
+          | Some ty, _ | None, Some ty -> Some ty
+          | None, None -> None
+        in
+        match head with
+        | None -> None
+        | Some ty ->
+          match get_desc ty with
+          | Tconstr (path, _, _) -> begin
+              match Env.find_type path env with
+              | { type_kind =
+                    Type_variant (cstrs', Variant_boxed layouts, _); _ } ->
+                Some
+                  (List.mapi
+                     (fun i (cd : Types.constructor_declaration) ->
+                        Ident.name cd.cd_id, cstr_layout_tag layouts.(i))
+                     cstrs')
+              | _ | exception Not_found -> None
+            end
+          | _ -> None
+      in
       let cstrs =
         let consts = ref 0 in
         let non_consts = ref 0 in
@@ -2559,7 +2679,14 @@ let rec update_decl_jkind env dpath decl =
           in
           let post_incr r = let value = !r in incr r; value in
           let tag =
-            if all_void then post_incr consts else post_incr non_consts
+            let inherited =
+              Option.bind inherited_tags
+                (List.assoc_opt (Ident.name cstr.Types.cd_id))
+            in
+            match inherited with
+            | Some tag when tag >= 0 -> tag
+            | Some _ | None ->
+              if all_void then post_incr consts else post_incr non_consts
           in
           let cstr_repr =
             update_constructor_representation env cd_args jkinds
@@ -3808,7 +3935,11 @@ let transl_type_decl env rec_flag sdecl_list =
         raise (Error (loc, Separability err))
   in
   (* Check re-exportation, updating [type_jkind] from the manifest *)
-  let decls = List.map2 (check_abbrev new_env) sdecl_list decls in
+  let group_ids =
+    List.fold_left (fun acc (id, _) -> Ident.Set.add id acc)
+      Ident.Set.empty ids_list
+  in
+  let decls = List.map2 (check_abbrev new_env ~group_ids) sdecl_list decls in
   let shapes = shape_declarations env decls in
   (* Compute the final environment with variance and immediacy *)
   let final_env = add_types_to_env ~shapes:(Some shapes) decls env in
@@ -4827,15 +4958,18 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       in
       cty, cty.ctyp_type
   in
-  let (tsup, sup) = match sdecl.ptype_supertype with
-      None -> None, None
-    | Some sty ->
-      let cty =
-        transl_simple_type ~new_var_jkind:Any env ~closed:no_row
-          Mode.Alloc.Const.legacy sty
-      in
-      Some cty, Some cty.ctyp_type
-  in
+  (* The grammar cannot put a supertype on a [with type] constraint; only a
+     preprocessor (ppx) could forge the AST. Reject it rather than silently
+     installing an unvalidated supertype. The legitimate case — constraining
+     a subtype member, e.g. [S with type t = vowel] — carries no supertype
+     here and inherits [sig_decl]'s below.
+     CR-someday lmaurer: [S with type t :> u] would be a reasonable feature
+     (the natural way to constrain the subtype member of a [module type of]).
+     Supporting it means validating this supertype like a source declaration
+     (see [check_supertype]) and extending the grammar; out of scope here. *)
+  (match sdecl.ptype_supertype with
+   | None -> ()
+   | Some sty -> raise (Error (sty.ptyp_loc, Supertype_in_with_constraint)));
   (* In the second part, we check the consistency between the two
      declarations and compute a "merged" declaration; we now need to
      work in the larger signature environment [sig_env], because
@@ -4923,6 +5057,16 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
       sig_decl.type_jkind
     else
       Type_abstract Definition, false, sig_decl.type_jkind
+  in
+  let sup =
+    (* A variant kind inherited from the signature keeps its supertype: the
+       constructors' tags come from it, and inclusion checks it. (For an
+       abstract signature declaration the manifest justifies the supertype
+       instead; see [Includecore.type_declarations].) A supertype spelled in
+       the constraint itself is rejected above, so there is none to prefer. *)
+    match type_kind with
+    | Type_variant _ -> sig_decl.type_supertype
+    | _ -> None
   in
   let new_sig_decl =
     { type_params = params;
@@ -5023,7 +5167,7 @@ let transl_with_constraint id ?fixed_row_path ~sig_env ~sig_decl ~outer_env
     typ_cstrs = constraints;
     typ_loc = loc;
     typ_manifest = Some tman;
-    typ_supertype = tsup;
+    typ_supertype = None;
     typ_kind = Ttype_abstract;
     typ_private = sdecl.ptype_private;
     typ_attributes = sdecl.ptype_attributes;
@@ -5151,7 +5295,7 @@ let check_recmod_typedecl env loc recmod_ids path decl =
      instead of fixing the spurious failures, we choose to just not perform the check,
      with the intention of fixing the jkind soundness issue once the other soundness issue
      is resolved. *)
-  check_kind_coherence env loc path decl
+  check_kind_coherence env loc ~group_ids:Ident.Set.empty path decl
 
 let check_recmod_jkind_decl env loc recmod_ids path decl =
   check_well_founded_jkind_decl env loc recmod_ids path decl
@@ -5947,6 +6091,36 @@ let report_error ~loc = function
       "%a can only be used on records whose fields \
        are all float64."
       Style.inline_code "[@@represent_as_float_array]"
+  | Manifest_and_supertype ->
+    Location.errorf ~loc
+      "A type declaration cannot have both a type equation and a supertype."
+  | Supertype_not_a_variant ty ->
+    Location.errorf ~loc
+      "@[The supertype@;<1 2>%a@ is not a variant type.@ \
+       Only a type declared as a variant can be a supertype.@]"
+      quoted_type ty
+  | Supertype_in_recursive_group ty ->
+    Location.errorf ~loc
+      "@[The supertype@;<1 2>%a@ must be defined before this declaration;@ \
+       it cannot be part of the same recursive group.@]"
+      quoted_type ty
+  | Supertype_on_non_variant ->
+    Location.errorf ~loc
+      "Only variant types can declare a supertype."
+  | Supertype_not_boxed ->
+    Location.errorf ~loc
+      "@[A variant type with a supertype must use the default (boxed)@ \
+       representation.@ A type with an unboxed or special representation@ \
+       cannot be a subtype.@]"
+  | Supertype_bad_parameters ty ->
+    Location.errorf ~loc
+      "@[The supertype@;<1 2>%a@ must be applied to the parameters of this@ \
+       type declaration.@]"
+      quoted_type ty
+  | Supertype_in_with_constraint ->
+    Location.errorf ~loc
+      "A supertype annotation is not allowed in a %a constraint."
+      Style.inline_code "with type"
 
 let () =
   Location.register_error_of_exn

--- a/typing/typedecl.mli
+++ b/typing/typedecl.mli
@@ -88,8 +88,11 @@ val check_recmod_jkind_decl:
     Env.t -> Location.t -> Ident.t list -> Path.t ->
     Types.jkind_declaration -> unit
 
-(* Checks that constraints are respected in the [type_declaration] *)
+(* Checks that constraints are respected in the [type_declaration].
+   [group_ids] are the other members of the declaration's recursive group,
+   which its supertype may not refer to. *)
 val check_coherence:
+    ?group_ids:Ident.Set.t ->
     Env.t -> Location.t -> Path.t -> type_declaration -> unit
 
 (* for fixed types *)
@@ -248,6 +251,13 @@ type error =
   | Misplaced_flatten_floats
   | Recursive_jkind_definition of Path.t * Env.t * reaching_kind_path
   | Bad_represent_as_float_array_attribute
+  | Manifest_and_supertype
+  | Supertype_not_a_variant of type_expr
+  | Supertype_in_recursive_group of type_expr
+  | Supertype_on_non_variant
+  | Supertype_not_boxed
+  | Supertype_bad_parameters of type_expr
+  | Supertype_in_with_constraint
 
 exception Error of Location.t * error
 

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -356,9 +356,9 @@ let compute_variance_decl env ~check decl (required, _ as rloc) =
                 | Type_record_unboxed_product _;
       type_manifest = _ } ->
     let mn =
-      match decl.type_manifest with
-        None -> []
-      | Some ty -> [ false, ty ]
+      List.map (fun ty -> false, ty)
+        (Option.to_list decl.type_manifest
+         @ Option.to_list decl.type_supertype)
     in
     let vari =
       match decl.type_kind with
@@ -377,7 +377,8 @@ let compute_variance_decl env ~check decl (required, _ as rloc) =
                      {decl with type_private = Private}
                      (add_false [ ty ])
                 )
-                (Option.to_list decl.type_manifest)
+                (Option.to_list decl.type_manifest
+                 @ Option.to_list decl.type_supertype)
             in
             let constructor_variance =
               List.map

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -920,6 +920,7 @@ and type_declaration =
     typ_kind: type_kind;
     typ_private: private_flag;
     typ_manifest: core_type option;
+    typ_supertype: core_type option;
     typ_loc: Location.t;
     typ_attributes: attribute list;
     typ_jkind_annotation: Parsetree.jkind_annotation option;

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1317,6 +1317,7 @@ and type_declaration =
     typ_kind: type_kind;
     typ_private: private_flag;
     typ_manifest: core_type option;
+    typ_supertype: core_type option;
     typ_loc: Location.t;
     typ_attributes: attributes;
     typ_jkind_annotation: Parsetree.jkind_annotation option;

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -977,6 +977,7 @@ module Merge = struct
               type_ikind = Types.ikinds_todo "merge constraint temporary";
               type_private = Private;
               type_manifest = None;
+              type_supertype = None;
               type_variance =
                 List.map
                   (fun (_, (v, i)) ->

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -992,11 +992,10 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
           idx+1,
           match result with
           | None -> None
-          | Some (num_nodes_visited,
-                  next_const, consts, next_tag, non_consts) ->
+          | Some (num_nodes_visited, consts, non_consts) ->
             match cstr_layouts.(idx) with
-            | Cstr_layout_variable -> None
-            | Cstr_layout_known { shape = cstr_shape; _ } ->
+            | Cstr_layout_variable _ -> None
+            | Cstr_layout_known { tag; shape = cstr_shape; _ } ->
                 let (is_mutable, num_nodes_visited), fields =
                   for_one_constructor constructor ~depth ~num_nodes_visited
                     ~cstr_shape
@@ -1005,26 +1004,23 @@ and value_kind_variant env ~loc ~visited ~depth ~num_nodes_visited
                 else match fields with
                 | Constructor_uniform xs
                     when List.compare_length_with xs 0 = 0 ->
-                  let consts = next_const :: consts in
-                  Some (num_nodes_visited,
-                        next_const + 1, consts, next_tag, non_consts)
+                  let consts = tag :: consts in
+                  Some (num_nodes_visited, consts, non_consts)
                 | Constructor_mixed shape
                     when mixed_block_shape_is_empty shape ->
-                  let consts = next_const :: consts in
-                  Some (num_nodes_visited,
-                        next_const + 1, consts, next_tag, non_consts)
+                  let consts = tag :: consts in
+                  Some (num_nodes_visited, consts, non_consts)
                 | Constructor_mixed _ | Constructor_uniform _ ->
                   let non_consts =
-                    (next_tag, fields) :: non_consts
+                    (tag, fields) :: non_consts
                   in
-                  Some (num_nodes_visited,
-                        next_const, consts, next_tag + 1, non_consts))
-          (0, Some (num_nodes_visited, 0, [], 0, []))
+                  Some (num_nodes_visited, consts, non_consts))
+          (0, Some (num_nodes_visited, [], []))
           cstrs
       in
       begin match result with
       | None -> (num_nodes_visited, Pgenval)
-      | Some (num_nodes_visited, _, consts, _, non_consts) ->
+      | Some (num_nodes_visited, consts, non_consts) ->
         match non_consts with
         | [] -> assert false  (* See [List.for_all is_constant], above *)
         | _::_ ->

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -931,6 +931,9 @@ let rec compare_mixed_block_element e1 e2 =
   | Void, _ -> -1
   | _, Void -> 1
 
+let cstr_layout_tag = function
+  | Cstr_layout_known { tag; _ } | Cstr_layout_variable { tag } -> tag
+
 let equal_mixed_product_shape_up_to_scannable_axes r1 r2 = r1 == r2 ||
   Misc.Stdlib.Array.equal equal_mixed_block_element_up_to_scannable_axes r1 r2
 
@@ -950,10 +953,11 @@ let equal_variant_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
         (fun l1 l2 -> match l1, l2 with
            | Cstr_layout_variable { tag = t1 },
              Cstr_layout_variable { tag = t2 } ->
-             t1 == t2
-           | Cstr_layout_known { shape = s1; sorts = ss1 },
-             Cstr_layout_known { shape = s2; sorts = ss2 } ->
-             equal_constructor_representation_up_to_scannable_axes s1 s2
+             t1 = t2
+           | Cstr_layout_known { tag = t1; shape = s1; sorts = ss1 },
+             Cstr_layout_known { tag = t2; shape = s2; sorts = ss2 } ->
+             t1 = t2
+             && equal_constructor_representation_up_to_scannable_axes s1 s2
              && Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal ss1 ss2
            | (Cstr_layout_known _ | Cstr_layout_variable _), _ -> false)
         layouts1

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -453,6 +453,9 @@ type type_declaration =
     type_ikind: constructor_ikind_entry;
     type_private: private_flag;
     type_manifest: type_expr option;
+    type_supertype: type_expr option;
+    (* CR-someday lmaurer: Could also be a list of supertypes (with a common
+       supertype) *)
     type_variance: Variance.t list;
     type_separability: Separability.t list;
     type_is_newtype: bool;
@@ -537,10 +540,11 @@ and variant_representation =
 
 and cstr_layout =
   | Cstr_layout_known of
-      { shape : constructor_representation;
+      { tag : int;
+        shape : constructor_representation;
         sorts : Jkind_types.Sort.Const.t array;
       }
-  | Cstr_layout_variable
+  | Cstr_layout_variable of { tag : int }
 
 and constructor_representation =
   | Constructor_uniform_value
@@ -944,12 +948,14 @@ let equal_variant_representation_up_to_scannable_axes r1 r2 = r1 == r2 ||
   | Variant_boxed layouts1, Variant_boxed layouts2 ->
       Misc.Stdlib.Array.equal
         (fun l1 l2 -> match l1, l2 with
-           | Cstr_layout_variable, Cstr_layout_variable -> true
+           | Cstr_layout_variable { tag = t1 },
+             Cstr_layout_variable { tag = t2 } ->
+             t1 == t2
            | Cstr_layout_known { shape = s1; sorts = ss1 },
              Cstr_layout_known { shape = s2; sorts = ss2 } ->
              equal_constructor_representation_up_to_scannable_axes s1 s2
              && Misc.Stdlib.Array.equal Jkind_types.Sort.Const.equal ss1 ss2
-           | (Cstr_layout_known _ | Cstr_layout_variable), _ -> false)
+           | (Cstr_layout_known _ | Cstr_layout_variable _), _ -> false)
         layouts1
         layouts2
   | Variant_extensible, Variant_extensible ->

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -1307,6 +1307,9 @@ val equal_record_unboxed_product_representation_up_to_scannable_axes :
 val equal_variant_representation_up_to_scannable_axes :
   variant_representation -> variant_representation -> bool
 
+(* The runtime tag of a constructor, from its layout. *)
+val cstr_layout_tag : cstr_layout -> int
+
 val mixed_block_element_of_const_sort :
   Jkind_types.Sort.Const.t -> mixed_block_element
 

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -841,6 +841,7 @@ type type_declaration =
 
     type_private: private_flag;
     type_manifest: type_expr option;
+    type_supertype: type_expr option;
     type_variance: Variance.t list;
     (* covariant, contravariant, weakly contravariant, injective *)
     type_separability: Separability.t list;
@@ -981,7 +982,8 @@ and variant_representation =
 
 and cstr_layout =
   | Cstr_layout_known of
-      { shape : constructor_representation;
+      { tag : int;
+        shape : constructor_representation;
         sorts : Jkind_types.Sort.Const.t array;
         (* [sorts] has a jkind for each argument of the corresponding
            constructor.
@@ -993,7 +995,7 @@ and cstr_layout =
            [Constructor_mixed] if the inlined record has any unboxed fields.
         *)
       }
-  | Cstr_layout_variable
+  | Cstr_layout_variable of { tag : int }
   (* The constructor's payload contains a field of layout [any], so neither
      its [shape] nor the [sorts] of its arguments can be determined at
      typedecl time. Counterpart of [Record_variable] for variants. *)

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -260,6 +260,7 @@ let type_declaration sub decl =
     ~kind:(sub.type_kind sub decl.typ_kind)
     ~priv:decl.typ_private
     ?manifest:(Option.map (sub.typ sub) decl.typ_manifest)
+    ?supertype:(Option.map (sub.typ sub) decl.typ_supertype)
     ~docs:Docstrings.empty_docs
     ?jkind_annotation:decl.typ_jkind_annotation
     (map_loc sub decl.typ_name)

--- a/utils/language_extension_kernel.ml
+++ b/utils/language_extension_kernel.ml
@@ -20,6 +20,7 @@ type _ t =
   | Let_mutable : unit t
   | Layout_poly : maturity t
   | Runtime_metaprogramming : unit t
+  | Subtypes : unit t
 
 (* When you update this, update [pair_of_string] below too. *)
 let to_string : type a. a t -> string = function
@@ -38,3 +39,4 @@ let to_string : type a. a t -> string = function
   | Let_mutable -> "let_mutable"
   | Layout_poly -> "layout_poly"
   | Runtime_metaprogramming -> "runtime_metaprogramming"
+  | Subtypes -> "subtypes"

--- a/utils/language_extension_kernel.mli
+++ b/utils/language_extension_kernel.mli
@@ -31,6 +31,7 @@ type _ t =
   | Let_mutable : unit t
   | Layout_poly : maturity t
   | Runtime_metaprogramming : unit t
+  | Subtypes : unit t
 
 (** Print and parse language extensions; parsing is case-insensitive *)
 val to_string : _ t -> string

--- a/utils/profile_counters_functions.ml
+++ b/utils/profile_counters_functions.ml
@@ -12,7 +12,7 @@ let count_language_extensions typing_input =
       Language_extension_kernel.to_string lang_ext
     | Mode | Unique | Polymorphic_parameters | Layouts | SIMD | Small_numbers
     | Instances | Overwriting | Let_mutable | Layout_poly
-    | Runtime_metaprogramming ->
+    | Runtime_metaprogramming | Subtypes ->
       let error_msg =
         Format.sprintf "No counters supported for language extension : %s."
           (Language_extension_kernel.to_string lang_ext)


### PR DESCRIPTION
> **Provenance — please read (this is an experiment).** I wrote the initial WIP
> commit: the parser and type-system scaffolding, with deliberately placeholder
> error messages. I then had Claude Code take it the rest of the way — the
> second commit is entirely its work. I have **not read the resulting code at
> all.** Rather than reviewing it myself, I had the agent run automated review
> over the whole change (an adversarial soundness panel, then blind simplify and
> code-review passes — "blind" meaning the review agents weren't told which
> lines were human- vs machine-written) and I accepted its suggestions. In the
> same spirit: the agent wrote this PR description too, including this very
> paragraph — I've only done light editing passes on it. Judge the feature on
> that basis: we may well not want to merge this PR in this form, but the
> experiment seemed worth sharing.

## Summary

Adds **variant subtype declarations** behind a new `-extension subtypes`
(Alpha): a variant type may be declared as a subtype of a previously-defined
boxed variant, sharing a name-and-order-preserving subset of its constructors
with identical argument types.

```ocaml
type letter = A | B | C | D | E
type vowel :> letter = A | E
type consonant :> letter = B | C | D
```

Each subtype constructor **inherits the supertype's runtime tag** (so
`E : vowel` has tag 4, not 1), which makes the coercion `(x : vowel :> letter)`
a runtime no-op. Coercion follows subtype chains transitively.

## What it does

- **Syntax / AST:** a `:> T` annotation on a type declaration
  (`ptype_supertype`, `typ_supertype`, `type_supertype`), plumbed through the
  parser, printers, mappers, and iterators.
- **Tag inheritance:** `Types.cstr_layout` carries an explicit tag;
  `Typedecl.update_decl_jkind` inherits same-named constructors' tags from the
  supertype (and from manifest variant re-exports), producing sparse tag sets.
- **Coercion:** `Ctype.subtype` expands a type to its declared supertype;
  `(x : t :> u)` type-checks with no runtime wrapper.
- **Signature inclusion:** a signature's supertype must be matched by the
  implementation (equal supertype, or a manifest whose head carries it); a
  runtime-tag comparison in `Includecore.Variant_diffing` is the soundness net
  that catches representation disagreements wherever variants are compared.
- **Runtime:** construction, pattern matching (sparse-tag switch compilation
  via `cstr_*_span`), comparison, marshalling, and DWARF debug info all handle
  the sparse tags, in both bytecode and native (incl. flambda2).
- **Gating:** the feature is unusable without `-extension subtypes`.

## Design highlights

- **Tags are part of the representation.** They are compared wherever variant
  kinds are compared, which keeps re-exports, signature inclusion, and functor
  application sound once tags can be sparse.
- **A supertype must be a previously-defined boxed variant** (no aliases, no
  members of the same recursive group, not `[@@unboxed]`). This keeps supertype
  chains well-founded — `subtype_rec` expansion terminates — and guarantees the
  inherited tags are final.
- **Recursive occurrences must match literally** (no `dpath -> path` self-
  substitution in the supertype coherence check): otherwise a shared mutable
  payload would make the zero-cost coercion memory-unsafe.

## Testing

- `testsuite/tests/typing-subtypes/` — expect tests for declarations, errors,
  recursion, parameters, modules/functors/`with`-constraints, re-exports, and
  extension gating; plus a `variants_runtime` test (bytecode + native) that
  asserts inherited tag values and exercises float / mixed-block / mutable
  payloads and a >=32-constructor sparse switch.
- Full suite green (2344 passed / 0 failed).

## Known limitations / follow-ups (CR-someday)

- `S with type t :> u` in a `with`-constraint (currently rejected; a small
  follow-up — the grammar plus reusing `check_supertype`).
- Combining a supertype with a bare equation (`type t :> letter = vowel`).
- Chain-weakening in signature inclusion (supertypes must be equal, not merely
  related).
- Depth subtyping of arguments, record/unboxed/multiple supertypes.
- DWARF sparse-tag output has no debug-info test yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
