### PR TITLE
cost_metrics: count separately size of current code_id and of nested code_ids.

### DIFF
--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -135,7 +135,7 @@ module Inlining = struct
 
   let definition_inlining_decision inline cost_metrics =
     let inline_threshold = threshold () in
-    let code_size = Cost_metrics.size cost_metrics in
+    let code_size = Cost_metrics.size_with_nested cost_metrics in
     match (inline : Inline_attribute.t) with
     | Never_inline ->
       Function_decl_inlining_decision_type.Never_inline_attribute

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -410,7 +410,10 @@ and code =
     result_mode : alloc_mode_for_assignments
   }
 
-and code_size = int
+and code_size =
+  { size : int;
+    nested_size : int
+  }
 
 and params_and_body =
   { params : kinded_parameter list;

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -783,7 +783,9 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
                ~default:Loopify_attribute.Default_loopify_and_not_tailrec
         in
         let cost_metrics =
-          Cost_metrics.from_size (Code_size.of_int code_size)
+          Cost_metrics.from_size_and_nested_size
+            (Code_size.of_int code_size.size)
+            ~nested_size:(Code_size.of_int code_size.nested_size)
         in
         (* CR ncourant: allow fexpr to specify modes? *)
         let param_modes =

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -971,7 +971,9 @@ code_id:
 ;
 
 code_size:
-  | i = plain_int { i }
+  | size = plain_int { { size; nested_size = 0 } }
+  | size = plain_int; LBRACK; nested_size = plain_int; RBRACK
+    { { size; nested_size } }
 
 function_slot:
   | v = variable { v }

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -497,8 +497,12 @@ and static_let_expr env bound_static defining_expr body : Fexpr.expr =
               body
             })
       in
-      let code_size =
-        Code.cost_metrics code |> Cost_metrics.size |> Code_size.to_int
+      let code_size : Fexpr.code_size =
+        let cost_metrics = Code.cost_metrics code in
+        { size = Cost_metrics.size cost_metrics |> Code_size.to_int;
+          nested_size =
+            Cost_metrics.nested_size cost_metrics |> Code_size.to_int
+        }
       in
       let result_mode : Fexpr.alloc_mode_for_assignments =
         match Code.result_mode code with

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -645,7 +645,9 @@ let loopify_attribute ppf (loopify : loopify_attribute) =
 let loopify_attribute_opt ~space ppf l =
   pp_option ~space loopify_attribute ppf l
 
-let code_size ppf code_size = Format.fprintf ppf "%d" code_size
+let code_size ppf ({ size; nested_size } : code_size) =
+  Format.fprintf ppf "%d" size;
+  if nested_size <> 0 then Format.fprintf ppf "[%d]" nested_size
 
 let or_blank f ppf ob =
   match ob with None -> Format.pp_print_string ppf "_" | Some a -> f ppf a

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -1822,33 +1822,32 @@ let rebuild_let_expr_holed_set_of_closures env res bvs ~set_of_closures
     let set_of_closures, res =
       rewrite_set_of_closures env res ~bound set_of_closures ~is_phantom
     in
-    let size_of_defining_expr =
-      Cost_metrics.size
-        (Cost_metrics.set_of_closures
-           ~find_code_characteristics:(fun code_id ->
-             let code_metadata =
-               if Current_unit.is_current (Code_id.get_compilation_unit code_id)
-               then
-                 match Code_id.Map.find code_id res.all_code with
-                 | exception Not_found ->
-                   Misc.fatal_errorf
-                     "When rebuilding set of closures %a, code_id %a not found \
-                      in [all_code]"
-                     Set_of_closures.print set_of_closures Code_id.print code_id
-                 | code -> Code.code_metadata code
-               else env.get_code_metadata code_id
-             in
-             { cost_metrics = Code_metadata.cost_metrics code_metadata;
-               params_arity =
-                 Flambda_arity.num_params
-                   (Code_metadata.params_arity code_metadata)
-             })
-           set_of_closures)
+    let cost_metrics_of_defining_expr =
+      Cost_metrics.set_of_closures
+        ~find_code_characteristics:(fun code_id ->
+          let code_metadata =
+            if Current_unit.is_current (Code_id.get_compilation_unit code_id)
+            then
+              match Code_id.Map.find code_id res.all_code with
+              | exception Not_found ->
+                Misc.fatal_errorf
+                  "When rebuilding set of closures %a, code_id %a not found in \
+                   [all_code]"
+                  Set_of_closures.print set_of_closures Code_id.print code_id
+              | code -> Code.code_metadata code
+            else env.get_code_metadata code_id
+          in
+          { cost_metrics = Code_metadata.cost_metrics code_metadata;
+            params_arity =
+              Flambda_arity.num_params
+                (Code_metadata.params_arity code_metadata)
+          })
+        set_of_closures
     in
     let expr =
