### PR TITLE
Add validation of the cfg reachability pass

### DIFF
--- a/backend/cfg/cfg_reachability_validate.ml
+++ b/backend/cfg/cfg_reachability_validate.ml
@@ -1,0 +1,156 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module Datalog = Flambda2_datalog.Datalog
+
+module Node : sig
+  type t
+
+  include Datalog.Column.S with type t := t
+
+  val of_label : Label.t -> t
+end = struct
+  include Datalog.Column.Make (struct
+    let name = "cfg_reachability_node"
+
+    let print fmt node = Format.fprintf fmt "n%d" node
+  end)
+
+  let of_label = Label.to_int
+end
+
+module Node_relation = Datalog.Schema.Relation1 (Node)
+module Node_node_relation = Datalog.Schema.Relation2 (Node) (Node)
+
+let create_relation name columns =
+  (* Validation only compares final relations, so derivation provenance is
+     unused. *)
+  Datalog.create_relation ~provenance:false ~name columns
+
+let edge = create_relation "cfg_reachability.edge" Node_node_relation.columns
+
+let entry = create_relation "cfg_reachability.entry" Node_relation.columns
+
+let reachable =
+  create_relation "cfg_reachability.reachable" Node_relation.columns
+
+let expected_reachable =
+  create_relation "cfg_reachability.expected_reachable" Node_relation.columns
+
+let reachable_entry_rule =
+  Datalog.compile ["entry"] (fun [entry_node] ->
+      Datalog.where
+        [Datalog.atom entry [entry_node]]
+        (Datalog.deduce (Datalog.atom reachable [entry_node])))
+
+let reachable_edge_rule =
+  Datalog.compile ["source"; "target"] (fun [source; target] ->
+      Datalog.where
+        [Datalog.atom reachable [source]; Datalog.atom edge [source; target]]
+        (Datalog.deduce (Datalog.atom reachable [target])))
+
+let schedule =
+  Datalog.Schedule.saturate [reachable_entry_rule; reachable_edge_rule]
+
+module Internal = struct
+  let validate (facts : Cfg_validation_facts.Graph.t) =
+    let node = Node.of_label in
+    let expected_facts =
+      List.fold_left
+        (fun relation label ->
+          Node_relation.add_or_replace [node label] () relation)
+        Node_relation.empty facts.Cfg_validation_facts.Graph.nodes
+    in
+    let edge_facts =
+      List.fold_left
+        (fun relation (source, target) ->
+          Node_node_relation.add_or_replace
+            [node source; node target]
+            () relation)
+        Node_node_relation.empty facts.edges
+    in
+    let db =
+      Datalog.empty
+      |> Datalog.set_table edge edge_facts
+      |> Datalog.set_table entry (Node_relation.singleton [node facts.entry] ())
+      |> Datalog.set_table expected_reachable expected_facts
+    in
+    let db = Datalog.Schedule.run schedule db in
+    let actual = Datalog.get_table reachable db in
+    let validation_succeeded =
+      Node.Map.equal (fun () () -> true) expected_facts actual
+    in
+    if validation_succeeded
+    then Ok ()
+    else Error "expected_reachable and reachable differ"
+end
+
+module Z3 = struct
+  let code (facts : Cfg_validation_facts.Graph.t) =
+    let nodes = facts.Cfg_validation_facts.Graph.nodes in
+    let max_id =
+      List.fold_left
+        (fun max_id label -> Int.max max_id (Label.to_int label))
+        0 nodes
+    in
+    let width =
+      match max_id with 0 | 1 -> 1 | max_id -> 1 + Misc.log2 max_id
+    in
+    let id label = Printf.sprintf "(_ bv%d %d)" (Label.to_int label) width in
+    let buffer = Buffer.create 4096 in
+    let fmt = Format.formatter_of_buffer buffer in
+    Format.fprintf fmt
+      {|
+(set-option :fp.engine datalog)
+(define-sort node () (_ BitVec %d))
+(declare-rel edge (node node))
+(declare-rel entry (node))
+(declare-rel reachable (node))
+(declare-rel expected-reachable (node))
+(declare-rel bad ())
+(declare-var a node)
+(declare-var b node)
+(rule (=> (entry a) (reachable a)))
+(rule (=> (and (reachable a) (edge a b)) (reachable b)))
+(rule (=> (and (reachable a) (not (expected-reachable a))) bad))
+(rule (=> (and (expected-reachable a) (not (reachable a))) bad))
+|}
+      width;
+    Cfg_z3.fmt_fact fmt "entry" [id facts.entry];
+    List.iter
+      (fun label -> Cfg_z3.fmt_fact fmt "expected-reachable" [id label])
+      nodes;
+    List.iter
+      (fun (source, target) ->
+        Cfg_z3.fmt_fact fmt "edge" [id source; id target])
+      facts.edges;
+    Format.pp_print_string fmt "(query bad)";
+    Format.pp_print_flush fmt ();
+    Buffer.contents buffer
+end
+
+let fallback cfg internal_failure z3_code =
+  let z3_result =
+    match Cfg_z3.run_z3 z3_code |> String.trim with
+    | "unsat" -> "Z3 accepted the compiler result; internal Datalog failed"
+    | "sat" -> "Z3 also rejected the compiler result"
+    | output -> Format.sprintf "unexpected Z3 output: %S" output
+    | exception exn -> Format.sprintf "Z3 raised: %s" (Printexc.to_string exn)
+  in
+  Misc.fatal_errorf
+    "validate_reachability: internal Datalog failed for CFG %S.@.%s@.%s@.Z3 \
+     reproducer:@.%s@.CFG:@.%a"
+    cfg.Cfg.fun_name internal_failure z3_result z3_code Printcfg.cfg cfg
+
+let validate_reachability (cfg : Cfg.t) =
+  let facts = Cfg_validation_facts.Graph.create cfg in
+  let z3_code () = Z3.code facts in
+  match Internal.validate facts with
+  | Ok () -> ()
+  | Error error -> fallback cfg error (z3_code ())
+  | exception exn ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let error =
+      Format.sprintf "exception: %s@.%s" (Printexc.to_string exn)
+        (Printexc.raw_backtrace_to_string backtrace)
+    in
+    fallback cfg error (z3_code ())

