### PR TITLE
regalloc validator: cost Equation_set.union by overlap, not by size

### DIFF
--- a/backend/regalloc/regalloc_validate.ml
+++ b/backend/regalloc/regalloc_validate.ml
@@ -883,23 +883,23 @@ end = struct
       t1.for_loc
 
   let union t1 t2 =
-    { for_loc =
-        Location.Map.merge
-          (fun _loc regs1 regs2 ->
-            match regs1, regs2 with
-            | None, None -> None
-            | Some r, None | None, Some r -> Some r
-            | Some r1, Some r2 -> Some (Register.Set.union r1 r2))
-          t1.for_loc t2.for_loc;
-      for_reg =
-        Register.Map.merge
-          (fun _reg locs1 locs2 ->
-            match locs1, locs2 with
-            | None, None -> None
-            | Some l, None | None, Some l -> Some l
-            | Some l1, Some l2 -> Some (Location.Set.union l1 l2))
-          t1.for_reg t2.for_reg
-    }
+    (* [Map.union] shares the subtrees that occur in only one operand, so this
+       costs O(overlap) rather than O(size); the guard keeps the join with an
+       empty set allocation-free. *)
+    if is_empty t1
+    then t2
+    else if is_empty t2
+    then t1
+    else
+      { for_loc =
+          Location.Map.union
+            (fun _loc regs1 regs2 -> Some (Register.Set.union regs1 regs2))
+            t1.for_loc t2.for_loc;
+        for_reg =
+          Register.Map.union
+            (fun _reg locs1 locs2 -> Some (Location.Set.union locs1 locs2))
+            t1.for_reg t2.for_reg
+      }
 
   let array_fold2 f acc arr1 arr2 =
     let acc = ref acc in


### PR DESCRIPTION
# regalloc validator: make `Equation_set.union` cost proportional to the overlap

## Summary

The register-allocation translation validator joins equation sets with
`Location.Map.merge` + `Register.Map.merge`. `Map.merge` is unconditionally
`Theta(|t1| + |t2|)`: it rebuilds the whole result and calls the combiner on
every key, even keys present in only one operand. Since the validator joins a
small set into a large one all the time, that makes the join term quadratic in
the size of a function.

`Map.union` computes the same result for this combiner and is the
divide-and-conquer version: it calls the combiner only on keys present in
*both* operands, shares (rather than copies) subtrees that occur in just one,
and short-circuits `Empty` at every level of the recursion. Cost drops from
`Theta(|t1| + |t2|)` to `O(m * log(n/m + 1))` for `m <= n`.

Validation runs on every native compile (`Oxcaml_flags.regalloc_validate`
defaults to `true`), so this is on by default.

No behaviour change: same equation sets, same accept/reject decision, and
byte-identical emitted objects.

## Where the cost was

Two call sites, both hot:

1. `Domain.join`, reached from the backward dataflow's per-edge
   `join_result`. On a block's first visit the accumulated value is `bot`, so
   this is `union bot X` — and `Map.merge` walks all of `X` anyway.

2. `append_equations`, the generalized per-instruction transfer, does
   `Equation_set.union equations exn_equations`. `basic` passes `~exn:None` for
   every instruction that is not a spill/reload/move, and `exn_equations` then
   defaults to `Domain.bot` — so **every** such instruction paid a full
   two-map merge over the entire live equation set. For a raising terminator
   inside a handler region, `exn_equations` is instead small-but-non-empty,
   which is the case an emptiness test cannot catch.

## Why both the guard and `Map.union`

An `is_empty` short-circuit alone fixes only case (1) and the `~exn:None` half
of case (2) — the *completely* empty operand. `Map.union` alone fixes the
general case but pays a small constant (a record allocation and two tree
descents) on the very common empty join. Measuring all four combinations, the
version in this PR — guard *and* `Map.union` — is the only one that is
best-or-tied in both regimes, so that is what it does.

## Measurements

