### PR TITLE
Optimize csel/cmov better

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -961,29 +961,7 @@ let transl_builtin name args dbg typ_res =
          *   (csel val (!= cond/306 1) ifso/304 ifnot/305))
          * [test_bool] goes from a tagged to an untagged bool. *)
         let cond = test_bool dbg cond in
-        match cond with
-        | Cconst_int (0, _) -> ifnot
-        | Cconst_int (1, _) -> ifso
-        | Cconst_int _ | Cconst_natint _
-        | Cconst_float32 (_, _)
-        | Cconst_float (_, _)
-        | Cconst_vec128 (_, _)
-        | Cconst_vec256 (_, _)
-        | Cconst_vec512 (_, _)
-        | Cconst_mask (_, _)
-        | Cconst_symbol (_, _)
-        | Cvar _
-        | Clet (_, _, _)
-        | Cphantom_let (_, _, _)
-        | Ctuple _
-        | Cop (_, _, _)
-        | Csequence (_, _)
-        | Cifthenelse (_, _, _, _, _, _)
-        | Cswitch (_, _, _, _)
-        | Ccatch (_, _, _)
-        | Cexit (_, _, _)
-        | Cinvalid _ ->
-          Cop (op, [cond; ifso; ifnot], dbg))
+        csel ~dbg typ_res ~cond ~ifso ~ifnot)
   | "caml_int8_shift_left_by_int8_untagged" ->
     let arg, count = two_args name args in
     shift ~bits:8 lsl_int arg count dbg

--- a/backend/cmm_helpers.ml
+++ b/backend/cmm_helpers.ml
@@ -1085,6 +1085,43 @@ let mk_not dbg cmm =
     (* 1 -> 3, 3 -> 1 *)
     Cop (Cxor, [Cconst_int (2, dbg); c], dbg)
 
+(** Whether two expressions are known to denote the same machine word. Only
+    variables and constants are recognised, so that evaluating one of the two
+    expressions instead of both is equivalent. *)
+let same_simple_value (e1 : expression) (e2 : expression) =
+  match e1, e2 with
+  | Cvar v1, Cvar v2 -> V.same v1 v2
+  | Cconst_int (n1, _), Cconst_int (n2, _) -> Int.equal n1 n2
+  | Cconst_natint (n1, _), Cconst_natint (n2, _) -> Nativeint.equal n1 n2
+  | Cconst_symbol (s1, _), Cconst_symbol (s2, _) ->
+    String.equal s1.sym_name s2.sym_name
+  | _ -> false
+
+(** Whether [cond] is an equality test between the two arms of a [csel], so that
+    the arms hold the same word on the edge where the test succeeds. Float
+    comparisons are excluded, since equal floats need not have the same
+    representation. *)
+let condition_equates_arms cond ~ifso ~ifnot =
+  match cond with
+  | Cop (Ccmpi (Ceq | Cne), [c1; c2], _) ->
+    (same_simple_value c1 ifso && same_simple_value c2 ifnot)
+    || (same_simple_value c1 ifnot && same_simple_value c2 ifso)
+  | _ -> false
+
+let csel ~dbg ty ~cond ~ifso ~ifnot =
+  match cond with
+  | Cconst_int (0, _) -> ifnot
+  | Cconst_int (1, _) -> ifso
+  | Cop (Ccmpi Ceq, _, _) when condition_equates_arms cond ~ifso ~ifnot -> ifnot
+  | Cop (Ccmpi Cne, _, _) when condition_equates_arms cond ~ifso ~ifnot -> ifso
+  | _ ->
+    if same_simple_value ifso ifnot
+    then
+      (* [cond] is still evaluated for its effects; dead code elimination drops
+         it when it has none. *)
+      Csequence (cond, ifso)
+    else Cop (Ccsel ty, [cond; ifso; ifnot], dbg)
+
 let mk_compare_ints_untagged dbg a1 a2 =
   bind "int_cmp" a2 (fun a2 ->
       bind "int_cmp" a1 (fun a1 ->
@@ -1101,7 +1138,7 @@ let mk_compare_ints_untagged dbg a1 a2 =
           let cond = Cop (Ccmpi Cge, [a1; a2], dbg) in
           let ifso = Cop (Ccmpi Cgt, [a1; a2], dbg) in
           let ifnot = Cconst_int (-1, dbg) in
-          Cop (Ccsel typ_int, [cond; ifso; ifnot], dbg)))
+          csel ~dbg typ_int ~cond ~ifso ~ifnot))
 
 let mk_unsigned_compare_ints_untagged dbg a1 a2 =
   bind "uint_cmp" a2 (fun a2 ->
@@ -1111,7 +1148,7 @@ let mk_unsigned_compare_ints_untagged dbg a1 a2 =
           let cond = Cop (Ccmpi Cuge, [a1; a2], dbg) in
           let ifso = Cop (Ccmpi Cugt, [a1; a2], dbg) in
           let ifnot = Cconst_int (-1, dbg) in
-          Cop (Ccsel typ_int, [cond; ifso; ifnot], dbg)))
+          csel ~dbg typ_int ~cond ~ifso ~ifnot))
 
 let mk_compare_ints dbg a1 a2 =
   match a1, a2 with

