### PR TITLE
Fuse float-comparison tagging into a single operation (amd64)

### DIFF
--- a/backend/amd64/CSE.ml
+++ b/backend/amd64/CSE.ml
@@ -33,6 +33,7 @@ let class_of_operation (op : Operation.t)
   | Specific spec ->
     begin match spec with
     | Ilea _ | Isextend32 | Izextend32 -> Class Op_pure
+    | Ifloatcomp_tagged _ -> Use_default
     | Istore_int(_, _, is_asg) -> Class (Op_store is_asg)
     | Ioffset_loc(_, _) -> Class (Op_store true)
     | Ifloatarithmem _ -> Class (Op_load Mutable)

--- a/backend/amd64/arch.ml
+++ b/backend/amd64/arch.ml
@@ -294,6 +294,9 @@ type specific_operation =
                                        (* Add a constant to a location *)
   | Ifloatarithmem of float_width * float_operation * addressing_mode
                                        (* Float arith operation with memory *)
+  | Ifloatcomp_tagged of float_width * Cmm.float_comparison
+                                       (* Float comparison yielding the tagged
+                                          boolean directly *)
   | Ibswap of { bitwidth: bswap_bitwidth; } (* endianness conversion *)
   | Isextend32                         (* 32 to 64 bit conversion with sign
                                           extension *)
@@ -410,7 +413,8 @@ let fold_delta_into_specific_operation op ~arg_is_folded_reg ~delta =
       then None
       else Some (Ilea (offset_addressing addr displ_delta))
     end
-  | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ | Isextend32
+  | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ifloatcomp_tagged _
+  | Ibswap _ | Isextend32
   | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32
   | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ | Illvm_intrinsic _ ->
     None
@@ -492,6 +496,9 @@ let print_specific_operation printreg op ppf arg =
     fprintf ppf "bswap_%i %a" (int_of_bswap_bitwidth bitwidth) printreg arg.(0)
   | Isextend32 ->
       fprintf ppf "sextend32 %a" printreg arg.(0)
+  | Ifloatcomp_tagged (_width, cmp) ->
+      fprintf ppf "floatcomp_tagged[%s] %a %a"
+        (Printcmm.float_comparison cmp) printreg arg.(0) printreg arg.(1)
   | Izextend32 ->
       fprintf ppf "zextend32 %a" printreg arg.(0)
   | Irdtsc ->
@@ -530,6 +537,7 @@ let specific_operation_name : specific_operation -> string = fun op ->
   | Ibswap { bitwidth } ->
       "bswap " ^ (bitwidth |> int_of_bswap_bitwidth |> string_of_int)
   | Isextend32 -> "sextend32"
+  | Ifloatcomp_tagged _ -> "floatcomp_tagged"
   | Izextend32 -> "zextend32"
   | Irdtsc -> "rdtsc"
   | Ilfence -> "lfence"
@@ -554,7 +562,7 @@ let win64 =
 (* Keep in sync with [Vectorize_specific] *)
 let operation_is_pure = function
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32
-  | Ifloatarithmem _  -> true
+  | Ifloatarithmem _ | Ifloatcomp_tagged _ -> true
   | Irdtsc | Irdpmc
   | Ilfence | Isfence | Imfence
   | Istore_int (_, _, _) | Ioffset_loc (_, _)
@@ -570,7 +578,7 @@ let operation_is_pure = function
 (* Keep in sync with [Vectorize_specific] *)
 let operation_allocates = function
   | Ilea _ | Ibswap _ | Isextend32 | Izextend32
-  | Ifloatarithmem _
+  | Ifloatarithmem _ | Ifloatcomp_tagged _
   | Irdtsc | Irdpmc  | Ipackf32
   | Isimd _ | Isimd_mem _
   | Ilfence | Isfence | Imfence
@@ -648,6 +656,8 @@ let equal_specific_operation left right =
     true
   | Izextend32, Izextend32 ->
     true
+  | Ifloatcomp_tagged (w1, c1), Ifloatcomp_tagged (w2, c2) ->
+    Cmm.equal_float_width w1 w2 && Cmm.equal_float_comparison c1 c2
   | Irdtsc, Irdtsc ->
     true
   | Irdpmc, Irdpmc ->
