### PR TITLE
Rename TraverseRebuild to Traverse_rebuild

### DIFF
--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -14,7 +14,7 @@
 (**************************************************************************)
 
 module Staged = struct
-  module TraverseRebuild = struct
+  module Traverse_rebuild = struct
     type t =
       { toplevel_expr : Rev_expr.t;
         code : Rev_expr.rev_code Code_id.Map.t;
@@ -43,7 +43,7 @@ module Staged = struct
       Traverse.run unit
     in
     let rebuild_data =
-      TraverseRebuild.
+      Traverse_rebuild.
         { toplevel_expr;
           code;
           ordered_code_ids;
@@ -78,7 +78,7 @@ module Staged = struct
         | Some code -> code
         | None -> Exported_code.find_exn (load_code ()) code_id)
     in
-    let TraverseRebuild.
+    let Traverse_rebuild.
           { toplevel_expr;
             code;
             ordered_code_ids;

--- a/middle_end/flambda2/reaper/reaper.mli
+++ b/middle_end/flambda2/reaper/reaper.mli
@@ -14,12 +14,12 @@
 (**************************************************************************)
 
 module Staged : sig
-  module TraverseRebuild : sig
+  module Traverse_rebuild : sig
     type t
   end
 
   (** Traverse the compilation unit in preparation for Reaper analysis. *)
-  val traverse : Flambda_unit.t -> Global_flow_graph.graph * TraverseRebuild.t
+  val traverse : Flambda_unit.t -> Global_flow_graph.graph * Traverse_rebuild.t
 
   (** Run Reaper analysis for a compilation unit producing a Reaper solution. *)
   val solve : Global_flow_graph.graph -> Unboxing_analysis.result
@@ -28,7 +28,7 @@ module Staged : sig
       with dead code removed. *)
   val rebuild :
     unit_metadata:Flambda_unit.Metadata.t ->
-    traverse_rebuild:TraverseRebuild.t ->
+    traverse_rebuild:Traverse_rebuild.t ->
     solved_dep:Unboxing_analysis.result ->
     machine_width:Target_system.Machine_width.t ->
     cmx_loader:Flambda_cmx.loader ->


### PR DESCRIPTION
Gives a recently introduced type a more conventional name.