### PR TITLE
Freeze & shift dynamic tables

### DIFF
--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -577,34 +577,13 @@ CAMLexport void caml_iterate_named_values(caml_named_action f)
 
 CAMLprim value caml_with_async_exns(value body_callback)
 {
-  // Save and restore the current dynamic binding state so that local bindings
-  // are not leaked upon raising an async exception.
-  dynamic_table_s tbl;
+  // Freeze the current dynamic binding state: bindings the body pushes are
+  // discarded if an async exception exits the body without popping them.
+  dynamic_table_t snapshot = caml_dynamic_state_snapshot();
 
-  dynamic_node_t node = Caml_state->current_stack->dyn_node;
-  if(node != NULL) {
-    if(!caml_dynamic_table_copy(/*dst=*/&tbl, /*src=*/&node->table)) {
-      caml_raise_out_of_memory();
-    }
-  } else {
-    caml_dynamic_table_init(&tbl);
-  }
-
-  // The saved table must be updated if its contents are promoted.
-  caml_dynamic_table_register_roots(&tbl);
   caml_result res = Result_encoded(caml_callback_exn(body_callback, Val_unit));
-  caml_dynamic_table_unregister_roots(&tbl);
 
-  // The body may have created the node. Only the table is restored; lexical
-  // edges belong to the fiber, not to the unwound bindings.
-  node = Caml_state->current_stack->dyn_node;
-  if(node != NULL) {
-    caml_dynamic_table_free(&node->table);
-    node->table = tbl;
-  } else {
-    CAMLassert(tbl.bindings == NULL);
-  }
-  caml_dynamic_cache_flush(Caml_state->dynamic_bindings);
+  caml_dynamic_state_restore(snapshot);
 
   /* raised as a normal exn, even if it was asynchronous */
   if (caml_result_is_exception(res)) {

--- a/runtime/caml/dynamic.h
+++ b/runtime/caml/dynamic.h
@@ -47,7 +47,9 @@ CAMLprim value caml_dynamic_pop(value dyn);
       spawn (fun () -> caml_dynamic_use_scope scope),
       spawn (fun () -> caml_dynamic_use_scope scope)
    in
-   await l, await r
+   let res = await l, await r in
+   caml_dynamic_thaw_scope scope;
+   res
 
    Using the scope in child fibers causes them to inherit dynamic bindings
    installed on the path to the root task, even if they're migrated to other
@@ -55,15 +57,18 @@ CAMLprim value caml_dynamic_pop(value dyn);
 
    All calls to [caml_dynamic_freeze_scope] must occur in a descendant of
    a fiber that called [caml_dynamic_set_root]. The returned [scope] must
-   outlive all child fibers that call [caml_dynamic_use_scope], and must
-   *not* outlive the current fiber. It is unsafe to modify the binding
-   state of any fiber on the frozen path (the current fiber up to the
-   enclosing task) during the lifetime of [scope]. */
+   outlive all child fibers that call [caml_dynamic_use_scope], the parent
+   must not perform an effect during the lifetime of [scope], and [scope]
+   must be passed to [caml_dynamic_thaw_scope] after all children exit. */
 CAMLprim value caml_dynamic_freeze_scope(value unit);
 
 /* Make a set of frozen dynamic bindings visible to the current fiber.
    See [caml_dynamic_freeze_scope] for usage. */
 CAMLprim value caml_dynamic_use_scope(value scope);
+
+/* Release a scope returned by [caml_dynamic_freeze_scope]. Must be called on
+   the fiber that froze the scope and the scope must not be in use. */
+CAMLprim value caml_dynamic_thaw_scope(value scope);
 
 /* Mark the current fiber as a root task. Dynamic bindings installed above
    the current fiber will not be captured by [caml_dynamic_freeze_scope].
@@ -121,45 +126,49 @@ typedef struct dynamic_table_s {
   size_t mask; /* capacity - 1 */
   size_t count;
   dynamic_stack_t bindings;
+  struct dynamic_table_s* parent;
+
+  /* Number of frozen scopes that refer to this table.
+     This table is immutable if [frozen] > 0. Attempting to change the binding
+     state of a frozen table instead allocates a fresh child table. */
+  uintnat frozen;
 } dynamic_table_s, *dynamic_table_t;
 
-/* Initialize a dynamic table to an empty state. */
-extern void caml_dynamic_table_init(dynamic_table_t table);
+/* Freeze and return the current table. Changes to the binding state
+   after [snapshot] will not be visible after [restore]. */
+extern dynamic_table_t caml_dynamic_state_snapshot(void);
 
-/* Uninitialize a dynamic table, freeing any internal allocations. */
-extern void caml_dynamic_table_free(dynamic_table_t table);
-
-/* Duplicate a dynamic table. Returns false if allocation fails. */
-extern bool caml_dynamic_table_copy(dynamic_table_t dst, dynamic_table_t src);
-
-/* Register all bindings as GC roots. */
-extern void caml_dynamic_table_register_roots(dynamic_table_t table);
-
-/* Unregister all bindings as GC roots. */
-extern void caml_dynamic_table_unregister_roots(dynamic_table_t table);
-
-/* Apply a GC scanning action to all bindings in a dynamic table. */
-extern void caml_dynamic_table_scan_roots(dynamic_table_t,
-                                          scanning_action,
-                                          scanning_action_flags,
-                                          void *);
+/* Restore the current table to its state at [snapshot], freeing any
+   intermediate tables installed in the interim. */
+extern void caml_dynamic_state_restore(dynamic_table_t snapshot);
 
 /* Per-fiber binding state. Owned by the fiber, but separately allocated for
    stability (the stack_info allocation may be resized). Scanned by the GC via
    the owning fiber only.
 
-   [lexical_parent] records the path from the current fiber to the root task.
+   [table] stores dynamic binding state at the base of the owning fiber.
+   Its chain of parent pointers records the path to the root task.
+
+   [newest] typically points to [table], unless [table] was frozen and another
+   binding was installed. In this case, [newest] points to a separately allocated
+   table whose parent pointer records the path to [table] (then to the root).
 
    [is_task] indicates whether this node is a concurrent task. If it is, lookup
-   prioritizes [lexical_parent], which points to the inherited binding state. */
+   proceeds into [table.parent], which points to the inherited binding state. */
 typedef struct dynamic_node_s {
   dynamic_table_s table;
-  struct dynamic_node_s* lexical_parent;
+  dynamic_table_t newest;
   bool is_task;
 } dynamic_node_s, *dynamic_node_t;
 
 /* Free a dynamic node and its contents. */
 extern void caml_dynamic_node_free(dynamic_node_t node);
+
+/* Apply a GC scanning action to all bindings in a node's chain. */
+extern void caml_dynamic_node_scan_roots(dynamic_node_t node,
+                                         scanning_action f,
+                                         scanning_action_flags fflags,
+                                         void *fdata);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/dynamic.c
+++ b/runtime/dynamic.c
@@ -105,27 +105,6 @@ static void dynamic_stack_free(dynamic_stack_t stack)
 }
 
 // Returns false if allocation fails.