-      RE.create_let bound_pattern
+      RE.create_let_set_of_closures bound_pattern
         (Named.create_set_of_closures ~alloc_mode set_of_closures)
-        ~size_of_defining_expr ~body:hole
+        ~cost_metrics_of_defining_expr ~body:hole
     in
     expr, res
 
@@ -2258,7 +2257,7 @@ and rebuild_function_params_and_body (env : env) res code_metadata
       Code_metadata.with_result_types result_types code_metadata
   in
   let update_size code_metadata (body : RE.t) =
-    let cost_metrics = Cost_metrics.from_size body.code_size in
+    let cost_metrics = body.cost_metrics in
     Code_metadata.with_inlining_decision
       (Function_decl_inlining_decision.make_decision
          ~inlining_arguments:(Code_metadata.inlining_arguments code_metadata)

--- a/middle_end/flambda2/reaper/rebuilt_expr.ml
+++ b/middle_end/flambda2/reaper/rebuilt_expr.ml
@@ -16,22 +16,23 @@
 type continuation_handler =
   { handler : Flambda.Continuation_handler.t;
     free_names : Name_occurrences.t;
-    code_size : Code_size.t
+    cost_metrics : Cost_metrics.t
   }
 
 type continuation_handlers =
   { handlers : Flambda.Continuation_handler.t Continuation.Lmap.t;
     free_names : Name_occurrences.t;
-    code_size : Code_size.t
+    cost_metrics : Cost_metrics.t
   }
 
 type t =
   { expr : Flambda.Expr.t;
     free_names : Name_occurrences.t;
-    code_size : Code_size.t
+    cost_metrics : Cost_metrics.t
   }
 
-let create_let bound_pattern defining_expr ~size_of_defining_expr ~body =
+let create_let0 bound_pattern defining_expr ~cost_metrics_of_defining_expr ~body
+    =
   let free_names =
     Name_occurrences.diff
       (Name_occurrences.union
@@ -43,13 +44,23 @@ let create_let bound_pattern defining_expr ~size_of_defining_expr ~body =
     Flambda.Let_expr.create bound_pattern defining_expr ~body:body.expr
       ~free_names_of_body:(Known body.free_names)
   in
-  let code_size =
+  let cost_metrics =
     if Name_mode.is_phantom (Bound_pattern.name_mode bound_pattern)
-    then body.code_size
-    else Code_size.( + ) body.code_size size_of_defining_expr
+    then body.cost_metrics
+    else Cost_metrics.( + ) body.cost_metrics cost_metrics_of_defining_expr
   in
   let expr = Flambda.Expr.create_let let_expr in
-  { expr; free_names; code_size }
+  { expr; free_names; cost_metrics }
+
+let create_let bound_pattern defining_expr ~size_of_defining_expr ~body =
+  create_let0 bound_pattern defining_expr
+    ~cost_metrics_of_defining_expr:
+      (Cost_metrics.from_size size_of_defining_expr)
+    ~body
+
+let create_let_set_of_closures bound_pattern defining_expr
+    ~cost_metrics_of_defining_expr ~body =
+  create_let0 bound_pattern defining_expr ~cost_metrics_of_defining_expr ~body
 
 let create_continuation_handler bound_parameters ~handler ~is_exn_handler
     ~is_cold =
@@ -57,24 +68,26 @@ let create_continuation_handler bound_parameters ~handler ~is_exn_handler
     Name_occurrences.diff handler.free_names
       ~without:(Bound_parameters.free_names bound_parameters)
   in
-  let code_size = handler.code_size in
+  let cost_metrics = handler.cost_metrics in
   let handler =
     Flambda.Continuation_handler.create bound_parameters ~handler:handler.expr
       ~free_names_of_handler:(Known handler.free_names) ~is_exn_handler ~is_cold
   in
-  { handler; free_names; code_size }
+  { handler; free_names; cost_metrics }
 
 let create_continuation_handlers handlers =
-  let (code_size, free_names), handlers =
+  let (cost_metrics, free_names), handlers =
     Continuation.Lmap.fold_left_map
-      (fun (code_size, free_names) _cont (handler : continuation_handler) ->
-        let code_size = Code_size.( + ) code_size handler.code_size in
+      (fun (cost_metrics, free_names) _cont (handler : continuation_handler) ->
+        let cost_metrics =
+          Cost_metrics.( + ) cost_metrics handler.cost_metrics
+        in
         let free_names = Name_occurrences.union free_names handler.free_names in
-        (code_size, free_names), handler.handler)
-      (Code_size.zero, Name_occurrences.empty)
+        (cost_metrics, free_names), handler.handler)
+      (Cost_metrics.zero, Name_occurrences.empty)
       handlers
   in
-  { handlers; free_names; code_size }
+  { handlers; free_names; cost_metrics }
 
 let create_non_recursive_let_cont cont (cont_handler : continuation_handler)
     ~body =
@@ -87,8 +100,10 @@ let create_non_recursive_let_cont cont (cont_handler : continuation_handler)
       (Name_occurrences.remove_continuation body.free_names ~continuation:cont)
       cont_handler.free_names
   in
-  let code_size = Code_size.( + ) body.code_size cont_handler.code_size in
-  { expr; free_names; code_size }
+  let cost_metrics =
+    Cost_metrics.( + ) body.cost_metrics cont_handler.cost_metrics
+  in
+  { expr; free_names; cost_metrics }
 
 let create_recursive_let_cont ~invariant_params handlers0 ~body =
   let handlers = create_continuation_handlers handlers0 in
@@ -110,7 +125,10 @@ let create_recursive_let_cont ~invariant_params handlers0 ~body =
         Name_occurrences.remove_continuation free_names ~continuation:cont)
       handlers0 free_names
   in
-  let code_size = Code_size.( + ) body.code_size handlers.code_size in
-  { expr; free_names; code_size }
+  let cost_metrics =
+    Cost_metrics.( + ) body.cost_metrics handlers.cost_metrics
+  in
+  { expr; free_names; cost_metrics }
 
-let from_expr ~expr ~free_names ~code_size = { expr; free_names; code_size }
+let from_expr ~expr ~free_names ~code_size =
+  { expr; free_names; cost_metrics = Cost_metrics.from_size code_size }

--- a/middle_end/flambda2/reaper/rebuilt_expr.mli
+++ b/middle_end/flambda2/reaper/rebuilt_expr.mli
@@ -16,25 +16,32 @@
 type continuation_handler =
   { handler : Flambda.Continuation_handler.t;
     free_names : Name_occurrences.t;
-    code_size : Code_size.t
+    cost_metrics : Cost_metrics.t
   }
 
 type continuation_handlers =
   { handlers : Flambda.Continuation_handler.t Continuation.Lmap.t;
     free_names : Name_occurrences.t;
-    code_size : Code_size.t
+    cost_metrics : Cost_metrics.t
   }
 
 type t =
   { expr : Flambda.expr;
     free_names : Name_occurrences.t;
-    code_size : Code_size.t
+    cost_metrics : Cost_metrics.t
   }
 
 val create_let :
   Bound_pattern.t ->
   Flambda.named ->
   size_of_defining_expr:Code_size.t ->
+  body:t ->
+  t
+
+val create_let_set_of_closures :
+  Bound_pattern.t ->
+  Flambda.named ->
+  cost_metrics_of_defining_expr:Cost_metrics.t ->
   body:t ->
   t
 

--- a/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
+++ b/middle_end/flambda2/simplify/inlining/call_site_inlining_decision.ml
@@ -123,29 +123,29 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
         in
         rebuild uacc ~after_rebuild:(fun expr uacc -> expr, uacc))
   in