--- a/backend/cfg/cfg_reachability_validate.mli
+++ b/backend/cfg/cfg_reachability_validate.mli
@@ -1,0 +1,3 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+val validate_reachability : Cfg.t -> unit

--- a/backend/cfg/cfg_simplify.ml
+++ b/backend/cfg/cfg_simplify.ml
@@ -302,4 +302,9 @@ let run cfg_with_layout =
   Simplify_terminator.run (Cfg_with_layout.cfg cfg_with_layout);
   Eliminate_dead_code.run cfg_with_layout |> acc;
   Cfg_with_layout.remove_blocks cfg_with_layout !dead_labels;
+  if !Oxcaml_flags.cfg_eliminate_dead_code_validate
+  then
+    Profile.record ~accumulate:true "validate_reachability"
+      Cfg_reachability_validate.validate_reachability
+      (Cfg_with_layout.cfg cfg_with_layout);
   cfg_with_layout

--- a/backend/cfg/cfg_validation_facts.ml
+++ b/backend/cfg/cfg_validation_facts.ml
@@ -1,0 +1,23 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+module Graph = struct
+  type t =
+    { entry : Label.t;
+      nodes : Label.t list;
+      edges : (Label.t * Label.t) list
+    }
+
+  let create (cfg : Cfg.t) =
+    (* CR-someday hwasilewski for xclerc: If this were built from a
+       [Cfg_with_layout.t], [nodes] could be obtained from its layout, perhaps
+       modulo mutability. *)
+    let nodes = cfg.blocks |> Label.Tbl.to_seq_keys |> List.of_seq in
+    let edges =
+      Cfg.fold_blocks cfg ~init:[] ~f:(fun source block edges ->
+          Label.Set.fold
+            (fun target edges -> (source, target) :: edges)
+            (Cfg.successor_labels ~normal:true ~exn:true block)
+            edges)
+    in
+    { entry = cfg.entry_label; nodes; edges }
+end

