### PR TITLE
n-way join: Further performance improvements

### DIFF
--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1332,6 +1332,8 @@ type t =
     bindings : Bindings_in_target_env.t
   }
 
+let create ~joined_envs ~bindings = { joined_envs; bindings }
+
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
 let joined_env t index = Joined_envs.get_nth_joined_env t.joined_envs index
@@ -1916,7 +1918,9 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
           env_extension_for_inverse_relations,
           symbol_projections,
           bindings ) =
-      loop { joined_envs; bindings } equations_to_join
+      loop
+        (create ~joined_envs ~bindings)
+        equations_to_join
         (Name_in_target_env.from_source_env_map
            (Bindings_in_target_env.alias_types_in_target_env bindings))
         Name.Map.empty
@@ -2450,7 +2454,8 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
       let ( equations,
             _env_extension_for_inverse_relations,
             { bindings = bindings_after_extension; _ } ) =
-        n_way_join_round ~n_way_join_type { joined_envs; bindings }
+        n_way_join_round ~n_way_join_type
+          (create ~joined_envs ~bindings)
           concrete_types_to_join alias_types_in_target_env Name.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -108,15 +108,6 @@ end
 (* CR bclement: These should be in [Flambda_algorithms]. *)
 
 module Iterator_utils : sig
-  (* Given two maps [m1] and [m2], calls [f name (find m1 name) (find m2 name)]
-     for each [name] in the intersection of [m1] and [m2]. *)
-  val fold_binary_join :
-    f:(Name.t -> 'a -> 'b -> 'c -> 'c) ->
-    init:'c ->
-    'a Name.Map.t ->
-    'b Name.Map.t ->
-    'c
-
   type ('a, 'b) incremental_join_entry
 
   val fold_incremental_join_entry :
@@ -172,19 +163,6 @@ end = struct
     in
     Name_map_join_iterator.init iterator;
     loop iterator init
-
-  let fold_binary_join ~f ~init a b =
-    (* CR bclement: create an [Name.Map.iterator], get its initial value, and
-       initialise the [Name_map_iterator] (and the [Name_map_join_iterator])
-       from it to avoid double lookups. *)
-    match Name.Map.choose_opt a, Name.Map.choose_opt b with
-    | None, _ | _, None -> init
-    | Some (_, dummy_a), Some (_, dummy_b) ->
-      let iterator_a, recv_a = naive_iterator ~init:a ~dummy:dummy_a in
-      let iterator_b, recv_b = naive_iterator ~init:b ~dummy:dummy_b in
-      let iterator = join_iterators [iterator_a; iterator_b] in
-      fold_iterator iterator ~init ~f:(fun name acc ->
-          f name (Channel.recv recv_a) (Channel.recv recv_b) acc)
 
   type ('a, 'b) incremental_join_entry = ('a * 'b Channel.receiver) list
 
@@ -264,7 +242,7 @@ end = struct
               || (Name.Map.is_empty previous && not (Name.Map.is_empty diff))
             in
             (* CR bclement: we should be able to initialise the iterator with
-               this value (see [fold_binary_join]). *)
+               this value. *)
             match Name.Map.choose_opt current with
             | None -> raise Join_is_empty
             | Some (_, dummy) ->
@@ -374,8 +352,6 @@ module Int_ids_in_env () = struct
   module Simple : sig
     include module type of Id_in_env (Simple) ()
 
-    val name : ?coercion:Coercion.t -> Name.t -> t
-
     val var : ?coercion:Coercion.t -> Variable.t -> t
 
     val pattern_match :
@@ -451,7 +427,6 @@ module Name_in_target_env = Int_ids_in_target_env.Name
 module Simple_in_target_env = Int_ids_in_target_env.Simple
 module Int_ids_in_one_joined_env = Int_ids_from_source_env ()
 module Variable_in_one_joined_env = Int_ids_in_one_joined_env.Variable
-module Name_in_one_joined_env = Int_ids_in_one_joined_env.Name
 module Simple_in_one_joined_env = Int_ids_in_one_joined_env.Simple
 
 module Type_in_env () : sig
@@ -483,17 +458,7 @@ end = struct
     create (TG.alias_type_of kind (simple : Simple_in_target_env.t :> Simple.t))
 end
 
-module Type_in_one_joined_env : sig
-  include module type of Type_in_env ()
-
-  val alias_type_of : K.t -> Simple_in_one_joined_env.t -> t
-end = struct
-  include Type_in_env ()
-
-  let alias_type_of kind simple =
-    create
-      (TG.alias_type_of kind (simple : Simple_in_one_joined_env.t :> Simple.t))
-end
+module Type_in_one_joined_env = Type_in_env ()
 
 (* {1:environments Environments} *)
 
@@ -706,31 +671,12 @@ module Bindings_in_target_env : sig
   val existential_for_these_simples :
     t -> Simples_in_joined_envs.t -> K.t -> Variable_in_target_env.t * t
 
-  (* Assuming that [t] derives from [since], extract the created variables from
-     [t], adding them to [since]. Any information about the created variables
-     besides their kind (in particular, their [definition_in_joined_env]) is
-     forgotten, and they won't appear in the [new_bindings]. *)
-  val forget_definition_of_created_variables : t -> since:t -> t
-
   val fold_imported_variables :
     (Variable_in_one_joined_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
 
   val fold_existential_variables :
     (Variable_in_target_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
-
-  (* These are for the join of env extensions, see [prepare_nested_join]. *)
-
-  val replay_definition_of_aliases_in_target_env :
-    t ->
-    Index.t ->
-    Type_in_one_joined_env.t Name.Map.t ->
-    Type_in_one_joined_env.t Name.Map.t
-
-  val definition_of_local_variables_in_one_joined_env :
-    t -> Index.t -> Type_in_one_joined_env.t Variable_in_target_env.Map.t
 end = struct
-  type coercion_to_canonical_in_target_env = Coercion.t
-
   type t =
     { source_env : Source_env.t;
       existential_for_these_simples :
@@ -741,46 +687,17 @@ end = struct
       imported_variables : K.t Variable_in_one_joined_env.Map.t;
           (* Set of variables that have been imported from at least one of the
              joined environments into the target environment. *)
-      existential_variables : K.t Variable_in_target_env.Map.t;
+      existential_variables : K.t Variable_in_target_env.Map.t
           (* This contains all the existential variables, created during the
              join, that exist in the target environment but not in the source
              environment or in any of the joined environments. *)
-      aliases_of_names_in_joined_envs :
-        coercion_to_canonical_in_target_env Name_in_target_env.Map.t
-        Name_in_one_joined_env.Map.t
-        Index.Map.t;
-          (* For each joined environment and each name in the joined
-             environment, record the set of names in the target environment it
-             is equal to (and the corresponding coercions).
-
-             This is used to implement
-             [replay_definitions_of_aliases_in_target_env] in the join of env
-             extensions, see [prepare_nested_join]. *)
-      equations_for_local_vars :
-        Type_in_one_joined_env.t Variable_in_target_env.Map.t Index.Map.t
-          (* Environment extensions to use in each of the joined environments to
-             replay the definition of local variables.
-
-             This is used to implement
-             [definitions_of_local_variables_in_one_joined_env] in the join of
-             env extensions, see [prepare_nested_join]. *)
     }
 
   let from_source_env source_env =
     { source_env;
       existential_for_these_simples = Simples_in_joined_envs.Map.empty;
       imported_variables = Variable_in_one_joined_env.Map.empty;
-      aliases_of_names_in_joined_envs = Index.Map.empty;
-      equations_for_local_vars = Index.Map.empty;
       existential_variables = Variable_in_target_env.Map.empty
-    }
-
-  let forget_definition_of_created_variables t ~since =
-    (* We still need to record the fact that we created those variables in order
-       to add them to the target environment at the end of the join. *)
-    { since with
-      existential_variables = t.existential_variables;
-      imported_variables = t.imported_variables
     }
 
   let source_env { source_env; _ } = source_env
@@ -799,30 +716,6 @@ end = struct
       then Some var
       else None
 
-  let update_aliases_of_names_in_joined_envs ~f simples aliases_in_target_env =
-    Index.Map.fold
-      (fun index simple aliases_in_target_env ->
-        Simple_in_one_joined_env.pattern_match simple
-          ~const:(fun _ -> aliases_in_target_env)
-          ~name:(fun name ~coercion ->
-            Index.Map.update index
-              (fun aliases ->
-                let aliases =
-                  Name_in_one_joined_env.Map.update name
-                    (fun aliases ->
-                      let aliases =
-                        f coercion
-                          (Option.value ~default:Name_in_target_env.Map.empty
-                             aliases)
-                      in
-                      Some aliases)
-                    (Option.value ~default:Name_in_one_joined_env.Map.empty
-                       aliases)
-                in
-                Some aliases)
-              aliases_in_target_env))
-      simples aliases_in_target_env
-
   let has_existential_for_these_simples t simples =
     Simples_in_joined_envs.Map.find_opt simples t.existential_for_these_simples
 
@@ -837,42 +730,11 @@ end = struct
       let existential_variables =
         Variable_in_target_env.Map.add var kind t.existential_variables
       in
-      let t = { t with existential_variables } in
       let existential_for_these_simples =
         Simples_in_joined_envs.Map.add simples var
           t.existential_for_these_simples
       in
-      (* The following is some bookkeeping so that we know how to replay the
-         definition of existential variables during nested joins (i.e. joins of
-         env extensions); see {!section-extensions}. *)
-      let equations_for_local_vars =
-        (* If the variable is a fresh variable, record it so that we can replay
-           its definition during the join of env extensions. *)
-        Index.Map.update_many
-          (fun _index existentials simple ->
-            let ty = Type_in_one_joined_env.alias_type_of kind simple in
-            let existentials_in_one_joined_env =
-              Variable_in_target_env.Map.add var ty
-                (Option.value ~default:Variable_in_target_env.Map.empty
-                   existentials)
-            in
-            Some existentials_in_one_joined_env)
-          t.equations_for_local_vars simples
-      in
-      let aliases_of_names_in_joined_envs =
-        update_aliases_of_names_in_joined_envs simples
-          t.aliases_of_names_in_joined_envs ~f:(fun coercion aliases ->
-            (* definition ~ coercion(name_in_joined_env) *)
-            Name_in_target_env.Map.add
-              (Name_in_target_env.var var)
-              coercion aliases)
-      in
-      ( var,
-        { t with
-          equations_for_local_vars;
-          existential_for_these_simples;
-          aliases_of_names_in_joined_envs
-        } )
+      var, { t with existential_variables; existential_for_these_simples }
 
   let import_from_all_envs t imported_var kind =
     if Variable_in_one_joined_env.Map.mem imported_var t.imported_variables
@@ -883,33 +745,6 @@ end = struct
           t.imported_variables
       in
       { t with imported_variables }
-
-  let replay_definition_of_aliases_in_target_env t index equations =
-    match Index.Map.find_opt index t.aliases_of_names_in_joined_envs with
-    | None -> equations
-    | Some aliases_in_target_env ->
-      fold_binary_join equations
-        (aliases_in_target_env
-          : Coercion.t Name_in_target_env.Map.t Name_in_one_joined_env.Map.t
-          :> Coercion.t Name_in_target_env.Map.t Name.Map.t)
-        ~init:equations
-        ~f:(fun[@inline] name ty aliases equations ->
-          let kind = Type_in_one_joined_env.kind ty in
-          let name = Name_in_one_joined_env.create name in
-          Name_in_target_env.Map.fold
-            (fun alias coercion equations ->
-              (* alias = coercion(name) *)
-              let ty =
-                Type_in_one_joined_env.alias_type_of kind
-                  (Simple_in_one_joined_env.name ~coercion name)
-              in
-              Name.Map.add (alias : Name_in_target_env.t :> Name.t) ty equations)
-            aliases equations)
-
-  let definition_of_local_variables_in_one_joined_env t index =
-    match Index.Map.find_opt index t.equations_for_local_vars with
-    | None -> Variable_in_target_env.Map.empty
-    | Some existentials -> existentials
 
   let fold_imported_variables f t acc =
     (* CR bclement: iterate in order consistent with the recorded binding
@@ -936,9 +771,6 @@ module Joined_envs : sig
     (TE.t * Type_in_one_joined_env.t Name.Map.t incremental) Index.Map.t -> t
 
   val get_nth_joined_env : t -> Index.t -> TE.t
-
-  val equations_in_nth_joined_env :
-    t -> Index.t -> Type_in_one_joined_env.t Name.Map.t
 
   val keys : t -> Index.Set.t
 
@@ -978,12 +810,6 @@ end = struct
     | Some (one_joined_env, _) -> one_joined_env
     | None ->
       Misc.fatal_errorf "Join does not include environment %a" Index.print index
-
-  let equations_in_nth_joined_env t index =
-    match Index.Map.find_opt index (envs_and_equations t) with
-    | None ->
-      Misc.fatal_errorf "Join does not include environment %a" Index.print index
-    | Some (_, { current; _ }) -> current
 
   let keys t = Index.Map.keys (envs_and_equations t)
 
@@ -1316,6 +1142,11 @@ and import_var_transitive env var =
       else
         let var = Variable_in_target_env.create var in
         import_or_delay_n_way_join_of_concrete_type env var types
+
+let import_name_transitive env name =
+  Name.pattern_match name
+    ~symbol:(fun _ -> env)
+    ~var:(fun var -> import_var_transitive env var)
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -2151,242 +1982,26 @@ let n_way_join_simples t kind simples : _ Or_bottom.t * t =
 
 (** {2:extensions Join of extensions} *)
 
-let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
-  let joined_envs_and_extensions =
-    List.fold_left
-      (fun joined_envs_and_extensions (index, extension) ->
-        let parent_env = Joined_envs.get_nth_joined_env joined_envs index in
-        (* The extension is not guaranteed to still be in canonical form, but we
-           need the equations to be in canonical form to known which variables
-           are actually touched by the extension, so we add it once then cut it.
-
-           Note: we need to cut it as a level, because the meets from
-           [add_env_extension_strict] could add perform nested joins which could
-           add new variables. *)
-        assert (not (TE.is_bottom parent_env));
-        let cut_after = TE.current_scope parent_env in
-        let typing_env = TE.increment_scope parent_env in
-        match
-          ME.use_meet_env_strict ~meet_expanded_head typing_env
-            ~f:(fun meet_env ->
-              ME.add_env_extension ~meet_expanded_head meet_env extension)
-        with
-        | Bottom ->
-          (* We can reach bottom here if the extension was created in a more
-             generic context, but is added in a context where it is no longer
-             reachable. *)
-          joined_envs_and_extensions
-        | Ok env ->
-          let level = TE.cut env ~cut_after in
-          Index.Map.add index (env, level) joined_envs_and_extensions)
-      Index.Map.empty extensions
-  in
-  Index.Map.mapi
-    (fun index (env, diff_level) ->
-      let previous_equations =
-        Joined_envs.equations_in_nth_joined_env joined_envs index
+let n_way_join_env_extension ~n_way_join_type:_ ~meet_expanded_head:_ t
+    extensions : _ Or_bottom.t =
+  (* Don't try to do something complicated for the join of env extensions for
+     now: simply import the content of the env extension if it is the same in
+     all joined environments (in particular, always import env extensions when
+     there is a single joined environment). *)
+  match extensions with
+  | [] -> Bottom
+  | (_, first_extension) :: other_extensions ->
+    if
+      List.for_all
+        (fun (_, ext) ->
+          Name.Map.equal ( == ) (TEE.to_map ext) (TEE.to_map first_extension))
+        other_extensions
+    then
+      let t =
+        TEE.fold first_extension t ~equation:(fun name ty env ->
+            import_type_transitive
+              (import_name_transitive env name)
+              (Type_in_one_joined_env.create ty))
       in
-      let diff_equations =
-        (* Note that we forget the potential newly created variables here, but
-           they could end up in the [Bindings_in_target_env] and cause issue if
-           they are ever used in the parent environment.
-
-           This is fine, however, because we drop any possible information about
-           these variables by calling [forget_definition_of_created_variables]
-           in [n_way_join_env_extension]. *)
-        Type_in_one_joined_env.create_equations (TEL.equations diff_level)
-      in
-      (* The call below to [replay_definition_of_aliases_in_target_env] is only
-         relevant when doing a nested join (join of env extensions); for a
-         toplevel join, [join_aliases] is empty and this does nothing.
-
-         Consider that we first perform the following join (assuming that [x]
-         and [y] exist in the source env and all other variables are local to
-         their joined env) of:
-
-         x: (= a) ; y: (= a)
-
-         and
-
-         x: (= c)
-
-         and that we later perform in the same context the join of nested
-         extensions:
-
-         a: (= d)
-
-         and
-
-         y: (= c)
-
-         We'd like to determine that the join of the extensions is:
-
-         x: (= y)
-
-         If we simply use the incremental join algorithm without taking
-         demotions into account, we'll find the join of [y: (= a)] (from the
-         outer scope in the left environment) and [y: (= c)] (from the nested
-         scope in the right environment) but we don't have a way to determine
-         that [x] and [y] are equal without reprocessing the equations on [x]
-         (in the outer scope, the canonicals for [x] were [(a, c)] so we
-         couldn't even find it from the canonicals of [y] in the inner scope,
-         which are [(d, c)]).
-
-         We do this by keeping track of the aliases of [a] in the joined env
-         ([x] and [y]), and adding back the corresponding demotions (only for
-         the variables that actually have an equation in the extension) to the
-         first extension, yielding:
-
-         x: (= a) ; y: (= a) ; a: (= d)
-
-         This will interact with the equation [y: (= c)] from the extension
-         scope in the right environment, and with the equation [x: (= c)] from
-         the parent scope in the right environment, from which we can deduce the
-         equality between [x] and [y].
-
-         Note that if we instead have:
-
-         x: (Block 0 (= a)) ; y: (Block 0 (= a))
-
-         and
-
-         x: (Block 0 (= c))
-
-         at the toplevel and
-
-         a: (= d)
-
-         and
-
-         y: (Block 0 (= c))
-
-         in the extensions, we will create a single existential variable [ac] at
-         the toplevel.
-
-         When performing the join of the extensions, we will add the equation
-         [ac: (= a)] to the left extension, but we also need to add an equation
-         [ac: (= c)] to the outer scope in the right env (see the call to
-         [defining_equations_of_existentials] below) in order to reprocess
-         [ac]. *)
-      let diff_equations =
-        Bindings_in_target_env.replay_definition_of_aliases_in_target_env
-          bindings index diff_equations
-      in
-      (* We call [union diff previous] rather than [union previous diff] because
-         we want maximum sharing with [diff] (see the computation of
-         [previous_equations] below). *)
-      let current_equations =
-        Name.Map.union_left_biased diff_equations previous_equations
-      in
-      (* Drop variables from the previous level if they get a more precise type
-         in the current level (otherwise they would appear in both $Pi$ and $Δi$
-         and be processed twice -- see [incremental_join]). *)
-      let previous_equations =
-        Name.Map.diff_shared
-          (fun _ _current_ty _diff_ty -> None)
-          current_equations diff_equations
-      in
-      (* This call is only relevant if we are doing a nested join (join of env
-         extensions); for a toplevel join, we don't have existential variables.
-
-         When doing a nested join, we need to make sure that any existential
-         variables created at an earlier level are tracked in the previous level
-         so that they can correctly interact with equations added by
-         [replay_definition_of_aliases_in_target_env] to the [diff_equations] of
-         another joined env (see the call to
-         [replay_definition_of_aliases_in_target_env] above). *)
-      (* CR bclement: it would be more efficient to do an union of iterators to
-         avoid re-processing all the existentials every time. *)
-      let previous_equations =
-        let defining_equations_of_existential_vars =
-          Bindings_in_target_env.definition_of_local_variables_in_one_joined_env
-            bindings index
-        in
-        (* Sometimes we might have already added the defining equation of an
-           existential due to [replay_definition_of_aliases_in_target_env],
-           which is fine. *)
-        Name.Map.union_left_biased previous_equations
-          (Name.var_map
-             (defining_equations_of_existential_vars
-               : Type_in_one_joined_env.t Variable_in_target_env.Map.t
-               :> Type_in_one_joined_env.t Variable.Map.t))
-      in
-      let incremental_equations =
-        { previous = previous_equations;
-          diff = diff_equations;
-          current = current_equations
-        }
-      in
-      env, incremental_equations)
-    joined_envs_and_extensions
-
-let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
-    env_before_extension extensions : _ Or_bottom.t =
-  let joined_equations =
-    try
-      prepare_nested_join ~meet_expanded_head
-        ~bindings:env_before_extension.bindings
-        ~joined_envs:env_before_extension.joined_envs extensions
-    with Misc.Fatal_error ->
-      let bt = Printexc.get_raw_backtrace () in
-      Format.eprintf
-        "\n@[<v 2>%tContext is:%t preparing join of env extensions:@ %a@]\n"
-        Flambda_colours.error Flambda_colours.pop
-        (Index.Map.print TEE.print)
-        (Index.Map.of_list extensions);
-      Printexc.raise_with_backtrace Misc.Fatal_error bt
-  in
-  if Index.Map.is_empty joined_equations
-  then Bottom
-  else
-    try
-      let joined_envs = Joined_envs.create joined_equations in
-      let env_in_extension =
-        create ~joined_envs ~bindings:env_before_extension.bindings
-      in
-      let env_in_extension =
-        join_aliases_into_bindings env_in_extension joined_equations
-      in
-      (* CR-someday bclement: if we create new existential variables during the
-         join of env extensions, we might need additional rounds for
-         completeness (see comment in [n_way_join_simples]) -- in practice one
-         round should be plenty. *)
-      let _env_extension_for_inverse_relations, env_in_extension =
-        n_way_join_round ~n_way_join_type env_in_extension
-          env_in_extension.types_in_joined_envs Variable.Map.empty
-      in
-      (* It is possible for the call to [add_env_extension] in
-         [prepare_nested_join] above to create new variables, which do not exist
-         in the parent environments. These variables must not leak into the
-         [bindings]: since they don't exist in the parent joined environments,
-         we won't be able to find a type for them in the target environment
-         outside of the extension.
-
-         For now, we avoid this problem by simply forgetting about the
-         definition of new variables (in the target env) during the join of
-         extensions. This means that in some cases we might create the same
-         variable twice (e.g. we might create a variable to represent {0, 1}
-         inside an env extension and then another one outside of the env
-         extension), but not incorrect, only slighly inefficient. *)
-      let bindings =
-        Bindings_in_target_env.forget_definition_of_created_variables
-          env_in_extension.bindings ~since:env_before_extension.bindings
-      in
-      Ok
-        ( TEE.from_map (env_in_extension.types_in_target_env :> TG.t Name.Map.t),
-          { env_before_extension with bindings } )
-    with Misc.Fatal_error ->
-      (* Note that we display the env extensions in their current canonical
-         form, which might differ from their form as recorded in the input
-         types. *)
-      let bt = Printexc.get_raw_backtrace () in
-      Format.eprintf "\n@[<v 2>%tContext is:%t join of env extensions:@ %a@]\n"
-        Flambda_colours.error Flambda_colours.pop
-        (Index.Map.print (fun ppf (_, extension) ->
-             TEE.print ppf
-               (TEE.from_map
-                  (extension.current
-                    : Type_in_one_joined_env.t Name.Map.t
-                    :> TG.t Name.Map.t))))
-        joined_equations;
-      Printexc.raise_with_backtrace Misc.Fatal_error bt
+      Ok (first_extension, t)
+    else Ok (TEE.empty, t)

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -362,9 +362,6 @@ module Int_ids_in_env () = struct
     val var : Variable.t -> t
 
     val symbol : Symbol.t -> t
-
-    val pattern_match :
-      t -> var:(Variable.t -> 'a) -> symbol:(Symbol.t -> 'a) -> 'a
   end = struct
     include Id_in_env (Name) ()
 
@@ -373,13 +370,6 @@ module Int_ids_in_env () = struct
 
     let symbol (symbol : Symbol.t) =
       create (Name.symbol (symbol :> Int_ids.Symbol.t))
-
-    let[@inline] pattern_match (t : t) ~var:when_var ~symbol:when_symbol =
-      Name.pattern_match
-        (t :> Name.t)
-        ~var:(fun var -> (when_var [@inlined hint]) (Variable.create var))
-        ~symbol:(fun symbol ->
-          (when_symbol [@inlined hint]) (Symbol.create symbol))
   end
 
   (* CR bclement: In practice, we consider that these must be canonicals in the
@@ -395,12 +385,6 @@ module Int_ids_in_env () = struct
     val symbol : ?coercion:Coercion.t -> Symbol.t -> t
 
     val var : ?coercion:Coercion.t -> Variable.t -> t
-
-    val coercion : t -> Coercion.t
-
-    val without_coercion : t -> t
-
-    val apply_coercion_exn : t -> Coercion.t -> t
 
     val pattern_match :
       t ->
@@ -428,14 +412,6 @@ module Int_ids_in_env () = struct
 
     let var ?coercion var = name ?coercion (Name.var var)
 
-    let coercion t = Simple.coercion (t : t :> Simple.t)
-
-    let without_coercion t =
-      create (Simple.without_coercion (t : t :> Simple.t))
-
-    let apply_coercion_exn t coercion =
-      create (Simple.apply_coercion_exn (t : t :> Simple.t) coercion)
-
     let[@inline always] pattern_match (t : t) ~name:when_name ~const =
       Simple.pattern_match
         (t :> Simple.t)
@@ -457,7 +433,6 @@ end
 
 module Int_ids_in_source_env = Int_ids_in_env ()
 module Variable_in_source_env = Int_ids_in_source_env.Variable
-module Name_in_source_env = Int_ids_in_source_env.Name
 module Symbol_in_source_env = Int_ids_in_source_env.Symbol
 module Simple_in_source_env = Int_ids_in_source_env.Simple
 
@@ -473,13 +448,7 @@ module Int_ids_from_source_env () = struct
   end
 
   module Symbol = Int_ids_in_env.Symbol
-
-  module Name = struct
-    include Int_ids_in_env.Name
-
-    (* See {!section-scope_of_names} *)
-    let from_source_env (name : Name_in_source_env.t) = create (name :> Name.t)
-  end
+  module Name = Int_ids_in_env.Name
 
   module Simple = struct
     include Int_ids_in_env.Simple
@@ -492,7 +461,6 @@ end
 
 module Int_ids_in_target_env = Int_ids_from_source_env ()
 module Variable_in_target_env = Int_ids_in_target_env.Variable
-module Symbol_in_target_env = Int_ids_in_target_env.Symbol
 module Name_in_target_env = Int_ids_in_target_env.Name
 module Simple_in_target_env = Int_ids_in_target_env.Simple
 module Int_ids_in_one_joined_env = Int_ids_from_source_env ()
@@ -739,12 +707,6 @@ module Bindings_in_target_env : sig
      - Existentials represent a specific set of simples in the joined
      environments.
 
-     {b Warning}: Each local variable is defined either as an imported variable
-     or as an existential, but imported variables and existentials are not
-     necessarily represented by local variables in the target environment: there
-     might already be a suitable name in the source environment to represent
-     this imported variable or existential.
-
      For instance, consider that we are doing the join of [x: (= a)] in env 0
      and [x: (= b)] in env 1, where [x] exists in the source environment but not
      [a] and [b]. Then we can use [x] to represent [((0 a) (1 b))], we do not
@@ -760,63 +722,19 @@ module Bindings_in_target_env : sig
 
   val exists_in_target_env : t -> Variable.t -> Variable_in_target_env.t option
 
-  (* Must only be called from the toplevel join, before creating any local
-     variable. *)
-  val add_alias_between_names_in_target_env :
-    t -> K.t -> Name_in_target_env.t -> Simple_in_source_env.t -> t
-
-  (* Record the [name_in_target_env] as the canonical name for this set of
-     simples in joined environments. If there was already a [name_in_target_env]
-     representing that set of simple, an alias is recorded in the
-     [alias_types_in_target_env] instead.
-
-     Must only be called from the toplevel join, before creating any local
-     variable. *)
-  val add_existential_for_these_simples :
-    t ->
-    name_in_target_env:Name_in_target_env.t ->
-    Simples_in_joined_envs.t ->
-    K.t ->
-    t
-
-  (* Record the [name_in_source_env] as the canonical name for this variable
-     (whenever it appears in any joined environment). If there was already a
-     [name_in_source_env] representing the variable, an alias is recorded in the
-     [alias_types_in_target_env] instead.
-
-     Must only be called from the toplevel join, before creating any local
-     variable. *)
-  val add_imported_var :
-    t ->
-    name_in_target_env:Name_in_target_env.t ->
-    coercion_to_name_in_source_env:Coercion.t ->
-    Variable_in_one_joined_env.t ->
-    K.t ->
-    t
-
   (* Return the (unique across the whole join) name to be used to represent an
-     imported variable.
-
-     This is usually the provided variable itself, unless a name for it was
-     recorded by [add_imported_var]. *)
+     imported variable. *)
   val import_from_all_envs :
-    t -> Variable_in_one_joined_env.t -> K.t -> Simple_in_target_env.t * t
+    t -> Variable_in_one_joined_env.t -> K.t -> Variable_in_target_env.t * t
 
   (* Return the (unique across the whole join) name to be used to represent this
-     set of simples in joined environments.
-
-     This is either a name that has been recorded with
-     [add_existential_for_these_simples], or an existential local variable
-     created to represent it. *)
+     set of simples in joined environments. *)
   val existential_for_these_simples :
-    t -> Simples_in_joined_envs.t -> K.t -> Simple_in_target_env.t * t
+    t -> Simples_in_joined_envs.t -> K.t -> Variable_in_target_env.t * t
 
   type definition_in_joined_envs =
     | Imported_var of Variable_in_one_joined_env.t * K.t
     | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
-  val alias_types_in_target_env :
-    t -> Type_in_target_env.t Name_in_target_env.Map.t
 
   (* Assuming that [t] derives from [since], returns the definitions of local
      variables that have been added to [t] after [since]. *)
@@ -851,26 +769,20 @@ end = struct
 
   type t =
     { source_env : Source_env.t;
-      alias_types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
-      (* Aliases shared across all the joined environments. *)
       existential_for_these_simples :
-        Simple_in_target_env.t Simples_in_joined_envs.Map.t;
+        Variable_in_target_env.t Simples_in_joined_envs.Map.t;
       (* Maps a set of [simples] in joined environments to the (unique across
          the whole join) name used to represent this exact set of simples in the
          target environment. *)
       imported_variables :
-        Simple_in_target_env.t Variable_in_one_joined_env.Map.t;
+        Variable_in_target_env.t Variable_in_one_joined_env.Map.t;
       (* Maps a local variable (a variable that exists in at least one joined
-         environment) to its (unique across the whole join) name in the target
-         environment.
+         environment) to its name in the target environment.
 
-         This same name is used for all the joined environments where the
-         variable exists.
+         The underlying variable used in the joined and target environments is
+         the same, only the type-level metadata changes.
 
-         {b Note}: This is not necessarily the variable itself. For instance, if
-         there is a variable [x] in the source environment that gets demoted to
-         a local variable [y] in all joined environments, then [x] might be used
-         as a name for [y]. *)
+         CR bclement: This should just be a set now. *)
       created_variables : K.t Variable_in_target_env.Map.t;
       (* This contains all the local variables (existentials or imported) that
          exist in the target environment but not in the source environment. *)
@@ -899,7 +811,6 @@ end = struct
 
   let from_source_env source_env =
     { source_env;
-      alias_types_in_target_env = Name_in_target_env.Map.empty;
       existential_for_these_simples = Simples_in_joined_envs.Map.empty;
       imported_variables = Variable_in_one_joined_env.Map.empty;
       aliases_of_names_in_joined_envs = Index.Map.empty;
@@ -907,40 +818,6 @@ end = struct
       equations_for_local_vars = Index.Map.empty;
       created_variables = Variable_in_target_env.Map.empty
     }
-
-  let add_alias t kind ~canonical_element:canonical_element_with_coercion
-      ~name_to_be_demoted ~coercion_to_name_to_be_demoted =
-    let canonical_element =
-      canonical_element_with_coercion |> Simple_in_target_env.without_coercion
-    in
-    let coercion_from_canonical_element_to_name_to_be_demoted =
-      Coercion.compose_exn
-        (Simple_in_target_env.coercion canonical_element_with_coercion)
-        ~then_:coercion_to_name_to_be_demoted
-    in
-    if
-      Simple_in_target_env.equal canonical_element
-        (Simple_in_target_env.name name_to_be_demoted)
-    then
-      if Coercion.is_id coercion_from_canonical_element_to_name_to_be_demoted
-      then t
-      else
-        Misc.fatal_errorf
-          "Cannot add alias of %a to itself with a non-identity coercion@ %a"
-          Simple_in_target_env.print canonical_element Coercion.print
-          (Coercion.inverse
-             coercion_from_canonical_element_to_name_to_be_demoted)
-    else
-      let alias_types_in_target_env =
-        Name_in_target_env.Map.add name_to_be_demoted
-          (Type_in_target_env.alias_type_of kind
-             (Simple_in_target_env.apply_coercion_exn canonical_element
-                coercion_from_canonical_element_to_name_to_be_demoted))
-          t.alias_types_in_target_env
-      in
-      { t with alias_types_in_target_env }
-
-  let alias_types_in_target_env t = t.alias_types_in_target_env
 
   let new_bindings t ~since =
     Name_in_target_env.Map.diff_shared
@@ -954,13 +831,10 @@ end = struct
 
   let source_env { source_env; _ } = source_env
 
-  let is_local_variable { created_variables; _ } name =
-    Name_in_target_env.pattern_match name
-      ~symbol:(fun _ -> None)
-      ~var:(fun var ->
-        if Variable_in_target_env.Map.mem var created_variables
-        then Some var
-        else None)
+  let is_local_variable { created_variables; _ } var =
+    if Variable_in_target_env.Map.mem var created_variables
+    then Some var
+    else None
 
   let exists_in_target_env t var =
     match Source_env.exists_in_source_env (source_env t) var with
@@ -971,13 +845,6 @@ end = struct
       if Variable_in_target_env.Map.mem var t.created_variables
       then Some var
       else None
-
-  let add_alias_between_names_in_target_env t kind name canonical =
-    assert (not (Name_in_target_env.Map.mem name t.alias_types_in_target_env));
-    assert (not (Name_in_target_env.Map.mem name t.definitions_in_joined_envs));
-    add_alias t kind ~name_to_be_demoted:name
-      ~coercion_to_name_to_be_demoted:Coercion.id
-      ~canonical_element:(Simple_in_target_env.from_source_env canonical)
 
   let update_aliases_of_names_in_joined_envs ~f simples aliases_in_target_env =
     Index.Map.fold
@@ -1003,29 +870,24 @@ end = struct
               aliases_in_target_env))
       simples aliases_in_target_env
 