-static bool dynamic_stack_copy(dynamic_stack_t dst, dynamic_stack_t src)
-{
-  dst->capacity = src->capacity;
-  dst->count = src->count;
-  dst->dyn = src->dyn;
-
-  if(src->vals) {
-    dst->vals = caml_stat_alloc_noexc(sizeof(value) * src->capacity);
-    if(dst->vals == NULL) {
-      return false;
-    }
-
-    memcpy(dst->vals, src->vals, sizeof(value) * src->count);
-  } else {
-    dst->vals = NULL;
-  }
-
-  return true;
-}
-
-// Returns false if allocation fails.
 static bool dynamic_stack_grow(dynamic_stack_t stack)
 {
   size_t old_capacity = stack->capacity;
@@ -183,26 +162,6 @@ static bool dynamic_stack_pop(dynamic_stack_t stack)
   return false;
 }
 
-static void dynamic_stack_register_roots(dynamic_stack_t stack)
-{
-  if(Is_this(stack->dyn)) {
-    caml_register_generational_global_root(&stack->dyn);
-    for(size_t i = 0; i < stack->count; ++i) {
-      caml_register_generational_global_root(&stack->vals[i]);
-    }
-  }
-}
-
-static void dynamic_stack_unregister_roots(dynamic_stack_t stack)
-{
-  if(Is_this(stack->dyn)) {
-    caml_remove_generational_global_root(&stack->dyn);
-    for(size_t i = 0; i < stack->count; ++i) {
-      caml_remove_generational_global_root(&stack->vals[i]);
-    }
-  }
-}
-
 static void dynamic_stack_scan_roots(dynamic_stack_t stack,
                                      scanning_action f,
                                      scanning_action_flags fflags,
@@ -224,14 +183,16 @@ static size_t dynamic_table_capacity(dynamic_table_t table) {
   return table->mask + 1;
 }
 
-CAMLexport void caml_dynamic_table_init(dynamic_table_t table)
+static void dynamic_table_init(dynamic_table_t table)
 {
   table->mask = (size_t)-1;
   table->count = 0;
   table->bindings = NULL;
+  table->frozen = 0;
+  table->parent = NULL;
 }
 
-CAMLexport void caml_dynamic_table_free(dynamic_table_t table)
+static void dynamic_table_free(dynamic_table_t table)
 {
   if(table->bindings) {
     size_t capacity = dynamic_table_capacity(table);
@@ -240,7 +201,7 @@ CAMLexport void caml_dynamic_table_free(dynamic_table_t table)
     }
     caml_stat_free(table->bindings);
   }
-  caml_dynamic_table_init(table);
+  dynamic_table_init(table);
 }
 
 static void dynamic_table_add(dynamic_table_t table, dynamic_stack_s stack)