--- a/backend/cfg/cfg_validation_facts.mli
+++ b/backend/cfg/cfg_validation_facts.mli
@@ -1,0 +1,15 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Facts extracted from CFGs for independent validation of compiler analyses.
+    They are also used to produce diagnostic Z3 reproducers when validation
+    fails. *)
+
+module Graph : sig
+  type t =
+    { entry : Label.t;
+      nodes : Label.t list;
+      edges : (Label.t * Label.t) list
+    }
+
+  val create : Cfg.t -> t
+end

--- a/backend/cfg/cfg_z3.ml
+++ b/backend/cfg/cfg_z3.ml
@@ -1,0 +1,30 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+let run_z3 code =
+  let with_temp_file suffix f =
+    let filename = Filename.temp_file "oxcaml-z3-" suffix in
+    Misc.try_finally
+      (fun () -> f filename)
+      ~always:(fun () -> Misc.remove_file filename)
+  in
+  with_temp_file ".smt2" @@ fun input_file ->
+  with_temp_file ".out" @@ fun output_file ->
+  Out_channel.with_open_text input_file (fun out_channel ->
+      Out_channel.output_string out_channel code);
+  let command =
+    Filename.quote_command "z3" ["-smt2"; input_file] ~stderr:output_file
+      ~stdout:output_file
+  in
+  let ret = Ccomp.command command in
+  let output = In_channel.with_open_text output_file In_channel.input_all in
+  if ret <> 0
+  then
+    Misc.fatal_errorf "Z3 failed with return code %d. Input: @.%s@.Output: @.%s"
+      ret code output;
+  output
+
+let fmt_fact fmt relation arguments =
+  let fmt_argument fmt argument = Format.fprintf fmt " %s" argument in
+  Format.fprintf fmt "(rule (%s%a))@." relation
+    (Format.pp_print_list fmt_argument)
+    arguments

--- a/backend/cfg/cfg_z3.mli
+++ b/backend/cfg/cfg_z3.mli
@@ -1,0 +1,9 @@
+[@@@ocaml.warning "+a-40-41-42"]
+
+(** Z3 support for CFG validators. Internal Datalog is the normal validation
+    path, this module produces and runs Z3 code as a fallback if internal
+    validation fails. *)
+
+val run_z3 : string -> string
+
+val fmt_fact : Format.formatter -> string -> string list -> unit

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -167,6 +167,16 @@ let mk_no_cfg_eliminate_dead_trap_handlers f =
     Arg.Unit f,
     " Do not eliminate dead trap handlers" )
 
+let mk_cfg_eliminate_dead_code_validate f =
+  ( "-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Validate the eliminate dead code pass" )
+
+let mk_no_cfg_eliminate_dead_code_validate f =
+  ( "-no-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Do not validate the eliminate dead code pass" )
+
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
 
@@ -1325,6 +1335,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1516,6 +1528,9 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_eliminate_dead_trap_handlers F.cfg_eliminate_dead_trap_handlers;
       mk_no_cfg_eliminate_dead_trap_handlers
         F.no_cfg_eliminate_dead_trap_handlers;
+      mk_cfg_eliminate_dead_code_validate F.cfg_eliminate_dead_code_validate;
+      mk_no_cfg_eliminate_dead_code_validate
+        F.no_cfg_eliminate_dead_code_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1867,6 +1882,12 @@ module Oxcaml_options_impl = struct
 
   let no_cfg_eliminate_dead_trap_handlers =
     clear' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+
+  let cfg_eliminate_dead_code_validate =
+    set' Oxcaml_flags.cfg_eliminate_dead_code_validate
+
+  let no_cfg_eliminate_dead_code_validate =
+    clear' Oxcaml_flags.cfg_eliminate_dead_code_validate
 
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
@@ -2457,6 +2478,8 @@ module Extra_params = struct
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+    | "cfg-eliminate-dead-code-validate" ->
+        set' Oxcaml_flags.cfg_eliminate_dead_code_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -177,6 +177,16 @@ let mk_no_cfg_eliminate_dead_trap_handlers f =
     Arg.Unit f,
     " Do not eliminate dead trap handlers" )
 
