### PR TITLE
Record yielding info on method sends

### DIFF
--- a/bytecomp/blambda.ml
+++ b/bytecomp/blambda.ml
@@ -181,7 +181,8 @@ and blambda =
         met : blambda;
         obj : blambda;
         args : blambda list;
-        nontail : bool
+        nontail : bool;
+        yielding : Lambda.yielding_kind
       }
   | Context_switch of context_switch * blambda list
   | Ifthenelse of

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -308,7 +308,7 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         nontail = is_nontail ap_region_close;
         yielding = ap_yielding
       }
-  | Lsend (kind, met, obj, args, rc, _, _, _) ->
+  | Lsend (kind, met, obj, args, rc, _, _, _, yielding) ->
     Send
       { method_kind =
           (match (kind : Lambda.meth_kind) with
@@ -318,7 +318,8 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         met = comp_expr met;
         obj = comp_expr obj;
         args = List.map comp_expr args;
-        nontail = is_nontail rc
+        nontail = is_nontail rc;
+        yielding
       }
   | Lfunction f -> Pseudo_event (Function (comp_fun f), f.loc)
   | Llet (_, _k, id, _duid, arg, body) | Lmutlet (_k, id, _duid, arg, body) ->

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -349,6 +349,15 @@ let rec contains_float32s_or_nulls = function
     Misc.fatal_error "[Const_mixed_block] not supported in bytecode."
   | _ -> false
 
+let send_lookup method_kind met obj args =
+  let obj_and_args = obj :: args in
+  match (method_kind : Blambda.method_kind) with
+  | Self -> Kgetmethod, met :: obj_and_args
+  | Public -> (
+    match met with
+    | Const (Const_base (Const_int n)) -> Kgetpubmet n, obj_and_args
+    | _ -> Kgetdynmet, met :: obj_and_args)
+
 let rec translate_float32s_or_nulls stack_info env cst sz cont =
   match cst with
   | Const_base (Const_float32 f | Const_unboxed_float32 f) ->
@@ -391,48 +400,36 @@ and comp_expr stack_info env exp sz cont =
     then translate_float32s_or_nulls stack_info env cst sz cont
     else add_const cst cont
   | Apply { func; args; nontail; yielding = _ } ->
-    let nargs = List.length args in
     if (not nontail) && is_tailcall cont
-    then
-      comp_args stack_info env args sz
-        (Kpush
-        :: comp_expr stack_info env func (sz + nargs)
-             (Kappterm (nargs, sz + nargs) :: discard_dead_code cont))
-    else if nargs < 4
-    then
-      comp_args stack_info env args sz
-        (Kpush
-        :: comp_expr stack_info env func (sz + nargs) (Kapply nargs :: cont))
+    then comp_tail_apply stack_info env func args sz cont
     else
-      let lbl, cont1 = label_code cont in
-      Kpush_retaddr lbl
-      :: comp_args stack_info env args (sz + 3)
-           (Kpush
-           :: comp_expr stack_info env func
-                (sz + 3 + nargs)
-                (Kapply nargs :: cont1))
+      let nargs = List.length args in
+      if nargs < 4
+      then
+        comp_args stack_info env args sz
+          (Kpush
+          :: comp_expr stack_info env func (sz + nargs) (Kapply nargs :: cont))
+      else
+        let lbl, cont1 = label_code cont in
+        Kpush_retaddr lbl
+        :: comp_args stack_info env args (sz + 3)
+             (Kpush
+             :: comp_expr stack_info env func
+                  (sz + 3 + nargs)
+                  (Kapply nargs :: cont1))
   | Send { method_kind; met; obj; args; nontail; yielding = _ } ->
-    let obj_and_args = obj :: args in
-    let nargs = List.length obj_and_args in
-    let getmethod, args' =
-      match method_kind with
-      | Self -> Kgetmethod, met :: obj_and_args
-      | Public -> (
-        match met with
-        | Const (Const_base (Const_int n)) -> Kgetpubmet n, obj_and_args
-        | _ -> Kgetdynmet, met :: obj_and_args)
-    in
-    if is_tailcall cont && not nontail
-    then
-      comp_args stack_info env args' sz
-        (getmethod :: Kappterm (nargs, sz + nargs) :: discard_dead_code cont)
-    else if nargs < 4
-    then comp_args stack_info env args' sz (getmethod :: Kapply nargs :: cont)
+    if (not nontail) && is_tailcall cont
+    then comp_tail_send stack_info env method_kind met obj args sz cont
     else
-      let lbl, cont1 = label_code cont in
-      Kpush_retaddr lbl
-      :: comp_args stack_info env args' (sz + 3)
-           (getmethod :: Kapply nargs :: cont1)
+      let nargs = List.length (obj :: args) in
+      let getmethod, args' = send_lookup method_kind met obj args in
+      if nargs < 4
+      then comp_args stack_info env args' sz (getmethod :: Kapply nargs :: cont)
+      else
+        let lbl, cont1 = label_code cont in
+        Kpush_retaddr lbl
+        :: comp_args stack_info env args' (sz + 3)
+             (getmethod :: Kapply nargs :: cont1)
   | Function { params; body; free_variables } ->
     (* assume kind = Curried *)
     let lbl = new_label () in
@@ -758,25 +755,20 @@ and comp_expr stack_info env exp sz cont =
       if preserve_tailcall && is_tailcall cont
       then
         (* don't destroy tail call opt *)
+        (* A tail call has no "after" point to attach the event to.
+           Instead, place a pseudo event right at the [Kappterm]
+           instruction recording that the call is unyielding. [Kevent]
+           emits no instruction (it only records the position), so the
+           tail call is preserved. *)
+        let unyielding_call_event nargs =
+          { (event Event_pseudo (Event_unyielding_call nargs)) with
+            ev_stacksize = sz + nargs
+          }
+        in
         match lam with
         | Apply { func; args; nontail = false; yielding = Unyielding } ->
-          (* A tail call has no "after" point to attach the event to.
-             Instead, place a pseudo event right at the [Kappterm]
-             instruction recording that the call is unyielding. [Kevent]
-             emits no instruction (it only records the position), so the
-             tail call is preserved. *)
-          let nargs = List.length args in
-          let ev =
-            { (event Event_pseudo (Event_unyielding_call nargs)) with
-              ev_stacksize = sz + nargs
-            }
-          in
-          comp_args stack_info env args sz
-            (Kpush
-            :: comp_expr stack_info env func (sz + nargs)
-                 (Kevent ev
-                 :: Kappterm (nargs, sz + nargs)
-                 :: discard_dead_code cont))
+          comp_tail_apply stack_info env func args sz cont
+            ~event:(unyielding_call_event (List.length args))
         | Send
             { method_kind;
               met;
@@ -785,27 +777,8 @@ and comp_expr stack_info env exp sz cont =
               nontail = false;
               yielding = Unyielding
             } ->
-          (* As [Apply]: the pseudo event sits at the [Kappterm] following the
-             method lookup. *)
-          let obj_and_args = obj :: args in
-          let nargs = List.length obj_and_args in
-          let getmethod, args' =
-            match method_kind with
-            | Self -> Kgetmethod, met :: obj_and_args
-            | Public -> (
-              match met with
-              | Const (Const_base (Const_int n)) -> Kgetpubmet n, obj_and_args
-              | _ -> Kgetdynmet, met :: obj_and_args)
-          in
-          let ev =
-            { (event Event_pseudo (Event_unyielding_call nargs)) with
-              ev_stacksize = sz + nargs
-            }
-          in
-          comp_args stack_info env args' sz
-            (getmethod :: Kevent ev
-            :: Kappterm (nargs, sz + nargs)
-            :: discard_dead_code cont)
+          comp_tail_send stack_info env method_kind met obj args sz cont
+            ~event:(unyielding_call_event (List.length (obj :: args)))
         | _ -> comp_expr stack_info env lam sz cont
       else
         let info =
@@ -859,9 +832,24 @@ and comp_expr stack_info env exp sz cont =
 (* Compile a list of arguments [e1; ...; eN] to a primitive operation.
    The values of eN ... e2 are pushed on the stack, e2 at top of stack,
    then e3, then ... The value of e1 is left in the accumulator. *)
-
 and comp_args stack_info env argl sz cont =
   comp_expr_list stack_info env (List.rev argl) sz cont
+
+(* Compile a call in tail position, replacing the frame via [Kappterm].
+   [event] is placed at the [Kappterm] *)
+and comp_tail_apply ?event stack_info env func args sz cont =
+  let nargs = List.length args in
+  let cont = Kappterm (nargs, sz + nargs) :: discard_dead_code cont in
+  let cont = match event with None -> cont | Some ev -> Kevent ev :: cont in
+  comp_args stack_info env args sz
+    (Kpush :: comp_expr stack_info env func (sz + nargs) cont)
+
+and comp_tail_send ?event stack_info env method_kind met obj args sz cont =
+  let nargs = List.length (obj :: args) in
+  let getmethod, args' = send_lookup method_kind met obj args in
+  let cont = Kappterm (nargs, sz + nargs) :: discard_dead_code cont in
+  let cont = match event with None -> cont | Some ev -> Kevent ev :: cont in
+  comp_args stack_info env args' sz (getmethod :: cont)
 
 and comp_expr_list stack_info env exprl sz cont =
   match exprl with

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -411,7 +411,7 @@ and comp_expr stack_info env exp sz cont =
            :: comp_expr stack_info env func
                 (sz + 3 + nargs)
                 (Kapply nargs :: cont1))
-  | Send { method_kind; met; obj; args; nontail } ->
+  | Send { method_kind; met; obj; args; nontail; yielding = _ } ->
     let obj_and_args = obj :: args in
     let nargs = List.length obj_and_args in
     let getmethod, args' =
@@ -777,6 +777,35 @@ and comp_expr stack_info env exp sz cont =
                  (Kevent ev
                  :: Kappterm (nargs, sz + nargs)
                  :: discard_dead_code cont))
