### PR TITLE
Get rid of machine widths in `One_bit_fewer`

### DIFF
--- a/middle_end/flambda2/numbers/one_bit_fewer.ml
+++ b/middle_end/flambda2/numbers/one_bit_fewer.ml
@@ -15,8 +15,6 @@
 module type S = sig
   type t
 
-  val machine_width : t -> Target_system.Machine_width.t
-
   val compare : t -> t -> int
 
   val equal : t -> t -> bool
@@ -25,19 +23,19 @@ module type S = sig
 
   val print : Format.formatter -> t -> unit
 
-  val min_value : Target_system.Machine_width.t -> t
+  val min_value : t
 
-  val max_value : Target_system.Machine_width.t -> t
+  val max_value : t
 
-  val minus_one : Target_system.Machine_width.t -> t
+  val minus_one : t
 
-  val zero : Target_system.Machine_width.t -> t
+  val zero : t
 
-  val one : Target_system.Machine_width.t -> t
+  val one : t
 
-  val ten : Target_system.Machine_width.t -> t
+  val ten : t
 
-  val hex_ff : Target_system.Machine_width.t -> t
+  val hex_ff : t
 
   val ( <= ) : t -> t -> bool
 
@@ -49,22 +47,19 @@ module type S = sig
 
   val bottom_byte_to_int : t -> int
 
-  val of_char : Target_system.Machine_width.t -> char -> t
+  val of_char : char -> t
 
-  val of_int :
-    Target_system.Machine_width.t ->
-    int ->
-    t (* CR mshinwell: clarify semantics *)
+  val of_int : int -> t (* CR mshinwell: clarify semantics *)
 
-  val of_int_option : Target_system.Machine_width.t -> int -> t option
+  val of_int_option : int -> t option
 
-  val of_int32 : Target_system.Machine_width.t -> int32 -> t
+  val of_int32 : int32 -> t
 
-  val of_int64 : Target_system.Machine_width.t -> int64 -> t
+  val of_int64 : int64 -> t
 
-  val of_targetint : Target_system.Machine_width.t -> Targetint_32_64.t -> t
+  val of_targetint : Targetint_32_64.t -> t
 
-  val of_float : Target_system.Machine_width.t -> float -> t
+  val of_float : float -> t
 
   val to_float : t -> float
 
@@ -127,8 +122,6 @@ module Make (I : S) : S with type t = I.t = struct
      range of numbers representable in {n-1} bits. *)
   type t = I.t
 
-  let machine_width = I.machine_width
-
   let compare = I.compare
 
   let equal = I.equal
@@ -145,19 +138,19 @@ module Make (I : S) : S with type t = I.t = struct
 
   let zero_extend t = I.shift_right_logical (I.shift_left t 1) 1
 
-  let min_value machine_width = I.shift_right (I.min_value machine_width) 1
+  let min_value = I.shift_right I.min_value 1
 
-  let max_value machine_width = I.shift_right (I.max_value machine_width) 1
+  let max_value = I.shift_right I.max_value 1
 
-  let minus_one machine_width = I.minus_one machine_width
+  let minus_one = I.minus_one
 
-  let zero machine_width = I.zero machine_width
+  let zero = I.zero
 
-  let one machine_width = I.one machine_width
+  let one = I.one
 
-  let ten machine_width = I.ten machine_width
+  let ten = I.ten
 
-  let hex_ff machine_width = I.hex_ff machine_width
+  let hex_ff = I.hex_ff
 
   let ( <= ) = I.( <= )
 
@@ -167,32 +160,30 @@ module Make (I : S) : S with type t = I.t = struct
 
   let ( > ) = I.( > )
 
-  let is_in_range machine_width n =
-    I.( >= ) n (min_value machine_width) && I.( <= ) n (max_value machine_width)
+  let is_in_range n = I.( >= ) n min_value && I.( <= ) n max_value
 
   let bottom_byte_to_int = I.bottom_byte_to_int
 
-  let of_char machine_width = I.of_char machine_width
+  let of_char = I.of_char
 
-  let of_int machine_width t = sign_extend (I.of_int machine_width t)
+  let of_int t = sign_extend (I.of_int t)
 
-  let of_int_option machine_width t =
-    Option.map sign_extend (I.of_int_option machine_width t)
+  let of_int_option t = Option.map sign_extend (I.of_int_option t)
 
-  let of_int32 machine_width t =
-    let x = I.of_int32 machine_width t in
+  let of_int32 t =
+    let x = I.of_int32 t in
     sign_extend x
 