Two workload families, both parameterised by `N` = number of simultaneously
live values. Metric: user-space instruction counts (`perf stat -e
instructions:u`, deterministic here) above a common validation-off control,
`-O3`, min of 3-5 runs, plus the `cfg_validate_description` phase time from
`-dtimings`. Legs: `base`, `guard only`, `Map.union only`, `guard +
Map.union` (this PR).

### Straight-line code (`N` chained lets, all live at one allocation)

Only *completely* empty joins arise here.

| N | base | guard only | this PR | phase, base -> this PR |
|---:|---:|---:|---:|---:|
| 100 | 42.9M | 29.2M | 29.3M | 0.003s -> 0.001s |
| 200 | 125.5M | 28.7M | 28.7M | 0.005s -> 0.002s |
| 400 | 780.9M | 129.5M | 129.5M | 0.084s -> 0.013s |
| 800 | 3351.2M | 299.9M | 297.7M | 0.366s -> 0.028s |
| 1600 | 12443.1M | 1685.1M | 1682.5M | 1.309s -> 0.083s |
| 3200 | 47260.4M | 5371.4M | 5729.3M | 6.774s -> 0.160s |

Base grows 3.3-4.3x per doubling of `N` (quadratic); the phase time goes from
6.77s to 0.16s at `N` = 3200.

### Exception edges (`N` values live across `N/4` calls that can raise, tiny handler)

Here `union` is called with a large normal-path set and a small non-empty
exceptional one — the "almost empty" case.

| N | base | guard only | this PR | this PR vs guard only |
|---:|---:|---:|---:|---:|
| 100 | 39.6M | 14.8M | 14.0M | 1.06x |
| 200 | 139.7M | 30.7M | 25.8M | 1.19x |
| 400 | 599.8M | 206.5M | 144.6M | 1.43x |
| 800 | 2128.7M | 340.1M | 171.1M | 1.99x |
| 1600 | 7024.5M | 965.8M | 401.7M | 2.40x |

The advantage over an emptiness test alone grows monotonically with `N`, which
is what removing a size-proportional term looks like. Phase time at `N` = 1600:
0.976s (base) -> 0.178s (guard only) -> 0.062s (this PR).

## Correctness

`Map.union f t1 t2` is documented as `merge f' t1 t2` with
`f' k None None = None`, `f' k (Some v) None = Some v`,
`f' k None (Some v) = Some v`, `f' k (Some a) (Some b) = f k a b`. The combiner
being replaced is exactly that: identity on one-sided keys, `Set.union` on
two-sided ones (its `None, None` arm was dead — `merge` never calls the
combiner with two `None`s). So the result is unchanged, including the invariant
that no key maps to an empty set: a `Set.union` of two non-empty sets is
non-empty.

Evidence:

- **Differential test.** A standalone harness ran old and new `union` over
  20,000 random equation-set pairs (empty, disjoint, overlapping, nested;
  0-25 bindings over a 40-key space): 0 mismatches.
- **Byte-identical output.** `.o` md5 identical across all four legs on every
  workload above (6 straight-line sizes, up to `N` = 3200).
- **Test suite** green on this exact source: `dune runtest` passes, and the
  upstream testsuite reports 2363 passed / 204 skipped / 0 failed / 0
  unexpected errors. That includes
  `oxcaml/tests/backend/validators/check_regalloc_validation`, which is the
  test that matters here: 29 cases pass, 25 of them asserting exact expected
  *failure* output — several printing the equation set contents, so a `union`
  that computed different sets would fail them — and 8 "check loop with N
  locations" cases, which are joins of two non-empty sets.

## Notes for reviewers

- The emptiness guard is a small refinement on top of the main change; the
  measurements for `Map.union` without it are in the tables above if you would
  prefer the smaller diff (it costs 2-8% of the validator on straight-line
  code and is otherwise equivalent).
- Two related things this PR deliberately does *not* touch: `subset`
  (`Domain.less_equal`) still walks its left operand on every dataflow edge,
  and `for_reg` is a full transpose of `for_loc` maintained in lockstep. Both
  look like further wins but are separate changes.
