### PR TITLE
Forbid `[%atomic.loc]` and mutable indices to polymorphic record fields

### DIFF
--- a/testsuite/tests/atomic-locs/atomic_fields.ml
+++ b/testsuite/tests/atomic-locs/atomic_fields.ml
@@ -181,6 +181,24 @@ Line 2, characters 53-70:
 Error: The record field "f" is not atomic
 |}]
 
+(* Test polymorphic atomic fields *)
+
+type poly_record = { mutable poly_field : 'a. 'a option [@atomic] }
+
+(* Reading the field instantiates it, which is fine. *)
+let test_poly_read (r : poly_record) = (r.poly_field : int option)
+[%%expect{|
+type poly_record = { mutable poly_field : 'a. 'a option [@atomic]; }
+val test_poly_read : poly_record -> int option = <fun>
+|}]
+
+(* CR rtjoa: unsound. [Atomic.Loc.set] through this location would store a value
+   of a single type into a field that must hold a polymorphic one. *)
+let test_poly_atomic_loc (r : poly_record) = [%atomic.loc r.poly_field]
+[%%expect{|
+val test_poly_atomic_loc : poly_record -> 'a option atomic_loc = <fun>
+|}]
+
 (* Test Invalid_atomic_loc_payload errors *)
 
 (* Empty payload *)

--- a/testsuite/tests/atomic-locs/atomic_fields.ml
+++ b/testsuite/tests/atomic-locs/atomic_fields.ml
@@ -197,8 +197,8 @@ let test_poly_atomic_loc (r : poly_record) = [%atomic.loc r.poly_field]
 Line 1, characters 45-71:
 1 | let test_poly_atomic_loc (r : poly_record) = [%atomic.loc r.poly_field]
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Use of "[%atomic.loc]" (here "poly_field")
-       for polymorphic record fields is forbidden.
+Error: Use of "[%atomic.loc]" with polymorphic record fields
+       (here "poly_field") is forbidden.
 |}]
 
 (* Test Invalid_atomic_loc_payload errors *)

--- a/testsuite/tests/atomic-locs/atomic_fields.ml
+++ b/testsuite/tests/atomic-locs/atomic_fields.ml
@@ -192,11 +192,13 @@ type poly_record = { mutable poly_field : 'a. 'a option [@atomic]; }
 val test_poly_read : poly_record -> int option = <fun>
 |}]
 
-(* CR rtjoa: unsound. [Atomic.Loc.set] through this location would store a value
-   of a single type into a field that must hold a polymorphic one. *)
 let test_poly_atomic_loc (r : poly_record) = [%atomic.loc r.poly_field]
 [%%expect{|
-val test_poly_atomic_loc : poly_record -> 'a option atomic_loc = <fun>
+Line 1, characters 45-71:
+1 | let test_poly_atomic_loc (r : poly_record) = [%atomic.loc r.poly_field]
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Use of "[%atomic.loc]" (here "poly_field")
+       for polymorphic record fields is forbidden.
 |}]
 
 (* Test Invalid_atomic_loc_payload errors *)

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -548,11 +548,13 @@ let ok = (.p_imm)
 val ok : (poly_imm, 'a option) idx_imm = <abstr>
 |}]
 
-(* CR rtjoa: unsound. [Idx_mut.set] through this index would store a value of a
-   single type into a field that must hold a polymorphic one. *)
 let bad = (.p_mut)
 [%%expect{|
-val bad : (poly_mut, 'a option) idx_mut = <abstr>
+Line 1, characters 12-17:
+1 | let bad = (.p_mut)
+                ^^^^^
+Error: Mutable block indices to polymorphic record fields
+       (here "p_mut") are forbidden.
 |}]
 
 type poly_unboxed = #{ p_u : 'a. 'a option }
@@ -562,11 +564,13 @@ type poly_unboxed = #{ p_u : 'a. 'a option; }
 type holds_poly = { mutable h : poly_unboxed; }
 |}]
 