-  let cost_metrics_of_lifted_constants =
-    if Flambda_features.Inlining.speculative_inlining_track_lifted_constants ()
-    then
-      (* If we are not at toplevel, there might still be lifted constants to be
-         placed in the accumulator whose size must be taken into account for
-         speculative inlining. *)
-      let lifted_constants = UA.lifted_constants uacc in
-      (* CR-someday bclement: Ideally we would simply call
-         [place_lifted_constants] in [after_rebuild] above so that we can share
-         the code with the non-speculative inlining code path; however, that
-         function expects to be called at toplevel and there could be unintended
-         consequences -- notably regarding the validity of the used value slots.
+  if Flambda_features.Inlining.speculative_inlining_track_lifted_constants ()
+  then
+    (* If we are not at toplevel, there might still be lifted constants to be
+       placed in the accumulator whose size must be taken into account for
+       speculative inlining. *)
+    let lifted_constants = UA.lifted_constants uacc in
+    (* CR-someday bclement: Ideally we would simply call
+       [place_lifted_constants] in [after_rebuild] above so that we can share
+       the code with the non-speculative inlining code path; however, that
+       function expects to be called at toplevel and there could be unintended
+       consequences -- notably regarding the validity of the used value slots.
 
-         At the time of writing, this means that we incorrectly:
+       At the time of writing, this means that we incorrectly:
 
-         - Ignore the size of the symbol projections created during speculative
-         inlining;
+       - Ignore the size of the symbol projections created during speculative
+       inlining;
 
-         - Count the size of unused value slots of lifted sets of closures
-         created during speculative inlining (but again, it is not clear that it
-         is always possible to compute a correct set of "used value slots" at
-         the time we are doing speculative inlining, because some value slots
-         could be used later in the compilation unit). *)
+       - Count the size of unused value slots of lifted sets of closures created
+       during speculative inlining (but again, it is not clear that it is always
+       possible to compute a correct set of "used value slots" at the time we
+       are doing speculative inlining, because some value slots could be used
+       later in the compilation unit). *)
+    let cost_metrics_of_lifted_constants =
       Lifted_constant_state.fold lifted_constants ~init:Cost_metrics.zero
         ~f:(fun cost_metrics lifted_constant ->
           List.fold_left
@@ -155,9 +155,20 @@ let speculative_inlining dacc ~apply ~function_type ~simplify_expr ~return_arity
                    (Lifted_constant.Definition.defining_expr definition)))
             cost_metrics
             (Lifted_constant.definitions lifted_constant))
