### PR TITLE
Remove stale CRs in testsuite/tests/codegen

### DIFF
--- a/testsuite/tests/codegen/arrays-no-flat-float-array.ml
+++ b/testsuite/tests/codegen/arrays-no-flat-float-array.ml
@@ -117,9 +117,6 @@ ref_unsafe_set:
   ret
 |}]
 
-(* CR ttebbi: Stackframe creation is only necessary on the GC-calling path.
-   In this case, this would require moving the stackframe creation into the
-   hidden block where the GC is actually called. *)
 let poly_unsafe_get (a : 'a array) (i : int) =
   Array.unsafe_get a i
 [%%expect_asm X86_64{|
@@ -453,10 +450,6 @@ ref_safe_set:
   jmp   *%r11
 |}]
 
-(* CR ttebbi: The header is loaded twice: once for the bounds check and once
-   for the tag check (to distingish float arrays). The non-float case should
-   be the inline one for code compactness.
-*)
 let poly_safe_get (a : 'a array) (i : int) =
   Array.get a i
 [%%expect_asm X86_64{|

--- a/testsuite/tests/codegen/float_u.ml
+++ b/testsuite/tests/codegen/float_u.ml
@@ -303,10 +303,7 @@ min_unchecked:
   ret
 |}]
 
-(* CR ttebbi: Bad codegen:
-      - useless spill and hence no need for a frame
-      - could negate vcmpsd predicate to replace (~res)*2+1 with res*2+3
-*)
+(* CR ttebbi: could negate vcmpsd predicate to replace (~res)*2+1 with res*2+3 *)
 let is_nan (x : Float_u.t) = Float.is_nan (Float_u.to_float x)
 [%%expect_asm X86_64{|
 is_nan:
@@ -318,10 +315,7 @@ is_nan:
 |}]
 
 
-(* CR ttebbi: Bad codegen:
-      - useless spill and hence no need for a frame
-      - could negate vcmpsd predicate to replace (~res)*2+1 with res*2+3
-*)
+(* CR ttebbi: could negate vcmpsd predicate to replace (~res)*2+1 with res*2+3 *)
 let is_finite (x : Float_u.t) =
   let equal x y = float_equal (Float_u.to_float x) (Float_u.to_float y) in
   let zero_or_nan = Float_u.sub x x in

--- a/testsuite/tests/codegen/int32_u.ml
+++ b/testsuite/tests/codegen/int32_u.ml
@@ -24,7 +24,7 @@ add:
   ret
 |}]
 
-(* CR ttebbi: Unnecessary moves at the beginning. *)
+(* CR ttebbi: This should be branchfree. *)
 let min x y = Int32_u.min x y
 [%%expect_asm X86_64{|
 min:

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -46,7 +46,6 @@ mul:
   ret
 |}]
 
-(* CR ttebbi: imul could be replaced with lea (x*2+x) *)
 let mul_3 x = Int64_u.mul x #3L
 [%%expect_asm X86_64{|
 mul_3:

--- a/testsuite/tests/codegen/select.ml
+++ b/testsuite/tests/codegen/select.ml
@@ -61,7 +61,6 @@ select_cmp_twice:
 |}]
 
 
-(* CR ttebbi: We could constant-fold this. *)
 let select_constant (x : int) = Builtins.select true x 55
 [%%expect_asm X86_64{|
 select_constant:


### PR DESCRIPTION
Several CR comments describe codegen deficiencies that the current expected output no longer exhibits:

- int64_u.ml: mul_3 already uses lea instead of imul
- select.ml: select_constant is already constant-folded to ret
- int32_u.ml: no moves remain at the start of min; reworded the CR to the live issue (branchy min), matching the int64_u.ml siblings
- float_u.ml: is_nan/is_finite no longer spill or set up a frame; kept the still-live predicate-polarity bullet
- arrays-no-flat-float-array.ml: poly_unsafe_get has no frame or GC call, and poly_safe_get loads the header once with the load inline (the flat-float-array twins are still live and unchanged)

Comment-only change; no [%%expect_asm] block is modified.