### PR TITLE
De-flake handle_tick_raises.ml

### DIFF
--- a/testsuite/tests/effects/preemption/handle_tick_raises.ml
+++ b/testsuite/tests/effects/preemption/handle_tick_raises.ml
@@ -12,8 +12,12 @@ open Effect.Deep
 
 let () =
   Domain.Tick.with_ ~interval_usec:1_000 (fun _ ->
+    let raised = Atomic.make false in
     Preemptible.try_with
-      ~on_tick:(fun () -> failwith "Raise from on_tick")
+      ~on_tick:(fun () ->
+        if Atomic.compare_and_set raised false true
+        then failwith "Raise from on_tick"
+        else Continue)
       (fun () ->
          let start_at = Sys.time () in
          while true do


### PR DESCRIPTION
On a slow or heavily loaded machine, this test could hit a case where a tick handler happened while handling the previous tick exception, causing the "Raise from on_tick" exception to be printed multiple times. This fixes that, by only raising the *first* time the tick handler is run.