### PR TITLE
Add `-omit-leaf-frame-pointers` flag (amd64)

### DIFF
--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -658,7 +658,8 @@ let initial_stack_offset ~num_stack_slots:_ ~contains_calls:_ = 0
 let trap_frame_size_in_bytes = 16
 
 let frame_required ~fun_contains_calls ~fun_num_stack_slots =
-  fp || fun_contains_calls ||
+  (fp && not !Oxcaml_flags.omit_leaf_frame_pointers)
+  || fun_contains_calls ||
   Stack_class.Tbl.exists
     fun_num_stack_slots
     ~f:(fun _stack_class num -> num > 0)

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -191,6 +191,17 @@ let mk_cfg_prologue_shrink_wrap_threshold f =
     Arg.Int f,
     "<n>  Only CFGs with fewer than n blocks will be shrink-wrapped" )
 
+let mk_omit_leaf_frame_pointers f =
+  ( "-omit-leaf-frame-pointers",
+    Arg.Unit f,
+    " Do not set up frames in leaf functions on frame-pointer-enabled builds" )
+
+let mk_no_omit_leaf_frame_pointers f =
+  ( "-no-omit-leaf-frame-pointers",
+    Arg.Unit f,
+    " Set up frames in all functions on frame-pointer-enabled builds (default)"
+  )
+
 let mk_cfg_merge_blocks f =
   ("-cfg-merge-blocks", Arg.Unit f, " Merge equivalent CFG blocks")
 
@@ -1330,6 +1341,8 @@ module type Oxcaml_options = sig
   val cfg_prologue_shrink_wrap : unit -> unit
   val no_cfg_prologue_shrink_wrap : unit -> unit
   val cfg_prologue_shrink_wrap_threshold : int -> unit
+  val omit_leaf_frame_pointers : unit -> unit
+  val no_omit_leaf_frame_pointers : unit -> unit
   val cfg_merge_blocks : unit -> unit
   val no_cfg_merge_blocks : unit -> unit
   val cfg_value_propagation : unit -> unit
@@ -1521,6 +1534,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_cfg_prologue_shrink_wrap F.cfg_prologue_shrink_wrap;
       mk_no_cfg_prologue_shrink_wrap F.no_cfg_prologue_shrink_wrap;
       mk_cfg_prologue_shrink_wrap_threshold F.cfg_prologue_shrink_wrap_threshold;
+      mk_omit_leaf_frame_pointers F.omit_leaf_frame_pointers;
+      mk_no_omit_leaf_frame_pointers F.no_omit_leaf_frame_pointers;
       mk_cfg_merge_blocks F.cfg_merge_blocks;
       mk_no_cfg_merge_blocks F.no_cfg_merge_blocks;
       mk_cfg_value_propagation F.cfg_value_propagation;
@@ -1872,6 +1887,8 @@ module Oxcaml_options_impl = struct
   let no_cfg_prologue_validate = clear' Oxcaml_flags.cfg_prologue_validate
   let cfg_prologue_shrink_wrap = set' Oxcaml_flags.cfg_prologue_shrink_wrap
   let no_cfg_prologue_shrink_wrap = clear' Oxcaml_flags.cfg_prologue_shrink_wrap
+  let omit_leaf_frame_pointers = set' Oxcaml_flags.omit_leaf_frame_pointers
+  let no_omit_leaf_frame_pointers = clear' Oxcaml_flags.omit_leaf_frame_pointers
   let cfg_merge_blocks = set' Oxcaml_flags.cfg_merge_blocks
   let no_cfg_merge_blocks = clear' Oxcaml_flags.cfg_merge_blocks
   let cfg_value_propagation = set' Oxcaml_flags.cfg_value_propagation
@@ -2459,6 +2476,7 @@ module Extra_params = struct
         set' Oxcaml_flags.cfg_eliminate_dead_trap_handlers
     | "cfg-prologue-validate" -> set' Oxcaml_flags.cfg_prologue_validate
     | "cfg-prologue-shrink-wrap" -> set' Oxcaml_flags.cfg_prologue_shrink_wrap
