### PR TITLE
Simplifier: extend collapse of `compare x y = 0` to direct comparison

### DIFF
--- a/middle_end/flambda2/simplify/simplify_binary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_binary_primitive.ml
@@ -1173,55 +1173,66 @@ let simplify_binary_primitive0 dacc original_prim (prim : P.binary_primitive)
   simplifier dacc ~original_term dbg ~arg1 ~arg1_ty ~arg2 ~arg2_ty ~result_var
 
 let recover_comparison_primitive dacc (prim : P.binary_primitive) ~arg1 ~arg2 =
+  let try_one_direction left right (op : _ P.comparison) =
+    Simple.pattern_match right
+      ~name:(fun _ ~coercion:_ -> None)
+      ~const:(fun const ->
+        match[@warning "-fragile-match"] Const.descr const with
+        | Tagged_immediate i
+          when Target_ocaml_int.(
+                 equal i (zero (DE.machine_width (DA.denv dacc)))) ->
+          Simple.pattern_match' left
+            ~const:(fun _ -> None)
+            ~symbol:(fun _ ~coercion:_ -> None)
+            ~var:(fun var ~coercion:_ ->
+              match DE.find_comparison_result (DA.denv dacc) var with
+              | None -> None
+              | Some comp ->
+                Some
+                  (Comparison_result.convert_result_compared_to_tagged_zero comp
+                     op))
+        | _ -> None)
+  in
+  let try_both_directions op ~swapped_op =
+    match try_one_direction arg1 arg2 op with
+    | Some p -> Some p
+    | None -> try_one_direction arg2 arg1 swapped_op
+  in
   match prim with
   | Block_set _ | Array_load _ | Int_arith _ | Int_shift _
   | Int_comp (_, Yielding_int_like_compare_functions _)
-  | Float_arith _ | Float_comp _ | Phys_equal _ | String_or_bigstring_load _
-  | Bigarray_load _ | Bigarray_get_alignment _ | Atomic_load_field _ | Poke _
-  | Read_offset _ ->
+  | Float_arith _ | Float_comp _ | String_or_bigstring_load _ | Bigarray_load _
+  | Bigarray_get_alignment _ | Atomic_load_field _ | Poke _ | Read_offset _ ->
     None
+  | Phys_equal op ->
+    (* Integer (in)equality reaches Flambda2 as [Phys_equal] (cf.
+       [Lambda_to_flambda_primitives]), so this is the form taken by e.g.
+       [compare x y = 0]. The result of a comparison is always a tagged
+       immediate, for which physical equality is value equality, so it collapses
+       like [Int_comp] equality does. *)
+    let op : _ P.comparison =
+      match (op : P.equality_comparison) with Eq -> Eq | Neq -> Neq
+    in
+    try_both_directions op ~swapped_op:op
   | Int_comp (kind, Yielding_bool op) -> (
     match kind with
     | Naked_immediate | Naked_int8 | Naked_int16 | Naked_int32 | Naked_int64
     | Naked_nativeint ->
       None
-    | Tagged_immediate -> (
-      let try_one_direction left right op =
-        Simple.pattern_match right
-          ~name:(fun _ ~coercion:_ -> None)
-          ~const:(fun const ->
-            match[@warning "-fragile-match"] Const.descr const with
-            | Tagged_immediate i
-              when Target_ocaml_int.(
-                     equal i (zero (DE.machine_width (DA.denv dacc)))) ->
-              Simple.pattern_match' left
-                ~const:(fun _ -> None)
-                ~symbol:(fun _ ~coercion:_ -> None)
-                ~var:(fun var ~coercion:_ ->
-                  match DE.find_comparison_result (DA.denv dacc) var with
-                  | None -> None
-                  | Some comp ->
-                    Some
-                      (Comparison_result.convert_result_compared_to_tagged_zero
-                         comp op))
-            | _ -> None)
+    | Tagged_immediate ->
+      let swapped_op : _ P.comparison =
+        match op with
+        | Eq -> Eq
+        | Neq -> Neq
+        (* Note that this is not handling a negation of an inequality, it is
+           simply a pattern match for when the inequality appears the other way
+           around. So e.g. [Lt] maps to [Gt], not [Ge]. *)
+        | Lt s -> Gt s
+        | Gt s -> Lt s
+        | Le s -> Ge s
+        | Ge s -> Le s
       in
-      match try_one_direction arg1 arg2 op with
-      | Some p -> Some p
-      | None ->
-        let op : _ P.comparison =
-          match op with
-          | Eq -> Eq
-          | Neq -> Neq
-          (* Note that this is not handling a negation of an inequality, it is
-             simply a pattern match for when the inequality appears the other
-             way around. So e.g. [Lt] maps to [Gt], not [Ge]. *)
-          | Lt s -> Gt s
-          | Gt s -> Lt s
-          | Le s -> Ge s
-          | Ge s -> Le s
-        in
-        try_one_direction arg2 arg1 op))
+      try_both_directions op ~swapped_op)
 
 let simplify_binary_primitive dacc original_prim (prim : P.binary_primitive)
     ~arg1 ~arg1_ty ~arg2 ~arg2_ty dbg ~result_var =