@@ -671,7 +681,8 @@ let equal_specific_operation left right =
   | Isimd_mem (l,al), Isimd_mem (r,ar) ->
     Simd.Mem.equal_operation l r && equal_addressing_mode al ar
   | Illvm_intrinsic l, Illvm_intrinsic r -> String.equal l r
-  | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
+  | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _
+    | Ifloatcomp_tagged _ | Ibswap _ |
      Isextend32 | Izextend32 |
      Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
      Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ |
@@ -761,6 +772,8 @@ let isomorphic_specific_operation op1 op2 =
     true
   | Izextend32, Izextend32 ->
     true
+  | Ifloatcomp_tagged (w1, c1), Ifloatcomp_tagged (w2, c2) ->
+    Cmm.equal_float_width w1 w2 && Cmm.equal_float_comparison c1 c2
   | Irdtsc, Irdtsc ->
     true
   | Irdpmc, Irdpmc ->
@@ -784,7 +797,8 @@ let isomorphic_specific_operation op1 op2 =
   | Isimd_mem (l,al), Isimd_mem (r,ar) ->
     Simd.Mem.equal_operation l r && equal_addressing_mode_without_displ al ar
   | Illvm_intrinsic l, Illvm_intrinsic r -> String.equal l r
-  | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _ |
+  | (Ilea _ | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _
+    | Ifloatcomp_tagged _ | Ibswap _ |
      Isextend32 | Izextend32 |
      Irdtsc | Irdpmc | Ilfence | Isfence | Imfence |
      Ipackf32 | Isimd _ | Isimd_mem _ | Icldemote _ | Iprefetch _ |

--- a/backend/amd64/arch.mli
+++ b/backend/amd64/arch.mli
@@ -88,6 +88,9 @@ type specific_operation =
                                         (* Store an integer constant *)
   | Ioffset_loc of int * addressing_mode (* Add a constant to a location *)
   | Ifloatarithmem of float_width * float_operation * addressing_mode
+  | Ifloatcomp_tagged of float_width * Cmm.float_comparison
+                                       (* Float comparison yielding the tagged
+                                          boolean directly *)
                                        (* Float arith operation with memory *)
   | Ibswap of { bitwidth: bswap_bitwidth; } (* endianness conversion *)
   | Isextend32                         (* 32 to 64 bit conversion with sign

--- a/backend/amd64/cfg_selection.ml
+++ b/backend/amd64/cfg_selection.ml
@@ -179,6 +179,28 @@ let pseudoregs_for_operation op arg res =
   | Int128op (Iadd128 | Isub128) ->
     [| res.(0); res.(1); arg.(2); arg.(3) |], res
   | Int128op (Imul64 _) -> [| rax; arg.(1) |], [| rax; rdx |]
+  | Specific (Ifloatcomp_tagged (Float64, cond)) ->
+    (* Same scratch-register discipline as [Icompf] below; the swap must be
+       computed for the *negated* comparison, which is the one emission uses. *)
+    let treg = Reg.create Float in
+    if Proc.has_three_operand_float_ops ()
+    then arg, [| res.(0); treg |]
+    else
+      let _, is_swapped =
+        float_cond_and_need_swap (Cmm.negate_float_comparison cond)
+      in
+      ( (if is_swapped then [| arg.(0); treg |] else [| treg; arg.(1) |]),
+        [| res.(0); treg |] )
+  | Specific (Ifloatcomp_tagged (Float32, cond)) ->
+    (* Emission keeps the original predicate for [Float32] (the tagged boolean
+       is obtained by shifting the zero-extended mask). *)
+    let treg = Reg.create Float32 in
+    if Proc.has_three_operand_float_ops ()
+    then arg, [| res.(0); treg |]
+    else
+      let _, is_swapped = float_cond_and_need_swap cond in
+      ( (if is_swapped then [| arg.(0); treg |] else [| treg; arg.(1) |]),
+        [| res.(0); treg |] )
   | Floatop (Float64, Icompf cond) ->
     (* We need to temporarily store the result of the comparison in a float
        register, but we don't want to clobber any of the inputs if they would
@@ -384,6 +406,20 @@ let select_operation'
     (args : Cmm.expression list) dbg ~label_after:_ :
     Cfg_selectgen_target_intf.select_operation_result =
   match op with
+  (* Tagging of a float-comparison result, [2 * (a <cmp> b) + 1]: fuse the
+     comparison with the tagging so that emission can absorb the usual mask
+     negation into the tag arithmetic (see [Ifloatcomp_tagged]). *)
+  | Caddi
+    when match args with
+         | [ Cop (Clsl, [Cop (Ccmpf _, _, _); Cconst_int (1, _)], _);
+             Cconst_int (1, _) ] ->
+           true
+         | _ -> false -> (
+    match args with
+    | [ Cop (Clsl, [Cop (Ccmpf (width, cmp), cmp_args, _); Cconst_int (1, _)], _);
+        Cconst_int (1, _) ] ->
+      Rewritten (specific (Ifloatcomp_tagged (width, cmp)), cmp_args)
+    | _ -> Use_default)
   (* Recognize the LEA instruction *)
   | Caddi | Caddv | Cadda | Csubi | Cor | Cmuli -> (
     match select_addressing Word_int (Cop (op, args, dbg)) with

--- a/backend/amd64/emit.ml
+++ b/backend/amd64/emit.ml
@@ -562,6 +562,14 @@ let arg_idx i n : X86_ast.reg_idx =
   | Mem64_RIP _ ->
     assert false
 
+let res_idx i n : X86_ast.reg_idx =
+  match res i n with
+  | Reg64 reg -> Scalar reg
+  | Regf reg -> Vector reg
+  | Imm _ | Sym _ | Reg8L _ | Reg8H _ | Reg16 _ | Reg32 _ | Regmask _ | Mem _
+  | Mem64_RIP _ ->
+    assert false
+
 let argX i n = arg_as_xmm (reg i.arg.(n))
 
 let resX i n = arg_as_xmm (reg i.res.(n))
@@ -2469,6 +2477,30 @@ let emit_instr ~first ~last ~fallthrough i =
        copy the result to the top 32 bits. *)
     I.movsxd r0_32 r0;
     I.neg r0
+  | Lop (Specific (Ifloatcomp_tagged (Float64, cmp))) ->
+    (* The comparison is emitted with the negated predicate: the mask is then [b
+       - 1] (0 when [cmp] holds, -1 otherwise), so the tagged boolean [2b + 1]
+       is [2 * mask + 3] and the usual [neg] is absorbed into the tag
+       arithmetic. *)
+    let cond, need_swap =
+      float_cond_and_need_swap (Cmm.negate_float_comparison cmp)
+    in
+    let r0, r1 = res i 0, res i 1 in
+    let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
+    cmp_sse_or_avx cmpsd vcmpsd_X_X_Xm64 cond a1 a0 r1;
+    movq r1 r0;
+    I.lea (mem64 NONE 3 (res_idx i 0) ~scale:1 ~base:(reg64 i.res.(0))) r0
+  | Lop (Specific (Ifloatcomp_tagged (Float32, cmp))) ->
+    (* The 32-bit mask is moved with a zero extension, so the tagged boolean is
+       [(mask lsr 30) lor 1] (0xFFFFFFFF yielding 3, and 0 yielding 1); this
+       saves both the sign extension and the negation. *)
+    let cond, need_swap = float_cond_and_need_swap cmp in
+    let r0, r0_32, r1 = res i 0, res32 i 0, res i 1 in
+    let a0, a1 = if need_swap then arg i 1, arg i 0 else arg i 0, arg i 1 in
+    cmp_sse_or_avx cmpss vcmpss_X_X_Xm32 cond a1 a0 r1;
+    movd r1 r0_32;
+    I.shr (int 30) r0;
+    I.or_ (int 1) r0
   | Lop (Floatop (Float64, Inegf)) ->
     sse_or_avx_dst xorpd vxorpd_X_X_Xm128
       (mem64_rip VEC128 (S.encode S.Predef.caml_negf_mask))

--- a/backend/amd64/proc.ml
+++ b/backend/amd64/proc.ml
@@ -590,7 +590,7 @@ let destroyed_at_basic (basic : Cfg_intf.S.basic) =
        | Begin_region
        | End_region
        | Specific (Ilea _ | Ioffset_loc _ | Ibswap _
-                  | Isextend32 | Izextend32
+                  | Isextend32 | Izextend32 | Ifloatcomp_tagged _
                   | Ilfence | Isfence | Imfence)
        | Name_for_debugger _ | Dls_get | Tls_get | Domain_index | Pause)
   | Poptrap _ | Prologue | Epilogue ->

--- a/backend/amd64/regalloc_stack_operands.ml
+++ b/backend/amd64/regalloc_stack_operands.ml
@@ -282,6 +282,7 @@ let basic (map : spilled_map) (instr : Cfg.basic Cfg.instruction) =
          | Istore_int (_, _, _)
          | Ioffset_loc (_, _)
          | Ifloatarithmem (_, _, _)
+         | Ifloatcomp_tagged (_, _)
          | Icldemote _ | Iprefetch _ | Ibswap _ ))
   | Reloadretaddr | Pushtrap _ | Poptrap _ | Prologue | Epilogue ->
     (* no rewrite *)

