### PR TITLE
[DRAFT] First-class modalities: `t @@ m` as a type

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -290,7 +290,7 @@ let iter_on_occurrences
       | Ttyp_unboxed_tuple _
       | Ttyp_quote _ | Ttyp_splice _ | Ttyp_of_kind _
       | Ttyp_alias _ | Ttyp_variant _ | Ttyp_poly _ | Ttyp_call_pos
-      | Ttyp_repr _ | Ttyp_newlayout _ -> ());
+      | Ttyp_repr _ | Ttyp_newlayout _ | Ttyp_modality _ -> ());
       default_iterator.typ sub ct);
 
   pat =

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2820,7 +2820,11 @@ let type_for_annotation ~env ~loc typ =
         | Tconstr (p, tyl, _) ->
           Ttyp_constr
             (p, mkloc (Untypeast.lident_of_path p) loc, List.map go tyl)
-        | Tmod _ -> fatal_errorf "Translquote: unexpected Tmod"
+        | Tmod _ ->
+          (* Reachable now that [t @@ m] is surface syntax, but quoting one is
+             not supported, as for [Trepr] and [Ttyp_of_kind]. *)
+          fatal_errorf "Translquote [at %a]: no support for Tmod"
+            Location.print_loc_in_lowercase loc
         | Tobject (fields, _) ->
           let Out_type.{ fields; open_row } =
             Out_type.tree_of_typobject_repr fields
@@ -3202,6 +3206,9 @@ and quote_core_type ~scopes ty =
       Location.print_loc (to_location loc)
   | Ttyp_of_kind _ ->
     fatal_errorf "Translquote [at %a]: Ttyp_of_kind not implemented."
+      Location.print_loc (to_location loc)
+  | Ttyp_modality _ ->
+    fatal_errorf "Translquote [at %a]: Ttyp_modality not implemented."
       Location.print_loc (to_location loc)
   | Ttyp_call_pos -> Type.wrap Type.call_pos
 

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -495,7 +495,7 @@ let remove_option typ =
     match t with
     | Tconstr(path, [ty], _)
       when Path.same path Predef.path_option -> get_desc ty
-    | Tmod _ -> Misc.fatal_error "Odoc_misc: unexpected Tmod"
+    | Types.Tmod (t, _) -> trim (get_desc t)
     | Tconstr _
     | Tvar _
     | Tunivar _

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -39,7 +39,7 @@ let rec is_arrow_type t =
   match Types.get_desc t with
     Types.Tarrow _ -> true
   | Types.Tlink t2 -> is_arrow_type t2
-  | Types.Tmod _ -> Misc.fatal_error "Odoc_str.is_arrow_type: unexpected Tmod"
+  | Types.Tmod (t2, _) -> is_arrow_type t2
   | Types.Ttuple _
   | Types.Tunboxed_tuple _
   | Types.Tconstr _
@@ -55,7 +55,7 @@ let rec need_parent t =
   match Types.get_desc t with
     Types.Tarrow _ | Types.Ttuple _ | Tunboxed_tuple _ -> true
   | Types.Tlink t2 -> need_parent t2
-  | Types.Tmod _ -> Misc.fatal_error "Odoc_str.need_parent: unexpected Tmod"
+  | Types.Tmod (t2, _) -> need_parent t2
   | Types.Tconstr _
   | Types.Tvar _ | Types.Tunivar _ | Types.Tobject _ | Types.Tpoly _
   | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ | Types.Trepr _

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -67,7 +67,7 @@ let parameter_list_from_arrows typ =
         (l, t1) :: (iter t2)
     | Types.Tlink texp
     | Types.Tpoly (texp, _) | Types.Trepr (texp, _) -> iter texp
-    | Types.Tmod _ -> Misc.fatal_error "Odoc_value: unexpected Tmod"
+    | Types.Tmod (texp, _) -> iter texp
     | Types.Tvar _
     | Types.Ttuple _
     | Types.Tunboxed_tuple _

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -85,6 +85,7 @@ module Typ = struct
   let repr ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_repr (a, b))
   let newlayout ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_newlayout (a, b))
   let of_kind ?loc ?attrs a = mk ?loc ?attrs (Ptyp_of_kind a)
+  let modality ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_modality (a, b))
 
   let force_poly t =
     match t.ptyp_desc with
@@ -151,6 +152,8 @@ module Typ = struct
             Ptyp_of_kind (loop_jkind jkind)
         | Ptyp_repr (var_lst, core_type) ->
             Ptyp_repr (var_lst, loop core_type)
+        | Ptyp_modality (core_type, modalities) ->
+            Ptyp_modality (loop core_type, modalities)
         | Ptyp_newlayout (var_lst, core_type) ->
             Ptyp_newlayout (var_lst, loop core_type)
         | Ptyp_extension (s, arg) ->

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -99,6 +99,8 @@ module Typ :
     val newlayout:
       ?loc:loc -> ?attrs:attrs -> str list -> core_type -> core_type
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> core_type
+    val modality:
+      ?loc:loc -> ?attrs:attrs -> core_type -> modalities -> core_type
 
     val force_poly: core_type -> core_type
 

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -173,6 +173,9 @@ module T = struct
     | Ptyp_of_kind jkind ->
         sub.jkind_annotation sub jkind
     | Ptyp_repr (_, t) -> sub.typ sub t
+    | Ptyp_modality (t, m) ->
+        sub.typ sub t;
+        sub.modalities sub m
     | Ptyp_newlayout (_, t) -> sub.typ sub t
     | Ptyp_extension x -> sub.extension sub x
 

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -220,6 +220,8 @@ module T = struct
         splice ~loc ~attrs (sub.typ sub t)
     | Ptyp_of_kind jkind ->
         of_kind ~loc ~attrs (sub.jkind_annotation sub jkind)
+    | Ptyp_modality (t, m) ->
+        modality ~loc ~attrs (sub.typ sub t) (sub.modalities sub m)
     | Ptyp_repr (lvars, t) ->
         repr ~loc ~attrs (List.map (map_loc sub) lvars) (sub.typ sub t)
     | Ptyp_newlayout (lvars, t) ->

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -127,6 +127,7 @@ let rec add_type bv ty =
   | Ptyp_splice t -> add_type bv t
   | Ptyp_of_kind jkind -> add_jkind bv jkind
   | Ptyp_repr(_, t) -> add_type bv t
+  | Ptyp_modality (t, _) -> add_type bv t
   | Ptyp_newlayout(_, t) -> add_type bv t
   | Ptyp_extension e -> handle_extension e
 

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4912,6 +4912,12 @@ tuple_type:
 delimited_type_supporting_local_open:
   | LPAREN type_ = core_type RPAREN
       { type_ }
+  (* A first-class modality. Only allowed in this delimited position, so that
+     the existing [@@] positions (val, record field, constructor argument,
+     include, jkind with-bound) are untouched: the parenthesis decides which
+     rule applies before [@@] is ever read. *)
+  | LPAREN type_ = core_type ATAT modalities = modalities RPAREN
+      { mktyp ~loc:$sloc (Ptyp_modality (type_, modalities)) }
   | LPAREN MODULE ext_attrs = ext_attributes package_type = package_type_ RPAREN
       { mktyp_attrs ~loc:$sloc (Ptyp_package package_type) ext_attrs }
   | mktyp(

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -224,6 +224,13 @@ and core_type_desc =
   | Ptyp_splice of core_type (** [$T] *)
   | Ptyp_of_kind of jkind_annotation (** [(type : k)] *)
   | Ptyp_repr of string loc list * core_type
+  | Ptyp_modality of core_type * modalities
+      (** [(T @@ modalities)] — a first-class modality.
+
+          Only written in delimited positions, so that the existing [@@]
+          positions ([val], record fields, constructor arguments, [include],
+          jkind with-bounds) keep their current meaning. An identity modality
+          is erased during translation. *)
   | Ptyp_extension of extension  (** [[%id]]. *)
 
 and arg_label = Asttypes.arg_label =

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -597,6 +597,8 @@ and core_type ctxt f x =
           (core_type ctxt) ct
     | Ptyp_of_kind jkind ->
       pp f "@[(type@ :@ %a)@]" (jkind_annotation reset_ctxt) jkind
+    | Ptyp_modality (ct, m) ->
+      pp f "@[<1>(%a%a)@]" (core_type ctxt) ct optional_space_atat_modalities m
     | _ -> pp f "@[<2>%a@]" (core_type1 ctxt) x
 
 and tuple_type_component ctxt f (label, ty) =
@@ -686,6 +688,7 @@ and core_type1 ctxt f x =
     | Ptyp_splice t ->
         pp f "@[<hov2>$(%a)@]" (core_type ctxt) t
     | Ptyp_extension e -> extension ctxt f e
+    | Ptyp_modality _ -> core_type ctxt f x
     | (Ptyp_arrow _ | Ptyp_alias _ | Ptyp_poly _ | Ptyp_repr _
       | Ptyp_newlayout _ | Ptyp_of_kind _) ->
        paren true (core_type ctxt) f x

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -236,6 +236,10 @@ let rec core_type i ppf x =
       core_type i ppf t
   | Ptyp_of_kind jkind ->
       line i ppf "Ptyp_of_kind %a\n" (jkind_annotation (i + 1)) jkind
+  | Ptyp_modality (ct, m) ->
+      line i ppf "Ptyp_modality\n";
+      core_type i ppf ct;
+      modalities i ppf m
   | Ptyp_repr (lvars, ct) ->
       line i ppf "Ptyp_repr\n";
       list i reprvar ppf lvars;

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -264,6 +264,10 @@ let rec core_type i ppf x =
       core_type i ppf ct;
   | Ptyp_of_kind jkind ->
       line i ppf "Ptyp_of_kind %a\n" (jkind_annotation (i+1)) jkind
+  | Ptyp_modality (ct, m) ->
+      line i ppf "Ptyp_modality\n";
+      core_type i ppf ct;
+      modalities i ppf m
   | Ptyp_extension (s, arg) ->
       line i ppf "Ptyp_extension \"%s\"\n" s.txt;
       payload i ppf arg

--- a/testsuite/tests/typing-modes/first_class_modality.ml
+++ b/testsuite/tests/typing-modes/first_class_modality.ml
@@ -5,10 +5,16 @@
 
 (* First-class modalities: [(t @@ m)] as a type.
 
-   This file covers what exists without automatic introduction/elimination:
-   syntax, printing, unification (invariant), signature inclusion (which
-   accepts a type crossing at least as much as expected), mode crossing, and
-   the validation inherited from the other [@@] positions. *)
+   This file covers syntax, printing, unification (invariant), signature
+   inclusion (which accepts a type crossing at least as much as expected),
+   mode crossing, and the validation inherited from the other [@@] positions.
+
+   Stage 4 added automatic unpacking, which changed several cases here. The
+   pattern is always the same: a top-level wrapper on an ACTUAL type now
+   unpacks, so a test that wanted to observe the wrapper itself has to keep it
+   out of top-level actual position -- either under a type constructor, or
+   behind the explicit-source form of [:>]. Each such case says so. The
+   unpacking rule itself is tested in [first_class_modality_unpack.ml]. *)
 
 type t
 [%%expect{|
@@ -34,26 +40,32 @@ Warning 220 [redundant-modality]: This modality is redundant.
 type v = int
 |}]
 
+(* The result type is the UNPACKED one: [@@ m] is a boundary annotation, not a
+   sticky property, so inference does not re-assert it. *)
 let f (x : (int @@ portable)) = x
 [%%expect{|
-val f : (int @@ portable) -> (int @@ portable) = <fun>
+val f : (int @@ portable) -> int = <fun>
 |}]
 
 (* Mode crossing: the wrapper crosses according to its modality, so a
    [nonportable] one is usable at [portable]. *)
 let cross (x : (t @@ portable) @ nonportable) = (x : _ @ portable)
 [%%expect{|
-val cross : (t @@ portable) -> (t @@ portable) = <fun>
+val cross : (t @@ portable) -> t = <fun>
 |}]
 
-(* Unification is invariant in the modality: differing bounds do not unify. *)
-let mismatch (x : (t @@ portable)) = (x : (t @@ global))
+(* Unification is invariant in the modality: differing bounds do not unify.
+   Tested under [list], because at top level the wrapper would unpack on both
+   sides and the two [t]s would then unify happily -- which says nothing about
+   invariance. *)
+let mismatch (x : (t @@ portable) list) = (x : (t @@ global) list)
 [%%expect{|
-Line 1, characters 38-39:
-1 | let mismatch (x : (t @@ portable)) = (x : (t @@ global))
-                                          ^
-Error: The value "x" has type "(t @@ portable)"
-       but an expression was expected of type "(t @@ global)"
+Line 1, characters 43-44:
+1 | let mismatch (x : (t @@ portable) list) = (x : (t @@ global) list)
+                                               ^
+Error: The value "x" has type "(t @@ portable) list"
+       but an expression was expected of type "(t @@ global) list"
+       Type "(t @@ portable)" is not compatible with type "(t @@ global)"
 |}]
 
 (* Signature inclusion, unlike unification, accepts an implementation that
@@ -156,17 +168,25 @@ Error: Signature mismatch:
 (* Coercion [:>] may weaken a modality. Unlike unification (invariant) and
    like inclusion, it accepts a source that crosses at least as much as the
    target. [subtype_rec] handles contravariance by swapping its arguments, so
-   the flip in argument position is automatic. *)
-let weaken (x : (t @@ portable global)) = (x :> (t @@ portable))
+   the flip in argument position is automatic.
+
+   These use the EXPLICIT-SOURCE form. With an implicit source the coercion
+   sees the type of an expression, and a top-level wrapper on an expression
+   now unpacks, so [(x :> ...)] would be coercing a bare [t] and would tell us
+   nothing about the modality. The explicit source is an expected-type
+   position, which packs, so the wrapper survives to be coerced. *)
+let weaken (x : (t @@ portable global)) =
+  (x : (t @@ portable global) :> (t @@ portable))
 [%%expect{|
 val weaken : (t @@ global portable) -> (t @@ portable) = <fun>
 |}]
 