+        | Send
+            { method_kind;
+              met;
+              obj;
+              args;
+              nontail = false;
+              yielding = Unyielding
+            } ->
+          (* As [Apply]: the pseudo event sits at the [Kappterm] following the
+             method lookup. *)
+          let obj_and_args = obj :: args in
+          let nargs = List.length obj_and_args in
+          let getmethod, args' =
+            match method_kind with
+            | Self -> Kgetmethod, met :: obj_and_args
+            | Public -> (
+              match met with
+              | Const (Const_base (Const_int n)) -> Kgetpubmet n, obj_and_args
+              | _ -> Kgetdynmet, met :: obj_and_args)
+          in
+          let ev =
+            { (event Event_pseudo (Event_unyielding_call nargs)) with
+              ev_stacksize = sz + nargs
+            }
+          in
+          comp_args stack_info env args' sz
+            (getmethod :: Kevent ev
+            :: Kappterm (nargs, sz + nargs)
+            :: discard_dead_code cont)
         | _ -> comp_expr stack_info env lam sz cont
       else
         let info =
@@ -784,6 +813,8 @@ and comp_expr stack_info env exp sz cont =
           | Apply { args; yielding = Unyielding; _ } ->
             Event_unyielding_call (List.length args)
           | Apply { args; _ } -> Event_return (List.length args)