--- a/backend/amd64/simd_selection.ml
+++ b/backend/amd64/simd_selection.ml
@@ -1518,9 +1518,9 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
             | Iindexed2scaled (scale, displ) -> Some scale, Some displ
             | Ibased _ -> None, None)
           | Istore_int _ | Ioffset_loc _ | Ifloatarithmem _ | Ibswap _
-          | Isextend32 | Izextend32 | Irdtsc | Irdpmc | Ilfence | Isfence
-          | Imfence | Ipackf32 | Isimd _ | Isimd_mem _ | Iprefetch _
-          | Icldemote _ | Illvm_intrinsic _ ->
+          | Isextend32 | Ifloatcomp_tagged _ | Izextend32 | Irdtsc | Irdpmc
+          | Ilfence | Isfence | Imfence | Ipackf32 | Isimd _ | Isimd_mem _
+          | Iprefetch _ | Icldemote _ | Illvm_intrinsic _ ->
             assert false)
         | Move | Load _ | Store _ | Intop _ | Intop_imm _ | Alloc _
         | Reinterpret_cast _ | Static_cast _ | Spill | Reload | Const_int _
@@ -1617,7 +1617,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
               make_binary_operation (Result 0) (New_Vec128 1) (Result 0) add ]
         | _ -> None)
       | Ibased _ -> None)
