### PR TITLE
binary-emitter: prevent stale files from causing verification failures

### DIFF
--- a/backend/arm64/binary_emitter_helpers.ml
+++ b/backend/arm64/binary_emitter_helpers.ml
@@ -113,7 +113,18 @@ let sections_to_list section_tbl =
 (* Save sections to files for verification *)
 let save_sections_to_files sections section_tbl =
   let dir = !Emitaux.output_prefix ^ ".binary-sections" in
-  (try Sys.mkdir dir 0o755 with Sys_error _ -> ());
+  (* Remove any files left over from a previous compilation with the same output
+     prefix (e.g. when a test compiles the same file twice with different
+     flags). Files are only written below for sections that exist and, for
+     relocations, only when there is at least one, so stale files would
+     otherwise be wrongly attributed to the current compilation during
+     verification. *)
+  if Sys.file_exists dir && Sys.is_directory dir
+  then
+    Array.iter
+      (fun file -> Misc.remove_file (Filename.concat dir file))
+      (Sys.readdir dir)
+  else Sys.mkdir dir 0o755;
   List.iter
     (fun (name, state) ->
       (* Convert section name like ".text" to "section_text" *)

--- a/backend/arm64/binary_emitter_helpers.ml
+++ b/backend/arm64/binary_emitter_helpers.ml
@@ -113,18 +113,7 @@ let sections_to_list section_tbl =
 (* Save sections to files for verification *)
 let save_sections_to_files sections section_tbl =
   let dir = !Emitaux.output_prefix ^ ".binary-sections" in
-  (* Remove any files left over from a previous compilation with the same output
-     prefix (e.g. when a test compiles the same file twice with different
-     flags). Files are only written below for sections that exist and, for
-     relocations, only when there is at least one, so stale files would
-     otherwise be wrongly attributed to the current compilation during
-     verification. *)
-  if Sys.file_exists dir && Sys.is_directory dir
-  then
-    Array.iter
-      (fun file -> Misc.remove_file (Filename.concat dir file))
-      (Sys.readdir dir)
-  else Sys.mkdir dir 0o755;
+  (try Sys.mkdir dir 0o755 with Sys_error _ -> ());
   List.iter
     (fun (name, state) ->
       (* Convert section name like ".text" to "section_text" *)
@@ -140,10 +129,16 @@ let save_sections_to_files sections section_tbl =
       close_out oc;
       (* Save relocations if any *)
       let relocs = BE.Section_state.relocations state in
+      let reloc_filename = Filename.concat dir (safe_name ^ ".relocs") in
       match relocs with
-      | [] -> ()
+      | [] ->
+        (* No relocations file is written in this case, so remove any left over
+           from a previous compilation with the same output prefix (e.g. when a
+           test compiles the same file twice with different flags). Otherwise
+           the stale file would be wrongly attributed to the current compilation
+           during verification. *)
+        Misc.remove_file reloc_filename
       | _ ->
-        let reloc_filename = Filename.concat dir (safe_name ^ ".relocs") in
         let oc = open_out reloc_filename in
         let module R = Arm64_binary_emitter.Relocation in
         let module ED = BE.Encode_directive in

--- a/testsuite/tests/binary-emitter/lib.ml
+++ b/testsuite/tests/binary-emitter/lib.ml
@@ -1,0 +1,1 @@
+let f x = x * x * x

--- a/testsuite/tests/binary-emitter/stale_binary_sections.ml
+++ b/testsuite/tests/binary-emitter/stale_binary_sections.ml
@@ -1,0 +1,36 @@
+(* TEST
+ arch_arm64;
+ flambda2;
+ readonly_files = "lib.ml";
+ setup-ocamlopt.byte-build-env;
+ ocamlopt_flags = "-verify-binary-emitter -flambda2-inline-small-function-size 1";
+ module = "lib.ml";
+ ocamlopt.byte;
+ {
+   ocamlopt_flags = "-verify-binary-emitter -flambda2-inline-threshold 0";
+   module = "stale_binary_sections.ml";
+   ocamlopt.byte;
+ }{
+   ocamlopt_flags = "-verify-binary-emitter -O3";
+   module = "stale_binary_sections.ml";
+   ocamlopt.byte;
+ }
+*)
+
+(* Regression test for stale files in the [<prefix>.binary-sections]
+   directory used by [-verify-binary-emitter].
+
+   This module is compiled twice with the same output prefix. [Lib] is
+   compiled with a small function size that makes [f] speculatively
+   inlinable rather than must-inline, so that the call sites below are
+   governed by the inlining threshold. The first compilation uses a zero
+   threshold: the tail call to [Lib.f] survives, so the text section
+   contains a relocation for it, which the binary emitter records in
+   [stale_binary_sections.binary-sections/section_text.relocs]. The second
+   compilation, at [-O3], inlines [Lib.f], leaving no text relocations at
+   all, in which case no relocations file is written. If the relocations
+   file from the first compilation is not removed, verification compares
+   the first compilation's relocations against the second compilation's
+   object file and fails with a relocation mismatch. *)
+
+let h x = Lib.f x


### PR DESCRIPTION
Found with the testcase on #6640 which failed CI on arm64; vibe-coded fix and testcase by Claude.