### PR TITLE
speculative inlining: fix bug where the code size of non-lifted closures was counted twice

### DIFF
--- a/middle_end/flambda2/simplify/rebuilt_static_const.ml
+++ b/middle_end/flambda2/simplify/rebuilt_static_const.ml
@@ -18,8 +18,9 @@ open! Flambda
 module ART = Are_rebuilding_terms
 module SC = Static_const
 
-(* The cost metrics for sets of closures do *not* include the code size of their
-   code_ids, as it will be counted in the lifted [Code] as well. *)
+(* The cost metrics for sets of closures include the code size of their
+   code_ids, like for non-lifted sets of closures. To avoid double counting, the
+   cost metrics of [Code] bindings are zero. *)
 type t =
   | Normal of
       { const : Static_const_or_code.t;
@@ -62,7 +63,7 @@ let cost_metrics t =
   | Block_not_rebuilt { cost_metrics; _ }
   | Set_of_closures_not_rebuilt { cost_metrics; _ } ->
     cost_metrics
-  | Code_not_rebuilt code -> Non_constructed_code.cost_metrics code
+  | Code_not_rebuilt _ -> Cost_metrics.zero
 
 let create_normal_non_code ~cost_metrics const =
   Normal
@@ -92,7 +93,7 @@ let create_code are_rebuilding ~params_and_body ~free_names_of_params_and_body =
         ( Normal
             { const = Static_const_or_code.create_code code;
               free_names = Code.free_names code;
-              cost_metrics = Code_metadata.cost_metrics code_metadata
+              cost_metrics = Cost_metrics.zero
             },
           Some code ))
 
@@ -100,8 +101,16 @@ let create_code' code =
   Normal
     { const = Static_const_or_code.create_code code;
       free_names = Code.free_names code;
-      cost_metrics = Code.cost_metrics code
+      cost_metrics = Cost_metrics.zero
     }
+
+let find_code_characteristics find_code_metadata code_id :
+    Cost_metrics.code_characteristics =
+  let code_metadata = find_code_metadata code_id in
+  { cost_metrics = Code_metadata.cost_metrics code_metadata;
+    params_arity =
+      Flambda_arity.num_params (Code_metadata.params_arity code_metadata)
+  }
 
 let create_set_of_closures are_rebuilding ~find_code_metadata set =
   let set =
@@ -112,12 +121,7 @@ let create_set_of_closures are_rebuilding ~find_code_metadata set =
   let free_names = Set_of_closures.free_names set in
   let cost_metrics =
     Cost_metrics.set_of_closures
-      ~find_code_characteristics:(fun code_id ->
-        { cost_metrics = Cost_metrics.zero;
-          params_arity =
-            Flambda_arity.num_params
-              (Code_metadata.params_arity (find_code_metadata code_id))
-        })
+      ~find_code_characteristics:(find_code_characteristics find_code_metadata)
       set
   in
   if ART.do_not_rebuild_terms are_rebuilding
@@ -335,12 +339,8 @@ let map_set_of_closures t ~find_code_metadata ~f =
         let set_of_closures = f set_of_closures in
         let cost_metrics =
           Cost_metrics.set_of_closures
-            ~find_code_characteristics:(fun code_id ->
-              { cost_metrics = Cost_metrics.zero;
-                params_arity =
-                  Flambda_arity.num_params
-                    (Code_metadata.params_arity (find_code_metadata code_id))
-              })
+            ~find_code_characteristics:
+              (find_code_characteristics find_code_metadata)
             set_of_closures
         in
         Normal

