### PR TITLE
reaper: remove unnecessary registering of kinds

### DIFF
--- a/middle_end/flambda2/reaper/reaper.ml
+++ b/middle_end/flambda2/reaper/reaper.ml
@@ -27,7 +27,6 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
           code;
           ordered_code_ids;
           deps;
-          kinds;
           fixed_arity_continuations;
           continuation_info;
           code_deps;
@@ -52,8 +51,7 @@ let run ~machine_width ~cmx_loader ~all_code ~final_typing_env
       =
     Rebuild.rebuild ~machine_width ~ordered_code_ids ~code_deps
       ~fixed_arity_continuations ~continuation_info ~final_typing_env
-      ~types_rewrite_context kinds solved_dep get_code_metadata toplevel_expr
-      code
+      ~types_rewrite_context solved_dep get_code_metadata toplevel_expr code
   in
   let all_code =
     Exported_code.add_code

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -80,7 +80,6 @@ type env =
     should_keep_function_param :
       Code_id.t -> Variable.t -> KS.t -> param_decision;
     function_return_decision : param_decision list Code_id.Map.t;
-    kinds : K.t Name.Map.t;
     should_preserve_direct_calls : should_preserve_direct_calls;
     old_typing_env : Typing_env.t option;
     inside_code_definition : bool;
@@ -114,7 +113,7 @@ let raw_is_var_used uses var kind =
   | Value | Naked_number _ -> Analysis.has_use uses (Code_id_or_name.var var)
 
 let is_var_used (env : env) var =
-  raw_is_var_used env.uses var (Name.Map.find (Name.var var) env.kinds)
+  raw_is_var_used env.uses var (Variable.kind var)
 
 let is_name_used (env : env) name =
   Name.pattern_match name ~symbol:(is_symbol_used env) ~var:(is_var_used env)
@@ -221,8 +220,7 @@ let get_arity params_decisions =
           (List.map (fun k -> Component_for_creation.Singleton k) arity) ])
 
 let is_dead_var env v =
-  let (kind : K.t) = Name.Map.find (Name.var v) env.kinds in
-  match kind with
+  match Variable.kind v with
   | Region | Rec_info -> false
   | Value | Naked_number _ ->
     not (Analysis.has_source env.uses (Code_id_or_name.var v))
@@ -324,21 +322,18 @@ let function_params_and_body_free_names fpb =
         f
         (regions @ (my_closure :: my_depth :: Bound_parameters.vars params)))
 
-let get_simple_kind env simple =
+let get_simple_kind simple =
   Simple.pattern_match'
     ~const:(fun const -> Reg_width_const.kind const)
     ~symbol:(fun _ ~coercion:_ -> K.value)
-    ~var:(fun var ~coercion:_ -> Name.Map.find (Name.var var) env.kinds)
+    ~var:(fun var ~coercion:_ -> Variable.kind var)
     simple
 
-let name_poison ~category env name =
+let name_poison ~category name =
   let kind =
-    match Name.Map.find_opt name env.kinds with
-    | Some k -> k
-    | None ->
-      if Name.is_symbol name
-      then K.value
-      else Misc.fatal_errorf "Unbound name %a" Name.print name
+    Name.pattern_match name
+      ~symbol:(fun _ -> K.value)
+      ~var:(fun var -> Variable.kind var)
   in
   poison category kind
 
@@ -352,10 +347,10 @@ let rewrite_simple (env : env) simple =
       then
         (* This can happen if an unboxed block now only has an application for
            its only use, see [unboxed_or_function.ml] test. *)
-        name_poison ~category:"reaper_rewrite_simple_unboxed" env name
+        name_poison ~category:"reaper_rewrite_simple_unboxed" name
       else if is_name_used env name
       then simple
-      else name_poison ~category:"reaper_unused_name" env name)
+      else name_poison ~category:"reaper_unused_name" name)
     ~const:(fun _ -> simple)
 
 let rewrite_simple_opt (env : env) = function
@@ -1227,7 +1222,7 @@ let rebuild_apply env apply =
                 Simple.pattern_match arg
                   ~const:(fun _ -> arg)
                   ~name:(fun name ~coercion:_ ->
-                    name_poison ~category:"reaper_unused_argument" env name)
+                    name_poison ~category:"reaper_unused_argument" name)
             in
             let args_and_keep =
               if known_arity
@@ -1508,7 +1503,7 @@ let rebuild_singleton_binding_which_is_being_unboxed env bv
               if nth < List.length args
               then
                 let arg = List.nth args nth in
-                if K.equal field_kind (get_simple_kind env arg)
+                if K.equal field_kind (get_simple_kind arg)
                 then arg
                 else poison "reaper_dead_unboxed_field" field_kind
               else poison "reaper_dead_unboxed_field" field_kind
@@ -2464,7 +2459,7 @@ type result =
 let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
     ~ordered_code_ids
     ~(continuation_info : Traverse_acc.continuation_info Continuation.Map.t)