-    else Cost_metrics.zero
-  in
-  Cost_metrics.( + ) (UA.cost_metrics uacc) cost_metrics_of_lifted_constants
+    in
+    (* The nested cost metrics have been included in the cost metrics of lifted
+       constants; skip them. They would be ignored anyway by
+       [Cost_metrics.evaluate]. *)
+    Cost_metrics.without_nested
+      (Cost_metrics.( + ) (UA.cost_metrics uacc)
+         cost_metrics_of_lifted_constants)
+  else
+    (* The nested cost metrics are ignored by [Cost_metrics.evaluate]; merge
+       them into the non-nested size. *)
+    let cost_metrics = UA.cost_metrics uacc in
+    Cost_metrics.notify_added
+      ~code_size:(Cost_metrics.nested_size cost_metrics)
+      (Cost_metrics.without_nested cost_metrics)
 
 let argument_types_useful dacc apply =
   if
@@ -181,9 +192,9 @@ let inlining_does_decrease_code_size ~code_or_metadata cost_metrics =
     code_or_metadata
     |> Code_or_metadata.code_metadata
     |> Code_metadata.cost_metrics
-    |> Cost_metrics.size
+    |> Cost_metrics.size_with_nested
   in
-  let inlined_code_size = Cost_metrics.size cost_metrics in
+  let inlined_code_size = Cost_metrics.size_with_nested cost_metrics in
   not (Code_size.( <= ) original_code_size inlined_code_size)
 
 let might_inline dacc ~apply ~code_or_metadata ~function_type ~simplify_expr

--- a/middle_end/flambda2/simplify_shared/function_decl_inlining_decision.ml
+++ b/middle_end/flambda2/simplify_shared/function_decl_inlining_decision.ml
@@ -35,7 +35,7 @@ let make_decision0 ~inlining_arguments:args ~inline ~stub ~cost_metrics:metrics
           ( Inlining_arguments.large_function_size args |> Code_size.of_int,
             Inlining_arguments.small_function_size args |> Code_size.of_int )
       in
-      let size = Cost_metrics.size metrics in
+      let size = Cost_metrics.size_with_nested metrics in
       let is_small = Code_size.( <= ) size small_size in
       let is_large = Code_size.( <= ) large_size size in
       let is_recursive =

--- a/middle_end/flambda2/simplify_shared/inlining_report.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_report.ml
@@ -195,13 +195,15 @@ module Context = struct
       |> Table.create
     in
     Format.fprintf ppf
-      "@[<v>@[<h>Code@ size@ was@ estimated@ to@ be@ %a@]@,\
+      "@[<v>@[<h>Code@ size@ was@ estimated@ to@ be@ %a (%a nested)@]@,\
        @,\
        @[<h>Benefits@ of@ inlining@ this@ call:@;\
        @]@,\
        @[<h>%a@]@]@,\
        @,"