+          | Send { obj; args; yielding = Unyielding; _ } ->
+            Event_unyielding_call (List.length (obj :: args))
           | Send { obj; args; _ } -> Event_return (List.length (obj :: args))
           | Prim (_, args) | Context_switch (_, args) ->
             Event_return (List.length args)

--- a/bytecomp/printblambda.ml
+++ b/bytecomp/printblambda.ml
@@ -187,10 +187,13 @@ let rec blambda ppf = function
       for_from
       (match for_dir with Upto -> "to" | Downto -> "downto")
       blambda for_to blambda for_body
-  | Send { method_kind; met; obj; args; nontail } ->
+  | Send { method_kind; met; obj; args; nontail; yielding } ->
     let name = match method_kind with Self -> "sendself" | Public -> "send" in
-    fprintf ppf "@[<2>(%s%s@ met=%a@ %a)@]" name
+    fprintf ppf "@[<2>(%s%s%s@ met=%a@ %a)@]" name
       (if nontail then " nontail" else "")
+      (match yielding with
+      | Lambda.May_yield -> " yielding"
+      | Lambda.Unyielding -> "")
       blambda met
       (pp_print_list ~pp_sep:pp_print_space blambda)
       (obj :: args)

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -1089,6 +1089,7 @@ type lambda =
   | Lsend of
       meth_kind * lambda * lambda * lambda list
       * region_close * locality_mode * scoped_location * layout
+      * yielding_kind
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout
@@ -1231,7 +1232,7 @@ let rec try_to_find_location lam =
   | Lfor { for_loc = loc; _ }
   | Lswitch (_, _, loc, _)
   | Lstringswitch (_, _, _, loc, _)
-  | Lsend (_, _, _, _, _, _, loc, _)
+  | Lsend (_, _, _, _, _, _, loc, _, _)
   | Levent (_, { lev_loc = loc; _ })
   | Lsplice (loc, _) ->
     loc
@@ -1687,8 +1688,9 @@ let make_key e =
         Lsequence (tr_rec env e1,tr_rec env e2)
     | Lassign (x,e) ->
         Lassign (x,tr_rec env e)
-    | Lsend (m,e1,e2,es,pos,mo,_loc,layout) ->
-        Lsend (m,tr_rec env e1,tr_rec env e2,tr_recs env es,pos,mo,Loc_unknown,layout)
+    | Lsend (m,e1,e2,es,pos,mo,_loc,layout,yielding) ->
+        Lsend (m,tr_rec env e1,tr_rec env e2,tr_recs env es,pos,mo,Loc_unknown,
+               layout,yielding)
     | Lifused (id,e) -> Lifused (id,tr_rec env e)
     | Lregion (e,layout) -> Lregion (tr_rec env e,layout)
     | Lexclave e -> Lexclave (tr_rec env e)
@@ -1791,7 +1793,7 @@ let shallow_iter ~tail ~non_tail:f = function
       f for_from; f for_to; f for_body
   | Lassign(_, e) ->
       f e
-  | Lsend (_k, met, obj, args, _, _, _, _) ->
+  | Lsend (_k, met, obj, args, _, _, _, _, _) ->
       List.iter f (met::obj::args)
   | Levent (e, _evt) ->
       tail e
@@ -1884,7 +1886,7 @@ let rec free_variables = function
            (Ident.Set.remove for_id (free_variables for_body)))
   | Lassign(id, e) ->
       Ident.Set.add id (free_variables e)
-  | Lsend (_k, met, obj, args, _, _, _, _) ->
+  | Lsend (_k, met, obj, args, _, _, _, _, _) ->
       free_variables_list
         (Ident.Set.union (free_variables met) (free_variables obj))
         args
@@ -2211,9 +2213,9 @@ let build_substs update_env ?(freshen_bound_variables = false) s =
         assert (not (Ident.Map.mem id s));
         let id = try Ident.Map.find id l with Not_found -> id in
         Lassign(id, subst s l e)
-    | Lsend (k, met, obj, args, pos, mode, loc, layout) ->
+    | Lsend (k, met, obj, args, pos, mode, loc, layout, yielding) ->
         Lsend (k, subst s l met, subst s l obj, subst_list s l args,
-               pos, mode, loc, layout)
+               pos, mode, loc, layout, yielding)
     | Levent (lam, evt) ->
         let old_env = evt.lev_env in
         let env_updates =
@@ -2492,13 +2494,13 @@ let shallow_map ~tail ~non_tail:f lam =
   | Lassign (v, old_e) ->
       let new_e = f old_e in
       if old_e == new_e then lam else Lassign (v, new_e)
-  | Lsend (k, old_m, old_o, old_el, pos, mode, loc, layout) ->
+  | Lsend (k, old_m, old_o, old_el, pos, mode, loc, layout, yielding) ->
       let new_m = f old_m in
       let new_o = f old_o in
       let new_el = Misc.Stdlib.List.map_sharing f old_el in
       if old_m == new_m && old_o == new_o && old_el == new_el
       then lam
-      else Lsend (k, new_m, new_o, new_el, pos, mode, loc, layout)
+      else Lsend (k, new_m, new_o, new_el, pos, mode, loc, layout, yielding)
   | Levent (old_l, ev) ->
       let new_l = tail old_l in
       if old_l == new_l then lam else Levent (new_l, ev)
@@ -3532,7 +3534,7 @@ let may_allocate_in_region lam =
 
     | Lapply {ap_mode=Alloc_local}
     | Lkindinstantiate {kinst_mode=Alloc_local}
