### PR TITLE
Fold Cconst_natint constants into immediate operands (CFG selection)

### DIFF
--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -290,7 +290,10 @@ let select_addressing chunk exp : addressing_mode * Cmm.expression =
 let select_store' ~is_assign addr (exp : Cmm.expression) :
     Cfg_selectgen_target_intf.select_store_result =
   match exp with
-  | Cconst_int (n, _dbg) when int_is_immediate n ->
+  (* The immediate of a store is never negated, so the full signed 32-bit range
+     applies (hence [is_immediate_natint] rather than [int_is_immediate], whose
+     range is symmetric). *)
+  | Cconst_int (n, _dbg) when is_immediate_natint (Nativeint.of_int n) ->
     Rewritten
       (Specific (Istore_int (Nativeint.of_int n, addr, is_assign)), Ctuple [])
   | Cconst_natint (n, _dbg) when is_immediate_natint n ->

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -160,17 +160,29 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
     | Is_immediate result -> result
     | Use_default -> is_immediate (Icomp cmp) n
 
+  (* Turn integer constants that fit in an OCaml integer into [Cconst_int], so
+     that the [Cconst_int] patterns below suffice to recognize all constants
+     that may be used as immediate arguments. *)
+  let normalize_int_constant (expr : Cmm.expression) : Cmm.expression =
+    match expr with
+    | Cconst_natint (n, dbg)
+      when Nativeint.equal (Nativeint.of_int (Nativeint.to_int n)) n ->
+      Cconst_int (Nativeint.to_int n, dbg)
+    | _ -> expr
+
   (* Instruction selection for conditionals *)
 
   let select_condition (arg : Cmm.expression) : Operation.test * Cmm.expression
       =
     match arg with
-    | Cop (Ccmpi cmp, [arg1; Cconst_int (n, _)], _) when is_immediate_test cmp n
-      ->
-      Iinttest_imm (cmp, n), arg1
-    | Cop (Ccmpi cmp, [Cconst_int (n, _); arg2], _)
-      when is_immediate_test (Cmm.swap_integer_comparison cmp) n ->
-      Iinttest_imm (Cmm.swap_integer_comparison cmp, n), arg2
+    | Cop (Ccmpi cmp, [arg1; arg2], _) -> (
+      match normalize_int_constant arg1, normalize_int_constant arg2 with
+      | arg1, Cconst_int (n, _) when is_immediate_test cmp n ->
+        Iinttest_imm (cmp, n), arg1
+      | Cconst_int (n, _), arg2
+        when is_immediate_test (Cmm.swap_integer_comparison cmp) n ->
+        Iinttest_imm (Cmm.swap_integer_comparison cmp, n), arg2
+      | arg1, arg2 -> Iinttest cmp, Ctuple [arg1; arg2])
     | Cop (Ccmpi cmp, args, _) -> Iinttest cmp, Ctuple args
     | Cop (Ccmpf (width, cmp), args, _) -> Ifloattest (width, cmp), Ctuple args
     | Cop (Cand, [arg1; Cconst_int (1, _)], _) -> Ioddtest, arg1
@@ -225,7 +237,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   let select_arith_comm (op : Operation.integer_operation)
       (args : Cmm.expression list) :
       Cfg.basic_or_terminator * Cmm.expression list =
-    match args with
+    match List.map normalize_int_constant args with
     | [arg; Cconst_int (n, _)] when is_immediate op n ->
       SU.basic_op (Intop_imm (op, n)), [arg]
     | [Cconst_int (n, _); arg] when is_immediate op n ->
@@ -235,7 +247,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   let select_arith (op : Operation.integer_operation)
       (args : Cmm.expression list) :
       Cfg.basic_or_terminator * Cmm.expression list =
-    match args with
+    match List.map normalize_int_constant args with
     | [arg; Cconst_int (n, _)] when is_immediate op n ->
       SU.basic_op (Intop_imm (op, n)), [arg]
     | _ -> SU.basic_op (Intop op), args
