### PR TITLE
Peephole: fold add/sub of an immediate into a following lea (amd64)

### DIFF
--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -360,17 +360,18 @@ let fold_delta_into_specific_operation op ~arg_is_folded_reg ~delta =
     if delta < -0x8000_0000 || delta > 0x7FFF_FFFF
     then None
     else begin
-      let multiplier = ref 0 in
-      Array.iteri
-        (fun i is_folded_reg ->
-          if is_folded_reg then multiplier := !multiplier + arg_weights.(i))
-        arg_is_folded_reg;
+      let multiplier =
+        Misc.Stdlib.Array.fold_lefti
+          (fun i multiplier is_folded_reg ->
+            if is_folded_reg then multiplier + arg_weights.(i) else multiplier)
+          0 arg_is_folded_reg
+      in
       (* Only fold if the operation actually reads the register: deleting the
          preceding addition must not shrink the register's live range. *)
-      if !multiplier = 0
+      if multiplier = 0
       then None
       else begin
-        let displ_delta = !multiplier * delta in
+        let displ_delta = multiplier * delta in
         let new_displ = displ + displ_delta in
         if new_displ < -0x8000_0000 || new_displ > 0x7FFF_FFFF
         then None

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -336,6 +336,52 @@ let num_args_addressing = function
   | Iscaled _ -> 1
   | Iindexed2scaled _ -> 2
 
+let fold_delta_into_specific_operation op ~arg_is_folded_reg ~delta =
+  match op with
+  | Ilea addr ->
+    (* The delta is absorbed into the displacement of the addressing
+       expression, multiplied by the total scale with which the folded
+       register contributes to the address. *)
+    let displ, arg_weights =
+      match addr with
+      | Ibased (_, _, displ) -> displ, [||]
+      | Iindexed displ -> displ, [| 1 |]
+      | Iindexed2 displ -> displ, [| 1; 1 |]
+      | Iscaled (scale, displ) -> displ, [| scale |]
+      | Iindexed2scaled (scale, displ) -> displ, [| 1; scale |]
+    in
+    if Array.length arg_is_folded_reg <> Array.length arg_weights
+    then
+      Misc.fatal_errorf
+        "Arch.fold_delta_into_specific_operation: addressing mode expects %d \
+         argument(s) but the instruction has %d"
+        (Array.length arg_weights)
+        (Array.length arg_is_folded_reg);
+    if delta < -0x8000_0000 || delta > 0x7FFF_FFFF
+    then None
+    else begin
+      let multiplier = ref 0 in
+      Array.iteri
+        (fun i is_folded_reg ->
+          if is_folded_reg then multiplier := !multiplier + arg_weights.(i))
+        arg_is_folded_reg;
+      (* Only fold if the operation actually reads the register: deleting the
+         preceding addition must not shrink the register's live range. *)
+      if !multiplier = 0
+      then None
+      else begin
+        let displ_delta = !multiplier * delta in
+        let new_displ = displ + displ_delta in
+        if new_displ < -0x8000_0000 || new_displ > 0x7FFF_FFFF
+        then None
+        else Some (Ilea (offset_addressing addr displ_delta))
+      end
+    end
+  | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isextend32
+  | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32
+  | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ | Illvm_intrinsic _ ->
+    None
+
 let addressing_displacement_for_llvmize addr =
   if not !Clflags.llvm_backend
   then

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -357,26 +357,24 @@ let fold_delta_into_specific_operation op ~arg_is_folded_reg ~delta =
          argument(s) but the instruction has %d"
         (Array.length arg_weights)
         (Array.length arg_is_folded_reg);
-    if delta < -0x8000_0000 || delta > 0x7FFF_FFFF
+    let multiplier =
+      Misc.Stdlib.Array.fold_lefti
+        (fun i multiplier is_folded_reg ->
+          if is_folded_reg then multiplier + arg_weights.(i) else multiplier)
+        0 arg_is_folded_reg
+    in
+    (* Only fold if the operation actually reads the register: deleting the
+       preceding addition must not shrink the register's live range. *)
+    if multiplier = 0
     then None
     else begin
-      let multiplier =
-        Misc.Stdlib.Array.fold_lefti
-          (fun i multiplier is_folded_reg ->
-            if is_folded_reg then multiplier + arg_weights.(i) else multiplier)
-          0 arg_is_folded_reg
-      in
-      (* Only fold if the operation actually reads the register: deleting the
-         preceding addition must not shrink the register's live range. *)
-      if multiplier = 0
+      (* Cannot overflow: the multiplier is at most 9 and [delta] comes from
+         an amd64 instruction immediate, which fits in 32 bits. *)
+      let displ_delta = multiplier * delta in
+      let new_displ = displ + displ_delta in
+      if new_displ < -0x8000_0000 || new_displ > 0x7FFF_FFFF
       then None
-      else begin
-        let displ_delta = multiplier * delta in
-        let new_displ = displ + displ_delta in
-        if new_displ < -0x8000_0000 || new_displ > 0x7FFF_FFFF
-        then None
-        else Some (Ilea (offset_addressing addr displ_delta))
-      end
+      else Some (Ilea (offset_addressing addr displ_delta))
     end
   | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isextend32
   | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -144,6 +144,18 @@ val offset_addressing : addressing_mode -> int -> addressing_mode
 
 val num_args_addressing : addressing_mode -> int
 
+(** [fold_delta_into_specific_operation op ~arg_is_folded_reg ~delta] is used
+    by the peephole optimizer to delete an instruction [r := r + delta] that
+    immediately precedes the instruction carrying [op].
+    [arg_is_folded_reg.(i)] is true iff the [i]-th argument of that
+    instruction is [r]. Returns [Some op'] where [op'], reading the value [r]
+    had before the deleted addition, computes the same result as [op] reading
+    [r + delta]; returns [None] when [op] cannot absorb the delta. Never
+    returns [Some] when [op] does not read [r] (this preserves liveness). *)
+val fold_delta_into_specific_operation :
+  specific_operation -> arg_is_folded_reg:bool array -> delta:int ->
+  specific_operation option
+
 val addressing_displacement_for_llvmize : addressing_mode -> int
 
 val print_addressing :

--- a/backend/arm64/arch.ml
+++ b/backend/arm64/arch.ml
@@ -145,6 +145,10 @@ let num_args_addressing = function
   | Iindexed _ -> 1
   | Ibased _ -> 0
 
+(* No arm64-specific operation can currently absorb a constant addition to one
+   of its source registers. *)
+let fold_delta_into_specific_operation _op ~arg_is_folded_reg:_ ~delta:_ = None
+
 let addressing_displacement_for_llvmize addr =
   if not !Clflags.llvm_backend
   then

--- a/backend/arm64/arch.mli
+++ b/backend/arm64/arch.mli
@@ -109,6 +109,18 @@ val offset_addressing : addressing_mode -> int -> addressing_mode
 
 val num_args_addressing : addressing_mode -> int
 
+(** [fold_delta_into_specific_operation op ~arg_is_folded_reg ~delta] is used
+    by the peephole optimizer to delete an instruction [r := r + delta] that
+    immediately precedes the instruction carrying [op].
+    [arg_is_folded_reg.(i)] is true iff the [i]-th argument of that
+    instruction is [r]. Returns [Some op'] where [op'], reading the value [r]
+    had before the deleted addition, computes the same result as [op] reading
+    [r + delta]; returns [None] when [op] cannot absorb the delta. Never
+    returns [Some] when [op] does not read [r] (this preserves liveness). *)
+val fold_delta_into_specific_operation :
+  specific_operation -> arg_is_folded_reg:bool array -> delta:int ->
+  specific_operation option
+
 val addressing_displacement_for_llvmize : addressing_mode -> int
 
 (* Printing operations and addressing modes *)

--- a/backend/peephole/peephole_rules.ml
+++ b/backend/peephole/peephole_rules.ml
@@ -190,6 +190,65 @@ let fold_intop_imm (cell : Cfg.basic Cfg.instruction DLL.cell) =
     else None
   | _ -> None
 
+(** Logical condition for simplifying the following case:
+    {v
+    <add/sub> imm, r
+    <specific> ...r..., r
+    v}
+
+    to:
+    {v <specific'> ...r..., r v}
+
+    where <specific> is an arch-specific operation that reads and overwrites
+    [r], and <specific'> is <specific> with the constant folded into its
+    addressing expression (e.g. the displacement of an amd64 [lea], as in
+    [popcnt r; dec r; lea 1(r,r), r] where the [dec] can be folded into the
+    [lea] as [-1(r,r)]). The arch-specific rewriting is delegated to
+    [Arch.fold_delta_into_specific_operation]. Deleting the first instruction is
+    sound because the second one overwrites [r], and it does not affect liveness
+    because <specific'> still reads [r]. *)
+let fold_intop_imm_into_specific (cell : Cfg.basic Cfg.instruction DLL.cell) =
+  match U.get_cells cell 2 with
+  | [fst; snd] -> (
+    let fst_val = DLL.value fst in
+    let snd_val = DLL.value snd in
+    let delta =
+      match fst_val.desc with
+      | Op (Intop_imm (Iadd, imm)) -> Some imm
+      | Op (Intop_imm (Isub, imm)) when imm <> min_int -> Some (-imm)
+      | _ -> None
+    in
+    match delta, snd_val.desc with
+    | Some delta, Op (Specific specific)
+      when Array.length fst_val.arg = 1
+           && Array.length fst_val.res = 1
+           && Array.length snd_val.res = 1
+           && U.are_equal_regs
+                (Array.unsafe_get fst_val.arg 0)
+                (Array.unsafe_get fst_val.res 0)
+           && U.are_equal_regs
+                (Array.unsafe_get fst_val.res 0)
+                (Array.unsafe_get snd_val.res 0) -> (
+      let reg = Array.unsafe_get fst_val.res 0 in
+      let arg_is_folded_reg =
+        Array.map (fun arg -> U.are_equal_regs reg arg) snd_val.arg
+      in
+      match
+        Arch.fold_delta_into_specific_operation specific ~arg_is_folded_reg
+          ~delta
+      with
+      | None -> None
+      | Some specific ->
+        let new_cell =
+          DLL.insert_and_return_before snd
+            { snd_val with desc = Cfg.Op (Specific specific) }
+        in
+        DLL.delete_curr fst;
+        DLL.delete_curr snd;
+        Some (U.prev_at_most U.go_back_const new_cell))
+    | _, _ -> None)
+  | _ -> None
+
 let remove_intop_neutral_element (cell : Cfg.basic Cfg.instruction DLL.cell) =
   (* CR-someday xclerc for xclerc: it is not clear we want these rewrites to
      happen here. Indeed, it is probably better to avoid these useless
@@ -241,4 +300,5 @@ let apply cell =
   |> if_none_do remove_overwritten_mov
   |> if_none_do remove_useless_mov
   |> if_none_do fold_intop_imm
+  |> if_none_do fold_intop_imm_into_specific
   |> if_none_do remove_intop_neutral_element

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -63,8 +63,7 @@ let clz32 x = Builtins.int32_clz (Int32_u.to_int32 x)
 clz32:
   movl  %eax, %eax
   lzcnt %rax, %rax
-  addq  $-32, %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  -63(%rax,%rax), %rax
   ret
 |}]
 
@@ -75,8 +74,7 @@ clz32_const:
   movl  $6, %eax
   movl  %eax, %eax
   lzcnt %rax, %rax
-  addq  $-32, %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  -63(%rax,%rax), %rax
   ret
 |}]
 
@@ -195,13 +193,11 @@ ctz_native_const:
 
 (* Population count - int *)
 
-(* CR ttebbi: The -1 should be folded into the lea. *)
 let popcnt_tagged x = Builtins.int_popcnt x
 [%%expect_asm X86_64{|
 popcnt_tagged:
   popcnt %rax, %rax
-  decq  %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  -1(%rax,%rax), %rax
   ret
 |}]
 
@@ -211,8 +207,7 @@ let popcnt_tagged_const () = Builtins.int_popcnt 6
 popcnt_tagged_const:
   movl  $13, %eax
   popcnt %rax, %rax
-  decq  %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  -1(%rax,%rax), %rax
   ret
 |}]
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -366,6 +366,13 @@ module Stdlib = struct
       done;
       !r
 
+    let fold_lefti f x a =
+      let r = ref x in
+      for i = 0 to Array.length a - 1 do
+        r := f i !r (Array.unsafe_get a i)
+      done;
+      !r
+
     let for_alli p a =
       let n = Array.length a in
       let rec loop i =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -290,6 +290,10 @@ module Stdlib : sig
         to have different lengths.
     *)
 
+    val fold_lefti : (int -> 'acc -> 'a -> 'acc) -> 'acc -> 'a array -> 'acc
+    (** [fold_lefti f init a] is like [Array.fold_left] but [f] also takes
+        as parameter the zero-based index of the element *)
+
     val for_alli : (int -> 'a -> bool) -> 'a array -> bool
     (** Same as [Array.for_all] from the standard library, but the
         function is applied with the index of the element as first argument,


### PR DESCRIPTION
As per title; I thought at first it should
handled be in the amd64 peephole rules,
but it looks like it is not too bad to have
it in the CFG rules. I find it easier to reason
over CFG rules, and having the rewrite
earlier in the pipeline is probably beneficial.