@@ -392,61 +353,29 @@ static void dynamic_table_pop(dynamic_table_t table, value dyn)
   }
 }
 
-// Returns false if allocation fails.
-CAMLexport bool caml_dynamic_table_copy(dynamic_table_t dst, dynamic_table_t src)
-{
-  size_t capacity = dynamic_table_capacity(src);
-
-  dst->mask = src->mask;
-  dst->count = src->count;
-
-  if(src->bindings) {
-    dst->bindings = caml_stat_alloc_noexc(sizeof(dynamic_stack_s) * capacity);
-    if(dst->bindings == NULL) {
-      return false;
-    }
-
-    for(size_t i = 0; i < capacity; ++i) {
-      if(!dynamic_stack_copy(&dst->bindings[i], &src->bindings[i])) {
-        for(size_t j = 0; j < i; ++j) {
-          dynamic_stack_free(&dst->bindings[j]);
-        }
-        caml_stat_free(dst->bindings);
-        return false;
-      }
-    }
-  } else {
-    dst->bindings = NULL;
-  }
-
-  return true;
-}
-
-CAMLexport void caml_dynamic_table_register_roots(dynamic_table_t table)
-{
-  size_t capacity = dynamic_table_capacity(table);
-  for(size_t i = 0; i < capacity; ++i) {
-    dynamic_stack_register_roots(&table->bindings[i]);
-  }
-}
-
-CAMLexport void caml_dynamic_table_unregister_roots(dynamic_table_t table)
-{
-  size_t capacity = dynamic_table_capacity(table);
-  for(size_t i = 0; i < capacity; ++i) {
-    dynamic_stack_unregister_roots(&table->bindings[i]);
-  }
-}
-
-CAMLexport void caml_dynamic_table_scan_roots(dynamic_table_t table,
-                                              scanning_action f,
-                                              scanning_action_flags fflags,
-                                              void *fdata)
+static void dynamic_table_scan_roots(dynamic_table_t table,
+                                     scanning_action f,
+                                     scanning_action_flags fflags,
+                                     void *fdata)
 {
   if(table->bindings) {
     size_t capacity = dynamic_table_capacity(table);
     for(size_t i = 0; i < capacity; ++i) {
       dynamic_stack_scan_roots(&table->bindings[i], f, fflags, fdata);
+    }
+  }
+}
+
+CAMLexport void caml_dynamic_node_scan_roots(dynamic_node_t node,
+                                             scanning_action f,
+                                             scanning_action_flags fflags,
+                                             void *fdata)
+{
+  /* Stops at the base: tables past it are scanned by their own fibers */
+  for(dynamic_table_t table = node->newest;; table = table->parent) {
+    dynamic_table_scan_roots(table, f, fflags, fdata);
+    if(table == &node->table) {
+      break;
     }
   }
 }
@@ -467,8 +396,8 @@ static dynamic_node_t dynamic_node_get_or_init(struct stack_info *stack)
     if(node == NULL) {
       caml_raise_out_of_memory();
     }
