### PR TITLE
Filter out all arguments to runtime C functions in oxcaml dwarf tests

### DIFF
--- a/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
+++ b/oxcaml/tests/backend/oxcaml_dwarf/filter_for_function_call_only.sh
@@ -31,22 +31,8 @@ sed \
   -e 's|\([a-z_][a-zA-Z0-9_]*\)_[0-9]\+_[0-9]\+_code|\1_XXX_XXX_code|g' \
   -e 's|\([a-z_][a-zA-Z0-9_]*\)_[0-9]\+_unboxed|\1_XXX_unboxed|g' | \
 # Second sed: Conceal unstable pointer values in C runtime function parameters
-# Note: Previous LLDB plugin versions used OCaml formatting (#140737333164432L),
-# current versions use native C formatting (140737333164432)
 sed \
-  -e '/caml_blit_bytes/s|s1=#\?[0-9]\{10,\}L\?|s1=<PTR>|g' \
-  -e '/caml_blit_bytes/s|s2=#\?[0-9]\{10,\}L\?|s2=<PTR>|g' \
-  -e '/caml_hash_exn/s|obj=#\?[0-9]\{5,\}L\?|obj=<PTR>|g' \
-  -e '/caml_compare/s|v1=#\?[0-9]\{5,\}L\?|v1=<PTR>|g' \
-  -e '/caml_compare/s|v2=#\?[0-9]\{5,\}L\?|v2=<PTR>|g' \
-  -e '/caml_output_value_to_buffer/s|buf=#\?[0-9]\{10,\}L\?|buf=<PTR>|g' \
-  -e '/caml_output_value_to_buffer/s|v=#\?[0-9]\{5,\}L\?|v=<PTR>|g' \
-  -e '/caml_input_value_from_bytes/s|str=#\?[0-9]\{10,\}L\?|str=<PTR>|g' \
-  -e '/caml_md5_string/s|str=#\?[0-9]\{5,\}L\?|str=<PTR>|g' \
-  -e '/caml_sys_getenv/s|var=#\?[0-9]\{5,\}L\?|var=<PTR>|g' \
-  -e '/caml_ba_create/s|vdim=#\?[0-9]\{5,\}L\?|vdim=<PTR>|g' \
-  -e 's|closure=#\?[0-9]\{5,\}L\?|closure=<PTR>|g' \
-  -e 's|body_callback=#\?[0-9]\{5,\}L\?|body_callback=<PTR>|g' | \
+  -e '/frame.*`caml_/s/([^)]*)/(...)/' | \
 # grep: Remove LLDB noise
 grep -v \
   -e '^(lldb) ' \

--- a/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
+++ b/oxcaml/tests/backend/oxcaml_dwarf/test_ocaml_and_c_dwarf.output
@@ -1,23 +1,23 @@
 === Testing OCaml/C boundary - string allocation ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_string(len=100)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_string(...)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.String.make [inlined]
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_allocate_string(param=[100, 120] : ocaml_value)
 === Testing OCaml/C boundary - array allocation ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_array_make(len=101, init=201)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_array_make(...)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_inner(x=50 : int @ value, y=100 : int @ value)
 === Testing OCaml/C boundary - bytes blit ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_blit_bytes(s1=<PTR>, ofs1=1, s2=<PTR>, ofs2=1, n=21)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_blit_bytes(...)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Bytes.blit [inlined]
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_bytes_blit(src=<unavailable>, dst=<unavailable>, len=<unavailable>)
 === Testing OCaml/C boundary - polymorphic hash ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_hash_exn(count=21, limit=201, seed=1, obj=<PTR>)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_hash_exn(...)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Stdlib.Hashtbl.add
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_hash(param="key" : ocaml_value, param=42 : ocaml_value)
 === Testing OCaml/C boundary - MD5 hash ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_md5_string(str=<PTR>, ofs=1, len=27)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_md5_string(...)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_md5(s=<unavailable>)
 === Testing OCaml/C boundary - large tuple (caml_alloc_shr_check_gc) ===
-    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_shr_check_gc(wosize=500, tag=0)
+    frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`caml_alloc_shr_check_gc(...)
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_large_tuple(n=42 : int @ value)
 === Testing OCaml/C boundary - callback (C calls OCaml) ===
     frame #N: <ADDRESS> test_ocaml_and_c_dwarf.exe`Test_ocaml_and_c_dwarf.f_callback_inner(param=0 : ocaml_value)


### PR DESCRIPTION
These tests flake quite a lot when hacking on the runtime, and I presume we don't intend to test LLDB's handling of C functions.