-    | Isextend32 -> (
+    | Isextend32 | Ifloatcomp_tagged _ -> (
       match width_type with
       | W512 -> None
       | W256 -> None
@@ -1654,7 +1654,7 @@ let vectorize_operation (width_type : Vectorize_utils.Width_in_bits.t)
               ( Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _
               | Irdtsc | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32
               | Isimd _ | Isimd_mem _ | Ilea _ | Ibswap _ | Isextend32
-              | Izextend32 | Illvm_intrinsic _ )
+              | Ifloatcomp_tagged _ | Izextend32 | Illvm_intrinsic _ )
           | Intop_imm _ | Move | Load _ | Store _ | Intop _ | Int128op _
           | Alloc _ | Reinterpret_cast _ | Static_cast _ | Spill | Reload
           | Const_int _ | Const_float32 _ | Const_float _ | Const_symbol _

--- a/backend/amd64/vectorize_specific.ml
+++ b/backend/amd64/vectorize_specific.ml
@@ -58,7 +58,7 @@ let memory_access : Arch.specific_operation -> Memory_access.t option =
   | Isimd_mem _ ->
     Misc.fatal_errorf
       "Unexpected simd instruction with memory operands before vectorization"
-  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 -> None
+  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 | Ifloatcomp_tagged _ -> None
   | Illvm_intrinsic intr ->
     Misc.fatal_errorf
       "Vectorize_specific: Unexpected llvm_intrinsic %s: not using LLVM backend"
@@ -71,7 +71,7 @@ let is_seed_store :
   | Istore_int _ -> Some W64
   | Ifloatarithmem _ | Ioffset_loc _ | Iprefetch _ | Icldemote _ | Irdtsc
   | Irdpmc | Ilfence | Isfence | Imfence | Ipackf32 | Isimd _ | Isimd_mem _
-  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 ->
+  | Ilea _ | Ibswap _ | Isextend32 | Izextend32 | Ifloatcomp_tagged _ ->
     None
   | Illvm_intrinsic intr ->
     Misc.fatal_errorf

--- a/testsuite/tests/codegen/float32_u.ml
+++ b/testsuite/tests/codegen/float32_u.ml
@@ -105,16 +105,13 @@ to_int:
   ret
 |}]
 
