### PR TITLE
Remove a `test` made redundant by a preceding `and`/`o`r/`xor` (x86 peephole)

### DIFF
--- a/backend/x86_peephole/x86_peephole_rules.ml
+++ b/backend/x86_peephole/x86_peephole_rules.ml
@@ -10,14 +10,16 @@ type peephole_stats =
   { mutable remove_mov_to_dead_register : int;
     mutable remove_redundant_cmp : int;
     mutable remove_redundant_extension : int;
-    mutable combine_add_rsp : int
+    mutable combine_add_rsp : int;
+    mutable remove_redundant_test : int
   }
 
 let create_peephole_stats () =
   { remove_mov_to_dead_register = 0;
     remove_redundant_cmp = 0;
     remove_redundant_extension = 0;
-    combine_add_rsp = 0
+    combine_add_rsp = 0;
+    remove_redundant_test = 0
   }
 
 let peephole_stats_to_counters stats =
@@ -29,6 +31,8 @@ let peephole_stats_to_counters stats =
   |> Profile.Counters.set "x86_peephole.remove_redundant_extension"
        stats.remove_redundant_extension
   |> Profile.Counters.set "x86_peephole.combine_add_rsp" stats.combine_add_rsp
+  |> Profile.Counters.set "x86_peephole.remove_redundant_test"
+       stats.remove_redundant_test
 
 (* Rewrite rule: combine adjacent ADD to RSP with CFI directives. Pattern: addq
    $n1, %rsp; .cfi_adjust_cfa_offset d1; addq $n2, %rsp; .cfi_adjust_cfa_offset
@@ -212,6 +216,32 @@ let remove_redundant_extension stats cell =
     | _, _ -> U.No_match)
   | _ -> U.No_match
 
+(* Rewrite rule: remove a TEST made redundant by the preceding instruction.
+   Pattern: op src, r; test r, r (where op is one of and/or/xor and r is a
+   64-bit register). Rewrite: op src, r
+
+   AND, OR and XOR set ZF, SF and PF according to their result and clear CF and
+   OF - exactly the flag state [test r, r] computes from that same value (AF is
+   undefined after both instructions). The deletion therefore leaves the flags
+   bit-for-bit identical, whatever condition is read afterwards. Other
+   arithmetic instructions (e.g. ADD, SUB) set CF and OF from the computation
+   rather than clearing them, so extending the rule to them would require
+   checking which flags the following instructions read. Both operands are
+   restricted to 64-bit registers so that the flag-setting operation and the
+   test have the same width. *)
+let remove_redundant_test stats cell =
+  match U.get_cells cell 2 with
+  | [cell1; cell2] -> (
+    match DLL.value cell1, DLL.value cell2 with
+    | ( Ins (AND (_, Reg64 dst) | OR (_, Reg64 dst) | XOR (_, Reg64 dst)),
+        Ins (TEST (Reg64 src1, Reg64 src2)) )
+      when equal_reg64 dst src1 && equal_reg64 dst src2 ->
+      DLL.delete_curr cell2;
+      stats.remove_redundant_test <- stats.remove_redundant_test + 1;
+      U.Matched (Some cell1)
+    | _, _ -> U.No_match)
+  | _ -> U.No_match
+
 (* Apply all rewrite rules in sequence using a pipeline. *)
 let apply stats cell =
   let[@inline always] if_no_match ~enabled f result =
@@ -232,3 +262,6 @@ let apply stats cell =
   |> if_no_match
        ~enabled:!Oxcaml_flags.x86_peephole_combine_add_rsp
        combine_add_rsp
+  |> if_no_match
+       ~enabled:!Oxcaml_flags.x86_peephole_remove_redundant_test
+       remove_redundant_test

--- a/driver/oxcaml_args.ml
+++ b/driver/oxcaml_args.ml
@@ -133,6 +133,11 @@ let mk_no_x86_peephole_combine_add_rsp f =
     Arg.Unit f,
     " Disable x86 peephole: combine adjacent add rsp" )
 
+let mk_no_x86_peephole_remove_redundant_test f =
+  ( "-no-x86-peephole-remove-redundant-test",
+    Arg.Unit f,
+    " Disable x86 peephole: remove redundant test" )
+
 let mk_cfg_cse_optimize f =
   ("-cfg-cse-optimize", Arg.Unit f, " Apply CSE optimizations to CFG")
 