-  let record_definition_for t ~name_in_target_env
-      ~coercion_to_name_in_target_env definition =
+  let record_definition_for t ~var_in_target_env definition =
     (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
     let definitions_in_joined_envs =
-      Name_in_target_env.Map.add name_in_target_env definition
-        t.definitions_in_joined_envs
-    in
-    let canonical_in_target_env =
-      Simple_in_target_env.name
-        ~coercion:(Coercion.inverse coercion_to_name_in_target_env)
-        name_in_target_env
+      Name_in_target_env.Map.add
+        (Name_in_target_env.var var_in_target_env)
+        definition t.definitions_in_joined_envs
     in
     match definition with
     | Imported_var (imported_var, _kind) ->
       let imported_variables =
-        Variable_in_one_joined_env.Map.add imported_var canonical_in_target_env
+        Variable_in_one_joined_env.Map.add imported_var var_in_target_env
           t.imported_variables
       in
-      ( canonical_in_target_env,
+      ( var_in_target_env,
         { t with imported_variables; definitions_in_joined_envs } )
     | These_canonicals (simples, kind) ->
       let existential_for_these_simples =
-        Simples_in_joined_envs.Map.add simples canonical_in_target_env
+        Simples_in_joined_envs.Map.add simples var_in_target_env
           t.existential_for_these_simples
       in
       (* The following is some bookkeeping so that we know how to replay the
@@ -1034,16 +896,12 @@ end = struct
       let equations_for_local_vars =
         (* If the variable is a fresh variable, record it so that we can replay
            its definition during the join of env extensions. *)
-        match is_local_variable t name_in_target_env with
+        match is_local_variable t var_in_target_env with
         | None -> t.equations_for_local_vars
         | Some var ->
           Index.Map.update_many
             (fun _index existentials simple ->
-              let ty =
-                Type_in_one_joined_env.alias_type_of kind
-                  (Simple_in_one_joined_env.apply_coercion_exn simple
-                     coercion_to_name_in_target_env)
-              in
+              let ty = Type_in_one_joined_env.alias_type_of kind simple in
               let existentials_in_one_joined_env =
                 Variable_in_target_env.Map.add var ty
                   (Option.value ~default:Variable_in_target_env.Map.empty
@@ -1055,16 +913,12 @@ end = struct
       let aliases_of_names_in_joined_envs =
         update_aliases_of_names_in_joined_envs simples
           t.aliases_of_names_in_joined_envs ~f:(fun coercion aliases ->
-            (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
             (* definition ~ coercion(name_in_joined_env) *)
-            let coercion_from_joined_to_target =
-              Coercion.compose_exn coercion
-                ~then_:coercion_to_name_in_target_env
-            in
-            Name_in_target_env.Map.add name_in_target_env
-              coercion_from_joined_to_target aliases)
+            Name_in_target_env.Map.add
+              (Name_in_target_env.var var_in_target_env)
+              coercion aliases)
       in
-      ( canonical_in_target_env,
+      ( var_in_target_env,
         { t with
           equations_for_local_vars;
           existential_for_these_simples;
@@ -1086,9 +940,7 @@ end = struct
       Variable_in_target_env.Map.add var kind t.created_variables
     in
     let t = { t with created_variables } in
-    let name_in_target_env = Name_in_target_env.var var in
-    record_definition_for t ~name_in_target_env
-      ~coercion_to_name_in_target_env:Coercion.id definition
+    record_definition_for t ~var_in_target_env:var definition
 
   let is_imported_from_all_joined_envs t var =
     Variable_in_one_joined_env.Map.find_opt var t.imported_variables
@@ -1102,46 +954,6 @@ end = struct
       is_imported_from_all_joined_envs t imported_var
     | These_canonicals (simples, _kind) ->
       has_existential_for_these_simples t simples
-
-  let add_name_for_definition t ~name_in_target_env
-      ~coercion_to_name_in_source_env definition =
-    (* name_in_target_env ~ coercion_to_name_in_source_env(definition) *)
-    match existing_canonical_for t definition with
-    | None ->
-      let _, t =
-        record_definition_for t ~name_in_target_env
-          ~coercion_to_name_in_target_env:coercion_to_name_in_source_env
-          definition
-      in
-      t
-    | Some existing_canonical ->
-      (* This can happen if multiple variables in the source environment are
-         demoted to the same local variable in all environments, in which case
-         we record an alias between these names instead.
-
-         Note that we might add aliases in the "wrong" order w.r.t binding times
-         here, but it is not a problem -- we only care that we have a single
-         definition for each name during the join. We don't have to use the
-         proper binding time ordering; the typing env will take care of giving
-         the proper orientation to aliases after the join is complete. *)
-      let kind =
-        match definition with
-        | Imported_var (_, kind) | These_canonicals (_, kind) -> kind
-      in
-      add_alias t kind ~canonical_element:existing_canonical
-        ~name_to_be_demoted:name_in_target_env
-        ~coercion_to_name_to_be_demoted:coercion_to_name_in_source_env
-
-  let add_existential_for_these_simples t ~name_in_target_env simples kind =
-    add_name_for_definition t ~name_in_target_env
-      ~coercion_to_name_in_source_env:Coercion.id
-      (These_canonicals (simples, kind))
-
-  let add_imported_var t ~name_in_target_env ~coercion_to_name_in_source_env
-      imported_var kind =
-    add_name_for_definition t ~name_in_target_env
-      ~coercion_to_name_in_source_env
-      (Imported_var (imported_var, kind))
 
   let get_or_create_canonical_for t definition =
     match existing_canonical_for t definition with
@@ -1318,10 +1130,12 @@ type 'a join_arg = env_id * 'a
 
 type t =
   { joined_envs : Joined_envs.t;
+    types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
   }
 
-let create ~joined_envs ~bindings = { joined_envs; bindings }
+let create ~joined_envs ~bindings =
+  { joined_envs; types_in_target_env = Name_in_target_env.Map.empty; bindings }
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1335,9 +1149,8 @@ type canonical_in_target_env =
   | Import_from_all_joined_envs of Variable_in_one_joined_env.t * Coercion.t
   | Existential_for_these_simples
 
-let get_canonical_in_target_env ~bindings ~joined_envs canonicals_in_joined_envs
-    =
-  let source_env = Bindings_in_target_env.source_env bindings in
+let get_canonical_in_target_env env canonicals_in_joined_envs =
+  let source_env = Bindings_in_target_env.source_env env.bindings in
   match
     Source_env.candidate_canonical_in_source_env source_env
       canonicals_in_joined_envs
@@ -1363,7 +1176,7 @@ let get_canonical_in_target_env ~bindings ~joined_envs canonicals_in_joined_envs
   | Latest_bound_source_var (var, coercion) ->
     let latest_simple = Simple_in_source_env.var var ~coercion in
     if
-      Joined_envs.equal_in_all_joined_envs joined_envs
+      Joined_envs.equal_in_all_joined_envs env.joined_envs
         (Simple_in_one_joined_env.from_source_env latest_simple)
         canonicals_in_joined_envs
     then Canonical_in_source_env latest_simple
@@ -1437,21 +1250,6 @@ let fold_incremental_join_in_target_env equations_to_join ~exists_in_target_env
         ~var:(fun var ->
           match exists_in_target_env var with
           | None -> acc
-          | Some var_in_target_env ->
-            f (Name_in_target_env.var var_in_target_env) join_entry acc)
-        ~symbol:(fun symbol ->
-          (* See {!section-lifted_constants} *)
-          let symbol = Symbol_in_target_env.create symbol in
-          let name = Name_in_target_env.symbol symbol in
-          f name join_entry acc))
-
-let fold_incremental_join_in_source_env equations_to_join ~exists_in_source_env
-    ~init ~f =
-  fold_incremental_join equations_to_join ~init ~f:(fun name join_entry acc ->
-      Name.pattern_match name
-        ~var:(fun var ->
-          match exists_in_source_env var with
-          | None -> acc
           | Some var_in_target_env -> f var_in_target_env join_entry acc)
         ~symbol:(fun _symbol ->
           (* If [name] is that of a lifted constant symbol generated during one
@@ -1475,60 +1273,65 @@ let fold_incremental_join_in_source_env equations_to_join ~exists_in_source_env
              fine with dropping the equation. *)
           acc))
 
+let add_equation env name ty =
+  assert (not (Name_in_target_env.Map.mem name env.types_in_target_env));
+  let types_in_target_env =
+    Name_in_target_env.Map.add name ty env.types_in_target_env
+  in
+  { env with types_in_target_env }
+
 (* This function is responsible for splitting the [equations_to_join] between
    those that are demotions in all joined environments, that are replayed in the
-   target environment by adding to the bindings, and the rest, that are expanded
-   to equations on concrete types that will be joined later.
+   target environment in the [types_in_target_env], and the rest, that are
+   expanded to equations on concrete types to be joined later.
 
    Note that we only care about names that have new types in all of the joined
    environments, otherwise the join can never be more precise than what we had
    initially. We also only care about names that exist in the target
-   environments; other names will be imported automatically during the join of
-   types and only if they are reachable.
-
-   {b Note}: This function is only used during a top-level join. For nested
-   joins, it would be incorrect to record aliases into the bindings (since they
-   are only valid during the env extension, and the bindings must be valid for
-   the whole join); [join_aliases_in_env_extension] is used instead. *)
-let join_aliases_into_bindings ~joined_envs ~bindings equations_to_join =
-  fold_incremental_join_in_source_env equations_to_join
-    ~exists_in_source_env:
-      (Source_env.exists_in_source_env
-         (Bindings_in_target_env.source_env bindings))
-    ~init:(Name_in_target_env.Map.empty, bindings)
-    ~f:(fun var join_entry (equations_to_join, bindings) ->
-      let name =
-        Name_in_target_env.from_source_env (Name_in_source_env.var var)
-      in
+   environment; other names will be imported automatically during the join of
+   types and only if they are reachable. *)
+let join_aliases_into_bindings env equations_to_join =
+  fold_incremental_join_in_target_env equations_to_join
+    ~exists_in_target_env:
+      (Bindings_in_target_env.exists_in_target_env env.bindings)
+    ~init:(Name_in_target_env.Map.empty, env)
+    ~f:(fun var join_entry (equations_to_join, env) ->
       match get_types_in_joined_envs join_entry with
       | Bottom -> Misc.fatal_error "Unexpected bottom during join"
       | Ok (No_alias_in_some_env types) ->
         let equations_to_join =
-          Name_in_target_env.Map.add name types equations_to_join
+          Name_in_target_env.Map.add
+            (Name_in_target_env.var var)
+            types equations_to_join
         in
-        equations_to_join, bindings
+        equations_to_join, env
       | Ok (Equals_in_all_envs (canonicals, kind)) -> (
-        match get_canonical_in_target_env ~bindings ~joined_envs canonicals with
+        let[@local] add_equals_in_target_env env canonical =
+          let env =
+            add_equation env
+              (Name_in_target_env.var var)
+              (Type_in_target_env.alias_type_of kind canonical)
+          in
+          equations_to_join, env
+        in
+        match get_canonical_in_target_env env canonicals with
         | Canonical_in_source_env canonical ->
-          let bindings =
-            Bindings_in_target_env.add_alias_between_names_in_target_env
-              bindings kind name canonical
+          add_equals_in_target_env env
+            (Simple_in_target_env.from_source_env canonical)
+        | Import_from_all_joined_envs (imported_var, coercion) ->
+          let imported_var, bindings =
+            Bindings_in_target_env.import_from_all_envs env.bindings
+              imported_var kind
           in
-          equations_to_join, bindings
-        | Import_from_all_joined_envs (var, coercion) ->
-          (* name = coercion(var) *)
-          let bindings =
-            Bindings_in_target_env.add_imported_var bindings
-              ~name_in_target_env:name ~coercion_to_name_in_source_env:coercion
-              var kind
-          in
-          equations_to_join, bindings
+          let simple = Simple_in_target_env.var ~coercion imported_var in
+          add_equals_in_target_env { env with bindings } simple
         | Existential_for_these_simples ->
-          let bindings =
-            Bindings_in_target_env.add_existential_for_these_simples bindings
-              ~name_in_target_env:name canonicals kind
+          let existential_var, bindings =
+            Bindings_in_target_env.existential_for_these_simples env.bindings
+              canonicals kind
           in
-          equations_to_join, bindings))
+          let simple = Simple_in_target_env.var existential_var in
+          add_equals_in_target_env { env with bindings } simple))
 
 let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     env_extension name relation ~scrutinee =
@@ -1719,12 +1522,12 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
     ty, inverse_relations
 
 let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
-    types_in_target_env inverse_relations =
+    inverse_relations =
   Name_in_target_env.Map.fold
-    (fun name types (types_in_target_env, inverse_relations, t) ->
+    (fun name types (inverse_relations, t) ->
       if
         Flambda_features.check_light_invariants ()
-        && Name_in_target_env.Map.mem name types_in_target_env
+        && Name_in_target_env.Map.mem name t.types_in_target_env
       then
         Misc.fatal_errorf
           "Processing join of %a but we already have a type for it."
@@ -1735,7 +1538,7 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
             : (Index.t * Type_in_one_joined_env.t) list
             :> (Index.t * TG.t) list)
       with
-      | Unknown, t -> types_in_target_env, inverse_relations, t
+      | Unknown, t -> inverse_relations, t
       | Known ty, t ->
         let exists_in_all_joined_envs =
           Joined_envs.exists_in_all_joined_envs t.joined_envs types
@@ -1750,11 +1553,8 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
           else ty, inverse_relations
         in
         let ty = Type_in_target_env.create ty in
-        ( Name_in_target_env.Map.add name ty types_in_target_env,
-          inverse_relations,
-          t ))
-    equations_to_join
-    (types_in_target_env, inverse_relations, t)
+        inverse_relations, add_equation t name ty)
+    equations_to_join (inverse_relations, t)
 
 (** {2:n-way-join Cut and n-way join} *)
 
@@ -1835,9 +1635,9 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
       Bindings_in_target_env.from_source_env (Source_env.create source_tenv)
     in
     let joined_envs = Joined_envs.create equations_to_join in
-    let concrete_equations_to_join, bindings =
-      join_aliases_into_bindings ~joined_envs ~bindings:empty_bindings
-        equations_to_join
+    let empty_env = create ~joined_envs ~bindings:empty_bindings in
+    let concrete_equations_to_join, env =
+      join_aliases_into_bindings empty_env equations_to_join
     in
     let equations_for_bindings bindings ~since =
       let new_bindings = Bindings_in_target_env.new_bindings bindings ~since in
@@ -1854,14 +1654,12 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
     in
     let equations_to_join =
       Name_in_target_env.Map.disjoint_union concrete_equations_to_join
-        (equations_for_bindings bindings ~since:empty_bindings)
+        (equations_for_bindings env.bindings ~since:empty_bindings)
     in
-    let rec loop t equations_to_join concrete_types_in_target_env
-        inverse_relations =
+    let rec loop t equations_to_join inverse_relations =
       let bindings_before_this_round = t.bindings in
-      let types_in_target_env, inverse_relations, t =
-        n_way_join_round ~n_way_join_type t equations_to_join
-          concrete_types_in_target_env inverse_relations
+      let inverse_relations, t =
+        n_way_join_round ~n_way_join_type t equations_to_join inverse_relations
       in
       let new_equations_to_join =
         equations_for_bindings t.bindings ~since:bindings_before_this_round
@@ -1884,21 +1682,17 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
              accessible.
 
              CR-someday bclement: perform CSE for symbol projections? *)
-          types_in_target_env,
+          t.types_in_target_env,
           env_extension_for_inverse_relations,
           n_way_join_symbol_projections t symbol_projections_to_join,
           t.bindings )
-      else loop t new_equations_to_join types_in_target_env inverse_relations
+      else loop t new_equations_to_join inverse_relations
     in
     let ( equations,
           env_extension_for_inverse_relations,
           symbol_projections,
           bindings ) =
-      loop
-        (create ~joined_envs ~bindings)
-        equations_to_join
-        (Bindings_in_target_env.alias_types_in_target_env bindings)
-        Variable.Map.empty
+      loop env equations_to_join Variable.Map.empty
     in
     let target_env =
       Bindings_in_target_env.fold_created_variables
@@ -2162,18 +1956,22 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
   let join_analysis = Analysis.create ~external_ids ~joined_envs bindings in
   target_env, join_analysis
 
-let n_way_join_canonicals ~bindings ~joined_envs kind simples =
-  match get_canonical_in_target_env ~bindings ~joined_envs simples with
+let n_way_join_canonicals env kind simples =
+  match get_canonical_in_target_env env simples with
   | Canonical_in_source_env simple ->
-    Simple_in_target_env.from_source_env simple, bindings
-  | Import_from_all_joined_envs (var, coercion) ->
-    let simple, bindings =
-      Bindings_in_target_env.import_from_all_envs bindings var kind
+    Simple_in_target_env.from_source_env simple, env
+  | Import_from_all_joined_envs (imported_var, coercion) ->
+    let imported_var, bindings =
+      Bindings_in_target_env.import_from_all_envs env.bindings imported_var kind
     in
-    let simple = Simple_in_target_env.apply_coercion_exn simple coercion in
-    simple, bindings
+    let simple = Simple_in_target_env.var ~coercion imported_var in
+    simple, { env with bindings }
   | Existential_for_these_simples ->
-    Bindings_in_target_env.existential_for_these_simples bindings simples kind
+    let existential_var, bindings =
+      Bindings_in_target_env.existential_for_these_simples env.bindings simples
+        kind
+    in
+    Simple_in_target_env.var existential_var, { env with bindings }
 
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
@@ -2184,12 +1982,10 @@ let n_way_join_simples t kind simples : _ Or_bottom.t * t =
        can be re-processed in the current env extension if applicable (if a
        local variable is created while processing an env extension, we currently
        lose any equation that the extension had for that variable). *)
-    let canonical_in_target_env, bindings =
-      n_way_join_canonicals ~bindings:t.bindings ~joined_envs:t.joined_envs kind
-        canonicals_in_joined_envs
+    let canonical_in_target_env, t =
+      n_way_join_canonicals t kind canonicals_in_joined_envs
     in
-    ( Ok (canonical_in_target_env : Simple_in_target_env.t :> Simple.t),
-      { t with bindings } )
+    Ok (canonical_in_target_env : Simple_in_target_env.t :> Simple.t), t
 
 (** {2:extensions Join of extensions} *)
 
@@ -2362,48 +2158,13 @@ let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
       env, incremental_equations)
     joined_envs_and_extensions
 
-(* This is similar to [join_aliases_into_bindings], except that when doing a
-   join of env extensions, we cannot just accumulate aliases into the [bindings]
-   because any demotion we process is local *just* to the current env extension,
-   and stops being valid once we leave the extension.
-
-   Instead, we just accumulate the (local) alias equations directly. *)
-let join_aliases_in_env_extension ~joined_envs ~bindings equations_to_join =
-  fold_incremental_join_in_target_env equations_to_join
-    ~exists_in_target_env:(Bindings_in_target_env.exists_in_target_env bindings)
-    ~init:(Name_in_target_env.Map.empty, Name_in_target_env.Map.empty, bindings)
-    ~f:(fun
-        name
-        join_entry
-        (equations_in_target_env, equations_to_join, bindings)
-      ->
-      match get_types_in_joined_envs join_entry with
-      | Bottom -> Misc.fatal_error "Unexpected bottom during join"
-      | Ok (No_alias_in_some_env types) ->
-        let equations_to_join =
-          Name_in_target_env.Map.add name types equations_to_join
-        in
-        equations_in_target_env, equations_to_join, bindings
-      | Ok (Equals_in_all_envs (canonicals, kind)) ->
-        (* CR-someday bclement: If this creates new variables, they will not be
-           processed inside the env extension (see also the comment in
-           [n_way_join_simples]). *)
-        let canonical, bindings =
-          n_way_join_canonicals ~bindings ~joined_envs kind canonicals
-        in
-        let equations_in_target_env =
-          Name_in_target_env.Map.add name
-            (Type_in_target_env.alias_type_of kind canonical)
-            equations_in_target_env
-        in
-        equations_in_target_env, equations_to_join, bindings)
-
-let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
-    _ Or_bottom.t =
+let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
+    env_before_extension extensions : _ Or_bottom.t =
   let joined_equations =
     try
-      prepare_nested_join ~meet_expanded_head ~bindings:t.bindings
-        ~joined_envs:t.joined_envs extensions
+      prepare_nested_join ~meet_expanded_head
+        ~bindings:env_before_extension.bindings
+        ~joined_envs:env_before_extension.joined_envs extensions
     with Misc.Fatal_error ->
       let bt = Printexc.get_raw_backtrace () in
       Format.eprintf
@@ -2418,20 +2179,19 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
   else
     try
       let joined_envs = Joined_envs.create joined_equations in
-      let alias_types_in_target_env, concrete_types_to_join, bindings =
-        join_aliases_in_env_extension ~joined_envs ~bindings:t.bindings
-          joined_equations
+      let env_in_extension =
+        create ~joined_envs ~bindings:env_before_extension.bindings
+      in
+      let concrete_types_to_join, env_in_extension =
+        join_aliases_into_bindings env_in_extension joined_equations
       in
       (* CR-someday bclement: if we create new existential variables during the
          join of env extensions, we might need additional rounds for
          completeness (see comment in [n_way_join_simples]) -- in practice one
          round should be plenty. *)
-      let ( equations,
-            _env_extension_for_inverse_relations,
-            { bindings = bindings_after_extension; _ } ) =
-        n_way_join_round ~n_way_join_type
-          (create ~joined_envs ~bindings)
-          concrete_types_to_join alias_types_in_target_env Variable.Map.empty
+      let _env_extension_for_inverse_relations, env_in_extension =
+        n_way_join_round ~n_way_join_type env_in_extension
+          concrete_types_to_join Variable.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in
          [prepare_nested_join] above to create new variables, which do not exist
@@ -2448,14 +2208,11 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
          extension), but not incorrect, only slighly inefficient. *)
       let bindings =
         Bindings_in_target_env.forget_definition_of_created_variables
-          bindings_after_extension ~since:t.bindings
+          env_in_extension.bindings ~since:env_before_extension.bindings
       in
       Ok
-        ( TEE.from_map
-            (equations
-              : Type_in_target_env.t Name_in_target_env.Map.t
-              :> TG.t Name.Map.t),
-          { t with bindings } )
+        ( TEE.from_map (env_in_extension.types_in_target_env :> TG.t Name.Map.t),
+          { env_before_extension with bindings } )
     with Misc.Fatal_error ->
       (* Note that we display the env extensions in their current canonical
          form, which might differ from their form as recorded in the input

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1964,6 +1964,10 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
   target_env, join_analysis
 
 (* Exposed to the outside world with a different type *)
+let import_type env ty =
+  import_type_transitive env (Type_in_one_joined_env.create ty)
+
+(* Exposed to the outside world with a different type *)
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
   | [] -> Bottom, t

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1463,13 +1463,28 @@ let fold_incremental_join_in_source_env equations_to_join ~exists_in_source_env
         ~var:(fun var ->
           match exists_in_source_env var with
           | None -> acc
-          | Some var_in_target_env ->
-            f (Name_in_source_env.var var_in_target_env) join_entry acc)
-        ~symbol:(fun symbol ->
-          (* See {!section-lifted_constants} *)
-          let symbol = Symbol_in_source_env.create symbol in
-          let name = Name_in_source_env.symbol symbol in
-          f name join_entry acc))
+          | Some var_in_target_env -> f var_in_target_env join_entry acc)
+        ~symbol:(fun _symbol ->
+          (* If [name] is that of a lifted constant symbol generated during one
+             of the levels, then ignore it. [Simplify_expr] will already have
+             made its type suitable for the [source_env] and inserted it into
+             that environment.
+
+             This should not be necessary, but if we don't ignore the join of
+             types for lifted constants, and one of them happen to be a
+             moderately large mutually recursive set of closures, we end up
+             computing a potentially very expensive but useless meet of closure
+             types (between the type from [make_suitable_for_environment] and
+             the one we are computing during the join).
+
+             It's quite brittle to depend on the set of known lifted constants,
+             however, so we just never propagate types on symbols for now. This
+             is fine, because if [name] is a symbol that is not a lifted
+             constant, it was defined before the fork and already has an
+             equation in the [source_env]. While it is possible that its type
+             could be refined by all of the branches, it is unlikely, so we are
+             fine with dropping the equation. *)
+          acc))
 
 (* This function is responsible for splitting the [equations_to_join] between
    those that are demotions in all joined environments, that are replayed in the
@@ -1492,46 +1507,17 @@ let join_aliases_into_bindings ~joined_envs ~bindings equations_to_join =
       (Source_env.exists_in_source_env
          (Bindings_in_target_env.source_env bindings))
     ~init:(Name_in_target_env.Map.empty, bindings)
-    ~f:(fun name join_entry (equations_to_join, bindings) ->
+    ~f:(fun var join_entry (equations_to_join, bindings) ->
+      let name = Name_in_source_env.var var in
       match get_types_in_joined_envs join_entry with
       | Bottom -> Misc.fatal_error "Unexpected bottom during join"
       | Ok (No_alias_in_some_env types) ->
-        (* If [name] is that of a lifted constant symbol generated during one of
-           the levels, then ignore it. [Simplify_expr] will already have made
-           its type suitable for the [source_env] and inserted it into that
-           environment.
-
-           This should not be necessary, but if we don't ignore the join of
-           types for lifted constants, and one of them happen to be a moderately
-           large mutually recursive set of closures, we end up computing a
-           potentially very expensive but useless meet of closure types (between
-           the type from [make_suitable_for_environment] and the one we are
-           computing during the join).
-
-           It's quite brittle to depend on the set of known lifted constants,
-           however, so we just never propagate types on symbols for now. This is
-           fine, because if [name] is a symbol that is not a lifted constant, it
-           was defined before the fork and already has an equation in the
-           [source_env]. While it is possible that its type could be refined by
-           all of the branches, it is unlikely, so we are fine with dropping the
-           equation.
-
-           CR bclement and vlaviron: This is OK (and is already what we were
-           doing with the previous join implementation); however, the n-way join
-           actually computes the same type as the one from
-           [make_suitable_for_environment] -- it would be better to simply
-           compute the type of symbols here and drop the call to
-           [make_suitable_for_environment] in [lifted_constant_state], resolving
-           at the same time the two CRs there. *)
-        if Name.is_symbol (name : Name_in_source_env.t :> Name.t)
-        then equations_to_join, bindings
-        else
-          let equations_to_join =
-            Name_in_target_env.Map.add
-              (Name_in_target_env.from_source_env name)
-              types equations_to_join
-          in
-          equations_to_join, bindings
+        let equations_to_join =
+          Name_in_target_env.Map.add
+            (Name_in_target_env.from_source_env name)
+            types equations_to_join
+        in
+        equations_to_join, bindings
       | Ok (Equals_in_all_envs (canonicals, kind)) -> (
         match get_canonical_in_target_env ~bindings ~joined_envs canonicals with
         | Canonical_in_source_env canonical ->

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -512,7 +512,9 @@ end = struct
           None
       with Not_found -> None
     in
-    match shared_name with Some raw_name -> raw_name | None -> "join_var"
+    match shared_name with
+    | Some raw_name -> "j" ^ raw_name
+    | None -> "join_var"
 end
 
 module Source_env : sig

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1786,7 +1786,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
      Note: we wrap the true [cut_and_n_way_join0] to avoid hurting readability
      by increasing indentation. *)
   if Index.Map.is_empty equations_to_join
-  then ME.make_bottom source_env, Name_in_target_env.Map.empty
+  then ME.make_bottom source_env, Variable_in_target_env.Map.empty
   else
     cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
       source_env source_tenv joined_envs equations_to_join

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1723,9 +1723,11 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
         n_way_join_delayed_equations env_next_round inverse_relations
           (new_equations_in_joined_envs env_next_round ~since:env_this_round)
     in
-    let rec n_way_join_loop env_this_round inverse_relations
+    let rec n_way_join_loop ~depth env_this_round inverse_relations
         existentials_this_round =
-      if Variable_in_target_env.Map.is_empty existentials_this_round
+      if
+        Variable_in_target_env.Map.is_empty existentials_this_round
+        || depth >= Flambda_features.join_depth ()
       then inverse_relations, env_this_round
       else
         let equations_in_joined_envs =
@@ -1739,7 +1741,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
           n_way_join_delayed_equations env_this_round inverse_relations
             equations_in_joined_envs
         in
-        n_way_join_loop env_next_round inverse_relations
+        n_way_join_loop ~depth:(depth + 1) env_next_round inverse_relations
           (new_definitions_of_existentials env_next_round ~since:env_this_round)
     in
     let inverse_relations, env =
@@ -1747,7 +1749,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
         (new_equations_in_joined_envs env ~since:empty_env)
     in
     let inverse_relations, env =
-      n_way_join_loop env inverse_relations
+      n_way_join_loop ~depth:0 env inverse_relations
         (new_definitions_of_existentials env ~since:empty_env)
     in
     let target_env, definitions =

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1797,8 +1797,8 @@ module Analysis = struct
     let canonical_definitions_at_normal_mode =
       Variable_in_target_env.Map.filter_map
         (fun _name (simples, kind) ->
-          let exists_at_normal_name_mode_in_all_envs_it_is_defined_in =
-            Index.Map.for_all
+          match
+            Index.Map.mapi
               (fun env_id simple ->
                 let typing_env =
                   match Index.Map.find_opt env_id joined_envs with
@@ -1807,12 +1807,13 @@ module Analysis = struct
                     Misc.fatal_errorf "Join does not include environment %a"
                       Index.print env_id
                 in
-                TE.mem_simple ~min_name_mode:Name_mode.normal typing_env simple)
+                TE.get_canonical_simple_exn typing_env simple
+                  ~min_name_mode:Name_mode.normal
+                |> Simple_in_one_joined_env.create)
               (simples : Simples_in_joined_envs.t :> Simple.t Index.Map.t)
-          in
-          if exists_at_normal_name_mode_in_all_envs_it_is_defined_in
-          then Some (simples, kind)
-          else None)
+          with
+          | exception Not_found -> None
+          | simples_at_normal_mode -> Some (simples_at_normal_mode, kind))
         definitions_in_joined_envs
     in
     { definitions_in_joined_envs;

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -361,16 +361,11 @@ module Int_ids_in_env () = struct
     include module type of Id_in_env (Name) ()
 
     val var : Variable.t -> t
-
-    val symbol : Symbol.t -> t
   end = struct
     include Id_in_env (Name) ()
 
     let var (var : Variable.t) : t =
       create (Name.var (var :> Int_ids.Variable.t))
-
-    let symbol (symbol : Symbol.t) =
-      create (Name.symbol (symbol :> Int_ids.Symbol.t))
   end
 
   (* CR bclement: In practice, we consider that these must be canonicals in the
@@ -379,11 +374,7 @@ module Int_ids_in_env () = struct
   module Simple : sig
     include module type of Id_in_env (Simple) ()
 
-    val const : Reg_width_const.t -> t
-
     val name : ?coercion:Coercion.t -> Name.t -> t
-
-    val symbol : ?coercion:Coercion.t -> Symbol.t -> t
 
     val var : ?coercion:Coercion.t -> Variable.t -> t
 
@@ -402,14 +393,10 @@ module Int_ids_in_env () = struct
   end = struct
     include Id_in_env (Simple) ()
 
-    let const const = create (Simple.const const)
-
     let name ?(coercion = Coercion.id) (name : Name.t) =
       let simple_without_coercion = Simple.name (name :> Int_ids.Name.t) in
       let simple = Simple.with_coercion simple_without_coercion coercion in
       create simple
-
-    let symbol ?coercion symbol = name ?coercion (Name.symbol symbol)
 
     let var ?coercion var = name ?coercion (Name.var var)
 
@@ -434,7 +421,6 @@ end
 
 module Int_ids_in_source_env = Int_ids_in_env ()
 module Variable_in_source_env = Int_ids_in_source_env.Variable
-module Symbol_in_source_env = Int_ids_in_source_env.Symbol
 module Simple_in_source_env = Int_ids_in_source_env.Simple
 
 module Int_ids_from_source_env () = struct
@@ -448,7 +434,6 @@ module Int_ids_from_source_env () = struct
       create (var :> Variable.t)
   end
 
-  module Symbol = Int_ids_in_env.Symbol
   module Name = Int_ids_in_env.Name
 
   module Simple = struct
@@ -466,15 +451,6 @@ module Name_in_target_env = Int_ids_in_target_env.Name
 module Simple_in_target_env = Int_ids_in_target_env.Simple
 module Int_ids_in_one_joined_env = Int_ids_from_source_env ()
 module Variable_in_one_joined_env = Int_ids_in_one_joined_env.Variable
-
-module Symbol_in_one_joined_env = struct
-  include Int_ids_in_one_joined_env.Symbol
-
-  (* See {!section-lifted_constants} *)
-  let in_source_env symbol =
-    Symbol_in_source_env.create (symbol : t :> Symbol.t)
-end
-
 module Name_in_one_joined_env = Int_ids_in_one_joined_env.Name
 module Simple_in_one_joined_env = Int_ids_in_one_joined_env.Simple
 
@@ -547,6 +523,12 @@ end = struct
   include Container_types.Make (T0)
 
   let choose_a_suitable_name t =
+    if
+      Flambda_features.check_light_invariants ()
+      && not (Index.Map.cardinal t > 1)
+    then
+      Misc.fatal_errorf "Should not try to create a new name single simple: %a"
+        print t;
     let shared_name =
       try
         Index.Map.fold
@@ -962,6 +944,9 @@ module Joined_envs : sig
 
   val exists_in_all_joined_envs : t -> _ Index.Map.t -> bool
 
+  val get_alias_then_canonical_simple_ignoring_name_mode_exn :
+    t -> Type_in_one_joined_env.t Index.Map.t -> Simples_in_joined_envs.t
+
   val find_simples_in_joined_envs :
     t -> Simples_in_joined_envs.t -> K.t -> Type_in_one_joined_env.t Index.Map.t
 
@@ -1020,6 +1005,15 @@ end = struct
                 (get_nth_joined_env t index)
                 simple))
       simples_in_joined_envs
+
+  let get_alias_then_canonical_simple_ignoring_name_mode_exn t types =
+    Index.Map.mapi
+      (fun index (ty : Type_in_one_joined_env.t) ->
+        let env = get_nth_joined_env t index in
+        Simple_in_one_joined_env.create
+          (TE.get_canonical_simple_ignoring_name_mode env
+             (TG.get_alias_exn (ty :> TG.t))))
+      types
 
   let find_simples_in_joined_envs t simples kind =
     Index.Map.mapi
@@ -1102,6 +1096,7 @@ type t =
     types_in_joined_envs :
       Type_in_one_joined_env.t Index.Map.t Variable_in_target_env.Map.t;
     aliases_of_existentials : Aliases_of_existentials.t;
+    imported_vars : Variable.Set.t;
     definitions_of_existentials :
       (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
@@ -1112,6 +1107,7 @@ let create ~joined_envs ~bindings =
     types_in_target_env = Name_in_target_env.Map.empty;
     types_in_joined_envs = Variable_in_target_env.Map.empty;
     aliases_of_existentials = Aliases_of_existentials.empty;
+    imported_vars = Variable.Set.empty;
     definitions_of_existentials = Variable_in_target_env.Map.empty;
     bindings
   }
@@ -1126,7 +1122,7 @@ let new_equations_in_joined_envs t ~since =
     (fun _ new_types _old_types -> Some new_types)
     t.types_in_joined_envs since.types_in_joined_envs
 
-let existential_for_these_simples env canonicals kind =
+let existential_for_these_canonicals env canonicals kind =
   let existential_var, bindings =
     Bindings_in_target_env.existential_for_these_simples env.bindings canonicals
       kind
@@ -1142,23 +1138,184 @@ let existential_for_these_simples env canonicals kind =
   in
   existential_var, { env with bindings; definitions_of_existentials }
 
-let import_from_all_envs env var kind =
-  let bindings =
-    Bindings_in_target_env.import_from_all_envs env.bindings var kind
+let add_alias_of_existential env kind var canonicals =
+  let existential_var, env =
+    existential_for_these_canonicals env canonicals kind
   in
-  let imported_var =
-    Variable_in_target_env.create
-      (var : Variable_in_one_joined_env.t :> Variable.t)
+  (* Note: we must not record alias equations at this time, because we might
+     select a different canonical in
+     [define_or_eliminate_variables_and_add_equations].
+
+     We will add alias equations to the chosen canonical (which might not be the
+     existential variable) at that time. *)
+  let aliases_of_existentials =
+    Aliases_of_existentials.add env.aliases_of_existentials ~demoted_var:var
+      ~existential_var
   in
+  { env with aliases_of_existentials }
+
+let add_equation_in_target_env env name ty =
+  assert (not (Name_in_target_env.Map.mem name env.types_in_target_env));
+  let types_in_target_env =
+    Name_in_target_env.Map.add name ty env.types_in_target_env
+  in
+  { env with types_in_target_env }
+
+let add_equations_in_joined_envs env var types =
   let types_in_joined_envs =
-    if Variable_in_target_env.Map.mem imported_var env.types_in_joined_envs
-    then env.types_in_joined_envs
-    else
-      Variable_in_target_env.Map.add imported_var
-        (Joined_envs.find_imported_var env.joined_envs var kind)
-        env.types_in_joined_envs
+    Variable_in_target_env.Map.add var types env.types_in_joined_envs
   in
-  { env with bindings; types_in_joined_envs }
+  { env with types_in_joined_envs }
+
+type canonical_in_target_env =
+  | Canonical_in_source_env of Simple_in_source_env.t
+  | Import_from_all_joined_envs of Variable_in_one_joined_env.t * Coercion.t
+  | Existential_for_these_canonicals of Simples_in_joined_envs.t
+
+let n_way_join_canonical_simples env canonicals =
+  let source_env = Bindings_in_target_env.source_env env.bindings in
+  match Source_env.candidate_canonical_in_source_env source_env canonicals with
+  | No_simples_in_joined_envs | No_canonical_in_source_env ->
+    Existential_for_these_canonicals canonicals
+  | Canonical_in_all_joined_envs simple ->
+    Simple_in_one_joined_env.pattern_match' simple
+      ~const:(fun const ->
+        Canonical_in_source_env
+          (Simple_in_source_env.create (Simple.const const)))
+      ~symbol:(fun symbol ~coercion ->
+        Canonical_in_source_env
+          (Simple_in_source_env.create
+             (Simple.with_coercion
+                (Simple.symbol (symbol :> Symbol.t))
+                coercion)))
+      ~var:(fun var ~coercion ->
+        match
+          Source_env.exists_in_source_env source_env (var :> Variable.t)
+        with
+        | Some var ->
+          Canonical_in_source_env (Simple_in_source_env.var var ~coercion)
+        | None -> Import_from_all_joined_envs (var, coercion))
+  | Latest_bound_source_var (var, coercion) ->
+    let latest_simple = Simple_in_source_env.var var ~coercion in
+    if
+      Joined_envs.equal_in_all_joined_envs env.joined_envs
+        (Simple_in_one_joined_env.from_source_env latest_simple)
+        canonicals
+    then Canonical_in_source_env latest_simple
+    else Existential_for_these_canonicals canonicals
+
+let rec import_or_delay_n_way_join_type env var types =
+  let _, any_ty =
+    try Index.Map.choose types
+    with Not_found -> Misc.fatal_error "N-way join of zero types"
+  in
+  match
+    Joined_envs.get_alias_then_canonical_simple_ignoring_name_mode_exn
+      env.joined_envs types
+  with
+  | canonical_simples ->
+    let kind = Type_in_one_joined_env.kind any_ty in
+    add_equals_in_joined_envs env kind var canonical_simples
+  | exception Not_found ->
+    import_or_delay_n_way_join_of_concrete_type env var types
+
+and import_or_delay_n_way_join_of_concrete_type env var types =
+  let _, any_ty =
+    try Index.Map.choose types
+    with Not_found -> Misc.fatal_error "N-way join of zero types"
+  in
+  if Index.Map.for_all (fun _ ty' -> any_ty == ty') types
+  then
+    let env =
+      add_equation_in_target_env env
+        (Name_in_target_env.var var)
+        (Type_in_target_env.create (any_ty : Type_in_one_joined_env.t :> TG.t))
+    in
+    import_type_transitive env any_ty
+  else add_equations_in_joined_envs env var types
+
+and add_equals_in_joined_envs env kind var simples =
+  let[@local] add_equals_in_target_env env simple =
+    add_equation_in_target_env env
+      (Name_in_target_env.var var)
+      (Type_in_target_env.alias_type_of kind simple)
+  in
+  match n_way_join_canonical_simples env simples with
+  | Canonical_in_source_env canonical ->
+    add_equals_in_target_env env
+      (Simple_in_target_env.from_source_env canonical)
+  | Import_from_all_joined_envs (var, coercion) ->
+    let env = import_var_transitive env (var :> Variable.t) in
+    add_equals_in_target_env env
+      (Simple_in_target_env.var
+         (Variable_in_target_env.create (var :> Variable.t))
+         ~coercion)
+  | Existential_for_these_canonicals canonicals ->
+    add_alias_of_existential env kind var canonicals
+
+and import_type_transitive env (ty : Type_in_one_joined_env.t) =
+  Name_occurrences.fold_variables ~init:env ~f:import_var_transitive
+    (TG.free_names (ty :> TG.t))
+
+and import_var_transitive env var =
+  match
+    Source_env.exists_in_source_env
+      (Bindings_in_target_env.source_env env.bindings)
+      var
+  with
+  | Some _ -> env
+  | None ->
+    if Variable.Set.mem var env.imported_vars
+    then env
+    else
+      let kind = Variable.kind var in
+      let imported_vars = Variable.Set.add var env.imported_vars in
+      let bindings =
+        Bindings_in_target_env.import_from_all_envs env.bindings
+          (Variable_in_one_joined_env.create var)
+          kind
+      in
+      let env = { env with bindings; imported_vars } in
+      let types =
+        Joined_envs.find_imported_var env.joined_envs
+          (Variable_in_one_joined_env.create var)
+          kind
+      in
+      (* If there is at least one alias type, enforce an alias to the
+         appropriate existential variable. This ensures that we see the equality
+         when that specific combination of canonical simples appears in a joined
+         (not imported) type. *)
+      let has_alias_type =
+        Index.Map.exists
+          (fun _ (ty : Type_in_one_joined_env.t) ->
+            Option.is_some (TG.get_alias_opt (ty :> TG.t)))
+          types
+      in
+      if has_alias_type
+      then
+        let alias_type_of_var =
+          Type_in_one_joined_env.create (TG.alias_type_of kind (Simple.var var))
+        in
+        let alias_types =
+          Index.Map.map
+            (fun (ty : Type_in_one_joined_env.t) ->
+              match TG.get_alias_opt (ty :> TG.t) with
+              | None -> alias_type_of_var
+              | Some _ -> ty)
+            types
+        in
+        match
+          Joined_envs.get_alias_then_canonical_simple_ignoring_name_mode_exn
+            env.joined_envs alias_types
+        with
+        | exception Not_found ->
+          Misc.fatal_error "Unexpected missing canonical simple for alias type"
+        | canonical_simples ->
+          let var = Variable_in_target_env.create var in
+          add_equals_in_joined_envs env kind var canonical_simples
+      else
+        let var = Variable_in_target_env.create var in
+        import_or_delay_n_way_join_of_concrete_type env var types
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1166,44 +1323,6 @@ let joined_env t index = Joined_envs.get_nth_joined_env t.joined_envs index
 
 let machine_width t =
   Source_env.machine_width (Bindings_in_target_env.source_env t.bindings)
-
-type canonical_in_target_env =
-  | Canonical_in_source_env of Simple_in_source_env.t
-  | Import_from_all_joined_envs of Variable_in_one_joined_env.t * Coercion.t
-  | Existential_for_these_simples
-
-let get_canonical_in_target_env env canonicals_in_joined_envs =
-  let source_env = Bindings_in_target_env.source_env env.bindings in
-  match
-    Source_env.candidate_canonical_in_source_env source_env
-      canonicals_in_joined_envs
-  with
-  | No_simples_in_joined_envs | No_canonical_in_source_env ->
-    Existential_for_these_simples
-  | Canonical_in_all_joined_envs simple ->
-    Simple_in_one_joined_env.pattern_match' simple
-      ~const:(fun const ->
-        Canonical_in_source_env (Simple_in_source_env.const const))
-      ~symbol:(fun symbol ~coercion ->
-        Canonical_in_source_env
-          (Simple_in_source_env.symbol ~coercion
-             (Symbol_in_one_joined_env.in_source_env symbol)))
-      ~var:(fun var ~coercion ->
-        match
-          Source_env.exists_in_source_env source_env
-            (var : Variable_in_one_joined_env.t :> Variable.t)
-        with
-        | Some var ->
-          Canonical_in_source_env (Simple_in_source_env.var ~coercion var)
-        | None -> Import_from_all_joined_envs (var, coercion))
-  | Latest_bound_source_var (var, coercion) ->
-    let latest_simple = Simple_in_source_env.var var ~coercion in
-    if
-      Joined_envs.equal_in_all_joined_envs env.joined_envs
-        (Simple_in_one_joined_env.from_source_env latest_simple)
-        canonicals_in_joined_envs
-    then Canonical_in_source_env latest_simple
-    else Existential_for_these_simples
 
 let fold_incremental_join ~f ~init equations_to_join =
   fold_incremental_join ~f ~init
@@ -1213,56 +1332,6 @@ let fold_incremental_join ~f ~init equations_to_join =
             (fun index (env, maps) -> f (index, env) maps)
             equations_to_join init)
     }