-    ~fixed_arity_continuations ~final_typing_env ~types_rewrite_context kinds
+    ~fixed_arity_continuations ~final_typing_env ~types_rewrite_context
     (solved_dep : Analysis.result) get_code_metadata toplevel_expr code =
   let should_keep_function_param code_id =
     let cannot_change_calling_convention =
@@ -2605,7 +2600,6 @@ let rebuild ~machine_width ~(code_deps : Traverse_acc.code_dep Code_id.Map.t)
       function_params_to_keep;
       should_keep_function_param;
       function_return_decision;
-      kinds;
       should_preserve_direct_calls;
       old_typing_env = final_typing_env;
       inside_code_definition = false;

--- a/middle_end/flambda2/reaper/rebuild.mli
+++ b/middle_end/flambda2/reaper/rebuild.mli
@@ -45,7 +45,6 @@ val rebuild :
   fixed_arity_continuations:Continuation.Set.t ->
   final_typing_env:Typing_env.t option ->
   types_rewrite_context:Types_rewriter.rewrite_context ->
-  Flambda_kind.t Name.Map.t ->
   Unboxing_analysis.result ->
   (Code_id.t -> Code_metadata.t) ->
   Rev_expr.t ->

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -108,7 +108,6 @@ let record_set_of_closures_deps denv names_and_function_slots set_of_closures
   let names_and_code_ids =
     Function_slot.Lmap.mapi
       (fun function_slot name ->
-        Acc.kind acc name K.value;
         let code_id =
           (Function_slot.Map.find function_slot funs
             : Function_declarations.code_id_in_function_declaration)
@@ -147,9 +146,6 @@ let record_set_of_closures_deps denv names_and_function_slots set_of_closures
 
 let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
     ~(default_bp : (Code_id_or_name.t -> unit) -> unit) =
-  Acc.kind acc
-    (Bound_var.name (Bound_pattern.must_be_singleton bound_pattern))
-    (Flambda_primitive.result_kind' prim);
   match prim with
   | Variadic (Make_block (block_kind, _mutability, _), fields) ->
     let _tag, block_shape = Flambda_primitive.Block_kind.to_shape block_kind in
@@ -546,9 +542,6 @@ let rec traverse_let denv acc let_expr : rev_expr =
   | Prim (prim, _dbg) ->
     traverse_prim denv acc ~bound_pattern prim ~default ~default_bp
   | Simple s ->
-    Acc.alias_kind acc
-      (Name.var (Bound_var.var (Bound_pattern.must_be_singleton bound_pattern)))
-      s;
     default_bp (fun to_ ->
         Acc.add_alias acc ~to_ ~from:(Acc.simple_to_node acc ~denv s))
   | Rec_info _ -> default acc);
@@ -676,13 +669,6 @@ and traverse_let_cont_recursive denv acc ~invariant_params ~body handlers =
         Env.add_cont denv cont (Normal params))
       handlers denv
   in