-      Code_size.print (Cost_metrics.size c) Table.print table
+      Code_size.print (Cost_metrics.size c) Code_size.print
+      (Cost_metrics.nested_size c)
+      Table.print table
 
   let print ppf
       { args;

--- a/middle_end/flambda2/terms/cost_metrics.ml
+++ b/middle_end/flambda2/terms/cost_metrics.ml
@@ -21,6 +21,7 @@
 
 type t =
   { size : Code_size.t;
+    nested_size : Code_size.t;
     removed : Removed_operations.t
   }
 
@@ -29,17 +30,33 @@ type code_characteristics =
     params_arity : int
   }
 
-let zero = { size = Code_size.zero; removed = Removed_operations.zero }
+let zero =
+  { size = Code_size.zero;
+    nested_size = Code_size.zero;
+    removed = Removed_operations.zero
+  }
 
 let size t = t.size
 
+let nested_size t = t.nested_size
+
+let size_with_nested t = Code_size.( + ) t.size t.nested_size
+
 let removed t = t.removed
 
-let print ppf t =
-  Format.fprintf ppf "@[<hov 1>size: %a removed: {%a}@]" Code_size.print t.size
-    Removed_operations.print t.removed
+let print ppf { size; nested_size; removed } =
+  Format.fprintf ppf "@[<hov 1>size: %a (%a nested) removed: {%a}@]"
+    Code_size.print size Code_size.print nested_size Removed_operations.print
+    removed
 
-let from_size size = { size; removed = Removed_operations.zero }
+let from_size size =
+  { size; nested_size = Code_size.zero; removed = Removed_operations.zero }
+
+let from_size_and_nested_size size ~nested_size =
+  { size; nested_size; removed = Removed_operations.zero }
+
+
+let without_nested t = { t with nested_size = Code_size.zero }
 
 let notify_added ~code_size t =
   { t with size = Code_size.( + ) t.size code_size }
@@ -49,6 +66,7 @@ let notify_removed ~operation t =
 
 let ( + ) a b =
   { size = Code_size.( + ) a.size b.size;
+    nested_size = Code_size.( + ) a.nested_size b.nested_size;
     removed = Removed_operations.( + ) a.removed b.removed
   }
 
@@ -62,32 +80,48 @@ let ( + ) a b =
  *   total number of value slots + sum of s(arity) for each closure
  * where s(a) = if a = 1 then 2 else 3
  *)
-let set_of_closures ~find_code_characteristics set_of_closures =
+let total_size_of_closures ~find_code_characteristics set_of_closures =
   let func_decls = Set_of_closures.function_decls set_of_closures in
   let funs = Function_declarations.funs func_decls in
   let num_clos_vars =
     Set_of_closures.value_slots set_of_closures |> Value_slot.Map.cardinal
   in
+  Function_slot.Map.fold
+    (fun _ (code_id : Function_declarations.code_id_in_function_declaration)
+         (metrics, num_words) ->
+      match code_id with
+      | Deleted { function_slot_size; _ } ->
+        metrics, Stdlib.( + ) num_words function_slot_size
+      | Code_id { code_id; only_full_applications = _ } ->
+        let { cost_metrics; params_arity } =
+          find_code_characteristics code_id
+        in
+        ( metrics + cost_metrics,
+          (* CR poechsel: valid until OCaml 4.12, as for named_size *)
+          Stdlib.( + ) num_words (if params_arity <= 1 then 2 else 3) ))
+    funs (zero, num_clos_vars)
+
+let set_of_closures ~find_code_characteristics set_of_closures =
   let cost_metrics, num_words =
-    Function_slot.Map.fold
-      (fun _ (code_id : Function_declarations.code_id_in_function_declaration)
-           (metrics, num_words) ->
-        match code_id with
-        | Deleted { function_slot_size; _ } ->
-          metrics, Stdlib.( + ) num_words function_slot_size
-        | Code_id { code_id; only_full_applications = _ } ->
-          let { cost_metrics; params_arity } =
-            find_code_characteristics code_id
-          in
-          ( metrics + cost_metrics,
-            (* CR poechsel: valid until OCaml 4.12, as for named_size *)
-            Stdlib.( + ) num_words (if params_arity <= 1 then 2 else 3) ))
-      funs (zero, num_clos_vars)
+    total_size_of_closures ~find_code_characteristics set_of_closures
   in
   let alloc_size =
     Code_size.( + ) Code_size.alloc_size (Code_size.of_int num_words)
   in