-
-type types_in_joined_envs =
-  | Equals_in_all_envs of Simples_in_joined_envs.t * K.t
-  | No_alias_in_some_env of Type_in_one_joined_env.t Index.Map.t
-
-let get_types_in_joined_envs join_entry : _ Or_bottom.t =
-  let kind, canonicals, concrete_equations =
-    fold_incremental_join_entry join_entry
-      ~init:(None, Index.Map.empty, Index.Map.empty)
-      ~f:(fun (index, env) ty (kind, canonicals, concrete_equations) ->
-        let kind =
-          match kind with
-          | None -> Type_in_one_joined_env.kind ty
-          | Some kind ->
-            if not (K.equal kind (Type_in_one_joined_env.kind ty))
-            then Misc.fatal_errorf "Incompatible kinds for variable during join";
-            kind
-        in
-        match TG.get_alias_opt (ty : Type_in_one_joined_env.t :> TG.t) with
-        | None ->
-          let concrete_equations = Index.Map.add index ty concrete_equations in
-          Some kind, canonicals, concrete_equations
-        | Some simple ->
-          let canonical =
-            Simple_in_one_joined_env.create
-              (TE.get_canonical_simple_ignoring_name_mode env simple)
-          in
-          let canonicals = Index.Map.add index canonical canonicals in
-          Some kind, canonicals, concrete_equations)
-  in
-  match kind with
-  | None ->
-    assert (
-      Index.Map.is_empty canonicals && Index.Map.is_empty concrete_equations);
-    Bottom
-  | Some kind ->
-    if Index.Map.is_empty concrete_equations
-    then Ok (Equals_in_all_envs (canonicals, kind))
-    else
-      (* CR-someday bclement: We could create a fresh (unique) existential here,
-         which would allow to preserve more information about identity in
-         subsequent joins, but it's not clear it would be useful. *)
-      let alias_equations =
-        Index.Map.map
-          (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
-          canonicals
-      in
-      Ok
-        (No_alias_in_some_env
-           (Index.Map.disjoint_union alias_equations concrete_equations))
 
 (* Wrapper around [fold_incremental_join] so that we only fold over equations
    for names that exist in the target env (see [prepare_nested_join]). *)
@@ -1296,13 +1365,6 @@ let fold_incremental_join_in_target_env equations_to_join ~exists_in_target_env
              fine with dropping the equation. *)
           acc))
 
-let add_equation env name ty =
-  assert (not (Name_in_target_env.Map.mem name env.types_in_target_env));
-  let types_in_target_env =
-    Name_in_target_env.Map.add name ty env.types_in_target_env
-  in
-  { env with types_in_target_env }
-
 (* This function is responsible for splitting the [equations_to_join] between
    those that are demotions in all joined environments, that are replayed in the
    target environment in the [types_in_target_env], and the rest, that are
@@ -1318,41 +1380,11 @@ let join_aliases_into_bindings env equations_to_join =
     ~exists_in_target_env:
       (Bindings_in_target_env.exists_in_target_env env.bindings) ~init:env
     ~f:(fun var join_entry env ->
-      match get_types_in_joined_envs join_entry with
-      | Bottom -> Misc.fatal_error "Unexpected bottom during join"
-      | Ok (No_alias_in_some_env types) ->
-        let types_in_joined_envs =
-          Variable_in_target_env.Map.add var types env.types_in_joined_envs
-        in
-        { env with types_in_joined_envs }
-      | Ok (Equals_in_all_envs (canonicals, kind)) -> (
-        let[@local] add_equals_in_target_env env canonical =
-          add_equation env
-            (Name_in_target_env.var var)
-            (Type_in_target_env.alias_type_of kind canonical)
-        in
-        match get_canonical_in_target_env env canonicals with
-        | Canonical_in_source_env canonical ->
-          add_equals_in_target_env env
-            (Simple_in_target_env.from_source_env canonical)
-        | Import_from_all_joined_envs (imported_var, coercion) ->
-          let env = import_from_all_envs env imported_var kind in
-          let imported_var =
-            Variable_in_target_env.create (imported_var :> Variable.t)
-          in
-          let simple = Simple_in_target_env.var ~coercion imported_var in
-          add_equals_in_target_env env simple
-        | Existential_for_these_simples ->
-          let existential_var, env =
-            existential_for_these_simples env canonicals kind
-          in
-          let aliases_of_existentials =
-            Aliases_of_existentials.add env.aliases_of_existentials
-              ~demoted_var:var ~existential_var
-          in
-          let env = { env with aliases_of_existentials } in
-          let simple = Simple_in_target_env.var existential_var in
-          add_equals_in_target_env env simple))
+      let types =
+        fold_incremental_join_entry join_entry ~init:Index.Map.empty
+          ~f:(fun (index, _) ty types -> Index.Map.add index ty types)
+      in
+      import_or_delay_n_way_join_type env var types)
 
 let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     env_extension name relation ~scrutinee =
@@ -1564,6 +1596,15 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
         let exists_in_all_joined_envs =
           Joined_envs.exists_in_all_joined_envs t.joined_envs types
         in
+        if
+          Flambda_features.check_light_invariants ()
+          && Option.is_some (TG.get_alias_opt ty)
+        then
+          Misc.fatal_errorf
+            "Unexpected alias type in join round (aliases should have been \
+             processed): %a@.From join of types:@ %a@."
+            TG.print ty (Index.Map.print TG.print)
+            (types : Type_in_one_joined_env.t Index.Map.t :> TG.t Index.Map.t);
         let ty, inverse_relations =
           if exists_in_all_joined_envs
           then
@@ -1574,7 +1615,7 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
           else ty, inverse_relations
         in
         let ty = Type_in_target_env.create ty in
-        inverse_relations, add_equation t name ty)
+        inverse_relations, add_equation_in_target_env t name ty)
     equations_to_join (inverse_relations, t)
 
 (** {2:n-way-join Cut and n-way join} *)
@@ -2091,36 +2132,22 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
   let join_analysis = Analysis.create ~external_ids ~joined_envs bindings in
   target_env, join_analysis
 
-let n_way_join_canonicals env kind simples =
-  match get_canonical_in_target_env env simples with
-  | Canonical_in_source_env simple ->
-    Simple_in_target_env.from_source_env simple, env
-  | Import_from_all_joined_envs (imported_var, coercion) ->
-    let env = import_from_all_envs env imported_var kind in
-    let imported_var =
-      Variable_in_target_env.create (imported_var :> Variable.t)
-    in
-    let simple = Simple_in_target_env.var ~coercion imported_var in
-    simple, env
-  | Existential_for_these_simples ->
-    let existential_var, env = existential_for_these_simples env simples kind in
-    Simple_in_target_env.var existential_var, env
-
+(* Exposed to the outside world with a different type *)
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
   | [] -> Bottom, t
-  | _ :: _ ->
-    let canonicals_in_joined_envs =
+  | _ :: _ -> (
+    let simples =
       Joined_envs.get_canonical_simples_ignoring_name_mode t.joined_envs simples
     in
-    (* CR-someday bclement: somehow mark the local variable as used, so that it
-       can be re-processed in the current env extension if applicable (if a
-       local variable is created while processing an env extension, we currently
-       lose any equation that the extension had for that variable). *)
-    let canonical_in_target_env, t =
-      n_way_join_canonicals t kind canonicals_in_joined_envs
-    in
-    Ok (canonical_in_target_env : Simple_in_target_env.t :> Simple.t), t
+    match n_way_join_canonical_simples t simples with
+    | Canonical_in_source_env simple -> Ok (simple :> Simple.t), t
+    | Import_from_all_joined_envs (var, coercion) ->
+      let t = import_var_transitive t (var :> Variable.t) in
+      Ok (Simple_in_one_joined_env.var ~coercion var :> Simple.t), t
+    | Existential_for_these_canonicals canonicals ->
+      let var, t = existential_for_these_canonicals t canonicals kind in
+      Ok (Simple.var (var :> Variable.t)), t)
 
 (** {2:extensions Join of extensions} *)
 

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1596,14 +1596,14 @@ let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     | Naked_vec256 _ | Naked_vec512 _ | Naked_mask _ | Rec_info _ | Region _ ->
       Misc.fatal_error "Kind mismatch for output of relation: expected %a")
 
-let add_to_inverse_relations inverse_relations name relation ~scrutinee =
-  Name.Map.union_total_shared
+let add_to_inverse_relations inverse_relations var relation ~scrutinee =
+  Variable.Map.union_total_shared
     (fun _ inv_rels1 inv_rels2 ->
       TG.Relation.Map.union_total_shared
         (fun _ names1 names2 -> Name.Set.union names1 names2)
         inv_rels1 inv_rels2)
     inverse_relations
