### PR TITLE
Add more profiling of cmx loading

### DIFF
--- a/middle_end/compilenv.ml
+++ b/middle_end/compilenv.ml
@@ -168,9 +168,10 @@ let equal_up_to_pack_prefix cu1 cu2 =
 let get_export_info infos =
   Option.map
     (fun export_info ->
+      Profile.record_call ~accumulate:true "cmx_from_raw" (fun () ->
       Flambda2_cmx.Flambda_cmx_format.from_raw
         ~sections:infos.ui_file_sections
-        export_info)
+        export_info))
     infos.ui_export_info
 
 let get_unit_export_info comp_unit =

--- a/middle_end/flambda2/cmx/flambda_cmx.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx.ml
@@ -35,16 +35,16 @@ let load_cmx_file_contents loader comp_unit =
   in
   match Imported_unit_map.find cmx_file loader.imported_units with
   | typing_env_or_none -> typing_env_or_none
-  | exception Not_found -> (
-    match loader.get_module_info accessible_comp_unit with
-    | None ->
-      (* To make things easier to think about, we never retry after a .cmx load
-         fails. *)
-      loader.imported_units
-        <- Imported_unit_map.add cmx_file None loader.imported_units;
-      None
-    | Some cmx ->
-      Profile.record_call ~accumulate:true "load_cmx" (fun () ->
+  | exception Not_found ->
+    Profile.record_call ~accumulate:true "load_cmx" (fun () ->
+        match loader.get_module_info accessible_comp_unit with
+        | None ->
+          (* To make things easier to think about, we never retry after a .cmx
+             load fails. *)
+          loader.imported_units
+            <- Imported_unit_map.add cmx_file None loader.imported_units;
+          None
+        | Some cmx ->
           let typing_env, all_code =
             Flambda_cmx_format.import_typing_env_and_code cmx
           in
@@ -54,7 +54,7 @@ let load_cmx_file_contents loader comp_unit =
           loader.imported_units
             <- Imported_unit_map.add cmx_file (Some typing_env)
                  loader.imported_units;
-          Some typing_env))
+          Some typing_env)
 
 let load_symbol_approx loader symbol : Code_or_metadata.t Value_approximation.t
     =


### PR DESCRIPTION
Take into account deserialization time inside `load_cmx`, with a specific `cmx_from_raw` section.