--- a/backend/cmm_helpers.mli
+++ b/backend/cmm_helpers.mli
@@ -193,6 +193,17 @@ val unsigned_mod_int : expression -> expression -> Debuginfo.t -> expression
 (** Boolean negation *)
 val mk_not : Debuginfo.t -> expression -> expression
 
+(** Conditional selection: [ifso] when [cond] is non-zero, [ifnot] otherwise.
+    Both arms are always evaluated. Simplifies away the conditional move when
+    the result does not depend on the condition. *)
+val csel :
+  dbg:Debuginfo.t ->
+  machtype ->
+  cond:expression ->
+  ifso:expression ->
+  ifnot:expression ->
+  expression
+
 (** Integer and float comparison that returns int not bool. The untagged
     versions do not tag the result and do not optimise known-constant cases. *)
 val mk_compare_ints : Debuginfo.t -> expression -> expression -> expression

--- a/backend/x86_peephole/x86_peephole_rules.ml
+++ b/backend/x86_peephole/x86_peephole_rules.ml
@@ -127,10 +127,7 @@ let remove_mov_to_dead_register stats cell =
     | _, _ -> U.No_match)
   | _ -> U.No_match
 
-(* Find a redundant CMP instruction with the same operands. [src_reg] and
-   [dst_reg] are the underlying 64-bit registers of [src] and [dst]. Returns
-   Some cell if found, None otherwise. *)
-let find_redundant_cmp src dst src_reg dst_reg start_cell =
+let find_redundant_cmp src dst start_cell =
   let rec loop cell_opt =
     match cell_opt with
     | None -> None
@@ -141,46 +138,40 @@ let find_redundant_cmp src dst src_reg dst_reg start_cell =
       else
         match value with
         | Ins instr -> (
-          match instr with
-          | CMP (src2, dst2) when equal_args src src2 && equal_args dst dst2 ->
-            Some cell
-          | _ ->
-            if U.maybe_writes_flags instr
-            then None
-            else if
-              U.writes_to_reg64 src_reg instr || U.writes_to_reg64 dst_reg instr
-            then None
-            else loop (DLL.next cell))
+          if not (U.arg_unchanged_by src instr && U.arg_unchanged_by dst instr)
+          then None
+          else
+            match instr with
+            | CMP (src2, dst2) when equal_args src src2 && equal_args dst dst2
+              ->
+              Some cell
+            | _ ->
+              if U.maybe_writes_flags instr then None else loop (DLL.next cell))
         | Directive _ -> loop (DLL.next cell))
   in
   loop (DLL.next start_cell)
 
