### PR TITLE
Fix unsound function argument/return sorts in partial GADT matches

### DIFF
--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_any.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_any.ml
@@ -1,0 +1,201 @@
+(* TEST
+ flags = "-extension layouts_alpha";
+ expect;
+*)
+
+type ('a : any) t = V : 'a t | B : ('a : bits64) t
+[%%expect{|
+type ('a : any) t = V : 'a t | B : ('a : bits64). 'a t
+|}]
+
+(* Regression test: we should not treat [x] as representable. Even though it
+   has kind [value] in the function body, this depends on being under the scope
+   of [V], yet a caller could pass [B], causing a segfault during the function
+   call before a match error can be raised. *)
+let f : type (a : any). a t -> a -> unit -> a = fun V x () -> x
+[%%expect{|
+Line 1, characters 52-53:
+1 | let f : type (a : any). a t -> a -> unit -> a = fun V x () -> x
+                                                        ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "B"
+
+val f : ('a : any). 'a t -> 'a -> unit -> 'a = <fun>
+|}]
+
+(* Like [f], but [Yes] equates [a] with a closed type, rather than with the
+   constructor's own (value-kinded) type variable as [V] does.
+   [g No #2L] used to segfault. *)
+type ('a : any) isf = Yes : (int -> int) isf | No : ('a : bits64) isf
+
+let g : type (a : any). a isf -> a -> unit -> (int -> int) =
+  fun Yes x () -> x
+[%%expect{|
+type ('a : any) isf = Yes : (int -> int) isf | No : ('a : bits64). 'a isf
+Line 4, characters 6-9:
+4 |   fun Yes x () -> x
+          ^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "No"
+
+val g : ('a : any). 'a isf -> 'a -> unit -> int -> int = <fun>
+|}]
+
+(* The result sort is part of the calling convention for the same reason. *)
+let f_ret : type (a : any). a t -> unit -> a = fun V () -> assert false
+[%%expect{|
+Line 1, characters 51-52:
+1 | let f_ret : type (a : any). a t -> unit -> a = fun V () -> assert false
+                                                       ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "B"
+
+val f_ret : ('a : any). 'a t -> unit -> 'a = <fun>
+|}]
+
+(* Trailing [function] cases form one function with the preceding parameters,
+   so their argument and result sorts are part of the calling convention
+   too. *)
+let f_cases : type (a : any). a t -> a -> a = fun V -> function x -> x
+[%%expect{|
+Line 1, characters 50-51:
+1 | let f_cases : type (a : any). a t -> a -> a = fun V -> function x -> x
+                                                      ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "B"
+
+val f_cases : ('a : any). 'a t -> 'a -> 'a = <fun>
+|}]
+
+(* The pattern on the optional argument covers its payload, but a caller can
+   omit the argument entirely. [g_opt #2L] used to segfault. *)
+type ('a : any) opt = YesO : (int -> int) opt
+
+let g_opt : type (a : any). ?x:(a opt) -> a -> unit -> (int -> int) =
+  fun ?x:(YesO = assert false) y () -> y
+[%%expect{|
+type ('a : any) opt = YesO : (int -> int) opt
+Line 4, characters 10-14:
+4 |   fun ?x:(YesO = assert false) y () -> y
+              ^^^^
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int -> int" and "a" as equal. But the knowledge of these types is not
+  principal.
+
+val g_opt : ('a : any). ?x:'a opt -> 'a -> unit -> int -> int = <fun>
+|}]
+
+(* Sound, as the later layouts do not rely on the optional argument's
+   narrowing. *)
+type _ w = AW : int w
+
+let opt_value : type a. ?x:(a w) -> a -> unit =
+  fun ?x:(AW = assert false) _y -> ()
+[%%expect{|
+type _ w = AW : int w
+Line 4, characters 10-12:
+4 |   fun ?x:(AW = assert false) _y -> ()
+              ^^
+Warning 18 [not-principal]: typing this pattern requires considering
+  "int" and "a" as equal. But the knowledge of these types is not principal.
+
+val opt_value : ?x:'a w -> 'a -> unit = <fun>
+|}]
+
+(* Sound, as the nested function is a separate closure, created only after
+   the match on [V] succeeds, so its sorts may rely on the narrowing. *)
+let nested : type (a : any). a t -> (a -> a) = fun V -> fun x -> x
+[%%expect{|
+Line 1, characters 51-52:
+1 | let nested : type (a : any). a t -> (a -> a) = fun V -> fun x -> x
+                                                       ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "B"
+
+val nested : ('a : any). 'a t -> 'a -> 'a = <fun>
+|}]
+
+(* Sound, as at [a : value], [B] is refuted by its kind, making the match
+   total. *)
+let total_by_refutation : type a. a t -> a -> a = fun V x -> x
+[%%expect{|
+val total_by_refutation : 'a t -> 'a -> 'a = <fun>
+|}]
+
+type ('a : any) s = I : int s
+[%%expect{|
+type ('a : any) s = I : int s
+|}]
+
+(* Sound, as a total single-constructor match may narrow later parameters'
+   sorts. *)
+let total : type (a : any). a s -> a -> a = fun I x -> x
+[%%expect{|
+val total : ('a : any). 'a s -> 'a -> 'a = <fun>
+|}]
+
+(* Sound, as [A]'s narrowing does not affect any layouts. *)
+type _ v = A : int v | C : string v
+let partial_value : type a. a v -> a -> unit = fun A _x -> ()
+[%%expect{|
+type _ v = A : int v | C : string v
+Line 2, characters 51-52:
+2 | let partial_value : type a. a v -> a -> unit = fun A _x -> ()
+                                                       ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "C"
+
+val partial_value : 'a v -> 'a -> unit = <fun>
+|}]
+
+(* Sound, as the branch body still sees the partial match's narrowing
+   (returning [x] at type [int] needs [a = int]); only caller-facing sorts
+   must be justified without it. *)
+let body_uses_narrowing : type a. a v -> a -> int = fun A x -> x
+[%%expect{|
+Line 1, characters 56-57:
+1 | let body_uses_narrowing : type a. a v -> a -> int = fun A x -> x
+                                                            ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "C"
+
+val body_uses_narrowing : 'a v -> 'a -> int = <fun>
+|}]
+
+(* An enclosing partial match conservatively also drops the narrowing of
+   later patterns, even an inner total match's: a later constraint's recorded
+   jkind may derive from the reverted refinements (see the [eq] case below),
+   so none of them can be kept. *)
+let partial_then_total : type a (b : any). a v -> b s -> b -> unit =
+  fun A I _x -> ()
+[%%expect{|
+Line 2, characters 6-7:
+2 |   fun A I _x -> ()
+          ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "C"
+
+val partial_then_total : 'a ('b : any). 'a v -> 'b s -> 'b -> unit = <fun>
+|}]
+
+(* A later pattern's equation can launder the reverted refinements: [Refl]'s
+   equation records [b]'s jkind as computed under [Val]'s refinement of [a],
+   so keeping it while reverting [Val]'s refinement would wrongly justify
+   [x]'s layout. [f_eq B64 Refl #2L] used to segfault. *)
+type ('a : any) tv = Val : ('a : value) tv | B64 : ('a : bits64) tv
+type ('x : any, 'y : any) eq = Refl : ('z : any). ('z, 'z) eq
+
+let f_eq : type (a : any) (b : any). a tv -> (a, b) eq -> b -> unit -> unit =
+  fun Val Refl x () -> ()
+[%%expect{|
+type ('a : any) tv = Val : 'a tv | B64 : ('a : bits64). 'a tv
+type ('x : any, 'y : any) eq = Refl : ('z : any). ('z, 'z) eq
+Line 5, characters 6-9:
+5 |   fun Val Refl x () -> ()
+          ^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "B64"
+
+val f_eq : ('a : any) ('b : any). 'a tv -> ('a, 'b) eq -> 'b -> unit -> unit =
+  <fun>
+|}]

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_any.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_any.ml
@@ -20,7 +20,13 @@ Line 1, characters 52-53:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched: "B"
 
-val f : ('a : any). 'a t -> 'a -> unit -> 'a = <fun>
+Line 1, characters 54-55:
+1 | let f : type (a : any). a t -> a -> unit -> a = fun V x () -> x
+                                                          ^
+Error: This function's argument has type a,
+       whose layout is known only from the GADT pattern match at line 1, characters 52-53.
+       That match is not exhaustive, so a caller could reach this argument at a different layout.
+       Function arguments and results must be representable independently of any non-exhaustive match.
 |}]
 
 (* Like [f], but [Yes] equates [a] with a closed type, rather than with the
@@ -38,7 +44,13 @@ Line 4, characters 6-9:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched: "No"
 
-val g : ('a : any). 'a isf -> 'a -> unit -> int -> int = <fun>
+Line 4, characters 10-11:
+4 |   fun Yes x () -> x
+              ^
+Error: This function's argument has type a,
+       whose layout is known only from the GADT pattern match at line 4, characters 6-9.
+       That match is not exhaustive, so a caller could reach this argument at a different layout.
+       Function arguments and results must be representable independently of any non-exhaustive match.
 |}]
 
 (* The result sort is part of the calling convention for the same reason. *)
@@ -50,7 +62,13 @@ Line 1, characters 51-52:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched: "B"
 
-val f_ret : ('a : any). 'a t -> unit -> 'a = <fun>
+Line 1, characters 53-71:
+1 | let f_ret : type (a : any). a t -> unit -> a = fun V () -> assert false
+                                                         ^^^^^^^^^^^^^^^^^^
+Error: This function's result has type a,
+       whose layout is known only from the GADT pattern match at line 1, characters 51-52.
+       That match is not exhaustive, so a caller could reach this result at a different layout.
+       Function arguments and results must be representable independently of any non-exhaustive match.
 |}]
 
 (* Trailing [function] cases form one function with the preceding parameters,
@@ -64,7 +82,13 @@ Line 1, characters 50-51:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched: "B"
 
-val f_cases : ('a : any). 'a t -> 'a -> 'a = <fun>
+Line 1, characters 55-70:
+1 | let f_cases : type (a : any). a t -> a -> a = fun V -> function x -> x
+                                                           ^^^^^^^^^^^^^^^
+Error: This function's argument has type a,
+       whose layout is known only from the GADT pattern match at line 1, characters 50-51.
+       That match is not exhaustive, so a caller could reach this argument at a different layout.
+       Function arguments and results must be representable independently of any non-exhaustive match.
 |}]
 
 (* The pattern on the optional argument covers its payload, but a caller can
@@ -82,7 +106,13 @@ Warning 18 [not-principal]: typing this pattern requires considering
   "int -> int" and "a" as equal. But the knowledge of these types is not
   principal.
 
-val g_opt : ('a : any). ?x:'a opt -> 'a -> unit -> int -> int = <fun>
+Line 4, characters 31-32:
+4 |   fun ?x:(YesO = assert false) y () -> y
+                                   ^
+Error: This function's argument has type a,
+       whose layout is known only from the GADT pattern match at line 4, characters 10-14.
+       That pattern matches an optional argument that a caller could omit, so a caller could reach this argument at a different layout.
+       Function arguments and results must be representable independently of the patterns of optional arguments.
 |}]
 
 (* Sound, as the later layouts do not rely on the optional argument's
@@ -148,9 +178,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 val partial_value : 'a v -> 'a -> unit = <fun>
 |}]
 
-(* Sound, as the branch body still sees the partial match's narrowing
-   (returning [x] at type [int] needs [a = int]); only caller-facing sorts
-   must be justified without it. *)
+(* It's sound for the body to still see the partial match's narrowing *)
 let body_uses_narrowing : type a. a v -> a -> int = fun A x -> x
 [%%expect{|
 Line 1, characters 56-57:
@@ -162,26 +190,7 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 val body_uses_narrowing : 'a v -> 'a -> int = <fun>
 |}]
 
-(* An enclosing partial match conservatively also drops the narrowing of
-   later patterns, even an inner total match's: a later constraint's recorded
-   jkind may derive from the reverted refinements (see the [eq] case below),
-   so none of them can be kept. *)
-let partial_then_total : type a (b : any). a v -> b s -> b -> unit =
-  fun A I _x -> ()
-[%%expect{|
-Line 2, characters 6-7:
-2 |   fun A I _x -> ()
-          ^
-Warning 8 [partial-match]: this pattern-matching is not exhaustive.
-  Here is an example of a case that is not matched: "C"
-
-val partial_then_total : 'a ('b : any). 'a v -> 'b s -> 'b -> unit = <fun>
-|}]
-
-(* A later pattern's equation can launder the reverted refinements: [Refl]'s
-   equation records [b]'s jkind as computed under [Val]'s refinement of [a],
-   so keeping it while reverting [Val]'s refinement would wrongly justify
-   [x]'s layout. [f_eq B64 Refl #2L] used to segfault. *)
+(* Test for multiple refinements on the same type *)
 type ('a : any) tv = Val : ('a : value) tv | B64 : ('a : bits64) tv
 type ('x : any, 'y : any) eq = Refl : ('z : any). ('z, 'z) eq
 
@@ -196,6 +205,32 @@ Line 5, characters 6-9:
 Warning 8 [partial-match]: this pattern-matching is not exhaustive.
   Here is an example of a case that is not matched: "B64"
 
-val f_eq : ('a : any) ('b : any). 'a tv -> ('a, 'b) eq -> 'b -> unit -> unit =
-  <fun>
+Line 5, characters 15-16:
+5 |   fun Val Refl x () -> ()
+                   ^
+Error: This function's argument has type b,
+       whose layout is known only from the GADT pattern match at line 5, characters 6-9.
+       That match is not exhaustive, so a caller could reach this argument at a different layout.
+       Function arguments and results must be representable independently of any non-exhaustive match.
+|}]
+
+(* Our check that sorts hold without pattern refinements also disallows
+   sound programs that rely on an inner total match's narrowing, but not the
+   enclosing partial match's. *)
+let partial_then_total : type a (b : any). a v -> b s -> b -> unit =
+  fun A I _x -> ()
+[%%expect{|
+Line 2, characters 6-7:
+2 |   fun A I _x -> ()
+          ^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "C"
+
+Line 2, characters 10-12:
+2 |   fun A I _x -> ()
+              ^^
+Error: This function's argument has type b,
+       whose layout is known only from the GADT pattern match at line 2, characters 6-7.
+       That match is not exhaustive, so a caller could reach this argument at a different layout.
+       Function arguments and results must be representable independently of any non-exhaustive match.
 |}]

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -678,6 +678,7 @@ type t = {
   jkinds : (empty, jkind_data, jkind_data) IdTbl.t;
   summary: summary;
   local_constraints: type_declaration StagedPath.Map.t;
+  local_constraints_update_count: int;
   implicit_jkinds: jkind_lr loc String.Map.t;
   flags: int;
   stage: stage;
@@ -981,6 +982,7 @@ let empty = {
   modules = IdTbl.empty; modtypes = IdTbl.empty;
   classes = IdTbl.empty; cltypes = IdTbl.empty;
   summary = Env_empty; local_constraints = StagedPath.Map.empty;
+  local_constraints_update_count = 0;
   implicit_jkinds = String.Map.empty;
   flags = 0;
   functor_args = Ident.empty;
@@ -2993,7 +2995,19 @@ let add_module ?arg ?shape id presence mty ?mode env =
 let add_local_constraint ~stage path info env =
   { env with
     local_constraints =
-      StagedPath.Map.add { stage; path } info env.local_constraints }
+      StagedPath.Map.add { stage; path } info env.local_constraints;
+    local_constraints_update_count = env.local_constraints_update_count + 1 }
+
+let local_constraints_have_been_added ~since env =
+  (* As this function assumes [env] derives from [since], constraints have been
+     added iff the count differs. *)
+  since.local_constraints_update_count <> env.local_constraints_update_count
+
+let replace_local_constraints ~with_constraints_from env =
+  { env with
+    local_constraints = with_constraints_from.local_constraints;
+    local_constraints_update_count =
+      with_constraints_from.local_constraints_update_count }
 
 let add_implicit_jkind ~loc name jkind env =
   { env with
@@ -4258,6 +4272,7 @@ let add_components slot root env0 comps (locks : locks) =
     jkinds;
     summary = Env_open(env0.summary, root);
     local_constraints = env0.local_constraints;
+    local_constraints_update_count = env0.local_constraints_update_count;
     implicit_jkinds = env0.implicit_jkinds;
     flags = env0.flags;
     stage = env0.stage;
@@ -4999,6 +5014,7 @@ let keep_only_summary env =
        empty with
        summary = env.summary;
        local_constraints = env.local_constraints;
+       local_constraints_update_count = env.local_constraints_update_count;
        flags = env.flags;
       }
     in
@@ -5012,6 +5028,7 @@ let env_of_only_summary env_from_summary env =
   let new_env = env_from_summary env.summary Subst.identity in
   { new_env with
     local_constraints = env.local_constraints;
+    local_constraints_update_count = env.local_constraints_update_count;
     flags = env.flags;
   }
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3003,11 +3003,10 @@ let local_constraints_have_been_added ~since env =
      added iff the count differs. *)
   since.local_constraints_update_count <> env.local_constraints_update_count
 
-let replace_local_constraints ~with_constraints_from env =
+let revert_local_constraints ~since env =
   { env with
-    local_constraints = with_constraints_from.local_constraints;
-    local_constraints_update_count =
-      with_constraints_from.local_constraints_update_count }
+    local_constraints = since.local_constraints;
+    local_constraints_update_count = since.local_constraints_update_count }
 
 let add_implicit_jkind ~loc name jkind env =
   { env with

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -477,7 +477,12 @@ val add_local_constraint: stage:stage -> Path.t -> type_declaration -> t -> t
 (** Assumes the environment was built by adding to [since] *)
 val local_constraints_have_been_added : since:t -> t -> bool
 
-val replace_local_constraints : with_constraints_from:t -> t -> t
+(** Assumes the environment was built by adding to [since].
+    [revert_local_constraints ~since env] is [env] with its local (GADT)
+    constraints replaced by [since]'s.
+
+    Arbitrary uses of this function may create ill-formed environments *)
+val revert_local_constraints : since:t -> t -> t
 
 val add_implicit_jkind: loc:Location.t -> string -> jkind_lr -> t -> t
 val clear_implicit_jkinds : t -> t

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -473,6 +473,12 @@ val add_modtype_lazy: update_summary:bool ->
 val add_class: Ident.t -> class_declaration -> t -> t
 val add_cltype: Ident.t -> class_type_declaration -> t -> t
 val add_local_constraint: stage:stage -> Path.t -> type_declaration -> t -> t
+
+(** Assumes the environment was built by adding to [since] *)
+val local_constraints_have_been_added : since:t -> t -> bool
+
+val replace_local_constraints : with_constraints_from:t -> t -> t
+
 val add_implicit_jkind: loc:Location.t -> string -> jkind_lr -> t -> t
 val clear_implicit_jkinds : t -> t
 val add_jkind:

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -6348,15 +6348,83 @@ type type_function_result_param =
     has_poly : bool;
   }
 
-(* A sort reflected in the function's calling convention. See
-   [check_calling_convention_sorts_against_partial_match]. *)
-type calling_convention_sort =
-  { ccs_ty : type_expr;
-    ccs_sort : Jkind.sort;
-    ccs_env : Env.t;
-    ccs_loc : Location.t;
-    ccs_kind : [`Argument | `Result];
-  }
+module Calling_convention_sort : sig
+  (* A sort reflected in the function's calling convention.
+
+     We can't allow constraints from parameters which partially match on GADTs
+     to justify the function's argument/return sorts, as a caller can still pass
+     a constructor missing from the partial match. See oxcaml/oxcaml#6689. *)
+  type t =
+    { ccs_ty : type_expr;
+      ccs_sort : Jkind.sort;
+      (* The environment the sort was derived in. *)
+      ccs_env : Env.t;
+      ccs_loc : Location.t;
+      ccs_kind : [`Argument | `Result];
+    }
+
+  val check_doesn't_rely_on_partial_match :
+    partial:partial -> has_default:bool -> match_loc:Location.t ->
+    outer_env:Env.t -> branch_env:Env.t -> t list -> unit
+end = struct
+  type t =
+    { ccs_ty : type_expr;
+      ccs_sort : Jkind.sort;
+      ccs_env : Env.t;
+      ccs_loc : Location.t;
+      ccs_kind : [`Argument | `Result];
+    }
+
+  let added_constraints_from_partial_match
+        ~partial ~has_default ~outer_env ~branch_env =
+    if not (Env.local_constraints_have_been_added ~since:outer_env branch_env)
+    then None
+    else
+      match partial, has_default with
+      | Total, false -> None
+      | Partial, _ -> Some `Partial_match
+      (* Optional arguments can be omitted, so they are effectively partial *)
+      | Total, true -> Some `Optional_argument
+
+  let check_doesn't_rely_on_partial_match
+        ~partial ~has_default ~match_loc ~outer_env ~branch_env ts =
+    match
+      added_constraints_from_partial_match ~partial ~has_default ~outer_env
+        ~branch_env
+    with
+    | None -> ()
+    | Some why ->
+      List.iter
+        (fun { ccs_ty; ccs_sort; ccs_env; ccs_loc; ccs_kind } ->
+          (* Try to re-derive the same sort using an environment without local
+             constraints added since [outer_env].
+
+             This is an approximate check of whether the sort relies on a
+             partial match, as it also disallows depending on parameters which
+             totally match on a GADT. *)
+          let weak_env =
+            Env.revert_local_constraints ccs_env ~since:outer_env
+          in
+          let sort_why =
+            match ccs_kind with
+            | `Argument -> Jkind.History.Function_argument
+            | `Result -> Jkind.History.Function_result
+          in
+          let ok =
+            match
+              Ctype.type_sort ~why:sort_why ~fixed:true weak_env ccs_ty
+            with
+            | Ok sort -> Jkind.Sort.equate sort ccs_sort
+            | Error _ -> false
+          in
+          if not ok then
+            raise
+              (Error
+                 (ccs_loc, ccs_env,
+                  Function_type_escapes_partial_match
+                    { ty = ccs_ty; match_loc; kind = ccs_kind; why })))
+        ts
+end
 
 (* The result of calling [type_function]. For the outer call to
    [type_function], it's the result of typechecking the entire function;
@@ -6383,7 +6451,7 @@ type type_function_result =
     *)
     ret_info: type_function_ret_info option;
     (* The argument/result sorts of this parameter suffix. *)
-    calling_convention_sorts: calling_convention_sort list;
+    calling_convention_sorts: Calling_convention_sort.t list;
   }
 
 and type_function_ret_info =
@@ -6392,43 +6460,6 @@ and type_function_ret_info =
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
   }
-
-(* We can't allow constraints from parameters which partially match on GADTs to
-   justify the function's argument/return sorts, as a caller can still pass a
-   constructor missing from the partial match.
-
-   This function is run at each partial-GADT-match/optional parameter and
-   checks that later sorts can be re-derived with local constraints reset to
-   [outer_env]'s. This is approximate, as it also disallows depending on later
-   parameters which totally match on a GADT.
-
-   See oxcaml/oxcaml#6689. *)
-let check_calling_convention_sorts_against_partial_match
-      ~why ~match_loc ~outer_env ~branch_env calling_convention_sorts =
-  if Env.local_constraints_have_been_added ~since:outer_env branch_env then
-    List.iter
-      (fun { ccs_ty; ccs_sort; ccs_env; ccs_loc; ccs_kind } ->
-        let weak_env =
-          Env.replace_local_constraints ccs_env
-            ~with_constraints_from:outer_env
-        in
-        let sort_why =
-          match ccs_kind with
-          | `Argument -> Jkind.History.Function_argument
-          | `Result -> Jkind.History.Function_result
-        in
-        let ok =
-          match Ctype.type_sort ~why:sort_why ~fixed:true weak_env ccs_ty with
-          | Ok sort -> Jkind.Sort.equate sort ccs_sort
-          | Error _ -> false
-        in
-        if not ok then
-          raise
-            (Error
-               (ccs_loc, ccs_env,
-                Function_type_escapes_partial_match
-                  { ty = ccs_ty; match_loc; kind = ccs_kind; why })))
-      calling_convention_sorts
 
 (* value binding elaboration *)
 
@@ -9452,20 +9483,9 @@ and type_function
         | [ result ], partial -> result, partial
         | ([] | _ :: _ :: _), _ -> assert false
       in
-      begin match partial, default_arg with
-      | Total, None -> ()
-      | Partial, _ | Total, Some _ ->
-        (* Optional arguments can be omitted, so they are effectively partial
-           wrt [check_calling_convention_sorts_against_partial_match]. *)
-        let why =
-          match partial with
-          | Partial -> `Partial_match
-          | Total -> `Optional_argument
-        in
-        check_calling_convention_sorts_against_partial_match ~why
-          ~match_loc:pat.pat_loc ~outer_env:env ~branch_env:ext_env
-          inner_calling_convention_sorts
-      end;
+      Calling_convention_sort.check_doesn't_rely_on_partial_match ~partial
+        ~has_default:(Option.is_some default_arg) ~match_loc:pat.pat_loc
+        ~outer_env:env ~branch_env:ext_env inner_calling_convention_sorts;
       let exp_type =
         instance
           (newgenty
@@ -9535,22 +9555,25 @@ and type_function
       in
       let calling_convention_sorts =
         (* These sorts are added after the call to
-           [check_calling_convention_sorts_against_partial_match] above, so they
-           aren't checked against this parameter's own pattern.
+           [Calling_convention_sort.check_doesn't_rely_on_partial_match]
+           above, so they aren't checked against this parameter's own pattern.
 
            This is sound as:
            1. A parameter pattern cannot refine its own sort
            2. The result type is created outside of the scope of the last
               parameter's pattern *)
         let arg_ccs =
-          { ccs_ty = ty_arg; ccs_sort = arg_sort; ccs_env = env;
-            ccs_loc = pparam_loc; ccs_kind = `Argument }
+          { Calling_convention_sort.ccs_ty = ty_arg; ccs_sort = arg_sort;
+            ccs_env = env; ccs_loc = pparam_loc; ccs_kind = `Argument }
         in
+        (* [ret_info] is [None] only in the innermost recursive call to
+           [type_function], when it is initially computed. In the other calls,
+           the result sort is already in [inner_calling_convention_sorts]. *)
         let ret_ccs =
           if Option.is_some ret_info then []
           else
-            [ { ccs_ty = ty_ret; ccs_sort = ret_sort; ccs_env = env;
-                ccs_loc = loc; ccs_kind = `Result } ]
+            [ { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
+                ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
         in
         arg_ccs :: ret_ccs @ inner_calling_convention_sorts
       in
@@ -11280,10 +11303,10 @@ and type_function_cases_expect
       }
     in
     let calling_convention_sorts =
-      [ { ccs_ty = ty_arg; ccs_sort = arg_sort; ccs_env = env;
-          ccs_loc = loc; ccs_kind = `Argument };
-        { ccs_ty = ty_ret; ccs_sort = ret_sort; ccs_env = env;
-          ccs_loc = loc; ccs_kind = `Result } ]
+      [ { Calling_convention_sort.ccs_ty = ty_arg; ccs_sort = arg_sort;
+          ccs_env = env; ccs_loc = loc; ccs_kind = `Argument };
+        { Calling_convention_sort.ccs_ty = ty_ret; ccs_sort = ret_sort;
+          ccs_env = env; ccs_loc = loc; ccs_kind = `Result } ]
     in
     cases, ty_fun, alloc_mode,
       { ret_sort;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -314,6 +314,12 @@ type error =
   | Exclave_returns_not_local
   | Unboxed_int_literals_not_supported
   | Function_type_not_rep of type_expr * Jkind.Violation.t
+  | Function_type_escapes_partial_match of
+      { ty : type_expr;
+        match_loc : Location.t;
+        kind : [`Argument | `Result];
+        why : [`Partial_match | `Optional_argument];
+      }
   | Record_projection_not_rep of type_expr * Jkind.Violation.t
   | Record_not_rep of type_expr * Jkind.Violation.t
   | Mutable_var_not_rep of type_expr * Jkind.Violation.t
@@ -6342,6 +6348,16 @@ type type_function_result_param =
     has_poly : bool;
   }
 
+(* A sort reflected in the function's calling convention. See
+   [check_calling_convention_sorts_against_partial_match]. *)
+type calling_convention_sort =
+  { ccs_ty : type_expr;
+    ccs_sort : Jkind.sort;
+    ccs_env : Env.t;
+    ccs_loc : Location.t;
+    ccs_kind : [`Argument | `Result];
+  }
+
 (* The result of calling [type_function]. For the outer call to
    [type_function], it's the result of typechecking the entire function;
    for recursive calls to [type_function], it's the result of typechecking
@@ -6366,6 +6382,8 @@ type type_function_result =
        left.
     *)
     ret_info: type_function_ret_info option;
+    (* The argument/result sorts of this parameter suffix. *)
+    calling_convention_sorts: calling_convention_sort list;
   }
 
 and type_function_ret_info =
@@ -6374,6 +6392,43 @@ and type_function_ret_info =
     (* The sort returned by the function. *)
     ret_sort: Jkind.sort;
   }
+
+(* We can't allow constraints from parameters which partially match on GADTs to
+   justify the function's argument/return sorts, as a caller can still pass a
+   constructor missing from the partial match.
+
+   This function is run at each partial-GADT-match/optional parameter and
+   checks that later sorts can be re-derived with local constraints reset to
+   [outer_env]'s. This is approximate, as it also disallows depending on later
+   parameters which totally match on a GADT.
+
+   See oxcaml/oxcaml#6689. *)
+let check_calling_convention_sorts_against_partial_match
+      ~why ~match_loc ~outer_env ~branch_env calling_convention_sorts =
+  if Env.local_constraints_have_been_added ~since:outer_env branch_env then
+    List.iter
+      (fun { ccs_ty; ccs_sort; ccs_env; ccs_loc; ccs_kind } ->
+        let weak_env =
+          Env.replace_local_constraints ccs_env
+            ~with_constraints_from:outer_env
+        in
+        let sort_why =
+          match ccs_kind with
+          | `Argument -> Jkind.History.Function_argument
+          | `Result -> Jkind.History.Function_result
+        in
+        let ok =
+          match Ctype.type_sort ~why:sort_why ~fixed:true weak_env ccs_ty with
+          | Ok sort -> Jkind.Sort.equate sort ccs_sort
+          | Error _ -> false
+        in
+        if not ok then
+          raise
+            (Error
+               (ccs_loc, ccs_env,
+                Function_type_escapes_partial_match
+                  { ty = ccs_ty; match_loc; kind = ccs_kind; why })))
+      calling_convention_sorts
 
 (* value binding elaboration *)
 
@@ -9211,12 +9266,13 @@ and type_function
   match params_suffix with
   | { pparam_desc = Pparam_newtype (newtype_var, jkind_annot) } :: rest ->
       (* Check everything else in the scope of (type a). *)
-      let (params, body, newtypes, contains_gadt, fun_alloc_mode, ret_info),
+      let (params, body, newtypes, contains_gadt, fun_alloc_mode, ret_info,
+           calling_convention_sorts),
           exp_type, id, uid =
         type_newtype env newtype_var jkind_annot (fun env ->
           let { function_ = exp_type, params, body;
                 newtypes; params_contain_gadt = contains_gadt;
-                fun_alloc_mode; ret_info;
+                fun_alloc_mode; ret_info; calling_convention_sorts;
               }
             =
             (* mimic the typing of Pexp_newtype by minting a new type var,
@@ -9226,7 +9282,8 @@ and type_function
               (newvar (Jkind.Builtin.any ~why:Dummy_jkind))
               rest body_constraint body ~in_function ~first
           in
-          (params, body, newtypes, contains_gadt, fun_alloc_mode, ret_info),
+          (params, body, newtypes, contains_gadt, fun_alloc_mode, ret_info,
+           calling_convention_sorts),
           exp_type)
       in
       let newtype = id, newtype_var, jkind_annot, uid in
@@ -9234,7 +9291,7 @@ and type_function
           unify_exp_types loc env exp_type (instance ty_expected));
       { function_ = exp_type, params, body;
         params_contain_gadt = contains_gadt; newtypes = newtype :: newtypes;
-        fun_alloc_mode; ret_info;
+        fun_alloc_mode; ret_info; calling_convention_sorts;
       }
   | { pparam_desc = Pparam_val (arg_label, default_arg, pat); pparam_loc }
       :: rest
@@ -9330,7 +9387,8 @@ and type_function
             ty_default_arg, Some (default_arg, arg_label, default_arg_sort),
               default_arg_sort
       in
-      let (pat, params, body, ret_info, newtypes, contains_gadt, curry), partial =
+      let (pat, params, body, ret_info, newtypes, contains_gadt, curry,
+           ext_env, inner_calling_convention_sorts), partial =
         (* Check everything else in the scope of the parameter. *)
         map_half_typed_cases Value env expected_pat_mode
           ty_arg_internal sort_arg_internal ty_ret pat.ppat_loc
@@ -9342,7 +9400,7 @@ and type_function
               ~contains_gadt:param_contains_gadt ->
               let { function_ = _, params_suffix, body;
                     newtypes; params_contain_gadt = suffix_contains_gadt;
-                    fun_alloc_mode; ret_info;
+                    fun_alloc_mode; ret_info; calling_convention_sorts;
                   }
                 =
                 type_function ext_env expected_inner_mode ty_expected
@@ -9385,7 +9443,8 @@ and type_function
                   end;
                   More_args {partial_mode = Alloc.disallow_right fun_alloc_mode}
               in
-              pat, params_suffix, body, ret_info, newtypes, contains_gadt, curry
+              pat, params_suffix, body, ret_info, newtypes, contains_gadt,
+              curry, ext_env, calling_convention_sorts
           end
         |> function
           (* The result must be a singleton because we passed a singleton
@@ -9393,6 +9452,20 @@ and type_function
         | [ result ], partial -> result, partial
         | ([] | _ :: _ :: _), _ -> assert false
       in
+      begin match partial, default_arg with
+      | Total, None -> ()
+      | Partial, _ | Total, Some _ ->
+        (* Optional arguments can be omitted, so they are effectively partial
+           wrt [check_calling_convention_sorts_against_partial_match]. *)
+        let why =
+          match partial with
+          | Partial -> `Partial_match
+          | Total -> `Optional_argument
+        in
+        check_calling_convention_sorts_against_partial_match ~why
+          ~match_loc:pat.pat_loc ~outer_env:env ~branch_env:ext_env
+          inner_calling_convention_sorts
+      end;
       let exp_type =
         instance
           (newgenty
@@ -9460,6 +9533,27 @@ and type_function
             };
         }
       in
+      let calling_convention_sorts =
+        (* These sorts are added after the call to
+           [check_calling_convention_sorts_against_partial_match] above, so they
+           aren't checked against this parameter's own pattern.
+
+           This is sound as:
+           1. A parameter pattern cannot refine its own sort
+           2. The result type is created outside of the scope of the last
+              parameter's pattern *)
+        let arg_ccs =
+          { ccs_ty = ty_arg; ccs_sort = arg_sort; ccs_env = env;
+            ccs_loc = pparam_loc; ccs_kind = `Argument }
+        in
+        let ret_ccs =
+          if Option.is_some ret_info then []
+          else
+            [ { ccs_ty = ty_ret; ccs_sort = ret_sort; ccs_env = env;
+                ccs_loc = loc; ccs_kind = `Result } ]
+        in
+        arg_ccs :: ret_ccs @ inner_calling_convention_sorts
+      in
       let ret_info =
         match ret_info with
         | Some _ as x -> x
@@ -9472,9 +9566,10 @@ and type_function
       { function_ = exp_type, param :: params, body;
         newtypes = []; params_contain_gadt = contains_gadt;
         ret_info; fun_alloc_mode = Some alloc_mode;
+        calling_convention_sorts;
       }
   | [] ->
-    let exp_type, body, fun_alloc_mode, ret_info =
+    let exp_type, body, fun_alloc_mode, ret_info, calling_convention_sorts =
       let { ret_type_constraint; mode_annotations; ret_mode_annotations } =
         body_constraint
       in
@@ -9516,14 +9611,15 @@ and type_function
               let extra = Texp_mode type_mode, body_loc, [] in
               { body with exp_extra = extra :: body.exp_extra }
           in
-          body.exp_type, Tfunction_body body, None, None
+          body.exp_type, Tfunction_body body, None, None, []
       | Pfunction_cases (cases, _, attributes) ->
           let type_cases_expect env expected_mode ty_expected =
             type_function_cases_expect
               env expected_mode ty_expected loc cases attributes ~in_function
               ~first
           in
-          let (cases, exp_type, fun_alloc_mode, ret_info), exp_extra =
+          let (cases, exp_type, fun_alloc_mode, ret_info,
+               calling_convention_sorts), exp_extra =
             match ret_type_constraint with
             | None -> type_cases_expect env expected_mode ty_expected, []
             | Some constraint_ ->
@@ -9541,20 +9637,24 @@ and type_function
               let function_cases_constraint_arg =
                 { is_self = (fun _ -> false);
                   type_with_constraint = (fun env expected_mode ty ->
-                    let cases, _, fun_alloc_mode, ret_info =
+                    let cases, _, fun_alloc_mode, ret_info,
+                        calling_convention_sorts =
                       type_cases_expect env expected_mode ty
                     in
-                    cases, fun_alloc_mode, ret_info);
+                    cases, fun_alloc_mode, ret_info, calling_convention_sorts);
                   type_without_constraint = (fun env expected_mode ->
-                    let cases, ty_fun, fun_alloc_mode, ret_info =
+                    let cases, ty_fun, fun_alloc_mode, ret_info,
+                        calling_convention_sorts =
                       (* The analogy to [type_exp] for expressions. *)
                       type_cases_expect env expected_mode
                         (newvar (Jkind.Builtin.any ~why:Dummy_jkind))
                     in
-                    (cases, fun_alloc_mode, ret_info), ty_fun);
+                    (cases, fun_alloc_mode, ret_info, calling_convention_sorts),
+                    ty_fun);
                 }
               in
-              let (body, fun_alloc_mode, ret_info), exp_type, exp_extra =
+              let (body, fun_alloc_mode, ret_info, calling_convention_sorts),
+                  exp_type, exp_extra =
                 type_constraint_expect function_cases_constraint_arg
                   env expected_mode loc type_mode.mode_modes constraint_
                   ty_expected ~loc_arg:loc
@@ -9565,14 +9665,17 @@ and type_function
                 | _ :: _ ->
                   [ Texp_mode type_mode ; exp_extra ]
               in
-              (body, exp_type, fun_alloc_mode, ret_info), exp_extra
+              (body, exp_type, fun_alloc_mode, ret_info,
+               calling_convention_sorts),
+              exp_extra
           in
           let cases =
             match exp_extra with
             | [] -> cases
             | _ :: _ as fc_exp_extra -> { cases with fc_exp_extra }
           in
-          exp_type, Tfunction_cases cases, Some fun_alloc_mode, Some ret_info
+          exp_type, Tfunction_cases cases, Some fun_alloc_mode, Some ret_info,
+          calling_convention_sorts
      in
      { function_ = exp_type, [], body; newtypes = [];
      (* [No_gadt] is fine because this return value is only meant to indicate
@@ -9580,7 +9683,7 @@ and type_function
         the body is a [Tfunction_cases] whose patterns include a GADT.
      *)
        params_contain_gadt = No_gadt;
-       ret_info; fun_alloc_mode;
+       ret_info; fun_alloc_mode; calling_convention_sorts;
      }
 
 and type_label_access
@@ -11176,10 +11279,17 @@ and type_function_cases_expect
         fc_arg_sort = arg_sort;
       }
     in
+    let calling_convention_sorts =
+      [ { ccs_ty = ty_arg; ccs_sort = arg_sort; ccs_env = env;
+          ccs_loc = loc; ccs_kind = `Argument };
+        { ccs_ty = ty_ret; ccs_sort = ret_sort; ccs_env = env;
+          ccs_loc = loc; ccs_kind = `Result } ]
+    in
     cases, ty_fun, alloc_mode,
       { ret_sort;
         ret_mode =
-          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} }
+          {mode_modes = Alloc.disallow_right ret_mode; mode_desc = []} },
+      calling_convention_sorts
   end
 
 and type_effect_cases
@@ -11718,7 +11828,7 @@ and type_n_ary_function
     let in_function = mk_expected (instance ty_expected) ?explanation, loc in
     let { function_ = exp_type, result_params, body;
           newtypes; params_contain_gadt = contains_gadt;
-          ret_info; fun_alloc_mode;
+          ret_info; fun_alloc_mode; calling_convention_sorts = _;
         } =
       type_function env expected_mode ty_expected params constraint_ body
         ~in_function ~first:true
@@ -13378,6 +13488,29 @@ let report_error ~loc env =
         (Jkind.Violation.report_with_offender
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
            env) violation
+  | Function_type_escapes_partial_match { ty; match_loc; kind; why } ->
+      let what =
+        match kind with `Argument -> "argument" | `Result -> "result"
+      in
+      let how, requirement =
+        match why with
+        | `Partial_match ->
+            "That match is not exhaustive",
+            "independently of any non-exhaustive match"
+        | `Optional_argument ->
+            "That pattern matches an optional argument that a caller could \
+             omit",
+            "independently of the patterns of optional arguments"
+      in
+      Location.errorf ~loc
+        "@[This function's %s has type %a,@ whose layout is known only from \
+         the GADT pattern match at %a.@ %s, so a caller could reach this %s \
+         at a different layout.@ Function arguments and results must be \
+         representable %s.@]"
+        what
+        Printtyp.type_expr ty
+        (Location.Doc.loc ~capitalize_first:false) match_loc
+        how what requirement
   | Record_projection_not_rep (ty,violation) ->
       Location.errorf ~loc
         "@[Records being projected from must be representable.@]@ %a"

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -360,6 +360,12 @@ type error =
   | Exclave_returns_not_local
   | Unboxed_int_literals_not_supported
   | Function_type_not_rep of type_expr * Jkind.Violation.t
+  | Function_type_escapes_partial_match of
+      { ty : type_expr;
+        match_loc : Location.t;
+        kind : [`Argument | `Result];
+        why : [`Partial_match | `Optional_argument];
+      }
   | Record_projection_not_rep of type_expr * Jkind.Violation.t
   | Record_not_rep of type_expr * Jkind.Violation.t
   | Mutable_var_not_rep of type_expr * Jkind.Violation.t


### PR DESCRIPTION
Function parameter patterns that partially match on a GADT constructor can narrow the sorts of later parameters, incorrectly using those sorts for the overall function's calling convention.

For example, the below program segfaults on native, as `x` gets sort `value` from the partial match on `V`, yet passing `B` for the first argument can actually allow `x` to be `bits64`.
```ocaml
type ('a : any) t = V : 'a t | B : ('a : bits64) t
let f : type (a : any). a t -> a -> unit -> a = fun V x () -> x
let i = (Sys.opaque_identity f) B #2L
let () = Gc.full_major ()
```
Instead, `x` should not be considered to be representable because it depends on information from the partial match.

In other words, refinements of the function calling convention from parameters which are partial matches are invalid because all parameters are "passed at the same time," allowing the mismatch in calling convention to be observed before a partial match error is raised.

The example focuses on partial matches in parameters affecting the calling convention of other parameters, but the bug also extends to optional arguments, as well as the return sort:
- Optional argument patterns may introduce equations, yet the caller may omit the argument.
- We also must not let the result type's sort be refined, even though a call with a missing constructor raises before ever returning, to avoid a flambda error.

**Fix.** To fix this, we raise an error when we detect that a calling convention sort depends on equations introduced at or after a partial-match or optional parameter. This is approximate, as it also disallows depending on parameters which totally match on a GADT, if an earlier pattern is a partial/optional GADT match.

**Alternative 1: Precise check.** We could extend our fix to allow functions with both partial-match/optional parameters and parameters-depending-on-total-match-parameters. We leave this work for later as it would introduce significant complexity.
- We can't simply keep the total matches' constraints, as they might include kind constraints that themselves derived from partial matches (see the `f_eq` test, which used to segfault this way).
- A precise check would have to redo all of the GADT equation solving without the partial matches' constraints, and that machinery is interleaved with pattern typechecking (i.e. it's not a separable step we could re-run).

**Alternative 2: Don't add constraints from partial-match/optional parameters.** This would be simple, but is likely overly conservative. It would prevent parameters from refining typing information for later parameters at all (not merely the information that determines calling convention), and would also disallow using information from partial/optional arguments in the *body* of the function (breaking programs such as [this existing test case](https://github.com/oxcaml/oxcaml/blob/a8b41abfeb30c3c505da842e24223dfe8b8d923c/testsuite/tests/typing-gadts/syntactic-arity.ml#L15-L16)). (This alternative is drafted in 0fc54646bbd9df4f33a625d262f79081ddc4ed01.)

**Context.** This is the jkind/sort analogue of the bug fixed by #6356. H/t @Ekdohibs for reporting both bugs.

**Review.** Review commit-by-commit.