-(* CR ttebbi: The 32bit bitmask can be turned into a boolean using either
-   (x >> 30) | 1 or using the negated comparison and sign_extend(x)*2+3 *)
 let eq x y = Float32_u.eq x y
 [%%expect_asm X86_64{|
 eq:
   vcmpss $0, %xmm1, %xmm0, %xmm0
   vmovd %xmm0, %eax
-  movslq %eax, %rax
-  neg   %rax
-  leaq  1(%rax,%rax), %rax
+  shrq  $30, %rax
+  orq   $1, %rax
   ret
 |}]
 
@@ -123,8 +120,7 @@ let lt x y = Float32_u.lt x y
 lt:
   vcmpss $1, %xmm1, %xmm0, %xmm0
   vmovd %xmm0, %eax
-  movslq %eax, %rax
-  neg   %rax
-  leaq  1(%rax,%rax), %rax
+  shrq  $30, %rax
+  orq   $1, %rax
   ret
 |}]

--- a/testsuite/tests/codegen/float_u.ml
+++ b/testsuite/tests/codegen/float_u.ml
@@ -118,15 +118,12 @@ external float_equal :
   (float[@local_opt]) -> (float[@local_opt]) -> bool @@ portable = "%equal"
 
 
-(* CR ttebbi: We could save the neg instruction by negating
-   the vcmpsd predicate. *)
 let equal x y = float_equal (Float_u.to_float x) (Float_u.to_float y)
 [%%expect_asm X86_64{|
 equal:
-  vcmpsd $0, %xmm1, %xmm0, %xmm0
+  vcmpsd $4, %xmm1, %xmm0, %xmm0
   vmovq %xmm0, %rax
-  neg   %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  3(%rax,%rax), %rax
   ret
 |}]
 
@@ -308,10 +305,9 @@ min_unchecked:
 let is_nan (x : Float_u.t) = Float.is_nan (Float_u.to_float x)
 [%%expect_asm X86_64{|
 is_nan:
-  vcmpsd $4, %xmm0, %xmm0, %xmm0
+  vcmpsd $0, %xmm0, %xmm0, %xmm0
   vmovq %xmm0, %rax
-  neg   %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  3(%rax,%rax), %rax
   ret
 |}]
 
@@ -328,10 +324,9 @@ let is_finite (x : Float_u.t) =
 [%%expect_asm X86_64{|
 is_finite:
   vsubsd %xmm0, %xmm0, %xmm0
-  vcmpsd $0, %xmm0, %xmm0, %xmm0
+  vcmpsd $4, %xmm0, %xmm0, %xmm0
   vmovq %xmm0, %rax
-  neg   %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  3(%rax,%rax), %rax
   ret
 |}]
 

--- a/testsuite/tests/codegen/unused_temporaries.ml
+++ b/testsuite/tests/codegen/unused_temporaries.ml
@@ -20,10 +20,9 @@ val is_nan : Intrinsics.Float_u.t -> bool = <fun>
 |}]
 [%%expect_asm X86_64{|
 is_nan:
-  vcmpsd $4, %xmm0, %xmm0, %xmm0
+  vcmpsd $0, %xmm0, %xmm0, %xmm0
   vmovq %xmm0, %rax
-  neg   %rax
-  leaq  1(%rax,%rax), %rax
+  leaq  3(%rax,%rax), %rax
   ret
 |}]
 


### PR DESCRIPTION
Materializing a float comparison as a tagged boolean previously
negated the `vcmp` mask (0/-1) into 0/1 before tagging:

```
  vcmpsd $0, %xmm1, %xmm0, %xmm0
  vmovq %xmm0, %rax
  neg   %rax
  leaq  1(%rax,%rax), %rax
```

This pull request adds an amd64-specific operation, selected from
the `2*(a cmp b)+1`, whose emission absorbs the negation into the
tag arithmetic. For float64 the comparison is emitted with the
negated predicate (an exact complement, so NaN behaviour is
unchanged): 

```
  vcmpsd $4, %xmm1, %xmm0, %xmm0
  vmovq %xmm0, %rax
  leaq  3(%rax,%rax), %rax
```
