### PR TITLE
Store dynamic bindings outside of stack_info

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -580,9 +580,14 @@ CAMLprim value caml_with_async_exns(value body_callback)
   // Save and restore the current dynamic binding state so that local bindings
   // are not leaked upon raising an async exception.
   dynamic_table_s tbl;
+
   dynamic_node_t node = Caml_state->current_stack->dyn_node;
-  if(node != NULL && !caml_dynamic_table_copy(/*dst=*/&tbl, /*src=*/&node->table)) {
-    caml_raise_out_of_memory();
+  if(node != NULL) {
+    if(!caml_dynamic_table_copy(/*dst=*/&tbl, /*src=*/&node->table)) {
+      caml_raise_out_of_memory();
+    }
+  } else {
+    caml_dynamic_table_init(&tbl);
   }
 
   // The saved table must be updated if its contents are promoted.

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -580,7 +580,9 @@ CAMLprim value caml_with_async_exns(value body_callback)
   // Save and restore the current dynamic binding state so that local bindings
   // are not leaked upon raising an async exception.
   dynamic_table_s tbl;
-  if(!caml_dynamic_table_copy(/*dst=*/&tbl, /*src=*/&Caml_state->current_stack->dyn)) {
+  caml_dynamic_table_init(&tbl);
+  dynamic_node_t node = Caml_state->current_stack->dyn_node;
+  if(node != NULL && !caml_dynamic_table_copy(/*dst=*/&tbl, /*src=*/&node->table)) {
     caml_raise_out_of_memory();
   }
 
@@ -589,8 +591,16 @@ CAMLprim value caml_with_async_exns(value body_callback)
   caml_result res = Result_encoded(caml_callback_exn(body_callback, Val_unit));
   caml_dynamic_table_unregister_roots(&tbl);
 
-  caml_dynamic_table_free(&Caml_state->current_stack->dyn);
-  Caml_state->current_stack->dyn = tbl;
+  // Re-read the node: the body may have created it (the node itself is
+  // stable across stack reallocation).
+  node = Caml_state->current_stack->dyn_node;
+  if(node != NULL) {
+    caml_dynamic_table_free(&node->table);
+    node->table = tbl;
+  } else {
+    // No bindings before or during the body, so nothing to restore.
+    CAMLassert(tbl.bindings == NULL);
+  }
   caml_dynamic_cache_flush(Caml_state->dynamic_bindings);
 
   /* raised as a normal exn, even if it was asynchronous */

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -580,7 +580,6 @@ CAMLprim value caml_with_async_exns(value body_callback)
   // Save and restore the current dynamic binding state so that local bindings
   // are not leaked upon raising an async exception.
   dynamic_table_s tbl;
-  caml_dynamic_table_init(&tbl);
   dynamic_node_t node = Caml_state->current_stack->dyn_node;
   if(node != NULL && !caml_dynamic_table_copy(/*dst=*/&tbl, /*src=*/&node->table)) {
     caml_raise_out_of_memory();
@@ -591,14 +590,12 @@ CAMLprim value caml_with_async_exns(value body_callback)
   caml_result res = Result_encoded(caml_callback_exn(body_callback, Val_unit));
   caml_dynamic_table_unregister_roots(&tbl);
 
-  // Re-read the node: the body may have created it (the node itself is
-  // stable across stack reallocation).
+  // The body may have created the node.
   node = Caml_state->current_stack->dyn_node;
   if(node != NULL) {
     caml_dynamic_table_free(&node->table);
     node->table = tbl;
   } else {
-    // No bindings before or during the body, so nothing to restore.
     CAMLassert(tbl.bindings == NULL);
   }
   caml_dynamic_cache_flush(Caml_state->dynamic_bindings);

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -193,9 +193,9 @@ typedef uint64_t uintnat;
 /* Number of words used in the control structure at the start of a stack
    (must match sizeof(struct stack_info) from fiber.h) */
 #ifdef ARCH_SIXTYFOUR
-#define Stack_ctx_words (13 + 1)
+#define Stack_ctx_words (11 + 1)
 #else
-#define Stack_ctx_words (13 + 2)
+#define Stack_ctx_words (11 + 2)
 #endif
 
 /* Whether to use guard pages for fiber stacks */

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -20,8 +20,6 @@
 #include "mlvalues.h"
 #include "roots.h"
 
-struct stack_info;
-
 /* Define a new dynamic value, which is an immediate unique ID. */
 CAMLprim value caml_dynamic_make(value unit);
 
@@ -112,18 +110,16 @@ extern void caml_dynamic_table_scan_roots(dynamic_table_t,
                                           void *);
 
 
-/* Per-fiber dynamic-binding state. Allocated lazily, owned by exactly one
-   fiber ([stack_info.dyn_node]) and freed with it, but allocated separately
-   from the stack block: stack reallocation moves [stack_info], not this
-   node, so the node stays stable for the fiber's whole lifetime.
+/* Per-fiber binding state. Owned by the fiber, but separately allocated
+   for stability (the stack_info allocation may be resized).
 
-   The GC scans each node's table via its owning fiber only. */
+   Scanned by the GC via the owning fiber only. */
 typedef struct dynamic_node_s {
   dynamic_table_s table;
 } dynamic_node_s, *dynamic_node_t;
 
-/* Free a fiber's dynamic-binding state, if any. */
-extern void caml_dynamic_node_free(struct stack_info* stack);
+/* Free a dynamic node and its contents. */
+extern void caml_dynamic_node_free(dynamic_node_t node);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -20,6 +20,8 @@
 #include "mlvalues.h"
 #include "roots.h"
 
+struct stack_info;
+
 /* Define a new dynamic value, which is an immediate unique ID. */
 CAMLprim value caml_dynamic_make(value unit);
 
@@ -108,6 +110,20 @@ extern void caml_dynamic_table_scan_roots(dynamic_table_t,
                                           scanning_action,
                                           scanning_action_flags,
                                           void *);
+
+
+/* Per-fiber dynamic-binding state. Allocated lazily, owned by exactly one
+   fiber ([stack_info.dyn_node]) and freed with it, but allocated separately
+   from the stack block: stack reallocation moves [stack_info], not this
+   node, so the node stays stable for the fiber's whole lifetime.
+
+   The GC scans each node's table via its owning fiber only. */
+typedef struct dynamic_node_s {
+  dynamic_table_s table;
+} dynamic_node_s, *dynamic_node_t;
+
+/* Free a fiber's dynamic-binding state, if any. */
+extern void caml_dynamic_node_free(struct stack_info* stack);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -72,11 +72,9 @@ struct stack_info {
   void* local_top;
   intnat local_limit;
 
-  /* Temporary dynamic bindings, applying only in this fiber, or NULL.
-     Allocated lazily, owned by this fiber and freed with it; the node
-     itself is stable across stack reallocation (see [dynamic_node_s] in
-     dynamic.h). */
-  struct dynamic_node_s* dyn_node;
+  /* Temporary dynamic bindings, applying only in this fiber.
+     Allocated lazily; may be NULL. */
+  dynamic_node_t dyn_node;
 };
 
 #ifdef STACK_GUARD_PAGES

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -72,8 +72,11 @@ struct stack_info {
   void* local_top;
   intnat local_limit;
 
-  /* Temporary dynamic bindings, applying only in this fiber */
-  struct dynamic_table_s dyn;
+  /* Temporary dynamic bindings, applying only in this fiber, or NULL.
+     Allocated lazily, owned by this fiber and freed with it; the node
+     itself is stable across stack reallocation (see [dynamic_node_s] in
+     dynamic.h). */
+  struct dynamic_node_s* dyn_node;
 };
 
 #ifdef STACK_GUARD_PAGES

--- a/runtime/dynamic.c
+++ b/runtime/dynamic.c
@@ -459,9 +459,7 @@ CAMLprim value caml_dynamic_make(value unit)
   CAMLreturn(hash);
 }
 
-/* Return the current fiber's node, allocating it on first use.
-   May raise Out_of_memory. */
-static dynamic_node_t dynamic_node(struct stack_info *stack)
+static dynamic_node_t dynamic_node_get_or_init(struct stack_info *stack)
 {
   dynamic_node_t node = stack->dyn_node;
   if(node == NULL) {
@@ -475,13 +473,11 @@ static dynamic_node_t dynamic_node(struct stack_info *stack)
   return node;
 }
 
-CAMLexport void caml_dynamic_node_free(struct stack_info *stack)
+CAMLexport void caml_dynamic_node_free(dynamic_node_t node)
 {
-  dynamic_node_t node = stack->dyn_node;
   if(node != NULL) {
     caml_dynamic_table_free(&node->table);
     caml_stat_free(node);
-    stack->dyn_node = NULL;
   }
 }
 
@@ -497,7 +493,6 @@ static bool dynamic_node_find(dynamic_node_t node, value dyn, value *val)
   return false;
 }
 
-/* Walk the fiber's parent chain for the innermost binding. */
 static value dynamic_lookup(struct stack_info *stack, value dyn)
 {
   value val;
@@ -537,7 +532,8 @@ CAMLprim value caml_dynamic_push(value dyn, value val)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  if(!dynamic_table_push(&dynamic_node(stack)->table, dyn, val)) {
+  dynamic_node_t node = dynamic_node_get_or_init(stack);
+  if(!dynamic_table_push(&node->table, dyn, val)) {
     caml_raise_out_of_memory();
   }
 
@@ -555,7 +551,7 @@ CAMLprim value caml_dynamic_pop(value dyn)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  /* Pops are paired with pushes on the same fiber, so the node exists */
+  /* There should be a corresponding push on this fiber */
   CAMLassert(stack->dyn_node);
   if(stack->dyn_node != NULL) {
     dynamic_table_pop(&stack->dyn_node->table, dyn);

--- a/runtime/dynamic.c
+++ b/runtime/dynamic.c
@@ -459,6 +459,57 @@ CAMLprim value caml_dynamic_make(value unit)
   CAMLreturn(hash);
 }
 
+/* Return the current fiber's node, allocating it on first use.
+   May raise Out_of_memory. */
+static dynamic_node_t dynamic_node(struct stack_info *stack)
+{
+  dynamic_node_t node = stack->dyn_node;
+  if(node == NULL) {
+    node = caml_stat_alloc_noexc(sizeof(dynamic_node_s));
+    if(node == NULL) {
+      caml_raise_out_of_memory();
+    }
+    caml_dynamic_table_init(&node->table);
+    stack->dyn_node = node;
+  }
+  return node;
+}
+
+CAMLexport void caml_dynamic_node_free(struct stack_info *stack)
+{
+  dynamic_node_t node = stack->dyn_node;
+  if(node != NULL) {
+    caml_dynamic_table_free(&node->table);
+    caml_stat_free(node);
+    stack->dyn_node = NULL;
+  }
+}
+
+static bool dynamic_node_find(dynamic_node_t node, value dyn, value *val)
+{
+  dynamic_stack_t bindings;
+  if(node != NULL
+     && dynamic_table_find(&node->table, dyn, &bindings)
+     && bindings->count > 0) {
+    *val = bindings->vals[bindings->count - 1];
+    return true;
+  }
+  return false;
+}
+
+/* Walk the fiber's parent chain for the innermost binding. */
+static value dynamic_lookup(struct stack_info *stack, value dyn)
+{
+  value val;
+
+  for(; stack != NULL; stack = Stack_parent(stack)) {
+    if(dynamic_node_find(stack->dyn_node, dyn, &val)) {
+      return val;
+    }
+  }
+  return Val_null;
+}
+
 CAMLprim value caml_dynamic_get(value dyn)
 {
   CAMLnoalloc;
@@ -472,17 +523,7 @@ CAMLprim value caml_dynamic_get(value dyn)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  value val = Val_null;
-  while(stack) {
-    dynamic_stack_t bindings;
-    if(dynamic_table_find(&stack->dyn, dyn, &bindings)) {
-      if(bindings->count > 0) {
-        val = bindings->vals[bindings->count - 1];
-        break;
-      }
-    }
-    stack = Stack_parent(stack);
-  }
+  value val = dynamic_lookup(stack, dyn);
 
   entry->dyn = dyn;
   entry->val = val;
@@ -496,7 +537,7 @@ CAMLprim value caml_dynamic_push(value dyn, value val)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  if(!dynamic_table_push(&stack->dyn, dyn, val)) {
+  if(!dynamic_table_push(&dynamic_node(stack)->table, dyn, val)) {
     caml_raise_out_of_memory();
   }
 
@@ -514,7 +555,11 @@ CAMLprim value caml_dynamic_pop(value dyn)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  dynamic_table_pop(&stack->dyn, dyn);
+  /* Pops are paired with pushes on the same fiber, so the node exists */
+  CAMLassert(stack->dyn_node);
+  if(stack->dyn_node != NULL) {
+    dynamic_table_pop(&stack->dyn_node->table, dyn);
+  }
 
   dynamic_binding_t entry = dynamic_cache_entry(dyn);
   if(entry->dyn == dyn) {

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -353,7 +353,7 @@ alloc_size_class_stack_noexc(mlsize_t wosize, int cache_bucket, value hval,
   stack->local_sp = 0;
   stack->local_top = NULL;
   stack->local_limit = 0;
-  caml_dynamic_table_init(&stack->dyn);
+  stack->dyn_node = NULL;
 #ifdef DEBUG
   stack->magic = 42;
 #endif
@@ -661,7 +661,8 @@ void caml_scan_stack(
     scan_stack_frames(f, fflags, fdata, stack, gc_regs, locals);
 
     /* Scan dynamic bindings */
-    caml_dynamic_table_scan_roots(&stack->dyn, f, fflags, fdata);
+    if (stack->dyn_node != NULL)
+      caml_dynamic_table_scan_roots(&stack->dyn_node->table, f, fflags, fdata);
 
     f(fdata, Stack_handle_value(stack), &Stack_handle_value(stack));
     f(fdata, Stack_handle_exception(stack), &Stack_handle_exception(stack));
@@ -803,7 +804,8 @@ void caml_scan_stack(
     }
 
     /* Scan dynamic bindings */
-    caml_dynamic_table_scan_roots(&stack->dyn, f, fflags, fdata);
+    if (stack->dyn_node != NULL)
+      caml_dynamic_table_scan_roots(&stack->dyn_node->table, f, fflags, fdata);
 
     if (is_scannable(fflags, Stack_handle_value(stack)))
       f(fdata, Stack_handle_value(stack), &Stack_handle_value(stack));
@@ -951,14 +953,15 @@ int caml_try_realloc_stack(asize_t required_space)
   new_stack->local_sp = old_stack->local_sp;
   new_stack->local_top = old_stack->local_top;
   new_stack->local_limit = old_stack->local_limit;
-  new_stack->dyn = old_stack->dyn;
+  /* The node is stable: it moves to the new stack without being copied */
+  new_stack->dyn_node = old_stack->dyn_node;
 
   // Detach locals stack and dynamic bindings from old_stack so they will not be freed
   old_stack->local_arenas = NULL;
   old_stack->local_sp = 0;
   old_stack->local_top = NULL;
   old_stack->local_limit = 0;
-  caml_dynamic_table_init(&old_stack->dyn);
+  old_stack->dyn_node = NULL;
 
 #ifdef NATIVE_CODE
   /* There's no need to do another pass rewriting from
@@ -1152,7 +1155,7 @@ void caml_free_stack (struct stack_info* stack)
   // Don't need to update local_sp since this is no longer the current stack.
   caml_free_local_arenas(stack->local_arenas);
 
-  caml_dynamic_table_free(&stack->dyn);
+  caml_dynamic_node_free(stack);
 
   if (cache_bucket != -1) {
 #if defined(DEBUG) && defined(STACK_CHECKS_ENABLED)

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -953,7 +953,6 @@ int caml_try_realloc_stack(asize_t required_space)
   new_stack->local_sp = old_stack->local_sp;
   new_stack->local_top = old_stack->local_top;
   new_stack->local_limit = old_stack->local_limit;
-  /* The node is stable: it moves to the new stack without being copied */
   new_stack->dyn_node = old_stack->dyn_node;
 
   // Detach locals stack and dynamic bindings from old_stack so they will not be freed
@@ -1155,7 +1154,7 @@ void caml_free_stack (struct stack_info* stack)
   // Don't need to update local_sp since this is no longer the current stack.
   caml_free_local_arenas(stack->local_arenas);
 
-  caml_dynamic_node_free(stack);
+  caml_dynamic_node_free(stack->dyn_node);
 
   if (cache_bucket != -1) {
 #if defined(DEBUG) && defined(STACK_CHECKS_ENABLED)

--- a/testsuite/tests/codegen/stack_check_save_simd.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd.ml
@@ -36,7 +36,7 @@ f:
   ret
 .L1:
   pushq %r10
-  leaq  -384(%rsp), %r10
+  leaq  -368(%rsp), %r10
   cmpq  40(%r14), %r10
   popq  %r10
   jb    .L9

--- a/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
+++ b/testsuite/tests/codegen/stack_check_save_simd_prologue.ml
@@ -33,7 +33,7 @@ f:
   cmpq  $1, %rdi
   jne   .L6
   pushq %r10
-  leaq  -384(%rsp), %r10
+  leaq  -368(%rsp), %r10
   cmpq  40(%r14), %r10
   popq  %r10
   jb    .L11


### PR DESCRIPTION
Allocates the per-fiber dynamic binding table separately from the fiber's `stack_info` struct, which moves when the fiber's stack grows (assuming stack checks are in use). This allows us to store a stable pointer to a running fiber's dynamic state in a following PR.