-    caml_dynamic_table_init(&node->table);
-    node->lexical_parent = NULL;
+    dynamic_table_init(&node->table);
+    node->newest = &node->table;
     node->is_task = false;
     stack->dyn_node = node;
   }
@@ -478,27 +407,23 @@ static dynamic_node_t dynamic_node_get_or_init(struct stack_info *stack)
 CAMLexport void caml_dynamic_node_free(dynamic_node_t node)
 {
   if(node != NULL) {
-    caml_dynamic_table_free(&node->table);
+
+    // Free tables from [node->newest] to [&node->table]
+    dynamic_table_t table = node->newest;
+    while(table != &node->table) {
+      dynamic_table_t prev = table->parent;
+      dynamic_table_free(table);
+      caml_stat_free(table);
+      table = prev;
+    }
+
+    dynamic_table_free(&node->table);
     caml_stat_free(node);
   }
 }
 
-static bool dynamic_node_find(dynamic_node_t node, value dyn, value *val)
-{
-  dynamic_stack_t bindings;
-  if(node != NULL
-     && dynamic_table_find(&node->table, dyn, &bindings)
-     && bindings->count > 0) {
-    *val = bindings->vals[bindings->count - 1];
-    return true;
-  }
-  return false;
-}
-
 static value dynamic_lookup(struct stack_info *stack, value dyn)
 {
-  value val;
-
   // Outer loop traverses the Stack_parent chain. In the absence of structured
   // concurrency, this is all we need.
   for(; stack != NULL; stack = Stack_parent(stack)) {
@@ -507,28 +432,22 @@ static value dynamic_lookup(struct stack_info *stack, value dyn)
     if(node == NULL) {
       continue;
     }
-    if(dynamic_node_find(node, dyn, &val)) {
-      return val;
-    }
 
-    // If the current node is a task whose lexical parent disagrees with its
-    // dynamic parent, traverse the lexical chain. Note we ignore plain nodes:
-    // their lexical parents only cache frozen parent pointers.
-    if(node->is_task &&
-       /* If lexical_parent is NULL, this is the root task. */
-       node->lexical_parent != NULL &&
-        /* If the lexical parent is suspended, its Stack_parent is NULL. */
-        (Stack_parent(stack) == NULL ||
-         Stack_parent(stack)->dyn_node != node->lexical_parent)) {
+    // Inner loop walks the fiber's tables newest-first. Plain fibers'
+    // lookups stop at their base; tasks continue toward the task root.
+    dynamic_table_t table = node->newest;
+    while(table != NULL) {
 
-      dynamic_node_t lex_node = node->lexical_parent;
-
-      // Inner loop traverses the lexical parent chain.
-      for(; lex_node != NULL; lex_node = lex_node->lexical_parent) {
-        if(dynamic_node_find(lex_node, dyn, &val)) {
-          return val;
-        }
+      dynamic_stack_t bindings;
+      bool found = dynamic_table_find(table, dyn, &bindings);
+      if(found && bindings->count > 0) {
+        return bindings->vals[bindings->count - 1];
       }
+
+      if(table == &node->table && !node->is_task) {
+        break;
+      }
+      table = table->parent;
     }
   }
   return Val_null;
@@ -565,8 +484,31 @@ CAMLprim value caml_dynamic_push(value dyn, value val)
   CAMLassert(stack);
 
   dynamic_node_t node = dynamic_node_get_or_init(stack);
-  if(!dynamic_table_push(&node->table, dyn, val)) {
-    caml_raise_out_of_memory();
+  dynamic_table_t table = node->newest;
+
+  // We cannot modify a frozen table, so push a fresh one
+  if(table->frozen > 0) {
+
+    dynamic_table_t fresh = caml_stat_alloc_noexc(sizeof(dynamic_table_s));
+    if(fresh != NULL) {
+      dynamic_table_init(fresh);
+    } else {
+      caml_raise_out_of_memory();
+    }
+
+    if(!dynamic_table_push(fresh, dyn, val)) {
+      dynamic_table_free(fresh);
+      caml_stat_free(fresh);
+      caml_raise_out_of_memory();
+    }
+
+    fresh->parent = table;
+    node->newest = fresh;
+
+  } else {
+    if(!dynamic_table_push(table, dyn, val)) {
+      caml_raise_out_of_memory();
+    }
   }
 
   dynamic_binding_t entry = dynamic_cache_entry(dyn);
@@ -583,10 +525,22 @@ CAMLprim value caml_dynamic_pop(value dyn)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  /* There should be a corresponding push on this fiber */
-  CAMLassert(stack->dyn_node);
-  if(stack->dyn_node != NULL) {
-    dynamic_table_pop(&stack->dyn_node->table, dyn);
+  // The binding being popped was pushed to the newest table
+  dynamic_node_t node = stack->dyn_node;
+  CAMLassert(node);
+
+  if(node != NULL) {
+    dynamic_table_t table = node->newest;
+    CAMLassert(table->frozen == 0);
+
+    dynamic_table_pop(table, dyn);
+
+    if(table != &node->table && table->count == 0 && table->frozen == 0) {
+      // The last binding scope below a freeze closed; free its table
+      node->newest = table->parent;
+      dynamic_table_free(table);
+      caml_stat_free(table);
+    }
   }
 
   dynamic_binding_t entry = dynamic_cache_entry(dyn);
@@ -597,15 +551,51 @@ CAMLprim value caml_dynamic_pop(value dyn)
   return Val_unit;
 }
 
+CAMLexport dynamic_table_t caml_dynamic_state_snapshot(void)
+{
+  dynamic_node_t node = dynamic_node_get_or_init(Caml_state->current_stack);
+  dynamic_table_t snapshot = node->newest;
+  snapshot->frozen++;
+  return snapshot;
+}
+
+CAMLexport void caml_dynamic_state_restore(dynamic_table_t snapshot)
+{
+  dynamic_node_t node = Caml_state->current_stack->dyn_node;
+  CAMLassert(node != NULL);
+
+  // Discard the tables pushed above the snapshot
+  dynamic_table_t table = node->newest;
+  while(table != snapshot && table != &node->table) {
+
+    CAMLassert(table->frozen == 0);
+    dynamic_table_t prev = table->parent;
+    dynamic_table_free(table);
+    caml_stat_free(table);
+    table = prev;
+  }
+
+  CAMLassert(table == snapshot);
+  node->newest = snapshot;
+
+  CAMLassert(snapshot->frozen > 0);
+  if(snapshot->frozen > 0) {
+    snapshot->frozen--;
+  }
+
+  caml_dynamic_cache_flush(Caml_state->dynamic_bindings);
+}
+
 CAMLprim value caml_dynamic_freeze_scope(value unit)
 {
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  dynamic_node_t node = dynamic_node_get_or_init(stack);
+  // Child fibers may concurrently read the current binding table, so freeze it
+  dynamic_table_t scope = caml_dynamic_state_snapshot();
 
-  // Link fibers up to the enclosing task into the lexical parent chain.
-  dynamic_node_t cur = node;
+  // Link fibers up to the enclosing task into the frozen path
+  dynamic_node_t cur = stack->dyn_node;
   while(!cur->is_task && Stack_parent(stack) != NULL) {
 
     stack = Stack_parent(stack);
@@ -615,10 +605,10 @@ CAMLprim value caml_dynamic_freeze_scope(value unit)
       continue;
     }
 
-    // Avoid writing the parent if we've already frozen it
-    // (children may be reading it concurrently)
-    if(cur->lexical_parent != next) {
-      cur->lexical_parent = next;
+    // Avoid writing the link if we've already frozen it
+    dynamic_table_t link = next->newest;
+    if(cur->table.parent != link) {
+      cur->table.parent = link;
     }
     cur = next;
   }
@@ -626,7 +616,7 @@ CAMLprim value caml_dynamic_freeze_scope(value unit)
   // Freezing must happen inside a root task, so the walk ends at a task node.
   CAMLassert(cur->is_task);
 
-  return Val_ptr(node);
+  return Val_ptr(scope);
 }
 
 CAMLprim value caml_dynamic_use_scope(value scope)
@@ -634,21 +624,36 @@ CAMLprim value caml_dynamic_use_scope(value scope)
   struct stack_info *stack = Caml_state->current_stack;
   CAMLassert(stack);
 
-  dynamic_node_t parent = Ptr_val(scope);
+  dynamic_table_t parent = Ptr_val(scope);
   CAMLassert(parent);
 
   dynamic_node_t node = dynamic_node_get_or_init(stack);
-  node->lexical_parent = parent;
+  node->table.parent = parent;
   node->is_task = true;
   caml_dynamic_cache_flush(Caml_state->dynamic_bindings);
 
   return Val_unit;
 }
 
+CAMLprim value caml_dynamic_thaw_scope(value scope)
+{
+  CAMLnoalloc;
+
+  // Scopes are thawed on the fiber that froze them, after any binding
+  // scopes opened in the interim have closed.
+  dynamic_table_t table = Ptr_val(scope);
+  CAMLassert(table);
+  CAMLassert(table->frozen > 0);
+  if(table->frozen > 0) {
+    table->frozen--;
+  }
+  return Val_unit;
+}
+
 CAMLprim value caml_dynamic_set_root(value unit)
 {
   dynamic_node_t node = dynamic_node_get_or_init(Caml_state->current_stack);
-  node->lexical_parent = NULL;
+  node->table.parent = NULL;
   node->is_task = true;
   caml_dynamic_cache_flush(Caml_state->dynamic_bindings);
   return Val_unit;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -662,7 +662,7 @@ void caml_scan_stack(
 
     /* Scan dynamic bindings */
     if (stack->dyn_node != NULL)
-      caml_dynamic_table_scan_roots(&stack->dyn_node->table, f, fflags, fdata);
+      caml_dynamic_node_scan_roots(stack->dyn_node, f, fflags, fdata);
 
     f(fdata, Stack_handle_value(stack), &Stack_handle_value(stack));
     f(fdata, Stack_handle_exception(stack), &Stack_handle_exception(stack));
@@ -805,7 +805,7 @@ void caml_scan_stack(
 
     /* Scan dynamic bindings */
     if (stack->dyn_node != NULL)
-      caml_dynamic_table_scan_roots(&stack->dyn_node->table, f, fflags, fdata);
+      caml_dynamic_node_scan_roots(stack->dyn_node, f, fflags, fdata);
 
     if (is_scannable(fflags, Stack_handle_value(stack)))
       f(fdata, Stack_handle_value(stack), &Stack_handle_value(stack));

--- a/testsuite/tests/effects/dynamic_lexical.ml
+++ b/testsuite/tests/effects/dynamic_lexical.ml
@@ -16,6 +16,7 @@ open Modes
 type scope
 external freeze_scope : unit -> scope = "caml_dynamic_freeze_scope"
 external use_scope : scope -> unit = "caml_dynamic_use_scope"
+external release_scope : scope -> unit = "caml_dynamic_thaw_scope"
 external set_root : unit -> unit = "caml_dynamic_set_root"
 
 let print_null = function
@@ -40,8 +41,9 @@ type _ Effect.t += Spawn_unpinned : (unit -> unit) -> unit Effect.t
 type _ Effect.t += Yield : unit Effect.t
 
 let fork_join f g =
-  let self = freeze_scope () in
-  Effect.perform (Fork (self, f, g))
+  let scope = freeze_scope () in
+  Effect.perform (Fork (scope, f, g));
+  release_scope scope
 
 let next_worker = ref 100
 let reset () = next_worker := 100
@@ -233,8 +235,8 @@ let () =
         end
       in
       ignore (grow 1_000);
-      let t = freeze_scope () in
       with_temp d_lex 1 ~f:(fun () ->
+        let t = freeze_scope () in
         passthrough (fun () ->
           (* fiber S: the child's own "worker" *)
           with_temp d_worker 222 ~f:(fun () ->
@@ -246,6 +248,7 @@ let () =
               Printf.printf
                 "child d_worker from own worker [expect 222]: %s\n"
                 (get d_worker))));
+        release_scope t;
         Printf.printf "parent d_worker [expect 111]: %s\n" (get d_worker))))
 
 (* A fiber created inside a fork child can escape the scheduler entirely
@@ -289,7 +292,7 @@ let () =
   | Some k -> with_temp d_lex 9 ~f:(fun () -> Effect.Deep.continue k ())
   | None -> assert false
 
-(* The fork-point handle is the fiber's stable dynamic-state node, so it
+(* The scope handle refers to the fiber's stable dynamic-state node, so it
    survives stack reallocation: growing the fork point's stack after taking
    the handle (bytecode fibers start tiny and grow by realloc) must not
    invalidate the edge or the bindings reached through it. *)
@@ -322,7 +325,8 @@ let () =
               Printf.printf "child d_lex after growth [expect 1]: %s\n"
                 (get d_lex);
               Printf.printf "child d_worker [expect 222]: %s\n"
-                (get d_worker)))))))
+                (get d_worker))));
+        release_scope t)))
 
 (* Freezing again from the same fork point must revalidate the chain: after
    the fork point is captured out of one intermediate fiber and resumed
@@ -357,11 +361,15 @@ let () =
               let s1 = freeze_scope () in
               run_child s1 (fun () ->
                 Printf.printf "child1 d_inter [expect 7]: %s\n" (get d_inter));
-              (* re-freezing an unchanged chain is a no-op *)
+              (* re-freezing an unchanged chain rewrites no links (children
+                 of the first scope may still be reading them) and freezes
+                 the fork point's table again; releases pair up LIFO *)
               let s1b = freeze_scope () in
               run_child s1b (fun () ->
                 Printf.printf "child1b d_inter [expect 7]: %s\n"
                   (get d_inter));
+              release_scope s1b;
+              release_scope s1;
               Printf.printf "F d_inter before capture [expect 7]: %s\n"
                 (get d_inter);
               Effect.perform Capture;
@@ -371,7 +379,8 @@ let () =
               let s2 = freeze_scope () in
               run_child s2 (fun () ->
                 Printf.printf "child2 d_inter [expect 8]: %s\n"
-                  (get d_inter))))
+                  (get d_inter));
+              release_scope s2))
           ()
           { retc = (fun () -> ());
             exnc = (fun e -> raise e);
@@ -383,3 +392,103 @@ let () =
     match !stash with
     | Some k -> with_temp d_inter 8 ~f:(fun () -> Effect.Deep.continue k ())
     | None -> assert false)