-    | Lsend (_,_,_,_,_,Alloc_local,_,_) -> raise Exit
+    | Lsend (_,_,_,_,_,Alloc_local,_,_,_) -> raise Exit
 
     | Lprim (prim, args, _) ->
        begin match primitive_may_allocate prim with

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -955,6 +955,7 @@ type lambda =
   | Lassign of Ident.t * lambda
   | Lsend of meth_kind * lambda * lambda * lambda list
              * region_close * locality_mode * scoped_location * layout
+             * yielding_kind
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
   | Lregion of lambda * layout

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -1408,13 +1408,19 @@ let rec lam ppf = function
        lam for_to lam for_body
   | Lassign(id, expr) ->
       fprintf ppf "@[<2>(assign@ %a@ %a)@]" Ident.print id lam expr
-  | Lsend (k, met, obj, largs, pos, reg, _, _) ->
+  | Lsend (k, met, obj, largs, pos, reg, _, _, yielding) ->
       let args ppf largs =
         List.iter (fun l -> fprintf ppf "@ %a" lam l) largs in
       let kind =
         if k = Self then "self" else if k = Cached then "cache" else "" in
       let form = apply_kind "send" pos reg in
-      fprintf ppf "@[<2>(%s%s@ %a@ %a%a)@]" form kind lam obj lam met args largs
+      let marker =
+        match yielding with
+        | May_yield -> "[yielding]"
+        | Unyielding -> ""
+      in
+      fprintf ppf "@[<2>(%s%s%s@ %a@ %a%a)@]" form kind marker
+        lam obj lam met args largs
   | Levent(expr, ev) ->
       let kind =
        match ev.lev_kind with

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -93,9 +93,9 @@ let rec eliminate_ref id = function
                     for_body = eliminate_ref id lf.for_body }
   | Lassign(v, e) ->
       Lassign(v, eliminate_ref id e)
-  | Lsend(k, m, o, el, pos, mode, loc, layout) ->
+  | Lsend(k, m, o, el, pos, mode, loc, layout, yielding) ->
       Lsend(k, eliminate_ref id m, eliminate_ref id o,
-            List.map (eliminate_ref id) el, pos, mode, loc, layout)
+            List.map (eliminate_ref id) el, pos, mode, loc, layout, yielding)
   | Levent(l, ev) ->
       Levent(eliminate_ref id l, ev)
   | Lifused(v, e) ->
@@ -196,7 +196,8 @@ let simplify_exits lam =
       count ~try_depth lf.for_to;
       count ~try_depth lf.for_body
   | Lassign(_v, l) -> count ~try_depth l
-  | Lsend(_k, m, o, ll, _, _, _, _) -> List.iter (count ~try_depth) (m::o::ll)
+  | Lsend(_k, m, o, ll, _, _, _, _, _) ->
+      List.iter (count ~try_depth) (m::o::ll)
   | Levent(l, _) -> count ~try_depth l
   | Lifused(_v, l) -> count ~try_depth l
   | Lregion (l, _) -> count ~try_depth:(try_depth+1) l
@@ -380,9 +381,10 @@ let simplify_exits lam =
                     for_to = simplif ~layout:None ~try_depth lf.for_to;
                     for_body = simplif ~layout:None ~try_depth lf.for_body}
   | Lassign(v, l) -> Lassign(v, simplif ~layout:None ~try_depth l)