-  Bound_parameters.iter
-    (fun bp -> Acc.bound_parameter_kind acc bp)
-    invariant_params;
-  Continuation.Lmap.iter
-    (fun _ (_, bp, _) ->
-      Bound_parameters.iter (fun bp -> Acc.bound_parameter_kind acc bp) bp)
-    handlers;
   let handlers =
     Continuation.Lmap.map
       (fun (cont_handler, bound_parameters, handler) ->
@@ -706,9 +692,6 @@ and traverse_cont_handler : type a.
   let is_cold = Continuation_handler.is_cold cont_handler in
   Continuation_handler.pattern_match cont_handler
     ~f:(fun bound_parameters ~handler ->
-      Bound_parameters.iter
-        (fun bp -> Acc.bound_parameter_kind acc bp)
-        bound_parameters;
       let expr = traverse denv acc handler in
       let handler = { bound_parameters; expr; is_exn_handler; is_cold } in
       k handler acc)
@@ -784,16 +767,6 @@ and traverse_function_params_and_body acc code_id code ~return_continuation
     Env.create ~parent:Hole ~conts ~should_preserve_direct_calls
       ~current_code_id:(Some code_id) ~le_monde_exterieur ~all_constants
   in
-  Bound_parameters.iter (fun bp -> Acc.bound_parameter_kind acc bp) params;
-  Acc.kind acc (Name.var my_closure) K.value;
-  (match (my_alloc_mode : Alloc_mode.For_applications.t) with
-  | Heap { alloc_region } ->
-    Acc.kind acc (Name.var alloc_region) Flambda_kind.region
-  | Local { alloc_region; region; ghost_region } ->
-    Acc.kind acc (Name.var alloc_region) Flambda_kind.region;
-    Acc.kind acc (Name.var region) Flambda_kind.region;
-    Acc.kind acc (Name.var ghost_region) Flambda_kind.region);
-  Acc.kind acc (Name.var my_depth) K.rec_info;
   if not is_opaque
   then (
     List.iter2
@@ -852,7 +825,6 @@ type result =
     code : Rev_expr.rev_code Code_id.Map.t;
     ordered_code_ids : Code_id.t array;
     deps : Global_flow_graph.graph;
-    kinds : K.t Name.Map.t;
     fixed_arity_continuations : Continuation.Set.t;
     continuation_info : Acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;
@@ -907,7 +879,6 @@ let run (unit : Flambda_unit.t) =
     Profile.record_call ~accumulate:false "down" (run0 unit acc ~all_constants)
   in
   let deps = Acc.deps ~all_constants:(Name.symbol all_constants) acc in
-  let kinds = Acc.kinds acc in
   let fixed_arity_continuations = Acc.fixed_arity_continuations acc in
   let continuation_info = Acc.get_continuation_info acc in
   let code_deps = Acc.code_deps acc in
@@ -916,7 +887,6 @@ let run (unit : Flambda_unit.t) =
     code = Acc.get_all_code acc;
     ordered_code_ids = Acc.sort_code_ids acc;
     deps;
-    kinds;
     fixed_arity_continuations;
     continuation_info;
     code_deps;

--- a/middle_end/flambda2/reaper/traverse.mli
+++ b/middle_end/flambda2/reaper/traverse.mli
@@ -18,7 +18,6 @@ type result =
     code : Rev_expr.rev_code Code_id.Map.t;
     ordered_code_ids : Code_id.t array;
     deps : Global_flow_graph.graph;
-    kinds : Flambda_kind.t Name.Map.t;
     fixed_arity_continuations : Continuation.Set.t;
     continuation_info : Traverse_acc.continuation_info Continuation.Map.t;
     code_deps : Traverse_acc.code_dep Code_id.Map.t;

--- a/middle_end/flambda2/reaper/traverse_acc.ml
+++ b/middle_end/flambda2/reaper/traverse_acc.ml
@@ -55,7 +55,6 @@ type t =
     mutable apply_deps : apply_dep list;
     mutable set_of_closures_deps : closure_dep list;
     deps : Graph.graph;
-    mutable kinds : K.t Name.Map.t;
     mutable fixed_arity_conts : Continuation.Set.t;
     mutable continuation_info : continuation_info Continuation.Map.t;
     mutable set_of_closures_graph : Code_id.Set.t Code_id.Map.t;
@@ -71,21 +70,11 @@ let create () =
     apply_deps = [];
     set_of_closures_deps = [];
     deps = Graph.create ();
-    kinds = Name.Map.empty;
     fixed_arity_conts = Continuation.Set.empty;
     continuation_info = Continuation.Map.empty;
     set_of_closures_graph = Code_id.Map.empty;
     all_sets_of_closures = []
   }
-
-let kinds t = t.kinds
-
-let kind t name k = t.kinds <- Name.Map.add name k t.kinds
-
-let bound_parameter_kind t (bp : Bound_parameter.t) =
-  let kind = K.With_subkind.kind (Bound_parameter.kind bp) in
-  let name = Name.var (Bound_parameter.var bp) in
-  t.kinds <- Name.Map.add name kind t.kinds
 
 (* CR-someday ncourant: it would be great if we kept constants and symbols from
    external compilation units in the graph as well, making effectively all
@@ -99,21 +88,6 @@ let simple_to_node t ~all_constants simple =
       if not (Current_unit.is_current (Symbol.compilation_unit s))
       then Graph.add_any_source t.deps (Code_id_or_name.symbol s);
       Code_id_or_name.symbol s)
-
-let alias_kind t name simple =
-  let kind =
-    Simple.pattern_match simple
-      ~name:(fun name ~coercion:_ ->
-        (* Symbols are always values and might not be in t.kinds *)
-        if Name.is_symbol name
-        then K.value
-        else
-          match Name.Map.find_opt name t.kinds with
-          | Some k -> k
-          | None -> Misc.fatal_errorf "Unbound name %a" Name.print name)
-      ~const:Reg_width_const.kind
-  in
-  t.kinds <- Name.Map.add name kind t.kinds
 
 let add_code_dep t code_id dep =
   t.code_deps <- Code_id.Map.add code_id dep t.code_deps

--- a/middle_end/flambda2/reaper/traverse_acc.mli
+++ b/middle_end/flambda2/reaper/traverse_acc.mli
@@ -57,18 +57,6 @@ type t
 (** Create a fresh, empty accumulator. *)
 val create : unit -> t
 
-(** Record the kind of a name. *)
-val kind : t -> Name.t -> Flambda_kind.t -> unit
-
-(** Record the kind of a bound parameter's variable. *)
-val bound_parameter_kind : t -> Bound_parameter.t -> unit
-
-(** Record the kind of [name] by inferring it from [simple]. *)
-val alias_kind : t -> Name.t -> Simple.t -> unit
-
-(** Return the map of all recorded kinds. *)
-val kinds : t -> Flambda_kind.t Name.Map.t
-
 (** Mark a continuation as having fixed arity (mostly function return
     continuations): the rebuild pass may not change its number of parameters. *)
 val fixed_arity_continuation : t -> Continuation.t -> unit


### PR DESCRIPTION
This also fixes a (very rare) bug, where an unsimplified binding of kind rec_info crashes the reaper. I did not add a test, because having an unsimplified binding of kind rec_info is also a bug, and a fix is coming for that one soon.