-  let of_int64 machine_width t =
-    let x = I.of_int64 machine_width t in
+  let of_int64 t =
+    let x = I.of_int64 t in
     sign_extend x
 
-  let of_targetint machine_width t =
-    let x = I.of_targetint machine_width t in
+  let of_targetint t =
+    let x = I.of_targetint t in
     sign_extend x
 
-  let of_float machine_width t =
-    let x = I.of_float machine_width t in
+  let of_float t =
+    let x = I.of_float t in
     sign_extend x
 
   let to_float = I.to_float
@@ -213,7 +204,7 @@ module Make (I : S) : S with type t = I.t = struct
 
   let get_least_significant_16_bits_then_byte_swap t =
     let res = I.get_least_significant_16_bits_then_byte_swap t in
-    assert (is_in_range (machine_width t) res);
+    assert (is_in_range res);
     res
 
   let add x y = sign_extend (I.add x y)

--- a/middle_end/flambda2/numbers/one_bit_fewer.mli
+++ b/middle_end/flambda2/numbers/one_bit_fewer.mli
@@ -1,8 +1,6 @@
 module type S = sig
   type t
 
-  val machine_width : t -> Target_system.Machine_width.t
-
   val compare : t -> t -> int
 
   val equal : t -> t -> bool
@@ -11,19 +9,19 @@ module type S = sig
 
   val print : Format.formatter -> t -> unit
 
-  val min_value : Target_system.Machine_width.t -> t
+  val min_value : t
 
-  val max_value : Target_system.Machine_width.t -> t
+  val max_value : t
 
-  val minus_one : Target_system.Machine_width.t -> t
+  val minus_one : t
 
-  val zero : Target_system.Machine_width.t -> t
+  val zero : t
 
-  val one : Target_system.Machine_width.t -> t
+  val one : t
 
-  val ten : Target_system.Machine_width.t -> t
+  val ten : t
 
-  val hex_ff : Target_system.Machine_width.t -> t
+  val hex_ff : t
 
   val ( <= ) : t -> t -> bool
 
@@ -35,19 +33,19 @@ module type S = sig
 
   val bottom_byte_to_int : t -> int
 
-  val of_char : Target_system.Machine_width.t -> char -> t
+  val of_char : char -> t
 
-  val of_int : Target_system.Machine_width.t -> int -> t
+  val of_int : int -> t
 
-  val of_int_option : Target_system.Machine_width.t -> int -> t option
+  val of_int_option : int -> t option
 
-  val of_int32 : Target_system.Machine_width.t -> int32 -> t
+  val of_int32 : int32 -> t
 
-  val of_int64 : Target_system.Machine_width.t -> int64 -> t
+  val of_int64 : int64 -> t
 
-  val of_targetint : Target_system.Machine_width.t -> Targetint_32_64.t -> t
+  val of_targetint : Targetint_32_64.t -> t
 
-  val of_float : Target_system.Machine_width.t -> float -> t
+  val of_float : float -> t
 
   val to_float : t -> float
 

--- a/middle_end/flambda2/numbers/target_ocaml_int.ml
+++ b/middle_end/flambda2/numbers/target_ocaml_int.ml
@@ -25,8 +25,6 @@ type t =
 module Int32_base = struct
   type t = int32
 
-  let machine_width _t = MW.Thirty_two
-
   let compare = Int32.compare
 
   let equal = Int32.equal
@@ -35,19 +33,19 @@ module Int32_base = struct
 
   let print ppf t = Format.fprintf ppf "%ld" t
 
-  let min_value _machine_width = Int32.min_int
+  let min_value = Int32.min_int
 
-  let max_value _machine_width = Int32.max_int
+  let max_value = Int32.max_int
 
-  let minus_one _machine_width = Int32.minus_one
+  let minus_one = Int32.minus_one
 
-  let zero _machine_width = Int32.zero
+  let zero = Int32.zero
 
-  let one _machine_width = Int32.one
+  let one = Int32.one
 
-  let ten _machine_width = 10l
+  let ten = 10l
 
-  let hex_ff _machine_width = 0xffl
+  let hex_ff = 0xffl
 
   let ( <= ) x y = Int32.compare x y <= 0
 
@@ -59,22 +57,22 @@ module Int32_base = struct
 
   let bottom_byte_to_int t = Int32.to_int (Int32.logand t 0xffl)
 
-  let of_char _machine_width c = Int32.of_int (Char.code c)
+  let of_char c = Int32.of_int (Char.code c)
 