--- a/testsuite/tests/flambda2/speculative_inlining_set_of_closures.ml
+++ b/testsuite/tests/flambda2/speculative_inlining_set_of_closures.ml
@@ -1,0 +1,41 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+
+   ocamlopt_flags += " -flambda2-inline-small-function-size 0";
+   ocamlopt_flags += " -flambda2-inline-threshold 60";
+   ocamlopt_flags += " -flambda2-speculative-inlining-track-lifted-constants";
+   ocamlopt_flags += " -no-flambda2-speculative-inlining-only-if-arguments-useful";
+
+   setup-ocamlopt.byte-build-env;
+   ocamlopt.byte with dump-simplify;
+   check-fexpr-dump;
+ *)
+
+[@@@ocaml.flambda_o3]
+
+(* We used to have a bug where the code size of a set of closures was counted
+   twice by speculative inlining when the set could not be lifted: once as part
+   of the cost of the set of closures itself, and once via the (lifted) code
+   bindings, which were tracked as lifted constants.  Sets of closures that
+   could be lifted were only counted once, as the cost metrics of lifted sets
+   of closures did not include the size of the code.
+
+   Both calls to [g] below should be inlined: the
+   cost of inlining either of them is around 50 (mostly the code size of [f],
+   which is 36), which is below the threshold of 60.  With the
+   double-counting bug, the speculative cost of inlining [g] in [r2] was
+   around 86, so the call in [r2] was not inlined, unlike the one in [r1]. *)
+
+let[@inline never] use f = f () + f ()
+
+let g x =
+  let f () =
+    let y = Sys.opaque_identity x in
+    (y * 2) + (y * 4) + (y * 6) + (y * 8) + (y * 10) + (y * 12)
+  in
+  use f
+
+let r1 () = g 1
+
+let r2 () = g (Sys.opaque_identity 1)