+    | "omit-leaf-frame-pointers" -> set' Oxcaml_flags.omit_leaf_frame_pointers
     | "cfg-merge-blocks" -> set' Oxcaml_flags.cfg_merge_blocks
     | "cfg-value-propagation" -> set' Oxcaml_flags.cfg_value_propagation
     | "cfg-value-propagation-float" ->

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -58,6 +58,8 @@ module type Oxcaml_options = sig
   val cfg_prologue_shrink_wrap : unit -> unit
   val no_cfg_prologue_shrink_wrap : unit -> unit
   val cfg_prologue_shrink_wrap_threshold : int -> unit
+  val omit_leaf_frame_pointers : unit -> unit
+  val no_omit_leaf_frame_pointers : unit -> unit
   val cfg_merge_blocks : unit -> unit
   val no_cfg_merge_blocks : unit -> unit
   val cfg_value_propagation : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -46,6 +46,8 @@ let cfg_prologue_shrink_wrap = ref true     (* -[no-]cfg-prologue-shrink-wrap *)
 let cfg_prologue_shrink_wrap_threshold = ref 16384
                                        (* -cfg-prologue-shrink-wrap-threshold *)
 
+let omit_leaf_frame_pointers = ref false (* -[no-]omit-leaf-frame-pointers *)
+
 let cfg_merge_blocks = ref false        (* -[no]-cfg-merge-blocks *)
 
 let cfg_value_propagation = ref true    (* -[no]-cfg-value-propagation *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -44,6 +44,7 @@ val cfg_eliminate_dead_trap_handlers : bool ref
 val cfg_prologue_validate : bool ref
 val cfg_prologue_shrink_wrap : bool ref
 val cfg_prologue_shrink_wrap_threshold : int ref
+val omit_leaf_frame_pointers : bool ref
 
 val cfg_merge_blocks : bool ref
 


### PR DESCRIPTION
### Change  

On `--enable-frame-pointers` builds, every function sets up a frame because frame_required in
  `backend/amd64/proc.ml` includes an unconditional `fp` term. For very small leaf functions, the `push rbp;
  mov rsp, rbp; ... pop rbp` sequence is a disproportionate fraction of the generated code (_e.g._ a
  two-instruction accessor becomes five instructions).

  This PR guards that term with a new flag, `-omit-leaf-frame-pointers` (with a `-no-` variant and an
  `OCAMLPARAM` key), default off. When enabled, functions that require no frame — no calls, allocations,
  polls, raises, C stubs, probes, or stack slots — no longer set one up. This is the equivalent of
  gcc/clang's `-momit-leaf-frame-pointer`. Non-leaf functions are unaffected: `fun_contains_calls` forces the
  frame. Since `prologue_required`, `frame_size`, and `slot_offset` all derive from `frame_required`, frame
  layout and code generation stay consistent, and no changes are needed in `Cfg_prologue` or the emitter.
  arm64 is untouched (its backend has no frame-pointer support).

  ### Why this does not affect the debugging experience

  - gdb/lldb and DWARF-based unwinding: in a frameless leaf, rsp never moves, so the function-entry
  default CFA (rsp + 8, return address at CFA - 8) is valid at every PC in the function. No CFI
  adjustments are needed (the patch emits none), and unwinders handle this exactly as they do C leaf
  functions compiled without frame pointers.
  - OCaml exception backtraces and GC stack walks: these are driven by frame descriptors recorded at
  call/allocation/raise sites, not by frame pointers. A strict leaf has no such sites, so it can never
  appear as an intermediate frame in these walks; anything that could put a function mid-stack (a call,
  an allocation, a regular raise) already forces a frame.
  - The fp chain itself stays well-formed: rbp remains a reserved register on fp builds and is never
  touched by a frameless leaf, so walkers always see a valid chain — no garbage frames.
  - The one observable change is confined to fp-chain-based profilers (e.g. perf --call-graph=fp): a
  sample whose IP lands inside a frameless leaf attributes it to its grand-caller, skipping the immediate
  caller — the standard, well-understood trade-off of leaf-frame-pointer omission. This is why the flag
  is off by default; DWARF-, LBR-, and Intel PT-based profiling are unaffected.

  🤖 Generated with Claude Code (https://claude.com/claude-code)