### PR TITLE
Use the `neg` instruction for integer negation (amd64)

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -32,7 +32,7 @@ let class_of_operation (op : Operation.t)
   match op with
   | Specific spec ->
     begin match spec with
-    | Ilea _ | Isextend32 | Izextend32 -> Class Op_pure
+    | Ilea _ | Isextend32 | Izextend32 | Ineg -> Class Op_pure
     | Istore_int(_, _, is_asg) -> Class (Op_store is_asg)
     | Ioffset_loc(_, _) -> Class (Op_store true)
     | Ifloatarithmem _ -> Class (Op_load Mutable)

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -299,6 +299,7 @@ type specific_operation =
                                           extension *)
   | Izextend32                         (* 32 to 64 bit conversion with zero
                                           extension *)
+  | Ineg                               (* integer negation *)
   | Irdtsc                             (* read timestamp *)
   | Irdpmc                             (* read performance counter *)
   | Ilfence                            (* load fence *)
@@ -411,8 +412,9 @@ let fold_delta_into_specific_operation op ~arg_is_folded_reg ~delta =
       else Some (Ilea (offset_addressing addr displ_delta))
     end
   | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isextend32
-  | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32
-  | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ | Illvm_intrinsic _ ->
+  | Izextend32 | Ineg | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence
+  | Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _
+  | Illvm_intrinsic _ ->
     None
 
 let addressing_displacement_for_llvmize addr =
@@ -494,6 +496,8 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "sextend32 %a" printreg arg.(0)
   | Izextend32 ->
       fprintf ppf "zextend32 %a" printreg arg.(0)
+  | Ineg ->
+      fprintf ppf "neg %a" printreg arg.(0)
   | Irdtsc ->
       fprintf ppf "rdtsc"
   | Ilfence ->
@@ -531,6 +535,7 @@ let specific_operation_name : specific_operation -> string = fun op ->
       "bswap " ^ (bitwidth |> int_of_bswap_bitwidth |> string_of_int)
   | Isextend32 -> "sextend32"
   | Izextend32 -> "zextend32"
+  | Ineg -> "neg"
   | Irdtsc -> "rdtsc"
   | Ilfence -> "lfence"
   | Isfence -> "sfence"
@@ -553,7 +558,7 @@ let win64 =
 (* Specific operations that are pure *)
 (* Keep in sync with [Vectorize_specific] *)
 let operation_is_pure = function
-  | Ilea _ | Ibswap _ | Isextend32 | Izextend32
+  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 | Ineg
   | Ifloatarithmem _  -> true
   | Irdtsc | Irdpmc
   | Ilfence | Isfence | Imfence
@@ -569,7 +574,7 @@ let operation_is_pure = function
 
 (* Keep in sync with [Vectorize_specific] *)
 let operation_allocates = function
-  | Ilea _ | Ibswap _ | Isextend32 | Izextend32
+  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 | Ineg
   | Ifloatarithmem _
   | Irdtsc | Irdpmc  | Ipackf32
   | Isimd _ | Isimd_mem _
@@ -648,6 +653,8 @@ let equal_specific_operation left right =
     true
   | Izextend32, Izextend32 ->
     true
+  | Ineg, Ineg ->
+    true
   | Irdtsc, Irdtsc ->
     true
   | Irdpmc, Irdpmc ->
@@ -672,7 +679,7 @@ let equal_specific_operation left right =
     Simd.Mem.equal_operation l r && equal_addressing_mode al ar
   | Illvm_intrinsic l, Illvm_intrinsic r -> String.equal l r
   | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
-     Isextend32 | Izextend32 |
+     Isextend32 | Izextend32 | Ineg |
      Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
      Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ |
      Illvm_intrinsic _), _ ->
@@ -761,6 +768,8 @@ let isomorphic_specific_operation op1 op2 =
     true
   | Izextend32, Izextend32 ->
     true
+  | Ineg, Ineg ->
+    true
   | Irdtsc, Irdtsc ->
     true
   | Irdpmc, Irdpmc ->
@@ -785,7 +794,7 @@ let isomorphic_specific_operation op1 op2 =
     Simd.Mem.equal_operation l r && equal_addressing_mode_without_displ al ar
   | Illvm_intrinsic l, Illvm_intrinsic r -> String.equal l r
   | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
-     Isextend32 | Izextend32 |
+     Isextend32 | Izextend32 | Ineg |
      Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
      Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ |
      Illvm_intrinsic _), _ ->

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -94,6 +94,7 @@ type specific_operation =
                                           extension *)
   | Izextend32                         (* 32 to 64 bit conversion with zero
                                           extension *)
+  | Ineg                               (* integer negation *)
   | Irdtsc                             (* read timestamp *)
   | Irdpmc                             (* read performance counter *)
   | Ilfence                            (* load fence *)

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -161,6 +161,7 @@ let pseudoregs_for_operation op arg res =
   | Intop_imm ((Imul | Iand | Ior | Ixor | Ilsl | Ilsr | Iasr), _)
   | Floatop ((Float64 | Float32), (Iabsf | Inegf))
   | Specific (Ibswap { bitwidth = Thirtytwo | Sixtyfour })