@@ -243,7 +255,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
   let select_arith_comp (cmp : Operation.integer_comparison)
       (args : Cmm.expression list) :
       Cfg.basic_or_terminator * Cmm.expression list =
-    match args with
+    match List.map normalize_int_constant args with
     | [arg; Cconst_int (n, _)] when is_immediate (Operation.Icomp cmp) n ->
       SU.basic_op (Intop_imm (Icomp cmp, n)), [arg]
     | [Cconst_int (n, _); arg]

--- a/oxcaml/tests/backend/llvmize/int_ops_ir.output
+++ b/oxcaml/tests/backend/llvmize/int_ops_ir.output
@@ -943,58 +943,55 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlInt_ops__mod_imm_HIDE_STAMP(i64 
   %14 = alloca i64
   %15 = alloca i64
   %16 = alloca i64
-  %17 = alloca i64
   br label %L1
 L1:
   br label %L262
 L262:
-  %18 = load i64, ptr %4
-  store i64 %18, ptr %5
-  %19 = ptrtoint ptr @camlInt_ops_data to i64
-  store i64 %19, ptr %6
-  %20 = load i64, ptr %6
-  %21 = inttoptr i64 %20 to ptr
-  %22 = load ptr addrspace(1), ptr %21
-  store ptr addrspace(1) %22, ptr %7
-  %23 = load i64, ptr %7
-  %24 = ashr i64 %23, 1
-  store i64 %24, ptr %8
-  %25 = load i64, ptr %8
-  store i64 %25, ptr %9
-  store i64 -4, ptr %10
-  %26 = load i64, ptr %9
-  %27 = ashr i64 %26, 1
-  store i64 %27, ptr %11
-  %28 = load i64, ptr %11
-  %29 = lshr i64 %28, 62
-  store i64 %29, ptr %12
-  %30 = load i64, ptr %9
-  %31 = load i64, ptr %12
-  %32 = add i64 %30, %31
-  store i64 %32, ptr %13
-  %33 = load i64, ptr %13
-  %34 = load i64, ptr %10
-  %35 = and i64 %33, %34
-  store i64 %35, ptr %14
-  %36 = load i64, ptr %9
+  %17 = load i64, ptr %4
+  store i64 %17, ptr %5
+  %18 = ptrtoint ptr @camlInt_ops_data to i64
+  store i64 %18, ptr %6
+  %19 = load i64, ptr %6
+  %20 = inttoptr i64 %19 to ptr
+  %21 = load ptr addrspace(1), ptr %20
+  store ptr addrspace(1) %21, ptr %7
+  %22 = load i64, ptr %7
+  %23 = ashr i64 %22, 1
+  store i64 %23, ptr %8
+  %24 = load i64, ptr %8
+  store i64 %24, ptr %9
+  %25 = load i64, ptr %9
+  %26 = ashr i64 %25, 1
+  store i64 %26, ptr %10
+  %27 = load i64, ptr %10
+  %28 = lshr i64 %27, 62
+  store i64 %28, ptr %11
+  %29 = load i64, ptr %9
+  %30 = load i64, ptr %11
+  %31 = add i64 %29, %30
+  store i64 %31, ptr %12
+  %32 = load i64, ptr %12
+  %33 = and i64 %32, -4
+  store i64 %33, ptr %13
+  %34 = load i64, ptr %9
+  %35 = load i64, ptr %13
+  %36 = sub i64 %34, %35
+  store i64 %36, ptr %14
   %37 = load i64, ptr %14
-  %38 = sub i64 %36, %37
+  %38 = shl i64 %37, 1
   store i64 %38, ptr %15
   %39 = load i64, ptr %15
-  %40 = shl i64 %39, 1
+  %40 = add i64 %39, 1
   store i64 %40, ptr %16
   %41 = load i64, ptr %16
-  %42 = add i64 %41, 1
-  store i64 %42, ptr %17
-  %43 = load i64, ptr %17
-  store i64 %43, ptr %4
-  %44 = load i64, ptr %4
-  %45 = load i64, ptr %ds
-  %46 = load i64, ptr %alloc
-  %47 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %45, 0, 0
-  %48 = insertvalue { { i64, i64 }, { i64 } } %47, i64 %46, 0, 1
-  %49 = insertvalue { { i64, i64 }, { i64 } } %48, i64 %44, 1, 0
-  ret { { i64, i64 }, { i64 } } %49
+  store i64 %41, ptr %4
+  %42 = load i64, ptr %4
+  %43 = load i64, ptr %ds
+  %44 = load i64, ptr %alloc
+  %45 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %43, 0, 0
+  %46 = insertvalue { { i64, i64 }, { i64 } } %45, i64 %44, 0, 1
+  %47 = insertvalue { { i64, i64 }, { i64 } } %46, i64 %42, 1, 0
+  ret { { i64, i64 }, { i64 } } %47
 }
 
 define  oxcamlcc { { i64, i64 }, { i64 } } @camlInt_ops__land_imm_HIDE_STAMP(i64 %0, i64 %1, i64 %2) gc "oxcaml" {

--- a/oxcaml/tests/backend/llvmize/tailcall_ir.output
+++ b/oxcaml/tests/backend/llvmize/tailcall_ir.output
@@ -132,90 +132,87 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__collatz_odd_HIDE_STAMP
   %16 = alloca i64
   %17 = alloca i64
   %18 = alloca i64
-  %19 = alloca i64
   br label %L1
 L1:
   br label %L125
 L125:
-  %20 = load i64, ptr %5
-  store i64 %20, ptr %7
-  %21 = load i64, ptr %6
-  store i64 %21, ptr %8
-  %22 = load i64, ptr %7
-  %23 = icmp slt i64 %22, 3
-  br i1 %23, label %L129, label %L148
+  %19 = load i64, ptr %5
+  store i64 %19, ptr %7
+  %20 = load i64, ptr %6
+  store i64 %20, ptr %8
+  %21 = load i64, ptr %7
+  %22 = icmp slt i64 %21, 3
+  br i1 %22, label %L129, label %L148
 L148:
-  %24 = load i64, ptr %7
-  %25 = icmp sgt i64 %24, 3
-  br i1 %25, label %L129, label %L127
+  %23 = load i64, ptr %7
+  %24 = icmp sgt i64 %23, 3
+  br i1 %24, label %L129, label %L127
 L127:
-  %26 = load i64, ptr %8
-  store i64 %26, ptr %5
-  %27 = load i64, ptr %5
-  %28 = load i64, ptr %ds
-  %29 = load i64, ptr %alloc
-  %30 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %28, 0, 0
-  %31 = insertvalue { { i64, i64 }, { i64 } } %30, i64 %29, 0, 1
-  %32 = insertvalue { { i64, i64 }, { i64 } } %31, i64 %27, 1, 0
-  ret { { i64, i64 }, { i64 } } %32
+  %25 = load i64, ptr %8
+  store i64 %25, ptr %5
+  %26 = load i64, ptr %5
+  %27 = load i64, ptr %ds
+  %28 = load i64, ptr %alloc
+  %29 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %27, 0, 0
+  %30 = insertvalue { { i64, i64 }, { i64 } } %29, i64 %28, 0, 1
+  %31 = insertvalue { { i64, i64 }, { i64 } } %30, i64 %26, 1, 0
+  ret { { i64, i64 }, { i64 } } %31
 L129:
-  %33 = load i64, ptr %7
-  %34 = ashr i64 %33, 1
-  store i64 %34, ptr %9
-  %35 = load i64, ptr %9
-  store i64 %35, ptr %10
-  store i64 -2, ptr %11
-  %36 = load i64, ptr %10
-  %37 = lshr i64 %36, 63
-  store i64 %37, ptr %12
-  %38 = load i64, ptr %10
-  %39 = load i64, ptr %12
-  %40 = add i64 %38, %39
-  store i64 %40, ptr %13
-  %41 = load i64, ptr %13
-  %42 = load i64, ptr %11
-  %43 = and i64 %41, %42
-  store i64 %43, ptr %14
-  %44 = load i64, ptr %10
+  %32 = load i64, ptr %7
+  %33 = ashr i64 %32, 1
+  store i64 %33, ptr %9
+  %34 = load i64, ptr %9
+  store i64 %34, ptr %10
+  %35 = load i64, ptr %10
+  %36 = lshr i64 %35, 63
+  store i64 %36, ptr %11
+  %37 = load i64, ptr %10
+  %38 = load i64, ptr %11
+  %39 = add i64 %37, %38
+  store i64 %39, ptr %12
+  %40 = load i64, ptr %12
+  %41 = and i64 %40, -2
+  store i64 %41, ptr %13
+  %42 = load i64, ptr %10
+  %43 = load i64, ptr %13
+  %44 = sub i64 %42, %43
+  store i64 %44, ptr %14
   %45 = load i64, ptr %14
-  %46 = sub i64 %44, %45
+  %46 = shl i64 %45, 1
   store i64 %46, ptr %15
   %47 = load i64, ptr %15
-  %48 = shl i64 %47, 1
+  %48 = add i64 %47, 1
   store i64 %48, ptr %16
   %49 = load i64, ptr %16
-  %50 = add i64 %49, 1
-  store i64 %50, ptr %17
-  %51 = load i64, ptr %17
-  %52 = icmp slt i64 %51, 3
-  br i1 %52, label %L143, label %L149
+  %50 = icmp slt i64 %49, 3
+  br i1 %50, label %L143, label %L149
 L149:
-  %53 = load i64, ptr %17
-  %54 = icmp sgt i64 %53, 3
-  br i1 %54, label %L143, label %L138
+  %51 = load i64, ptr %16
+  %52 = icmp sgt i64 %51, 3
+  br i1 %52, label %L143, label %L138
 L138:
-  %55 = load i64, ptr %8
-  %56 = add i64 %55, 2
+  %53 = load i64, ptr %8
+  %54 = add i64 %53, 2
+  store i64 %54, ptr %17
+  %55 = load i64, ptr %7
+  %56 = mul i64 %55, 3
   store i64 %56, ptr %18
-  %57 = load i64, ptr %7
-  %58 = mul i64 %57, 3
-  store i64 %58, ptr %19
-  %59 = load i64, ptr %19
-  store i64 %59, ptr %5
-  %60 = load i64, ptr %18
-  store i64 %60, ptr %6
+  %57 = load i64, ptr %18
+  store i64 %57, ptr %5
+  %58 = load i64, ptr %17
+  store i64 %58, ptr %6
   br label %L125
 L143:
-  %61 = load i64, ptr %7
-  store i64 %61, ptr %5
-  %62 = load i64, ptr %8
-  store i64 %62, ptr %6
-  %63 = load i64, ptr %5
-  %64 = load i64, ptr %6
-  %65 = load i64, ptr %ds
-  %66 = load i64, ptr %alloc
-  %67 = musttail call oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__collatz_even_HIDE_STAMP(i64 %65, i64 %66, i64 %63, i64 %64) "statepoint-id"="0"
-  ret { { i64, i64 }, { i64 } } %67
+  %59 = load i64, ptr %7
+  store i64 %59, ptr %5
+  %60 = load i64, ptr %8
+  store i64 %60, ptr %6
+  %61 = load i64, ptr %5
+  %62 = load i64, ptr %6
+  %63 = load i64, ptr %ds
+  %64 = load i64, ptr %alloc
+  %65 = musttail call oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__collatz_even_HIDE_STAMP(i64 %63, i64 %64, i64 %61, i64 %62) "statepoint-id"="0"
+  ret { { i64, i64 }, { i64 } } %65
 }
 
 define  oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__collatz_even_HIDE_STAMP(i64 %0, i64 %1, i64 %2, i64 %3) gc "oxcaml" {
@@ -245,108 +242,105 @@ define  oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__collatz_even_HIDE_STAM
   %22 = alloca i64
   %23 = alloca i64
   %24 = alloca i64
-  %25 = alloca i64
   br label %L1
 L1:
   br label %L151
 L151:
-  %26 = load i64, ptr %5
-  store i64 %26, ptr %7
-  %27 = load i64, ptr %6
-  store i64 %27, ptr %8
-  %28 = load i64, ptr %7
-  %29 = icmp slt i64 %28, 3
-  br i1 %29, label %L155, label %L179
+  %25 = load i64, ptr %5
+  store i64 %25, ptr %7
+  %26 = load i64, ptr %6
+  store i64 %26, ptr %8
+  %27 = load i64, ptr %7
+  %28 = icmp slt i64 %27, 3
+  br i1 %28, label %L155, label %L179
 L179:
-  %30 = load i64, ptr %7
-  %31 = icmp sgt i64 %30, 3
-  br i1 %31, label %L155, label %L153
+  %29 = load i64, ptr %7
+  %30 = icmp sgt i64 %29, 3
+  br i1 %30, label %L155, label %L153
 L153:
-  %32 = load i64, ptr %8
-  store i64 %32, ptr %5
-  %33 = load i64, ptr %5
-  %34 = load i64, ptr %ds
-  %35 = load i64, ptr %alloc
-  %36 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %34, 0, 0
-  %37 = insertvalue { { i64, i64 }, { i64 } } %36, i64 %35, 0, 1
-  %38 = insertvalue { { i64, i64 }, { i64 } } %37, i64 %33, 1, 0
-  ret { { i64, i64 }, { i64 } } %38
+  %31 = load i64, ptr %8
+  store i64 %31, ptr %5
+  %32 = load i64, ptr %5
+  %33 = load i64, ptr %ds
+  %34 = load i64, ptr %alloc
+  %35 = insertvalue { { i64, i64 }, { i64 } } poison, i64 %33, 0, 0
+  %36 = insertvalue { { i64, i64 }, { i64 } } %35, i64 %34, 0, 1
+  %37 = insertvalue { { i64, i64 }, { i64 } } %36, i64 %32, 1, 0
+  ret { { i64, i64 }, { i64 } } %37
 L155:
-  %39 = load i64, ptr %7
-  %40 = ashr i64 %39, 1
-  store i64 %40, ptr %9
-  %41 = load i64, ptr %9
-  store i64 %41, ptr %10
-  store i64 -2, ptr %11
-  %42 = load i64, ptr %10
-  %43 = lshr i64 %42, 63
-  store i64 %43, ptr %12
-  %44 = load i64, ptr %10
-  %45 = load i64, ptr %12
-  %46 = add i64 %44, %45
-  store i64 %46, ptr %13
-  %47 = load i64, ptr %13
-  %48 = load i64, ptr %11
-  %49 = and i64 %47, %48
-  store i64 %49, ptr %14
-  %50 = load i64, ptr %10
+  %38 = load i64, ptr %7
+  %39 = ashr i64 %38, 1
+  store i64 %39, ptr %9
+  %40 = load i64, ptr %9
+  store i64 %40, ptr %10
+  %41 = load i64, ptr %10
+  %42 = lshr i64 %41, 63
+  store i64 %42, ptr %11
+  %43 = load i64, ptr %10
+  %44 = load i64, ptr %11
+  %45 = add i64 %43, %44
+  store i64 %45, ptr %12
+  %46 = load i64, ptr %12
+  %47 = and i64 %46, -2
+  store i64 %47, ptr %13
+  %48 = load i64, ptr %10
+  %49 = load i64, ptr %13
+  %50 = sub i64 %48, %49
+  store i64 %50, ptr %14
   %51 = load i64, ptr %14
-  %52 = sub i64 %50, %51
+  %52 = shl i64 %51, 1
   store i64 %52, ptr %15
   %53 = load i64, ptr %15
-  %54 = shl i64 %53, 1
+  %54 = add i64 %53, 1
   store i64 %54, ptr %16
   %55 = load i64, ptr %16
-  %56 = add i64 %55, 1
-  store i64 %56, ptr %17
-  %57 = load i64, ptr %17
-  %58 = icmp slt i64 %57, 1
-  br i1 %58, label %L174, label %L180
+  %56 = icmp slt i64 %55, 1
+  br i1 %56, label %L174, label %L180
 L180:
-  %59 = load i64, ptr %17
-  %60 = icmp sgt i64 %59, 1
-  br i1 %60, label %L174, label %L164
+  %57 = load i64, ptr %16
+  %58 = icmp sgt i64 %57, 1
+  br i1 %58, label %L174, label %L164
 L164:
-  %61 = load i64, ptr %8
-  %62 = add i64 %61, 2
+  %59 = load i64, ptr %8
+  %60 = add i64 %59, 2
+  store i64 %60, ptr %17
+  %61 = load i64, ptr %7
+  %62 = ashr i64 %61, 1
   store i64 %62, ptr %18
-  %63 = load i64, ptr %7
-  %64 = ashr i64 %63, 1
-  store i64 %64, ptr %19
-  %65 = load i64, ptr %19
+  %63 = load i64, ptr %18
+  store i64 %63, ptr %19
+  %64 = load i64, ptr %19
+  %65 = lshr i64 %64, 63
   store i64 %65, ptr %20
-  %66 = load i64, ptr %20
-  %67 = lshr i64 %66, 63
-  store i64 %67, ptr %21
-  %68 = load i64, ptr %20
+  %66 = load i64, ptr %19
+  %67 = load i64, ptr %20
+  %68 = add i64 %66, %67
+  store i64 %68, ptr %21
   %69 = load i64, ptr %21
-  %70 = add i64 %68, %69
+  %70 = ashr i64 %69, 1
   store i64 %70, ptr %22
   %71 = load i64, ptr %22
-  %72 = ashr i64 %71, 1
+  %72 = shl i64 %71, 1
   store i64 %72, ptr %23
   %73 = load i64, ptr %23
-  %74 = shl i64 %73, 1
+  %74 = add i64 %73, 1
   store i64 %74, ptr %24
   %75 = load i64, ptr %24
-  %76 = add i64 %75, 1
-  store i64 %76, ptr %25
-  %77 = load i64, ptr %25
-  store i64 %77, ptr %5
-  %78 = load i64, ptr %18
-  store i64 %78, ptr %6
+  store i64 %75, ptr %5
+  %76 = load i64, ptr %17
+  store i64 %76, ptr %6
   br label %L151
 L174:
-  %79 = load i64, ptr %7
-  store i64 %79, ptr %5
-  %80 = load i64, ptr %8
-  store i64 %80, ptr %6
-  %81 = load i64, ptr %5
-  %82 = load i64, ptr %6
-  %83 = load i64, ptr %ds
-  %84 = load i64, ptr %alloc
-  %85 = musttail call oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__collatz_odd_HIDE_STAMP(i64 %83, i64 %84, i64 %81, i64 %82) "statepoint-id"="0"
-  ret { { i64, i64 }, { i64 } } %85
+  %77 = load i64, ptr %7
+  store i64 %77, ptr %5
+  %78 = load i64, ptr %8
+  store i64 %78, ptr %6
+  %79 = load i64, ptr %5
+  %80 = load i64, ptr %6
+  %81 = load i64, ptr %ds
+  %82 = load i64, ptr %alloc
+  %83 = musttail call oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__collatz_odd_HIDE_STAMP(i64 %81, i64 %82, i64 %79, i64 %80) "statepoint-id"="0"
+  ret { { i64, i64 }, { i64 } } %83
 }
 
 define  oxcamlcc { { i64, i64 }, { i64 } } @camlTailcall__tail_call_outside_HIDE_STAMP(i64 %0, i64 %1, i64 %2, ptr addrspace(1) %3) gc "oxcaml" {

--- a/testsuite/tests/codegen/fields.ml
+++ b/testsuite/tests/codegen/fields.ml
@@ -230,3 +230,23 @@ set_mut_unboxed:
   movl  $1, %eax
   ret
 |}]
