### PR TITLE
Remove redundant sign/zero extensions (amd64 peephole)

### DIFF
--- a/backend/x86_peephole/x86_peephole_rules.ml
+++ b/backend/x86_peephole/x86_peephole_rules.ml
@@ -201,7 +201,11 @@ let remove_redundant_extension stats cell =
   | [cell1; cell2] -> (
     match DLL.value cell1, DLL.value cell2 with
     | Ins ins1, Ins ins2 -> (
-      match ins1, ins2 with
+      | Ins (MOVSX (src1, dst1)), Ins (MOVSX (src2, dst2))
+      | Ins (MOVSXD (src1, dst1)), Ins (MOVSXD (src2, dst2))
+      | Ins (MOVZX (src1, dst1)), Ins (MOVZX (src2, dst2))
+        when ... -> ...
+      | _, _ -> U.No_match
       | MOVSX (src1, dst1), MOVSX (src2, dst2)
       | MOVSXD (src1, dst1), MOVSXD (src2, dst2)
       | MOVZX (src1, dst1), MOVZX (src2, dst2)

--- a/backend/x86_peephole/x86_peephole_rules.ml
+++ b/backend/x86_peephole/x86_peephole_rules.ml
@@ -9,12 +9,14 @@ module U = X86_peephole_utils
 type peephole_stats =
   { mutable remove_mov_to_dead_register : int;
     mutable remove_redundant_cmp : int;
+    mutable remove_redundant_extension : int;
     mutable combine_add_rsp : int
   }
 
 let create_peephole_stats () =
   { remove_mov_to_dead_register = 0;
     remove_redundant_cmp = 0;
+    remove_redundant_extension = 0;
     combine_add_rsp = 0
   }
 
@@ -24,6 +26,8 @@ let peephole_stats_to_counters stats =
        stats.remove_mov_to_dead_register
   |> Profile.Counters.set "x86_peephole.remove_redundant_cmp"
        stats.remove_redundant_cmp
+  |> Profile.Counters.set "x86_peephole.remove_redundant_extension"
+       stats.remove_redundant_extension
   |> Profile.Counters.set "x86_peephole.combine_add_rsp" stats.combine_add_rsp
 
 (* Rewrite rule: combine adjacent ADD to RSP with CFI directives. Pattern: addq
@@ -179,6 +183,38 @@ let remove_redundant_cmp stats cell =
     | (Some _ | None), _ -> U.No_match)
   | _ -> U.No_match
 
+(* Rewrite rule: remove a sign/zero-extension instruction that immediately
+   follows an identical one. Pattern: ext src, dst; ext src, dst (where ext is
+   one of movsx/movsxd/movzx and src is a register). Rewrite: ext src, dst
+
+   The first instruction only writes [dst], and an extension writes the bits it
+   read, unchanged, into the low bits of [dst]. So even when [src] is a
+   subregister of [dst], the second instruction recomputes the same value. This
+   does not hold for a high-8-bit source such as %ah when [dst] overlaps it (the
+   extension moves those bits to the low byte), so such sources are excluded.
+   Extensions do not write flags. *)
+let is_low_part_register (arg : X86_ast.arg) =
+  match arg with Reg8L _ | Reg16 _ | Reg32 _ | Reg64 _ -> true | _ -> false
+
+let remove_redundant_extension stats cell =
+  match U.get_cells cell 2 with
+  | [cell1; cell2] -> (
+    match DLL.value cell1, DLL.value cell2 with
+    | Ins ins1, Ins ins2 -> (
+      match ins1, ins2 with
+      | MOVSX (src1, dst1), MOVSX (src2, dst2)
+      | MOVSXD (src1, dst1), MOVSXD (src2, dst2)
+      | MOVZX (src1, dst1), MOVZX (src2, dst2)
+        when equal_arg src1 src2 && equal_arg dst1 dst2
+             && is_low_part_register src1 ->
+        DLL.delete_curr cell2;
+        stats.remove_redundant_extension <- stats.remove_redundant_extension + 1;
+        (* Return cell1 so that a third identical extension is also removed *)
+        U.Matched (Some cell1)
+      | _, _ -> U.No_match)
+    | _, _ -> U.No_match)
+  | _ -> U.No_match
+
 (* Apply all rewrite rules in sequence using a pipeline. *)
 let apply stats cell =
   let[@inline always] if_no_match ~enabled f result =
@@ -193,6 +229,9 @@ let apply stats cell =
   |> if_no_match
        ~enabled:!Oxcaml_flags.x86_peephole_remove_redundant_cmp
        remove_redundant_cmp
+  |> if_no_match
+       ~enabled:!Oxcaml_flags.x86_peephole_remove_redundant_extension
+       remove_redundant_extension
   |> if_no_match
        ~enabled:!Oxcaml_flags.x86_peephole_combine_add_rsp
        combine_add_rsp

--- a/backend/x86_peephole/x86_peephole_rules.ml
+++ b/backend/x86_peephole/x86_peephole_rules.ml
@@ -200,22 +200,15 @@ let remove_redundant_extension stats cell =
   match U.get_cells cell 2 with
   | [cell1; cell2] -> (
     match DLL.value cell1, DLL.value cell2 with
-    | Ins ins1, Ins ins2 -> (
-      | Ins (MOVSX (src1, dst1)), Ins (MOVSX (src2, dst2))
-      | Ins (MOVSXD (src1, dst1)), Ins (MOVSXD (src2, dst2))
-      | Ins (MOVZX (src1, dst1)), Ins (MOVZX (src2, dst2))
-        when ... -> ...
-      | _, _ -> U.No_match
-      | MOVSX (src1, dst1), MOVSX (src2, dst2)
-      | MOVSXD (src1, dst1), MOVSXD (src2, dst2)
-      | MOVZX (src1, dst1), MOVZX (src2, dst2)
-        when equal_arg src1 src2 && equal_arg dst1 dst2
-             && is_low_part_register src1 ->
-        DLL.delete_curr cell2;
-        stats.remove_redundant_extension <- stats.remove_redundant_extension + 1;
-        (* Return cell1 so that a third identical extension is also removed *)
-        U.Matched (Some cell1)
-      | _, _ -> U.No_match)
+    | Ins (MOVSX (src1, dst1)), Ins (MOVSX (src2, dst2))
+    | Ins (MOVSXD (src1, dst1)), Ins (MOVSXD (src2, dst2))
+    | Ins (MOVZX (src1, dst1)), Ins (MOVZX (src2, dst2))
+      when equal_arg src1 src2 && equal_arg dst1 dst2
+           && is_low_part_register src1 ->
+      DLL.delete_curr cell2;
+      stats.remove_redundant_extension <- stats.remove_redundant_extension + 1;
+      (* Return cell1 so that a third identical extension is also removed *)
+      U.Matched (Some cell1)
     | _, _ -> U.No_match)
   | _ -> U.No_match
 

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -123,6 +123,11 @@ let mk_no_x86_peephole_remove_redundant_cmp f =
     Arg.Unit f,
     " Disable x86 peephole: remove redundant cmp" )
 
+let mk_no_x86_peephole_remove_redundant_extension f =
+  ( "-no-x86-peephole-remove-redundant-extension",
+    Arg.Unit f,
+    " Disable x86 peephole: remove redundant sign/zero extension" )
+
 let mk_no_x86_peephole_combine_add_rsp f =
   ( "-no-x86-peephole-combine-add-rsp",
     Arg.Unit f,
@@ -1330,6 +1335,7 @@ module type Oxcaml_options = sig
   val no_x86_peephole_optimize : unit -> unit
   val no_x86_peephole_remove_mov_to_dead_register : unit -> unit
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
+  val no_x86_peephole_remove_redundant_extension : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
@@ -1522,6 +1528,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
         F.no_x86_peephole_remove_mov_to_dead_register;
       mk_no_x86_peephole_remove_redundant_cmp
         F.no_x86_peephole_remove_redundant_cmp;
+      mk_no_x86_peephole_remove_redundant_extension
+        F.no_x86_peephole_remove_redundant_extension;
       mk_no_x86_peephole_combine_add_rsp F.no_x86_peephole_combine_add_rsp;
       mk_cfg_stack_checks F.cfg_stack_checks;
       mk_no_cfg_stack_checks F.no_cfg_stack_checks;
@@ -1864,6 +1872,9 @@ module Oxcaml_options_impl = struct
 
   let no_x86_peephole_remove_redundant_cmp =
     clear' Oxcaml_flags.x86_peephole_remove_redundant_cmp
+
+  let no_x86_peephole_remove_redundant_extension =
+    clear' Oxcaml_flags.x86_peephole_remove_redundant_extension
 
   let no_x86_peephole_combine_add_rsp =
     clear' Oxcaml_flags.x86_peephole_combine_add_rsp

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -47,6 +47,7 @@ module type Oxcaml_options = sig
   val no_x86_peephole_optimize : unit -> unit
   val no_x86_peephole_remove_mov_to_dead_register : unit -> unit
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
+  val no_x86_peephole_remove_redundant_extension : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -33,6 +33,7 @@ let cfg_peephole_optimize = ref true    (* -[no-]cfg-peephole-optimize *)
 let x86_peephole_optimize = ref false   (* -[no-]x86-peephole-optimize *)
 let x86_peephole_remove_mov_to_dead_register = ref true
 let x86_peephole_remove_redundant_cmp = ref true
+let x86_peephole_remove_redundant_extension = ref true
 let x86_peephole_combine_add_rsp = ref true
 
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -34,6 +34,7 @@ val cfg_peephole_optimize: bool ref
 val x86_peephole_optimize : bool ref
 val x86_peephole_remove_mov_to_dead_register : bool ref
 val x86_peephole_remove_redundant_cmp : bool ref
+val x86_peephole_remove_redundant_extension : bool ref
 val x86_peephole_combine_add_rsp : bool ref
 
 val cfg_stack_checks : bool ref

--- a/external/merlin/src/kernel/mconfig.ml
+++ b/external/merlin/src/kernel/mconfig.ml
@@ -594,6 +594,7 @@ let ocaml_ignored_flags =
     "-no-x86-peephole-optimize";
     "-no-x86-peephole-remove-mov-to-dead-register";
     "-no-x86-peephole-remove-redundant-cmp";
+    "-no-x86-peephole-remove-redundant-extension";
     "-no-x86-peephole-combine-add-rsp";
     "-verbose-types";
     "-no-verbose-types";

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -266,7 +266,6 @@ external memcmp :
   = "caml_no_bytecode_impl" "memcmp"
 [@@noalloc]
 
-(* CR ttebbi: Double sign extension instructions. *)
 let int32_box_unbox_after_call (a : ptr) (b : ptr) =
   Int32_u.of_int (Int32_u.to_int (memcmp a b ~len:#5n))
 [%%expect_asm X86_64{|
@@ -276,7 +275,6 @@ int32_box_unbox_after_call:
   movq  %rbx, %rsi
   movl  $5, %edx
   call  memcmp@PLT
-  movslq %eax, %rax
   movslq %eax, %rax
   addq  $8, %rsp
   ret


### PR DESCRIPTION
This pull request adds a simple peephole rule to delete
a `movsx`/`movsxd`/`movzx` instruction immediately following
an identical one.