-(* Rewrite rule: remove redundant CMP with identical operands. Pattern: cmp A,
-   B; ...; cmp A, B (where ... doesn't write flags or modify A or B) Rewrite:
-   cmp A, B; ...
+(** Rewrite rule: remove redundant CMP with identical operands. Pattern: cmp A,
+    B; ...; cmp A, B (where ... doesn't write flags or modify A or B) Rewrite:
+    cmp A, B; ...
 
-   This is safe when: - Both operands are registers (to avoid memory aliasing
-   issues) - Neither operand is modified between the two CMPs - Flags are not
-   written between the two CMPs (but can be read) - No hard barriers like
-   control flow between the CMPs *)
+    This is safe when:
+    - Neither operand is modified between the two CMPs (we currently only allow
+      immediates and registers)
+    - Flags are not written between the two CMPs (but can be read)
+    - No hard barriers like control flow between the CMPs *)
 let remove_redundant_cmp stats cell =
   match DLL.value cell with
-  (* Only optimize comparisons between general-purpose registers, to avoid
-     issues with mutable memory. [underlying_reg64] returns None for the other
-     kinds of arguments, including float registers. *)
   | Ins (CMP (src, dst)) -> (
-    match U.underlying_reg64 src, U.underlying_reg64 dst with
-    | Some src_reg, Some dst_reg -> (
-      (* Search for a redundant CMP *)
-      match find_redundant_cmp src dst src_reg dst_reg cell with
-      | Some redundant_cell ->
-        (* Delete the redundant CMP *)
-        DLL.delete_curr redundant_cell;
-        stats.remove_redundant_cmp <- stats.remove_redundant_cmp + 1;
-        (* Return the first CMP cell to allow iterative removal *)
-        U.Matched (Some cell)
-      | None -> U.No_match)
-    | (Some _ | None), _ -> U.No_match)
+    (* Search for a redundant CMP *)
+    match find_redundant_cmp src dst cell with
+    | Some redundant_cell ->
+      (* Delete the redundant CMP *)
+      DLL.delete_curr redundant_cell;
+      stats.remove_redundant_cmp <- stats.remove_redundant_cmp + 1;
+      (* Return the first CMP cell to allow iterative removal *)
+      U.Matched (Some cell)
+    | None -> U.No_match)
   | _ -> U.No_match
 
 (* Rewrite rule: remove a sign/zero-extension instruction that immediately

--- a/backend/x86_peephole/x86_peephole_utils.ml
+++ b/backend/x86_peephole/x86_peephole_utils.ml
@@ -146,7 +146,7 @@ let arg_unchanged_by arg instr =
   | Imm _ | Sym _ -> true
   | Reg8L _ | Reg8H _ | Reg16 _ | Reg32 _ | Reg64 _ ->
     not (writes_to_reg64 (underlying_reg64 arg |> Option.get) instr)
-  | Regf _ | Mem _ | Mem64_RIP _ -> false
+  | Regmask _ | Regf _ | Mem _ | Mem64_RIP _ -> false
 
 let reads_from_reg64 target = function
   | MOV (src, dst)

--- a/backend/x86_peephole/x86_peephole_utils.ml
+++ b/backend/x86_peephole/x86_peephole_utils.ml
@@ -141,6 +141,13 @@ let writes_to_reg64 target = function
     (* Conservative: assume any SIMD instruction may write to target. *)
     true
 
+let arg_unchanged_by arg instr =
+  match arg with
+  | Imm _ | Sym _ -> true
+  | Reg8L _ | Reg8H _ | Reg16 _ | Reg32 _ | Reg64 _ ->
+    not (writes_to_reg64 (underlying_reg64 arg |> Option.get) instr)
+  | Regf _ | Mem _ | Mem64_RIP _ -> false
+
 let reads_from_reg64 target = function
   | MOV (src, dst)
   | MOVSX (src, dst)

--- a/backend/x86_peephole/x86_peephole_utils.mli
+++ b/backend/x86_peephole/x86_peephole_utils.mli
@@ -28,10 +28,9 @@ val arg_contains_reg64 : reg64 -> arg -> bool
 
 val writes_to_reg64 : reg64 -> instruction -> bool
 
-(** Whether [instr] is certain to leave the value of the operand unchanged: an
-    immediate never changes, and a general-purpose register only changes when
-    written to. We currently conservatively return [false] for all other
-    operands. *)
+(** Whether [instr] is certain to leave the value of the operand unchanged. We
+    currently handle immediates and register operands, but conservatively return
+    [false] for others. *)
 val arg_unchanged_by : arg -> instruction -> bool
 
 val reads_from_reg64 : reg64 -> instruction -> bool

--- a/backend/x86_peephole/x86_peephole_utils.mli
+++ b/backend/x86_peephole/x86_peephole_utils.mli
@@ -28,6 +28,12 @@ val arg_contains_reg64 : reg64 -> arg -> bool
 
 val writes_to_reg64 : reg64 -> instruction -> bool
 
+(** Whether [instr] is certain to leave the value of the operand unchanged: an
+    immediate never changes, and a general-purpose register only changes when
+    written to. We currently conservatively return [false] for all other
+    operands. *)
+val arg_unchanged_by : arg -> instruction -> bool
+
 val reads_from_reg64 : reg64 -> instruction -> bool
 
 val maybe_writes_flags : instruction -> bool

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -113,8 +113,8 @@ combine_comparisons:
   ret
 |}]
 
