### PR TITLE
Move `Btype.hash_variant` to `Obj`

### DIFF
--- a/external/merlin/src/ocaml/typing/btype.ml
+++ b/external/merlin/src/ocaml/typing/btype.ml
@@ -243,7 +243,17 @@ let tvariant_not_immediate row =
       | _ -> false)
     (row_fields row)
 
-let hash_variant = Misc.hash_variant
+(* This function is now in Obj upstream, but cannot be removed from here until
+   the system compiler is OCaml 5.6+ *)
+let hash_variant s =
+  let accu = ref 0 in
+  for i = 0 to String.length s - 1 do
+    accu := 223 * !accu + Char.code s.[i]
+  done;
+  (* reduce to 31 bits *)
+  accu := !accu land (1 lsl 31 - 1);
+  (* make it signed for 64 bits architectures *)
+  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
 
 let proxy ty =
   match get_desc ty with

--- a/external/merlin/src/ocaml/utils/misc.ml
+++ b/external/merlin/src/ocaml/utils/misc.ml
@@ -1219,17 +1219,6 @@ let create_hashtable size init =
   List.iter (fun (key, data) -> Hashtbl.add tbl key data) init;
   tbl
 
-(* This would be better in Obj, but we'd need upstream to do the same *)
-let hash_variant s =
-  let accu = ref 0 in
-  for i = 0 to String.length s - 1 do
-    accu := 223 * !accu + Char.code s.[i]
-  done;
-  (* reduce to 31 bits *)
-  accu := !accu land (1 lsl 31 - 1);
-  (* make it signed for 64 bits architectures *)
-  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
-
 (* File copy *)
 
 let copy_file ic oc =

--- a/external/merlin/src/ocaml/utils/misc.mli
+++ b/external/merlin/src/ocaml/utils/misc.mli
@@ -114,10 +114,6 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
        (** Create a hashtable with the given initial size and fills it
            with the given bindings. *)
 
-(* TODO Move this to Obj when the system compiler includes ocaml/ocaml/#14939 *)
-val hash_variant: string -> int
-        (** Hash function for variant tags *)
-
 (** {1 Extensions to the standard library} *)
 
 module Stdlib : sig

--- a/external/merlin/upstream/ocaml_flambda/typing/btype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/btype.ml
@@ -243,7 +243,17 @@ let tvariant_not_immediate row =
       | _ -> false)
     (row_fields row)
 
-let hash_variant = Misc.hash_variant
+(* This function is now in Obj upstream, but cannot be removed from here until
+   the system compiler is OCaml 5.6+ *)
+let hash_variant s =
+  let accu = ref 0 in
+  for i = 0 to String.length s - 1 do
+    accu := 223 * !accu + Char.code s.[i]
+  done;
+  (* reduce to 31 bits *)
+  accu := !accu land (1 lsl 31 - 1);
+  (* make it signed for 64 bits architectures *)
+  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
 
 let proxy ty =
   match get_desc ty with

--- a/external/merlin/upstream/ocaml_flambda/utils/misc.ml
+++ b/external/merlin/upstream/ocaml_flambda/utils/misc.ml
@@ -1015,17 +1015,6 @@ let create_hashtable size init =
   List.iter (fun (key, data) -> Hashtbl.add tbl key data) init;
   tbl
 
-(* This would be better in Obj, but we'd need upstream to do the same *)
-let hash_variant s =
-  let accu = ref 0 in
-  for i = 0 to String.length s - 1 do
-    accu := 223 * !accu + Char.code s.[i]
-  done;
-  (* reduce to 31 bits *)
-  accu := !accu land (1 lsl 31 - 1);
-  (* make it signed for 64 bits architectures *)
-  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
-
 (* File copy *)
 
 let copy_file ic oc =

--- a/external/merlin/upstream/ocaml_flambda/utils/misc.mli
+++ b/external/merlin/upstream/ocaml_flambda/utils/misc.mli
@@ -114,10 +114,6 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
        (** Create a hashtable with the given initial size and fills it
            with the given bindings. *)
 
-(* TODO Move this to Obj when the system compiler includes ocaml/ocaml/#14939 *)
-val hash_variant: string -> int
-        (** Hash function for variant tags *)
-
 (** {1 Extensions to the standard library} *)
 
 module Stdlib : sig

--- a/stdlib/obj.ml
+++ b/stdlib/obj.ml
@@ -95,6 +95,20 @@ external dup : t -> t @@ portable = "%obj_dup"
 external add_offset : t -> Int32.t -> t @@ portable = "caml_obj_add_offset"
 external with_tag : int -> t -> t @@ portable = "caml_obj_with_tag"
 
+(* Prevent module dependency on String and Char *)
+external string_get : string -> int -> char @@ portable = "%string_safe_get"
+external string_length : string -> int @@ portable = "%string_length"
+external char_code: char -> int @@ portable = "%identity"
+let hash_variant s =
+  let accu = ref 0 in
+  for i = 0 to string_length s - 1 do
+    accu := 223 * !accu + char_code (string_get s i)
+  done;
+  (* reduce to 31 bits *)
+  accu := !accu land (1 lsl 31 - 1);
+  (* make it signed for 64 bits architectures *)
+  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
+
 let first_non_constant_constructor_tag = 0
 let last_non_constant_constructor_tag = 243
 

--- a/stdlib/obj.mli
+++ b/stdlib/obj.mli
@@ -94,6 +94,9 @@ external add_offset : t -> Int32.t -> t = "caml_obj_add_offset"
 external with_tag : int -> t -> t = "caml_obj_with_tag"
   (* @since 4.09 *)
 
+val hash_variant: string -> int
+  (* @since 5.6 *)
+
 val first_non_constant_constructor_tag : int
 val last_non_constant_constructor_tag : int
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -243,7 +243,17 @@ let tvariant_not_immediate row =
       | _ -> false)
     (row_fields row)
 
-let hash_variant = Misc.hash_variant
+(* This function is now in Obj upstream, but cannot be removed from here until
+   the system compiler is OCaml 5.6+ *)
+let hash_variant s =
+  let accu = ref 0 in
+  for i = 0 to String.length s - 1 do
+    accu := 223 * !accu + Char.code s.[i]
+  done;
+  (* reduce to 31 bits *)
+  accu := !accu land (1 lsl 31 - 1);
+  (* make it signed for 64 bits architectures *)
+  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
 
 let proxy ty =
   match get_desc ty with

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1004,17 +1004,6 @@ let create_hashtable size init =
   List.iter (fun (key, data) -> Hashtbl.add tbl key data) init;
   tbl
 
-(* This would be better in Obj, but we'd need upstream to do the same *)
-let hash_variant s =
-  let accu = ref 0 in
-  for i = 0 to String.length s - 1 do
-    accu := 223 * !accu + Char.code s.[i]
-  done;
-  (* reduce to 31 bits *)
-  accu := !accu land (1 lsl 31 - 1);
-  (* make it signed for 64 bits architectures *)
-  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
-
 (* File copy *)
 
 let copy_file ic oc =

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -1015,17 +1015,6 @@ let create_hashtable size init =
   List.iter (fun (key, data) -> Hashtbl.add tbl key data) init;
   tbl
 
-(* This would be better in Obj, but we'd need upstream to do the same *)
-let hash_variant s =
-  let accu = ref 0 in
-  for i = 0 to String.length s - 1 do
-    accu := 223 * !accu + Char.code s.[i]
-  done;
-  (* reduce to 31 bits *)
-  accu := !accu land (1 lsl 31 - 1);
-  (* make it signed for 64 bits architectures *)
-  if !accu > 0x3FFFFFFF then !accu - (1 lsl 31) else !accu
-
 (* File copy *)
 
 let copy_file ic oc =

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -114,10 +114,6 @@ val create_hashtable: int -> ('a * 'b) list -> ('a, 'b) Hashtbl.t
        (** Create a hashtable with the given initial size and fills it
            with the given bindings. *)
 
-(* TODO Move this to Obj when the system compiler includes ocaml/ocaml/#14939 *)
-val hash_variant: string -> int
-        (** Hash function for variant tags *)
-
 (** {1 Extensions to the standard library} *)
 
 module Stdlib : sig


### PR DESCRIPTION
Backports the first commit of https://github.com/ocaml/ocaml/pull/14939. The second commit from that PR can't be adopted until the system compiler is OCaml 5.6. Backporting this follows on from #6530, and removes the need for an OxCaml shim for the function's location.