--- a/testsuite/tests/flambda2/speculative_inlining_set_of_closures.simplify.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_set_of_closures.simplify.reference
@@ -1,0 +1,132 @@
+let code use_0 deleted in
+let code f_2 deleted in
+let code g_1 deleted in
+let code r1_3 deleted in
+let code r2_4 deleted in
+let code inline(never) loopify(never) size(15) newer_version_of(use_0)
+      use_0_1 (f : val)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  apply &my_alloc_region f (0) -> k2 * k1
+    where k2 (apply_result : imm tagged) =
+      (apply &my_alloc_region f (0) -> k2 * k1
+         where k2 (apply_result_1 : imm tagged) =
+           let int_add = %int_barith.add (apply_result_1, apply_result) in
+           cont k (int_add))
+in
+let $camlSpeculative_inlining_set_of_closures__use_5 =
+  closure use_0_1 @use &toplevel.alloc_region
+in
+let code loopify(never) size(36) newer_version_of(f_2)
+      f_2_1 (param : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let x = %project_value_slot.[f].[x] (my_closure) in
+  let y = %opaque (x) in
+  let int_mul = %int_barith.mul (y, 12) in
+  let int_mul_1 = %int_barith.mul (y, 10) in
+  let int_mul_2 = %int_barith.mul (y, 8) in
+  let int_mul_3 = %int_barith.mul (y, 6) in
+  let int_mul_4 = %int_barith.mul (y, 4) in
+  let int_mul_5 = %int_barith.mul (y, 2) in
+  let int_add = %int_barith.add (int_mul_5, int_mul_4) in
+  let int_add_1 = %int_barith.add (int_add, int_mul_3) in
+  let int_add_2 = %int_barith.add (int_add_1, int_mul_2) in
+  let int_add_3 = %int_barith.add (int_add_2, int_mul_1) in
+  let int_add_4 = %int_barith.add (int_add_3, int_mul) in
+  cont k (int_add_4)
+in
+let code loopify(never) size(48) newer_version_of(g_1)
+      g_1_1 (x : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let f = closure f_2_1 @f &my_alloc_region with { x = x } in
+  apply direct(use_0_1 &my_alloc_region)
+    ($camlSpeculative_inlining_set_of_closures__use_5 : _ -> imm tagged)
+      (f)
+      -> k * k1
+in
+let $camlSpeculative_inlining_set_of_closures__g_6 =
+  closure g_1_1 @g &toplevel.alloc_region
+in
+let code loopify(never) size(35) newer_version_of(f_2_1)
+      f_2_2 (param : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let y = %opaque (1) in
+  let int_mul = %int_barith.mul (y, 12) in
+  let int_mul_1 = %int_barith.mul (y, 10) in
+  let int_mul_2 = %int_barith.mul (y, 8) in
+  let int_mul_3 = %int_barith.mul (y, 6) in
+  let int_mul_4 = %int_barith.mul (y, 4) in
+  let int_mul_5 = %int_barith.mul (y, 2) in
+  let int_add = %int_barith.add (int_mul_5, int_mul_4) in
+  let int_add_1 = %int_barith.add (int_add, int_mul_3) in
+  let int_add_2 = %int_barith.add (int_add_1, int_mul_2) in
+  let int_add_3 = %int_barith.add (int_add_2, int_mul_1) in
+  let int_add_4 = %int_barith.add (int_add_3, int_mul) in
+  cont k (int_add_4)
+in
+let $camlSpeculative_inlining_set_of_closures__f_9 =
+  closure f_2_2 @f &toplevel.alloc_region
+  with { x = 1 }
+in
+let code loopify(never) size(4) newer_version_of(r1_3)
+      r1_3_1 (param : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  apply direct(use_0_1 &my_alloc_region) inlining_state(depth(10))
+    ($camlSpeculative_inlining_set_of_closures__use_5 : _ -> imm tagged)
+      ($camlSpeculative_inlining_set_of_closures__f_9)
+      -> k * k1
+in
+let $camlSpeculative_inlining_set_of_closures__r1_7 =
+  closure r1_3_1 @r1 &toplevel.alloc_region
+in
+let code loopify(never) size(36) newer_version_of(f_2_1)
+      f_2_3 (param : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let x = %project_value_slot.[f].[x] (my_closure) in
+  let y = %opaque (x) in
+  let int_mul = %int_barith.mul (y, 12) in
+  let int_mul_1 = %int_barith.mul (y, 10) in
+  let int_mul_2 = %int_barith.mul (y, 8) in
+  let int_mul_3 = %int_barith.mul (y, 6) in
+  let int_mul_4 = %int_barith.mul (y, 4) in
+  let int_mul_5 = %int_barith.mul (y, 2) in
+  let int_add = %int_barith.add (int_mul_5, int_mul_4) in
+  let int_add_1 = %int_barith.add (int_add, int_mul_3) in
+  let int_add_2 = %int_barith.add (int_add_1, int_mul_2) in
+  let int_add_3 = %int_barith.add (int_add_2, int_mul_1) in
+  let int_add_4 = %int_barith.add (int_add_3, int_mul) in
+  cont k (int_add_4)
+in
+let code loopify(never) size(48) newer_version_of(r2_4)
+      r2_4_1 (param : imm tagged)
+        my_closure &my_alloc_region my_depth
+        -> k * k1
+        : imm tagged =
+  let Popaque = %opaque (1) in
+  let f = closure f_2_3 @f &my_alloc_region with { x = Popaque } in
+  apply direct(use_0_1 &my_alloc_region) inlining_state(depth(10))
+    ($camlSpeculative_inlining_set_of_closures__use_5 : _ -> imm tagged)
+      (f)
+      -> k * k1
+in
+let $camlSpeculative_inlining_set_of_closures__r2_10 =
+  closure r2_4_1 @r2 &toplevel.alloc_region
+in
+let $camlSpeculative_inlining_set_of_closures =
+  Block 0 ($camlSpeculative_inlining_set_of_closures__use_5,
+           $camlSpeculative_inlining_set_of_closures__g_6,
+           $camlSpeculative_inlining_set_of_closures__r1_7,
+           $camlSpeculative_inlining_set_of_closures__r2_10)
+in
+cont done ($camlSpeculative_inlining_set_of_closures)


### PR DESCRIPTION
As discussed, instead of #6666.