-  cost_metrics + from_size alloc_size
+  (* CR ncourant: If we don't track lifted constants with the speculative
+     inlining, we won't look at the removed_operations of the code_ids of those
+     closures, so include them here. This is very much a hack to preserve the
+     existing behaviour while the flag is not enabled; we expect the flag to
+     become the default as soon as possible. *)
+  let removed =
+    if Flambda_features.Inlining.speculative_inlining_track_lifted_constants ()
+    then Removed_operations.zero
+    else cost_metrics.removed
+  in
+  { size = alloc_size;
+    nested_size = Code_size.( + ) cost_metrics.size cost_metrics.nested_size;
+    removed
+  }
 
 let increase_due_to_let_expr ~is_phantom ~cost_metrics_of_defining_expr =
   if is_phantom then zero else cost_metrics_of_defining_expr
@@ -101,6 +135,8 @@ let increase_due_to_let_cont_recursive ~cost_metrics_of_handlers =
 let evaluate ~args (t : t) =
   Code_size.evaluate ~args t.size -. Removed_operations.evaluate ~args t.removed
 
-let equal { size = size1; removed = removed1 }
-    { size = size2; removed = removed2 } =
-  Code_size.equal size1 size2 && Removed_operations.equal removed1 removed2
+let equal { size = size1; nested_size = nested_size1; removed = removed1 }
+    { size = size2; nested_size = nested_size2; removed = removed2 } =
+  Code_size.equal size1 size2
+  && Code_size.equal nested_size1 nested_size2
+  && Removed_operations.equal removed1 removed2

--- a/middle_end/flambda2/terms/cost_metrics.mli
+++ b/middle_end/flambda2/terms/cost_metrics.mli
@@ -20,7 +20,15 @@ val zero : t
 
 val from_size : Code_size.t -> t
 
+val from_size_and_nested_size : Code_size.t -> nested_size:Code_size.t -> t
+
+val without_nested : t -> t
+
 val size : t -> Code_size.t
+
+val nested_size : t -> Code_size.t
+
+val size_with_nested : t -> Code_size.t
 
 val removed : t -> Removed_operations.t
 

--- a/testsuite/tests/flambda2/examples/functors.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functors.simplify.reference
@@ -49,7 +49,7 @@ apply direct(init_mod_4 &toplevel.alloc_region)
          in
          let $camlFunctors__na_5 = closure na_1_1 @na &toplevel.alloc_region
          in
-         let code loopify(never) size(45) newer_version_of(Make_0)
+         let code loopify(never) size(18[27]) newer_version_of(Make_0)
                Make_0_1 (X : val)
                  my_closure &my_alloc_region my_depth
                  -> k * k1

--- a/testsuite/tests/flambda2/examples/phantom.simplify.reference
+++ b/testsuite/tests/flambda2/examples/phantom.simplify.reference
@@ -118,7 +118,7 @@ in
 let $camlPhantom__is_true_7 =
   closure is_true_1_1 @is_true &toplevel.alloc_region
 in
-let code inline(always) loopify(never) size(176) newer_version_of(Make_0)
+let code inline(always) loopify(never) size(43[133]) newer_version_of(Make_0)
       Make_0_1 (F : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
   apply ccall noalloc
     ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k2 * k1
@@ -233,7 +233,7 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3_1)
            let Pmakeblock = %block.[`0`].my_alloc_region (0, lvl) in
            cont k (Pmakeblock))
 in
-let code inline(always) loopify(never) size(176) newer_version_of(Make2_5)
+let code inline(always) loopify(never) size(43[133]) newer_version_of(Make2_5)
       Make2_5_1 (F : val)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/tests11.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests11.raw.reference
@@ -14,7 +14,7 @@ let $camlTests11__first_const = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    cont k1 (x)
  in
- let code size(23)
+ let code size(21[2])
        `fn[tests11.ml:23,2--70]_1` (param : imm tagged)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =
@@ -35,7 +35,7 @@ let $camlTests11__first_const = Block 0 () in
        (`fn[tests11.ml:23,39--51]`, `fn[tests11.ml:23,52--67]`, 0)
        -> k1 * k2
  in
- let code inline(always) size(32)
+ let code inline(always) size(9[23])
        bar_0 (map_foo : val)
          my_closure &my_alloc_region my_depth
          -> k1 * k2

--- a/testsuite/tests/flambda2/examples/tests11.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests11.simplify.reference
@@ -39,7 +39,7 @@ let code loopify(never) size(7) newer_version_of(`fn[tests11.ml:23,2--70]_1`)
 in
 let $camlTests11__map_foo_8 =
   closure map_foo_4_1 @map_foo &toplevel.alloc_region