+
+(* Test 11: shifting. fork_join freezes the fork point's chain before
+   publishing the stolen child, then runs the other child inline as a plain
+   call on the same fiber. The inline child's with_temps go to a fresh
+   table pushed above the frozen one: the fiber's own chain sees them, but
+   the stolen child — reading from the scope's bound — keeps seeing the
+   state as it was when the scope was frozen. (The "stolen" child is
+   simulated by fibers mounted above the inline execution; unlike a real
+   stolen child its spine passes through the frozen fiber, so we only
+   assert lookups that resolve before reaching it.) *)
+
+let d_str : string Dynamic.t = Dynamic.make ()
+
+let () =
+  reset ();
+  print_endline
+    "\n# Test 11: bindings above a freeze are invisible to bounded children";
+  passthrough (fun () ->
+    (* fiber F: the fork point *)
+    set_root ();
+    with_temp d_lex 1 ~f:(fun () ->
+      let s = freeze_scope () in
+      (* the inline child: a plain call on F, rebinding d_lex *)
+      with_temp d_lex 9 ~f:(fun () ->
+        with_temp d_child 5 ~f:(fun () ->
+          Printf.printf "inline sees own rebind [expect 9]: %s\n" (get d_lex);
+          Printf.printf "inline sees own binding [expect 5]: %s\n"
+            (get d_child);
+          passthrough (fun () ->
+            (* fiber S: the stolen child's worker *)
+            with_temp d_child 7 ~f:(fun () ->
+              passthrough (fun () ->
+                (* fiber C: the stolen child, pinned and bounded *)
+                use_scope s;
+                Printf.printf
+                  "stolen child sees frozen state [expect 1]: %s\n"
+                  (get d_lex);
+                Printf.printf
+                  "stolen child misses inline binding [expect 7]: %s\n"
+                  (get d_child))));
+          Printf.printf "inline still sees rebind [expect 9]: %s\n"
+            (get d_lex)));
+      Printf.printf "after inline child [expect 1]: %s\n" (get d_lex);
+      (* a second scope while still frozen gets a fresh table again *)
+      with_temp d_lex 8 ~f:(fun () ->
+        Printf.printf "second scope above freeze [expect 8]: %s\n" (get d_lex));
+      Printf.printf "after second scope [expect 1]: %s\n" (get d_lex);
+      (* bindings above a freeze are GC roots *)
+      with_temp d_str (String.concat "-" ["over"; "lay"]) ~f:(fun () ->
+        Gc.full_major ();
+        (match Dynamic.get d_str with
+         | This str ->
+           Printf.printf "fresh table survives GC [expect over-lay]: %s\n" str
+         | Null -> print_endline "fresh table survives GC: null"));
+      release_scope s;
+      Printf.printf "after release [expect 1]: %s\n" (get d_lex));
+    Printf.printf "after scope [expect null]: %s\n" (get d_lex))
+
+(* Test 12: nested scopes while frozen. Each freeze marks the fork point's
+   newest table and bounds that scope's children there: children of the
+   outer scope never see bindings the inline child pushed (even once a
+   nested freeze makes them immutable), while children of the nested scope
+   do. *)
+
+let () =
+  reset ();
+  print_endline "\n# Test 12: nested freezes bound their children separately";
+  passthrough (fun () ->
+    set_root ();
+    with_temp d_lex 1 ~f:(fun () ->
+      let outer = freeze_scope () in
+      (* outer inline child *)
+      with_temp d_child 5 ~f:(fun () ->
+        let nested = freeze_scope () in
+        (* a child of the nested scope sees the inline child's bindings *)
+        passthrough (fun () ->
+          with_temp d_worker 200 ~f:(fun () ->
+            passthrough (fun () ->
+              use_scope nested;
+              Printf.printf
+                "nested child sees inline binding [expect 5]: %s\n"
+                (get d_child);
+              Printf.printf "nested child sees outer scope [expect 1]: %s\n"
+                (get d_lex);
+              Printf.printf "nested child own worker [expect 200]: %s\n"
+                (get d_worker))));
+        (* a child of the outer scope does not *)
+        passthrough (fun () ->
+          with_temp d_child 7 ~f:(fun () ->
+            passthrough (fun () ->
+              use_scope outer;
+              Printf.printf
+                "outer child misses inline binding [expect 7]: %s\n"
+                (get d_child);
+              Printf.printf "outer child sees outer scope [expect 1]: %s\n"
+                (get d_lex))));
+        release_scope nested);
+      Printf.printf "after nested inline [expect null]: %s\n" (get d_child);
+      release_scope outer);
+    Printf.printf "after scope [expect null]: %s\n" (get d_lex))

--- a/testsuite/tests/effects/dynamic_lexical.reference
+++ b/testsuite/tests/effects/dynamic_lexical.reference
@@ -55,3 +55,25 @@ child1b d_inter [expect 7]: 7
 F d_inter before capture [expect 7]: 7
 F d_inter after resume [expect 8]: 8
 child2 d_inter [expect 8]: 8
+
+# Test 11: bindings above a freeze are invisible to bounded children
+inline sees own rebind [expect 9]: 9
+inline sees own binding [expect 5]: 5
+stolen child sees frozen state [expect 1]: 1
+stolen child misses inline binding [expect 7]: 7
+inline still sees rebind [expect 9]: 9
+after inline child [expect 1]: 1
+second scope above freeze [expect 8]: 8
+after second scope [expect 1]: 1
+fresh table survives GC [expect over-lay]: over-lay
+after release [expect 1]: 1
+after scope [expect null]: null
+
+# Test 12: nested freezes bound their children separately
+nested child sees inline binding [expect 5]: 5
+nested child sees outer scope [expect 1]: 1
+nested child own worker [expect 200]: 200
+outer child misses inline binding [expect 7]: 7
+outer child sees outer scope [expect 1]: 1
+after nested inline [expect null]: null
+after scope [expect null]: null


### PR DESCRIPTION
Previously, it was unsafe to change binding state after freezing the scope, since child fibers are allowed to concurrently read from it. However, we need to support this so that the parent running the `with_scope` callback / the left child of `fork_join` can still bind dynamics. 

Now, freezing the scope marks the current table such that further mutation attempts allocate a fresh table linked to the frozen one. The scheduler must explicitly thaw the scope after the children return:
```
   caml_dynamic_set_root ();
   let scope = caml_dynamic_freeze_scope () in
   let l, r =
      spawn (fun () -> caml_dynamic_use_scope scope),
      spawn (fun () -> caml_dynamic_use_scope scope)
   in
   let res = await l, await r in
   caml_dynamic_thaw_scope scope;
   res
```
We can also use this mechanism to implement save/restore for `with_async_exns` cleanly.

However, it's still unsafe for the parent to perform an effect while the scope is in use, since that effect will be handled by a _grandparent_, and if the handler modifies binding state, it may race against its still-running grandchildren. This means we cannot yet allow `with_scope`/`fork_join` to run `yielding` functions.