-  | Lsend(k, m, o, ll, pos, mode, loc, layout) ->
+  | Lsend(k, m, o, ll, pos, mode, loc, layout, yielding) ->
       Lsend(k, simplif ~layout:None ~try_depth m, simplif ~layout:None ~try_depth o,
-            List.map (simplif ~layout:None ~try_depth) ll, pos, mode, loc, layout)
+            List.map (simplif ~layout:None ~try_depth) ll, pos, mode, loc,
+            layout, yielding)
   | Levent(l, ev) -> Levent(simplif ~layout ~try_depth l, ev)
   | Lifused(v, l) -> Lifused (v,simplif ~layout ~try_depth l)
   | Lregion (l, ly) -> Lregion (
@@ -536,7 +538,7 @@ let simplify_lets lam ~restrict_to_upstream_dwarf ~gdwarf_may_alter_codegen =
       (* Lalias-bound variables are never assigned, so don't increase
          v's refcount *)
       count bv l
-  | Lsend(_, m, o, ll, _, _, _, _) -> List.iter (count bv) (m::o::ll)
+  | Lsend(_, m, o, ll, _, _, _, _, _) -> List.iter (count bv) (m::o::ll)
   | Levent(l, _) -> count bv l
   | Lifused(v, l) ->
       if count_var v > 0 then count bv l
@@ -714,8 +716,9 @@ let simplify_lets lam ~restrict_to_upstream_dwarf ~gdwarf_may_alter_codegen =
                              for_to = simplif lf.for_to;
                              for_body = simplif lf.for_body}
   | Lassign(v, l) -> Lassign(v, simplif l)
-  | Lsend(k, m, o, ll, pos, mode, loc, layout) ->
-      Lsend(k, simplif m, simplif o, List.map simplif ll, pos, mode, loc, layout)
+  | Lsend(k, m, o, ll, pos, mode, loc, layout, yielding) ->
+      Lsend(k, simplif m, simplif o, List.map simplif ll, pos, mode, loc,
+            layout, yielding)
   | Levent(l, ev) -> Levent(simplif l, ev)
   | Lifused(v, l) ->
       if count_var v > 0 then simplif l else lambda_unit
@@ -808,7 +811,7 @@ let rec emit_tail_infos is_tail lambda =
       emit_tail_infos false for_body
   | Lassign (_, lam) ->
       emit_tail_infos false lam
-  | Lsend (_, meth, obj, args, _, _, _loc, _) ->
+  | Lsend (_, meth, obj, args, _, _, _loc, _, _) ->
       emit_tail_infos false meth;
       emit_tail_infos false obj;
       list_emit_tail_infos false args

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -292,14 +292,14 @@ let rec fracture_lam lambda : slambda =
   | Lassign (id, lam) ->
     let value = fracture_dynamic lam in
     create_dynamic (if lam == value then lambda else Lassign (id, value))
-  | Lsend (kind, met, obj, args, pos, mode, loc, layout) ->
+  | Lsend (kind, met, obj, args, pos, mode, loc, layout, yielding) ->
     let fmet = fracture_dynamic met in
     let fobj = fracture_dynamic obj in
     let fargs = fracture_dynamic_list args in
     create_dynamic
       (if fmet == met && fobj == obj && fargs == args
        then lambda
-       else Lsend (kind, fmet, fobj, fargs, pos, mode, loc, layout))
+       else Lsend (kind, fmet, fobj, fargs, pos, mode, loc, layout, yielding))
   | Levent (lam, ev) ->
     slet_local "body" lam (fun body_c body_r ->
         SLhalves

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -282,11 +282,13 @@ and eval_lam_shallow env lam =
     if new_layout == old_layout
     then lam
     else Lifthenelse (cond, iftrue, iffalse, new_layout)
-  | Lsend (kind, met, obj, args, region_close, mode, loc, old_layout) ->
+  | Lsend (kind, met, obj, args, region_close, mode, loc, old_layout, yielding)
+    ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout
     then lam
-    else Lsend (kind, met, obj, args, region_close, mode, loc, new_layout)
+    else
+      Lsend (kind, met, obj, args, region_close, mode, loc, new_layout, yielding)
   | Lregion (body, old_layout) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then lam else Lregion (body, new_layout)
@@ -585,7 +587,7 @@ let rec assert_no_splices (lam : Lambda.lambda) =
   | Ltrywith (_, _, _, _, layout) -> assert_layout_contains_no_splices layout
   | Lifthenelse (_, _, _, layout) -> assert_layout_contains_no_splices layout
   | Lsequence _ | Lwhile _ | Lfor _ | Lassign _ -> ()
-  | Lsend (_, _, _, _, _, _, _, layout) ->
+  | Lsend (_, _, _, _, _, _, _, layout, _) ->
     assert_layout_contains_no_splices layout
   | Levent _ | Lifused _ -> ()
   | Lregion (_, layout) -> assert_layout_contains_no_splices layout

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -963,7 +963,7 @@ let rec builtin_meths self env env2 body =
         "var", [Lvar n]
     | Lprim(Pfield(n, _, _), [Lvar e], _) when Ident.same e env ->
         "env", [Lvar env2; (tagged_immediate n)]
-    | Lsend(Self, met, Lvar s, [], _, _, _, _) when List.mem s self ->
+    | Lsend(Self, met, Lvar s, [], _, _, _, _, _) when List.mem s self ->
         "meth", [met]
     | _ -> raise Not_found
   in
@@ -978,15 +978,15 @@ let rec builtin_meths self env env2 body =
   | Lapply{ap_func = f; ap_args = [p; arg]} when const_path f && const_path p ->
       let s, args = conv arg in
       ("app_const_"^s, f :: p :: args)
-  | Lsend(Self, Lvar n, Lvar s, [arg], _, _, _, _) when List.mem s self ->
+  | Lsend(Self, Lvar n, Lvar s, [arg], _, _, _, _, _) when List.mem s self ->
       let s, args = conv arg in
       ("meth_app_"^s, Lvar n :: args)
-  | Lsend(Self, met, Lvar s, [], _, _, _, _) when List.mem s self ->
+  | Lsend(Self, met, Lvar s, [], _, _, _, _, _) when List.mem s self ->
       ("get_meth", [met])
-  | Lsend(Public, met, arg, [], _, _, _, _) ->
+  | Lsend(Public, met, arg, [], _, _, _, _, _) ->
       let s, args = conv arg in
       ("send_"^s, met :: args)
-  | Lsend(Cached, met, arg, [_;_], _, _, _, _) ->
+  | Lsend(Cached, met, arg, [_;_], _, _, _, _, _) ->
       let s, args = conv arg in
       ("send_"^s, met :: args)
   | Lfunction {kind = Curried _; params = [{name = x; _}]; body} ->
@@ -1078,7 +1078,7 @@ let free_methods l =
   let rec free l =
     Lambda.iter_head_constructor free l;
     match l with
-    | Lsend(Self, Lvar meth, _, _, _, _, _, _) ->
+    | Lsend(Self, Lvar meth, _, _, _, _, _, _, _) ->
         fv := Ident.Set.add meth !fv
     | Lsend _ -> ()
     | Lfunction{params} ->

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -197,8 +197,9 @@ let maybe_region get_layout lam =
   let rec remove_tail_markers_and_exclave = function
     | Lapply ({ap_region_close = Rc_close_at_apply} as ap) ->
        Lapply ({ap with ap_region_close = Rc_normal})
-    | Lsend (k, lmet, lobj, largs, Rc_close_at_apply, mode, loc, layout) ->
-       Lsend (k, lmet, lobj, largs, Rc_normal, mode, loc, layout)
+    | Lsend (k, lmet, lobj, largs, Rc_close_at_apply, mode, loc, layout,
+             yielding) ->
+       Lsend (k, lmet, lobj, largs, Rc_normal, mode, loc, layout, yielding)
     | Lregion _ as lam -> lam
     | Lexclave lam -> lam
     | Lsplice _ ->
@@ -1161,12 +1162,12 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
         match met with
         | Tmeth_val id ->
             let obj = transl_exp ~scopes Lambda.layout_object expr in
-            Lsend (Self, Lvar id, obj, [], pos, mode, loc, layout)
+            Lsend (Self, Lvar id, obj, [], pos, mode, loc, layout, Unyielding)
         | Tmeth_name nm ->
             let obj = transl_exp ~scopes Lambda.layout_object expr in
             let (tag, cache) = Translobj.meth obj nm in
             let kind = if cache = [] then Public else Cached in
-            Lsend (kind, tag, obj, cache, pos, mode, loc, layout)
+            Lsend (kind, tag, obj, cache, pos, mode, loc, layout, Unyielding)
         | Tmeth_ancestor(meth, path_self) ->
             let self = transl_value_path loc e.exp_env path_self in
             Lapply {ap_loc = loc;
@@ -1174,9 +1175,8 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
                     ap_args = [self];
                     ap_result_layout = layout;
                     ap_mode = mode;
-                    (* Object code can never close over a yielding value (see
-                       the OO tests in yielding_lambda.ml), so calling an
-                       ancestor method cannot yield *)
+                    (* Object code can never close over a yielding value, so
+                       calling an ancestor method cannot yield *)
                     ap_yielding = Unyielding;
                     ap_region_close = pos;
                     ap_probe = None;
@@ -1198,8 +1198,7 @@ and transl_exp0 ~in_new_scope ~scopes (layout : Lambda.layout) e =
         ap_region_close=pos;
         ap_mode=alloc_heap;
         (* [new] runs the object's initialization, but object code can never
-           close over a yielding value (see the OO tests in
-           yielding_lambda.ml), so it cannot yield *)
+           close over a yielding value, so it cannot yield *)
         ap_yielding=Unyielding;
         ap_tailcall=Default_tailcall;
         ap_inlined=Default_inlined;
@@ -1639,23 +1638,29 @@ and transl_apply ~scopes
   =
   let lapply funct args loc pos mode result_layout =
     match funct, pos with
-    | Lsend((Self | Public) as k, lmet, lobj, [], _, _, _, _), _ ->
-        Lsend(k, lmet, lobj, args, pos, mode, loc, result_layout)
-    | Lsend(Cached, lmet, lobj, ([_; _] as largs), _, _, _, _), _ ->
-        Lsend(Cached, lmet, lobj, largs @ args, pos, mode, loc, result_layout)
-    | Lsend(k, lmet, lobj, largs, (Rc_normal | Rc_nontail), _, _, _),
+    | Lsend((Self | Public) as k, lmet, lobj, [], _, _, _, _, sy), _ ->
+        Lsend(k, lmet, lobj, args, pos, mode, loc, result_layout,
+              join_yielding_kind sy yielding)
+    | Lsend(Cached, lmet, lobj, ([_; _] as largs), _, _, _, _, sy), _ ->
+        Lsend(Cached, lmet, lobj, largs @ args, pos, mode, loc, result_layout,
+              join_yielding_kind sy yielding)
+    | Lsend(k, lmet, lobj, largs, (Rc_normal | Rc_nontail), _, _, _, sy),
       (Rc_normal | Rc_nontail) ->
-        Lsend(k, lmet, lobj, largs @ args, pos, mode, loc, result_layout)
+        Lsend(k, lmet, lobj, largs @ args, pos, mode, loc, result_layout,
+              join_yielding_kind sy yielding)
     | Levent(
-      Lsend((Self | Public) as k, lmet, lobj, [], _, _, _, _), _), _ ->
-        Lsend(k, lmet, lobj, args, pos, mode, loc, result_layout)
+      Lsend((Self | Public) as k, lmet, lobj, [], _, _, _, _, sy), _), _ ->
+        Lsend(k, lmet, lobj, args, pos, mode, loc, result_layout,
+              join_yielding_kind sy yielding)
     | Levent(
-      Lsend(Cached, lmet, lobj, ([_; _] as largs), _, _, _, _), _), _ ->
-        Lsend(Cached, lmet, lobj, largs @ args, pos, mode, loc, result_layout)
+      Lsend(Cached, lmet, lobj, ([_; _] as largs), _, _, _, _, sy), _), _ ->
+        Lsend(Cached, lmet, lobj, largs @ args, pos, mode, loc, result_layout,
+              join_yielding_kind sy yielding)
     | Levent(
-      Lsend(k, lmet, lobj, largs, (Rc_normal | Rc_nontail), _, _, _), _),
+      Lsend(k, lmet, lobj, largs, (Rc_normal | Rc_nontail), _, _, _, sy), _),
       (Rc_normal | Rc_nontail) ->