-and code rec loopify(never) size(69) newer_version_of(map_foo_4)
+and code rec loopify(never) size(61[8]) newer_version_of(map_foo_4)
       map_foo_4_1 (f : val, seq : val, param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/tests12.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests12.raw.reference
@@ -14,7 +14,7 @@ let $camlTests12__first_const = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    cont k1 (x)
  in
- let code size(23)
+ let code size(21[2])
        `fn[tests12.ml:25,2--70]_1` (param : imm tagged)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =
@@ -35,7 +35,7 @@ let $camlTests12__first_const = Block 0 () in
        (`fn[tests12.ml:25,39--51]`, `fn[tests12.ml:25,52--67]`, 0)
        -> k1 * k2
  in
- let code inline(always) size(32)
+ let code inline(always) size(9[23])
        bar_0 (map_foo : val)
          my_closure &my_alloc_region my_depth
          -> k1 * k2

--- a/testsuite/tests/flambda2/examples/tests12.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests12.simplify.reference
@@ -38,7 +38,7 @@ let code loopify(never) size(7) newer_version_of(`fn[tests12.ml:25,2--70]_1`)
        0)
       -> k * k1
 in
-let code inline(always) loopify(never) size(16) newer_version_of(bar_0)
+let code inline(always) loopify(never) size(9[7]) newer_version_of(bar_0)
       bar_0_1 (map_foo : val)
         my_closure &my_alloc_region my_depth
         -> k * k1
@@ -53,7 +53,7 @@ in
 let $camlTests12__bar_5 = closure bar_0_1 @bar &toplevel.alloc_region in
 let $camlTests12__map_foo_8 =
   closure map_foo_4_1 @map_foo &toplevel.alloc_region
-and code rec loopify(never) size(75) newer_version_of(map_foo_4)
+and code rec loopify(never) size(67[8]) newer_version_of(map_foo_4)
       map_foo_4_1 (f : val, seq : val, param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/tests13.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests13.raw.reference
@@ -14,7 +14,7 @@ let $camlTests13__first_const = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    cont k1 (x)
  in
- let code size(26)
+ let code size(24[2])
        `fn[tests13.ml:27,2--118]_1` (param : imm tagged)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =
@@ -39,7 +39,7 @@ let $camlTests13__first_const = Block 0 () in
        (`fn[tests13.ml:30,31--43]`, `fn[tests13.ml:30,44--59]`, 0)
        -> k1 * k2
  in
- let code inline(always) size(36)
+ let code inline(always) size(10[26])
        bar_0 (i : imm tagged, map_foo : val)
          my_closure &my_alloc_region my_depth
          -> k1 * k2
@@ -60,7 +60,7 @@ let $camlTests13__first_const = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    cont k1 (0)
  in
- let code rec size(72)
+ let code rec size(71[1])
        map_foo_4 (f : val, seq : val, param : imm tagged)
          my_closure &my_alloc_region my_depth
          -> k1 * k2

--- a/testsuite/tests/flambda2/examples/tests13.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests13.simplify.reference
@@ -55,7 +55,7 @@ let $`camlTests13__fn[tests13.ml:41,15--28]_10` =
 in
 let $camlTests13__map_foo_9 =
   closure map_foo_4_1 @map_foo &toplevel.alloc_region
-and code rec loopify(never) size(77) newer_version_of(map_foo_4)
+and code rec loopify(never) size(69[8]) newer_version_of(map_foo_4)
       map_foo_4_1 (f : val, seq : val, param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/tests8.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests8.raw.reference
@@ -15,7 +15,7 @@ let $camlTests8__first_const = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    cont k1 (x)
  in
- let code size(21)
+ let code size(19[2])
        `fn[tests8.ml:20,12--80]_1` (param : imm tagged)
          my_closure &my_alloc_region my_depth
          -> k1 * k2
@@ -37,7 +37,7 @@ let $camlTests8__first_const = Block 0 () in
      (map_foo : _ -> [ 0 | 0 of val * val ])
        (`fn[tests8.ml:20,49--61]`, `fn[tests8.ml:20,62--77]`, 0)
        -> k1 * k2
- and code rec size(65)
+ and code rec size(44[21])
        map_foo_0 (f : val, seq : val, param : imm tagged)
          my_closure &my_alloc_region my_depth
          -> k1 * k2

--- a/testsuite/tests/flambda2/examples/tests8.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests8.simplify.reference
@@ -25,7 +25,7 @@ let $`camlTests8__fn[tests8.ml:20,62--77]_5` =
 in
 let $camlTests8__map_foo_4 =
   closure map_foo_0_1 @map_foo &toplevel.alloc_region
-and code rec loopify(never) size(44) newer_version_of(map_foo_0)
+and code rec loopify(never) size(40[4]) newer_version_of(map_foo_0)
       map_foo_0_1 (f : val, seq : val, param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/tests9.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests9.raw.reference
@@ -1502,7 +1502,7 @@
                           (s1, s2, 0)
                           -> k1 * k2)))
  in