-(* CR ttebbi: We branch twice on the same comparison, even though we realise
-   it is the same one. *)
+(* CR ttebbi: We branch twice on the same comparison, materializing a boolean
+   for the second branch. *)
 let repeat_comparisons r _f =
   let a = !r > 5 in
   let b = !r > 5 in
@@ -125,7 +125,6 @@ repeat_comparisons:
   xorl  %eax, %eax
   cmpq  $11, %rbx
   setg  %al
-  cmpq  $11, %rbx
   jle   .L0
   testq %rax, %rax
   je    .L0

--- a/testsuite/tests/codegen/select.ml
+++ b/testsuite/tests/codegen/select.ml
@@ -39,8 +39,7 @@ select_cmp:
   ret
 |}]
 
-(* CR ttebbi: We shouldn't materialize the bit, and ideally even share the
-   cmp instructions. *)
+(* CR ttebbi: We shouldn't materialize the bit. *)
 let select_cmp_twice (x : int) (y: int) =
   (Builtins.select (x < y) x y) + (Builtins.select (x < y) 10 20)
 [%%expect_asm X86_64{|
@@ -54,7 +53,6 @@ select_cmp_twice:
   movl  $21, %edx
   cmpq  $1, %rax
   cmovne %rdx, %rdi
-  cmpq  $1, %rax
   cmovne %rsi, %rbx
   leaq  -1(%rbx,%rdi), %rax
   ret
@@ -123,12 +121,11 @@ repeated_select_shared:
   cmpq  $1, %r8
   cmovne %rdi, %rax
   movq  %rcx, %rbx
-  cmpq  $1, %r8
   cmovne %rdx, %rbx
   ret
 |}]
 
-(* CR ttebbi: We should not materialize the boolean, ideally even share the cmpq. *)
+(* CR ttebbi: We should not materialize the boolean. *)
 let repeated_select_repeated x y z w  a b =
   let q =
     Builtins.select_int64 ((Int64_u.to_int64 x) < (Int64_u.to_int64 y)) z w
@@ -147,7 +144,6 @@ repeated_select_repeated:
   cmpq  $1, %r8
   cmovne %rdi, %rax
   movq  %rcx, %rbx
-  cmpq  $1, %r8
   cmovne %rdx, %rbx
   ret
 |}]
@@ -182,5 +178,30 @@ unboxing_through_select:
   movq  8(%rdx), %rax
   movq  %rsi, 64(%r14)
   addq  $8, %rsp
+  ret
+|}]
+
+(* Both arms are the same constant, so no csel is needed. *)
+let select_same_constant x = Builtins.select x 0 0
+[%%expect_asm X86_64{|
+select_same_constant:
+  movl  $1, %eax
+  ret
+|}]
+
+(* Both arms are the same value, so no csel is needed. *)
+let select_same_arg x y = Builtins.select x y y
+[%%expect_asm X86_64{|
+select_same_arg:
+  movq  %rbx, %rax
+  ret
+|}]
+
+(* When the condition holds the two arms are equal, so this is the identity
+   on [y]. *)
+let select_equal (x : int) (y : int) = Builtins.select (x = y) x y
+[%%expect_asm X86_64{|
+select_equal:
+  movq  %rbx, %rax
   ret
 |}]


### PR DESCRIPTION
## Two optimizations for `csel`/`cmov`

### 1. Fold `csel` when the result does not depend on the condition

New `Cmm_helpers.csel` smart constructor. Beyond the existing constant-condition case it recognizes:

- both arms the same value → that arm (the condition stays as a `Csequence` and
  dies in dead code elimination when pure);
- the condition is an integer equality test between the two arms → they hold the
  same word wherever it succeeds, so the `csel` is the identity on one of them.
  `Ccmpi` only, since equal floats need not share a representation.

Only variables and constants are compared, so nothing effectful is dropped or
duplicated. `select x 0 0`, `select x y y` and `select (x = y) x y` now compile
to a single `mov` instead of a `cmp`/`cmov` pair.

### 2. Share the `cmp` feeding several `cmov`s

`remove_redundant_cmp` in the x86 peephole only fired when both operands were
general-purpose registers, missing the common `cmpq $1, %reg` in front of a
`cmov`. It now uses a new `X86_peephole_utils.arg_unchanged_by`, which also
holds for immediates.