-        Lsend(k, lmet, lobj, largs @ args, pos, mode, loc, result_layout)
+        Lsend(k, lmet, lobj, largs @ args, pos, mode, loc, result_layout,
+              join_yielding_kind sy yielding)
     | Lapply ({ ap_region_close = (Rc_normal | Rc_nontail) } as ap),
       (Rc_normal | Rc_nontail) ->
         (* The merged application applies more arguments through the

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -2263,15 +2263,16 @@ let lambda_of_prim prim_name prim ~yielding loc args arg_exps =
       Lprim(Pmakeblock(0, Immutable, All_value, alloc_heap),
             [lam; arg], loc)
   | Send (pos, layout), [obj; meth] ->
-      Lsend(Public, meth, obj, [], pos, alloc_heap, loc, layout)
+      Lsend(Public, meth, obj, [], pos, alloc_heap, loc, layout, Unyielding)
   | Send_self (pos, layout), [obj; meth] ->
-      Lsend(Self, meth, obj, [], pos, alloc_heap, loc, layout)
+      Lsend(Self, meth, obj, [], pos, alloc_heap, loc, layout, Unyielding)
   | Send_cache (apos, layout), [obj; meth; cache; pos] ->
       (* Cached mode only works in the native backend *)
       if !Clflags.native_code then
-        Lsend(Cached, meth, obj, [cache; pos], apos, alloc_heap, loc, layout)
+        Lsend(Cached, meth, obj, [cache; pos], apos, alloc_heap, loc, layout,
+              Unyielding)
       else
-        Lsend(Public, meth, obj, [], apos, alloc_heap, loc, layout)
+        Lsend(Public, meth, obj, [], apos, alloc_heap, loc, layout, Unyielding)
   | Frame_pointers, [] ->
      (of_bool (!Clflags.native_code && Config.with_frame_pointers))
   | Identity, [arg] -> arg

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -878,7 +878,7 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
         let body acc ccenv = cps_tail acc body_env ccenv body k k_exn in
         CC.close_let_cont acc ccenv ~name:continuation ~is_exn_handler:false
           ~params ~recursive ~body ~handler)