+
+(* The immediate of a store is never negated, so the full signed 32-bit range
+   applies: -0x8000_0000 is stored directly, while -0x8000_0001 must be
+   materialized in a register first. *)
+let set_mut_unboxed_min_int32 (r : mutable_unboxed) = r.p <- -#0x80000000L
+[%%expect_asm X86_64{|
+set_mut_unboxed_min_int32:
+  movq  $-2147483648, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]
+
+let set_mut_unboxed_below_min_int32 (r : mutable_unboxed) = r.p <- -#0x80000001L
+[%%expect_asm X86_64{|
+set_mut_unboxed_below_min_int32:
+  movabsq $-2147483649, %rbx
+  movq  %rbx, 8(%rax)
+  movl  $1, %eax
+  ret
+|}]

--- a/testsuite/tests/codegen/int.ml
+++ b/testsuite/tests/codegen/int.ml
@@ -133,11 +133,10 @@ let rem_2 x = x mod 2
 [%%expect_asm X86_64{|
 rem_2:
   sarq  $1, %rax
-  movq  $-2, %rdi
   movq  %rax, %rbx
   shrq  $63, %rbx
   addq  %rax, %rbx
-  andq  %rdi, %rbx
+  andq  $-2, %rbx
   subq  %rbx, %rax
   leaq  1(%rax,%rax), %rax
   ret
@@ -149,12 +148,11 @@ let is_divisible_by_128 x = (x mod 128) = 0
 [%%expect_asm X86_64{|
 is_divisible_by_128:
   sarq  $1, %rax
-  movq  $-128, %rdi
   movq  %rax, %rbx
   sarq  $6, %rbx
   shrq  $57, %rbx
   addq  %rax, %rbx
-  andq  %rdi, %rbx
+  andq  $-128, %rbx
   subq  %rbx, %rax
   leaq  1(%rax,%rax), %rax
   cmpq  $1, %rax
@@ -368,12 +366,11 @@ collatz:
   addq  $2, %rax
   movq  %rbx, %rdi
   sarq  $1, %rdi
-  movq  $-2, %rcx
   movq  %rdi, %rsi
   shrq  $63, %rsi
   leaq  (%rdi,%rsi), %rdx
   movq  %rdx, %rsi
-  andq  %rcx, %rsi
+  andq  $-2, %rsi
   subq  %rsi, %rdi
   leaq  1(%rdi,%rdi), %rdi
   cmpq  $1, %rdi

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -242,12 +242,10 @@ unsigned_rem_7:
   ret
 |}]
 
-(* CR ttebbi: Could instead start with [cmpq $-1, %rax] *)
 let unsigned_div_umaxint x = Int64_u.unsigned_div x (-#1L)
 [%%expect_asm X86_64{|
 unsigned_div_umaxint:
-  movq  $-1, %rbx
-  cmpq  %rbx, %rax
+  cmpq  $-1, %rax
   jne   .L0
   movl  $1, %eax
   ret
@@ -259,8 +257,7 @@ unsigned_div_umaxint:
 let unsigned_rem_umaxint x = Int64_u.unsigned_rem x (-#1L)
 [%%expect_asm X86_64{|
 unsigned_rem_umaxint:
-  movq  $-1, %rbx
-  cmpq  %rbx, %rax
+  cmpq  $-1, %rax
   jne   .L0
   xorl  %eax, %eax
   ret

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -623,8 +623,7 @@ popcount:
 let ctz x = Int8_u.ctz x
 [%%expect_asm X86_64{|
 ctz:
-  movl  $256, %ebx
-  orq   %rbx, %rax
+  orq   $256, %rax
   tzcnt %rax, %rax
   salq  $56, %rax
   sarq  $56, %rax


### PR DESCRIPTION
As per title; we currently match only `Cconst_int`
in some selection patterns, but should also match
`Cconst_natint`.