-  let of_int _machine_width i = Int32.of_int i
+  let of_int i = Int32.of_int i
 
-  let of_int_option _machine_width i = Some (Int32.of_int i)
+  let of_int_option i = Some (Int32.of_int i)
 
-  let of_int32 _machine_width i = i
+  let of_int32 i = i
 
-  let of_int64 _machine_width i = Int64.to_int32 i
+  let of_int64 i = Int64.to_int32 i
 
-  let of_targetint _machine_width t =
+  let of_targetint t =
     match Targetint_32_64.repr t with
     | Targetint_32_64.Int32 x -> x
     | Targetint_32_64.Int64 x -> Int64.to_int32 x
 
-  let of_float _machine_width f = Int32.of_float f
+  let of_float f = Int32.of_float f
 
   let to_float = Int32.to_float
 
@@ -147,8 +145,6 @@ end
 module Int64_base = struct
   type t = int64
 
-  let machine_width _t = MW.Sixty_four
-
   let compare = Int64.compare
 
   let equal = Int64.equal
@@ -157,19 +153,19 @@ module Int64_base = struct
 
   let print ppf t = Format.fprintf ppf "%Ld" t
 
-  let min_value _machine_width = Int64.min_int
+  let min_value = Int64.min_int
 
-  let max_value _machine_width = Int64.max_int
+  let max_value = Int64.max_int
 
-  let minus_one _machine_width = Int64.minus_one
+  let minus_one = Int64.minus_one
 
-  let zero _machine_width = Int64.zero
+  let zero = Int64.zero
 
-  let one _machine_width = Int64.one
+  let one = Int64.one
 
-  let ten _machine_width = 10L
+  let ten = 10L
 
-  let hex_ff _machine_width = 0xffL
+  let hex_ff = 0xffL
 
   let ( <= ) x y = Int64.compare x y <= 0
 
@@ -181,22 +177,22 @@ module Int64_base = struct
 
   let bottom_byte_to_int t = Int64.to_int (Int64.logand t 0xffL)
 
-  let of_char _machine_width c = Int64.of_int (Char.code c)
+  let of_char c = Int64.of_int (Char.code c)
 
-  let of_int _machine_width i = Int64.of_int i
+  let of_int i = Int64.of_int i
 
-  let of_int_option _machine_width i = Some (Int64.of_int i)
+  let of_int_option i = Some (Int64.of_int i)
 
-  let of_int32 _machine_width i = Int64.of_int32 i
+  let of_int32 i = Int64.of_int32 i
 
-  let of_int64 _machine_width i = i
+  let of_int64 i = i
 
-  let of_targetint _machine_width t =
+  let of_targetint t =
     match Targetint_32_64.repr t with
     | Targetint_32_64.Int32 x -> Int64.of_int32 x
     | Targetint_32_64.Int64 x -> x
 
-  let of_float _machine_width f = Int64.of_float f
+  let of_float f = Int64.of_float f
 
   let to_float = Int64.to_float
 
@@ -298,45 +294,45 @@ let hash = function
 
 let zero machine_width =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.zero MW.Thirty_two)
+  | MW.Thirty_two -> Int31 Int31.zero
   | MW.Thirty_two_no_gc_tag_bit -> Int32 0l
-  | MW.Sixty_four -> Int63 (Int63.zero MW.Sixty_four)
+  | MW.Sixty_four -> Int63 Int63.zero
 
 let one machine_width =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.one MW.Thirty_two)
+  | MW.Thirty_two -> Int31 Int31.one
   | MW.Thirty_two_no_gc_tag_bit -> Int32 1l
-  | MW.Sixty_four -> Int63 (Int63.one MW.Sixty_four)
+  | MW.Sixty_four -> Int63 Int63.one
 
 let minus_one machine_width =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.minus_one MW.Thirty_two)
+  | MW.Thirty_two -> Int31 Int31.minus_one
   | MW.Thirty_two_no_gc_tag_bit -> Int32 (-1l)
-  | MW.Sixty_four -> Int63 (Int63.minus_one MW.Sixty_four)
+  | MW.Sixty_four -> Int63 Int63.minus_one
 
 let ten machine_width =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.ten MW.Thirty_two)
+  | MW.Thirty_two -> Int31 Int31.ten
   | MW.Thirty_two_no_gc_tag_bit -> Int32 10l
-  | MW.Sixty_four -> Int63 (Int63.ten MW.Sixty_four)
+  | MW.Sixty_four -> Int63 Int63.ten
 
 let hex_ff machine_width =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.hex_ff MW.Thirty_two)
