### PR TITLE
ocamltest: Make `set` work sensibly within `split`

### DIFF
--- a/ocamltest/main.ml
+++ b/ocamltest/main.ml
@@ -191,12 +191,26 @@ let run_test_tree log add_msg behavior env summ ast =
         ~must_do_something
     | Split alternatives :: rest ->
       let count = List.length alternatives in
+      (* Scope the [set]s within each branch to that branch only. Once all
+         branches have run, restore the union of their registrations, so that
+         adding a [split] doesn't change which variables count as registered
+         afterwards *)
+      let snapshot = Variables.snapshot () in
+      let arm_snapshots = ref [] in
       let run_alternative i alternative =
         Printf.fprintf log "Running split branch %d of %d\n%!" (i + 1) count;
-        run_statements behavior env summ alternative (rest :: segments)
-          subs ~branches:(i + 1 :: branches) ~must_do_something
+        Fun.protect
+          (fun () ->
+             run_statements behavior env summ alternative (rest :: segments)
+               subs ~branches:(i + 1 :: branches) ~must_do_something)
+          ~finally:(fun () ->
+             arm_snapshots := Variables.snapshot () :: !arm_snapshots;
+             Variables.restore snapshot)
       in
-      join_list_parallel (List.mapi run_alternative alternatives)
+      let summ = join_list_parallel (List.mapi run_alternative alternatives) in
+      let combined_snapshot = Variables.union (snapshot :: !arm_snapshots) in
+      Variables.restore combined_snapshot;
+      summ
     | [] ->
       run_segments behavior env summ segments subs ~branches ~must_do_something
   and run_segments behavior env summ segments subs ~branches

--- a/ocamltest/variables.ml
+++ b/ocamltest/variables.ml
@@ -62,6 +62,19 @@ let register_variable variable =
   then raise (Variable_already_registered variable.variable_name)
   else Hashtbl.add variables variable.variable_name variable
 
+type snapshot = (string, t) Hashtbl.t
+
+let snapshot () = Hashtbl.copy variables
+
+let restore s =
+  Hashtbl.reset variables;
+  Hashtbl.iter (Hashtbl.add variables) s
+
+let union snapshots =
+  let u = Hashtbl.create 10 in
+  List.iter (Hashtbl.iter (Hashtbl.replace u)) snapshots;
+  u
+
 let find_variable variable_name =
   try Some (Hashtbl.find variables variable_name)
   with Not_found -> None

--- a/ocamltest/variables.mli
+++ b/ocamltest/variables.mli
@@ -19,6 +19,8 @@ type value = string
 
 type exporter = value -> string * string
 
+type snapshot
+
 type t
 
 val compare : t -> t -> int
@@ -40,6 +42,12 @@ val name_of_variable : t -> string
 val description_of_variable : t -> string
 
 val register_variable : t -> unit
+
+val snapshot : unit -> snapshot
+
+val restore : snapshot -> unit
+
+val union : snapshot list -> snapshot
 
 val find_variable : string -> t option
 

--- a/testsuite/tests/tool-ocamltest/split-accum.sh
+++ b/testsuite/tests/tool-ocamltest/split-accum.sh
@@ -2,4 +2,4 @@
 
 # Helper for split.ml: record which split alternative is running.
 
-echo "$arm" >> arms.txt
+echo "$arm-$in_arm-$inner-$after_split" >> arms.txt

--- a/testsuite/tests/tool-ocamltest/split-check.sh
+++ b/testsuite/tests/tool-ocamltest/split-check.sh
@@ -2,4 +2,4 @@
 
 # Helper for split.ml: check that every split alternative ran, in order.
 
-printf 'a\nb\nc\n' | cmp -s - arms.txt
+printf 'a-x-1-ax1\na-x-2-ax2\nb-y-0-by0\nc-z-0-cz0\n' | cmp -s - arms.txt

--- a/testsuite/tests/tool-ocamltest/split.ml
+++ b/testsuite/tests/tool-ocamltest/split.ml
@@ -2,20 +2,35 @@
  set arm = "unset";
  {
    split [
-   | arm = "a";
-   | arm = "b";
-   | arm = "c";
+   | arm = "a"; set in_arm = "x";
+     split [
+     | set inner = "1";
+     | set inner = "2";
+     ]
+   | arm = "b"; set in_arm = "y"; set inner = "0";
+   | arm = "c"; set in_arm = "z"; set inner = "0";
    ]
+   set after_split = "${arm}${in_arm}${inner}";
    script = "sh ${test_source_directory}/split-accum.sh";
    script;
  }
  {
+   in_arm = "w";
+   inner = "3";
+   after_split = "done";
    script = "sh ${test_source_directory}/split-check.sh";
    script;
  }
 *)
 
 (* This file tests the "split" syntax of ocamltest. The first block should run once per
-   alternative, each run appending the value of the variable "arm" to a file in the test
-   build directory; the second block checks that all three alternatives actually ran, in
-   order. *)
+   alternative (twice for arm "a", which splits again), each run appending the values of
+   several variables to a file in the test build directory; the second block checks that
+   every alternative actually ran, in order. The [set] statements check that variable
+   registrations are scoped to each branch: [in_arm] (declared in each arm),
+   [after_split] (declared once per branch by the statements following the split), and
+   [inner] (declared in each arm of the nested split, and again in arms "b" and "c" of
+   the outer one) would otherwise collide as soon as the second branch runs. The plain
+   assignments in the second block check that the registrations nonetheless remain in
+   effect after the split, as they would if there were no [split]: assigning to an
+   undeclared variable is an error. *)


### PR DESCRIPTION
Each `set` has a global effect and can only run once, which is a problem
with `split`, whose whole purpose is to run more than once.

This PR combines the effects of `set`s that happen while executing the
different branches of a `split` (either the arm or the post-split
statements). Concretely, this means that either

```
split [ | set a = "foo"; | set a = "bar"; ]
... $a ...
```

or

```
split [ | ... | ... ]
set a = "foo";
```

works. The somewhat strange global behavior of `set` (a `set` is visible even
to, say, a sibling block) is preserved so that adding `split` to arbitrary
test code should work.

Note that only the *registry* is affected. Environment *values* already
flowed per-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