+  | Specific Ineg
   | Opaque ->
     res, res
   (* For xchg, args must be a register allowing access to high 8 bit register
@@ -381,12 +382,17 @@ let select_operation'
     (args : Cmm.expression list) dbg ~label_after:_ :
     Cfg_selectgen_target_intf.select_operation_result =
   match op with
-  (* Recognize the LEA instruction *)
+  (* Recognize the NEG and LEA instructions *)
   | Caddi | Caddv | Cadda | Csubi | Cor | Cmuli -> (
-    match select_addressing Word_int (Cop (op, args, dbg)) with
-    | Iindexed _, _ | Iindexed2 0, _ -> Use_default
-    | ((Iindexed2 _ | Iscaled _ | Iindexed2scaled _ | Ibased _) as addr), arg ->
-      Rewritten (specific (Ilea addr), [arg]))
+    match op, args with
+    | Csubi, ([Cconst_int (0, _); arg] | [Cconst_natint (0n, _); arg]) ->
+      Rewritten (specific Ineg, [arg])
+    | _, _ -> (
+      match select_addressing Word_int (Cop (op, args, dbg)) with
+      | Iindexed _, _ | Iindexed2 0, _ -> Use_default
+      | ((Iindexed2 _ | Iscaled _ | Iindexed2scaled _ | Ibased _) as addr), arg
+        ->
+        Rewritten (specific (Ilea addr), [arg])))
   (* Recognize float arithmetic with memory. *)
   | Caddf width -> select_floatarith true width Iaddf Ifloatadd args
   | Csubf width -> select_floatarith false width Isubf Ifloatsub args

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -2512,6 +2512,7 @@ let emit_instr ~first ~last ~fallthrough i =
   | Lop (Specific (Ibswap { bitwidth = Sixtyfour })) -> I.bswap (res i 0)
   | Lop (Specific Isextend32) -> I.movsxd (arg32 i 0) (res i 0)
   | Lop (Specific Izextend32) -> I.mov (arg32 i 0) (res32 i 0)
+  | Lop (Specific Ineg) -> I.neg (res i 0)
   | Lop (Intop Iclz) ->
     (* CR-someday gyorsh: can we do it at selection? mshinwell: We need to
        address this and the similar CRs below. My feeling is that we should try

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -590,7 +590,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Begin_region
        | End_region
        | Specific (Ilea _ | Ioffset_loc _ | Ibswap _
-                  | Isextend32 | Izextend32
+                  | Isextend32 | Izextend32 | Ineg
                   | Ilfence | Isfence | Imfence)
        | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Pause)
   | Poptrap _ | Prologue | Epilogue ->

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -278,7 +278,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
          (Int_of_value | Value_of_int | Mask_of_int64 | Int64_of_mask))
   | Op
       (Specific
-         ( Isextend32 | Izextend32 | Ilea _
+         ( Isextend32 | Izextend32 | Ineg | Ilea _
          | Istore_int (_, _, _)
          | Ioffset_loc (_, _)
          | Ifloatarithmem (_, _, _)

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1510,7 +1510,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
             | Iindexed2scaled (scale, displ) -> Some scale, Some displ
             | Ibased _ -> None, None)
           | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-          | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence
+          | Isextend32 | Izextend32 | Ineg | Irdtsc | Irdpmc | Ilfence | Isfence
           | Imfence | Ipackf32 | Isimd _ | Isimd_mem _ | Iprefetch _
           | Icldemote _ | Illvm_intrinsic _ ->
             assert false)
@@ -1646,7 +1646,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
               ( Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _
               | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32
               | Isimd _ | Isimd_mem _ | Ilea _ | Ibswap _ | Isextend32
-              | Izextend32 | Illvm_intrinsic _ )
+              | Izextend32 | Ineg | Illvm_intrinsic _ )
           | Intop_imm _ | Move | Load _ | Store _ | Intop _ | Int128op _
           | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload
           | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _
@@ -1748,8 +1748,8 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
         Some [load; arith]
     | Isimd_mem _ ->
       Misc.fatal_error "Unexpected simd operation with memory arguments"
-    | Ioffset_loc _ | Ibswap _ | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence
-    | Ipackf32 | Isimd _ | Iprefetch _ | Icldemote _ ->
+    | Ioffset_loc _ | Ibswap _ | Ineg | Irdtsc | Irdpmc | Ilfence | Isfence
+    | Imfence | Ipackf32 | Isimd _ | Iprefetch _ | Icldemote _ ->
       None
     | Illvm_intrinsic intr ->
       Misc.fatal_errorf

--- a/backend/amd64/vectorize_specific.ml
+++ b/backend/amd64/vectorize_specific.ml
@@ -58,7 +58,7 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
   | Isimd_mem _ ->
     Misc.fatal_errorf
       "Unexpected simd instruction with memory operands before vectorization"