-  | Lsend (meth_kind, meth, obj, args, pos, mode, loc, layout) ->
+  | Lsend (meth_kind, meth, obj, args, pos, mode, loc, layout, _yielding) ->
     cps_non_tail_simple acc env ccenv obj
       (fun acc env ccenv obj _obj_arity ->
         let obj = must_be_singleton_simple obj in

--- a/testsuite/tests/tool-dumpobj-events/send.ml
+++ b/testsuite/tests/tool-dumpobj-events/send.ml
@@ -6,9 +6,7 @@
  check-program-output;
 *)
 
-(* Like test.ml, but for method sends. Objects need CamlinternalOO, so
-   this program links the stdlib; send.run filters the dump down to this
-   file's events. *)
+(* Like test.ml, but for method sends. *)
 
 let o = object
   method m x = x + 1

--- a/testsuite/tests/tool-dumpobj-events/send.ml
+++ b/testsuite/tests/tool-dumpobj-events/send.ml
@@ -1,0 +1,30 @@
+(* TEST
+ flags = "-g";
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+ run;
+ check-program-output;
+*)
+
+(* Like test.ml, but for method sends. Objects need CamlinternalOO, so
+   this program links the stdlib; send.run filters the dump down to this
+   file's events. *)
+
+let o = object
+  method m x = x + 1
+  method uses (_ : (unit -> int) @ yielding) = 0
+end
+
+(* Non-tail unyielding send: expect "after/unyielding-call(2)" (the object
+   counts as an argument). *)
+let send_nontail () = o#m 41 + 1
+
+(* Unyielding tail send: expect "pseudo/unyielding-call(2)" at APPTERM. *)
+let send_tail () = o#m 42
+
+(* A send passing a yielding argument may yield: expect a plain
+   "after/ret(2)". *)
+let send_yielding_arg (h : (unit -> int) @ yielding) = o#uses h + 1
+
+(* Yielding tail send: no event at all. *)
+let send_tail_yielding (h : (unit -> int) @ yielding) = o#uses h

--- a/testsuite/tests/tool-dumpobj-events/send.reference
+++ b/testsuite/tests/tool-dumpobj-events/send.reference
@@ -1,0 +1,30 @@
+File "send.ml", line 30, characters 56-64:
+Event before/fun
+File "send.ml", line 27, characters 55-67:
+Event before/fun
+File "send.ml", line 27, characters 55-63:
+Event after/ret(2)
+File "send.ml", line 23, characters 19-25:
+Event before/fun
+File "send.ml", line 23, characters 19-25:
+Event pseudo/unyielding-call(2)
+File "send.ml", line 20, characters 22-32:
+Event before/fun
+File "send.ml", line 20, characters 22-28:
+Event after/unyielding-call(2)
+File "send.ml", line 14, characters 15-20:
+Event before/fun
+File "send.ml", line 15, characters 47-48:
+Event before/fun
+File "send.ml", line 20, characters 17-32:
+Event pseudo
+File "send.ml", line 23, characters 14-25:
+Event pseudo
+File "send.ml", line 27, characters 22-67:
+Event pseudo
+File "send.ml", line 30, characters 23-64:
+Event pseudo
+File "send.ml", line 0, characters -1--1:
+Event pseudo
+File "send.ml", line 0, characters -1--1:
+Event pseudo

--- a/testsuite/tests/tool-dumpobj-events/send.reference
+++ b/testsuite/tests/tool-dumpobj-events/send.reference
@@ -1,28 +1,28 @@
-File "send.ml", line 30, characters 56-64:
+File "send.ml", line 28, characters 56-64:
 Event before/fun
-File "send.ml", line 27, characters 55-67:
+File "send.ml", line 25, characters 55-67:
 Event before/fun
-File "send.ml", line 27, characters 55-63:
+File "send.ml", line 25, characters 55-63:
 Event after/ret(2)
-File "send.ml", line 23, characters 19-25:
+File "send.ml", line 21, characters 19-25:
 Event before/fun
-File "send.ml", line 23, characters 19-25:
+File "send.ml", line 21, characters 19-25:
 Event pseudo/unyielding-call(2)
-File "send.ml", line 20, characters 22-32:
+File "send.ml", line 18, characters 22-32:
 Event before/fun
-File "send.ml", line 20, characters 22-28:
+File "send.ml", line 18, characters 22-28:
 Event after/unyielding-call(2)
-File "send.ml", line 14, characters 15-20:
+File "send.ml", line 12, characters 15-20:
 Event before/fun
-File "send.ml", line 15, characters 47-48:
+File "send.ml", line 13, characters 47-48:
 Event before/fun
-File "send.ml", line 20, characters 17-32:
+File "send.ml", line 18, characters 17-32:
 Event pseudo
-File "send.ml", line 23, characters 14-25:
+File "send.ml", line 21, characters 14-25:
 Event pseudo
-File "send.ml", line 27, characters 22-67:
+File "send.ml", line 25, characters 22-67:
 Event pseudo
-File "send.ml", line 30, characters 23-64:
+File "send.ml", line 28, characters 23-64:
 Event pseudo
 File "send.ml", line 0, characters -1--1:
 Event pseudo

--- a/testsuite/tests/tool-dumpobj-events/send.run
+++ b/testsuite/tests/tool-dumpobj-events/send.run
@@ -1,5 +1,7 @@
 if [ "${os_type}" = 'Win32' ]; then
   ocamlrun=$(cygpath "${ocamlrun}")
 fi
+# Unlike test.ml, this program links the stdlib (objects need
+# CamlinternalOO), so filter the dump down to send.ml's own events.
 "${ocamlrun}" "${ocamlsrcdir}/tools/dumpobj" -nobanners "${program}" \
   | awk '/^File "send.ml"/ { print; if (getline > 0) print }' > "${output}"

--- a/testsuite/tests/tool-dumpobj-events/send.run
+++ b/testsuite/tests/tool-dumpobj-events/send.run
@@ -1,0 +1,5 @@
+if [ "${os_type}" = 'Win32' ]; then
+  ocamlrun=$(cygpath "${ocamlrun}")
+fi
+"${ocamlrun}" "${ocamlsrcdir}/tools/dumpobj" -nobanners "${program}" \
+  | awk '/^File "send.ml"/ { print; if (getline > 0) print }' > "${output}"

--- a/testsuite/tests/typing-modes/yielding_lambda.ml
+++ b/testsuite/tests/typing-modes/yielding_lambda.ml
@@ -1028,3 +1028,102 @@ module Gf :
            (apply[yielding] (field_imm 1 M) 0)))))
   0)
 |}]