--- a/testsuite/tests/codegen/int.ml
+++ b/testsuite/tests/codegen/int.ml
@@ -287,19 +287,11 @@ equal:
 |}]
 
 
-(* CR ttebbi: This is very inefficient, should be like `equal`. *)
 let equal_using_compare (x : int) (y : int) =
   Int.compare x y = 0
 [%%expect_asm X86_64{|
 equal_using_compare:
-  movq  %rax, %rsi
-  movq  $-1, %rdi
-  xorl  %eax, %eax
-  cmpq  %rbx, %rsi
-  setg  %al
-  cmovge %rax, %rdi
-  leaq  1(%rdi,%rdi), %rax
-  cmpq  $1, %rax
+  cmpq  %rbx, %rax
   sete  %al
   movzbq %al, %rax
   leaq  1(%rax,%rax), %rax

--- a/testsuite/tests/codegen/int64_u.ml
+++ b/testsuite/tests/codegen/int64_u.ml
@@ -559,18 +559,10 @@ equal:
   ret
 |}]
 
-(* CR ttebbi: This is very inefficient, should be like `equal`. *)
 let equal_using_compare x y = Int64_u.compare x y = 0
 [%%expect_asm X86_64{|
 equal_using_compare:
-  movq  %rax, %rsi
-  movq  $-1, %rdi
-  xorl  %eax, %eax
-  cmpq  %rbx, %rsi
-  setg  %al
-  cmovge %rax, %rdi
-  leaq  1(%rdi,%rdi), %rax
-  cmpq  $1, %rax
+  cmpq  %rbx, %rax
   sete  %al
   movzbq %al, %rax
   leaq  1(%rax,%rax), %rax

--- a/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
@@ -173,7 +173,7 @@ in
 let $camlMap_remove__merge_8 =
   closure merge_3_1 @merge &toplevel.alloc_region
 in
-let code loopify(never) size(36) newer_version_of(remove_4)
+let code loopify(never) size(30) newer_version_of(remove_4)
       remove_4_1
         (x : imm tagged,
          param :
@@ -192,10 +192,8 @@ let code loopify(never) size(36) newer_version_of(remove_4)
     where k2 =
       let l = %block_load.[`0`] (param) in
       let Pfield = %block_load.[`1`] (param) in
-      let prim_1 = %int_comp.qmark (x, Pfield) in
-      let int_compare = %tag_imm (prim_1) in
-      let prim_2 = %phys_eq (int_compare, 0) in
-      (switch prim_2
+      let prim_1 = %int_comp.eq (x, Pfield) in
+      (switch prim_1
          | 0 -> k (l)
          | 1 -> k2
          where k2 =


### PR DESCRIPTION
Simplify already recovers a direct comparison from a three-way compare result
tested against zero (Comparison_result / recover_comparison_primitive), and the
relational cases ('compare x y < 0' etc.) already collapsed. Equality was the one
gap: integer (in)equality reaches Flambda2 as Phys_equal, which the recovery
rejected, so 'compare x y = 0' - the most common shape of the idiom - kept
building the full tri-state.