-let strengthen (x : (t @@ portable)) = (x :> (t @@ portable global))
+let strengthen (x : (t @@ portable)) =
+  (x : (t @@ portable) :> (t @@ portable global))
 [%%expect{|
-Line 1, characters 39-68:
-1 | let strengthen (x : (t @@ portable)) = (x :> (t @@ portable global))
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 2-49:
+2 |   (x : (t @@ portable) :> (t @@ portable global))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "(t @@ portable)" is not a subtype of "(t @@ global portable)"
 |}]
 
@@ -268,11 +288,12 @@ Error: Type "t -> unit" is not a subtype of "t @ local -> unit"
    [meet (portable, global)], below the target's) but is rejected, because the
    comparison looks only at the outer bounds. Pinned so that a future
    normalisation change is forced to revisit it. *)
-let nested_incomplete (x : ((t @@ portable) @@ global)) = (x :> (t @@ portable))
+let nested_incomplete (x : ((t @@ portable) @@ global)) =
+  (x : ((t @@ portable) @@ global) :> (t @@ portable))
 [%%expect{|
-Line 1, characters 58-80:
-1 | let nested_incomplete (x : ((t @@ portable) @@ global)) = (x :> (t @@ portable))
-                                                              ^^^^^^^^^^^^^^^^^^^^^^
+Line 2, characters 2-54:
+2 |   (x : ((t @@ portable) @@ global) :> (t @@ portable))
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "((t @@ portable) @@ global)" is not a subtype of "(t @@ portable)"
 |}]
 
@@ -282,7 +303,8 @@ type abbrev = (t @@ portable)
 type abbrev = (t @@ portable)
 |}]
 
-let via_abbrev (x : (t @@ portable global)) = (x :> abbrev)
+let via_abbrev (x : (t @@ portable global)) =
+  (x : (t @@ portable global) :> abbrev)
 [%%expect{|
 val via_abbrev : (t @@ global portable) -> abbrev = <fun>
 |}]
@@ -303,7 +325,10 @@ let no_launder_global (x : (t @@ portable) @ local) = ((x :> t) : t @ global)
 Line 1, characters 56-57:
 1 | let no_launder_global (x : (t @@ portable) @ local) = ((x :> t) : t @ global)
                                                             ^
-Error: This value is "local" to the parent region but is expected to be "global".
+Error: This value is "local" to the parent region
+         because it is the payload of a first-class modality
+         which is "local" to the parent region.
+       However, the highlighted expression is expected to be "global".
 |}]
 
 let no_launder_portable (x : (t @@ global) @ nonportable) =
@@ -312,7 +337,10 @@ let no_launder_portable (x : (t @@ global) @ nonportable) =
 Line 2, characters 4-5:
 2 |   ((x :> t) : t @ portable)
         ^
-Error: This value is "nonportable" but is expected to be "portable".
+Error: This value is "nonportable"
+         because it is the payload of a first-class modality
+         which is "nonportable".
+       However, the highlighted expression is expected to be "portable".
 |}]
 
 (* ... whereas matching the axis is accepted, so the sentinels above are
@@ -323,21 +351,25 @@ val launder_ok_global : (t @@ global) @ local -> t = <fun>
 |}]
 
 (* Coercion with an implicit source must be ground -- a pre-existing OCaml
-   restriction, not specific to modalities. A ground source is fine... *)
-let implicit_ground (x : (t list @@ portable)) = (x :> t list)
+   restriction, not specific to modalities. The wrapper is inside a tuple so
+   that the implicit source still has one to forget: at top level it would
+   unpack before [:>] saw it, and the pair below would stop discriminating.
+   A ground source is fine... *)
+let implicit_ground (x : ((t @@ portable) * t)) = (x :> (t * t))
 [%%expect{|
-val implicit_ground : (t list @@ portable) -> t list = <fun>
+val implicit_ground : (t @@ portable) * t -> t * t = <fun>
 |}]
 
 (* ... but a non-ground one needs the explicit-source form. *)
-let implicit_nonground (x : ('a list @@ portable)) = (x :> 'a list)
+let implicit_nonground (x : ((t @@ portable) * 'a)) = (x :> (t * 'a))
 [%%expect{|
-Line 1, characters 54-55:
-1 | let implicit_nonground (x : ('a list @@ portable)) = (x :> 'a list)
-                                                          ^
-Error: This expression cannot be coerced to type ""'a list""; it has type
-         "('a list @@ portable)"
-       but is here used with type "'a list"
+Line 1, characters 55-56:
+1 | let implicit_nonground (x : ((t @@ portable) * 'a)) = (x :> (t * 'a))
+                                                           ^
+Error: This expression cannot be coerced to type ""t * 'a""; it has type
+         "(t @@ portable) * 'a"
+       but is here used with type "t * 'a"
+       Type "(t @@ portable)" is not compatible with type "t"
 |}]
 
 let explicit_source (x : ('a list @@ portable)) =
@@ -359,11 +391,12 @@ let priv_forget (x : priv) = (x :> t)
 val priv_forget : priv -> t = <fun>
 |}]
 
-let priv_target (x : (t @@ portable global)) = (x :> priv)
+let priv_target (x : (t @@ portable global)) =
+  (x : (t @@ portable global) :> priv)
 [%%expect{|
-Line 1, characters 47-58:
-1 | let priv_target (x : (t @@ portable global)) = (x :> priv)
-                                                   ^^^^^^^^^^^
+Line 2, characters 2-38:
+2 |   (x : (t @@ portable global) :> priv)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Type "(t @@ global portable)" is not a subtype of "priv"
 |}]
 
@@ -418,10 +451,10 @@ type r = { old_field : t @@ portable; new_field : (t @@ portable); }
 |}]
 
 (* Toplevel value printing goes through [genprintval], which is one of the
-   sites Stage 3 changed from a fatal error to a look-through. [Obj.magic] is
-   the only way to obtain a value of this type before Stage 4 adds automatic
-   introduction. *)
-let x : (int @@ portable) = Obj.magic 5
+   sites Stage 3 changed from a fatal error to a look-through. This used
+   [Obj.magic] before Stage 4, which was then the only way to obtain a value
+   of this type; automatic introduction now supplies one directly. *)
+let x : (int @@ portable) = 5
 [%%expect{|
 val x : (int @@ portable) @@ stateless = 5
 |}]
@@ -433,13 +466,12 @@ type nested = ((int @@ portable) @@ contended)
 type nested = ((int @@ portable) @@ contended)
 |}]
 
-(* Without automatic introduction, a bare value does not acquire a modality;
-   this is what Stage 4 will change. *)
-let no_auto_intro : (int @@ portable) = 1
+(* Automatic introduction (Stage 4): a bare value acquires the modality, being
+   checked at the modality applied to the expected mode. This case was written
+   as an error, under the name [no_auto_intro], when unpacking did not exist.
+   Both directions of the rule are exercised in
+   [first_class_modality_unpack.ml]. *)
+let auto_intro : (int @@ portable) = 1
 [%%expect{|
-Line 1, characters 40-41:
-1 | let no_auto_intro : (int @@ portable) = 1
-                                            ^
-Error: The constant "1" has type "int" but an expression was expected of type
-         "(int @@ portable)"
+val auto_intro : (int @@ portable) @@ stateless = 1
 |}]

--- a/testsuite/tests/typing-modes/first_class_modality.ml
+++ b/testsuite/tests/typing-modes/first_class_modality.ml
@@ -9,11 +9,10 @@
    inclusion (which accepts a type crossing at least as much as expected),
    mode crossing, and the validation inherited from the other [@@] positions.
 
-   Stage 4 added automatic unpacking, which changed several cases here. The
-   pattern is always the same: a top-level wrapper on an ACTUAL type now
-   unpacks, so a test that wanted to observe the wrapper itself has to keep it
-   out of top-level actual position -- either under a type constructor, or
-   behind the explicit-source form of [:>]. Each such case says so. The
+   Because a top-level wrapper on an ACTUAL type unpacks automatically, a test
+   that wants to observe the wrapper itself must keep it out of top-level
+   actual position -- either under a type constructor, or behind the
+   explicit-source form of [:>]. Each such case says so. The
    unpacking rule itself is tested in [first_class_modality_unpack.ml]. *)
 
 type t
@@ -450,26 +449,23 @@ type r = { old_field : t @@ portable; new_field : (t @@ portable) }
 type r = { old_field : t @@ portable; new_field : (t @@ portable); }
 |}]
 
-(* Toplevel value printing goes through [genprintval], which is one of the
-   sites Stage 3 changed from a fatal error to a look-through. This used
-   [Obj.magic] before Stage 4, which was then the only way to obtain a value
-   of this type; automatic introduction now supplies one directly. *)
+(* Toplevel value printing goes through [genprintval], which looks through the
+   wrapper. *)
 let x : (int @@ portable) = 5
 [%%expect{|
 val x : (int @@ portable) @@ stateless = 5
 |}]
 
-(* Nested wrappers are distinct types and do not normalise (design question
-   Q2): [((t @@ m1) @@ m2)] is not identified with [(t @@ m1 m2)]. *)
+(* Nested wrappers are distinct types and do not normalise:
+   [((t @@ m1) @@ m2)] is not identified with [(t @@ m1 m2)]. *)
 type nested = ((int @@ portable) @@ contended)
 [%%expect{|
 type nested = ((int @@ portable) @@ contended)
 |}]
 
