### PR TITLE
Fix merlin jump to definition

### DIFF
--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -93,7 +93,7 @@ boot_targets = \
   ocamltest/ocamltest.native
 
 boot-compiler: _build/_bootinstall
-	$(dune) build $(ws_boot) $(coverage_dune_flags) $(boot_targets)
+	$(dune) build $(ws_boot) $(coverage_dune_flags) @merlin-support $(boot_targets)
 
 boot-runtest: boot-compiler
 	$(dune) build $(ws_boot) $(coverage_dune_flags) --force $(runtest_targets)
@@ -479,7 +479,7 @@ promote-one-no-rebuild:
 # This target is like a polling version of upstream "make ocamlopt"
 .PHONY: hacking
 hacking: _build/_bootinstall
-	$(dune) build $(ws_boot) -w $(boot_targets)
+	$(dune) build $(ws_boot) -w @merlin-support $(boot_targets)
 
 # The `hacking-emacs-poller` and `hacking-emacs-builder` targets make it
 # possible to run the polling build with Emacs's `M-x compile`.  You should run
@@ -493,7 +493,7 @@ hacking-emacs-poller: _build/_bootinstall
 
 .PHONY: hacking-emacs-builder
 hacking-emacs-builder: _build/_bootinstall
-	$(dune) rpc build $(ws_boot) -w $(boot_targets)
+	$(dune) rpc build $(ws_boot) -w @merlin-support $(boot_targets)
 	$(dune) diagnostics
 
 .PHONY: debug-printers

--- a/dune
+++ b/dune
@@ -1005,6 +1005,28 @@
  (section lib)
  (package ocaml))
 
+; Build all the files that Merlin needs to work on the compiler. Building @check
+; for the entire repo will build too much, as we don't want to build directories
+; like stdlib/ or the tests. Also, aliases like `@typing/check` are empty in our
+; build rules, which is why we glob on cmi, cmt, and cmti files.
+(alias
+ (name merlin-support)
+ (deps
+  (glob_files .ocamlcommon.objs/byte/*.{cmi,cmt,cmti})
+  (glob_files .ocamlbytecomp.objs/byte/*.{cmi,cmt,cmti})
+  (glob_files .ocamloptcomp.objs/byte/*.{cmi,cmt,cmti})
+  (glob_files .ocamljcomp.objs/byte/*.{cmi,cmt,cmti})
+  (glob_files .oxcaml_common.objs/byte/*.{cmi,cmt,cmti})
+  (alias_rec middle_end/check)
+  (alias_rec backend/check)
+  (alias_rec driver/check)
+  (alias_rec file_formats/check)
+  (alias_rec lex/check)
+  (alias_rec printer/check)
+  (alias_rec chamelon/check)
+  (alias_rec extract_externals/check)
+  (alias_rec ocamltest/check)))
+
 (rule
  (targets compiler-libs-installation.sexp)
  (deps


### PR DESCRIPTION
When we [recently upgraded dune](https://github.com/oxcaml/oxcaml/pull/6259) Merlin recently stopped working properly when working on the compiler. Specifically, it became unable to jump to definition. The issue is due to a change in dune from 3.21.1 to 3.22.0. Here's a fable-written description of what broke and how this PR fixes it:

 ## Why merlin's jump-to-definition broke with dune 3.22.0

Merlin's `locate` needs byte `.cmt` files (e.g. `_build/default/.ocamlcommon.objs/byte/jkind.cmt`). Dune only declares `.cmt` targets on its **bytecode** compilation rules, and the boot build's targets are all native — so nothing in the boot build directly demands them. (The `.cmt` files in `.objs/native/` are untracked side effects of `-bin-annot` in `(flags)`; dune doesn't know about them and merlin isn't pointed there.)

Under dune ≤ 3.21.1 we got the byte `.cmt`s anyway, **by accident**:

1. `ocamltest`'s `(ocamlyacc ...)` stanza resolved the `ocamlyacc` binary through the package install directory: `_build/install/default/bin/ocamlyacc`.
2. `ocamlyacc` is installed by package `ocaml`, whose install stanza contains `(include compiler-libs-installation.sexp)` — so laying out the install dir forces dune to *build* that sexp.
3. That rule's deps are `(glob_files .ocamlcommon.objs/byte/*.{cmi,cmo,cmt,cmti})` (and the same for ocamlbytecomp/ocamloptcomp), which compiled every byte `.cmo`/`.cmt` on every boot build.

Dune 3.22.0 ([ocaml/dune#13098](https://github.com/ocaml/dune/pull/13098), the ocamllex/ocamlyacc sandboxing rework) changed parser-generator rules to resolve the tool with `~where:Original_path`: the rule now runs `_build/default/ocamlyacc` directly and never touches the install machinery. The accidental dependency chain disappeared, byte `.cmt`s stopped being built, and merlin could only find `.cmti`s — hence `locate` landing on interfaces.

Fix: build the `.cmt` files on purpose — the `@merlin-support` alias (byte-objs globs for the root compiler libraries + `@check` of the subtrees that build in the boot workspace), included in `make boot-compiler`/`make hacking`. A plain recursive `@check` can't be used because `stdlib/`, `otherlibs/`, and the test dirs only build with the new compiler, and since `(lang dune 3.23)` the root `check` alias also generates `compile_commands.json`, which requires resolving every foreign-stubs stanza in the workspace.