### PR TITLE
Remove runtime 5 markers

### DIFF
--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -23,7 +23,6 @@
    perf_demangled_symbols
    stack_allocation
    poll_insertion
-   runtime5
    address_sanitizer
    stack_checks
    multidomain

--- a/build_ocaml_compiler.sexp
+++ b/build_ocaml_compiler.sexp
@@ -23,6 +23,7 @@
    perf_demangled_symbols
    stack_allocation
    poll_insertion
+   runtime5
    address_sanitizer
    stack_checks
    multidomain

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -76,7 +76,6 @@ let caml_sys_const name =
     | Ostype_win32 -> "ostype_win32"
     | Ostype_cygwin -> "ostype_cygwin"
     | Backend_type -> "backend_type"
-    | Runtime5 -> "runtime5"
     | Arch_amd64 -> "arch_amd64"
     | Arch_arm64 -> "arch_arm64"
   in

--- a/bytecomp/bytepackager.ml
+++ b/bytecomp/bytepackager.ml
@@ -71,21 +71,11 @@ let empty_state = {
 
 (* Record a relocation, updating its offset. *)
 
+(* upstream, rename_relocation unique-izes dotted global names and remaps
+   relocations We don't need that because [Reloc_getcompunit] carries a
+   [Compilation_unit.t] whose pack prefix is already structural. *)
 let rename_relocation base (rel, ofs) =
-  (* Nothing to do here following the symbols patches *)
   rel, base + ofs
-
-(* XXX mshinwell: the above function in runtime5 has:
-
-  (* PR#5276: unique-ize dotted global names, which appear if one of
-    the units being consolidated is itself a packed module. *)
-  let make_compunit_name_unique cu =
-    if CU.is_packed cu
-    then CU (packagename ^ "." ^ (CU.name cu))
-    else cu
-  in
-
-*)
 
 (* Record and update a debugging event *)
 

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -19,7 +19,7 @@ type dll_handle
 type dll_address
 type dll_mode = For_checking | For_execution
 
-external dll_open: dll_mode -> string -> dll_handle = "caml_dynlink_open_lib"
+external dll_open: string -> dll_handle = "caml_dynlink_open_lib"
 external dll_close: dll_handle -> unit = "caml_dynlink_close_lib"
 external dll_sym: dll_handle -> string -> dll_address
                 = "caml_dynlink_lookup_symbol"
@@ -81,7 +81,7 @@ let open_dll mode name =
           failwith (fullname ^ ": " ^ Binutils.error_to_string err)
       end
   | (None | Some (Checking _) as current), For_execution ->
-      begin match dll_open For_execution fullname with
+      begin match dll_open fullname with
       | dll ->
           let opened = match current with
             | None -> List.remove_assoc fullname !opened_dlls

--- a/configure.ac
+++ b/configure.ac
@@ -35,12 +35,6 @@ m4_include([build-aux/ax_compare_version.m4])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
-# TODO: Remove this check
-AC_ARG_ENABLE([runtime5], [],
-  [AS_IF([test "x$enableval" != 'xyes'],
-    [AC_MSG_ERROR(m4_normalize([OxCaml 5.4 does not support runtime4 and must be
-                               configured with --enable-runtime5]))])], [])
-
 # Optionally pin to a specific opam switch for reproducible builds
 AC_PATH_PROG([opam], [opam], [])
 

--- a/external/js_of_ocaml/compiler/tests-full/stdlib.cma.expected.js
+++ b/external/js_of_ocaml/compiler/tests-full/stdlib.cma.expected.js
@@ -22626,11 +22626,6 @@
       [0,
        [11, "heap_chunks: ", [4, 0, 0, 0, [12, 10, 0]]],
        "heap_chunks: %d\n"];
-   function eventlog_pause(param){
-     /*<<gc.ml:65:24>>*/ return 0;
-    /*<<gc.ml:65:26>>*/ }
-   function eventlog_resume(param){ /*<<gc.ml:66:25>>*/ return 0;
-    /*<<gc.ml:66:27>>*/ }
    function print_stat(c){
     var st =  /*<<gc.ml:71:11>>*/ runtime.caml_gc_stat(0);
      /*<<gc.ml:72:2>>*/ caml_call3(Stdlib_Printf[1], c, _a_, st[4]);
@@ -22704,8 +22699,6 @@
        function(_u_){return runtime.caml_final_release(_u_);},
        create_alarm,
        delete_alarm,
-       eventlog_pause,
-       eventlog_resume,
        [0,
         null_tracker,
         start,

--- a/external/js_of_ocaml/runtime/js/dynlink.js
+++ b/external/js_of_ocaml/runtime/js/dynlink.js
@@ -26,7 +26,7 @@ function get_current_libs() {
 //Provides: caml_dynlink_open_lib
 //Requires: get_current_libs, caml_failwith
 //Requires: caml_jsstring_of_string
-function caml_dynlink_open_lib(_mode, file) {
+function caml_dynlink_open_lib(file) {
   var name = caml_jsstring_of_string(file);
   console.log("Dynlink: try to open ", name);
   //caml_failwith("file not found: "+name)

--- a/external/js_of_ocaml/runtime/js/gc.js
+++ b/external/js_of_ocaml/runtime/js/gc.js
@@ -86,18 +86,6 @@ function caml_memprof_discard(t) {
   return 0;
 }
 
-//Provides: caml_eventlog_resume
-//Version: < 5.0
-function caml_eventlog_resume(unit) {
-  return 0;
-}
-
-//Provides: caml_eventlog_pause
-//Version: < 5.0
-function caml_eventlog_pause(unit) {
-  return 0;
-}
-
 //Provides: caml_gc_huge_fallback_count
 //Version: < 5.0
 function caml_gc_huge_fallback_count(unit) {

--- a/external/js_of_ocaml/runtime/js/sys.js
+++ b/external/js_of_ocaml/runtime/js/sys.js
@@ -300,11 +300,6 @@ function caml_sys_isatty(_chan) {
   return 0;
 }
 
-//Provides: caml_sys_const_runtime5 const
-function caml_sys_const_runtime5(_unit) {
-    return 0;
-}
-
 //Provides: arch
 var arch = globalThis.process?.arch === "arm64?" ? "arm64" : "amd64";
 

--- a/external/js_of_ocaml/runtime/wasm/gc.wat
+++ b/external/js_of_ocaml/runtime/wasm/gc.wat
@@ -112,10 +112,4 @@
 
    (func (export "caml_memprof_discard") (param (ref eq)) (result (ref eq))
       (ref.i31 (i32.const 0)))
-
-   (func (export "caml_eventlog_pause") (param (ref eq)) (result (ref eq))
-      (ref.i31 (i32.const 0)))
-
-   (func (export "caml_eventlog_resume") (param (ref eq)) (result (ref eq))
-      (ref.i31 (i32.const 0)))
 )

--- a/external/js_of_ocaml/runtime/wasm/sys.wat
+++ b/external/js_of_ocaml/runtime/wasm/sys.wat
@@ -155,10 +155,6 @@
       (param (ref eq)) (result (ref eq))
       (ref.i31 (i32.const 0)))
 
-   (func (export "caml_sys_const_runtime5")
-      (param (ref eq)) (result (ref eq))
-      (ref.i31 (i32.const 0)))
-
    (func (export "caml_sys_const_arch_amd64")
       (param (ref eq)) (result (ref eq))
       (ref.i31 (i32.eqz (global.get $on_arm64))))

--- a/external/merlin/upstream/ocaml_flambda/utils/config.mli
+++ b/external/merlin/upstream/ocaml_flambda/utils/config.mli
@@ -349,10 +349,6 @@ val poll_insertion : bool
 val ar_supports_response_files: bool
 (** Whether ar supports @FILE arguments. *)
 
-val runtime5 : bool
-(** Always [true], Previously:[false] when using the
-    OCaml 4.14 runtime. *)
-
 val no_stack_checks : bool
 (** [true] if stack checks are disabled. *)
 

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -29,7 +29,6 @@ type compile_time_constant =
   | Ostype_win32
   | Ostype_cygwin
   | Backend_type
-  | Runtime5
   | Arch_amd64
   | Arch_arm64
 
@@ -3660,7 +3659,7 @@ let primitive_result_layout (p : primitive) =
     end
   | Pctconst (
     Big_endian | Word_size | Int_size | Max_wosize
-    | Ostype_unix | Ostype_cygwin | Ostype_win32 | Backend_type | Runtime5
+    | Ostype_unix | Ostype_cygwin | Ostype_win32 | Backend_type
     | Arch_amd64 | Arch_arm64
   ) ->
     (* Compile-time constants only ever return ints for now,

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -33,7 +33,6 @@ type compile_time_constant =
   | Ostype_win32
   | Ostype_cygwin
   | Backend_type
-  | Runtime5
   | Arch_amd64
   | Arch_arm64
 

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -645,8 +645,7 @@ let primitive ppf = function
        | Ostype_cygwin -> "ostype_cygwin"
        | Backend_type -> "backend_type"
        | Arch_amd64 -> "arch_amd64"
-       | Arch_arm64 -> "arch_arm64"
-       | Runtime5 -> "runtime5" in
+       | Arch_arm64 -> "arch_arm64" in
      fprintf ppf "sys.constant_%s" const_name
   | Pisint { variant_only } ->
       fprintf ppf (if variant_only then "isint" else "obj_is_int")

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -725,7 +725,6 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%ostype_unix" -> Primitive ((Pctconst Ostype_unix), 1)
     | "%ostype_win32" -> Primitive ((Pctconst Ostype_win32), 1)
     | "%ostype_cygwin" -> Primitive ((Pctconst Ostype_cygwin), 1)
-    | "%runtime5" -> Primitive ((Pctconst Runtime5), 1)
     | "%arch_amd64" -> Primitive ((Pctconst Arch_amd64), 1)
     | "%arch_arm64" -> Primitive ((Pctconst Arch_arm64), 1)
     | "%frame_pointers" -> Frame_pointers

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -3040,10 +3040,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
         [ Simple
             (Simple.const_bool machine_width
                (String.equal Config.architecture "arm64")) ]
-      | Backend_type ->
-        [Simple (Simple.const_zero machine_width)]
-        (* constructor 0 is the same as Native here *)
-      | Runtime5 -> [Simple (Simple.const_bool machine_width true)]))
+      | Backend_type -> [Simple (Simple.const_zero machine_width)]))
   | Pint_as_pointer mode, [[arg]] ->
     (* This is not a stack allocation, but nonetheless has a region
        constraint. *)

--- a/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_lambda_transforms.ml
@@ -1120,7 +1120,6 @@ let transform_primitive0 env (prim : L.primitive) args loc =
       | Ostype_win32 -> "ostype_win32"
       | Ostype_cygwin -> "ostype_cygwin"
       | Backend_type -> "backend_type"
-      | Runtime5 -> "runtime5"
       | Arch_amd64 -> "arch_amd64"
       | Arch_arm64 -> "arch_arm64"
     in

--- a/oxcaml/tests/backend/zero_alloc_checker/fail1.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail1.output
@@ -1,2 +1,2 @@
 File "fail1.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail1.test15 (camlFail1.test15_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail1.test15 (camlFail1__test15_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail10.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail10.output
@@ -1,2 +1,2 @@
 File "fail10.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail10.test7 (camlFail10.test7_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail10.test7 (camlFail10__test7_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail12.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail12.output
@@ -1,5 +1,5 @@
 File "fail12.ml", line 5, characters 46-56:
-Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12.fn[fail12.ml:5,40--68]_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail12.Inner.bar.(fun) (camlFail12__fn[fail12.ml:5,40--68]_HIDE_STAMP).
 
 File "fail12.ml", line 5, characters 63-67:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/fail13.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail13.output
@@ -1,2 +1,2 @@
 File "fail13.ml", line 3, characters 15-29:
-Error: Annotation check for zero_alloc failed on function Fail13.fail_loud2 (camlFail13.fail_loud2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail13.fail_loud2 (camlFail13__fail_loud2_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail14.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail14.output
@@ -1,2 +1,2 @@
 File "fail14.ml", line 6, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail14.foo (camlFail14.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail14.foo (camlFail14__foo_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail15.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail15.output
@@ -3,4 +3,4 @@ Warning 54 [duplicated-attribute]: the zero_alloc attribute is used more than on
   on this expression
 
 File "fail15.ml", line 8, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail15.call (camlFail15.call_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail15.call (camlFail15__call_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail16.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail16.output
@@ -1,2 +1,2 @@
 File "fail16.ml", lines 17-19, characters 6-6:
-Error: Annotation check for zero_alloc failed on function Fail16.f (camlFail16.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail16.f (camlFail16__f_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail17.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail17.output
@@ -1,2 +1,2 @@
 File "fail17.ml", lines 7-9, characters 6-15:
-Error: Annotation check for zero_alloc failed on function Fail17.f (camlFail17.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail17.f (camlFail17__f_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail18.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail18.output
@@ -1,2 +1,2 @@
 File "fail18.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail18.f (camlFail18.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail18.f (camlFail18__f_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail19.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail19.output
@@ -1,18 +1,18 @@
 File "fail19.ml", line 6, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail19.foo (camlFail19.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail19.foo (camlFail19__foo_HIDE_STAMP).
 
 File "fail19.ml", line 10, characters 9-13:
 Error: allocation of 24 bytes
 
 File "fail19.ml", line 12, characters 12-17:
-Error: called function may allocate (direct call camlFail19.bar_HIDE_STAMP)
+Error: called function may allocate (direct call camlFail19__bar_HIDE_STAMP)
 
 File "fail19.ml", line 13, characters 15-18:
 Error: called function may allocate (indirect call)
 
 File "fail19.ml", line 15, characters 8-37:
 Error: expression may allocate
-       (probe "test" handler camlFail19.probe_handler_test_HIDE_STAMP)
+       (probe "test" handler camlFail19__probe_handler_test_HIDE_STAMP)
 
 File "fail19.ml", line 16, characters 8-16:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/fail2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail2.output
@@ -1,2 +1,2 @@
 File "fail2.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail2.test (camlFail2.test_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail2.test (camlFail2__test_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail20.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail20.output
@@ -1,5 +1,5 @@
 File "fail20.ml", line 10, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail20.foo1 (camlFail20.foo1_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail20.foo1 (camlFail20__foo1_HIDE_STAMP).
 
 File "fail20.ml", line 3, characters 18-30:
 Error: allocation of 32 bytes on a path to exceptional return
@@ -7,13 +7,13 @@ inlined from
 fail20.ml:12,7--18[Fail20.foo1]
 
 File "fail20.ml", line 17, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail20.foo (camlFail20__foo_HIDE_STAMP).
 
 File "fail20.ml", line 19, characters 6-21:
-Error: called function may allocate (direct call camlFail20.bar_HIDE_STAMP)
+Error: called function may allocate (direct call camlFail20__bar_HIDE_STAMP)
 
 File "fail20.ml", line 21, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail20.zee (camlFail20.zee_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail20.zee (camlFail20__zee_HIDE_STAMP).
 
 File "fail20.ml", line 21, characters 27-58:
-Error: called function may allocate (direct tailcall camlFail20.foo_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail20__foo_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/fail21.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail21.output
@@ -1,5 +1,5 @@
 File "fail21.ml", line 9, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail21.test4 (camlFail21.test4_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail21.test4 (camlFail21__test4_HIDE_STAMP).
 
 File "fail21.ml", line 3, characters 30-34:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/fail22.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail22.output
@@ -1,5 +1,5 @@
 File "fail22.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail22.foo (camlFail22.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail22.foo (camlFail22__foo_HIDE_STAMP).
 
 File "fail22.ml", line 2, characters 29-33:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/fail23.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail23.output
@@ -1,5 +1,5 @@
 File "fail23.ml", line 4, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23.test1_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail23.test1 (camlFail23__test1_HIDE_STAMP).
 
 File "fail23.ml", line 5, characters 33-63:
 Error: allocation of 32 bytes on a path to exceptional return

--- a/oxcaml/tests/backend/zero_alloc_checker/fail24.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail24.output
@@ -1,5 +1,5 @@
 File "fail24.ml", line 2, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Fail24.f.unsafe_set_int64 (camlFail24.unsafe_set_int64_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail24.f.unsafe_set_int64 (camlFail24__unsafe_set_int64_HIDE_STAMP).
 
 File "fail24.ml", line 3, characters 4-54:
 Error: called function may allocate (external call to caml_ba_set_1)

--- a/oxcaml/tests/backend/zero_alloc_checker/fail25.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail25.output
@@ -1,43 +1,43 @@
 File "fail25.ml", line 41, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail25.g (camlFail25.g_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail25.g (camlFail25__g_HIDE_STAMP).
 
 File "fail25.ml", line 42, characters 39-42:
-Error: called function may allocate (direct call camlFail25.g_HIDE_STAMP)
+Error: called function may allocate (direct call camlFail25__g_HIDE_STAMP)
 Hint: Recompile without -disable-precise-zero-alloc-checker for more precise results.
 
 
 File "fail25.ml", line 46, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail25.foo (camlFail25.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail25.foo (camlFail25__foo_HIDE_STAMP).
 
 File "fail25.ml", line 46, characters 29-40:
-Error: called function may allocate (direct tailcall camlFail25.bar_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail25__bar_HIDE_STAMP)
 Hint: Recompile without -disable-precise-zero-alloc-checker for more precise results.
 
 
 File "fail25.ml", line 48, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail25.bar (camlFail25.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail25.bar (camlFail25__bar_HIDE_STAMP).
 
 File "fail25.ml", line 48, characters 25-36:
-Error: called function may allocate (direct tailcall camlFail25.foo_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail25__foo_HIDE_STAMP)
 
 File "fail25.ml", line 50, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail25.f1 (camlFail25.f1_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail25.f1 (camlFail25__f1_HIDE_STAMP).
 
 File "fail25.ml", line 50, characters 70-80:
-Error: called function may allocate (direct tailcall camlFail25.f2_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail25__f2_HIDE_STAMP)
 Hint: Recompile without -disable-precise-zero-alloc-checker for more precise results.
 
 
 File "fail25.ml", line 52, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail25.f2 (camlFail25.f2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail25.f2 (camlFail25__f2_HIDE_STAMP).
 
 File "fail25.ml", line 52, characters 24-34:
-Error: called function may allocate (direct tailcall camlFail25.f1_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail25__f1_HIDE_STAMP)
 
 File "fail25.ml", line 56, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail25.outer (camlFail25.outer_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail25.outer (camlFail25__outer_HIDE_STAMP).
 
 File "fail25.ml", line 60, characters 2-15:
-Error: called function may allocate (direct tailcall camlFail25.inner_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail25__inner_HIDE_STAMP)
 Hint: Recompile without -disable-precise-zero-alloc-checker for more precise results.
 

--- a/oxcaml/tests/backend/zero_alloc_checker/fail26.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail26.output
@@ -1,23 +1,23 @@
 File "fail26.ml", line 38, characters 3-13:
-Error: Annotation check for zero_alloc failed on function Fail26.raise_invalid_index_FAIL (camlFail26.raise_invalid_index_FAIL_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.raise_invalid_index_FAIL (camlFail26__raise_invalid_index_FAIL_HIDE_STAMP).
 
 File "fail26.ml", line 41, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail26.g (camlFail26.g_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.g (camlFail26__g_HIDE_STAMP).
 
 File "fail26.ml", line 46, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail26.foo (camlFail26.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.foo (camlFail26__foo_HIDE_STAMP).
 
 File "fail26.ml", line 48, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail26.bar (camlFail26.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.bar (camlFail26__bar_HIDE_STAMP).
 
 File "fail26.ml", line 50, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail26.f1 (camlFail26.f1_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.f1 (camlFail26__f1_HIDE_STAMP).
 
 File "fail26.ml", line 52, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail26.f2 (camlFail26.f2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.f2 (camlFail26__f2_HIDE_STAMP).
 
 File "fail26.ml", line 56, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail26.outer (camlFail26.outer_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.outer (camlFail26__outer_HIDE_STAMP).
 
 File "fail26.ml", line 57, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Fail26.outer.inner (camlFail26.inner_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail26.outer.inner (camlFail26__inner_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail27.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail27.output
@@ -1,11 +1,11 @@
 File "fail27.ml", line 1, characters 8-19:
-Error: Annotation check for zero_alloc failed on function Fail27.foo (camlFail27.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27.foo (camlFail27__foo_HIDE_STAMP).
 
 File "fail27.ml", line 1, characters 14-19:
 Error: allocation of 24 bytes
 
 File "fail27.ml", line 3, characters 8-19:
-Error: Annotation check for zero_alloc failed on function Fail27.bar (camlFail27.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27.bar (camlFail27__bar_HIDE_STAMP).
 
 File "fail27.ml", line 3, characters 14-19:
 Error: allocation of 24 bytes
@@ -14,13 +14,13 @@ File "fail27.ml", line 3, characters 17-19:
 Error: allocation of 24 bytes
 
 File "fail27.ml", lines 5-11, characters 10-15:
-Error: Annotation check for zero_alloc failed on function Fail27.outer (camlFail27.outer_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27.outer (camlFail27__outer_HIDE_STAMP).
 
 File "fail27.ml", line 11, characters 2-15:
-Error: called function may allocate (direct tailcall camlFail27.inner_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail27__inner_HIDE_STAMP)
 
 File "fail27.ml", lines 7-9, characters 60-30:
-Error: Annotation check for zero_alloc failed on function Fail27.outer.inner (camlFail27.inner_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27.outer.inner (camlFail27__inner_HIDE_STAMP).
 
 File "fail27.ml", line 8, characters 18-23:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/fail27_default.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail27_default.output
@@ -1,5 +1,5 @@
 File "fail27_default.ml", line 16, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail27_default.only_check_me_in_opt (camlFail27_default.only_check_me_in_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27_default.only_check_me_in_opt (camlFail27_default__only_check_me_in_opt_HIDE_STAMP).
 
 File "fail27_default.ml", line 17, characters 2-11:
 Error: allocation of 32 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/fail27_opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail27_opt.output
@@ -1,11 +1,11 @@
 File "fail27_opt.ml", line 1, characters 8-19:
-Error: Annotation check for zero_alloc failed on function Fail27_opt.foo (camlFail27_opt.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27_opt.foo (camlFail27_opt__foo_HIDE_STAMP).
 
 File "fail27_opt.ml", line 1, characters 14-19:
 Error: allocation of 24 bytes
 
 File "fail27_opt.ml", line 3, characters 8-19:
-Error: Annotation check for zero_alloc failed on function Fail27_opt.bar (camlFail27_opt.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27_opt.bar (camlFail27_opt__bar_HIDE_STAMP).
 
 File "fail27_opt.ml", line 3, characters 14-19:
 Error: allocation of 24 bytes
@@ -14,19 +14,19 @@ File "fail27_opt.ml", line 3, characters 17-19:
 Error: allocation of 24 bytes
 
 File "fail27_opt.ml", lines 5-11, characters 10-15:
-Error: Annotation check for zero_alloc failed on function Fail27_opt.outer (camlFail27_opt.outer_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27_opt.outer (camlFail27_opt__outer_HIDE_STAMP).
 
 File "fail27_opt.ml", line 11, characters 2-15:
-Error: called function may allocate (direct tailcall camlFail27_opt.inner_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail27_opt__inner_HIDE_STAMP)
 
 File "fail27_opt.ml", lines 7-9, characters 60-30:
-Error: Annotation check for zero_alloc failed on function Fail27_opt.outer.inner (camlFail27_opt.inner_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27_opt.outer.inner (camlFail27_opt__inner_HIDE_STAMP).
 
 File "fail27_opt.ml", line 8, characters 18-23:
 Error: allocation of 24 bytes
 
 File "fail27_opt.ml", line 16, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail27_opt.only_check_me_in_opt (camlFail27_opt.only_check_me_in_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail27_opt.only_check_me_in_opt (camlFail27_opt__only_check_me_in_opt_HIDE_STAMP).
 
 File "fail27_opt.ml", line 17, characters 2-11:
 Error: allocation of 32 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/fail28.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail28.output
@@ -1,13 +1,13 @@
 File "fail28.ml", line 18, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail28.check_me_strict (camlFail28.check_me_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail28.check_me_strict (camlFail28__check_me_strict_HIDE_STAMP).
 
 File "fail28.ml", line 19, characters 38-76:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 fail28.ml:19,38--76[Fail28.check_me_strict]
 
 File "fail28.ml", line 19, characters 29-77:

--- a/oxcaml/tests/backend/zero_alloc_checker/fail28_opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail28_opt.output
@@ -1,11 +1,11 @@
 File "fail28_opt.ml", line 3, characters 8-18:
-Error: Annotation check for zero_alloc failed on function Fail28_opt.foo (camlFail28_opt.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail28_opt.foo (camlFail28_opt__foo_HIDE_STAMP).
 
 File "fail28_opt.ml", line 3, characters 14-18:
 Error: allocation of 24 bytes
 
 File "fail28_opt.ml", line 5, characters 8-20:
-Error: Annotation check for zero_alloc failed on function Fail28_opt.bar (camlFail28_opt.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail28_opt.bar (camlFail28_opt__bar_HIDE_STAMP).
 
 File "fail28_opt.ml", line 5, characters 14-20:
 Error: allocation of 24 bytes
@@ -14,33 +14,33 @@ File "fail28_opt.ml", line 5, characters 18-20:
 Error: allocation of 24 bytes
 
 File "fail28_opt.ml", lines 7-12, characters 10-15:
-Error: Annotation check for zero_alloc failed on function Fail28_opt.outer (camlFail28_opt.outer_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail28_opt.outer (camlFail28_opt__outer_HIDE_STAMP).
 
 File "fail28_opt.ml", line 12, characters 2-15:
-Error: called function may allocate (direct tailcall camlFail28_opt.inner_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail28_opt__inner_HIDE_STAMP)
 
 File "fail28_opt.ml", lines 9-10, characters 62-49:
-Error: Annotation check for zero_alloc failed on function Fail28_opt.outer.inner (camlFail28_opt.inner_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail28_opt.outer.inner (camlFail28_opt__inner_HIDE_STAMP).
 
 File "fail28_opt.ml", line 10, characters 18-22:
 Error: allocation of 24 bytes
 
 File "fail28_opt.ml", line 16, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail28_opt.only_check_me_in_opt (camlFail28_opt.only_check_me_in_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail28_opt.only_check_me_in_opt (camlFail28_opt__only_check_me_in_opt_HIDE_STAMP).
 
 File "fail28_opt.ml", line 16, characters 55-66:
 Error: allocation of 32 bytes
 
 File "fail28_opt.ml", line 18, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail28_opt.check_me_strict (camlFail28_opt.check_me_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail28_opt.check_me_strict (camlFail28_opt__check_me_strict_HIDE_STAMP).
 
 File "fail28_opt.ml", line 19, characters 38-76:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 fail28_opt.ml:19,38--76[Fail28_opt.check_me_strict]
 
 File "fail28_opt.ml", line 19, characters 29-77:

--- a/oxcaml/tests/backend/zero_alloc_checker/fail29.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail29.output
@@ -1,11 +1,11 @@
 File "fail29.ml", line 1, characters 8-18:
-Error: Annotation check for zero_alloc failed on function Fail29.foo (camlFail29.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail29.foo (camlFail29__foo_HIDE_STAMP).
 
 File "fail29.ml", line 1, characters 14-18:
 Error: allocation of 24 bytes
 
 File "fail29.ml", line 3, characters 8-20:
-Error: Annotation check for zero_alloc failed on function Fail29.bar (camlFail29.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail29.bar (camlFail29__bar_HIDE_STAMP).
 
 File "fail29.ml", line 3, characters 14-20:
 Error: allocation of 24 bytes
@@ -14,21 +14,21 @@ File "fail29.ml", line 3, characters 18-20:
 Error: allocation of 24 bytes
 
 File "fail29.ml", lines 5-10, characters 10-15:
-Error: Annotation check for zero_alloc failed on function Fail29.outer (camlFail29.outer_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail29.outer (camlFail29__outer_HIDE_STAMP).
 
 File "fail29.ml", line 10, characters 2-15:
-Error: called function may allocate (direct tailcall camlFail29.inner_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail29__inner_HIDE_STAMP)
 
 File "fail29.ml", line 16, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail29.check_me_strict (camlFail29.check_me_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail29.check_me_strict (camlFail29__check_me_strict_HIDE_STAMP).
 
 File "fail29.ml", line 17, characters 38-76:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 fail29.ml:17,38--76[Fail29.check_me_strict]
 
 File "fail29.ml", line 17, characters 29-77:

--- a/oxcaml/tests/backend/zero_alloc_checker/fail29_opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail29_opt.output
@@ -1,13 +1,13 @@
 File "fail29_opt.ml", line 16, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail29_opt.check_me_strict (camlFail29_opt.check_me_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail29_opt.check_me_strict (camlFail29_opt__check_me_strict_HIDE_STAMP).
 
 File "fail29_opt.ml", line 17, characters 38-76:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 fail29_opt.ml:17,38--76[Fail29_opt.check_me_strict]
 
 File "fail29_opt.ml", line 17, characters 29-77:

--- a/oxcaml/tests/backend/zero_alloc_checker/fail29_opt2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail29_opt2.output
@@ -1,11 +1,11 @@
 File "fail29_opt2.ml", line 1, characters 8-18:
-Error: Annotation check for zero_alloc failed on function Fail29_opt2.foo (camlFail29_opt2.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.foo (camlFail29_opt2__foo_HIDE_STAMP).
 
 File "fail29_opt2.ml", line 1, characters 14-18:
 Error: allocation of 24 bytes
 
 File "fail29_opt2.ml", line 3, characters 8-20:
-Error: Annotation check for zero_alloc failed on function Fail29_opt2.bar (camlFail29_opt2.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.bar (camlFail29_opt2__bar_HIDE_STAMP).
 
 File "fail29_opt2.ml", line 3, characters 14-20:
 Error: allocation of 24 bytes
@@ -14,27 +14,27 @@ File "fail29_opt2.ml", line 3, characters 18-20:
 Error: allocation of 24 bytes
 
 File "fail29_opt2.ml", lines 5-10, characters 10-15:
-Error: Annotation check for zero_alloc failed on function Fail29_opt2.outer (camlFail29_opt2.outer_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.outer (camlFail29_opt2__outer_HIDE_STAMP).
 
 File "fail29_opt2.ml", line 10, characters 2-15:
-Error: called function may allocate (direct tailcall camlFail29_opt2.inner_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlFail29_opt2__inner_HIDE_STAMP)
 
 File "fail29_opt2.ml", line 14, characters 25-42:
-Error: Annotation check for zero_alloc failed on function Fail29_opt2.only_check_me_in_opt (camlFail29_opt2.only_check_me_in_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail29_opt2.only_check_me_in_opt (camlFail29_opt2__only_check_me_in_opt_HIDE_STAMP).
 
 File "fail29_opt2.ml", line 14, characters 31-42:
 Error: allocation of 32 bytes
 
 File "fail29_opt2.ml", line 16, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail29_opt2.check_me_strict (camlFail29_opt2.check_me_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail29_opt2.check_me_strict (camlFail29_opt2__check_me_strict_HIDE_STAMP).
 
 File "fail29_opt2.ml", line 17, characters 38-76:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 fail29_opt2.ml:17,38--76[Fail29_opt2.check_me_strict]
 
 File "fail29_opt2.ml", line 17, characters 29-77:

--- a/oxcaml/tests/backend/zero_alloc_checker/fail3.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail3.output
@@ -1,2 +1,2 @@
 File "fail3.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail3.test (camlFail3.test_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail3.test (camlFail3__test_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail4.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail4.output
@@ -1,2 +1,2 @@
 File "fail4.ml", line 2, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Fail4.test (camlFail4.test_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Fail4.test (camlFail4__test_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail5.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail5.output
@@ -1,2 +1,2 @@
 File "fail5.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail5.test (camlFail5.test_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail5.test (camlFail5__test_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail6.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail6.output
@@ -1,2 +1,2 @@
 File "fail6.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail6.test3 (camlFail6.test3_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail6.test3 (camlFail6__test3_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail7.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail7.output
@@ -1,2 +1,2 @@
 File "fail7.ml", line 9, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail7.test (camlFail7.test_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail7.test (camlFail7__test_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/fail9.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/fail9.output
@@ -1,2 +1,2 @@
 File "fail9.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Fail9.g (camlFail9.g_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Fail9.g (camlFail9__g_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/filter.sh
+++ b/oxcaml/tests/backend/zero_alloc_checker/filter.sh
@@ -1,6 +1,3 @@
 #!/bin/sh
 
-# CR ocaml 5 all-runtime5: remove __ mangling once we're always using the 5 runtime
-sed -r 's/caml(.*)_[0-9]+_[0-9]+_code?/caml\1_HIDE_STAMP/' \
-| \
-    sed 's/__/./g'
+sed -r 's/caml(.*)_[0-9]+_[0-9]+_code?/caml\1_HIDE_STAMP/'

--- a/oxcaml/tests/backend/zero_alloc_checker/filter.sh
+++ b/oxcaml/tests/backend/zero_alloc_checker/filter.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-sed -r 's/caml(.*)_[0-9]+_[0-9]+_code?/caml\1_HIDE_STAMP/'
+# The second sed strips the "./" prefix that dune >= 3.24 adds to source paths.
+sed -r 's/caml(.*)_[0-9]+_[0-9]+_code?/caml\1_HIDE_STAMP/' \
+| \
+    sed -e 's|\([("[/ ]\)\./|\1|g' -e 's|^\./||'

--- a/oxcaml/tests/backend/zero_alloc_checker/t1.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/t1.output
@@ -1,5 +1,5 @@
 File "t1.ml", line 13, characters 7-17:
-Error: Annotation check for zero_alloc failed on function T1.Params.test12 (camlT1.test12_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function T1.Params.test12 (camlT1__test12_HIDE_STAMP).
 
 File "t1.ml", line 13, characters 32-48:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_all_opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_all_opt.output
@@ -1,5 +1,5 @@
 File "test_all_opt.ml", line 9, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_all_opt.bar (camlTest_all_opt.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_all_opt.bar (camlTest_all_opt__bar_HIDE_STAMP).
 
 File "test_all_opt.ml", line 9, characters 25-31:
 Error: allocation of 24 bytes
@@ -8,7 +8,7 @@ File "test_all_opt.ml", line 9, characters 29-31:
 Error: allocation of 24 bytes
 
 File "test_all_opt.ml", line 11, characters 8-26:
-Error: Annotation check for zero_alloc failed on function Test_all_opt.baz (camlTest_all_opt.baz_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_all_opt.baz (camlTest_all_opt__baz_HIDE_STAMP).
 
 File "test_all_opt.ml", line 11, characters 12-26:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_all_opt2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_all_opt2.output
@@ -1,11 +1,11 @@
 File "test_all_opt2.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_all_opt2.foo (camlTest_all_opt2.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_all_opt2.foo (camlTest_all_opt2__foo_HIDE_STAMP).
 
 File "test_all_opt2.ml", line 5, characters 29-33:
 Error: allocation of 24 bytes
 
 File "test_all_opt2.ml", line 9, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_all_opt2.bar (camlTest_all_opt2.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_all_opt2.bar (camlTest_all_opt2__bar_HIDE_STAMP).
 
 File "test_all_opt2.ml", line 9, characters 25-31:
 Error: allocation of 24 bytes
@@ -14,7 +14,7 @@ File "test_all_opt2.ml", line 9, characters 29-31:
 Error: allocation of 24 bytes
 
 File "test_all_opt2.ml", line 11, characters 8-26:
-Error: Annotation check for zero_alloc failed on function Test_all_opt2.baz (camlTest_all_opt2.baz_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_all_opt2.baz (camlTest_all_opt2__baz_HIDE_STAMP).
 
 File "test_all_opt2.ml", line 11, characters 12-26:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_all_opt3.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_all_opt3.output
@@ -1,5 +1,5 @@
 File "test_all_opt3.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_all_opt3.foo (camlTest_all_opt3.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_all_opt3.foo (camlTest_all_opt3__foo_HIDE_STAMP).
 
 File "test_all_opt3.ml", line 5, characters 29-33:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_arch_specific_witness.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_arch_specific_witness.output
@@ -1,5 +1,5 @@
 File "test_arch_specific_witness.ml", line 12, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_arch_specific_witness.max_with_assume (camlTest_arch_specific_witness.max_with_assume_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_arch_specific_witness.max_with_assume (camlTest_arch_specific_witness__max_with_assume_HIDE_STAMP).
 
 File "test_arch_specific_witness.ml", line 12, characters 48-87:
 Error: expression may allocate on a path to diverge

--- a/oxcaml/tests/backend/zero_alloc_checker/test_arity.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_arity.output
@@ -1,5 +1,5 @@
 File "test_arity.ml", line 8, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_arity.f_not_zero_alloc (camlTest_arity.f_not_zero_alloc_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_arity.f_not_zero_alloc (camlTest_arity__f_not_zero_alloc_HIDE_STAMP).
 
 File "test_arity.ml", line 8, characters 60-64:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_error.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_error.output
@@ -1,26 +1,26 @@
 File "test_assume_error.ml", line 28, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_error.A1.foo (camlTest_assume_error.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_error.A1.foo (camlTest_assume_error__foo_HIDE_STAMP).
 
 File "test_assume_error.ml", line 22, characters 10-13:
-Error: called function may allocate (direct call camlTest_assume_error.g_HIDE_STAMP)
+Error: called function may allocate (direct call camlTest_assume_error__g_HIDE_STAMP)
 inlined from
 test_assume_error.ml:28,31--34[Test_assume_error.A1.foo]
 
 File "test_assume_error.ml", line 24, characters 6-66:
-Error: called function may allocate (direct call camlTest_assume_error.handle_exn_HIDE_STAMP)
+Error: called function may allocate (direct call camlTest_assume_error__handle_exn_HIDE_STAMP)
 inlined from
 test_assume_error.ml:28,31--34[Test_assume_error.A1.foo]
 
 File "test_assume_error.ml", line 56, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_error.A2.foo (camlTest_assume_error.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_error.A2.foo (camlTest_assume_error__foo_HIDE_STAMP).
 
 File "test_assume_error.ml", line 50, characters 10-13:
-Error: called function may allocate (direct call camlTest_assume_error.g_HIDE_STAMP)
+Error: called function may allocate (direct call camlTest_assume_error__g_HIDE_STAMP)
 inlined from
 test_assume_error.ml:58,14--17[Test_assume_error.A2.foo]
 
 File "test_assume_error.ml", line 52, characters 6-66:
-Error: called function may allocate (direct call camlTest_assume_error.handle_exn_HIDE_STAMP)
+Error: called function may allocate (direct call camlTest_assume_error__handle_exn_HIDE_STAMP)
 inlined from
 test_assume_error.ml:58,14--17[Test_assume_error.A2.foo]
 
@@ -31,29 +31,29 @@ File "test_assume_error.ml", line 61, characters 6-30:
 Error: called function may allocate (indirect call)
 
 File "printf.ml", line 27, characters 2-63:
-Error: called function may allocate (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:34,21--43[Stdlib.Printf.fprintf][camlStdlib.Printf.fprintf_HIDE_STAMP]
-stdlib/printf.ml:38,17--35[Stdlib.Printf.printf][camlStdlib.Printf.printf_HIDE_STAMP]
+stdlib/printf.ml:34,21--43[Stdlib__Printf.fprintf][camlStdlib__Printf__fprintf_HIDE_STAMP]
+stdlib/printf.ml:38,17--35[Stdlib__Printf.printf][camlStdlib__Printf__printf_HIDE_STAMP]
 test_assume_error.ml:61,6--30[Test_assume_error.A2.foo]
 
 File "test_assume_error.ml", line 63, characters 6-10:
 Error: allocation of 24 bytes
 
 File "test_assume_error.ml", line 92, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_error.A3.foo (camlTest_assume_error.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_error.A3.foo (camlTest_assume_error__foo_HIDE_STAMP).
 
 File "test_assume_error.ml", line 95, characters 6-10:
 Error: allocation of 24 bytes
 
 File "test_assume_error.ml", line 186, characters 7-17:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_error.A6.f (camlTest_assume_error.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_error.A6.f (camlTest_assume_error__f_HIDE_STAMP).
 
 File "test_assume_error.ml", line 187, characters 10-13:
-Error: called function may allocate on a path to diverge (direct call camlTest_assume_error.g_HIDE_STAMP)
+Error: called function may allocate on a path to diverge (direct call camlTest_assume_error__g_HIDE_STAMP)
 
 File "test_assume_error.ml", line 233, characters 7-17:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_error.A8.f (camlTest_assume_error.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_error.A8.f (camlTest_assume_error__f_HIDE_STAMP).
 
 File "test_assume_error.ml", line 236, characters 6-20:
-Error: called function may allocate on a path to exceptional return (direct call camlTest_assume_error.handle_exn_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlTest_assume_error__handle_exn_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_fail.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_fail.output
@@ -1,11 +1,11 @@
 File "test_assume_fail.ml", line 6, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo (camlTest_assume_fail.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo (camlTest_assume_fail__foo_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 6, characters 32-37:
-Error: called function may allocate on a path to exceptional return (direct tailcall camlTest_assume_fail.bar_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct tailcall camlTest_assume_fail__bar_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 12, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo' (camlTest_assume_fail.foo'_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.foo' (camlTest_assume_fail__foo'_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 9, characters 25-53:
 Error: called function may allocate on a path to exceptional return (indirect call)
@@ -13,24 +13,24 @@ inlined from
 repo/root/relative/dir/test_assume_fail.ml:12,33--39[Test_assume_fail.foo']
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
-repo/root/relative/dir/test_assume_fail.ml:9,25--53[Test_assume_fail.bar'][camlTest_assume_fail.bar'_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
+repo/root/relative/dir/test_assume_fail.ml:9,25--53[Test_assume_fail.bar'][camlTest_assume_fail__bar'_HIDE_STAMP]
 repo/root/relative/dir/test_assume_fail.ml:12,33--39[Test_assume_fail.foo']
 
 File "test_assume_fail.ml", line 17, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test48 (camlTest_assume_fail.test48_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test48 (camlTest_assume_fail__test48_HIDE_STAMP).
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
-repo/root/relative/dir/test_assume_fail.ml:15,25--48[Test_assume_fail.test46][camlTest_assume_fail.test46_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
+repo/root/relative/dir/test_assume_fail.ml:15,25--48[Test_assume_fail.test46][camlTest_assume_fail__test46_HIDE_STAMP]
 repo/root/relative/dir/test_assume_fail.ml:18,2--56[Test_assume_fail.test48]
 
 File "test_assume_fail.ml", line 36, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test51 (camlTest_assume_fail.test51_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test51 (camlTest_assume_fail__test51_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 34, characters 75-79:
 Error: allocation of 24 bytes on a path to diverge
@@ -38,13 +38,13 @@ inlined from
 repo/root/relative/dir/test_assume_fail.ml:36,35--43[Test_assume_fail.test51]
 
 File "test_assume_fail.ml", line 40, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test53 (camlTest_assume_fail.test53_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test53 (camlTest_assume_fail__test53_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 40, characters 35-43:
-Error: called function may allocate on a path to exceptional return (direct tailcall camlTest_assume_fail.test52_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct tailcall camlTest_assume_fail__test52_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 74, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test64 (camlTest_assume_fail.test64_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test64 (camlTest_assume_fail__test64_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 75, characters 10-20:
 Error: allocation of 24 bytes on a path to exceptional return
@@ -53,28 +53,28 @@ File "test_assume_fail.ml", line 75, characters 14-20:
 Error: allocation of 24 bytes on a path to exceptional return
 
 File "test_assume_fail.ml", line 76, characters 2-56:
-Error: called function may allocate on a path to exceptional return (direct tailcall camlTest_assume_fail.test62_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct tailcall camlTest_assume_fail__test62_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 90, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test68 (camlTest_assume_fail.test68_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_assume_fail.test68 (camlTest_assume_fail__test68_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 92, characters 2-6:
 Error: allocation of 24 bytes
 
 File "test_assume_fail.ml", line 114, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_assume_fail.g1 (camlTest_assume_fail.g1_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_fail.g1 (camlTest_assume_fail__g1_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 115, characters 10-42:
-Error: called function may allocate (direct tailcall camlTest_assume_fail.f_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_assume_fail__f_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 118, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_assume_fail.g2 (camlTest_assume_fail.g2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_fail.g2 (camlTest_assume_fail__g2_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 119, characters 10-40:
-Error: called function may allocate (direct tailcall camlTest_assume_fail.f_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_assume_fail__f_HIDE_STAMP)
 
 File "test_assume_fail.ml", line 122, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_assume_fail.g3 (camlTest_assume_fail.g3_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_fail.g3 (camlTest_assume_fail__g3_HIDE_STAMP).
 
 File "test_assume_fail.ml", line 123, characters 10-63:
-Error: called function may allocate (direct tailcall camlTest_assume_fail.f_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_assume_fail__f_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_inlining.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_inlining.output
@@ -1,7 +1,7 @@
 File "test_assume_inlining.ml", line 27, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_inlining.A2.foo (camlTest_assume_inlining.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_inlining.A2.foo (camlTest_assume_inlining__foo_HIDE_STAMP).
 
 File "test_assume_inlining.ml", line 25, characters 55-58:
-Error: called function may allocate (direct call camlTest_assume_inlining.f_HIDE_STAMP)
+Error: called function may allocate (direct call camlTest_assume_inlining__f_HIDE_STAMP)
 inlined from
 test_assume_inlining.ml:27,27--32[Test_assume_inlining.A2.foo]

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_on_call.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_on_call.output
@@ -3,7 +3,7 @@ Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
   Only the following combinations are supported in this context: 'zero_alloc assume', 'zero_alloc assume_unless_opt', `zero_alloc assume strict`, `zero_alloc assume error`,`zero_alloc assume never_returns_normally`,`zero_alloc assume never_returns_normally strict`.
 
 File "test_assume_on_call.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test1 (camlTest_assume_on_call.test1_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_on_call.test1 (camlTest_assume_on_call__test1_HIDE_STAMP).
 
 File "test_assume_on_call.ml", line 1, characters 28-32:
 Error: allocation of 24 bytes (test_assume_on_call.ml:3,27--48)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_stub.heap_allocation.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_stub.heap_allocation.output
@@ -1,11 +1,11 @@
 File "test_assume_stub.ml", line 22, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_stub.A3.overapplied (camlTest_assume_stub.overapplied_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_stub.A3.overapplied (camlTest_assume_stub__overapplied_HIDE_STAMP).
 
 File "test_assume_stub.ml", line 22, characters 37-75:
 Error: called function may allocate (indirect tailcall)
 
 File "test_assume_stub.ml", line 34, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_stub.A4.baz (camlTest_assume_stub.baz_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_stub.A4.baz (camlTest_assume_stub__baz_HIDE_STAMP).
 
 File "test_assume_stub.ml", line 35, characters 4-59:
 Error: called function may allocate (indirect tailcall)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_stub.stack_allocation.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_stub.stack_allocation.output
@@ -1,5 +1,5 @@
 File "test_assume_stub.ml", line 34, characters 7-17:
-Error: Annotation check for zero_alloc failed on function Test_assume_stub.A4.baz (camlTest_assume_stub.baz_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_stub.A4.baz (camlTest_assume_stub__baz_HIDE_STAMP).
 
 File "test_assume_stub.ml", line 35, characters 4-59:
 Error: called function may allocate (indirect tailcall)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt.output
@@ -1,5 +1,5 @@
 File "test_assume_unless_opt.ml", line 3, characters 36-46:
-Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt.foo (camlTest_assume_unless_opt.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt.foo (camlTest_assume_unless_opt__foo_HIDE_STAMP).
 
 File "test_assume_unless_opt.ml", line 4, characters 8-13:
-Error: called function may allocate (direct call camlTest_assume_unless_opt.bar_HIDE_STAMP)
+Error: called function may allocate (direct call camlTest_assume_unless_opt__bar_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call.output
@@ -3,7 +3,7 @@ Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
   It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_assume_unless_opt_on_call.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call.test_warning (camlTest_assume_unless_opt_on_call.test_warning_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call.test_warning (camlTest_assume_unless_opt_on_call__test_warning_HIDE_STAMP).
 
 File "test_assume_unless_opt_on_call.ml", line 1, characters 12-16:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_on_call2.output
@@ -3,7 +3,7 @@ Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
   It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_assume_unless_opt_on_call2.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call2.bar (camlTest_assume_unless_opt_on_call2.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call2.bar (camlTest_assume_unless_opt_on_call2__bar_HIDE_STAMP).
 
 File "test_assume_unless_opt_on_call2.ml", line 1, characters 12-16:
 Error: allocation of 24 bytes
@@ -11,7 +11,7 @@ inlined from
 test_assume_unless_opt_on_call2.ml:3,25--64[Test_assume_unless_opt_on_call2.bar]
 
 File "test_assume_unless_opt_on_call2.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call2.test_warning (camlTest_assume_unless_opt_on_call2.test_warning_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_on_call2.test_warning (camlTest_assume_unless_opt_on_call2__test_warning_HIDE_STAMP).
 
 File "test_assume_unless_opt_on_call2.ml", line 1, characters 12-16:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_assume_unless_opt_sig2.output
@@ -3,13 +3,13 @@ Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
   The payload "assume_unless_opt" is not supported in signatures.
 
 File "test_assume_unless_opt_sig2.ml", line 4, characters 23-33:
-Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_sig2.Test_fail_in_opt_only.foo (camlTest_assume_unless_opt_sig2.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_sig2.Test_fail_in_opt_only.foo (camlTest_assume_unless_opt_sig2__foo_HIDE_STAMP).
 
 File "test_assume_unless_opt_sig2.ml", line 4, characters 61-65:
 Error: allocation of 24 bytes
 
 File "test_assume_unless_opt_sig2.ml", line 21, characters 23-33:
-Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_sig2.Test_error.foo (camlTest_assume_unless_opt_sig2.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_assume_unless_opt_sig2.Test_error.foo (camlTest_assume_unless_opt_sig2__foo_HIDE_STAMP).
 
 File "test_assume_unless_opt_sig2.ml", line 21, characters 61-65:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_attr_check.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_attr_check.output
@@ -1,5 +1,5 @@
 File "test_attr_check.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_attr_check.test (camlTest_attr_check.test_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_attr_check.test (camlTest_attr_check__test_HIDE_STAMP).
 
 File "test_attr_check.ml", line 3, characters 26-30:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_attr_check_all.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_attr_check_all.output
@@ -1,11 +1,11 @@
 File "test_attr_check_all.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test (camlTest_attr_check_all.test_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test (camlTest_attr_check_all__test_HIDE_STAMP).
 
 File "test_attr_check_all.ml", line 3, characters 26-30:
 Error: allocation of 24 bytes
 
 File "test_attr_check_all.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test_opt (camlTest_attr_check_all.test_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_attr_check_all.test_opt (camlTest_attr_check_all__test_opt_HIDE_STAMP).
 
 File "test_attr_check_all.ml", line 5, characters 34-38:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_attr_check_opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_attr_check_opt.output
@@ -1,5 +1,5 @@
 File "test_attr_check_opt.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_attr_check_opt.test_opt (camlTest_attr_check_opt.test_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_attr_check_opt.test_opt (camlTest_attr_check_opt__test_opt_HIDE_STAMP).
 
 File "test_attr_check_opt.ml", line 5, characters 34-38:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_attr_unused.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_attr_unused.output
@@ -6,7 +6,7 @@ File "test_attr_unused.ml", line 16, characters 27-37:
 Warning 53 [misplaced-attribute]: the zero_alloc attribute cannot appear in this context
 
 File "test_attr_unused.ml", line 8, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_attr_unused.g (camlTest_attr_unused.g_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_attr_unused.g (camlTest_attr_unused__g_HIDE_STAMP).
 
 File "test_attr_unused.ml", line 10, characters 2-6:
 Error: allocation of 24 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_attribute_error_duplicate.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_attribute_error_duplicate.output
@@ -19,4 +19,4 @@ Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
   It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_attribute_error_duplicate.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate.test1_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_attribute_error_duplicate.test1 (camlTest_attribute_error_duplicate__test1_HIDE_STAMP).

--- a/oxcaml/tests/backend/zero_alloc_checker/test_bounded_join2.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_bounded_join2.output
@@ -1,9 +1,9 @@
 File "test_bounded_join2.ml", line 13, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_bounded_join2.foo (camlTest_bounded_join2.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_bounded_join2.foo (camlTest_bounded_join2__foo_HIDE_STAMP).
 
 File "test_bounded_join2.ml", lines 13-33, characters 25-19:
 Error: details are not available. This may be a false alarm due to conservative analysis.
 Hint: for more precise results, recompile this function with
 "-function-layout topological" or "-zero-alloc-checker-join 0" flags.
 The "-zero-alloc-checker-join 0" flag may substantially increase compilation time.
-(widening applied in function camlTest_bounded_join2.foo_HIDE_STAMP)
+(widening applied in function camlTest_bounded_join2__foo_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_bounded_join3.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_bounded_join3.output
@@ -1,23 +1,23 @@
 File "test_bounded_join3.ml", line 13, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_bounded_join3.foo (camlTest_bounded_join3.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_bounded_join3.foo (camlTest_bounded_join3__foo_HIDE_STAMP).
 
 File "test_bounded_join3.ml", lines 14-15, characters 24-61:
 Error: allocation of 200 bytes for closure
 
 File "test_bounded_join3.ml", line 28, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join3.do_a_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join3__do_a_HIDE_STAMP)
 
 File "test_bounded_join3.ml", line 29, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join3.do_b_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join3__do_b_HIDE_STAMP)
 
 File "test_bounded_join3.ml", line 30, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join3.do_c_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join3__do_c_HIDE_STAMP)
 
 File "test_bounded_join3.ml", line 31, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join3.do_d_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join3__do_d_HIDE_STAMP)
 
 File "test_bounded_join3.ml", line 32, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join3.do_e_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join3__do_e_HIDE_STAMP)
 
 File "test_bounded_join3.ml", line 33, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join3.do_f_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join3__do_f_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_bounded_join4.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_bounded_join4.output
@@ -1,11 +1,11 @@
 File "test_bounded_join4.ml", line 13, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_bounded_join4.foo (camlTest_bounded_join4.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_bounded_join4.foo (camlTest_bounded_join4__foo_HIDE_STAMP).
 
 File "test_bounded_join4.ml", lines 14-15, characters 24-61:
 Error: allocation of 200 bytes for closure
 
 File "test_bounded_join4.ml", line 28, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join4.do_a_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join4__do_a_HIDE_STAMP)
 
 File "test_bounded_join4.ml", line 29, characters 11-19:
-Error: called function may allocate (direct tailcall camlTest_bounded_join4.do_b_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_bounded_join4__do_b_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.opt.output
@@ -11,14 +11,14 @@ Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
   It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_custom_error_msg.ml", line 2, characters 3-13:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.foo (camlTest_custom_error_msg.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.foo (camlTest_custom_error_msg__foo_HIDE_STAMP).
 This annotation is for testing custom error messages.
 
 File "test_custom_error_msg.ml", line 1, characters 12-16:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg.ml", line 6, characters 3-13:
-Error: Annotation check for zero_alloc strict failed on function Test_custom_error_msg.bar (camlTest_custom_error_msg.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_custom_error_msg.bar (camlTest_custom_error_msg__bar_HIDE_STAMP).
 This annotation is for testing custom error messages.
 
 File "stdlib.ml", line 280, characters 2-19:
@@ -30,7 +30,7 @@ File "test_custom_error_msg.ml", line 5, characters 43-70:
 Error: allocation of 24 bytes on a path to exceptional return
 
 File "test_custom_error_msg.ml", line 13, characters 3-13:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.fast (camlTest_custom_error_msg.fast_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.fast (camlTest_custom_error_msg__fast_HIDE_STAMP).
 This annotation is for testing custom error messages 
 in combination with "opt" payload and newlines.
 
@@ -43,7 +43,7 @@ File "test_custom_error_msg.ml", line 12, characters 5-11:
 Error: called function may allocate (external call to caml_equal)
 
 File "test_custom_error_msg.ml", line 41, characters 10-18:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T1.M1.f (camlTest_custom_error_msg.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T1.M1.f (camlTest_custom_error_msg__f_HIDE_STAMP).
 foo
 bar
 
@@ -51,13 +51,13 @@ File "test_custom_error_msg.ml", line 41, characters 14-18:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg.ml", line 62, characters 9-19:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T2.M2.f (camlTest_custom_error_msg.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T2.M2.f (camlTest_custom_error_msg__f_HIDE_STAMP).
 
 File "test_custom_error_msg.ml", line 62, characters 27-31:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg.ml", line 80, characters 9-19:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T3.M3.f (camlTest_custom_error_msg.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T3.M3.f (camlTest_custom_error_msg__f_HIDE_STAMP).
 use this, throw the others away
 
 File "test_custom_error_msg.ml", line 82, characters 6-10:

--- a/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg.output
@@ -11,14 +11,14 @@ Warning 47 [attribute-payload]: illegal payload for attribute zero_alloc.
   It must be either 'assume', 'assume_unless_opt', 'strict', 'opt', 'opt strict', 'assume strict', 'assume never_returns_normally', 'assume never_returns_normally strict', 'assume error', 'ignore', 'arity <int_constant>', 'custom_error_message <string_constant>' or empty
 
 File "test_custom_error_msg.ml", line 2, characters 3-13:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.foo (camlTest_custom_error_msg.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.foo (camlTest_custom_error_msg__foo_HIDE_STAMP).
 This annotation is for testing custom error messages.
 
 File "test_custom_error_msg.ml", line 1, characters 12-16:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg.ml", line 6, characters 3-13:
-Error: Annotation check for zero_alloc strict failed on function Test_custom_error_msg.bar (camlTest_custom_error_msg.bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_custom_error_msg.bar (camlTest_custom_error_msg__bar_HIDE_STAMP).
 This annotation is for testing custom error messages.
 
 File "stdlib.ml", line 280, characters 2-19:
@@ -30,7 +30,7 @@ File "test_custom_error_msg.ml", line 5, characters 43-70:
 Error: allocation of 24 bytes on a path to exceptional return
 
 File "test_custom_error_msg.ml", line 41, characters 10-18:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T1.M1.f (camlTest_custom_error_msg.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T1.M1.f (camlTest_custom_error_msg__f_HIDE_STAMP).
 foo
 bar
 
@@ -38,13 +38,13 @@ File "test_custom_error_msg.ml", line 41, characters 14-18:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg.ml", line 62, characters 9-19:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T2.M2.f (camlTest_custom_error_msg.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T2.M2.f (camlTest_custom_error_msg__f_HIDE_STAMP).
 
 File "test_custom_error_msg.ml", line 62, characters 27-31:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg.ml", line 80, characters 9-19:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T3.M3.f (camlTest_custom_error_msg.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg.T3.M3.f (camlTest_custom_error_msg__f_HIDE_STAMP).
 use this, throw the others away
 
 File "test_custom_error_msg.ml", line 82, characters 6-10:

--- a/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg_sig.opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg_sig.opt.output
@@ -1,39 +1,39 @@
 File "test_custom_error_msg_sig.ml", line 1, characters 21-29:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.expected_to_fail (camlTest_custom_error_msg_sig.expected_to_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.expected_to_fail (camlTest_custom_error_msg_sig__expected_to_fail_HIDE_STAMP).
 BOO
 
 File "test_custom_error_msg_sig.ml", line 1, characters 25-29:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 7, characters 20-28:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.check_me_in_opt (camlTest_custom_error_msg_sig.check_me_in_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.check_me_in_opt (camlTest_custom_error_msg_sig__check_me_in_opt_HIDE_STAMP).
 BOO
 
 File "test_custom_error_msg_sig.ml", line 7, characters 24-28:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 9, characters 37-47:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg (camlTest_custom_error_msg_sig.mismatched_error_msg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg (camlTest_custom_error_msg_sig__mismatched_error_msg_HIDE_STAMP).
 BOOM
 
 File "test_custom_error_msg_sig.ml", line 9, characters 29-33:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 11, characters 38-48:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg2 (camlTest_custom_error_msg_sig.mismatched_error_msg2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg2 (camlTest_custom_error_msg_sig__mismatched_error_msg2_HIDE_STAMP).
 
 File "test_custom_error_msg_sig.ml", line 11, characters 30-34:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 13, characters 38-48:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg3 (camlTest_custom_error_msg_sig.mismatched_error_msg3_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg3 (camlTest_custom_error_msg_sig__mismatched_error_msg3_HIDE_STAMP).
 BOOM
 
 File "test_custom_error_msg_sig.ml", line 13, characters 30-34:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 15, characters 34-44:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.matched_error_msg (camlTest_custom_error_msg_sig.matched_error_msg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.matched_error_msg (camlTest_custom_error_msg_sig__matched_error_msg_HIDE_STAMP).
 BOO
 
 File "test_custom_error_msg_sig.ml", line 15, characters 26-30:

--- a/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg_sig.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_custom_error_msg_sig.output
@@ -1,32 +1,32 @@
 File "test_custom_error_msg_sig.ml", line 1, characters 21-29:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.expected_to_fail (camlTest_custom_error_msg_sig.expected_to_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.expected_to_fail (camlTest_custom_error_msg_sig__expected_to_fail_HIDE_STAMP).
 BOO
 
 File "test_custom_error_msg_sig.ml", line 1, characters 25-29:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 9, characters 37-47:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg (camlTest_custom_error_msg_sig.mismatched_error_msg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg (camlTest_custom_error_msg_sig__mismatched_error_msg_HIDE_STAMP).
 BOOM
 
 File "test_custom_error_msg_sig.ml", line 9, characters 29-33:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 11, characters 38-48:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg2 (camlTest_custom_error_msg_sig.mismatched_error_msg2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg2 (camlTest_custom_error_msg_sig__mismatched_error_msg2_HIDE_STAMP).
 
 File "test_custom_error_msg_sig.ml", line 11, characters 30-34:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 13, characters 38-48:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg3 (camlTest_custom_error_msg_sig.mismatched_error_msg3_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.mismatched_error_msg3 (camlTest_custom_error_msg_sig__mismatched_error_msg3_HIDE_STAMP).
 BOOM
 
 File "test_custom_error_msg_sig.ml", line 13, characters 30-34:
 Error: allocation of 24 bytes
 
 File "test_custom_error_msg_sig.ml", line 15, characters 34-44:
-Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.matched_error_msg (camlTest_custom_error_msg_sig.matched_error_msg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_custom_error_msg_sig.matched_error_msg (camlTest_custom_error_msg_sig__matched_error_msg_HIDE_STAMP).
 BOO
 
 File "test_custom_error_msg_sig.ml", line 15, characters 26-30:

--- a/oxcaml/tests/backend/zero_alloc_checker/test_inference.opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_inference.opt.output
@@ -1,77 +1,77 @@
 File "test_inference.ml", line 6, characters 27-35:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_alloc (camlTest_inference.f_alloc_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_alloc (camlTest_inference__f_alloc_HIDE_STAMP).
 
 File "test_inference.ml", line 6, characters 31-35:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", line 15, characters 30-38:
-Error: Annotation check for zero_alloc failed on function Test_inference.M_alloc_var.f_alloc2 (camlTest_inference.f_alloc2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.M_alloc_var.f_alloc2 (camlTest_inference__f_alloc2_HIDE_STAMP).
 
 File "test_inference.ml", line 15, characters 34-38:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", lines 25-27, characters 16-16:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference.f_arity_one_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference__f_arity_one_HIDE_STAMP).
 
 File "test_inference.ml", line 27, characters 2-16:
 Error: allocation of 32 bytes for closure
 
 File "test_inference.ml", line 40, characters 19-27:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference.f_shadow_alloc_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference__f_shadow_alloc_HIDE_STAMP).
 
 File "test_inference.ml", line 40, characters 23-27:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", line 46, characters 24-36:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc_both (camlTest_inference.f_shadow_alloc_both_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc_both (camlTest_inference__f_shadow_alloc_both_HIDE_STAMP).
 
 File "test_inference.ml", line 46, characters 28-36:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", line 61, characters 17-25:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_basic_fail (camlTest_inference.f_basic_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_basic_fail (camlTest_inference__f_basic_fail_HIDE_STAMP).
 
 File "test_inference.ml", line 61, characters 21-25:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", lines 66-71, characters 18-15:
-Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_fail (camlTest_inference.f_strict_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_fail (camlTest_inference__f_strict_fail_HIDE_STAMP).
 
 File "test_inference.ml", line 70, characters 12-35:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 test_inference.ml:70,12--35[Test_inference.f_strict_fail]
 
 File "test_inference.ml", line 71, characters 10-15:
 Error: allocation of 24 bytes on a path to exceptional return
 
 File "test_inference.ml", line 82, characters 15-23:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_opt_fail (camlTest_inference.f_opt_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_opt_fail (camlTest_inference__f_opt_fail_HIDE_STAMP).
 
 File "test_inference.ml", line 82, characters 19-23:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", lines 88-93, characters 22-15:
-Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_opt_fail (camlTest_inference.f_strict_opt_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_opt_fail (camlTest_inference__f_strict_opt_fail_HIDE_STAMP).
 
 File "test_inference.ml", line 92, characters 12-35:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 test_inference.ml:92,12--35[Test_inference.f_strict_opt_fail]
 
 File "test_inference.ml", line 93, characters 10-15:
 Error: allocation of 24 bytes on a path to exceptional return
 
 File "test_inference.ml", line 104, characters 17-27:
-Error: Annotation check for zero_alloc failed on function Test_inference.F.f (camlTest_inference.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.F.f (camlTest_inference__f_HIDE_STAMP).
 
 File "test_inference.ml", line 104, characters 21-27:
 Error: allocation of 16 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_inference.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_inference.output
@@ -1,56 +1,56 @@
 File "test_inference.ml", line 6, characters 27-35:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_alloc (camlTest_inference.f_alloc_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_alloc (camlTest_inference__f_alloc_HIDE_STAMP).
 
 File "test_inference.ml", line 6, characters 31-35:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", line 15, characters 30-38:
-Error: Annotation check for zero_alloc failed on function Test_inference.M_alloc_var.f_alloc2 (camlTest_inference.f_alloc2_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.M_alloc_var.f_alloc2 (camlTest_inference__f_alloc2_HIDE_STAMP).
 
 File "test_inference.ml", line 15, characters 34-38:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", lines 25-27, characters 16-16:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference.f_arity_one_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_arity_one (camlTest_inference__f_arity_one_HIDE_STAMP).
 
 File "test_inference.ml", line 27, characters 2-16:
 Error: allocation of 32 bytes for closure
 
 File "test_inference.ml", line 40, characters 19-27:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference.f_shadow_alloc_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc (camlTest_inference__f_shadow_alloc_HIDE_STAMP).
 
 File "test_inference.ml", line 40, characters 23-27:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", line 46, characters 24-36:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc_both (camlTest_inference.f_shadow_alloc_both_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_shadow_alloc_both (camlTest_inference__f_shadow_alloc_both_HIDE_STAMP).
 
 File "test_inference.ml", line 46, characters 28-36:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", line 61, characters 17-25:
-Error: Annotation check for zero_alloc failed on function Test_inference.f_basic_fail (camlTest_inference.f_basic_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.f_basic_fail (camlTest_inference__f_basic_fail_HIDE_STAMP).
 
 File "test_inference.ml", line 61, characters 21-25:
 Error: allocation of 24 bytes
 
 File "test_inference.ml", lines 66-71, characters 18-15:
-Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_fail (camlTest_inference.f_strict_fail_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_inference.f_strict_fail (camlTest_inference__f_strict_fail_HIDE_STAMP).
 
 File "test_inference.ml", line 70, characters 12-35:
 Error: called function may allocate on a path to exceptional return (indirect call)
 
 File "printf.ml", line 46, characters 2-31:
-Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat.make_printf_HIDE_STAMP)
+Error: called function may allocate on a path to exceptional return (direct call camlCamlinternalFormat__make_printf_HIDE_STAMP)
 inlined from
-stdlib/printf.ml:48,18--43[Stdlib.Printf.sprintf][camlStdlib.Printf.sprintf_HIDE_STAMP]
+stdlib/printf.ml:48,18--43[Stdlib__Printf.sprintf][camlStdlib__Printf__sprintf_HIDE_STAMP]
 test_inference.ml:70,12--35[Test_inference.f_strict_fail]
 
 File "test_inference.ml", line 71, characters 10-15:
 Error: allocation of 24 bytes on a path to exceptional return
 
 File "test_inference.ml", line 104, characters 17-27:
-Error: Annotation check for zero_alloc failed on function Test_inference.F.f (camlTest_inference.f_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_inference.F.f (camlTest_inference__f_HIDE_STAMP).
 
 File "test_inference.ml", line 104, characters 21-27:
 Error: allocation of 16 bytes

--- a/oxcaml/tests/backend/zero_alloc_checker/test_misplaced_assume.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_misplaced_assume.output
@@ -2,7 +2,7 @@ File "test_misplaced_assume.ml", line 5, characters 33-43:
 Warning 53 [misplaced-attribute]: the zero_alloc attribute cannot appear in this context
 
 File "test_misplaced_assume.ml", line 5, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_misplaced_assume.foo (camlTest_misplaced_assume.foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_misplaced_assume.foo (camlTest_misplaced_assume__foo_HIDE_STAMP).
 
 File "test_misplaced_assume.ml", line 5, characters 25-30:
-Error: called function may allocate (direct tailcall camlTest_misplaced_assume.bar_HIDE_STAMP)
+Error: called function may allocate (direct tailcall camlTest_misplaced_assume__bar_HIDE_STAMP)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_missing_cmx/test.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_missing_cmx/test.output
@@ -1,17 +1,17 @@
 File "c.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc failed on function C.test_foo (camlC.test_foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function C.test_foo (camlC__test_foo_HIDE_STAMP).
 
 File "a.ml", line 3, characters 28-39:
-Error: called function may allocate (direct tailcall camlA.inner_foo_HIDE_STAMP) (b.ml:1,17--24;c.ml:1,30--42)
+Error: called function may allocate (direct tailcall camlA__inner_foo_HIDE_STAMP) (b.ml:1,17--24;c.ml:1,30--42)
 Hint: Build artifacts for the library containing the callee are not available.
 Try adding the library as an explicit dependency.
 
 
 File "c.ml", line 3, characters 5-15:
-Error: Annotation check for zero_alloc failed on function C.test_bar (camlC.test_bar_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function C.test_bar (camlC__test_bar_HIDE_STAMP).
 
 File "a.ml", line 7, characters 28-39:
-Error: called function may allocate (direct tailcall camlA.inner_bar_HIDE_STAMP) (b.ml:3,17--24;c.ml:3,30--42)
+Error: called function may allocate (direct tailcall camlA__inner_bar_HIDE_STAMP) (b.ml:3,17--24;c.ml:3,30--42)
 Hint: Build artifacts for the library containing the callee are not available.
 Try adding the library as an explicit dependency.
 

--- a/oxcaml/tests/backend/zero_alloc_checker/test_present_cmx/test.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_present_cmx/test.output
@@ -1,5 +1,5 @@
 File "c.ml", line 1, characters 5-15:
-Error: Annotation check for zero_alloc failed on function C.test_foo (camlC.test_foo_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function C.test_foo (camlC__test_foo_HIDE_STAMP).
 
 File "a.ml", line 3, characters 28-39:
-Error: called function may allocate (direct tailcall camlA.inner_foo_HIDE_STAMP) (b.ml:1,17--24;c.ml:1,30--42)
+Error: called function may allocate (direct tailcall camlA__inner_foo_HIDE_STAMP) (b.ml:1,17--24;c.ml:1,30--42)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_remove_inferred_assume.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_remove_inferred_assume.output
@@ -1,9 +1,9 @@
 File "test_remove_inferred_assume.ml", line 80, characters 15-25:
-Error: Annotation check for zero_alloc failed on function Test_remove_inferred_assume.read_exn (camlTest_remove_inferred_assume.read_exn_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_remove_inferred_assume.read_exn (camlTest_remove_inferred_assume__read_exn_HIDE_STAMP).
 
 File "test_remove_inferred_assume.ml", line 60, characters 70-82:
 Error: allocation of 24 bytes for boxed_int64
 inlined from
-test_remove_inferred_assume.ml:70,26--46[Test_remove_inferred_assume.Offset.to_int][camlTest_remove_inferred_assume.to_int_HIDE_STAMP]
-test_remove_inferred_assume.ml:75,12--32[Test_remove_inferred_assume.bounds_check][camlTest_remove_inferred_assume.bounds_check_HIDE_STAMP]
+test_remove_inferred_assume.ml:70,26--46[Test_remove_inferred_assume.Offset.to_int][camlTest_remove_inferred_assume__to_int_HIDE_STAMP]
+test_remove_inferred_assume.ml:75,12--32[Test_remove_inferred_assume.bounds_check][camlTest_remove_inferred_assume__bounds_check_HIDE_STAMP]
 test_remove_inferred_assume.ml:81,2--22[Test_remove_inferred_assume.read_exn]

--- a/oxcaml/tests/backend/zero_alloc_checker/test_signatures_first_class_modules.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_signatures_first_class_modules.output
@@ -1,11 +1,11 @@
 File "test_signatures_first_class_modules.ml", line 24, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_first_class_modules.g_strict_bad (camlTest_signatures_first_class_modules.g_strict_bad_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_first_class_modules.g_strict_bad (camlTest_signatures_first_class_modules__g_strict_bad_HIDE_STAMP).
 
 File "test_signatures_first_class_modules.ml", line 26, characters 2-7:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)
 
 File "test_signatures_first_class_modules.ml", line 35, characters 9-19:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_first_class_modules.h_strict.f_bad (camlTest_signatures_first_class_modules.f_bad_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_first_class_modules.h_strict.f_bad (camlTest_signatures_first_class_modules__f_bad_HIDE_STAMP).
 
 File "test_signatures_first_class_modules.ml", line 35, characters 38-49:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_signatures_functors.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_signatures_functors.output
@@ -1,5 +1,5 @@
 File "test_signatures_functors.ml", line 18, characters 7-17:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_functors.F_strict_bad.g (camlTest_signatures_functors.g_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_functors.F_strict_bad.g (camlTest_signatures_functors__g_HIDE_STAMP).
 
 File "test_signatures_functors.ml", line 18, characters 32-37:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_signatures_separate.opt.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_signatures_separate.opt.output
@@ -1,77 +1,77 @@
 File "test_signatures_separate_b.ml", line 14, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_is_not_za_strict (camlTest_signatures_separate_b.f_id_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_is_not_za_strict (camlTest_signatures_separate_b__f_id_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 14, characters 50-58:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 22, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_assume_is_not_za_strict (camlTest_signatures_separate_b.f_tuple_assume_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_assume_is_not_za_strict (camlTest_signatures_separate_b__f_tuple_assume_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 22, characters 60-78:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 24, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za (camlTest_signatures_separate_b.f_tuple_no_assume_is_not_za_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za (camlTest_signatures_separate_b__f_tuple_no_assume_is_not_za_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 24, characters 49-70:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 26, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za_strict (camlTest_signatures_separate_b.f_tuple_no_assume_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za_strict (camlTest_signatures_separate_b__f_tuple_no_assume_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 27, characters 2-23:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 45, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_opt_is_not_za_strict_opt (camlTest_signatures_separate_b.f_id_opt_is_not_za_strict_opt_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_opt_is_not_za_strict_opt (camlTest_signatures_separate_b__f_id_opt_is_not_za_strict_opt_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 45, characters 62-74:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 47, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_opt_is_not_za_strict (camlTest_signatures_separate_b.f_id_opt_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_opt_is_not_za_strict (camlTest_signatures_separate_b__f_id_opt_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 47, characters 54-66:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 55, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_one_is_not_za_two_args (camlTest_signatures_separate_b.f_arity_one_is_not_za_two_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_one_is_not_za_two_args (camlTest_signatures_separate_b__f_arity_one_is_not_za_two_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 55, characters 52-80:
 Error: called function may allocate (direct tailcall caml_apply2)
 
 File "test_signatures_separate_b.ml", line 57, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_one_arg (camlTest_signatures_separate_b.f_arity_two_is_not_za_one_arg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_one_arg (camlTest_signatures_separate_b__f_arity_two_is_not_za_one_arg_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 57, characters 51-66:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 61, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_three_args (camlTest_signatures_separate_b.f_arity_two_is_not_za_three_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_three_args (camlTest_signatures_separate_b__f_arity_two_is_not_za_three_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 61, characters 58-77:
 Error: called function may allocate (direct tailcall caml_apply3)
 
 File "test_signatures_separate_b.ml", line 63, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_one_arg (camlTest_signatures_separate_b.f_arity_three_is_not_za_one_arg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_one_arg (camlTest_signatures_separate_b__f_arity_three_is_not_za_one_arg_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 63, characters 53-70:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 65, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_two_args (camlTest_signatures_separate_b.f_arity_three_is_not_za_two_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_two_args (camlTest_signatures_separate_b__f_arity_three_is_not_za_two_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 65, characters 56-75:
 Error: called function may allocate (direct tailcall caml_apply2)
 
 File "test_signatures_separate_b.ml", line 69, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_one_arg (camlTest_signatures_separate_b.f_arity_two_sig_is_not_za_one_arg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_one_arg (camlTest_signatures_separate_b__f_arity_two_sig_is_not_za_one_arg_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 70, characters 2-29:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 75, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_three_args (camlTest_signatures_separate_b.f_arity_two_sig_is_not_za_three_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_three_args (camlTest_signatures_separate_b__f_arity_two_sig_is_not_za_three_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 76, characters 2-33:
 Error: called function may allocate (direct tailcall caml_apply3)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_signatures_separate.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_signatures_separate.output
@@ -1,77 +1,77 @@
 File "test_signatures_separate_b.ml", line 14, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_is_not_za_strict (camlTest_signatures_separate_b.f_id_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_is_not_za_strict (camlTest_signatures_separate_b__f_id_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 14, characters 50-58:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 22, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_assume_is_not_za_strict (camlTest_signatures_separate_b.f_tuple_assume_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_assume_is_not_za_strict (camlTest_signatures_separate_b__f_tuple_assume_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 22, characters 60-78:
 Error: called function may allocate on a path to exceptional return (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 24, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za (camlTest_signatures_separate_b.f_tuple_no_assume_is_not_za_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za (camlTest_signatures_separate_b__f_tuple_no_assume_is_not_za_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 24, characters 49-70:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 26, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za_strict (camlTest_signatures_separate_b.f_tuple_no_assume_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_tuple_no_assume_is_not_za_strict (camlTest_signatures_separate_b__f_tuple_no_assume_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 27, characters 2-23:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 43, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_id_opt_is_za_iff_all (camlTest_signatures_separate_b.f_id_opt_is_za_iff_all_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_id_opt_is_za_iff_all (camlTest_signatures_separate_b__f_id_opt_is_za_iff_all_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 43, characters 44-56:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 47, characters 5-15:
-Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_opt_is_not_za_strict (camlTest_signatures_separate_b.f_id_opt_is_not_za_strict_HIDE_STAMP).
+Error: Annotation check for zero_alloc strict failed on function Test_signatures_separate_b.f_id_opt_is_not_za_strict (camlTest_signatures_separate_b__f_id_opt_is_not_za_strict_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 47, characters 54-66:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 55, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_one_is_not_za_two_args (camlTest_signatures_separate_b.f_arity_one_is_not_za_two_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_one_is_not_za_two_args (camlTest_signatures_separate_b__f_arity_one_is_not_za_two_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 55, characters 52-80:
 Error: called function may allocate (direct tailcall caml_apply2)
 
 File "test_signatures_separate_b.ml", line 57, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_one_arg (camlTest_signatures_separate_b.f_arity_two_is_not_za_one_arg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_one_arg (camlTest_signatures_separate_b__f_arity_two_is_not_za_one_arg_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 57, characters 51-66:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 61, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_three_args (camlTest_signatures_separate_b.f_arity_two_is_not_za_three_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_is_not_za_three_args (camlTest_signatures_separate_b__f_arity_two_is_not_za_three_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 61, characters 58-77:
 Error: called function may allocate (direct tailcall caml_apply3)
 
 File "test_signatures_separate_b.ml", line 63, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_one_arg (camlTest_signatures_separate_b.f_arity_three_is_not_za_one_arg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_one_arg (camlTest_signatures_separate_b__f_arity_three_is_not_za_one_arg_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 63, characters 53-70:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 65, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_two_args (camlTest_signatures_separate_b.f_arity_three_is_not_za_two_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_three_is_not_za_two_args (camlTest_signatures_separate_b__f_arity_three_is_not_za_two_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 65, characters 56-75:
 Error: called function may allocate (direct tailcall caml_apply2)
 
 File "test_signatures_separate_b.ml", line 69, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_one_arg (camlTest_signatures_separate_b.f_arity_two_sig_is_not_za_one_arg_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_one_arg (camlTest_signatures_separate_b__f_arity_two_sig_is_not_za_one_arg_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 70, characters 2-29:
 Error: called function may allocate (indirect tailcall)
 
 File "test_signatures_separate_b.ml", line 75, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_three_args (camlTest_signatures_separate_b.f_arity_two_sig_is_not_za_three_args_HIDE_STAMP).
+Error: Annotation check for zero_alloc failed on function Test_signatures_separate_b.f_arity_two_sig_is_not_za_three_args (camlTest_signatures_separate_b__f_arity_two_sig_is_not_za_three_args_HIDE_STAMP).
 
 File "test_signatures_separate_b.ml", line 76, characters 2-33:
 Error: called function may allocate (direct tailcall caml_apply3)

--- a/oxcaml/tests/backend/zero_alloc_checker/test_sort_witnesses.output
+++ b/oxcaml/tests/backend/zero_alloc_checker/test_sort_witnesses.output
@@ -1,28 +1,28 @@
 File "test_sort_witnesses.ml", line 42, characters 5-15:
-Error: Annotation check for zero_alloc failed on function Test_sort_witnesses.compute (camlTest_sort_witnesses.compute_5_5).
+Error: Annotation check for zero_alloc failed on function Test_sort_witnesses.compute (camlTest_sort_witnesses__compute_5_5).
 
 File "test_sort_witnesses.ml", line 38, characters 19-43:
 Error: allocation of 16 bytes
 inlined from
-test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses.size_6_6]
+test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses__size_6_6]
 test_sort_witnesses.ml:49,10--16[Test_sort_witnesses.compute]
 
 File "test_sort_witnesses.ml", line 26, characters 35-77:
 Error: allocation of 16 bytes for float
 inlined from
-test_sort_witnesses.ml:38,24--43[Test_sort_witnesses.S.to_float_option][camlTest_sort_witnesses.to_float_option_4_4]
-test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses.size_6_6]
+test_sort_witnesses.ml:38,24--43[Test_sort_witnesses.S.to_float_option][camlTest_sort_witnesses__to_float_option_4_4]
+test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses__size_6_6]
 test_sort_witnesses.ml:49,10--16[Test_sort_witnesses.compute]
 
 File "test_sort_witnesses.ml", line 38, characters 19-43:
 Error: allocation of 16 bytes
 inlined from
-test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses.size_6_6]
+test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses__size_6_6]
 test_sort_witnesses.ml:50,10--16[Test_sort_witnesses.compute]
 
 File "test_sort_witnesses.ml", line 26, characters 35-77:
 Error: allocation of 16 bytes for float
 inlined from
-test_sort_witnesses.ml:38,24--43[Test_sort_witnesses.S.to_float_option][camlTest_sort_witnesses.to_float_option_4_4]
-test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses.size_6_6]
+test_sort_witnesses.ml:38,24--43[Test_sort_witnesses.S.to_float_option][camlTest_sort_witnesses__to_float_option_4_4]
+test_sort_witnesses.ml:44,4--30[Test_sort_witnesses.compute.size][camlTest_sort_witnesses__size_6_6]
 test_sort_witnesses.ml:50,10--16[Test_sort_witnesses.compute]

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -19,9 +19,6 @@
 /* This runtime provides some OxCaml-specific features */
 #define OXCAML_RUNTIME 1
 
-/* CR ocaml 5 all-runtime5: remove this and all uses of it */
-#define CAML_RUNTIME_5
-
 #include "m.h"
 #include "s.h"
 #include "compatibility.h"

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -301,9 +301,7 @@ CAMLprim value caml_dynlink_get_bytecode_sections(value unit)
 
 #define Handle_val(v) (*((void **) (v)))
 
-/* The mode argument is here for compatibility with runtime4. */
-/* CR ocaml 5 all-runtime5: Remove [mode] when all-runtime5. */
-CAMLprim value caml_dynlink_open_lib(value mode, value filename)
+CAMLprim value caml_dynlink_open_lib(value filename)
 {
   void * handle;
   value result;

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -870,15 +870,3 @@ CAMLexport value caml_runtime_events_user_resolve(
 
   CAMLreturn (Val_none);
 }
-
-/* Linker compatibility with unused 4 stdlib externals */
-
-CAMLprim value caml_eventlog_resume(value v)
-{
-  caml_failwith("caml_eventlog_resume: not supported in OCaml 5.");
-}
-
-CAMLprim value caml_eventlog_pause(value v)
-{
-  caml_failwith("caml_eventlog_pause: not supported in OCaml 5.");
-}

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -686,11 +686,6 @@ CAMLprim value caml_sys_const_backend_type(value unit)
   return Val_int(1); /* Bytecode backed */
 }
 
-CAMLprim value caml_sys_const_runtime5(value unit)
-{
-  return Val_true;
-}
-
 CAMLprim value caml_sys_const_arch_amd64(value unit)
 {
 #if defined(__x86_64__)

--- a/stdlib/gc.ml
+++ b/stdlib/gc.ml
@@ -67,14 +67,6 @@ external full_major : unit -> unit @@ portable = "caml_gc_full_major"
 external compact : unit -> unit @@ portable = "caml_gc_compaction"
 external get_minor_free : unit -> int @@ portable = "caml_get_minor_free"
 
-(* CR ocaml 5 all-runtime5: These functions are no-ops upstream. We should
-   make them no-ops internally when we delete the corresponding C functions
-   from the runtime -- they're already marked as deprecated in the mli.
-*)
-
-external eventlog_pause : unit -> unit @@ portable = "caml_eventlog_pause"
-external eventlog_resume : unit -> unit @@ portable = "caml_eventlog_resume"
-
 open Printf
 
 let print_stat c =

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -469,12 +469,6 @@ val delete_alarm : alarm -> unit
 (** [delete_alarm a] will stop the calls to the function associated
    to [a]. Calling [delete_alarm a] again has no effect. *)
 
-val eventlog_pause : unit -> unit
-[@@ocaml.deprecated "Use Runtime_events.pause instead."]
-
-val eventlog_resume : unit -> unit
-[@@ocaml.deprecated "Use Runtime_events.resume instead."]
-
 (** Submodule containing non-backwards-compatible functions which enforce thread safety
     via modes. *)
 module Safe : sig

--- a/testsuite/tests/lib-obj/get_header.ml
+++ b/testsuite/tests/lib-obj/get_header.ml
@@ -10,10 +10,10 @@
  }
 *)
 
-(* We're likely to remove %get_header in favour of calls to
-   caml_obj_is_stack under runtime5 (since testing a block's colour isn't
-   sufficient to check for local allocations) so this doesn't check for local
-   allocations any more. *)
+(* The only way to test for a block being stack-allocated is with
+   caml_obj_is_stack (previously the colour bits were sufficient) so
+   this test doesn't check for local allocations any more. *)
+
 
 external repr : ('a[@local_opt]) -> (Obj.t[@local_opt]) = "%identity"
 external get_header_unsafe : (Obj.t[@local_opt]) -> nativeint = "%get_header"

--- a/utils/config.common.ml.in
+++ b/utils/config.common.ml.in
@@ -168,7 +168,6 @@ let configuration_variables () =
   p_bool "probes" probes;
   p_bool "stack_allocation" stack_allocation;
 
-  p_bool "runtime5" true;
   p_bool "no_stack_checks" no_stack_checks;
   p_bool "multidomain" multidomain;
   p_bool "poll_insertion" poll_insertion;

--- a/utils/config.fixed.ml
+++ b/utils/config.fixed.ml
@@ -89,7 +89,6 @@ let systhread_supported = false
 let flexdll_dirs = []
 let ar_supports_response_files = true
 
-let runtime5 = true
 let no_stack_checks = false
 (* This setting is only for bootstrap, does not affect dune-built compilers: *)
 let naked_pointers = false

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -106,8 +106,6 @@ let flexdll_dirs = [@flexdll_dir@]
 
 let ar_supports_response_files = @ar_supports_response_files@
 
-let runtime5 = true
-
 let syntax_quotations = "@enable_syntax_quotations@" = "yes"
 
 let reserved_header_bits = @reserved_header_bits@

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -349,10 +349,6 @@ val poll_insertion : bool
 val ar_supports_response_files: bool
 (** Whether ar supports @FILE arguments. *)
 
-val runtime5 : bool
-(** Always [true], Previously:[false] when using the
-    OCaml 4.14 runtime. *)
-
 val no_stack_checks : bool
 (** [true] if stack checks are disabled. *)
 

--- a/utils/symbol.ml
+++ b/utils/symbol.ml
@@ -49,7 +49,7 @@ let caml_symbol_prefix = "caml"
 
 (* NB OCaml 5.4 uses [.] as a separator only on Linux and uses $ on other
       systems. The mangling convention in OxCaml has not yet been changed
-      to match.4 merge. *)
+      to match *)
 let upstream_symbol_separator =
   match Config.ccomp_type with
   | "msvc" -> '$' (* MASM does not allow for dots in symbol names *)


### PR DESCRIPTION
This is the sequel to #6218, removing the last few runtime 5 markers which were left in at that time to support third-party code which depended on them, as mentioned in that PR description. Extensive cleaning of that third-party code has occurred in the meantime, and will soon be complete. Removed:
```
Config.runtime5
%runtime5
CAML_RUNTIME_5
(the first argument of) caml_dynlink_open_lib
caml_sys_const_runtime5
Gc.eventlog_pause
Gc.eventlog_resume
```