-(* CR rtjoa: unsound for the same reason: the mutability comes from [h], and the
-   polymorphism from the unboxed field [p_u]. *)
 let bad_unboxed = (.h.#p_u)
 [%%expect{|
-val bad_unboxed : (holds_poly, 'a option) idx_mut = <abstr>
+Line 1, characters 23-26:
+1 | let bad_unboxed = (.h.#p_u)
+                           ^^^
+Error: Mutable block indices to polymorphic record fields
+       (here "p_u") are forbidden.
 |}]
 
 (**************)

--- a/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
+++ b/testsuite/tests/typing-layouts-block-indices/basics_block_indices.ml
@@ -532,6 +532,43 @@ Line 2, characters 13-17:
 Error: Block indices do not yet support [@atomic] record fields.
 |}]
 
+(**********************************************)
+(* Block indices to polymorphic record fields *)
+
+type poly_imm = { p_imm : 'a. 'a option }
+type poly_mut = { mutable p_mut : 'a. 'a option }
+[%%expect{|
+type poly_imm = { p_imm : 'a. 'a option; }
+type poly_mut = { mutable p_mut : 'a. 'a option; }
+|}]
+
+(* Immutable indices only read, so instantiating the field is fine. *)
+let ok = (.p_imm)
+[%%expect{|
+val ok : (poly_imm, 'a option) idx_imm = <abstr>
+|}]
+
+(* CR rtjoa: unsound. [Idx_mut.set] through this index would store a value of a
+   single type into a field that must hold a polymorphic one. *)
+let bad = (.p_mut)
+[%%expect{|
+val bad : (poly_mut, 'a option) idx_mut = <abstr>
+|}]
+
+type poly_unboxed = #{ p_u : 'a. 'a option }
+type holds_poly = { mutable h : poly_unboxed }
+[%%expect{|
+type poly_unboxed = #{ p_u : 'a. 'a option; }
+type holds_poly = { mutable h : poly_unboxed; }
+|}]
+
+(* CR rtjoa: unsound for the same reason: the mutability comes from [h], and the
+   polymorphism from the unboxed field [p_u]. *)
+let bad_unboxed = (.h.#p_u)
+[%%expect{|
+val bad_unboxed : (holds_poly, 'a option) idx_mut = <abstr>
+|}]
+
 (**************)
 (* Modalities *)
 

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -260,6 +260,7 @@ type error =
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
   | Mixed_record_atomic_loc of Longident.t
+  | Polymorphic_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string
@@ -301,6 +302,7 @@ type error =
   | Block_index_modality_mismatch of
       { mut : bool; err : Modality.equate_error }
   | Block_index_atomic_unsupported
+  | Block_index_polymorphic_field of Longident.t
   | Submode_failed of Value.error * submode_reason
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
@@ -1327,9 +1329,11 @@ let check_project_mutability ~loc ~env mut_name mutability mode =
   if Types.is_mutable mutability then
     submode ~loc ~env mode (mode_project_mutable mut_name)
 
-let check_atomic_loc ~loc ~env record_repres mutability lid =
-  if not (Types.is_atomic mutability) then
+let check_atomic_loc ~loc ~env record_repres label lid =
+  if not (Types.is_atomic label.lbl_mut) then
     raise (Error (loc, env, Label_not_atomic lid));
+  if is_poly_Tpoly label.lbl_arg then
+    raise (Error (loc, env, Polymorphic_atomic_loc lid));
   match record_repres with
   | Record_boxed | Record_inlined (_, Constructor_uniform_value, _) -> ()
   | Record_mixed _ | Record_inlined (_, Constructor_mixed _, _) ->
@@ -1343,6 +1347,21 @@ let check_atomic_loc ~loc ~env record_repres mutability lid =
   (* We should know record representation at this point. *)
   | Record_dummy _ | Record_variable ->
       Misc.fatal_error "check_atomic_loc: unexpected record representation"
+
+(* Mutable indices to polymorphic fields cannot be taken, as they would allow
+   writing non-polymorphic values. *)
+let check_index_not_to_poly_field ~env ba uas =
+  let check lid lbl_arg =
+    if is_poly_Tpoly lbl_arg then
+      raise (Error (lid.loc, env, Block_index_polymorphic_field lid.txt))
+  in
+  begin match ba with
+  | Baccess_field (lid, label, _) -> check lid label.lbl_arg
+  | Baccess_block _ -> ()
+  end;
+  List.iter
+    (fun (Uaccess_unboxed_field (lid, label, _)) -> check lid label.lbl_arg)
+    uas
 
 (* Represents information about an array type inferred using type-directed
    disambiguation. *)
@@ -7774,6 +7793,7 @@ and type_expect_
         (el_ty, modality)
         uas
     in
+    if mut then check_index_not_to_poly_field ~env ba uas;
     let expected_modality = Typemode.idx_expected_modalities ~mut in
     begin
       match Modality.Const.equate modality expected_modality with
@@ -8533,7 +8553,7 @@ and type_expect_
               Legacy lid
           in
           Env.mark_label_used Env.Projection label.lbl_uid;
-          check_atomic_loc ~loc ~env record_repres label.lbl_mut lid.txt;
+          check_atomic_loc ~loc ~env record_repres label lid.txt;
           let alloc_mode, argument_mode =
             register_allocation ~loc expected_mode
           in
@@ -13069,6 +13089,11 @@ let report_error ~loc env =
         "Use of %a with mixed record fields (here %a) is forbidden."
         Style.inline_code "[%atomic.loc]"
         quoted_longident lid
+  | Polymorphic_atomic_loc lid ->
+      Location.errorf ~loc
+        "Use of %a (here %a)@ for polymorphic record fields is forbidden."
+        Style.inline_code "[%atomic.loc]"
+        quoted_longident lid
   | Literal_overflow ty ->
       Location.errorf ~loc
         "Integer literal exceeds the range of representable integers of type %a"
@@ -13256,6 +13281,11 @@ let report_error ~loc env =
   | Block_index_atomic_unsupported ->
     Location.error ~loc
       "Block indices do not yet support [@atomic] record fields."
+  | Block_index_polymorphic_field lid ->
+    Location.errorf ~loc
+      "Mutable block indices to polymorphic record fields@ (here %a) are \
+       forbidden."
+      quoted_longident lid
   | Submode_failed(e, submode_reason) ->
     let Mode.Value.Error (ax, _) = Mode.Value.to_simple_error e in
     (* CR-soon zqian: move the following hints into the new hint system, then

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -302,7 +302,7 @@ type error =
   | Block_index_modality_mismatch of
       { mut : bool; err : Modality.equate_error }
   | Block_index_atomic_unsupported
-  | Block_index_polymorphic_field of Longident.t
+  | Mutable_block_index_polymorphic_field of Longident.t
   | Submode_failed of Value.error * submode_reason
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]
@@ -1353,7 +1353,8 @@ let check_atomic_loc ~loc ~env record_repres label lid =
 let check_index_not_to_poly_field ~env ba uas =
   let check lid lbl_arg =
     if is_poly_Tpoly lbl_arg then
-      raise (Error (lid.loc, env, Block_index_polymorphic_field lid.txt))
+      raise
+        (Error (lid.loc, env, Mutable_block_index_polymorphic_field lid.txt))
   in
   begin match ba with
   | Baccess_field (lid, label, _) -> check lid label.lbl_arg
@@ -13091,7 +13092,7 @@ let report_error ~loc env =
         quoted_longident lid
   | Polymorphic_atomic_loc lid ->
       Location.errorf ~loc
-        "Use of %a (here %a)@ for polymorphic record fields is forbidden."
+        "Use of %a with polymorphic record fields@ (here %a) is forbidden."
         Style.inline_code "[%atomic.loc]"
         quoted_longident lid
   | Literal_overflow ty ->
@@ -13281,7 +13282,7 @@ let report_error ~loc env =
   | Block_index_atomic_unsupported ->
     Location.error ~loc
       "Block indices do not yet support [@atomic] record fields."
-  | Block_index_polymorphic_field lid ->
+  | Mutable_block_index_polymorphic_field lid ->
     Location.errorf ~loc
       "Mutable block indices to polymorphic record fields@ (here %a) are \
        forbidden."

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -348,7 +348,7 @@ type error =
   | Block_index_modality_mismatch of
       { mut : bool; err : Mode.Modality.equate_error }
   | Block_index_atomic_unsupported
-  | Block_index_polymorphic_field of Longident.t
+  | Mutable_block_index_polymorphic_field of Longident.t
   | Submode_failed of Mode.Value.error * submode_reason
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -304,6 +304,7 @@ type error =
   | Atomic_in_pattern of Longident.t
   | Atomic_in_functional_update of label
   | Mixed_record_atomic_loc of Longident.t
+  | Polymorphic_atomic_loc of Longident.t
   | Probe_format
   | Probe_name_format of string
   | Probe_name_undefined of string
@@ -347,6 +348,7 @@ type error =
   | Block_index_modality_mismatch of
       { mut : bool; err : Mode.Modality.equate_error }
   | Block_index_atomic_unsupported
+  | Block_index_polymorphic_field of Longident.t
   | Submode_failed of Mode.Value.error * submode_reason
   | Curried_application_complete of
       arg_label * Mode.Alloc.error * [`Prefix|`Single_arg|`Entire_apply]


### PR DESCRIPTION
Atomic locations and mutable indices to polymorphic record fields are unsound, as they allow the fields to be filled with values that are not polymorphic.

This can be exploited to implement `Obj.magic`. Both of the below programs typecheck with `val magic : 'a -> 'b`.
```ocaml
type t = { mutable c : 'a. 'a option [@atomic] }

let magic (type a b) (x : a) : b =
  let r = { c = None } in
  Atomic.Loc.set [%atomic.loc r.c] (Some x);
  match r.c with
  | Some y -> y
  | None -> let rec loop () = loop () in loop ()
```

```ocaml
type t = { mutable c : 'a. 'a option }

let magic (type a b) (x : a) : b =
  let r = { c = None } in
  Stdlib_stable.Idx_mut.set r (.c) (Some x);
  match r.c with
  | Some y -> y
  | None -> let rec loop () = loop () in loop ()
```

This PR adds type errors for such atomic locations and mutable indices. Immutable indices to polymorphic record fields are still allowed.