### PR TITLE
Fix yielding inference for Stdlib.Effect.Shallow.fiber

### DIFF
--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -339,7 +339,7 @@ module Shallow = struct
   let fiber : type a b. (a -> b) -> (a, b) continuation = fun f ->
     let module M = struct type _ t += Initial_setup__ : a t end in
     let exception E of (a,b) continuation in
-    let f' () = f (perform M.Initial_setup__) in
+    let f () = Safe.perform (Handler.unsafe_make ()) M.Initial_setup__ in
     let error _ = failwith "impossible" in
     let effc (type a2) (eff : a2 t) (k : (a2,b,_) cont) _last_fiber =
       match eff with
@@ -350,7 +350,7 @@ module Shallow = struct
           continue (Handler.unsafe_make ()) k ()
       | _ -> error ()
     in
-    match Prim.with_stack error error effc f' () with
+    match Prim.with_stack error error effc f () with
     | exception E k -> k
     | _ -> error ()
 

--- a/stdlib/effect.ml
+++ b/stdlib/effect.ml
@@ -339,7 +339,7 @@ module Shallow = struct
   let fiber : type a b. (a -> b) -> (a, b) continuation = fun f ->
     let module M = struct type _ t += Initial_setup__ : a t end in
     let exception E of (a,b) continuation in
-    let f' () = f (perform M.Initial_setup__) in
+    let f' () = f (Safe.perform (Handler.unsafe_make ()) M.Initial_setup__) in
     let error _ = failwith "impossible" in
     let effc (type a2) (eff : a2 t) (k : (a2,b,_) cont) _last_fiber =
       match eff with


### PR DESCRIPTION
The setup effect that's `perform`ed at the beginning of Shallow.fiber needs to be in a yielding context, or else the JSOO compiler will direct-call the computation for the fiber and the effect will raise Unhandled.

Tested (internally) on the JSOO compiler with oxcaml patches, and it fixes the tests for shallow stdlib effects