- let code size(1692)
+ let code size(62[1630])
        sort_uniq_4 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure &my_alloc_region my_depth
          -> k1 * k2
@@ -1635,7 +1635,7 @@
            (n, l)
            -> k1 * k2
  in
- let code size(119)
+ let code size(16[103])
        foo_9 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
          my_closure &my_alloc_region my_depth
          -> k1 * k2

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -1042,7 +1042,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                          (s1, s2, 0)
                          -> k * k1)))
 in
-let code loopify(never) size(1411) newer_version_of(sort_uniq_4)
+let code loopify(never) size(55[1356]) newer_version_of(sort_uniq_4)
       sort_uniq_4_1
         (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure &my_alloc_region my_depth
@@ -1141,7 +1141,7 @@ and code rec loopify(never) size(5) newer_version_of(sort_10)
       (n, l)
       -> k * k1
 in
-let code loopify(never) size(98) newer_version_of(foo_9)
+let code loopify(never) size(16[82]) newer_version_of(foo_9)
       foo_9_1 (cmp : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
@@ -68,7 +68,7 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
            in
            cont k (int_add))
 in
-let code inline(always) loopify(never) size(101) newer_version_of(inline_0)
+let code inline(always) loopify(never) size(26[75]) newer_version_of(inline_0)
       inline_0_1 (a : imm tagged, b : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
@@ -16,7 +16,7 @@ let code loopify(never) size(7) newer_version_of(`fn[unbox_closure.ml:12,12--25]
   let int_add_1 = %int_barith.add (int_add, z) in
   cont k (int_add_1)
 in
-let code loopify(never) size(18) newer_version_of(bar_1)
+let code loopify(never) size(11[7]) newer_version_of(bar_1)
       bar_1_1 (y : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1
@@ -30,7 +30,7 @@ let code loopify(never) size(18) newer_version_of(bar_1)
   in
   cont k (`fn[unbox_closure.ml:12,12--25]`)
 in
-let code loopify(never) size(53) newer_version_of(foobar_0)
+let code loopify(never) size(35[18]) newer_version_of(foobar_0)
       foobar_0_1 (b : imm tagged, x : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
@@ -21,7 +21,7 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar2_1)
   let int_mul_1 = %int_barith.mul (int_mul, y) in
   cont k (int_mul_1)
 in
-let code loopify(never) size(64) newer_version_of(foobar_0)
+let code loopify(never) size(49[15]) newer_version_of(foobar_0)
       foobar_0_1 (b : imm tagged, x : imm tagged, z : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1

--- a/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
@@ -11,7 +11,7 @@ let code loopify(never) size(2) newer_version_of(`fn[wrong_allocation_moving.ml:
   in
   cont k (y)
 in
-let code loopify(never) size(57) newer_version_of(f_0)
+let code loopify(never) size(55[2]) newer_version_of(f_0)
       f_0_1 (x : float boxed, foo : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =

--- a/testsuite/tests/flambda2/examples/unroll4.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.raw.reference
@@ -44,7 +44,7 @@ let $camlUnroll4__first_const = Block 0 () in
      where k3 =
        apply &my_alloc_region inlined(hint) k (0) -> k1 * k2
  in
- let code inline(always) size(93)
+ let code inline(always) size(31[62])
        parity_is_0 (p : imm tagged, n : imm tagged, k : val)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =

--- a/testsuite/tests/flambda2/examples/unroll4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.simplify.reference
@@ -32,7 +32,7 @@ and code rec loopify(never) size(26) newer_version_of(even_1)
       apply direct(odd_2_1 &my_alloc_region)
         odd ~ depth my_depth -> succ my_depth (int_sub) -> k * k1
 in
-let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
+let code inline(always) loopify(never) size(169[52]) newer_version_of(parity_is_0)
       parity_is_0_1 (p : imm tagged, n : imm tagged, k : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -24,7 +24,7 @@ let code loopify(never) size(10) newer_version_of(h_2)
       let int_add_1 = %int_barith.add (int_add, apply_result) in
       cont k (int_add_1)
 in
-let code loopify(never) size(58) newer_version_of(f_0)
+let code loopify(never) size(36[22]) newer_version_of(f_0)
       f_0_1 (x : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
         my_closure &my_alloc_region my_depth
         -> k * k1


### PR DESCRIPTION
Fixes #5141.