### PR TITLE
cleanup: Get rid of some unused code

### DIFF
--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -1409,5 +1409,4 @@ let flambda_units u1 u2 =
       let module_symbol = Flambda_unit.module_symbol u1 in
       Flambda_unit.create ~return_continuation:ret_cont
         ~exn_continuation:exn_cont ~body ~module_symbol
-        ~used_value_slots:Unknown ~toplevel_my_alloc_region ~toplevel_my_region
-        ~toplevel_my_ghost_region)
+        ~toplevel_my_alloc_region ~toplevel_my_region ~toplevel_my_ghost_region)

--- a/middle_end/flambda2/flambda2.ml
+++ b/middle_end/flambda2/flambda2.ml
@@ -123,7 +123,6 @@ let build_run_result unit ~free_names ~final_typing_env ~sections ~all_code
     Flambda_cmx.prepare_cmx_file_contents ~final_typing_env ~module_symbol
       ~used_value_slots ~exported_offsets ~sections all_code
   in
-  let unit = Flambda_unit.with_used_value_slots unit used_value_slots in
   { cmx; unit; all_code; exported_offsets; reachable_names }
 
 type flambda_result =

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -4186,7 +4186,7 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
     let unit =
       Flambda_unit.create ~return_continuation:return_cont ~exn_continuation
         ~toplevel_my_region ~toplevel_my_ghost_region ~toplevel_my_alloc_region
-        ~body ~module_symbol ~used_value_slots:Unknown
+        ~body ~module_symbol
     in
     { unit; code_slot_offsets; metadata = Normal }
   | Classic ->
@@ -4221,7 +4221,7 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
     let unit =
       Flambda_unit.create ~return_continuation:return_cont ~exn_continuation
         ~toplevel_my_region ~toplevel_my_ghost_region ~toplevel_my_alloc_region
-        ~body ~module_symbol ~used_value_slots:(Known used_value_slots)
+        ~body ~module_symbol
     in
     { unit;
       code_slot_offsets;

--- a/middle_end/flambda2/identifiers/variable.ml
+++ b/middle_end/flambda2/identifiers/variable.ml
@@ -19,14 +19,11 @@ include Int_ids.Variable
 let create_with_same_name_as_ident ?user_visible ident kind : t =
   create ?user_visible (Ident.name ident) kind
 
-let rename ?append t =
-  let name = match append with None -> name t | Some s -> name t ^ s in
+let rename t =
   let user_visible = if user_visible t then Some () else None in
-  create ?user_visible name (kind t)
+  create ?user_visible (name t) (kind t)
 
-let is_renamed_version_of t t' =
-  (* We only keep track of variables renamed with an empty {append} parameter *)
-  String.equal (name t) (name t')
+let is_renamed_version_of t t' = String.equal (name t) (name t')
 
 let raw_name = name
 

--- a/middle_end/flambda2/identifiers/variable.mli
+++ b/middle_end/flambda2/identifiers/variable.mli
@@ -23,7 +23,7 @@ val create_with_same_name_as_ident :
 
 (** [rename] always returns a variable with a compilation unit set to that of
     the current unit, not the unit of the variable passed in. *)
-val rename : ?append:string -> t -> t
+val rename : t -> t
 
 val is_renamed_version_of : t -> t -> bool
 

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -1026,6 +1026,5 @@ let conv comp_unit (fexpr : Fexpr.flambda_unit) : conv_result =
       ~toplevel_my_alloc_region:toplevel_alloc_region
       ~toplevel_my_region:toplevel_region
       ~toplevel_my_ghost_region:toplevel_ghost_region ~body ~module_symbol
-      ~used_value_slots:Unknown
   in
   { unit; code_slot_offsets }

--- a/middle_end/flambda2/simplify/simplify.ml
+++ b/middle_end/flambda2/simplify/simplify.ml
@@ -87,7 +87,6 @@ let run ~cmx_loader ~machine_width ~round ~code_slot_offsets unit =
   let unit =
     FU.create ~return_continuation ~exn_continuation ~toplevel_my_region
       ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~module_symbol ~body
-      ~used_value_slots:Unknown
   in
   { unit;
     free_names = name_occurrences;

--- a/middle_end/flambda2/terms/flambda_unit.ml
+++ b/middle_end/flambda2/terms/flambda_unit.ml
@@ -21,21 +21,18 @@ type t =
     toplevel_my_ghost_region : Variable.t;
     toplevel_my_alloc_region : Variable.t;
     body : Flambda.Expr.t;
-    module_symbol : Symbol.t;
-    used_value_slots : Value_slot.Set.t Or_unknown.t
+    module_symbol : Symbol.t
   }
 
 let create ~return_continuation ~exn_continuation ~toplevel_my_region
-    ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~body ~module_symbol
-    ~used_value_slots =
+    ~toplevel_my_ghost_region ~toplevel_my_alloc_region ~body ~module_symbol =
   { return_continuation;
     exn_continuation;
     toplevel_my_region;
     toplevel_my_ghost_region;
     toplevel_my_alloc_region;
     body;
-    module_symbol;
-    used_value_slots
+    module_symbol
   }
 
 let return_continuation t = t.return_continuation
@@ -52,17 +49,12 @@ let body t = t.body
 
 let module_symbol t = t.module_symbol
 
-let used_value_slots t = t.used_value_slots
-
-let with_used_value_slots t used_value_slots =
-  { t with used_value_slots = Known used_value_slots }
-
 let with_body t body = { t with body }
 
 let [@ocamlformat "disable"] print ppf
       { return_continuation; exn_continuation; toplevel_my_region;
         toplevel_my_ghost_region; toplevel_my_alloc_region; body;
-        module_symbol; used_value_slots;
+        module_symbol;
       } =
   Format.fprintf ppf "@[<hov 1>(\
         @[<hov 1>(module_symbol@ %a)@]@ \
@@ -71,7 +63,6 @@ let [@ocamlformat "disable"] print ppf
         @[<hov 1>(toplevel_my_region@ %a)@]@ \
         @[<hov 1>(toplevel_my_ghost_region@ %a)@]@ \
         @[<hov 1>(toplevel_my_alloc_region@ %a)@]@ \
-        @[<hov 1>(used_value_slots@ %a)@]@ \
         @[<hov 1>%a@]\
       )@]"
     Symbol.print module_symbol