-    (Name.Map.singleton name
+    (Variable.Map.singleton var
        (TG.Relation.Map.singleton relation (Name.Set.singleton scrutinee)))
 
 let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
@@ -1634,7 +1634,7 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
       (* If we have no immediates, we can add the inverse relation on [get_tag]
          at the toplevel. *)
       let inverse_relations =
-        add_to_inverse_relations inverse_relations (Name.var get_tag_var)
+        add_to_inverse_relations inverse_relations get_tag_var
           TG.Relation.get_tag ~scrutinee:name
       in
       ty, inverse_relations
@@ -1655,7 +1655,7 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
         match is_int with
         | None -> inverse_relations
         | Some is_int_var ->
-          add_to_inverse_relations inverse_relations (Name.var is_int_var)
+          add_to_inverse_relations inverse_relations is_int_var
             TG.Relation.is_int ~scrutinee:name
       in
       let ty =
@@ -1703,7 +1703,7 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
       match is_null with
       | None -> inverse_relations
       | Some is_null_var ->
-        add_to_inverse_relations inverse_relations (Name.var is_null_var)
+        add_to_inverse_relations inverse_relations is_null_var
           TG.Relation.is_null ~scrutinee:name
     in
     ty, inverse_relations
@@ -1870,12 +1870,13 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
       then
         let env_extension_for_inverse_relations =
           TEE.from_map
-            (Name.Map.map
+            (Variable.Map.map
                (fun inverse_relations ->
                  TG.create_from_head_naked_immediate
                    (TG.Head_of_kind_naked_immediate.create_inverse_relations
                       inverse_relations))
-               inverse_relations)
+               inverse_relations
+            |> Name.var_map)
         in
         ( (* We compute symbol projections last so that we can pick up
              existential variables, but there is no need to create existential
@@ -1897,7 +1898,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
         (create ~joined_envs ~bindings)
         equations_to_join
         (Bindings_in_target_env.alias_types_in_target_env bindings)
-        Name.Map.empty
+        Variable.Map.empty
     in
     let target_env =
       Bindings_in_target_env.fold_created_variables
@@ -2430,7 +2431,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
             { bindings = bindings_after_extension; _ } ) =
         n_way_join_round ~n_way_join_type
           (create ~joined_envs ~bindings)
-          concrete_types_to_join alias_types_in_target_env Name.Map.empty
+          concrete_types_to_join alias_types_in_target_env Variable.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in
          [prepare_nested_join] above to create new variables, which do not exist

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -722,24 +722,14 @@ module Bindings_in_target_env : sig
 
   val exists_in_target_env : t -> Variable.t -> Variable_in_target_env.t option
 
-  (* Return the (unique across the whole join) name to be used to represent an
-     imported variable. *)
-  val import_from_all_envs :
-    t -> Variable_in_one_joined_env.t -> K.t -> Variable_in_target_env.t * t
+  (* Mark a variable as imported in the target env, so that it gets redefined in
+     the target env. *)
+  val import_from_all_envs : t -> Variable_in_one_joined_env.t -> K.t -> t
 
   (* Return the (unique across the whole join) name to be used to represent this
      set of simples in joined environments. *)
   val existential_for_these_simples :
     t -> Simples_in_joined_envs.t -> K.t -> Variable_in_target_env.t * t
-
-  type definition_in_joined_envs =
-    | Imported_var of Variable_in_one_joined_env.t * K.t
-    | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
-  (* Assuming that [t] derives from [since], returns the definitions of local
-     variables that have been added to [t] after [since]. *)
-  val new_bindings :
-    t -> since:t -> definition_in_joined_envs Name_in_target_env.Map.t
 
   (* Assuming that [t] derives from [since], extract the created variables from
      [t], adding them to [since]. Any information about the created variables
@@ -747,7 +737,10 @@ module Bindings_in_target_env : sig
      forgotten, and they won't appear in the [new_bindings]. *)
   val forget_definition_of_created_variables : t -> since:t -> t
 
-  val fold_created_variables :
+  val fold_imported_variables :
+    (Variable_in_one_joined_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
+
+  val fold_existential_variables :
     (Variable_in_target_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
 
   (* These are for the join of env extensions, see [prepare_nested_join]. *)
@@ -763,42 +756,31 @@ module Bindings_in_target_env : sig
 end = struct
   type coercion_to_canonical_in_target_env = Coercion.t
 
-  type definition_in_joined_envs =
-    | Imported_var of Variable_in_one_joined_env.t * K.t
-    | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
   type t =
     { source_env : Source_env.t;
       existential_for_these_simples :
         Variable_in_target_env.t Simples_in_joined_envs.Map.t;
-      (* Maps a set of [simples] in joined environments to the (unique across
-         the whole join) name used to represent this exact set of simples in the
-         target environment. *)
-      imported_variables :
-        Variable_in_target_env.t Variable_in_one_joined_env.Map.t;
-      (* Maps a local variable (a variable that exists in at least one joined
-         environment) to its name in the target environment.
-
-         The underlying variable used in the joined and target environments is
-         the same, only the type-level metadata changes.
-
-         CR bclement: This should just be a set now. *)
-      created_variables : K.t Variable_in_target_env.Map.t;
-      (* This contains all the local variables (existentials or imported) that
-         exist in the target environment but not in the source environment. *)
-      definitions_in_joined_envs :
-        definition_in_joined_envs Name_in_target_env.Map.t;
-      (* Reverse map from local variables to their definition. *)
+          (* Maps a set of [simples] in joined environments to the (unique
+             across the whole join) name used to represent this exact set of
+             simples in the target environment. *)
+      imported_variables : K.t Variable_in_one_joined_env.Map.t;
+          (* Set of variables that have been imported from at least one of the
+             joined environments into the target environment. *)
+      existential_variables : K.t Variable_in_target_env.Map.t;
+          (* This contains all the existential variables, created during the
+             join, that exist in the target environment but not in the source
+             environment or in any of the joined environments. *)
       aliases_of_names_in_joined_envs :
         coercion_to_canonical_in_target_env Name_in_target_env.Map.t
         Name_in_one_joined_env.Map.t
         Index.Map.t;
-      (* For each joined environment and each name in the joined environment,
-         record the set of names in the target environment it is equal to (and
-         the corresponding coercions).
+          (* For each joined environment and each name in the joined
+             environment, record the set of names in the target environment it
+             is equal to (and the corresponding coercions).
 
-         This is used to implement [replay_definitions_of_aliases_in_target_env]
-         in the join of env extensions, see [prepare_nested_join]. *)
+             This is used to implement
+             [replay_definitions_of_aliases_in_target_env] in the join of env
+             extensions, see [prepare_nested_join]. *)
       equations_for_local_vars :
         Type_in_one_joined_env.t Variable_in_target_env.Map.t Index.Map.t
           (* Environment extensions to use in each of the joined environments to
@@ -814,27 +796,19 @@ end = struct
       existential_for_these_simples = Simples_in_joined_envs.Map.empty;
       imported_variables = Variable_in_one_joined_env.Map.empty;
       aliases_of_names_in_joined_envs = Index.Map.empty;
-      definitions_in_joined_envs = Name_in_target_env.Map.empty;
       equations_for_local_vars = Index.Map.empty;
-      created_variables = Variable_in_target_env.Map.empty
+      existential_variables = Variable_in_target_env.Map.empty
     }
-
-  let new_bindings t ~since =
-    Name_in_target_env.Map.diff_shared
-      (fun _ new_definition _old_definition -> Some new_definition)
-      t.definitions_in_joined_envs since.definitions_in_joined_envs
 
   let forget_definition_of_created_variables t ~since =
     (* We still need to record the fact that we created those variables in order
        to add them to the target environment at the end of the join. *)
-    { since with created_variables = t.created_variables }
+    { since with
+      existential_variables = t.existential_variables;
+      imported_variables = t.imported_variables
+    }
 
   let source_env { source_env; _ } = source_env
-
-  let is_local_variable { created_variables; _ } var =
-    if Variable_in_target_env.Map.mem var created_variables
-    then Some var
-    else None
 
   let exists_in_target_env t var =
     match Source_env.exists_in_source_env (source_env t) var with
@@ -842,7 +816,11 @@ end = struct
       Some (Variable_in_target_env.from_source_env var_in_source_env)
     | None ->
       let var = Variable_in_target_env.create var in
-      if Variable_in_target_env.Map.mem var t.created_variables
+      if
+        Variable_in_target_env.Map.mem var t.existential_variables
+        || Variable_in_one_joined_env.Map.mem
+             (Variable_in_one_joined_env.create (var :> Variable.t))
+             t.imported_variables
       then Some var
       else None
 
@@ -870,24 +848,23 @@ end = struct
               aliases_in_target_env))
       simples aliases_in_target_env
 
-  let record_definition_for t ~var_in_target_env definition =
-    (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
-    let definitions_in_joined_envs =
-      Name_in_target_env.Map.add
-        (Name_in_target_env.var var_in_target_env)
-        definition t.definitions_in_joined_envs
-    in
-    match definition with
-    | Imported_var (imported_var, _kind) ->
-      let imported_variables =
-        Variable_in_one_joined_env.Map.add imported_var var_in_target_env
-          t.imported_variables
+  let has_existential_for_these_simples t simples =
+    Simples_in_joined_envs.Map.find_opt simples t.existential_for_these_simples
+
+  let existential_for_these_simples t simples kind =
+    match has_existential_for_these_simples t simples with
+    | Some existing_canonical -> existing_canonical, t
+    | None ->
+      let var =
+        let name = Simples_in_joined_envs.choose_a_suitable_name simples in
+        Variable_in_target_env.create (Variable.create name kind)
       in
-      ( var_in_target_env,
-        { t with imported_variables; definitions_in_joined_envs } )
-    | These_canonicals (simples, kind) ->
+      let existential_variables =
+        Variable_in_target_env.Map.add var kind t.existential_variables
+      in
+      let t = { t with existential_variables } in
       let existential_for_these_simples =
-        Simples_in_joined_envs.Map.add simples var_in_target_env
+        Simples_in_joined_envs.Map.add simples var
           t.existential_for_these_simples
       in
       (* The following is some bookkeeping so that we know how to replay the
@@ -896,75 +873,41 @@ end = struct
       let equations_for_local_vars =
         (* If the variable is a fresh variable, record it so that we can replay
            its definition during the join of env extensions. *)
-        match is_local_variable t var_in_target_env with
-        | None -> t.equations_for_local_vars
-        | Some var ->
-          Index.Map.update_many
-            (fun _index existentials simple ->
-              let ty = Type_in_one_joined_env.alias_type_of kind simple in
-              let existentials_in_one_joined_env =
-                Variable_in_target_env.Map.add var ty
-                  (Option.value ~default:Variable_in_target_env.Map.empty
-                     existentials)
-              in
-              Some existentials_in_one_joined_env)
-            t.equations_for_local_vars simples
+        Index.Map.update_many
+          (fun _index existentials simple ->
+            let ty = Type_in_one_joined_env.alias_type_of kind simple in
+            let existentials_in_one_joined_env =
+              Variable_in_target_env.Map.add var ty
+                (Option.value ~default:Variable_in_target_env.Map.empty
+                   existentials)
+            in
+            Some existentials_in_one_joined_env)
+          t.equations_for_local_vars simples
       in
       let aliases_of_names_in_joined_envs =
         update_aliases_of_names_in_joined_envs simples
           t.aliases_of_names_in_joined_envs ~f:(fun coercion aliases ->
             (* definition ~ coercion(name_in_joined_env) *)
             Name_in_target_env.Map.add
-              (Name_in_target_env.var var_in_target_env)
+              (Name_in_target_env.var var)
               coercion aliases)
       in
-      ( var_in_target_env,
+      ( var,
         { t with
           equations_for_local_vars;
           existential_for_these_simples;
-          aliases_of_names_in_joined_envs;
-          definitions_in_joined_envs
+          aliases_of_names_in_joined_envs
         } )
 
-  let create_name_for_definition t definition =
-    let var, kind =
-      match definition with
-      | Imported_var (var, kind) ->
-        let var = (var : Variable_in_one_joined_env.t :> Variable.t) in
-        Variable_in_target_env.create var, kind
-      | These_canonicals (simples, kind) ->
-        let name = Simples_in_joined_envs.choose_a_suitable_name simples in
-        Variable_in_target_env.create (Variable.create name kind), kind
-    in
-    let created_variables =
-      Variable_in_target_env.Map.add var kind t.created_variables
-    in
-    let t = { t with created_variables } in
-    record_definition_for t ~var_in_target_env:var definition
-
-  let is_imported_from_all_joined_envs t var =
-    Variable_in_one_joined_env.Map.find_opt var t.imported_variables
-
-  let has_existential_for_these_simples t simples =
-    Simples_in_joined_envs.Map.find_opt simples t.existential_for_these_simples
-
-  let existing_canonical_for t definition =
-    match definition with
-    | Imported_var (imported_var, _kind) ->
-      is_imported_from_all_joined_envs t imported_var
-    | These_canonicals (simples, _kind) ->
-      has_existential_for_these_simples t simples
-
-  let get_or_create_canonical_for t definition =
-    match existing_canonical_for t definition with
-    | None -> create_name_for_definition t definition
-    | Some existing_canonical -> existing_canonical, t
-
-  let existential_for_these_simples t simples kind =
-    get_or_create_canonical_for t (These_canonicals (simples, kind))
-
   let import_from_all_envs t imported_var kind =
-    get_or_create_canonical_for t (Imported_var (imported_var, kind))
+    if Variable_in_one_joined_env.Map.mem imported_var t.imported_variables
+    then t
+    else
+      let imported_variables =
+        Variable_in_one_joined_env.Map.add imported_var kind
+          t.imported_variables
+      in
+      { t with imported_variables }
 
   let replay_definition_of_aliases_in_target_env t index equations =
     match Index.Map.find_opt index t.aliases_of_names_in_joined_envs with
@@ -993,10 +936,15 @@ end = struct
     | None -> Variable_in_target_env.Map.empty
     | Some existentials -> existentials
 
-  let fold_created_variables f t acc =
+  let fold_imported_variables f t acc =
     (* CR bclement: iterate in order consistent with the recorded binding
        times. *)
-    Variable_in_target_env.Map.fold f t.created_variables acc
+    Variable_in_one_joined_env.Map.fold f t.imported_variables acc
+
+  let fold_existential_variables f t acc =
+    (* CR bclement: iterate in order consistent with the recorded binding
+       times. *)
+    Variable_in_target_env.Map.fold f t.existential_variables acc
 end
 
 module Joined_envs : sig
@@ -1128,14 +1076,65 @@ type env_id = Index.t
 
 type 'a join_arg = env_id * 'a
 
+type definition_in_joined_envs =
+  | Imported_var of Variable_in_one_joined_env.t * K.t
+  | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
+
 type t =
   { joined_envs : Joined_envs.t;
     types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
+    definitions_in_joined_envs :
+      definition_in_joined_envs Variable_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
   }
 
 let create ~joined_envs ~bindings =
-  { joined_envs; types_in_target_env = Name_in_target_env.Map.empty; bindings }
+  { joined_envs;
+    types_in_target_env = Name_in_target_env.Map.empty;
+    definitions_in_joined_envs = Variable_in_target_env.Map.empty;
+    bindings
+  }
+
+let new_definitions_in_joined_envs t ~since =
+  Variable_in_target_env.Map.diff_shared
+    (fun _ new_definition _old_definition -> Some new_definition)
+    t.definitions_in_joined_envs since.definitions_in_joined_envs
+
+let existential_for_these_simples env canonicals kind =
+  let existential_var, bindings =
+    Bindings_in_target_env.existential_for_these_simples env.bindings canonicals
+      kind
+  in
+  let definitions_in_joined_envs =
+    if
+      Variable_in_target_env.Map.mem existential_var
+        env.definitions_in_joined_envs
+    then env.definitions_in_joined_envs
+    else
+      Variable_in_target_env.Map.add existential_var
+        (These_canonicals (canonicals, kind))
+        env.definitions_in_joined_envs
+  in
+  existential_var, { env with bindings; definitions_in_joined_envs }
+
+let import_from_all_envs env var kind =
+  let bindings =
+    Bindings_in_target_env.import_from_all_envs env.bindings var kind
+  in
+  let imported_var =
+    Variable_in_target_env.create
+      (var : Variable_in_one_joined_env.t :> Variable.t)
+  in
+  let definitions_in_joined_envs =
+    if
+      Variable_in_target_env.Map.mem imported_var env.definitions_in_joined_envs
+    then env.definitions_in_joined_envs
+    else
+      Variable_in_target_env.Map.add imported_var
+        (Imported_var (var, kind))
+        env.definitions_in_joined_envs
+  in
+  { env with bindings; definitions_in_joined_envs }
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1319,19 +1318,18 @@ let join_aliases_into_bindings env equations_to_join =
           add_equals_in_target_env env
             (Simple_in_target_env.from_source_env canonical)
         | Import_from_all_joined_envs (imported_var, coercion) ->
-          let imported_var, bindings =
-            Bindings_in_target_env.import_from_all_envs env.bindings
-              imported_var kind
+          let env = import_from_all_envs env imported_var kind in
+          let imported_var =
+            Variable_in_target_env.create (imported_var :> Variable.t)
           in
           let simple = Simple_in_target_env.var ~coercion imported_var in
-          add_equals_in_target_env { env with bindings } simple
+          add_equals_in_target_env env simple
         | Existential_for_these_simples ->
-          let existential_var, bindings =
-            Bindings_in_target_env.existential_for_these_simples env.bindings
-              canonicals kind
+          let existential_var, env =
+            existential_for_these_simples env canonicals kind
           in
           let simple = Simple_in_target_env.var existential_var in
-          add_equals_in_target_env { env with bindings } simple))
+          add_equals_in_target_env env simple))
 
 let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     env_extension name relation ~scrutinee =
@@ -1639,10 +1637,10 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
     let concrete_equations_to_join, env =
       join_aliases_into_bindings empty_env equations_to_join
     in
-    let equations_for_bindings bindings ~since =
-      let new_bindings = Bindings_in_target_env.new_bindings bindings ~since in
-      Name_in_target_env.Map.map
-        (fun (definition : Bindings_in_target_env.definition_in_joined_envs) ->
+    let equations_for_bindings env ~since =
+      let new_bindings = new_definitions_in_joined_envs env ~since in
+      Variable.Map.map
+        (fun (definition : definition_in_joined_envs) ->
           match definition with
           | Imported_var (var, kind) ->
             Joined_envs.alias_types_of_local_var joined_envs kind var
@@ -1650,19 +1648,20 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
             Index.Map.map
               (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
               simples)
-        new_bindings
+        (new_bindings :> definition_in_joined_envs Variable.Map.t)
+      |> Name.var_map |> Name_in_target_env.create_map
     in
     let equations_to_join =
       Name_in_target_env.Map.disjoint_union concrete_equations_to_join
-        (equations_for_bindings env.bindings ~since:empty_bindings)
+        (equations_for_bindings env ~since:empty_env)
     in
     let rec loop t equations_to_join inverse_relations =
-      let bindings_before_this_round = t.bindings in
+      let env_before_this_round = t in
       let inverse_relations, t =
         n_way_join_round ~n_way_join_type t equations_to_join inverse_relations
       in
       let new_equations_to_join =
-        equations_for_bindings t.bindings ~since:bindings_before_this_round
+        equations_for_bindings env ~since:env_before_this_round
       in
       if Name_in_target_env.Map.is_empty new_equations_to_join
       then
@@ -1685,22 +1684,28 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
           t.types_in_target_env,
           env_extension_for_inverse_relations,
           n_way_join_symbol_projections t symbol_projections_to_join,
-          t.bindings )
+          t )
       else loop t new_equations_to_join inverse_relations
     in
-    let ( equations,
-          env_extension_for_inverse_relations,
-          symbol_projections,
-          bindings ) =
+    let equations, env_extension_for_inverse_relations, symbol_projections, env
+        =
       loop env equations_to_join Variable.Map.empty
     in
     let target_env =
-      Bindings_in_target_env.fold_created_variables
+      Bindings_in_target_env.fold_imported_variables
+        (fun var kind target_env ->
+          ME.add_variable_definition target_env
+            (var :> Variable.t)
+            kind Name_mode.in_types)
+        env.bindings source_env
+    in
+    let target_env =
+      Bindings_in_target_env.fold_existential_variables
         (fun var kind target_env ->
           ME.add_variable_definition target_env
             (var : Variable_in_target_env.t :> Variable.t)
             kind Name_mode.in_types)
-        bindings source_env
+        env.bindings target_env
     in
     let target_env =
       ME.add_env_extension ~meet_expanded_head target_env
@@ -1721,8 +1726,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
             symbol_projection)
         symbol_projections target_env
     in
-    ( target_env,
-      Bindings_in_target_env.new_bindings bindings ~since:empty_bindings )
+    target_env, new_definitions_in_joined_envs env ~since:empty_env
   with Misc.Fatal_error ->
     let bt = Printexc.get_raw_backtrace () in
     Format.eprintf "\n@[<v 2>%tContext is:%t cut and join of levels:@ %a@]\n"
@@ -1736,16 +1740,16 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
 module Analysis = struct
   type 'a t =
     { definitions_in_joined_envs :
-        Bindings_in_target_env.definition_in_joined_envs
-        Name_in_target_env.Map.t;
+        definition_in_joined_envs Variable_in_target_env.Map.t;
       canonical_definitions_at_normal_mode :
-        (Simple_in_one_joined_env.t Index.Map.t * K.t) Name_in_target_env.Map.t;
+        (Simple_in_one_joined_env.t Index.Map.t * K.t)
+        Variable_in_target_env.Map.t;
       external_ids : 'a Index.Map.t
     }
 
   let print ppf { definitions_in_joined_envs; _ } =
-    Name_in_target_env.Map.print
-      (fun ppf (def : Bindings_in_target_env.definition_in_joined_envs) ->
+    Variable_in_target_env.Map.print
+      (fun ppf (def : definition_in_joined_envs) ->
         match def with
         | Imported_var (var, _) ->
           Format.fprintf ppf "@[<hov 1>(imported@ %a)@]"
@@ -1756,9 +1760,8 @@ module Analysis = struct
 
   let create ~external_ids ~joined_envs definitions_in_joined_envs =
     let canonical_definitions_at_normal_mode =
-      Name_in_target_env.Map.filter_map
-        (fun _name
-             (definition : Bindings_in_target_env.definition_in_joined_envs) ->
+      Variable_in_target_env.Map.filter_map
+        (fun _name (definition : definition_in_joined_envs) ->
           match definition with
           | Imported_var (var, kind) ->
             let var = (var :> Variable.t) in
@@ -1837,8 +1840,8 @@ module Analysis = struct
       ~symbol:(fun _ ~coercion:_ -> Invariant_in_all_uses simple)
       ~var:(fun var ~coercion:_ ->
         match
-          Name_in_target_env.Map.find_opt
-            (Name_in_target_env.create (Name.var var))
+          Variable_in_target_env.Map.find_opt
+            (Variable_in_target_env.create var)
             t.definitions_in_joined_envs
         with
         | None ->
@@ -1881,10 +1884,10 @@ module Analysis = struct
   end
 
   let fold_variables_created_at_join ~f t ~init =
-    Name_in_target_env.Map.fold
-      (fun name (canonicals_in_joined_envs, kind) acc ->
+    Variable_in_target_env.Map.fold
+      (fun var (canonicals_in_joined_envs, kind) acc ->
         (f [@inlined hint])
-          (name :> Name.t)
+          (Name.var (var :> Variable.t))
           { Simples_at_join.canonicals_in_joined_envs;
             external_ids = t.external_ids
           }
@@ -1961,17 +1964,15 @@ let n_way_join_canonicals env kind simples =
   | Canonical_in_source_env simple ->
     Simple_in_target_env.from_source_env simple, env
   | Import_from_all_joined_envs (imported_var, coercion) ->
-    let imported_var, bindings =
-      Bindings_in_target_env.import_from_all_envs env.bindings imported_var kind
+    let env = import_from_all_envs env imported_var kind in
+    let imported_var =
+      Variable_in_target_env.create (imported_var :> Variable.t)
     in
     let simple = Simple_in_target_env.var ~coercion imported_var in
-    simple, { env with bindings }
+    simple, env
   | Existential_for_these_simples ->
-    let existential_var, bindings =
-      Bindings_in_target_env.existential_for_these_simples env.bindings simples
-        kind
-    in
-    Simple_in_target_env.var existential_var, { env with bindings }
+    let existential_var, env = existential_for_these_simples env simples kind in
+    Simple_in_target_env.var existential_var, env
 
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -524,8 +524,6 @@ end
 module Simples_in_joined_envs : sig
   include Container_types.S with type t = Simple_in_one_joined_env.t Index.Map.t
 
-  val of_list : (Index.t * Simple.t) list -> t
-
   val choose_a_suitable_name : t -> string
 end = struct
   module T0 = struct
@@ -547,12 +545,6 @@ end = struct
 
   include T0
   include Container_types.Make (T0)
-
-  let of_list simples =
-    List.fold_left
-      (fun simples (index, simple) ->
-        Index.Map.add index (Simple_in_one_joined_env.create simple) simples)
-      Index.Map.empty simples
 
   let choose_a_suitable_name t =
     let shared_name =
@@ -981,6 +973,9 @@ module Joined_envs : sig
 
   val equal_in_all_joined_envs :
     t -> Simple_in_one_joined_env.t -> Simples_in_joined_envs.t -> bool
+
+  val get_canonical_simples_ignoring_name_mode :
+    t -> (Index.t * Simple.t) list -> Simples_in_joined_envs.t
 end = struct
   type t =
     { envs_and_equations :
@@ -1055,6 +1050,17 @@ end = struct
         then Some (Type_in_one_joined_env.create (TE.find env name (Some kind)))
         else None)
       (envs_and_equations t)
+
+  let get_canonical_simples_ignoring_name_mode t simples =
+    List.fold_left
+      (fun acc (index, simple) ->
+        let env = get_nth_joined_env t index in
+        let canonical =
+          Simple_in_one_joined_env.create
+            (TE.get_canonical_simple_ignoring_name_mode env simple)
+        in
+        Index.Map.add index canonical acc)
+      Index.Map.empty simples
 end
 
 module Aliases_of_existentials = struct
@@ -2104,7 +2110,9 @@ let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
   | [] -> Bottom, t
   | _ :: _ ->
-    let canonicals_in_joined_envs = Simples_in_joined_envs.of_list simples in
+    let canonicals_in_joined_envs =
+      Joined_envs.get_canonical_simples_ignoring_name_mode t.joined_envs simples
+    in
     (* CR-someday bclement: somehow mark the local variable as used, so that it
        can be re-processed in the current env extension if applicable (if a
        local variable is created while processing an env extension, we currently

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -86,6 +86,7 @@
 
 module K = Flambda_kind
 module TG = Type_grammar
+module MTC = More_type_creators
 module TE = Typing_env
 module ME = Meet_env
 module TEE = Typing_env_extension
@@ -1717,7 +1718,31 @@ let define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
           kind Name_mode.in_types)
       env.bindings source_env
   in
+  let names_in_inverse_relations =
+    Variable.Map.fold
+      (fun var relations names_in_inverse_relations ->
+        TG.Relation.Map.fold
+          (fun _ names names_in_inverse_relations ->
+            Name.Set.union names names_in_inverse_relations)
+          relations
+          (Name.Set.add (Name.var var) names_in_inverse_relations))
+      inverse_relations Name.Set.empty
+  in
   let equations = (env.types_in_target_env :> TG.t Name.Map.t) in
+  let free_vars_in_equations =
+    Name.Map.fold
+      (fun _ ty free_names_in_equations ->
+        Name_occurrences.with_only_variables (TG.free_names ty)
+        |> Name_occurrences.union free_names_in_equations)
+      equations Name_occurrences.empty
+  in
+  let unique_occurence_is_in_equations var =
+    (not (Name.Set.mem (Name.var var) names_in_inverse_relations))
+    &&
+    match Name_occurrences.count_variable free_vars_in_equations var with
+    | Zero | One -> true
+    | More_than_one -> false
+  in
   let definitions = env.definitions_in_joined_envs in
   let target_env, to_expand, equations, inverse_relations, definitions =
     Bindings_in_target_env.fold_existential_variables
@@ -1730,17 +1755,38 @@ let define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
         let var = (var :> Variable.t) in
         match Variable_in_target_env.Set.choose_opt aliases_of_var with
         | None ->
-          (* This includes existential variables that have no other aliases, and
-             imported variables. *)
-          let target_env =
-            ME.add_variable_definition target_env var kind Name_mode.in_types
-          in
-          target_env, to_expand, equations, inverse_relations, definitions
+          (* Project out variables with a single occurrence. This is important
+             to cut out the size of the resulting environments.
+
+             If the variable appears anywhere in the [inverse_relations] map, we
+             don't remove it: it means that it is the result of a primitive
+             (%is_int, %is_null, %get_tag, ...) that we are likely to later do a
+             switch on, and we need the variable to exist in the analysis for
+             the match-in-match transform. *)
+          if unique_occurence_is_in_equations var
+          then
+            let ty, equations =
+              match Name.Map.find (Name.var var) equations with
+              | exception Not_found -> MTC.unknown kind, equations
+              | ty -> ty, Name.Map.remove (Name.var var) equations
+            in
+            let to_expand = Variable.Map.add var ty to_expand in
+            let definitions =
+              Variable_in_target_env.Map.remove
+                (Variable_in_target_env.create var)
+                definitions
+            in
+            target_env, to_expand, equations, inverse_relations, definitions
+          else
+            let target_env =
+              ME.add_variable_definition target_env var kind Name_mode.in_types
+            in
+            target_env, to_expand, equations, inverse_relations, definitions
         | Some canon_var ->
           let demoted_aliases =
             Variable_in_target_env.Set.remove canon_var aliases_of_var
           in
-          let canon_var = (var :> Variable.t) in
+          let canon_var = (canon_var :> Variable.t) in
           let definitions =
             move_definition definitions ~from:var ~to_:canon_var
           in

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -970,19 +970,13 @@ module Joined_envs : sig
 
   val exists_in_all_joined_envs : t -> _ Index.Map.t -> bool
 
-  (** Returns the aliases of a variable in all the environments where it exists.
+  val find_simples_in_joined_envs :
+    t -> Simples_in_joined_envs.t -> K.t -> Type_in_one_joined_env.t Index.Map.t
 
-      The provided variable {b must} be defined in the current compilation unit.
-  *)
-  val alias_types_of_local_var :
+  val find_imported_var :
     t ->
-    K.t ->
     Variable_in_one_joined_env.t ->
-    Type_in_one_joined_env.t Index.Map.t
-
-  val expand_heads :
-    t ->
-    Type_in_one_joined_env.t Index.Map.t ->
+    K.t ->
     Type_in_one_joined_env.t Index.Map.t
 
   val equal_in_all_joined_envs :
@@ -1032,43 +1026,35 @@ end = struct
                 simple))
       simples_in_joined_envs
 
-  let alias_types_of_local_var t kind var =
+  let find_simples_in_joined_envs t simples kind =
+    Index.Map.mapi
+      (fun index simple ->
+        Simple_in_one_joined_env.pattern_match simple
+          ~const:(fun const -> ET.create_const const |> ET.to_type)
+          ~name:(fun name ~coercion ->
+            let env = get_nth_joined_env t index in
+            let ty = TE.find env (name :> Name.t) (Some kind) in
+            TG.apply_coercion ty coercion)
+        |> Type_in_one_joined_env.create)
+      simples
+
+  let find_imported_var t var kind =
+    let erased_var = (var : Variable_in_one_joined_env.t :> Variable.t) in
     if Flambda_features.check_light_invariants ()
     then
-      if
-        not
-          (Current_unit.is_current
-             (Variable.compilation_unit
-                (var : Variable_in_one_joined_env.t :> Variable.t)))
+      if not (Current_unit.is_current (Variable.compilation_unit erased_var))
       then
         Misc.fatal_errorf
           "Cannot re-define variable %a defined in another compilation unit \
            into the target environment of join"
-          Variable.print
-          (var : Variable_in_one_joined_env.t :> Variable.t);
+          Variable.print erased_var;
     Index.Map.filter_map
       (fun _index (env, _) ->
-        if
-          TE.mem env
-            (Name.var (var : Variable_in_one_joined_env.t :> Variable.t))
-        then
-          let canonical =
-            get_canonical_simple_ignoring_name_mode env
-              (Simple_in_one_joined_env.var var)
-          in
-          Some (Type_in_one_joined_env.alias_type_of kind canonical)
+        let name = Name.var erased_var in
+        if TE.mem env name
+        then Some (Type_in_one_joined_env.create (TE.find env name (Some kind)))
         else None)
       (envs_and_equations t)
-
-  let expand_heads t types =
-    Index.Map.mapi
-      (fun index ty ->
-        let typing_env = get_nth_joined_env t index in
-        Type_in_one_joined_env.create
-          (ET.to_type
-             (Expand_head.expand_head typing_env
-                (ty : Type_in_one_joined_env.t :> TG.t))))
-      types
 end
 
 module Aliases_of_existentials = struct
@@ -1104,48 +1090,51 @@ type env_id = Index.t
 
 type 'a join_arg = env_id * 'a
 
-type definition_in_joined_envs =
-  | Imported_var of Variable_in_one_joined_env.t * K.t
-  | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
 type t =
   { joined_envs : Joined_envs.t;
     types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
+    types_in_joined_envs :
+      Type_in_one_joined_env.t Index.Map.t Variable_in_target_env.Map.t;
     aliases_of_existentials : Aliases_of_existentials.t;
-    definitions_in_joined_envs :
-      definition_in_joined_envs Variable_in_target_env.Map.t;
+    definitions_of_existentials :
+      (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
   }
 
 let create ~joined_envs ~bindings =
   { joined_envs;
     types_in_target_env = Name_in_target_env.Map.empty;
+    types_in_joined_envs = Variable_in_target_env.Map.empty;
     aliases_of_existentials = Aliases_of_existentials.empty;
-    definitions_in_joined_envs = Variable_in_target_env.Map.empty;
+    definitions_of_existentials = Variable_in_target_env.Map.empty;
     bindings
   }
 
-let new_definitions_in_joined_envs t ~since =
+let new_definitions_of_existentials t ~since =
   Variable_in_target_env.Map.diff_shared
     (fun _ new_definition _old_definition -> Some new_definition)
-    t.definitions_in_joined_envs since.definitions_in_joined_envs
+    t.definitions_of_existentials since.definitions_of_existentials
+
+let new_equations_in_joined_envs t ~since =
+  Variable_in_target_env.Map.diff_shared
+    (fun _ new_types _old_types -> Some new_types)
+    t.types_in_joined_envs since.types_in_joined_envs
 
 let existential_for_these_simples env canonicals kind =
   let existential_var, bindings =
     Bindings_in_target_env.existential_for_these_simples env.bindings canonicals
       kind
   in
-  let definitions_in_joined_envs =
+  let definitions_of_existentials =
     if
       Variable_in_target_env.Map.mem existential_var
-        env.definitions_in_joined_envs
-    then env.definitions_in_joined_envs
+        env.definitions_of_existentials
+    then env.definitions_of_existentials
     else
-      Variable_in_target_env.Map.add existential_var
-        (These_canonicals (canonicals, kind))
-        env.definitions_in_joined_envs
+      Variable_in_target_env.Map.add existential_var (canonicals, kind)
+        env.definitions_of_existentials
   in
-  existential_var, { env with bindings; definitions_in_joined_envs }
+  existential_var, { env with bindings; definitions_of_existentials }
 
 let import_from_all_envs env var kind =
   let bindings =
@@ -1155,16 +1144,15 @@ let import_from_all_envs env var kind =
     Variable_in_target_env.create
       (var : Variable_in_one_joined_env.t :> Variable.t)
   in
-  let definitions_in_joined_envs =
-    if
-      Variable_in_target_env.Map.mem imported_var env.definitions_in_joined_envs
-    then env.definitions_in_joined_envs
+  let types_in_joined_envs =
+    if Variable_in_target_env.Map.mem imported_var env.types_in_joined_envs
+    then env.types_in_joined_envs
     else
       Variable_in_target_env.Map.add imported_var
-        (Imported_var (var, kind))
-        env.definitions_in_joined_envs
+        (Joined_envs.find_imported_var env.joined_envs var kind)
+        env.types_in_joined_envs
   in
-  { env with bindings; definitions_in_joined_envs }
+  { env with bindings; types_in_joined_envs }
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1322,26 +1310,20 @@ let add_equation env name ty =
 let join_aliases_into_bindings env equations_to_join =
   fold_incremental_join_in_target_env equations_to_join
     ~exists_in_target_env:
-      (Bindings_in_target_env.exists_in_target_env env.bindings)
-    ~init:(Name_in_target_env.Map.empty, env)
-    ~f:(fun var join_entry (equations_to_join, env) ->
+      (Bindings_in_target_env.exists_in_target_env env.bindings) ~init:env
+    ~f:(fun var join_entry env ->
       match get_types_in_joined_envs join_entry with
       | Bottom -> Misc.fatal_error "Unexpected bottom during join"
       | Ok (No_alias_in_some_env types) ->
-        let equations_to_join =
-          Name_in_target_env.Map.add
-            (Name_in_target_env.var var)
-            types equations_to_join
+        let types_in_joined_envs =
+          Variable_in_target_env.Map.add var types env.types_in_joined_envs
         in
-        equations_to_join, env
+        { env with types_in_joined_envs }
       | Ok (Equals_in_all_envs (canonicals, kind)) -> (
         let[@local] add_equals_in_target_env env canonical =
-          let env =
-            add_equation env
-              (Name_in_target_env.var var)
-              (Type_in_target_env.alias_type_of kind canonical)
-          in
-          equations_to_join, env
+          add_equation env
+            (Name_in_target_env.var var)
+            (Type_in_target_env.alias_type_of kind canonical)
         in
         match get_canonical_in_target_env env canonicals with
         | Canonical_in_source_env canonical ->
@@ -1556,8 +1538,9 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
 
 let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
     inverse_relations =
-  Name_in_target_env.Map.fold
-    (fun name types (inverse_relations, t) ->
+  Variable_in_target_env.Map.fold
+    (fun var types (inverse_relations, t) ->
+      let name = Name_in_target_env.var var in
       if
         Flambda_features.check_light_invariants ()
         && Name_in_target_env.Map.mem name t.types_in_target_env
@@ -1565,12 +1548,11 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
         Misc.fatal_errorf
           "Processing join of %a but we already have a type for it."
           Name_in_target_env.print name;
-      match
-        n_way_join_type t
-          (Index.Map.bindings (Joined_envs.expand_heads t.joined_envs types)
-            : (Index.t * Type_in_one_joined_env.t) list
-            :> (Index.t * TG.t) list)
-      with
+      let heads =
+        Index.Map.bindings
+          (types : Type_in_one_joined_env.t Index.Map.t :> TG.t Index.Map.t)
+      in
+      match n_way_join_type t heads with
       | Unknown, t -> inverse_relations, t
       | Known ty, t ->
         let exists_in_all_joined_envs =
@@ -1743,7 +1725,7 @@ let define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
     | Zero | One -> true
     | More_than_one -> false
   in
-  let definitions = env.definitions_in_joined_envs in
+  let definitions = env.definitions_of_existentials in
   let target_env, to_expand, equations, inverse_relations, definitions =
     Bindings_in_target_env.fold_existential_variables
       (fun var kind
@@ -1850,41 +1832,45 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
     in
     let joined_envs = Joined_envs.create equations_to_join in
     let empty_env = create ~joined_envs ~bindings:empty_bindings in
-    let concrete_equations_to_join, env =
-      join_aliases_into_bindings empty_env equations_to_join
+    let env = join_aliases_into_bindings empty_env equations_to_join in
+    let rec n_way_join_delayed_equations env_this_round inverse_relations
+        equations_this_round =
+      if Variable_in_target_env.Map.is_empty equations_this_round
+      then inverse_relations, env_this_round
+      else
+        let inverse_relations, env_next_round =
+          n_way_join_round ~n_way_join_type env_this_round equations_this_round
+            inverse_relations
+        in
+        n_way_join_delayed_equations env_next_round inverse_relations
+          (new_equations_in_joined_envs env_next_round ~since:env_this_round)
     in
-    let equations_for_bindings env ~since =
-      let new_bindings = new_definitions_in_joined_envs env ~since in
-      Variable.Map.map
-        (fun (definition : definition_in_joined_envs) ->
-          match definition with
-          | Imported_var (var, kind) ->
-            Joined_envs.alias_types_of_local_var joined_envs kind var
-          | These_canonicals (simples, kind) ->
-            Index.Map.map
-              (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
-              simples)
-        (new_bindings :> definition_in_joined_envs Variable.Map.t)
-      |> Name.var_map |> Name_in_target_env.create_map
-    in
-    let equations_to_join =
-      Name_in_target_env.Map.disjoint_union concrete_equations_to_join
-        (equations_for_bindings env ~since:empty_env)
-    in
-    let rec loop t equations_to_join inverse_relations =
-      let env_before_this_round = t in
-      let inverse_relations, t =
-        n_way_join_round ~n_way_join_type t equations_to_join inverse_relations
-      in
-      let new_equations_to_join =
-        equations_for_bindings env ~since:env_before_this_round
-      in
-      if Name_in_target_env.Map.is_empty new_equations_to_join
-      then inverse_relations, t
-      else loop t new_equations_to_join inverse_relations
+    let rec n_way_join_loop env_this_round inverse_relations
+        existentials_this_round =
+      if Variable_in_target_env.Map.is_empty existentials_this_round
+      then inverse_relations, env_this_round
+      else
+        let equations_in_joined_envs =
+          Variable_in_target_env.Map.map
+            (fun (simples, kind) ->
+              Joined_envs.find_simples_in_joined_envs env_this_round.joined_envs
+                simples kind)
+            existentials_this_round
+        in
+        let inverse_relations, env_next_round =
+          n_way_join_delayed_equations env_this_round inverse_relations
+            equations_in_joined_envs
+        in
+        n_way_join_loop env_next_round inverse_relations
+          (new_definitions_of_existentials env_next_round ~since:env_this_round)
     in
     let inverse_relations, env =
-      loop env equations_to_join Variable.Map.empty
+      n_way_join_delayed_equations env Variable.Map.empty
+        (new_equations_in_joined_envs env ~since:empty_env)
+    in
+    let inverse_relations, env =
+      n_way_join_loop env inverse_relations
+        (new_definitions_of_existentials env ~since:empty_env)
     in
     let target_env, definitions =
       define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
@@ -1913,68 +1899,38 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
 module Analysis = struct
   type 'a t =
     { definitions_in_joined_envs :
-        definition_in_joined_envs Variable_in_target_env.Map.t;
+        (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
       canonical_definitions_at_normal_mode :
-        (Simple_in_one_joined_env.t Index.Map.t * K.t)
-        Variable_in_target_env.Map.t;
+        (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
       external_ids : 'a Index.Map.t
     }
 
   let print ppf { definitions_in_joined_envs; _ } =
     Variable_in_target_env.Map.print
-      (fun ppf (def : definition_in_joined_envs) ->
-        match def with
-        | Imported_var (var, _) ->
-          Format.fprintf ppf "@[<hov 1>(imported@ %a)@]"
-            Variable_in_one_joined_env.print var
-        | These_canonicals (simples, _) ->
-          Index.Map.print Simple_in_one_joined_env.print ppf simples)
+      (fun ppf (simples, _) ->
+        Index.Map.print Simple_in_one_joined_env.print ppf simples)
       ppf definitions_in_joined_envs
 
   let create ~external_ids ~joined_envs definitions_in_joined_envs =
     let canonical_definitions_at_normal_mode =
       Variable_in_target_env.Map.filter_map
-        (fun _name (definition : definition_in_joined_envs) ->
-          match definition with
-          | Imported_var (var, kind) ->
-            let var = (var :> Variable.t) in
-            let exists_at_normal_name_mode_in_all_envs =
-              Index.Map.for_all
-                (fun _env_id typing_env ->
-                  TE.mem ~min_name_mode:Name_mode.normal typing_env
-                    (Name.var var))
-                joined_envs
-            in
-            if exists_at_normal_name_mode_in_all_envs
-            then
-              Some
-                ( Index.Map.map
-                    (fun typing_env ->
-                      Simple_in_one_joined_env.create
-                        (TE.get_canonical_simple_exn
-                           ~min_name_mode:Name_mode.normal typing_env
-                           (Simple.var var)))
-                    joined_envs,
-                  kind )
-            else None
-          | These_canonicals (simples, kind) ->
-            let exists_at_normal_name_mode_in_all_envs_it_is_defined_in =
-              Index.Map.for_all
-                (fun env_id simple ->
-                  let typing_env =
-                    match Index.Map.find_opt env_id joined_envs with
-                    | Some typing_env -> typing_env
-                    | None ->
-                      Misc.fatal_errorf "Join does not include environment %a"
-                        Index.print env_id
-                  in
-                  TE.mem_simple ~min_name_mode:Name_mode.normal typing_env
-                    simple)
-                (simples :> Simple.t Index.Map.t)
-            in
-            if exists_at_normal_name_mode_in_all_envs_it_is_defined_in
-            then Some (simples, kind)
-            else None)
+        (fun _name (simples, kind) ->
+          let exists_at_normal_name_mode_in_all_envs_it_is_defined_in =
+            Index.Map.for_all
+              (fun env_id simple ->
+                let typing_env =
+                  match Index.Map.find_opt env_id joined_envs with
+                  | Some typing_env -> typing_env
+                  | None ->
+                    Misc.fatal_errorf "Join does not include environment %a"
+                      Index.print env_id
+                in
+                TE.mem_simple ~min_name_mode:Name_mode.normal typing_env simple)
+              (simples : Simples_in_joined_envs.t :> Simple.t Index.Map.t)
+          in
+          if exists_at_normal_name_mode_in_all_envs_it_is_defined_in
+          then Some (simples, kind)
+          else None)
         definitions_in_joined_envs
     in
     { definitions_in_joined_envs;
@@ -2026,10 +1982,7 @@ module Analysis = struct
              [Latest_bound_source_var] / [Canonical_in_source_env] case in
              [join_aliases_into_bindings]. *)
           Not_refined_at_join
-        | Some (Imported_var (var, _)) ->
-          Invariant_in_all_uses
-            (Simple.var (var : Variable_in_one_joined_env.t :> Variable.t))
-        | Some (These_canonicals (canonicals_in_joined_envs, kind)) ->
+        | Some (canonicals_in_joined_envs, kind) ->
           Variable_refined_at_these_uses
             { Variable_refined_at_join.canonicals_in_joined_envs;
               kind;
@@ -2356,7 +2309,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
       let env_in_extension =
         create ~joined_envs ~bindings:env_before_extension.bindings
       in
-      let concrete_types_to_join, env_in_extension =
+      let env_in_extension =
         join_aliases_into_bindings env_in_extension joined_equations
       in
       (* CR-someday bclement: if we create new existential variables during the
@@ -2365,7 +2318,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
          round should be plenty. *)
       let _env_extension_for_inverse_relations, env_in_extension =
         n_way_join_round ~n_way_join_type env_in_extension
-          concrete_types_to_join Variable.Map.empty
+          env_in_extension.types_in_joined_envs Variable.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in
          [prepare_nested_join] above to create new variables, which do not exist

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1070,6 +1070,33 @@ end = struct
       types
 end
 
+module Aliases_of_existentials = struct
+  type t =
+    { aliases_of_variables :
+        Variable_in_target_env.Set.t Variable_in_target_env.Map.t
+    }
+
+  let empty = { aliases_of_variables = Variable_in_target_env.Map.empty }
+
+  let aliases_of_existential_var t var =
+    try Variable_in_target_env.Map.find var t.aliases_of_variables
+    with Not_found -> Variable_in_target_env.Set.empty
+
+  let add t ~(demoted_var : Variable_in_target_env.t)
+      ~(existential_var : Variable_in_target_env.t) =
+    let aliases_of_canonical_element =
+      aliases_of_existential_var t existential_var
+    in
+    let aliases_of_existential_var =
+      Variable_in_target_env.Set.add demoted_var aliases_of_canonical_element
+    in
+    let aliases_of_variables =
+      Variable_in_target_env.Map.add existential_var aliases_of_existential_var
+        t.aliases_of_variables
+    in
+    { aliases_of_variables }
+end
+
 (** {1 Public interface} *)
 
 type env_id = Index.t
@@ -1083,6 +1110,7 @@ type definition_in_joined_envs =
 type t =
   { joined_envs : Joined_envs.t;
     types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
+    aliases_of_existentials : Aliases_of_existentials.t;
     definitions_in_joined_envs :
       definition_in_joined_envs Variable_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
@@ -1091,6 +1119,7 @@ type t =
 let create ~joined_envs ~bindings =
   { joined_envs;
     types_in_target_env = Name_in_target_env.Map.empty;
+    aliases_of_existentials = Aliases_of_existentials.empty;
     definitions_in_joined_envs = Variable_in_target_env.Map.empty;
     bindings
   }
@@ -1328,6 +1357,11 @@ let join_aliases_into_bindings env equations_to_join =
           let existential_var, env =
             existential_for_these_simples env canonicals kind
           in
+          let aliases_of_existentials =
+            Aliases_of_existentials.add env.aliases_of_existentials
+              ~demoted_var:var ~existential_var
+          in
+          let env = { env with aliases_of_existentials } in
           let simple = Simple_in_target_env.var existential_var in
           add_equals_in_target_env env simple))
 
@@ -1625,6 +1659,142 @@ let cut_for_join typing_env ~cut_after =
   in
   incremental_equations, symbol_projections
 
+let move_inverse_relation ~from ~to_ inverse_relations =
+  match Variable.Map.find from inverse_relations with
+  | exception Not_found -> inverse_relations
+  | names ->
+    let inverse_relations = Variable.Map.remove from inverse_relations in
+    Variable.Map.union_total_shared
+      (fun _ rels1 rels2 ->
+        TG.Relation.Map.union_total_shared
+          (fun _ names1 names2 -> Name.Set.union names1 names2)
+          rels1 rels2)
+      (Variable.Map.singleton to_ names)
+      inverse_relations
+
+let move_equation ~from ~to_ equations =
+  let from = Name.var from in
+  let to_ = Name.var to_ in
+  if Name.Map.mem to_ equations
+  then
+    Misc.fatal_errorf
+      "Cannot move equation from %a to %a: there is already an equation: %a"
+      Name.print from Name.print to_ TG.print
+      (Name.Map.find to_ equations);
+  match Name.Map.find from equations with
+  | exception Not_found -> equations
+  | ty ->
+    let equations = Name.Map.remove from equations in
+    Name.Map.add to_ ty equations
+
+let move_definition ~from ~to_ definitions =
+  let from = Variable_in_target_env.create from in
+  let to_ = Variable_in_target_env.create to_ in
+  match Variable_in_target_env.Map.find from definitions with
+  | exception Not_found -> definitions
+  | defn ->
+    let definitions = Variable_in_target_env.Map.remove from definitions in
+    Variable_in_target_env.Map.add to_ defn definitions
+
+let alias_equations_for_existential kind ~canonical_element ~demoted_aliases
+    equations =
+  let ty = TG.alias_type_of kind canonical_element in
+  let equations =
+    Variable_in_target_env.Set.fold
+      (fun alias equations ->
+        Name.Map.add (Name.var (alias :> Variable.t)) ty equations)
+      demoted_aliases equations
+  in
+  ty, equations
+
+let define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
+    source_env inverse_relations =
+  let target_env =
+    Bindings_in_target_env.fold_imported_variables
+      (fun var kind target_env ->
+        ME.add_variable_definition target_env
+          (var :> Variable.t)
+          kind Name_mode.in_types)
+      env.bindings source_env
+  in
+  let equations = (env.types_in_target_env :> TG.t Name.Map.t) in
+  let definitions = env.definitions_in_joined_envs in
+  let target_env, to_expand, equations, inverse_relations, definitions =
+    Bindings_in_target_env.fold_existential_variables
+      (fun var kind
+           (target_env, to_expand, equations, inverse_relations, definitions) ->
+        let aliases_of_var =
+          Aliases_of_existentials.aliases_of_existential_var
+            env.aliases_of_existentials var
+        in
+        let var = (var :> Variable.t) in
+        match Variable_in_target_env.Set.choose_opt aliases_of_var with
+        | None ->
+          (* This includes existential variables that have no other aliases, and
+             imported variables. *)
+          let target_env =
+            ME.add_variable_definition target_env var kind Name_mode.in_types
+          in
+          target_env, to_expand, equations, inverse_relations, definitions
+        | Some canon_var ->
+          let demoted_aliases =
+            Variable_in_target_env.Set.remove canon_var aliases_of_var
+          in
+          let canon_var = (var :> Variable.t) in
+          let definitions =
+            move_definition definitions ~from:var ~to_:canon_var
+          in
+          let equations = move_equation equations ~from:var ~to_:canon_var in
+          let inverse_relations =
+            move_inverse_relation inverse_relations ~from:var ~to_:canon_var
+          in
+          let ty, equations =
+            alias_equations_for_existential kind equations
+              ~canonical_element:(Simple.var canon_var) ~demoted_aliases
+          in
+          let to_expand = Variable.Map.add var ty to_expand in
+          target_env, to_expand, equations, inverse_relations, definitions)
+      env.bindings
+      (target_env, Variable.Map.empty, equations, inverse_relations, definitions)
+  in
+  let to_project = Variable.Map.keys to_expand in
+  let rec expand var =
+    match Variable.Map.find var to_expand with
+    | exception Not_found -> assert false
+    | ty -> (
+      match TG.get_alias_opt ty with
+      | None -> TG.project_variables_out ~to_project ~expand ty
+      | Some simple ->
+        Simple.pattern_match' simple
+          ~const:(fun _ -> ty)
+          ~symbol:(fun _ ~coercion:_ -> ty)
+          ~var:(fun var ~coercion ->
+            if Variable.Set.mem var to_project
+            then TG.apply_coercion (expand var) coercion
+            else ty))
+  in
+  let equations =
+    Name.Map.map (TG.project_variables_out ~to_project ~expand) equations
+  in
+  let equations_for_inverse_relations =
+    Variable.Map.map
+      (fun inverse_relations ->
+        TG.Head_of_kind_naked_immediate.create_inverse_relations
+          inverse_relations
+        |> TG.create_from_head_naked_immediate
+        |> TG.project_variables_out ~to_project ~expand)
+      inverse_relations
+    |> Name.var_map
+  in
+  let target_env =
+    ME.add_env_extension ~meet_expanded_head target_env (TEE.from_map equations)
+  in
+  let target_env =
+    ME.add_env_extension ~meet_expanded_head target_env
+      (TEE.from_map equations_for_inverse_relations)
+  in
+  target_env, definitions
+
 let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
     source_env source_tenv joined_envs equations_to_join
     symbol_projections_to_join =
@@ -1664,59 +1834,15 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
         equations_for_bindings env ~since:env_before_this_round
       in
       if Name_in_target_env.Map.is_empty new_equations_to_join
-      then
-        let env_extension_for_inverse_relations =
-          TEE.from_map
-            (Variable.Map.map
-               (fun inverse_relations ->
-                 TG.create_from_head_naked_immediate
-                   (TG.Head_of_kind_naked_immediate.create_inverse_relations
-                      inverse_relations))
-               inverse_relations
-            |> Name.var_map)
-        in
-        ( (* We compute symbol projections last so that we can pick up
-             existential variables, but there is no need to create existential
-             variables from symbol projections since they would not be
-             accessible.
-
-             CR-someday bclement: perform CSE for symbol projections? *)
-          t.types_in_target_env,
-          env_extension_for_inverse_relations,
-          n_way_join_symbol_projections t symbol_projections_to_join,
-          t )
+      then inverse_relations, t
       else loop t new_equations_to_join inverse_relations
     in
-    let equations, env_extension_for_inverse_relations, symbol_projections, env
-        =
+    let inverse_relations, env =
       loop env equations_to_join Variable.Map.empty
     in
-    let target_env =
-      Bindings_in_target_env.fold_imported_variables
-        (fun var kind target_env ->
-          ME.add_variable_definition target_env
-            (var :> Variable.t)
-            kind Name_mode.in_types)
-        env.bindings source_env
-    in
-    let target_env =
-      Bindings_in_target_env.fold_existential_variables
-        (fun var kind target_env ->
-          ME.add_variable_definition target_env
-            (var : Variable_in_target_env.t :> Variable.t)
-            kind Name_mode.in_types)
-        env.bindings target_env
-    in
-    let target_env =
-      ME.add_env_extension ~meet_expanded_head target_env
-        (TEE.from_map
-           (equations
-             : Type_in_target_env.t Name_in_target_env.Map.t
-             :> TG.t Name.Map.t))
-    in
-    let target_env =
-      ME.add_env_extension ~meet_expanded_head target_env
-        env_extension_for_inverse_relations
+    let target_env, definitions =
+      define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
+        source_env inverse_relations
     in
     let target_env =
       Variable_in_target_env.Map.fold
@@ -1724,9 +1850,10 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
           ME.add_symbol_projection target_env
             (var :> Variable.t)
             symbol_projection)
-        symbol_projections target_env
+        (n_way_join_symbol_projections env symbol_projections_to_join)
+        target_env
     in
-    target_env, new_definitions_in_joined_envs env ~since:empty_env
+    target_env, definitions
   with Misc.Fatal_error ->
     let bt = Printexc.get_raw_backtrace () in
     Format.eprintf "\n@[<v 2>%tContext is:%t cut and join of levels:@ %a@]\n"

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -479,9 +479,6 @@ module Int_ids_from_source_env () = struct
 
     (* See {!section-scope_of_names} *)
     let from_source_env (name : Name_in_source_env.t) = create (name :> Name.t)
-
-    let from_source_env_map (type a) map =
-      create_map (map : a Name_in_source_env.Map.t :> a Name.Map.t)
   end
 
   module Simple = struct
@@ -765,11 +762,11 @@ module Bindings_in_target_env : sig
 
   (* Must only be called from the toplevel join, before creating any local
      variable. *)
-  val add_alias_between_names_in_source_env :
-    t -> K.t -> Name_in_source_env.t -> Simple_in_source_env.t -> t
+  val add_alias_between_names_in_target_env :
+    t -> K.t -> Name_in_target_env.t -> Simple_in_source_env.t -> t
 
-  (* Record the [name_in_source_env] as the canonical name for this set of
-     simples in joined environments. If there was already a [name_in_source_env]
+  (* Record the [name_in_target_env] as the canonical name for this set of
+     simples in joined environments. If there was already a [name_in_target_env]
      representing that set of simple, an alias is recorded in the
      [alias_types_in_target_env] instead.
 
@@ -777,7 +774,7 @@ module Bindings_in_target_env : sig
      variable. *)
   val add_existential_for_these_simples :
     t ->
-    name_in_source_env:Name_in_source_env.t ->
+    name_in_target_env:Name_in_target_env.t ->
     Simples_in_joined_envs.t ->
     K.t ->
     t
@@ -791,7 +788,7 @@ module Bindings_in_target_env : sig
      variable. *)
   val add_imported_var :
     t ->
-    name_in_source_env:Name_in_source_env.t ->
+    name_in_target_env:Name_in_target_env.t ->
     coercion_to_name_in_source_env:Coercion.t ->
     Variable_in_one_joined_env.t ->
     K.t ->
@@ -819,7 +816,7 @@ module Bindings_in_target_env : sig
     | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
 
   val alias_types_in_target_env :
-    t -> Type_in_target_env.t Name_in_source_env.Map.t
+    t -> Type_in_target_env.t Name_in_target_env.Map.t
 
   (* Assuming that [t] derives from [since], returns the definitions of local
      variables that have been added to [t] after [since]. *)
@@ -854,7 +851,7 @@ end = struct
 
   type t =
     { source_env : Source_env.t;
-      alias_types_in_target_env : Type_in_target_env.t Name_in_source_env.Map.t;
+      alias_types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
       (* Aliases shared across all the joined environments. *)
       existential_for_these_simples :
         Simple_in_target_env.t Simples_in_joined_envs.Map.t;
@@ -902,7 +899,7 @@ end = struct
 
   let from_source_env source_env =
     { source_env;
-      alias_types_in_target_env = Name_in_source_env.Map.empty;
+      alias_types_in_target_env = Name_in_target_env.Map.empty;
       existential_for_these_simples = Simples_in_joined_envs.Map.empty;
       imported_variables = Variable_in_one_joined_env.Map.empty;
       aliases_of_names_in_joined_envs = Index.Map.empty;
@@ -923,8 +920,7 @@ end = struct
     in
     if
       Simple_in_target_env.equal canonical_element
-        (Simple_in_target_env.from_source_env
-           (Simple_in_source_env.name name_to_be_demoted))
+        (Simple_in_target_env.name name_to_be_demoted)
     then
       if Coercion.is_id coercion_from_canonical_element_to_name_to_be_demoted
       then t
@@ -936,7 +932,7 @@ end = struct
              coercion_from_canonical_element_to_name_to_be_demoted)
     else
       let alias_types_in_target_env =
-        Name_in_source_env.Map.add name_to_be_demoted
+        Name_in_target_env.Map.add name_to_be_demoted
           (Type_in_target_env.alias_type_of kind
              (Simple_in_target_env.apply_coercion_exn canonical_element
                 coercion_from_canonical_element_to_name_to_be_demoted))
@@ -976,13 +972,9 @@ end = struct
       then Some var
       else None
 
-  let add_alias_between_names_in_source_env t kind name canonical =
-    assert (not (Name_in_source_env.Map.mem name t.alias_types_in_target_env));
-    assert (
-      not
-        (Name_in_target_env.Map.mem
-           (Name_in_target_env.from_source_env name)
-           t.definitions_in_joined_envs));
+  let add_alias_between_names_in_target_env t kind name canonical =
+    assert (not (Name_in_target_env.Map.mem name t.alias_types_in_target_env));
+    assert (not (Name_in_target_env.Map.mem name t.definitions_in_joined_envs));
     add_alias t kind ~name_to_be_demoted:name
       ~coercion_to_name_to_be_demoted:Coercion.id
       ~canonical_element:(Simple_in_target_env.from_source_env canonical)
@@ -1111,12 +1103,9 @@ end = struct
     | These_canonicals (simples, _kind) ->
       has_existential_for_these_simples t simples
 
-  let add_name_for_definition t ~name_in_source_env
+  let add_name_for_definition t ~name_in_target_env
       ~coercion_to_name_in_source_env definition =
-    (* name_in_source_env ~ coercion_to_name_in_source_env(definition) *)
-    let name_in_target_env =
-      Name_in_target_env.from_source_env name_in_source_env
-    in
+    (* name_in_target_env ~ coercion_to_name_in_source_env(definition) *)
     match existing_canonical_for t definition with
     | None ->
       let _, t =
@@ -1140,17 +1129,17 @@ end = struct
         | Imported_var (_, kind) | These_canonicals (_, kind) -> kind
       in
       add_alias t kind ~canonical_element:existing_canonical
-        ~name_to_be_demoted:name_in_source_env
+        ~name_to_be_demoted:name_in_target_env
         ~coercion_to_name_to_be_demoted:coercion_to_name_in_source_env
 
-  let add_existential_for_these_simples t ~name_in_source_env simples kind =
-    add_name_for_definition t ~name_in_source_env
+  let add_existential_for_these_simples t ~name_in_target_env simples kind =
+    add_name_for_definition t ~name_in_target_env
       ~coercion_to_name_in_source_env:Coercion.id
       (These_canonicals (simples, kind))
 
-  let add_imported_var t ~name_in_source_env ~coercion_to_name_in_source_env
+  let add_imported_var t ~name_in_target_env ~coercion_to_name_in_source_env
       imported_var kind =
-    add_name_for_definition t ~name_in_source_env
+    add_name_for_definition t ~name_in_target_env
       ~coercion_to_name_in_source_env
       (Imported_var (imported_var, kind))
 
@@ -1508,21 +1497,21 @@ let join_aliases_into_bindings ~joined_envs ~bindings equations_to_join =
          (Bindings_in_target_env.source_env bindings))
     ~init:(Name_in_target_env.Map.empty, bindings)
     ~f:(fun var join_entry (equations_to_join, bindings) ->
-      let name = Name_in_source_env.var var in
+      let name =
+        Name_in_target_env.from_source_env (Name_in_source_env.var var)
+      in
       match get_types_in_joined_envs join_entry with
       | Bottom -> Misc.fatal_error "Unexpected bottom during join"
       | Ok (No_alias_in_some_env types) ->
         let equations_to_join =
-          Name_in_target_env.Map.add
-            (Name_in_target_env.from_source_env name)
-            types equations_to_join
+          Name_in_target_env.Map.add name types equations_to_join
         in
         equations_to_join, bindings
       | Ok (Equals_in_all_envs (canonicals, kind)) -> (
         match get_canonical_in_target_env ~bindings ~joined_envs canonicals with
         | Canonical_in_source_env canonical ->
           let bindings =
-            Bindings_in_target_env.add_alias_between_names_in_source_env
+            Bindings_in_target_env.add_alias_between_names_in_target_env
               bindings kind name canonical
           in
           equations_to_join, bindings
@@ -1530,14 +1519,14 @@ let join_aliases_into_bindings ~joined_envs ~bindings equations_to_join =
           (* name = coercion(var) *)
           let bindings =
             Bindings_in_target_env.add_imported_var bindings
-              ~name_in_source_env:name ~coercion_to_name_in_source_env:coercion
+              ~name_in_target_env:name ~coercion_to_name_in_source_env:coercion
               var kind
           in
           equations_to_join, bindings
         | Existential_for_these_simples ->
           let bindings =
             Bindings_in_target_env.add_existential_for_these_simples bindings
-              ~name_in_source_env:name canonicals kind
+              ~name_in_target_env:name canonicals kind
           in
           equations_to_join, bindings))
 
@@ -1907,8 +1896,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
       loop
         (create ~joined_envs ~bindings)
         equations_to_join
-        (Name_in_target_env.from_source_env_map
-           (Bindings_in_target_env.alias_types_in_target_env bindings))
+        (Bindings_in_target_env.alias_types_in_target_env bindings)
         Name.Map.empty
     in
     let target_env =

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -722,24 +722,14 @@ module Bindings_in_target_env : sig
 
   val exists_in_target_env : t -> Variable.t -> Variable_in_target_env.t option
 
-  (* Return the (unique across the whole join) name to be used to represent an
-     imported variable. *)
-  val import_from_all_envs :
-    t -> Variable_in_one_joined_env.t -> K.t -> Variable_in_target_env.t * t
+  (* Mark a variable as imported in the target env, so that it gets redefined in
+     the target env. *)
+  val import_from_all_envs : t -> Variable_in_one_joined_env.t -> K.t -> t
 
   (* Return the (unique across the whole join) name to be used to represent this
      set of simples in joined environments. *)
   val existential_for_these_simples :
     t -> Simples_in_joined_envs.t -> K.t -> Variable_in_target_env.t * t
-
-  type definition_in_joined_envs =
-    | Imported_var of Variable_in_one_joined_env.t * K.t
-    | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
-  (* Assuming that [t] derives from [since], returns the definitions of local
-     variables that have been added to [t] after [since]. *)
-  val new_bindings :
-    t -> since:t -> definition_in_joined_envs Name_in_target_env.Map.t
 
   (* Assuming that [t] derives from [since], extract the created variables from
      [t], adding them to [since]. Any information about the created variables
@@ -747,7 +737,10 @@ module Bindings_in_target_env : sig
      forgotten, and they won't appear in the [new_bindings]. *)
   val forget_definition_of_created_variables : t -> since:t -> t
 
-  val fold_created_variables :
+  val fold_imported_variables :
+    (Variable_in_one_joined_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
+
+  val fold_existential_variables :
     (Variable_in_target_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
 
   (* These are for the join of env extensions, see [prepare_nested_join]. *)
@@ -763,42 +756,31 @@ module Bindings_in_target_env : sig
 end = struct
   type coercion_to_canonical_in_target_env = Coercion.t
 
-  type definition_in_joined_envs =
-    | Imported_var of Variable_in_one_joined_env.t * K.t
-    | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
   type t =
     { source_env : Source_env.t;
       existential_for_these_simples :
         Variable_in_target_env.t Simples_in_joined_envs.Map.t;
-      (* Maps a set of [simples] in joined environments to the (unique across
-         the whole join) name used to represent this exact set of simples in the
-         target environment. *)
-      imported_variables :
-        Variable_in_target_env.t Variable_in_one_joined_env.Map.t;
-      (* Maps a local variable (a variable that exists in at least one joined
-         environment) to its name in the target environment.
-
-         The underlying variable used in the joined and target environments is
-         the same, only the type-level metadata changes.
-
-         CR bclement: This should just be a set now. *)
-      created_variables : K.t Variable_in_target_env.Map.t;
-      (* This contains all the local variables (existentials or imported) that
-         exist in the target environment but not in the source environment. *)
-      definitions_in_joined_envs :
-        definition_in_joined_envs Name_in_target_env.Map.t;
-      (* Reverse map from local variables to their definition. *)
+          (* Maps a set of [simples] in joined environments to the (unique
+             across the whole join) name used to represent this exact set of
+             simples in the target environment. *)
+      imported_variables : K.t Variable_in_one_joined_env.Map.t;
+          (* Set of variables that have been imported from at least one of the
+             joined environments into the target environment. *)
+      existential_variables : K.t Variable_in_target_env.Map.t;
+          (* This contains all the existential variables, created during the
+             join, that exist in the target environment but not in the source
+             environment or in any of the joined environments. *)
       aliases_of_names_in_joined_envs :
         coercion_to_canonical_in_target_env Name_in_target_env.Map.t
         Name_in_one_joined_env.Map.t
         Index.Map.t;
-      (* For each joined environment and each name in the joined environment,
-         record the set of names in the target environment it is equal to (and
-         the corresponding coercions).
+          (* For each joined environment and each name in the joined
+             environment, record the set of names in the target environment it
+             is equal to (and the corresponding coercions).
 
-         This is used to implement [replay_definitions_of_aliases_in_target_env]
-         in the join of env extensions, see [prepare_nested_join]. *)
+             This is used to implement
+             [replay_definitions_of_aliases_in_target_env] in the join of env
+             extensions, see [prepare_nested_join]. *)
       equations_for_local_vars :
         Type_in_one_joined_env.t Variable_in_target_env.Map.t Index.Map.t
           (* Environment extensions to use in each of the joined environments to
@@ -814,27 +796,19 @@ end = struct
       existential_for_these_simples = Simples_in_joined_envs.Map.empty;
       imported_variables = Variable_in_one_joined_env.Map.empty;
       aliases_of_names_in_joined_envs = Index.Map.empty;
-      definitions_in_joined_envs = Name_in_target_env.Map.empty;
       equations_for_local_vars = Index.Map.empty;
-      created_variables = Variable_in_target_env.Map.empty
+      existential_variables = Variable_in_target_env.Map.empty
     }
-
-  let new_bindings t ~since =
-    Name_in_target_env.Map.diff_shared
-      (fun _ new_definition _old_definition -> Some new_definition)
-      t.definitions_in_joined_envs since.definitions_in_joined_envs
 
   let forget_definition_of_created_variables t ~since =
     (* We still need to record the fact that we created those variables in order
        to add them to the target environment at the end of the join. *)
-    { since with created_variables = t.created_variables }
+    { since with
+      existential_variables = t.existential_variables;
+      imported_variables = t.imported_variables
+    }
 
   let source_env { source_env; _ } = source_env
-
-  let is_local_variable { created_variables; _ } var =
-    if Variable_in_target_env.Map.mem var created_variables
-    then Some var
-    else None
 
   let exists_in_target_env t var =
     match Source_env.exists_in_source_env (source_env t) var with
@@ -842,7 +816,11 @@ end = struct
       Some (Variable_in_target_env.from_source_env var_in_source_env)
     | None ->
       let var = Variable_in_target_env.create var in
-      if Variable_in_target_env.Map.mem var t.created_variables
+      if
+        Variable_in_target_env.Map.mem var t.existential_variables
+        || Variable_in_one_joined_env.Map.mem
+             (Variable_in_one_joined_env.create (var :> Variable.t))
+             t.imported_variables
       then Some var
       else None
 
@@ -870,24 +848,23 @@ end = struct
               aliases_in_target_env))
       simples aliases_in_target_env
 
-  let record_definition_for t ~var_in_target_env definition =
-    (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
-    let definitions_in_joined_envs =
-      Name_in_target_env.Map.add
-        (Name_in_target_env.var var_in_target_env)
-        definition t.definitions_in_joined_envs
-    in
-    match definition with
-    | Imported_var (imported_var, _kind) ->
-      let imported_variables =
-        Variable_in_one_joined_env.Map.add imported_var var_in_target_env
-          t.imported_variables
+  let has_existential_for_these_simples t simples =
+    Simples_in_joined_envs.Map.find_opt simples t.existential_for_these_simples
+
+  let existential_for_these_simples t simples kind =
+    match has_existential_for_these_simples t simples with
+    | Some existing_canonical -> existing_canonical, t
+    | None ->
+      let var =
+        let name = Simples_in_joined_envs.choose_a_suitable_name simples in
+        Variable_in_target_env.create (Variable.create name kind)
       in
-      ( var_in_target_env,
-        { t with imported_variables; definitions_in_joined_envs } )
-    | These_canonicals (simples, kind) ->
+      let existential_variables =
+        Variable_in_target_env.Map.add var kind t.existential_variables
+      in
+      let t = { t with existential_variables } in
       let existential_for_these_simples =
-        Simples_in_joined_envs.Map.add simples var_in_target_env
+        Simples_in_joined_envs.Map.add simples var
           t.existential_for_these_simples
       in
       (* The following is some bookkeeping so that we know how to replay the
@@ -896,75 +873,41 @@ end = struct
       let equations_for_local_vars =
         (* If the variable is a fresh variable, record it so that we can replay
            its definition during the join of env extensions. *)
-        match is_local_variable t var_in_target_env with
-        | None -> t.equations_for_local_vars
-        | Some var ->
-          Index.Map.update_many
-            (fun _index existentials simple ->
-              let ty = Type_in_one_joined_env.alias_type_of kind simple in
-              let existentials_in_one_joined_env =
-                Variable_in_target_env.Map.add var ty
-                  (Option.value ~default:Variable_in_target_env.Map.empty
-                     existentials)
-              in
-              Some existentials_in_one_joined_env)
-            t.equations_for_local_vars simples
+        Index.Map.update_many
+          (fun _index existentials simple ->
+            let ty = Type_in_one_joined_env.alias_type_of kind simple in
+            let existentials_in_one_joined_env =
+              Variable_in_target_env.Map.add var ty
+                (Option.value ~default:Variable_in_target_env.Map.empty
+                   existentials)
+            in
+            Some existentials_in_one_joined_env)
+          t.equations_for_local_vars simples
       in
       let aliases_of_names_in_joined_envs =
         update_aliases_of_names_in_joined_envs simples
           t.aliases_of_names_in_joined_envs ~f:(fun coercion aliases ->
             (* definition ~ coercion(name_in_joined_env) *)
             Name_in_target_env.Map.add
-              (Name_in_target_env.var var_in_target_env)
+              (Name_in_target_env.var var)
               coercion aliases)
       in
-      ( var_in_target_env,
+      ( var,
         { t with
           equations_for_local_vars;
           existential_for_these_simples;
-          aliases_of_names_in_joined_envs;
-          definitions_in_joined_envs
+          aliases_of_names_in_joined_envs
         } )
 
-  let create_name_for_definition t definition =
-    let var, kind =
-      match definition with
-      | Imported_var (var, kind) ->
-        let var = (var : Variable_in_one_joined_env.t :> Variable.t) in
-        Variable_in_target_env.create var, kind
-      | These_canonicals (simples, kind) ->
-        let name = Simples_in_joined_envs.choose_a_suitable_name simples in
-        Variable_in_target_env.create (Variable.create name kind), kind
-    in
-    let created_variables =
-      Variable_in_target_env.Map.add var kind t.created_variables
-    in
-    let t = { t with created_variables } in
-    record_definition_for t ~var_in_target_env:var definition
-
-  let is_imported_from_all_joined_envs t var =
-    Variable_in_one_joined_env.Map.find_opt var t.imported_variables
-
-  let has_existential_for_these_simples t simples =
-    Simples_in_joined_envs.Map.find_opt simples t.existential_for_these_simples
-
-  let existing_canonical_for t definition =
-    match definition with
-    | Imported_var (imported_var, _kind) ->
-      is_imported_from_all_joined_envs t imported_var
-    | These_canonicals (simples, _kind) ->
-      has_existential_for_these_simples t simples
-
-  let get_or_create_canonical_for t definition =
-    match existing_canonical_for t definition with
-    | None -> create_name_for_definition t definition
-    | Some existing_canonical -> existing_canonical, t
-
-  let existential_for_these_simples t simples kind =
-    get_or_create_canonical_for t (These_canonicals (simples, kind))
-
   let import_from_all_envs t imported_var kind =
-    get_or_create_canonical_for t (Imported_var (imported_var, kind))
+    if Variable_in_one_joined_env.Map.mem imported_var t.imported_variables
+    then t
+    else
+      let imported_variables =
+        Variable_in_one_joined_env.Map.add imported_var kind
+          t.imported_variables
+      in
+      { t with imported_variables }
 
   let replay_definition_of_aliases_in_target_env t index equations =
     match Index.Map.find_opt index t.aliases_of_names_in_joined_envs with
@@ -993,10 +936,15 @@ end = struct
     | None -> Variable_in_target_env.Map.empty
     | Some existentials -> existentials
 
-  let fold_created_variables f t acc =
+  let fold_imported_variables f t acc =
     (* CR bclement: iterate in order consistent with the recorded binding
        times. *)
-    Variable_in_target_env.Map.fold f t.created_variables acc
+    Variable_in_one_joined_env.Map.fold f t.imported_variables acc
+
+  let fold_existential_variables f t acc =
+    (* CR bclement: iterate in order consistent with the recorded binding
+       times. *)
+    Variable_in_target_env.Map.fold f t.existential_variables acc
 end
 
 module Joined_envs : sig
@@ -1128,14 +1076,65 @@ type env_id = Index.t
 
 type 'a join_arg = env_id * 'a
 
+type definition_in_joined_envs =
+  | Imported_var of Variable_in_one_joined_env.t * K.t
+  | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
+
 type t =
   { joined_envs : Joined_envs.t;
     types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
+    definitions_in_joined_envs :
+      definition_in_joined_envs Variable_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
   }
 
 let create ~joined_envs ~bindings =
-  { joined_envs; types_in_target_env = Name_in_target_env.Map.empty; bindings }
+  { joined_envs;
+    types_in_target_env = Name_in_target_env.Map.empty;
+    definitions_in_joined_envs = Variable_in_target_env.Map.empty;
+    bindings
+  }
+
+let new_definitions_in_joined_envs t ~since =
+  Variable_in_target_env.Map.diff_shared
+    (fun _ new_definition _old_definition -> Some new_definition)
+    t.definitions_in_joined_envs since.definitions_in_joined_envs
+
+let existential_for_these_simples env canonicals kind =
+  let existential_var, bindings =
+    Bindings_in_target_env.existential_for_these_simples env.bindings canonicals
+      kind
+  in
+  let definitions_in_joined_envs =
+    if
+      Variable_in_target_env.Map.mem existential_var
+        env.definitions_in_joined_envs
+    then env.definitions_in_joined_envs
+    else
+      Variable_in_target_env.Map.add existential_var
+        (These_canonicals (canonicals, kind))
+        env.definitions_in_joined_envs
+  in
+  existential_var, { env with bindings; definitions_in_joined_envs }
+
+let import_from_all_envs env var kind =
+  let bindings =
+    Bindings_in_target_env.import_from_all_envs env.bindings var kind
+  in
+  let imported_var =
+    Variable_in_target_env.create
+      (var : Variable_in_one_joined_env.t :> Variable.t)
+  in
+  let definitions_in_joined_envs =
+    if
+      Variable_in_target_env.Map.mem imported_var env.definitions_in_joined_envs
+    then env.definitions_in_joined_envs
+    else
+      Variable_in_target_env.Map.add imported_var
+        (Imported_var (var, kind))
+        env.definitions_in_joined_envs
+  in
+  { env with bindings; definitions_in_joined_envs }
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1319,19 +1318,18 @@ let join_aliases_into_bindings env equations_to_join =
           add_equals_in_target_env env
             (Simple_in_target_env.from_source_env canonical)
         | Import_from_all_joined_envs (imported_var, coercion) ->
-          let imported_var, bindings =
-            Bindings_in_target_env.import_from_all_envs env.bindings
-              imported_var kind
+          let env = import_from_all_envs env imported_var kind in
+          let imported_var =
+            Variable_in_target_env.create (imported_var :> Variable.t)
           in
           let simple = Simple_in_target_env.var ~coercion imported_var in
-          add_equals_in_target_env { env with bindings } simple
+          add_equals_in_target_env env simple
         | Existential_for_these_simples ->
-          let existential_var, bindings =
-            Bindings_in_target_env.existential_for_these_simples env.bindings
-              canonicals kind
+          let existential_var, env =
+            existential_for_these_simples env canonicals kind
           in
           let simple = Simple_in_target_env.var existential_var in
-          add_equals_in_target_env { env with bindings } simple))
+          add_equals_in_target_env env simple))
 
 let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     env_extension name relation ~scrutinee =
@@ -1639,10 +1637,10 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
     let concrete_equations_to_join, env =
       join_aliases_into_bindings empty_env equations_to_join
     in
-    let equations_for_bindings bindings ~since =
-      let new_bindings = Bindings_in_target_env.new_bindings bindings ~since in
-      Name_in_target_env.Map.map
-        (fun (definition : Bindings_in_target_env.definition_in_joined_envs) ->
+    let equations_for_bindings env ~since =
+      let new_bindings = new_definitions_in_joined_envs env ~since in
+      Variable.Map.map
+        (fun (definition : definition_in_joined_envs) ->
           match definition with
           | Imported_var (var, kind) ->
             Joined_envs.alias_types_of_local_var joined_envs kind var
@@ -1650,19 +1648,20 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
             Index.Map.map
               (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
               simples)
-        new_bindings
+        (new_bindings :> definition_in_joined_envs Variable.Map.t)
+      |> Name.var_map |> Name_in_target_env.create_map
     in
     let equations_to_join =
       Name_in_target_env.Map.disjoint_union concrete_equations_to_join
-        (equations_for_bindings env.bindings ~since:empty_bindings)
+        (equations_for_bindings env ~since:empty_env)
     in
     let rec loop t equations_to_join inverse_relations =
-      let bindings_before_this_round = t.bindings in
+      let env_before_this_round = t in
       let inverse_relations, t =
         n_way_join_round ~n_way_join_type t equations_to_join inverse_relations
       in
       let new_equations_to_join =
-        equations_for_bindings t.bindings ~since:bindings_before_this_round
+        equations_for_bindings env ~since:env_before_this_round
       in
       if Name_in_target_env.Map.is_empty new_equations_to_join
       then
@@ -1685,22 +1684,28 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
           t.types_in_target_env,
           env_extension_for_inverse_relations,
           n_way_join_symbol_projections t symbol_projections_to_join,
-          t.bindings )
+          t )
       else loop t new_equations_to_join inverse_relations
     in
-    let ( equations,
-          env_extension_for_inverse_relations,
-          symbol_projections,
-          bindings ) =
+    let equations, env_extension_for_inverse_relations, symbol_projections, env
+        =
       loop env equations_to_join Variable.Map.empty
     in
     let target_env =
-      Bindings_in_target_env.fold_created_variables
+      Bindings_in_target_env.fold_imported_variables
+        (fun var kind target_env ->
+          ME.add_variable_definition target_env
+            (var :> Variable.t)
+            kind Name_mode.in_types)
+        env.bindings source_env
+    in
+    let target_env =
+      Bindings_in_target_env.fold_existential_variables
         (fun var kind target_env ->
           ME.add_variable_definition target_env
             (var : Variable_in_target_env.t :> Variable.t)
             kind Name_mode.in_types)
-        bindings source_env
+        env.bindings target_env
     in
     let target_env =
       ME.add_env_extension ~meet_expanded_head target_env
@@ -1721,8 +1726,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
             symbol_projection)
         symbol_projections target_env
     in
-    ( target_env,
-      Bindings_in_target_env.new_bindings bindings ~since:empty_bindings )
+    target_env, new_definitions_in_joined_envs env ~since:empty_env
   with Misc.Fatal_error ->
     let bt = Printexc.get_raw_backtrace () in
     Format.eprintf "\n@[<v 2>%tContext is:%t cut and join of levels:@ %a@]\n"
@@ -1752,16 +1756,16 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
 module Analysis = struct
   type 'a t =
     { definitions_in_joined_envs :
-        Bindings_in_target_env.definition_in_joined_envs
-        Name_in_target_env.Map.t;
+        definition_in_joined_envs Variable_in_target_env.Map.t;
       canonical_definitions_at_normal_mode :
-        (Simple_in_one_joined_env.t Index.Map.t * K.t) Name_in_target_env.Map.t;
+        (Simple_in_one_joined_env.t Index.Map.t * K.t)
+        Variable_in_target_env.Map.t;
       external_ids : 'a Index.Map.t
     }
 
   let print ppf { definitions_in_joined_envs; _ } =
-    Name_in_target_env.Map.print
-      (fun ppf (def : Bindings_in_target_env.definition_in_joined_envs) ->
+    Variable_in_target_env.Map.print
+      (fun ppf (def : definition_in_joined_envs) ->
         match def with
         | Imported_var (var, _) ->
           Format.fprintf ppf "@[<hov 1>(imported@ %a)@]"
@@ -1772,9 +1776,8 @@ module Analysis = struct
 
   let create ~external_ids ~joined_envs definitions_in_joined_envs =
     let canonical_definitions_at_normal_mode =
-      Name_in_target_env.Map.filter_map
-        (fun _name
-             (definition : Bindings_in_target_env.definition_in_joined_envs) ->
+      Variable_in_target_env.Map.filter_map
+        (fun _name (definition : definition_in_joined_envs) ->
           match definition with
           | Imported_var (var, kind) ->
             let var = (var :> Variable.t) in
@@ -1853,8 +1856,8 @@ module Analysis = struct
       ~symbol:(fun _ ~coercion:_ -> Invariant_in_all_uses simple)
       ~var:(fun var ~coercion:_ ->
         match
-          Name_in_target_env.Map.find_opt
-            (Name_in_target_env.create (Name.var var))
+          Variable_in_target_env.Map.find_opt
+            (Variable_in_target_env.create var)
             t.definitions_in_joined_envs
         with
         | None ->
@@ -1897,10 +1900,10 @@ module Analysis = struct
   end
 
   let fold_variables_created_at_join ~f t ~init =
-    Name_in_target_env.Map.fold
-      (fun name (canonicals_in_joined_envs, kind) acc ->
+    Variable_in_target_env.Map.fold
+      (fun var (canonicals_in_joined_envs, kind) acc ->
         (f [@inlined hint])
-          (name :> Name.t)
+          (Name.var (var :> Variable.t))
           { Simples_at_join.canonicals_in_joined_envs;
             external_ids = t.external_ids
           }
@@ -1977,17 +1980,15 @@ let n_way_join_canonicals env kind simples =
   | Canonical_in_source_env simple ->
     Simple_in_target_env.from_source_env simple, env
   | Import_from_all_joined_envs (imported_var, coercion) ->
-    let imported_var, bindings =
-      Bindings_in_target_env.import_from_all_envs env.bindings imported_var kind
+    let env = import_from_all_envs env imported_var kind in
+    let imported_var =
+      Variable_in_target_env.create (imported_var :> Variable.t)
     in
     let simple = Simple_in_target_env.var ~coercion imported_var in
-    simple, { env with bindings }
+    simple, env
   | Existential_for_these_simples ->
-    let existential_var, bindings =
-      Bindings_in_target_env.existential_for_these_simples env.bindings simples
-        kind
-    in
-    Simple_in_target_env.var existential_var, { env with bindings }
+    let existential_var, env = existential_for_these_simples env simples kind in
+    Simple_in_target_env.var existential_var, env
 
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1596,14 +1596,14 @@ let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     | Naked_vec256 _ | Naked_vec512 _ | Naked_mask _ | Rec_info _ | Region _ ->
       Misc.fatal_error "Kind mismatch for output of relation: expected %a")
 
-let add_to_inverse_relations inverse_relations name relation ~scrutinee =
-  Name.Map.union_total_shared
+let add_to_inverse_relations inverse_relations var relation ~scrutinee =
+  Variable.Map.union_total_shared
     (fun _ inv_rels1 inv_rels2 ->
       TG.Relation.Map.union_total_shared
         (fun _ names1 names2 -> Name.Set.union names1 names2)
         inv_rels1 inv_rels2)
     inverse_relations
-    (Name.Map.singleton name
+    (Variable.Map.singleton var
        (TG.Relation.Map.singleton relation (Name.Set.singleton scrutinee)))
 
 let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
@@ -1634,7 +1634,7 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
       (* If we have no immediates, we can add the inverse relation on [get_tag]
          at the toplevel. *)
       let inverse_relations =
-        add_to_inverse_relations inverse_relations (Name.var get_tag_var)
+        add_to_inverse_relations inverse_relations get_tag_var
           TG.Relation.get_tag ~scrutinee:name
       in
       ty, inverse_relations
@@ -1655,7 +1655,7 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
         match is_int with
         | None -> inverse_relations
         | Some is_int_var ->
-          add_to_inverse_relations inverse_relations (Name.var is_int_var)
+          add_to_inverse_relations inverse_relations is_int_var
             TG.Relation.is_int ~scrutinee:name
       in
       let ty =
@@ -1703,7 +1703,7 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
       match is_null with
       | None -> inverse_relations
       | Some is_null_var ->
-        add_to_inverse_relations inverse_relations (Name.var is_null_var)
+        add_to_inverse_relations inverse_relations is_null_var
           TG.Relation.is_null ~scrutinee:name
     in
     ty, inverse_relations
@@ -1870,12 +1870,13 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
       then
         let env_extension_for_inverse_relations =
           TEE.from_map
-            (Name.Map.map
+            (Variable.Map.map
                (fun inverse_relations ->
                  TG.create_from_head_naked_immediate
                    (TG.Head_of_kind_naked_immediate.create_inverse_relations
                       inverse_relations))
-               inverse_relations)
+               inverse_relations
+            |> Name.var_map)
         in
         ( (* We compute symbol projections last so that we can pick up
              existential variables, but there is no need to create existential
@@ -1897,7 +1898,7 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
         (create ~joined_envs ~bindings)
         equations_to_join
         (Bindings_in_target_env.alias_types_in_target_env bindings)
-        Name.Map.empty
+        Variable.Map.empty
     in
     let target_env =
       Bindings_in_target_env.fold_created_variables
@@ -2446,7 +2447,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
             { bindings = bindings_after_extension; _ } ) =
         n_way_join_round ~n_way_join_type
           (create ~joined_envs ~bindings)
-          concrete_types_to_join alias_types_in_target_env Name.Map.empty
+          concrete_types_to_join alias_types_in_target_env Variable.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in
          [prepare_nested_join] above to create new variables, which do not exist

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -361,16 +361,11 @@ module Int_ids_in_env () = struct
     include module type of Id_in_env (Name) ()
 
     val var : Variable.t -> t
-
-    val symbol : Symbol.t -> t
   end = struct
     include Id_in_env (Name) ()
 
     let var (var : Variable.t) : t =
       create (Name.var (var :> Int_ids.Variable.t))
-
-    let symbol (symbol : Symbol.t) =
-      create (Name.symbol (symbol :> Int_ids.Symbol.t))
   end
 
   (* CR bclement: In practice, we consider that these must be canonicals in the
@@ -379,11 +374,7 @@ module Int_ids_in_env () = struct
   module Simple : sig
     include module type of Id_in_env (Simple) ()
 
-    val const : Reg_width_const.t -> t
-
     val name : ?coercion:Coercion.t -> Name.t -> t
-
-    val symbol : ?coercion:Coercion.t -> Symbol.t -> t
 
     val var : ?coercion:Coercion.t -> Variable.t -> t
 
@@ -402,14 +393,10 @@ module Int_ids_in_env () = struct
   end = struct
     include Id_in_env (Simple) ()
 
-    let const const = create (Simple.const const)
-
     let name ?(coercion = Coercion.id) (name : Name.t) =
       let simple_without_coercion = Simple.name (name :> Int_ids.Name.t) in
       let simple = Simple.with_coercion simple_without_coercion coercion in
       create simple
-
-    let symbol ?coercion symbol = name ?coercion (Name.symbol symbol)
 
     let var ?coercion var = name ?coercion (Name.var var)
 
@@ -434,7 +421,6 @@ end
 
 module Int_ids_in_source_env = Int_ids_in_env ()
 module Variable_in_source_env = Int_ids_in_source_env.Variable
-module Symbol_in_source_env = Int_ids_in_source_env.Symbol
 module Simple_in_source_env = Int_ids_in_source_env.Simple
 
 module Int_ids_from_source_env () = struct
@@ -448,7 +434,6 @@ module Int_ids_from_source_env () = struct
       create (var :> Variable.t)
   end
 
-  module Symbol = Int_ids_in_env.Symbol
   module Name = Int_ids_in_env.Name
 
   module Simple = struct
@@ -466,15 +451,6 @@ module Name_in_target_env = Int_ids_in_target_env.Name
 module Simple_in_target_env = Int_ids_in_target_env.Simple
 module Int_ids_in_one_joined_env = Int_ids_from_source_env ()
 module Variable_in_one_joined_env = Int_ids_in_one_joined_env.Variable
-
-module Symbol_in_one_joined_env = struct
-  include Int_ids_in_one_joined_env.Symbol
-
-  (* See {!section-lifted_constants} *)
-  let in_source_env symbol =
-    Symbol_in_source_env.create (symbol : t :> Symbol.t)
-end
-
 module Name_in_one_joined_env = Int_ids_in_one_joined_env.Name
 module Simple_in_one_joined_env = Int_ids_in_one_joined_env.Simple
 
@@ -547,6 +523,12 @@ end = struct
   include Container_types.Make (T0)
 
   let choose_a_suitable_name t =
+    if
+      Flambda_features.check_light_invariants ()
+      && not (Index.Map.cardinal t > 1)
+    then
+      Misc.fatal_errorf "Should not try to create a new name single simple: %a"
+        print t;
     let shared_name =
       try
         Index.Map.fold
@@ -962,6 +944,9 @@ module Joined_envs : sig
 
   val exists_in_all_joined_envs : t -> _ Index.Map.t -> bool
 
+  val get_alias_then_canonical_simple_ignoring_name_mode_exn :
+    t -> Type_in_one_joined_env.t Index.Map.t -> Simples_in_joined_envs.t
+
   val find_simples_in_joined_envs :
     t -> Simples_in_joined_envs.t -> K.t -> Type_in_one_joined_env.t Index.Map.t
 
@@ -1020,6 +1005,15 @@ end = struct
                 (get_nth_joined_env t index)
                 simple))
       simples_in_joined_envs
+
+  let get_alias_then_canonical_simple_ignoring_name_mode_exn t types =
+    Index.Map.mapi
+      (fun index (ty : Type_in_one_joined_env.t) ->
+        let env = get_nth_joined_env t index in
+        Simple_in_one_joined_env.create
+          (TE.get_canonical_simple_ignoring_name_mode env
+             (TG.get_alias_exn (ty :> TG.t))))
+      types
 
   let find_simples_in_joined_envs t simples kind =
     Index.Map.mapi
@@ -1102,6 +1096,7 @@ type t =
     types_in_joined_envs :
       Type_in_one_joined_env.t Index.Map.t Variable_in_target_env.Map.t;
     aliases_of_existentials : Aliases_of_existentials.t;
+    imported_vars : Variable.Set.t;
     definitions_of_existentials :
       (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
@@ -1112,6 +1107,7 @@ let create ~joined_envs ~bindings =
     types_in_target_env = Name_in_target_env.Map.empty;
     types_in_joined_envs = Variable_in_target_env.Map.empty;
     aliases_of_existentials = Aliases_of_existentials.empty;
+    imported_vars = Variable.Set.empty;
     definitions_of_existentials = Variable_in_target_env.Map.empty;
     bindings
   }
@@ -1126,7 +1122,7 @@ let new_equations_in_joined_envs t ~since =
     (fun _ new_types _old_types -> Some new_types)
     t.types_in_joined_envs since.types_in_joined_envs
 
-let existential_for_these_simples env canonicals kind =
+let existential_for_these_canonicals env canonicals kind =
   let existential_var, bindings =
     Bindings_in_target_env.existential_for_these_simples env.bindings canonicals
       kind
@@ -1142,23 +1138,184 @@ let existential_for_these_simples env canonicals kind =
   in
   existential_var, { env with bindings; definitions_of_existentials }
 
-let import_from_all_envs env var kind =
-  let bindings =
-    Bindings_in_target_env.import_from_all_envs env.bindings var kind
+let add_alias_of_existential env kind var canonicals =
+  let existential_var, env =
+    existential_for_these_canonicals env canonicals kind
   in
-  let imported_var =
-    Variable_in_target_env.create
-      (var : Variable_in_one_joined_env.t :> Variable.t)
+  (* Note: we must not record alias equations at this time, because we might
+     select a different canonical in
+     [define_or_eliminate_variables_and_add_equations].
+
+     We will add alias equations to the chosen canonical (which might not be the
+     existential variable) at that time. *)
+  let aliases_of_existentials =
+    Aliases_of_existentials.add env.aliases_of_existentials ~demoted_var:var
+      ~existential_var
   in
+  { env with aliases_of_existentials }
+
+let add_equation_in_target_env env name ty =
+  assert (not (Name_in_target_env.Map.mem name env.types_in_target_env));
+  let types_in_target_env =
+    Name_in_target_env.Map.add name ty env.types_in_target_env
+  in
+  { env with types_in_target_env }
+
+let add_equations_in_joined_envs env var types =
   let types_in_joined_envs =
-    if Variable_in_target_env.Map.mem imported_var env.types_in_joined_envs
-    then env.types_in_joined_envs
-    else
-      Variable_in_target_env.Map.add imported_var
-        (Joined_envs.find_imported_var env.joined_envs var kind)
-        env.types_in_joined_envs
+    Variable_in_target_env.Map.add var types env.types_in_joined_envs
   in
-  { env with bindings; types_in_joined_envs }
+  { env with types_in_joined_envs }
+
+type canonical_in_target_env =
+  | Canonical_in_source_env of Simple_in_source_env.t
+  | Import_from_all_joined_envs of Variable_in_one_joined_env.t * Coercion.t
+  | Existential_for_these_canonicals of Simples_in_joined_envs.t
+
+let n_way_join_canonical_simples env canonicals =
+  let source_env = Bindings_in_target_env.source_env env.bindings in
+  match Source_env.candidate_canonical_in_source_env source_env canonicals with
+  | No_simples_in_joined_envs | No_canonical_in_source_env ->
+    Existential_for_these_canonicals canonicals
+  | Canonical_in_all_joined_envs simple ->
+    Simple_in_one_joined_env.pattern_match' simple
+      ~const:(fun const ->
+        Canonical_in_source_env
+          (Simple_in_source_env.create (Simple.const const)))
+      ~symbol:(fun symbol ~coercion ->
+        Canonical_in_source_env
+          (Simple_in_source_env.create
+             (Simple.with_coercion
+                (Simple.symbol (symbol :> Symbol.t))
+                coercion)))
+      ~var:(fun var ~coercion ->
+        match
+          Source_env.exists_in_source_env source_env (var :> Variable.t)
+        with
+        | Some var ->
+          Canonical_in_source_env (Simple_in_source_env.var var ~coercion)
+        | None -> Import_from_all_joined_envs (var, coercion))
+  | Latest_bound_source_var (var, coercion) ->
+    let latest_simple = Simple_in_source_env.var var ~coercion in
+    if
+      Joined_envs.equal_in_all_joined_envs env.joined_envs
+        (Simple_in_one_joined_env.from_source_env latest_simple)
+        canonicals
+    then Canonical_in_source_env latest_simple
+    else Existential_for_these_canonicals canonicals
+
+let rec import_or_delay_n_way_join_type env var types =
+  let _, any_ty =
+    try Index.Map.choose types
+    with Not_found -> Misc.fatal_error "N-way join of zero types"
+  in
+  match
+    Joined_envs.get_alias_then_canonical_simple_ignoring_name_mode_exn
+      env.joined_envs types
+  with
+  | canonical_simples ->
+    let kind = Type_in_one_joined_env.kind any_ty in
+    add_equals_in_joined_envs env kind var canonical_simples
+  | exception Not_found ->
+    import_or_delay_n_way_join_of_concrete_type env var types
+
+and import_or_delay_n_way_join_of_concrete_type env var types =
+  let _, any_ty =
+    try Index.Map.choose types
+    with Not_found -> Misc.fatal_error "N-way join of zero types"
+  in
+  if Index.Map.for_all (fun _ ty' -> any_ty == ty') types
+  then
+    let env =
+      add_equation_in_target_env env
+        (Name_in_target_env.var var)
+        (Type_in_target_env.create (any_ty : Type_in_one_joined_env.t :> TG.t))
+    in
+    import_type_transitive env any_ty
+  else add_equations_in_joined_envs env var types
+
+and add_equals_in_joined_envs env kind var simples =
+  let[@local] add_equals_in_target_env env simple =
+    add_equation_in_target_env env
+      (Name_in_target_env.var var)
+      (Type_in_target_env.alias_type_of kind simple)
+  in
+  match n_way_join_canonical_simples env simples with
+  | Canonical_in_source_env canonical ->
+    add_equals_in_target_env env
+      (Simple_in_target_env.from_source_env canonical)
+  | Import_from_all_joined_envs (var, coercion) ->
+    let env = import_var_transitive env (var :> Variable.t) in
+    add_equals_in_target_env env
+      (Simple_in_target_env.var
+         (Variable_in_target_env.create (var :> Variable.t))
+         ~coercion)
+  | Existential_for_these_canonicals canonicals ->
+    add_alias_of_existential env kind var canonicals
+
+and import_type_transitive env (ty : Type_in_one_joined_env.t) =
+  Name_occurrences.fold_variables ~init:env ~f:import_var_transitive
+    (TG.free_names (ty :> TG.t))
+
+and import_var_transitive env var =
+  match
+    Source_env.exists_in_source_env
+      (Bindings_in_target_env.source_env env.bindings)
+      var
+  with
+  | Some _ -> env
+  | None ->
+    if Variable.Set.mem var env.imported_vars
+    then env
+    else
+      let kind = Variable.kind var in
+      let imported_vars = Variable.Set.add var env.imported_vars in
+      let bindings =
+        Bindings_in_target_env.import_from_all_envs env.bindings
+          (Variable_in_one_joined_env.create var)
+          kind
+      in
+      let env = { env with bindings; imported_vars } in
+      let types =
+        Joined_envs.find_imported_var env.joined_envs
+          (Variable_in_one_joined_env.create var)
+          kind
+      in
+      (* If there is at least one alias type, enforce an alias to the
+         appropriate existential variable. This ensures that we see the equality
+         when that specific combination of canonical simples appears in a joined
+         (not imported) type. *)
+      let has_alias_type =
+        Index.Map.exists
+          (fun _ (ty : Type_in_one_joined_env.t) ->
+            Option.is_some (TG.get_alias_opt (ty :> TG.t)))
+          types
+      in
+      if has_alias_type
+      then
+        let alias_type_of_var =
+          Type_in_one_joined_env.create (TG.alias_type_of kind (Simple.var var))
+        in
+        let alias_types =
+          Index.Map.map
+            (fun (ty : Type_in_one_joined_env.t) ->
+              match TG.get_alias_opt (ty :> TG.t) with
+              | None -> alias_type_of_var
+              | Some _ -> ty)
+            types
+        in
+        match
+          Joined_envs.get_alias_then_canonical_simple_ignoring_name_mode_exn
+            env.joined_envs alias_types
+        with
+        | exception Not_found ->
+          Misc.fatal_error "Unexpected missing canonical simple for alias type"
+        | canonical_simples ->
+          let var = Variable_in_target_env.create var in
+          add_equals_in_joined_envs env kind var canonical_simples
+      else
+        let var = Variable_in_target_env.create var in
+        import_or_delay_n_way_join_of_concrete_type env var types
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1166,44 +1323,6 @@ let joined_env t index = Joined_envs.get_nth_joined_env t.joined_envs index
 
 let machine_width t =
   Source_env.machine_width (Bindings_in_target_env.source_env t.bindings)
-
-type canonical_in_target_env =
-  | Canonical_in_source_env of Simple_in_source_env.t
-  | Import_from_all_joined_envs of Variable_in_one_joined_env.t * Coercion.t
-  | Existential_for_these_simples
-
-let get_canonical_in_target_env env canonicals_in_joined_envs =
-  let source_env = Bindings_in_target_env.source_env env.bindings in
-  match
-    Source_env.candidate_canonical_in_source_env source_env
-      canonicals_in_joined_envs
-  with
-  | No_simples_in_joined_envs | No_canonical_in_source_env ->
-    Existential_for_these_simples
-  | Canonical_in_all_joined_envs simple ->
-    Simple_in_one_joined_env.pattern_match' simple
-      ~const:(fun const ->
-        Canonical_in_source_env (Simple_in_source_env.const const))
-      ~symbol:(fun symbol ~coercion ->
-        Canonical_in_source_env
-          (Simple_in_source_env.symbol ~coercion
-             (Symbol_in_one_joined_env.in_source_env symbol)))
-      ~var:(fun var ~coercion ->
-        match
-          Source_env.exists_in_source_env source_env
-            (var : Variable_in_one_joined_env.t :> Variable.t)
-        with
-        | Some var ->
-          Canonical_in_source_env (Simple_in_source_env.var ~coercion var)
-        | None -> Import_from_all_joined_envs (var, coercion))
-  | Latest_bound_source_var (var, coercion) ->
-    let latest_simple = Simple_in_source_env.var var ~coercion in
-    if
-      Joined_envs.equal_in_all_joined_envs env.joined_envs
-        (Simple_in_one_joined_env.from_source_env latest_simple)
-        canonicals_in_joined_envs
-    then Canonical_in_source_env latest_simple
-    else Existential_for_these_simples
 
 let fold_incremental_join ~f ~init equations_to_join =
   fold_incremental_join ~f ~init
@@ -1213,56 +1332,6 @@ let fold_incremental_join ~f ~init equations_to_join =
             (fun index (env, maps) -> f (index, env) maps)
             equations_to_join init)
     }
-
-type types_in_joined_envs =
-  | Equals_in_all_envs of Simples_in_joined_envs.t * K.t
-  | No_alias_in_some_env of Type_in_one_joined_env.t Index.Map.t
-
-let get_types_in_joined_envs join_entry : _ Or_bottom.t =
-  let kind, canonicals, concrete_equations =
-    fold_incremental_join_entry join_entry
-      ~init:(None, Index.Map.empty, Index.Map.empty)
-      ~f:(fun (index, env) ty (kind, canonicals, concrete_equations) ->
-        let kind =
-          match kind with
-          | None -> Type_in_one_joined_env.kind ty
-          | Some kind ->
-            if not (K.equal kind (Type_in_one_joined_env.kind ty))
-            then Misc.fatal_errorf "Incompatible kinds for variable during join";
-            kind
-        in
-        match TG.get_alias_opt (ty : Type_in_one_joined_env.t :> TG.t) with
-        | None ->
-          let concrete_equations = Index.Map.add index ty concrete_equations in
-          Some kind, canonicals, concrete_equations
-        | Some simple ->
-          let canonical =
-            Simple_in_one_joined_env.create
-              (TE.get_canonical_simple_ignoring_name_mode env simple)
-          in
-          let canonicals = Index.Map.add index canonical canonicals in
-          Some kind, canonicals, concrete_equations)
-  in
-  match kind with
-  | None ->
-    assert (
-      Index.Map.is_empty canonicals && Index.Map.is_empty concrete_equations);
-    Bottom
-  | Some kind ->
-    if Index.Map.is_empty concrete_equations
-    then Ok (Equals_in_all_envs (canonicals, kind))
-    else
-      (* CR-someday bclement: We could create a fresh (unique) existential here,
-         which would allow to preserve more information about identity in
-         subsequent joins, but it's not clear it would be useful. *)
-      let alias_equations =
-        Index.Map.map
-          (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
-          canonicals
-      in
-      Ok
-        (No_alias_in_some_env
-           (Index.Map.disjoint_union alias_equations concrete_equations))
 
 (* Wrapper around [fold_incremental_join] so that we only fold over equations
    for names that exist in the target env (see [prepare_nested_join]). *)
@@ -1296,13 +1365,6 @@ let fold_incremental_join_in_target_env equations_to_join ~exists_in_target_env
              fine with dropping the equation. *)
           acc))
 
-let add_equation env name ty =
-  assert (not (Name_in_target_env.Map.mem name env.types_in_target_env));
-  let types_in_target_env =
-    Name_in_target_env.Map.add name ty env.types_in_target_env
-  in
-  { env with types_in_target_env }
-
 (* This function is responsible for splitting the [equations_to_join] between
    those that are demotions in all joined environments, that are replayed in the
    target environment in the [types_in_target_env], and the rest, that are
@@ -1318,41 +1380,11 @@ let join_aliases_into_bindings env equations_to_join =
     ~exists_in_target_env:
       (Bindings_in_target_env.exists_in_target_env env.bindings) ~init:env
     ~f:(fun var join_entry env ->
-      match get_types_in_joined_envs join_entry with
-      | Bottom -> Misc.fatal_error "Unexpected bottom during join"
-      | Ok (No_alias_in_some_env types) ->
-        let types_in_joined_envs =
-          Variable_in_target_env.Map.add var types env.types_in_joined_envs
-        in
-        { env with types_in_joined_envs }
-      | Ok (Equals_in_all_envs (canonicals, kind)) -> (
-        let[@local] add_equals_in_target_env env canonical =
-          add_equation env
-            (Name_in_target_env.var var)
-            (Type_in_target_env.alias_type_of kind canonical)
-        in
-        match get_canonical_in_target_env env canonicals with
-        | Canonical_in_source_env canonical ->
-          add_equals_in_target_env env
-            (Simple_in_target_env.from_source_env canonical)
-        | Import_from_all_joined_envs (imported_var, coercion) ->
-          let env = import_from_all_envs env imported_var kind in
-          let imported_var =
-            Variable_in_target_env.create (imported_var :> Variable.t)
-          in
-          let simple = Simple_in_target_env.var ~coercion imported_var in
-          add_equals_in_target_env env simple
-        | Existential_for_these_simples ->
-          let existential_var, env =
-            existential_for_these_simples env canonicals kind
-          in
-          let aliases_of_existentials =
-            Aliases_of_existentials.add env.aliases_of_existentials
-              ~demoted_var:var ~existential_var
-          in
-          let env = { env with aliases_of_existentials } in
-          let simple = Simple_in_target_env.var existential_var in
-          add_equals_in_target_env env simple))
+      let types =
+        fold_incremental_join_entry join_entry ~init:Index.Map.empty
+          ~f:(fun (index, _) ty types -> Index.Map.add index ty types)
+      in
+      import_or_delay_n_way_join_type env var types)
 
 let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     env_extension name relation ~scrutinee =
@@ -1564,6 +1596,15 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
         let exists_in_all_joined_envs =
           Joined_envs.exists_in_all_joined_envs t.joined_envs types
         in
+        if
+          Flambda_features.check_light_invariants ()
+          && Option.is_some (TG.get_alias_opt ty)
+        then
+          Misc.fatal_errorf
+            "Unexpected alias type in join round (aliases should have been \
+             processed): %a@.From join of types:@ %a@."
+            TG.print ty (Index.Map.print TG.print)
+            (types : Type_in_one_joined_env.t Index.Map.t :> TG.t Index.Map.t);
         let ty, inverse_relations =
           if exists_in_all_joined_envs
           then
@@ -1574,7 +1615,7 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
           else ty, inverse_relations
         in
         let ty = Type_in_target_env.create ty in
-        inverse_relations, add_equation t name ty)
+        inverse_relations, add_equation_in_target_env t name ty)
     equations_to_join (inverse_relations, t)
 
 (** {2:n-way-join Cut and n-way join} *)
@@ -2107,36 +2148,22 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
   let join_analysis = Analysis.create ~external_ids ~joined_envs bindings in
   target_env, join_analysis
 
-let n_way_join_canonicals env kind simples =
-  match get_canonical_in_target_env env simples with
-  | Canonical_in_source_env simple ->
-    Simple_in_target_env.from_source_env simple, env
-  | Import_from_all_joined_envs (imported_var, coercion) ->
-    let env = import_from_all_envs env imported_var kind in
-    let imported_var =
-      Variable_in_target_env.create (imported_var :> Variable.t)
-    in
-    let simple = Simple_in_target_env.var ~coercion imported_var in
-    simple, env
-  | Existential_for_these_simples ->
-    let existential_var, env = existential_for_these_simples env simples kind in
-    Simple_in_target_env.var existential_var, env
-
+(* Exposed to the outside world with a different type *)
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
   | [] -> Bottom, t
-  | _ :: _ ->
-    let canonicals_in_joined_envs =
+  | _ :: _ -> (
+    let simples =
       Joined_envs.get_canonical_simples_ignoring_name_mode t.joined_envs simples
     in
-    (* CR-someday bclement: somehow mark the local variable as used, so that it
-       can be re-processed in the current env extension if applicable (if a
-       local variable is created while processing an env extension, we currently
-       lose any equation that the extension had for that variable). *)
-    let canonical_in_target_env, t =
-      n_way_join_canonicals t kind canonicals_in_joined_envs
-    in
-    Ok (canonical_in_target_env : Simple_in_target_env.t :> Simple.t), t
+    match n_way_join_canonical_simples t simples with
+    | Canonical_in_source_env simple -> Ok (simple :> Simple.t), t
+    | Import_from_all_joined_envs (var, coercion) ->
+      let t = import_var_transitive t (var :> Variable.t) in
+      Ok (Simple_in_one_joined_env.var ~coercion var :> Simple.t), t
+    | Existential_for_these_canonicals canonicals ->
+      let var, t = existential_for_these_canonicals t canonicals kind in
+      Ok (Simple.var (var :> Variable.t)), t)
 
 (** {2:extensions Join of extensions} *)
 

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -970,19 +970,13 @@ module Joined_envs : sig
 
   val exists_in_all_joined_envs : t -> _ Index.Map.t -> bool
 
-  (** Returns the aliases of a variable in all the environments where it exists.
+  val find_simples_in_joined_envs :
+    t -> Simples_in_joined_envs.t -> K.t -> Type_in_one_joined_env.t Index.Map.t
 
-      The provided variable {b must} be defined in the current compilation unit.
-  *)
-  val alias_types_of_local_var :
+  val find_imported_var :
     t ->
-    K.t ->
     Variable_in_one_joined_env.t ->
-    Type_in_one_joined_env.t Index.Map.t
-
-  val expand_heads :
-    t ->
-    Type_in_one_joined_env.t Index.Map.t ->
+    K.t ->
     Type_in_one_joined_env.t Index.Map.t
 
   val equal_in_all_joined_envs :
@@ -1032,43 +1026,35 @@ end = struct
                 simple))
       simples_in_joined_envs
 
-  let alias_types_of_local_var t kind var =
+  let find_simples_in_joined_envs t simples kind =
+    Index.Map.mapi
+      (fun index simple ->
+        Simple_in_one_joined_env.pattern_match simple
+          ~const:(fun const -> ET.create_const const |> ET.to_type)
+          ~name:(fun name ~coercion ->
+            let env = get_nth_joined_env t index in
+            let ty = TE.find env (name :> Name.t) (Some kind) in
+            TG.apply_coercion ty coercion)
+        |> Type_in_one_joined_env.create)
+      simples
+
+  let find_imported_var t var kind =
+    let erased_var = (var : Variable_in_one_joined_env.t :> Variable.t) in
     if Flambda_features.check_light_invariants ()
     then
-      if
-        not
-          (Current_unit.is_current
-             (Variable.compilation_unit
-                (var : Variable_in_one_joined_env.t :> Variable.t)))
+      if not (Current_unit.is_current (Variable.compilation_unit erased_var))
       then
         Misc.fatal_errorf
           "Cannot re-define variable %a defined in another compilation unit \
            into the target environment of join"
-          Variable.print
-          (var : Variable_in_one_joined_env.t :> Variable.t);
+          Variable.print erased_var;
     Index.Map.filter_map
       (fun _index (env, _) ->
-        if
-          TE.mem env
-            (Name.var (var : Variable_in_one_joined_env.t :> Variable.t))
-        then
-          let canonical =
-            get_canonical_simple_ignoring_name_mode env
-              (Simple_in_one_joined_env.var var)
-          in
-          Some (Type_in_one_joined_env.alias_type_of kind canonical)
+        let name = Name.var erased_var in
+        if TE.mem env name
+        then Some (Type_in_one_joined_env.create (TE.find env name (Some kind)))
         else None)
       (envs_and_equations t)
-
-  let expand_heads t types =
-    Index.Map.mapi
-      (fun index ty ->
-        let typing_env = get_nth_joined_env t index in
-        Type_in_one_joined_env.create
-          (ET.to_type
-             (Expand_head.expand_head typing_env
-                (ty : Type_in_one_joined_env.t :> TG.t))))
-      types
 end
 
 module Aliases_of_existentials = struct
@@ -1104,48 +1090,51 @@ type env_id = Index.t
 
 type 'a join_arg = env_id * 'a
 
-type definition_in_joined_envs =
-  | Imported_var of Variable_in_one_joined_env.t * K.t
-  | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
 type t =
   { joined_envs : Joined_envs.t;
     types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
+    types_in_joined_envs :
+      Type_in_one_joined_env.t Index.Map.t Variable_in_target_env.Map.t;
     aliases_of_existentials : Aliases_of_existentials.t;
-    definitions_in_joined_envs :
-      definition_in_joined_envs Variable_in_target_env.Map.t;
+    definitions_of_existentials :
+      (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
   }
 
 let create ~joined_envs ~bindings =
   { joined_envs;
     types_in_target_env = Name_in_target_env.Map.empty;
+    types_in_joined_envs = Variable_in_target_env.Map.empty;
     aliases_of_existentials = Aliases_of_existentials.empty;
-    definitions_in_joined_envs = Variable_in_target_env.Map.empty;
+    definitions_of_existentials = Variable_in_target_env.Map.empty;
     bindings
   }
 
-let new_definitions_in_joined_envs t ~since =
+let new_definitions_of_existentials t ~since =
   Variable_in_target_env.Map.diff_shared
     (fun _ new_definition _old_definition -> Some new_definition)
-    t.definitions_in_joined_envs since.definitions_in_joined_envs
+    t.definitions_of_existentials since.definitions_of_existentials
+
+let new_equations_in_joined_envs t ~since =
+  Variable_in_target_env.Map.diff_shared
+    (fun _ new_types _old_types -> Some new_types)
+    t.types_in_joined_envs since.types_in_joined_envs
 
 let existential_for_these_simples env canonicals kind =
   let existential_var, bindings =
     Bindings_in_target_env.existential_for_these_simples env.bindings canonicals
       kind
   in
-  let definitions_in_joined_envs =
+  let definitions_of_existentials =
     if
       Variable_in_target_env.Map.mem existential_var
-        env.definitions_in_joined_envs
-    then env.definitions_in_joined_envs
+        env.definitions_of_existentials
+    then env.definitions_of_existentials
     else
-      Variable_in_target_env.Map.add existential_var
-        (These_canonicals (canonicals, kind))
-        env.definitions_in_joined_envs
+      Variable_in_target_env.Map.add existential_var (canonicals, kind)
+        env.definitions_of_existentials
   in
-  existential_var, { env with bindings; definitions_in_joined_envs }
+  existential_var, { env with bindings; definitions_of_existentials }
 
 let import_from_all_envs env var kind =
   let bindings =
@@ -1155,16 +1144,15 @@ let import_from_all_envs env var kind =
     Variable_in_target_env.create
       (var : Variable_in_one_joined_env.t :> Variable.t)
   in
-  let definitions_in_joined_envs =
-    if
-      Variable_in_target_env.Map.mem imported_var env.definitions_in_joined_envs
-    then env.definitions_in_joined_envs
+  let types_in_joined_envs =
+    if Variable_in_target_env.Map.mem imported_var env.types_in_joined_envs
+    then env.types_in_joined_envs
     else
       Variable_in_target_env.Map.add imported_var
-        (Imported_var (var, kind))
-        env.definitions_in_joined_envs
+        (Joined_envs.find_imported_var env.joined_envs var kind)
+        env.types_in_joined_envs
   in
-  { env with bindings; definitions_in_joined_envs }
+  { env with bindings; types_in_joined_envs }
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1322,26 +1310,20 @@ let add_equation env name ty =
 let join_aliases_into_bindings env equations_to_join =
   fold_incremental_join_in_target_env equations_to_join
     ~exists_in_target_env:
-      (Bindings_in_target_env.exists_in_target_env env.bindings)
-    ~init:(Name_in_target_env.Map.empty, env)
-    ~f:(fun var join_entry (equations_to_join, env) ->
+      (Bindings_in_target_env.exists_in_target_env env.bindings) ~init:env
+    ~f:(fun var join_entry env ->
       match get_types_in_joined_envs join_entry with
       | Bottom -> Misc.fatal_error "Unexpected bottom during join"
       | Ok (No_alias_in_some_env types) ->
-        let equations_to_join =
-          Name_in_target_env.Map.add
-            (Name_in_target_env.var var)
-            types equations_to_join
+        let types_in_joined_envs =
+          Variable_in_target_env.Map.add var types env.types_in_joined_envs
         in
-        equations_to_join, env
+        { env with types_in_joined_envs }
       | Ok (Equals_in_all_envs (canonicals, kind)) -> (
         let[@local] add_equals_in_target_env env canonical =
-          let env =
-            add_equation env
-              (Name_in_target_env.var var)
-              (Type_in_target_env.alias_type_of kind canonical)
-          in
-          equations_to_join, env
+          add_equation env
+            (Name_in_target_env.var var)
+            (Type_in_target_env.alias_type_of kind canonical)
         in
         match get_canonical_in_target_env env canonicals with
         | Canonical_in_source_env canonical ->
@@ -1556,8 +1538,9 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
 
 let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
     inverse_relations =
-  Name_in_target_env.Map.fold
-    (fun name types (inverse_relations, t) ->
+  Variable_in_target_env.Map.fold
+    (fun var types (inverse_relations, t) ->
+      let name = Name_in_target_env.var var in
       if
         Flambda_features.check_light_invariants ()
         && Name_in_target_env.Map.mem name t.types_in_target_env
@@ -1565,12 +1548,11 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
         Misc.fatal_errorf
           "Processing join of %a but we already have a type for it."
           Name_in_target_env.print name;
-      match
-        n_way_join_type t
-          (Index.Map.bindings (Joined_envs.expand_heads t.joined_envs types)
-            : (Index.t * Type_in_one_joined_env.t) list
-            :> (Index.t * TG.t) list)
-      with
+      let heads =
+        Index.Map.bindings
+          (types : Type_in_one_joined_env.t Index.Map.t :> TG.t Index.Map.t)
+      in
+      match n_way_join_type t heads with
       | Unknown, t -> inverse_relations, t
       | Known ty, t ->
         let exists_in_all_joined_envs =
@@ -1743,7 +1725,7 @@ let define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
     | Zero | One -> true
     | More_than_one -> false
   in
-  let definitions = env.definitions_in_joined_envs in
+  let definitions = env.definitions_of_existentials in
   let target_env, to_expand, equations, inverse_relations, definitions =
     Bindings_in_target_env.fold_existential_variables
       (fun var kind
@@ -1850,41 +1832,45 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
     in
     let joined_envs = Joined_envs.create equations_to_join in
     let empty_env = create ~joined_envs ~bindings:empty_bindings in
-    let concrete_equations_to_join, env =
-      join_aliases_into_bindings empty_env equations_to_join
+    let env = join_aliases_into_bindings empty_env equations_to_join in
+    let rec n_way_join_delayed_equations env_this_round inverse_relations
+        equations_this_round =
+      if Variable_in_target_env.Map.is_empty equations_this_round
+      then inverse_relations, env_this_round
+      else
+        let inverse_relations, env_next_round =
+          n_way_join_round ~n_way_join_type env_this_round equations_this_round
+            inverse_relations
+        in
+        n_way_join_delayed_equations env_next_round inverse_relations
+          (new_equations_in_joined_envs env_next_round ~since:env_this_round)
     in
-    let equations_for_bindings env ~since =
-      let new_bindings = new_definitions_in_joined_envs env ~since in
-      Variable.Map.map
-        (fun (definition : definition_in_joined_envs) ->
-          match definition with
-          | Imported_var (var, kind) ->
-            Joined_envs.alias_types_of_local_var joined_envs kind var
-          | These_canonicals (simples, kind) ->
-            Index.Map.map
-              (fun simple -> Type_in_one_joined_env.alias_type_of kind simple)
-              simples)
-        (new_bindings :> definition_in_joined_envs Variable.Map.t)
-      |> Name.var_map |> Name_in_target_env.create_map
-    in
-    let equations_to_join =
-      Name_in_target_env.Map.disjoint_union concrete_equations_to_join
-        (equations_for_bindings env ~since:empty_env)
-    in
-    let rec loop t equations_to_join inverse_relations =
-      let env_before_this_round = t in
-      let inverse_relations, t =
-        n_way_join_round ~n_way_join_type t equations_to_join inverse_relations
-      in
-      let new_equations_to_join =
-        equations_for_bindings env ~since:env_before_this_round
-      in
-      if Name_in_target_env.Map.is_empty new_equations_to_join
-      then inverse_relations, t
-      else loop t new_equations_to_join inverse_relations
+    let rec n_way_join_loop env_this_round inverse_relations
+        existentials_this_round =
+      if Variable_in_target_env.Map.is_empty existentials_this_round
+      then inverse_relations, env_this_round
+      else
+        let equations_in_joined_envs =
+          Variable_in_target_env.Map.map
+            (fun (simples, kind) ->
+              Joined_envs.find_simples_in_joined_envs env_this_round.joined_envs
+                simples kind)
+            existentials_this_round
+        in
+        let inverse_relations, env_next_round =
+          n_way_join_delayed_equations env_this_round inverse_relations
+            equations_in_joined_envs
+        in
+        n_way_join_loop env_next_round inverse_relations
+          (new_definitions_of_existentials env_next_round ~since:env_this_round)
     in
     let inverse_relations, env =
-      loop env equations_to_join Variable.Map.empty
+      n_way_join_delayed_equations env Variable.Map.empty
+        (new_equations_in_joined_envs env ~since:empty_env)
+    in
+    let inverse_relations, env =
+      n_way_join_loop env inverse_relations
+        (new_definitions_of_existentials env ~since:empty_env)
     in
     let target_env, definitions =
       define_or_eliminate_variables_and_add_equations ~meet_expanded_head env
@@ -1929,68 +1915,38 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
 module Analysis = struct
   type 'a t =
     { definitions_in_joined_envs :
-        definition_in_joined_envs Variable_in_target_env.Map.t;
+        (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
       canonical_definitions_at_normal_mode :
-        (Simple_in_one_joined_env.t Index.Map.t * K.t)
-        Variable_in_target_env.Map.t;
+        (Simples_in_joined_envs.t * K.t) Variable_in_target_env.Map.t;
       external_ids : 'a Index.Map.t
     }
 
   let print ppf { definitions_in_joined_envs; _ } =
     Variable_in_target_env.Map.print
-      (fun ppf (def : definition_in_joined_envs) ->
-        match def with
-        | Imported_var (var, _) ->
-          Format.fprintf ppf "@[<hov 1>(imported@ %a)@]"
-            Variable_in_one_joined_env.print var
-        | These_canonicals (simples, _) ->
-          Index.Map.print Simple_in_one_joined_env.print ppf simples)
+      (fun ppf (simples, _) ->
+        Index.Map.print Simple_in_one_joined_env.print ppf simples)
       ppf definitions_in_joined_envs
 
   let create ~external_ids ~joined_envs definitions_in_joined_envs =
     let canonical_definitions_at_normal_mode =
       Variable_in_target_env.Map.filter_map
-        (fun _name (definition : definition_in_joined_envs) ->
-          match definition with
-          | Imported_var (var, kind) ->
-            let var = (var :> Variable.t) in
-            let exists_at_normal_name_mode_in_all_envs =
-              Index.Map.for_all
-                (fun _env_id typing_env ->
-                  TE.mem ~min_name_mode:Name_mode.normal typing_env
-                    (Name.var var))
-                joined_envs
-            in
-            if exists_at_normal_name_mode_in_all_envs
-            then
-              Some
-                ( Index.Map.map
-                    (fun typing_env ->
-                      Simple_in_one_joined_env.create
-                        (TE.get_canonical_simple_exn
-                           ~min_name_mode:Name_mode.normal typing_env
-                           (Simple.var var)))
-                    joined_envs,
-                  kind )
-            else None
-          | These_canonicals (simples, kind) ->
-            let exists_at_normal_name_mode_in_all_envs_it_is_defined_in =
-              Index.Map.for_all
-                (fun env_id simple ->
-                  let typing_env =
-                    match Index.Map.find_opt env_id joined_envs with
-                    | Some typing_env -> typing_env
-                    | None ->
-                      Misc.fatal_errorf "Join does not include environment %a"
-                        Index.print env_id
-                  in
-                  TE.mem_simple ~min_name_mode:Name_mode.normal typing_env
-                    simple)
-                (simples :> Simple.t Index.Map.t)
-            in
-            if exists_at_normal_name_mode_in_all_envs_it_is_defined_in
-            then Some (simples, kind)
-            else None)
+        (fun _name (simples, kind) ->
+          let exists_at_normal_name_mode_in_all_envs_it_is_defined_in =
+            Index.Map.for_all
+              (fun env_id simple ->
+                let typing_env =
+                  match Index.Map.find_opt env_id joined_envs with
+                  | Some typing_env -> typing_env
+                  | None ->
+                    Misc.fatal_errorf "Join does not include environment %a"
+                      Index.print env_id
+                in
+                TE.mem_simple ~min_name_mode:Name_mode.normal typing_env simple)
+              (simples : Simples_in_joined_envs.t :> Simple.t Index.Map.t)
+          in
+          if exists_at_normal_name_mode_in_all_envs_it_is_defined_in
+          then Some (simples, kind)
+          else None)
         definitions_in_joined_envs
     in
     { definitions_in_joined_envs;
@@ -2042,10 +1998,7 @@ module Analysis = struct
              [Latest_bound_source_var] / [Canonical_in_source_env] case in
              [join_aliases_into_bindings]. *)
           Not_refined_at_join
-        | Some (Imported_var (var, _)) ->
-          Invariant_in_all_uses
-            (Simple.var (var : Variable_in_one_joined_env.t :> Variable.t))
-        | Some (These_canonicals (canonicals_in_joined_envs, kind)) ->
+        | Some (canonicals_in_joined_envs, kind) ->
           Variable_refined_at_these_uses
             { Variable_refined_at_join.canonicals_in_joined_envs;
               kind;
@@ -2372,7 +2325,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
       let env_in_extension =
         create ~joined_envs ~bindings:env_before_extension.bindings
       in
-      let concrete_types_to_join, env_in_extension =
+      let env_in_extension =
         join_aliases_into_bindings env_in_extension joined_equations
       in
       (* CR-someday bclement: if we create new existential variables during the
@@ -2381,7 +2334,7 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
          round should be plenty. *)
       let _env_extension_for_inverse_relations, env_in_extension =
         n_way_join_round ~n_way_join_type env_in_extension
-          concrete_types_to_join Variable.Map.empty
+          env_in_extension.types_in_joined_envs Variable.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in
          [prepare_nested_join] above to create new variables, which do not exist

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -108,15 +108,6 @@ end
 (* CR bclement: These should be in [Flambda_algorithms]. *)
 
 module Iterator_utils : sig
-  (* Given two maps [m1] and [m2], calls [f name (find m1 name) (find m2 name)]
-     for each [name] in the intersection of [m1] and [m2]. *)
-  val fold_binary_join :
-    f:(Name.t -> 'a -> 'b -> 'c -> 'c) ->
-    init:'c ->
-    'a Name.Map.t ->
-    'b Name.Map.t ->
-    'c
-
   type ('a, 'b) incremental_join_entry
 
   val fold_incremental_join_entry :
@@ -172,19 +163,6 @@ end = struct
     in
     Name_map_join_iterator.init iterator;
     loop iterator init
-
-  let fold_binary_join ~f ~init a b =
-    (* CR bclement: create an [Name.Map.iterator], get its initial value, and
-       initialise the [Name_map_iterator] (and the [Name_map_join_iterator])
-       from it to avoid double lookups. *)
-    match Name.Map.choose_opt a, Name.Map.choose_opt b with
-    | None, _ | _, None -> init
-    | Some (_, dummy_a), Some (_, dummy_b) ->
-      let iterator_a, recv_a = naive_iterator ~init:a ~dummy:dummy_a in
-      let iterator_b, recv_b = naive_iterator ~init:b ~dummy:dummy_b in
-      let iterator = join_iterators [iterator_a; iterator_b] in
-      fold_iterator iterator ~init ~f:(fun name acc ->
-          f name (Channel.recv recv_a) (Channel.recv recv_b) acc)
 
   type ('a, 'b) incremental_join_entry = ('a * 'b Channel.receiver) list
 
@@ -264,7 +242,7 @@ end = struct
               || (Name.Map.is_empty previous && not (Name.Map.is_empty diff))
             in
             (* CR bclement: we should be able to initialise the iterator with
-               this value (see [fold_binary_join]). *)
+               this value. *)
             match Name.Map.choose_opt current with
             | None -> raise Join_is_empty
             | Some (_, dummy) ->
@@ -374,8 +352,6 @@ module Int_ids_in_env () = struct
   module Simple : sig
     include module type of Id_in_env (Simple) ()
 
-    val name : ?coercion:Coercion.t -> Name.t -> t
-
     val var : ?coercion:Coercion.t -> Variable.t -> t
 
     val pattern_match :
@@ -451,7 +427,6 @@ module Name_in_target_env = Int_ids_in_target_env.Name
 module Simple_in_target_env = Int_ids_in_target_env.Simple
 module Int_ids_in_one_joined_env = Int_ids_from_source_env ()
 module Variable_in_one_joined_env = Int_ids_in_one_joined_env.Variable
-module Name_in_one_joined_env = Int_ids_in_one_joined_env.Name
 module Simple_in_one_joined_env = Int_ids_in_one_joined_env.Simple
 
 module Type_in_env () : sig
@@ -483,17 +458,7 @@ end = struct
     create (TG.alias_type_of kind (simple : Simple_in_target_env.t :> Simple.t))
 end
 
-module Type_in_one_joined_env : sig
-  include module type of Type_in_env ()
-
-  val alias_type_of : K.t -> Simple_in_one_joined_env.t -> t
-end = struct
-  include Type_in_env ()
-
-  let alias_type_of kind simple =
-    create
-      (TG.alias_type_of kind (simple : Simple_in_one_joined_env.t :> Simple.t))
-end
+module Type_in_one_joined_env = Type_in_env ()
 
 (* {1:environments Environments} *)
 
@@ -706,31 +671,12 @@ module Bindings_in_target_env : sig
   val existential_for_these_simples :
     t -> Simples_in_joined_envs.t -> K.t -> Variable_in_target_env.t * t
 
-  (* Assuming that [t] derives from [since], extract the created variables from
-     [t], adding them to [since]. Any information about the created variables
-     besides their kind (in particular, their [definition_in_joined_env]) is
-     forgotten, and they won't appear in the [new_bindings]. *)
-  val forget_definition_of_created_variables : t -> since:t -> t
-
   val fold_imported_variables :
     (Variable_in_one_joined_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
 
   val fold_existential_variables :
     (Variable_in_target_env.t -> K.t -> 'a -> 'a) -> t -> 'a -> 'a
-
-  (* These are for the join of env extensions, see [prepare_nested_join]. *)
-
-  val replay_definition_of_aliases_in_target_env :
-    t ->
-    Index.t ->
-    Type_in_one_joined_env.t Name.Map.t ->
-    Type_in_one_joined_env.t Name.Map.t
-
-  val definition_of_local_variables_in_one_joined_env :
-    t -> Index.t -> Type_in_one_joined_env.t Variable_in_target_env.Map.t
 end = struct
-  type coercion_to_canonical_in_target_env = Coercion.t
-
   type t =
     { source_env : Source_env.t;
       existential_for_these_simples :
@@ -741,46 +687,17 @@ end = struct
       imported_variables : K.t Variable_in_one_joined_env.Map.t;
           (* Set of variables that have been imported from at least one of the
              joined environments into the target environment. *)
-      existential_variables : K.t Variable_in_target_env.Map.t;
+      existential_variables : K.t Variable_in_target_env.Map.t
           (* This contains all the existential variables, created during the
              join, that exist in the target environment but not in the source
              environment or in any of the joined environments. *)
-      aliases_of_names_in_joined_envs :
-        coercion_to_canonical_in_target_env Name_in_target_env.Map.t
-        Name_in_one_joined_env.Map.t
-        Index.Map.t;
-          (* For each joined environment and each name in the joined
-             environment, record the set of names in the target environment it
-             is equal to (and the corresponding coercions).
-
-             This is used to implement
-             [replay_definitions_of_aliases_in_target_env] in the join of env
-             extensions, see [prepare_nested_join]. *)
-      equations_for_local_vars :
-        Type_in_one_joined_env.t Variable_in_target_env.Map.t Index.Map.t
-          (* Environment extensions to use in each of the joined environments to
-             replay the definition of local variables.
-
-             This is used to implement
-             [definitions_of_local_variables_in_one_joined_env] in the join of
-             env extensions, see [prepare_nested_join]. *)
     }
 
   let from_source_env source_env =
     { source_env;
       existential_for_these_simples = Simples_in_joined_envs.Map.empty;
       imported_variables = Variable_in_one_joined_env.Map.empty;
-      aliases_of_names_in_joined_envs = Index.Map.empty;
-      equations_for_local_vars = Index.Map.empty;
       existential_variables = Variable_in_target_env.Map.empty
-    }
-
-  let forget_definition_of_created_variables t ~since =
-    (* We still need to record the fact that we created those variables in order
-       to add them to the target environment at the end of the join. *)
-    { since with
-      existential_variables = t.existential_variables;
-      imported_variables = t.imported_variables
     }
 
   let source_env { source_env; _ } = source_env
@@ -799,30 +716,6 @@ end = struct
       then Some var
       else None
 
-  let update_aliases_of_names_in_joined_envs ~f simples aliases_in_target_env =
-    Index.Map.fold
-      (fun index simple aliases_in_target_env ->
-        Simple_in_one_joined_env.pattern_match simple
-          ~const:(fun _ -> aliases_in_target_env)
-          ~name:(fun name ~coercion ->
-            Index.Map.update index
-              (fun aliases ->
-                let aliases =
-                  Name_in_one_joined_env.Map.update name
-                    (fun aliases ->
-                      let aliases =
-                        f coercion
-                          (Option.value ~default:Name_in_target_env.Map.empty
-                             aliases)
-                      in
-                      Some aliases)
-                    (Option.value ~default:Name_in_one_joined_env.Map.empty
-                       aliases)
-                in
-                Some aliases)
-              aliases_in_target_env))
-      simples aliases_in_target_env
-
   let has_existential_for_these_simples t simples =
     Simples_in_joined_envs.Map.find_opt simples t.existential_for_these_simples
 
@@ -837,42 +730,11 @@ end = struct
       let existential_variables =
         Variable_in_target_env.Map.add var kind t.existential_variables
       in
-      let t = { t with existential_variables } in
       let existential_for_these_simples =
         Simples_in_joined_envs.Map.add simples var
           t.existential_for_these_simples
       in
-      (* The following is some bookkeeping so that we know how to replay the
-         definition of existential variables during nested joins (i.e. joins of
-         env extensions); see {!section-extensions}. *)
-      let equations_for_local_vars =
-        (* If the variable is a fresh variable, record it so that we can replay
-           its definition during the join of env extensions. *)
-        Index.Map.update_many
-          (fun _index existentials simple ->
-            let ty = Type_in_one_joined_env.alias_type_of kind simple in
-            let existentials_in_one_joined_env =
-              Variable_in_target_env.Map.add var ty
-                (Option.value ~default:Variable_in_target_env.Map.empty
-                   existentials)
-            in
-            Some existentials_in_one_joined_env)
-          t.equations_for_local_vars simples
-      in
-      let aliases_of_names_in_joined_envs =
-        update_aliases_of_names_in_joined_envs simples
-          t.aliases_of_names_in_joined_envs ~f:(fun coercion aliases ->
-            (* definition ~ coercion(name_in_joined_env) *)
-            Name_in_target_env.Map.add
-              (Name_in_target_env.var var)
-              coercion aliases)
-      in
-      ( var,
-        { t with
-          equations_for_local_vars;
-          existential_for_these_simples;
-          aliases_of_names_in_joined_envs
-        } )
+      var, { t with existential_variables; existential_for_these_simples }
 
   let import_from_all_envs t imported_var kind =
     if Variable_in_one_joined_env.Map.mem imported_var t.imported_variables
@@ -883,33 +745,6 @@ end = struct
           t.imported_variables
       in
       { t with imported_variables }
-
-  let replay_definition_of_aliases_in_target_env t index equations =
-    match Index.Map.find_opt index t.aliases_of_names_in_joined_envs with
-    | None -> equations
-    | Some aliases_in_target_env ->
-      fold_binary_join equations
-        (aliases_in_target_env
-          : Coercion.t Name_in_target_env.Map.t Name_in_one_joined_env.Map.t
-          :> Coercion.t Name_in_target_env.Map.t Name.Map.t)
-        ~init:equations
-        ~f:(fun[@inline] name ty aliases equations ->
-          let kind = Type_in_one_joined_env.kind ty in
-          let name = Name_in_one_joined_env.create name in
-          Name_in_target_env.Map.fold
-            (fun alias coercion equations ->
-              (* alias = coercion(name) *)
-              let ty =
-                Type_in_one_joined_env.alias_type_of kind
-                  (Simple_in_one_joined_env.name ~coercion name)
-              in
-              Name.Map.add (alias : Name_in_target_env.t :> Name.t) ty equations)
-            aliases equations)
-
-  let definition_of_local_variables_in_one_joined_env t index =
-    match Index.Map.find_opt index t.equations_for_local_vars with
-    | None -> Variable_in_target_env.Map.empty
-    | Some existentials -> existentials
 
   let fold_imported_variables f t acc =
     (* CR bclement: iterate in order consistent with the recorded binding
@@ -936,9 +771,6 @@ module Joined_envs : sig
     (TE.t * Type_in_one_joined_env.t Name.Map.t incremental) Index.Map.t -> t
 
   val get_nth_joined_env : t -> Index.t -> TE.t
-
-  val equations_in_nth_joined_env :
-    t -> Index.t -> Type_in_one_joined_env.t Name.Map.t
 
   val keys : t -> Index.Set.t
 
@@ -978,12 +810,6 @@ end = struct
     | Some (one_joined_env, _) -> one_joined_env
     | None ->
       Misc.fatal_errorf "Join does not include environment %a" Index.print index
-
-  let equations_in_nth_joined_env t index =
-    match Index.Map.find_opt index (envs_and_equations t) with
-    | None ->
-      Misc.fatal_errorf "Join does not include environment %a" Index.print index
-    | Some (_, { current; _ }) -> current
 
   let keys t = Index.Map.keys (envs_and_equations t)
 
@@ -1316,6 +1142,11 @@ and import_var_transitive env var =
       else
         let var = Variable_in_target_env.create var in
         import_or_delay_n_way_join_of_concrete_type env var types
+
+let import_name_transitive env name =
+  Name.pattern_match name
+    ~symbol:(fun _ -> env)
+    ~var:(fun var -> import_var_transitive env var)
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -2167,242 +1998,26 @@ let n_way_join_simples t kind simples : _ Or_bottom.t * t =
 
 (** {2:extensions Join of extensions} *)
 
-let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
-  let joined_envs_and_extensions =
-    List.fold_left
-      (fun joined_envs_and_extensions (index, extension) ->
-        let parent_env = Joined_envs.get_nth_joined_env joined_envs index in
-        (* The extension is not guaranteed to still be in canonical form, but we
-           need the equations to be in canonical form to known which variables
-           are actually touched by the extension, so we add it once then cut it.
-
-           Note: we need to cut it as a level, because the meets from
-           [add_env_extension_strict] could add perform nested joins which could
-           add new variables. *)
-        assert (not (TE.is_bottom parent_env));
-        let cut_after = TE.current_scope parent_env in
-        let typing_env = TE.increment_scope parent_env in
-        match
-          ME.use_meet_env_strict ~meet_expanded_head typing_env
-            ~f:(fun meet_env ->
-              ME.add_env_extension ~meet_expanded_head meet_env extension)
-        with
-        | Bottom ->
-          (* We can reach bottom here if the extension was created in a more
-             generic context, but is added in a context where it is no longer
-             reachable. *)
-          joined_envs_and_extensions
-        | Ok env ->
-          let level = TE.cut env ~cut_after in
-          Index.Map.add index (env, level) joined_envs_and_extensions)
-      Index.Map.empty extensions
-  in
-  Index.Map.mapi
-    (fun index (env, diff_level) ->
-      let previous_equations =
-        Joined_envs.equations_in_nth_joined_env joined_envs index
+let n_way_join_env_extension ~n_way_join_type:_ ~meet_expanded_head:_ t
+    extensions : _ Or_bottom.t =
+  (* Don't try to do something complicated for the join of env extensions for
+     now: simply import the content of the env extension if it is the same in
+     all joined environments (in particular, always import env extensions when
+     there is a single joined environment). *)
+  match extensions with
+  | [] -> Bottom
+  | (_, first_extension) :: other_extensions ->
+    if
+      List.for_all
+        (fun (_, ext) ->
+          Name.Map.equal ( == ) (TEE.to_map ext) (TEE.to_map first_extension))
+        other_extensions
+    then
+      let t =
+        TEE.fold first_extension t ~equation:(fun name ty env ->
+            import_type_transitive
+              (import_name_transitive env name)
+              (Type_in_one_joined_env.create ty))
       in
-      let diff_equations =
-        (* Note that we forget the potential newly created variables here, but
-           they could end up in the [Bindings_in_target_env] and cause issue if
-           they are ever used in the parent environment.
-
-           This is fine, however, because we drop any possible information about
-           these variables by calling [forget_definition_of_created_variables]
-           in [n_way_join_env_extension]. *)
-        Type_in_one_joined_env.create_equations (TEL.equations diff_level)
-      in
-      (* The call below to [replay_definition_of_aliases_in_target_env] is only
-         relevant when doing a nested join (join of env extensions); for a
-         toplevel join, [join_aliases] is empty and this does nothing.
-
-         Consider that we first perform the following join (assuming that [x]
-         and [y] exist in the source env and all other variables are local to
-         their joined env) of:
-
-         x: (= a) ; y: (= a)
-
-         and
-
-         x: (= c)
-
-         and that we later perform in the same context the join of nested
-         extensions:
-
-         a: (= d)
-
-         and
-
-         y: (= c)
-
-         We'd like to determine that the join of the extensions is:
-
-         x: (= y)
-
-         If we simply use the incremental join algorithm without taking
-         demotions into account, we'll find the join of [y: (= a)] (from the
-         outer scope in the left environment) and [y: (= c)] (from the nested
-         scope in the right environment) but we don't have a way to determine
-         that [x] and [y] are equal without reprocessing the equations on [x]
-         (in the outer scope, the canonicals for [x] were [(a, c)] so we
-         couldn't even find it from the canonicals of [y] in the inner scope,
-         which are [(d, c)]).
-
-         We do this by keeping track of the aliases of [a] in the joined env
-         ([x] and [y]), and adding back the corresponding demotions (only for
-         the variables that actually have an equation in the extension) to the
-         first extension, yielding:
-
-         x: (= a) ; y: (= a) ; a: (= d)
-
-         This will interact with the equation [y: (= c)] from the extension
-         scope in the right environment, and with the equation [x: (= c)] from
-         the parent scope in the right environment, from which we can deduce the
-         equality between [x] and [y].
-
-         Note that if we instead have:
-
-         x: (Block 0 (= a)) ; y: (Block 0 (= a))
-
-         and
-
-         x: (Block 0 (= c))
-
-         at the toplevel and
-
-         a: (= d)
-
-         and
-
-         y: (Block 0 (= c))
-
-         in the extensions, we will create a single existential variable [ac] at
-         the toplevel.
-
-         When performing the join of the extensions, we will add the equation
-         [ac: (= a)] to the left extension, but we also need to add an equation
-         [ac: (= c)] to the outer scope in the right env (see the call to
-         [defining_equations_of_existentials] below) in order to reprocess
-         [ac]. *)
-      let diff_equations =
-        Bindings_in_target_env.replay_definition_of_aliases_in_target_env
-          bindings index diff_equations
-      in
-      (* We call [union diff previous] rather than [union previous diff] because
-         we want maximum sharing with [diff] (see the computation of
-         [previous_equations] below). *)
-      let current_equations =
-        Name.Map.union_left_biased diff_equations previous_equations
-      in
-      (* Drop variables from the previous level if they get a more precise type
-         in the current level (otherwise they would appear in both $Pi$ and $Δi$
-         and be processed twice -- see [incremental_join]). *)
-      let previous_equations =
-        Name.Map.diff_shared
-          (fun _ _current_ty _diff_ty -> None)
-          current_equations diff_equations
-      in
-      (* This call is only relevant if we are doing a nested join (join of env
-         extensions); for a toplevel join, we don't have existential variables.
-
-         When doing a nested join, we need to make sure that any existential
-         variables created at an earlier level are tracked in the previous level
-         so that they can correctly interact with equations added by
-         [replay_definition_of_aliases_in_target_env] to the [diff_equations] of
-         another joined env (see the call to
-         [replay_definition_of_aliases_in_target_env] above). *)
-      (* CR bclement: it would be more efficient to do an union of iterators to
-         avoid re-processing all the existentials every time. *)
-      let previous_equations =
-        let defining_equations_of_existential_vars =
-          Bindings_in_target_env.definition_of_local_variables_in_one_joined_env
-            bindings index
-        in
-        (* Sometimes we might have already added the defining equation of an
-           existential due to [replay_definition_of_aliases_in_target_env],
-           which is fine. *)
-        Name.Map.union_left_biased previous_equations
-          (Name.var_map
-             (defining_equations_of_existential_vars
-               : Type_in_one_joined_env.t Variable_in_target_env.Map.t
-               :> Type_in_one_joined_env.t Variable.Map.t))
-      in
-      let incremental_equations =
-        { previous = previous_equations;
-          diff = diff_equations;
-          current = current_equations
-        }
-      in
-      env, incremental_equations)
-    joined_envs_and_extensions
-
-let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
-    env_before_extension extensions : _ Or_bottom.t =
-  let joined_equations =
-    try
-      prepare_nested_join ~meet_expanded_head
-        ~bindings:env_before_extension.bindings
-        ~joined_envs:env_before_extension.joined_envs extensions
-    with Misc.Fatal_error ->
-      let bt = Printexc.get_raw_backtrace () in
-      Format.eprintf
-        "\n@[<v 2>%tContext is:%t preparing join of env extensions:@ %a@]\n"
-        Flambda_colours.error Flambda_colours.pop
-        (Index.Map.print TEE.print)
-        (Index.Map.of_list extensions);
-      Printexc.raise_with_backtrace Misc.Fatal_error bt
-  in
-  if Index.Map.is_empty joined_equations
-  then Bottom
-  else
-    try
-      let joined_envs = Joined_envs.create joined_equations in
-      let env_in_extension =
-        create ~joined_envs ~bindings:env_before_extension.bindings
-      in
-      let env_in_extension =
-        join_aliases_into_bindings env_in_extension joined_equations
-      in
-      (* CR-someday bclement: if we create new existential variables during the
-         join of env extensions, we might need additional rounds for
-         completeness (see comment in [n_way_join_simples]) -- in practice one
-         round should be plenty. *)
-      let _env_extension_for_inverse_relations, env_in_extension =
-        n_way_join_round ~n_way_join_type env_in_extension
-          env_in_extension.types_in_joined_envs Variable.Map.empty
-      in
-      (* It is possible for the call to [add_env_extension] in
-         [prepare_nested_join] above to create new variables, which do not exist
-         in the parent environments. These variables must not leak into the
-         [bindings]: since they don't exist in the parent joined environments,
-         we won't be able to find a type for them in the target environment
-         outside of the extension.
-
-         For now, we avoid this problem by simply forgetting about the
-         definition of new variables (in the target env) during the join of
-         extensions. This means that in some cases we might create the same
-         variable twice (e.g. we might create a variable to represent {0, 1}
-         inside an env extension and then another one outside of the env
-         extension), but not incorrect, only slighly inefficient. *)
-      let bindings =
-        Bindings_in_target_env.forget_definition_of_created_variables
-          env_in_extension.bindings ~since:env_before_extension.bindings
-      in
-      Ok
-        ( TEE.from_map (env_in_extension.types_in_target_env :> TG.t Name.Map.t),
-          { env_before_extension with bindings } )
-    with Misc.Fatal_error ->
-      (* Note that we display the env extensions in their current canonical
-         form, which might differ from their form as recorded in the input
-         types. *)
-      let bt = Printexc.get_raw_backtrace () in
-      Format.eprintf "\n@[<v 2>%tContext is:%t join of env extensions:@ %a@]\n"
-        Flambda_colours.error Flambda_colours.pop
-        (Index.Map.print (fun ppf (_, extension) ->
-             TEE.print ppf
-               (TEE.from_map
-                  (extension.current
-                    : Type_in_one_joined_env.t Name.Map.t
-                    :> TG.t Name.Map.t))))
-        joined_equations;
-      Printexc.raise_with_backtrace Misc.Fatal_error bt
+      Ok (first_extension, t)
+    else Ok (TEE.empty, t)

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -362,9 +362,6 @@ module Int_ids_in_env () = struct
     val var : Variable.t -> t
 
     val symbol : Symbol.t -> t
-
-    val pattern_match :
-      t -> var:(Variable.t -> 'a) -> symbol:(Symbol.t -> 'a) -> 'a
   end = struct
     include Id_in_env (Name) ()
 
@@ -373,13 +370,6 @@ module Int_ids_in_env () = struct
 
     let symbol (symbol : Symbol.t) =
       create (Name.symbol (symbol :> Int_ids.Symbol.t))
-
-    let[@inline] pattern_match (t : t) ~var:when_var ~symbol:when_symbol =
-      Name.pattern_match
-        (t :> Name.t)
-        ~var:(fun var -> (when_var [@inlined hint]) (Variable.create var))
-        ~symbol:(fun symbol ->
-          (when_symbol [@inlined hint]) (Symbol.create symbol))
   end
 
   (* CR bclement: In practice, we consider that these must be canonicals in the
@@ -395,12 +385,6 @@ module Int_ids_in_env () = struct
     val symbol : ?coercion:Coercion.t -> Symbol.t -> t
 
     val var : ?coercion:Coercion.t -> Variable.t -> t
-
-    val coercion : t -> Coercion.t
-
-    val without_coercion : t -> t
-
-    val apply_coercion_exn : t -> Coercion.t -> t
 
     val pattern_match :
       t ->
@@ -428,14 +412,6 @@ module Int_ids_in_env () = struct
 
     let var ?coercion var = name ?coercion (Name.var var)
 
-    let coercion t = Simple.coercion (t : t :> Simple.t)
-
-    let without_coercion t =
-      create (Simple.without_coercion (t : t :> Simple.t))
-
-    let apply_coercion_exn t coercion =
-      create (Simple.apply_coercion_exn (t : t :> Simple.t) coercion)
-
     let[@inline always] pattern_match (t : t) ~name:when_name ~const =
       Simple.pattern_match
         (t :> Simple.t)
@@ -457,7 +433,6 @@ end
 
 module Int_ids_in_source_env = Int_ids_in_env ()
 module Variable_in_source_env = Int_ids_in_source_env.Variable
-module Name_in_source_env = Int_ids_in_source_env.Name
 module Symbol_in_source_env = Int_ids_in_source_env.Symbol
 module Simple_in_source_env = Int_ids_in_source_env.Simple
 
@@ -473,13 +448,7 @@ module Int_ids_from_source_env () = struct
   end
 
   module Symbol = Int_ids_in_env.Symbol
-
-  module Name = struct
-    include Int_ids_in_env.Name
-
-    (* See {!section-scope_of_names} *)
-    let from_source_env (name : Name_in_source_env.t) = create (name :> Name.t)
-  end
+  module Name = Int_ids_in_env.Name
 
   module Simple = struct
     include Int_ids_in_env.Simple
@@ -492,7 +461,6 @@ end
 
 module Int_ids_in_target_env = Int_ids_from_source_env ()
 module Variable_in_target_env = Int_ids_in_target_env.Variable
-module Symbol_in_target_env = Int_ids_in_target_env.Symbol
 module Name_in_target_env = Int_ids_in_target_env.Name
 module Simple_in_target_env = Int_ids_in_target_env.Simple
 module Int_ids_in_one_joined_env = Int_ids_from_source_env ()
@@ -739,12 +707,6 @@ module Bindings_in_target_env : sig
      - Existentials represent a specific set of simples in the joined
      environments.
 
-     {b Warning}: Each local variable is defined either as an imported variable
-     or as an existential, but imported variables and existentials are not
-     necessarily represented by local variables in the target environment: there
-     might already be a suitable name in the source environment to represent
-     this imported variable or existential.
-
      For instance, consider that we are doing the join of [x: (= a)] in env 0
      and [x: (= b)] in env 1, where [x] exists in the source environment but not
      [a] and [b]. Then we can use [x] to represent [((0 a) (1 b))], we do not
@@ -760,63 +722,19 @@ module Bindings_in_target_env : sig
 
   val exists_in_target_env : t -> Variable.t -> Variable_in_target_env.t option
 
-  (* Must only be called from the toplevel join, before creating any local
-     variable. *)
-  val add_alias_between_names_in_target_env :
-    t -> K.t -> Name_in_target_env.t -> Simple_in_source_env.t -> t
-
-  (* Record the [name_in_target_env] as the canonical name for this set of
-     simples in joined environments. If there was already a [name_in_target_env]
-     representing that set of simple, an alias is recorded in the
-     [alias_types_in_target_env] instead.
-
-     Must only be called from the toplevel join, before creating any local
-     variable. *)
-  val add_existential_for_these_simples :
-    t ->
-    name_in_target_env:Name_in_target_env.t ->
-    Simples_in_joined_envs.t ->
-    K.t ->
-    t
-
-  (* Record the [name_in_source_env] as the canonical name for this variable
-     (whenever it appears in any joined environment). If there was already a
-     [name_in_source_env] representing the variable, an alias is recorded in the
-     [alias_types_in_target_env] instead.
-
-     Must only be called from the toplevel join, before creating any local
-     variable. *)
-  val add_imported_var :
-    t ->
-    name_in_target_env:Name_in_target_env.t ->
-    coercion_to_name_in_source_env:Coercion.t ->
-    Variable_in_one_joined_env.t ->
-    K.t ->
-    t
-
   (* Return the (unique across the whole join) name to be used to represent an
-     imported variable.
-
-     This is usually the provided variable itself, unless a name for it was
-     recorded by [add_imported_var]. *)
+     imported variable. *)
   val import_from_all_envs :
-    t -> Variable_in_one_joined_env.t -> K.t -> Simple_in_target_env.t * t
+    t -> Variable_in_one_joined_env.t -> K.t -> Variable_in_target_env.t * t
 
   (* Return the (unique across the whole join) name to be used to represent this
-     set of simples in joined environments.
-
-     This is either a name that has been recorded with
-     [add_existential_for_these_simples], or an existential local variable
-     created to represent it. *)
+     set of simples in joined environments. *)
   val existential_for_these_simples :
-    t -> Simples_in_joined_envs.t -> K.t -> Simple_in_target_env.t * t
+    t -> Simples_in_joined_envs.t -> K.t -> Variable_in_target_env.t * t
 
   type definition_in_joined_envs =
     | Imported_var of Variable_in_one_joined_env.t * K.t
     | These_canonicals of Simple_in_one_joined_env.t Index.Map.t * K.t
-
-  val alias_types_in_target_env :
-    t -> Type_in_target_env.t Name_in_target_env.Map.t
 
   (* Assuming that [t] derives from [since], returns the definitions of local
      variables that have been added to [t] after [since]. *)
@@ -851,26 +769,20 @@ end = struct
 
   type t =
     { source_env : Source_env.t;
-      alias_types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
-      (* Aliases shared across all the joined environments. *)
       existential_for_these_simples :
-        Simple_in_target_env.t Simples_in_joined_envs.Map.t;
+        Variable_in_target_env.t Simples_in_joined_envs.Map.t;
       (* Maps a set of [simples] in joined environments to the (unique across
          the whole join) name used to represent this exact set of simples in the
          target environment. *)
       imported_variables :
-        Simple_in_target_env.t Variable_in_one_joined_env.Map.t;
+        Variable_in_target_env.t Variable_in_one_joined_env.Map.t;
       (* Maps a local variable (a variable that exists in at least one joined
-         environment) to its (unique across the whole join) name in the target
-         environment.
+         environment) to its name in the target environment.
 
-         This same name is used for all the joined environments where the
-         variable exists.
+         The underlying variable used in the joined and target environments is
+         the same, only the type-level metadata changes.
 
-         {b Note}: This is not necessarily the variable itself. For instance, if
-         there is a variable [x] in the source environment that gets demoted to
-         a local variable [y] in all joined environments, then [x] might be used
-         as a name for [y]. *)
+         CR bclement: This should just be a set now. *)
       created_variables : K.t Variable_in_target_env.Map.t;
       (* This contains all the local variables (existentials or imported) that
          exist in the target environment but not in the source environment. *)
@@ -899,7 +811,6 @@ end = struct
 
   let from_source_env source_env =
     { source_env;
-      alias_types_in_target_env = Name_in_target_env.Map.empty;
       existential_for_these_simples = Simples_in_joined_envs.Map.empty;
       imported_variables = Variable_in_one_joined_env.Map.empty;
       aliases_of_names_in_joined_envs = Index.Map.empty;
@@ -907,40 +818,6 @@ end = struct
       equations_for_local_vars = Index.Map.empty;
       created_variables = Variable_in_target_env.Map.empty
     }
-
-  let add_alias t kind ~canonical_element:canonical_element_with_coercion
-      ~name_to_be_demoted ~coercion_to_name_to_be_demoted =
-    let canonical_element =
-      canonical_element_with_coercion |> Simple_in_target_env.without_coercion
-    in
-    let coercion_from_canonical_element_to_name_to_be_demoted =
-      Coercion.compose_exn
-        (Simple_in_target_env.coercion canonical_element_with_coercion)
-        ~then_:coercion_to_name_to_be_demoted
-    in
-    if
-      Simple_in_target_env.equal canonical_element
-        (Simple_in_target_env.name name_to_be_demoted)
-    then
-      if Coercion.is_id coercion_from_canonical_element_to_name_to_be_demoted
-      then t
-      else
-        Misc.fatal_errorf
-          "Cannot add alias of %a to itself with a non-identity coercion@ %a"
-          Simple_in_target_env.print canonical_element Coercion.print
-          (Coercion.inverse
-             coercion_from_canonical_element_to_name_to_be_demoted)
-    else
-      let alias_types_in_target_env =
-        Name_in_target_env.Map.add name_to_be_demoted
-          (Type_in_target_env.alias_type_of kind
-             (Simple_in_target_env.apply_coercion_exn canonical_element
-                coercion_from_canonical_element_to_name_to_be_demoted))
-          t.alias_types_in_target_env
-      in
-      { t with alias_types_in_target_env }
-
-  let alias_types_in_target_env t = t.alias_types_in_target_env
 
   let new_bindings t ~since =
     Name_in_target_env.Map.diff_shared
@@ -954,13 +831,10 @@ end = struct
 
   let source_env { source_env; _ } = source_env
 
-  let is_local_variable { created_variables; _ } name =
-    Name_in_target_env.pattern_match name
-      ~symbol:(fun _ -> None)
-      ~var:(fun var ->
-        if Variable_in_target_env.Map.mem var created_variables
-        then Some var
-        else None)
+  let is_local_variable { created_variables; _ } var =
+    if Variable_in_target_env.Map.mem var created_variables
+    then Some var
+    else None
 
   let exists_in_target_env t var =
     match Source_env.exists_in_source_env (source_env t) var with
@@ -971,13 +845,6 @@ end = struct
       if Variable_in_target_env.Map.mem var t.created_variables
       then Some var
       else None
-
-  let add_alias_between_names_in_target_env t kind name canonical =
-    assert (not (Name_in_target_env.Map.mem name t.alias_types_in_target_env));
-    assert (not (Name_in_target_env.Map.mem name t.definitions_in_joined_envs));
-    add_alias t kind ~name_to_be_demoted:name
-      ~coercion_to_name_to_be_demoted:Coercion.id
-      ~canonical_element:(Simple_in_target_env.from_source_env canonical)
 
   let update_aliases_of_names_in_joined_envs ~f simples aliases_in_target_env =
     Index.Map.fold
@@ -1003,29 +870,24 @@ end = struct
               aliases_in_target_env))
       simples aliases_in_target_env
 
-  let record_definition_for t ~name_in_target_env
-      ~coercion_to_name_in_target_env definition =
+  let record_definition_for t ~var_in_target_env definition =
     (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
     let definitions_in_joined_envs =
-      Name_in_target_env.Map.add name_in_target_env definition
-        t.definitions_in_joined_envs
-    in
-    let canonical_in_target_env =
-      Simple_in_target_env.name
-        ~coercion:(Coercion.inverse coercion_to_name_in_target_env)
-        name_in_target_env
+      Name_in_target_env.Map.add
+        (Name_in_target_env.var var_in_target_env)
+        definition t.definitions_in_joined_envs
     in
     match definition with
     | Imported_var (imported_var, _kind) ->
       let imported_variables =
-        Variable_in_one_joined_env.Map.add imported_var canonical_in_target_env
+        Variable_in_one_joined_env.Map.add imported_var var_in_target_env
           t.imported_variables
       in
-      ( canonical_in_target_env,
+      ( var_in_target_env,
         { t with imported_variables; definitions_in_joined_envs } )
     | These_canonicals (simples, kind) ->
       let existential_for_these_simples =
-        Simples_in_joined_envs.Map.add simples canonical_in_target_env
+        Simples_in_joined_envs.Map.add simples var_in_target_env
           t.existential_for_these_simples
       in
       (* The following is some bookkeeping so that we know how to replay the
@@ -1034,16 +896,12 @@ end = struct
       let equations_for_local_vars =
         (* If the variable is a fresh variable, record it so that we can replay
            its definition during the join of env extensions. *)
-        match is_local_variable t name_in_target_env with
+        match is_local_variable t var_in_target_env with
         | None -> t.equations_for_local_vars
         | Some var ->
           Index.Map.update_many
             (fun _index existentials simple ->
-              let ty =
-                Type_in_one_joined_env.alias_type_of kind
-                  (Simple_in_one_joined_env.apply_coercion_exn simple
-                     coercion_to_name_in_target_env)
-              in
+              let ty = Type_in_one_joined_env.alias_type_of kind simple in
               let existentials_in_one_joined_env =
                 Variable_in_target_env.Map.add var ty
                   (Option.value ~default:Variable_in_target_env.Map.empty
@@ -1055,16 +913,12 @@ end = struct
       let aliases_of_names_in_joined_envs =
         update_aliases_of_names_in_joined_envs simples
           t.aliases_of_names_in_joined_envs ~f:(fun coercion aliases ->
-            (* name_in_target_env ~ coercion_to_name_in_target_env(definition) *)
             (* definition ~ coercion(name_in_joined_env) *)
-            let coercion_from_joined_to_target =
-              Coercion.compose_exn coercion
-                ~then_:coercion_to_name_in_target_env
-            in
-            Name_in_target_env.Map.add name_in_target_env
-              coercion_from_joined_to_target aliases)
+            Name_in_target_env.Map.add
+              (Name_in_target_env.var var_in_target_env)
+              coercion aliases)
       in
-      ( canonical_in_target_env,
+      ( var_in_target_env,
         { t with
           equations_for_local_vars;
           existential_for_these_simples;
@@ -1086,9 +940,7 @@ end = struct
       Variable_in_target_env.Map.add var kind t.created_variables
     in
     let t = { t with created_variables } in
-    let name_in_target_env = Name_in_target_env.var var in
-    record_definition_for t ~name_in_target_env
-      ~coercion_to_name_in_target_env:Coercion.id definition
+    record_definition_for t ~var_in_target_env:var definition
 
   let is_imported_from_all_joined_envs t var =
     Variable_in_one_joined_env.Map.find_opt var t.imported_variables
@@ -1102,46 +954,6 @@ end = struct
       is_imported_from_all_joined_envs t imported_var
     | These_canonicals (simples, _kind) ->
       has_existential_for_these_simples t simples
-
-  let add_name_for_definition t ~name_in_target_env
-      ~coercion_to_name_in_source_env definition =
-    (* name_in_target_env ~ coercion_to_name_in_source_env(definition) *)
-    match existing_canonical_for t definition with
-    | None ->
-      let _, t =
-        record_definition_for t ~name_in_target_env
-          ~coercion_to_name_in_target_env:coercion_to_name_in_source_env
-          definition
-      in
-      t
-    | Some existing_canonical ->
-      (* This can happen if multiple variables in the source environment are
-         demoted to the same local variable in all environments, in which case
-         we record an alias between these names instead.
-
-         Note that we might add aliases in the "wrong" order w.r.t binding times
-         here, but it is not a problem -- we only care that we have a single
-         definition for each name during the join. We don't have to use the
-         proper binding time ordering; the typing env will take care of giving
-         the proper orientation to aliases after the join is complete. *)
-      let kind =
-        match definition with
-        | Imported_var (_, kind) | These_canonicals (_, kind) -> kind
-      in
-      add_alias t kind ~canonical_element:existing_canonical
-        ~name_to_be_demoted:name_in_target_env
-        ~coercion_to_name_to_be_demoted:coercion_to_name_in_source_env
-
-  let add_existential_for_these_simples t ~name_in_target_env simples kind =
-    add_name_for_definition t ~name_in_target_env
-      ~coercion_to_name_in_source_env:Coercion.id
-      (These_canonicals (simples, kind))
-
-  let add_imported_var t ~name_in_target_env ~coercion_to_name_in_source_env
-      imported_var kind =
-    add_name_for_definition t ~name_in_target_env
-      ~coercion_to_name_in_source_env
-      (Imported_var (imported_var, kind))
 
   let get_or_create_canonical_for t definition =
     match existing_canonical_for t definition with
@@ -1318,10 +1130,12 @@ type 'a join_arg = env_id * 'a
 
 type t =
   { joined_envs : Joined_envs.t;
+    types_in_target_env : Type_in_target_env.t Name_in_target_env.Map.t;
     bindings : Bindings_in_target_env.t
   }
 
-let create ~joined_envs ~bindings = { joined_envs; bindings }
+let create ~joined_envs ~bindings =
+  { joined_envs; types_in_target_env = Name_in_target_env.Map.empty; bindings }
 
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
@@ -1335,9 +1149,8 @@ type canonical_in_target_env =
   | Import_from_all_joined_envs of Variable_in_one_joined_env.t * Coercion.t
   | Existential_for_these_simples
 
-let get_canonical_in_target_env ~bindings ~joined_envs canonicals_in_joined_envs
-    =
-  let source_env = Bindings_in_target_env.source_env bindings in
+let get_canonical_in_target_env env canonicals_in_joined_envs =
+  let source_env = Bindings_in_target_env.source_env env.bindings in
   match
     Source_env.candidate_canonical_in_source_env source_env
       canonicals_in_joined_envs
@@ -1363,7 +1176,7 @@ let get_canonical_in_target_env ~bindings ~joined_envs canonicals_in_joined_envs
   | Latest_bound_source_var (var, coercion) ->
     let latest_simple = Simple_in_source_env.var var ~coercion in
     if
-      Joined_envs.equal_in_all_joined_envs joined_envs
+      Joined_envs.equal_in_all_joined_envs env.joined_envs
         (Simple_in_one_joined_env.from_source_env latest_simple)
         canonicals_in_joined_envs
     then Canonical_in_source_env latest_simple
@@ -1437,21 +1250,6 @@ let fold_incremental_join_in_target_env equations_to_join ~exists_in_target_env
         ~var:(fun var ->
           match exists_in_target_env var with
           | None -> acc
-          | Some var_in_target_env ->
-            f (Name_in_target_env.var var_in_target_env) join_entry acc)
-        ~symbol:(fun symbol ->
-          (* See {!section-lifted_constants} *)
-          let symbol = Symbol_in_target_env.create symbol in
-          let name = Name_in_target_env.symbol symbol in
-          f name join_entry acc))
-
-let fold_incremental_join_in_source_env equations_to_join ~exists_in_source_env
-    ~init ~f =
-  fold_incremental_join equations_to_join ~init ~f:(fun name join_entry acc ->
-      Name.pattern_match name
-        ~var:(fun var ->
-          match exists_in_source_env var with
-          | None -> acc
           | Some var_in_target_env -> f var_in_target_env join_entry acc)
         ~symbol:(fun _symbol ->
           (* If [name] is that of a lifted constant symbol generated during one
@@ -1475,60 +1273,65 @@ let fold_incremental_join_in_source_env equations_to_join ~exists_in_source_env
              fine with dropping the equation. *)
           acc))
 
+let add_equation env name ty =
+  assert (not (Name_in_target_env.Map.mem name env.types_in_target_env));
+  let types_in_target_env =
+    Name_in_target_env.Map.add name ty env.types_in_target_env
+  in
+  { env with types_in_target_env }
+
 (* This function is responsible for splitting the [equations_to_join] between
    those that are demotions in all joined environments, that are replayed in the
-   target environment by adding to the bindings, and the rest, that are expanded
-   to equations on concrete types that will be joined later.
+   target environment in the [types_in_target_env], and the rest, that are
+   expanded to equations on concrete types to be joined later.
 
    Note that we only care about names that have new types in all of the joined
    environments, otherwise the join can never be more precise than what we had
    initially. We also only care about names that exist in the target
-   environments; other names will be imported automatically during the join of
-   types and only if they are reachable.
-
-   {b Note}: This function is only used during a top-level join. For nested
-   joins, it would be incorrect to record aliases into the bindings (since they
-   are only valid during the env extension, and the bindings must be valid for
-   the whole join); [join_aliases_in_env_extension] is used instead. *)
-let join_aliases_into_bindings ~joined_envs ~bindings equations_to_join =
-  fold_incremental_join_in_source_env equations_to_join
-    ~exists_in_source_env:
-      (Source_env.exists_in_source_env
-         (Bindings_in_target_env.source_env bindings))
-    ~init:(Name_in_target_env.Map.empty, bindings)
-    ~f:(fun var join_entry (equations_to_join, bindings) ->
-      let name =
-        Name_in_target_env.from_source_env (Name_in_source_env.var var)
-      in
+   environment; other names will be imported automatically during the join of
+   types and only if they are reachable. *)
+let join_aliases_into_bindings env equations_to_join =
+  fold_incremental_join_in_target_env equations_to_join
+    ~exists_in_target_env:
+      (Bindings_in_target_env.exists_in_target_env env.bindings)
+    ~init:(Name_in_target_env.Map.empty, env)
+    ~f:(fun var join_entry (equations_to_join, env) ->
       match get_types_in_joined_envs join_entry with
       | Bottom -> Misc.fatal_error "Unexpected bottom during join"
       | Ok (No_alias_in_some_env types) ->
         let equations_to_join =
-          Name_in_target_env.Map.add name types equations_to_join
+          Name_in_target_env.Map.add
+            (Name_in_target_env.var var)
+            types equations_to_join
         in
-        equations_to_join, bindings
+        equations_to_join, env
       | Ok (Equals_in_all_envs (canonicals, kind)) -> (
-        match get_canonical_in_target_env ~bindings ~joined_envs canonicals with
+        let[@local] add_equals_in_target_env env canonical =
+          let env =
+            add_equation env
+              (Name_in_target_env.var var)
+              (Type_in_target_env.alias_type_of kind canonical)
+          in
+          equations_to_join, env
+        in
+        match get_canonical_in_target_env env canonicals with
         | Canonical_in_source_env canonical ->
-          let bindings =
-            Bindings_in_target_env.add_alias_between_names_in_target_env
-              bindings kind name canonical
+          add_equals_in_target_env env
+            (Simple_in_target_env.from_source_env canonical)
+        | Import_from_all_joined_envs (imported_var, coercion) ->
+          let imported_var, bindings =
+            Bindings_in_target_env.import_from_all_envs env.bindings
+              imported_var kind
           in
-          equations_to_join, bindings
-        | Import_from_all_joined_envs (var, coercion) ->
-          (* name = coercion(var) *)
-          let bindings =
-            Bindings_in_target_env.add_imported_var bindings
-              ~name_in_target_env:name ~coercion_to_name_in_source_env:coercion
-              var kind
-          in
-          equations_to_join, bindings
+          let simple = Simple_in_target_env.var ~coercion imported_var in
+          add_equals_in_target_env { env with bindings } simple
         | Existential_for_these_simples ->
-          let bindings =
-            Bindings_in_target_env.add_existential_for_these_simples bindings
-              ~name_in_target_env:name canonicals kind
+          let existential_var, bindings =
+            Bindings_in_target_env.existential_for_these_simples env.bindings
+              canonicals kind
           in
-          equations_to_join, bindings))
+          let simple = Simple_in_target_env.var existential_var in
+          add_equals_in_target_env { env with bindings } simple))
 
 let rec add_inverse_relation_to_env_extension ?(seen = Name.Set.empty)
     env_extension name relation ~scrutinee =
@@ -1719,12 +1522,12 @@ let recover_inverse_relations ~exists_in_all_joined_envs inverse_relations name
     ty, inverse_relations
 
 let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
-    types_in_target_env inverse_relations =
+    inverse_relations =
   Name_in_target_env.Map.fold
-    (fun name types (types_in_target_env, inverse_relations, t) ->
+    (fun name types (inverse_relations, t) ->
       if
         Flambda_features.check_light_invariants ()
-        && Name_in_target_env.Map.mem name types_in_target_env
+        && Name_in_target_env.Map.mem name t.types_in_target_env
       then
         Misc.fatal_errorf
           "Processing join of %a but we already have a type for it."
@@ -1735,7 +1538,7 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
             : (Index.t * Type_in_one_joined_env.t) list
             :> (Index.t * TG.t) list)
       with
-      | Unknown, t -> types_in_target_env, inverse_relations, t
+      | Unknown, t -> inverse_relations, t
       | Known ty, t ->
         let exists_in_all_joined_envs =
           Joined_envs.exists_in_all_joined_envs t.joined_envs types
@@ -1750,11 +1553,8 @@ let n_way_join_round ~(n_way_join_type : n_way_join_type) t equations_to_join
           else ty, inverse_relations
         in
         let ty = Type_in_target_env.create ty in
-        ( Name_in_target_env.Map.add name ty types_in_target_env,
-          inverse_relations,
-          t ))
-    equations_to_join
-    (types_in_target_env, inverse_relations, t)
+        inverse_relations, add_equation t name ty)
+    equations_to_join (inverse_relations, t)
 
 (** {2:n-way-join Cut and n-way join} *)
 
@@ -1835,9 +1635,9 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
       Bindings_in_target_env.from_source_env (Source_env.create source_tenv)
     in
     let joined_envs = Joined_envs.create equations_to_join in
-    let concrete_equations_to_join, bindings =
-      join_aliases_into_bindings ~joined_envs ~bindings:empty_bindings
-        equations_to_join
+    let empty_env = create ~joined_envs ~bindings:empty_bindings in
+    let concrete_equations_to_join, env =
+      join_aliases_into_bindings empty_env equations_to_join
     in
     let equations_for_bindings bindings ~since =
       let new_bindings = Bindings_in_target_env.new_bindings bindings ~since in
@@ -1854,14 +1654,12 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
     in
     let equations_to_join =
       Name_in_target_env.Map.disjoint_union concrete_equations_to_join
-        (equations_for_bindings bindings ~since:empty_bindings)
+        (equations_for_bindings env.bindings ~since:empty_bindings)
     in
-    let rec loop t equations_to_join concrete_types_in_target_env
-        inverse_relations =
+    let rec loop t equations_to_join inverse_relations =
       let bindings_before_this_round = t.bindings in
-      let types_in_target_env, inverse_relations, t =
-        n_way_join_round ~n_way_join_type t equations_to_join
-          concrete_types_in_target_env inverse_relations
+      let inverse_relations, t =
+        n_way_join_round ~n_way_join_type t equations_to_join inverse_relations
       in
       let new_equations_to_join =
         equations_for_bindings t.bindings ~since:bindings_before_this_round
@@ -1884,21 +1682,17 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
              accessible.
 
              CR-someday bclement: perform CSE for symbol projections? *)
-          types_in_target_env,
+          t.types_in_target_env,
           env_extension_for_inverse_relations,
           n_way_join_symbol_projections t symbol_projections_to_join,
           t.bindings )
-      else loop t new_equations_to_join types_in_target_env inverse_relations
+      else loop t new_equations_to_join inverse_relations
     in
     let ( equations,
           env_extension_for_inverse_relations,
           symbol_projections,
           bindings ) =
-      loop
-        (create ~joined_envs ~bindings)
-        equations_to_join
-        (Bindings_in_target_env.alias_types_in_target_env bindings)
-        Variable.Map.empty
+      loop env equations_to_join Variable.Map.empty
     in
     let target_env =
       Bindings_in_target_env.fold_created_variables
@@ -2178,18 +1972,22 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
   let join_analysis = Analysis.create ~external_ids ~joined_envs bindings in
   target_env, join_analysis
 
-let n_way_join_canonicals ~bindings ~joined_envs kind simples =
-  match get_canonical_in_target_env ~bindings ~joined_envs simples with
+let n_way_join_canonicals env kind simples =
+  match get_canonical_in_target_env env simples with
   | Canonical_in_source_env simple ->
-    Simple_in_target_env.from_source_env simple, bindings
-  | Import_from_all_joined_envs (var, coercion) ->
-    let simple, bindings =
-      Bindings_in_target_env.import_from_all_envs bindings var kind
+    Simple_in_target_env.from_source_env simple, env
+  | Import_from_all_joined_envs (imported_var, coercion) ->
+    let imported_var, bindings =
+      Bindings_in_target_env.import_from_all_envs env.bindings imported_var kind
     in
-    let simple = Simple_in_target_env.apply_coercion_exn simple coercion in
-    simple, bindings
+    let simple = Simple_in_target_env.var ~coercion imported_var in
+    simple, { env with bindings }
   | Existential_for_these_simples ->
-    Bindings_in_target_env.existential_for_these_simples bindings simples kind
+    let existential_var, bindings =
+      Bindings_in_target_env.existential_for_these_simples env.bindings simples
+        kind
+    in
+    Simple_in_target_env.var existential_var, { env with bindings }
 
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
@@ -2200,12 +1998,10 @@ let n_way_join_simples t kind simples : _ Or_bottom.t * t =
        can be re-processed in the current env extension if applicable (if a
        local variable is created while processing an env extension, we currently
        lose any equation that the extension had for that variable). *)
-    let canonical_in_target_env, bindings =
-      n_way_join_canonicals ~bindings:t.bindings ~joined_envs:t.joined_envs kind
-        canonicals_in_joined_envs
+    let canonical_in_target_env, t =
+      n_way_join_canonicals t kind canonicals_in_joined_envs
     in
-    ( Ok (canonical_in_target_env : Simple_in_target_env.t :> Simple.t),
-      { t with bindings } )
+    Ok (canonical_in_target_env : Simple_in_target_env.t :> Simple.t), t
 
 (** {2:extensions Join of extensions} *)
 
@@ -2378,48 +2174,13 @@ let prepare_nested_join ~meet_expanded_head ~joined_envs ~bindings extensions =
       env, incremental_equations)
     joined_envs_and_extensions
 
-(* This is similar to [join_aliases_into_bindings], except that when doing a
-   join of env extensions, we cannot just accumulate aliases into the [bindings]
-   because any demotion we process is local *just* to the current env extension,
-   and stops being valid once we leave the extension.
-
-   Instead, we just accumulate the (local) alias equations directly. *)
-let join_aliases_in_env_extension ~joined_envs ~bindings equations_to_join =
-  fold_incremental_join_in_target_env equations_to_join
-    ~exists_in_target_env:(Bindings_in_target_env.exists_in_target_env bindings)
-    ~init:(Name_in_target_env.Map.empty, Name_in_target_env.Map.empty, bindings)
-    ~f:(fun
-        name
-        join_entry
-        (equations_in_target_env, equations_to_join, bindings)
-      ->
-      match get_types_in_joined_envs join_entry with
-      | Bottom -> Misc.fatal_error "Unexpected bottom during join"
-      | Ok (No_alias_in_some_env types) ->
-        let equations_to_join =
-          Name_in_target_env.Map.add name types equations_to_join
-        in
-        equations_in_target_env, equations_to_join, bindings
-      | Ok (Equals_in_all_envs (canonicals, kind)) ->
-        (* CR-someday bclement: If this creates new variables, they will not be
-           processed inside the env extension (see also the comment in
-           [n_way_join_simples]). *)
-        let canonical, bindings =
-          n_way_join_canonicals ~bindings ~joined_envs kind canonicals
-        in
-        let equations_in_target_env =
-          Name_in_target_env.Map.add name
-            (Type_in_target_env.alias_type_of kind canonical)
-            equations_in_target_env
-        in
-        equations_in_target_env, equations_to_join, bindings)
-
-let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
-    _ Or_bottom.t =
+let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head
+    env_before_extension extensions : _ Or_bottom.t =
   let joined_equations =
     try
-      prepare_nested_join ~meet_expanded_head ~bindings:t.bindings
-        ~joined_envs:t.joined_envs extensions
+      prepare_nested_join ~meet_expanded_head
+        ~bindings:env_before_extension.bindings
+        ~joined_envs:env_before_extension.joined_envs extensions
     with Misc.Fatal_error ->
       let bt = Printexc.get_raw_backtrace () in
       Format.eprintf
@@ -2434,20 +2195,19 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
   else
     try
       let joined_envs = Joined_envs.create joined_equations in
-      let alias_types_in_target_env, concrete_types_to_join, bindings =
-        join_aliases_in_env_extension ~joined_envs ~bindings:t.bindings
-          joined_equations
+      let env_in_extension =
+        create ~joined_envs ~bindings:env_before_extension.bindings
+      in
+      let concrete_types_to_join, env_in_extension =
+        join_aliases_into_bindings env_in_extension joined_equations
       in
       (* CR-someday bclement: if we create new existential variables during the
          join of env extensions, we might need additional rounds for
          completeness (see comment in [n_way_join_simples]) -- in practice one
          round should be plenty. *)
-      let ( equations,
-            _env_extension_for_inverse_relations,
-            { bindings = bindings_after_extension; _ } ) =
-        n_way_join_round ~n_way_join_type
-          (create ~joined_envs ~bindings)
-          concrete_types_to_join alias_types_in_target_env Variable.Map.empty
+      let _env_extension_for_inverse_relations, env_in_extension =
+        n_way_join_round ~n_way_join_type env_in_extension
+          concrete_types_to_join Variable.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in
          [prepare_nested_join] above to create new variables, which do not exist
@@ -2464,14 +2224,11 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
          extension), but not incorrect, only slighly inefficient. *)
       let bindings =
         Bindings_in_target_env.forget_definition_of_created_variables
-          bindings_after_extension ~since:t.bindings
+          env_in_extension.bindings ~since:env_before_extension.bindings
       in
       Ok
-        ( TEE.from_map
-            (equations
-              : Type_in_target_env.t Name_in_target_env.Map.t
-              :> TG.t Name.Map.t),
-          { t with bindings } )
+        ( TEE.from_map (env_in_extension.types_in_target_env :> TG.t Name.Map.t),
+          { env_before_extension with bindings } )
     with Misc.Fatal_error ->
       (* Note that we display the env extensions in their current canonical
          form, which might differ from their form as recorded in the input

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -524,8 +524,6 @@ end
 module Simples_in_joined_envs : sig
   include Container_types.S with type t = Simple_in_one_joined_env.t Index.Map.t
 
-  val of_list : (Index.t * Simple.t) list -> t
-
   val choose_a_suitable_name : t -> string
 end = struct
   module T0 = struct
@@ -547,12 +545,6 @@ end = struct
 
   include T0
   include Container_types.Make (T0)
-
-  let of_list simples =
-    List.fold_left
-      (fun simples (index, simple) ->
-        Index.Map.add index (Simple_in_one_joined_env.create simple) simples)
-      Index.Map.empty simples
 
   let choose_a_suitable_name t =
     let shared_name =
@@ -981,6 +973,9 @@ module Joined_envs : sig
 
   val equal_in_all_joined_envs :
     t -> Simple_in_one_joined_env.t -> Simples_in_joined_envs.t -> bool
+
+  val get_canonical_simples_ignoring_name_mode :
+    t -> (Index.t * Simple.t) list -> Simples_in_joined_envs.t
 end = struct
   type t =
     { envs_and_equations :
@@ -1055,6 +1050,17 @@ end = struct
         then Some (Type_in_one_joined_env.create (TE.find env name (Some kind)))
         else None)
       (envs_and_equations t)
+
+  let get_canonical_simples_ignoring_name_mode t simples =
+    List.fold_left
+      (fun acc (index, simple) ->
+        let env = get_nth_joined_env t index in
+        let canonical =
+          Simple_in_one_joined_env.create
+            (TE.get_canonical_simple_ignoring_name_mode env simple)
+        in
+        Index.Map.add index canonical acc)
+      Index.Map.empty simples
 end
 
 module Aliases_of_existentials = struct
@@ -2120,7 +2126,9 @@ let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
   | [] -> Bottom, t
   | _ :: _ ->
-    let canonicals_in_joined_envs = Simples_in_joined_envs.of_list simples in
+    let canonicals_in_joined_envs =
+      Joined_envs.get_canonical_simples_ignoring_name_mode t.joined_envs simples
+    in
     (* CR-someday bclement: somehow mark the local variable as used, so that it
        can be re-processed in the current env extension if applicable (if a
        local variable is created while processing an env extension, we currently

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1813,8 +1813,8 @@ module Analysis = struct
     let canonical_definitions_at_normal_mode =
       Variable_in_target_env.Map.filter_map
         (fun _name (simples, kind) ->
-          let exists_at_normal_name_mode_in_all_envs_it_is_defined_in =
-            Index.Map.for_all
+          match
+            Index.Map.mapi
               (fun env_id simple ->
                 let typing_env =
                   match Index.Map.find_opt env_id joined_envs with
@@ -1823,12 +1823,13 @@ module Analysis = struct
                     Misc.fatal_errorf "Join does not include environment %a"
                       Index.print env_id
                 in
-                TE.mem_simple ~min_name_mode:Name_mode.normal typing_env simple)
+                TE.get_canonical_simple_exn typing_env simple
+                  ~min_name_mode:Name_mode.normal
+                |> Simple_in_one_joined_env.create)
               (simples : Simples_in_joined_envs.t :> Simple.t Index.Map.t)
-          in
-          if exists_at_normal_name_mode_in_all_envs_it_is_defined_in
-          then Some (simples, kind)
-          else None)
+          with
+          | exception Not_found -> None
+          | simples_at_normal_mode -> Some (simples_at_normal_mode, kind))
         definitions_in_joined_envs
     in
     { definitions_in_joined_envs;

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1980,6 +1980,10 @@ let cut_and_n_way_join_with_analysis ~n_way_join_type ~meet_expanded_head
   target_env, join_analysis
 
 (* Exposed to the outside world with a different type *)
+let import_type env ty =
+  import_type_transitive env (Type_in_one_joined_env.create ty)
+
+(* Exposed to the outside world with a different type *)
 let n_way_join_simples t kind simples : _ Or_bottom.t * t =
   match simples with
   | [] -> Bottom, t

--- a/middle_end/flambda2/types/env/join_env.ml
+++ b/middle_end/flambda2/types/env/join_env.ml
@@ -1332,6 +1332,8 @@ type t =
     bindings : Bindings_in_target_env.t
   }
 
+let create ~joined_envs ~bindings = { joined_envs; bindings }
+
 type n_way_join_type = t -> TG.t join_arg list -> TG.t Or_unknown.t * t
 
 let joined_env t index = Joined_envs.get_nth_joined_env t.joined_envs index
@@ -1916,7 +1918,9 @@ let cut_and_n_way_join0 ~n_way_join_type ~meet_expanded_head ~cut_after
           env_extension_for_inverse_relations,
           symbol_projections,
           bindings ) =
-      loop { joined_envs; bindings } equations_to_join
+      loop
+        (create ~joined_envs ~bindings)
+        equations_to_join
         (Name_in_target_env.from_source_env_map
            (Bindings_in_target_env.alias_types_in_target_env bindings))
         Name.Map.empty
@@ -2466,7 +2470,8 @@ let n_way_join_env_extension ~n_way_join_type ~meet_expanded_head t extensions :
       let ( equations,
             _env_extension_for_inverse_relations,
             { bindings = bindings_after_extension; _ } ) =
-        n_way_join_round ~n_way_join_type { joined_envs; bindings }
+        n_way_join_round ~n_way_join_type
+          (create ~joined_envs ~bindings)
           concrete_types_to_join alias_types_in_target_env Name.Map.empty
       in
       (* It is possible for the call to [add_env_extension] in

--- a/middle_end/flambda2/types/env/join_env.mli
+++ b/middle_end/flambda2/types/env/join_env.mli
@@ -26,6 +26,8 @@ val joined_env : t -> env_id -> Typing_env.t
 
 val machine_width : t -> Target_system.Machine_width.t
 
+val import_type : t -> Type_grammar.t -> t
+
 val n_way_join_simples :
   t -> Flambda_kind.t -> Simple.t join_arg list -> Simple.t Or_bottom.t * t
 

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -900,23 +900,11 @@ let deduce_get_tag_simple ~machine_width blocks get_tag_var :
   | Unknown, Some var -> Ok (Simple.var var)
   | Unknown, None -> Unknown
 
-let n_way_join_simples env kind simples =
-  let canonical_simples =
-    List.map
-      (fun (id, simple) ->
-        ( id,
-          TE.get_canonical_simple_ignoring_name_mode
-            (Join_env.joined_env env id)
-            simple ))
-      simples
-  in
-  Join_env.n_way_join_simples env kind canonical_simples
-
 let n_way_join_relation_simples env simples_opt =
   match simples_opt with
   | None -> None, env
   | Some simples -> (
-    match n_way_join_simples env K.naked_immediate simples with
+    match Join_env.n_way_join_simples env K.naked_immediate simples with
     | Bottom, env -> None, env
     | Ok simple, env ->
       Simple.pattern_match' simple
@@ -1907,16 +1895,7 @@ and n_way_join env (ts : _ Join_env.join_arg list) : TG.t n_way_join_result =
       kind
   in
   let ts = List.filter (fun (_, ty) -> not (TG.is_obviously_bottom ty)) ts in
-  match
-    List.map
-      (fun (id, ty) ->
-        ( id,
-          TE.get_alias_then_canonical_simple_exn
-            ~min_name_mode:Name_mode.in_types
-            (Join_env.joined_env env id)
-            ty ))
-      ts
-  with
+  match List.map (fun (id, ty) -> id, TG.get_alias_exn ty) ts with
   | canonical_simples -> (
     match Join_env.n_way_join_simples env kind canonical_simples with
     | Bottom, join_env -> Known (MTC.bottom kind), join_env
@@ -2142,7 +2121,9 @@ and n_way_join_head_of_kind_value env
     | is_null_simples -> (
       (* Note: we ideally would use [n_way_join_relation_simples] here, but we
          need to store a [Not_null] constructor if the join is [false]. *)
-      match n_way_join_simples env K.naked_immediate is_null_simples with
+      match
+        Join_env.n_way_join_simples env K.naked_immediate is_null_simples
+      with
       | Bottom, env -> TG.Maybe_null { is_null = None }, env
       | Ok simple, env ->
         let is_null =

--- a/middle_end/flambda2/types/meet_and_n_way_join.ml
+++ b/middle_end/flambda2/types/meet_and_n_way_join.ml
@@ -3034,35 +3034,64 @@ and n_way_join_value_slot_indexed_product env
 and n_way_join_int_indexed_product env shape
     (fields : TG.Product.Int_indexed.t Join_env.join_arg list) :
     TG.Product.Int_indexed.t * Join_env.t =
-  let length =
-    match fields with
-    | [] -> Misc.fatal_error "Join of empty int indexed product."
-    | (_, first_fields) :: other_fields ->
+  match fields with
+  | [] -> Misc.fatal_error "Join of empty int indexed product."
+  | (_, first_fields) :: other_fields ->
+    let length =
       List.fold_left
         (fun length (_, other_fields) -> min length (Array.length other_fields))
         (Array.length first_fields)
         other_fields
-  in
-  let fields, env =
-    let env_ref = ref env in
-    let fields =
-      Array.init length (fun index ->
-          (* CR bclement: if fields are all physically equal and only involve
-             variables defined in the central env, we should reuse the type. *)
-          let fields =
-            List.map (fun (id, fields) -> id, fields.(index)) fields
-          in
-          match n_way_join !env_ref fields with
-          | Unknown, env ->
-            env_ref := env;
-            MTC.unknown_from_shape shape index
-          | Known ty, env ->
-            env_ref := env;
-            ty)
     in
-    fields, !env_ref
-  in
-  TG.Product.Int_indexed.create_from_array fields, env
+    let all_phys_equal =
+      try
+        for index = 0 to length - 1 do
+          let first_field = Array.unsafe_get first_fields index in
+          if
+            List.exists
+              (fun (_, other_fields) ->
+                Array.unsafe_get other_fields index != first_field)
+              other_fields
+          then raise_notrace Exit
+        done;
+        true
+      with Exit -> false
+    in
+    if all_phys_equal
+    then
+      match
+        List.find_map
+          (fun (_, fields) ->
+            if Array.length fields = length then Some fields else None)
+          fields
+      with
+      | None -> assert false
+      | Some fields ->
+        ( TG.Product.Int_indexed.create_from_array fields,
+          Array.fold_left (fun env ty -> Join_env.import_type env ty) env fields
+        )
+    else
+      let fields, env =
+        let env_ref = ref env in
+        let fields =
+          Array.init length (fun index ->
+              (* CR bclement: if fields are all physically equal and only
+                 involve variables defined in the central env, we should reuse
+                 the type. *)
+              let fields =
+                List.map (fun (id, fields) -> id, fields.(index)) fields
+              in
+              match n_way_join !env_ref fields with
+              | Unknown, env ->
+                env_ref := env;
+                MTC.unknown_from_shape shape index
+              | Known ty, env ->
+                env_ref := env;
+                ty)
+        in
+        fields, !env_ref
+      in
+      TG.Product.Int_indexed.create_from_array fields, env
 
 and n_way_join_function_type (env : Join_env.t)
     (func_types : TG.Function_type.t Or_unknown.t Join_env.join_arg list) :

--- a/testsuite/tests/flambda2/issue5721.simplify.reference
+++ b/testsuite/tests/flambda2/issue5721.simplify.reference
@@ -17,8 +17,8 @@ let code loopify(never) size(33) newer_version_of(main_0)
             (apply &my_alloc_region f (0) -> k3 * k1
                where k3 (param : imm tagged) =
                  cont k2 (1i))))
-    where k2 (join_param : imm) =
-      let Pisint = %tag_imm (join_param) in
+    where k2 (cse_param : imm) =
+      let Pisint = %tag_imm (cse_param) in
       let Pnot = %boolean_not (Pisint) in
       cont k (Pnot)
 in

--- a/testsuite/tests/flambda2/n_way_join_preserves_null.simplify.reference
+++ b/testsuite/tests/flambda2/n_way_join_preserves_null.simplify.reference
@@ -11,8 +11,8 @@ let code loopify(never) size(30) newer_version_of(f_0)
      where k3 =
        let prim_1 = %int_comp.gt (bit, bit') in
        cont k2 (prim_1))
-    where k2 (join_param : imm) =
-      (switch join_param
+    where k2 (naked_immediate : imm) =
+      (switch naked_immediate
          | 0 -> k (0)
          | 1 -> k2
          where k2 =


### PR DESCRIPTION
This PR improves the performance of the n-way join algorithm in two ways:

 - Existential variables that only occur linearly in the types are projected out. This ensures that we don't keep around names that are essentially useless while preserving sharing when the same existential variable has multiple occurrences.
 - Types that are physically equal in all the joined environments are imported as is, as well as the variable that they mention, transitively. This is an optimisation that is useful for the variables that dominate a join point but are not in scope at the join point -- a situation that occurs much more frequently when match-in-match is enabled. This unfortunately requires some deep changes in the join algorithm, since we now need to be able to import variables that are not canonical while previously the code assumed that we only imported variables that *were* canonical.

This PR introduces a significant improvement to the performance of the join algorithm: the time spent in the join is cut in half when building the compiler itself, a reduction of about 1% of the total compilation time compared to the binary join while generating better code. We lose a tiny bit of optimisations compared to the current implementation of the n-way join, but these are situations that were "accidentally" optimised: as far as I can tell, these are situations where we were creating a `join_param` to represent a variable that was dominating the join, and we no longer do so because we no longer record definitions for variables that are identical in all the joined environments. This was not what the `join_param` mechanism was intended for initially and I'd consider it accidental that it did so (it was only meant to help with cases where the CSE of `%get_tag` and `%is_int` primitives got confused). That said, it would be easy to re-introduce these optimisations if we want, but this happens ~~exactly 3 times on the whole compiler code base so I'm not sure it is worth caring about~~ a bit more than 3 times actually, but I still think we should not worry about it.

Review commit by commit. 

 - The first few commits are simple refactorings to make the follow-up changes easier.
 - Commits "Always create existential variables", "Store definition of variables outside of the bindings", "Project existential variables with non-existential alias" and 'Project variables that occur linearly" implement the first part of the actual change (projecting existential variables).
 - Commits "Join types of imported and existential variables separately" and "n-way join: canonicalise simples in join_env.ml" are further simple refactorings.
 - Commit "Import types without canonicalisation" implements the second part of the actual change (importing types and variables when they are physically equal in all joined environments). Commit "Use physical equality test inside join of blocks" further improves on this by performing the same optimisation for the fields of variants.
 - The remaining commits are some further cleaning up, including removing the join of env extensions that does not seem to matter in practice and somewhat simplifies the implementation.

Fixes #6586 