+  | MW.Thirty_two -> Int31 Int31.hex_ff
   | MW.Thirty_two_no_gc_tag_bit -> Int32 0xffl
-  | MW.Sixty_four -> Int63 (Int63.hex_ff MW.Sixty_four)
+  | MW.Sixty_four -> Int63 Int63.hex_ff
 
 let min_value machine_width =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.min_value MW.Thirty_two)
+  | MW.Thirty_two -> Int31 Int31.min_value
   | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.min_int
-  | MW.Sixty_four -> Int63 (Int63.min_value MW.Sixty_four)
+  | MW.Sixty_four -> Int63 Int63.min_value
 
 let max_value machine_width =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.max_value MW.Thirty_two)
+  | MW.Thirty_two -> Int31 Int31.max_value
   | MW.Thirty_two_no_gc_tag_bit -> Int32 Int32.max_int
-  | MW.Sixty_four -> Int63 (Int63.max_value MW.Sixty_four)
+  | MW.Sixty_four -> Int63 Int63.max_value
 
 let bool_true machine_width = one machine_width
 
@@ -358,35 +354,35 @@ let bottom_byte_to_int = function
 
 let of_char machine_width c =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.of_char MW.Thirty_two c)
+  | MW.Thirty_two -> Int31 (Int31.of_char c)
   | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_int (Char.code c))
-  | MW.Sixty_four -> Int63 (Int63.of_char MW.Sixty_four c)
+  | MW.Sixty_four -> Int63 (Int63.of_char c)
 
 let of_int machine_width i =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.of_int MW.Thirty_two i)
+  | MW.Thirty_two -> Int31 (Int31.of_int i)
   | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_int i)
-  | MW.Sixty_four -> Int63 (Int63.of_int MW.Sixty_four i)
+  | MW.Sixty_four -> Int63 (Int63.of_int i)
 
 let of_int_option machine_width i = Some (of_int machine_width i)
 
 let of_int32 machine_width i =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.of_int32 MW.Thirty_two i)
+  | MW.Thirty_two -> Int31 (Int31.of_int32 i)
   | MW.Thirty_two_no_gc_tag_bit -> Int32 i
-  | MW.Sixty_four -> Int63 (Int63.of_int32 MW.Sixty_four i)
+  | MW.Sixty_four -> Int63 (Int63.of_int32 i)
 
 let of_int64 machine_width i =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.of_int64 MW.Thirty_two i)
+  | MW.Thirty_two -> Int31 (Int31.of_int64 i)
   | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int64.to_int32 i)
-  | MW.Sixty_four -> Int63 (Int63.of_int64 MW.Sixty_four i)
+  | MW.Sixty_four -> Int63 (Int63.of_int64 i)
 
 let of_float machine_width f =
   match machine_width with
-  | MW.Thirty_two -> Int31 (Int31.of_float MW.Thirty_two f)
+  | MW.Thirty_two -> Int31 (Int31.of_float f)
   | MW.Thirty_two_no_gc_tag_bit -> Int32 (Int32.of_float f)
-  | MW.Sixty_four -> Int63 (Int63.of_float MW.Sixty_four f)
+  | MW.Sixty_four -> Int63 (Int63.of_float f)
 
 let to_float = function
   | Int31 x -> Int31.to_float x
@@ -426,11 +422,9 @@ let to_int_exn t =
 
 let of_targetint machine_width t =
   match machine_width, Targetint_32_64.repr t with
-  | MW.Thirty_two, Targetint_32_64.Int32 x ->
-    Int31 (Int31.of_int32 MW.Thirty_two x)
+  | MW.Thirty_two, Targetint_32_64.Int32 x -> Int31 (Int31.of_int32 x)
   | MW.Thirty_two_no_gc_tag_bit, Targetint_32_64.Int32 x -> Int32 x
-  | MW.Sixty_four, Targetint_32_64.Int64 x ->
-    Int63 (Int63.of_int64 MW.Sixty_four x)
+  | MW.Sixty_four, Targetint_32_64.Int64 x -> Int63 (Int63.of_int64 x)
   | MW.Thirty_two, Targetint_32_64.Int64 _
   | MW.Thirty_two_no_gc_tag_bit, Targetint_32_64.Int64 _
   | MW.Sixty_four, Targetint_32_64.Int32 _ ->


### PR DESCRIPTION
By definition, the width of fixed-width integers does not change depending on the target system.