-  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 -> None
+  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 | Ineg -> None
   | Illvm_intrinsic intr ->
     Misc.fatal_errorf
       "Vectorize_specific: Unexpected llvm_intrinsic %s: not using LLVM backend"
@@ -71,7 +71,7 @@ let is_seed_store :
   | Istore_int _ -> Some W64
   | Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _ | Irdtsc
   | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32 | Isimd _ | Isimd_mem _
-  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 ->
+  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 | Ineg ->
     None
   | Illvm_intrinsic intr ->
     Misc.fatal_errorf

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -751,10 +751,9 @@ let ptr_fetch_sub_int (p : nativeint#) v =
 [%%expect_asm X86_64{|
 ptr_fetch_sub_int:
   sarq  $1, %rbx
-  xorl  %edi, %edi
-  subq  %rbx, %rdi
-  lock xaddq %rdi, (%rax)
-  leaq  1(%rdi,%rdi), %rax
+  neg   %rbx
+  lock xaddq %rbx, (%rax)
+  leaq  1(%rbx,%rbx), %rax
   ret
 |}]
 
@@ -796,8 +795,8 @@ let ptr_fetch_sub_int64 (p : nativeint#) (v : int64#) =
 [%%expect_asm X86_64{|
 ptr_fetch_sub_int64:
   movq  %rax, %rdi
-  xorl  %eax, %eax
-  subq  %rbx, %rax
+  movq  %rbx, %rax
+  neg   %rax
   lock xaddq %rax, (%rdi)
   ret
 |}]
@@ -838,10 +837,9 @@ let ptr_fetch_sub_int32 (p : nativeint#) (v : int32#) =
        (Nativeint_u.to_nativeint p) (Int32_u.to_int32 v))
 [%%expect_asm X86_64{|
 ptr_fetch_sub_int32:
-  xorl  %edi, %edi
-  subq  %rbx, %rdi
-  lock xaddl %edi, (%rax)
-  movslq %edi, %rax
+  neg   %rbx
+  lock xaddl %ebx, (%rax)
+  movslq %ebx, %rax
   ret
 |}]
 
@@ -885,8 +883,8 @@ let ptr_fetch_sub_nativeint (p : nativeint#) (v : nativeint#) =
 [%%expect_asm X86_64{|
 ptr_fetch_sub_nativeint:
   movq  %rax, %rdi
-  xorl  %eax, %eax
-  subq  %rbx, %rax
+  movq  %rbx, %rax
+  neg   %rax
   lock xaddq %rax, (%rdi)
   ret
 |}]

--- a/testsuite/tests/codegen/int16_u.ml
+++ b/testsuite/tests/codegen/int16_u.ml
@@ -140,13 +140,10 @@ bswap:
   ret
 |}]
 
-(* CR-someday jrayman: Could use a [neg] instruction instead *)
 let neg x = Int16_u.neg x
 [%%expect_asm X86_64{|
 neg:
-  xorl  %ebx, %ebx
-  subq  %rax, %rbx
-  movq  %rbx, %rax
+  neg   %rax
   salq  $48, %rax
   sarq  $48, %rax
   ret

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -15,13 +15,10 @@ open Intrinsics
 
 (* Codegen tests for Int64_u operations *)
 
-(* CR ttebbi: This should use the neg instruction. *)
 let neg x = Int64_u.neg x
 [%%expect_asm X86_64{|
 neg:
-  movq  %rax, %rbx
-  xorl  %eax, %eax
-  subq  %rbx, %rax
+  neg   %rax
   ret
 |}]
 
@@ -66,9 +63,7 @@ div:
   idivq %rcx
   ret
 .L0:
-  xorl  %ebx, %ebx
-  subq  %rax, %rbx
-  movq  %rbx, %rax
+  neg   %rax
   ret
 .L1:
   movq  caml_exn_Division_by_zero@GOTPCREL(%rip), %rax
@@ -290,9 +285,7 @@ abs:
   jl    .L0
   ret
 .L0:
-  xorl  %ebx, %ebx
-  subq  %rax, %rbx
-  movq  %rbx, %rax
+  neg   %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -131,9 +131,7 @@ bswap:
 let neg x = Int8_u.neg x
 [%%expect_asm X86_64{|
 neg:
-  xorl  %ebx, %ebx
-  subq  %rax, %rbx
-  movq  %rbx, %rax
+  neg   %rax
   salq  $56, %rax
   sarq  $56, %rax
   ret

--- a/testsuite/tests/codegen/nativeint_u.ml
+++ b/testsuite/tests/codegen/nativeint_u.ml
@@ -27,13 +27,10 @@ sub:
   ret
 |}]
 
-(* CR ttebbi: This should use the neg instruction. *)
 let neg x = Nativeint_u.neg x
 [%%expect_asm X86_64{|
 neg:
-  movq  %rax, %rbx
-  xorl  %eax, %eax
-  subq  %rbx, %rax
+  neg   %rax
   ret
 |}]
 


### PR DESCRIPTION
As per title; this is done at selection rather than
through peephole optimizations, because it has
an impact on register allocation.