+let mk_cfg_eliminate_dead_code_validate f =
+  ( "-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Validate the eliminate dead code pass" )
+
+let mk_no_cfg_eliminate_dead_code_validate f =
+  ( "-no-cfg-eliminate-dead-code-validate",
+    Arg.Unit f,
+    " Do not validate the eliminate dead code pass" )
+
 let mk_cfg_prologue_validate f =
   ("-cfg-prologue-validate", Arg.Unit f, " Validate prologues added to CFG")
 
@@ -1336,6 +1346,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit
@@ -1533,6 +1545,9 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_eliminate_dead_trap_handlers F.cfg_eliminate_dead_trap_handlers;
       mk_no_cfg_eliminate_dead_trap_handlers
         F.no_cfg_eliminate_dead_trap_handlers;
+      mk_cfg_eliminate_dead_code_validate F.cfg_eliminate_dead_code_validate;
+      mk_no_cfg_eliminate_dead_code_validate
+        F.no_cfg_eliminate_dead_code_validate;
       mk_cfg_prologue_validate F.cfg_prologue_validate;
       mk_no_cfg_prologue_validate F.no_cfg_prologue_validate;
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
@@ -1892,6 +1907,12 @@ module Oxcaml_options_impl = struct
 
   let no_cfg_eliminate_dead_trap_handlers =
     clear' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+
+  let cfg_eliminate_dead_code_validate =
+    set' Oxcaml_flags.cfg_eliminate_dead_code_validate
+
+  let no_cfg_eliminate_dead_code_validate =
+    clear' Oxcaml_flags.cfg_eliminate_dead_code_validate
 
   let cfg_prologue_validate = set' Oxcaml_flags.cfg_prologue_validate
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
@@ -2468,6 +2489,8 @@ module Extra_params = struct
     | "cfg-stack-checks" -> set' Oxcaml_flags.cfg_stack_checks
     | "cfg-eliminate-dead-trap-handlers" ->
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
+    | "cfg-eliminate-dead-code-validate" ->
+        set' Oxcaml_flags.cfg_eliminate_dead_code_validate
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
     | "omit-leaf-frame-pointers" -> set' Oxcaml_flags.omit_leaf_frame_pointers

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -53,6 +53,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -55,6 +55,8 @@ module type Oxcaml_options = sig
   val cfg_stack_checks_threshold : int -> unit
   val cfg_eliminate_dead_trap_handlers : unit -> unit
   val no_cfg_eliminate_dead_trap_handlers : unit -> unit
+  val cfg_eliminate_dead_code_validate : unit -> unit
+  val no_cfg_eliminate_dead_code_validate : unit -> unit
   val cfg_prologue_validate : unit -> unit
   val no_cfg_prologue_validate : unit -> unit
   val cfg_prologue_shrink_wrap : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -39,7 +39,10 @@ let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let cfg_eliminate_dead_trap_handlers = ref true
-                                       (* -cfg-eliminate-dead-trap-handlers *)
+(* -cfg-eliminate-dead-trap-handlers *)
+
+let cfg_eliminate_dead_code_validate = ref false
+(* -cfg-eliminate-dead-code-validate *)
 
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -41,7 +41,10 @@ let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)
 
 let cfg_eliminate_dead_trap_handlers = ref true
-                                       (* -cfg-eliminate-dead-trap-handlers *)
+(* -cfg-eliminate-dead-trap-handlers *)
+
+let cfg_eliminate_dead_code_validate = ref false
+(* -cfg-eliminate-dead-code-validate *)
 
 let cfg_prologue_validate = ref true     (* -[no-]cfg-prologue-validate *)
 let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -40,6 +40,7 @@ val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref
 
 val cfg_eliminate_dead_trap_handlers : bool ref
+val cfg_eliminate_dead_code_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -42,6 +42,7 @@ val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref
 
 val cfg_eliminate_dead_trap_handlers : bool ref
+val cfg_eliminate_dead_code_validate : bool ref
 
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref

--- a/dune
+++ b/dune
@@ -655,14 +655,17 @@
   cfg_dataflow
   cfg_deadcode
   cfg_liveness
+  cfg_validation_facts
   cfg_dominators
   cfg_loop_infos
   cfg_to_linear_desc
   cfg_cse
   cfg_cse_target_intf
+  cfg_reachability_validate
   cfg_stack_checks
   cfg_polling
   cfg_simplify
+  cfg_z3
   cfg_prologue
   cfg_merge_blocks
   extra_debug
@@ -746,6 +749,7 @@
   oxcaml_common
   flambda2_identifiers
   flambda2_cmx
+  flambda2_datalog
   compiler_owee
   gc_timings
   arm64_ast

--- a/dune
+++ b/dune
@@ -665,14 +665,17 @@
   cfg_dataflow
   cfg_deadcode
   cfg_liveness
+  cfg_validation_facts
   cfg_dominators
   cfg_loop_infos
   cfg_to_linear_desc
   cfg_cse
   cfg_cse_target_intf
+  cfg_reachability_validate
   cfg_stack_checks
   cfg_polling
   cfg_simplify
+  cfg_z3
   cfg_prologue
   cfg_merge_blocks
   cfg_block_layout
@@ -758,6 +761,7 @@
   oxcaml_common
   flambda2_identifiers
   flambda2_cmx
+  flambda2_datalog
   compiler_owee
   gc_timings
   arm64_ast

--- a/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
+++ b/oxcaml/tests/backend/validators/check_cfg_analysis_validation.ml
@@ -1,0 +1,49 @@
+open Cfg_intf.S
+open Utils
+
+let sequence = ref (InstructionId.make_sequence ())
+
+let make_id () = InstructionId.get_and_incr !sequence
+
+let terminator ?(arg = [||]) desc : Terminator.t =
+  { id = make_id (); desc; arg; res = [||] }
+
+let block ?(body = []) ?exn start terminator : Block.t =
+  { start; body; terminator; exn }
+
+let make_cfg blocks =
+  sequence := InstructionId.make_sequence ();
+  Cfg_desc.make_pre_regalloc
+    { fun_args = [| int.(0); int.(1) |];
+      blocks;
+      fun_contains_calls = false;
+      fun_ret_type = Cmm.typ_int
+    }
+
+let expect_fatal f =
+  let fmt = Format.err_formatter in
+  Format.pp_print_flush fmt ();
+  let previous = Format.pp_get_formatter_out_functions fmt () in
+  let sink = Format.formatter_of_buffer (Buffer.create 0) in
+  Format.pp_set_formatter_out_functions fmt
+    (Format.pp_get_formatter_out_functions sink ());
+  let raised =
+    Fun.protect
+      ~finally:(fun () -> Format.pp_set_formatter_out_functions fmt previous)
+      (fun () ->
+        match f () with () -> false | exception Misc.Fatal_error -> true)
+  in
+  if not raised then failwith "expected a fatal error"
+
+let test_unreachable () =
+  let dead = new_label 13 in
+  let cfg_with_infos =
+    make_cfg
+      [ block entry_label (terminator ~arg:[| int.(0) |] Return);
+        block dead (terminator ~arg:[| int.(1) |] Return) ]
+  in
+  expect_fatal (fun () ->
+      Cfg_reachability_validate.validate_reachability
+        (Cfg_with_infos.cfg cfg_with_infos))
+
+let () = test_unreachable ()

--- a/oxcaml/tests/backend/validators/dune
+++ b/oxcaml/tests/backend/validators/dune
@@ -12,6 +12,6 @@
   (:standard -no-principal -w -27-32))
  (libraries utils))
 (tests
- (names check_prologue_validation)
- (modules check_prologue_validation)
+ (names check_prologue_validation check_cfg_analysis_validation)
+ (modules check_prologue_validation check_cfg_analysis_validation)
  (libraries utils))


### PR DESCRIPTION
Adds a validator for dead-code elimination, which independently computes reachability using the internal Datalog engine (using Z3 as a fallback) and compares it. It introduces additional CFG fact infrastructure and the `-cfg-eliminate-dead-code-validate` flag.