-(* Automatic introduction (Stage 4): a bare value acquires the modality, being
-   checked at the modality applied to the expected mode. This case was written
-   as an error, under the name [no_auto_intro], when unpacking did not exist.
-   Both directions of the rule are exercised in
+(* Automatic introduction: a bare value acquires the modality, being checked
+   at the modality applied to the expected mode. Both directions of the rule
+   are exercised in
    [first_class_modality_unpack.ml]. *)
 let auto_intro : (int @@ portable) = 1
 [%%expect{|

--- a/testsuite/tests/typing-modes/first_class_modality.ml
+++ b/testsuite/tests/typing-modes/first_class_modality.ml
@@ -1,0 +1,445 @@
+(* TEST
+ flags = "-extension mode_alpha";
+ expect;
+*)
+
+(* First-class modalities: [(t @@ m)] as a type.
+
+   This file covers what exists without automatic introduction/elimination:
+   syntax, printing, unification (invariant), signature inclusion (which
+   accepts a type crossing at least as much as expected), mode crossing, and
+   the validation inherited from the other [@@] positions. *)
+
+type t
+[%%expect{|
+type t
+|}]
+
+(* The type round-trips through parsing and printing. *)
+type u = (int @@ portable)
+[%%expect{|
+type u = (int @@ portable)
+|}]
+
+(* An identity modality is erased during translation, so [(int @@ nonportable)]
+   denotes just [int]. The redundancy warning is inherited from the shared
+   modality translation, as at every other [@@] position. *)
+type v = (int @@ nonportable)
+[%%expect{|
+Line 1, characters 17-28:
+1 | type v = (int @@ nonportable)
+                     ^^^^^^^^^^^
+Warning 220 [redundant-modality]: This modality is redundant.
+
+type v = int
+|}]
+
+let f (x : (int @@ portable)) = x
+[%%expect{|
+val f : (int @@ portable) -> (int @@ portable) = <fun>
+|}]
+
+(* Mode crossing: the wrapper crosses according to its modality, so a
+   [nonportable] one is usable at [portable]. *)
+let cross (x : (t @@ portable) @ nonportable) = (x : _ @ portable)
+[%%expect{|
+val cross : (t @@ portable) -> (t @@ portable) = <fun>
+|}]
+
+(* Unification is invariant in the modality: differing bounds do not unify. *)
+let mismatch (x : (t @@ portable)) = (x : (t @@ global))
+[%%expect{|
+Line 1, characters 38-39:
+1 | let mismatch (x : (t @@ portable)) = (x : (t @@ global))
+                                          ^
+Error: The value "x" has type "(t @@ portable)"
+       but an expression was expected of type "(t @@ global)"
+|}]
+
+(* Signature inclusion, unlike unification, accepts an implementation that
+   crosses at least as much as the signature demands. Return position, so
+   covariant. *)
+module A : sig val f : unit -> (int @@ portable) end = struct
+  let f () : (int @@ portable global) = assert false
+end
+[%%expect{|
+module A : sig val f : unit -> (int @@ portable) end @@ stateless
+|}]
+
+(* ... and rejects one that crosses less. *)
+module B : sig val f : unit -> (int @@ portable global) end = struct
+  let f () : (int @@ portable) = assert false
+end
+[%%expect{|
+Lines 1-3, characters 62-3:
+1 | ..............................................................struct
+2 |   let f () : (int @@ portable) = assert false
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : unit -> (int @@ portable) @@ stateless end
+       is not included in
+         sig val f : unit -> (int @@ global portable) end
+       Values do not match:
+         val f : unit -> (int @@ portable) @@ stateless
+       is not included in
+         val f : unit -> (int @@ global portable)
+       The type "unit -> (int @@ portable)" is not compatible with the type
+         "unit -> (int @@ global portable)"
+       Type "(int @@ portable)" is not compatible with type
+         "(int @@ global portable)"
+|}]
+
+(* The inclusion ordering must follow variance. In a contravariant position
+   (a function parameter) it flips: an implementation may demand LESS crossing
+   than the signature promises, but not more. Getting this backwards is
+   unsound -- the body would assume a crossing the caller never guaranteed. *)
+module C : sig val g : (t @@ portable) -> unit end = struct
+  let g (_ : (t @@ portable global)) = ()
+end
+[%%expect{|
+Lines 1-3, characters 53-3:
+1 | .....................................................struct
+2 |   let g (_ : (t @@ portable global)) = ()
+3 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val g : (t @@ global portable) -> unit @@ stateless end
+       is not included in
+         sig val g : (t @@ portable) -> unit end
+       Values do not match:
+         val g : (t @@ global portable) -> unit @@ stateless
+       is not included in
+         val g : (t @@ portable) -> unit
+       The type "(t @@ global portable) -> unit"
+       is not compatible with the type "(t @@ portable) -> unit"
+       Type "(t @@ global portable)" is not compatible with type
+         "(t @@ portable)"
+|}]
+
+module D : sig val g : (t @@ portable global) -> unit end = struct
+  let g (_ : (t @@ portable)) = ()
+end
+[%%expect{|
+module D : sig val g : (t @@ global portable) -> unit end @@ stateless
+|}]
+
+(* The same defect, shown with a consequence: if the contravariant direction
+   were reversed, [call] could hand a merely-portable value to a body that
+   treats it as [global], escaping the region. Must be rejected at the module
+   boundary. *)
+module E : sig
+  val f : (t @@ portable) @ local -> unit
+end = struct
+  let f (x : (t @@ global portable) @ local) = ignore (x : _ @ global)
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x : (t @@ global portable) @ local) = ignore (x : _ @ global)
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : (t @@ global portable) @ local -> unit @@ portable end
+       is not included in
+         sig val f : (t @@ portable) @ local -> unit end
+       Values do not match:
+         val f : (t @@ global portable) @ local -> unit @@ portable
+       is not included in
+         val f : (t @@ portable) @ local -> unit
+       The type "(t @@ global portable) @ local -> unit"
+       is not compatible with the type "(t @@ portable) @ local -> unit"
+       Type "(t @@ global portable)" is not compatible with type
+         "(t @@ portable)"
+|}]
+
+(* Coercion [:>] may weaken a modality. Unlike unification (invariant) and
+   like inclusion, it accepts a source that crosses at least as much as the
+   target. [subtype_rec] handles contravariance by swapping its arguments, so
+   the flip in argument position is automatic. *)
+let weaken (x : (t @@ portable global)) = (x :> (t @@ portable))
+[%%expect{|
+val weaken : (t @@ global portable) -> (t @@ portable) = <fun>
+|}]
+
+let strengthen (x : (t @@ portable)) = (x :> (t @@ portable global))
+[%%expect{|
+Line 1, characters 39-68:
+1 | let strengthen (x : (t @@ portable)) = (x :> (t @@ portable global))
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(t @@ portable)" is not a subtype of "(t @@ global portable)"
+|}]
+
+(* Forgetting a modality is safe: it only discards the ability to cross. *)
+let forget (x : (t @@ portable)) = (x :> t)
+[%%expect{|
+val forget : (t @@ portable) -> t = <fun>
+|}]
+
+(* Inventing one is not: it would claim a crossing the value does not have. *)
+let invent (x : t) = (x :> (t @@ portable))
+[%%expect{|
+Line 1, characters 21-43:
+1 | let invent (x : t) = (x :> (t @@ portable))
+                         ^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "t" is not a subtype of "(t @@ portable)"
+|}]
+
+(* Contravariant position: the direction flips. *)
+let contra_bad (g : (t @@ portable global) -> unit) =
+  (g :> (t @@ portable) -> unit)
+[%%expect{|
+Line 2, characters 2-32:
+2 |   (g :> (t @@ portable) -> unit)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(t @@ global portable) -> unit" is not a subtype of
+         "(t @@ portable) -> unit"
+       Type "(t @@ portable)" is not a subtype of "(t @@ global portable)"
+|}]
+
+let contra_ok (g : (t @@ portable) -> unit) =
+  (g :> (t @@ portable global) -> unit)
+[%%expect{|
+val contra_ok : ((t @@ portable) -> unit) -> (t @@ global portable) -> unit =
+  <fun>
+|}]
+
+(* Covariant position nested in a type constructor. *)
+let nested_ok (x : (t @@ portable global) list) = (x :> (t @@ portable) list)
+[%%expect{|
+val nested_ok : (t @@ global portable) list -> (t @@ portable) list = <fun>
+|}]
+
+(* Contravariance at depth 2: parity must alternate. Depth 1 alone cannot
+   distinguish "swaps correctly" from "flips exactly once". *)
+let depth2_ok (g : ((t @@ portable) -> unit) -> unit) =
+  (g :> (t -> unit) -> unit)
+[%%expect{|
+val depth2_ok : (((t @@ portable) -> unit) -> unit) -> (t -> unit) -> unit =
+  <fun>
+|}]
+
+let depth2_bad (g : (t -> unit) -> unit) =
+  (g :> ((t @@ portable) -> unit) -> unit)
+[%%expect{|
+Line 2, characters 2-42:
+2 |   (g :> ((t @@ portable) -> unit) -> unit)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "(t -> unit) -> unit" is not a subtype of
+         "((t @@ portable) -> unit) -> unit"
+       Type "t" is not a subtype of "(t @@ portable)"
+|}]
+
+(* Objects and rows are the traditional home of [:>]. Forgetting under a
+   method type is fine; inventing one is not. *)
+let obj_forget (x : < m : (t @@ portable) >) = (x :> < m : t >)
+[%%expect{|
+val obj_forget : < m : (t @@ portable) > -> < m : t > = <fun>
+|}]
+
+let obj_invent (x : < m : t >) = (x :> < m : (t @@ portable) >)
+[%%expect{|
+Line 1, characters 33-63:
+1 | let obj_invent (x : < m : t >) = (x :> < m : (t @@ portable) >)
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "< m : t >" is not a subtype of "< m : (t @@ portable) >"
+       Type "t" is not a subtype of "(t @@ portable)"
+|}]
+
+(* Arrow modes are checked against the EXPECTED domain, so the target's
+   modality can supply the crossing that lets a [local] argument reach a
+   [global]-requiring function. Sound -- a caller really does supply a
+   [(t @@ global)] -- and this is the sharpest behaviour the forgetting arm
+   enables. The second case shows the modality is what makes the difference. *)
+let arrow_mode (g : t @ global -> unit) = (g :> (t @@ global) @ local -> unit)
+[%%expect{|
+val arrow_mode : (t -> unit) -> (t @@ global) @ local -> unit = <fun>
+|}]
+
+let arrow_mode_no_modality (g : t @ global -> unit) = (g :> t @ local -> unit)
+[%%expect{|
+Line 1, characters 54-78:
+1 | let arrow_mode_no_modality (g : t @ global -> unit) = (g :> t @ local -> unit)
+                                                          ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "t -> unit" is not a subtype of "t @ local -> unit"
+|}]
+
+(* Nested wrappers: this coercion is sound (the source's effective crossing is
+   [meet (portable, global)], below the target's) but is rejected, because the
+   comparison looks only at the outer bounds. Pinned so that a future
+   normalisation change is forced to revisit it. *)
+let nested_incomplete (x : ((t @@ portable) @@ global)) = (x :> (t @@ portable))
+[%%expect{|
+Line 1, characters 58-80:
+1 | let nested_incomplete (x : ((t @@ portable) @@ global)) = (x :> (t @@ portable))
+                                                              ^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "((t @@ portable) @@ global)" is not a subtype of "(t @@ portable)"
+|}]
+
+(* Arm ordering against the abbreviation-expanding arms above. *)
+type abbrev = (t @@ portable)
+[%%expect{|
+type abbrev = (t @@ portable)
+|}]
+
+let via_abbrev (x : (t @@ portable global)) = (x :> abbrev)
+[%%expect{|
+val via_abbrev : (t @@ global portable) -> abbrev = <fun>
+|}]
+
+let via_abbrev_bad (x : t) = (x :> abbrev)
+[%%expect{|
+Line 1, characters 29-42:
+1 | let via_abbrev_bad (x : t) = (x :> abbrev)
+                                 ^^^^^^^^^^^^^
+Error: Type "t" is not a subtype of "abbrev" = "(t @@ portable)"
+|}]
+
+(* Mode-level sentinels: forgetting a modality must not let the payload be
+   used at a mode the modality never licensed. These are the cross-axis
+   checks -- the wrapper crosses one axis, the use demands another. *)
+let no_launder_global (x : (t @@ portable) @ local) = ((x :> t) : t @ global)
+[%%expect{|
+Line 1, characters 56-57:
+1 | let no_launder_global (x : (t @@ portable) @ local) = ((x :> t) : t @ global)
+                                                            ^
+Error: This value is "local" to the parent region but is expected to be "global".
+|}]
+
+let no_launder_portable (x : (t @@ global) @ nonportable) =
+  ((x :> t) : t @ portable)
+[%%expect{|
+Line 2, characters 4-5:
+2 |   ((x :> t) : t @ portable)
+        ^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* ... whereas matching the axis is accepted, so the sentinels above are
+   discriminating rather than vacuous. *)
+let launder_ok_global (x : (t @@ global) @ local) = ((x :> t) : t @ global)
+[%%expect{|
+val launder_ok_global : (t @@ global) @ local -> t = <fun>
+|}]
+
+(* Coercion with an implicit source must be ground -- a pre-existing OCaml
+   restriction, not specific to modalities. A ground source is fine... *)
+let implicit_ground (x : (t list @@ portable)) = (x :> t list)
+[%%expect{|
+val implicit_ground : (t list @@ portable) -> t list = <fun>
+|}]
+
+(* ... but a non-ground one needs the explicit-source form. *)
+let implicit_nonground (x : ('a list @@ portable)) = (x :> 'a list)
+[%%expect{|
+Line 1, characters 54-55:
+1 | let implicit_nonground (x : ('a list @@ portable)) = (x :> 'a list)
+                                                          ^
+Error: This expression cannot be coerced to type ""'a list""; it has type
+         "('a list @@ portable)"
+       but is here used with type "'a list"
+|}]
+
+let explicit_source (x : ('a list @@ portable)) =
+  (x : ('a list @@ portable) :> 'a list)
+[%%expect{|
+val explicit_source : ('a list @@ portable) -> 'a list = <fun>
+|}]
+
+(* Private abbreviations. These also pin the arm ordering: the new arms sit
+   BELOW the abbreviation-expanding arms, and the error must blame the private
+   target rather than the payload. *)
+type priv = private (t @@ portable)
+[%%expect{|
+type priv = private (t @@ portable)
+|}]
+
+let priv_forget (x : priv) = (x :> t)
+[%%expect{|
+val priv_forget : priv -> t = <fun>
+|}]
+
+let priv_target (x : (t @@ portable global)) = (x :> priv)
+[%%expect{|
+Line 1, characters 47-58:
+1 | let priv_target (x : (t @@ portable global)) = (x :> priv)
+                                                   ^^^^^^^^^^^
+Error: Type "(t @@ global portable)" is not a subtype of "priv"
+|}]
+
+(* Polymorphic variants: forgetting under a payload, and row widening. *)
+let variant_forget (x : [ `A of (t @@ portable) ]) = (x :> [ `A of t ])
+[%%expect{|
+val variant_forget : [ `A of (t @@ portable) ] -> [ `A of t ] = <fun>
+|}]
+
+let variant_invent (x : [ `A of t ]) = (x :> [ `A of (t @@ portable) ])
+[%%expect{|
+Line 1, characters 39-71:
+1 | let variant_invent (x : [ `A of t ]) = (x :> [ `A of (t @@ portable) ])
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "[ `A of t ]" is not a subtype of "[ `A of (t @@ portable) ]"
+       Type "t" is not a subtype of "(t @@ portable)"
+|}]
+
+(* The codomain mirror of the arrow-mode case above: the return-mode check
+   consults the EXPECTED codomain, which no longer carries the crossing the
+   source had, so this sound coercion is rejected. Conservative, and pinned. *)
+let codomain_mirror (g : unit -> (t @@ global) @ local) = (g :> unit -> t @ global)
+[%%expect{|
+Line 1, characters 58-83:
+1 | let codomain_mirror (g : unit -> (t @@ global) @ local) = (g :> unit -> t @ global)
+                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Type "unit -> (t @@ global) @ local" is not a subtype of "unit -> t"
+|}]
+
+(* Validation is shared with the other [@@] positions. *)
+type bad = (t @@ global unique)
+[%%expect{|
+Line 1, characters 17-30:
+1 | type bad = (t @@ global unique)
+                     ^^^^^^^^^^^^^
+Error: The modality "global" can't be used together with "unique"
+|}]
+
+(* Ownership regression: the existing [@@] positions must keep their current
+   meaning. Only the parenthesised form is a type-level modality. *)
+module type S = sig
+  val old_ : t @@ portable
+  val new_ : (t @@ portable)
+end
+[%%expect{|
+module type S = sig val old_ : t @@ portable val new_ : (t @@ portable) end
+|}]
+
+type r = { old_field : t @@ portable; new_field : (t @@ portable) }
+[%%expect{|
+type r = { old_field : t @@ portable; new_field : (t @@ portable); }
+|}]
+
+(* Toplevel value printing goes through [genprintval], which is one of the
+   sites Stage 3 changed from a fatal error to a look-through. [Obj.magic] is
+   the only way to obtain a value of this type before Stage 4 adds automatic
+   introduction. *)
+let x : (int @@ portable) = Obj.magic 5
+[%%expect{|
+val x : (int @@ portable) @@ stateless = 5
+|}]
+
+(* Nested wrappers are distinct types and do not normalise (design question
+   Q2): [((t @@ m1) @@ m2)] is not identified with [(t @@ m1 m2)]. *)
+type nested = ((int @@ portable) @@ contended)
+[%%expect{|
+type nested = ((int @@ portable) @@ contended)
+|}]
+
+(* Without automatic introduction, a bare value does not acquire a modality;
+   this is what Stage 4 will change. *)
+let no_auto_intro : (int @@ portable) = 1
+[%%expect{|
+Line 1, characters 40-41:
+1 | let no_auto_intro : (int @@ portable) = 1
+                                            ^
+Error: The constant "1" has type "int" but an expression was expected of type
+         "(int @@ portable)"
+|}]

--- a/testsuite/tests/typing-modes/first_class_modality_unpack.ml
+++ b/testsuite/tests/typing-modes/first_class_modality_unpack.ml
@@ -1,0 +1,424 @@
+(* TEST
+ flags = "-extension mode_alpha";
+ expect;
+*)
+
+(* Automatic unpacking of first-class modalities.
+
+   A [(t @@ m)] never survives at the top level of an actual or an expected
+   type: the modality leaves the type and enters the mode. The reference
+   behaviour is the one-field unboxed record [{ x : t @@ m } [@@unboxed]], and
+   the cases below are checked against it. Both directions apply the same map
+   to the mode, but that map moves comonadic and monadic axes in opposite
+   directions, so each axis group is exercised separately. *)
+
+type t
+let use_portable (_ : t @ portable) = ()
+let use_nonportable (_ : t @ nonportable) = ()
+let use_uncontended (_ : t @ uncontended) = ()
+let use_contended (_ : t @ contended) = ()
+[%%expect{|
+type t
+val use_portable : t @ portable -> unit = <fun>
+val use_nonportable : t -> unit = <fun>
+val use_uncontended : t -> unit = <fun>
+val use_contended : t @ contended -> unit = <fun>
+|}]
+
+(* ACTUAL SIDE, comonadic. A value whose type carries [@@ portable] is a [t]
+   at [portable], whatever mode the wrapper itself is at. *)
+let elim_comonadic (e : (t @@ portable) @ nonportable) = use_portable e
+[%%expect{|
+val elim_comonadic : (t @@ portable) -> unit = <fun>
+|}]
+
+(* ACTUAL SIDE, monadic. The movement is the other way: unpacking a
+   [@@ contended] wrapper produces a CONTENDED value even from an uncontended
+   wrapper, exactly as projecting the field of the unboxed record does. So the
+   payload is usable at [contended] ... *)
+let elim_monadic (e : (t @@ contended) @ uncontended) = use_contended e
+[%%expect{|
+val elim_monadic : (t @@ contended) -> unit = <fun>
+|}]
+
+(* ... and NOT at [uncontended]. Getting this backwards would let the wrapper
+   launder a contended value. *)
+let elim_monadic_bad (e : (t @@ contended) @ uncontended) = use_uncontended e
+[%%expect{|
+Line 1, characters 76-77:
+1 | let elim_monadic_bad (e : (t @@ contended) @ uncontended) = use_uncontended e
+                                                                                ^
+Error: This value is "contended"
+         because it is the payload of a first-class modality (with some modality).
+       However, the highlighted expression is expected to be "uncontended".
+|}]
+
+(* Inference does not re-assert the modality: with no annotation on the
+   result, the unpacked type is what propagates. *)
+let no_resticking (x : (t @@ portable)) = x
+[%%expect{|
+val no_resticking : (t @@ portable) -> t = <fun>
+|}]
+
+(* EXPECTED SIDE. The round trip through annotations: the modality is put back
+   by the return annotation, and the body is checked at the modality applied
+   to the expected mode. *)
+let round_trip (x : (t @@ portable)) : (t @@ portable) = x
+[%%expect{|
+val round_trip : (t @@ portable) -> (t @@ portable) = <fun>
+|}]
+
+(* Introduction from a plain value. This is the case the pre-Stage-4 test file
+   pinned as an error under the name [no_auto_intro]. *)
+let intro : (int @@ portable) = 1
+[%%expect{|
+val intro : (int @@ portable) @@ stateless = 1
+|}]
+
+(* EXPECTED SIDE, comonadic: the payload must satisfy the modality. *)
+let intro_comonadic (y : t @ portable) : (t @@ portable) = y
+[%%expect{|
+val intro_comonadic : t @ portable -> (t @@ portable) = <fun>
+|}]
+
+let intro_comonadic_bad (y : t @ nonportable) : (t @@ portable) = y
+[%%expect{|
+Line 1, characters 66-67:
+1 | let intro_comonadic_bad (y : t @ nonportable) : (t @@ portable) = y
+                                                                      ^
+Error: This value is "nonportable"
+       but is expected to be "portable"
+         because it is the payload of a first-class modality (with some modality).
+|}]
+
+(* EXPECTED SIDE, monadic: the expected mode is RELAXED rather than tightened,
+   so a contended payload may be packed into a wrapper claimed uncontended.
+   That is sound only because reading it back re-contends it -- see
+   [elim_monadic_bad] above. *)
+let intro_monadic (y : t @ contended) : (t @@ contended) = y
+[%%expect{|
+val intro_monadic : t @ contended -> (t @@ contended) = <fun>
+|}]
+
+(* The two halves compose to the identity, not to a laundering device. *)
+let no_launder_monadic (y : t @ contended) : t @ uncontended =
+  let w : (t @@ contended) = y in
+  w
+[%%expect{|
+Line 3, characters 2-3:
+3 |   w
+      ^
+Error: This value is "contended"
+         because it is the payload of a first-class modality (with some modality).
+       However, the highlighted expression is expected to be "uncontended".
+|}]
+
+(* Same round trip at a mode the modality does license. *)
+let launder_ok_monadic (y : t @ contended) : t @ contended =
+  let w : (t @@ contended) = y in
+  w
+[%%expect{|
+val launder_ok_monadic : t @ contended -> t @ contended = <fun>
+|}]
+
+(* An expression annotation is an EXPECTED-type position, so [(e : (t @@ m))]
+   PACKS, exactly like a return-type annotation. The two spellings must agree;
+   if they ever diverge again, these two lines are what catches it. *)
+let via_constraint (x : (t @@ portable)) = (x : (t @@ portable))
+[%%expect{|
+val via_constraint : (t @@ portable) -> (t @@ portable) = <fun>
+|}]
+
+let via_return (x : (t @@ portable)) : (t @@ portable) = x
+[%%expect{|
+val via_return : (t @@ portable) -> (t @@ portable) = <fun>
+|}]
+
+(* Packing checks the payload at the modality applied to the expected mode, so
+   a payload that does not satisfy the modality is rejected. *)
+let annot_pack_bad (y : t @ nonportable) = (y : (t @@ portable))
+[%%expect{|
+Line 1, characters 44-45:
+1 | let annot_pack_bad (y : t @ nonportable) = (y : (t @@ portable))
+                                                ^
+Error: This value is "nonportable"
+       but is expected to be "portable"
+         because it is the payload of a first-class modality (with some modality).
+|}]
+
+(* Because the annotation packs, it is NOT a way to spell elimination: in a
+   context wanting a bare [t] it is a type mismatch, not a silent unpack. *)
+let annot_is_not_elim (y : t @ portable) : t @ nonportable =
+  (y : (t @@ portable))
+[%%expect{|
+Line 2, characters 2-23:
+2 |   (y : (t @@ portable))
+      ^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "(t @@ portable)"
+       but an expression was expected of type "t"
+|}]
+
+(* Explicit elimination needs no form of its own -- [(e : t)] works, because
+   the actual side has already unpacked [e]. So both directions stay
+   writable. *)
+let elim_via_annot (x : (t @@ portable) @ nonportable) = (x : t @ portable)
+[%%expect{|
+val elim_via_annot : (t @@ portable) -> t = <fun>
+|}]
+
+(* Cross-axis sentinels: unpacking must not hand out a mode on an axis the
+   modality says nothing about. *)
+let cross_axis_bad (e : (t @@ portable) @ local) = (e : t @ global)
+[%%expect{|
+Line 1, characters 52-53:
+1 | let cross_axis_bad (e : (t @@ portable) @ local) = (e : t @ global)
+                                                        ^
+Error: This value is "local" to the parent region
+         because it is the payload of a first-class modality
+         which is "local" to the parent region.
+       However, the highlighted expression is expected to be "global".
+|}]
+
+let cross_axis_ok (e : (t @@ global) @ local) = (e : t @ global)
+[%%expect{|
+val cross_axis_ok : (t @@ global) @ local -> t = <fun>
+|}]
+
+(* Linearity (comonadic) and uniqueness (monadic) behave like portability and
+   contention respectively. *)
+let linearity_bad (y : t @ once) : (t @@ many) = y
+[%%expect{|
+Line 1, characters 49-50:
+1 | let linearity_bad (y : t @ once) : (t @@ many) = y
+                                                     ^
+Error: This value is "once"
+       but is expected to be "many"
+         because it is the payload of a first-class modality (with some modality).
+|}]
+
+let uniqueness_bad (e : (t @@ aliased)) = (e : t @ unique)
+[%%expect{|
+Line 1, characters 43-44:
+1 | let uniqueness_bad (e : (t @@ aliased)) = (e : t @ unique)
+                                               ^
+Error: This value is "aliased"
+         because it is the payload of a first-class modality (with some modality).
+       However, the highlighted expression is expected to be "unique".
+|}]
+
+(* MIDDLE modalities. [shareable] and [shared] sit strictly between the
+   endpoints of their axes, and the unpacking must carry the exact bound
+   rather than rounding it to an endpoint. These cases cannot be checked
+   against the unboxed-record encoding, whose kind inference treats a middle
+   modality as identity-like; they are checked against [(t @@ m)] directly.
+
+   Comonadic middle, actual side: unpacking gives exactly [shareable] ... *)
+let middle_comonadic (x : (t @@ shareable) @ nonportable) = (x : _ @ shareable)
+[%%expect{|
+val middle_comonadic : (t @@ shareable) -> t = <fun>
+|}]
+
+(* ... and not [portable], which would be rounding the bound down. *)
+let middle_comonadic_exact (x : (t @@ shareable) @ nonportable) =
+  (x : _ @ portable)
+[%%expect{|
+Line 2, characters 3-4:
+2 |   (x : _ @ portable)
+       ^
+Error: This value is "shareable"
+         because it is the payload of a first-class modality
+         which is "shareable" because it crosses with something
+         which is "nonportable".
+       However, the highlighted expression is expected to be "portable".
+|}]
+
+(* Comonadic middle, expected side: the payload must reach [shareable], and
+   a value that already exceeds it is fine. *)
+let middle_comonadic_intro (y : t @ shareable) : (t @@ shareable) = y
+[%%expect{|
+val middle_comonadic_intro : t @ shareable -> (t @@ shareable) = <fun>
+|}]
+
+let middle_comonadic_intro_bad (y : t @ nonportable) : (t @@ shareable) = y
+[%%expect{|
+Line 1, characters 74-75:
+1 | let middle_comonadic_intro_bad (y : t @ nonportable) : (t @@ shareable) = y
+                                                                              ^
+Error: This value is "nonportable"
+       but is expected to be "shareable"
+         because it is the payload of a first-class modality (with some modality).
+|}]
+
+(* Monadic middle, actual side: unpacking a [@@ shared] wrapper held at
+   [uncontended] gives exactly [shared] -- not [uncontended] (which would drop
+   the modality) and not [contended] (which would round it up). *)
+let middle_monadic (e : (t @@ shared) @ uncontended) = (e : _ @ shared)
+[%%expect{|
+val middle_monadic : (t @@ shared) -> t @ shared = <fun>
+|}]
+
+let middle_monadic_exact (e : (t @@ shared) @ uncontended) =
+  (e : _ @ uncontended)
+[%%expect{|
+Line 2, characters 3-4:
+2 |   (e : _ @ uncontended)
+       ^
+Error: This value is "shared"
+         because it is the payload of a first-class modality (with some modality).
+       However, the highlighted expression is expected to be "uncontended".
+|}]
+
+(* Monadic middle, expected side. Packing a value that is WORSE than the
+   modality does not fail outright: the wrapper's own mode rises to absorb the
+   difference, which is visible in the inferred return mode. *)
+let middle_monadic_intro (y : t @ contended) : (t @@ shared) = y
+[%%expect{|
+val middle_monadic_intro : t @ contended -> (t @@ shared) @ corrupted = <fun>
+|}]
+
+(* ... and that absorption is not a laundering route, because the use site
+   unpacks at the raised wrapper mode, not at the modality's constant. *)
+let middle_monadic_follow (y : t @ contended) =
+  (middle_monadic_intro y : t @ shared)
+[%%expect{|
+Line 2, characters 3-25:
+2 |   (middle_monadic_intro y : t @ shared)
+       ^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is weaker than "corrupted"
+         because it is the payload of a first-class modality
+         which is "corrupted"
+         because it is a first-class modality wrapping (with some modality) the expression at line 1, characters 63-64.
+       However, the highlighted expression is expected to be "shared" or "uncontended".
+|}]
+
+let middle_monadic_launder (y : t @ contended) : t @ shared =
+  let w : (t @@ shared) = y in
+  w
+[%%expect{|
+Line 3, characters 2-3:
+3 |   w
+      ^
+Error: This value is "corrupted"
+         because it is the payload of a first-class modality
+         which is "corrupted"
+         because it is a first-class modality wrapping (with some modality) the expression at line 2, characters 26-27.
+       However, the highlighted expression is expected to be "shared" or "uncontended".
+|}]
+
+let middle_monadic_launder_ok (y : t @ shared) : t @ shared =
+  let w : (t @@ shared) = y in
+  w
+[%%expect{|
+val middle_monadic_launder_ok : t @ shared -> t @ shared = <fun>
+|}]
+
+(* Application results and record projections unpack too, not just
+   identifiers. *)
+let via_application (f : unit -> (t @@ portable) @ nonportable) =
+  use_portable (f ())
+[%%expect{|
+val via_application : (unit -> (t @@ portable)) -> unit = <fun>
+|}]
+
+type r = { fld : (t @@ portable) }
+let via_projection (x : r @ nonportable) = use_portable x.fld
+[%%expect{|
+type r = { fld : (t @@ portable); }
+val via_projection : r -> unit = <fun>
+|}]
+
+(* Only the top level unpacks. [(t @@ m) list] keeps its modality, because
+   there is no mode for it to move into. *)
+let nested_keeps (x : (t @@ portable) list) = x
+[%%expect{|
+val nested_keeps : (t @@ portable) list -> (t @@ portable) list = <fun>
+|}]
+
+(* Nested wrappers unpack all the way down in one step. *)
+let doubly_nested (e : ((t @@ portable) @@ contended) @ uncontended) =
+  use_contended e
+[%%expect{|
+val doubly_nested : ((t @@ portable) @@ contended) -> unit = <fun>
+|}]
+
+(* Inline lambdas passed to a POLYMORPHIC higher-order function. The argument
+   is typed against the function's scheme, with the instance reconciled
+   afterwards, so what the lambda's own annotations say matters. Annotating
+   the parameter is what gives the body something to unpack; with no parameter
+   annotation the parameter's type is a fresh variable, nothing unpacks, and a
+   return annotation then demands a modality the parameter never had. *)
+let hof : ('a -> 'b) -> 'a -> 'b = fun f x -> f x
+[%%expect{|
+val hof : ('a -> 'b) -> 'a -> 'b = <fun>
+|}]
+
+let hof_both_annotations (x : (t @@ portable)) =
+  hof (fun (s : (t @@ portable)) : (t @@ portable) -> s) x
+[%%expect{|
+val hof_both_annotations : (t @@ portable) -> t = <fun>
+|}]
+
+let hof_param_annotation (x : (t @@ portable)) =
+  hof (fun (s : (t @@ portable)) -> s) x
+[%%expect{|
+val hof_param_annotation : (t @@ portable) -> t = <fun>
+|}]
+
+let hof_return_annotation_only (x : (t @@ portable)) =
+  hof (fun s : (t @@ portable) -> s) x
+[%%expect{|
+Line 2, characters 34-35:
+2 |   hof (fun s : (t @@ portable) -> s) x
+                                      ^
+Error: This value is "nonportable"
+       but is expected to be "portable"
+         because it is the payload of a first-class modality (with some modality).
+|}]
+
+(* Signatures are unaffected: a [val] keeps the wrapper at the top of its
+   TYPE, and inclusion still compares wrapper to wrapper. *)
+let use_portable_int (_ : int @ portable) = ()
+module M : sig val x : (int @@ portable) end = struct
+  let x : (int @@ portable) = 1
+end
+[%%expect{|
+val use_portable_int : int @ portable -> unit = <fun>
+module M : sig val x : (int @@ portable) end @@ stateless
+|}]
+
+(* ... and the value read out of the module unpacks at the use site. *)
+let from_module () = use_portable_int M.x
+[%%expect{|
+val from_module : unit -> unit = <fun>
+|}]
+
+(* Patterns need nothing of their own. A variable bound at type [(t @@ m)]
+   keeps the wrapper, which is exactly what makes its use sites unpack; and a
+   destructuring pattern is matched against the type of the scrutinee, which
+   the expression rule has already unpacked. *)
+let pattern_keeps_wrapper (x : (t @@ portable)) =
+  let y = x in
+  use_portable y
+[%%expect{|
+val pattern_keeps_wrapper : (t @@ portable) -> unit = <fun>
+|}]
+
+let pattern_destructure (x : ((t * t) @@ portable)) =
+  let (a, _) = x in
+  a
+[%%expect{|
+val pattern_destructure : (t * t @@ portable) -> t = <fun>
+|}]
+
+(* The one pattern position that is NOT reached by the expression rule is a
+   [Tmod] written directly on a destructuring parameter: there the pattern,
+   not an expression, meets the wrapper. Pinned as a known gap. *)
+let pattern_param ((a, _) : ((t * t) @@ portable)) = a
+[%%expect{|
+Line 1, characters 19-25:
+1 | let pattern_param ((a, _) : ((t * t) @@ portable)) = a
+                       ^^^^^^
+Error: This pattern matches values of type "'a * 'b"
+       but a pattern was expected which matches values of type
+         "(t * t @@ portable)"
+|}]

--- a/testsuite/tests/typing-modes/first_class_modality_unpack.ml
+++ b/testsuite/tests/typing-modes/first_class_modality_unpack.ml
@@ -480,3 +480,69 @@ Error: This value is "local"
          which is "local".
        However, the highlighted expression is expected to be "global".
 |}]
+
+(* ABBREVIATIONS. The rule is about the head of the expanded type, not about
+   how the type was spelled, so an abbreviation of a wrapper unpacks. *)
+type ta = (t @@ portable)
+let via_alias (x : ta @ nonportable) = use_portable x
+[%%expect{|
+type ta = (t @@ portable)
+val via_alias : ta -> unit = <fun>
+|}]
+
+(* Including a parameterised abbreviation whose manifest is the parameter --
+   the shape [Univ_map]'s [type 'a data = 'a] has, and the one that decides
+   whether the head is a wrapper by looking at an ARGUMENT. *)
+type 'a id = 'a
+let via_param_alias (x : (t @@ portable) id @ nonportable) = use_portable x
+[%%expect{|
+type 'a id = 'a
+val via_param_alias : (t @@ portable) id -> unit = <fun>
+|}]
+
+(* A private abbreviation keeps its wrapper hidden, so it does not unpack. *)
+module Priv : sig
+  type tp = private (t @@ portable)
+end = struct
+  type tp = (t @@ portable)
+end
+let via_private_alias (x : Priv.tp @ nonportable) = use_portable x
+[%%expect{|
+module Priv : sig type tp = private (t @@ portable) end @@ stateless
+Line 6, characters 65-66:
+6 | let via_private_alias (x : Priv.tp @ nonportable) = use_portable x
+                                                                     ^
+Error: The value "x" has type "Priv.tp" but an expression was expected of type "t"
+|}]
+
+(* An abbreviation revealed only by a local (GADT) equation does not unpack:
+   that would make unpacking depend on non-principal information. *)
+type _ reveals_ta = Reveals_ta : ta reveals_ta
+let via_equation (type a) (e : a reveals_ta) (x : a @ nonportable) =
+  match e with
+  | Reveals_ta -> use_portable x
+[%%expect{|
+type _ reveals_ta = Reveals_ta : ta reveals_ta
+Line 4, characters 31-32:
+4 |   | Reveals_ta -> use_portable x
+                                   ^
+Error: The value "x" has type "a" = "(t @@ portable)"
+       but an expression was expected of type "t"
+|}]
+
+(* Never expanding is not an option either, which is why the two cases above
+   differ. [:>] does expand, so an abbreviation of an [@@ aliased] wrapper
+   that never unpacked could have its modality forgotten by a coercion while
+   the mode side never applied it -- handing out a [unique] value from an
+   [aliased] one. *)
+type tu = (t @@ aliased)
+let coercion_stays_sound (x : tu @ unique) : t @ unique = (x :> t)
+[%%expect{|
+type tu = (t @@ aliased)
+Line 2, characters 59-60:
+2 | let coercion_stays_sound (x : tu @ unique) : t @ unique = (x :> t)
+                                                               ^
+Error: This value is "aliased"
+         because it is the payload of a first-class modality (with some modality).
+       However, the highlighted expression is expected to be "unique".
+|}]

--- a/testsuite/tests/typing-modes/first_class_modality_unpack.ml
+++ b/testsuite/tests/typing-modes/first_class_modality_unpack.ml
@@ -68,8 +68,7 @@ let round_trip (x : (t @@ portable)) : (t @@ portable) = x
 val round_trip : (t @@ portable) -> (t @@ portable) = <fun>
 |}]
 
-(* Introduction from a plain value. This is the case the pre-Stage-4 test file
-   pinned as an error under the name [no_auto_intro]. *)
+(* Introduction from a plain value. *)
 let intro : (int @@ portable) = 1
 [%%expect{|
 val intro : (int @@ portable) @@ stateless = 1
@@ -166,14 +165,11 @@ let elim_via_annot (x : (t @@ portable) @ nonportable) = (x : t @ portable)
 val elim_via_annot : (t @@ portable) -> t = <fun>
 |}]
 
-(* SENTINEL for the interaction between the two annotation positions.
-   [let w : (t @@ m) = e in ...] desugars to a constraint on BOTH the pattern
-   and the expression, so the expected-side hook (firing on the pattern's
-   type) meets the expression's own re-stated annotation. If the hook is
-   allowed to fire on a node that carries its own type, the wrapper and the
-   stripped expectation fail to unify and this stops compiling with
-   "this expression has type (t @@ portable) but an expression was expected of
-   type t". Keep this passing. *)
+(* [let w : (t @@ m) = e] desugars to a constraint on BOTH the pattern and the
+   expression, so the expected-side unpacking (firing on the pattern's type)
+   meets the expression's own annotation. If unpacking is allowed to fire on a
+   node that carries its own type, the wrapper and the stripped expectation
+   fail to unify and this stops compiling. *)
 let annotated_binding (y : t @ portable) =
   let w : (t @@ portable) = y in
   w
@@ -436,4 +432,51 @@ Line 1, characters 19-25:
 Error: This pattern matches values of type "'a * 'b"
        but a pattern was expected which matches values of type
          "(t * t @@ portable)"
+|}]
+
+(* A worked example. [decorate] builds its result list in the caller's region,
+   so the spine costs nothing and dies there, while the strings it handles are
+   ordinary heap data that outlives it: the closure keeps one in [last_long],
+   and [twice] feeds the result back in. Without the modality the elements
+   would be tarred with the list's mode and neither would be allowed. *)
+let last_long : string ref = ref ""
+
+let rec decorate (xs : (string @@ global) list @ local)
+  : (string @@ global) list @ local =
+  exclave_
+  match xs with
+  | [] -> []
+  | s :: rest ->
+    (if String.length s > 10 then last_long := s);
+    (s ^ "!") :: decorate rest
+[%%expect{|
+val last_long : string ref @@ stateless = {contents = ""}
+val decorate :
+  (string @@ global) list @ local -> (string @@ global) list @ local = <fun>
+|}]
+
+(* The modality on the RESULT is what lets the output be fed back in. *)
+let twice (xs : (string @@ global) list @ local)
+  : (string @@ global) list @ local =
+  exclave_ decorate (decorate xs)
+[%%expect{|
+val twice :
+  (string @@ global) list @ local -> (string @@ global) list @ local = <fun>
+|}]
+
+(* Without it, the same code is rejected: an element of a local list is local,
+   so it can neither be retained nor returned as global. *)
+let rejected (xs : string list @ local) : string list @ local =
+  exclave_
+  match xs with
+  | [] -> []
+  | s :: rest -> (if String.length s > 10 then last_long := s); s :: rejected rest
+[%%expect{|
+Line 5, characters 60-61:
+5 |   | s :: rest -> (if String.length s > 10 then last_long := s); s :: rejected rest
+                                                                ^
+Error: This value is "local"
+         because it is contained (via constructor "::") in the value at line 5, characters 4-13
+         which is "local".
+       However, the highlighted expression is expected to be "global".
 |}]

--- a/testsuite/tests/typing-modes/first_class_modality_unpack.ml
+++ b/testsuite/tests/typing-modes/first_class_modality_unpack.ml
@@ -166,6 +166,21 @@ let elim_via_annot (x : (t @@ portable) @ nonportable) = (x : t @ portable)
 val elim_via_annot : (t @@ portable) -> t = <fun>
 |}]
 
+(* SENTINEL for the interaction between the two annotation positions.
+   [let w : (t @@ m) = e in ...] desugars to a constraint on BOTH the pattern
+   and the expression, so the expected-side hook (firing on the pattern's
+   type) meets the expression's own re-stated annotation. If the hook is
+   allowed to fire on a node that carries its own type, the wrapper and the
+   stripped expectation fail to unify and this stops compiling with
+   "this expression has type (t @@ portable) but an expression was expected of
+   type t". Keep this passing. *)
+let annotated_binding (y : t @ portable) =
+  let w : (t @@ portable) = y in
+  w
+[%%expect{|
+val annotated_binding : t @ portable -> t = <fun>
+|}]
+
 (* Cross-axis sentinels: unpacking must not hand out a mode on an axis the
    modality says nothing about. *)
 let cross_axis_bad (e : (t @@ portable) @ local) = (e : t @ global)

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -490,8 +490,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 Oval_stuff "<box>"
               | ty -> tree_of_val depth obj ty
               end
-          | Tsubst _ | Tfield(_, _, _, _) | Tnil | Tlink _ | Tof_kind _
-          | Tmod _ ->
+          | Tmod (ty, _) ->
+              (* Transparent wrapper: print the payload. *)
+              tree_of_val depth obj ty
+          | Tsubst _ | Tfield(_, _, _, _) | Tnil | Tlink _ | Tof_kind _ ->
               fatal_error "Printval.outval_of_value"
           | Tpoly (ty, _) ->
               tree_of_val (depth - 1) obj ty

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2658,9 +2658,10 @@ let rec extract_concrete_typedecl env ty =
           end
       end
   | Tpoly(ty, _) -> extract_concrete_typedecl env ty
-  (* Deliberately opaque: looking through would allow record/variant
-     operations on [t @@ m] while dropping the modality from the mode, which
-     is only sound once elimination is implemented. Revisit in Stage 4. *)
+  (* Deliberately opaque. Looking through would allow record and variant
+     operations directly on [t @@ m] while dropping the modality from the
+     mode; such uses must unpack first, which happens on the actual side in
+     [Typecore]. *)
   | Tmod _ -> Has_no_typedecl
   | Trepr _ -> Has_no_typedecl
   | Tquote ty -> extract_concrete_typedecl (incr_stage env) ty

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -2658,8 +2658,10 @@ let rec extract_concrete_typedecl env ty =
           end
       end
   | Tpoly(ty, _) -> extract_concrete_typedecl env ty
-  | Tmod _ ->
-    Misc.fatal_error "Ctype.extract_concrete_typedecl: unexpected Tmod"
+  (* Deliberately opaque: looking through would allow record/variant
+     operations on [t @@ m] while dropping the modality from the mode, which
+     is only sound once elimination is implemented. Revisit in Stage 4. *)
+  | Tmod _ -> Has_no_typedecl
   | Trepr _ -> Has_no_typedecl
   | Tquote ty -> extract_concrete_typedecl (incr_stage env) ty
   | Tsplice ty -> extract_concrete_typedecl (decr_stage env) ty
@@ -5092,6 +5094,8 @@ and unify3 uenv t1 t1' t2 t2' =
       unify_with_decr_stage uenv (fun uenv -> unify uenv (new_quote_ty t1') s2)
   | (_, Tquote s2) when is_flexible_ty s2 ->
       unify_with_incr_stage uenv (fun uenv -> unify uenv (new_splice_ty t1') s2)
+  | (Tmod (t1, b1), Tmod (t2, b2)) when Jkind0.Mod_bounds.equal b1 b2 ->
+      unify uenv t1 t2
   | (Tbox t1, Tbox t2) ->
       unify uenv t1 t2
   | (_, Tbox t2) when is_unboxable_ty (get_env uenv) t1' ->
@@ -6310,6 +6314,8 @@ let crossing_of_ty env ?modalities ty =
   | None -> crossing
   | Some m -> Crossing.modality m crossing
 
+let mod_bounds_le b1 b2 = Jkind0.Mod_bounds.(equal (meet b1 b2) b1)
+
 let cross_left env ?modalities ty mode =
   let crossing = crossing_of_ty env ?modalities ty in
   mode |> Value.disallow_right |> Crossing.apply_left crossing
@@ -6471,6 +6477,21 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
           | (Tquote_eval t1, Tquote_eval t2) ->
               moregen inst_nongen variance type_pairs
                 (incr_stage env) t1 t2
+          | (Tmod (u1, b1), Tmod (u2, b2)) ->
+              (* Q1: inclusion accepts a type crossing at least as much as the
+                 one expected. Smaller mod-bounds mean more crossing. The
+                 direction must follow [variance], as in [moregen_alloc_mode]:
+                 in a contravariant position the implementation must accept
+                 everything the signature promises, so the ordering flips. *)
+              let ok =
+                match variance with
+                | Invariant -> Jkind0.Mod_bounds.equal b1 b2
+                | Covariant -> mod_bounds_le b1 b2
+                | Contravariant -> mod_bounds_le b2 b1
+                | Bivariant -> true
+              in
+              if not ok then raise_unexplained_for Moregen;
+              moregen inst_nongen variance type_pairs env u1 u2
           | (Tbox t1, Tbox t2) ->
               moregen inst_nongen variance type_pairs env t1 t2
           | (Tbox t, _) when is_unboxable_ty env t2' ->
@@ -6984,6 +7005,10 @@ let rec eqtype rename type_pairs subst env ~do_jkind_check t1 t2 =
           | (Tquote_eval t1, Tquote_eval t2) ->
               eqtype rename type_pairs subst
                 (incr_stage env) ~do_jkind_check t1 t2
+          | (Tmod (u1, b1), Tmod (u2, b2)) ->
+              if not (Jkind0.Mod_bounds.equal b1 b2)
+              then raise_unexplained_for Equality;
+              eqtype rename type_pairs subst env ~do_jkind_check u1 u2
           | (Tbox t1, Tbox t2) ->
               eqtype rename type_pairs subst env ~do_jkind_check t1 t2
           | (_, _) ->
@@ -7923,6 +7948,42 @@ let rec subtype_rec env trace t1 t2 cstrs =
            (Subtype.Diff {got = t1; expected = t2} :: trace)
            t1 t2
            cstrs
+    (* A coercion may weaken a first-class modality: [t @@ m1 :> t @@ m2] when
+       [m1] crosses at least as much as [m2]. Unlike [moregen], [subtype_rec]
+       handles contravariance by swapping its arguments (see the [Tarrow] arm),
+       so no variance dispatch is needed here: every recursive call preserves
+       the "got on the left" invariant. If the bounds are not ordered this
+       falls through to the default arm, which defers to unification and is
+       invariant, so the coercion is rejected.
+
+       Both this arm and the forgetting arm below rely on subtyping being
+       crossing-monotone: [t1 <: t2] must imply that [t1] crosses at least as
+       much as [t2]. That holds today (widening only ever removes crossing),
+       but it is an obligation on any future subtyping rule, not something
+       enforced here.
+
+       Incompleteness: the comparison uses only the outer bounds, while the
+       effective crossing is [meet (crossing of payload) bounds]. So a sound
+       coercion between nested wrappers such as
+       [((t @@ m1) @@ m2) :> (t @@ m1)] is rejected. That is consistent with
+       nested wrappers not normalising; revisit together. *)
+    | (Tmod (u1, b1), Tmod (u2, b2)) when mod_bounds_le b1 b2 ->
+         subtype_rec
+           env
+           (Subtype.Diff {got = u1; expected = u2} :: trace)
+           u1 u2
+           cstrs
+    (* Forgetting a modality is always safe: it only discards the ability to
+       cross. The reverse ([t :> t @@ m]) must NOT be allowed, as it would
+       claim a crossing the value does not have; it falls through below.
+
+       This step deliberately does NOT push a [Subtype.Diff]. Unwrapping is
+       transparent, so a failure whose real cause is on the target side should
+       still be reported against the original pair; pushing a diff here made
+       such errors blame the payload instead. *)
+    | (Tmod (u1, _), _)
+      when not (match get_desc t2 with Tmod _ -> true | _ -> false) ->
+         subtype_rec env trace u1 t2 cstrs
     | (_, _) ->
         (trace, t1, t2, !univar_pairs)::cstrs
   end

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -300,6 +300,7 @@ val reduce_head:
     [box]es into [Tquote_eval] and [Tbox], enabling further reductions. *)
 
 val try_expand_once_opt: Env.t -> type_expr -> type_expr
+val try_expand_safe: Env.t -> type_expr -> type_expr
 val try_expand_safe_opt: Env.t -> type_expr -> type_expr
 
 val expand_head_once: Env.t -> type_expr -> type_expr

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -4828,6 +4828,9 @@ module Report = struct
             Fmt.dprintf "contains %t%a defined as %t"
               (print_structure_item ~capitalize:false x)
               maybe_modality moda print_pp
+          | First_class_modality moda ->
+            Fmt.dprintf "is a first-class modality wrapping%a %t" maybe_modality
+              moda print_pp
         in
         pr, contained)
 
@@ -4858,6 +4861,9 @@ module Report = struct
         maybe_modality moda
         (Location.Doc.loc ~capitalize_first:false)
         container
+    | First_class_modality moda ->
+      Fmt.dprintf "is the payload of a first-class modality%a" maybe_modality
+        moda
 
   let print_is_contained_by :
       fixpoint:bool -> is_contained_by -> (Fmt.formatter -> unit) * pinpoint =

--- a/typing/mode_hint.mli
+++ b/typing/mode_hint.mli
@@ -87,6 +87,9 @@ type containing =
   | Array of modality
   | Constructor of string * modality
   | Structure of structure_item * modality
+  | First_class_modality of modality
+      (** The [(t @@ m)] type wrapper, which contains its payload in the same
+          way a one-field unboxed record does. *)
 (* Some structure items (such as classes) don't have modalities. We gloss over
      for simplicity. *)
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -435,6 +435,10 @@ let rec core_type i ppf x =
       core_type i ppf ct
   | Ttyp_of_kind jkind ->
       line i ppf "Ttyp_of_kind %a\n" (jkind_annotation i) jkind;
+  | Ttyp_modality (ct, m) ->
+      line i ppf "Ttyp_modality\n";
+      core_type i ppf ct;
+      modalities i ppf m
   | Ttyp_call_pos -> line i ppf "Ttyp_call_pos\n";
 
 and labeled_core_type i ppf (l, t) =

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -777,6 +777,9 @@ let typ sub {ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes; _} =
   | Ttyp_repr (_, ct) -> sub.typ sub ct
   | Ttyp_newlayout (_, ct) -> sub.typ sub ct
   | Ttyp_of_kind jkind -> sub.jkind_annotation sub jkind
+  | Ttyp_modality (ct, m) ->
+    sub.typ sub ct;
+    sub.modalities sub m
   | Ttyp_call_pos -> ()
 
 let class_structure sub {cstr_self; cstr_fields; _} =

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -1087,6 +1087,8 @@ let typ sub x =
         Ttyp_of_kind (sub.jkind_annotation sub jkind)
     | Ttyp_quote t -> Ttyp_quote (sub.typ sub t)
     | Ttyp_splice t -> Ttyp_splice (sub.typ sub t)
+    | Ttyp_modality (ct, m) ->
+        Ttyp_modality (sub.typ sub ct, sub.modalities sub m)
   in
   let ctyp_attributes = sub.attributes sub x.ctyp_attributes in
   {x with ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes}

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -291,8 +291,9 @@ module Type_shape = struct
             Option.value shape ~default:unknown_shape_any
             (* CR sspies: We could ask the environment here for extra layout
                information about the type. *)
-          | Tmod _ ->
-            Misc.fatal_error "Type_shape.of_type_expr: unexpected Tmod"
+          | Tmod (type_expr, _) ->
+            (* Transparent wrapper: the shape is that of the payload. *)
+            of_type_expr_go ~depth ~visited type_expr subst shape_for_constr
           | Ttuple exprs -> Shape.tuple (of_expr_list (List.map snd exprs))
           | Tvar { name = _; jkind } -> unknown_shape_from_jkind jkind
           | Tpoly (type_expr, _type_vars) ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -649,13 +649,44 @@ let rec expand_head_for_modality env ty =
     | _ | (exception Not_found) -> ty)
   | _ -> ty
 
+(* Pure counterpart of [expand_head_for_modality]: the same stopping rules,
+   but lowering no levels and memoizing no expansion. *)
+let rec has_modality_head env fuel ty =
+  (* Backstop only; cyclic abbreviations are rejected by [Typedecl]. *)
+  if fuel <= 0 then true
+  else
+    match get_desc ty with
+    | Tmod _ -> true
+    | Tconstr (path, args, _) -> (
+      match Env.find_type path env with
+      | { type_is_newtype = true; _ } -> false
+      | { type_manifest = Some body; type_private = Public; type_params; _ } ->
+        (* Where the manifest is a parameter, the head of the expansion is
+           the matching argument. *)
+        let body =
+          match get_desc body with
+          | Tvar _ ->
+            let rec argument_for params args =
+              match params, args with
+              | param :: params, arg :: args ->
+                if eq_type param body then arg else argument_for params args
+              | _, _ -> body
+            in
+            argument_for type_params args
+          | _ -> body
+        in
+        has_modality_head env (fuel - 1) body
+      | _ -> false
+      | exception Not_found -> false)
+    | _ -> false
+
 let unpack_modality ~loc:_ env ty =
   let found payload bounds =
     Some (Typemode.modality_of_mod_bounds bounds, payload)
   in
   match get_desc ty with
   | Tmod (payload, bounds) -> found payload bounds
-  | Tconstr _ -> (
+  | Tconstr _ when has_modality_head env 100 ty -> (
     match get_desc (expand_head_for_modality env ty) with
     | Tmod (payload, bounds) -> found payload bounds
     | _ -> None)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -619,27 +619,24 @@ let modality_hint ~loc : Mode.Hint.is_contained_by =
   { containing = First_class_modality Modality;
     container = (loc, Expression) }
 
-(* On [-principal]: no warning is emitted here, deliberately. A [Tmod] only
-   ever enters a type from a written annotation, so the decision below is not
-   a guess made from inferred information in the way that record-field or
-   array-literal disambiguation is. The usual proxy for "principal enough",
-   [is_principal] (i.e. generalised), is also unusable at this site: the
-   expected type of an expression is essentially never at [generic_level], so
-   gating on it warns on every single use of the feature. What remains
-   unaccounted for is an annotation reaching a type through unification with a
-   LATER expression, e.g. [fun y -> ignore (y : (t @@ portable)); y]; see the
-   report. *)
-(* Expand manifest aliases far enough to see a wrapper, WITHOUT consulting
+(* No [-principal] warning is emitted here, deliberately: a [Tmod] only ever
+   enters a type from a written annotation, so this is not a guess made from
+   inferred information in the way record-field disambiguation is. The usual
+   proxy, [is_principal], is unusable at this site anyway -- an expression's
+   expected type is essentially never at [generic_level], so gating on it
+   would warn on every use of the feature. Not covered: an annotation reaching
+   a type by unification with a later expression, as in
+   [fun y -> ignore (y : (t @@ portable)); y]. *)
+(* Expand manifest aliases far enough to reveal a wrapper, without consulting
    local (GADT) equations.
 
-   Refusing to expand at all whenever the environment holds a local equation
-   is unsound, not merely conservative: a public alias for [(t @@ aliased)]
-   can be forgotten by [:>], which does expand, while the mode side never
-   applies the modality -- yielding a [unique] value from an [aliased] one.
-   Conversely, expanding through a local equation would make unpacking depend
-   on non-principal information. Stopping at locally abstract types avoids
-   both: a globally manifest alias always unpacks, and one revealed only by a
-   local equation never does, in either mode. *)
+   Both extremes are wrong here. Never expanding is unsound: [:>] does expand,
+   so it can forget a public alias for [(t @@ aliased)] while the mode side
+   never applies the modality, yielding a [unique] value from an [aliased]
+   one. Always expanding would make unpacking depend on non-principal
+   information. Stopping at locally abstract types gives a globally manifest
+   alias that always unpacks and a locally revealed one that never does, in
+   either mode. *)
 let rec expand_head_for_modality env ty =
   match get_desc ty with
   | Tconstr (path, _, _) -> (
@@ -6643,15 +6640,13 @@ and type_expect ?recarg ?(overwrite=No_overwrite) env
 and type_expect_
     ?(recarg=Rejected) ?(overwrite=No_overwrite)
     env (expected_mode : expected_mode) sexp ty_expected_explained =
-  (* [(e : ty)] and [(e :> ty)] carry a type of their own and unify it with
+  (* [(e : ty)] and [(e :> ty)] carry their own type and unify it with
      [ty_expected] themselves, so the hook below must not fire on them: it
-     would take the wrapper off the expectation while the node still reports
-     the annotation as written, and the two would then fail to unify. The
-     recursive call those nodes make on their subexpression reaches this hook
-     with the annotation as the expected type, which is where the rule
-     belongs -- so [(e : (t @@ m))] PACKS, exactly like a return-type
-     annotation. Explicit unpacking is spelled [(e : t)], which needs nothing
-     here because the actual side already unpacks [e]. *)
+     would strip the wrapper from the expectation while the node still reports
+     the annotation as written, and the two would fail to unify. Their
+     recursive call on the subexpression reaches this hook with the annotation
+     as the expected type, so [(e : (t @@ m))] packs. Explicit unpacking is
+     [(e : t)], handled by the actual side. *)
   let carries_own_type =
     match sexp.pexp_desc with
     | Pexp_constraint (_, Some _, _) | Pexp_coerce _ -> true
@@ -6662,11 +6657,9 @@ and type_expect_
     else unpack_modality ~loc:sexp.pexp_loc env ty_expected_explained.ty
   with
   | Some (modality, payload) ->
-      (* The expected type has [@@ m] at top level. Check the expression
-         against the payload, at [m] applied to the expected mode. The
-         recorded [exp_type] keeps the wrapper, so that this expression still
-         answers the question its caller asked; whoever wants the payload
-         unpacks on the actual side. *)
+      (* Check the expression against the payload, at [m] applied to the
+         expected mode. [exp_type] keeps the wrapper; consumers that want the
+         payload unpack on the actual side. *)
       let expected_mode =
         mode_unpack_modality ~loc:sexp.pexp_loc modality expected_mode
       in
@@ -9303,9 +9296,7 @@ and type_ident env ?(recarg=Rejected) lid =
   in
   (* after layout instantiation, the value loses layout polymorphism. *)
   let val_lpoly = Lpoly.determined [] in
-  (* A value whose type is [(t @@ m)] is seen as a [t] at [m] applied to its
-     mode. This is the actual-side counterpart of the unpacking in
-     [type_expect_]. *)
+  (* A value of type [(t @@ m)] is seen as a [t] at [m] applied to its mode. *)
   let val_type, actual_mode =
     unpack_modality_actual ~loc:lid.loc env val_type actual_mode
   in

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -629,20 +629,39 @@ let modality_hint ~loc : Mode.Hint.is_contained_by =
    unaccounted for is an annotation reaching a type through unification with a
    LATER expression, e.g. [fun y -> ignore (y : (t @@ portable)); y]; see the
    report. *)
+(* Expand manifest aliases far enough to see a wrapper, WITHOUT consulting
+   local (GADT) equations.
+
+   Refusing to expand at all whenever the environment holds a local equation
+   is unsound, not merely conservative: a public alias for [(t @@ aliased)]
+   can be forgotten by [:>], which does expand, while the mode side never
+   applies the modality -- yielding a [unique] value from an [aliased] one.
+   Conversely, expanding through a local equation would make unpacking depend
+   on non-principal information. Stopping at locally abstract types avoids
+   both: a globally manifest alias always unpacks, and one revealed only by a
+   local equation never does, in either mode. *)
+let rec expand_head_for_modality env ty =
+  match get_desc ty with
+  | Tconstr (path, _, _) -> (
+    match Env.find_type path env with
+    | { type_is_newtype = true; _ } -> ty
+    | { type_manifest = Some _; type_private = Public; _ } -> (
+      match try_expand_safe env ty with
+      | expanded -> expand_head_for_modality env expanded
+      | exception Cannot_expand -> ty)
+    | _ | (exception Not_found) -> ty)
+  | _ -> ty
+
 let unpack_modality ~loc:_ env ty =
   let found payload bounds =
     Some (Typemode.modality_of_mod_bounds bounds, payload)
   in
   match get_desc ty with
   | Tmod (payload, bounds) -> found payload bounds
-  | Tconstr _ when not (Env.has_local_constraints env) ->
-      (* An abbreviation may stand for a wrapper. The expansion is skipped in
-         the presence of local (GADT) equations, where expanding the head can
-         capture an equation that is about to go out of scope; an abbreviation
-         of a wrapper then simply does not unpack. *)
-      (match get_desc (expand_head env ty) with
-       | Tmod (payload, bounds) -> found payload bounds
-       | _ -> None)
+  | Tconstr _ -> (
+    match get_desc (expand_head_for_modality env ty) with
+    | Tmod (payload, bounds) -> found payload bounds
+    | _ -> None)
   | _ -> None
 
 (* Expected side: the payload is checked at the modality applied to the

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -602,6 +602,69 @@ let mode_modality modality expected_mode =
   |> Modality.Const.apply_right modality
   |> mode_default
 
+(* First-class modalities: automatic unpacking.
+
+   A [Tmod] must never survive at the top level of an actual or of an expected
+   type. Where one is found there, the modality leaves the type and enters the
+   mode, in the same direction as for the one-field unboxed record
+   [type 'a w = { x : 'a @@ m } [@@unboxed]]: reading the payload out of a
+   wrapper at mode [a] gives [m] applied to [a] (as [w.x] does), and putting a
+   payload into a wrapper expected at mode [a] demands [m] applied to [a] (as
+   [{ x = e }] does). The map is the same on both sides; only the mode
+   allowance differs.
+
+   [unpack_modality] is the single place that decides whether a type has a
+   top-level modality. *)
+let modality_hint ~loc : Mode.Hint.is_contained_by =
+  { containing = First_class_modality Modality;
+    container = (loc, Expression) }
+
+(* On [-principal]: no warning is emitted here, deliberately. A [Tmod] only
+   ever enters a type from a written annotation, so the decision below is not
+   a guess made from inferred information in the way that record-field or
+   array-literal disambiguation is. The usual proxy for "principal enough",
+   [is_principal] (i.e. generalised), is also unusable at this site: the
+   expected type of an expression is essentially never at [generic_level], so
+   gating on it warns on every single use of the feature. What remains
+   unaccounted for is an annotation reaching a type through unification with a
+   LATER expression, e.g. [fun y -> ignore (y : (t @@ portable)); y]; see the
+   report. *)
+let unpack_modality ~loc:_ env ty =
+  let found payload bounds =
+    Some (Typemode.modality_of_mod_bounds bounds, payload)
+  in
+  match get_desc ty with
+  | Tmod (payload, bounds) -> found payload bounds
+  | Tconstr _ when not (Env.has_local_constraints env) ->
+      (* An abbreviation may stand for a wrapper. The expansion is skipped in
+         the presence of local (GADT) equations, where expanding the head can
+         capture an equation that is about to go out of scope; an abbreviation
+         of a wrapper then simply does not unpack. *)
+      (match get_desc (expand_head env ty) with
+       | Tmod (payload, bounds) -> found payload bounds
+       | _ -> None)
+  | _ -> None
+
+(* Expected side: the payload is checked at the modality applied to the
+   expected mode of the wrapper. *)
+let mode_unpack_modality ~loc modality expected_mode =
+  mode_morph
+    (apply_right_is_contained_by (modality_hint ~loc) ~modalities:modality)
+    expected_mode
+
+(* Actual side: the payload's mode is the modality applied to the mode of the
+   wrapper. Iterated, so nested wrappers unpack in one go. *)
+let unpack_modality_actual ~loc env ty mode =
+  let rec loop ty (mode : Value.l) =
+    match unpack_modality ~loc env ty with
+    | None -> ty, mode
+    | Some (modality, payload) ->
+        loop payload
+          (apply_left_is_contained_by (modality_hint ~loc) ~modalities:modality
+             mode)
+  in
+  loop ty (Value.disallow_right mode)
+
 (* used when entering a function;
 mode is the mode of the function region *)
 let mode_return mode =
@@ -6561,6 +6624,39 @@ and type_expect ?recarg ?(overwrite=No_overwrite) env
 and type_expect_
     ?(recarg=Rejected) ?(overwrite=No_overwrite)
     env (expected_mode : expected_mode) sexp ty_expected_explained =
+  (* [(e : ty)] and [(e :> ty)] carry a type of their own and unify it with
+     [ty_expected] themselves, so the hook below must not fire on them: it
+     would take the wrapper off the expectation while the node still reports
+     the annotation as written, and the two would then fail to unify. The
+     recursive call those nodes make on their subexpression reaches this hook
+     with the annotation as the expected type, which is where the rule
+     belongs -- so [(e : (t @@ m))] PACKS, exactly like a return-type
+     annotation. Explicit unpacking is spelled [(e : t)], which needs nothing
+     here because the actual side already unpacks [e]. *)
+  let carries_own_type =
+    match sexp.pexp_desc with
+    | Pexp_constraint (_, Some _, _) | Pexp_coerce _ -> true
+    | _ -> false
+  in
+  match
+    if carries_own_type then None
+    else unpack_modality ~loc:sexp.pexp_loc env ty_expected_explained.ty
+  with
+  | Some (modality, payload) ->
+      (* The expected type has [@@ m] at top level. Check the expression
+         against the payload, at [m] applied to the expected mode. The
+         recorded [exp_type] keeps the wrapper, so that this expression still
+         answers the question its caller asked; whoever wants the payload
+         unpacks on the actual side. *)
+      let expected_mode =
+        mode_unpack_modality ~loc:sexp.pexp_loc modality expected_mode
+      in
+      let exp =
+        type_expect_ ~recarg ~overwrite env expected_mode sexp
+          { ty_expected_explained with ty = payload }
+      in
+      { exp with exp_type = ty_expected_explained.ty }
+  | None ->
   let { ty = ty_expected; explanation } = ty_expected_explained in
   let loc = sexp.pexp_loc in
   (* Record the expression type before unifying it with the expected type *)
@@ -7291,6 +7387,9 @@ and type_expect_
       let mode_ret = Alloc.disallow_right mode_ret in
       let ap_mode = Alloc.proj_comonadic Areality mode_ret in
       let mode_ret = cross_left env ty_ret (alloc_as_value mode_ret) in
+      let ty_ret, mode_ret =
+        unpack_modality_actual ~loc env ty_ret mode_ret
+      in
       let zero_alloc =
         Builtin_attributes.get_zero_alloc_attribute ~in_signature:false
           ~on_application:true
@@ -7524,6 +7623,7 @@ and type_expect_
         apply_left_is_contained_by is_contained_by
           ~modalities:label.lbl_modalities mode
       in
+      let ty_arg, mode = unpack_modality_actual ~loc env ty_arg mode in
       let boxing : texp_field_boxing =
         let is_float_boxing =
           match record_repres with
@@ -7593,6 +7693,7 @@ and type_expect_
         apply_left_is_contained_by is_contained_by
           ~modalities:label.lbl_modalities mode
       in
+      let ty_arg, mode = unpack_modality_actual ~loc env ty_arg mode in
       let mode = cross_left env ty_arg mode in
       submode ~loc ~env mode expected_mode;
       let uu = unique_use ~loc ~env mode (as_single_mode expected_mode) in
@@ -9183,6 +9284,12 @@ and type_ident env ?(recarg=Rejected) lid =
   in
   (* after layout instantiation, the value loses layout polymorphism. *)
   let val_lpoly = Lpoly.determined [] in
+  (* A value whose type is [(t @@ m)] is seen as a [t] at [m] applied to its
+     mode. This is the actual-side counterpart of the unpacking in
+     [type_expect_]. *)
+  let val_type, actual_mode =
+    unpack_modality_actual ~loc:lid.loc env val_type actual_mode
+  in
   path, actual_mode, layout_args,
   { desc with val_type; val_lpoly }, kind
 

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -148,7 +148,7 @@ let rec immediate_subtypes : type_expr -> type_expr list = fun ty ->
          but "better safe than sorry" *)
       immediate_subtypes_object_row [] ty
   | Tquote ty | Tsplice ty | Tquote_eval ty | Tbox ty -> [ty]
-  | Tmod _ -> Misc.fatal_error "immediate_subtypes: Tmod"
+  | Tmod (ty, _) -> [ty]
   | Tlink _ | Tsubst _ -> assert false (* impossible due to Ctype.repr *)
   | Tvar _ | Tunivar _ -> []
   | Tof_kind _ -> []
@@ -473,8 +473,8 @@ let check_type
         assert false
     | (Tunivar(_)         , _      ) -> empty
     | (Tof_kind(_)         , _      ) -> empty
-    | (Tmod(_, _)          , _      ) ->
-        Misc.fatal_error "check_type: unexpected Tmod"
+    | (Tmod(ty, _)         , m      ) ->
+        check_type hyps ty m
     (* Type constructor case. *)
     | (Tconstr(path,tys,_), m      ) ->
         let msig = (Env.find_type path env).type_separability in

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -87,8 +87,8 @@ let compute_variance env visited vari ty =
           with Not_found ->
             List.iter (compute_variance_rec env unknown) tl
         end
-    | Tmod _ ->
-        Misc.fatal_error "compute_variance_rec: unexpected Tmod"
+    | Tmod (ty, _) ->
+        compute_same ty
     | Tobject (ty, _) ->
         compute_same ty
     | Tquote ty ->

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -879,6 +879,7 @@ and core_type_desc =
   | Ttyp_repr of string list * core_type
   | Ttyp_newlayout of string loc list * core_type
   | Ttyp_of_kind of Parsetree.jkind_annotation
+  | Ttyp_modality of core_type * modalities
   | Ttyp_call_pos
 
 and package_type = {

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1298,6 +1298,10 @@ and core_type_desc =
           A variable in [vars] may have no associated location if it is freshly
           created during type inference for [val poly_] value descriptions. *)
   | Ttyp_of_kind of Parsetree.jkind_annotation
+  | Ttyp_modality of core_type * modalities
+      (** [Ttyp_modality (ty, m)] represents [(ty @@ m)], a first-class
+          modality. Translation erases an identity modality, so this node
+          always carries a non-identity one. *)
   | Ttyp_call_pos
       (** [Ttyp_call_pos] represents the type of the value of a Position
           argument ([lbl:[%call_pos] -> ...]). *)

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -387,6 +387,14 @@ let transl_mod_bounds annots =
   ( create crossing ~externality,
     (raw_modifiers.nullability, raw_modifiers.separability) )
 
+(* [t @@ m] is, for mode-crossing purposes, the unboxed one-field record
+   [{ x : t @@ m }]: the wrapper's crossing IS the modality. Externality is
+   pinned to [max] (no claim), which is what distinguishes a surface [Tmod]
+   from one manufactured by the with-bounds engine. *)
+let mod_bounds_of_modality modality =
+  let open Jkind.Mod_bounds in
+  create (Crossing.modality modality Crossing.max) ~externality:Externality.max
+
 let default_mode_annots (annots : Alloc.Const.Option.t) =
   (* [forkable] has a different default depending on whether [areality]
      is [global] or [local]. *)

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -395,6 +395,13 @@ let mod_bounds_of_modality modality =
   let open Jkind.Mod_bounds in
   create (Crossing.modality modality Crossing.max) ~externality:Externality.max
 
+(* The inverse of [mod_bounds_of_modality]: [Crossing.to_modality] is
+   documented as the inverse of [Crossing.modality _ max], so this recovers
+   exactly the modality a surface [Tmod] was built from. Externality is not
+   part of a crossing and is dropped; surface [Tmod]s pin it to [max]. *)
+let modality_of_mod_bounds bounds =
+  Crossing.to_modality (Jkind.Mod_bounds.crossing bounds)
+
 let default_mode_annots (annots : Alloc.Const.Option.t) =
   (* [forkable] has a different default depending on whether [areality]
      is [global] or [local]. *)

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -89,3 +89,7 @@ val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t
 (** The mod-bounds of [t @@ m], given [m]. Externality is set to [max], i.e. no
     externality claim; see [modality_of_mod_bounds] for the inverse. *)
 val mod_bounds_of_modality : Mode.Modality.Const.t -> Jkind.Mod_bounds.t
+
+(** The inverse of [mod_bounds_of_modality]. Only meaningful on the mod-bounds
+    of a surface [Tmod]; the externality of the argument is ignored. *)
+val modality_of_mod_bounds : Jkind.Mod_bounds.t -> Mode.Modality.Const.t

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -85,3 +85,7 @@ val transl_mod_bounds :
 val untransl_mod_bounds : ?verbose:bool -> Jkind.Mod_bounds.t -> Parsetree.modes
 
 val idx_expected_modalities : mut:bool -> Mode.Modality.Const.t
+
+(** The mod-bounds of [t @@ m], given [m]. Externality is set to [max], i.e. no
+    externality claim; see [modality_of_mod_bounds] for the inverse. *)
+val mod_bounds_of_modality : Mode.Modality.Const.t -> Jkind.Mod_bounds.t

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -52,9 +52,16 @@ exception Error of Location.t * error
    about the runtime properties of a type - in particular, in
    [maybe_pointer_ty], when checking whether a type crosses externality. *)
 let scrape_ty env ty =
+  (* [Tmod] is a transparent wrapper: [t @@ m] erases at runtime, so its
+     representation is exactly that of [t]. Strip it here, as for [Tpoly], so
+     that the representation consumers downstream never see one. *)
+  let rec strip_mod ty =
+    match get_desc ty with Tmod (ty, _) -> strip_mod ty | _ -> ty
+  in
+  let ty = strip_mod ty in
   let ty =
     match get_desc ty with
-    | Tpoly(ty, _) -> ty
+    | Tpoly(ty, _) -> strip_mod ty
     | _ -> ty
   in
   match get_desc ty with
@@ -208,9 +215,11 @@ let classify ~classify_product env ty layout : _ classification =
     if Ctype.check_type_nullability env ty Non_null
     then Immediate else Immediate_or_null
   else match get_desc ty with
-  | Tvar _ | Tunivar _ | Tof_kind _ ->
+  | Tvar _ | Tunivar _ | Tof_kind _
+  (* [scrape_ty] strips [Tmod], so this is unreachable; [Any] is the safe
+     answer regardless. *)
+  | Tmod _ ->
       Any
-  | Tmod _ -> Misc.fatal_error "Typeopt.classify: unexpected Tmod"
   | Tconstr (p, _args, _abbrev) ->
       begin match Predef.find_type_constr p with
       | Some `Float -> Float
@@ -858,7 +867,8 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
         match get_desc ty with
         | Tunboxed_tuple fields ->
           Misc.Stdlib.Array.of_list_map (fun (_, field) -> Some field) fields
-        | Tmod _ -> Misc.fatal_error "Typeopt: unexpected Tmod"
+        (* Unreachable: [scrape_ty] strips [Tmod]. *)
+        | Tmod _ -> unknown ()
         | Tconstr(p, args, _) ->
           begin match Env.find_type p env with
           | exception Not_found -> unknown ()

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -205,7 +205,7 @@ and type_desc =
       they do for [Tpoly]; generic structural traversals rebuild it; and the
       leaf consumers that classify a runtime representation look through it
       too (the [scrape_ty] functions strip it, so most of them never see one).
-      Do not reintroduce a [fatal_error] on this constructor. *)
+  *)
 
   | Tobject of type_expr * (Path.t * type_expr list) option ref
   (** [Tobject (`f1:t1;...;fn: tn', `None')] ==> [< f1: t1; ...; fn: tn >]

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -193,10 +193,19 @@ and type_desc =
   (** [Tmod (t, bounds)] ==> [t @@ bounds]
       The type [t] with its mode crossing bounded by [bounds]. This is a
       transparent wrapper: it constrains mode crossing only, and erases at
-      runtime. The unboxing and kind-computation paths look through it to [t],
-      as they do for [Tpoly]; generic structural traversals rebuild it; the
-      leaf consumers that classify a type's runtime representation raise,
-      since a [Tmod] is not expected to reach them. *)
+      runtime.
+
+      Two kinds of node share this constructor. Surface nodes come from the
+      first-class modality syntax [(t @@ m)] and always have [externality =
+      max]; the with-bounds engine also manufactures nodes during GADT payload
+      projection, and those may carry a non-max externality.
+
+      Because surface [Tmod]s reach the back end, every consumer must handle
+      them: the unboxing and kind-computation paths look through to [t], as
+      they do for [Tpoly]; generic structural traversals rebuild it; and the
+      leaf consumers that classify a runtime representation look through it
+      too (the [scrape_ty] functions strip it, so most of them never see one).
+      Do not reintroduce a [fatal_error] on this constructor. *)
 
   | Tobject of type_expr * (Path.t * type_expr list) option ref
   (** [Tobject (`f1:t1;...;fn: tn', `None')] ==> [< f1: t1; ...; fn: tn >]

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1327,6 +1327,24 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       in
       let ty = newty (Tof_kind tjkind) in
       ctyp (Ttyp_of_kind jkind) ty
+  | Ptyp_modality (t, modalities) ->
+      Language_extension.assert_enabled ~loc Mode Language_extension.Alpha;
+      let cty = transl_type env ~policy ~row_context mode t in
+      let modalities =
+        Typemode.transl_modalities ~maturity:Language_extension.Stable Immutable
+          modalities
+      in
+      let m = modalities.moda_modalities in
+      (* An identity modality is erased: [(t @@ <identity>)] denotes [t]. This
+         keeps [Tmod] nodes out of types where they would carry no information
+         and would only obstruct unification. *)
+      let ty =
+        if Mode.Modality.Const.is_id m
+        then cty.ctyp_type
+        else
+          newty (Tmod (cty.ctyp_type, Typemode.mod_bounds_of_modality m))
+      in
+      ctyp (Ttyp_modality (cty, modalities)) ty
   | Ptyp_quote t ->
       if not (Language_extension.is_enabled Runtime_metaprogramming) then
         raise (Error (loc, env, Unsupported_extension Runtime_metaprogramming));

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -1328,7 +1328,6 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let ty = newty (Tof_kind tjkind) in
       ctyp (Ttyp_of_kind jkind) ty
   | Ptyp_modality (t, modalities) ->
-      Language_extension.assert_enabled ~loc Mode Language_extension.Alpha;
       let cty = transl_type env ~policy ~row_context mode t in
       let modalities =
         Typemode.transl_modalities ~maturity:Language_extension.Stable Immutable

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -1150,6 +1150,8 @@ let core_type sub ct =
     | Ttyp_newlayout (list, ct) ->
         Ptyp_newlayout (list, sub.typ sub ct)
     | Ttyp_of_kind jkind -> Ptyp_of_kind jkind
+    | Ttyp_modality (ct, m) ->
+        Ptyp_modality (sub.typ sub ct, Typemode.untransl_modalities m)
     | Ttyp_call_pos ->
         Ptyp_extension call_pos_extension
   in

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -70,7 +70,12 @@ let rec batch_add_subst args vals subst =
    links, and [@@unboxed] types. The returned type will therefore be none
    of these cases (except in case of missing cmis). *)
 let scrape_ty env ty =
-  let ty = match get_desc ty with Tpoly (ty, _) -> ty | _ -> ty in
+  (* [Tmod] is a transparent wrapper; strip it as for [Tpoly]. *)
+  let rec strip_mod ty =
+    match get_desc ty with Tmod (ty, _) -> strip_mod ty | _ -> ty
+  in
+  let ty = strip_mod ty in
+  let ty = match get_desc ty with Tpoly (ty, _) -> strip_mod ty | _ -> ty in
   match get_desc ty with
   | Tconstr _ -> (
     let ty' = Ctype.expand_head_opt env ty in
@@ -104,9 +109,8 @@ let classify env ty : classification =
   then Int
   else
     match get_desc ty with
-    | Tvar _ | Tunivar _ -> Any
-    | Tmod _ ->
-      Misc.fatal_error "Vicuna_traverse_typed_tree.classify: unexpected Tmod"
+    (* [Tmod] is unreachable here: [scrape_ty] strips it. [Any] is safe. *)
+    | Tvar _ | Tunivar _ | Tmod _ -> Any
     | Tconstr (p, _args, _abbrev) -> (
       if Path.same p Predef.path_float
       then Float
@@ -182,8 +186,8 @@ let rec value_kind env (subst : value_shape Subst.t) ~visited ~depth ty :
   in
   let scty = scrape_ty env ty in
   match get_desc scty with
-  | Tmod _ ->
-    Misc.fatal_error "Vicuna_traverse_typed_tree.value_kind: unexpected Tmod"
+  (* Unreachable: [scrape_ty] strips [Tmod]. *)
+  | Tmod _ -> Value
   | Tconstr (p, _, _) when Path.same p Predef.path_int -> Imm
   | Tconstr (p, _, _) when Path.same p Predef.path_char -> Imm
   | Tconstr (p, _, _) when Path.same p Predef.path_unit -> Imm


### PR DESCRIPTION
Poor man's first class modalities: an attempt to get 80% of the value at 20% of the cost (see known limitations below).

Makes a modality writable in a type, and converts automatically between the
modality and the mode so that ordinary code does not have to wrap/unwrap anything.

`t @@ m` already existed as an inert `type_desc` constructor (`Tmod`, #6430). This PR gives it
surface syntax, makes it a real type in `Ctype`, and adds *automatic* introduction and
elimination rules.

## Why

`Stdlib.Modes` is this feature, hand-rolled. It is eight modules whose only content
is a one-field unboxed record with a modality on the field:

```ocaml
module Global : sig
  type ('a : value_or_null) t = { global : 'a @@ global } [@@unboxed]
end
```

`Modes.{Portable,Global,Contended,...}.t` has hundreds of use sites that each need to wrap/unwrap it.

## Example of what this PR buys instead

Build a list in the caller's region so the spine costs nothing and dies there, while
the strings it holds are ordinary heap data that outlives it:

```ocaml
  let rec decorate (xs : string Modes.Global.t list @ local)
    : string Modes.Global.t list @ local =
    exclave_
    match xs with
    | [] -> []
    | s :: rest ->
      { Modes.Global.global = s.Modes.Global.global ^ "!" } :: decorate rest
```

With this PR, it becomes:

```ocaml
  let rec decorate (xs : (string @@ global) list @ local)
    : (string @@ global) list @ local =
    exclave_
    match xs with
    | [] -> []
    | s :: rest -> 
      (s ^ "!") :: decorate rest
```

## The rule

A known `t @@ m` never survives at the top level of an actual or an expected type.

- **Actual side.** An expression whose type has `@@ m` at top level unpacks: the type
  becomes `t`, and the mode becomes `m` applied to the expression's mode.
- **Expected side.** An expected type with `@@ m` at top level unpacks: the expression
  is checked against `t`, at `m` applied to the expected mode.

## Known limitations

- You only ever get modalities that you explicitly wrote in an annotation
- There is no general inference of modalities
- It doesn't have algebraic laws, like `t @@ m1 m2 == (t @@ m1) @@ m2`
- It doesn't automatically push modalities into type constructors
- The information used to decide whether to wrap/unwrap the modality makes the type checker more order dependent