### PR TITLE
Avoid materializing a zero for the merge operand of vsqrtsd (amd64)

### DIFF
--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -50,8 +50,16 @@ let seq_or_avx sse vex ?i args =
 let seq_or_avx_zeroed ~dbg seq instr ?i args =
   if Arch.Extension.enabled AVX
   then
-    cfg_operation (Simd.instruction instr i)
-      (Cmm_helpers.vec128 ~dbg { word0 = 0L; word1 = 0L } :: args)
+    let args =
+      match[@warning "-4"] args with
+      | [(Cmm.Cvar _ as arg)] ->
+        (* The first operand only supplies the upper bits of the result, which
+           are irrelevant here. Using the source avoids materializing a zero,
+           and does not add a dependency since the source is read anyway. *)
+        [arg; arg]
+      | _ -> Cmm_helpers.vec128 ~dbg { word0 = 0L; word1 = 0L } :: args
+    in
+    cfg_operation (Simd.instruction instr i) args
   else cfg_operation (Simd.sequence seq i) args
 
 let simd_load ~mode instr args =

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -47,7 +47,7 @@ let seq_or_avx sse vex ?i args =
   let seq = if Arch.Extension.enabled AVX then vex else sse in
   cfg_operation (Simd.sequence seq i) args
 
-let seq_or_avx_zeroed ~dbg seq instr ?i args =
+let seq_or_avx_with_merge ~dbg seq instr ?i args =
   if Arch.Extension.enabled AVX
   then
     let args =
@@ -229,7 +229,7 @@ let select_operation_sse ~dbg op args =
     simd_store_sse_or_avx ~mode:Arch.identity_addressing movntps vmovntps_m128_X
       args
   | "caml_sse_float32_sqrt" | "sqrtf" ->
-    seq_or_avx_zeroed ~dbg Seq.sqrtss vsqrtss_X_X_Xm32 args
+    seq_or_avx_with_merge ~dbg Seq.sqrtss vsqrtss_X_X_Xm32 args
   | "caml_simd_float32_max" | "caml_sse_float32_max" ->
     sse_or_avx maxss vmaxss_X_X_Xm32 args
   | "caml_simd_float32_min" | "caml_sse_float32_min" ->
@@ -301,7 +301,7 @@ let select_operation_sse2 ~dbg op args =
     (* Does not have a mode; base address is always in rdi. *)
     sse_or_avx maskmovdqu vmaskmovdqu args
   | "caml_sse2_float64_sqrt" | "sqrt" ->
-    seq_or_avx_zeroed ~dbg Seq.sqrtsd vsqrtsd_X_X_Xm64 args
+    seq_or_avx_with_merge ~dbg Seq.sqrtsd vsqrtsd_X_X_Xm64 args
   | "caml_simd_float64_max" | "caml_sse2_float64_max" ->
     sse_or_avx maxsd vmaxsd_X_X_Xm64 args
   | "caml_simd_float64_min" | "caml_sse2_float64_min" ->
@@ -612,43 +612,43 @@ let select_operation_sse41 ~dbg op args =
     | "caml_sse41_float64_round" ->
       let i, args = extract_constant args ~max:15 op in
       check_float_rounding i;
-      seq_or_avx_zeroed ~dbg Seq.roundsd vroundsd ~i args
+      seq_or_avx_with_merge ~dbg Seq.roundsd vroundsd ~i args
     | "caml_simd_float64_round_current" | "caml_sse41_float64_round_current" ->
-      seq_or_avx_zeroed ~dbg Seq.roundsd vroundsd
+      seq_or_avx_with_merge ~dbg Seq.roundsd vroundsd
         ~i:(int_of_float_rounding RoundCurrent)
         args
     | "caml_simd_float64_round_neg_inf" | "caml_sse41_float64_round_neg_inf" ->