@@ -1337,6 +1342,7 @@ module type Oxcaml_options = sig
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
   val no_x86_peephole_remove_redundant_extension : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
+  val no_x86_peephole_remove_redundant_test : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit
@@ -1531,6 +1537,8 @@ module Make_oxcaml_options (F : Oxcaml_options) = struct
       mk_no_x86_peephole_remove_redundant_extension
         F.no_x86_peephole_remove_redundant_extension;
       mk_no_x86_peephole_combine_add_rsp F.no_x86_peephole_combine_add_rsp;
+      mk_no_x86_peephole_remove_redundant_test
+        F.no_x86_peephole_remove_redundant_test;
       mk_cfg_stack_checks F.cfg_stack_checks;
       mk_no_cfg_stack_checks F.no_cfg_stack_checks;
       mk_cfg_stack_checks_threshold F.cfg_stack_checks_threshold;
@@ -1878,6 +1886,9 @@ module Oxcaml_options_impl = struct
 
   let no_x86_peephole_combine_add_rsp =
     clear' Oxcaml_flags.x86_peephole_combine_add_rsp
+
+  let no_x86_peephole_remove_redundant_test =
+    clear' Oxcaml_flags.x86_peephole_remove_redundant_test
 
   let cfg_stack_checks = set' Oxcaml_flags.cfg_stack_checks
   let no_cfg_stack_checks = clear' Oxcaml_flags.cfg_stack_checks

--- a/driver/oxcaml_args.mli
+++ b/driver/oxcaml_args.mli
@@ -49,6 +49,7 @@ module type Oxcaml_options = sig
   val no_x86_peephole_remove_redundant_cmp : unit -> unit
   val no_x86_peephole_remove_redundant_extension : unit -> unit
   val no_x86_peephole_combine_add_rsp : unit -> unit
+  val no_x86_peephole_remove_redundant_test : unit -> unit
   val cfg_stack_checks : unit -> unit
   val no_cfg_stack_checks : unit -> unit
   val cfg_stack_checks_threshold : int -> unit

--- a/driver/oxcaml_flags.ml
+++ b/driver/oxcaml_flags.ml
@@ -35,6 +35,7 @@ let x86_peephole_remove_mov_to_dead_register = ref true
 let x86_peephole_remove_redundant_cmp = ref true
 let x86_peephole_remove_redundant_extension = ref true
 let x86_peephole_combine_add_rsp = ref true
+let x86_peephole_remove_redundant_test = ref true
 
 let cfg_stack_checks = ref true         (* -[no-]cfg-stack-check *)
 let cfg_stack_checks_threshold = ref 16384 (* -cfg-stack-threshold *)

--- a/driver/oxcaml_flags.mli
+++ b/driver/oxcaml_flags.mli
@@ -36,6 +36,7 @@ val x86_peephole_remove_mov_to_dead_register : bool ref
 val x86_peephole_remove_redundant_cmp : bool ref
 val x86_peephole_remove_redundant_extension : bool ref
 val x86_peephole_combine_add_rsp : bool ref
+val x86_peephole_remove_redundant_test : bool ref
 
 val cfg_stack_checks : bool ref
 val cfg_stack_checks_threshold : int ref

--- a/testsuite/tests/codegen/instruction_selection.ml
+++ b/testsuite/tests/codegen/instruction_selection.ml
@@ -55,13 +55,11 @@ f:
   ret
 |}]
 
-(* CR ttebbi: We could merge the and and test instructions *)
 let do_intersect t1 t2 =
   Int64_u.(if equal (logand t1 t2) #0L then #100L else #200L)
 [%%expect_asm X86_64{|
 do_intersect:
   andq  %rbx, %rax
-  testq %rax, %rax
   jne   .L0
   movl  $100, %eax
   ret


### PR DESCRIPTION
Pattern: `op src, r; test r, r` - where `op` is one of `and`/`or`/`xor` writing the 64-bit register `r`.

These instructions set ZF, SF and PF according to their result and clear CF and OF, which is bit-for-bit the flag state `test r, r` computes from that same value (AF is undefined after both). The test is therefore deleted without any flag-liveness analysis, whatever condition is read afterwards; `add`/`sub` are excluded since they set CF/OF from the computation instead of clearing them.