+
+(* Object code can never close over a yielding value, so a send may yield
+   only via its arguments. *)
+let o = object
+  method m x = x + 1
+  method uses (_ : Yielding.t @ yielding) = 0
+end
+[%%expect{|
+(let
+  (shared =a (opaque [0: #"uses" #"m"])
+   o =
+     (let
+       (class =?
+          (opaque (apply (field_imm 15 (global CamlinternalOO!)) shared))
+        obj_init =
+          (let
+            (ids =?
+               (opaque
+                 (apply (field_imm 7 (global CamlinternalOO!)) class shared))
+             uses =o? (field_mut 0 ids)
+             m =o? (field_mut 1 ids))
+            (seq
+              (opaque
+                (apply (field_imm 10 (global CamlinternalOO!)) class
+                  (opaque
+                    (makeblock 0 m
+                      (function {nlocal = 0} self-8 x[value<int>] : int
+                        (%int_add x 1))
+                      uses (function {nlocal = 0} self-8 param : int 0)))))
+              (function {nlocal = 0} env
+                (opaque
+                  (apply (field_imm 23 (global CamlinternalOO!)) 0 class))))))
+       (seq (opaque (apply (field_imm 16 (global CamlinternalOO!)) class))
+         (opaque (apply obj_init 0)))))
+  (apply (field_imm 1 (global Toploop!)) "o" o))
+val o : < m : int -> int; uses : Yielding.t @ yielding -> int > = <obj>
+|}]
+
+let bare = o#m
+let applied = o#m 3
+[%%expect{|
+(let (o =? (apply (field_imm 0 (global Toploop!)) "o") bare = (send o 109))
+  (apply (field_imm 1 (global Toploop!)) "bare" bare))
+val bare : int -> int = <fun>
+(let
+  (o =? (apply (field_imm 0 (global Toploop!)) "o")
+   applied =[value<int>] (send o 109 3))
+  (apply (field_imm 1 (global Toploop!)) "applied" applied))
+val applied : int = 4
+|}]
+
+(* Passing a yielding argument makes the send yielding *)
+let (_ : int) = Yielding.with_ (fun y -> o#uses y)
+[%%expect{|
+(let
+  (o =? (apply (field_imm 0 (global Toploop!)) "o")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/296"))
+  (apply (field_imm 0 Yielding)
+    (function {nlocal = 0} y : int (send[yielding] o -844262836 y))))
+- : int = 0
+|}]
+
+(* A send to self may be optimized into a CamlinternalOO builtin method,
+   in which case no send remains *)
+class c2 = object (self)
+  method m x = x + 1
+  method call_m = self#m 4
+end
+[%%expect{|
+(let
+  (shared =a (opaque [0: #"m" #"call_m"])
+   c2 =?
+     (let
+       (c2_init =
+          (function {nlocal = 0} class?
+            (let
+              (ids =?
+                 (opaque
+                   (apply (field_imm 7 (global CamlinternalOO!)) class
+                     shared))
+               m =o? (field_mut 0 ids)
+               call_m =o? (field_mut 1 ids))
+              (seq
+                (opaque
+                  (apply (field_imm 10 (global CamlinternalOO!)) class
+                    (opaque
+                      (makeblock 0 m
+                        (function {nlocal = 0} self-9 x[value<int>] : int
+                          (%int_add x 1))
+                        call_m 16 m 4))))
+                (function {nlocal = 0} env self?
+                  (opaque
+                    (apply (field_imm 23 (global CamlinternalOO!)) self
+                      class)))))))
+       (opaque
+         (apply (field_imm 18 (global CamlinternalOO!)) shared c2_init))))
+  (apply (field_imm 1 (global Toploop!)) "c2/928" c2))
+class c2 : object method call_m : int method m : int -> int end
+|}]


### PR DESCRIPTION
Compute the yieldingness of method sends, by adding a new `yielding_kind` field
to `Lsend`, and computing it in `transl_apply` by taking the join of all the
arguments.

Code by claude, comments + description by me