-      seq_or_avx_zeroed ~dbg Seq.roundsd vroundsd
+      seq_or_avx_with_merge ~dbg Seq.roundsd vroundsd
         ~i:(int_of_float_rounding RoundDown)
         args
     | "caml_simd_float64_round_pos_inf" | "caml_sse41_float64_round_pos_inf" ->
-      seq_or_avx_zeroed ~dbg Seq.roundsd vroundsd
+      seq_or_avx_with_merge ~dbg Seq.roundsd vroundsd
         ~i:(int_of_float_rounding RoundUp)
         args
     | "caml_simd_float64_round_towards_zero"
     | "caml_sse41_float64_round_towards_zero" ->
-      seq_or_avx_zeroed ~dbg Seq.roundsd vroundsd
+      seq_or_avx_with_merge ~dbg Seq.roundsd vroundsd
         ~i:(int_of_float_rounding RoundTruncate)
         args
     | "caml_sse41_float32_round" ->
       let i, args = extract_constant args ~max:15 op in
       check_float_rounding i;
-      seq_or_avx_zeroed ~dbg Seq.roundss vroundss ~i args
+      seq_or_avx_with_merge ~dbg Seq.roundss vroundss ~i args
     | "caml_simd_float32_round_current" | "caml_sse41_float32_round_current" ->
-      seq_or_avx_zeroed ~dbg Seq.roundss vroundss
+      seq_or_avx_with_merge ~dbg Seq.roundss vroundss
         ~i:(int_of_float_rounding RoundCurrent)
         args
     | "caml_simd_float32_round_neg_inf" | "caml_sse41_float32_round_neg_inf" ->
-      seq_or_avx_zeroed ~dbg Seq.roundss vroundss
+      seq_or_avx_with_merge ~dbg Seq.roundss vroundss
         ~i:(int_of_float_rounding RoundDown)
         args
     | "caml_simd_float32_round_pos_inf" | "caml_sse41_float32_round_pos_inf" ->
-      seq_or_avx_zeroed ~dbg Seq.roundss vroundss
+      seq_or_avx_with_merge ~dbg Seq.roundss vroundss
         ~i:(int_of_float_rounding RoundUp)
         args
     | "caml_simd_float32_round_towards_zero"
     | "caml_sse41_float32_round_towards_zero" ->
-      seq_or_avx_zeroed ~dbg Seq.roundss vroundss
+      seq_or_avx_with_merge ~dbg Seq.roundss vroundss
         ~i:(int_of_float_rounding RoundTruncate)
         args
     | "caml_sse41_int8x16_max" -> sse_or_avx pmaxsb vpmaxsb_X_X_Xm128 args

--- a/testsuite/tests/codegen/float_u.ml
+++ b/testsuite/tests/codegen/float_u.ml
@@ -56,12 +56,10 @@ abs:
   ret
 |}]
 
-(* CR ttebbi: This should be vsqrtsd %xmm0, %xmm0, %xmm0 *)
 let sqrt x = Float_u.sqrt x
 [%%expect_asm X86_64{|
 sqrt:
-  vxorpd %xmm1, %xmm1, %xmm1
-  vsqrtsd %xmm0, %xmm1, %xmm0
+  vsqrtsd %xmm0, %xmm0, %xmm0
   ret
 |}]
 


### PR DESCRIPTION
With AVX enabled, scalar sqrt/round are selected as the three-operand forms (e.g. vsqrtsd src2, src1, dst), whose first source operand only supplies the upper bits of the result. The selector was prepending a zero vec128 constant as that operand, which materialized as an extra vxorpd and consumed a register:

  vxorpd %xmm1, %xmm1, %xmm1
  vsqrtsd %xmm0, %xmm1, %xmm0

When the argument is a variable, use the source itself as the merge operand instead. This adds no dependency (the source is read anyway) and the upper bits of the result are irrelevant:

  vsqrtsd %xmm0, %xmm0, %xmm0

Non-variable arguments keep the zeroed fallback to avoid duplicating the evaluation of the argument expression. roundss/roundsd are selected through the same helper and benefit likewise.