@@ -80,5 +71,4 @@ let [@ocamlformat "disable"] print ppf
     Variable.print toplevel_my_region
     Variable.print toplevel_my_ghost_region
     Variable.print toplevel_my_alloc_region
-    (Or_unknown.print Value_slot.Set.print) used_value_slots
     Flambda.Expr.print body

--- a/middle_end/flambda2/terms/flambda_unit.mli
+++ b/middle_end/flambda2/terms/flambda_unit.mli
@@ -28,7 +28,6 @@ val create :
   toplevel_my_alloc_region:Variable.t ->
   body:Flambda.Expr.t ->
   module_symbol:Symbol.t ->
-  used_value_slots:Value_slot.Set.t Or_unknown.t ->
   t
 
 val return_continuation : t -> Continuation.t
@@ -42,10 +41,6 @@ val toplevel_my_ghost_region : t -> Variable.t
 val toplevel_my_alloc_region : t -> Variable.t
 
 val module_symbol : t -> Symbol.t
-
-val used_value_slots : t -> Value_slot.Set.t Or_unknown.t
-
-val with_used_value_slots : t -> Value_slot.Set.t -> t
 
 val body : t -> Flambda.Expr.t
 

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -1093,8 +1093,6 @@ module Serializable : sig
 
   val print : Format.formatter -> t -> unit
 
-  val name_domain : t -> Name.Set.t
-
   val ids_for_export : t -> Ids_for_export.t
 
   val apply_renaming : t -> Renaming.t -> t
@@ -1167,12 +1165,6 @@ end = struct
     Cached_level.free_function_slots_and_value_slots t.just_after_level
 
   let print = print_serializable
-
-  let name_domain t =
-    List.fold_left
-      (fun name_domain symbol -> Name.Set.add (Name.symbol symbol) name_domain)
-      (Name.Map.keys (Cached_level.names_to_types t.just_after_level))
-      t.defined_symbols_without_equations
 
   let ids_for_export
       { defined_symbols_without_equations; code_age_relation; just_after_level }

--- a/middle_end/flambda2/types/env/typing_env.mli
+++ b/middle_end/flambda2/types/env/typing_env.mli
@@ -45,8 +45,6 @@ module Serializable : sig
 
   val print : Format.formatter -> t -> unit
 
-  val name_domain : t -> Name.Set.t
-
   val ids_for_export : t -> Ids_for_export.t
 
   val apply_renaming : t -> Renaming.t -> t

--- a/middle_end/flambda2/types/flambda2_types.mli
+++ b/middle_end/flambda2/types/flambda2_types.mli
@@ -152,8 +152,6 @@ module Typing_env : sig
 
     val print : Format.formatter -> t -> unit
 
-    val name_domain : t -> Name.Set.t
-
     val ids_for_export : t -> Ids_for_export.t
 
     val apply_renaming : t -> Renaming.t -> t


### PR DESCRIPTION
 - The `append` parameter to `Variable.rename` is no longer used, and it is dangerous since #4243 -- better be explicit about the name and kind of the expected variable and use `create`.

 - The `used_value_slots` field in `Flambda_unit` is unused since #496, when it was called `used_closure_vars` (one might argue it was never used!).

 - The `name_domain` function in `TE.Serializable` is unused since #6100 (originally #5886).