### PR TITLE
Use alloc_regions to track zero-alloc annotations.

### DIFF
--- a/middle_end/flambda2/bound_identifiers/alloc_mode.ml
+++ b/middle_end/flambda2/bound_identifiers/alloc_mode.ml
@@ -292,6 +292,19 @@ module For_allocations = struct
         | Some region -> Local { alloc_region = current_alloc_region; region }
         | None -> Misc.fatal_error "Local allocation without a region")
 
+  let map_alloc_region t ~f =
+    match t with
+    | Heap { alloc_region } ->
+      let alloc_region' = f alloc_region in
+      if alloc_region == alloc_region'
+      then t
+      else Heap { alloc_region = alloc_region' }
+    | Local { alloc_region; region } ->
+      let alloc_region' = f alloc_region in
+      if alloc_region == alloc_region'
+      then t
+      else Local { alloc_region = alloc_region'; region }
+
   let free_names t =
     match t with
     | Heap { alloc_region } ->

--- a/middle_end/flambda2/bound_identifiers/alloc_mode.mli
+++ b/middle_end/flambda2/bound_identifiers/alloc_mode.mli
@@ -106,6 +106,10 @@ module For_allocations : sig
     current_region:Variable.t option ->
     t
 
+  (** Apply [f] to the allocation region, leaving any stack allocation region
+      unchanged. *)
+  val map_alloc_region : t -> f:(Variable.t -> Variable.t) -> t
+
   include Contains_names.S with type t := t
 
   include Contains_ids.S with type t := t

--- a/middle_end/flambda2/compare/compare.ml
+++ b/middle_end/flambda2/compare/compare.ml
@@ -440,6 +440,7 @@ and subst_apply env apply =
   let args = List.map (subst_simple env) (Apply_expr.args apply) in
   let call_kind = subst_call_kind env (Apply_expr.call_kind apply) in
   let return_mode = Apply_expr.return_mode apply in
+  let alloc_checks = Apply_expr.alloc_checks apply in
   let dbg = Apply_expr.dbg apply in
   let inlined = Apply_expr.inlined apply in
   let inlining_state = Apply_expr.inlining_state apply in
@@ -448,16 +449,17 @@ and subst_apply env apply =
   let args_arity = Apply_expr.args_arity apply in
   let return_arity = Apply_expr.return_arity apply in
   Apply_expr.create ~callee ~continuation exn_continuation ~args ~call_kind
-    ~return_mode dbg ~inlined ~inlining_state ~probe:None ~position
-    ~relative_history ~args_arity ~return_arity
+    ~return_mode ~alloc_checks dbg ~inlined ~inlining_state ~probe:None
+    ~position ~relative_history ~args_arity ~return_arity
   |> Expr.create_apply
 
 and subst_apply_cont env apply_cont =
   let trap_action = Apply_cont_expr.trap_action apply_cont in
+  let check_actions = Apply_cont_expr.check_actions apply_cont in
   let cont = Apply_cont_expr.continuation apply_cont in
   let args = List.map (subst_simple env) (Apply_cont_expr.args apply_cont) in
   let dbg = Apply_cont_expr.debuginfo apply_cont in
-  Apply_cont_expr.create ?trap_action cont ~args ~dbg
+  Apply_cont_expr.create ?trap_action ~check_actions cont ~args ~dbg
 
 and subst_switch env switch =
   let scrutinee = subst_simple env (Switch_expr.scrutinee switch) in
@@ -1062,8 +1064,9 @@ let apply_exprs env apply1 apply2 : Expr.t Comparison.t =
             ~continuation:(Apply.continuation apply1)
             (Apply.exn_continuation apply1)
             ~args:args1' ~call_kind:call_kind1'
-            ~return_mode:(Apply.return_mode apply1) (Apply.dbg apply1)
-            ~inlined:(Apply.inlined apply1)
+            ~return_mode:(Apply.return_mode apply1)
+            ~alloc_checks:(Apply.alloc_checks apply1)
+            (Apply.dbg apply1) ~inlined:(Apply.inlined apply1)
             ~inlining_state:(Apply.inlining_state apply1)
             ~probe:None ~position:(Apply.position apply1)
             ~relative_history:(Apply_expr.relative_history apply1)
@@ -1081,11 +1084,14 @@ let apply_cont_exprs env apply_cont1 apply_cont2 : Apply_cont.t Comparison.t =
     (Format.pp_print_option Trap_action.print)
     (Apply_cont.trap_action apply_cont1)
     (Apply_cont.trap_action apply_cont2);
+  let check_actions1 = Apply_cont.check_actions apply_cont1 in
+  let check_actions2 = Apply_cont.check_actions apply_cont2 in
   if
     Option.compare Trap_action.compare
       (Apply_cont.trap_action apply_cont1)
       (Apply_cont.trap_action apply_cont2)
     = 0
+    && Misc.Stdlib.List.equal Check_action.equal check_actions1 check_actions2
     && Continuation.equal
          (Apply_cont.continuation apply_cont1)
          (Apply_cont.continuation apply_cont2)
@@ -1094,6 +1100,7 @@ let apply_cont_exprs env apply_cont1 apply_cont2 : Apply_cont.t Comparison.t =
     |> Comparison.map ~f:(fun args1' ->
         Apply_cont.create
           ?trap_action:(Apply_cont.trap_action apply_cont1)
+          ~check_actions:check_actions1
           (Apply_cont.continuation apply_cont1)
           ~args:args1'
           ~dbg:(Apply_cont.debuginfo apply_cont1))

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -423,7 +423,7 @@ module Inlining = struct
   let make_inlined_body acc ~callee ~called_code_id ~region_inlined_into ~params
       ~args ~my_closure ~my_alloc_mode ~my_depth ~body ~free_names_of_body
       ~exn_continuation ~return_continuation ~apply_exn_continuation
-      ~apply_return_continuation ~apply_depth ~apply_dbg =
+      ~apply_return_continuation ~apply_depth ~apply_dbg ~alloc_checks =
     let my_depth_duid = Flambda_debug_uid.none in
     let my_closure_duid = Flambda_debug_uid.none in
     let rec_info =
@@ -448,6 +448,19 @@ module Inlining = struct
         (Named.create_rec_info rec_info)
         ~body
     in
+    let bind_alloc_region ~my_alloc_region ~alloc_region ~alloc_checks
+        ~body:(acc, body) =
+      let alloc_checks =
+        P.alloc_region_checks_with_action alloc_checks ~action:P.Transfer
+      in
+      Let_with_acc.create acc
+        (Bound_pattern.singleton
+           (VB.create my_alloc_region Flambda_debug_uid.none Name_mode.normal))
+        (Named.create_prim
+           (P.Unary (New_alloc_region alloc_checks, Simple.var alloc_region))
+           apply_dbg)
+        ~body
+    in
     let apply_renaming (acc, body) renaming =
       let acc =
         Acc.with_free_names
@@ -462,7 +475,8 @@ module Inlining = struct
         ~my_closure:(my_closure, my_closure_duid)
         ~my_alloc_mode ~my_depth ~rec_info ~body:(acc, body) ~exn_continuation
         ~return_continuation ~apply_exn_continuation ~apply_return_continuation
-        ~bind_params ~bind_depth ~apply_renaming
+        ~alloc_checks ~bind_params ~bind_depth ~bind_alloc_region
+        ~apply_renaming
     in
     let inlined_debuginfo =
       Inlined_debuginfo.create ~called_code_id ~apply_dbg
@@ -537,6 +551,7 @@ module Inlining = struct
             ~params:(Bound_parameters.vars_and_uids params)
             ~args ~my_closure ~my_alloc_mode ~my_depth ~body ~free_names_of_body
             ~exn_continuation ~return_continuation ~apply_depth ~apply_dbg
+            ~alloc_checks:(Apply.alloc_checks apply)
         in
         let acc = Acc.with_free_names Name_occurrences.empty acc in
         let acc = Acc.increment_metrics cost_metrics acc in
@@ -722,6 +737,58 @@ let unarize_extern_repr ~machine_width alloc_mode
         return_transformer = Some P.Tag_immediate
       } ]
 
+let normal_check_actions acc continuation =
+  let _, return_continuation, _ = Acc.current_alloc_exit_context acc in
+  if Continuation.equal continuation return_continuation
+  then [Acc.close_alloc_region_action acc ~exit:Normal]
+  else []
+
+let alloc_checks_for_continuations acc ~continuation ~exn_handler =
+  let _, return_continuation, function_exn_continuation =
+    Acc.current_alloc_exit_context acc
+  in
+  let close_if condition =
+    if condition then Alloc_checks.Close else Alloc_checks.Forward
+  in
+  let normal = close_if (Continuation.equal continuation return_continuation) in
+  let exn =
+    close_if (Continuation.equal exn_handler function_exn_continuation)
+  in
+  Alloc_checks.{ normal; exn; notrace = exn; div = Close }
+
+let alloc_checks_for_apply acc ~continuation
+    (exn_continuation : IR.exn_continuation) =
+  alloc_checks_for_continuations acc ~continuation
+    ~exn_handler:exn_continuation.exn_handler
+
+let close_new_alloc_region acc env ~alloc_region ~actions ~normal_continuation
+    ~exn_continuation ~body =
+  let parent_region, _, _ = Acc.current_alloc_exit_context acc in
+  let alloc_checks =
+    P.alloc_region_checks_with_actions
+      (alloc_checks_for_continuations acc ~continuation:normal_continuation
+         ~exn_handler:exn_continuation)
+      ~actions
+  in
+  let env, alloc_region_var =
+    Env.add_var_like env alloc_region Not_user_visible K.With_subkind.region
+  in
+  let acc =
+    Acc.push_alloc_region acc ~alloc_region:alloc_region_var
+      ~normal_continuation ~exn_continuation
+  in
+  let acc, body = body acc env in
+  let acc = Acc.pop_alloc_region acc ~alloc_region:alloc_region_var in
+  (* [alloc_regions] never correspond to runtime code, so no debug uids or
+     debuginfo are needed. *)
+  Let_with_acc.create acc
+    (Bound_pattern.singleton
+       (VB.create alloc_region_var Flambda_debug_uid.none Name_mode.normal))
+    (Named.create_prim
+       (P.Unary (New_alloc_region alloc_checks, Simple.var parent_region))
+       Debuginfo.none)
+    ~body
+
 let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
     (({ prim_name;
         prim_arity;
@@ -805,7 +872,7 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
       (fun { return_transformer; _ } -> Option.is_some return_transformer)
       unarized_results
   in
-  let return_continuation, needs_wrapper =
+  let return_continuation, return_check_actions, needs_wrapper =
     match Expr.descr body with
     | Apply_cont apply_cont
       when Simple.List.equal
@@ -813,8 +880,9 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
              (Simple.vars (List.map fst let_bound_vars))
            && Option.is_none (Apply_cont_expr.trap_action apply_cont)
            && not need_return_transformer ->
-      Apply_cont_expr.continuation apply_cont, false
-    | _ -> Continuation.create (), true
+      let check_actions = Apply_cont_expr.check_actions apply_cont in
+      Apply_cont_expr.continuation apply_cont, check_actions, false
+    | _ -> Continuation.create (), [], true
   in
   (* Unlike for OCaml function calls, we don't preserve unboxed product arity
      information here, as there is no partial application etc. *)
@@ -861,6 +929,7 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
             let bindable = Bound_pattern.singleton result' in
             let acc, return_result =
               Apply_cont_with_acc.create acc return_continuation
+                ~check_actions:return_check_actions
                 ~args:[Simple.var result]
                 ~dbg
             in
@@ -890,10 +959,34 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
     | _ ->
       let callee = Simple.symbol call_symbol in
       let apply =
+        (* [normal_check_actions] should produce the exact same check_actions as
+           [return_check_actions] (which were taken from the return [Apply_cont]
+           of the body, when there is one). *)
+        (let expected_check_actions =
+           normal_check_actions acc return_continuation
+         in
+         if
+           not
+             (Misc.Stdlib.List.equal Check_action.equal return_check_actions
+                expected_check_actions)
+         then
+           Misc.fatal_errorf
+             "Check actions on the return [Apply_cont] of the C call to %s@ \
+              (%a)@ do not match those implied by the current allocation \
+              region context@ (%a)"
+             prim_name
+             (Format.pp_print_list Check_action.print)
+             return_check_actions
+             (Format.pp_print_list Check_action.print)
+             expected_check_actions);
+        let alloc_checks =
+          alloc_checks_for_continuations acc ~continuation:return_continuation
+            ~exn_handler:(Exn_continuation.exn_handler exn_continuation)
+        in
         Apply.create ~callee:(Some callee)
           ~continuation:(Return return_continuation) exn_continuation ~args
           ~args_arity:param_arity ~return_arity ~call_kind
-          ~return_mode:alloc_mode_app dbg ~inlined:Default_inlined
+          ~return_mode:alloc_mode_app ~alloc_checks dbg ~inlined:Default_inlined
           ~inlining_state:(Inlining_state.default ~round:0)
           ~probe:None ~position:Normal
           ~relative_history:(Env.relative_history_from_scoped ~loc env)
@@ -1067,6 +1160,7 @@ let close_exn_continuation acc env (exn_continuation : IR.exn_continuation) =
 let close_raise0 acc env ~raise_kind ~arg ~dbg exn_continuation =
   let acc, exn_cont = close_exn_continuation acc env exn_continuation in
   let exn_handler = Exn_continuation.exn_handler exn_cont in
+  let check_actions = Acc.raise_check_actions acc ~raise_kind exn_handler in
   let args =
     (* CR mshinwell: Share with [Lambda_to_flambda_primitives_helpers] *)
     let extra_args =
@@ -1079,7 +1173,8 @@ let close_raise0 acc env ~raise_kind ~arg ~dbg exn_continuation =
   let raise_kind = Some (Trap_action.Raise_kind.from_lambda raise_kind) in
   let trap_action = Trap_action.Pop { exn_handler; raise_kind } in
   let acc, apply_cont =
-    Apply_cont_with_acc.create acc ~trap_action exn_handler ~args ~dbg
+    Apply_cont_with_acc.create acc ~trap_action ~check_actions exn_handler ~args
+      ~dbg
   in
   (* Since raising of an exception doesn't terminate, we don't call [k]. *)
   Expr_with_acc.create_apply_cont acc apply_cont
@@ -1123,6 +1218,10 @@ let close_effect_primitive acc env ~dbg exn_continuation
   in
   let close call_kind =
     let apply acc =
+      let alloc_checks =
+        alloc_checks_for_continuations acc ~continuation
+          ~exn_handler:(Exn_continuation.exn_handler exn_continuation)
+      in
       Apply_expr.create ~callee:None ~continuation:(Return continuation)
         exn_continuation ~args:[] ~args_arity:Flambda_arity.nullary
         ~return_arity:
@@ -1132,7 +1231,7 @@ let close_effect_primitive acc env ~dbg exn_continuation
         ~return_mode:
           (Alloc_mode.For_applications.not_alloc_stack
              ~alloc_region:current_alloc_region)
-        dbg ~inlined:Never_inlined
+        ~alloc_checks dbg ~inlined:Never_inlined
         ~inlining_state:(Inlining_state.default ~round:0)
         ~probe:None ~position:Normal
         ~relative_history:Inlining_history.Relative.empty
@@ -1894,6 +1993,9 @@ let close_exact_or_unknown_apply acc env
       close_exn_continuation acc env exn_continuation
     in
     let acc, args = find_simples acc env args in
+    let alloc_checks =
+      alloc_checks_for_apply acc ~continuation exn_continuation
+    in
     let inlined_call = Inlined_attribute.from_lambda inlined in
     let probe = Probe.from_lambda probe in
     let position =
@@ -1905,7 +2007,7 @@ let close_exact_or_unknown_apply acc env
       Apply.create
         ~callee:(if can_erase_callee then None else Some callee)
         ~continuation:(Return continuation) apply_exn_continuation ~args
-        ~args_arity ~return_arity ~call_kind ~return_mode:mode dbg
+        ~args_arity ~return_arity ~call_kind ~return_mode:mode ~alloc_checks dbg
         ~inlined:inlined_call
         ~inlining_state:(Inlining_state.default ~round:0)
         ~probe ~position
@@ -1944,9 +2046,11 @@ let close_exact_or_unknown_apply acc env
 let close_apply_cont acc env ~dbg cont trap_action args : Expr_with_acc.t =
   let acc, args = find_simples acc env args in
   let trap_action = close_trap_action_opt trap_action in
+  let check_actions = normal_check_actions acc cont in
   let args_approx = List.map (find_value_approximation env) args in
   let acc, apply_cont =
-    Apply_cont_with_acc.create acc ?trap_action ~args_approx cont ~args ~dbg
+    Apply_cont_with_acc.create acc ?trap_action ~check_actions ~args_approx cont
+      ~args ~dbg
   in
   Expr_with_acc.create_apply_cont acc apply_cont
 
@@ -1974,11 +2078,12 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
     List.fold_left_map
       (fun acc (case, cont, dbg, trap_action, args) ->
         let trap_action = close_trap_action_opt trap_action in
+        let check_actions = normal_check_actions acc cont in
         let acc, args = find_simples acc env args in
         let args_approx = List.map (find_value_approximation env) args in
         let action acc =
-          Apply_cont_with_acc.create acc ?trap_action ~args_approx cont ~args
-            ~dbg
+          Apply_cont_with_acc.create acc ?trap_action ~check_actions
+            ~args_approx cont ~args ~dbg
         in
         acc, (Target_ocaml_int.of_int (Acc.machine_width acc) case, action))
       acc sw.consts
@@ -2007,7 +2112,9 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
     let acc, default_action =
       let acc, args = find_simples acc env default_args in
       let trap_action = close_trap_action_opt default_trap_action in
-      Apply_cont_with_acc.create acc ?trap_action default_action ~args ~dbg
+      let check_actions = normal_check_actions acc default_action in
+      Apply_cont_with_acc.create acc ?trap_action ~check_actions default_action
+        ~args ~dbg
     in
     let acc, switch =
       let scrutinee = Simple.var comparison_result in
@@ -2030,6 +2137,7 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
       match sw.failaction with
       | None -> acc, Target_ocaml_int.Map.of_list arms
       | Some (default, dbg, trap_action, args) ->
+        let check_actions = normal_check_actions acc default in
         Numeric_types.Int.Set.fold
           (fun case (acc, cases) ->
             let case = Target_ocaml_int.of_int (Acc.machine_width acc) case in
@@ -2039,7 +2147,8 @@ let close_switch acc env ~condition_dbg scrutinee (sw : IR.switch) :
               let acc, args = find_simples acc env args in
               let trap_action = close_trap_action_opt trap_action in
               let default acc =
-                Apply_cont_with_acc.create acc ?trap_action default ~args ~dbg
+                Apply_cont_with_acc.create acc ?trap_action ~check_actions
+                  default ~args ~dbg
               in
               acc, Target_ocaml_int.Map.add case default cases)
           (Numeric_types.Int.zero_to_n (sw.numconsts - 1))
@@ -2235,6 +2344,9 @@ let compute_body_of_unboxed_function acc my_region my_alloc_region my_closure
       let acc, body = body acc in
       acc, body, return, return_continuation
     | Some (k, _) ->
+      (* CR ncourant: this closes the alloc_region earlier than we would like:
+         we close it at the normal return of the function, instead of after the
+         unboxing primitives at the end. *)
       let vars_with_kinds = variables_for_unboxing "result" k in
       let unboxed_return_continuation =
         Continuation.create ~sort:Return ~name:"unboxed_return" ()
@@ -2407,7 +2519,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
              (fun kind -> Flambda_arity.Component_for_creation.Singleton kind)
              args_arity) ]
   in
-  let make_body cont =
+  let make_body ~is_tail cont =
     let main_application =
       Apply_expr.create
         ~callee:(Some (Simple.var main_closure))
@@ -2420,6 +2532,12 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
              (Function_decl.result_mode decl)
              ~current_alloc_region:my_alloc_region ~current_region:my_region
              ~current_ghost_region:my_ghost_region)
+        ~alloc_checks:
+          { normal = (if is_tail then Close else Forward);
+            exn = Close;
+            notrace = Close;
+            div = Close
+          }
         Debuginfo.none ~inlined:Inlined_attribute.Default_inlined
         ~inlining_state:(Inlining_state.default ~round:0)
         ~probe:None ~position:Normal
@@ -2453,7 +2571,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
   in
   let make_return_wrapper box_result =
     let cont = Continuation.create () in
-    let body, free_names_of_body = make_body cont in
+    let body, free_names_of_body = make_body ~is_tail:false cont in
     let handler, free_names_of_handler =
       let unboxed_returns =
         Bound_parameters.create
@@ -2472,6 +2590,9 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
         let boxed_return_duid = Flambda_debug_uid.none in
         let return_apply_cont =
           Apply_cont.create return_continuation
+            ~check_actions:
+              [ Check_action.Close_alloc_region
+                  { region = my_alloc_region; exit = Normal } ]
             ~args:[Simple.var boxed_return]
             ~dbg:Debuginfo.none
         in
@@ -2513,7 +2634,7 @@ let make_unboxed_function_wrapper acc function_slot ~unarized_params:params
   in
   let body, free_names_of_body =
     match unboxed_return with
-    | None -> make_body return_continuation
+    | None -> make_body ~is_tail:true return_continuation
     | Some (k, alloc_mode) ->
       let alloc_mode =
         Alloc_mode.For_allocations.from_lambda alloc_mode
@@ -2628,10 +2749,6 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
     | Recursive, [_] -> true
     | Recursive, ([] | _ :: _ :: _) -> false
     | Non_recursive, _ -> false
-  in
-  let acc =
-    Acc.push_closure_info acc ~return_continuation ~exn_continuation ~my_closure
-      ~is_purely_tailrec:is_single_recursive_function ~code_id
   in
   let my_alloc_region = Function_decl.my_alloc_region decl in
   let my_region = Function_decl.my_region decl in
@@ -2766,6 +2883,11 @@ let close_one_function acc ~code_id ~external_env ~by_function_slot
         Some ghost_region,
         Alloc_mode.For_applications.maybe_alloc_stack ~alloc_region ~region
           ~ghost_region )
+  in
+  let acc =
+    Acc.push_closure_info acc ~return_continuation ~exn_continuation ~my_closure
+      ~my_alloc_region:alloc_region
+      ~is_purely_tailrec:is_single_recursive_function ~code_id
   in
   let closure_env = Env.with_depth closure_env my_depth in
   let closure_env, absolute_history, relative_history =
@@ -3551,8 +3673,9 @@ let wrap_partial_application acc env apply_continuation (apply : IR.apply)
     in
     let body acc env =
       let arg = find_simple_from_id env wrapper_id in
+      let check_actions = normal_check_actions acc apply_continuation in
       let acc, apply_cont =
-        Apply_cont_with_acc.create acc
+        Apply_cont_with_acc.create acc ~check_actions
           ~args_approx:[find_value_approximation env arg]
           apply_continuation ~args:[arg] ~dbg:Debuginfo.none
       in
@@ -3573,6 +3696,10 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
   in
   let acc, remaining = find_simples acc env remaining in
   let apply_dbg = Debuginfo.from_location apply.loc in
+  let original_alloc_checks =
+    alloc_checks_for_apply acc ~continuation:apply.continuation
+      apply.exn_continuation
+  in
   let needs_region =
     match
       (apply.mode : Lambda.return_mode), (result_mode : Lambda.return_mode)
@@ -3617,13 +3744,21 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
       | None -> apply_return_continuation
       | Some (_, _, cont) -> Apply.Result_continuation.Return cont
     in
+    let alloc_checks =
+      match original_alloc_checks.normal with
+      | Forward -> original_alloc_checks
+      | Close ->
+        if Option.is_some needs_region
+        then { original_alloc_checks with normal = Alloc_checks.Forward }
+        else original_alloc_checks
+    in
     let over_application =
       Apply.create
         ~callee:(Some (Simple.var returned_func))
         ~continuation apply_exn_continuation ~args:remaining
         ~args_arity:remaining_arity ~return_arity:apply.return_arity
         ~call_kind:Call_kind.indirect_function_call_unknown_arity ~return_mode
-        apply_dbg ~inlined
+        ~alloc_checks apply_dbg ~inlined
         ~inlining_state:(Inlining_state.default ~round:0)
         ~probe ~position
         ~relative_history:(Env.relative_history_from_scoped ~loc:apply.loc env)
@@ -3646,7 +3781,8 @@ let wrap_over_application acc env full_call (apply : IR.apply) ~remaining
       let handler acc =
         let acc, call_return_continuation =
           let acc, apply_cont_expr =
-            Apply_cont_with_acc.create acc apply.continuation
+            let check_actions = normal_check_actions acc apply.continuation in
+            Apply_cont_with_acc.create acc apply.continuation ~check_actions
               ~args:(List.map BP.simple over_application_results)
               ~dbg:apply_dbg
           in
@@ -4159,7 +4295,11 @@ let close_program (type mode) ~(mode : mode Flambda_features.mode)
     Env.add_var_like env toplevel_my_alloc_region Not_user_visible
       Flambda_kind.With_subkind.region
   in
-  let acc = Acc.create ~cmx_loader ~machine_width in
+  let acc =
+    Acc.create ~cmx_loader ~machine_width
+      ~toplevel_return_continuation:prog_return_cont
+      ~toplevel_exn_continuation:exn_continuation ~toplevel_my_alloc_region
+  in
   let acc, body =
     wrap_final_module_block acc env ~program ~prog_return_cont ~module_repr
       ~return_cont ~module_symbol

--- a/middle_end/flambda2/from_lambda/closure_conversion.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion.mli
@@ -58,6 +58,16 @@ val close_let_cont :
 
 val close_apply : Acc.t -> Env.t -> IR.apply -> Expr_with_acc.t
 
+val close_new_alloc_region :
+  Acc.t ->
+  Env.t ->
+  alloc_region:Ident.t ->
+  actions:Flambda_primitive.alloc_check_actions ->
+  normal_continuation:Continuation.t ->
+  exn_continuation:Continuation.t ->
+  body:(Acc.t -> Env.t -> Expr_with_acc.t) ->
+  Expr_with_acc.t
+
 val close_apply_cont :
   Acc.t ->
   Env.t ->

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.ml
@@ -352,6 +352,7 @@ module Acc = struct
     { code_id : Code_id.t;
       return_continuation : Continuation.t;
       exn_continuation : Exn_continuation.t;
+      my_alloc_region : Variable.t;
       my_closure : Variable.t;
       is_purely_tailrec : bool;
       slot_offsets_at_definition : Slot_offsets.t
@@ -359,6 +360,12 @@ module Acc = struct
              rather a property of its point of definition (i.e. the state of the
              slot_offsets right before we entered the current closure). It's
              mainly stored here for efficiency reasons. *)
+    }
+
+  type alloc_region =
+    { region : Variable.t;
+      normal_continuation : Continuation.t;
+      exn_continuation : Continuation.t
     }
 
   type t =
@@ -377,7 +384,8 @@ module Acc = struct
       seen_a_function : bool;
       slot_offsets : Slot_offsets.t;
       code_slot_offsets : Slot_offsets.t Code_id.Map.t;
-      closure_infos : closure_info list
+      closure_infos : closure_info list;
+      alloc_regions : alloc_region list
     }
 
   let cost_metrics t = t.cost_metrics
@@ -450,7 +458,8 @@ module Acc = struct
         externals := Symbol.Map.add symbol approx !externals;
         approx
 
-  let create ~cmx_loader ~machine_width =
+  let create ~cmx_loader ~machine_width ~toplevel_return_continuation
+      ~toplevel_exn_continuation ~toplevel_my_alloc_region =
     { machine_width;
       declared_symbols = [];
       lifted_sets_of_closures = [];
@@ -468,7 +477,12 @@ module Acc = struct
       seen_a_function = false;
       slot_offsets = Slot_offsets.empty;
       code_slot_offsets = Code_id.Map.empty;
-      closure_infos = []
+      closure_infos = [];
+      alloc_regions =
+        [ { region = toplevel_my_alloc_region;
+            normal_continuation = toplevel_return_continuation;
+            exn_continuation = toplevel_exn_continuation
+          } ]
     }
 
   let declared_symbols t = t.declared_symbols
@@ -715,14 +729,60 @@ module Acc = struct
     | [] -> None
     | closure_info :: _ -> Some closure_info
 
+  let current_alloc_exit_context t =
+    match t.alloc_regions with
+    | [] -> Misc.fatal_error "No current allocation region"
+    | { region; normal_continuation; exn_continuation } :: _ ->
+      region, normal_continuation, exn_continuation
+
+  let push_alloc_region t ~alloc_region ~normal_continuation ~exn_continuation =
+    { t with
+      alloc_regions =
+        { region = alloc_region; normal_continuation; exn_continuation }
+        :: t.alloc_regions
+    }
+
+  let pop_alloc_region t ~alloc_region:region =
+    match t.alloc_regions with
+    | [] -> Misc.fatal_error "No allocation region to pop"
+    | alloc_region :: alloc_regions ->
+      if not (Variable.equal alloc_region.region region)
+      then
+        Misc.fatal_errorf
+          "Trying to pop allocation region %a, but current region is %a"
+          Variable.print region Variable.print alloc_region.region;
+      { t with alloc_regions }
+
+  let close_alloc_region_action t ~exit =
+    let region, _, _ = current_alloc_exit_context t in
+    Check_action.Close_alloc_region { region; exit }
+
+  let raise_check_actions t ~raise_kind exn_handler =
+    let _, _, function_exn_continuation = current_alloc_exit_context t in
+    if Continuation.equal exn_handler function_exn_continuation
+    then
+      let exit =
+        match (raise_kind : Lambda.raise_kind) with
+        | Raise_regular | Raise_reraise -> Check_action.Exn
+        | Raise_notrace -> Check_action.Notrace
+      in
+      [close_alloc_region_action t ~exit]
+    else []
+
   let push_closure_info t ~return_continuation ~exn_continuation ~my_closure
-      ~is_purely_tailrec ~code_id =
+      ~my_alloc_region ~is_purely_tailrec ~code_id =
+    let t =
+      push_alloc_region t ~alloc_region:my_alloc_region
+        ~normal_continuation:return_continuation
+        ~exn_continuation:(Exn_continuation.exn_handler exn_continuation)
+    in
     { t with
       slot_offsets = Slot_offsets.empty;
       closure_infos =
         { code_id;
           return_continuation;
           exn_continuation;
+          my_alloc_region;
           my_closure;
           is_purely_tailrec;
           slot_offsets_at_definition = t.slot_offsets
@@ -739,6 +799,7 @@ module Acc = struct
     let code_slot_offsets =
       Code_id.Map.add closure_info.code_id t.slot_offsets t.code_slot_offsets
     in
+    let t = pop_alloc_region t ~alloc_region:closure_info.my_alloc_region in
     let closure_infos =
       match closure_infos with
       | [] -> []
@@ -1061,8 +1122,10 @@ module Expr_with_acc = struct
 end
 
 module Apply_cont_with_acc = struct
-  let create acc ?trap_action ?args_approx cont ~args ~dbg =
-    let apply_cont = Apply_cont.create ?trap_action cont ~args ~dbg in
+  let create acc ?trap_action ?check_actions ?args_approx cont ~args ~dbg =
+    let apply_cont =
+      Apply_cont.create ?trap_action ?check_actions cont ~args ~dbg
+    in
     let acc = Acc.add_continuation_application ~cont args_approx acc in
     let acc =
       Acc.add_free_names_and_check_my_closure_use

--- a/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
+++ b/middle_end/flambda2/from_lambda/closure_conversion_aux.mli
@@ -224,6 +224,7 @@ module Acc : sig
     { code_id : Code_id.t;
       return_continuation : Continuation.t;
       exn_continuation : Exn_continuation.t;
+      my_alloc_region : Variable.t;
       my_closure : Variable.t;
       is_purely_tailrec : bool;
       slot_offsets_at_definition : Slot_offsets.t
@@ -234,6 +235,9 @@ module Acc : sig
   val create :
     cmx_loader:Flambda_cmx.loader ->
     machine_width:Target_system.Machine_width.t ->
+    toplevel_return_continuation:Continuation.t ->
+    toplevel_exn_continuation:Continuation.t ->
+    toplevel_my_alloc_region:Variable.t ->
     t
 
   val declared_symbols : t -> (Symbol.t * Static_const.t) list
@@ -313,11 +317,35 @@ module Acc : sig
 
   val top_closure_info : t -> closure_info option
 
+  val current_alloc_exit_context :
+    t -> Variable.t * Continuation.t * Continuation.t
+
+  val push_alloc_region :
+    t ->
+    alloc_region:Variable.t ->
+    normal_continuation:Continuation.t ->
+    exn_continuation:Continuation.t ->
+    t
+
+  val pop_alloc_region : t -> alloc_region:Variable.t -> t
+
+  (** The check action closing the current allocation region at the given exit.
+  *)
+  val close_alloc_region_action :
+    t -> exit:Check_action.close_alloc_region_type -> Check_action.t
+
+  (** The check actions for a raise to [exn_handler]: closes the current
+      allocation region if [exn_handler] is the exception continuation of the
+      current allocation region context. *)
+  val raise_check_actions :
+    t -> raise_kind:Lambda.raise_kind -> Continuation.t -> Check_action.t list
+
   val push_closure_info :
     t ->
     return_continuation:Continuation.t ->
     exn_continuation:Exn_continuation.t ->
     my_closure:Variable.t ->
+    my_alloc_region:Variable.t ->
     is_purely_tailrec:bool ->
     code_id:Code_id.t ->
     t
@@ -480,6 +508,7 @@ module Apply_cont_with_acc : sig
   val create :
     Acc.t ->
     ?trap_action:Trap_action.t ->
+    ?check_actions:Check_action.t list ->
     ?args_approx:Env.value_approximation list ->
     Continuation.t ->
     args:Simple.t list ->

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda.ml
@@ -1085,6 +1085,43 @@ let rec cps acc env ccenv (lam : L.lambda) (k : cps_continuation)
        by completely removing it (replacing by unit). *)
     Misc.fatal_error
       "[Lifused] should have been removed by [Simplif.simplify_lets]"
+  (* In the future, there should be a Lzero_alloc constructor for zero-alloc on
+   * expressions. It should work like this:
+   *
+   * | Lzero_alloc { attr; body } ->
+   *   let actions action ~strict =
+   *     if strict then
+   *       { normal = action; exn = action; notrace = action; div = action }
+   *     else
+   *       { normal = action;
+   *         exn = Flambda_primitive.Transfer;
+   *         notrace = action;
+   *         div = Flambda_primitive.Transfer
+   *       }
+   *   in
+   *   let actions = match attr with
+   *     | Default_zero_alloc ->
+   *       actions Transfer ~strict:true
+   *     (* CR ncourant: [Check.custom_error_msg] and
+   *      [Assume.never_returns_normally]/[Assume.never_raises] are currently
+   *      ignored. *)
+   *     | Check { strict; _ } ->
+   *       actions Check ~strict
+   *     | Assume { strict; _ } ->
+   *       actions Discard ~strict
+   *   in
+   *   let alloc_region = Ident.create_local "zero_alloc_region" in
+   *   let layout = Lambda.layout_of_lambda body in
+   *   (* Insert a let-cont to make the delimitation of the zero_alloc region
+   *      easier. With [maybe_insert_let_cont], this never breaks tail calls. *)
+   *   maybe_insert_let_cont "zero_alloc_region_return" layout k acc env ccenv
+   *     (fun acc env ccenv normal_continuation ->
+   *       CC.close_new_alloc_region acc ccenv ~alloc_region ~actions
+   *         ~normal_continuation ~exn_continuation:k_exn
+   *         ~body:(fun acc ccenv ->
+   *           let env = Env.entering_alloc_region env alloc_region in
+   *           cps_tail acc env ccenv body normal_continuation k_exn))
+   *)
   | Lregion (body, _) when not (Flambda_features.stack_allocation_enabled ()) ->
     cps acc env ccenv body k k_exn
   | Lexclave body ->
@@ -1636,7 +1673,34 @@ and cps_function env ~fid ~fuid ~(recursive : Recursive.t)
   let body acc ccenv =
     let ccenv = CCenv.set_path_to_root ccenv loc in
     let ccenv = CCenv.set_not_at_toplevel ccenv in
-    cps_tail acc new_env ccenv body body_cont body_exn_cont
+    let close_zero_alloc_region ~action ~strict =
+      let alloc_region = Ident.create_local "zero_alloc_region" in
+      let new_env = Env.entering_alloc_region new_env alloc_region in
+      let actions : Flambda_primitive.alloc_check_actions =
+        if strict
+        then { normal = action; exn = action; notrace = action; div = action }
+        else
+          { normal = action;
+            exn = Flambda_primitive.Transfer;
+            notrace = action;
+            div = Flambda_primitive.Transfer
+          }
+      in
+      CC.close_new_alloc_region acc ccenv ~alloc_region ~actions
+        ~normal_continuation:body_cont ~exn_continuation:body_exn_cont
+        ~body:(fun acc ccenv ->
+          cps_tail acc new_env ccenv body body_cont body_exn_cont)
+    in
+    match attr.zero_alloc with
+    | Default_zero_alloc ->
+      cps_tail acc new_env ccenv body body_cont body_exn_cont
+    (* CR ncourant: [Check.custom_error_msg] and
+       [Assume.never_returns_normally]/[Assume.never_raises] are currently
+       ignored. *)
+    | Check { strict; _ } ->
+      close_zero_alloc_region ~action:Flambda_primitive.Check ~strict
+    | Assume { strict; _ } ->
+      close_zero_alloc_region ~action:Flambda_primitive.Discard ~strict
   in
   Function_decl.create ~let_rec_ident:(Some fid) ~let_rec_uid:fuid
     ~function_slot ~kind ~params ~params_arity ~removed_params ~return

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.ml
@@ -358,6 +358,8 @@ let current_region t =
    have a single alloc_region for a function. *)
 let current_alloc_region t = t.my_alloc_region
 
+let entering_alloc_region t my_alloc_region = { t with my_alloc_region }
+
 let parent_region t =
   if not (Flambda_features.stack_allocation_enabled ())
   then t.my_region

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_env.mli
@@ -216,3 +216,5 @@ val region_closure_continuation :
   t -> Region_stack_element.t -> region_closure_continuation
 
 val current_alloc_region : t -> Ident.t
+
+val entering_alloc_region : t -> Ident.t -> t

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives_helpers.ml
@@ -129,6 +129,9 @@ let print_list_of_lists_of_simple_or_prim ppf simple_or_prim_list_list =
 
 let raise_exn_for_failure acc ~dbg exn_cont exn_bucket =
   let exn_handler = Exn_continuation.exn_handler exn_cont in
+  let check_actions =
+    Acc.raise_check_actions acc ~raise_kind:L.Raise_regular exn_handler
+  in
   let trap_action =
     Trap_action.Pop { exn_handler; raise_kind = Some Regular }
   in
@@ -141,7 +144,8 @@ let raise_exn_for_failure acc ~dbg exn_cont exn_bucket =
     exn_bucket :: extra_args
   in
   let acc, apply_cont =
-    Apply_cont_with_acc.create acc ~trap_action exn_handler ~args ~dbg
+    Apply_cont_with_acc.create acc ~trap_action ~check_actions exn_handler ~args
+      ~dbg
   in
   Expr_with_acc.create_apply_cont acc apply_cont
 

--- a/middle_end/flambda2/parser/fexpr.ml
+++ b/middle_end/flambda2/parser/fexpr.ml
@@ -213,6 +213,7 @@ type simple =
   | Var of variable
   | Symbol of symbol
   | Const of const
+  | Region of region
   | Coerce of simple * coercion
 
 type cont_extra_arg = simple * kind_with_subkind
@@ -305,6 +306,7 @@ type apply =
     args : simple list;
     call_kind : call_kind;
     alloc_mode : region alloc_mode_for_applications;
+    alloc_checks : Alloc_checks.t;
     arities : function_arities option;
     inlined : inlined_attribute option;
     inlining_state : inlining_state option
@@ -312,9 +314,16 @@ type apply =
 
 type size = int
 
+type check_action =
+  | Close_alloc_region of
+      { exit : Check_action.close_alloc_region_type;
+        region : region
+      }
+
 type apply_cont =
   { cont : continuation;
     trap_action : trap_action option;
+    check_actions : check_action list;
     args : simple list
   }
 

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -860,6 +860,38 @@ let make_lazy =
     unary "%lazy" ~params:(param2 lazy_tag alloc_region)
       (fun _ (lazy_tag, alloc_region) -> P.Make_lazy { lazy_tag; alloc_region }))
 
+let close_alloc_region_type =
+  D.(
+    constructor_flag
+      Check_action.["normal", Normal; "exn", Exn; "notrace", Notrace])
+
+let alloc_region_checks : P.alloc_region_checks param_cons =
+  let open D in
+  let alloc_check =
+    constructor_flag Alloc_checks.["forward", Forward; "close", Close]
+  in
+  let alloc_check_action =
+    constructor_flag P.["transfer", Transfer; "check", Check; "discard", Discard]
+  in
+  let check = param2 alloc_check alloc_check_action in
+  D.maps
+    (param4 (labeled "normal" check) (labeled "exn" check)
+       (labeled "notrace" check) (labeled "div" check))
+    ~to_:(fun _env { Alloc_checks.normal; exn; notrace; div } ->
+      normal, exn, notrace, div)
+    ~from:(fun _env (normal, exn, notrace, div) ->
+      { Alloc_checks.normal; exn; notrace; div })
+
+let close_alloc_region =
+  D.(
+    unary "%close_alloc_region" ~params:(positional close_alloc_region_type)
+      (fun _ kind -> P.Close_alloc_region kind))
+
+let new_alloc_region =
+  D.(
+    unary "%new_alloc_region" ~params:(positional alloc_region_checks)
+      (fun _ alloc_checks -> P.New_alloc_region alloc_checks))
+
 let opaque_identity =
   D.(
     unary "%opaque" ~params:param0 (fun _ () ->
@@ -1379,6 +1411,8 @@ module OfFlambda = struct
     | Peek standard_int_or_float -> peek env standard_int_or_float
     | Duplicate_block { kind; alloc_region } ->
       duplicate_block env (kind, alloc_region)
+    | Close_alloc_region kind -> close_alloc_region env kind
+    | New_alloc_region alloc_checks -> new_alloc_region env alloc_checks
 
   let binop env (op : P.binary_primitive) =
     match op with

--- a/middle_end/flambda2/parser/fexpr_to_flambda.ml
+++ b/middle_end/flambda2/parser/fexpr_to_flambda.ml
@@ -150,6 +150,7 @@ let rec simple env (s : Fexpr.simple) : Simple.t =
     | Some var -> Simple.var var)
   | Const c -> Simple.const (const c)
   | Symbol sym -> Simple.symbol (get_symbol env sym)
+  | Region r -> Simple.var (find_region env r)
   | Coerce (s, co) -> Simple.apply_coercion_exn (simple env s) (coercion env co)
 
 let field_of_block env (v : Fexpr.field_of_block) =
@@ -306,7 +307,8 @@ let set_of_closures env fun_decls value_slots =
   in
   Set_of_closures.create ~value_slots fun_decls
 
-let apply_cont env acc ({ cont; args; trap_action } : Fexpr.apply_cont) =
+let apply_cont env acc
+    ({ cont; args; trap_action; check_actions } : Fexpr.apply_cont) =
   let trap_action : Trap_action.t option =
     trap_action
     |> Option.map (fun (ta : Fexpr.trap_action) : Trap_action.t ->
@@ -329,7 +331,17 @@ let apply_cont env acc ({ cont; args; trap_action } : Fexpr.apply_cont) =
      in
      Misc.fatal_errorf "wrong continuation arity %s" cont_str);
   let args = List.map (simple env) args in
-  acc, Flambda.Apply_cont.create c ~args ~dbg:Debuginfo.none ?trap_action
+  let check_actions =
+    List.map
+      (fun (action : Fexpr.check_action) : Check_action.t ->
+        match action with
+        | Close_alloc_region { exit; region } ->
+          Close_alloc_region { exit; region = find_region env region })
+      check_actions
+  in
+  ( acc,
+    Flambda.Apply_cont.create c ~args ~dbg:Debuginfo.none ?trap_action
+      ~check_actions )
 
 let continuation_sort (sort : Fexpr.continuation_sort) : Continuation.Sort.t =
   match sort with
@@ -840,6 +852,7 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
       { func;
         call_kind;
         alloc_mode;
+        alloc_checks;
         inlined;
         inlining_state;
         continuation;
@@ -945,8 +958,8 @@ let rec expr env acc (e : Fexpr.expr) : _ * Flambda.Expr.t =
         ~callee:(Option.map (simple env) func)
         ~continuation exn_continuation
         ~args:((List.map (simple env)) args)
-        ~args_arity ~return_arity ~call_kind ~return_mode Debuginfo.none
-        ~inlined ~inlining_state ~probe:None ~position:Normal
+        ~args_arity ~return_arity ~call_kind ~return_mode ~alloc_checks
+        Debuginfo.none ~inlined ~inlining_state ~probe:None ~position:Normal
         ~relative_history:Inlining_history.Relative.empty
     in
     acc, Flambda.Expr.create_apply apply

--- a/middle_end/flambda2/parser/flambda_lex.mll
+++ b/middle_end/flambda2/parser/flambda_lex.mll
@@ -41,6 +41,7 @@ let keyword_table =
     "self", KWD_SELF;
     "public", KWD_PUBLIC;
     "cached", KWD_CACHED;
+    "close", KWD_CLOSE;
     "closure", KWD_CLOSURE;
     "code", KWD_CODE;
     "cont", KWD_CONT;
@@ -56,6 +57,7 @@ let keyword_table =
     "exn", KWD_EXN;
     "float", KWD_FLOAT;
     "float32", KWD_FLOAT32;
+    "forward", KWD_FORWARD;
     "halt_and_catch_fire", KWD_HCF;
     "hint", KWD_HINT;
     "id", KWD_ID;
@@ -80,6 +82,7 @@ let keyword_table =
     "never", KWD_NEVER;
     "newer_version_of", KWD_NEWER_VERSION_OF;
     "noalloc", KWD_NOALLOC;
+    "normal", KWD_NORMAL;
     "notrace", KWD_NOTRACE;
     "null", KWD_NULL;
     "of", KWD_OF;

--- a/middle_end/flambda2/parser/flambda_parser.messages
+++ b/middle_end/flambda2/parser/flambda_parser.messages
@@ -8,7 +8,7 @@
 
 flambda_unit: KWD_APPLY KWD_WITH
 ##
-## Ends in an error in state: 514.
+## Ends in an error in state: 529.
 ##
 ## atomic_expr -> KWD_APPLY . apply_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -23,7 +23,7 @@ Example of an application:
 
 flambda_unit: KWD_CONT IDENT LPAREN SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 234.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
 ## separated_nonempty_list(COMMA,simple) -> simple . COMMA separated_nonempty_list(COMMA,simple) [ RPAREN ]
@@ -37,7 +37,7 @@ Expected a simple value (a symbol, variable, or literal).
 
 flambda_unit: KWD_CONT IDENT LPAREN KWD_WITH
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 233.
 ##
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ RPAREN PIPE MINUSGREATER KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -54,7 +54,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT IDENT KWD_VAL
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 511.
 ##
 ## apply_cont_expr -> continuation . option(trap_action) simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -70,7 +70,7 @@ Examples of continuation calls:
 
 flambda_unit: KWD_CONT KWD_WITH
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 506.
 ##
 ## atomic_expr -> KWD_CONT . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -96,7 +96,7 @@ Example of a continuation call:
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_WITH
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 206.
 ##
 ## deleted_code -> KWD_CODE code_id . KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -116,7 +116,7 @@ Examples of argument lists:
 
 flambda_unit: KWD_LET KWD_CODE KWD_REC KWD_HCF
 ##
-## Ends in an error in state: 148.
+## Ends in an error in state: 163.
 ##
 ## code_header -> KWD_CODE recursive . option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -128,7 +128,7 @@ Expected a code id.
 
 flambda_unit: KWD_LET KWD_CODE KWD_WITH
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 161.
 ##
 ## code_header -> KWD_CODE . recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ## deleted_code -> KWD_CODE . code_id KWD_DELETED [ KWD_WITH KWD_IN KWD_AND ]
@@ -150,7 +150,7 @@ Examples of code definitions:
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT KWD_VAL
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 114.
 ##
 ## fun_decl -> KWD_CLOSURE code_id . function_slot_opt alloc_mode_for_allocations [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -162,7 +162,7 @@ Expected "with", "in", "end", or "and".
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_WITH
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 246.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol EQUAL . static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -179,7 +179,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 245.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_IN KWD_AND ]
 ## static_data_binding -> symbol . EQUAL static_data [ KWD_WITH KWD_IN KWD_AND ]
@@ -196,7 +196,7 @@ Example of a block expression:
 
 flambda_unit: KWD_LET KWD_WITH
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 499.
 ##
 ## let_expr(expr) -> KWD_LET . let_(expr) [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## let_symbol(expr) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
@@ -213,7 +213,7 @@ Examples of let expressions:
 
 flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ##
-## Ends in an error in state: 674.
+## Ends in an error in state: 698.
 ##
 ## flambda_unit -> module_ . EOF [ # ]
 ##
@@ -224,13 +224,13 @@ flambda_unit: KWD_SWITCH SYMBOL KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 80, spurious reduction of production option(PIPE) ->
-## In state 103, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
-## In state 671, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
-## In state 102, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
-## In state 645, spurious reduction of production inner_expr -> inlined_expr
-## In state 610, spurious reduction of production expr -> inner_expr
-## In state 677, spurious reduction of production module_ -> expr
+## In state 82, spurious reduction of production option(PIPE) ->
+## In state 105, spurious reduction of production loption(separated_nonempty_list(PIPE,switch_case)) ->
+## In state 695, spurious reduction of production switch -> option(PIPE) loption(separated_nonempty_list(PIPE,switch_case))
+## In state 104, spurious reduction of production inlined_expr -> KWD_SWITCH simple switch
+## In state 669, spurious reduction of production inner_expr -> inlined_expr
+## In state 634, spurious reduction of production expr -> inner_expr
+## In state 701, spurious reduction of production module_ -> expr
 ##
 
 Expected one or more switch cases, separated by semicolons, surrounded by {}.
@@ -248,6 +248,61 @@ flambda_unit: KWD_WITH
 ##
 
 Expected an expression.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -541,7 +596,7 @@ flambda_unit: KWD_SWITCH KWD_POISON TILDE
 ##
 ## Ends in an error in state: 5.
 ##
-## const -> KWD_POISON . DOT kind_with_subkind DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## const -> KWD_POISON . DOT kind_with_subkind DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_POISON
@@ -553,7 +608,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT TILDE
 ##
 ## Ends in an error in state: 6.
 ##
-## const -> KWD_POISON DOT . kind_with_subkind DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## const -> KWD_POISON DOT . kind_with_subkind DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_POISON DOT
@@ -700,9 +755,21 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_NATIVEINT TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT8 TILDE
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_MASK TILDE
 ##
 ## Ends in an error in state: 28.
+##
+## subkind -> KWD_MASK . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_LOCAL EQUAL DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## KWD_MASK
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT8 TILDE
+##
+## Ends in an error in state: 30.
 ##
 ## subkind -> KWD_INT8 . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ##
@@ -714,7 +781,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT8 TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT64 TILDE
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 32.
 ##
 ## naked_number_kind -> KWD_INT64 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ## subkind -> KWD_INT64 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
@@ -728,7 +795,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT64 TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT32 TILDE
 ##
-## Ends in an error in state: 33.
+## Ends in an error in state: 35.
 ##
 ## naked_number_kind -> KWD_INT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ## subkind -> KWD_INT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
@@ -742,7 +809,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT32 TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT16 TILDE
 ##
-## Ends in an error in state: 36.
+## Ends in an error in state: 38.
 ##
 ## subkind -> KWD_INT16 . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ##
@@ -754,7 +821,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT16 TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT TILDE
 ##
-## Ends in an error in state: 38.
+## Ends in an error in state: 40.
 ##
 ## subkind -> KWD_INT . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ##
@@ -766,7 +833,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_INT TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_IMM TILDE
 ##
-## Ends in an error in state: 40.
+## Ends in an error in state: 42.
 ##
 ## naked_number_kind -> KWD_IMM . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ## subkind -> KWD_IMM . KWD_TAGGED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
@@ -780,7 +847,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_IMM TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 45.
 ##
 ## naked_number_kind -> KWD_FLOAT32 . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ## subkind -> KWD_FLOAT32 . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
@@ -794,7 +861,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 48.
 ##
 ## naked_number_kind -> KWD_FLOAT . [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ## subkind -> KWD_FLOAT . KWD_BOXED [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
@@ -809,7 +876,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT CARET TILDE
 ##
-## Ends in an error in state: 49.
+## Ends in an error in state: 51.
 ##
 ## subkind -> KWD_FLOAT CARET . plain_int [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ##
@@ -821,7 +888,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT CARET TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_ANY TILDE
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 54.
 ##
 ## subkind -> KWD_ANY . KWD_ARRAY [ STAR RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL DOT COMMA ]
 ##
@@ -831,9 +898,9 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_ANY TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT DOT
+flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 58.
+## Ends in an error in state: 60.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . [ RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL ]
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind . STAR separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL ]
@@ -841,19 +908,12 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT DOT
 ## The known suffix of the stack is as follows:
 ## kind_with_subkind
 ##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT STAR TILDE
 ##
-## Ends in an error in state: 59.
+## Ends in an error in state: 61.
 ##
 ## separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind STAR . separated_nonempty_list(STAR,kind_with_subkind) [ RPAREN RBRACK PIPE MINUSGREATER KWD_STACK EQUAL ]
 ##
@@ -865,7 +925,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT STAR TILDE
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT RPAREN
 ##
-## Ends in an error in state: 63.
+## Ends in an error in state: 65.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . [ RBRACK ]
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor . PIPE separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
@@ -877,18 +937,18 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 58, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 55, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 57, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
+## In state 48, spurious reduction of production naked_number_kind -> KWD_FLOAT
+## In state 58, spurious reduction of production kind_with_subkind -> naked_number_kind
+## In state 60, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
+## In state 57, spurious reduction of production kinds_with_subkinds_nonempty -> separated_nonempty_list(STAR,kind_with_subkind)
+## In state 59, spurious reduction of production nonconst_ctor -> tag KWD_OF kinds_with_subkinds_nonempty
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT PIPE TILDE
 ##
-## Ends in an error in state: 64.
+## Ends in an error in state: 66.
 ##
 ## separated_nonempty_list(PIPE,nonconst_ctor) -> nonconst_ctor PIPE . separated_nonempty_list(PIPE,nonconst_ctor) [ RBRACK ]
 ##
@@ -898,30 +958,23 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT LBRACK INT KWD_OF KWD_FLOAT PIPE TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT STAR
+flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 71.
+## Ends in an error in state: 73.
 ##
-## const -> KWD_POISON DOT kind_with_subkind . DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## const -> KWD_POISON DOT kind_with_subkind . DOT STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_POISON DOT kind_with_subkind
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT DOT TILDE
 ##
-## Ends in an error in state: 72.
+## Ends in an error in state: 74.
 ##
-## const -> KWD_POISON DOT kind_with_subkind DOT . STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## const -> KWD_POISON DOT kind_with_subkind DOT . STRING [ TILDE SEMICOLON RPAREN RBRACKPIPE RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_POISON DOT kind_with_subkind DOT
@@ -931,7 +984,7 @@ flambda_unit: KWD_SWITCH KWD_POISON DOT KWD_FLOAT DOT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT SYMBOL
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 82.
 ##
 ## inlined_expr -> KWD_SWITCH simple . switch [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND INT EOF ]
@@ -944,9 +997,9 @@ flambda_unit: KWD_SWITCH FLOAT SYMBOL
 
 flambda_unit: KWD_SWITCH FLOAT TILDE TILDE
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 83.
 ##
-## simple -> simple TILDE . coercion [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## simple -> simple TILDE . coercion [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## simple TILDE
@@ -956,9 +1009,9 @@ flambda_unit: KWD_SWITCH FLOAT TILDE TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 85.
 ##
-## coercion -> KWD_DEPTH . rec_info MINUSGREATER rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## coercion -> KWD_DEPTH . rec_info MINUSGREATER rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DEPTH
@@ -968,9 +1021,9 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN TILDE
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 86.
 ##
-## rec_info_atom -> LPAREN . rec_info RPAREN [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## rec_info_atom -> LPAREN . rec_info RPAREN [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -980,9 +1033,9 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 85.
+## Ends in an error in state: 87.
 ##
-## rec_info -> KWD_UNROLL . plain_int rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## rec_info -> KWD_UNROLL . plain_int rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL
@@ -992,9 +1045,9 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL INT TILDE
 ##
-## Ends in an error in state: 86.
+## Ends in an error in state: 88.
 ##
-## rec_info -> KWD_UNROLL plain_int . rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## rec_info -> KWD_UNROLL plain_int . rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL plain_int
@@ -1004,9 +1057,9 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_UNROLL INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_SUCC TILDE
 ##
-## Ends in an error in state: 92.
+## Ends in an error in state: 94.
 ##
-## rec_info -> KWD_SUCC . rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## rec_info -> KWD_SUCC . rec_info_atom [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_SUCC
@@ -1016,9 +1069,9 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH KWD_SUCC TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN INT TILDE
 ##
-## Ends in an error in state: 95.
+## Ends in an error in state: 97.
 ##
-## rec_info_atom -> LPAREN rec_info . RPAREN [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## rec_info_atom -> LPAREN rec_info . RPAREN [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN rec_info
@@ -1028,9 +1081,9 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO LPAREN INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT TILDE
 ##
-## Ends in an error in state: 97.
+## Ends in an error in state: 99.
 ##
-## coercion -> KWD_DEPTH rec_info . MINUSGREATER rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## coercion -> KWD_DEPTH rec_info . MINUSGREATER rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DEPTH rec_info
@@ -1040,9 +1093,9 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 100.
 ##
-## coercion -> KWD_DEPTH rec_info MINUSGREATER . rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
+## coercion -> KWD_DEPTH rec_info MINUSGREATER . rec_info [ TILDE SEMICOLON RPAREN RBRACE PIPE MINUSGREATER LPAREN LBRACK KWD_WITH KWD_WHERE KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IN KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY KWD_ANDWHERE KWD_AND INT EOF COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DEPTH rec_info MINUSGREATER
@@ -1052,7 +1105,7 @@ flambda_unit: KWD_SWITCH FLOAT TILDE KWD_DEPTH INT MINUSGREATER TILDE
 
 flambda_unit: KWD_SWITCH FLOAT PIPE TILDE
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 105.
 ##
 ## switch -> option(PIPE) . loption(separated_nonempty_list(PIPE,switch_case)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -1064,7 +1117,7 @@ flambda_unit: KWD_SWITCH FLOAT PIPE TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT TILDE
 ##
-## Ends in an error in state: 104.
+## Ends in an error in state: 106.
 ##
 ## switch_case -> tag . MINUSGREATER apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## switch_case -> tag . MINUSGREATER atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -1077,7 +1130,7 @@ flambda_unit: KWD_SWITCH FLOAT INT TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 107.
 ##
 ## switch_case -> tag MINUSGREATER . apply_cont_expr [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## switch_case -> tag MINUSGREATER . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -1090,7 +1143,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET TILDE
 ##
-## Ends in an error in state: 106.
+## Ends in an error in state: 108.
 ##
 ## let_expr(atomic_body) -> KWD_LET . let_(atomic_body) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(atomic_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -1103,7 +1156,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES TILDE
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 109.
 ##
 ## static_set_of_closures -> KWD_SET_OF_CLOSURES . separated_nonempty_list(KWD_AND,static_closure_binding) with_value_slots_opt KWD_END [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1115,7 +1168,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL TILDE
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 110.
 ##
 ## static_closure_binding -> symbol . EQUAL fun_decl [ KWD_WITH KWD_END KWD_AND ]
 ##
@@ -1127,7 +1180,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL TILDE
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 111.
 ##
 ## static_closure_binding -> symbol EQUAL . fun_decl [ KWD_WITH KWD_END KWD_AND ]
 ##
@@ -1139,7 +1192,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE TILDE
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 112.
 ##
 ## fun_decl -> KWD_CLOSURE . code_id function_slot_opt alloc_mode_for_allocations [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -1151,7 +1204,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT TILDE
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 115.
 ##
 ## function_slot_opt -> AT . function_slot [ AMP ]
 ##
@@ -1163,7 +1216,7 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 118.
 ##
 ## fun_decl -> KWD_CLOSURE code_id function_slot_opt . alloc_mode_for_allocations [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -1175,7 +1228,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AT IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 119.
 ##
 ## alloc_mode_for_allocations -> AMP . region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ## alloc_mode_for_allocations -> AMP . region AMP region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
@@ -1188,9 +1241,9 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP TILDE
 
 flambda_unit: KWD_APPLY AMP KWD_TOPLEVEL TILDE
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 120.
 ##
-## region -> KWD_TOPLEVEL . DOT IDENT [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_WITH KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED KWD_IN KWD_END KWD_AND INT IDENT FLOAT AMP ]
+## region -> KWD_TOPLEVEL . DOT IDENT [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_WITH KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED KWD_IN KWD_END KWD_AND INT IDENT FLOAT AMP ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_TOPLEVEL
@@ -1200,9 +1253,9 @@ flambda_unit: KWD_APPLY AMP KWD_TOPLEVEL TILDE
 
 flambda_unit: KWD_APPLY AMP KWD_TOPLEVEL DOT TILDE
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 121.
 ##
-## region -> KWD_TOPLEVEL DOT . IDENT [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_WITH KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED KWD_IN KWD_END KWD_AND INT IDENT FLOAT AMP ]
+## region -> KWD_TOPLEVEL DOT . IDENT [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_WITH KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED KWD_IN KWD_END KWD_AND INT IDENT FLOAT AMP ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_TOPLEVEL DOT
@@ -1212,7 +1265,7 @@ flambda_unit: KWD_APPLY AMP KWD_TOPLEVEL DOT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 122.
+## Ends in an error in state: 124.
 ##
 ## alloc_mode_for_allocations -> AMP region . [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ## alloc_mode_for_allocations -> AMP region . AMP region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
@@ -1225,7 +1278,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 125.
 ##
 ## alloc_mode_for_allocations -> AMP region AMP . region [ KWD_WITH KWD_IN KWD_END KWD_AND ]
 ##
@@ -1237,7 +1290,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT AMP TILDE
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT KWD_IN
 ##
-## Ends in an error in state: 127.
+## Ends in an error in state: 129.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . [ KWD_WITH KWD_END ]
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding . KWD_AND separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
@@ -1249,16 +1302,16 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 122, spurious reduction of production alloc_mode_for_allocations -> AMP region
-## In state 125, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations
-## In state 126, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
+## In state 124, spurious reduction of production alloc_mode_for_allocations -> AMP region
+## In state 127, spurious reduction of production fun_decl -> KWD_CLOSURE code_id function_slot_opt alloc_mode_for_allocations
+## In state 128, spurious reduction of production static_closure_binding -> symbol EQUAL fun_decl
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT KWD_AND TILDE
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 130.
 ##
 ## separated_nonempty_list(KWD_AND,static_closure_binding) -> static_closure_binding KWD_AND . separated_nonempty_list(KWD_AND,static_closure_binding) [ KWD_WITH KWD_END ]
 ##
@@ -1270,7 +1323,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 ##
-## Ends in an error in state: 131.
+## Ends in an error in state: 133.
 ##
 ## with_value_slots_opt -> KWD_WITH . LBRACE loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -1282,7 +1335,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 134.
 ##
 ## with_value_slots_opt -> KWD_WITH LBRACE . loption(separated_nonempty_list(SEMICOLON,value_slot)) RBRACE [ KWD_IN KWD_END ]
 ##
@@ -1294,9 +1347,10 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 ##
-## Ends in an error in state: 134.
+## Ends in an error in state: 136.
 ##
 ## value_slot -> value_slot_for_projection . EQUAL simple [ SEMICOLON RBRACE ]
+## value_slot -> value_slot_for_projection . COLON naked_number_kind EQUAL simple [ SEMICOLON RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
 ## value_slot_for_projection
@@ -1306,7 +1360,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 137.
 ##
 ## value_slot -> value_slot_for_projection EQUAL . simple [ SEMICOLON RBRACE ]
 ##
@@ -1318,7 +1372,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 136.
+## Ends in an error in state: 138.
 ##
 ## simple -> simple . TILDE coercion [ TILDE SEMICOLON RBRACE ]
 ## value_slot -> value_slot_for_projection EQUAL simple . [ SEMICOLON RBRACE ]
@@ -1329,9 +1383,58 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SYMBOL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT COLON TILDE
+##
+## Ends in an error in state: 140.
+##
+## value_slot -> value_slot_for_projection COLON . naked_number_kind EQUAL simple [ SEMICOLON RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## value_slot_for_projection COLON
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT COLON KWD_FLOAT TILDE
+##
+## Ends in an error in state: 150.
+##
+## value_slot -> value_slot_for_projection COLON naked_number_kind . EQUAL simple [ SEMICOLON RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## value_slot_for_projection COLON naked_number_kind
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT COLON KWD_FLOAT EQUAL TILDE
+##
+## Ends in an error in state: 151.
+##
+## value_slot -> value_slot_for_projection COLON naked_number_kind EQUAL . simple [ SEMICOLON RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## value_slot_for_projection COLON naked_number_kind EQUAL
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT COLON KWD_FLOAT EQUAL FLOAT SYMBOL
+##
+## Ends in an error in state: 152.
+##
+## simple -> simple . TILDE coercion [ TILDE SEMICOLON RBRACE ]
+## value_slot -> value_slot_for_projection COLON naked_number_kind EQUAL simple . [ SEMICOLON RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## value_slot_for_projection COLON naked_number_kind EQUAL simple
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 139.
+## Ends in an error in state: 154.
 ##
 ## separated_nonempty_list(SEMICOLON,value_slot) -> value_slot SEMICOLON . separated_nonempty_list(SEMICOLON,value_slot) [ RBRACE ]
 ##
@@ -1343,7 +1446,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE IDENT EQUAL FLOAT SEMICOL
 
 flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDENT KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 159.
 ##
 ## static_set_of_closures -> KWD_SET_OF_CLOSURES separated_nonempty_list(KWD_AND,static_closure_binding) with_value_slots_opt . KWD_END [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1355,7 +1458,7 @@ flambda_unit: KWD_LET KWD_SET_OF_CLOSURES SYMBOL EQUAL KWD_CLOSURE IDENT AMP IDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 164.
 ##
 ## inline -> KWD_UNROLL . LPAREN plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1367,7 +1470,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 165.
 ##
 ## inline -> KWD_UNROLL LPAREN . plain_int RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1379,7 +1482,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 166.
 ##
 ## inline -> KWD_UNROLL LPAREN plain_int . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1391,7 +1494,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 168.
 ##
 ## inline -> KWD_INLINE . LPAREN KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE . LPAREN KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1406,7 +1509,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 ##
-## Ends in an error in state: 154.
+## Ends in an error in state: 169.
 ##
 ## inline -> KWD_INLINE LPAREN . KWD_ALWAYS RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ## inline -> KWD_INLINE LPAREN . KWD_AVAILABLE RPAREN [ KWD_SIZE KWD_LOOPIFY ]
@@ -1421,7 +1524,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 170.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_NEVER . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1433,7 +1536,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 157.
+## Ends in an error in state: 172.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_DEFAULT . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1445,7 +1548,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 ##
-## Ends in an error in state: 159.
+## Ends in an error in state: 174.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_AVAILABLE . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1457,7 +1560,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_AVAILABLE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 176.
 ##
 ## inline -> KWD_INLINE LPAREN KWD_ALWAYS . RPAREN [ KWD_SIZE KWD_LOOPIFY ]
 ##
@@ -1469,7 +1572,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 163.
+## Ends in an error in state: 178.
 ##
 ## code_header -> KWD_CODE recursive option(inline) . loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1481,7 +1584,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_INLINE LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 179.
 ##
 ## loopify_opt -> KWD_LOOPIFY . LPAREN loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1493,7 +1596,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 ##
-## Ends in an error in state: 165.
+## Ends in an error in state: 180.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN . loopify RPAREN [ KWD_SIZE ]
 ##
@@ -1505,7 +1608,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 183.
 ##
 ## loopify -> KWD_DEFAULT . KWD_TAILREC [ RPAREN ]
 ## loopify -> KWD_DEFAULT . [ RPAREN ]
@@ -1518,7 +1621,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 186.
 ##
 ## loopify_opt -> KWD_LOOPIFY LPAREN loopify . RPAREN [ KWD_SIZE ]
 ##
@@ -1530,7 +1633,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 188.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt . KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1542,7 +1645,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_LOOPIFY LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 189.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE . LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1554,7 +1657,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 ##
-## Ends in an error in state: 175.
+## Ends in an error in state: 190.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN . code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1566,7 +1669,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 192.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size . RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1578,7 +1681,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 193.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN . option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1590,7 +1693,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF TILDE
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 194.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF . LPAREN code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1602,7 +1705,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF T
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN TILDE
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 195.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN . code_id RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1614,7 +1717,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 196.
 ##
 ## newer_version_of -> KWD_NEWER_VERSION_OF LPAREN code_id . RPAREN [ KWD_TUPLED KWD_STUB IDENT ]
 ##
@@ -1626,7 +1729,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 198.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) . boption(KWD_TUPLED) boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1638,7 +1741,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_NEWER_VERSION_OF L
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 ##
-## Ends in an error in state: 185.
+## Ends in an error in state: 200.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) . boption(KWD_STUB) code_id [ LPAREN IDENT ]
 ##
@@ -1650,7 +1753,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_TUPLED TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_STUB TILDE
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 202.
 ##
 ## code_header -> KWD_CODE recursive option(inline) loopify_opt KWD_SIZE LPAREN code_size RPAREN option(newer_version_of) boption(KWD_TUPLED) boption(KWD_STUB) . code_id [ LPAREN IDENT ]
 ##
@@ -1662,7 +1765,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN KWD_STUB TILDE
 
 flambda_unit: KWD_LET IDENT TILDE
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 208.
 ##
 ## let_binding -> variable . EQUAL named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1674,7 +1777,7 @@ flambda_unit: KWD_LET IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 209.
 ##
 ## let_binding -> variable EQUAL . named [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1686,7 +1789,7 @@ flambda_unit: KWD_LET IDENT EQUAL TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 210.
 ##
 ## prim_op -> PRIM . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1698,7 +1801,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 ##
-## Ends in an error in state: 196.
+## Ends in an error in state: 211.
 ##
 ## list(pair(DOT,prim_param)) -> DOT . prim_param list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1710,7 +1813,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 212.
 ##
 ## prim_param -> LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
@@ -1722,7 +1825,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 219.
 ##
 ## prim_param -> prim_param_val . [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ## prim_param -> prim_param_val . LBRACK separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
@@ -1735,7 +1838,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 220.
 ##
 ## prim_param -> prim_param_val LBRACK . separated_nonempty_list(COMMA,prim_param) RBRACK [ RBRACK LPAREN KWD_WITH KWD_IN KWD_AND DOT COMMA ]
 ##
@@ -1747,7 +1850,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT LBRACK TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 223.
 ##
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param . [ RBRACK ]
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param . COMMA separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
@@ -1759,14 +1862,14 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT LPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 202, spurious reduction of production prim_param -> prim_param_val
+## In state 219, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 224.
 ##
 ## separated_nonempty_list(COMMA,prim_param) -> prim_param COMMA . separated_nonempty_list(COMMA,prim_param) [ RBRACK ]
 ##
@@ -1778,7 +1881,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT LBRACK IDENT COMMA TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 226.
 ##
 ## list(pair(DOT,prim_param)) -> DOT prim_param . list(pair(DOT,prim_param)) [ LPAREN KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1789,14 +1892,14 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM DOT IDENT RBRACK
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 202, spurious reduction of production prim_param -> prim_param_val
+## In state 219, spurious reduction of production prim_param -> prim_param_val
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 229.
 ##
 ## named -> KWD_REC_INFO . rec_info_atom [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1808,7 +1911,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 231.
 ##
 ## named -> simple . [ KWD_WITH KWD_IN KWD_AND ]
 ## simple -> simple . TILDE coercion [ TILDE KWD_WITH KWD_IN KWD_AND ]
@@ -1821,7 +1924,7 @@ flambda_unit: KWD_LET IDENT EQUAL FLOAT SYMBOL
 
 flambda_unit: KWD_CONT IDENT LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 235.
 ##
 ## separated_nonempty_list(COMMA,simple) -> simple COMMA . separated_nonempty_list(COMMA,simple) [ RPAREN ]
 ##
@@ -1831,9 +1934,9 @@ flambda_unit: KWD_CONT IDENT LPAREN FLOAT COMMA TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED RPAREN
+flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED TILDE
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 243.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding . KWD_AND separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
@@ -1846,7 +1949,7 @@ flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED RPAREN
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_AND TILDE
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 244.
 ##
 ## separated_nonempty_list(KWD_AND,symbol_binding) -> symbol_binding KWD_AND . separated_nonempty_list(KWD_AND,symbol_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -1858,7 +1961,7 @@ flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_AND TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY TILDE
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 248.
 ##
 ## static_data -> STATIC_CONST_VEC512_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(vec512))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1870,7 +1973,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 249.
 ##
 ## static_data -> STATIC_CONST_VEC512_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(vec512))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -1882,7 +1985,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 TILDE
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 250.
 ##
 ## vec512 -> KWD_VEC512 . LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1894,7 +1997,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK TILDE
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 251.
 ##
 ## vec512 -> KWD_VEC512 LBRACK . INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1906,7 +2009,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT TILDE
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 252.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT . COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1918,7 +2021,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON TILDE
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 253.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON . INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1930,7 +2033,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT TILDE
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 254.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT . COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1942,7 +2045,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 255.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON . INT COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1954,7 +2057,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 256.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT . COLON INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1966,7 +2069,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 257.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON . INT COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1978,7 +2081,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 258.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT . COLON INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -1990,7 +2093,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 259.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON . INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2002,7 +2105,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 260.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT . COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2014,7 +2117,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 261.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON . INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2026,7 +2129,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 262.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT . COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2038,7 +2141,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 263.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON . INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2050,7 +2153,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 264.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT . COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2062,7 +2165,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 265.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON . INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2074,7 +2177,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 266.
 ##
 ## vec512 -> KWD_VEC512 LBRACK INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT COLON INT . RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2086,7 +2189,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE KWD_VEC5
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 271.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec512)) -> or_variable(vec512) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(vec512)) -> or_variable(vec512) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(vec512)) [ RBRACKPIPE ]
@@ -2099,7 +2202,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 272.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec512)) -> or_variable(vec512) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(vec512)) [ RBRACKPIPE ]
 ##
@@ -2111,7 +2214,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC512_ARRAY LBRACKPIPE IDENT SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY TILDE
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 276.
 ##
 ## static_data -> STATIC_CONST_VEC256_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(vec256))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2123,7 +2226,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 277.
 ##
 ## static_data -> STATIC_CONST_VEC256_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(vec256))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2135,7 +2238,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 TILDE
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 278.
 ##
 ## vec256 -> KWD_VEC256 . LBRACK INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2147,7 +2250,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK TILDE
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 279.
 ##
 ## vec256 -> KWD_VEC256 LBRACK . INT COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2159,7 +2262,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT TILDE
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 280.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT . COLON INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2171,7 +2274,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON TILDE
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 281.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON . INT COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2183,7 +2286,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT TILDE
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 282.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT . COLON INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2195,7 +2298,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 283.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON . INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2207,7 +2310,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 284.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON INT . COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2219,7 +2322,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON INT COLON TILDE
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 285.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON INT COLON . INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2231,7 +2334,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC256 LBRACK INT COLON INT COLON INT COLON INT TILDE
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 286.
 ##
 ## vec256 -> KWD_VEC256 LBRACK INT COLON INT COLON INT COLON INT . RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2243,7 +2346,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE KWD_VEC2
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 291.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec256)) -> or_variable(vec256) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(vec256)) -> or_variable(vec256) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(vec256)) [ RBRACKPIPE ]
@@ -2256,7 +2359,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 292.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec256)) -> or_variable(vec256) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(vec256)) [ RBRACKPIPE ]
 ##
@@ -2268,7 +2371,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC256_ARRAY LBRACKPIPE IDENT SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY TILDE
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 296.
 ##
 ## static_data -> STATIC_CONST_VEC128_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(vec128))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2280,7 +2383,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 297.
 ##
 ## static_data -> STATIC_CONST_VEC128_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(vec128))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2292,7 +2395,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 TILDE
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 298.
 ##
 ## vec128 -> KWD_VEC128 . LBRACK INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2304,7 +2407,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK TILDE
 ##
-## Ends in an error in state: 282.
+## Ends in an error in state: 299.
 ##
 ## vec128 -> KWD_VEC128 LBRACK . INT COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2316,7 +2419,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK INT TILDE
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 300.
 ##
 ## vec128 -> KWD_VEC128 LBRACK INT . COLON INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2328,7 +2431,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK INT COLON TILDE
 ##
-## Ends in an error in state: 284.
+## Ends in an error in state: 301.
 ##
 ## vec128 -> KWD_VEC128 LBRACK INT COLON . INT RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2340,7 +2443,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC128 LBRACK INT COLON INT TILDE
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 302.
 ##
 ## vec128 -> KWD_VEC128 LBRACK INT COLON INT . RBRACK [ SEMICOLON RBRACKPIPE ]
 ##
@@ -2352,7 +2455,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE KWD_VEC1
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT TILDE
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 307.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec128)) -> or_variable(vec128) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(vec128)) -> or_variable(vec128) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(vec128)) [ RBRACKPIPE ]
@@ -2365,7 +2468,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT TI
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT SEMICOLON TILDE
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 308.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(vec128)) -> or_variable(vec128) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(vec128)) [ RBRACKPIPE ]
 ##
@@ -2377,7 +2480,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VEC128_ARRAY LBRACKPIPE IDENT SE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 312.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2389,7 +2492,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 313.
 ##
 ## static_data -> STATIC_CONST_VALUE_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,field_of_block)) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2401,7 +2504,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT TILDE
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 319.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block . SEMICOLON separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
@@ -2414,7 +2517,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 303.
+## Ends in an error in state: 320.
 ##
 ## separated_nonempty_list(SEMICOLON,field_of_block) -> field_of_block SEMICOLON . separated_nonempty_list(SEMICOLON,field_of_block) [ RBRACKPIPE ]
 ##
@@ -2426,7 +2529,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_VALUE_ARRAY LBRACKPIPE FLOAT SEM
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY TILDE
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 323.
 ##
 ## static_data -> STATIC_CONST_NATIVEINT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(nativeint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2438,7 +2541,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 324.
 ##
 ## static_data -> STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(nativeint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2450,7 +2553,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 328.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(nativeint)) [ RBRACKPIPE ]
@@ -2463,7 +2566,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 329.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(nativeint)) -> or_variable(nativeint) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(nativeint)) [ RBRACKPIPE ]
 ##
@@ -2475,7 +2578,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_NATIVEINT_ARRAY LBRACKPIPE INT S
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY TILDE
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 334.
 ##
 ## static_data -> STATIC_CONST_INT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(targetint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2487,7 +2590,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 335.
 ##
 ## static_data -> STATIC_CONST_INT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(targetint))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2499,7 +2602,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 340.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(targetint)) [ RBRACKPIPE ]
@@ -2512,7 +2615,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 341.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(targetint)) -> or_variable(targetint) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(targetint)) [ RBRACKPIPE ]
 ##
@@ -2524,7 +2627,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT_ARRAY LBRACKPIPE INT SEMICOL
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY TILDE
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 345.
 ##
 ## static_data -> STATIC_CONST_INT8_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int8))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2536,7 +2639,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 346.
 ##
 ## static_data -> STATIC_CONST_INT8_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int8))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2548,7 +2651,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 350.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int8)) [ RBRACKPIPE ]
@@ -2561,7 +2664,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 351.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int8)) -> or_variable(int8) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int8)) [ RBRACKPIPE ]
 ##
@@ -2573,7 +2676,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT8_ARRAY LBRACKPIPE INT SEMICO
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY TILDE
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 356.
 ##
 ## static_data -> STATIC_CONST_INT64_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int64))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2585,7 +2688,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 357.
 ##
 ## static_data -> STATIC_CONST_INT64_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int64))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2597,7 +2700,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 361.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int64)) [ RBRACKPIPE ]
@@ -2610,7 +2713,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 362.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int64)) -> or_variable(int64) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int64)) [ RBRACKPIPE ]
 ##
@@ -2622,7 +2725,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT64_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY TILDE
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 367.
 ##
 ## static_data -> STATIC_CONST_INT32_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int32))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2634,7 +2737,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 368.
 ##
 ## static_data -> STATIC_CONST_INT32_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int32))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2646,7 +2749,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 372.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int32)) [ RBRACKPIPE ]
@@ -2659,7 +2762,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 373.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int32)) -> or_variable(int32) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int32)) [ RBRACKPIPE ]
 ##
@@ -2671,7 +2774,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT32_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY TILDE
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 378.
 ##
 ## static_data -> STATIC_CONST_INT16_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(int16))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2683,7 +2786,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 362.
+## Ends in an error in state: 379.
 ##
 ## static_data -> STATIC_CONST_INT16_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(int16))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2695,7 +2798,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT TILDE
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 383.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(int16)) [ RBRACKPIPE ]
@@ -2708,7 +2811,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT SEMICOLON TILDE
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 384.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(int16)) -> or_variable(int16) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(int16)) [ RBRACKPIPE ]
 ##
@@ -2720,7 +2823,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_INT16_ARRAY LBRACKPIPE INT SEMIC
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 389.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK . LPAREN loption(separated_nonempty_list(COMMA,or_variable(float))) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2732,7 +2835,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 390.
 ##
 ## static_data -> STATIC_CONST_FLOAT_BLOCK LPAREN . loption(separated_nonempty_list(COMMA,or_variable(float))) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2744,7 +2847,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT TILDE
 ##
-## Ends in an error in state: 377.
+## Ends in an error in state: 394.
 ##
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) . [ RPAREN ]
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) . COMMA separated_nonempty_list(COMMA,or_variable(float)) [ RPAREN ]
@@ -2757,7 +2860,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 378.
+## Ends in an error in state: 395.
 ##
 ## separated_nonempty_list(COMMA,or_variable(float)) -> or_variable(float) COMMA . separated_nonempty_list(COMMA,or_variable(float)) [ RPAREN ]
 ##
@@ -2769,7 +2872,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_BLOCK LPAREN FLOAT COMMA T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 400.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2781,7 +2884,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 384.
+## Ends in an error in state: 401.
 ##
 ## static_data -> STATIC_CONST_FLOAT_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2793,7 +2896,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT TILDE
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 403.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) . [ RBRACKPIPE ]
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) . SEMICOLON separated_nonempty_list(SEMICOLON,or_variable(float)) [ RBRACKPIPE ]
@@ -2806,7 +2909,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT T
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT SEMICOLON TILDE
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 404.
 ##
 ## separated_nonempty_list(SEMICOLON,or_variable(float)) -> or_variable(float) SEMICOLON . separated_nonempty_list(SEMICOLON,or_variable(float)) [ RBRACKPIPE ]
 ##
@@ -2818,7 +2921,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE FLOAT S
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY TILDE
 ##
-## Ends in an error in state: 391.
+## Ends in an error in state: 408.
 ##
 ## static_data -> STATIC_CONST_FLOAT32_ARRAY . LBRACKPIPE loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2830,7 +2933,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE TILDE
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 409.
 ##
 ## static_data -> STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE . loption(separated_nonempty_list(SEMICOLON,or_variable(float))) RBRACKPIPE [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2842,7 +2945,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_FLOAT32_ARRAY LBRACKPIPE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_EMPTY_ARRAY TILDE
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 412.
 ##
 ## static_data -> STATIC_CONST_EMPTY_ARRAY . empty_array_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2854,7 +2957,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_EMPTY_ARRAY TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 425.
 ##
 ## static_data -> STATIC_CONST_BLOCK . mutability tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2866,7 +2969,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 428.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability . tag LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2878,7 +2981,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK KWD_IMMUTABLE_UNIQUE TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 429.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag . LPAREN loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2890,7 +2993,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 430.
 ##
 ## static_data -> STATIC_CONST_BLOCK mutability tag LPAREN . loption(separated_nonempty_list(COMMA,field_of_block)) RPAREN [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2902,7 +3005,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT TILDE
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 434.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . [ RPAREN ]
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block . COMMA separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
@@ -2915,7 +3018,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 435.
 ##
 ## separated_nonempty_list(COMMA,field_of_block) -> field_of_block COMMA . separated_nonempty_list(COMMA,field_of_block) [ RPAREN ]
 ##
@@ -2927,7 +3030,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL STATIC_CONST_BLOCK INT LPAREN FLOAT COMMA TIL
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 439.
 ##
 ## static_data -> variable . COLON static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2939,7 +3042,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 440.
 ##
 ## static_data -> variable COLON . static_data_kind [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2951,7 +3054,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC512 TILDE
 ##
-## Ends in an error in state: 426.
+## Ends in an error in state: 441.
 ##
 ## static_data_kind -> KWD_VEC512 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2963,7 +3066,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC512 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC256 TILDE
 ##
-## Ends in an error in state: 428.
+## Ends in an error in state: 443.
 ##
 ## static_data_kind -> KWD_VEC256 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2975,7 +3078,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC256 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC128 TILDE
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 445.
 ##
 ## static_data_kind -> KWD_VEC128 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2987,7 +3090,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_VEC128 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 447.
 ##
 ## static_data_kind -> KWD_NATIVEINT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -2999,7 +3102,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_NATIVEINT TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 449.
 ##
 ## static_data_kind -> KWD_INT64 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3011,7 +3114,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT64 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 451.
 ##
 ## static_data_kind -> KWD_INT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3023,7 +3126,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_INT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 453.
 ##
 ## static_data_kind -> KWD_FLOAT32 . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3035,7 +3138,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT32 TILDE
 
 flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 455.
 ##
 ## static_data_kind -> KWD_FLOAT . KWD_BOXED [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3047,7 +3150,7 @@ flambda_unit: KWD_LET SYMBOL EQUAL IDENT COLON KWD_FLOAT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 464.
 ##
 ## code -> code_header . kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3059,7 +3162,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 465.
 ##
 ## kinded_args -> LPAREN . separated_nonempty_list(COMMA,kinded_variable) RPAREN [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EQUAL EOF ]
 ##
@@ -3071,7 +3174,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 466.
 ##
 ## kinded_variable -> variable . kind_with_subkind_opt [ RPAREN COMMA ]
 ##
@@ -3083,7 +3186,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 467.
 ##
 ## kind_with_subkind_opt -> COLON . kind_with_subkind [ RPAREN COMMA ]
 ##
@@ -3093,9 +3196,9 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_FLOAT STAR
+flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 472.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . [ RPAREN ]
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable . COMMA separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
@@ -3103,21 +3206,12 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COLON KWD_FLOAT STAR
 ## The known suffix of the stack is as follows:
 ## kinded_variable
 ##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 453, spurious reduction of production kind_with_subkind_opt -> COLON kind_with_subkind
-## In state 454, spurious reduction of production kinded_variable -> variable kind_with_subkind_opt
-##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 473.
 ##
 ## separated_nonempty_list(COMMA,kinded_variable) -> kinded_variable COMMA . separated_nonempty_list(COMMA,kinded_variable) [ RPAREN ]
 ##
@@ -3129,7 +3223,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT COMMA TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 460.
+## Ends in an error in state: 475.
 ##
 ## code -> code_header kinded_args . variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3141,7 +3235,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT LPAREN IDENT RPA
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 476.
 ##
 ## code -> code_header kinded_args variable . alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3153,7 +3247,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP TILDE
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 477.
 ##
 ## alloc_mode_for_function_params -> AMP . variable [ IDENT ]
 ## alloc_mode_for_function_params -> AMP . variable AMP variable AMP variable [ IDENT ]
@@ -3166,7 +3260,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP TILDE
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 478.
 ##
 ## alloc_mode_for_function_params -> AMP variable . [ IDENT ]
 ## alloc_mode_for_function_params -> AMP variable . AMP variable AMP variable [ IDENT ]
@@ -3179,7 +3273,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 479.
 ##
 ## alloc_mode_for_function_params -> AMP variable AMP . variable AMP variable [ IDENT ]
 ##
@@ -3191,7 +3285,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 480.
 ##
 ## alloc_mode_for_function_params -> AMP variable AMP variable . AMP variable [ IDENT ]
 ##
@@ -3203,7 +3297,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 466.
+## Ends in an error in state: 481.
 ##
 ## alloc_mode_for_function_params -> AMP variable AMP variable AMP . variable [ IDENT ]
 ##
@@ -3215,7 +3309,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 468.
+## Ends in an error in state: 483.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params . variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3227,7 +3321,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT TILDE
 ##
-## Ends in an error in state: 469.
+## Ends in an error in state: 484.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params variable . MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3239,7 +3333,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 470.
+## Ends in an error in state: 485.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER . continuation_id exn_continuation_id return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3251,7 +3345,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 472.
+## Ends in an error in state: 487.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id . exn_continuation_id return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3263,7 +3357,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 488.
 ##
 ## exn_continuation_id -> STAR . continuation_id [ KWD_STACK EQUAL COLON ]
 ##
@@ -3275,7 +3369,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 490.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id . return_arity boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3287,7 +3381,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON TILDE
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 491.
 ##
 ## return_arity -> COLON . kinds_with_subkinds [ KWD_STACK EQUAL ]
 ##
@@ -3297,31 +3391,21 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_FLOAT RPAREN
+flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 480.
+## Ends in an error in state: 495.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity . boption(KWD_STACK) EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
 ## The known suffix of the stack is as follows:
 ## code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity
 ##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 58, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 478, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 479, spurious reduction of production return_arity -> COLON kinds_with_subkinds
-##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT KWD_STACK TILDE
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 497.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_STACK) . EQUAL expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3333,7 +3417,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT IDENT MINUSGREATER IDENT STAR IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 498.
 ##
 ## code -> code_header kinded_args variable alloc_mode_for_function_params variable MINUSGREATER continuation_id exn_continuation_id return_arity boption(KWD_STACK) EQUAL . expr [ KWD_WITH KWD_IN KWD_AND ]
 ##
@@ -3345,7 +3429,7 @@ flambda_unit: KWD_LET KWD_CODE KWD_SIZE LPAREN INT RPAREN IDENT IDENT AMP IDENT 
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 501.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3357,7 +3441,7 @@ flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 502.
 ##
 ## let_symbol(expr) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -3369,7 +3453,7 @@ flambda_unit: KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 
 flambda_unit: KWD_INVALID TILDE
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 503.
 ##
 ## atomic_expr -> KWD_INVALID . STRING [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3381,7 +3465,7 @@ flambda_unit: KWD_INVALID TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 ##
-## Ends in an error in state: 497.
+## Ends in an error in state: 512.
 ##
 ## trap_action -> KWD_PUSH . LPAREN continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3393,7 +3477,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 513.
 ##
 ## trap_action -> KWD_PUSH LPAREN . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3405,7 +3489,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 514.
 ##
 ## trap_action -> KWD_PUSH LPAREN continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3417,7 +3501,7 @@ flambda_unit: KWD_CONT IDENT KWD_PUSH LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 ##
-## Ends in an error in state: 501.
+## Ends in an error in state: 516.
 ##
 ## trap_action -> KWD_POP . LPAREN option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3429,7 +3513,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 ##
-## Ends in an error in state: 502.
+## Ends in an error in state: 517.
 ##
 ## trap_action -> KWD_POP LPAREN . option(raise_kind) continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3441,7 +3525,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 ##
-## Ends in an error in state: 507.
+## Ends in an error in state: 522.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) . continuation RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3453,7 +3537,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN KWD_NOTRACE TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 508.
+## Ends in an error in state: 523.
 ##
 ## trap_action -> KWD_POP LPAREN option(raise_kind) continuation . RPAREN [ RPAREN PIPE LPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3465,7 +3549,7 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT TILDE
 
 flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 526.
 ##
 ## apply_cont_expr -> continuation option(trap_action) . simple_args [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -3477,9 +3561,9 @@ flambda_unit: KWD_CONT IDENT KWD_POP LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL TILDE
 ##
-## Ends in an error in state: 515.
+## Ends in an error in state: 530.
 ##
-## call_kind -> KWD_MCALL . LPAREN method_kind simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL . LPAREN method_kind simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL
@@ -3489,9 +3573,9 @@ flambda_unit: KWD_APPLY KWD_MCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN TILDE
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 531.
 ##
-## call_kind -> KWD_MCALL LPAREN . method_kind simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN . method_kind simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN
@@ -3501,9 +3585,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED TILDE
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 535.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind . simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind . simple RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN method_kind
@@ -3513,9 +3597,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT SYMBOL
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 536.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind simple . RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind simple . RPAREN AMP region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -3526,9 +3610,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT SYMBOL
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 522.
+## Ends in an error in state: 537.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind simple RPAREN . AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind simple RPAREN . AMP region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN method_kind simple RPAREN
@@ -3538,9 +3622,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT RPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT RPAREN AMP TILDE
 ##
-## Ends in an error in state: 523.
+## Ends in an error in state: 538.
 ##
-## call_kind -> KWD_MCALL LPAREN method_kind simple RPAREN AMP . region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_MCALL LPAREN method_kind simple RPAREN AMP . region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_MCALL LPAREN method_kind simple RPAREN AMP
@@ -3550,9 +3634,9 @@ flambda_unit: KWD_APPLY KWD_MCALL LPAREN KWD_CACHED FLOAT RPAREN AMP TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 540.
 ##
-## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT . LPAREN code_id function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT
@@ -3562,9 +3646,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 541.
 ##
-## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN . code_id function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN
@@ -3574,9 +3658,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 ##
-## Ends in an error in state: 527.
+## Ends in an error in state: 542.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id . function_slot_opt alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id
@@ -3586,9 +3670,9 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 543.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt . alloc_mode_for_applications RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id function_slot_opt
@@ -3598,10 +3682,10 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AT IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP TILDE
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 544.
 ##
-## alloc_mode_for_applications -> AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
-## alloc_mode_for_applications -> AMP . region AMP region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP . region AMP region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP
@@ -3611,10 +3695,10 @@ flambda_unit: KWD_APPLY AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT TILDE
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 545.
 ##
-## alloc_mode_for_applications -> AMP region . [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
-## alloc_mode_for_applications -> AMP region . AMP region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region . [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region . AMP region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region
@@ -3624,9 +3708,9 @@ flambda_unit: KWD_APPLY AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 546.
 ##
-## alloc_mode_for_applications -> AMP region AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region AMP . region AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region AMP
@@ -3636,9 +3720,9 @@ flambda_unit: KWD_APPLY AMP IDENT AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP IDENT TILDE
 ##
-## Ends in an error in state: 532.
+## Ends in an error in state: 547.
 ##
-## alloc_mode_for_applications -> AMP region AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region AMP region . AMP region [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region AMP region
@@ -3648,9 +3732,9 @@ flambda_unit: KWD_APPLY AMP IDENT AMP IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT AMP IDENT AMP TILDE
 ##
-## Ends in an error in state: 533.
+## Ends in an error in state: 548.
 ##
-## alloc_mode_for_applications -> AMP region AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## alloc_mode_for_applications -> AMP region AMP region AMP . region [ SYMBOL RPAREN MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## AMP region AMP region AMP
@@ -3660,9 +3744,9 @@ flambda_unit: KWD_APPLY AMP IDENT AMP IDENT AMP TILDE
 
 flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT SYMBOL
 ##
-## Ends in an error in state: 535.
+## Ends in an error in state: 550.
 ##
-## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications . RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_DIRECT LPAREN code_id function_slot_opt alloc_mode_for_applications
@@ -3671,16 +3755,16 @@ flambda_unit: KWD_APPLY KWD_DIRECT LPAREN IDENT AMP IDENT SYMBOL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 530, spurious reduction of production alloc_mode_for_applications -> AMP region
+## In state 545, spurious reduction of production alloc_mode_for_applications -> AMP region
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY KWD_CCALL TILDE
 ##
-## Ends in an error in state: 537.
+## Ends in an error in state: 552.
 ##
-## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_CCALL . boption(KWD_NOALLOC) AMP region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CCALL
@@ -3690,9 +3774,9 @@ flambda_unit: KWD_APPLY KWD_CCALL TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 ##
-## Ends in an error in state: 539.
+## Ends in an error in state: 554.
 ##
-## call_kind -> KWD_CCALL boption(KWD_NOALLOC) . AMP region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_CCALL boption(KWD_NOALLOC) . AMP region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CCALL boption(KWD_NOALLOC)
@@ -3702,9 +3786,9 @@ flambda_unit: KWD_APPLY KWD_CCALL KWD_NOALLOC TILDE
 
 flambda_unit: KWD_APPLY KWD_CCALL AMP TILDE
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 555.
 ##
-## call_kind -> KWD_CCALL boption(KWD_NOALLOC) AMP . region [ SYMBOL MINUSGREATER LPAREN KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
+## call_kind -> KWD_CCALL boption(KWD_NOALLOC) AMP . region [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_UNROLL KWD_POISON KWD_NULL KWD_INLINING_STATE KWD_INLINED INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_CCALL boption(KWD_NOALLOC) AMP
@@ -3714,11 +3798,11 @@ flambda_unit: KWD_APPLY KWD_CCALL AMP TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT RPAREN
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 557.
 ##
-## apply_expr -> call_kind . option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind . option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind . option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind . option(inlined) option(inlining_state) option(alloc_checks) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind . option(inlined) option(inlining_state) option(alloc_checks) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind . option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind
@@ -3727,17 +3811,17 @@ flambda_unit: KWD_APPLY AMP IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 530, spurious reduction of production alloc_mode_for_applications -> AMP region
-## In state 606, spurious reduction of production call_kind -> alloc_mode_for_applications
+## In state 545, spurious reduction of production alloc_mode_for_applications -> AMP region
+## In state 630, spurious reduction of production call_kind -> alloc_mode_for_applications
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL TILDE
 ##
-## Ends in an error in state: 543.
+## Ends in an error in state: 558.
 ##
-## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_UNROLL . LPAREN plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL
@@ -3747,9 +3831,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL LPAREN TILDE
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 559.
 ##
-## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_UNROLL LPAREN . plain_int RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL LPAREN
@@ -3759,9 +3843,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL LPAREN TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL LPAREN INT TILDE
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 560.
 ##
-## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_UNROLL LPAREN plain_int . RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_UNROLL LPAREN plain_int
@@ -3771,12 +3855,12 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_UNROLL LPAREN INT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED TILDE
 ##
-## Ends in an error in state: 547.
+## Ends in an error in state: 562.
 ##
-## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED . LPAREN KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED . LPAREN KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED . LPAREN KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED
@@ -3786,12 +3870,12 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN TILDE
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 563.
 ##
-## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED LPAREN . KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
-## inlined -> KWD_INLINED LPAREN . KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_ALWAYS RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_HINT RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_NEVER RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN . KWD_DEFAULT RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN
@@ -3801,9 +3885,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_NEVER TILDE
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 564.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_NEVER . RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_NEVER
@@ -3813,9 +3897,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_NEVER TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_HINT TILDE
 ##
-## Ends in an error in state: 551.
+## Ends in an error in state: 566.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_HINT . RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_HINT
@@ -3825,9 +3909,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_HINT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_DEFAULT TILDE
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 568.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_DEFAULT . RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_DEFAULT
@@ -3837,9 +3921,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_DEFAULT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_ALWAYS TILDE
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 570.
 ##
-## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
+## inlined -> KWD_INLINED LPAREN KWD_ALWAYS . RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL KWD_INLINING_STATE INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINED LPAREN KWD_ALWAYS
@@ -3849,11 +3933,11 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_ALWAYS TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 572.
 ##
-## apply_expr -> call_kind option(inlined) . option(inlining_state) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) . option(inlining_state) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) . option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) . option(inlining_state) option(alloc_checks) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) . option(inlining_state) option(alloc_checks) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) . option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined)
@@ -3863,9 +3947,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINED LPAREN KWD_ALWAYS RPAREN TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE TILDE
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 573.
 ##
-## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+## inlining_state -> KWD_INLINING_STATE . LPAREN inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINING_STATE
@@ -3875,9 +3959,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN TILDE
 ##
-## Ends in an error in state: 559.
+## Ends in an error in state: 574.
 ##
-## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+## inlining_state -> KWD_INLINING_STATE LPAREN . inlining_state_depth RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINING_STATE LPAREN
@@ -3887,7 +3971,7 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 575.
 ##
 ## inlining_state_depth -> KWD_DEPTH . LPAREN plain_int RPAREN [ RPAREN ]
 ##
@@ -3899,7 +3983,7 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TILDE
 ##
-## Ends in an error in state: 561.
+## Ends in an error in state: 576.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN . plain_int RPAREN [ RPAREN ]
 ##
@@ -3911,7 +3995,7 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN TIL
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT TILDE
 ##
-## Ends in an error in state: 562.
+## Ends in an error in state: 577.
 ##
 ## inlining_state_depth -> KWD_DEPTH LPAREN plain_int . RPAREN [ RPAREN ]
 ##
@@ -3923,9 +4007,9 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN TILDE
 ##
-## Ends in an error in state: 564.
+## Ends in an error in state: 579.
 ##
-## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+## inlining_state -> KWD_INLINING_STATE LPAREN inlining_state_depth . RPAREN [ SYMBOL MINUSGREATER LPAREN LBRACK KWD_POISON KWD_NULL INT IDENT FLOAT ]
 ##
 ## The known suffix of the stack is as follows:
 ## KWD_INLINING_STATE LPAREN inlining_state_depth
@@ -3935,11 +4019,11 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT
 
 flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT RPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 566.
+## Ends in an error in state: 581.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) option(inlining_state) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
-## apply_expr -> call_kind option(inlined) option(inlining_state) . LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) . option(alloc_checks) simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) . option(alloc_checks) simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) . option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## call_kind option(inlined) option(inlining_state)
@@ -3947,152 +4031,207 @@ flambda_unit: KWD_APPLY AMP IDENT KWD_INLINING_STATE LPAREN KWD_DEPTH LPAREN INT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+flambda_unit: KWD_APPLY AMP IDENT LBRACK TILDE
+##
+## Ends in an error in state: 582.
+##
+## alloc_checks -> LBRACK . alloc_check alloc_check alloc_check alloc_check RBRACK [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## LBRACK
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT LBRACK KWD_FORWARD TILDE
+##
+## Ends in an error in state: 584.
+##
+## alloc_checks -> LBRACK alloc_check . alloc_check alloc_check alloc_check RBRACK [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## LBRACK alloc_check
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT LBRACK KWD_FORWARD KWD_FORWARD TILDE
+##
+## Ends in an error in state: 585.
+##
+## alloc_checks -> LBRACK alloc_check alloc_check . alloc_check alloc_check RBRACK [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## LBRACK alloc_check alloc_check
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT LBRACK KWD_FORWARD KWD_FORWARD KWD_FORWARD TILDE
+##
+## Ends in an error in state: 586.
+##
+## alloc_checks -> LBRACK alloc_check alloc_check alloc_check . alloc_check RBRACK [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## LBRACK alloc_check alloc_check alloc_check
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT LBRACK KWD_FORWARD KWD_FORWARD KWD_FORWARD KWD_FORWARD TILDE
+##
+## Ends in an error in state: 587.
+##
+## alloc_checks -> LBRACK alloc_check alloc_check alloc_check alloc_check . RBRACK [ SYMBOL MINUSGREATER LPAREN KWD_POISON KWD_NULL INT IDENT FLOAT ]
+##
+## The known suffix of the stack is as follows:
+## LBRACK alloc_check alloc_check alloc_check alloc_check
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+flambda_unit: KWD_APPLY AMP IDENT LBRACK KWD_FORWARD KWD_FORWARD KWD_FORWARD KWD_FORWARD RBRACK TILDE
+##
+## Ends in an error in state: 589.
+##
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) . simple simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) . LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+##
+## The known suffix of the stack is as follows:
+## call_kind option(inlined) option(inlining_state) option(alloc_checks)
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 flambda_unit: KWD_APPLY AMP IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 567.
+## Ends in an error in state: 590.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN . simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple_args -> LPAREN . loption(separated_nonempty_list(COMMA,simple)) RPAREN [ MINUSGREATER ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 568.
+## Ends in an error in state: 591.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple . COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(COMMA,simple) -> simple . [ RPAREN ]
 ## separated_nonempty_list(COMMA,simple) -> simple . COMMA separated_nonempty_list(COMMA,simple) [ RPAREN ]
 ## simple -> simple . TILDE coercion [ TILDE RPAREN COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON TILDE
 ##
-## Ends in an error in state: 569.
+## Ends in an error in state: 592.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON . blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT RPAREN
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_UNIT TILDE
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 595.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) . MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds)
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 58, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 478, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
-## In state 571, spurious reduction of production blank_or(kinds_with_subkinds) -> kinds_with_subkinds
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 573.
+## Ends in an error in state: 596.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER . kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RBRACK
+flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_UNIT TILDE
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 597.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds . RPAREN simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 58, spurious reduction of production separated_nonempty_list(STAR,kind_with_subkind) -> kind_with_subkind
-## In state 478, spurious reduction of production kinds_with_subkinds -> separated_nonempty_list(STAR,kind_with_subkind)
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN TILDE
 ##
-## Ends in an error in state: 575.
+## Ends in an error in state: 598.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 599.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER TILDE
 ##
-## Ends in an error in state: 577.
+## Ends in an error in state: 600.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN FLOAT COLON KWD_FLOAT MINUSGREATER KWD_FLOAT RPAREN MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 579.
+## Ends in an error in state: 602.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) LPAREN simple COLON blank_or(kinds_with_subkinds) MINUSGREATER kinds_with_subkinds RPAREN simple_args MINUSGREATER result_continuation
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR TILDE
 ##
-## Ends in an error in state: 580.
+## Ends in an error in state: 603.
 ##
 ## exn_continuation -> STAR . continuation loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4104,7 +4243,7 @@ flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT TILDE
 ##
-## Ends in an error in state: 581.
+## Ends in an error in state: 604.
 ##
 ## exn_continuation -> STAR continuation . loption(exn_extra_args) [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4116,7 +4255,7 @@ flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 ##
-## Ends in an error in state: 582.
+## Ends in an error in state: 605.
 ##
 ## exn_extra_args -> LPAREN . separated_nonempty_list(COMMA,exn_extra_arg) RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4128,10 +4267,10 @@ flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN TILDE
 
 flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYMBOL
 ##
-## Ends in an error in state: 583.
+## Ends in an error in state: 606.
 ##
 ## exn_extra_arg -> simple . kind_with_subkind [ RPAREN COMMA ]
-## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
+## simple -> simple . TILDE coercion [ TILDE LBRACK KWD_VEC512 KWD_VEC256 KWD_VEC128 KWD_VAL KWD_REGION KWD_REC_INFO KWD_PRODUCT KWD_NATIVEINT KWD_MASK KWD_INT8 KWD_INT64 KWD_INT32 KWD_INT16 KWD_INT KWD_IMM KWD_FLOAT32 KWD_FLOAT KWD_ANY ]
 ##
 ## The known suffix of the stack is as follows:
 ## simple
@@ -4139,9 +4278,9 @@ flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT SYM
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT STAR
+flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_REC_INFO TILDE
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 610.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . [ RPAREN ]
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg . COMMA separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
@@ -4149,20 +4288,12 @@ flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD
 ## The known suffix of the stack is as follows:
 ## exn_extra_arg
 ##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 46, spurious reduction of production naked_number_kind -> KWD_FLOAT
-## In state 56, spurious reduction of production kind_with_subkind -> naked_number_kind
-## In state 584, spurious reduction of production exn_extra_arg -> simple kind_with_subkind
-##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD_FLOAT COMMA TILDE
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 611.
 ##
 ## separated_nonempty_list(COMMA,exn_extra_arg) -> exn_extra_arg COMMA . separated_nonempty_list(COMMA,exn_extra_arg) [ RPAREN ]
 ##
@@ -4174,92 +4305,92 @@ flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT STAR IDENT LPAREN FLOAT KWD
 
 flambda_unit: KWD_APPLY AMP IDENT LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 594.
+## Ends in an error in state: 617.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple_args
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) simple_args
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 595.
+## Ends in an error in state: 618.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) simple_args MINUSGREATER
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 596.
+## Ends in an error in state: 619.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple_args MINUSGREATER result_continuation
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) simple_args MINUSGREATER result_continuation
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT FLOAT SYMBOL
 ##
-## Ends in an error in state: 598.
+## Ends in an error in state: 621.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) simple . simple_args MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## simple -> simple . TILDE coercion [ TILDE MINUSGREATER LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) simple
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT FLOAT LPAREN RPAREN TILDE
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 622.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) simple simple_args . MINUSGREATER result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple simple_args
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) simple simple_args
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT FLOAT MINUSGREATER TILDE
 ##
-## Ends in an error in state: 600.
+## Ends in an error in state: 623.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) simple simple_args MINUSGREATER . result_continuation exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) simple simple_args MINUSGREATER
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 flambda_unit: KWD_APPLY AMP IDENT FLOAT MINUSGREATER IDENT TILDE
 ##
-## Ends in an error in state: 601.
+## Ends in an error in state: 624.
 ##
-## apply_expr -> call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
+## apply_expr -> call_kind option(inlined) option(inlining_state) option(alloc_checks) simple simple_args MINUSGREATER result_continuation . exn_continuation [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## call_kind option(inlined) option(inlining_state) simple simple_args MINUSGREATER result_continuation
+## call_kind option(inlined) option(inlining_state) option(alloc_checks) simple simple_args MINUSGREATER result_continuation
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_HCF KWD_ANDWHERE
+flambda_unit: KWD_HCF TILDE
 ##
-## Ends in an error in state: 610.
+## Ends in an error in state: 634.
 ##
 ## expr -> inner_expr . [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ## where_expr -> inner_expr . KWD_WHERE cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -4272,7 +4403,7 @@ flambda_unit: KWD_HCF KWD_ANDWHERE
 
 flambda_unit: KWD_HCF KWD_WHERE TILDE
 ##
-## Ends in an error in state: 611.
+## Ends in an error in state: 635.
 ##
 ## where_expr -> inner_expr KWD_WHERE . cont_recursive loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -4284,7 +4415,7 @@ flambda_unit: KWD_HCF KWD_WHERE TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 636.
 ##
 ## cont_recursive -> KWD_REC . kinded_args [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND IDENT EOF ]
 ##
@@ -4296,7 +4427,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 638.
 ##
 ## where_expr -> inner_expr KWD_WHERE cont_recursive . loption(separated_nonempty_list(KWD_ANDWHERE,continuation_binding)) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -4308,7 +4439,7 @@ flambda_unit: KWD_HCF KWD_WHERE KWD_REC LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 ##
-## Ends in an error in state: 617.
+## Ends in an error in state: 641.
 ##
 ## continuation_binding -> continuation_id . continuation_sort kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4320,7 +4451,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 ##
-## Ends in an error in state: 620.
+## Ends in an error in state: 644.
 ##
 ## continuation_binding -> continuation_id continuation_sort . kinded_args EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4332,7 +4463,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT KWD_DEFINE_ROOT_SYMBOL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 ##
-## Ends in an error in state: 621.
+## Ends in an error in state: 645.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args . EQUAL continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4344,7 +4475,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT LPAREN IDENT RPAREN TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 646.
 ##
 ## continuation_binding -> continuation_id continuation_sort kinded_args EQUAL . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4356,7 +4487,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 ##
-## Ends in an error in state: 623.
+## Ends in an error in state: 647.
 ##
 ## let_expr(continuation_body) -> KWD_LET . let_(continuation_body) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## let_symbol(continuation_body) -> KWD_LET . separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -4369,7 +4500,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET TILDE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 625.
+## Ends in an error in state: 649.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4381,7 +4512,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 626.
+## Ends in an error in state: 650.
 ##
 ## let_symbol(continuation_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4393,7 +4524,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET KWD_CODE IDENT KWD_DELETED K
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 633.
+## Ends in an error in state: 657.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4405,7 +4536,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_WITH LB
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 634.
+## Ends in an error in state: 658.
 ##
 ## let_(continuation_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . continuation_body [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4415,9 +4546,9 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_LET IDENT EQUAL PRIM KWD_IN TILD
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT KWD_END
+flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT TILDE
 ##
-## Ends in an error in state: 636.
+## Ends in an error in state: 660.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . [ KWD_WITH KWD_IN ]
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding . KWD_AND separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
@@ -4430,7 +4561,7 @@ flambda_unit: KWD_LET IDENT EQUAL KWD_REC_INFO INT KWD_END
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 ##
-## Ends in an error in state: 637.
+## Ends in an error in state: 661.
 ##
 ## separated_nonempty_list(KWD_AND,let_binding) -> let_binding KWD_AND . separated_nonempty_list(KWD_AND,let_binding) [ KWD_WITH KWD_IN ]
 ##
@@ -4440,9 +4571,9 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_AND TILDE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF PIPE
+flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF TILDE
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 666.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding . KWD_ANDWHERE separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
@@ -4455,7 +4586,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF PIPE
 
 flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 ##
-## Ends in an error in state: 643.
+## Ends in an error in state: 667.
 ##
 ## separated_nonempty_list(KWD_ANDWHERE,continuation_binding) -> continuation_binding KWD_ANDWHERE . separated_nonempty_list(KWD_ANDWHERE,continuation_binding) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_AND EOF ]
 ##
@@ -4467,7 +4598,7 @@ flambda_unit: KWD_HCF KWD_WHERE IDENT EQUAL KWD_HCF KWD_ANDWHERE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 648.
+## Ends in an error in state: 672.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -4479,7 +4610,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 
 flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 649.
+## Ends in an error in state: 673.
 ##
 ## let_(expr) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . expr [ RPAREN KWD_WITH KWD_IN KWD_AND EOF ]
 ##
@@ -4491,7 +4622,7 @@ flambda_unit: KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 654.
+## Ends in an error in state: 678.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4503,7 +4634,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELETED KWD_IN TILDE
 ##
-## Ends in an error in state: 655.
+## Ends in an error in state: 679.
 ##
 ## let_symbol(atomic_body) -> KWD_LET separated_nonempty_list(KWD_AND,symbol_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4515,7 +4646,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET KWD_CODE IDENT KWD_DELET
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WITH LBRACE RBRACE TILDE
 ##
-## Ends in an error in state: 661.
+## Ends in an error in state: 685.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt . KWD_IN atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4527,7 +4658,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_WIT
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN TILDE
 ##
-## Ends in an error in state: 662.
+## Ends in an error in state: 686.
 ##
 ## let_(atomic_body) -> separated_nonempty_list(KWD_AND,let_binding) with_value_slots_opt KWD_IN . atomic_body [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4539,7 +4670,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_LET IDENT EQUAL PRIM KWD_IN 
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 ##
-## Ends in an error in state: 667.
+## Ends in an error in state: 691.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case . PIPE separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
@@ -4552,7 +4683,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER KWD_HCF TILDE
 
 flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 ##
-## Ends in an error in state: 668.
+## Ends in an error in state: 692.
 ##
 ## separated_nonempty_list(PIPE,switch_case) -> switch_case PIPE . separated_nonempty_list(PIPE,switch_case) [ RPAREN KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4564,7 +4695,7 @@ flambda_unit: KWD_SWITCH FLOAT INT MINUSGREATER IDENT PIPE TILDE
 
 flambda_unit: LPAREN KWD_HCF KWD_WITH
 ##
-## Ends in an error in state: 672.
+## Ends in an error in state: 696.
 ##
 ## atomic_expr -> LPAREN expr . RPAREN [ RPAREN PIPE KWD_WITH KWD_WHERE KWD_IN KWD_ANDWHERE KWD_AND EOF ]
 ##
@@ -4575,7 +4706,7 @@ flambda_unit: LPAREN KWD_HCF KWD_WITH
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 610, spurious reduction of production expr -> inner_expr
+## In state 634, spurious reduction of production expr -> inner_expr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/middle_end/flambda2/parser/flambda_parser.mly
+++ b/middle_end/flambda2/parser/flambda_parser.mly
@@ -124,6 +124,7 @@ let make_boxed_const_int (i, m) : static_data =
 %token KWD_SELF  [@symbol "self"]
 %token KWD_PUBLIC  [@symbol "public"]
 %token KWD_CACHED  [@symbol "cached"]
+%token KWD_CLOSE  [@symbol "close"]
 %token KWD_CLOSURE  [@symbol "closure"]
 %token KWD_CODE  [@symbol "code"]
 %token KWD_CONT  [@symbol "cont"]
@@ -139,6 +140,7 @@ let make_boxed_const_int (i, m) : static_data =
 %token KWD_EXN   [@symbol "exn"]
 %token KWD_FLOAT [@symbol "float"]
 %token KWD_FLOAT32 [@symbol "float32"]
+%token KWD_FORWARD [@symbol "forward"]
 %token KWD_HCF   [@symbol "halt_and_catch_fire"]
 %token KWD_HINT  [@symbol "hint"]
 %token KWD_ID    [@symbol "id"]
@@ -163,6 +165,7 @@ let make_boxed_const_int (i, m) : static_data =
 %token KWD_NEVER  [@symbol "never"]
 %token KWD_NEWER_VERSION_OF [@symbol "newer_version_of"]
 %token KWD_NOALLOC [@symbol "noalloc"]
+%token KWD_NORMAL [@symbol "normal"]
 %token KWD_NOTRACE [@symbol "notrace"]
 %token KWD_NULL [@symbol "null"]
 %token KWD_OF     [@symbol "of"]
@@ -234,6 +237,10 @@ let make_boxed_const_int (i, m) : static_data =
 %type <Fexpr.rec_info> rec_info
 %type <Fexpr.rec_info> rec_info_atom
 %type <Fexpr.region> region
+%type <Fexpr.region> toplevel_region
+%type <Fexpr.check_action> check_action
+%type <Check_action.close_alloc_region_type> close_alloc_region_type
+%type <Alloc_checks.t> alloc_checks
 %type <Fexpr.special_continuation> special_continuation
 %type <Fexpr.static_data> static_data
 %type <Fexpr.static_data_binding> static_data_binding
@@ -629,6 +636,7 @@ apply_expr:
   | call_kind_and_alloc_mode = call_kind;
     inlined = option(inlined);
     inlining_state = option(inlining_state);
+    alloc_checks = alloc_checks;
     func = func_name_with_optional_arities;
     args = simple_args;
     MINUSGREATER
@@ -641,6 +649,7 @@ apply_expr:
           args = args;
           call_kind;
           alloc_mode;
+          alloc_checks;
           inlined;
           inlining_state;
           arities;
@@ -669,6 +678,19 @@ call_kind:
     { (Method { kind; obj },
         (Not_alloc_stack { alloc_region }
           : region alloc_mode_for_applications)) }
+;
+
+alloc_check:
+  | KWD_FORWARD { Alloc_checks.Forward }
+  | KWD_CLOSE { Alloc_checks.Close }
+;
+
+(* In normal/exn/notrace/div order *)
+alloc_checks:
+  | LBRACK; c1 = alloc_check; c2 = alloc_check;
+    c3 = alloc_check; c4 = alloc_check; RBRACK
+    { { Alloc_checks.normal = c1; exn = c2; notrace = c3; div = c4 } }
+  | (* empty *) { Alloc_checks.{ normal = Forward; exn = Forward; notrace = Forward; div = Close } }
 ;
 
 inline:
@@ -711,10 +733,14 @@ loopify:
 
 region:
   | v = variable { Named v }
+  | r = toplevel_region { r }
+;
+
+toplevel_region:
+  | KWD_TOPLEVEL; DOT; KWD_REGION { Toplevel_region }
   | KWD_TOPLEVEL; DOT; i = IDENT {
     match i with
     | "alloc_region" -> Toplevel_alloc_region
-    | "region" -> Toplevel_region
     | "ghost_region" -> Toplevel_ghost_region
     | _ -> Misc.fatal_errorf "toplevel. must be followed \
       by alloc_region, region or ghost_region" }
@@ -726,8 +752,20 @@ result_continuation:
 ;
 
 apply_cont_expr:
-  | cont = continuation; trap_action = option(trap_action); args = simple_args
-    { { cont; args; trap_action } }
+  | cont = continuation; trap_action = option(trap_action);
+    check_actions = list(check_action); args = simple_args
+    { { cont; args; trap_action; check_actions } }
+;
+
+check_action:
+  | KWD_CLOSE; LBRACK; exit = close_alloc_region_type; RBRACK; r = region
+    { Close_alloc_region { exit; region = r } }
+;
+
+close_alloc_region_type:
+  | KWD_NORMAL { Normal }
+  | KWD_EXN { Exn }
+  | KWD_NOTRACE { Notrace }
 ;
 
 trap_action:
@@ -949,6 +987,7 @@ simple:
   | s = symbol { Symbol s }
   | v = variable { Var v }
   | c = const { Const c }
+  | r = toplevel_region { Region r }
   | s = simple; TILDE; c = coercion { Coerce (s, c) }
 ;
 

--- a/middle_end/flambda2/parser/flambda_to_fexpr.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr.ml
@@ -1,11 +1,6 @@
 open! Flambda.Import
 open Flambda_to_fexpr_commons
 
-let name env n =
-  Name.pattern_match n
-    ~var:(fun v : Fexpr.name -> Var (Env.find_var_exn env v))
-    ~symbol:(fun s : Fexpr.name -> Symbol (Env.find_symbol_exn env s))
-
 let float32 f = f |> Numeric_types.Float32_by_bit_pattern.to_float
 
 let float f = f |> Numeric_types.Float_by_bit_pattern.to_float
@@ -173,7 +168,12 @@ let simple env s =
   Simple.pattern_match s
     ~name:(fun n ~coercion:co : Fexpr.simple ->
       let s : Fexpr.simple =
-        match name env n with Var v -> Var v | Symbol s -> Symbol s
+        Name.pattern_match n
+          ~var:(fun v : Fexpr.simple ->
+            match Env.find_toplevel_region env v with
+            | Some r -> Region r
+            | None -> Var (Env.find_var_exn env v))
+          ~symbol:(fun s : Fexpr.simple -> Symbol (Env.find_symbol_exn env s))
       in
       if Coercion.is_id co
       then s
@@ -697,6 +697,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
       | Never_inlined -> Some Never_inlined
   in
   let inlining_state = inlining_state (Apply_expr.inlining_state app) in
+  let alloc_checks = Apply_expr.alloc_checks app in
   Apply
     { func;
       continuation;
@@ -704,6 +705,7 @@ and apply_expr env (app : Apply_expr.t) : Fexpr.expr =
       args;
       call_kind;
       alloc_mode;
+      alloc_checks;
       inlined;
       inlining_state;
       arities
@@ -727,8 +729,16 @@ and apply_cont env app_cont : Fexpr.apply_cont =
           let exn_handler = Env.find_continuation_exn env exn_handler in
           Pop { exn_handler; raise_kind })
   in
+  let check_actions =
+    List.map
+      (fun (action : Check_action.t) : Fexpr.check_action ->
+        match action with
+        | Close_alloc_region { exit; region } ->
+          Close_alloc_region { exit; region = Env.find_region_exn env region })
+      (Apply_cont_expr.check_actions app_cont)
+  in
   let args = List.map (simple env) (Apply_cont_expr.args app_cont) in
-  { cont; trap_action; args }
+  { cont; trap_action; check_actions; args }
 
 and switch_expr env switch : Fexpr.expr =
   let scrutinee = simple env (Switch_expr.scrutinee switch) in

--- a/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
+++ b/middle_end/flambda2/parser/flambda_to_fexpr_commons.ml
@@ -170,6 +170,8 @@ module Env : sig
 
   val find_continuation_exn : t -> Continuation.t -> Fexpr.continuation
 
+  val find_toplevel_region : t -> Variable.t -> Fexpr.region option
+
   val find_region_exn : t -> Variable.t -> Fexpr.region
 
   val translate_function_slot : t -> Function_slot.t -> Fexpr.function_slot
@@ -369,17 +371,18 @@ end = struct
   let find_continuation_exn t c =
     Continuation_name_map.find_exn t.continuations c
 
+  let find_toplevel_region t r =
+    List.find_map
+      (function
+        | Some region, result ->
+          if Variable.equal region r then Some result else None
+        | None, _ -> None)
+      [ t.toplevel_alloc_region, Fexpr.Toplevel_alloc_region;
+        t.toplevel_region, Fexpr.Toplevel_region;
+        t.toplevel_ghost_region, Fexpr.Toplevel_ghost_region ]
+
   let find_region_exn t r : Fexpr.region =
-    match
-      List.find_map
-        (function
-          | Some region, result ->
-            if Variable.equal region r then Some result else None
-          | None, _ -> None)
-        [ t.toplevel_alloc_region, Fexpr.Toplevel_alloc_region;
-          t.toplevel_region, Fexpr.Toplevel_region;
-          t.toplevel_ghost_region, Fexpr.Toplevel_ghost_region ]
-    with
+    match find_toplevel_region t r with
     | Some result -> result
     | None -> Named (find_var_exn t r)
 

--- a/middle_end/flambda2/parser/print_fexpr.ml
+++ b/middle_end/flambda2/parser/print_fexpr.ml
@@ -342,6 +342,7 @@ let rec simple ppf : simple -> unit = function
   | Symbol s -> symbol ppf s
   | Var v -> variable ppf v
   | Const c -> const ppf c
+  | Region r -> region ppf r
   | Coerce (s, co) -> Format.fprintf ppf "%a ~ %a" simple s coercion co
 
 let simple_args ~space ~omit_if_empty ppf = function
@@ -395,6 +396,19 @@ let alloc_mode_for_applications pp ppf (alloc : _ alloc_mode_for_applications)
     pp_spaced ~space ppf "&%a" pp alloc_region
   | Maybe_alloc_stack { alloc_region; region; ghost_region } ->
     pp_spaced ~space ppf "&%a &%a &%a" pp alloc_region pp region pp ghost_region
+
+let alloc_check ppf = function
+  | Alloc_checks.Forward -> Format.pp_print_string ppf "forward"
+  | Alloc_checks.Close -> Format.pp_print_string ppf "close"
+
+let alloc_checks ~space ppf { Alloc_checks.normal; exn; notrace; div } =
+  match normal, exn, notrace, div with
+  | Alloc_checks.(Forward, Forward, Forward, Close) ->
+    (* This is the default when the clause is omitted. *)
+    ()
+  | Alloc_checks.(Forward | Close), _, _, _ ->
+    pp_spaced ~space ppf "[%a %a %a %a]" alloc_check normal alloc_check exn
+      alloc_check notrace alloc_check div
 
 let boxed_variable ppf var ~kind =
   Format.fprintf ppf "%a : %s boxed" variable var kind
@@ -541,10 +555,25 @@ let trap_action ppf = function
       (pp_option ~space:After raise_kind)
       rk continuation exn_handler
 
-let apply_cont ppf ({ cont; trap_action = action; args } : Fexpr.apply_cont) =
-  Format.fprintf ppf "@[<hv2>%a%a%a@]" continuation cont
+let check_action ppf (action : Fexpr.check_action) =
+  match action with
+  | Close_alloc_region { exit; region = r } ->
+    let exit =
+      match exit with Normal -> "normal" | Exn -> "exn" | Notrace -> "notrace"
+    in
+    Format.fprintf ppf "close[%s] %a" exit region r
+
+let check_actions ppf = function
+  | [] -> ()
+  | actions ->
+    pp_spaced ~space:Before ppf "%a" (pp_list ~sep:"@ " check_action) actions
+
+let apply_cont ppf
+    ({ cont; trap_action = action; check_actions = actions; args } :
+      Fexpr.apply_cont) =
+  Format.fprintf ppf "@[<hv2>%a%a%a%a@]" continuation cont
     (pp_option ~space:Before trap_action)
-    action
+    action check_actions actions
     (simple_args ~space:Before ~omit_if_empty:true)
     args
 
@@ -726,6 +755,7 @@ let rec expr scope ppf = function
   | Apply
       { call_kind = kind;
         alloc_mode;
+        alloc_checks = ac;
         inlined;
         inlining_state = is;
         continuation = ret;
@@ -740,13 +770,15 @@ let rec expr scope ppf = function
         ppf is
     in
     Format.fprintf ppf
-      "@[<hv 2>%tapply%t@[<2>%t%a%a%a%t@]@ @[<hv 2>%a%a@ @[<hov>-> %a@ %a@]@]@]"
+      "@[<hv 2>%tapply%t@[<2>%t%a%a%a%a%t@]@ @[<hv 2>%a%a@ @[<hov>-> %a@ \
+       %a@]@]@]"
       Flambda_colours.expr_keyword Flambda_colours.pop Flambda_colours.elide
       (call_kind_and_alloc_mode ~space:Before)
       (kind, alloc_mode)
       (inlined_attribute_opt ~space:Before)
-      inlined pp_inlining_state () Flambda_colours.pop
-      func_name_with_optional_arities (func, arities)
+      inlined pp_inlining_state ()
+      (alloc_checks ~space:Before)
+      ac Flambda_colours.pop func_name_with_optional_arities (func, arities)
       (simple_args ~space:Before ~omit_if_empty:true)
       args result_continuation ret exn_continuation ek
 

--- a/middle_end/flambda2/reaper/rebuild.ml
+++ b/middle_end/flambda2/reaper/rebuild.ml
@@ -826,11 +826,14 @@ let reaper_produce_invalid_when_never_returns =
   Sys.getenv_opt "REAPER_INVALIDS" <> None
 
 let make_apply_wrapper env
-    (make_apply : continuation:Apply_expr.Result_continuation.t -> Apply_expr.t)
-    apply_continuation return_decisions =
+    (make_apply :
+      continuation:Apply_expr.Result_continuation.t ->
+      alloc_checks:Alloc_checks.t ->
+      Apply_expr.t) apply_continuation (alloc_checks : Alloc_checks.t)
+    return_decisions =
   match (apply_continuation : Apply_expr.Result_continuation.t) with
   | Never_returns ->
-    let apply = make_apply ~continuation:Never_returns in
+    let apply = make_apply ~continuation:Never_returns ~alloc_checks in
     RE.from_expr ~expr:(Expr.create_apply apply)
       ~free_names:(Apply.free_names apply) ~code_size:(Code_size.apply apply)
   | Return return_cont -> (
@@ -838,8 +841,6 @@ let make_apply_wrapper env
     let apply_decisions =
       Continuation.Map.find return_cont env.cont_params_to_keep
     in
-    let return_cont_wrapper = Continuation.rename return_cont in
-    let apply = make_apply ~continuation:(Return return_cont_wrapper) in
     let rev_args_or_invalid =
       List.fold_left2
         (fun (rev_args_or_invalid : _ Or_invalid.t) apply_decision func_decision
@@ -853,7 +854,8 @@ let make_apply_wrapper env
                 Misc.fatal_errorf
                   "Inconsistent apply (%a) and func (%a) decisions:@ %a@."
                   print_param_decision apply_decision print_param_decision
-                  func_decision Apply.print apply
+                  func_decision Apply.print
+                  (make_apply ~continuation:(Return return_cont) ~alloc_checks)
               in
               (* let direct_or_indirect = match Apply.call_kind apply with |
                  Function { function_call = Direct _; _ } -> error () | Function
@@ -887,6 +889,36 @@ let make_apply_wrapper env
         apply_decisions return_decisions
     in
     let return_parameters = get_parameters return_decisions in
+    let make_wrapped_apply () =
+      let return_cont_wrapper = Continuation.rename return_cont in
+      let alloc_checks, need_close_alloc_region =
+        match alloc_checks.normal with
+        | Forward -> alloc_checks, false
+        | Close -> { alloc_checks with normal = Alloc_checks.Forward }, true
+      in
+      let apply =
+        make_apply ~continuation:(Return return_cont_wrapper) ~alloc_checks
+      in
+      ( return_cont_wrapper,
+        apply,
+        fun body ->
+          if need_close_alloc_region
+          then
+            RE.create_let
+              (Bound_pattern.singleton
+                 (Bound_var.create
+                    (Variable.create "close_region" K.value)
+                    Flambda_debug_uid.none Name_mode.normal))
+              (Named.create_prim
+                 (Flambda_primitive.Unary
+                    ( Close_alloc_region Normal,
+                      Simple.var
+                        (Alloc_mode.For_applications.alloc_region
+                           (Apply.return_mode apply)) ))
+                 (Apply.dbg apply))
+              ~size_of_defining_expr:Code_size.zero ~body
+          else body )
+    in
     match rev_args_or_invalid with
     | Ok (_, rev_args) ->
       let args = List.rev rev_args in
@@ -929,11 +961,14 @@ let make_apply_wrapper env
            can only happen because the uses of [g] do not match those of [f],
            which would be the case if a loop of tail calls between them
            existed. *)
-        let apply = make_apply ~continuation:(Return return_cont) in
+        let apply =
+          make_apply ~continuation:(Return return_cont) ~alloc_checks
+        in
         RE.from_expr ~expr:(Expr.create_apply apply)
           ~free_names:(Apply.free_names apply)
           ~code_size:(Code_size.apply apply)
       else
+        let return_cont_wrapper, apply, wrap_handler = make_wrapped_apply () in
         let apply_expr = Expr.create_apply apply in
         let handler =
           let apply_cont =
@@ -944,6 +979,7 @@ let make_apply_wrapper env
             ~free_names:(Apply_cont_expr.free_names apply_cont)
             ~code_size:(Code_size.apply_cont apply_cont)
         in
+        let handler = wrap_handler handler in
         let cont_handler =
           RE.create_continuation_handler
             (Bound_parameters.create return_parameters)
@@ -969,6 +1005,7 @@ let make_apply_wrapper env
          would blow up the stack. *)
       if reaper_produce_invalid_when_never_returns
       then
+        let return_cont_wrapper, apply, wrap_handler = make_wrapped_apply () in
         let handler =
           RE.from_expr
             ~expr:
@@ -979,6 +1016,7 @@ let make_apply_wrapper env
                        (Option.get (Apply.callee apply)))))
             ~free_names:Name_occurrences.empty ~code_size:Code_size.invalid
         in
+        let handler = wrap_handler handler in
         let cont_handler =
           RE.create_continuation_handler
             (Bound_parameters.create return_parameters)
@@ -991,7 +1029,7 @@ let make_apply_wrapper env
         in
         RE.create_non_recursive_let_cont return_cont_wrapper cont_handler ~body
       else
-        let apply = make_apply ~continuation:Never_returns in
+        let apply = make_apply ~continuation:Never_returns ~alloc_checks in
         RE.from_expr ~expr:(Expr.create_apply apply)
           ~free_names:(Apply.free_names apply)
           ~code_size:(Code_size.apply apply))
@@ -1263,7 +1301,7 @@ let rebuild_apply env apply =
             (Flambda_arity.unarized_components return_arity)
         in
         make_apply_wrapper env make_apply (Apply.continuation apply)
-          func_decisions)
+          (Apply.alloc_checks apply) func_decisions)
     | Changing_calling_convention code_id ->
       (* Format.eprintf "CHANGING CALLING CONVENTION %a %a@." Code_id.print
          code_id Apply.print apply; *)
@@ -1392,7 +1430,7 @@ let rebuild_apply env apply =
           ~relative_history:(Apply.relative_history apply)
       in
       make_apply_wrapper env make_apply (Apply.continuation apply)
-        return_decisions
+        (Apply.alloc_checks apply) return_decisions
 
 let load_field_from_value_which_is_being_unboxed env ~to_bind field arg dbg
     ~hole =

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -217,7 +217,8 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
         | Num_conv _ | Boolean_not | Reinterpret_64_bit_word _
         | Reinterpret_boxed_vector | Untag_immediate | Tag_immediate
         | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
-        | Obj_dup _ | Get_header | Peek _ | Make_lazy _ ),
+        | Obj_dup _ | Get_header | Peek _ | Make_lazy _ | Close_alloc_region _
+        | New_alloc_region _ ),
         _ )
   | Binary
       ( ( Block_set _ | Array_load _ | String_or_bigstring_load _

--- a/middle_end/flambda2/simplify/continuation_shortcut.ml
+++ b/middle_end/flambda2/simplify/continuation_shortcut.ml
@@ -16,14 +16,17 @@
 type t =
   { params : Bound_parameters.t;
     continuation : Continuation.t;
-    args : Simple.t list
+    args : Simple.t list;
+    check_actions : Check_action.t list
   }
 
-let[@ocamlformat "disable"] print ppf { params; continuation; args } =
+let[@ocamlformat "disable"] print ppf
+    { params; continuation; args; check_actions } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(params@ %a)@]@ \
       @[<hov 1>(continuation@ %a)@]@ \
-      @[<hov 1>(args@ %a)@]\
+      @[<hov 1>(args@ %a)@]@ \
+      @[<hov 1>(check_actions@ %a)@]\
     )@]"
     Bound_parameters.print params
     Continuation.print continuation
@@ -31,12 +34,15 @@ let[@ocamlformat "disable"] print ppf { params; continuation; args } =
        ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
        Simple.print)
     args
+    (Format.pp_print_list Check_action.print)
+    check_actions
 
-let create ~params continuation args = { params; continuation; args }
+let create ~params ~check_actions continuation args =
+  { params; continuation; args; check_actions }
 
 let continuation { continuation; _ } = continuation
 
-let apply { params; continuation; args } shortcut_args =
+let apply { params; continuation; args; check_actions } shortcut_args =
   let subst =
     List.fold_left2
       (fun subst param arg -> Variable.Map.add param arg subst)
@@ -44,20 +50,39 @@ let apply { params; continuation; args } shortcut_args =
       (Bound_parameters.vars params)
       shortcut_args
   in
-  ( continuation,
+  let subst_simple arg =
+    Simple.pattern_match' arg
+      ~var:(fun var ~coercion ->
+        match Variable.Map.find_or_null var subst with
+        | Null -> arg
+        | This simple -> Simple.apply_coercion_exn simple coercion)
+      ~symbol:(fun _ ~coercion:_ -> arg)
+      ~const:(fun _ -> arg)
+  in
+  let check_actions =
     List.map
-      (fun arg ->
-        Simple.pattern_match' arg
-          ~var:(fun var ~coercion ->
-            match Variable.Map.find_or_null var subst with
-            | Null -> arg
-            | This simple -> Simple.apply_coercion_exn simple coercion)
-          ~symbol:(fun _ ~coercion:_ -> arg)
-          ~const:(fun _ -> arg))
-      args )
+      (fun (check_action : Check_action.t) ->
+        match check_action with
+        | Close_alloc_region { region; exit } ->
+          let region = subst_simple (Simple.var region) in
+          let region =
+            match Simple.must_be_var region with
+            | Some (region, _) -> region
+            | None ->
+              Misc.fatal_errorf
+                "Region parameter substituted by a non-variable in a \
+                 continuation shortcut:@ %a"
+                Simple.print region
+          in
+          Check_action.Close_alloc_region { region; exit })
+      check_actions
+  in
+  continuation, List.map subst_simple args, check_actions
 
 let to_alias t =
   let params = Bound_parameters.simples t.params in
-  if Misc.Stdlib.List.equal Simple.equal t.args params
+  if
+    List.is_empty t.check_actions
+    && Misc.Stdlib.List.equal Simple.equal t.args params
   then Some t.continuation
   else None

--- a/middle_end/flambda2/simplify/continuation_shortcut.mli
+++ b/middle_end/flambda2/simplify/continuation_shortcut.mli
@@ -20,9 +20,15 @@ type t
 
 val print : Format.formatter -> t -> unit
 
-val create : params:Bound_parameters.t -> Continuation.t -> Simple.t list -> t
+val create :
+  params:Bound_parameters.t ->
+  check_actions:Check_action.t list ->
+  Continuation.t ->
+  Simple.t list ->
+  t
 
-val apply : t -> Simple.t list -> Continuation.t * Simple.t list
+val apply :
+  t -> Simple.t list -> Continuation.t * Simple.t list * Check_action.t list
 
 val continuation : t -> Continuation.t
 

--- a/middle_end/flambda2/simplify/env/downwards_env.ml
+++ b/middle_end/flambda2/simplify/env/downwards_env.ml
@@ -95,13 +95,17 @@ type t =
         (* This cost is the number of parameters that would have to be created
            if we lifted all continuations that are defined in the current
            continuation's handler. *)
-    has_seen_a_non_liftable_continuation : bool
+    has_seen_a_non_liftable_continuation : bool;
         (* This flag is used to mark as non-liftable any continuation that is
            bound after a non-liftable continuation, since any continuation bound
            after a non-liftable continuation may refer to it.
 
            CR gbury: we may not need to do this if we had free_names on handlers
            that we have not explored yet. *)
+    removed_alloc_regions : (Variable.t * Alloc_checks.t) Variable.Map.t
+        (* Allocation regions whose [New_alloc_region] binding has been removed,
+           mapped to their parent region and the Forward/Close flags they were
+           created with. *)
   }
 
 let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
@@ -116,6 +120,7 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
                 loopify_state; replay_history; specialization_cost; defined_variables_by_scope;
                 lifted = _; cost_of_lifting_continuations_out_of_current_one;
                 has_seen_a_non_liftable_continuation; join_analysis;
+                removed_alloc_regions;
               } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(round@ %d)@]@ \
@@ -142,7 +147,8 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
       @[<hov 1>(join_analysis@ %a)@]@ \
       @[<hov 1>(defined_variables_by_scope@ %a)@]@ \
       @[<hov 1>(cost_of_lifting_continuation_out_of_current_one %d)@]@ \
-      @[<hov 1>(has_seen_a_non_liftable_continuation %b)@]\
+      @[<hov 1>(has_seen_a_non_liftable_continuation %b)@]@ \
+      @[<hov 1>(removed_alloc_regions@ %a)@]\
       )@]"
     round
     Target_system.Machine_width.print machine_width
@@ -170,6 +176,10 @@ let [@ocamlformat "disable"] print ppf { round; machine_width; typing_env;
     (Format.pp_print_list ~pp_sep:Format.pp_print_space Lifted_cont_params.print) defined_variables_by_scope
     cost_of_lifting_continuations_out_of_current_one
     has_seen_a_non_liftable_continuation
+    (Variable.Map.print (fun ppf (parent, checks) ->
+      Format.fprintf ppf "@[<hov 1>(%a@ %a)@]"
+        Variable.print parent Alloc_checks.print checks))
+    removed_alloc_regions
 
 let define_continuations ~can_be_lifted t conts =
   let replay_history =
@@ -255,16 +265,22 @@ let create ~round ~machine_width ~(resolver : resolver)
       lifted = Variable.Set.empty;
       cost_of_lifting_continuations_out_of_current_one = 0;
       has_seen_a_non_liftable_continuation = false;
-      join_analysis = None
+      join_analysis = None;
+      removed_alloc_regions = Variable.Map.empty
     }
   in
   let my_region_duid = Flambda_debug_uid.none in
   let my_ghost_region_duid = Flambda_debug_uid.none in
+  let my_alloc_region_duid = Flambda_debug_uid.none in
   define_variable
-    (define_variable t
-       (Bound_var.create toplevel_my_region my_region_duid Name_mode.normal)
+    (define_variable
+       (define_variable t
+          (Bound_var.create toplevel_my_region my_region_duid Name_mode.normal)
+          K.region)
+       (Bound_var.create toplevel_my_ghost_region my_ghost_region_duid
+          Name_mode.normal)
        K.region)
-    (Bound_var.create toplevel_my_ghost_region my_ghost_region_duid
+    (Bound_var.create toplevel_my_alloc_region my_alloc_region_duid
        Name_mode.normal)
     K.region
 
@@ -292,6 +308,38 @@ let unit_toplevel_exn_continuation t = t.unit_toplevel_exn_continuation
 let unit_toplevel_return_continuation t = t.unit_toplevel_return_continuation
 
 let unit_toplevel_alloc_region t = t.unit_toplevel_alloc_region
+
+let removed_alloc_regions t = t.removed_alloc_regions
+
+let add_removed_alloc_region t region ~parent ~checks =
+  { t with
+    removed_alloc_regions =
+      Variable.Map.add region (parent, checks) t.removed_alloc_regions
+  }
+
+let find_removed_alloc_region t region =
+  Variable.Map.find_opt region t.removed_alloc_regions
+
+(* We rely on the (subtle) invariant that no removed alloc_region ever appears
+   as an argument to a continuation. During the downward pass, this holds
+   because nothing introduces region variables as continuation arguments.
+   Continuation lifting can produce region parameters, but if they correspond to
+   a region that can be removed, it should be immediately removed and won't
+   stay. *)
+let rename_removed_alloc_regions t renaming =
+  if Variable.Map.is_empty t.removed_alloc_regions
+  then t
+  else
+    { t with
+      removed_alloc_regions =
+        Variable.Map.fold
+          (fun region (parent, checks) removed ->
+            Variable.Map.add
+              (Renaming.apply_variable renaming region)
+              (Renaming.apply_variable renaming parent, checks)
+              removed)
+          t.removed_alloc_regions Variable.Map.empty
+    }
 
 let at_unit_toplevel t = t.at_unit_toplevel
 
@@ -356,7 +404,8 @@ let enter_set_of_closures
       lifted = _;
       cost_of_lifting_continuations_out_of_current_one = _;
       has_seen_a_non_liftable_continuation = _;
-      join_analysis = _
+      join_analysis = _;
+      removed_alloc_regions = _
     } =
   { machine_width;
     round;
@@ -385,7 +434,10 @@ let enter_set_of_closures
     defined_variables_by_scope = [Lifted_cont_params.empty];
     lifted = Variable.Set.empty;
     cost_of_lifting_continuations_out_of_current_one = 0;
-    has_seen_a_non_liftable_continuation = false
+    has_seen_a_non_liftable_continuation = false;
+    (* Allocation regions from outer scopes cannot occur inside closure bodies:
+       the body only sees its own [my_alloc_region]. *)
+    removed_alloc_regions = Variable.Map.empty
   }
 
 let define_symbol t sym kind =
@@ -820,6 +872,7 @@ let denv_for_lifted_continuation ~denv_for_join ~denv =
       denv.disable_partial_application_stub_generation;
     inlining_state = denv.inlining_state;
     inlining_history_tracker = denv.inlining_history_tracker;
+    removed_alloc_regions = denv.removed_alloc_regions;
     (* denv_for_join *)
     all_code = denv_for_join.all_code;
     typing_env = denv_for_join.typing_env;

--- a/middle_end/flambda2/simplify/env/downwards_env.mli
+++ b/middle_end/flambda2/simplify/env/downwards_env.mli
@@ -66,6 +66,25 @@ val unit_toplevel_exn_continuation : t -> Continuation.t
 
 val unit_toplevel_alloc_region : t -> Variable.t
 
+(** Allocation regions whose [New_alloc_region] binding has been removed by
+    simplification, mapped to their parent region and the Forward/Close flags
+    they were created with. *)
+val removed_alloc_regions : t -> (Variable.t * Alloc_checks.t) Variable.Map.t
+
+val add_removed_alloc_region :
+  t -> Variable.t -> parent:Variable.t -> checks:Alloc_checks.t -> t
+
+val find_removed_alloc_region :
+  t -> Variable.t -> (Variable.t * Alloc_checks.t) option
+
+(** Rename the regions and parents of [removed_alloc_regions]. Used when lifting
+    a continuation: regions defined between the join point and the lifted
+    continuation's definition become lifted parameters, which are renamed to
+    fresh variables; the corresponding entries must follow that renaming so that
+    the lifted handler's uses of those parameters still find the Forward/Close
+    flags of the original regions. *)
+val rename_removed_alloc_regions : t -> Renaming.t -> t
+
 val increment_continuation_scope : t -> t
 
 val bump_current_level_scope : t -> t

--- a/middle_end/flambda2/simplify/env/upwards_env.ml
+++ b/middle_end/flambda2/simplify/env/upwards_env.ml
@@ -94,7 +94,7 @@ let add_invalid_continuation t cont arity =
 let continuation_arity t cont =
   find_continuation t cont |> Continuation_in_env.arity
 
-let add_continuation_shortcut t cont ~params ~shortcut_to ~args =
+let add_continuation_shortcut t cont ~params ~shortcut_to ~args ~check_actions =
   if Continuation.Map.mem shortcut_to t.continuation_shortcuts
   then
     Misc.fatal_errorf
@@ -109,7 +109,9 @@ let add_continuation_shortcut t cont ~params ~shortcut_to ~args =
       Continuation.print cont Continuation.print shortcut_to Continuation.print
       (Continuation_shortcut.continuation existing_shortcut)
   | Null ->
-    let shortcut = Continuation_shortcut.create ~params shortcut_to args in
+    let shortcut =
+      Continuation_shortcut.create ~params ~check_actions shortcut_to args
+    in
     (* For now we keep the pre-existing check for aliases, but ideally we should
        check that the arities match after applying the substitution. However it
        seems like we should have a more general mechanism for checking arities

--- a/middle_end/flambda2/simplify/env/upwards_env.mli
+++ b/middle_end/flambda2/simplify/env/upwards_env.mli
@@ -44,6 +44,7 @@ val add_continuation_shortcut :
   params:Bound_parameters.t ->
   shortcut_to:Continuation.t ->
   args:Simple.t list ->
+  check_actions:Check_action.t list ->
   t
 
 val add_linearly_used_inlinable_continuation :

--- a/middle_end/flambda2/simplify/expr_builder.ml
+++ b/middle_end/flambda2/simplify/expr_builder.ml
@@ -65,6 +65,29 @@ let add_set_of_closures_offsets ~is_phantom named uacc =
   Named.fold_code_and_sets_of_closures named ~init:uacc
     ~f_code:add_offsets_from_code ~f_set:add_offsets_from_set
 
+let fold_check_action_into_apply_cont (bound_vars : Bound_pattern.t)
+    (defining_expr : Named.t) ~free_names_of_body ~body =
+  match defining_expr with
+  | Simple _ | Set_of_closures _ | Static_consts _ | Rec_info _ -> None
+  | Prim (prim, _dbg) -> (
+    match P.is_check_action prim with
+    | None -> None
+    | Some check_action -> (
+      let bound_var = Bound_pattern.must_be_singleton bound_vars in
+      if Name_occurrences.mem_var free_names_of_body (VB.var bound_var)
+      then
+        Misc.fatal_errorf
+          "[fold_check_action_into_apply_cont]: check actions are supposed to \
+           be unit-returning, so the bound pattern %a must never appear in the \
+           body %a"
+          Bound_pattern.print bound_vars
+          (RE.print Are_rebuilding_terms.are_rebuilding)
+          body;
+      match RE.to_apply_cont body with
+      | Some apply_cont ->
+        Some (Apply_cont.prepend_check_actions apply_cont [check_action])
+      | None -> None))
+
 let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
     ~free_names_of_defining_expr ~body ~cost_metrics_of_defining_expr =
   (* The name occurrences component of [uacc] is expected to be in the state
@@ -72,36 +95,48 @@ let create_let uacc (bound_vars : Bound_pattern.t) (defining_expr : Named.t)
   let name_mode = Bound_pattern.name_mode bound_vars in
   let is_phantom = Name_mode.is_phantom name_mode in
   let free_names_of_body = UA.name_occurrences uacc in
-  let free_names_of_defining_expr =
-    if not is_phantom
-    then free_names_of_defining_expr
-    else
-      Name_occurrences.downgrade_occurrences_at_strictly_greater_name_mode
-        free_names_of_defining_expr name_mode
-  in
-  let free_names_of_let =
-    let without_bound_vars =
-      Bound_pattern.fold_all_bound_vars bound_vars ~init:free_names_of_body
-        ~f:(fun free_names bound_var ->
-          Name_occurrences.remove_var free_names ~var:(VB.var bound_var))
+  match
+    fold_check_action_into_apply_cont bound_vars defining_expr
+      ~free_names_of_body ~body
+  with
+  | Some apply_cont ->
+    let uacc =
+      UA.with_name_occurrences uacc
+        ~name_occurrences:(Apply_cont.free_names apply_cont)
     in
-    Name_occurrences.union without_bound_vars free_names_of_defining_expr
-  in
-  let uacc =
-    UA.add_cost_metrics_and_with_name_occurrences uacc
-      (Cost_metrics.increase_due_to_let_expr ~is_phantom
-         ~cost_metrics_of_defining_expr)
-      free_names_of_let
-  in
-  let uacc =
-    if Are_rebuilding_terms.do_not_rebuild_terms (UA.are_rebuilding_terms uacc)
-    then uacc
-    else add_set_of_closures_offsets ~is_phantom defining_expr uacc
-  in
-  ( RE.create_let
-      (UA.are_rebuilding_terms uacc)
-      bound_vars defining_expr ~body ~free_names_of_body,
-    uacc )
+    RE.create_apply_cont apply_cont, uacc
+  | None ->
+    let free_names_of_defining_expr =
+      if not is_phantom
+      then free_names_of_defining_expr
+      else
+        Name_occurrences.downgrade_occurrences_at_strictly_greater_name_mode
+          free_names_of_defining_expr name_mode
+    in
+    let free_names_of_let =
+      let without_bound_vars =
+        Bound_pattern.fold_all_bound_vars bound_vars ~init:free_names_of_body
+          ~f:(fun free_names bound_var ->
+            Name_occurrences.remove_var free_names ~var:(VB.var bound_var))
+      in
+      Name_occurrences.union without_bound_vars free_names_of_defining_expr
+    in
+    let uacc =
+      UA.add_cost_metrics_and_with_name_occurrences uacc
+        (Cost_metrics.increase_due_to_let_expr ~is_phantom
+           ~cost_metrics_of_defining_expr)
+        free_names_of_let
+    in
+    let uacc =
+      if
+        Are_rebuilding_terms.do_not_rebuild_terms (UA.are_rebuilding_terms uacc)
+      then uacc
+      else add_set_of_closures_offsets ~is_phantom defining_expr uacc
+    in
+    ( RE.create_let
+        (UA.are_rebuilding_terms uacc)
+        bound_vars defining_expr ~body ~free_names_of_body,
+      uacc )
 
 let create_let_binding uacc bound_vars defining_expr
     ~free_names_of_defining_expr ~body ~cost_metrics_of_defining_expr =
@@ -168,6 +203,25 @@ let create_coerced_singleton_let uacc var defining_expr
         outer
       in
       generate_outer_binding (Bound_var.name_mode var)
+
+let check_action_bindings uacc ~dbg check_actions =
+  let machine_width = UE.machine_width (UA.uenv uacc) in
+  List.map
+    (fun check_action ->
+      let named = Named.create_prim (P.of_check_action check_action) dbg in
+      let let_bound =
+        Bound_var.create
+          (Variable.create "unit" Flambda_kind.value)
+          Flambda_debug_uid.none Name_mode.normal
+        |> Bound_pattern.singleton
+      in
+      Keep_binding
+        { let_bound;
+          simplified_defining_expr =
+            Simplified_named.create ~machine_width named;
+          original_defining_expr = Some named
+        })
+    check_actions
 
 let make_new_let_bindings uacc ~bindings_outermost_first ~body =
   (* The name occurrences component of [uacc] is expected to be in the state
@@ -550,10 +604,13 @@ let apply_continuation_shortcuts uenv apply_cont =
   with
   | None -> apply_cont
   | Some shortcut ->
-    let cont, args =
+    let cont, args, check_actions =
       Continuation_shortcut.apply shortcut (Apply_cont.args apply_cont)
     in
-    Apply_cont.with_continuation_and_args apply_cont cont ~args
+    let apply_cont =
+      Apply_cont.with_continuation_and_args apply_cont cont ~args
+    in
+    Apply_cont.add_check_actions apply_cont check_actions
 
 let apply_continuation_aliases uenv cont =
   match UE.find_continuation_shortcut uenv cont with

--- a/middle_end/flambda2/simplify/expr_builder.mli
+++ b/middle_end/flambda2/simplify/expr_builder.mli
@@ -42,6 +42,15 @@ type binding_to_place =
       }
   | Delete_binding of { original_defining_expr : Named.t option }
 
+(** [Keep_binding]s performing the given check actions, to be placed (with
+    [make_new_let_bindings]) around the handler of a continuation that a jump
+    carrying these actions is being replaced by. *)
+val check_action_bindings :
+  Upwards_acc.t ->
+  dbg:Debuginfo.t ->
+  Check_action.t list ->
+  binding_to_place list
+
 (** Create [Let] binding(s) around a given body. (The type of this function
     prevents it from being used to create "let symbol" bindings; use the other
     functions in this module instead.) Bindings will be elided if they are

--- a/middle_end/flambda2/simplify/flow/flow.mli
+++ b/middle_end/flambda2/simplify/flow/flow.mli
@@ -83,6 +83,10 @@ module Acc : sig
       separately. *)
   val add_used_in_current_handler : Name_occurrences.t -> t -> t
 
+  (** Record the regions occurring in the check actions of an [Apply_cont] (or
+      [Switch] arm) in the current handler. *)
+  val add_check_actions : Check_action.t list -> t -> t
+
   (** Add the given continuation as being used as the return continuation for a
       function call. *)
   val add_apply_conts :

--- a/middle_end/flambda2/simplify/flow/flow_acc.ml
+++ b/middle_end/flambda2/simplify/flow/flow_acc.ml
@@ -233,6 +233,19 @@ let add_used_in_current_handler name_occurrences t =
       in
       { elt with used_in_handler })
 
+let add_check_actions check_actions t =
+  match check_actions with
+  | [] -> t
+  | _ :: _ ->
+    let free_names =
+      List.fold_left
+        (fun free_names check_action ->
+          Name_occurrences.union free_names
+            (Check_action.free_names check_action))
+        Name_occurrences.empty check_actions
+    in
+    add_used_in_current_handler free_names t
+
 let add_apply_conts ~result_cont ~exn_cont ~result_arity t =
   update_top_of_stack ~t ~f:(fun elt ->
       let add_func_result cont rewrite_id ~result_arity ~extra_args

--- a/middle_end/flambda2/simplify/flow/flow_acc.mli
+++ b/middle_end/flambda2/simplify/flow/flow_acc.mli
@@ -104,6 +104,10 @@ val record_value_slot : Name.t -> Value_slot.t -> Name_occurrences.t -> t -> t
     *excluding* uses in apply_cont expressions, which are tracked separately. *)
 val add_used_in_current_handler : Name_occurrences.t -> t -> t
 
+(** Record the regions occurring in the check actions of an [Apply_cont] (or
+    [Switch] arm) in the current handler. *)
+val add_check_actions : Check_action.t list -> t -> t
+
 (** Add the given continuation as being used as the return continuation for a
     function call. *)
 val add_apply_conts :

--- a/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
+++ b/middle_end/flambda2/simplify/inlining/inlining_transforms.ml
@@ -18,11 +18,13 @@ open! Simplify_import
 module DA = Downwards_acc
 module DE = Downwards_env
 module FT = Flambda2_types.Function_type
+module P = Flambda_primitive
 module VB = Bound_var
 
-let make_inlined_body ~callee ~called_code_id ~unroll_to ~params ~args
-    ~my_closure ~my_alloc_mode ~my_depth ~rec_info ~body ~exn_continuation
-    ~return_continuation ~apply_exn_continuation ~apply_return_continuation =
+let make_inlined_body ~callee ~called_code_id ~region_inlined_into ~unroll_to
+    ~params ~args ~my_closure ~my_alloc_mode ~my_depth ~rec_info ~body
+    ~exn_continuation ~return_continuation ~apply_exn_continuation
+    ~apply_return_continuation ~alloc_checks =
   let callee, rec_info =
     match callee with
     | None ->
@@ -78,10 +80,27 @@ let make_inlined_body ~callee ~called_code_id ~unroll_to ~params ~args
       ~body ~free_names_of_body:Unknown
     |> Expr.create_let
   in
-  Inlining_helpers.make_inlined_body ~callee ~called_code_id ~params ~args
-    ~my_closure ~my_alloc_mode ~my_depth ~rec_info ~body ~exn_continuation
-    ~return_continuation ~apply_exn_continuation ~apply_return_continuation
-    ~bind_params ~bind_depth ~apply_renaming:Expr.apply_renaming
+  let bind_alloc_region ~my_alloc_region ~alloc_region ~alloc_checks ~body =
+    let bound =
+      Bound_pattern.singleton
+        (VB.create my_alloc_region Flambda_debug_uid.none Name_mode.normal)
+    in
+    let alloc_checks =
+      P.alloc_region_checks_with_action alloc_checks ~action:P.Transfer
+    in
+    Let.create bound
+      (Named.create_prim
+         (P.Unary (New_alloc_region alloc_checks, Simple.var alloc_region))
+         Debuginfo.none)
+      ~body ~free_names_of_body:Unknown
+    |> Expr.create_let
+  in
+  Inlining_helpers.make_inlined_body ~callee ~called_code_id
+    ~region_inlined_into ~params ~args ~my_closure ~my_alloc_mode ~my_depth
+    ~rec_info ~body ~exn_continuation ~return_continuation
+    ~apply_exn_continuation ~apply_return_continuation ~alloc_checks
+    ~bind_params ~bind_depth ~bind_alloc_region
+    ~apply_renaming:Expr.apply_renaming
 
 let wrap_inlined_body_for_exn_extra_args ~extra_args ~apply_exn_continuation
     ~apply_return_continuation ~result_arity ~make_inlined_body =
@@ -165,6 +184,7 @@ let inline dacc ~apply ~unroll_to ~was_inline_always function_decl =
             ~params:(Bound_parameters.to_list params)
             ~args ~my_closure ~my_alloc_mode ~my_depth ~rec_info ~body
             ~exn_continuation ~return_continuation
+            ~alloc_checks:(Apply.alloc_checks apply)
         in
         let expr =
           match Exn_continuation.extra_args apply_exn_continuation with

--- a/middle_end/flambda2/simplify/original_handlers.ml
+++ b/middle_end/flambda2/simplify/original_handlers.ml
@@ -55,13 +55,12 @@ let can_be_lifted = function
   | Non_recursive { can_be_lifted; _ } -> can_be_lifted
   | Recursive { can_be_lifted; _ } -> can_be_lifted
 
-let add_params_to_lift t params_to_lift =
-  let lifted_params, renaming = Lifted_cont_params.rename params_to_lift in
+let add_params_to_lift t lifted_params ~renaming =
   let[@inline] fail () =
     Misc.fatal_errorf
       "Cannot add lifted params to a continuation that already has lifted \
-       params:@ params_to_lift=%a@ t=%a"
-      Lifted_cont_params.print params_to_lift print t
+       params:@ lifted_params=%a@ t=%a"
+      Lifted_cont_params.print lifted_params print t
   in
   match t with
   | Recursive

--- a/middle_end/flambda2/simplify/original_handlers.mli
+++ b/middle_end/flambda2/simplify/original_handlers.mli
@@ -37,4 +37,7 @@ val bound_continuations : t -> Continuation.t list
 
 val can_be_lifted : t -> bool
 
-val add_params_to_lift : t -> Lifted_cont_params.t -> t
+(** Record [lifted_params] (as returned by [Lifted_cont_params.rename], together
+    with [renaming], which maps the original variables to the fresh lifted
+    parameters) on the given handlers, applying [renaming] to them. *)
+val add_params_to_lift : t -> Lifted_cont_params.t -> renaming:Renaming.t -> t

--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -55,6 +55,11 @@ let inline_linearly_used_continuation uacc ~params:params' ~handler
             original_defining_expr = Some named
           })
   in
+  let bindings_outermost_first =
+    EB.check_action_bindings uacc ~dbg:(AC.debuginfo apply_cont)
+      (AC.check_actions apply_cont)
+    @ bindings_outermost_first
+  in
   let expr, uacc =
     let uacc =
       UA.with_name_occurrences uacc ~name_occurrences:free_names_of_handler
@@ -150,6 +155,12 @@ let rebuild_apply_cont apply_cont ~args ~rewrite_id uacc ~after_rebuild =
   create_apply_cont ~apply_cont_to_expr
 
 let simplify_apply_cont dacc apply_cont ~down_to_up =
+  let apply_cont =
+    AC.with_check_actions apply_cont
+      (Simplify_common.rewrite_check_actions_for_removed_alloc_regions
+         (DA.denv dacc)
+         (AC.check_actions apply_cont))
+  in
   let { S.simples = args; simple_tys = arg_types } =
     S.simplify_simples dacc (AC.args apply_cont)
   in
@@ -162,12 +173,13 @@ let simplify_apply_cont dacc apply_cont ~down_to_up =
       use_kind ~env_at_use:(DA.denv dacc) ~arg_types
   in
   let dacc =
-    let record_args_for_data_flow data_flow =
+    let record_for_data_flow data_flow =
       Flow.Acc.add_apply_cont_args
         (AC.continuation apply_cont)
         ~rewrite_id args data_flow
+      |> Flow.Acc.add_check_actions (AC.check_actions apply_cont)
     in
-    DA.map_flow_acc dacc ~f:record_args_for_data_flow
+    DA.map_flow_acc dacc ~f:record_for_data_flow
   in
   let dbg = AC.debuginfo apply_cont in
   let dbg = DE.add_inlined_debuginfo (DA.denv dacc) dbg in

--- a/middle_end/flambda2/simplify/simplify_apply_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_expr.ml
@@ -647,6 +647,8 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
             Apply.create ~callee ~continuation:(Return return_continuation)
               exn_continuation ~args ~args_arity:param_arity
               ~return_arity:result_arity ~call_kind ~return_mode:my_alloc_mode
+              ~alloc_checks:
+                { normal = Close; exn = Close; notrace = Close; div = Close }
               dbg ~inlined:Default_inlined
               ~inlining_state:(Apply.inlining_state apply)
               ~position:Normal ~probe:None
@@ -766,8 +768,21 @@ let simplify_direct_partial_application ~simplify_expr dacc apply
           code_id,
           code )
       in
+      let check_actions =
+        match (Apply.alloc_checks apply).normal with
+        | Forward -> []
+        | Close ->
+          [ Check_action.Close_alloc_region
+              { region =
+                  Alloc_mode.For_applications.alloc_region
+                    (Apply.return_mode apply);
+                exit = Normal
+              } ]
+      in
       let apply_cont =
-        Apply_cont.create apply_continuation ~args:[Simple.var wrapper_var] ~dbg
+        Apply_cont.create apply_continuation ~check_actions
+          ~args:[Simple.var wrapper_var]
+          ~dbg
       in
       let expr =
         let wrapper_var =
@@ -1211,7 +1226,28 @@ type ('a, 'b) simplify_apply_shared_result =
   | Ok of 'a
   | Invalid of 'b
 
+let rewrite_apply_for_removed_alloc_regions denv apply =
+  let return_mode = Apply.return_mode apply in
+  let alloc_region = Alloc_mode.For_applications.alloc_region return_mode in
+  let alloc_region =
+    Simplify_common.canonicalize_alloc_region denv alloc_region
+  in
+  match DE.find_removed_alloc_region denv alloc_region with
+  | None -> apply
+  | Some (parent, flags) ->
+    let return_mode =
+      match (return_mode : Alloc_mode.For_applications.t) with
+      | Not_alloc_stack _ ->
+        Alloc_mode.For_applications.not_alloc_stack ~alloc_region:parent
+      | Maybe_alloc_stack { alloc_region = _; region; ghost_region } ->
+        Alloc_mode.For_applications.maybe_alloc_stack ~alloc_region:parent
+          ~region ~ghost_region
+    in
+    let alloc_checks = Alloc_checks.meet (Apply.alloc_checks apply) flags in
+    Apply.with_return_mode_and_checks apply ~return_mode ~alloc_checks
+
 let simplify_apply_shared dacc apply : _ simplify_apply_shared_result =
+  let apply = rewrite_apply_for_removed_alloc_regions (DA.denv dacc) apply in
   let callee_ty, simplified_callee =
     match Apply.callee apply with
     | None -> None, None
@@ -1259,6 +1295,7 @@ let simplify_apply_shared dacc apply : _ simplify_apply_shared_result =
         ~return_arity:(Apply.return_arity apply)
         ~call_kind:(Apply.call_kind apply)
         ~return_mode:(Apply.return_mode apply)
+        ~alloc_checks:(Apply.alloc_checks apply)
         (DE.add_inlined_debuginfo (DA.denv dacc) (Apply.dbg apply))
         ~inlined:(Apply.inlined apply) ~inlining_state
         ~probe:(Apply.probe apply) ~position:(Apply.position apply)

--- a/middle_end/flambda2/simplify/simplify_common.ml
+++ b/middle_end/flambda2/simplify/simplify_common.ml
@@ -153,6 +153,20 @@ let split_direct_over_application apply ~callee's_code_id
             ~ghost_region )
       | Maybe_alloc_stack _ -> None, apply_alloc_mode)
   in
+  let alloc_checks = Apply.alloc_checks apply in
+  let ( inner_apply_alloc_checks,
+        outer_apply_alloc_checks,
+        needs_close_alloc_region ) =
+    match alloc_checks.normal with
+    | Forward -> alloc_checks, alloc_checks, false
+    | Close ->
+      let forward_checks =
+        { alloc_checks with normal = Alloc_checks.Forward }
+      in
+      if Option.is_some needs_region
+      then forward_checks, forward_checks, true
+      else forward_checks, alloc_checks, false
+  in
   let perform_over_application =
     let continuation =
       (* If there is no need for a new region, then the second (over)
@@ -171,8 +185,8 @@ let split_direct_over_application apply ~callee's_code_id
       ~args:remaining_args ~args_arity:remaining_arity
       ~return_arity:(Apply.return_arity apply)
       ~call_kind:Call_kind.indirect_function_call_unknown_arity
-      ~return_mode:outer_apply_alloc_mode (Apply.dbg apply)
-      ~inlined:(Apply.inlined apply)
+      ~return_mode:outer_apply_alloc_mode ~alloc_checks:outer_apply_alloc_checks
+      (Apply.dbg apply) ~inlined:(Apply.inlined apply)
       ~inlining_state:(Apply.inlining_state apply)
       ~probe:(Apply.probe apply) ~position:(Apply.position apply)
       ~relative_history:(Apply.relative_history apply)
@@ -246,6 +260,27 @@ let split_direct_over_application apply ~callee's_code_id
         NO.add_variable call_return_continuation_free_names region
           Name_mode.normal
       in
+      let handler_expr, handler_expr_free_names =
+        if needs_close_alloc_region
+        then
+          let alloc_region =
+            Alloc_mode.For_applications.alloc_region (Apply.return_mode apply)
+          in
+          ( Let.create
+              (Bound_pattern.singleton
+                 (Bound_var.create
+                    (Variable.create "unit" K.value)
+                    Flambda_debug_uid.none Name_mode.normal))
+              (Named.create_prim
+                 (Unary (Close_alloc_region Normal, Simple.var alloc_region))
+                 (Apply.dbg apply))
+              ~body:handler_expr
+              ~free_names_of_body:(Known handler_expr_free_names)
+            |> Expr.create_let,
+            NO.add_variable handler_expr_free_names alloc_region
+              Name_mode.normal )
+        else handler_expr, handler_expr_free_names
+      in
       let handler =
         Continuation_handler.create
           (Bound_parameters.create over_application_results)
@@ -294,8 +329,8 @@ let split_direct_over_application apply ~callee's_code_id
       ~args:first_args ~args_arity:callee's_params_arity
       ~return_arity:(Code_metadata.result_arity callee's_code_metadata)
       ~call_kind:(Call_kind.direct_function_call callee's_code_id)
-      ~return_mode:inner_apply_alloc_mode (Apply.dbg apply)
-      ~inlined:(Apply.inlined apply)
+      ~return_mode:inner_apply_alloc_mode ~alloc_checks:inner_apply_alloc_checks
+      (Apply.dbg apply) ~inlined:(Apply.inlined apply)
       ~inlining_state:(Apply.inlining_state apply)
       ~probe:(Apply.probe apply) ~position:(Apply.position apply)
       ~relative_history:(Apply.relative_history apply)
@@ -472,3 +507,51 @@ let add_symbol_projection dacc ~projected_from projection ~projection_bound_to
         let var = Bound_var.var projection_bound_to in
         DA.map_denv dacc ~f:(fun denv -> DE.add_symbol_projection denv var proj))
       ~var:(fun _ ~coercion:_ -> dacc)
+
+let canonicalize_alloc_region denv region =
+  match
+    TE.get_canonical_simple_exn (DE.typing_env denv) ~min_name_mode:NM.normal
+      (Simple.var region)
+  with
+  | exception Not_found -> region
+  | simple -> (
+    match Simple.must_be_var simple with
+    | Some (region, _coercion) -> region
+    | None ->
+      Misc.fatal_errorf
+        "Canonical simple of allocation region %a is not a variable:@ %a"
+        Variable.print region Simple.print simple)
+
+let rewrite_check_actions_for_removed_alloc_regions denv check_actions =
+  let removed = DE.removed_alloc_regions denv in
+  List.filter_map
+    (fun (check_action : Check_action.t) ->
+      match check_action with
+      | Close_alloc_region { region; exit } -> (
+        let region = canonicalize_alloc_region denv region in
+        match Variable.Map.find_opt region removed with
+        | None -> Some (Check_action.Close_alloc_region { region; exit })
+        | Some (parent, flags) -> (
+          match
+            Check_action.alloc_check_for_close_alloc_region_type flags exit
+          with
+          | Close ->
+            Some (Check_action.Close_alloc_region { region = parent; exit })
+          | Forward -> None)))
+    check_actions
+
+(* This must be applied to every allocation region embedded in a term being
+   simplified (allocating primitives, sets of closures), so that no occurrence
+   of a removed region remains in the simplified term. The regions taken as
+   arguments by [New_alloc_region] and [Close_alloc_region] are instead dealt
+   with by the simplifiers of these primitives, which take the Forward/Close
+   flags of the removed region into account. *)
+let simplify_alloc_region denv region =
+  let region = canonicalize_alloc_region denv region in
+  match DE.find_removed_alloc_region denv region with
+  | None -> region
+  | Some (parent, _flags) -> parent
+
+let simplify_alloc_mode denv alloc_mode =
+  Alloc_mode.For_allocations.map_alloc_region alloc_mode
+    ~f:(simplify_alloc_region denv)

--- a/middle_end/flambda2/simplify/simplify_common.mli
+++ b/middle_end/flambda2/simplify/simplify_common.mli
@@ -170,3 +170,30 @@ val add_symbol_projection :
   projection_bound_to:Bound_var.t ->
   kind:Flambda_kind.With_subkind.t ->
   Downwards_acc.t
+
+(** Canonicalise an allocation region (following aliases). *)
+val canonicalize_alloc_region : Downwards_env.t -> Variable.t -> Variable.t
+
+(** Rewrite check actions that refer to allocation regions removed by
+    simplification: actions closing such a region at an exit whose creation flag
+    was [Close] are retargeted to the parent region; those at exits whose
+    creation flag was [Forward] are deleted. *)
+val rewrite_check_actions_for_removed_alloc_regions :
+  Downwards_env.t -> Check_action.t list -> Check_action.t list
+
+(** Simplify an allocation region: canonicalise it (following aliases) and, if
+    its [New_alloc_region] binding was removed by simplification, replace it by
+    its parent region. This must be applied to every allocation region embedded
+    in a term being simplified, so that no occurrence of a removed region
+    remains in the simplified term. The regions taken as arguments by
+    [New_alloc_region] and [Close_alloc_region] are instead dealt with by the
+    simplifiers of these primitives, which take the Forward/Close flags of the
+    removed region into account. *)
+val simplify_alloc_region : Downwards_env.t -> Variable.t -> Variable.t
+
+(** Apply [simplify_alloc_region] to the allocation region of the given
+    allocation mode. *)
+val simplify_alloc_mode :
+  Downwards_env.t ->
+  Alloc_mode.For_allocations.t ->
+  Alloc_mode.For_allocations.t

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -353,7 +353,7 @@ let add_extra_params_for_mutable_unboxing cont uacc extra_params_and_args =
 
 type behaviour =
   | Invalid
-  | Shortcut_to of Continuation.t * Simple.t list
+  | Shortcut_to of Continuation.t * Simple.t list * Check_action.t list
   | Unknown
 
 let get_removed_aliased_params uacc cont =
@@ -468,9 +468,9 @@ let rebuild_let_cont (data : rebuild_let_cont_data) ~after_rebuild body uacc =
          which case we're left with the body; or if the body is just an
          [Apply_cont] (with no trap action) of [cont], in which case we're left
          with the handler. *)
-      let expr, name_occurrences, cost_metrics =
+      let expr, name_occurrences, cost_metrics, uacc =
         if remove_let_cont_leaving_body
-        then body, name_occurrences_body, cost_metrics_of_body
+        then body, name_occurrences_body, cost_metrics_of_body, uacc
         else
           let remove_let_cont_leaving_handler =
             match RE.to_apply_cont body with
@@ -478,19 +478,34 @@ let rebuild_let_cont (data : rebuild_let_cont_data) ~after_rebuild body uacc =
               if
                 not
                   (Continuation.equal cont (Apply_cont.continuation apply_cont))
-              then false
+              then None
               else
                 match Apply_cont.args apply_cont with
-                | [] -> Option.is_none (Apply_cont.trap_action apply_cont)
-                | _ :: _ -> false)
-            | None -> false
+                | [] ->
+                  if Option.is_none (Apply_cont.trap_action apply_cont)
+                  then Some apply_cont
+                  else None
+                | _ :: _ -> None)
+            | None -> None
           in
-          if remove_let_cont_leaving_handler
-          then
-            ( handler.handler_expr,
-              handler.name_occurrences_of_handler,
-              handler.cost_metrics_of_handler )
-          else
+          match remove_let_cont_leaving_handler with
+          | Some apply_cont ->
+            let bindings_outermost_first =
+              EB.check_action_bindings uacc
+                ~dbg:(Apply_cont.debuginfo apply_cont)
+                (Apply_cont.check_actions apply_cont)
+            in
+            let uacc =
+              UA.with_name_occurrences uacc
+                ~name_occurrences:handler.name_occurrences_of_handler
+              |> UA.with_cost_metrics handler.cost_metrics_of_handler
+            in
+            let expr, uacc =
+              EB.make_new_let_bindings uacc ~bindings_outermost_first
+                ~body:handler.handler_expr
+            in
+            expr, UA.name_occurrences uacc, UA.cost_metrics uacc, uacc
+          | None ->
             let name_occurrences =
               NO.union name_occurrences_body handler.name_occurrences_of_handler
             in
@@ -505,7 +520,7 @@ let rebuild_let_cont (data : rebuild_let_cont_data) ~after_rebuild body uacc =
                 cont handler.handler ~body ~num_free_occurrences_of_cont_in_body
                 ~is_applied_with_traps
             in
-            expr, name_occurrences, cost_metrics
+            expr, name_occurrences, cost_metrics, uacc
       in
       rebuild_groups expr name_occurrences cost_metrics uacc groups
     | Recursive { continuation_handlers; invariant_params } :: groups ->
@@ -763,7 +778,10 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
                 | Some _ -> Unknown
                 | None ->
                   let args = Apply_cont.args apply_cont in
-                  Shortcut_to (Apply_cont.continuation apply_cont, args))
+                  Shortcut_to
+                    ( Apply_cont.continuation apply_cont,
+                      args,
+                      Apply_cont.check_actions apply_cont ))
               | None ->
                 if
                   RE.can_be_removed_as_invalid handler
@@ -775,8 +793,9 @@ let rebuild_single_non_recursive_handler ~at_unit_toplevel
           | Invalid ->
             let arity = Bound_parameters.arity params in
             UE.add_invalid_continuation uenv cont arity
-          | Shortcut_to (shortcut_to, args) ->
+          | Shortcut_to (shortcut_to, args, check_actions) ->
             UE.add_continuation_shortcut uenv cont ~params ~shortcut_to ~args
+              ~check_actions
           | Unknown ->
             UE.add_non_inlinable_continuation uenv cont ~params
               ~handler:(if is_cold then Unknown else Known handler)
@@ -1759,10 +1778,18 @@ and after_downwards_traversal_of_body ~simplify_expr ~down_to_up
       let params_to_lift =
         DE.variables_defined_in_current_continuation denv_for_join
       in
-      let handlers =
-        Original_handlers.add_params_to_lift data.handlers params_to_lift
+      let lifted_params, lifted_params_renaming =
+        Lifted_cont_params.rename params_to_lift
       in
-      let dacc = DA.add_lifted_continuation data.denv_for_join handlers dacc in
+      let handlers =
+        Original_handlers.add_params_to_lift data.handlers lifted_params
+          ~renaming:lifted_params_renaming
+      in
+      let denv_at_definition =
+        DE.rename_removed_alloc_regions data.denv_for_join
+          lifted_params_renaming
+      in
+      let dacc = DA.add_lifted_continuation denv_at_definition handlers dacc in
       (* Restore lifted constants in dacc *)
       let dacc =
         DA.add_to_lifted_constant_accumulator dacc data.prior_lifted_constants

--- a/middle_end/flambda2/simplify/simplify_let_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_expr.ml
@@ -436,6 +436,15 @@ let simplify_let0 ~simplify_expr ~simplify_function_body dacc let_expr
                ~lifted_constants_from_defining_expr simplify_named_result)
       in
       let at_unit_toplevel = DE.at_unit_toplevel (DA.denv dacc) in
+      let removed_alloc_region =
+        match Bound_pattern.must_be_singleton_opt bound_pattern with
+        | None -> None
+        | Some bound_var -> (
+          let var = VB.var bound_var in
+          match DE.find_removed_alloc_region (DA.denv dacc) var with
+          | None -> None
+          | Some _ -> Some var)
+      in
       (* Simplify the body of the let-expression and make the new [Let] bindings
          around the simplified body. [Simplify_named] will already have prepared
          [dacc] with the necessary bindings for the simplification of the
@@ -443,6 +452,20 @@ let simplify_let0 ~simplify_expr ~simplify_function_body dacc let_expr
       let down_to_up dacc ~rebuild:rebuild_body =
         let rebuild uacc ~after_rebuild =
           let after_rebuild body uacc =
+            (match removed_alloc_region with
+            | None -> ()
+            | Some region ->
+              if
+                Name_mode.Or_absent.is_present
+                  (Name_occurrences.greatest_name_mode_var
+                     (UA.name_occurrences uacc) region)
+              then
+                Misc.fatal_errorf
+                  "Allocation region %a, whose [New_alloc_region] binding was \
+                   removed by simplification, still occurs in the body:@ %a"
+                  Variable.print region
+                  (RE.print (UA.are_rebuilding_terms uacc))
+                  body);
             rebuild_let simplify_named_result removed_operations
               ~lifted_constants_from_defining_expr ~at_unit_toplevel
               ~closure_info ~body uacc ~after_rebuild ~rewrite_id

--- a/middle_end/flambda2/simplify/simplify_named.ml
+++ b/middle_end/flambda2/simplify/simplify_named.ml
@@ -184,6 +184,9 @@ let simplify_named0 dacc (bound_pattern : Bound_pattern.t) (named : Named.t)
             in
             Simplified_named.Simplified result))
   | Set_of_closures (set_of_closures, alloc_mode) ->
+    let alloc_mode =
+      Simplify_common.simplify_alloc_mode (DA.denv dacc) alloc_mode
+    in
     ok
       (Simplify_set_of_closures.simplify_non_lifted_set_of_closures dacc
          bound_pattern set_of_closures alloc_mode ~simplify_function_body)

--- a/middle_end/flambda2/simplify/simplify_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_primitive.ml
@@ -99,6 +99,10 @@ let arg_kind_mismatch prim arg_tys_with_expected_kinds =
 
 let simplify_primitive dacc (prim : P.t) dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
+  let prim =
+    P.map_alloc_regions prim
+      ~f:(Simplify_common.simplify_alloc_region (DA.denv dacc))
+  in
   match prim with
   | Nullary prim' ->
     Simplify_nullary_primitive.simplify_nullary_primitive dacc prim prim' dbg

--- a/middle_end/flambda2/simplify/simplify_switch_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_switch_expr.ml
@@ -27,7 +27,8 @@ type mergeable_arms =
   | No_arms
   | Mergeable of
       { cont : Continuation.t;
-        args : alias_set list
+        args : alias_set list;
+        check_actions : Check_action.t list
       }
   | Not_mergeable
 
@@ -43,6 +44,9 @@ let inter_alias_set alias1 alias2 =
         "[inter_alias_set]: intersection of poison with different kinds %a and \
          %a"
         Flambda_kind.print kind1 Flambda_kind.print kind2
+
+let equal_check_actions actions1 actions2 =
+  Misc.Stdlib.List.equal Check_action.equal actions1 actions2
 
 let find_all_aliases env arg =
   let find_all_aliases () =
@@ -109,7 +113,10 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
         else
           let check_handler ~handler ~action =
             match RE.to_apply_cont handler with
-            | Some action -> Some action
+            | Some handler_action ->
+              Some
+                (Apply_cont.prepend_check_actions handler_action
+                   (Apply_cont.check_actions action))
             | None -> Some action
           in
           match cont_info_from_uenv with
@@ -161,11 +168,16 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
             in
             ( new_let_conts,
               arms,
-              Mergeable { cont; args },
+              Mergeable
+                { cont; args; check_actions = Apply_cont.check_actions action },
               identity_arms,
               not_arms )
-          | Mergeable { cont; args } ->
-            if not (Continuation.equal cont (Apply_cont.continuation action))
+          | Mergeable { cont; args; check_actions } ->
+            if
+              (not (Continuation.equal cont (Apply_cont.continuation action)))
+              || not
+                   (equal_check_actions check_actions
+                      (Apply_cont.check_actions action))
             then new_let_conts, arms, Not_mergeable, identity_arms, not_arms
             else
               let args =
@@ -176,7 +188,7 @@ let rebuild_arm uacc arm (action, use_id, arity, env_at_use)
               in
               ( new_let_conts,
                 arms,
-                Mergeable { cont; args },
+                Mergeable { cont; args; check_actions },
                 identity_arms,
                 not_arms )
       in
@@ -401,8 +413,21 @@ let recognize_switch_with_single_arg_to_same_destination dbg machine_width ~arms
   if TI.Map.cardinal arms < 3
   then None
   else
-    recognize_switch_with_single_arg_to_same_destination0 dbg machine_width
-      ~arms
+    match TI.Map.data arms with
+    | [] -> None
+    | first :: rest ->
+      let check_actions = Apply_cont.check_actions first in
+      if
+        List.for_all
+          (fun action ->
+            equal_check_actions check_actions (Apply_cont.check_actions action))
+          rest
+      then
+        Option.map
+          (fun (dest, fields) -> dest, check_actions, fields)
+          (recognize_switch_with_single_arg_to_same_destination0 dbg
+             machine_width ~arms)
+      else None
 
 (* Tiny DSL to preserve sanity while rebuilding expressions. *)
 
@@ -497,7 +522,8 @@ let create_lookup_table_array_const dbg (array_kind : P.Array_kind.t) rebuilding
       P.Array_kind.print array_kind Debuginfo.print_compact dbg
 
 let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
-    ~scrutinee ~dest ~(lookup_table_fields : lookup_table_fields) dbg =
+    ~scrutinee ~dest ~check_actions ~(lookup_table_fields : lookup_table_fields)
+    dbg =
   let rebuilding = UA.are_rebuilding_terms uacc in
   let block_sym =
     Symbol.manufacture (Current_unit.get_cu_exn ()) "switch_block"
@@ -567,7 +593,7 @@ let rebuild_switch_with_single_arg_to_same_destination uacc ~dacc_before_switch
         continuations in [Name_occurrences] and then try to inline out [dest].
         This might happen anyway in the backend though so this probably isn't
         that important for now. *)
-     let apply_cont = Apply_cont.create dest ~args:[arg] ~dbg in
+     let apply_cont = Apply_cont.create dest ~args:[arg] ~check_actions ~dbg in
      let free_names_of_body = Apply_cont.free_names apply_cont in
      let expr =
        let body = RE.create_apply_cont apply_cont in
@@ -608,7 +634,7 @@ type affine_immediate_kind =
   | Naked
 
 let rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch
-    ~scrutinee ~dest ~offset ~slope ~immediate_kind dbg =
+    ~scrutinee ~dest ~check_actions ~offset ~slope ~immediate_kind dbg =
   (* We are creating the following fragment: *)
   (* let scaled = x * slope in
    * let final = scaled + offset in
@@ -625,7 +651,9 @@ let rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch
         (Int_arith (standard_int, Add), scaled_arg, Simple.const (const offset))
     in
     let$ final_arg = bound_prim "final_arg" kind add_prim dbg in
-    let apply_cont = Apply_cont.create dest ~args:[final_arg] ~dbg in
+    let apply_cont =
+      Apply_cont.create dest ~args:[final_arg] ~check_actions ~dbg
+    in
     let free_names = Apply_cont.free_names apply_cont in
     let added_code_size = Code_size.apply_cont apply_cont in
     return ~added_code_size ~free_names (RE.create_apply_cont apply_cont)
@@ -653,14 +681,30 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
   let switch_merged =
     match mergeable_arms with
     | No_arms | Not_mergeable -> None
-    | Mergeable { cont; args } ->
+    | Mergeable { cont; args; check_actions } ->
       let num_args = List.length args in
       let required_names = UA.required_names uacc in
       let args =
         List.filter_map (filter_and_choose_alias required_names) args
       in
       if List.compare_length_with args num_args = 0
-      then Some (cont, args)
+      then Some (cont, args, check_actions)
+      else None
+  in
+  let common_destination_and_check_actions arms =
+    match TI.Map.data arms with
+    | [] -> None
+    | first :: rest ->
+      let cont = Apply_cont.continuation first in
+      let check_actions = Apply_cont.check_actions first in
+      if
+        List.for_all
+          (fun action ->
+            Continuation.equal cont (Apply_cont.continuation action)
+            && equal_check_actions check_actions
+                 (Apply_cont.check_actions action))
+          rest
+      then Some (cont, check_actions)
       else None
   in
   let switch_is_identity =
@@ -668,10 +712,7 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
     let identity_arms_discrs = TI.Map.keys identity_arms in
     if not (TI.Set.equal arm_discrs identity_arms_discrs)
     then None
-    else
-      TI.Map.data identity_arms
-      |> List.map Apply_cont.continuation
-      |> Continuation.Set.of_list |> Continuation.Set.get_singleton
+    else common_destination_and_check_actions identity_arms
   in
   let machine_width = DE.machine_width (DA.denv dacc_before_switch) in
   let switch_is_boolean_not =
@@ -681,10 +722,7 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
       (not (TI.Set.equal arm_discrs (TI.all_bools machine_width)))
       || not (TI.Set.equal arm_discrs not_arms_discrs)
     then None
-    else
-      TI.Map.data not_arms
-      |> List.map Apply_cont.continuation
-      |> Continuation.Set.of_list |> Continuation.Set.get_singleton
+    else common_destination_and_check_actions not_arms
   in
   let switch_is_single_arg_to_same_destination =
     recognize_switch_with_single_arg_to_same_destination condition_dbg
@@ -720,7 +758,7 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
       let[@inline] normal_case uacc =
         match switch_is_single_arg_to_same_destination with
         | None -> normal_case0 uacc
-        | Some (dest, lookup_table_fields) -> (
+        | Some (dest, check_actions, lookup_table_fields) -> (
           let try_affine immediate_kind consts =
             assert (List.length consts = TI.Map.cardinal arms);
             Option.map
@@ -756,23 +794,25 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
           match affine with
           | None ->
             rebuild_switch_with_single_arg_to_same_destination uacc
-              ~dacc_before_switch ~scrutinee ~dest ~lookup_table_fields dbg
+              ~dacc_before_switch ~scrutinee ~dest ~check_actions
+              ~lookup_table_fields dbg
           | Some (immediate_kind, offset, slope) ->
             rebuild_affine_switch_to_same_destination uacc ~dacc_before_switch
-              ~scrutinee ~dest ~offset ~slope ~immediate_kind dbg)
+              ~scrutinee ~dest ~check_actions ~offset ~slope ~immediate_kind dbg
+          )
       in
       match switch_merged with
-      | Some (dest, args) ->
+      | Some (dest, args, check_actions) ->
         let uacc =
           UA.notify_removed ~operation:Removed_operations.branch uacc
         in
-        let apply_cont = Apply_cont.create dest ~args ~dbg in
+        let apply_cont = Apply_cont.create dest ~args ~check_actions ~dbg in
         let expr = RE.create_apply_cont apply_cont in
         let uacc = UA.add_free_names uacc (Apply_cont.free_names apply_cont) in
         expr, UA.notify_added ~code_size:(Code_size.apply_cont apply_cont) uacc
       | None -> (
         match switch_is_identity with
-        | Some dest ->
+        | Some (dest, check_actions) ->
           let uacc =
             (* CR mshinwell: it seems like this should be registering the
                potentially significant reduction in code size -- likewise in
@@ -787,7 +827,8 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
                  dbg
              in
              let apply_cont =
-               Apply_cont.create dest ~args:[tagged_scrutinee] ~dbg
+               Apply_cont.create dest ~args:[tagged_scrutinee] ~check_actions
+                 ~dbg
              in
              let expr = RE.create_apply_cont apply_cont in
              return
@@ -796,7 +837,7 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
                expr)
         | None -> (
           match switch_is_boolean_not with
-          | Some dest ->
+          | Some (dest, check_actions) ->
             let uacc =
               UA.notify_removed ~operation:Removed_operations.branch uacc
             in
@@ -812,7 +853,8 @@ let rebuild_switch ~arms ~condition_dbg ~scrutinee ~scrutinee_ty
                    dbg
                in
                let apply_cont =
-                 Apply_cont.create dest ~args:[not_scrutinee] ~dbg
+                 Apply_cont.create dest ~args:[not_scrutinee] ~check_actions
+                   ~dbg
                in
                let free_names = Apply_cont.free_names apply_cont in
                let added_code_size = Code_size.apply_cont apply_cont in
@@ -828,6 +870,11 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
   match T.meet typing_env_at_use scrutinee_ty shape with
   | Bottom -> arms, dacc
   | Ok (_meet_ty, env_at_use) ->
+    let action =
+      AC.with_check_actions action
+        (Simplify_common.rewrite_check_actions_for_removed_alloc_regions
+           (DA.denv dacc) (AC.check_actions action))
+    in
     let denv_at_use = DE.with_typing_env (DA.denv dacc) env_at_use in
     let args = AC.args action in
     let use_kind =
@@ -850,11 +897,11 @@ let simplify_arm ~typing_env_at_use ~scrutinee_ty arm action (arms, dacc) =
     let dbg = DE.add_inlined_debuginfo (DA.denv dacc) dbg in
     let action = AC.with_debuginfo action ~dbg in
     let dacc =
-      DA.map_flow_acc dacc
-        ~f:
-          (Flow.Acc.add_apply_cont_args ~rewrite_id
-             (Apply_cont.continuation action)
-             args)
+      DA.map_flow_acc dacc ~f:(fun data_flow ->
+          Flow.Acc.add_apply_cont_args ~rewrite_id
+            (Apply_cont.continuation action)
+            args data_flow
+          |> Flow.Acc.add_check_actions (Apply_cont.check_actions action))
     in
     let arms = TI.Map.add arm (action, rewrite_id, arity, env_at_use) arms in
     arms, dacc

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -1005,6 +1005,86 @@ let simplify_peek ~original_prim dacc ~original_term ~arg:_ ~arg_ty:_
     (P.result_kind' original_prim)
     ~original_term
 
+(* Regions removed by simplification are given an unknown type, not an alias
+   type, so that their occurrences reach the simplifiers below unchanged: the
+   rewriting to the parent region must go through [DE.find_removed_alloc_region]
+   in order to take the Forward/Close flags into account. Aliases of regions, on
+   the other hand, are given alias types, so [arg] below (which has been
+   simplified, hence canonicalised) denotes either a live region or a removed
+   one, never an alias. *)
+(* CR-someday ncourant: should we actually track removed regions in the
+   typing_env instead? *)
+let simplify_close_alloc_region (exit : Check_action.close_alloc_region_type)
+    dbg ~original_prim:_ dacc ~original_term ~arg ~arg_ty:_ ~result_var =
+  let removed =
+    match Simple.must_be_var arg with
+    | None -> None
+    | Some (region, _coercion) ->
+      DE.find_removed_alloc_region (DA.denv dacc) region
+  in
+  let machine_width = DE.machine_width (DA.denv dacc) in
+  let unit_ty = T.this_tagged_immediate (Target_ocaml_int.zero machine_width) in
+  let dacc = DA.add_variable dacc result_var unit_ty in
+  match removed with
+  | None -> SPR.create original_term ~try_reify:false dacc
+  | Some (parent, flags) -> (
+    match Check_action.alloc_check_for_close_alloc_region_type flags exit with
+    | Close ->
+      (* The closed region was created with [Close] for this exit: its closure
+         also stood for the closure of its parent, so the parent must now be
+         closed here. *)
+      let named =
+        Named.create_prim
+          (P.of_check_action (Close_alloc_region { region = parent; exit }))
+          dbg
+      in
+      SPR.create named ~try_reify:false dacc
+    | Forward ->
+      (* The closed region was created with [Forward] for this exit: closing it
+         only merged it into its (still open) parent, which is a no-op now that
+         its allocations are directly attributed to the parent. *)
+      let named = Named.create_simple (Simple.const_unit machine_width) in
+      SPR.create named ~try_reify:false dacc)
+
+let simplify_new_alloc_region (checks : P.alloc_region_checks) dbg
+    ~original_prim:_ dacc ~original_term:_ ~arg ~arg_ty:_ ~result_var =
+  let parent =
+    match Simple.must_be_var arg with
+    | Some (parent, _coercion) -> parent
+    | None ->
+      Misc.fatal_errorf "[New_alloc_region] applied to a non-variable:@ %a"
+        Simple.print arg
+  in
+  let checks, parent =
+    match DE.find_removed_alloc_region (DA.denv dacc) parent with
+    | None -> checks, parent
+    | Some (grandparent, parent_flags) ->
+      (* An exit of the new region cascades into a close of the grandparent only
+         if both this region and the removed parent were created with [Close]
+         for that exit. *)
+      P.meet_alloc_region_checks checks parent_flags, grandparent
+  in
+  let parent_simple = Simple.var parent in
+  if P.alloc_region_checks_only_transfer checks
+  then
+    (* A region whose every action is [Transfer] performs no checking of its
+       own: allocations in it can be attributed directly to its parent, and the
+       region itself can be removed. Its uses are rewritten as they are
+       simplified, using the mapping recorded here. *)
+    let dacc =
+      DA.map_denv dacc ~f:(fun denv ->
+          DE.add_removed_alloc_region denv (Bound_var.var result_var) ~parent
+            ~checks:(P.alloc_region_checks_flags checks))
+    in
+    let dacc = DA.add_variable dacc result_var (T.unknown K.region) in
+    SPR.create (Named.create_simple parent_simple) ~try_reify:false dacc
+  else
+    let named =
+      Named.create_prim (Unary (New_alloc_region checks, parent_simple)) dbg
+    in
+    let dacc = DA.add_variable dacc result_var (T.unknown K.region) in
+    SPR.create named ~try_reify:false dacc
+
 let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     ~arg_ty dbg ~result_var =
   let min_name_mode = Bound_var.name_mode result_var in
@@ -1074,5 +1154,9 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
     | Get_header -> simplify_get_header ~original_prim
     | Peek _ -> simplify_peek ~original_prim
     | Make_lazy _ -> simplify_lazy ~original_prim
+    | Close_alloc_region exit ->
+      simplify_close_alloc_region exit dbg ~original_prim
+    | New_alloc_region checks ->
+      simplify_new_alloc_region checks dbg ~original_prim
   in
   simplifier dacc ~original_term ~arg ~arg_ty ~result_var

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.ml
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.ml
@@ -18,9 +18,10 @@ open! Flambda.Import
 module RC = Apply.Result_continuation
 
 let make_inlined_body ~callee ~called_code_id:_ ~region_inlined_into ~params
-    ~args ~my_closure ~my_alloc_mode ~my_depth ~rec_info ~body ~exn_continuation
-    ~return_continuation ~apply_exn_continuation ~apply_return_continuation
-    ~bind_params ~bind_depth ~apply_renaming =
+    ~args ~my_closure ~my_alloc_mode ~my_depth ~rec_info ~body ~alloc_checks
+    ~exn_continuation ~return_continuation ~apply_exn_continuation
+    ~apply_return_continuation ~bind_params ~bind_depth ~bind_alloc_region
+    ~apply_renaming =
   let renaming = Renaming.empty in
   let renaming =
     match (apply_return_continuation : RC.t) with
@@ -30,7 +31,7 @@ let make_inlined_body ~callee ~called_code_id:_ ~region_inlined_into ~params
   let renaming =
     Renaming.add_continuation renaming exn_continuation apply_exn_continuation
   in
-  let renaming =
+  let renaming, my_alloc_region, alloc_region =
     (* If region_inlined_into is Heap, then this function should return a heap
        value, and as such, never allocate in the caller's region. As such,
        [my_region] should be unused in the body. *)
@@ -38,7 +39,7 @@ let make_inlined_body ~callee ~called_code_id:_ ~region_inlined_into ~params
     | Not_alloc_stack { alloc_region } -> (
       match (my_alloc_mode : Alloc_mode.For_applications.t) with
       | Not_alloc_stack { alloc_region = my_alloc_region } ->
-        Renaming.add_variable renaming my_alloc_region alloc_region
+        renaming, my_alloc_region, alloc_region
       | Maybe_alloc_stack _ ->
         Misc.fatal_error
           "Cannot inline a local returning function into a global function; \
@@ -55,13 +56,13 @@ let make_inlined_body ~callee ~called_code_id:_ ~region_inlined_into ~params
             region = my_region;
             ghost_region = my_ghost_region
           } ->
-        Renaming.add_variable
-          (Renaming.add_variable
-             (Renaming.add_variable renaming my_region region)
-             my_ghost_region ghost_region)
-          my_alloc_region alloc_region
+        ( Renaming.add_variable
+            (Renaming.add_variable renaming my_region region)
+            my_ghost_region ghost_region,
+          my_alloc_region,
+          alloc_region )
       | Not_alloc_stack { alloc_region = my_alloc_region } ->
-        Renaming.add_variable renaming my_alloc_region alloc_region)
+        renaming, my_alloc_region, alloc_region)
   in
   let body =
     match callee with
@@ -70,6 +71,9 @@ let make_inlined_body ~callee ~called_code_id:_ ~region_inlined_into ~params
     | None -> bind_params ~params ~args ~body
   in
   let body = bind_depth ~my_depth ~rec_info ~body in
+  let body =
+    bind_alloc_region ~my_alloc_region ~alloc_region ~alloc_checks ~body
+  in
   apply_renaming body renaming
 
 let wrap_inlined_body_for_exn_extra_args acc ~extra_args ~apply_exn_continuation

--- a/middle_end/flambda2/simplify_shared/inlining_helpers.mli
+++ b/middle_end/flambda2/simplify_shared/inlining_helpers.mli
@@ -25,6 +25,7 @@ val make_inlined_body :
   my_depth:Variable.t ->
   rec_info:Rec_info_expr.t ->
   body:'expr_with_acc ->
+  alloc_checks:Alloc_checks.t ->
   exn_continuation:Continuation.t ->
   return_continuation:Continuation.t ->
   apply_exn_continuation:Continuation.t ->
@@ -37,6 +38,12 @@ val make_inlined_body :
   bind_depth:
     (my_depth:Variable.t ->
     rec_info:Rec_info_expr.t ->
+    body:'expr_with_acc ->
+    'expr_with_acc) ->
+  bind_alloc_region:
+    (my_alloc_region:Variable.t ->
+    alloc_region:Variable.t ->
+    alloc_checks:Alloc_checks.t ->
     body:'expr_with_acc ->
     'expr_with_acc) ->
   apply_renaming:('expr_with_acc -> Renaming.t -> 'expr_with_acc) ->

--- a/middle_end/flambda2/terms/alloc_checks.ml
+++ b/middle_end/flambda2/terms/alloc_checks.ml
@@ -1,0 +1,87 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                    Nathanaëlle Courant, OCamlPro                       *)
+(*                                                                        *)
+(*   Copyright 2026 OCamlPro SAS                                          *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a per_exit =
+  { normal : 'a;
+    exn : 'a;
+    notrace : 'a;
+    div : 'a
+  }
+
+type check =
+  | Forward
+  | Close
+
+type t = check per_exit
+
+let map { normal; exn; notrace; div } ~f =
+  { normal = f normal; exn = f exn; notrace = f notrace; div = f div }
+
+let map2 { normal = normal1; exn = exn1; notrace = notrace1; div = div1 }
+    { normal = normal2; exn = exn2; notrace = notrace2; div = div2 } ~f =
+  { normal = f normal1 normal2;
+    exn = f exn1 exn2;
+    notrace = f notrace1 notrace2;
+    div = f div1 div2
+  }
+
+let for_all { normal; exn; notrace; div } ~f =
+  f normal && f exn && f notrace && f div
+
+let compare_per_exit compare_elt
+    { normal = normal1; exn = exn1; notrace = notrace1; div = div1 }
+    { normal = normal2; exn = exn2; notrace = notrace2; div = div2 } =
+  let c = compare_elt normal1 normal2 in
+  if c <> 0
+  then c
+  else
+    let c = compare_elt exn1 exn2 in
+    if c <> 0
+    then c
+    else
+      let c = compare_elt notrace1 notrace2 in
+      if c <> 0 then c else compare_elt div1 div2
+
+let meet_check check1 check2 =
+  match check1, check2 with
+  | Close, Close -> Close
+  | (Forward | Close), (Forward | Close) -> Forward
+
+let compare_check check1 check2 =
+  match check1, check2 with
+  | Forward, Forward | Close, Close -> 0
+  | Forward, Close -> -1
+  | Close, Forward -> 1
+
+let meet t1 t2 = map2 t1 t2 ~f:meet_check
+
+let print_check ppf = function
+  | Forward -> Format.pp_print_string ppf "Forward"
+  | Close -> Format.pp_print_string ppf "Close"
+
+let [@ocamlformat "disable"] print_per_exit print_elt ppf
+    { normal; exn; notrace; div } =
+  Format.fprintf ppf "@[<hov 1>(\
+      @[<hov 1>(normal@ %a)@]@ \
+      @[<hov 1>(exn@ %a)@]@ \
+      @[<hov 1>(notrace@ %a)@]@ \
+      @[<hov 1>(div@ %a)@]\
+      )@]"
+    print_elt normal
+    print_elt exn
+    print_elt notrace
+    print_elt div
+
+let print ppf t = print_per_exit print_check ppf t

--- a/middle_end/flambda2/terms/alloc_checks.mli
+++ b/middle_end/flambda2/terms/alloc_checks.mli
@@ -1,0 +1,66 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                    Nathanaëlle Courant, OCamlPro                       *)
+(*                                                                        *)
+(*   Copyright 2026 OCamlPro SAS                                          *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** What happens to the state of the current allocation region at each of the
+    ways control can leave a function call or a region.
+
+    Invariant on allocation regions:
+
+    At every point in the program, there is a stack of allocation regions; the
+    current state is the stack of open regions. Every region primitive must
+    operate on the most recent region of the stack. A region created with
+    [Close] at every exit REPLACES its parent region on the stack (closing it at
+    any exit also stands for closing its parent). At a join point, the stacks of
+    all incoming edges must be identical (it is fine to use a region parameter
+    of the join continuation to capture differing regions). When control leaves
+    the function, the stack must be empty: all regions must have been closed. *)
+
+type 'a per_exit =
+  { normal : 'a;
+    exn : 'a;
+    notrace : 'a;
+    div : 'a
+  }
+
+(** Whether an exit closes the current allocation region, or forwards it, still
+    open, to the context. *)
+type check =
+  | Forward
+  | Close
+
+type t = check per_exit
+
+val map : 'a per_exit -> f:('a -> 'b) -> 'b per_exit
+
+val map2 : 'a per_exit -> 'b per_exit -> f:('a -> 'b -> 'c) -> 'c per_exit
+
+val for_all : 'a per_exit -> f:('a -> bool) -> bool
+
+val compare_per_exit : ('a -> 'a -> int) -> 'a per_exit -> 'a per_exit -> int
+
+(** [Close] iff both arguments are [Close]. *)
+val meet_check : check -> check -> check
+
+val compare_check : check -> check -> int
+
+(** Pointwise [meet_check]. *)
+val meet : t -> t -> t
+
+val print_check : Format.formatter -> check -> unit
+
+val print_per_exit :
+  (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a per_exit -> unit
+
+val print : Format.formatter -> t -> unit

--- a/middle_end/flambda2/terms/apply_cont_expr.ml
+++ b/middle_end/flambda2/terms/apply_cont_expr.ml
@@ -18,6 +18,7 @@ type t =
   { k : Continuation.t;
     args : Simple.t list;
     trap_action : Trap_action.Option.t;
+    check_actions : Check_action.t list;
     dbg : Debuginfo.t
   }
 
@@ -31,7 +32,8 @@ let print_or_elide_debuginfo ppf dbg =
 include Container_types.Make (struct
   type nonrec t = t
 
-  let [@ocamlformat "disable"] print ppf { k; args; trap_action; dbg; } =
+  let [@ocamlformat "disable"] print ppf
+      { k; args; check_actions; trap_action; dbg; } =
     let name, trap_action =
       match Continuation.sort k, trap_action, args with
       | Normal_or_exn, None, [] -> "goto", None
@@ -68,7 +70,15 @@ include Container_types.Make (struct
       | Toplevel_return, Some trap_action, _::_ ->
         "module_init_end", Some trap_action
     in
-    Format.fprintf ppf "@[<hov 1>%a%t%s%t %a"
+    let print_check_actions ppf check_actions =
+      List.iter
+        (fun check_action ->
+          Format.fprintf ppf "%a@ %tthen%t@ " Check_action.print check_action
+            Flambda_colours.expr_keyword Flambda_colours.pop)
+        check_actions
+    in
+    Format.fprintf ppf "@[<hov 1>%a%a%t%s%t %a"
+      print_check_actions check_actions
       Trap_action.Option.print trap_action
       Flambda_colours.expr_keyword
       name
@@ -86,8 +96,19 @@ include Container_types.Make (struct
 
   let hash _ = Misc.fatal_error "Not yet implemented"
 
-  let compare { k = k1; args = args1; trap_action = trap_action1; dbg = dbg1 }
-      { k = k2; args = args2; trap_action = trap_action2; dbg = dbg2 } =
+  let compare
+      { k = k1;
+        args = args1;
+        check_actions = check_actions1;
+        trap_action = trap_action1;
+        dbg = dbg1
+      }
+      { k = k2;
+        args = args2;
+        check_actions = check_actions2;
+        trap_action = trap_action2;
+        dbg = dbg2
+      } =
     let c = Continuation.compare k1 k2 in
     if c <> 0
     then c
@@ -96,16 +117,27 @@ include Container_types.Make (struct
       if c <> 0
       then c
       else
-        let c = Option.compare Trap_action.compare trap_action1 trap_action2 in
-        if c <> 0 then c else Debuginfo.compare dbg1 dbg2
+        let c =
+          Misc.Stdlib.List.compare Check_action.compare check_actions1
+            check_actions2
+        in
+        if c <> 0
+        then c
+        else
+          let c =
+            Option.compare Trap_action.compare trap_action1 trap_action2
+          in
+          if c <> 0 then c else Debuginfo.compare dbg1 dbg2
 
   let equal t1 t2 = compare t1 t2 = 0
 end)
 
 (* CR mshinwell: Check the sort of [k]. *)
-let create ?trap_action k ~args ~dbg = { k; args; trap_action; dbg }
+let create ?trap_action ?(check_actions = []) k ~args ~dbg =
+  { k; args; trap_action; check_actions; dbg }
 
-let goto k = { k; args = []; trap_action = None; dbg = Debuginfo.none }
+let goto k =
+  { k; args = []; trap_action = None; check_actions = []; dbg = Debuginfo.none }
 
 let continuation t = t.k
 
@@ -113,10 +145,18 @@ let args t = t.args
 
 let trap_action t = t.trap_action
 
+let check_actions t = t.check_actions
+
 let debuginfo t = t.dbg
 
-let free_names { k; args; trap_action; dbg = _ } =
+let free_names { k; args; trap_action; check_actions; dbg = _ } =
   let default = Simple.List.free_names args in
+  let default =
+    List.fold_left
+      (fun names check_action ->
+        Name_occurrences.union names (Check_action.free_names check_action))
+      default check_actions
+  in
   match trap_action with
   | None -> Name_occurrences.add_continuation default k ~has_traps:false
   | Some trap_action ->
@@ -124,21 +164,42 @@ let free_names { k; args; trap_action; dbg = _ } =
       (Name_occurrences.union default (Trap_action.free_names trap_action))
       k ~has_traps:true
 
-let apply_renaming ({ k; args; trap_action; dbg } as t) renaming =
+let apply_renaming ({ k; args; trap_action; check_actions; dbg } as t) renaming
+    =
   let k' = Renaming.apply_continuation renaming k in
   let args' = Simple.List.apply_renaming args renaming in
   let trap_action' = Trap_action.Option.apply_renaming trap_action renaming in
-  if k == k' && args == args' && trap_action == trap_action'
+  let check_actions' =
+    Misc.Stdlib.List.map_sharing
+      (fun check_action -> Check_action.apply_renaming check_action renaming)
+      check_actions
+  in
+  if
+    k == k' && args == args'
+    && trap_action == trap_action'
+    && check_actions == check_actions'
   then t
-  else { k = k'; args = args'; trap_action = trap_action'; dbg }
+  else
+    { k = k';
+      args = args';
+      trap_action = trap_action';
+      check_actions = check_actions';
+      dbg
+    }
 
-let ids_for_export { k; args; trap_action; dbg = _ } =
+let ids_for_export { k; args; trap_action; check_actions; dbg = _ } =
+  let ids =
+    List.fold_left
+      (fun ids arg -> Ids_for_export.add_simple ids arg)
+      (Ids_for_export.add_continuation
+         (Trap_action.Option.ids_for_export trap_action)
+         k)
+      args
+  in
   List.fold_left
-    (fun ids arg -> Ids_for_export.add_simple ids arg)
-    (Ids_for_export.add_continuation
-       (Trap_action.Option.ids_for_export trap_action)
-       k)
-    args
+    (fun ids check_action ->
+      Ids_for_export.union ids (Check_action.ids_for_export check_action))
+    ids check_actions
 
 let with_continuation t continuation = { t with k = continuation }
 
@@ -148,6 +209,21 @@ let with_continuation_and_args t cont ~args =
   else { t with k = cont; args }
 
 let update_args t ~args = if args == t.args then t else { t with args }
+
+let with_check_actions t check_actions =
+  (* Physical equality suffices to preserve sharing in the common case where
+     both lists are empty. *)
+  if t.check_actions == check_actions then t else { t with check_actions }
+
+let add_check_actions t check_actions =
+  if List.is_empty check_actions
+  then t
+  else { t with check_actions = t.check_actions @ check_actions }
+
+let prepend_check_actions t check_actions =
+  if List.is_empty check_actions
+  then t
+  else { t with check_actions = check_actions @ t.check_actions }
 
 let with_debuginfo t ~dbg = if dbg == t.dbg then t else { t with dbg }
 

--- a/middle_end/flambda2/terms/apply_cont_expr.mli
+++ b/middle_end/flambda2/terms/apply_cont_expr.mli
@@ -25,6 +25,7 @@ include Contains_ids.S with type t := t
 
 val create :
   ?trap_action:Trap_action.t ->
+  ?check_actions:Check_action.t list ->
   Continuation.t ->
   args:Simple.t list ->
   dbg:Debuginfo.t ->
@@ -38,6 +39,8 @@ val args : t -> Simple.t list
 
 val trap_action : t -> Trap_action.t option
 
+val check_actions : t -> Check_action.t list
+
 val debuginfo : t -> Debuginfo.t
 
 val with_continuation : t -> Continuation.t -> t
@@ -45,6 +48,12 @@ val with_continuation : t -> Continuation.t -> t
 val with_continuation_and_args : t -> Continuation.t -> args:Simple.t list -> t
 
 val update_args : t -> args:Simple.t list -> t
+
+val with_check_actions : t -> Check_action.t list -> t
+
+val add_check_actions : t -> Check_action.t list -> t
+
+val prepend_check_actions : t -> Check_action.t list -> t
 
 val with_debuginfo : t -> dbg:Debuginfo.t -> t
 

--- a/middle_end/flambda2/terms/apply_expr.ml
+++ b/middle_end/flambda2/terms/apply_expr.ml
@@ -77,6 +77,7 @@ type t =
     return_arity : [`Unarized] Flambda_arity.t;
     call_kind : Call_kind.t;
     return_mode : Alloc_mode.For_applications.t;
+    alloc_checks : Alloc_checks.t;
     dbg : Debuginfo.t;
     inlined : Inlined_attribute.t;
     inlining_state : Inlining_state.t;
@@ -92,7 +93,7 @@ let [@ocamlformat "disable"] print_inlining_paths ppf relative_history =
 
 let [@ocamlformat "disable"] print_normal ppf
     { callee; continuation; exn_continuation; args; args_arity;
-      return_arity; call_kind; return_mode; dbg; inlined; inlining_state; probe;
+      return_arity; call_kind; return_mode; alloc_checks; dbg; inlined; inlining_state; probe;
       position; relative_history } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(%a\u{3008}%a\u{3009}\u{300a}%a\u{300b}\
@@ -101,6 +102,7 @@ let [@ocamlformat "disable"] print_normal ppf
       @[<hov 1>(return_arity@ %a)@]@ \
       @[<hov 1>(call_kind@ %a)@]@ \
       @[<hov 1>(return_mode@ %a)@]@ \
+      @[<hov 1>(alloc_checks@ %a)@]@ \
       @[<hov 1>%t(dbg@ %a)%t@]@ \
       @[<hov 1>(inline@ %a)@]@ \
       @[<hov 1>(inlining_state@ %a)@]@ \
@@ -116,6 +118,7 @@ let [@ocamlformat "disable"] print_normal ppf
     Flambda_arity.print return_arity
     Call_kind.print call_kind
     Alloc_mode.For_applications.print return_mode
+    Alloc_checks.print alloc_checks
     Flambda_colours.debuginfo
     Debuginfo.print_compact dbg
     Flambda_colours.pop
@@ -131,17 +134,19 @@ let [@ocamlformat "disable"] print_normal ppf
 
 let [@ocamlformat "disable"] print_effect ppf
     { callee = _; continuation; exn_continuation; args = _; args_arity = _;
-      return_arity = _; call_kind; return_mode; dbg; inlined = _; inlining_state = _;
+      return_arity = _; call_kind; return_mode; alloc_checks; dbg; inlined = _; inlining_state = _;
       probe = _; position; relative_history = _ } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>%a@]@ \
       @[<hov 1>(return_mode %a)@]@ \
+      @[<hov 1>(alloc_checks %a)@]@ \
       @[<hov 1>\u{3008}%a\u{3009}\u{300a}%a\u{300b}@]@ \
       @[<hov 1>%t(dbg@ %a)%t@]@ \
       @[<hov 1>(position@ %a)@]\
       )@]"
     Call_kind.print call_kind
     Alloc_mode.For_applications.print return_mode
+    Alloc_checks.print alloc_checks
     Result_continuation.print continuation
     Exn_continuation.print exn_continuation
     Flambda_colours.debuginfo
@@ -167,6 +172,7 @@ let invariant
        return_arity;
        call_kind;
        return_mode = _;
+       alloc_checks = _;
        dbg = _;
        inlined = _;
        inlining_state = _;
@@ -213,8 +219,8 @@ let invariant
       "Length of argument and arity lists disagree in [Apply]:@ %a" print t
 
 let create ~callee ~continuation exn_continuation ~args ~args_arity
-    ~return_arity ~(call_kind : Call_kind.t) ~return_mode dbg ~inlined
-    ~inlining_state ~probe ~position ~relative_history =
+    ~return_arity ~(call_kind : Call_kind.t) ~return_mode ~alloc_checks dbg
+    ~inlined ~inlining_state ~probe ~position ~relative_history =
   let t =
     { callee;
       continuation;
@@ -224,6 +230,7 @@ let create ~callee ~continuation exn_continuation ~args ~args_arity
       return_arity;
       call_kind;
       return_mode;
+      alloc_checks;
       dbg;
       inlined;
       inlining_state;
@@ -247,6 +254,8 @@ let call_kind t = t.call_kind
 
 let return_mode t = t.return_mode
 
+let alloc_checks t = t.alloc_checks
+
 let dbg t = t.dbg
 
 let inlined t = t.inlined
@@ -266,6 +275,7 @@ let free_names_without_exn_continuation
       return_arity = _;
       call_kind;
       return_mode;
+      alloc_checks = _;
       dbg = _;
       inlined = _;
       inlining_state = _;
@@ -291,6 +301,7 @@ let free_names_except_callee
       return_arity = _;
       call_kind;
       return_mode;
+      alloc_checks = _;
       dbg = _;
       inlined = _;
       inlining_state = _;
@@ -321,6 +332,7 @@ let apply_renaming
        return_arity;
        call_kind;
        return_mode;
+       alloc_checks;
        dbg;
        inlined;
        inlining_state;
@@ -361,6 +373,7 @@ let apply_renaming
       return_arity;
       call_kind = call_kind';
       return_mode = return_mode';
+      alloc_checks;
       dbg;
       inlined;
       inlining_state;
@@ -378,6 +391,7 @@ let ids_for_export
       return_arity = _;
       call_kind;
       return_mode;
+      alloc_checks = _;
       dbg = _;
       inlined = _;
       inlining_state = _;
@@ -421,6 +435,9 @@ let with_call_kind t call_kind =
   t
 
 let with_args t args ~args_arity = { t with args; args_arity }
+
+let with_return_mode_and_checks t ~return_mode ~alloc_checks =
+  { t with return_mode; alloc_checks }
 
 let inlining_arguments t = inlining_state t |> Inlining_state.arguments
 

--- a/middle_end/flambda2/terms/apply_expr.mli
+++ b/middle_end/flambda2/terms/apply_expr.mli
@@ -55,6 +55,7 @@ val create :
   return_arity:[`Unarized] Flambda_arity.t ->
   call_kind:Call_kind.t ->
   return_mode:Alloc_mode.For_applications.t ->
+  alloc_checks:Alloc_checks.t ->
   Debuginfo.t ->
   inlined:Inlined_attribute.t ->
   inlining_state:Inlining_state.t ->
@@ -88,6 +89,8 @@ val call_kind : t -> Call_kind.t
 
 val return_mode : t -> Alloc_mode.For_applications.t
 
+val alloc_checks : t -> Alloc_checks.t
+
 (** Where to send the result of the application. *)
 val continuation : t -> Result_continuation.t
 
@@ -115,6 +118,13 @@ val with_exn_continuation : t -> Exn_continuation.t -> t
 
 (** Change the arguments of an application *)
 val with_args : t -> Simple.t list -> args_arity:[`Complex] Flambda_arity.t -> t
+
+(** Change the allocation mode and allocation checks of an application. *)
+val with_return_mode_and_checks :
+  t ->
+  return_mode:Alloc_mode.For_applications.t ->
+  alloc_checks:Alloc_checks.t ->
+  t
 
 (** Change the call kind of an application. *)
 val with_call_kind : t -> Call_kind.t -> t

--- a/middle_end/flambda2/terms/check_action.ml
+++ b/middle_end/flambda2/terms/check_action.ml
@@ -1,0 +1,75 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                    Nathanaëlle Courant, OCamlPro                       *)
+(*                                                                        *)
+(*   Copyright 2026 OCamlPro SAS                                          *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type close_alloc_region_type =
+  | Normal
+  | Exn
+  | Notrace
+
+let compare_close_alloc_region_type (exit1 : close_alloc_region_type)
+    (exit2 : close_alloc_region_type) =
+  let numbering (exit : close_alloc_region_type) =
+    match exit with Normal -> 0 | Exn -> 1 | Notrace -> 2
+  in
+  Int.compare (numbering exit1) (numbering exit2)
+
+let alloc_check_for_close_alloc_region_type (flags : Alloc_checks.t)
+    (exit : close_alloc_region_type) =
+  match exit with
+  | Normal -> flags.normal
+  | Exn -> flags.exn
+  | Notrace -> flags.notrace
+
+type t =
+  | Close_alloc_region of
+      { exit : close_alloc_region_type;
+        region : Variable.t
+      }
+
+let print ppf t =
+  match t with
+  | Close_alloc_region { exit; region } ->
+    let name =
+      match exit with Normal -> "normal" | Exn -> "exn" | Notrace -> "notrace"
+    in
+    Format.fprintf ppf "%tclose[%s]%t@ %a" Flambda_colours.expr_keyword name
+      Flambda_colours.pop Variable.print region
+
+let compare t1 t2 =
+  match t1, t2 with
+  | ( Close_alloc_region { exit = exit1; region = region1 },
+      Close_alloc_region { exit = exit2; region = region2 } ) ->
+    let c = compare_close_alloc_region_type exit1 exit2 in
+    if c <> 0 then c else Variable.compare region1 region2
+
+let equal t1 t2 = compare t1 t2 = 0
+
+let free_names t =
+  match t with
+  | Close_alloc_region { exit = _; region } ->
+    Name_occurrences.singleton_variable region Name_mode.normal
+
+let apply_renaming t renaming =
+  match t with
+  | Close_alloc_region { exit; region } ->
+    let region' = Renaming.apply_variable renaming region in
+    if region == region'
+    then t
+    else Close_alloc_region { exit; region = region' }
+
+let ids_for_export t =
+  match t with
+  | Close_alloc_region { exit = _; region } ->
+    Ids_for_export.singleton_variable region

--- a/middle_end/flambda2/terms/check_action.mli
+++ b/middle_end/flambda2/terms/check_action.mli
@@ -1,0 +1,52 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                    Nathanaëlle Courant, OCamlPro                       *)
+(*                                                                        *)
+(*   Copyright 2026 OCamlPro SAS                                          *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** "Check actions" are ghost code to check some properties of the program. They
+    are always associated with an [Apply_cont] node; the check action is
+    executed before the application of the continuation.
+
+    For now, check actions are isomorphic to the [Close_alloc_region] primitive
+    (see [Flambda_primitive.of_check_action]). *)
+
+(** The exits of an allocation region at which it can be explicitly closed
+    ([Alloc_checks.per_exit] minus divergence, which no explicit closing can
+    observe). *)
+type close_alloc_region_type =
+  | Normal
+  | Exn
+  | Notrace
+
+val compare_close_alloc_region_type :
+  close_alloc_region_type -> close_alloc_region_type -> int
+
+(** The Forward/Close flag corresponding to the given region exit kind. *)
+val alloc_check_for_close_alloc_region_type :
+  Alloc_checks.t -> close_alloc_region_type -> Alloc_checks.check
+
+type t =
+  | Close_alloc_region of
+      { exit : close_alloc_region_type;
+        region : Variable.t
+      }
+
+include Expr_std.S with type t := t
+
+val compare : t -> t -> int
+
+val equal : t -> t -> bool
+
+val ids_for_export : t -> Ids_for_export.t
+
+val apply_renaming : t -> Renaming.t -> t

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -455,6 +455,7 @@ let unary_prim_size ~machine_width prim =
   | Get_header -> 2
   | Peek _ -> 1
   | Make_lazy _ -> alloc_size + 1
+  | Close_alloc_region _ | New_alloc_region _ -> 0
 
 let binary_prim_size ~machine_width prim =
   match (prim : Flambda_primitive.binary_primitive) with

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1210,6 +1210,12 @@ let nullary_classify_for_printing p =
   | Dls_get | Tls_get | Domain_index | Poll | Cpu_relax ->
     Neither
 
+let map_alloc_regions_nullary_primitive p ~f:_ =
+  match p with
+  | Invalid _ | Optimised_out _ | Probe_is_enabled _ | Enter_inlined_apply _
+  | Dls_get | Tls_get | Domain_index | Poll | Cpu_relax ->
+    p
+
 module Reinterpret_64_bit_word = struct
   type t =
     | Tagged_int63_as_unboxed_int64
@@ -1290,6 +1296,52 @@ type unary_primitive =
       { lazy_tag : Lazy_block_tag.t;
         alloc_region : Variable.t
       }
+  | Close_alloc_region of Check_action.close_alloc_region_type
+  | New_alloc_region of alloc_region_checks
+
+and alloc_check_action =
+  | Transfer
+  | Check
+  | Discard
+
+and alloc_region_checks =
+  (Alloc_checks.check * alloc_check_action) Alloc_checks.per_exit
+
+and alloc_check_actions = alloc_check_action Alloc_checks.per_exit
+
+let alloc_region_checks_with_actions (checks : Alloc_checks.t)
+    ~(actions : alloc_check_actions) : alloc_region_checks =
+  Alloc_checks.map2 checks actions ~f:(fun check action -> check, action)
+
+let alloc_region_checks_with_action checks ~action =
+  Alloc_checks.map checks ~f:(fun check -> check, action)
+
+let meet_alloc_region_checks (checks : alloc_region_checks)
+    (flags : Alloc_checks.t) : alloc_region_checks =
+  Alloc_checks.map2 checks flags ~f:(fun (check, action) flag ->
+      Alloc_checks.meet_check check flag, action)
+
+let alloc_region_checks_flags (checks : alloc_region_checks) : Alloc_checks.t =
+  Alloc_checks.map checks ~f:fst
+
+let alloc_region_checks_only_transfer (checks : alloc_region_checks) =
+  Alloc_checks.for_all checks ~f:(fun (_check, action) ->
+      match action with Transfer -> true | Check | Discard -> false)
+
+let compare_alloc_check_action (action1 : alloc_check_action)
+    (action2 : alloc_check_action) =
+  let numbering (action : alloc_check_action) =
+    match action with Transfer -> 0 | Check -> 1 | Discard -> 2
+  in
+  Int.compare (numbering action1) (numbering action2)
+
+let compare_alloc_region_checks (checks1 : alloc_region_checks)
+    (checks2 : alloc_region_checks) =
+  Alloc_checks.compare_per_exit
+    (fun (check1, action1) (check2, action2) ->
+      let c = Alloc_checks.compare_check check1 check2 in
+      if c <> 0 then c else compare_alloc_check_action action1 action2)
+    checks1 checks2
 
 (* Here and below, operations that are genuine projections shouldn't be eligible
    for CSE, since we deal with projections through types. *)
@@ -1324,6 +1376,7 @@ let unary_primitive_eligible_for_cse p ~arg =
   | Project_function_slot _ | Project_value_slot _ -> false
   | Is_boxed_float | Is_flat_float_array -> true
   | End_region _ | End_try_region _ | Obj_dup _ | Peek _ | Make_lazy _ -> false
+  | Close_alloc_region _ | New_alloc_region _ -> false
 
 let compare_unary_primitive p1 p2 =
   let unary_primitive_numbering p =
@@ -1359,6 +1412,8 @@ let compare_unary_primitive p1 p2 =
     | Peek _ -> 28
     | Make_lazy _ -> 29
     | Reinterpret_boxed_vector -> 30
+    | Close_alloc_region _ -> 31
+    | New_alloc_region _ -> 32
   in
   match p1, p2 with
   | ( Block_load { kind = kind1; mut = mut1; field = field1 },
@@ -1457,6 +1512,10 @@ let compare_unary_primitive p1 p2 =
       Make_lazy { lazy_tag = lazy_tag2; alloc_region = alloc_region2 } ) ->
     let c = Lazy_block_tag.compare lazy_tag1 lazy_tag2 in
     if c <> 0 then c else Variable.compare alloc_region1 alloc_region2
+  | Close_alloc_region exit1, Close_alloc_region exit2 ->
+    Check_action.compare_close_alloc_region_type exit1 exit2
+  | New_alloc_region checks1, New_alloc_region checks2 ->
+    compare_alloc_region_checks checks1 checks2
   | ( ( Block_load _ | Duplicate_array _ | Duplicate_block _ | Is_int _
       | Is_null | Get_tag | String_length _ | Int_as_pointer _
       | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
@@ -1465,7 +1524,7 @@ let compare_unary_primitive p1 p2 =
       | Untag_immediate | Tag_immediate | Project_function_slot _
       | Project_value_slot _ | Is_boxed_float | Is_flat_float_array
       | End_region _ | End_try_region _ | Obj_dup _ | Get_header | Peek _
-      | Make_lazy _ ),
+      | Make_lazy _ | Close_alloc_region _ | New_alloc_region _ ),
       _ ) ->
     Stdlib.compare (unary_primitive_numbering p1) (unary_primitive_numbering p2)
 
@@ -1539,6 +1598,25 @@ let print_unary_primitive ppf p =
   | Make_lazy { lazy_tag; alloc_region } ->
     fprintf ppf "@[<hov 1>(Make_lazy@ (lazy_tag %a)@ (alloc_region %a))@]"
       Lazy_block_tag.print lazy_tag Variable.print alloc_region
+  | Close_alloc_region kind ->
+    let name =
+      match kind with Normal -> "normal" | Exn -> "exn" | Notrace -> "notrace"
+    in
+    fprintf ppf "Close_alloc_region[%s]" name
+  | New_alloc_region alloc_checks ->
+    let print_action ppf action =
+      Format.pp_print_string ppf
+        (match action with
+        | Transfer -> "Transfer"
+        | Check -> "Check"
+        | Discard -> "Discard")
+    in
+    let print_check ppf (check, action) =
+      fprintf ppf "%a@ %a" Alloc_checks.print_check check print_action action
+    in
+    fprintf ppf "@[<hov 1>(New_alloc_region@ %a)@]"
+      (Alloc_checks.print_per_exit print_check)
+      alloc_checks
 
 let arg_kind_of_unary_primitive p =
   match p with
@@ -1575,6 +1653,8 @@ let arg_kind_of_unary_primitive p =
   | Get_header -> K.value
   | Peek _ -> K.naked_nativeint
   | Make_lazy _ -> K.value
+  | Close_alloc_region _ -> K.region
+  | New_alloc_region _ -> K.region
 
 let result_kind_of_unary_primitive p : result_kind =
   match p with
@@ -1614,6 +1694,8 @@ let result_kind_of_unary_primitive p : result_kind =
   | Get_header -> Singleton K.naked_nativeint
   | Peek kind -> Singleton (K.Standard_int_or_float.to_kind kind)
   | Make_lazy _ -> Singleton K.value
+  | Close_alloc_region _ -> Singleton K.value
+  | New_alloc_region _ -> Singleton K.region
 
 let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
   match p with
@@ -1738,6 +1820,9 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
       No_coeffects,
       Strict,
       Can't_move_before_any_branch )
+  | Close_alloc_region _ | New_alloc_region _ ->
+    (* These need special-casing for deletion. *)
+    Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
 
 let unary_classify_for_printing p =
   match p with
@@ -1756,6 +1841,7 @@ let unary_classify_for_printing p =
   | Get_header -> Neither
   | Peek _ -> Neither
   | Make_lazy _ -> Constructive
+  | Close_alloc_region _ | New_alloc_region _ -> Neither
 
 let free_names_unary_primitive p =
   match p with
@@ -1782,7 +1868,8 @@ let free_names_unary_primitive p =
   | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
   | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
   | End_try_region _ | Get_header
-  | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
+  | Peek (_ : Flambda_kind.Standard_int_or_float.t)
+  | Close_alloc_region _ | New_alloc_region _ ->
     Name_occurrences.empty
 
 let apply_renaming_unary_primitive p renaming =
@@ -1831,7 +1918,58 @@ let apply_renaming_unary_primitive p renaming =
   | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
   | End_try_region _ | Project_function_slot _ | Project_value_slot _
   | Get_header
-  | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
+  | Peek (_ : Flambda_kind.Standard_int_or_float.t)
+  | Close_alloc_region _ | New_alloc_region _ ->
+    p
+
+let map_alloc_regions_unary_primitive p ~f =
+  match p with
+  | Box_number (kind, alloc_mode) ->
+    let alloc_mode' =
+      Alloc_mode.For_allocations.map_alloc_region alloc_mode ~f
+    in
+    if alloc_mode == alloc_mode' then p else Box_number (kind, alloc_mode')
+  | Int_as_pointer alloc_mode ->
+    let alloc_mode' =
+      Alloc_mode.For_allocations.map_alloc_region alloc_mode ~f
+    in
+    if alloc_mode == alloc_mode' then p else Int_as_pointer alloc_mode'
+  | Duplicate_array
+      { alloc_region; kind; source_mutability; destination_mutability } ->
+    let alloc_region' = f alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else
+      Duplicate_array
+        { alloc_region = alloc_region';
+          kind;
+          source_mutability;
+          destination_mutability
+        }
+  | Duplicate_block { alloc_region; kind } ->
+    let alloc_region' = f alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else Duplicate_block { alloc_region = alloc_region'; kind }
+  | Obj_dup { alloc_region } ->
+    let alloc_region' = f alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else Obj_dup { alloc_region = alloc_region' }
+  | Make_lazy { alloc_region; lazy_tag } ->
+    let alloc_region' = f alloc_region in
+    if alloc_region == alloc_region'
+    then p
+    else Make_lazy { alloc_region = alloc_region'; lazy_tag }
+  | Block_load _ | Is_int _ | Is_null | Get_tag | String_length _
+  | Opaque_identity _ | Int_arith _ | Num_conv _ | Boolean_not
+  | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector | Float_arith _
+  | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
+  | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
+  | End_try_region _ | Project_function_slot _ | Project_value_slot _
+  | Get_header
+  | Peek (_ : Flambda_kind.Standard_int_or_float.t)
+  | Close_alloc_region _ | New_alloc_region _ ->
     p
 
 let ids_for_export_unary_primitive p =
@@ -1850,7 +1988,8 @@ let ids_for_export_unary_primitive p =
   | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
   | End_try_region _ | Project_function_slot _ | Project_value_slot _
   | Get_header
-  | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
+  | Peek (_ : Flambda_kind.Standard_int_or_float.t)
+  | Close_alloc_region _ | New_alloc_region _ ->
     Ids_for_export.empty
 
 type binary_int_arith_op =
@@ -2209,6 +2348,15 @@ let ids_for_export_binary_primitive p =
   | Read_offset _ ->
     Ids_for_export.empty
 
+let map_alloc_regions_binary_primitive p ~f:_ =
+  match p with
+  | Block_set _ | Array_load _ | String_or_bigstring_load _ | Bigarray_load _
+  | Phys_equal _ | Int_arith _ | Int_shift _ | Int_comp _ | Float_arith _
+  | Float_comp _ | Bigarray_get_alignment _ | Atomic_load_field _
+  | Poke (_ : Flambda_kind.Standard_int_or_float.t)
+  | Read_offset _ ->
+    p
+
 type int_atomic_op =
   | Fetch_add
   | Add
@@ -2553,6 +2701,17 @@ let ids_for_export_quaternary_primitive p =
   | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ ->
     Ids_for_export.empty
 
+let map_alloc_regions_ternary_primitive p ~f:_ =
+  match p with
+  | Array_set _ | Bytes_or_bigstring_set _ | Bigarray_set _
+  | Atomic_field_int_arith _ | Atomic_set_field _ | Atomic_exchange_field _
+  | Write_offset _ ->
+    p
+
+let map_alloc_regions_quaternary_primitive p ~f:_ =
+  match p with
+  | Atomic_compare_and_set_field _ | Atomic_compare_exchange_field _ -> p
+
 type variadic_primitive =
   | Begin_region of { ghost : bool }
   | Begin_try_region of { ghost : bool }
@@ -2676,6 +2835,20 @@ let apply_renaming_variadic_primitive p renaming =
   | Make_array (kind, mut, alloc_mode) ->
     let alloc_mode' =
       Alloc_mode.For_allocations.apply_renaming alloc_mode renaming
+    in
+    if alloc_mode == alloc_mode' then p else Make_array (kind, mut, alloc_mode')
+
+let map_alloc_regions_variadic_primitive p ~f =
+  match p with
+  | Begin_region _ | Begin_try_region _ -> p
+  | Make_block (kind, mut, alloc_mode) ->
+    let alloc_mode' =
+      Alloc_mode.For_allocations.map_alloc_region alloc_mode ~f
+    in
+    if alloc_mode == alloc_mode' then p else Make_block (kind, mut, alloc_mode')
+  | Make_array (kind, mut, alloc_mode) ->
+    let alloc_mode' =
+      Alloc_mode.For_allocations.map_alloc_region alloc_mode ~f
     in
     if alloc_mode == alloc_mode' then p else Make_array (kind, mut, alloc_mode')
 
@@ -2943,6 +3116,11 @@ let args t =
   | Quaternary (_, x0, x1, x2, x3) -> [x0; x1; x2; x3]
   | Variadic (_, xs) -> xs
 
+let of_check_action (check_action : Check_action.t) : t =
+  match check_action with
+  | Close_alloc_region { exit; region } ->
+    Unary (Close_alloc_region exit, Simple.var region)
+
 let map_args f t =
   match t with
   | Nullary _ -> t
@@ -2969,6 +3147,27 @@ let map_args f t =
   | Variadic (p, xs) ->
     let xs' = Misc.Stdlib.List.map_sharing f xs in
     if xs == xs' then t else Variadic (p, xs')
+
+let map_alloc_regions t ~f =
+  match t with
+  | Nullary p ->
+    let p' = map_alloc_regions_nullary_primitive p ~f in
+    if p == p' then t else Nullary p'
+  | Unary (p, x0) ->
+    let p' = map_alloc_regions_unary_primitive p ~f in
+    if p == p' then t else Unary (p', x0)
+  | Binary (p, x0, x1) ->
+    let p' = map_alloc_regions_binary_primitive p ~f in
+    if p == p' then t else Binary (p', x0, x1)
+  | Ternary (p, x0, x1, x2) ->
+    let p' = map_alloc_regions_ternary_primitive p ~f in
+    if p == p' then t else Ternary (p', x0, x1, x2)
+  | Quaternary (p, x0, x1, x2, x3) ->
+    let p' = map_alloc_regions_quaternary_primitive p ~f in
+    if p == p' then t else Quaternary (p', x0, x1, x2, x3)
+  | Variadic (p, xs) ->
+    let p' = map_alloc_regions_variadic_primitive p ~f in
+    if p == p' then t else Variadic (p', xs)
 
 let result_kind (t : t) =
   match t with
@@ -3297,6 +3496,17 @@ let is_end_region t =
     | Some (region, _coercion) -> Some region
     | None ->
       Misc.fatal_errorf "End_region with non-Variable argument:@ %a"
+        Simple.print region)
+  | _ -> None
+[@@ocaml.warning "-fragile-match"]
+
+let is_check_action t : Check_action.t option =
+  match t with
+  | Unary (Close_alloc_region exit, region) -> (
+    match Simple.must_be_var region with
+    | Some (region, _coercion) -> Some (Close_alloc_region { exit; region })
+    | None ->
+      Misc.fatal_errorf "Close_alloc_region with non-Variable argument:@ %a"
         Simple.print region)
   | _ -> None
 [@@ocaml.warning "-fragile-match"]

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -513,6 +513,41 @@ type unary_primitive =
       { lazy_tag : Lazy_block_tag.t;
         alloc_region : Variable.t
       }
+  | Close_alloc_region of Check_action.close_alloc_region_type
+  | New_alloc_region of alloc_region_checks
+
+(** What to do with the allocation state of a region when it is closed: transfer
+    it to the parent region, check that no allocation occurred, or discard it.
+*)
+and alloc_check_action =
+  | Transfer
+  | Check
+  | Discard
+
+and alloc_region_checks =
+  (Alloc_checks.check * alloc_check_action) Alloc_checks.per_exit
+
+and alloc_check_actions = alloc_check_action Alloc_checks.per_exit
+
+(** Pair every check of the given [Alloc_checks.t] with the corresponding action
+    from [actions]. *)
+val alloc_region_checks_with_actions :
+  Alloc_checks.t -> actions:alloc_check_actions -> alloc_region_checks
+
+(** Pair every check of the given [Alloc_checks.t] with the same [action]. *)
+val alloc_region_checks_with_action :
+  Alloc_checks.t -> action:alloc_check_action -> alloc_region_checks
+
+(** Meet the Forward/Close flags of the given checks pointwise with [flags]
+    (Close iff both are Close), leaving the actions unchanged. *)
+val meet_alloc_region_checks :
+  alloc_region_checks -> Alloc_checks.t -> alloc_region_checks
+
+(** The Forward/Close flags of the given checks, without the actions. *)
+val alloc_region_checks_flags : alloc_region_checks -> Alloc_checks.t
+
+(** Whether every action of the given checks is [Transfer]. *)
+val alloc_region_checks_only_transfer : alloc_region_checks -> bool
 
 (** Whether a comparison is to yield a boolean result, as given by a particular
     comparison operator, or whether it is to behave in the manner of "compare"
@@ -666,6 +701,16 @@ val args : t -> Simple.t list
 
 val map_args : (Simple.t -> Simple.t) -> t -> t
 
+(** The primitive performing the given check action, when it is made explicit
+    rather than attached to an [Apply_cont]. *)
+val of_check_action : Check_action.t -> t
+
+(** Apply [f] to the allocation regions embedded in the given primitive, i.e.
+    those indicating where it allocates. The regions taken as arguments by
+    [New_alloc_region] and [Close_alloc_region] are not affected, nor are any
+    stack allocation regions. *)
+val map_alloc_regions : t -> f:(Variable.t -> Variable.t) -> t
+
 (** Simpler version (e.g. for [Inlining_cost]), where only the actual primitive
     matters, not the arguments. *)
 module Without_args : sig
@@ -810,3 +855,8 @@ val is_begin_or_end_region : t -> bool
 val is_begin_region : t -> bool
 
 val is_end_region : t -> Variable.t option
+
+(** The check action performing the same operation as the given primitive, if
+    there is one (i.e. if it is a [Close_alloc_region]). Inverse of
+    [of_check_action]. *)
+val is_check_action : t -> Check_action.t option

--- a/middle_end/flambda2/to_cmm/to_cmm.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm.ml
@@ -91,9 +91,19 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
       ~param_types:(List.map snd return_cont_params)
   in
   (* See comment in [To_cmm_set_of_closures] about binding [my_region] *)
+  let env, toplevel_alloc_region_var =
+    Env.create_bound_parameter env
+      ( Flambda_unit.toplevel_my_alloc_region flambda_unit,
+        Flambda_debug_uid.none )
+  in
   let env, toplevel_region_var =
     Env.create_bound_parameter env
       (Flambda_unit.toplevel_my_region flambda_unit, Flambda_debug_uid.none)
+  in
+  let env, toplevel_ghost_region_var =
+    Env.create_bound_parameter env
+      ( Flambda_unit.toplevel_my_ghost_region flambda_unit,
+        Flambda_debug_uid.none )
   in
   let r =
     R.create ~reachable_names
@@ -108,7 +118,12 @@ let unit0 ~offsets ~all_code ~reachable_names flambda_unit =
       "Did not find where to place the following symbol initializations: %a"
       To_cmm_env.Symbol_inits.print body_symbol_inits;
   let free_vars =
-    To_cmm_shared.remove_var_with_provenance body_free_vars toplevel_region_var
+    To_cmm_shared.remove_var_with_provenance
+      (To_cmm_shared.remove_var_with_provenance
+         (To_cmm_shared.remove_var_with_provenance body_free_vars
+            toplevel_alloc_region_var)
+         toplevel_region_var)
+      toplevel_ghost_region_var
   in
   if not (Backend_var.Set.is_empty free_vars)
   then

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -1309,6 +1309,12 @@ let unary_primitive env res dbg f (_arg_simple : Simple.t option)
     (* CR alloc_regions: propagate alloc_regions to CMM. *)
     let tag = Tag.to_int (P.Lazy_block_tag.to_tag lazy_tag) in
     None, res, C.make_alloc ~mode:Heap dbg ~tag [arg]
+  | Close_alloc_region _ ->
+    (* CR alloc_regions: propagate to CMM. *)
+    None, res, C.unit ~dbg
+  | New_alloc_region _ ->
+    (* CR alloc_regions: propagate to CMM. *)
+    None, res, C.unit ~dbg
 
 let binary_primitive env dbg f (_x_simple : Simple.t option)
     (_y_simple : Simple.t option) (x : Cmm.expression) (y : Cmm.expression) =

--- a/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_set_of_closures.ml
@@ -500,13 +500,24 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
      so we don't need any binder for it (this is why we can ignore
      [_bound_var]). If it does end up in generated code, Selection will complain
      and refuse to compile the code. *)
-  let env, my_region_var, my_ghost_region_var =
+  let env, my_alloc_region_var, my_region_var, my_ghost_region_var =
     (* CR alloc_regions: my_alloc_region should be propagated as well. *)
     match (my_alloc_mode : Alloc_mode.For_applications.t) with
-    | Not_alloc_stack { alloc_region = _ } -> env, None, None
+    | Not_alloc_stack { alloc_region = my_alloc_region } ->
+      let my_alloc_region_duid = Flambda_debug_uid.none in
+      let env, alloc_region =
+        Env.create_bound_parameter env (my_alloc_region, my_alloc_region_duid)
+      in
+      env, alloc_region, None, None
     | Maybe_alloc_stack
-        { alloc_region = _; region = my_region; ghost_region = my_ghost_region }
-      ->
+        { alloc_region = my_alloc_region;
+          region = my_region;
+          ghost_region = my_ghost_region
+        } ->
+      let my_alloc_region_duid = Flambda_debug_uid.none in
+      let env, alloc_region =
+        Env.create_bound_parameter env (my_alloc_region, my_alloc_region_duid)
+      in
       let my_region_duid = Flambda_debug_uid.none in
       let env, region =
         Env.create_bound_parameter env (my_region, my_region_duid)
@@ -515,7 +526,7 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
       let env, ghost_region =
         Env.create_bound_parameter env (my_ghost_region, my_ghost_region_duid)
       in
-      env, Some region, Some ghost_region
+      env, alloc_region, Some region, Some ghost_region
   in
   (* Translate the arg list and body *)
   let env, fun_params = C.function_bound_parameters env params in
@@ -530,10 +541,12 @@ let params_and_body0 env res code_id ~result_arity ~fun_dbg
       To_cmm_env.Symbol_inits.print fun_body_symbol_inits;
   let fun_free_vars =
     C.remove_vars_with_machtype
-      (C.remove_var_opt_with_provenance
-         (C.remove_var_opt_with_provenance fun_body_free_vars
-            my_ghost_region_var)
-         my_region_var)
+      (C.remove_var_with_provenance
+         (C.remove_var_opt_with_provenance
+            (C.remove_var_opt_with_provenance fun_body_free_vars
+               my_ghost_region_var)
+            my_region_var)
+         my_alloc_region_var)
       fun_params
   in
   if not (Backend_var.Set.is_empty fun_free_vars)

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -321,6 +321,7 @@ let unary_exn ~env ~res (f : Flambda_primitive.unary_primitive) x =
     in
     let var = Jsir.Var.fresh () in
     Some var, env, To_jsir_result.add_instr_exn res (Let (var, expr))
+  | Close_alloc_region _ | New_alloc_region _ -> no_op ~env ~res
 
 let binary_exn ~env ~res (f : Flambda_primitive.binary_primitive) x y =
   let use_prim' prim = use_prim' ~env ~res prim [x; y] in

--- a/testsuite/tests/codegen/load_elimination.ml
+++ b/testsuite/tests/codegen/load_elimination.ml
@@ -11,7 +11,7 @@ let immutable_load l = (List.hd l) + (List.hd l)
 immutable_load:
   testb $1, %al
   je    .L0
-  movq  camlStdlib__List__Pmakeblock2545_19@GOTPCREL(%rip), %rax
+  movq  camlStdlib__List__Pmakeblock2547_19@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11

--- a/testsuite/tests/codegen/loops.ml
+++ b/testsuite/tests/codegen/loops.ml
@@ -97,7 +97,7 @@ loop_with_non_dominating_load:
 .L0:
   testb $1, %bl
   je    .L1
-  movq  camlStdlib__List__Pmakeblock2545_19@GOTPCREL(%rip), %rax
+  movq  camlStdlib__List__Pmakeblock2547_19@GOTPCREL(%rip), %rax
   movq  48(%r14), %rsp
   popq  48(%r14)
   popq  %r11

--- a/testsuite/tests/flambda/match_in_match_seq.raw.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.raw.reference
@@ -4,22 +4,25 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let f = %project_value_slot.[aux].[f] (my_closure) in
    let next = %project_value_slot.[aux].[next] (my_closure) in
-   apply &my_alloc_region inlined(hint) next (s) -> k3 * k2
+   apply &my_alloc_region inlined(hint) [forward close close close]
+     next (s) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
          (let untagged = %untag_imm (Pisint) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (acc))
+            | 1 -> k1 close[normal] my_alloc_region (acc))
            where k4 =
              cont k3)
           where k3 =
             let Pfield = %block_load.[`1`] (`*match*`) in
             ((let Pfield_1 = %block_load.[`0`] (`*match*`) in
-              apply &my_alloc_region f (acc, Pfield_1) -> k3 * k2)
+              apply &my_alloc_region [forward close close close]
+                f (acc, Pfield_1) -> k3 * k2)
                where k3 (apply_result) =
                  apply direct(aux_1 &my_alloc_region)
+                        [close close close close]
                    my_closure ~ depth my_depth -> next_depth
                      (apply_result, Pfield)
                      -> k1 * k2))
@@ -35,7 +38,8 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
    with { f = f; next = next }
    in
    let Pfield = %block_load.[`0`] (`*match*`) in
-   apply direct(aux_1 &my_alloc_region) aux (acc, Pfield) -> k1 * k2
+   apply direct(aux_1 &my_alloc_region) [close close close close]
+     aux (acc, Pfield) -> k1 * k2
  in
  let code size(39)
        `fn[match_in_match_seq.ml:35,14--125]_3` (s : val)
@@ -51,25 +55,27 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
      %project_value_slot.[`fn[match_in_match_seq.ml:35,14--125]`].[next_1]
        (my_closure)
    in
-   apply &my_alloc_region inlined(hint) next (s) -> k3 * k2
+   apply &my_alloc_region inlined(hint) [forward close close close]
+     next (s) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
          (let untagged = %untag_imm (Pisint) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (0))
+            | 1 -> k1 close[normal] my_alloc_region (0))
            where k4 =
              cont k3)
           where k3 =
             let Pfield = %block_load.[`1`] (`*match*`) in
             ((let Pfield_1 = %block_load.[`0`] (`*match*`) in
-              apply &my_alloc_region f (Pfield_1) -> k3 * k2)
+              apply &my_alloc_region [forward close close close]
+                f (Pfield_1) -> k3 * k2)
                where k3 (apply_result : val) =
                  let Pmakeblock =
                    %block.[`0`].my_alloc_region (apply_result, Pfield)
                  in
-                 cont k1 (Pmakeblock)))
+                 cont k1 close[normal] my_alloc_region (Pmakeblock)))
  in
  let code inline(always) size(65)
        map_2 (f : val, param : [ 0 of [ 0 of val * val ] ])
@@ -90,7 +96,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
        (Pfield, `fn[match_in_match_seq.ml:35,14--125]`)
    in
    let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
-   cont k1 (Pmakeblock_1)
+   cont k1 close[normal] my_alloc_region (Pmakeblock_1)
  in
  let code rec inline(always) loopify(always) size(56)
        aux_5 (s : val)
@@ -100,20 +106,22 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let f = %project_value_slot.[aux_1].[f_2] (my_closure) in
    let next = %project_value_slot.[aux_1].[next_2] (my_closure) in
-   apply &my_alloc_region inlined(hint) next (s) -> k3 * k2
+   apply &my_alloc_region inlined(hint) [forward close close close]
+     next (s) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
          (let untagged = %untag_imm (Pisint) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (0))
+            | 1 -> k1 close[normal] my_alloc_region (0))
            where k4 =
              cont k3)
           where k3 =
             let s' = %block_load.[`1`] (`*match*`) in
             let x = %block_load.[`0`] (`*match*`) in
-            (apply &my_alloc_region f (x) -> k5 * k2
+            (apply &my_alloc_region [forward close close close]
+               f (x) -> k5 * k2
                where k5 (apply_result : [ 0 |1 ]) =
                  ((let untagged = %untag_imm (apply_result) in
                    switch untagged
@@ -125,13 +133,14 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
                       cont k4)
                where k4 =
                  apply direct(aux_5 &my_alloc_region)
+                        [close close close close]
                    (my_closure ~ depth my_depth -> next_depth
                     : _ -> [ 0 | 0 of val * val ])
                      (s')
                      -> k1 * k2
                where k3 =
                  let Pmakeblock = %block.[`0`].my_alloc_region (x, s') in
-                 cont k1 (Pmakeblock)))
+                 cont k1 close[normal] my_alloc_region (Pmakeblock)))
  in
  let code inline(always) size(82)
        filter_4 (f : val, param : [ 0 of [ 0 of val * val ] ])
@@ -147,7 +156,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
    let Pfield = %block_load.[`0`] (`*match*`) in
    let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, aux) in
    let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
-   cont k1 (Pmakeblock_1)
+   cont k1 close[normal] my_alloc_region (Pmakeblock_1)
  in
  let code inline(always) size(14)
        unfold_6 (f : val, acc : val)
@@ -157,7 +166,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let Pmakeblock = %block.[`0`].my_alloc_region (acc, f) in
    let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
-   cont k1 (Pmakeblock_1)
+   cont k1 close[normal] my_alloc_region (Pmakeblock_1)
  in
  let code inline(always) size(5)
        square_7 (x : imm tagged)
@@ -166,7 +175,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_mul = %int_barith.mul (x, x) in
-   cont k1 (int_mul)
+   cont k1 close[normal] my_alloc_region (int_mul)
  in
  let code size(27)
        `fn[match_in_match_seq.ml:55,11--63]_9` (i : imm tagged)
@@ -183,13 +192,13 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
     (let untagged = %untag_imm (int_greaterthan) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (0))
+       | 1 -> k1 close[normal] my_alloc_region (0))
       where k4 =
         cont k3)
      where k3 =
        let int_add = %int_barith.add (i, 1) in
        let Pmakeblock = %block.[`0`].my_alloc_region (i, int_add) in
-       cont k1 (Pmakeblock)
+       cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code inline(always) size(40)
        ints_8 (lo : imm tagged, hi : imm tagged)
@@ -203,7 +212,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
        @`fn[match_in_match_seq.ml:55,11--63]` &my_alloc_region
    with { hi = hi }
    in
-   apply direct(unfold_6 &my_alloc_region)
+   apply direct(unfold_6 &my_alloc_region) [close close close close]
      (unfold : _ -> [ 0 of [ 0 of val * val ] ])
        (`fn[match_in_match_seq.ml:55,11--63]`, lo)
        -> k1 * k2
@@ -216,7 +225,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_add = %int_barith.add (prim, prim_1) in
-   cont k1 (int_add)
+   cont k1 close[normal] my_alloc_region (int_add)
  in
  let code inline(always) size(16)
        sum_10 (s : [ 0 of [ 0 of val * val ] ])
@@ -229,7 +238,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
      closure `fn[match_in_match_seq.ml:57,33--36]_11`
        @`fn[match_in_match_seq.ml:57,33--36]` &my_alloc_region
    in
-   apply direct(fold_left_0 &my_alloc_region)
+   apply direct(fold_left_0 &my_alloc_region) [close close close close]
      (fold_left : _ -> imm tagged)
        (`fn[match_in_match_seq.ml:57,33--36]`, 0, s)
        -> k1 * k2
@@ -242,7 +251,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let prim = %int_comp.gt (i, 5) in
    let int_greaterthan = %tag_imm (prim) in
-   cont k1 (int_greaterthan)
+   cont k1 close[normal] my_alloc_region (int_greaterthan)
  in
  let code size(33)
        foo_12 (param : imm tagged)
@@ -255,24 +264,24 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
    let square = %project_value_slot.[foo].[square] (my_closure) in
    let ints = %project_value_slot.[foo].[ints] (my_closure) in
    let sum = %project_value_slot.[foo].[sum] (my_closure) in
-   apply direct(ints_8 &my_alloc_region)
+   apply direct(ints_8 &my_alloc_region) [forward close close close]
      (ints : _ -> [ 0 of [ 0 of val * val ] ]) (0, 11) -> k5 * k2
      where k5 (apply_result : [ 0 of [ 0 of val * val ] ]) =
        let `fn[match_in_match_seq.ml:60,28--44]` =
          closure `fn[match_in_match_seq.ml:60,28--44]_13`
            @`fn[match_in_match_seq.ml:60,28--44]` &my_alloc_region
        in
-       apply direct(filter_4 &my_alloc_region)
+       apply direct(filter_4 &my_alloc_region) [forward close close close]
          (filter : _ -> [ 0 of [ 0 of val * val ] ])
            (`fn[match_in_match_seq.ml:60,28--44]`, apply_result)
            -> k4 * k2
      where k4 (apply_result : [ 0 of [ 0 of val * val ] ]) =
-       apply direct(map_2 &my_alloc_region)
+       apply direct(map_2 &my_alloc_region) [forward close close close]
          (map : _ -> [ 0 of [ 0 of val * val ] ])
            (square, apply_result)
            -> k3 * k2
      where k3 (apply_result : [ 0 of [ 0 of val * val ] ]) =
-       apply direct(sum_10 &my_alloc_region)
+       apply direct(sum_10 &my_alloc_region) [close close close close]
          (sum : _ -> imm tagged) (apply_result) -> k1 * k2
  in
  (let fold_left = closure fold_left_0 @fold_left &toplevel.alloc_region in
@@ -299,7 +308,7 @@ let $camlMatch_in_match_seq__first_const_0 = Block 0 () in
   cont k1 (Pmakeblock))
    where k1 (Seq : val) =
      let Pmakeblock = %block.[`0`].`toplevel` (Seq) in
-     cont k (Pmakeblock))
+     cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlMatch_in_match_seq = Block 0 (field_0) in

--- a/testsuite/tests/flambda/match_in_match_seq.simplify.reference
+++ b/testsuite/tests/flambda/match_in_match_seq.simplify.reference
@@ -11,7 +11,7 @@ let code loopify(never) size(35) newer_version_of(foo_12)
            let prim = %int_comp.gt (s_1, 11) in
            (switch prim
               | 0 -> k3
-              | 1 -> k (acc)
+              | 1 -> k close[normal] my_alloc_region (acc)
               where k3 =
                 let int_add = %int_barith.add (s_1, 1) in
                 let prim_1 = %int_comp.gt (s_1, 5) in
@@ -31,6 +31,7 @@ in
 let $camlMatch_in_match_seq__Pmakeblock_20 =
   Block 0 ($camlMatch_in_match_seq__foo_9)
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlMatch_in_match_seq =
   Block 0 ($camlMatch_in_match_seq__Pmakeblock_20)
 in

--- a/testsuite/tests/flambda2/alloc_regions_inline.ml
+++ b/testsuite/tests/flambda2/alloc_regions_inline.ml
@@ -1,0 +1,25 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+(* Inlining binds the callee's allocation region to a [New_alloc_region] whose
+   actions are all [Transfer]; such regions should be removed by [Simplify]. *)
+
+let[@inline always] add1 x = x + 1
+
+let[@inline always] add2 x = add1 (add1 x)
+
+let[@zero_alloc] chain t = add2 (add2 t)
+
+(* Inlining a function which has its own zero_alloc region: the inner
+   [New_alloc_region] is not removed, since its actions are not all
+   [Transfer]. *)
+let[@zero_alloc] [@inline always] checked_add1 x = x + 1
+
+let call_checked y = checked_add1 (checked_add1 y)
+
+let[@zero_alloc assume] tail_call_checked y = checked_add1 y

--- a/testsuite/tests/flambda2/alloc_regions_join.ml
+++ b/testsuite/tests/flambda2/alloc_regions_join.ml
@@ -1,0 +1,25 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+(* Join points whose incoming jumps carry region-closing check actions:
+   regions used only by check actions must be seen by the flow analysis, the
+   [Switch] simplifications may only merge arms with identical check actions,
+   and continuations lifted out of a handler that defines (and removes)
+   regions must have the corresponding entries renamed along with their lifted
+   parameters. *)
+
+let[@inline always] abs' x = if x > 0 then x else -x
+
+let[@zero_alloc] join1 b t =
+  let r = if b then abs' t else abs' (t + 1) in
+  if r = 0 then 1 else r * 2
+
+let[@zero_alloc] switch_arms t =
+  match t with 0 -> 10 | 1 -> 20 | 2 -> 30 | _ -> 40
+
+let[@zero_alloc assume] tail_if b x y = if b then abs' x else abs' y

--- a/testsuite/tests/flambda2/alloc_regions_lifted_cont.ml
+++ b/testsuite/tests/flambda2/alloc_regions_lifted_cont.ml
@@ -1,0 +1,36 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3 -flambda2-match-in-match";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+(* Match-in-match lifts the continuations for the arms of the match in [f]
+   (inlined into [h]) out of the handler that binds (and removes, since its
+   actions are all [Transfer]) the allocation region of the inlined [p]. The
+   [removed_alloc_regions] entries must be renamed along with the lifted
+   parameters ([DE.rename_removed_alloc_regions]), so that the check actions
+   in the lifted handlers still find the removed region.
+
+   This also checks that the flow analysis sees the regions used only by check
+   actions ([Flow.Acc.add_check_actions]): without it, the lifted region
+   parameters would be removed as unused while still occurring in the check
+   actions of the lifted handlers. *)
+external (+) : int -> int -> int = "%addint"
+type t = A | B | C of int
+
+let[@inline] f g x y =
+  let r =
+    match x with
+    | A -> g (y, y) + 1
+    | B -> y
+    | C a -> a + 1
+  in
+  r + 1
+
+let[@inline] [@zero_alloc assume] p f g x y = f g x y
+
+let h g x y =
+  let z = match x with A -> B | B -> C y | C _ -> A in
+  p f g z y

--- a/testsuite/tests/flambda2/alloc_regions_over_apply.ml
+++ b/testsuite/tests/flambda2/alloc_regions_over_apply.ml
@@ -1,0 +1,15 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+let[@inline never] make_adder x =
+  let x2 = Sys.opaque_identity (x * 2) in
+  fun y -> x2 + y
+
+let over1 x = make_adder x 5
+
+let[@zero_alloc assume] over2 x = make_adder x 5

--- a/testsuite/tests/flambda2/alloc_regions_partial_apply.ml
+++ b/testsuite/tests/flambda2/alloc_regions_partial_apply.ml
@@ -1,0 +1,21 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+let[@inline never] add3 x y z = x + y + z
+
+(* Tail position: the application's alloc checks close the region on normal
+   return. *)
+let[@zero_alloc assume] partial_tail x = add3 x
+
+(* Non-tail position. *)
+let partial_nontail x =
+  let f = add3 x 1 in
+  let () = () in
+  f
+
+let use x = partial_tail x 1 2 + (partial_nontail x) 2

--- a/testsuite/tests/flambda2/alloc_regions_raises.ml
+++ b/testsuite/tests/flambda2/alloc_regions_raises.ml
@@ -1,0 +1,21 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+exception E
+
+let[@zero_alloc assume strict] div_exact a b = a / b
+
+let[@zero_alloc assume strict] nth (a : int array) i = a.(i)
+
+let[@zero_alloc] raise_e () = raise E
+
+let[@zero_alloc assume] reraise f x = try f x with e -> raise e
+
+let catch g x = try g x with _ -> 0
+
+let notrace_path f x = try f x with Not_found -> raise_notrace E

--- a/testsuite/tests/flambda2/alloc_regions_zero_alloc.ml
+++ b/testsuite/tests/flambda2/alloc_regions_zero_alloc.ml
@@ -1,0 +1,31 @@
+(* TEST
+ compile_only = "true";
+ ocamlopt_flags = "-O3";
+ flambda2;
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+let[@unboxable] f1 x = x +. 1.
+
+let f2 (x [@unboxable]) = x +. 1.
+
+let g x = raise x
+
+type t = A | B | C
+
+let[@zero_alloc] h t = match t with A -> A | B -> B | C -> C
+
+let[@zero_alloc strict] h_strict t = match t with A -> B | B -> C | C -> A
+
+let z t =
+  let y = h t in
+  match y with A -> B | B -> C | C -> A
+
+let[@zero_alloc assume] pair x = (x, x)
+
+let[@zero_alloc assume strict] pair_strict x = (x, x)
+
+external exp : float -> float = "caml_exp_float"
+
+let p r = exp (exp r)

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -9,7 +9,7 @@ let code loopify(never) size(52) newer_version_of(sum_0)
   let for_stop = %int_barith.sub (Parraylength, 1) in
   let prim = %int_comp.le (0, for_stop) in
   switch prim
-    | 0 -> k (0)
+    | 0 -> k close[normal] my_alloc_region (0)
     | 1 -> k2
     where k2 =
       let prim_1 = %untag_imm (for_stop) in
@@ -34,12 +34,13 @@ let code loopify(never) size(52) newer_version_of(sum_0)
                   %int_comp.`int64`.le (for_next_naked, for_stop_naked)
                 in
                 switch prim_3
-                  | 0 -> k (return_val0)
+                  | 0 -> k close[normal] my_alloc_region (return_val0)
                   | 1 -> k2 (for_next_naked, return_val0)))
 in
 let $camlArray_element_kind_meet__sum_1 =
   closure sum_0_1 @sum &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlArray_element_kind_meet =
   Block 0 ($camlArray_element_kind_meet__sum_1)
 in

--- a/testsuite/tests/flambda2/code_size_of_boolean_not_switch.simplify.reference
+++ b/testsuite/tests/flambda2/code_size_of_boolean_not_switch.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(2) newer_version_of(f_0)
         -> k * k1
         : imm tagged =
   let not_scrutinee = %boolean_not (b) in
-  cont k (not_scrutinee)
+  cont k close[normal] my_alloc_region (not_scrutinee)
 in
 let $camlCode_size_of_boolean_not_switch__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
@@ -16,7 +16,7 @@ let code loopify(never) size(4) newer_version_of(g_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(f_0_1 &my_alloc_region)
+  apply direct(f_0_1 &my_alloc_region) [close close close close]
     ($camlCode_size_of_boolean_not_switch__f_1 : _ -> imm tagged)
       (b)
       -> k * k1
@@ -24,6 +24,7 @@ in
 let $camlCode_size_of_boolean_not_switch__g_2 =
   closure g_1_1 @g &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCode_size_of_boolean_not_switch =
   Block 0 ($camlCode_size_of_boolean_not_switch__f_1,
            $camlCode_size_of_boolean_not_switch__g_2)

--- a/testsuite/tests/flambda2/code_size_of_single_arg_switch.simplify.reference
+++ b/testsuite/tests/flambda2/code_size_of_single_arg_switch.simplify.reference
@@ -15,7 +15,7 @@ let code loopify(never) size(2) newer_version_of(switch_converted_to_lookup_tabl
   let arg =
     %array_load ($camlCode_size_of_single_arg_switch__switch_block_2, x)
   in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table_1 =
   closure switch_converted_to_lookup_table_0_1
@@ -27,6 +27,7 @@ let code loopify(never) size(4) newer_version_of(switch_converted_to_lookup_tabl
         -> k * k1
         : imm tagged =
   apply direct(switch_converted_to_lookup_table_0_1 &my_alloc_region)
+         [close close close close]
     ($camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table_1
      : _ -> imm tagged)
       (x)
@@ -43,7 +44,7 @@ let code loopify(never) size(7) newer_version_of(switch_converted_to_affine_2)
         : imm tagged =
   let scaled_arg = %int_barith.mul (x, 1) in
   let final_arg = %int_barith.add (scaled_arg, 7) in
-  cont k (final_arg)
+  cont k close[normal] my_alloc_region (final_arg)
 in
 let $camlCode_size_of_single_arg_switch__switch_converted_to_affine_4 =
   closure switch_converted_to_affine_2_1 @switch_converted_to_affine
@@ -55,6 +56,7 @@ let code loopify(never) size(4) newer_version_of(switch_converted_to_affine'_3)
         -> k * k1
         : imm tagged =
   apply direct(switch_converted_to_affine_2_1 &my_alloc_region)
+         [close close close close]
     ($camlCode_size_of_single_arg_switch__switch_converted_to_affine_4
      : _ -> imm tagged)
       (x)
@@ -64,6 +66,7 @@ let $camlCode_size_of_single_arg_switch__switch_converted_to_affine'_5 =
   closure switch_converted_to_affine'_3_1 @switch_converted_to_affine'
     &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCode_size_of_single_arg_switch =
   Block 0 ($camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table_1,
            $camlCode_size_of_single_arg_switch__switch_converted_to_lookup_table'_3,

--- a/testsuite/tests/flambda2/cse_immutable_array_load.simplify.reference
+++ b/testsuite/tests/flambda2/cse_immutable_array_load.simplify.reference
@@ -4,11 +4,12 @@ let code loopify(never) size(1) newer_version_of(f_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (1)
+  cont k close[normal] my_alloc_region (1)
 in
 let $camlCse_immutable_array_load__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCse_immutable_array_load =
   Block 0 ($camlCse_immutable_array_load__f_1)
 in

--- a/testsuite/tests/flambda2/cse_immutable_array_load_var_index.simplify.reference
+++ b/testsuite/tests/flambda2/cse_immutable_array_load_var_index.simplify.reference
@@ -4,11 +4,12 @@ let code loopify(never) size(1) newer_version_of(f_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (1)
+  cont k close[normal] my_alloc_region (1)
 in
 let $camlCse_immutable_array_load_var_index__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCse_immutable_array_load_var_index =
   Block 0 ($camlCse_immutable_array_load_var_index__f_1)
 in

--- a/testsuite/tests/flambda2/examples/andor.simplify.reference
+++ b/testsuite/tests/flambda2/examples/andor.simplify.reference
@@ -12,19 +12,20 @@ let code loopify(never) size(41) newer_version_of(is_valid_0)
        let prim_1 = %int_comp.le (i, 55295) in
        switch prim_1
          | 0 -> k2
-         | 1 -> k (1))
+         | 1 -> k close[normal] my_alloc_region (1))
     where k2 =
       let prim = %int_comp.le (57344, i) in
       (switch prim
-         | 0 -> k (0)
+         | 0 -> k close[normal] my_alloc_region (0)
          | 1 -> k2
          where k2 =
            let prim_1 = %int_comp.le (i, 1114111) in
            let int_lessequal = %tag_imm (prim_1) in
-           cont k (int_lessequal))
+           cont k close[normal] my_alloc_region (int_lessequal))
 in
 let $camlAndor__is_valid_1 =
   closure is_valid_0_1 @is_valid &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlAndor = Block 0 ($camlAndor__is_valid_1) in
 cont done ($camlAndor)

--- a/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.raw.reference
+++ b/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.raw.reference
@@ -2,7 +2,7 @@ let $camlApp_unarized_to_single_kind__first_const_0 = Block 0 () in
 (let code size(1)
        f_0 (x) my_closure &my_alloc_region my_depth -> k1 * k2 : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (x)
+   cont k1 close[normal] my_alloc_region (x)
  in
  let code size(6)
        g_1 (f : val, x)
@@ -10,20 +10,21 @@ let $camlApp_unarized_to_single_kind__first_const_0 = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   apply &my_alloc_region f (x) -> k1 * k2
+   apply &my_alloc_region [close close close close] f (x) -> k1 * k2
  in
  let code size(6)
        h_2 (x) my_closure &my_alloc_region my_depth -> k1 * k2 : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let f = %project_value_slot.[h].[f] (my_closure) in
    let g = %project_value_slot.[h].[g] (my_closure) in
-   apply direct(g_1 &my_alloc_region) (g : _ -> imm tagged) (f, x) -> k1 * k2
+   apply direct(g_1 &my_alloc_region) [close close close close]
+     (g : _ -> imm tagged) (f, x) -> k1 * k2
  in
  let f = closure f_0 @f &toplevel.alloc_region in
  let g = closure g_1 @g &toplevel.alloc_region in
  let h = closure h_2 @h &toplevel.alloc_region with { f = f; g = g } in
  let Pmakeblock = %block.[`0`].`toplevel` (f, g, h) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.simplify.reference
+++ b/testsuite/tests/flambda2/examples/app_unarized_to_single_kind.simplify.reference
@@ -3,7 +3,7 @@ let code g_1 deleted in
 let code h_2 deleted in
 let code loopify(never) size(1) newer_version_of(f_0)
       f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $camlApp_unarized_to_single_kind__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
@@ -13,18 +13,19 @@ let code loopify(never) size(6) newer_version_of(g_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply &my_alloc_region f (x) -> k * k1
+  apply &my_alloc_region [close close close close] f (x) -> k * k1
 in
 let $camlApp_unarized_to_single_kind__g_2 =
   closure g_1_1 @g &toplevel.alloc_region
 in
 let code loopify(never) size(1) newer_version_of(h_2)
       h_2_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $camlApp_unarized_to_single_kind__h_3 =
   closure h_2_1 @h &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlApp_unarized_to_single_kind =
   Block 0 ($camlApp_unarized_to_single_kind__f_1,
            $camlApp_unarized_to_single_kind__g_2,

--- a/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
+++ b/testsuite/tests/flambda2/examples/array_specialisation_examples.simplify.reference
@@ -19,9 +19,12 @@ let code loopify(never) size(22) newer_version_of(f_0)
      | 1 -> k3)
     where k3 =
       let ifnot_result = %array_load.mut (arr, 0) in
-      cont k (ifnot_result)
+      cont k close[normal] my_alloc_region (ifnot_result)
     where k2 =
-      cont k1 pop(regular k1) ($camlArray_specialisation_examples__block_1)
+      cont k1
+             pop(regular k1)
+             close[exn] my_alloc_region
+             ($camlArray_specialisation_examples__block_1)
 in
 let $camlArray_specialisation_examples__f_2 =
   closure f_0_1 @f &toplevel.alloc_region
@@ -33,7 +36,7 @@ let code loopify(never) size(8) newer_version_of(g_1)
         : [ 0 | 0 of val ] =
   let a = %array.mut.my_alloc_region (x) in
   let ifnot_result = %array_load.mut (a, 0) in
-  cont k (ifnot_result)
+  cont k close[normal] my_alloc_region (ifnot_result)
 in
 let $camlArray_specialisation_examples__g_3 =
   closure g_1_1 @g &toplevel.alloc_region
@@ -45,7 +48,7 @@ let code loopify(never) size(8) newer_version_of(h_2)
         : imm tagged =
   let ifnot_result = %array.mut.my_alloc_region (x) in
   let Parrayrefs = %array_load.`imm`.mut (ifnot_result, 0) in
-  cont k (Parrayrefs)
+  cont k close[normal] my_alloc_region (Parrayrefs)
 in
 let $camlArray_specialisation_examples__h_4 =
   closure h_2_1 @h &toplevel.alloc_region
@@ -88,14 +91,16 @@ let code loopify(never) size(62) newer_version_of(i_3)
               where k3 =
                 cont k1
                        pop(regular k1)
+                       close[exn] my_alloc_region
                        ($camlArray_specialisation_examples__block_1)))
     where k2 (region_return : imm tagged) =
       let `unit` = %end_region (`region`) in
-      cont k (region_return)
+      cont k close[normal] my_alloc_region (region_return)
 in
 let $camlArray_specialisation_examples__i_5 =
   closure i_3_1 @i &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlArray_specialisation_examples =
   Block 0 ($camlArray_specialisation_examples__f_2,
            $camlArray_specialisation_examples__g_3,

--- a/testsuite/tests/flambda2/examples/arrays_compatibility.simplify.reference
+++ b/testsuite/tests/flambda2/examples/arrays_compatibility.simplify.reference
@@ -14,7 +14,7 @@ let code inline(never) loopify(never) size(8) newer_version_of(index_0)
         : imm array =
   let Pmakearray = %array.`imm`.mut.my_alloc_region (0, 0) in
   let Popaque = %opaque (Pmakearray) in
-  cont k (Popaque)
+  cont k close[normal] my_alloc_region (Popaque)
 in
 let $camlArrays_compatibility__index_3 =
   closure index_0_1 @index &toplevel.alloc_region
@@ -47,13 +47,16 @@ let code inline(always) loopify(never) size(60) newer_version_of(convert_fast_1)
                  let int_add = %int_barith.add (int_sub_1, 1) in
                  cont k2 (int_add)
                where k4 =
-                 cont k1 pop(regular k1) ($camlArrays_compatibility__block_2))))
+                 cont k1
+                        pop(regular k1)
+                        close[exn] my_alloc_region
+                        ($camlArrays_compatibility__block_2))))
     where k3 =
       let int_add = %int_barith.add (offset, 1) in
       cont k2 (int_add)
     where k2 (col : imm tagged) =
       let Pmakeblock = %block.[`0`].my_alloc_region (line, col) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlArrays_compatibility__convert_fast_4 =
   closure convert_fast_1_1 @convert_fast &toplevel.alloc_region
@@ -73,7 +76,7 @@ let code loopify(never) size(75) newer_version_of(f_2)
      | 0 -> k2 ($camlArrays_compatibility__empty_array_0)
      | 1 -> k3)
     where k3 =
-      apply direct(index_0_1 &my_alloc_region)
+      apply direct(index_0_1 &my_alloc_region) [forward close close close]
         ($camlArrays_compatibility__index_3 : _ -> val) (source) -> k2 * k1
     where k2 (index : val) =
       let line = %opaque (0) in
@@ -102,16 +105,18 @@ let code loopify(never) size(75) newer_version_of(f_2)
                     where k4 =
                       cont k1
                              pop(regular k1)
+                             close[exn] my_alloc_region
                              ($camlArrays_compatibility__block_2))))
          where k3 =
            let int_add = %int_barith.add (offset, 1) in
            cont k2 (int_add)
          where k2 (col : imm tagged) =
            let Pmakeblock = %block.[`0`].my_alloc_region (line, col) in
-           cont k (Pmakeblock))
+           cont k close[normal] my_alloc_region (Pmakeblock))
 in
 let $camlArrays_compatibility__f_6 = closure f_2_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlArrays_compatibility =
   Block 0 ($camlArrays_compatibility__Pmakeblock_5,
            $camlArrays_compatibility__f_6)

--- a/testsuite/tests/flambda2/examples/block_closure_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/block_closure_rec.simplify.reference
@@ -8,7 +8,8 @@ and code rec loopify(never) size(8) newer_version_of(foo_0)
       (3505894,
        $camlBlock_closure_rec__foo_1 ~ depth my_depth -> succ my_depth)
   in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlBlock_closure_rec = Block 0 ($camlBlock_closure_rec__foo_1) in
 cont done ($camlBlock_closure_rec)

--- a/testsuite/tests/flambda2/examples/block_unboxed.simplify.reference
+++ b/testsuite/tests/flambda2/examples/block_unboxed.simplify.reference
@@ -21,9 +21,10 @@ let code loopify(never) size(25) newer_version_of(foo_0)
       let prim = %num_conv.[`float`].[`imm`] (unboxed_float) in
       let int_of_float = %tag_imm (prim) in
       let int_add = %int_barith.add (unboxed_field_0, int_of_float) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let $camlBlock_unboxed__foo_1 = closure foo_0_1 @foo &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlBlock_unboxed = Block 0 ($camlBlock_unboxed__foo_1) in
 cont done ($camlBlock_unboxed)

--- a/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/code_id_join_b.simplify.reference
@@ -30,6 +30,7 @@ cont `self` ($camlCode_id_join_b__const_block_12)
                      ($Code_id_join_a.`camlCode_id_join_a__fn[code_id_join_a.ml:9,24--35]_8`))
             where k1 (full_apply) =
               (apply &toplevel.alloc_region inlining_state(depth(20))
+                      [forward close close close]
                  full_apply (42) -> k2 * error
                  where k2 (param_1 : imm tagged) =
                    cont k1
@@ -37,5 +38,6 @@ cont `self` ($camlCode_id_join_b__const_block_12)
                    let Pfield_1 = %block_load.[`1`] (param) in
                    cont `self` (Pfield_1))))
   where k =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlCode_id_join_b = Block 0 () in
     cont done ($camlCode_id_join_b)

--- a/testsuite/tests/flambda2/examples/cross_function_cse_a.raw.reference
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_a.raw.reference
@@ -4,7 +4,7 @@
          -> k1 * k2
          : [ 0 | 0 of val ] =
    let Pmakeblock = %block.[`0`].my_alloc_region (x) in
-   cont k1 (Pmakeblock)
+   cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code size(21)
        f_1 (x)
@@ -13,12 +13,17 @@
          : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
    let a = %block.[`0`].my_alloc_region (x) in
    (let inlined_dbg = %inlined_apply () in
+    let my_alloc_region_1 =
+      %new_alloc_region.[`normal`[`forward`, transfer], `exn`[`close`,
+        transfer], `notrace`[`close`, transfer], div[`close`, transfer]]
+        (my_alloc_region)
+    in
     let x_1 = x in
-    let Pmakeblock = %block.[`0`].my_alloc_region (x_1) in
-    cont k3 (Pmakeblock))
+    let Pmakeblock = %block.[`0`].my_alloc_region_1 (x_1) in
+    cont k3 close[normal] my_alloc_region_1 (Pmakeblock))
      where k3 (b : [ 0 | 0 of val ]) =
        let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-       cont k1 (Pmakeblock)
+       cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code size(21)
        g_2 (x)
@@ -26,13 +31,18 @@
          -> k1 * k2
          : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
    (let inlined_dbg = %inlined_apply () in
+    let my_alloc_region_1 =
+      %new_alloc_region.[`normal`[`forward`, transfer], `exn`[`close`,
+        transfer], `notrace`[`close`, transfer], div[`close`, transfer]]
+        (my_alloc_region)
+    in
     let x_1 = x in
-    let Pmakeblock = %block.[`0`].my_alloc_region (x_1) in
-    cont k3 (Pmakeblock))
+    let Pmakeblock = %block.[`0`].my_alloc_region_1 (x_1) in
+    cont k3 close[normal] my_alloc_region_1 (Pmakeblock))
      where k3 (a : [ 0 | 0 of val ]) =
        let b = %block.[`0`].my_alloc_region (x) in
        let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-       cont k1 (Pmakeblock)
+       cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let $camlCross_function_cse_a__s0 =
    closure some_0 @some &toplevel.alloc_region
@@ -44,7 +54,7 @@
             $camlCross_function_cse_a__s1,
             $camlCross_function_cse_a__s2)
  in
- cont k ($camlCross_function_cse_a__s3))
+ cont k close[normal] toplevel.alloc_region ($camlCross_function_cse_a__s3))
   where k define_root_symbol (module_block) =
     let field_0 = $camlCross_function_cse_a__s0 in
     let field_1 = $camlCross_function_cse_a__s1 in

--- a/testsuite/tests/flambda2/examples/cross_function_cse_b.raw.reference
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_b.raw.reference
@@ -6,7 +6,7 @@ let $camlCross_function_cse_b__first_const_0 = Block 0 () in
          : [ 0 | 0 of val ] =
    let next_depth = rec_info (succ my_depth) in
    let Pmakeblock = %block.[`0`].my_alloc_region (x) in
-   cont k1 (Pmakeblock)
+   cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code size(19)
        f_1 (x)
@@ -16,11 +16,11 @@ let $camlCross_function_cse_b__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let some = %project_value_slot.[f].[some] (my_closure) in
    let a = %block.[`0`].my_alloc_region (x) in
-   apply direct(some_0 &my_alloc_region)
+   apply direct(some_0 &my_alloc_region) [forward close close close]
      (some : _ -> [ 0 | 0 of val ]) (x) -> k3 * k2
      where k3 (b : [ 0 | 0 of val ]) =
        let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-       cont k1 (Pmakeblock)
+       cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code size(19)
        g_2 (x)
@@ -29,12 +29,12 @@ let $camlCross_function_cse_b__first_const_0 = Block 0 () in
          : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
    let next_depth = rec_info (succ my_depth) in
    let some = %project_value_slot.[g].[some_1] (my_closure) in
-   apply direct(some_0 &my_alloc_region)
+   apply direct(some_0 &my_alloc_region) [forward close close close]
      (some : _ -> [ 0 | 0 of val ]) (x) -> k3 * k2
      where k3 (a : [ 0 | 0 of val ]) =
        let b = %block.[`0`].my_alloc_region (x) in
        let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-       cont k1 (Pmakeblock)
+       cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code size(7)
        f_classic_3 (x)
@@ -45,7 +45,8 @@ let $camlCross_function_cse_b__first_const_0 = Block 0 () in
    let Pfield =
      %block_load.[`1`] ($Cross_function_cse_a.camlCross_function_cse_a)
    in
-   apply &my_alloc_region inlined(always) Pfield (x) -> k1 * k2
+   apply &my_alloc_region inlined(always) [close close close close]
+     Pfield (x) -> k1 * k2
  in
  let code size(7)
        g_classic_4 (x)
@@ -56,7 +57,8 @@ let $camlCross_function_cse_b__first_const_0 = Block 0 () in
    let Pfield =
      %block_load.[`2`] ($Cross_function_cse_a.camlCross_function_cse_a)
    in
-   apply &my_alloc_region inlined(always) Pfield (x) -> k1 * k2
+   apply &my_alloc_region inlined(always) [close close close close]
+     Pfield (x) -> k1 * k2
  in
  let some = closure some_0 @some &toplevel.alloc_region in
  let f = closure f_1 @f &toplevel.alloc_region with { some = some } in
@@ -65,7 +67,7 @@ let $camlCross_function_cse_b__first_const_0 = Block 0 () in
  let g_classic = closure g_classic_4 @g_classic &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (some, f, g, f_classic, g_classic)
  in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`5`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`5`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/cross_function_cse_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/cross_function_cse_b.simplify.reference
@@ -9,7 +9,7 @@ let code inline(always) loopify(never) size(7) newer_version_of(some_0)
         -> k * k1
         : [ 0 | 0 of val ] =
   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlCross_function_cse_b__some_1 =
   closure some_0_1 @some &toplevel.alloc_region
@@ -21,7 +21,7 @@ let code loopify(never) size(14) newer_version_of(f_1)
         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
   let a = %block.[`0`].my_alloc_region (x) in
   let Pmakeblock = %block.[`0`].my_alloc_region (a, a) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlCross_function_cse_b__f_2 = closure f_1_1 @f &toplevel.alloc_region
 in
@@ -32,7 +32,7 @@ let code loopify(never) size(14) newer_version_of(g_2)
         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
   let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, Pmakeblock) in
-  cont k (Pmakeblock_1)
+  cont k close[normal] my_alloc_region (Pmakeblock_1)
 in
 let $camlCross_function_cse_b__g_3 = closure g_2_1 @g &toplevel.alloc_region
 in
@@ -43,7 +43,7 @@ let code loopify(never) size(14) newer_version_of(f_classic_3)
         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
   let a = %block.[`0`].my_alloc_region (x) in
   let Pmakeblock = %block.[`0`].my_alloc_region (a, a) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlCross_function_cse_b__f_classic_4 =
   closure f_classic_3_1 @f_classic &toplevel.alloc_region
@@ -55,11 +55,12 @@ let code loopify(never) size(14) newer_version_of(g_classic_4)
         : [ 0 of [ 0 | 0 of val ] * [ 0 | 0 of val ] ] =
   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
   let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, Pmakeblock) in
-  cont k (Pmakeblock_1)
+  cont k close[normal] my_alloc_region (Pmakeblock_1)
 in
 let $camlCross_function_cse_b__g_classic_5 =
   closure g_classic_4_1 @g_classic &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCross_function_cse_b =
   Block 0 ($camlCross_function_cse_b__some_1,
            $camlCross_function_cse_b__f_2,

--- a/testsuite/tests/flambda2/examples/cse_minus.simplify.reference
+++ b/testsuite/tests/flambda2/examples/cse_minus.simplify.reference
@@ -26,16 +26,24 @@ let code loopify(never) size(43) newer_version_of(f_0)
        let Parrayrefs = %array_load.mut (table_1, int_sub_2) in
        let prim = %phys_eq (Parrayrefs, 0) in
        switch prim
-         | 0 -> k1 pop(regular k1) ($camlCse_minus__Pmakeblock_4)
+         | 0 ->
+           k1
+             pop(regular k1)
+             close[exn] my_alloc_region
+             ($camlCse_minus__Pmakeblock_4)
          | 1 -> k2 (int_sub_2)
      where k3 =
-       cont k1 pop(regular k1) ($camlCse_minus__block_1))
+       cont k1
+              pop(regular k1)
+              close[exn] my_alloc_region
+              ($camlCse_minus__block_1))
     where k2 (int_sub) =
       let cse_param = int_sub in
       let Pmakeblock = %block.[`0`].my_alloc_region (t) in
       let Parraysets = %array_set (table_1, cse_param, Pmakeblock) in
-      cont k (0)
+      cont k close[normal] my_alloc_region (0)
 in
 let $camlCse_minus__f_5 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCse_minus = Block 0 ($camlCse_minus__f_5) in
 cont done ($camlCse_minus)

--- a/testsuite/tests/flambda2/examples/cse_needing_canonicalisation.simplify.reference
+++ b/testsuite/tests/flambda2/examples/cse_needing_canonicalisation.simplify.reference
@@ -6,11 +6,12 @@ let code loopify(never) size(10) newer_version_of(f_0)
         : [ 0 of imm tagged * imm tagged ] =
   let a = %int_barith.add (x, y) in
   let Pmakeblock = %block.[`0`].my_alloc_region (a, a) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlCse_needing_canonicalisation__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCse_needing_canonicalisation =
   Block 0 ($camlCse_needing_canonicalisation__f_1)
 in

--- a/testsuite/tests/flambda2/examples/data_flow_rec_exn.simplify.reference
+++ b/testsuite/tests/flambda2/examples/data_flow_rec_exn.simplify.reference
@@ -11,7 +11,10 @@ let $camlData_flow_rec_exn__const_block_3 = Block 0 (12) in
 let code stuff_1 deleted in
 let code loopify(never) size(3) newer_version_of(do_stuff_0)
       do_stuff_0_1 (env) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlData_flow_rec_exn__Pmakeblock_2)
+  cont k1
+         pop(regular k1)
+         close[exn] my_alloc_region
+         ($camlData_flow_rec_exn__Pmakeblock_2)
 in
 let $camlData_flow_rec_exn__do_stuff_4 =
   closure do_stuff_0_1 @do_stuff &toplevel.alloc_region
@@ -54,11 +57,12 @@ let code loopify(never) size(35) newer_version_of(stuff_1)
     where k2 =
       let `unit` = %end_region (`region`) in
       let unit_1 = %end_ghost_region (ghost_region) in
-      cont k (0)
+      cont k close[normal] my_alloc_region (0)
 in
 let $camlData_flow_rec_exn__stuff_5 =
   closure stuff_1_1 @stuff &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlData_flow_rec_exn =
   Block 0 ($camlData_flow_rec_exn__do_stuff_4,
            $camlData_flow_rec_exn__stuff_5)

--- a/testsuite/tests/flambda2/examples/deep_try_with.simplify.reference
+++ b/testsuite/tests/flambda2/examples/deep_try_with.simplify.reference
@@ -1,13 +1,13 @@
 let $camlDeep_try_with__immstring_1 = "Deep_try_with.E2" in
 let $camlDeep_try_with__immstring_0 = "Deep_try_with.E1" in
-apply ccall noalloc
+apply ccall noalloc [forward close close close]
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
     let $camlDeep_try_with__E1_2 =
       Block immutable_unique
       248 ($camlDeep_try_with__immstring_0, Pccall)
     in
-    (apply ccall noalloc
+    (apply ccall noalloc [forward close close close]
        ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
        where k (Pccall_1) =
          let $camlDeep_try_with__E2_3 =
@@ -49,11 +49,18 @@ apply ccall noalloc
                let unit_1 = %end_try_ghost_region (try_ghost_region) in
                let prim = %phys_eq (`exn`, $camlDeep_try_with__E2_3) in
                switch prim
-                 | 0 -> error pop(reraise error) (`exn`)
+                 | 0 ->
+                   error
+                     pop(reraise error)
+                     close[exn] toplevel.alloc_region
+                     (`exn`)
                  | 1 -> k (4, 5))
             where k (x : imm tagged, y : imm tagged) =
               let int_add = %int_barith.add (x, y) in
               let Popaque = %opaque (int_add) in
+              let `unit` =
+                %close_alloc_region.[`normal`] (toplevel.alloc_region)
+              in
               let $camlDeep_try_with =
                 Block 0 ($camlDeep_try_with__E1_2, $camlDeep_try_with__E2_3)
               in

--- a/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/deleted_code_printing.simplify.reference
@@ -12,7 +12,7 @@ and code loopify(never) size(4) newer_version_of(foobar_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(aux_1_1 &my_alloc_region)
+  apply direct(aux_1_1 &my_alloc_region) [close close close close]
     ($camlDeleted_code_printing__aux_2 : _ -> imm tagged) (0) -> k * k1
 and set_of_closures
       $camlDeleted_code_printing__aux_2 =
@@ -36,8 +36,9 @@ and code loopify(done) size(15) newer_version_of(aux_1)
           | 1 -> k2)
          where k2 =
            let Pfield = %block_load.mut.[`0`] (env_2) in
-           cont k (Pfield))
+           cont k close[normal] my_alloc_region (Pfield))
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlDeleted_code_printing =
   Block 0 (env, $camlDeleted_code_printing__foobar_1)
 in

--- a/testsuite/tests/flambda2/examples/direct_app_parameter_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/direct_app_parameter_kind_check_simplify.simplify.reference
@@ -9,12 +9,13 @@ let code loopify(never) size(21) newer_version_of(send_0)
   let prim = %is_int (`*match*`) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       let `*match*_1` = %block_load.[`0`] (`*match*`) in
       let Pfield = %block_load.[`1`] (`*match*_1`) in
       let Pfield_1 = %block_load.[`0`] (`*match*_1`) in
-      apply &my_alloc_region c (Pfield_1, Pfield) -> k * k1
+      apply &my_alloc_region [close close close close]
+        c (Pfield_1, Pfield) -> k * k1
 in
 let $camlDirect_app_parameter_kind_check_simplify__send_1 =
   closure send_0_1 @send &toplevel.alloc_region
@@ -25,7 +26,7 @@ let code loopify(never) size(7) newer_version_of(create_1)
         -> k * k1
         : val =
   let Pmakeblock = %block.mut.[`0`].my_alloc_region (0) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlDirect_app_parameter_kind_check_simplify__create_2 =
   closure create_1_1 @create &toplevel.alloc_region
@@ -37,8 +38,9 @@ in
    | 0 -> k1
    | 1 -> k
    where k1 =
-     invalid "(Direct_application_parameter_kind_mismatch\n (params_arity #(\240\157\149\141? \226\168\175 \240\157\149\141?)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (apply_expr\n  (((Some\n    Direct_app_parameter_kind_check_simplify.camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_3)\227\128\136k28\227\128\137\227\128\138k2\227\128\139(Pfield/94N\n    Pfield/93N)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (return_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154)\n   (call_kind\n    (Function\n     (function_call\n      (Direct camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc toplevel_my_alloc_region/2N)))\n   (dbg\n    direct_app_parameter_kind_check_simplify.ml:26,9--38;direct_app_parameter_kind_check_simplify.ml:21,32--43)\n   (inline Default_inlined)\n   (inlining_state (depth 10, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))")
+     invalid "(Direct_application_parameter_kind_mismatch\n (params_arity #(\240\157\149\141? \226\168\175 \240\157\149\141?)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (apply_expr\n  (((Some\n    Direct_app_parameter_kind_check_simplify.camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_3)\227\128\136k28\227\128\137\227\128\138k2\227\128\139(Pfield/96N\n    Pfield/95N)) (args_arity \240\157\149\141? \226\168\175 \240\157\149\141?) (return_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154)\n   (call_kind\n    (Function\n     (function_call\n      (Direct camlDirect_app_parameter_kind_check_simplify__fn[direct_app_parameter_kind_check_simplify.ml:26,25--38]_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc toplevel_my_alloc_region/2N)))\n   (alloc_checks ((normal Forward) (exn Close) (notrace Close) (div Close)))\n   (dbg\n    direct_app_parameter_kind_check_simplify.ml:26,9--38;direct_app_parameter_kind_check_simplify.ml:21,32--43)\n   (inline Default_inlined)\n   (inlining_state (depth 10, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))")
   where k =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlDirect_app_parameter_kind_check_simplify =
       Block 0 (0,
                $camlDirect_app_parameter_kind_check_simplify__send_1,

--- a/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
+++ b/testsuite/tests/flambda2/examples/exn_extra_args.simplify.reference
@@ -6,7 +6,7 @@ let code inline(never) loopify(never) size(1) newer_version_of(input_line_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  cont k ($camlExn_extra_args__immstring_0)
+  cont k close[normal] my_alloc_region ($camlExn_extra_args__immstring_0)
 in
 let $camlExn_extra_args__input_line_1 =
   closure input_line_0_1 @input_line &toplevel.alloc_region
@@ -55,15 +55,16 @@ let code loopify(never) size(49) newer_version_of(ld_conf_contents_1)
       let Pfield = %block_load.[`0`] (exn_1) in
       let prim = %phys_eq (Pfield, $`*predef*`.caml_exn_Sys_error) in
       switch prim
-        | 0 -> k1 pop(reraise k1) (exn_1)
+        | 0 -> k1 pop(reraise k1) close[exn] my_alloc_region (exn_1)
         | 1 -> k2 (path_unboxed0)
     where k2 (path_unboxed0) =
       let path_unboxed0_1 = path_unboxed0 in
-      cont k (path_unboxed0_1)
+      cont k close[normal] my_alloc_region (path_unboxed0_1)
 in
 let $camlExn_extra_args__ld_conf_contents_2 =
   closure ld_conf_contents_1_1 @ld_conf_contents &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlExn_extra_args =
   Block 0 ($camlExn_extra_args__input_line_1,
            $camlExn_extra_args__ld_conf_contents_2)

--- a/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
+++ b/testsuite/tests/flambda2/examples/extra_args_and_staticraise.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(31) newer_version_of(f_0)
         : imm tagged =
   let prim = %int_comp.le (0, x) in
   switch prim
-    | 0 -> k (init)
+    | 0 -> k close[normal] my_alloc_region (init)
     | 1 -> k2
     where k2 =
       let prim_1 = %untag_imm (x) in
@@ -22,12 +22,13 @@ let code loopify(never) size(31) newer_version_of(f_0)
            let prim_3 = %int_comp.`int64`.le (for_next_naked, for_stop_naked)
            in
            switch prim_3
-             | 0 -> k (int_add)
+             | 0 -> k close[normal] my_alloc_region (int_add)
              | 1 -> k2 (for_next_naked, int_add))
 in
 let $camlExtra_args_and_staticraise__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlExtra_args_and_staticraise =
   Block 0 ($camlExtra_args_and_staticraise__f_1)
 in

--- a/testsuite/tests/flambda2/examples/float32_literal_conv.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float32_literal_conv.simplify.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(1) newer_version_of(a_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float32 boxed =
-  cont k ($camlFloat32_literal_conv__float32_0)
+  cont k close[normal] my_alloc_region ($camlFloat32_literal_conv__float32_0)
 in
 let $camlFloat32_literal_conv__a_2 = closure a_0_1 @a &toplevel.alloc_region
 in
@@ -16,10 +16,11 @@ let code loopify(never) size(1) newer_version_of(b_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float32 boxed =
-  cont k ($camlFloat32_literal_conv__float32_1)
+  cont k close[normal] my_alloc_region ($camlFloat32_literal_conv__float32_1)
 in
 let $camlFloat32_literal_conv__b_3 = closure b_1_1 @b &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat32_literal_conv =
   Block 0 ($camlFloat32_literal_conv__a_2, $camlFloat32_literal_conv__b_3)
 in

--- a/testsuite/tests/flambda2/examples/float_and_int_mix.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_and_int_mix.simplify.reference
@@ -5,7 +5,7 @@ let code inline(never) loopify(never) size(1) newer_version_of(read_int_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (42)
+  cont k close[normal] my_alloc_region (42)
 in
 let $camlFloat_and_int_mix__read_int_1 =
   closure read_int_0_1 @read_int &toplevel.alloc_region
@@ -21,6 +21,7 @@ in
 let $camlFloat_and_int_mix__gasp_in_horror_2 =
   closure gasp_in_horror_1_1 @gasp_in_horror &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat_and_int_mix =
   Block 0 ($camlFloat_and_int_mix__read_int_1,
            $camlFloat_and_int_mix__gasp_in_horror_2)

--- a/testsuite/tests/flambda2/examples/float_fn.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_fn.simplify.reference
@@ -8,7 +8,7 @@ let code inline(never) loopify(never) size(9) newer_version_of(g_0)
   let prim = %unbox_num.`float` (x) in
   let prim_1 = %bfloat_arith.add (prim, 0x1.5p+5) in
   let float_add = %box_num.`float`.my_alloc_region (prim_1) in
-  cont k (float_add)
+  cont k close[normal] my_alloc_region (float_add)
 in
 let $camlFloat_fn__g_2 = closure g_0_1 @g &toplevel.alloc_region in
 let code loopify(never) size(13) newer_version_of(f_1)
@@ -16,14 +16,15 @@ let code loopify(never) size(13) newer_version_of(f_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  apply direct(g_0_1 &my_alloc_region)
+  apply direct(g_0_1 &my_alloc_region) [forward close close close]
     ($camlFloat_fn__g_2 : _ -> float boxed) (x) -> k2 * k1
     where k2 (y : float boxed) =
       let prim = %unbox_num.`float` (y) in
       let prim_1 = %bfloat_arith.add (prim, 0x0p+0) in
       let float_add = %box_num.`float`.my_alloc_region (prim_1) in
-      cont k (float_add)
+      cont k close[normal] my_alloc_region (float_add)
 in
 let $camlFloat_fn__f_3 = closure f_1_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat_fn = Block 0 ($camlFloat_fn__g_2, $camlFloat_fn__f_3) in
 cont done ($camlFloat_fn)

--- a/testsuite/tests/flambda2/examples/float_fn_tuple.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_fn_tuple.simplify.reference
@@ -11,7 +11,7 @@ let code inline(never) loopify(never) size(23) newer_version_of(g_0)
   let prim_2 = %bfloat_arith.add (prim, 0x1.5p+5) in
   let float_add_1 = %box_num.`float`.my_alloc_region (prim_2) in
   let Pmakeblock = %block.[`0`].my_alloc_region (float_add_1, float_add) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlFloat_fn_tuple__g_2 = closure g_0_1 @g &toplevel.alloc_region in
 let code loopify(never) size(16) newer_version_of(f_1)
@@ -19,7 +19,7 @@ let code loopify(never) size(16) newer_version_of(f_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  apply direct(g_0_1 &my_alloc_region)
+  apply direct(g_0_1 &my_alloc_region) [forward close close close]
     ($camlFloat_fn_tuple__g_2 : _ -> [ 0 of float boxed * float boxed ])
       (x)
       -> k2 * k1
@@ -30,9 +30,10 @@ let code loopify(never) size(16) newer_version_of(f_1)
       let prim_1 = %unbox_num.`float` (Pfield_1) in
       let prim_2 = %bfloat_arith.add (prim_1, prim) in
       let float_add = %box_num.`float`.my_alloc_region (prim_2) in
-      cont k (float_add)
+      cont k close[normal] my_alloc_region (float_add)
 in
 let $camlFloat_fn_tuple__f_3 = closure f_1_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat_fn_tuple =
   Block 0 ($camlFloat_fn_tuple__g_2, $camlFloat_fn_tuple__f_3)
 in

--- a/testsuite/tests/flambda2/examples/float_tuple.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_tuple.simplify.reference
@@ -20,8 +20,9 @@ let code loopify(never) size(29) newer_version_of(f_0)
     where k2 (unboxed_float : float, unboxed_float_1 : float) =
       let prim = %bfloat_arith.add (unboxed_float_1, unboxed_float) in
       let float_add = %box_num.`float`.my_alloc_region (prim) in
-      cont k (float_add)
+      cont k close[normal] my_alloc_region (float_add)
 in
 let $camlFloat_tuple__f_3 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat_tuple = Block 0 ($camlFloat_tuple__f_3) in
 cont done ($camlFloat_tuple)

--- a/testsuite/tests/flambda2/examples/float_unboxed.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxed.simplify.reference
@@ -19,8 +19,9 @@ let code loopify(never) size(27) newer_version_of(f_0)
     where k2 (unboxed_float : float) =
       let prim = %bfloat_arith.add (unboxed_float, 0x0p+0) in
       let float_add = %box_num.`float`.my_alloc_region (prim) in
-      cont k (float_add)
+      cont k close[normal] my_alloc_region (float_add)
 in
 let $camlFloat_unboxed__f_3 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat_unboxed = Block 0 ($camlFloat_unboxed__f_3) in
 cont done ($camlFloat_unboxed)

--- a/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxing.simplify.reference
@@ -31,9 +31,10 @@ let code loopify(never) size(44) newer_version_of(f_0)
              | 1 -> k3 (for_next_naked, prim_2))
     where k2 (float_add) =
       let r_unboxed0 = float_add in
-      cont k (r_unboxed0)
+      cont k close[normal] my_alloc_region (r_unboxed0)
 in
 let $camlFloat_unboxing__f_2 = closure f_0_1 @f &toplevel.alloc_region in
 let $camlFloat_unboxing__Pmakeblock_3 = Block 0 ($camlFloat_unboxing__f_2) in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat_unboxing = Block 0 ($camlFloat_unboxing__Pmakeblock_3) in
 cont done ($camlFloat_unboxing)

--- a/testsuite/tests/flambda2/examples/float_unboxing_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/float_unboxing_rec.simplify.reference
@@ -31,8 +31,9 @@ let code loopify(never) size(41) newer_version_of(f_0)
     where k2 (unboxed_float : float) =
       let prim = %bfloat_arith.add (unboxed_float, 0x0p+0) in
       let float_add = %box_num.`float`.my_alloc_region (prim) in
-      cont k (float_add)
+      cont k close[normal] my_alloc_region (float_add)
 in
 let $camlFloat_unboxing_rec__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFloat_unboxing_rec = Block 0 ($camlFloat_unboxing_rec__f_1) in
 cont done ($camlFloat_unboxing_rec)

--- a/testsuite/tests/flambda2/examples/from_core_char_test.simplify.reference
+++ b/testsuite/tests/flambda2/examples/from_core_char_test.simplify.reference
@@ -34,7 +34,11 @@ let code inline(always) loopify(never) size(40) newer_version_of(char_of_string_
   let prim_1 = %int_comp.ne (`*match*`, 1) in
   switch prim_1
     | 0 -> k2
-    | 1 -> k1 pop(regular k1) ($camlFrom_core_char_test__Pmakeblock_4)
+    | 1 ->
+      k1
+        pop(regular k1)
+        close[exn] my_alloc_region
+        ($camlFrom_core_char_test__Pmakeblock_4)
     where k2 =
       ((let prim_2 = %num_conv.[`imm`].[`nativeint`] (prim) in
         let prim_3 = %int_comp.`nativeint`.unsigned.lt (0n, prim_2) in
@@ -44,9 +48,12 @@ let code inline(always) loopify(never) size(40) newer_version_of(char_of_string_
          where k3 =
            let prim_2 = %string_load.[`8`] (s, 0n) in
            let Pstringrefs = %tag_imm (prim_2) in
-           cont k (Pstringrefs)
+           cont k close[normal] my_alloc_region (Pstringrefs)
          where k2 =
-           cont k1 pop(regular k1) ($camlFrom_core_char_test__block_1))
+           cont k1
+                  pop(regular k1)
+                  close[exn] my_alloc_region
+                  ($camlFrom_core_char_test__block_1))
 in
 let $camlFrom_core_char_test__char_of_string_9 =
   closure char_of_string_0_1 @char_of_string &toplevel.alloc_region
@@ -58,7 +65,7 @@ let code inline(always) loopify(never) size(5) newer_version_of(result_is_error_
         : imm tagged =
   let prim = %get_tag (r) in
   let tagged_scrutinee = %tag_imm (prim) in
-  cont k (tagged_scrutinee)
+  cont k close[normal] my_alloc_region (tagged_scrutinee)
 in
 let $camlFrom_core_char_test__result_is_error_10 =
   closure result_is_error_1_1 @result_is_error &toplevel.alloc_region
@@ -75,12 +82,12 @@ let code inline(always) loopify(never) size(29) newer_version_of(result_try_with
       (apply &my_alloc_region f (0) -> k3 * k2
          where k3 (apply_result : val) =
            let Pmakeblock = %block.[`0`].my_alloc_region (apply_result) in
-           cont k pop(k2) (Pmakeblock))
+           cont k pop(k2) close[normal] my_alloc_region (Pmakeblock))
     where k2 exn (`exn` : val) =
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       let Pmakeblock = %block.[`1`].my_alloc_region (`exn`) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlFrom_core_char_test__result_try_with_11 =
   closure result_try_with_2_1 @result_try_with &toplevel.alloc_region
@@ -95,14 +102,14 @@ let code inline(always) loopify(never) size(20) newer_version_of(test_3)
   let Pstringrefs = %tag_imm (prim) in
   let prim_1 = %phys_eq (Pstringrefs, 99) in
   switch prim_1
-    | 0 -> k (0)
+    | 0 -> k close[normal] my_alloc_region (0)
     | 1 -> k2
     where k2 =
       let try_region = %begin_try_region () in
       let try_ghost_region = %begin_try_ghost_region () in
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
-      cont k (1)
+      cont k close[normal] my_alloc_region (1)
 in
 let $camlFrom_core_char_test__test_12 =
   closure test_3_1 @test &toplevel.alloc_region
@@ -127,12 +134,17 @@ let code loopify(never) size(30) newer_version_of(top_5)
        cont k2 (1i))
     where k2 (naked_immediate : imm) =
       switch naked_immediate
-        | 0 -> k1 pop(regular k1) ($camlFrom_core_char_test__Pmakeblock_8)
-        | 1 -> k (0)
+        | 0 ->
+          k1
+            pop(regular k1)
+            close[exn] my_alloc_region
+            ($camlFrom_core_char_test__Pmakeblock_8)
+        | 1 -> k close[normal] my_alloc_region (0)
 in
 let $camlFrom_core_char_test__top_15 =
   closure top_5_1 @top &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFrom_core_char_test =
   Block 0 ($camlFrom_core_char_test__char_of_string_9,
            $camlFrom_core_char_test__result_is_error_10,

--- a/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
+++ b/testsuite/tests/flambda2/examples/from_odoc_texi.simplify.reference
@@ -8,7 +8,7 @@ let code loopify(never) size(2) newer_version_of(`!_0`)
         -> k * k1
         : val =
   let Pfield = %block_load.mut.[`0`] (param) in
-  cont k (Pfield)
+  cont k close[normal] my_alloc_region (Pfield)
 in
 let $`camlFrom_odoc_texi__!_2` = closure `!_0_1` @`!` &toplevel.alloc_region
 in
@@ -16,7 +16,7 @@ let esc_8bits = %block.mut.[`0`].`toplevel` (0) in
 let code inline(never) loopify(never) size(1) newer_version_of(foo_1)
       foo_1_1 (x : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
   let Popaque = %opaque (x) in
-  cont k (Popaque)
+  cont k close[normal] my_alloc_region (Popaque)
 in
 let $camlFrom_odoc_texi__foo_3 = closure foo_1_1 @foo &toplevel.alloc_region
 in
@@ -27,6 +27,7 @@ in
     | 1 -> k1)
    where k1 =
      (apply direct(foo_1_1 &toplevel.alloc_region)
+             [forward close close close]
         ($camlFrom_odoc_texi__foo_3 : _ -> val)
           ($camlFrom_odoc_texi__immstring_0)
           -> k1 * error
@@ -38,6 +39,7 @@ in
           let Pmakeblock_1 = %block.[`0`].`toplevel` (Pmakeblock, 0) in
           cont k (Pmakeblock_1)))
   where k (y : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlFrom_odoc_texi =
       Block 0 ($`camlFrom_odoc_texi__!_2`,
                esc_8bits,

--- a/testsuite/tests/flambda2/examples/function_never_returns.simplify.reference
+++ b/testsuite/tests/flambda2/examples/function_never_returns.simplify.reference
@@ -6,7 +6,10 @@ let code inline(never) loopify(never) size(3) newer_version_of(f_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1474_42)
+  cont k1
+         pop(reraise k1)
+         close[exn] my_alloc_region
+         ($Stdlib.camlStdlib__Exit1474_42)
 in
 let $camlFunction_never_returns__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
@@ -16,7 +19,7 @@ let code loopify(never) size(4) newer_version_of(foo_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(f_0_1 &my_alloc_region)
+  apply direct(f_0_1 &my_alloc_region) [forward close close close]
     ($camlFunction_never_returns__f_1 : _ -> imm tagged) (0) -> never * k1
 in
 let $camlFunction_never_returns__foo_2 =
@@ -28,11 +31,13 @@ let code loopify(never) size(4) newer_version_of(bar_2)
         -> k * k1
         : imm tagged =
   apply direct(f_0_1 &my_alloc_region) inlining_state(depth(1))
+         [forward close close close]
     ($camlFunction_never_returns__f_1 : _ -> imm tagged) (0) -> never * k1
 in
 let $camlFunction_never_returns__bar_3 =
   closure bar_2_1 @bar &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFunction_never_returns =
   Block 0 ($camlFunction_never_returns__f_1,
            $camlFunction_never_returns__foo_2,

--- a/testsuite/tests/flambda2/examples/functor_call.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functor_call.simplify.reference
@@ -6,7 +6,7 @@ let code inline(always) loopify(never) size(5) newer_version_of(test_2)
         : imm tagged =
   let prim = %int_comp.gt (x, 0) in
   let int_greaterthan = %tag_imm (prim) in
-  cont k (int_greaterthan)
+  cont k close[normal] my_alloc_region (int_greaterthan)
 in
 let $camlFunctor_call__test_4 = closure test_2_1 @test &toplevel.alloc_region
 in
@@ -21,7 +21,7 @@ let code loopify(done) size(16) newer_version_of(foo_1_1)
       let prim = %int_comp.gt (x_1, 0) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (x_1)
+         | 1 -> k close[normal] my_alloc_region (x_1)
          where k2 =
            let int_add = %int_barith.add (x_1, 1) in
            cont `self` (int_add))
@@ -30,6 +30,7 @@ let $camlFunctor_call__foo_6 =
   closure foo_1 @foo &toplevel.alloc_region
   with { X = $camlFunctor_call__Pmakeblock_5 }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFunctor_call =
   Block 0 ($camlFunctor_call__Pmakeblock_5, $camlFunctor_call__foo_6)
 in

--- a/testsuite/tests/flambda2/examples/functors.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functors.simplify.reference
@@ -11,12 +11,13 @@ let $camlFunctors__const_block_3 = Block 0 ($camlFunctors__const_block_2) in
 let $camlFunctors__const_block_1 =
   Block 0 ($camlFunctors__immstring_0, 13, 6)
 in
-apply direct(init_mod_4 &toplevel.alloc_region)
+apply direct(init_mod_4 &toplevel.alloc_region) [forward close close close]
   ($CamlinternalMod.camlCamlinternalMod__init_mod_4_11 : _ -> val)
     ($camlFunctors__const_block_1, $camlFunctors__const_block_3)
     -> k * error
   where k (M0 : val) =
     (apply direct(init_mod_4 &toplevel.alloc_region)
+            [forward close close close]
        ($CamlinternalMod.camlCamlinternalMod__init_mod_4_11 : _ -> val)
          ($camlFunctors__const_block_4, $camlFunctors__const_block_3)
          -> k * error
@@ -30,16 +31,17 @@ apply direct(init_mod_4 &toplevel.alloc_region)
            let prim = %is_int (t) in
            switch prim
              | 0 -> k2
-             | 1 -> k (0)
+             | 1 -> k close[normal] my_alloc_region (0)
              where k2 =
                ((let Pfield = %block_load.[`0`] (t) in
                  let Pfield_1 = %block_load.[`0`] (X) in
-                 apply &my_alloc_region Pfield_1 (Pfield) -> k2 * k1)
+                 apply &my_alloc_region [forward close close close]
+                   Pfield_1 (Pfield) -> k2 * k1)
                   where k2 (apply_result : val) =
                     let Pmakeblock =
                       %block.[`0`].my_alloc_region (apply_result)
                     in
-                    cont k (Pmakeblock))
+                    cont k close[normal] my_alloc_region (Pmakeblock))
          in
          let code loopify(never) size(7) newer_version_of(na_1)
                na_1_1 (x : val)
@@ -47,7 +49,7 @@ apply direct(init_mod_4 &toplevel.alloc_region)
                  -> k * k1
                  : [ 0 | 0 of val ] =
            let Pmakeblock = %block.[`0`].my_alloc_region (x) in
-           cont k (Pmakeblock)
+           cont k close[normal] my_alloc_region (Pmakeblock)
          in
          let $camlFunctors__na_6 = closure na_1_1 @na &toplevel.alloc_region
          in
@@ -60,7 +62,7 @@ apply direct(init_mod_4 &toplevel.alloc_region)
            let Pmakeblock =
              %block.[`0`].my_alloc_region (0, $camlFunctors__na_6, foo)
            in
-           cont k (Pmakeblock)
+           cont k close[normal] my_alloc_region (Pmakeblock)
          in
          let $camlFunctors__Make_5 =
            closure Make_0_1 @Make &toplevel.alloc_region
@@ -76,12 +78,14 @@ apply direct(init_mod_4 &toplevel.alloc_region)
              let M_1 = %project_value_slot.[foo_1].[M] ($camlFunctors__foo_8)
              in
              let Pfield = %block_load.[`0`] (M_1) in
-             apply &my_alloc_region Pfield (42, t) -> k1 * k2
+             apply &my_alloc_region [close close close close]
+               Pfield (42, t) -> k1 * k2
              with { M = M }
            in
            let $camlFunctors__Pmakeblock_9 = Block 0 ($camlFunctors__foo_8)
            in
            apply direct(update_mod_7 &toplevel.alloc_region)
+                  [forward close close close]
              ($CamlinternalMod.camlCamlinternalMod__update_mod_7_15
               : _ -> imm tagged)
                ($camlFunctors__const_block_3, M0, $camlFunctors__Pmakeblock_9)
@@ -90,11 +94,13 @@ apply direct(init_mod_4 &toplevel.alloc_region)
                cont k)
             where k =
               (apply direct(Make_0_1 &toplevel.alloc_region)
+                      [forward close close close]
                  ($camlFunctors__Make_5 : _ -> val) (M0) -> k1 * error
                  where k1 (include : val) =
                    let Pfield = %block_load.[`2`] (include) in
                    let $camlFunctors__Pmakeblock_10 = Block 0 (Pfield) in
                    (apply direct(update_mod_7 &toplevel.alloc_region)
+                           [forward close close close]
                       ($CamlinternalMod.camlCamlinternalMod__update_mod_7_15
                        : _ -> imm tagged)
                         ($camlFunctors__const_block_3,
@@ -104,6 +110,9 @@ apply direct(init_mod_4 &toplevel.alloc_region)
                       where k1 (param : imm tagged) =
                         cont k)
                  where k =
+                   let `unit` =
+                     %close_alloc_region.[`normal`] (toplevel.alloc_region)
+                   in
                    let $camlFunctors =
                      Block 0 (M0, M, $camlFunctors__Pmakeblock_7)
                    in

--- a/testsuite/tests/flambda2/examples/functors2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/functors2.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(14) newer_version_of(F1_0)
   let Pfield = %block_load.[`0`] (M) in
   let x = %block.[`0`].my_alloc_region (Pfield) in
   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlFunctors2__F1_1 = closure F1_0_1 @F1 &toplevel.alloc_region in
 let code loopify(never) size(22) newer_version_of(F2_1)
@@ -19,7 +19,7 @@ let code loopify(never) size(22) newer_version_of(F2_1)
   let x = %block.[`0`].my_alloc_region (Pfield_1, Pfield) in
   let Pmakeblock = %block.[`0`].my_alloc_region (x) in
   let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock) in
-  cont k (Pmakeblock_1)
+  cont k close[normal] my_alloc_region (Pmakeblock_1)
 in
 let $camlFunctors2__F2_2 = closure F2_1_1 @F2 &toplevel.alloc_region in
 let code loopify(never) size(13) newer_version_of(F3_2)
@@ -27,14 +27,15 @@ let code loopify(never) size(13) newer_version_of(F3_2)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  apply direct(F2_1_1 &my_alloc_region)
+  apply direct(F2_1_1 &my_alloc_region) [forward close close close]
     ($camlFunctors2__F2_2 : _ -> val) (M1, M2) -> k2 * k1
     where k2 (include : val) =
       let Pfield = %block_load.[`0`] (include) in
       let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, 0) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlFunctors2__F3_3 = closure F3_2_1 @F3 &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFunctors2 =
   Block 0 ($camlFunctors2__F1_1, $camlFunctors2__F2_2, $camlFunctors2__F3_3)
 in

--- a/testsuite/tests/flambda2/examples/id_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/id_switch.simplify.reference
@@ -8,7 +8,7 @@ let code inline(always) loopify(never) size(5) newer_version_of(x_0)
         : imm tagged =
   let prim = %int_comp.ne (xt0, 0) in
   let int_notequal = %tag_imm (prim) in
-  cont k (int_notequal)
+  cont k close[normal] my_alloc_region (int_notequal)
 in
 let $camlId_switch__x_1 = closure x_0_1 @x &toplevel.alloc_region in
 let code loopify(never) size(1) newer_version_of(id_switch_1)
@@ -16,7 +16,7 @@ let code loopify(never) size(1) newer_version_of(id_switch_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (t0)
+  cont k close[normal] my_alloc_region (t0)
 in
 let $camlId_switch__id_switch_2 =
   closure id_switch_1_1 @id_switch &toplevel.alloc_region
@@ -27,11 +27,12 @@ let code loopify(never) size(2) newer_version_of(not_switch_2)
         -> k * k1
         : imm tagged =
   let Pnot = %boolean_not (t2) in
-  cont k (Pnot)
+  cont k close[normal] my_alloc_region (Pnot)
 in
 let $camlId_switch__not_switch_3 =
   closure not_switch_2_1 @not_switch &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlId_switch =
   Block 0 ($camlId_switch__x_1,
            $camlId_switch__id_switch_2,

--- a/testsuite/tests/flambda2/examples/ifs_and_records.simplify.reference
+++ b/testsuite/tests/flambda2/examples/ifs_and_records.simplify.reference
@@ -29,10 +29,10 @@ let code inline(always) loopify(never) size(27) newer_version_of(help_desired_0)
      | 1 -> k3)
     where k3 =
       let Pmakeblock = %block.[`0`].my_alloc_region (b, a) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
     where k2 =
       let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIfs_and_records__help_desired_1 =
   closure help_desired_0_1 @help_desired &toplevel.alloc_region
@@ -49,7 +49,7 @@ let code inline(always) loopify(never) size(19) newer_version_of(help_wrap_1)
      | 1 -> k2 (b, a))
     where k2 (a_1 : imm tagged, b_1 : imm tagged) =
       let Pmakeblock = %block.[`0`].my_alloc_region (a_1, b_1) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIfs_and_records__help_wrap_2 =
   closure help_wrap_1_1 @help_wrap &toplevel.alloc_region
@@ -66,10 +66,10 @@ let code inline(always) loopify(never) size(27) newer_version_of(help_variant_2)
      | 1 -> k3)
     where k3 =
       let Pmakeblock = %block.[`0`].my_alloc_region (b, a) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
     where k2 =
       let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIfs_and_records__help_variant_3 =
   closure help_variant_2_1 @help_variant &toplevel.alloc_region
@@ -86,7 +86,7 @@ let code inline(always) loopify(never) size(19) newer_version_of(help_wrap_varia
      | 1 -> k2 (b, a))
     where k2 (a_1 : imm tagged, b_1 : imm tagged) =
       let Pmakeblock = %block.[`0`].my_alloc_region (a_1, b_1) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIfs_and_records__help_wrap_variant_4 =
   closure help_wrap_variant_3_1 @help_wrap_variant &toplevel.alloc_region
@@ -102,10 +102,10 @@ let code inline(always) loopify(never) size(27) newer_version_of(help_tuple_4)
      | 1 -> k3)
     where k3 =
       let Pmakeblock = %block.[`0`].my_alloc_region (b, a) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
     where k2 =
       let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIfs_and_records__help_tuple_5 =
   closure help_tuple_4_1 @help_tuple &toplevel.alloc_region
@@ -129,7 +129,7 @@ let code inline(always) loopify(never) size(30) newer_version_of(help_interior_i
            let Pmakeblock =
              %block.[`0`].my_alloc_region (switch_result_1, switch_result)
            in
-           cont k (Pmakeblock))
+           cont k close[normal] my_alloc_region (Pmakeblock))
 in
 let $camlIfs_and_records__help_interior_if_6 =
   closure help_interior_if_5_1 @help_interior_if &toplevel.alloc_region
@@ -140,7 +140,7 @@ let code inline(always) loopify(never) size(8) newer_version_of(help_no_if_6)
         -> k * k1
         : [ 0 of imm tagged * imm tagged ] =
   let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIfs_and_records__help_no_if_7 =
   closure help_no_if_6_1 @help_no_if &toplevel.alloc_region
@@ -151,7 +151,7 @@ let code inline(always) loopify(never) size(8) newer_version_of(help_no_if_tuple
         -> k * k1
         : [ 0 of val * val ] =
   let Pmakeblock = %block.[`0`].my_alloc_region (a, b) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIfs_and_records__help_no_if_tuple_8 =
   closure help_no_if_tuple_7_1 @help_no_if_tuple &toplevel.alloc_region
@@ -168,7 +168,7 @@ let code loopify(never) size(14) newer_version_of(main_desired_8)
      | 1 -> k2 (a, b))
     where k2 (unboxed_field_1, unboxed_field_0) =
       let int_sub = %int_barith.sub (unboxed_field_0, unboxed_field_1) in
-      cont k (int_sub)
+      cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_desired_9 =
   closure main_desired_8_1 @main_desired &toplevel.alloc_region
@@ -185,7 +185,7 @@ let code loopify(never) size(14) newer_version_of(main_wrap_9)
      | 1 -> k2 (b, a))
     where k2 (a_1 : imm tagged, b_1 : imm tagged) =
       let int_sub = %int_barith.sub (a_1, b_1) in
-      cont k (int_sub)
+      cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_wrap_10 =
   closure main_wrap_9_1 @main_wrap &toplevel.alloc_region
@@ -202,7 +202,7 @@ let code loopify(never) size(14) newer_version_of(main_variant_10)
      | 1 -> k2 (a, b))
     where k2 (unboxed_field_1, unboxed_field_0) =
       let int_sub = %int_barith.sub (unboxed_field_0, unboxed_field_1) in
-      cont k (int_sub)
+      cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_variant_11 =
   closure main_variant_10_1 @main_variant &toplevel.alloc_region
@@ -219,7 +219,7 @@ let code loopify(never) size(14) newer_version_of(main_wrap_variant_11)
      | 1 -> k2 (b, a))
     where k2 (a_1 : imm tagged, b_1 : imm tagged) =
       let int_sub = %int_barith.sub (a_1, b_1) in
-      cont k (int_sub)
+      cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_wrap_variant_12 =
   closure main_wrap_variant_11_1 @main_wrap_variant &toplevel.alloc_region
@@ -236,7 +236,7 @@ let code loopify(never) size(14) newer_version_of(main_tuple_12)
      | 1 -> k2 (a, b))
     where k2 (unboxed_field_1, unboxed_field_0) =
       let int_sub = %int_barith.sub (unboxed_field_0, unboxed_field_1) in
-      cont k (int_sub)
+      cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_tuple_13 =
   closure main_tuple_12_1 @main_tuple &toplevel.alloc_region
@@ -258,7 +258,7 @@ let code loopify(never) size(25) newer_version_of(main_interior_if_13)
           | 1 -> k2 (b))
          where k2 (switch_result_1 : imm tagged) =
            let int_sub = %int_barith.sub (switch_result_1, switch_result) in
-           cont k (int_sub))
+           cont k close[normal] my_alloc_region (int_sub))
 in
 let $camlIfs_and_records__main_interior_if_14 =
   closure main_interior_if_13_1 @main_interior_if &toplevel.alloc_region
@@ -269,7 +269,7 @@ let code loopify(never) size(3) newer_version_of(main_no_if_14)
         -> k * k1
         : imm tagged =
   let int_sub = %int_barith.sub (a, b) in
-  cont k (int_sub)
+  cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_no_if_15 =
   closure main_no_if_14_1 @main_no_if &toplevel.alloc_region
@@ -280,7 +280,7 @@ let code loopify(never) size(3) newer_version_of(main_no_if_tuple_15)
         -> k * k1
         : imm tagged =
   let int_sub = %int_barith.sub (a, b) in
-  cont k (int_sub)
+  cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_no_if_tuple_16 =
   closure main_no_if_tuple_15_1 @main_no_if_tuple &toplevel.alloc_region
@@ -297,7 +297,7 @@ let code loopify(never) size(14) newer_version_of(main_hand_inline_16)
      | 1 -> k2 (a, b))
     where k2 (unboxed_field_1, unboxed_field_0) =
       let int_sub = %int_barith.sub (unboxed_field_0, unboxed_field_1) in
-      cont k (int_sub)
+      cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_hand_inline_17 =
   closure main_hand_inline_16_1 @main_hand_inline &toplevel.alloc_region
@@ -314,12 +314,13 @@ let code loopify(never) size(14) newer_version_of(main_hand_inline_tuple_17)
      | 1 -> k2 (b, a))
     where k2 (a_1 : imm tagged, b_1 : imm tagged) =
       let int_sub = %int_barith.sub (a_1, b_1) in
-      cont k (int_sub)
+      cont k close[normal] my_alloc_region (int_sub)
 in
 let $camlIfs_and_records__main_hand_inline_tuple_18 =
   closure main_hand_inline_tuple_17_1 @main_hand_inline_tuple
     &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlIfs_and_records =
   Block 0 ($camlIfs_and_records__empty_block_0,
            $camlIfs_and_records__empty_block_0,

--- a/testsuite/tests/flambda2/examples/inlined_rec.raw.reference
+++ b/testsuite/tests/flambda2/examples/inlined_rec.raw.reference
@@ -2,7 +2,8 @@ let $camlInlined_rec__first_const_0 = Block 0 () in
 (let code inline(always) size(6)
        apply_0 (f : val, i) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   apply &my_alloc_region inlined(hint) f (i) -> k1 * k2
+   apply &my_alloc_region inlined(hint) [close close close close]
+     f (i) -> k1 * k2
  in
  let code rec size(28)
        fact_1 (n : imm tagged)
@@ -15,29 +16,29 @@ let $camlInlined_rec__first_const_0 = Block 0 () in
     let int_notequal = %tag_imm (prim) in
     (let untagged = %untag_imm (int_notequal) in
      switch untagged
-       | 0 -> k1 (1)
+       | 0 -> k1 close[normal] my_alloc_region (1)
        | 1 -> k4)
       where k4 =
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (n, 1) in
-         apply direct(apply_0 &my_alloc_region)
+         apply direct(apply_0 &my_alloc_region) [forward close close close]
            (`apply` : _ -> imm tagged)
              (my_closure ~ depth my_depth -> next_depth, int_sub)
              -> k3 * k2)
           where k3 (apply_result : imm tagged) =
             let int_mul = %int_barith.mul (n, apply_result) in
-            cont k1 (int_mul))
+            cont k1 close[normal] my_alloc_region (int_mul))
  in
  let `apply` = closure apply_0 @`apply` &toplevel.alloc_region in
  let fact = closure fact_1 @fact &toplevel.alloc_region
  with { `apply` = `apply` }
  in
- apply direct(fact_1 &toplevel.alloc_region)
+ apply direct(fact_1 &toplevel.alloc_region) [forward close close close]
    (fact : _ -> imm tagged) (1000000) -> k1 * error
    where k1 (i : imm tagged) =
      let Pmakeblock = %block.[`0`].`toplevel` (`apply`, fact, i) in
-     cont k (Pmakeblock))
+     cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/inlined_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/inlined_rec.simplify.reference
@@ -2,7 +2,8 @@ let code apply_0 deleted in
 let code fact_1 deleted in
 let code inline(always) loopify(never) size(6) newer_version_of(apply_0)
       apply_0_1 (f : val, i) my_closure &my_alloc_region my_depth -> k * k1 =
-  apply &my_alloc_region inlined(hint) f (i) -> k * k1
+  apply &my_alloc_region inlined(hint) [close close close close]
+    f (i) -> k * k1
 in
 let $camlInlined_rec__apply_1 =
   closure apply_0_1 @`apply` &toplevel.alloc_region
@@ -16,7 +17,7 @@ and code rec loopify(never) size(42) newer_version_of(fact_1)
         : imm tagged =
   let prim = %int_comp.ne (n, 0) in
   switch prim
-    | 0 -> k (1)
+    | 0 -> k close[normal] my_alloc_region (1)
     | 1 -> k2
     where k2 =
       ((let int_sub = %int_barith.sub (n, 1) in
@@ -27,7 +28,7 @@ and code rec loopify(never) size(42) newer_version_of(fact_1)
           where k3 =
             ((let int_sub_1 = %int_barith.sub (int_sub, 1) in
               apply direct(fact_1_1 &my_alloc_region)
-                     inlining_state(depth(12))
+                     inlining_state(depth(12)) [forward close close close]
                 $camlInlined_rec__fact_2 ~ depth my_depth -> succ (unroll 1 (succ my_depth))
                   (int_sub_1)
                   -> k3 * k1)
@@ -36,11 +37,12 @@ and code rec loopify(never) size(42) newer_version_of(fact_1)
                  cont k2 (int_mul)))
          where k2 (apply_result : imm tagged) =
            let int_mul = %int_barith.mul (n, apply_result) in
-           cont k (int_mul))
+           cont k close[normal] my_alloc_region (int_mul))
 in
-apply direct(fact_1_1 &toplevel.alloc_region)
+apply direct(fact_1_1 &toplevel.alloc_region) [forward close close close]
   ($camlInlined_rec__fact_2 : _ -> imm tagged) (1000000) -> k * error
   where k (i : imm tagged) =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlInlined_rec =
       Block 0 ($camlInlined_rec__apply_1, $camlInlined_rec__fact_2, i)
     in

--- a/testsuite/tests/flambda2/examples/int_array_modify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/int_array_modify.simplify.reference
@@ -4,12 +4,13 @@ let code loopify(never) size(12) newer_version_of(f_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm array =
-  apply ccall
+  apply ccall [forward close close close]
     ($`*extern*`.caml_array_make : val * val -> val) (42, 0) -> k2 * k1
     where k2 (a) =
       let Parraysetu = %array_set.gc_ign (a, 0, x) in
-      cont k (a)
+      cont k close[normal] my_alloc_region (a)
 in
 let $camlInt_array_modify__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlInt_array_modify = Block 0 ($camlInt_array_modify__f_1) in
 cont done ($camlInt_array_modify)

--- a/testsuite/tests/flambda2/examples/int_to_float32_conv.simplify.reference
+++ b/testsuite/tests/flambda2/examples/int_to_float32_conv.simplify.reference
@@ -6,7 +6,9 @@ let code loopify(never) size(1) newer_version_of(a_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float32 boxed =
-  cont k ($camlInt_to_float32_conv__float32_of_int_2)
+  cont k
+         close[normal] my_alloc_region
+         ($camlInt_to_float32_conv__float32_of_int_2)
 in
 let $camlInt_to_float32_conv__a_1 = closure a_0_1 @a &toplevel.alloc_region
 in
@@ -16,10 +18,13 @@ let code loopify(never) size(1) newer_version_of(b_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float32 boxed =
-  cont k ($camlInt_to_float32_conv__float32_of_int_4)
+  cont k
+         close[normal] my_alloc_region
+         ($camlInt_to_float32_conv__float32_of_int_4)
 in
 let $camlInt_to_float32_conv__b_3 = closure b_1_1 @b &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlInt_to_float32_conv =
   Block 0 ($camlInt_to_float32_conv__a_1, $camlInt_to_float32_conv__b_3)
 in

--- a/testsuite/tests/flambda2/examples/invalid.compilers.reference
+++ b/testsuite/tests/flambda2/examples/invalid.compilers.reference
@@ -13,9 +13,9 @@
 (data
  int 21500
  "camlInvalid__invalid_9":
- string "(Defining_expr_of_let (bound_pattern prim/111N)
+ string "(Defining_expr_of_let (bound_pattern prim/113N)
  (defining_expr
-  (((Array_load Naked_floats Naked_floats Mutable) t2/107UV 0)
+  (((Array_load Naked_floats Naked_floats Mutable) t2/109UV 0)
    invalid.ml:29,2--23)))"
  skip 7
  byte 7)
@@ -62,7 +62,7 @@
         G:"camlInvalid__check_0_3_code" Pmakearray/0
         L:"camlInvalid__empty_array_2" int))
    (invalid
-     "(Defining_expr_of_let (bound_pattern prim/111N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/107UV 0)\n   invalid.ml:29,2--23)))"
+     "(Defining_expr_of_let (bound_pattern prim/113N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/109UV 0)\n   invalid.ml:29,2--23)))"
      L:"camlInvalid__invalid_9")) )
 
 (function no_cse reduce_code_size linscan camlInvalid__entry () : val

--- a/testsuite/tests/flambda2/examples/invalid.simplify.reference
+++ b/testsuite/tests/flambda2/examples/invalid.simplify.reference
@@ -15,8 +15,12 @@ let code inline(never) loopify(never) size(22) newer_version_of(check_0)
   let Parraylength_1 = %array_length.generic (t1) in
   let prim = %phys_ne (Parraylength_1, Parraylength) in
   switch prim
-    | 0 -> k (0)
-    | 1 -> k1 pop(reraise k1) ($camlInvalid__Pmakeblock_5)
+    | 0 -> k close[normal] my_alloc_region (0)
+    | 1 ->
+      k1
+        pop(reraise k1)
+        close[exn] my_alloc_region
+        ($camlInvalid__Pmakeblock_5)
 in
 let $camlInvalid__check_4 = closure check_0_1 @check &toplevel.alloc_region
 in
@@ -25,7 +29,7 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(check_0_1 &my_alloc_region)
+  apply direct(check_0_1 &my_alloc_region) [forward close close close]
     ($camlInvalid__check_4 : _ -> imm tagged) (t1, t2) -> k3 * k1
     where k3 (param : imm tagged) =
       cont k2
@@ -33,7 +37,7 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar_1)
       let prim = %array_load.`float`.mut (t2, 0) in
       let prim_1 = %float_comp.eq (prim, 0x0p+0) in
       let float_ordered_and_equal = %tag_imm (prim_1) in
-      cont k (float_ordered_and_equal)
+      cont k close[normal] my_alloc_region (float_ordered_and_equal)
 in
 let $camlInvalid__bar_6 = closure bar_1_1 @bar &toplevel.alloc_region in
 let code loopify(never) size(11) newer_version_of(foo_2)
@@ -43,15 +47,17 @@ let code loopify(never) size(11) newer_version_of(foo_2)
         : imm tagged =
   let Pmakearray = %array.`float`.mut.my_alloc_region (0x1p+0) in
   apply direct(check_0_1 &my_alloc_region) inlining_state(depth(1))
+         [forward close close close]
     ($camlInvalid__check_4 : _ -> imm tagged)
       (Pmakearray, $camlInvalid__empty_array_2)
       -> k3 * k1
     where k3 (param_1 : imm tagged) =
       cont k2
     where k2 =
-      invalid "(Defining_expr_of_let (bound_pattern prim/111N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/107UV 0)\n   invalid.ml:29,2--23)))"
+      invalid "(Defining_expr_of_let (bound_pattern prim/113N)\n (defining_expr\n  (((Array_load Naked_floats Naked_floats Mutable) t2/109UV 0)\n   invalid.ml:29,2--23)))"
 in
 let $camlInvalid__foo_7 = closure foo_2_1 @foo &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlInvalid =
   Block 0 ($camlInvalid__check_4, $camlInvalid__bar_6, $camlInvalid__foo_7)
 in

--- a/testsuite/tests/flambda2/examples/is_int_2020_07_21.simplify.reference
+++ b/testsuite/tests/flambda2/examples/is_int_2020_07_21.simplify.reference
@@ -7,7 +7,7 @@ let code inline(always) loopify(never) size(4) newer_version_of(of_src_0)
         : imm tagged =
   let prim = %is_int (param) in
   let Pisint = %tag_imm (prim) in
-  cont k (Pisint)
+  cont k close[normal] my_alloc_region (Pisint)
 in
 let $camlIs_int_2020_07_21__of_src_1 =
   closure of_src_0_1 @of_src &toplevel.alloc_region
@@ -16,7 +16,7 @@ let code loopify(never) size(28) newer_version_of(test_1)
       test_1_1 (src : [ 0 | 0 of imm tagged ], f : val, g : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply &my_alloc_region f (0) -> k4 * k1
+  apply &my_alloc_region [forward close close close] f (0) -> k4 * k1
     where k4 (param : [ 0 |1 ]) =
       let unboxed_field = %untag_imm (param) in
       cont k3 (unboxed_field)
@@ -30,11 +30,12 @@ let code loopify(never) size(28) newer_version_of(test_1)
            let Pisint = %tag_imm (prim) in
            cont k2 (Pisint))
     where k2 (dst : imm tagged) =
-      apply &my_alloc_region g (dst) -> k * k1
+      apply &my_alloc_region [close close close close] g (dst) -> k * k1
 in
 let $camlIs_int_2020_07_21__test_2 =
   closure test_1_1 @test &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlIs_int_2020_07_21 =
   Block 0 ($camlIs_int_2020_07_21__of_src_1, $camlIs_int_2020_07_21__test_2)
 in

--- a/testsuite/tests/flambda2/examples/let_symbol_order_atexit.simplify.reference
+++ b/testsuite/tests/flambda2/examples/let_symbol_order_atexit.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(1) newer_version_of(id_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlLet_symbol_order_atexit__id_1 =
   closure id_0_1 @`id` &toplevel.alloc_region
@@ -26,7 +26,7 @@ and code loopify(never) size(8) newer_version_of(do_at_exit_1)
       ($camlLet_symbol_order_atexit__do_at_exit_2)
   in
   let Pfield = %block_load.mut.[`0`] (exit_function_1) in
-  apply &my_alloc_region Pfield (0) -> k * k1
+  apply &my_alloc_region [close close close close] Pfield (0) -> k * k1
   with { exit_function = exit_function }
 in
 let code loopify(never) size(19) newer_version_of(exit_3)
@@ -39,16 +39,19 @@ let code loopify(never) size(19) newer_version_of(exit_3)
        ($camlLet_symbol_order_atexit__do_at_exit_2)
    in
    let Pfield = %block_load.mut.[`0`] (exit_function_1) in
-   apply &my_alloc_region inlining_state(depth(10)) Pfield (0) -> k3 * k1
+   apply &my_alloc_region inlining_state(depth(10))
+          [forward close close close]
+     Pfield (0) -> k3 * k1
      where k3 (param : imm tagged) =
        cont k2)
     where k2 =
-      apply ccall
+      apply ccall [close close close close]
         ($`*extern*`.caml_sys_exit : val -> val) (retcode) -> k * k1
 in
 let $camlLet_symbol_order_atexit__exit_4 =
   closure exit_3_1 @exit &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlLet_symbol_order_atexit =
   Block 0 ($camlLet_symbol_order_atexit__exit_4,
            $camlLet_symbol_order_atexit__do_at_exit_2)

--- a/testsuite/tests/flambda2/examples/lifting.simplify.reference
+++ b/testsuite/tests/flambda2/examples/lifting.simplify.reference
@@ -1,9 +1,12 @@
 let code f_0 deleted in
-apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
+apply ccall [forward close close close]
+  ($`*extern*`.rand : val -> val) (0) -> k * error
   where k (r0) =
-    (apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
+    (apply ccall [forward close close close]
+       ($`*extern*`.rand : val -> val) (0) -> k * error
        where k (r1) =
-         (apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
+         (apply ccall [forward close close close]
+            ($`*extern*`.rand : val -> val) (0) -> k * error
             where k (r2) =
               let $camlLifting__f_1 =
                 closure f_0_1 @f &toplevel.alloc_region
@@ -21,8 +24,11 @@ apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
                 let int_add = %int_barith.add (x, r0_1) in
                 let int_add_1 = %int_barith.add (int_add, r1_1) in
                 let int_add_2 = %int_barith.add (int_add_1, r2_1) in
-                cont k (int_add_2)
+                cont k close[normal] my_alloc_region (int_add_2)
                 with { r0 = r0; r1 = r1; r2 = r2 }
+              in
+              let `unit` =
+                %close_alloc_region.[`normal`] (toplevel.alloc_region)
               in
               let $camlLifting = Block 0 (r2, $camlLifting__f_1) in
               cont done ($camlLifting)))

--- a/testsuite/tests/flambda2/examples/lifting2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/lifting2.simplify.reference
@@ -1,9 +1,15 @@
-apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
+apply ccall [forward close close close]
+  ($`*extern*`.rand : val -> val) (0) -> k * error
   where k (r0) =
-    (apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
+    (apply ccall [forward close close close]
+       ($`*extern*`.rand : val -> val) (0) -> k * error
        where k (r1) =
-         (apply ccall ($`*extern*`.rand : val -> val) (0) -> k * error
+         (apply ccall [forward close close close]
+            ($`*extern*`.rand : val -> val) (0) -> k * error
             where k (r2) =
               let $camlLifting2__t_1 = Block 0 (r0, r1, r2) in
+              let `unit` =
+                %close_alloc_region.[`normal`] (toplevel.alloc_region)
+              in
               let $camlLifting2 = Block 0 (r2, $camlLifting2__t_1) in
               cont done ($camlLifting2)))

--- a/testsuite/tests/flambda2/examples/meet_with_incompatible_kinds.simplify.reference
+++ b/testsuite/tests/flambda2/examples/meet_with_incompatible_kinds.simplify.reference
@@ -8,13 +8,16 @@ let code inline(always) loopify(never) size(20) newer_version_of(aux_0)
         : float boxed =
   (let prim = %get_tag (x) in
    switch prim
-     | 0 -> k ($camlMeet_with_incompatible_kinds__float_0)
+     | 0 ->
+       k
+         close[normal] my_alloc_region
+         ($camlMeet_with_incompatible_kinds__float_0)
      | 1 -> k2)
     where k2 =
       let Pfield = %block_load.[`0`] (x) in
       let prim = %block_load.`float`.[`0`] (Pfield) in
       let Pfloatfield = %box_num.`float`.my_alloc_region (prim) in
-      cont k (Pfloatfield)
+      cont k close[normal] my_alloc_region (Pfloatfield)
 in
 let $camlMeet_with_incompatible_kinds__aux_1 =
   closure aux_0_1 @aux &toplevel.alloc_region
@@ -30,11 +33,12 @@ let code loopify(never) size(10) newer_version_of(f_1)
     %block.[`0`].my_alloc_region
       ($camlMeet_with_incompatible_kinds__float_0, n)
   in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlMeet_with_incompatible_kinds__f_2 =
   closure f_1_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlMeet_with_incompatible_kinds =
   Block 0 ($camlMeet_with_incompatible_kinds__aux_1,
            $camlMeet_with_incompatible_kinds__f_2)

--- a/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
+++ b/testsuite/tests/flambda2/examples/mutable_vars1.simplify.reference
@@ -8,7 +8,7 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
   let for_stop = %tag_imm (prim) in
   let prim_1 = %int_comp.le (0, for_stop) in
   switch prim_1
-    | 0 -> k (0)
+    | 0 -> k close[normal] my_alloc_region (0)
     | 1 -> k2
     where k2 =
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim) in
@@ -44,11 +44,12 @@ let code loopify(never) size(64) newer_version_of(escape_string_0)
                   %int_comp.`int64`.le (for_next_naked, for_stop_naked)
                 in
                 switch prim_5
-                  | 0 -> k (0)
+                  | 0 -> k close[normal] my_alloc_region (0)
                   | 1 -> k2 (for_next_naked, int_add)))
 in
 let $camlMutable_vars1__escape_string_1 =
   closure escape_string_0_1 @escape_string &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlMutable_vars1 = Block 0 ($camlMutable_vars1__escape_string_1) in
 cont done ($camlMutable_vars1)

--- a/testsuite/tests/flambda2/examples/nan.simplify.reference
+++ b/testsuite/tests/flambda2/examples/nan.simplify.reference
@@ -1,3 +1,4 @@
 let $camlNan__nan_1 = nan in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlNan = Block 0 ($camlNan__nan_1) in
 cont done ($camlNan)

--- a/testsuite/tests/flambda2/examples/neg_float.simplify.reference
+++ b/testsuite/tests/flambda2/examples/neg_float.simplify.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(1) newer_version_of(make_pos_float_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  cont k ($camlNeg_float__float_sub_5)
+  cont k close[normal] my_alloc_region ($camlNeg_float__float_sub_5)
 in
 let $camlNeg_float__make_pos_float_4 =
   closure make_pos_float_0_1 @make_pos_float &toplevel.alloc_region
@@ -18,11 +18,12 @@ let code loopify(never) size(1) newer_version_of(make_neg_float_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : float boxed =
-  cont k ($camlNeg_float__float_sub_7)
+  cont k close[normal] my_alloc_region ($camlNeg_float__float_sub_7)
 in
 let $camlNeg_float__make_neg_float_6 =
   closure make_neg_float_1_1 @make_neg_float &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlNeg_float =
   Block 0 ($camlNeg_float__float_0,
            $camlNeg_float__make_pos_float_4,

--- a/testsuite/tests/flambda2/examples/nested_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/nested_switch.simplify.reference
@@ -10,10 +10,10 @@ let code inline(always) loopify(never) size(31) newer_version_of(test_0)
      | 0 -> k2
      | 1 -> k3)
     where k3 =
-      apply ccall
+      apply ccall [close close close close]
         ($`*extern*`.caml_lessthan : val * val -> val) (x, y) -> k * k1
     where k2 =
-      apply ccall
+      apply ccall [close close close close]
         ($`*extern*`.caml_greaterthan : val * val -> val) (x, y) -> k * k1
 in
 let $camlNested_switch__test_1 =
@@ -27,12 +27,13 @@ let code loopify(never) size(21) newer_version_of(f_1)
   (let untagged = %untag_imm (foo) in
    switch untagged
      | 0 -> k2
-     | 1 -> k (0))
+     | 1 -> k close[normal] my_alloc_region (0))
     where k2 =
-      apply ccall inlining_state(depth(1))
+      apply ccall inlining_state(depth(1)) [close close close close]
         ($`*extern*`.caml_greaterthan : val * val -> val) (x, y) -> k * k1
 in
 let $camlNested_switch__f_2 = closure f_1_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlNested_switch =
   Block 0 ($camlNested_switch__test_1, $camlNested_switch__f_2)
 in

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_classic.raw.reference
@@ -1,6 +1,6 @@
 (let code inline(never) size(1)
        f_1 (param) my_closure &my_alloc_region my_depth -> k1 * k2 : int64 =
-   cont k1 (0L)
+   cont k1 close[normal] my_alloc_region (0L)
  in
  let code inline(never) size(0)
        test_0 (u : imm tagged, a, b)
@@ -18,7 +18,9 @@
  let $camlOver_app_kind_check_classic__s1 =
    closure f_1 @f &toplevel.alloc_region
  in
- cont k ($camlOver_app_kind_check_classic__s2))
+ cont k
+        close[normal] toplevel.alloc_region
+        ($camlOver_app_kind_check_classic__s2))
   where k define_root_symbol (module_block) =
     let field_0 = $camlOver_app_kind_check_classic__s0 in
     let $camlOver_app_kind_check_classic = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.raw.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.raw.reference
@@ -5,12 +5,12 @@ let $camlOver_app_kind_check_simplify__first_const_0 = Block 0 () in
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (x)
+   cont k1 close[normal] my_alloc_region (x)
  in
  let code inline(never) size(1)
        f_2 (param) my_closure &my_alloc_region my_depth -> k1 * k2 : int64 =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0L)
+   cont k1 close[normal] my_alloc_region (0L)
  in
  let code size(27)
        test_0 (u : imm tagged, a, b)
@@ -20,13 +20,15 @@ let $camlOver_app_kind_check_simplify__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let cast = closure cast_1 @cast &my_alloc_region in
    let f = closure f_2 @f &my_alloc_region in
-   apply direct(cast_1 &my_alloc_region) (cast : _ -> val) (u, f) -> k3 * k2
+   apply direct(cast_1 &my_alloc_region) [forward close close close]
+     (cast : _ -> val) (u, f) -> k3 * k2
      where k3 (apply_result : val) =
-       apply &my_alloc_region apply_result (0, 0) -> k1 * k2
+       apply &my_alloc_region [close close close close]
+         apply_result (0, 0) -> k1 * k2
  in
  let test = closure test_0 @test &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (test) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlOver_app_kind_check_simplify = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/over_app_kind_check_simplify.simplify.reference
@@ -4,11 +4,12 @@ let code loopify(never) size(0) newer_version_of(test_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  invalid "(Application_result_kind_mismatch\n (result_arity \226\132\149\240\157\159\158\240\157\159\156) (apply_expr\n  (((Some Over_app_kind_check_simplify.camlOver_app_kind_check_simplify__f_3)\227\128\136k32\227\128\137\227\128\138k31\227\128\139(0\n    0)) (args_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154 \226\168\175 \240\157\149\141=tagged_\226\132\149\240\157\149\154) (return_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154)\n   (call_kind\n    (Function\n     (function_call (Direct camlOver_app_kind_check_simplify__f_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc my_alloc_region/82N)))\n   (dbg over_app_kind_check_simplify.ml:16,2--16) (inline Default_inlined)\n   (inlining_state (depth 0, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))"
+  invalid "(Application_result_kind_mismatch\n (result_arity \226\132\149\240\157\159\158\240\157\159\156) (apply_expr\n  (((Some Over_app_kind_check_simplify.camlOver_app_kind_check_simplify__f_3)\227\128\136k32\227\128\137\227\128\138k31\227\128\139(0\n    0)) (args_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154 \226\168\175 \240\157\149\141=tagged_\226\132\149\240\157\149\154) (return_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154)\n   (call_kind\n    (Function\n     (function_call (Direct camlOver_app_kind_check_simplify__f_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc my_alloc_region/82N)))\n   (alloc_checks ((normal Close) (exn Close) (notrace Close) (div Close)))\n   (dbg over_app_kind_check_simplify.ml:16,2--16) (inline Default_inlined)\n   (inlining_state (depth 0, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))"
 in
 let $camlOver_app_kind_check_simplify__test_1 =
   closure test_0_1 @test &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlOver_app_kind_check_simplify =
   Block 0 ($camlOver_app_kind_check_simplify__test_1)
 in

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_classic.raw.reference
@@ -3,7 +3,7 @@
          my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code inline(never) size(0)
        test_0 (u : imm tagged, a, b)
@@ -21,7 +21,9 @@
  let $camlPartial_app_kind_check_classic__s1 =
    closure f_1 @f &toplevel.alloc_region
  in
- cont k ($camlPartial_app_kind_check_classic__s2))
+ cont k
+        close[normal] toplevel.alloc_region
+        ($camlPartial_app_kind_check_classic__s2))
   where k define_root_symbol (module_block) =
     let field_0 = $camlPartial_app_kind_check_classic__s0 in
     let $camlPartial_app_kind_check_classic = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.raw.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.raw.reference
@@ -5,7 +5,7 @@ let $camlPartial_app_kind_check_simplify__first_const_0 = Block 0 () in
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (x)
+   cont k1 close[normal] my_alloc_region (x)
  in
  let code inline(never) size(1)
        f_2 (param, param_1)
@@ -13,7 +13,7 @@ let $camlPartial_app_kind_check_simplify__first_const_0 = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code size(28)
        test_0 (u : imm tagged, a, b)
@@ -23,13 +23,15 @@ let $camlPartial_app_kind_check_simplify__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let cast = closure cast_1 @cast &my_alloc_region in
    let f = closure f_2 @f &my_alloc_region in
-   apply direct(cast_1 &my_alloc_region) (cast : _ -> val) (u, f) -> k3 * k2
+   apply direct(cast_1 &my_alloc_region) [forward close close close]
+     (cast : _ -> val) (u, f) -> k3 * k2
      where k3 (apply_result : val) =
-       apply &my_alloc_region apply_result (0) -> k1 * k2
+       apply &my_alloc_region [close close close close]
+         apply_result (0) -> k1 * k2
  in
  let test = closure test_0 @test &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (test) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlPartial_app_kind_check_simplify = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_app_kind_check_simplify.simplify.reference
@@ -4,11 +4,12 @@ let code loopify(never) size(0) newer_version_of(test_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : int64 =
-  invalid "(Application_result_kind_mismatch\n (result_arity \240\157\149\141?) (apply_expr\n  (((Some\n    Partial_app_kind_check_simplify.camlPartial_app_kind_check_simplify__f_3)\227\128\136k32\227\128\137\227\128\138k31\227\128\139(0))\n   (args_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154) (return_arity \226\132\149\240\157\159\158\240\157\159\156)\n   (call_kind\n    (Function\n     (function_call (Direct camlPartial_app_kind_check_simplify__f_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc my_alloc_region/85N)))\n   (dbg partial_app_kind_check_simplify.ml:16,2--14) (inline Default_inlined)\n   (inlining_state (depth 0, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))"
+  invalid "(Application_result_kind_mismatch\n (result_arity \240\157\149\141?) (apply_expr\n  (((Some\n    Partial_app_kind_check_simplify.camlPartial_app_kind_check_simplify__f_3)\227\128\136k32\227\128\137\227\128\138k31\227\128\139(0))\n   (args_arity \240\157\149\141=tagged_\226\132\149\240\157\149\154) (return_arity \226\132\149\240\157\159\158\240\157\159\156)\n   (call_kind\n    (Function\n     (function_call (Direct camlPartial_app_kind_check_simplify__f_2_5_code))))\n   (return_mode (Not_alloc_stack (alloc my_alloc_region/85N)))\n   (alloc_checks ((normal Close) (exn Close) (notrace Close) (div Close)))\n   (dbg partial_app_kind_check_simplify.ml:16,2--14) (inline Default_inlined)\n   (inlining_state (depth 0, stub_depth 0, arguments O3)) (probe ())\n   (position Normal))))"
 in
 let $camlPartial_app_kind_check_simplify__test_1 =
   closure test_0_1 @test &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlPartial_app_kind_check_simplify =
   Block 0 ($camlPartial_app_kind_check_simplify__test_1)
 in

--- a/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/partial_closure.simplify.reference
@@ -9,7 +9,7 @@ let code loopify(never) size(17) newer_version_of(foo_1)
       let prim = %is_int (l) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (accu)
+         | 1 -> k close[normal] my_alloc_region (accu)
          where k2 =
            let Pfield = %block_load.[`1`] (l) in
            let Pfield_1 = %block_load.[`0`] (l) in
@@ -18,5 +18,6 @@ let code loopify(never) size(17) newer_version_of(foo_1)
 in
 let $camlPartial_closure__foo_3 = closure foo_1_1 @foo &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlPartial_closure = Block 0 ($camlPartial_closure__foo_3) in
 cont done ($camlPartial_closure)

--- a/testsuite/tests/flambda2/examples/phantom.simplify.reference
+++ b/testsuite/tests/flambda2/examples/phantom.simplify.reference
@@ -52,14 +52,14 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4)
                 let eq = %tag_imm (prim) in
                 cont k3 (eq)))
     where k3 (body_result : imm tagged) =
-      cont k pop(k2) (body_result)
+      cont k pop(k2) close[normal] my_alloc_region (body_result)
     where k2 exn (`exn` : val) =
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       let prim = %phys_eq (`exn`, UndecidedLit) in
       switch prim
-        | 0 -> k1 pop(reraise k1) (`exn`)
-        | 1 -> k (0)
+        | 0 -> k1 pop(reraise k1) close[exn] my_alloc_region (`exn`)
+        | 1 -> k close[normal] my_alloc_region (0)
 in
 let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3)
       eval_level_3_1 (_st, a : val)
@@ -79,21 +79,25 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3)
     where k3 =
       ((let prim = %int_comp.ge (lvl, 0) in
         switch prim
-          | 0 -> k1 pop(regular k1) ($camlPhantom__Pmakeblock_3)
+          | 0 ->
+            k1
+              pop(regular k1)
+              close[exn] my_alloc_region
+              ($camlPhantom__Pmakeblock_3)
           | 1 -> k3)
          where k3 =
            let Pmakeblock = %block.[`0`].my_alloc_region (1, lvl) in
-           cont k (Pmakeblock))
+           cont k close[normal] my_alloc_region (Pmakeblock))
     where k2 =
       let Pfield_2 = %block_load.[`2`] (a) in
       let Pfield_3 = %block_load.mut.[`3`] (Pfield_2) in
       ((let untagged = %untag_imm (Pfield_3) in
         switch untagged
-          | 0 -> k1 pop(reraise k1) (UndecidedLit)
+          | 0 -> k1 pop(reraise k1) close[exn] my_alloc_region (UndecidedLit)
           | 1 -> k2)
          where k2 =
            let Pmakeblock = %block.[`0`].my_alloc_region (0, lvl) in
-           cont k (Pmakeblock))
+           cont k close[normal] my_alloc_region (Pmakeblock))
 in
 let code inline(always) loopify(never) size(3) newer_version_of(is_false_2)
       is_false_2_1 (a : val)
@@ -102,7 +106,7 @@ let code inline(always) loopify(never) size(3) newer_version_of(is_false_2)
         : imm tagged =
   let Pfield = %block_load.[`2`] (a) in
   let Pfield_1 = %block_load.mut.[`3`] (Pfield) in
-  cont k (Pfield_1)
+  cont k close[normal] my_alloc_region (Pfield_1)
 in
 let $camlPhantom__is_false_7 =
   closure is_false_2_1 @is_false &toplevel.alloc_region
@@ -113,14 +117,14 @@ let code inline(always) loopify(never) size(2) newer_version_of(is_true_1)
         -> k * k1
         : imm tagged =
   let Pfield = %block_load.mut.[`3`] (a) in
-  cont k (Pfield)
+  cont k close[normal] my_alloc_region (Pfield)
 in
 let $camlPhantom__is_true_6 =
   closure is_true_1_1 @is_true &toplevel.alloc_region
 in
 let code inline(always) loopify(never) size(176) newer_version_of(Make_0)
       Make_0_1 (F : val) my_closure &my_alloc_region my_depth -> k * k1 : val =
-  apply ccall noalloc
+  apply ccall noalloc [forward close close close]
     ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k2 * k1
     where k2 (Pccall) =
       let UndecidedLit =
@@ -146,7 +150,7 @@ let code inline(always) loopify(never) size(176) newer_version_of(Make_0)
            eval_level,
            true_at_level0)
       in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlPhantom__Make_5 = closure Make_0_1 @Make &toplevel.alloc_region in
 let code loopify(never) size(77) newer_version_of(true_at_level0_4_1)
@@ -190,14 +194,14 @@ let code loopify(never) size(77) newer_version_of(true_at_level0_4_1)
                 let eq = %tag_imm (prim) in
                 cont k3 (eq)))
     where k3 (body_result : imm tagged) =
-      cont k pop(k2) (body_result)
+      cont k pop(k2) close[normal] my_alloc_region (body_result)
     where k2 exn (`exn` : val) =
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
       let prim = %phys_eq (`exn`, UndecidedLit) in
       switch prim
-        | 0 -> k1 pop(reraise k1) (`exn`)
-        | 1 -> k (0)
+        | 0 -> k1 pop(reraise k1) close[exn] my_alloc_region (`exn`)
+        | 1 -> k close[normal] my_alloc_region (0)
 in
 let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3_1)
       eval_level_3_2 (_st, a : val)
@@ -217,28 +221,32 @@ let code inline(always) loopify(never) size(56) newer_version_of(eval_level_3_1)
     where k3 =
       ((let prim = %int_comp.ge (lvl, 0) in
         switch prim
-          | 0 -> k1 pop(regular k1) ($camlPhantom__Pmakeblock_3)
+          | 0 ->
+            k1
+              pop(regular k1)
+              close[exn] my_alloc_region
+              ($camlPhantom__Pmakeblock_3)
           | 1 -> k3)
          where k3 =
            let Pmakeblock = %block.[`0`].my_alloc_region (1, lvl) in
-           cont k (Pmakeblock))
+           cont k close[normal] my_alloc_region (Pmakeblock))
     where k2 =
       let Pfield_2 = %block_load.[`2`] (a) in
       let Pfield_3 = %block_load.mut.[`3`] (Pfield_2) in
       ((let untagged = %untag_imm (Pfield_3) in
         switch untagged
-          | 0 -> k1 pop(reraise k1) (UndecidedLit)
+          | 0 -> k1 pop(reraise k1) close[exn] my_alloc_region (UndecidedLit)
           | 1 -> k2)
          where k2 =
            let Pmakeblock = %block.[`0`].my_alloc_region (0, lvl) in
-           cont k (Pmakeblock))
+           cont k close[normal] my_alloc_region (Pmakeblock))
 in
 let code inline(always) loopify(never) size(176) newer_version_of(Make2_5)
       Make2_5_1 (F : val)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  apply ccall noalloc inlining_state(depth(1))
+  apply ccall noalloc inlining_state(depth(1)) [forward close close close]
     ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k2 * k1
     where k2 (Pccall) =
       let UndecidedLit =
@@ -264,9 +272,10 @@ let code inline(always) loopify(never) size(176) newer_version_of(Make2_5)
            eval_level,
            true_at_level0)
       in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlPhantom__Make2_8 = closure Make2_5_1 @Make2 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlPhantom = Block 0 ($camlPhantom__Make_5, $camlPhantom__Make2_8) in
 cont done ($camlPhantom)

--- a/testsuite/tests/flambda2/examples/product_join_with_mixed_kinds.simplify.reference
+++ b/testsuite/tests/flambda2/examples/product_join_with_mixed_kinds.simplify.reference
@@ -21,11 +21,12 @@ let code loopify(never) size(34) newer_version_of(f_0)
       cont k2 (Pmakefloatblock)
     where k2 (x_1 : val) =
       let Pmakeblock = %block.[`0`].my_alloc_region (x_1, 0) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlProduct_join_with_mixed_kinds__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlProduct_join_with_mixed_kinds =
   Block 0 ($camlProduct_join_with_mixed_kinds__f_1)
 in

--- a/testsuite/tests/flambda2/examples/string_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/string_switch.simplify.reference
@@ -16,37 +16,38 @@ let code loopify(never) size(60) newer_version_of(of_string_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply ccall noalloc
+  apply ccall noalloc [forward close close close]
     ($`*extern*`.caml_string_notequal : val * val -> val)
       (str, $camlString_switch__immstring_0)
       -> k2 * k1
     where k2 (Pccall) =
       ((let untagged = %untag_imm (Pccall) in
         switch untagged
-          | 0 -> k (1)
+          | 0 -> k close[normal] my_alloc_region (1)
           | 1 -> k2)
          where k2 =
-           (apply ccall noalloc
+           (apply ccall noalloc [forward close close close]
               ($`*extern*`.caml_string_notequal : val * val -> val)
                 (str, $camlString_switch__immstring_1)
                 -> k2 * k1
               where k2 (Pccall_1) =
                 ((let untagged = %untag_imm (Pccall_1) in
                   switch untagged
-                    | 0 -> k (2)
+                    | 0 -> k close[normal] my_alloc_region (2)
                     | 1 -> k2)
                    where k2 =
-                     (apply ccall noalloc
+                     (apply ccall noalloc [forward close close close]
                         ($`*extern*`.caml_string_notequal : val * val -> val)
                           (str, $camlString_switch__immstring_2)
                           -> k2 * k1
                         where k2 (Pccall_2) =
                           ((let untagged = %untag_imm (Pccall_2) in
                             switch untagged
-                              | 0 -> k (3)
+                              | 0 -> k close[normal] my_alloc_region (3)
                               | 1 -> k2)
                              where k2 =
                                (apply ccall noalloc
+                                       [forward close close close]
                                   ($`*extern*`.caml_string_notequal
                                    : val * val -> val)
                                     (str, $camlString_switch__immstring_3)
@@ -54,14 +55,17 @@ let code loopify(never) size(60) newer_version_of(of_string_0)
                                   where k2 (Pccall_3) =
                                     let untagged = %untag_imm (Pccall_3) in
                                     switch untagged
-                                      | 0 -> k (0)
+                                      | 0 ->
+                                        k close[normal] my_alloc_region (0)
                                       | 1 ->
                                         k1
                                           pop(regular k1)
+                                          close[exn] my_alloc_region
                                           ($camlString_switch__Pmakeblock_6)))))))
 in
 let $camlString_switch__of_string_7 =
   closure of_string_0_1 @of_string &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlString_switch = Block 0 ($camlString_switch__of_string_7) in
 cont done ($camlString_switch)

--- a/testsuite/tests/flambda2/examples/symbol_projections.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections.simplify.reference
@@ -32,7 +32,7 @@ let $camlSymbol_projections__immstring_0 = "FOO" in
       let Pmakeblock =
         %block.[`0`].my_alloc_region (x, $camlSymbol_projections__g_2)
       in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
     and set_of_closures
           $camlSymbol_projections__g_2 =
           closure g_1_1 @g &toplevel.alloc_region
@@ -48,12 +48,13 @@ let $camlSymbol_projections__immstring_0 = "FOO" in
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged
-         | 0 -> k (y)
+         | 0 -> k close[normal] my_alloc_region (y)
          | 1 -> k2)
         where k2 =
           let int_add = %int_barith.add (y, y) in
-          cont k (int_add)
+          cont k close[normal] my_alloc_region (int_add)
     in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlSymbol_projections = Block 0 (foo, $camlSymbol_projections__f_1)
     in
     cont done ($camlSymbol_projections)

--- a/testsuite/tests/flambda2/examples/symbol_projections2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections2.simplify.reference
@@ -6,7 +6,7 @@ let code inline(never) loopify(never) size(1) newer_version_of(ignore_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlSymbol_projections2__ignore_1 =
   closure ignore_0_1 @ignore &toplevel.alloc_region
@@ -23,10 +23,11 @@ and code loopify(never) size(5) newer_version_of(g_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  apply direct(ignore_0_1 &my_alloc_region)
+  apply direct(ignore_0_1 &my_alloc_region) [forward close close close]
     ($camlSymbol_projections2__ignore_1 : _ -> imm tagged) (0) -> k2 * k1
     where k2 (param_1 : imm tagged) =
       cont k
+             close[normal] my_alloc_region
              ($`camlSymbol_projections2__fn[symbol_projections2.ml:21,8--17]_3`)
 and set_of_closures
       $`camlSymbol_projections2__fn[symbol_projections2.ml:21,8--17]_3` =
@@ -44,8 +45,9 @@ and code loopify(never) size(4) newer_version_of(`fn[symbol_projections2.ml:21,8
       ($`camlSymbol_projections2__fn[symbol_projections2.ml:21,8--17]_3`)
   in
   let int_add = %int_barith.add (x, v_2) in
-  cont k (int_add)
+  cont k close[normal] my_alloc_region (int_add)
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlSymbol_projections2 =
   Block 0 ($camlSymbol_projections2__ignore_1,
            v,

--- a/testsuite/tests/flambda2/examples/symbol_projections3.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections3.simplify.reference
@@ -35,7 +35,7 @@ let $camlSymbol_projections3__immstring_0 = "FOO" in
            $camlSymbol_projections3__g_2,
            $camlSymbol_projections3__block_to_lift_3)
       in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
     and set_of_closures
           $camlSymbol_projections3__g_2 =
           closure g_1_1 @g &toplevel.alloc_region
@@ -51,14 +51,15 @@ let $camlSymbol_projections3__immstring_0 = "FOO" in
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged
-         | 0 -> k (y)
+         | 0 -> k close[normal] my_alloc_region (y)
          | 1 -> k2)
         where k2 =
           let int_add = %int_barith.add (y, y) in
-          cont k (int_add)
+          cont k close[normal] my_alloc_region (int_add)
     and $camlSymbol_projections3__block_to_lift_3 =
       Block 0 (foo_1, foo_1)
     in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlSymbol_projections3 =
       Block 0 (foo, $camlSymbol_projections3__f_1)
     in

--- a/testsuite/tests/flambda2/examples/symbol_projections4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections4.simplify.reference
@@ -38,12 +38,12 @@ let $camlSymbol_projections4__immstring_0 = "FOO" in
           let Pmakeblock =
             %block.[`0`].my_alloc_region (x, $camlSymbol_projections4__g_3)
           in
-          cont k (Pmakeblock)
+          cont k close[normal] my_alloc_region (Pmakeblock)
         where k2 =
           let Pmakeblock =
             %block.[`0`].my_alloc_region (x, $camlSymbol_projections4__h_2)
           in
-          cont k (Pmakeblock)
+          cont k close[normal] my_alloc_region (Pmakeblock)
     and set_of_closures
           $camlSymbol_projections4__h_2 =
           closure h_1_1 @h &toplevel.alloc_region
@@ -59,12 +59,12 @@ let $camlSymbol_projections4__immstring_0 = "FOO" in
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged
-         | 0 -> k (y)
+         | 0 -> k close[normal] my_alloc_region (y)
          | 1 -> k2)
         where k2 =
           let int_add = %int_barith.add (y, y) in
           let int_add_1 = %int_barith.add (int_add, y) in
-          cont k (int_add_1)
+          cont k close[normal] my_alloc_region (int_add_1)
     and set_of_closures
           $camlSymbol_projections4__g_3 =
           closure g_2_1 @g &toplevel.alloc_region
@@ -80,12 +80,13 @@ let $camlSymbol_projections4__immstring_0 = "FOO" in
       in
       (let untagged = %untag_imm (foo_2) in
        switch untagged
-         | 0 -> k (y)
+         | 0 -> k close[normal] my_alloc_region (y)
          | 1 -> k2)
         where k2 =
           let int_add = %int_barith.add (y, y) in
-          cont k (int_add)
+          cont k close[normal] my_alloc_region (int_add)
     in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlSymbol_projections4 =
       Block 0 (foo, $camlSymbol_projections4__f_1)
     in

--- a/testsuite/tests/flambda2/examples/symbol_projections5.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections5.simplify.reference
@@ -35,13 +35,13 @@ let $camlSymbol_projections5__immstring_0 = "FOO" in
             %block.[`0`].my_alloc_region
               ($camlSymbol_projections5__g_3 ~ depth my_depth -> succ my_depth)
           in
-          cont k (Pmakeblock)
+          cont k close[normal] my_alloc_region (Pmakeblock)
         where k2 =
           let Pmakeblock =
             %block.[`1`].my_alloc_region
               ($camlSymbol_projections5__g_3 ~ depth my_depth -> succ my_depth)
           in
-          cont k (Pmakeblock)
+          cont k close[normal] my_alloc_region (Pmakeblock)
     in
     let $camlSymbol_projections5__h_2 =
       closure h_1_1 @h &toplevel.alloc_region
@@ -59,13 +59,13 @@ let $camlSymbol_projections5__immstring_0 = "FOO" in
             %block.[`0`].my_alloc_region
               ($camlSymbol_projections5__h_2 ~ depth my_depth -> succ my_depth)
           in
-          cont k (Pmakeblock)
+          cont k close[normal] my_alloc_region (Pmakeblock)
         where k2 =
           let Pmakeblock =
             %block.[`1`].my_alloc_region
               ($camlSymbol_projections5__h_2 ~ depth my_depth -> succ my_depth)
           in
-          cont k (Pmakeblock)
+          cont k close[normal] my_alloc_region (Pmakeblock)
     in
     let code loopify(never) size(11) newer_version_of(f_0)
           f_0_1 (b : imm tagged)
@@ -74,12 +74,15 @@ let $camlSymbol_projections5__immstring_0 = "FOO" in
             : val =
       let untagged = %untag_imm (b) in
       switch untagged
-        | 0 -> k ($camlSymbol_projections5__h_2)
-        | 1 -> k ($camlSymbol_projections5__g_3)
+        | 0 ->
+          k close[normal] my_alloc_region ($camlSymbol_projections5__h_2)
+        | 1 ->
+          k close[normal] my_alloc_region ($camlSymbol_projections5__g_3)
     in
     let $camlSymbol_projections5__f_1 =
       closure f_0_1 @f &toplevel.alloc_region
     in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlSymbol_projections5 =
       Block 0 (foo, $camlSymbol_projections5__f_1)
     in

--- a/testsuite/tests/flambda2/examples/symbol_projections6.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections6.simplify.reference
@@ -32,8 +32,10 @@ let $camlSymbol_projections6__immstring_0 = "FOO" in
             : val =
       let untagged = %untag_imm (b) in
       switch untagged
-        | 0 -> k ($camlSymbol_projections6__h_2)
-        | 1 -> k ($camlSymbol_projections6__g_3)
+        | 0 ->
+          k close[normal] my_alloc_region ($camlSymbol_projections6__h_2)
+        | 1 ->
+          k close[normal] my_alloc_region ($camlSymbol_projections6__g_3)
     and set_of_closures
           $camlSymbol_projections6__h_2 =
           closure h_1_1 @h &toplevel.alloc_region
@@ -64,7 +66,7 @@ let $camlSymbol_projections6__immstring_0 = "FOO" in
                 let Pmakeblock_1 =
                   %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
                 in
-                cont k (Pmakeblock_1)))
+                cont k close[normal] my_alloc_region (Pmakeblock_1)))
         where k2 =
           let Pmakeblock =
             %block.[`1`].my_alloc_region
@@ -72,7 +74,7 @@ let $camlSymbol_projections6__immstring_0 = "FOO" in
           in
           let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
           in
-          cont k (Pmakeblock_1)
+          cont k close[normal] my_alloc_region (Pmakeblock_1)
     and set_of_closures
           $camlSymbol_projections6__g_3 =
           closure g_2_1 @g &toplevel.alloc_region
@@ -103,7 +105,7 @@ let $camlSymbol_projections6__immstring_0 = "FOO" in
                 let Pmakeblock_1 =
                   %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
                 in
-                cont k (Pmakeblock_1)))
+                cont k close[normal] my_alloc_region (Pmakeblock_1)))
         where k2 =
           let Pmakeblock =
             %block.[`1`].my_alloc_region
@@ -111,8 +113,9 @@ let $camlSymbol_projections6__immstring_0 = "FOO" in
           in
           let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, foo_2)
           in
-          cont k (Pmakeblock_1)
+          cont k close[normal] my_alloc_region (Pmakeblock_1)
     in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlSymbol_projections6 =
       Block 0 (foo, $camlSymbol_projections6__f_1)
     in

--- a/testsuite/tests/flambda2/examples/symbol_projections7.simplify.reference
+++ b/testsuite/tests/flambda2/examples/symbol_projections7.simplify.reference
@@ -13,9 +13,10 @@ and code loopify(never) size(4) newer_version_of(`fn[symbol_projections7.ml:20,4
       ($`camlSymbol_projections7__fn[symbol_projections7.ml:20,4--18]_3`)
   in
   let int_add = %int_barith.add (x, y_1) in
-  cont k (int_add)
+  cont k close[normal] my_alloc_region (int_add)
   with { y = y }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlSymbol_projections7 =
   Block 0 ($`camlSymbol_projections7__fn[symbol_projections7.ml:20,4--18]_3`)
 in

--- a/testsuite/tests/flambda2/examples/tests.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests.raw.reference
@@ -5,7 +5,7 @@ let $camlTests__first_const_0 = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (42)
+   cont k1 close[normal] my_alloc_region (42)
  in
  let code size(79)
        f_1
@@ -48,7 +48,7 @@ let $camlTests__first_const_0 = Block 0 () in
               (let untagged = %untag_imm (Pisint) in
                switch untagged
                  | 0 -> k4
-                 | 1 -> k1 (0))
+                 | 1 -> k1 close[normal] my_alloc_region (0))
                 where k4 =
                   cont k3)
                where k3 =
@@ -57,7 +57,7 @@ let $camlTests__first_const_0 = Block 0 () in
                    (let untagged = %untag_imm (Pisint) in
                     switch untagged
                       | 0 -> k4
-                      | 1 -> k1 (1))
+                      | 1 -> k1 close[normal] my_alloc_region (1))
                      where k4 =
                        cont k3)
                     where k3 =
@@ -66,6 +66,7 @@ let $camlTests__first_const_0 = Block 0 () in
                       let int_add = %int_barith.add (Pfield_1, Pfield) in
                       let int_add_1 = %int_barith.add (x, y) in
                       apply direct(to_inline_0 &my_alloc_region)
+                             [close close close close]
                         (to_inline : _ -> imm tagged)
                           (int_add_1, int_add)
                           -> k1 * k2)))
@@ -75,7 +76,7 @@ let $camlTests__first_const_0 = Block 0 () in
  with { to_inline = to_inline }
  in
  let Pmakeblock = %block.[`0`].`toplevel` (to_inline, f) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests.simplify.reference
@@ -5,7 +5,7 @@ let code inline(always) loopify(never) size(1) newer_version_of(to_inline_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (42)
+  cont k close[normal] my_alloc_region (42)
 in
 let $camlTests__to_inline_1 =
   closure to_inline_0_1 @to_inline &toplevel.alloc_region
@@ -23,13 +23,14 @@ let code loopify(never) size(22) newer_version_of(f_1)
   let prim = %is_int (m) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       let prim_1 = %is_int (n) in
       switch prim_1
-        | 0 -> k (42)
-        | 1 -> k (1)
+        | 0 -> k close[normal] my_alloc_region (42)
+        | 1 -> k close[normal] my_alloc_region (1)
 in
 let $camlTests__f_2 = closure f_1_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests = Block 0 ($camlTests__to_inline_1, $camlTests__f_2) in
 cont done ($camlTests)

--- a/testsuite/tests/flambda2/examples/tests0.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests0.raw.reference
@@ -13,18 +13,18 @@ let $camlTests0__first_const_0 = Block 0 () in
       | 1 -> k4)
      where k4 =
        let untagged = %untag_imm (0) in
-       cont k1 (0)
+       cont k1 close[normal] my_alloc_region (0)
      where k3 =
        let prim = %get_tag (0) in
        let scrutinee_tag = %tag_imm (prim) in
        let untagged = %untag_imm (scrutinee_tag) in
        switch untagged
-         | 0 -> k1 (1)
-         | 1 -> k1 (2)
+         | 0 -> k1 close[normal] my_alloc_region (1)
+         | 1 -> k1 close[normal] my_alloc_region (2)
  in
  let f = closure f_0 @f &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (f) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlTests0 = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/tests0.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests0.simplify.reference
@@ -4,8 +4,9 @@ let code loopify(never) size(1) newer_version_of(f_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlTests0__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests0 = Block 0 ($camlTests0__f_1) in
 cont done ($camlTests0)

--- a/testsuite/tests/flambda2/examples/tests10.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests10.raw.reference
@@ -10,11 +10,11 @@ let $camlTests10__first_const_0 = Block 0 () in
        (my_closure ~ depth my_depth -> next_depth,
         my_closure ~ depth my_depth -> next_depth)
    in
-   cont k1 (Pmakeblock)
+   cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let f = closure f_0 @f &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (f) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlTests10 = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/tests10.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests10.simplify.reference
@@ -11,7 +11,8 @@ and code rec loopify(never) size(8) newer_version_of(f_0)
       ($camlTests10__f_1 ~ depth my_depth -> succ my_depth,
        $camlTests10__f_1 ~ depth my_depth -> succ my_depth)
   in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests10 = Block 0 ($camlTests10__f_1) in
 cont done ($camlTests10)

--- a/testsuite/tests/flambda2/examples/tests11.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests11.raw.reference
@@ -5,14 +5,14 @@ let $camlTests11__first_const_0 = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code size(1)
        `fn[tests11.ml:23,39--51]_3` (x)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (x)
+   cont k1 close[normal] my_alloc_region (x)
  in
  let code size(23)
        `fn[tests11.ml:23,2--70]_1` (param : imm tagged)
@@ -30,7 +30,7 @@ let $camlTests11__first_const_0 = Block 0 () in
      closure `fn[tests11.ml:23,39--51]_3` @`fn[tests11.ml:23,39--51]`
        &my_alloc_region
    in
-   apply &my_alloc_region inlined(never)
+   apply &my_alloc_region inlined(never) [close close close close]
      map_foo
        (`fn[tests11.ml:23,39--51]`, `fn[tests11.ml:23,52--67]`, 0)
        -> k1 * k2
@@ -46,7 +46,7 @@ let $camlTests11__first_const_0 = Block 0 () in
        &my_alloc_region
    with { map_foo = map_foo }
    in
-   cont k1 (`fn[tests11.ml:23,2--70]`)
+   cont k1 close[normal] my_alloc_region (`fn[tests11.ml:23,2--70]`)
  in
  let code rec size(58)
        map_foo_4 (f : val, seq : val, param : imm tagged)
@@ -55,14 +55,14 @@ let $camlTests11__first_const_0 = Block 0 () in
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
-   apply &my_alloc_region seq (0) -> k3 * k2
+   apply &my_alloc_region [forward close close close] seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
          (let untagged = %untag_imm (Pisint) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (0))
+            | 1 -> k1 close[normal] my_alloc_region (0))
            where k4 =
              cont k3)
           where k3 =
@@ -77,30 +77,33 @@ let $camlTests11__first_const_0 = Block 0 () in
                   cont k5)
                where k5 =
                  apply direct(bar_0 &my_alloc_region)
+                        [forward close close close]
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k4 =
                  apply direct(bar_0 &my_alloc_region)
+                        [forward close close close]
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k3 (staticcatch_result : val) =
                  ((let Pfield = %block_load.[`0`] (`*match*`) in
-                   apply &my_alloc_region f (Pfield) -> k3 * k2)
+                   apply &my_alloc_region [forward close close close]
+                     f (Pfield) -> k3 * k2)
                     where k3 (apply_result : val) =
                       let Pmakeblock =
                         %block.[`0`].my_alloc_region
                           (apply_result, staticcatch_result)
                       in
-                      cont k1 (Pmakeblock))))
+                      cont k1 close[normal] my_alloc_region (Pmakeblock))))
  in
  let bar = closure bar_0 @bar &toplevel.alloc_region in
  let map_foo = closure map_foo_4 @map_foo &toplevel.alloc_region
  with { bar = bar }
  in
  let Pmakeblock = %block.[`0`].`toplevel` (map_foo) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlTests11 = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/tests11.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests11.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests11.ml:23,39--51]_3`)
       `fn[tests11.ml:23,39--51]_3_1` (x)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $`camlTests11__fn[tests11.ml:23,39--51]_3` =
   closure `fn[tests11.ml:23,39--51]_3_1` @`fn[tests11.ml:23,39--51]`
@@ -17,7 +17,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests11.ml:23,52--67]_2`)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $`camlTests11__fn[tests11.ml:23,52--67]_2` =
   closure `fn[tests11.ml:23,52--67]_2_1` @`fn[tests11.ml:23,52--67]`
@@ -30,7 +30,7 @@ let code loopify(never) size(7) newer_version_of(`fn[tests11.ml:23,2--70]_1`)
   let map_foo =
     %project_value_slot.[`fn[tests11.ml:23,2--70]`].[map_foo] (my_closure)
   in
-  apply &my_alloc_region inlined(never)
+  apply &my_alloc_region inlined(never) [close close close close]
     map_foo
       ($`camlTests11__fn[tests11.ml:23,39--51]_3`,
        $`camlTests11__fn[tests11.ml:23,52--67]_2`,
@@ -44,12 +44,12 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply &my_alloc_region seq (0) -> k2 * k1
+  apply &my_alloc_region [forward close close close] seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (0)
+         | 1 -> k close[normal] my_alloc_region (0)
          where k2 =
            ((let Popaque = %opaque (0) in
              (let untagged = %untag_imm (Popaque) in
@@ -78,19 +78,20 @@ and code rec loopify(never) size(69) newer_version_of(map_foo_4)
                  cont k2 (`fn[tests11.ml:23,2--70]`))
               where k2 (staticcatch_result : val) =
                 ((let Pfield = %block_load.[`0`] (`*match*`) in
-                  apply &my_alloc_region f (Pfield) -> k2 * k1)
+                  apply &my_alloc_region [forward close close close]
+                    f (Pfield) -> k2 * k1)
                    where k2 (apply_result : val) =
                      let Pmakeblock =
                        %block.[`0`].my_alloc_region
                          (apply_result, staticcatch_result)
                      in
-                     cont k (Pmakeblock))))
+                     cont k close[normal] my_alloc_region (Pmakeblock))))
 and code loopify(never) size(4) newer_version_of(`fn[tests11.ml:23,2--70]_1_1`)
       `fn[tests11.ml:23,2--70]_1_2` (param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
-         inlining_state(depth(1))
+         inlining_state(depth(1)) [close close close close]
     $camlTests11__map_foo_4 ~ depth do_not_inline -> do_not_inline
       ($`camlTests11__fn[tests11.ml:23,39--51]_3`,
        $`camlTests11__fn[tests11.ml:23,52--67]_2`,
@@ -101,12 +102,13 @@ and code loopify(never) size(4) newer_version_of(`fn[tests11.ml:23,2--70]_1_1`)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
-         inlining_state(depth(1))
+         inlining_state(depth(1)) [close close close close]
     $camlTests11__map_foo_4 ~ depth do_not_inline -> do_not_inline
       ($`camlTests11__fn[tests11.ml:23,39--51]_3`,
        $`camlTests11__fn[tests11.ml:23,52--67]_2`,
        0)
       -> k * k1
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests11 = Block 0 ($camlTests11__map_foo_4) in
 cont done ($camlTests11)

--- a/testsuite/tests/flambda2/examples/tests12.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests12.raw.reference
@@ -5,14 +5,14 @@ let $camlTests12__first_const_0 = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code size(1)
        `fn[tests12.ml:25,39--51]_3` (x)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (x)
+   cont k1 close[normal] my_alloc_region (x)
  in
  let code size(23)
        `fn[tests12.ml:25,2--70]_1` (param : imm tagged)
@@ -30,7 +30,7 @@ let $camlTests12__first_const_0 = Block 0 () in
      closure `fn[tests12.ml:25,39--51]_3` @`fn[tests12.ml:25,39--51]`
        &my_alloc_region
    in
-   apply &my_alloc_region inlined(never)
+   apply &my_alloc_region inlined(never) [close close close close]
      map_foo
        (`fn[tests12.ml:25,39--51]`, `fn[tests12.ml:25,52--67]`, 0)
        -> k1 * k2
@@ -46,7 +46,7 @@ let $camlTests12__first_const_0 = Block 0 () in
        &my_alloc_region
    with { map_foo = map_foo }
    in
-   cont k1 (`fn[tests12.ml:25,2--70]`)
+   cont k1 close[normal] my_alloc_region (`fn[tests12.ml:25,2--70]`)
  in
  let code rec size(64)
        map_foo_4 (f : val, seq : val, param : imm tagged)
@@ -55,14 +55,14 @@ let $camlTests12__first_const_0 = Block 0 () in
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
-   apply &my_alloc_region seq (0) -> k3 * k2
+   apply &my_alloc_region [forward close close close] seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
          (let untagged = %untag_imm (Pisint) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (0))
+            | 1 -> k1 close[normal] my_alloc_region (0))
            where k4 =
              cont k3)
           where k3 =
@@ -77,32 +77,37 @@ let $camlTests12__first_const_0 = Block 0 () in
                   cont k5)
                where k5 =
                  apply direct(bar_0 &my_alloc_region)
+                        [forward close close close]
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k4 =
                  apply direct(bar_0 &my_alloc_region)
+                        [forward close close close]
                    (bar : _ -> val)
                      (my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k3 (g : val) =
-                 (apply &my_alloc_region inlined(always) g (0) -> k3 * k2
+                 (apply &my_alloc_region inlined(always)
+                         [forward close close close]
+                    g (0) -> k3 * k2
                     where k3 (g_result : [ 0 | 0 of val * val ]) =
                       let Popaque = %opaque (g_result) in
                       ((let Pfield = %block_load.[`0`] (`*match*`) in
-                        apply &my_alloc_region f (Pfield) -> k3 * k2)
+                        apply &my_alloc_region [forward close close close]
+                          f (Pfield) -> k3 * k2)
                          where k3 (apply_result : val) =
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (apply_result, g)
                            in
-                           cont k1 (Pmakeblock)))))
+                           cont k1 close[normal] my_alloc_region (Pmakeblock)))))
  in
  let bar = closure bar_0 @bar &toplevel.alloc_region in
  let map_foo = closure map_foo_4 @map_foo &toplevel.alloc_region
  with { bar = bar }
  in
  let Pmakeblock = %block.[`0`].`toplevel` (bar, map_foo) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests12.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests12.simplify.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests12.ml:25,39--51]_3`)
       `fn[tests12.ml:25,39--51]_3_1` (x)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $`camlTests12__fn[tests12.ml:25,39--51]_3` =
   closure `fn[tests12.ml:25,39--51]_3_1` @`fn[tests12.ml:25,39--51]`
@@ -18,7 +18,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests12.ml:25,52--67]_2`)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $`camlTests12__fn[tests12.ml:25,52--67]_2` =
   closure `fn[tests12.ml:25,52--67]_2_1` @`fn[tests12.ml:25,52--67]`
@@ -31,7 +31,7 @@ let code loopify(never) size(7) newer_version_of(`fn[tests12.ml:25,2--70]_1`)
   let map_foo =
     %project_value_slot.[`fn[tests12.ml:25,2--70]`].[map_foo] (my_closure)
   in
-  apply &my_alloc_region inlined(never)
+  apply &my_alloc_region inlined(never) [close close close close]
     map_foo
       ($`camlTests12__fn[tests12.ml:25,39--51]_3`,
        $`camlTests12__fn[tests12.ml:25,52--67]_2`,
@@ -48,7 +48,7 @@ let code inline(always) loopify(never) size(16) newer_version_of(bar_0)
       &my_alloc_region
   with { map_foo = map_foo }
   in
-  cont k (`fn[tests12.ml:25,2--70]`)
+  cont k close[normal] my_alloc_region (`fn[tests12.ml:25,2--70]`)
 in
 let $camlTests12__bar_1 = closure bar_0_1 @bar &toplevel.alloc_region in
 let $camlTests12__map_foo_4 =
@@ -58,12 +58,12 @@ and code rec loopify(never) size(75) newer_version_of(map_foo_4)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply &my_alloc_region seq (0) -> k2 * k1
+  apply &my_alloc_region [forward close close close] seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (0)
+         | 1 -> k close[normal] my_alloc_region (0)
          where k2 =
            ((let Popaque = %opaque (0) in
              (let untagged = %untag_imm (Popaque) in
@@ -91,22 +91,25 @@ and code rec loopify(never) size(75) newer_version_of(map_foo_4)
                  in
                  cont k2 (`fn[tests12.ml:25,2--70]`))
               where k2 (g : val) =
-                (apply &my_alloc_region inlined(always) g (0) -> k2 * k1
+                (apply &my_alloc_region inlined(always)
+                        [forward close close close]
+                   g (0) -> k2 * k1
                    where k2 (g_result : [ 0 | 0 of val * val ]) =
                      let Popaque = %opaque (g_result) in
                      ((let Pfield = %block_load.[`0`] (`*match*`) in
-                       apply &my_alloc_region f (Pfield) -> k2 * k1)
+                       apply &my_alloc_region [forward close close close]
+                         f (Pfield) -> k2 * k1)
                         where k2 (apply_result : val) =
                           let Pmakeblock =
                             %block.[`0`].my_alloc_region (apply_result, g)
                           in
-                          cont k (Pmakeblock)))))
+                          cont k close[normal] my_alloc_region (Pmakeblock)))))
 and code loopify(never) size(4) newer_version_of(`fn[tests12.ml:25,2--70]_1_1`)
       `fn[tests12.ml:25,2--70]_1_2` (param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
-         inlining_state(depth(1))
+         inlining_state(depth(1)) [close close close close]
     $camlTests12__map_foo_4 ~ depth do_not_inline -> do_not_inline
       ($`camlTests12__fn[tests12.ml:25,39--51]_3`,
        $`camlTests12__fn[tests12.ml:25,52--67]_2`,
@@ -117,12 +120,13 @@ and code loopify(never) size(4) newer_version_of(`fn[tests12.ml:25,2--70]_1_1`)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
-         inlining_state(depth(1))
+         inlining_state(depth(1)) [close close close close]
     $camlTests12__map_foo_4 ~ depth do_not_inline -> do_not_inline
       ($`camlTests12__fn[tests12.ml:25,39--51]_3`,
        $`camlTests12__fn[tests12.ml:25,52--67]_2`,
        0)
       -> k * k1
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests12 = Block 0 ($camlTests12__bar_1, $camlTests12__map_foo_4) in
 cont done ($camlTests12)

--- a/testsuite/tests/flambda2/examples/tests13.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests13.raw.reference
@@ -5,14 +5,14 @@ let $camlTests13__first_const_0 = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code size(1)
        `fn[tests13.ml:30,31--43]_3` (x)
          my_closure &my_alloc_region my_depth
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (x)
+   cont k1 close[normal] my_alloc_region (x)
  in
  let code size(26)
        `fn[tests13.ml:27,2--118]_1` (param : imm tagged)
@@ -34,7 +34,7 @@ let $camlTests13__first_const_0 = Block 0 () in
      closure `fn[tests13.ml:30,31--43]_3` @`fn[tests13.ml:30,31--43]`
        &my_alloc_region
    in
-   apply &my_alloc_region inlined(never)
+   apply &my_alloc_region inlined(never) [close close close close]
      map_foo
        (`fn[tests13.ml:30,31--43]`, `fn[tests13.ml:30,44--59]`, 0)
        -> k1 * k2
@@ -50,7 +50,7 @@ let $camlTests13__first_const_0 = Block 0 () in
        &my_alloc_region
    with { i = i; map_foo = map_foo }
    in
-   cont k1 (`fn[tests13.ml:27,2--118]`)
+   cont k1 close[normal] my_alloc_region (`fn[tests13.ml:27,2--118]`)
  in
  let code size(1)
        `fn[tests13.ml:41,15--28]_5` (param : imm tagged)
@@ -58,7 +58,7 @@ let $camlTests13__first_const_0 = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code rec size(72)
        map_foo_4 (f : val, seq : val, param : imm tagged)
@@ -67,14 +67,14 @@ let $camlTests13__first_const_0 = Block 0 () in
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let bar = %project_value_slot.[map_foo].[bar] (my_closure) in
-   apply &my_alloc_region seq (0) -> k3 * k2
+   apply &my_alloc_region [forward close close close] seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
          (let untagged = %untag_imm (Pisint) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (0))
+            | 1 -> k1 close[normal] my_alloc_region (0))
            where k4 =
              cont k3)
           where k3 =
@@ -89,16 +89,20 @@ let $camlTests13__first_const_0 = Block 0 () in
                   cont k5)
                where k5 =
                  apply direct(bar_0 &my_alloc_region)
+                        [forward close close close]
                    (bar : _ -> val)
                      (20, my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k4 =
                  apply direct(bar_0 &my_alloc_region)
+                        [forward close close close]
                    (bar : _ -> val)
                      (10, my_closure ~ depth my_depth -> next_depth)
                      -> k3 * k2
                where k3 (g : val) =
-                 (apply &my_alloc_region inlined(always) g (0) -> k3 * k2
+                 (apply &my_alloc_region inlined(always)
+                         [forward close close close]
+                    g (0) -> k3 * k2
                     where k3 (g_result : [ 0 | 0 of val * val ]) =
                       let Popaque = %opaque (g_result) in
                       let `fn[tests13.ml:41,15--28]` =
@@ -106,20 +110,21 @@ let $camlTests13__first_const_0 = Block 0 () in
                           @`fn[tests13.ml:41,15--28]` &my_alloc_region
                       in
                       ((let Pfield = %block_load.[`0`] (`*match*`) in
-                        apply &my_alloc_region f (Pfield) -> k3 * k2)
+                        apply &my_alloc_region [forward close close close]
+                          f (Pfield) -> k3 * k2)
                          where k3 (apply_result : val) =
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region
                                (apply_result, `fn[tests13.ml:41,15--28]`)
                            in
-                           cont k1 (Pmakeblock)))))
+                           cont k1 close[normal] my_alloc_region (Pmakeblock)))))
  in
  let bar = closure bar_0 @bar &toplevel.alloc_region in
  let map_foo = closure map_foo_4 @map_foo &toplevel.alloc_region
  with { bar = bar }
  in
  let Pmakeblock = %block.[`0`].`toplevel` (map_foo) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlTests13 = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/tests13.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests13.simplify.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests13.ml:30,31--43]_3`)
       `fn[tests13.ml:30,31--43]_3_1` (x)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $`camlTests13__fn[tests13.ml:30,31--43]_3` =
   closure `fn[tests13.ml:30,31--43]_3_1` @`fn[tests13.ml:30,31--43]`
@@ -18,7 +18,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests13.ml:30,44--59]_2`)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $`camlTests13__fn[tests13.ml:30,44--59]_2` =
   closure `fn[tests13.ml:30,44--59]_2_1` @`fn[tests13.ml:30,44--59]`
@@ -35,7 +35,7 @@ let code loopify(never) size(10) newer_version_of(`fn[tests13.ml:27,2--118]_1`)
   in
   let j = %int_barith.add (i, 3) in
   let Popaque = %opaque (j) in
-  apply &my_alloc_region inlined(never)
+  apply &my_alloc_region inlined(never) [close close close close]
     map_foo
       ($`camlTests13__fn[tests13.ml:30,31--43]_3`,
        $`camlTests13__fn[tests13.ml:30,44--59]_2`,
@@ -47,7 +47,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests13.ml:41,15--28]_5`)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $`camlTests13__fn[tests13.ml:41,15--28]_5` =
   closure `fn[tests13.ml:41,15--28]_5_1` @`fn[tests13.ml:41,15--28]`
@@ -60,12 +60,12 @@ and code rec loopify(never) size(77) newer_version_of(map_foo_4)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply &my_alloc_region seq (0) -> k2 * k1
+  apply &my_alloc_region [forward close close close] seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (0)
+         | 1 -> k close[normal] my_alloc_region (0)
          where k2 =
            ((let Popaque = %opaque (0) in
              (let untagged = %untag_imm (Popaque) in
@@ -95,25 +95,28 @@ and code rec loopify(never) size(77) newer_version_of(map_foo_4)
                  in
                  cont k2 (`fn[tests13.ml:27,2--118]`))
               where k2 (g : val) =
-                (apply &my_alloc_region inlined(always) g (0) -> k2 * k1
+                (apply &my_alloc_region inlined(always)
+                        [forward close close close]
+                   g (0) -> k2 * k1
                    where k2 (g_result : [ 0 | 0 of val * val ]) =
                      let Popaque = %opaque (g_result) in
                      ((let Pfield = %block_load.[`0`] (`*match*`) in
-                       apply &my_alloc_region f (Pfield) -> k2 * k1)
+                       apply &my_alloc_region [forward close close close]
+                         f (Pfield) -> k2 * k1)
                         where k2 (apply_result : val) =
                           let Pmakeblock =
                             %block.[`0`].my_alloc_region
                               (apply_result,
                                $`camlTests13__fn[tests13.ml:41,15--28]_5`)
                           in
-                          cont k (Pmakeblock)))))
+                          cont k close[normal] my_alloc_region (Pmakeblock)))))
 and code loopify(never) size(4) newer_version_of(`fn[tests13.ml:27,2--118]_1_1`)
       `fn[tests13.ml:27,2--118]_1_2` (param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   let Popaque = %opaque (23) in
   apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
-         inlining_state(depth(1))
+         inlining_state(depth(1)) [close close close close]
     $camlTests13__map_foo_4 ~ depth do_not_inline -> do_not_inline
       ($`camlTests13__fn[tests13.ml:30,31--43]_3`,
        $`camlTests13__fn[tests13.ml:30,44--59]_2`,
@@ -125,12 +128,13 @@ and code loopify(never) size(4) newer_version_of(`fn[tests13.ml:27,2--118]_1_1`)
         -> k * k1 =
   let Popaque = %opaque (13) in
   apply direct(map_foo_4_1 &my_alloc_region) inlined(never)
-         inlining_state(depth(1))
+         inlining_state(depth(1)) [close close close close]
     $camlTests13__map_foo_4 ~ depth do_not_inline -> do_not_inline
       ($`camlTests13__fn[tests13.ml:30,31--43]_3`,
        $`camlTests13__fn[tests13.ml:30,44--59]_2`,
        0)
       -> k * k1
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests13 = Block 0 ($camlTests13__map_foo_4) in
 cont done ($camlTests13)

--- a/testsuite/tests/flambda2/examples/tests14.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests14.raw.reference
@@ -6,7 +6,7 @@ let $camlTests14__first_const_0 = Block 0 () in
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let Psetfield = %block_set.`imm`.[`0`] (t, 42) in
-   cont k1 (Psetfield)
+   cont k1 close[normal] my_alloc_region (Psetfield)
  in
  let code size(7)
        nth_char_1 (s : val, n : imm tagged)
@@ -17,7 +17,7 @@ let $camlTests14__first_const_0 = Block 0 () in
    let prim = %num_conv.[tagged_imm].[`nativeint`] (n) in
    let prim_1 = %string_load.[`8`] (s, prim) in
    let Pstringrefu = %tag_imm (prim_1) in
-   cont k1 (Pstringrefu)
+   cont k1 close[normal] my_alloc_region (Pstringrefu)
  in
  let code size(32)
        needs_try_region_2 (param : imm tagged)
@@ -42,13 +42,13 @@ let $camlTests14__first_const_0 = Block 0 () in
           (let untagged = %untag_imm (eq) in
            switch untagged
              | 0 -> k5
-             | 1 -> k1 (0))
+             | 1 -> k1 close[normal] my_alloc_region (0))
             where k5 =
               cont k4)
            where k4 =
-             cont k2 pop(reraise k2) (`exn`)))
+             cont k2 pop(reraise k2) close[exn] my_alloc_region (`exn`)))
      where k3 (n : imm tagged) =
-       cont k1 (1)
+       cont k1 close[normal] my_alloc_region (1)
  in
  let code size(12)
        gadt_match_3 (x : [ 0 |1 | 0 of imm tagged ], n : val)
@@ -58,11 +58,11 @@ let $camlTests14__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    (let untagged = %untag_imm (x) in
     switch untagged
-      | 0 -> k1 (n)
+      | 0 -> k1 close[normal] my_alloc_region (n)
       | 1 -> k3)
      where k3 =
        let Popaque = %opaque (n) in
-       cont k1 (Popaque)
+       cont k1 close[normal] my_alloc_region (Popaque)
  in
  let set = closure set_0 @set &toplevel.alloc_region in
  let nth_char = closure nth_char_1 @nth_char &toplevel.alloc_region in
@@ -73,7 +73,7 @@ let $camlTests14__first_const_0 = Block 0 () in
  let Pmakeblock =
    %block.[`0`].`toplevel` (set, nth_char, needs_try_region, gadt_match)
  in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`4`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`4`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests14.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests14.simplify.reference
@@ -8,7 +8,7 @@ let code loopify(never) size(5) newer_version_of(set_0)
         -> k * k1
         : imm tagged =
   let Psetfield = %block_set.`imm`.[`0`] (t, 42) in
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlTests14__set_1 = closure set_0_1 @set &toplevel.alloc_region in
 let code loopify(never) size(7) newer_version_of(nth_char_1)
@@ -19,7 +19,7 @@ let code loopify(never) size(7) newer_version_of(nth_char_1)
   let prim = %num_conv.[tagged_imm].[`nativeint`] (n) in
   let prim_1 = %string_load.[`8`] (s, prim) in
   let Pstringrefu = %tag_imm (prim_1) in
-  cont k (Pstringrefu)
+  cont k close[normal] my_alloc_region (Pstringrefu)
 in
 let $camlTests14__nth_char_2 =
   closure nth_char_1_1 @nth_char &toplevel.alloc_region
@@ -30,7 +30,7 @@ let code loopify(never) size(1) newer_version_of(needs_try_region_2)
         -> k * k1
         : imm tagged =
   let Popaque = %opaque (42) in
-  cont k (1)
+  cont k close[normal] my_alloc_region (1)
 in
 let $camlTests14__needs_try_region_3 =
   closure needs_try_region_2_1 @needs_try_region &toplevel.alloc_region
@@ -42,15 +42,16 @@ let code loopify(never) size(12) newer_version_of(gadt_match_3)
         : val =
   (let untagged = %untag_imm (x) in
    switch untagged
-     | 0 -> k (n)
+     | 0 -> k close[normal] my_alloc_region (n)
      | 1 -> k2)
     where k2 =
       let Popaque = %opaque (n) in
-      cont k (Popaque)
+      cont k close[normal] my_alloc_region (Popaque)
 in
 let $camlTests14__gadt_match_4 =
   closure gadt_match_3_1 @gadt_match &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests14 =
   Block 0 ($camlTests14__set_1,
            $camlTests14__nth_char_2,

--- a/testsuite/tests/flambda2/examples/tests15.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests15.raw.reference
@@ -23,9 +23,12 @@
       where k5 =
         cont k4)
      where k4 =
-       cont k2 pop(regular k2) ($camlTests15__Pmakeblock_2)
+       cont k2
+              pop(regular k2)
+              close[exn] my_alloc_region
+              ($camlTests15__Pmakeblock_2)
      where k3 =
-       cont k1 ($camlTests15__empty_array_3)
+       cont k1 close[normal] my_alloc_region ($camlTests15__empty_array_3)
  in
  let code size(18)
        is_c_1
@@ -43,9 +46,9 @@
     let eq = %int_comp.`imm`.eq (untagged, 2i) in
     switch eq
       | 0 -> k3
-      | 1 -> k1 (1))
+      | 1 -> k1 close[normal] my_alloc_region (1))
      where k3 =
-       cont k1 (0)
+       cont k1 close[normal] my_alloc_region (0)
  in
  let code size(6)
        set_to_x_2 (b : val, i : imm tagged)
@@ -56,7 +59,7 @@
    let prim = %num_conv.[tagged_imm].[`int8`] (120) in
    let prim_1 = %num_conv.[tagged_imm].[`nativeint`] (i) in
    let Pbytessetu = %bytes_or_bigstring_set.bytes.[`8`] (b, prim_1, prim) in
-   cont k1 (Pbytessetu)
+   cont k1 close[normal] my_alloc_region (Pbytessetu)
  in
  let code size(3)
        classical_id_3 (b : imm tagged)
@@ -66,7 +69,7 @@
    let next_depth = rec_info (succ my_depth) in
    let Pnot = %boolean_not (b) in
    let Pnot_1 = %boolean_not (Pnot) in
-   cont k1 (Pnot_1)
+   cont k1 close[normal] my_alloc_region (Pnot_1)
  in
  let code size(8)
        swapped_4 (param : imm tagged)
@@ -75,7 +78,7 @@
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_bswap = %int_uarith.bswp (287454020) in
-   cont k1 (int_bswap)
+   cont k1 close[normal] my_alloc_region (int_bswap)
  in
  let code size(3)
        negate_5 (x : imm tagged)
@@ -84,7 +87,7 @@
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_neg = %int_barith.sub (0, x) in
-   cont k1 (int_neg)
+   cont k1 close[normal] my_alloc_region (int_neg)
  in
  let code size(2)
        foo_6 (x : imm tagged)
@@ -93,7 +96,7 @@
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_or = %int_barith.or (x, 42) in
-   cont k1 (int_or)
+   cont k1 close[normal] my_alloc_region (int_or)
  in
  let $camlTests15__immstring_4 = " \\ \n " in
  let list_to_array =
@@ -118,7 +121,7 @@
       $camlTests15__immstring_4,
       foo)
  in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`8`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`8`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests15.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests15.simplify.reference
@@ -20,8 +20,12 @@ let code loopify(never) size(11) newer_version_of(list_to_array_0)
         : any array =
   let prim = %is_int (param) in
   switch prim
-    | 0 -> k1 pop(regular k1) ($camlTests15__Pmakeblock_2)
-    | 1 -> k ($camlTests15__empty_array_3)
+    | 0 ->
+      k1
+        pop(regular k1)
+        close[exn] my_alloc_region
+        ($camlTests15__Pmakeblock_2)
+    | 1 -> k close[normal] my_alloc_region ($camlTests15__empty_array_3)
 in
 let $camlTests15__list_to_array_5 =
   closure list_to_array_0_1 @list_to_array &toplevel.alloc_region
@@ -38,7 +42,7 @@ let code loopify(never) size(7) newer_version_of(is_c_1)
   let prim = %get_tag (param) in
   let eq = %int_comp.`imm`.eq (prim, 2i) in
   let tagged_scrutinee = %tag_imm (eq) in
-  cont k (tagged_scrutinee)
+  cont k close[normal] my_alloc_region (tagged_scrutinee)
 in
 let $camlTests15__is_c_6 = closure is_c_1_1 @is_c &toplevel.alloc_region in
 let code loopify(never) size(5) newer_version_of(set_to_x_2)
@@ -48,7 +52,7 @@ let code loopify(never) size(5) newer_version_of(set_to_x_2)
         : imm tagged =
   let prim = %num_conv.[tagged_imm].[`nativeint`] (i) in
   let Pbytessetu = %bytes_or_bigstring_set.bytes.[`8`] (b, prim, 120s) in
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlTests15__set_to_x_7 =
   closure set_to_x_2_1 @set_to_x &toplevel.alloc_region
@@ -60,7 +64,7 @@ let code loopify(never) size(3) newer_version_of(classical_id_3)
         : imm tagged =
   let Pnot = %boolean_not (b) in
   let Pnot_1 = %boolean_not (Pnot) in
-  cont k (Pnot_1)
+  cont k close[normal] my_alloc_region (Pnot_1)
 in
 let $camlTests15__classical_id_8 =
   closure classical_id_3_1 @classical_id &toplevel.alloc_region
@@ -70,7 +74,7 @@ let code loopify(never) size(1) newer_version_of(swapped_4)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (17459)
+  cont k close[normal] my_alloc_region (17459)
 in
 let $camlTests15__swapped_9 =
   closure swapped_4_1 @swapped &toplevel.alloc_region
@@ -81,7 +85,7 @@ let code loopify(never) size(3) newer_version_of(negate_5)
         -> k * k1
         : imm tagged =
   let int_neg = %int_barith.sub (0, x) in
-  cont k (int_neg)
+  cont k close[normal] my_alloc_region (int_neg)
 in
 let $camlTests15__negate_10 =
   closure negate_5_1 @negate &toplevel.alloc_region
@@ -92,9 +96,10 @@ let code loopify(never) size(2) newer_version_of(foo_6)
         -> k * k1
         : imm tagged =
   let int_or = %int_barith.or (x, 42) in
-  cont k (int_or)
+  cont k close[normal] my_alloc_region (int_or)
 in
 let $camlTests15__foo_11 = closure foo_6_1 @foo &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests15 =
   Block 0 ($camlTests15__list_to_array_5,
            $camlTests15__is_c_6,

--- a/testsuite/tests/flambda2/examples/tests2.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests2.raw.reference
@@ -9,26 +9,27 @@ let $camlTests2__first_const_0 = Block 0 () in
     let int_greaterthan = %tag_imm (prim) in
     (let untagged = %untag_imm (int_greaterthan) in
      switch untagged
-       | 0 -> k1 (42)
+       | 0 -> k1 close[normal] my_alloc_region (42)
        | 1 -> k4)
       where k4 =
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (x, 1) in
-         apply direct(f_0 &my_alloc_region)
+         apply direct(f_0 &my_alloc_region) [forward close close close]
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (int_sub)
              -> k3 * k2)
           where k3 (apply_result : imm tagged) =
             let int_add = %int_barith.add (1, apply_result) in
-            cont k1 (int_add))
+            cont k1 close[normal] my_alloc_region (int_add))
  in
  let f = closure f_0 @f &toplevel.alloc_region in
  apply direct(f_0 &toplevel.alloc_region) unroll(10)
+        [forward close close close]
    (f : _ -> imm tagged) (5) -> k1 * error
    where k1 (n : imm tagged) =
      let Pmakeblock = %block.[`0`].`toplevel` (f, n) in
-     cont k (Pmakeblock))
+     cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests2.simplify.reference
@@ -8,18 +8,19 @@ and code rec loopify(never) size(21) newer_version_of(f_0)
         : imm tagged =
   let prim = %int_comp.gt (x, 0) in
   switch prim
-    | 0 -> k (42)
+    | 0 -> k close[normal] my_alloc_region (42)
     | 1 -> k2
     where k2 =
       ((let int_sub = %int_barith.sub (x, 1) in
-        apply direct(f_0_1 &my_alloc_region)
+        apply direct(f_0_1 &my_alloc_region) [forward close close close]
           ($camlTests2__f_1 ~ depth my_depth -> succ my_depth
            : _ -> imm tagged)
             (int_sub)
             -> k2 * k1)
          where k2 (apply_result : imm tagged) =
            let int_add = %int_barith.add (1, apply_result) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests2 = Block 0 ($camlTests2__f_1, 47) in
 cont done ($camlTests2)

--- a/testsuite/tests/flambda2/examples/tests3.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests3.raw.reference
@@ -16,7 +16,10 @@
      where k6 =
        cont k4
      where k5 =
-       cont k2 pop(regular k2) ($camlTests3__block_1)
+       cont k2
+              pop(regular k2)
+              close[exn] my_alloc_region
+              ($camlTests3__block_1)
      where k4 =
        ((let cond_result = %is_flat_float_array (arr) in
          switch cond_result
@@ -30,7 +33,8 @@
             let ifso_result = %box_num.`float`.my_alloc_region (prim) in
             cont k4 (ifso_result)
           where k4 (if_then_else_result) =
-            apply &my_alloc_region f (if_then_else_result) -> k3 * k2)
+            apply &my_alloc_region [forward close close close]
+              f (if_then_else_result) -> k3 * k2)
      where k3 (apply_result : val) =
        ((let prim = %array_length.generic (arr) in
          let prim_1 = %int_comp.unsigned.lt (i, prim) in
@@ -40,7 +44,10 @@
           where k5 =
             cont k3
           where k4 =
-            cont k2 pop(regular k2) ($camlTests3__block_1)
+            cont k2
+                   pop(regular k2)
+                   close[exn] my_alloc_region
+                   ($camlTests3__block_1)
           where k3 =
             ((let cond_result = %is_flat_float_array (arr) in
               switch cond_result
@@ -54,7 +61,7 @@
                  let ifso_result = %array_set.`float` (arr, i, prim) in
                  cont k3 (ifso_result)
                where k3 (if_then_else_result : imm tagged) =
-                 cont k1 (if_then_else_result)))
+                 cont k1 close[normal] my_alloc_region (if_then_else_result)))
  in
  let code size(41)
        f_1 (c : imm tagged, m, n, x' : imm tagged, y' : imm tagged)
@@ -87,12 +94,12 @@
             cont k3 (int_add)
           where k3 (y : imm tagged) =
             let int_add = %int_barith.add (x, y) in
-            cont k1 (int_add))
+            cont k1 close[normal] my_alloc_region (int_add))
  in
  let foo = closure foo_0 @foo &toplevel.alloc_region in
  let f = closure f_1 @f &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (foo, f) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests3.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests3.simplify.reference
@@ -27,9 +27,13 @@ let code loopify(never) size(72) newer_version_of(foo_0)
            let ifso_result = %box_num.`float`.my_alloc_region (prim) in
            cont k4 (ifso_result)
          where k4 (if_then_else_result) =
-           apply &my_alloc_region f (if_then_else_result) -> k2 * k1)
+           apply &my_alloc_region [forward close close close]
+             f (if_then_else_result) -> k2 * k1)
     where k3 =
-      cont k1 pop(regular k1) ($camlTests3__block_1)
+      cont k1
+             pop(regular k1)
+             close[exn] my_alloc_region
+             ($camlTests3__block_1)
     where k2 (apply_result : val) =
       ((let cond_result = %is_flat_float_array (arr) in
         switch cond_result
@@ -44,7 +48,7 @@ let code loopify(never) size(72) newer_version_of(foo_0)
            cont k2
          where k2 =
            let if_then_else_result = 0 in
-           cont k (if_then_else_result))
+           cont k close[normal] my_alloc_region (if_then_else_result))
 in
 let $camlTests3__foo_2 = closure foo_0_1 @foo &toplevel.alloc_region in
 let code loopify(never) size(33) newer_version_of(f_1)
@@ -69,8 +73,9 @@ let code loopify(never) size(33) newer_version_of(f_1)
             cont k2 (int_add))
          where k2 (y : imm tagged) =
            let int_add = %int_barith.add (x, y) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let $camlTests3__f_3 = closure f_1_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests3 = Block 0 ($camlTests3__foo_2, $camlTests3__f_3) in
 cont done ($camlTests3)

--- a/testsuite/tests/flambda2/examples/tests4.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests4.raw.reference
@@ -35,7 +35,7 @@
        let prim_3 = %unbox_num.`float` (float_of_int) in
        let prim_4 = %bfloat_arith.sub (prim_3, prim_2) in
        let float_sub = %box_num.`float`.my_alloc_region (prim_4) in
-       cont k1 (float_sub)
+       cont k1 close[normal] my_alloc_region (float_sub)
  in
  let code size(54)
        pr2162_2_1 (z : imm tagged, x : imm tagged, y : float boxed)
@@ -72,7 +72,7 @@
        let prim_3 = %unbox_num.`float` (float_of_int) in
        let prim_4 = %bfloat_arith.sub (prim_3, prim_2) in
        let float_sub = %box_num.`float`.my_alloc_region (prim_4) in
-       cont k1 (float_sub)
+       cont k1 close[normal] my_alloc_region (float_sub)
  in
  let code size(70)
        pr2162_3_2 (z : imm tagged, x : imm tagged, y : float boxed)
@@ -113,7 +113,7 @@
        let prim_3 = %unbox_num.`float` (float_of_int) in
        let prim_4 = %bfloat_arith.sub (prim_3, prim_2) in
        let float_sub = %box_num.`float`.my_alloc_region (prim_4) in
-       cont k1 (float_sub)
+       cont k1 close[normal] my_alloc_region (float_sub)
  in
  let $camlTests4__int64_2 = 0L in
  let $camlTests4__int32_3 = 2l in
@@ -181,7 +181,7 @@
        let int64_sub = %box_num.`int64`.my_alloc_region (prim_9) in
        let Pmakeblock = %block.[`0`].my_alloc_region (int64_sub, int32_sub)
        in
-       cont k1 (Pmakeblock)
+       cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let pr2162_2_first =
    closure pr2162_2_first_0 @pr2162_2_first &toplevel.alloc_region
@@ -195,7 +195,7 @@
    %block.[`0`].`toplevel`
      (pr2162_2_first, pr2162_2, pr2162_3, pr2162_3_as_int64)
  in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`4`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`4`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests4.simplify.reference
@@ -26,7 +26,7 @@ let code loopify(never) size(34) newer_version_of(pr2162_2_first_0)
       let prim = %num_conv.[`imm`].[`float`] (naked_immediate) in
       let prim_1 = %bfloat_arith.sub (prim, unboxed_float) in
       let float_sub = %box_num.`float`.my_alloc_region (prim_1) in
-      cont k (float_sub)
+      cont k close[normal] my_alloc_region (float_sub)
 in
 let $camlTests4__pr2162_2_first_6 =
   closure pr2162_2_first_0_1 @pr2162_2_first &toplevel.alloc_region
@@ -55,7 +55,7 @@ let code loopify(never) size(34) newer_version_of(pr2162_2_1)
       let prim = %num_conv.[`imm`].[`float`] (naked_immediate) in
       let prim_1 = %bfloat_arith.sub (prim, unboxed_float) in
       let float_sub = %box_num.`float`.my_alloc_region (prim_1) in
-      cont k (float_sub)
+      cont k close[normal] my_alloc_region (float_sub)
 in
 let $camlTests4__pr2162_2_7 =
   closure pr2162_2_1_1 @pr2162_2 &toplevel.alloc_region
@@ -84,7 +84,7 @@ let code loopify(never) size(34) newer_version_of(pr2162_3_2)
       let prim = %num_conv.[`imm`].[`float`] (naked_immediate) in
       let prim_1 = %bfloat_arith.sub (prim, unboxed_float) in
       let float_sub = %box_num.`float`.my_alloc_region (prim_1) in
-      cont k (float_sub)
+      cont k close[normal] my_alloc_region (float_sub)
 in
 let $camlTests4__pr2162_3_8 =
   closure pr2162_3_2_1 @pr2162_3 &toplevel.alloc_region
@@ -122,11 +122,12 @@ let code loopify(never) size(49) newer_version_of(pr2162_3_as_int64_3)
       let prim_3 = %int_barith.`int64`.sub (prim_2, unboxed_int64) in
       let int64_sub = %box_num.`int64`.my_alloc_region (prim_3) in
       let Pmakeblock = %block.[`0`].my_alloc_region (int64_sub, int32_sub) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlTests4__pr2162_3_as_int64_9 =
   closure pr2162_3_as_int64_3_1 @pr2162_3_as_int64 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests4 =
   Block 0 ($camlTests4__pr2162_2_first_6,
            $camlTests4__pr2162_2_7,

--- a/testsuite/tests/flambda2/examples/tests4a.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests4a.raw.reference
@@ -17,13 +17,13 @@ let $camlTests4a__first_const_0 = Block 0 () in
      where k3 (y : imm tagged) =
        let prim = %phys_eq (y, x) in
        let eq = %tag_imm (prim) in
-       cont k1 (eq)
+       cont k1 close[normal] my_alloc_region (eq)
  in
  let pr2162_3_as_int64 =
    closure pr2162_3_as_int64_0 @pr2162_3_as_int64 &toplevel.alloc_region
  in
  let Pmakeblock = %block.[`0`].`toplevel` (pr2162_3_as_int64) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlTests4a = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/tests4a.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests4a.simplify.reference
@@ -14,10 +14,11 @@ let code loopify(never) size(21) newer_version_of(pr2162_3_as_int64_0)
     where k2 (y : imm tagged) =
       let prim = %phys_eq (y, x) in
       let eq = %tag_imm (prim) in
-      cont k (eq)
+      cont k close[normal] my_alloc_region (eq)
 in
 let $camlTests4a__pr2162_3_as_int64_1 =
   closure pr2162_3_as_int64_0_1 @pr2162_3_as_int64 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests4a = Block 0 ($camlTests4a__pr2162_3_as_int64_1) in
 cont done ($camlTests4a)

--- a/testsuite/tests/flambda2/examples/tests5.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests5.raw.reference
@@ -10,13 +10,13 @@ let $camlTests5__first_const_0 = Block 0 () in
     let int_lessthan = %tag_imm (prim) in
     (let untagged = %untag_imm (int_lessthan) in
      switch untagged
-       | 0 -> k1 (42)
+       | 0 -> k1 close[normal] my_alloc_region (42)
        | 1 -> k4)
       where k4 =
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (x, 1) in
-       apply direct(g_1 &my_alloc_region)
+       apply direct(g_1 &my_alloc_region) [close close close close]
          (g ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
@@ -31,13 +31,13 @@ let $camlTests5__first_const_0 = Block 0 () in
     let int_greaterthan = %tag_imm (prim) in
     (let untagged = %untag_imm (int_greaterthan) in
      switch untagged
-       | 0 -> k1 (7)
+       | 0 -> k1 close[normal] my_alloc_region (7)
        | 1 -> k4)
       where k4 =
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (y, 1) in
-       apply direct(f_0 &my_alloc_region)
+       apply direct(f_0 &my_alloc_region) [close close close close]
          (f ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
@@ -46,7 +46,7 @@ let $camlTests5__first_const_0 = Block 0 () in
  and g = closure g_1 @g &toplevel.alloc_region
  in
  let Pmakeblock = %block.[`0`].`toplevel` (f, g) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests5.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests5.simplify.reference
@@ -10,11 +10,11 @@ and code rec loopify(never) size(18) newer_version_of(g_1)
         : imm tagged =
   let prim = %int_comp.gt (y, 3) in
   switch prim
-    | 0 -> k (7)
+    | 0 -> k close[normal] my_alloc_region (7)
     | 1 -> k2
     where k2 =
       let int_sub = %int_barith.sub (y, 1) in
-      apply direct(f_0_1 &my_alloc_region)
+      apply direct(f_0_1 &my_alloc_region) [close close close close]
         ($camlTests5__f_1 ~ depth my_depth -> succ my_depth : _ -> imm tagged
          )
           (int_sub)
@@ -26,15 +26,16 @@ and code rec loopify(never) size(18) newer_version_of(f_0)
         : imm tagged =
   let prim = %int_comp.lt (x, 4) in
   switch prim
-    | 0 -> k (42)
+    | 0 -> k close[normal] my_alloc_region (42)
     | 1 -> k2
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
-      apply direct(g_1_1 &my_alloc_region)
+      apply direct(g_1_1 &my_alloc_region) [close close close close]
         ($camlTests5__g_2 ~ depth my_depth -> succ my_depth : _ -> imm tagged
          )
           (int_sub)
           -> k * k1
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests5 = Block 0 ($camlTests5__f_1, $camlTests5__g_2) in
 cont done ($camlTests5)

--- a/testsuite/tests/flambda2/examples/tests6.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests6.raw.reference
@@ -9,24 +9,25 @@ let $camlTests6__first_const_0 = Block 0 () in
     let int_greaterthan = %tag_imm (prim) in
     (let untagged = %untag_imm (int_greaterthan) in
      switch untagged
-       | 0 -> k1 (42)
+       | 0 -> k1 close[normal] my_alloc_region (42)
        | 1 -> k4)
       where k4 =
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (x, 1) in
-         apply direct(f_0 &my_alloc_region)
+         apply direct(f_0 &my_alloc_region) [forward close close close]
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (int_sub)
              -> k3 * k2)
           where k3 (apply_result : imm tagged) =
             let int_add = %int_barith.add (1, apply_result) in
-            cont k1 (int_add))
+            cont k1 close[normal] my_alloc_region (int_add))
  in
  (let `region` = %begin_region () in
   let ghost_region = %begin_ghost_region () in
   (let f = closure f_0 @f &toplevel.alloc_region &`region` in
    apply direct(f_0 &toplevel.alloc_region) unroll(10)
+          [forward close close close]
      (f : _ -> imm tagged) (3) -> k2 * error)
     where k2 (region_return : imm tagged) =
       let `unit` = %end_region (`region`) in
@@ -34,7 +35,7 @@ let $camlTests6__first_const_0 = Block 0 () in
       cont k1 (region_return))
    where k1 (n : imm tagged) =
      let Pmakeblock = %block.[`0`].`toplevel` (n) in
-     cont k (Pmakeblock))
+     cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlTests6 = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/tests6.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests6.simplify.reference
@@ -1,2 +1,3 @@
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests6 = Block 0 (45) in
 cont done ($camlTests6)

--- a/testsuite/tests/flambda2/examples/tests7.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests7.raw.reference
@@ -18,7 +18,7 @@
    let int_add_1 = %int_barith.add (int_add, Pstringlength_2) in
    let int_add_2 = %int_barith.add (int_add_1, Pstringlength_1) in
    let int_add_3 = %int_barith.add (int_add_2, Pstringlength) in
-   cont k1 (int_add_3)
+   cont k1 close[normal] my_alloc_region (int_add_3)
  in
  let code size(31)
        foo_1 (af : float ^ 2, y : float boxed)
@@ -38,7 +38,7 @@
    let prim_6 = %unbox_num.`float` (x) in
    let prim_7 = %bfloat_arith.add (prim_6, prim_5) in
    let float_add = %box_num.`float`.my_alloc_region (prim_7) in
-   cont k1 (float_add)
+   cont k1 close[normal] my_alloc_region (float_add)
  in
  let $camlTests7__empty_block_0 = Block 0 () in
  let f = closure f_0 @f &toplevel.alloc_region in
@@ -51,7 +51,7 @@
       f,
       foo)
  in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = $camlTests7__empty_block_0 in
     let field_1 = $camlTests7__immstring_1 in

--- a/testsuite/tests/flambda2/examples/tests7.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests7.simplify.reference
@@ -14,7 +14,7 @@ let code loopify(never) size(16) newer_version_of(f_0)
   let int_add_1 = %int_barith.add (int_add, 5) in
   let int_add_2 = %int_barith.add (int_add_1, Pstringlength) in
   let int_add_3 = %int_barith.add (int_add_2, Pstringlength) in
-  cont k (int_add_3)
+  cont k close[normal] my_alloc_region (int_add_3)
 in
 let $camlTests7__f_3 = closure f_0_1 @f &toplevel.alloc_region in
 let code loopify(never) size(13) newer_version_of(foo_1)
@@ -28,9 +28,10 @@ let code loopify(never) size(13) newer_version_of(foo_1)
   let prim_3 = %unbox_num.`float` (y) in
   let prim_4 = %bfloat_arith.add (prim_2, prim_3) in
   let float_add = %box_num.`float`.my_alloc_region (prim_4) in
-  cont k (float_add)
+  cont k close[normal] my_alloc_region (float_add)
 in
 let $camlTests7__foo_4 = closure foo_1_1 @foo &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests7 =
   Block 0 ($camlTests7__empty_block_0,
            $camlTests7__immstring_1,

--- a/testsuite/tests/flambda2/examples/tests8.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests8.raw.reference
@@ -5,7 +5,7 @@ let $camlTests8__first_const_0 = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code size(1)
        `fn[tests8.ml:20,49--61]_3` (x : val)
@@ -13,7 +13,7 @@ let $camlTests8__first_const_0 = Block 0 () in
          -> k1 * k2
          : val =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (x)
+   cont k1 close[normal] my_alloc_region (x)
  in
  let code size(21)
        `fn[tests8.ml:20,12--80]_1` (param : imm tagged)
@@ -34,6 +34,7 @@ let $camlTests8__first_const_0 = Block 0 () in
        &my_alloc_region
    in
    apply direct(map_foo_0 &my_alloc_region) inlined(never)
+          [close close close close]
      (map_foo : _ -> [ 0 | 0 of val * val ])
        (`fn[tests8.ml:20,49--61]`, `fn[tests8.ml:20,62--77]`, 0)
        -> k1 * k2
@@ -43,14 +44,14 @@ let $camlTests8__first_const_0 = Block 0 () in
          -> k1 * k2
          : [ 0 | 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
-   apply &my_alloc_region seq (0) -> k3 * k2
+   apply &my_alloc_region [forward close close close] seq (0) -> k3 * k2
      where k3 (`*match*` : [ 0 | 0 of val * val ]) =
        ((let prim = %is_int (`*match*`) in
          let Pisint = %tag_imm (prim) in
          (let untagged = %untag_imm (Pisint) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (0))
+            | 1 -> k1 close[normal] my_alloc_region (0))
            where k4 =
              cont k3)
           where k3 =
@@ -60,17 +61,18 @@ let $camlTests8__first_const_0 = Block 0 () in
             with { my_closure = my_closure ~ depth my_depth -> next_depth }
             in
             ((let Pfield = %block_load.[`0`] (`*match*`) in
-              apply &my_alloc_region f (Pfield) -> k3 * k2)
+              apply &my_alloc_region [forward close close close]
+                f (Pfield) -> k3 * k2)
                where k3 (apply_result : val) =
                  let Pmakeblock =
                    %block.[`0`].my_alloc_region
                      (apply_result, `fn[tests8.ml:20,12--80]`)
                  in
-                 cont k1 (Pmakeblock)))
+                 cont k1 close[normal] my_alloc_region (Pmakeblock)))
  in
  let map_foo = closure map_foo_0 @map_foo &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (map_foo) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlTests8 = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/examples/tests8.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests8.simplify.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests8.ml:20,49--61]_3`)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : val =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $`camlTests8__fn[tests8.ml:20,49--61]_3` =
   closure `fn[tests8.ml:20,49--61]_3_1` @`fn[tests8.ml:20,49--61]`
@@ -17,7 +17,7 @@ let code loopify(never) size(1) newer_version_of(`fn[tests8.ml:20,62--77]_2`)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $`camlTests8__fn[tests8.ml:20,62--77]_2` =
   closure `fn[tests8.ml:20,62--77]_2_1` @`fn[tests8.ml:20,62--77]`
@@ -30,12 +30,12 @@ and code rec loopify(never) size(44) newer_version_of(map_foo_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
-  apply &my_alloc_region seq (0) -> k2 * k1
+  apply &my_alloc_region [forward close close close] seq (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val * val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (0)
+         | 1 -> k close[normal] my_alloc_region (0)
          where k2 =
            let `fn[tests8.ml:20,12--80]` =
              closure `fn[tests8.ml:20,12--80]_1_1` @`fn[tests8.ml:20,12--80]`
@@ -46,19 +46,21 @@ and code rec loopify(never) size(44) newer_version_of(map_foo_0)
            }
            in
            ((let Pfield = %block_load.[`0`] (`*match*`) in
-             apply &my_alloc_region f (Pfield) -> k2 * k1)
+             apply &my_alloc_region [forward close close close]
+               f (Pfield) -> k2 * k1)
               where k2 (apply_result : val) =
                 let Pmakeblock =
                   %block.[`0`].my_alloc_region
                     (apply_result, `fn[tests8.ml:20,12--80]`)
                 in
-                cont k (Pmakeblock)))
+                cont k close[normal] my_alloc_region (Pmakeblock)))
 and code loopify(never) size(4) newer_version_of(`fn[tests8.ml:20,12--80]_1`)
       `fn[tests8.ml:20,12--80]_1_1` (param : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * val ] =
   apply direct(map_foo_0_1 &my_alloc_region) inlined(never)
+         [close close close close]
     ($camlTests8__map_foo_1 ~ depth do_not_inline -> do_not_inline
      : _ -> [ 0 | 0 of val * val ])
       ($`camlTests8__fn[tests8.ml:20,49--61]_3`,
@@ -66,5 +68,6 @@ and code loopify(never) size(4) newer_version_of(`fn[tests8.ml:20,12--80]_1`)
        0)
       -> k * k1
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests8 = Block 0 ($camlTests8__map_foo_1) in
 cont done ($camlTests8)

--- a/testsuite/tests/flambda2/examples/tests9.raw.reference
+++ b/testsuite/tests/flambda2/examples/tests9.raw.reference
@@ -10,13 +10,13 @@
     (let untagged = %untag_imm (Pisint) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (len))
+       | 1 -> k1 close[normal] my_alloc_region (len))
       where k4 =
         cont k3)
      where k3 =
        let Pfield = %block_load.[`1`] (param) in
        let int_add = %int_barith.add (len, 1) in
-       apply direct(length_aux_0 &my_alloc_region)
+       apply direct(length_aux_0 &my_alloc_region) [close close close close]
          (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_add, Pfield)
            -> k1 * k2
@@ -28,7 +28,7 @@
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let length_aux = %project_value_slot.[length].[length_aux] (my_closure) in
-   apply direct(length_aux_0 &my_alloc_region)
+   apply direct(length_aux_0 &my_alloc_region) [close close close close]
      (length_aux : _ -> imm tagged) (0, l) -> k1 * k2
  in
  let code rec loopify(default tailrec) size(28)
@@ -44,14 +44,14 @@
     (let untagged = %untag_imm (Pisint) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (l2))
+       | 1 -> k1 close[normal] my_alloc_region (l2))
       where k4 =
         cont k3)
      where k3 =
        let Pfield = %block_load.[`0`] (l1) in
        let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, l2) in
        let Pfield_1 = %block_load.[`1`] (l1) in
-       apply direct(rev_append_2 &my_alloc_region)
+       apply direct(rev_append_2 &my_alloc_region) [close close close close]
          (my_closure ~ depth my_depth -> next_depth
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (Pfield_1, Pmakeblock)
@@ -74,7 +74,7 @@
     (let untagged = %untag_imm (eq) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (l))
+       | 1 -> k1 close[normal] my_alloc_region (l))
       where k4 =
         cont k3)
      where k3 =
@@ -91,13 +91,16 @@
           where k4 =
             let Pfield = %block_load.[`1`] (l) in
             let int_sub = %int_barith.sub (k, 1) in
-            apply direct(chop_3 &my_alloc_region)
+            apply direct(chop_3 &my_alloc_region) [close close close close]
               (my_closure ~ depth my_depth -> next_depth
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (int_sub, Pfield)
                 -> k1 * k2
           where k3 =
-            cont k2 pop(regular k2) ($camlTests9__Pmakeblock_2))
+            cont k2
+                   pop(regular k2)
+                   close[exn] my_alloc_region
+                   ($camlTests9__Pmakeblock_2))
  in
  let code rec loopify(default tailrec) size(119)
        rev_merge_5
@@ -137,7 +140,8 @@
             let h2 = %block_load.[`0`] (l2) in
             let t1 = %block_load.[`1`] (l1) in
             let h1 = %block_load.[`0`] (l1) in
-            (apply &my_alloc_region cmp (h1, h2) -> k5 * k2
+            (apply &my_alloc_region [forward close close close]
+               cmp (h1, h2) -> k5 * k2
                where k5 (c : imm tagged) =
                  ((let prim = %phys_eq (c, 0) in
                    let eq = %tag_imm (prim) in
@@ -165,6 +169,7 @@
                              %block.[`0`].my_alloc_region (h2, accu)
                            in
                            apply direct(rev_merge_5 &my_alloc_region)
+                                  [close close close close]
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -176,6 +181,7 @@
                              %block.[`0`].my_alloc_region (h1, accu)
                            in
                            apply direct(rev_merge_5 &my_alloc_region)
+                                  [close close close close]
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -187,17 +193,19 @@
                         %block.[`0`].my_alloc_region (h1, accu)
                       in
                       apply direct(rev_merge_5 &my_alloc_region)
+                             [close close close close]
                         (my_closure ~ depth my_depth -> next_depth
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (t1, t2, Pmakeblock)
                           -> k1 * k2))
           where k4 =
             apply direct(rev_append_2 &my_alloc_region)
+                   [close close close close]
               (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (l1, accu)
                 -> k1 * k2)
      where k3 =
-       apply direct(rev_append_2 &my_alloc_region)
+       apply direct(rev_append_2 &my_alloc_region) [close close close close]
          (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (l2, accu)
            -> k1 * k2
@@ -241,7 +249,8 @@
             let h2 = %block_load.[`0`] (l2) in
             let t1 = %block_load.[`1`] (l1) in
             let h1 = %block_load.[`0`] (l1) in
-            (apply &my_alloc_region cmp (h1, h2) -> k5 * k2
+            (apply &my_alloc_region [forward close close close]
+               cmp (h1, h2) -> k5 * k2
                where k5 (c : imm tagged) =
                  ((let prim = %phys_eq (c, 0) in
                    let eq = %tag_imm (prim) in
@@ -269,6 +278,7 @@
                              %block.[`0`].my_alloc_region (h2, accu)
                            in
                            apply direct(rev_merge_rev_6 &my_alloc_region)
+                                  [close close close close]
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -280,6 +290,7 @@
                              %block.[`0`].my_alloc_region (h1, accu)
                            in
                            apply direct(rev_merge_rev_6 &my_alloc_region)
+                                  [close close close close]
                              (my_closure ~ depth my_depth -> next_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -291,17 +302,19 @@
                         %block.[`0`].my_alloc_region (h1, accu)
                       in
                       apply direct(rev_merge_rev_6 &my_alloc_region)
+                             [close close close close]
                         (my_closure ~ depth my_depth -> next_depth
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (t1, t2, Pmakeblock)
                           -> k1 * k2))
           where k4 =
             apply direct(rev_append_2 &my_alloc_region)
+                   [close close close close]
               (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (l1, accu)
                 -> k1 * k2)
      where k3 =
-       apply direct(rev_append_2 &my_alloc_region)
+       apply direct(rev_append_2 &my_alloc_region) [close close close close]
          (rev_append : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (l2, accu)
            -> k1 * k2
@@ -355,7 +368,8 @@
                where k5 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply &my_alloc_region cmp (x1, x2) -> k5 * k2
+                 (apply &my_alloc_region [forward close close close]
+                    cmp (x1, x2) -> k5 * k2
                     where k5 (c : imm tagged) =
                       ((let prim = %phys_eq (c, 0) in
                         let eq = %tag_imm (prim) in
@@ -386,7 +400,9 @@
                                   %block.[`0`].my_alloc_region
                                     (x2, Pmakeblock)
                                 in
-                                cont k1 (Pmakeblock_1)
+                                cont k1
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1)
                               where k6 =
                                 let Pmakeblock =
                                   %block.[`0`].my_alloc_region (x2, 0)
@@ -395,12 +411,14 @@
                                   %block.[`0`].my_alloc_region
                                     (x1, Pmakeblock)
                                 in
-                                cont k1 (Pmakeblock_1))
+                                cont k1
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1))
                          where k5 =
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x1, 0)
                            in
-                           cont k1 (Pmakeblock)))))
+                           cont k1 close[normal] my_alloc_region (Pmakeblock)))))
      where k4 =
        ((let prim = %int_comp.ne (n, 3) in
          let int_notequal = %tag_imm (prim) in
@@ -451,7 +469,9 @@
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k2
+                           (apply &my_alloc_region
+                                   [forward close close close]
+                              cmp (x1, x2) -> k4 * k2
                               where k4 (c : imm tagged) =
                                 ((let prim = %phys_eq (c, 0) in
                                   let eq = %tag_imm (prim) in
@@ -478,6 +498,7 @@
                                            cont k6)
                                         where k6 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x1, x3) -> k6 * k2
                                              where k6 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
@@ -514,6 +535,7 @@
                                                        where k8 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x2, x3)
                                                               -> k8 * k2
@@ -587,6 +609,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k9 =
@@ -606,6 +629,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2))
                                                                  where 
                                                                    k8 =
@@ -620,6 +644,7 @@
                                                                    in
                                                                    cont 
                                                                    k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)))
                                                        where k7 =
                                                          let Pmakeblock =
@@ -636,6 +661,7 @@
                                                               Pmakeblock_1)
                                                          in
                                                          cont k1
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2))
                                                   where k6 =
                                                     let Pmakeblock =
@@ -646,9 +672,12 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1)))
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)))
                                         where k5 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x2, x3) -> k5 * k2
                                              where k5 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
@@ -685,6 +714,7 @@
                                                        where k7 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x1, x3)
                                                               -> k7 * k2
@@ -758,6 +788,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k8 =
@@ -777,6 +808,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2))
                                                                  where 
                                                                    k7 =
@@ -791,6 +823,7 @@
                                                                    in
                                                                    cont 
                                                                    k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)))
                                                        where k6 =
                                                          let Pmakeblock =
@@ -807,6 +840,7 @@
                                                               Pmakeblock_1)
                                                          in
                                                          cont k1
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2))
                                                   where k5 =
                                                     let Pmakeblock =
@@ -817,9 +851,12 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1))))
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1))))
                                    where k4 =
                                      (apply &my_alloc_region
+                                             [forward close close close]
                                         cmp (x2, x3) -> k4 * k2
                                         where k4 (c_1 : imm tagged) =
                                           ((let prim = %phys_eq (c_1, 0) in
@@ -859,7 +896,9 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1)
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
                                                       %block.[`0`].my_alloc_region
@@ -869,35 +908,42 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1))
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1))
                                              where k4 =
                                                let Pmakeblock =
                                                  %block.[`0`].my_alloc_region
                                                    (x2, 0)
                                                in
-                                               cont k1 (Pmakeblock)))))))))
+                                               cont k1
+                                                      close[normal] my_alloc_region
+                                                      (Pmakeblock)))))))))
      where k3 =
        let prim = %untag_imm (1) in
        let n1 = %int_shift.asr (n, prim) in
        let n2 = %int_barith.sub (n, n1) in
-       (apply direct(chop_3 &my_alloc_region)
+       (apply direct(chop_3 &my_alloc_region) [forward close close close]
           (chop : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
             (n1, l)
             -> k3 * k2
           where k3 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
             (apply direct(rev_sort_8 &my_alloc_region)
+                    [forward close close close]
                (rev_sort ~ depth my_depth -> next_depth
                 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                  (n1, l)
                  -> k3 * k2
                where k3 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                  (apply direct(rev_sort_8 &my_alloc_region)
+                         [forward close close close]
                     (rev_sort ~ depth my_depth -> next_depth
                      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       (n2, l2)
                       -> k3 * k2
                     where k3 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                       apply direct(rev_merge_rev_6 &my_alloc_region)
+                             [close close close close]
                         (rev_merge_rev
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (s1, s2, 0)
@@ -952,7 +998,8 @@
                where k5 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply &my_alloc_region cmp (x1, x2) -> k5 * k2
+                 (apply &my_alloc_region [forward close close close]
+                    cmp (x1, x2) -> k5 * k2
                     where k5 (c : imm tagged) =
                       ((let prim = %phys_eq (c, 0) in
                         let eq = %tag_imm (prim) in
@@ -983,7 +1030,9 @@
                                   %block.[`0`].my_alloc_region
                                     (x2, Pmakeblock)
                                 in
-                                cont k1 (Pmakeblock_1)
+                                cont k1
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1)
                               where k6 =
                                 let Pmakeblock =
                                   %block.[`0`].my_alloc_region (x2, 0)
@@ -992,12 +1041,14 @@
                                   %block.[`0`].my_alloc_region
                                     (x1, Pmakeblock)
                                 in
-                                cont k1 (Pmakeblock_1))
+                                cont k1
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1))
                          where k5 =
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x1, 0)
                            in
-                           cont k1 (Pmakeblock)))))
+                           cont k1 close[normal] my_alloc_region (Pmakeblock)))))
      where k4 =
        ((let prim = %int_comp.ne (n, 3) in
          let int_notequal = %tag_imm (prim) in
@@ -1048,7 +1099,9 @@
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k2
+                           (apply &my_alloc_region
+                                   [forward close close close]
+                              cmp (x1, x2) -> k4 * k2
                               where k4 (c : imm tagged) =
                                 ((let prim = %phys_eq (c, 0) in
                                   let eq = %tag_imm (prim) in
@@ -1076,6 +1129,7 @@
                                            cont k6)
                                         where k6 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x1, x3) -> k6 * k2
                                              where k6 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
@@ -1112,6 +1166,7 @@
                                                        where k8 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x2, x3)
                                                               -> k8 * k2
@@ -1185,6 +1240,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k9 =
@@ -1204,6 +1260,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2))
                                                                  where 
                                                                    k8 =
@@ -1218,6 +1275,7 @@
                                                                    in
                                                                    cont 
                                                                    k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)))
                                                        where k7 =
                                                          let Pmakeblock =
@@ -1234,6 +1292,7 @@
                                                               Pmakeblock_1)
                                                          in
                                                          cont k1
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2))
                                                   where k6 =
                                                     let Pmakeblock =
@@ -1244,9 +1303,12 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1)))
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)))
                                         where k5 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x2, x3) -> k5 * k2
                                              where k5 (c_1 : imm tagged) =
                                                ((let prim = %phys_eq (c_1, 0)
@@ -1283,6 +1345,7 @@
                                                        where k7 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x1, x3)
                                                               -> k7 * k2
@@ -1356,6 +1419,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k8 =
@@ -1375,6 +1439,7 @@
                                                                     in
                                                                     cont 
                                                                     k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2))
                                                                  where 
                                                                    k7 =
@@ -1389,6 +1454,7 @@
                                                                    in
                                                                    cont 
                                                                    k1
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)))
                                                        where k6 =
                                                          let Pmakeblock =
@@ -1405,6 +1471,7 @@
                                                               Pmakeblock_1)
                                                          in
                                                          cont k1
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2))
                                                   where k5 =
                                                     let Pmakeblock =
@@ -1415,9 +1482,12 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1))))
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1))))
                                    where k4 =
                                      (apply &my_alloc_region
+                                             [forward close close close]
                                         cmp (x2, x3) -> k4 * k2
                                         where k4 (c_1 : imm tagged) =
                                           ((let prim = %phys_eq (c_1, 0) in
@@ -1458,7 +1528,9 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1)
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
                                                       %block.[`0`].my_alloc_region
@@ -1468,35 +1540,42 @@
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k1 (Pmakeblock_1))
+                                                    cont k1
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1))
                                              where k4 =
                                                let Pmakeblock =
                                                  %block.[`0`].my_alloc_region
                                                    (x2, 0)
                                                in
-                                               cont k1 (Pmakeblock)))))))))
+                                               cont k1
+                                                      close[normal] my_alloc_region
+                                                      (Pmakeblock)))))))))
      where k3 =
        let prim = %untag_imm (1) in
        let n1 = %int_shift.asr (n, prim) in
        let n2 = %int_barith.sub (n, n1) in
-       (apply direct(chop_3 &my_alloc_region)
+       (apply direct(chop_3 &my_alloc_region) [forward close close close]
           (chop : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
             (n1, l)
             -> k3 * k2
           where k3 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
             (apply direct(sort_7 &my_alloc_region)
+                    [forward close close close]
                (sort ~ depth my_depth -> next_depth
                 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                  (n1, l)
                  -> k3 * k2
                where k3 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                  (apply direct(sort_7 &my_alloc_region)
+                         [forward close close close]
                     (sort ~ depth my_depth -> next_depth
                      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       (n2, l2)
                       -> k3 * k2
                     where k3 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                       apply direct(rev_merge_5 &my_alloc_region)
+                             [close close close close]
                         (rev_merge
                          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                           (s1, s2, 0)
@@ -1529,7 +1608,7 @@
      rev_merge_rev = rev_merge_rev
    }
    in
-   apply direct(length_1 &my_alloc_region)
+   apply direct(length_1 &my_alloc_region) [forward close close close]
      (length : _ -> imm tagged) (l) -> k3 * k2
      where k3 (len : imm tagged) =
        ((let prim = %int_comp.lt (len, 2) in
@@ -1537,11 +1616,11 @@
          (let untagged = %untag_imm (int_lessthan) in
           switch untagged
             | 0 -> k4
-            | 1 -> k1 (l))
+            | 1 -> k1 close[normal] my_alloc_region (l))
            where k4 =
              cont k3)
           where k3 =
-            apply direct(sort_7 &my_alloc_region)
+            apply direct(sort_7 &my_alloc_region) [close close close close]
               (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (len, l)
                 -> k1 * k2)
@@ -1556,7 +1635,7 @@
    let cmp = %project_value_slot.[sort_1].[cmp_3] (my_closure) in
    let rev_sort = %project_function_slot.[sort_1].[rev_sort_1] (my_closure)
    in
-   apply direct(rev_sort_11 &my_alloc_region)
+   apply direct(rev_sort_11 &my_alloc_region) [close close close close]
      (rev_sort ~ depth my_depth -> next_depth
       : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
        (n, l)
@@ -1606,7 +1685,8 @@
                where k4 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply &my_alloc_region cmp (x1, x2) -> k4 * k2
+                 (apply &my_alloc_region [forward close close close]
+                    cmp (x1, x2) -> k4 * k2
                     where k4 (c : imm tagged) =
                       ((let prim = %int_comp.lt (c, 0) in
                         let int_lessthan = %tag_imm (prim) in
@@ -1622,14 +1702,14 @@
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x2, 0)
                            in
-                           cont k1 (Pmakeblock)
+                           cont k1 close[normal] my_alloc_region (Pmakeblock)
                          where k4 =
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x1, 0)
                            in
-                           cont k1 (Pmakeblock)))))
+                           cont k1 close[normal] my_alloc_region (Pmakeblock)))))
      where k3 =
-       apply direct(sort_10 &my_alloc_region)
+       apply direct(sort_10 &my_alloc_region) [close close close close]
          (sort ~ depth my_depth -> next_depth
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (n, l)
@@ -1645,7 +1725,7 @@
    and rev_sort = closure rev_sort_11 @rev_sort_1 &my_alloc_region
    with { cmp_3 = cmp }
    in
-   apply direct(sort_10 &my_alloc_region)
+   apply direct(sort_10 &my_alloc_region) [close close close close]
      (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
        (42, l)
        -> k1 * k2
@@ -1664,7 +1744,7 @@
    %block.[`0`].`toplevel`
      (length_aux, length, rev_append, chop, sort_uniq, foo)
  in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`6`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`6`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/tests9.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tests9.simplify.reference
@@ -27,7 +27,7 @@ let code loopify(done) size(16) newer_version_of(length_aux_0)
       let prim = %is_int (param_1) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (len_1)
+         | 1 -> k close[normal] my_alloc_region (len_1)
          where k2 =
            let Pfield = %block_load.[`1`] (param_1) in
            let int_add = %int_barith.add (len_1, 1) in
@@ -41,7 +41,7 @@ let code loopify(never) size(4) newer_version_of(length_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(length_aux_0_1 &my_alloc_region)
+  apply direct(length_aux_0_1 &my_alloc_region) [close close close close]
     ($camlTests9__length_aux_3 : _ -> imm tagged) (0, l) -> k * k1
 in
 let $camlTests9__length_4 = closure length_1_1 @length &toplevel.alloc_region
@@ -60,7 +60,7 @@ let code loopify(done) size(22) newer_version_of(rev_append_2)
       let prim = %is_int (l1_1) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (l2_1)
+         | 1 -> k close[normal] my_alloc_region (l2_1)
          where k2 =
            let Pfield = %block_load.[`0`] (l1_1) in
            let Pmakeblock = %block.[`0`].my_alloc_region (Pfield, l2_1) in
@@ -83,12 +83,16 @@ let code loopify(done) size(28) newer_version_of(chop_3)
       let prim = %phys_eq (k_1, 0) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (l_1)
+         | 1 -> k close[normal] my_alloc_region (l_1)
          where k2 =
            let prim_1 = %is_int (l_1) in
            (switch prim_1
               | 0 -> k2
-              | 1 -> k1 pop(regular k1) ($camlTests9__Pmakeblock_2)
+              | 1 ->
+                k1
+                  pop(regular k1)
+                  close[exn] my_alloc_region
+                  ($camlTests9__Pmakeblock_2)
               where k2 =
                 let Pfield = %block_load.[`1`] (l_1) in
                 let int_sub = %int_barith.sub (k_1, 1) in
@@ -115,6 +119,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
          | 1 -> k3
          where k3 =
            apply direct(rev_append_2_1 &my_alloc_region)
+                  [close close close close]
              ($camlTests9__rev_append_5
               : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                (l2_1, accu_1)
@@ -126,6 +131,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
               | 1 -> k3
               where k3 =
                 apply direct(rev_append_2_1 &my_alloc_region)
+                       [close close close close]
                   ($camlTests9__rev_append_5
                    : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                     (l1_1, accu_1)
@@ -135,7 +141,8 @@ let code loopify(done) size(90) newer_version_of(rev_merge_5)
                 let h2 = %block_load.[`0`] (l2_1) in
                 let t1 = %block_load.[`1`] (l1_1) in
                 let h1 = %block_load.[`0`] (l1_1) in
-                (apply &my_alloc_region cmp (h1, h2) -> k2 * k1
+                (apply &my_alloc_region [forward close close close]
+                   cmp (h1, h2) -> k2 * k1
                    where k2 (c : imm tagged) =
                      let prim_2 = %phys_eq (c, 0) in
                      (switch prim_2
@@ -182,6 +189,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
          | 1 -> k3
          where k3 =
            apply direct(rev_append_2_1 &my_alloc_region)
+                  [close close close close]
              ($camlTests9__rev_append_5
               : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                (l2_1, accu_1)
@@ -193,6 +201,7 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
               | 1 -> k3
               where k3 =
                 apply direct(rev_append_2_1 &my_alloc_region)
+                       [close close close close]
                   ($camlTests9__rev_append_5
                    : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                     (l1_1, accu_1)
@@ -202,7 +211,8 @@ let code loopify(done) size(90) newer_version_of(rev_merge_rev_6)
                 let h2 = %block_load.[`0`] (l2_1) in
                 let t1 = %block_load.[`1`] (l1_1) in
                 let h1 = %block_load.[`0`] (l1_1) in
-                (apply &my_alloc_region cmp (h1, h2) -> k2 * k1
+                (apply &my_alloc_region [forward close close close]
+                   cmp (h1, h2) -> k2 * k1
                    where k2 (c : imm tagged) =
                      let prim_2 = %phys_eq (c, 0) in
                      (switch prim_2
@@ -268,7 +278,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k1
+                           (apply &my_alloc_region
+                                   [forward close close close]
+                              cmp (x1, x2) -> k4 * k1
                               where k4 (c : imm tagged) =
                                 let prim_5 = %phys_eq (c, 0) in
                                 (switch prim_5
@@ -276,6 +288,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                    | 1 -> k5
                                    where k5 =
                                      (apply &my_alloc_region
+                                             [forward close close close]
                                         cmp (x2, x3) -> k5 * k1
                                         where k5 (c_1 : imm tagged) =
                                           let prim_6 = %phys_eq (c_1, 0) in
@@ -287,7 +300,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                  %block.[`0`].my_alloc_region
                                                    (x2, 0)
                                                in
-                                               cont k (Pmakeblock)
+                                               cont k
+                                                      close[normal] my_alloc_region
+                                                      (Pmakeblock)
                                              where k5 =
                                                let prim_7 =
                                                  %int_comp.gt (c_1, 0)
@@ -304,7 +319,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1)
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
                                                       %block.[`0`].my_alloc_region
@@ -314,7 +331,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                       %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1))))
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1))))
                                    where k4 =
                                      let prim_6 = %int_comp.gt (c, 0) in
                                      (switch prim_6
@@ -322,6 +341,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                         | 1 -> k5
                                         where k5 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x2, x3) -> k5 * k1
                                              where k5 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
@@ -338,7 +358,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                       %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1)
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k5 =
                                                     let prim_8 =
                                                       %int_comp.gt (c_1, 0)
@@ -361,10 +383,12 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                               Pmakeblock_1)
                                                          in
                                                          cont k
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2)
                                                        where k5 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x1, x3)
                                                               -> k5 * k1
@@ -392,6 +416,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                    in
                                                                    cont 
                                                                    k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)
                                                                  where 
                                                                    k5 =
@@ -420,6 +445,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k5 =
@@ -439,9 +465,11 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)))))))
                                         where k4 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x1, x3) -> k4 * k1
                                              where k4 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
@@ -458,7 +486,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1)
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k4 =
                                                     let prim_8 =
                                                       %int_comp.gt (c_1, 0)
@@ -481,10 +511,12 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                               Pmakeblock_1)
                                                          in
                                                          cont k
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2)
                                                        where k4 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x2, x3)
                                                               -> k4 * k1
@@ -512,6 +544,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                    in
                                                                    cont 
                                                                    k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)
                                                                  where 
                                                                    k4 =
@@ -540,6 +573,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k4 =
@@ -559,6 +593,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2))))))))))))))
      where k3 =
        let prim_1 = %is_int (l) in
@@ -574,7 +609,8 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                where k3 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply &my_alloc_region cmp (x1, x2) -> k3 * k1
+                 (apply &my_alloc_region [forward close close close]
+                    cmp (x1, x2) -> k3 * k1
                     where k3 (c : imm tagged) =
                       let prim_3 = %phys_eq (c, 0) in
                       (switch prim_3
@@ -584,7 +620,7 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x1, 0)
                            in
-                           cont k (Pmakeblock)
+                           cont k close[normal] my_alloc_region (Pmakeblock)
                          where k3 =
                            let prim_4 = %int_comp.gt (c, 0) in
                            (switch prim_4
@@ -598,7 +634,9 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                   %block.[`0`].my_alloc_region
                                     (x1, Pmakeblock)
                                 in
-                                cont k (Pmakeblock_1)
+                                cont k
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1)
                               where k3 =
                                 let Pmakeblock =
                                   %block.[`0`].my_alloc_region (x1, 0)
@@ -607,29 +645,34 @@ let code rec loopify(never) size(588) newer_version_of(rev_sort_8)
                                   %block.[`0`].my_alloc_region
                                     (x2, Pmakeblock)
                                 in
-                                cont k (Pmakeblock_1)))))))
+                                cont k
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1)))))))
     where k2 =
       let n1 = %int_shift.asr (n, 1i) in
       let n2 = %int_barith.sub (n, n1) in
-      (apply direct(chop_3_1 &my_alloc_region)
+      (apply direct(chop_3_1 &my_alloc_region) [forward close close close]
          ($camlTests9__chop_6
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (n1, l)
            -> k2 * k1
          where k2 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
            (apply direct(sort_7_1 &my_alloc_region)
+                   [forward close close close]
               (sort ~ depth my_depth -> succ my_depth
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (n1, l)
                 -> k2 * k1
               where k2 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                 (apply direct(sort_7_1 &my_alloc_region)
+                        [forward close close close]
                    (sort ~ depth my_depth -> succ my_depth
                     : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                      (n2, l2)
                      -> k2 * k1
                    where k2 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                      apply direct(rev_merge_5_1 &my_alloc_region)
+                            [close close close close]
                        (rev_merge
                         : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                          (s1, s2, 0)
@@ -674,7 +717,9 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                            let x3 = %block_load.[`0`] (`*match*_1`) in
                            let x2 = %block_load.[`0`] (`*match*`) in
                            let x1 = %block_load.[`0`] (l) in
-                           (apply &my_alloc_region cmp (x1, x2) -> k4 * k1
+                           (apply &my_alloc_region
+                                   [forward close close close]
+                              cmp (x1, x2) -> k4 * k1
                               where k4 (c : imm tagged) =
                                 let prim_5 = %phys_eq (c, 0) in
                                 (switch prim_5
@@ -682,6 +727,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                    | 1 -> k5
                                    where k5 =
                                      (apply &my_alloc_region
+                                             [forward close close close]
                                         cmp (x2, x3) -> k5 * k1
                                         where k5 (c_1 : imm tagged) =
                                           let prim_6 = %phys_eq (c_1, 0) in
@@ -693,7 +739,9 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                  %block.[`0`].my_alloc_region
                                                    (x2, 0)
                                                in
-                                               cont k (Pmakeblock)
+                                               cont k
+                                                      close[normal] my_alloc_region
+                                                      (Pmakeblock)
                                              where k5 =
                                                let prim_7 =
                                                  %int_comp.lt (c_1, 0)
@@ -710,7 +758,9 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1)
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k5 =
                                                     let Pmakeblock =
                                                       %block.[`0`].my_alloc_region
@@ -720,7 +770,9 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                       %block.[`0`].my_alloc_region
                                                         (x3, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1))))
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1))))
                                    where k4 =
                                      let prim_6 = %int_comp.lt (c, 0) in
                                      (switch prim_6
@@ -728,6 +780,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                         | 1 -> k5
                                         where k5 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x2, x3) -> k5 * k1
                                              where k5 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
@@ -744,7 +797,9 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                       %block.[`0`].my_alloc_region
                                                         (x1, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1)
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k5 =
                                                     let prim_8 =
                                                       %int_comp.lt (c_1, 0)
@@ -767,10 +822,12 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                               Pmakeblock_1)
                                                          in
                                                          cont k
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2)
                                                        where k5 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x1, x3)
                                                               -> k5 * k1
@@ -798,6 +855,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                    in
                                                                    cont 
                                                                    k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)
                                                                  where 
                                                                    k5 =
@@ -826,6 +884,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k5 =
@@ -845,9 +904,11 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)))))))
                                         where k4 =
                                           (apply &my_alloc_region
+                                                  [forward close close close]
                                              cmp (x1, x3) -> k4 * k1
                                              where k4 (c_1 : imm tagged) =
                                                let prim_7 = %phys_eq (c_1, 0)
@@ -864,7 +925,9 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                       %block.[`0`].my_alloc_region
                                                         (x2, Pmakeblock)
                                                     in
-                                                    cont k (Pmakeblock_1)
+                                                    cont k
+                                                           close[normal] my_alloc_region
+                                                           (Pmakeblock_1)
                                                   where k4 =
                                                     let prim_8 =
                                                       %int_comp.lt (c_1, 0)
@@ -887,10 +950,12 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                               Pmakeblock_1)
                                                          in
                                                          cont k
+                                                                close[normal] my_alloc_region
                                                                 (Pmakeblock_2)
                                                        where k4 =
                                                          (apply
                                                                  &my_alloc_region
+                                                                 [forward close close close]
                                                             cmp
                                                               (x2, x3)
                                                               -> k4 * k1
@@ -918,6 +983,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                    in
                                                                    cont 
                                                                    k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_1)
                                                                  where 
                                                                    k4 =
@@ -946,6 +1012,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2)
                                                                     where 
                                                                     k4 =
@@ -965,6 +1032,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                                                     in
                                                                     cont 
                                                                     k
+                                                                    close[normal] my_alloc_region
                                                                     (Pmakeblock_2))))))))))))))
      where k3 =
        let prim_1 = %is_int (l) in
@@ -980,7 +1048,8 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                where k3 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply &my_alloc_region cmp (x1, x2) -> k3 * k1
+                 (apply &my_alloc_region [forward close close close]
+                    cmp (x1, x2) -> k3 * k1
                     where k3 (c : imm tagged) =
                       let prim_3 = %phys_eq (c, 0) in
                       (switch prim_3
@@ -990,7 +1059,7 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x1, 0)
                            in
-                           cont k (Pmakeblock)
+                           cont k close[normal] my_alloc_region (Pmakeblock)
                          where k3 =
                            let prim_4 = %int_comp.lt (c, 0) in
                            (switch prim_4
@@ -1004,7 +1073,9 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                   %block.[`0`].my_alloc_region
                                     (x1, Pmakeblock)
                                 in
-                                cont k (Pmakeblock_1)
+                                cont k
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1)
                               where k3 =
                                 let Pmakeblock =
                                   %block.[`0`].my_alloc_region (x1, 0)
@@ -1013,29 +1084,34 @@ and code rec loopify(never) size(588) newer_version_of(sort_7)
                                   %block.[`0`].my_alloc_region
                                     (x2, Pmakeblock)
                                 in
-                                cont k (Pmakeblock_1)))))))
+                                cont k
+                                       close[normal] my_alloc_region
+                                       (Pmakeblock_1)))))))
     where k2 =
       let n1 = %int_shift.asr (n, 1i) in
       let n2 = %int_barith.sub (n, n1) in
-      (apply direct(chop_3_1 &my_alloc_region)
+      (apply direct(chop_3_1 &my_alloc_region) [forward close close close]
          ($camlTests9__chop_6
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (n1, l)
            -> k2 * k1
          where k2 (l2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
            (apply direct(rev_sort_8_1 &my_alloc_region)
+                   [forward close close close]
               (rev_sort ~ depth my_depth -> succ my_depth
                : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (n1, l)
                 -> k2 * k1
               where k2 (s1 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                 (apply direct(rev_sort_8_1 &my_alloc_region)
+                        [forward close close close]
                    (rev_sort ~ depth my_depth -> succ my_depth
                     : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                      (n2, l2)
                      -> k2 * k1
                    where k2 (s2 : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                      apply direct(rev_merge_rev_6_1 &my_alloc_region)
+                            [close close close close]
                        (rev_merge_rev
                         : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                          (s1, s2, 0)
@@ -1064,14 +1140,15 @@ let code loopify(never) size(1411) newer_version_of(sort_uniq_4)
   }
   in
   apply direct(length_aux_0_1 &my_alloc_region) inlining_state(depth(10))
+         [forward close close close]
     ($camlTests9__length_aux_3 : _ -> imm tagged) (0, l) -> k2 * k1
     where k2 (len : imm tagged) =
       let prim = %int_comp.lt (len, 2) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (l)
+         | 1 -> k close[normal] my_alloc_region (l)
          where k2 =
-           apply direct(sort_7_1 &my_alloc_region)
+           apply direct(sort_7_1 &my_alloc_region) [close close close close]
              (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                (len, l)
                -> k * k1)
@@ -1105,7 +1182,8 @@ let code rec loopify(never) size(77) newer_version_of(rev_sort_11)
                where k3 =
                  let x2 = %block_load.[`0`] (`*match*`) in
                  let x1 = %block_load.[`0`] (l) in
-                 (apply &my_alloc_region cmp (x1, x2) -> k3 * k1
+                 (apply &my_alloc_region [forward close close close]
+                    cmp (x1, x2) -> k3 * k1
                     where k3 (c : imm tagged) =
                       let prim_3 = %int_comp.lt (c, 0) in
                       (switch prim_3
@@ -1115,14 +1193,14 @@ let code rec loopify(never) size(77) newer_version_of(rev_sort_11)
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x1, 0)
                            in
-                           cont k (Pmakeblock)
+                           cont k close[normal] my_alloc_region (Pmakeblock)
                          where k3 =
                            let Pmakeblock =
                              %block.[`0`].my_alloc_region (x2, 0)
                            in
-                           cont k (Pmakeblock))))))
+                           cont k close[normal] my_alloc_region (Pmakeblock))))))
     where k2 =
-      apply direct(sort_10_1 &my_alloc_region)
+      apply direct(sort_10_1 &my_alloc_region) [close close close close]
         (sort ~ depth my_depth -> succ my_depth
          : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
           (n, l)
@@ -1134,7 +1212,7 @@ and code rec loopify(never) size(5) newer_version_of(sort_10)
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
   let rev_sort = %project_function_slot.[sort_1].[rev_sort_1] (my_closure) in
-  apply direct(rev_sort_11_1 &my_alloc_region)
+  apply direct(rev_sort_11_1 &my_alloc_region) [close close close close]
     (rev_sort ~ depth my_depth -> succ my_depth
      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
       (n, l)
@@ -1149,10 +1227,11 @@ let code loopify(never) size(98) newer_version_of(foo_9)
   and rev_sort = closure rev_sort_11_1 @rev_sort_1 &my_alloc_region
   with { cmp_3 = cmp }
   in
-  apply direct(sort_10_1 &my_alloc_region)
+  apply direct(sort_10_1 &my_alloc_region) [close close close close]
     (sort : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) (42, l) -> k * k1
 in
 let $camlTests9__foo_8 = closure foo_9_1 @foo &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTests9 =
   Block 0 ($camlTests9__length_aux_3,
            $camlTests9__length_4,

--- a/testsuite/tests/flambda2/examples/toplevel_closures.simplify.reference
+++ b/testsuite/tests/flambda2/examples/toplevel_closures.simplify.reference
@@ -11,7 +11,7 @@ and code loopify(never) size(5) newer_version_of(f_0)
   let r_1 = %project_value_slot.[f].[r] ($camlToplevel_closures__f_1) in
   let Pfield = %block_load.mut.[`0`] (r_1) in
   let int_add = %int_barith.add (x, Pfield) in
-  cont k (int_add)
+  cont k close[normal] my_alloc_region (int_add)
   with { r = r }
 in
 let $camlToplevel_closures__g_2 =
@@ -26,9 +26,10 @@ and code loopify(never) size(8) newer_version_of(g_1)
   let Pfield_1 = %block_load.mut.[`0`] (r_1) in
   let int_add = %int_barith.add (x, Pfield_1) in
   let int_add_1 = %int_barith.add (int_add, Pfield) in
-  cont k (int_add_1)
+  cont k close[normal] my_alloc_region (int_add_1)
   with { r_1 = r }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlToplevel_closures =
   Block 0 (r, $camlToplevel_closures__f_1, $camlToplevel_closures__g_2)
 in

--- a/testsuite/tests/flambda2/examples/toplevel_rec.simplify.reference
+++ b/testsuite/tests/flambda2/examples/toplevel_rec.simplify.reference
@@ -11,14 +11,14 @@ and code rec loopify(never) size(10) newer_version_of(g_1)
         : imm tagged =
   let z_1 = %project_value_slot.[g].[z] ($camlToplevel_rec__g_2) in
   (let int_sub = %int_barith.sub (y, 1) in
-   apply direct(f_0_1 &my_alloc_region)
+   apply direct(f_0_1 &my_alloc_region) [forward close close close]
      ($camlToplevel_rec__f_1 ~ depth my_depth -> succ my_depth
       : _ -> imm tagged)
        (int_sub)
        -> k2 * k1)
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (z_1, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 and code rec loopify(never) size(10) newer_version_of(f_0)
       f_0_1 (x : imm tagged)
         my_closure &my_alloc_region my_depth
@@ -26,16 +26,17 @@ and code rec loopify(never) size(10) newer_version_of(f_0)
         : imm tagged =
   let z_1 = %project_value_slot.[f].[z] ($camlToplevel_rec__f_1) in
   (let int_add = %int_barith.add (x, 1) in
-   apply direct(g_1_1 &my_alloc_region)
+   apply direct(g_1_1 &my_alloc_region) [forward close close close]
      ($camlToplevel_rec__g_2 ~ depth my_depth -> succ my_depth
       : _ -> imm tagged)
        (int_add)
        -> k2 * k1)
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (z_1, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
   with { z = z }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlToplevel_rec =
   Block 0 (z, $camlToplevel_rec__f_1, $camlToplevel_rec__g_2)
 in

--- a/testsuite/tests/flambda2/examples/tuple_stub.simplify.reference
+++ b/testsuite/tests/flambda2/examples/tuple_stub.simplify.reference
@@ -3,9 +3,10 @@ let code loopify(never) size(1) newer_version_of(thd3_0) tupled
       thd3_0_1 (param, param_1, param_2)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  cont k (param_2)
+  cont k close[normal] my_alloc_region (param_2)
 in
 let $camlTuple_stub__thd3_1 = closure thd3_0_1 @thd3 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTuple_stub = Block 0 ($camlTuple_stub__thd3_1) in
 cont done ($camlTuple_stub)

--- a/testsuite/tests/flambda2/examples/unboxing_gadt.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unboxing_gadt.simplify.reference
@@ -8,10 +8,10 @@ let code loopify(never) size(13) newer_version_of(f_0)
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       let Pfield = %block_load.[`0`] (param) in
-      cont k (Pfield)
+      cont k close[normal] my_alloc_region (Pfield)
 in
 let $camlUnboxing_gadt__f_1 = closure f_0_1 @f &toplevel.alloc_region in
 let code loopify(never) size(23) newer_version_of(baz_1)
@@ -27,7 +27,7 @@ let code loopify(never) size(23) newer_version_of(baz_1)
      | 0 -> k3
      | 1 -> k4)
     where k4 =
-      apply direct(f_0_1 &my_alloc_region)
+      apply direct(f_0_1 &my_alloc_region) [forward close close close]
         ($camlUnboxing_gadt__f_1 : _ -> [ 0 of float boxed |1 of imm tagged ]
          )
           (x)
@@ -37,10 +37,11 @@ let code loopify(never) size(23) newer_version_of(baz_1)
       cont k2 (Pmakeblock)
     where k2 (a : [ 0 of float boxed |1 of imm tagged ]) =
       let Popaque = %opaque (a) in
-      cont k (Popaque)
+      cont k close[normal] my_alloc_region (Popaque)
 in
 let $camlUnboxing_gadt__baz_2 = closure baz_1_1 @baz &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlUnboxing_gadt =
   Block 0 ($camlUnboxing_gadt__f_1, $camlUnboxing_gadt__baz_2)
 in

--- a/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/alt_ergo.simplify.reference
@@ -45,14 +45,23 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
     where k3 =
       let untagged = %untag_imm (b) in
       switch untagged
-        | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock_2)
-        | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock_4)
+        | 0 ->
+          k1
+            pop(regular k1)
+            close[exn] my_alloc_region
+            ($camlAlt_ergo__Pmakeblock_2)
+        | 1 ->
+          k1
+            pop(regular k1)
+            close[exn] my_alloc_region
+            ($camlAlt_ergo__Pmakeblock_4)
     where k2 =
       ((let Pfield = %block_load.[`0`] (b) in
         let Pfield_1 = %block_load.[`0`] (Pfield) in
         let Popaque = %opaque (0) in
         let Pobj_magic = %opaque (Popaque) in
-        apply &my_alloc_region Pobj_magic (Pfield_1) -> k3 * k1
+        apply &my_alloc_region [forward close close close]
+          Pobj_magic (Pfield_1) -> k3 * k1
           where k3 (param : [ 0 |1 ]) =
             let unboxed_field = %untag_imm (param) in
             cont k2 (unboxed_field))
@@ -60,7 +69,7 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
            let naked_immediate = unboxed_field in
            (switch naked_immediate
               | 0 -> k2
-              | 1 -> k (1)
+              | 1 -> k close[normal] my_alloc_region (1)
               where k2 =
                 ((let prim_1 = %get_tag (b) in
                   switch prim_1
@@ -77,7 +86,7 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
                      let Pmakeblock_1 =
                        %block.[`1`].my_alloc_region (Pmakeblock)
                      in
-                     cont k (Pmakeblock_1)
+                     cont k close[normal] my_alloc_region (Pmakeblock_1)
                    where k2 =
                      let Pfield = %block_load.[`0`] (b) in
                      let Pfield_1 = %block_load.[`1`] (Pfield) in
@@ -89,7 +98,7 @@ let code loopify(never) size(86) newer_version_of(inv_borne_sup_1)
                      let Pmakeblock_1 =
                        %block.[`0`].my_alloc_region (Pmakeblock)
                      in
-                     cont k (Pmakeblock_1))))
+                     cont k close[normal] my_alloc_region (Pmakeblock_1))))
 in
 let $camlAlt_ergo__inv_borne_sup_10 =
   closure inv_borne_sup_1_1 @inv_borne_sup &toplevel.alloc_region
@@ -104,6 +113,7 @@ let code loopify(never) size(14) newer_version_of(inv_bornes_2)
   let u = %block_load.[`1`] (param) in
   (let Pfield = %block_load.[`0`] (param) in
    apply direct(inv_borne_sup_1_1 &my_alloc_region)
+          [forward close close close]
      ($camlAlt_ergo__inv_borne_sup_10
       : _ ->
         [ 0 |1 | 0 of [ 0 of imm tagged * imm tagged ]
@@ -116,7 +126,7 @@ let code loopify(never) size(14) newer_version_of(inv_bornes_2)
                [ 0 |1 | 0 of [ 0 of imm tagged * imm tagged ]
                |1 of [ 0 of imm tagged * imm tagged ] ]) =
       let Pmakeblock = %block.[`0`].my_alloc_region (apply_result, u) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlAlt_ergo__inv_bornes_11 =
   closure inv_bornes_2_1 @inv_bornes &toplevel.alloc_region
@@ -129,12 +139,20 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
-    | 1 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock_6)
+    | 1 ->
+      k1
+        pop(regular k1)
+        close[exn] my_alloc_region
+        ($camlAlt_ergo__Pmakeblock_6)
     where k2 =
       let Pfield = %block_load.[`1`] (param) in
       let prim_1 = %is_int (Pfield) in
       (switch prim_1
-         | 0 -> k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock_6)
+         | 0 ->
+           k1
+             pop(regular k1)
+             close[exn] my_alloc_region
+             ($camlAlt_ergo__Pmakeblock_6)
          | 1 -> k2
          where k2 =
            let `*match*` = %block_load.[`0`] (param) in
@@ -144,6 +162,7 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
                %block.[`0`].my_alloc_region (Pfield_2, Pfield_1)
              in
              apply direct(inv_bornes_2_1 &my_alloc_region)
+                    [forward close close close]
                ($camlAlt_ergo__inv_bornes_11
                 : _ ->
                   [ 0 of [ 0 |1 | 0 of val |1 of val ] *
@@ -158,7 +177,7 @@ let code loopify(never) size(45) newer_version_of(inv_3) tupled
                 let Pmakeblock =
                   %block.[`0`].my_alloc_region (apply_result, 0)
                 in
-                cont k (Pmakeblock)))
+                cont k close[normal] my_alloc_region (Pmakeblock)))
 in
 let $camlAlt_ergo__inv_12 = closure inv_3_1 @inv &toplevel.alloc_region in
 let code loopify(never) size(11) newer_version_of(div_4)
@@ -168,15 +187,19 @@ let code loopify(never) size(11) newer_version_of(div_4)
   (let tuple_field = %block_load.tag[`0`].`size`[`3`].[`0`] (i2) in
    let tuple_field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (i2) in
    let tuple_field_2 = %block_load.tag[`0`].`size`[`3`].[`2`] (i2) in
-   apply direct(inv_3_1 &my_alloc_region)
+   apply direct(inv_3_1 &my_alloc_region) [forward close close close]
      ($camlAlt_ergo__inv_12 : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
        (tuple_field, tuple_field_1, tuple_field_2)
        -> k3 * k1
      where k3 (param : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
        cont k2)
     where k2 =
-      cont k1 pop(regular k1) ($camlAlt_ergo__Pmakeblock_8)
+      cont k1
+             pop(regular k1)
+             close[exn] my_alloc_region
+             ($camlAlt_ergo__Pmakeblock_8)
 in
 let $camlAlt_ergo__div_13 = closure div_4_1 @div &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlAlt_ergo = Block 0 ($camlAlt_ergo__div_13) in
 cont done ($camlAlt_ergo)

--- a/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/array_set_bottom.simplify.reference
@@ -7,8 +7,9 @@ let code loopify(never) size(3) newer_version_of(f_0)
   let Pobj_magic = %opaque (a) in
   let prim = %unbox_num.`float` (v) in
   let Parraysetu = %array_set.`float` (Pobj_magic, 0, prim) in
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlArray_set_bottom__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlArray_set_bottom = Block 0 ($camlArray_set_bottom__f_1) in
 cont done ($camlArray_set_bottom)

--- a/testsuite/tests/flambda2/examples/unknown/bigarrays.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/bigarrays.simplify.reference
@@ -4,7 +4,7 @@ let $camlBigarrays__block_1 =
 in
 (let `region` = %begin_region () in
  (let Pmakearray = %array.`imm`.mut.`toplevel`.local[`region`] (3, 3) in
-  apply ccall inlining_state(depth(10))
+  apply ccall inlining_state(depth(10)) [forward close close close]
     ($`*extern*`.caml_ba_create : val * val * val -> val)
       (8, 0, Pmakearray)
       -> k1 * error)
@@ -36,6 +36,7 @@ in
                    ($Stdlib.camlStdlib__print_int_45_96)
                in
                (apply ccall inlining_state(depth(20))
+                       [forward close close close]
                   ($`*extern*`.caml_format_int : val * val -> val)
                     ($Stdlib.camlStdlib__immstring_19, i)
                     -> k2 * error
@@ -43,6 +44,7 @@ in
                     let prim_4 = %string_length (apply_result) in
                     let Pstringlength = %tag_imm (prim_4) in
                     (apply ccall inlining_state(depth(20))
+                            [forward close close close]
                        ($`*extern*`.caml_ml_output
                         : val * val * val * val -> val)
                          (stdout, apply_result, 0, Pstringlength)
@@ -50,7 +52,11 @@ in
                        where k2 (param) =
                          cont k)))
         where k1 =
-          cont error pop(regular error) ($camlBigarrays__block_1)))
+          cont error
+                 pop(regular error)
+                 close[exn] toplevel.alloc_region
+                 ($camlBigarrays__block_1)))
   where k =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlBigarrays = Block 0 () in
     cont done ($camlBigarrays)

--- a/testsuite/tests/flambda2/examples/unknown/c.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/c.simplify.reference
@@ -7,8 +7,9 @@ let code loopify(never) size(9) newer_version_of(neg_0)
   let prim = %unbox_num.`float` (x) in
   let prim_1 = %ufloat_arith.neg (prim) in
   let float_neg = %box_num.`float`.my_alloc_region (prim_1) in
-  cont k (float_neg)
+  cont k close[normal] my_alloc_region (float_neg)
 in
 let $camlC__neg_1 = closure neg_0_1 @neg &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlC = Block 0 ($camlC__neg_1) in
 cont done ($camlC)

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_bug.simplify.reference
@@ -73,6 +73,7 @@ let Popaque = %opaque ($camlData_flow_bug__immstring_3) in
                                 | 1 -> k
                                 where k1 =
                                   (apply ccall noalloc
+                                          [forward close close close]
                                      ($`*extern*`.caml_string_notequal
                                       : val * val -> val)
                                        (Popaque,
@@ -131,6 +132,7 @@ let Popaque = %opaque ($camlData_flow_bug__immstring_3) in
                                                            in
                                                            (apply ccall
                                                                    inlining_state(depth(10))
+                                                                   [forward close close close]
                                                               ($`*extern*`.caml_compare
                                                                : val * val ->
                                                                  val
@@ -161,7 +163,10 @@ let Popaque = %opaque ($camlData_flow_bug__immstring_3) in
                                                where k1 =
                                                  cont error
                                                         pop(regular error)
+                                                        close[exn] toplevel.alloc_region
                                                         ($camlData_flow_bug__block_5)))))))))
        where k =
+         let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region)
+         in
          let $camlData_flow_bug = Block 0 () in
          cont done ($camlData_flow_bug))

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_exception_bug.simplify.reference
@@ -11,7 +11,10 @@ let code do_stuff_0 deleted in
 let code stuff_1 deleted in
 let code loopify(never) size(3) newer_version_of(do_stuff_0)
       do_stuff_0_1 (env) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlData_flow_exception_bug__Pmakeblock_2)
+  cont k1
+         pop(regular k1)
+         close[exn] my_alloc_region
+         ($camlData_flow_exception_bug__Pmakeblock_2)
 in
 let $camlData_flow_exception_bug__do_stuff_3 =
   closure do_stuff_0_1 @do_stuff &toplevel.alloc_region
@@ -41,11 +44,12 @@ let code loopify(never) size(20) newer_version_of(stuff_1)
     where k2 (region_return : [ 0 | 0 of val ]) =
       let `unit` = %end_region (`region`) in
       let unit_1 = %end_ghost_region (ghost_region) in
-      cont k (region_return)
+      cont k close[normal] my_alloc_region (region_return)
 in
 let $camlData_flow_exception_bug__stuff_4 =
   closure stuff_1_1 @stuff &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlData_flow_exception_bug =
   Block 0 ($camlData_flow_exception_bug__do_stuff_3,
            $camlData_flow_exception_bug__stuff_4)

--- a/testsuite/tests/flambda2/examples/unknown/data_flow_opam_bug.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/data_flow_opam_bug.simplify.reference
@@ -12,11 +12,12 @@ let code loopify(never) size(12) newer_version_of(to_string_0)
      | 1 -> k2 ($camlData_flow_opam_bug__immstring_0))
     where k2 (f) =
       let is_int = 0i in
-      cont k (f)
+      cont k close[normal] my_alloc_region (f)
 in
 let $camlData_flow_opam_bug__to_string_2 =
   closure to_string_0_1 @to_string &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlData_flow_opam_bug = Block 0 ($camlData_flow_opam_bug__to_string_2)
 in
 cont done ($camlData_flow_opam_bug)

--- a/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/direct_app_parameter_kind_check_classic.raw.reference
@@ -9,14 +9,15 @@
     (let untagged = %untag_imm (Pisint) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (0))
+       | 1 -> k1 close[normal] my_alloc_region (0))
       where k4 =
         cont k3)
      where k3 =
        let `*match*_1` = %block_load.[`0`] (`*match*`) in
        let Pfield = %block_load.[`1`] (`*match*_1`) in
        let Pfield_1 = %block_load.[`0`] (`*match*_1`) in
-       apply &my_alloc_region c (Pfield_1, Pfield) -> k1 * k2
+       apply &my_alloc_region [close close close close]
+         c (Pfield_1, Pfield) -> k1 * k2
  in
  let code size(7)
        create_1 (_arity : imm tagged)
@@ -24,14 +25,14 @@
          -> k1 * k2
          : val =
    let Pmakeblock = %block.mut.[`0`].my_alloc_region (0) in
-   cont k1 (Pmakeblock)
+   cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code size(1)
        fn_2 (param_unboxed0, param_unboxed1)
          my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let $camlDirect_app_parameter_kind_check_classic__s0 =
    closure send_0 @send &toplevel.alloc_region
@@ -48,10 +49,20 @@
    closure fn_2 @fn &toplevel.alloc_region
  in
  (let inlined_dbg = %inlined_apply () in
-  let Pmakeblock = %block.mut.[`0`].`toplevel` (0) in
-  cont k2 (Pmakeblock))
+  let my_alloc_region =
+    %new_alloc_region.[`normal`[`forward`, transfer], `exn`[`close`,
+      transfer], `notrace`[`close`, transfer], div[`close`, transfer]]
+      (toplevel.alloc_region)
+  in
+  let Pmakeblock = %block.mut.[`0`].my_alloc_region (0) in
+  cont k2 close[normal] my_alloc_region (Pmakeblock))
    where k2 (apply_result : val) =
      let inlined_dbg = %inlined_apply () in
+     let my_alloc_region =
+       %new_alloc_region.[`normal`[`forward`, transfer], `exn`[`close`,
+         transfer], `notrace`[`close`, transfer], div[`close`, transfer]]
+         (toplevel.alloc_region)
+     in
      let c = $camlDirect_app_parameter_kind_check_classic__s2 in
      let t = apply_result in
      let `*match*` = %block_load.mut.[`0`] (t) in
@@ -60,16 +71,19 @@
        (let untagged = %untag_imm (Pisint) in
         switch untagged
           | 0 -> k3
-          | 1 -> k1 (0))
+          | 1 -> k1 close[normal] my_alloc_region (0))
          where k3 =
            cont k2)
         where k2 =
           let `*match*_1` = %block_load.[`0`] (`*match*`) in
           let Pfield = %block_load.[`1`] (`*match*_1`) in
           let Pfield_1 = %block_load.[`0`] (`*match*_1`) in
-          apply &toplevel.alloc_region c (Pfield_1, Pfield) -> k1 * error)
+          apply &my_alloc_region [close close close close]
+            c (Pfield_1, Pfield) -> k1 * error)
    where k1 (`*match*` : imm tagged) =
-     cont k ($camlDirect_app_parameter_kind_check_classic__s3))
+     cont k
+            close[normal] toplevel.alloc_region
+            ($camlDirect_app_parameter_kind_check_classic__s3))
   where k define_root_symbol (module_block) =
     let field_0 = 0 in
     let field_1 = $camlDirect_app_parameter_kind_check_classic__s0 in

--- a/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/emitcode_repro.simplify.reference
@@ -13,7 +13,7 @@ let code inline(never) loopify(never) size(1) newer_version_of(out_0)
         -> k * k1
         : imm tagged =
   let Popaque = %opaque (0) in
-  cont k (Popaque)
+  cont k close[normal] my_alloc_region (Popaque)
 in
 let $camlEmitcode_repro__out_6 = closure out_0_1 @out &toplevel.alloc_region
 in
@@ -37,22 +37,22 @@ let code loopify(never) size(50) newer_version_of(emit_instr_1)
         | 0 -> k4
         | 1 -> k5
     where k5 =
-      apply direct(out_0_1 &my_alloc_region)
+      apply direct(out_0_1 &my_alloc_region) [close close close close]
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_0)
           -> k * k1
     where k4 =
-      apply direct(out_0_1 &my_alloc_region)
+      apply direct(out_0_1 &my_alloc_region) [close close close close]
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_1)
           -> k * k1
     where k3 =
-      apply direct(out_0_1 &my_alloc_region)
+      apply direct(out_0_1 &my_alloc_region) [close close close close]
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_2)
           -> k * k1
     where k2 =
-      apply direct(out_0_1 &my_alloc_region)
+      apply direct(out_0_1 &my_alloc_region) [close close close close]
         ($camlEmitcode_repro__out_6 : _ -> imm tagged)
           ($camlEmitcode_repro__const_block_3)
           -> k * k1
@@ -70,7 +70,7 @@ let code loopify(done) size(115) newer_version_of(emit_2)
       let prim = %is_int (param_1) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (0)
+         | 1 -> k close[normal] my_alloc_region (0)
          where k2 =
            let instr = %block_load.[`0`] (param_1) in
            ((let prim_1 = %is_int (instr) in
@@ -89,6 +89,7 @@ let code loopify(done) size(115) newer_version_of(emit_2)
                   | 1 -> k4
               where k4 =
                 (apply direct(out_0_1 &my_alloc_region)
+                        [forward close close close]
                    ($camlEmitcode_repro__out_6 : _ -> imm tagged)
                      ($camlEmitcode_repro__const_block_4)
                      -> k5 * k1
@@ -122,6 +123,7 @@ let code loopify(done) size(115) newer_version_of(emit_2)
                               | 1 -> k3)
                              where k3 =
                                (apply direct(out_0_1 &my_alloc_region)
+                                       [forward close close close]
                                   ($camlEmitcode_repro__out_6
                                    : _ -> imm tagged)
                                     ($camlEmitcode_repro__const_block_5)
@@ -135,6 +137,7 @@ let code loopify(done) size(115) newer_version_of(emit_2)
                                     cont `self` (Pfield_1)))))
               where k2 =
                 (apply direct(emit_instr_1_1 &my_alloc_region)
+                        [forward close close close]
                    ($camlEmitcode_repro__emit_instr_7 : _ -> imm tagged)
                      (instr)
                      -> k3 * k1
@@ -147,5 +150,6 @@ in
 let $camlEmitcode_repro__emit_8 =
   closure emit_2_1 @emit &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlEmitcode_repro = Block 0 ($camlEmitcode_repro__emit_8) in
 cont done ($camlEmitcode_repro)

--- a/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/eol_detect.simplify.reference
@@ -28,12 +28,13 @@ let code loopify(never) size(48) newer_version_of(f_0)
                 let Pnot = %boolean_not (int_notequal) in
                 cont k3 (Pnot)))
     where k3 (body_result : imm tagged) =
-      cont k pop(k2) (body_result)
+      cont k pop(k2) close[normal] my_alloc_region (body_result)
     where k2 exn (`exn` : val) =
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
-      cont k (0)
+      cont k close[normal] my_alloc_region (0)
 in
 let $camlEol_detect__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlEol_detect = Block 0 ($camlEol_detect__f_1) in
 cont done ($camlEol_detect)

--- a/testsuite/tests/flambda2/examples/unknown/f.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/f.simplify.reference
@@ -14,7 +14,7 @@ let code loopify(never) size(82) newer_version_of(maxson_0)
   let int_add_2 = %int_barith.add (i31, 1) in
   let prim = %int_comp.lt (int_add_2, l) in
   switch prim
-    | 0 -> k (0)
+    | 0 -> k close[normal] my_alloc_region (0)
     | 1 -> k2
     where k2 =
       ((let prim_1 = %array_length.`float` (a) in
@@ -34,18 +34,25 @@ let code loopify(never) size(82) newer_version_of(maxson_0)
                 let prim_3 = %array_load.`float`.mut (a, i31) in
                 let Parrayrefs_1 = %box_num.`float`.my_alloc_region (prim_3)
                 in
-                (apply &my_alloc_region
+                (apply &my_alloc_region [forward close close close]
                    cmp (Parrayrefs_1, Parrayrefs) -> k4 * k1
                    where k4 (return_val0 : imm tagged) =
                      let prim_4 = %int_comp.lt (return_val0, 0) in
                      switch prim_4
-                       | 0 -> k (0)
-                       | 1 -> k (int_add_2))
+                       | 0 -> k close[normal] my_alloc_region (0)
+                       | 1 -> k close[normal] my_alloc_region (int_add_2))
               where k3 =
-                cont k1 pop(regular k1) ($camlF__block_1))
+                cont k1
+                       pop(regular k1)
+                       close[exn] my_alloc_region
+                       ($camlF__block_1))
          where k2 =
-           cont k1 pop(regular k1) ($camlF__block_1))
+           cont k1
+                  pop(regular k1)
+                  close[exn] my_alloc_region
+                  ($camlF__block_1))
 in
 let $camlF__maxson_2 = closure maxson_0_1 @maxson &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlF = Block 0 ($camlF__maxson_2) in
 cont done ($camlF)

--- a/testsuite/tests/flambda2/examples/unknown/fob.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/fob.simplify.reference
@@ -1,3 +1,4 @@
 let $camlFob__infinity_1 = infinity in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlFob = Block 0 ($camlFob__infinity_1) in
 cont done ($camlFob)

--- a/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/gadt_meet.simplify.reference
@@ -16,7 +16,7 @@ let code loopify(never) size(10) newer_version_of(with_y_0)
   let Pfield = %block_load.[`0`] (b) in
   let int_add = %int_barith.add (Pfield, y) in
   let Pmakeblock = %block.[`0`].my_alloc_region (int_add) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlGadt_meet__with_y_4 =
   closure with_y_0_1 @with_y &toplevel.alloc_region
@@ -26,7 +26,7 @@ let code inline(never) loopify(never) size(1) newer_version_of(f_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of [ 0 of imm tagged ] |1 of imm tagged ] =
-  cont k ($camlGadt_meet__const_block_1)
+  cont k close[normal] my_alloc_region ($camlGadt_meet__const_block_1)
 in
 let $camlGadt_meet__f_5 = closure f_1_1 @f &toplevel.alloc_region in
 let code loopify(never) size(2) newer_version_of(get_2)
@@ -35,7 +35,7 @@ let code loopify(never) size(2) newer_version_of(get_2)
         -> k * k1
         : [ 0 of imm tagged ] =
   let Pfield = %block_load.[`0`] (t) in
-  cont k (Pfield)
+  cont k close[normal] my_alloc_region (Pfield)
 in
 let $camlGadt_meet__get_6 = closure get_2_1 @get &toplevel.alloc_region in
 let code loopify(never) size(44) newer_version_of(test_3)
@@ -43,19 +43,19 @@ let code loopify(never) size(44) newer_version_of(test_3)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val ] =
-  apply direct(f_1_1 &my_alloc_region)
+  apply direct(f_1_1 &my_alloc_region) [forward close close close]
     ($camlGadt_meet__f_5 : _ -> [ 0 of [ 0 of imm tagged ] |1 of imm tagged ]
      )
       (0)
       -> k2 * k1
     where k2 (op : [ 0 of [ 0 of imm tagged ] |1 of imm tagged ]) =
       let Pfield = %block_load.[`0`] (op) in
-      (apply direct(with_y_0_1 &my_alloc_region)
+      (apply direct(with_y_0_1 &my_alloc_region) [forward close close close]
          ($camlGadt_meet__with_y_4 : _ -> [ 0 of imm tagged ])
            (Pfield, 1)
            -> k2 * k1
          where k2 (apply_result : [ 0 of imm tagged ]) =
-           (apply ccall
+           (apply ccall [forward close close close]
               ($`*extern*`.caml_equal : val * val -> val)
                 (apply_result, $camlGadt_meet__const_block_2)
                 -> k2 * k1
@@ -63,13 +63,13 @@ let code loopify(never) size(44) newer_version_of(test_3)
                 ((let untagged = %untag_imm (Pccall) in
                   switch untagged
                     | 0 -> k2
-                    | 1 -> k (0))
+                    | 1 -> k close[normal] my_alloc_region (0))
                    where k2 =
                      let Pmakeblock = %block.[`0`].my_alloc_region (x, op) in
                      let Pmakeblock_1 =
                        %block.[`0`].my_alloc_region (Pmakeblock)
                      in
-                     cont k (Pmakeblock_1))))
+                     cont k close[normal] my_alloc_region (Pmakeblock_1))))
 in
 let $camlGadt_meet__test_7 = closure test_3_1 @test &toplevel.alloc_region in
 let $camlGadt_meet__Pmakeblock_9 =
@@ -80,18 +80,23 @@ let code loopify(never) size(17) newer_version_of(foo_4)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of imm tagged * [ 0 of val |1 of imm tagged ] ] =
-  apply direct(test_3_1 &my_alloc_region)
+  apply direct(test_3_1 &my_alloc_region) [forward close close close]
     ($camlGadt_meet__test_7 : _ -> [ 0 | 0 of val ]) (0) -> k2 * k1
     where k2 (`*match*` : [ 0 | 0 of val ]) =
       let prim = %is_int (`*match*`) in
       (switch prim
          | 0 -> k2
-         | 1 -> k1 pop(reraise k1) ($camlGadt_meet__Pmakeblock_9)
+         | 1 ->
+           k1
+             pop(reraise k1)
+             close[exn] my_alloc_region
+             ($camlGadt_meet__Pmakeblock_9)
          where k2 =
            let Pfield = %block_load.[`0`] (`*match*`) in
-           cont k (Pfield))
+           cont k close[normal] my_alloc_region (Pfield))
 in
 let $camlGadt_meet__foo_8 = closure foo_4_1 @foo &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlGadt_meet =
   Block 0 ($camlGadt_meet__with_y_4,
            $camlGadt_meet__f_5,

--- a/testsuite/tests/flambda2/examples/unknown/genlex2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/genlex2.simplify.reference
@@ -1,7 +1,7 @@
 let $camlGenlex2__immstring_1 = "" in
 let code foo_0 deleted in
 let $camlGenlex2__immstring_0 = "Genlex2.Error" in
-apply ccall noalloc
+apply ccall noalloc [forward close close close]
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
     let $camlGenlex2__Error_2 =
@@ -22,7 +22,7 @@ apply ccall noalloc
       let prim = %int_comp.ne (f, 97) in
       switch prim
         | 0 -> k2
-        | 1 -> k (0)
+        | 1 -> k close[normal] my_alloc_region (0)
         where k2 =
           let try_region = %begin_try_region () in
           let try_ghost_region = %begin_try_ghost_region () in
@@ -40,12 +40,20 @@ apply ccall noalloc
                let prim_1 = %phys_eq (Pfield, $`*predef*`.caml_exn_Failure)
                in
                switch prim_1
-                 | 0 -> k1 pop(reraise k1) (`exn`)
-                 | 1 -> k1 pop(regular k1) ($camlGenlex2__Pmakeblock_4)
+                 | 0 -> k1 pop(reraise k1) close[exn] my_alloc_region (`exn`)
+                 | 1 ->
+                   k1
+                     pop(regular k1)
+                     close[exn] my_alloc_region
+                     ($camlGenlex2__Pmakeblock_4)
              where k2 =
-               cont k1 pop(regular k1) ($camlGenlex2__Pmakeblock_5))
+               cont k1
+                      pop(regular k1)
+                      close[exn] my_alloc_region
+                      ($camlGenlex2__Pmakeblock_5))
     in
     let $camlGenlex2__foo_3 = closure foo_0_1 @foo &toplevel.alloc_region in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlGenlex2 = Block 0 ($camlGenlex2__Error_2, $camlGenlex2__foo_3)
     in
     cont done ($camlGenlex2)

--- a/testsuite/tests/flambda2/examples/unknown/get_tag_2020_07_21.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/get_tag_2020_07_21.simplify.reference
@@ -7,7 +7,7 @@ let code inline(always) loopify(never) size(5) newer_version_of(of_src_0)
         : imm tagged =
   let prim = %get_tag (param) in
   let tagged_scrutinee = %tag_imm (prim) in
-  cont k (tagged_scrutinee)
+  cont k close[normal] my_alloc_region (tagged_scrutinee)
 in
 let $camlGet_tag_2020_07_21__of_src_1 =
   closure of_src_0_1 @of_src &toplevel.alloc_region
@@ -16,7 +16,7 @@ let code loopify(never) size(29) newer_version_of(test_1)
       test_1_1 (src : [ 0 of imm tagged |1 of imm tagged ], f : val, g : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply &my_alloc_region f (0) -> k4 * k1
+  apply &my_alloc_region [forward close close close] f (0) -> k4 * k1
     where k4 (param : [ 0 |1 ]) =
       let unboxed_field = %untag_imm (param) in
       cont k3 (unboxed_field)
@@ -30,11 +30,12 @@ let code loopify(never) size(29) newer_version_of(test_1)
            let tagged_scrutinee = %tag_imm (prim) in
            cont k2 (tagged_scrutinee))
     where k2 (dst : imm tagged) =
-      apply &my_alloc_region g (dst) -> k * k1
+      apply &my_alloc_region [close close close close] g (dst) -> k * k1
 in
 let $camlGet_tag_2020_07_21__test_2 =
   closure test_1_1 @test &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlGet_tag_2020_07_21 =
   Block 0 ($camlGet_tag_2020_07_21__of_src_1, $camlGet_tag_2020_07_21__test_2)
 in

--- a/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/includecore_repro.simplify.reference
@@ -21,7 +21,7 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
      where k4 =
        let untagged = %untag_imm (`*match*_1`) in
        switch untagged
-         | 0 -> k (0)
+         | 0 -> k close[normal] my_alloc_region (0)
          | 1 -> k3)
     where k3 =
       ((let prim = %is_int (`*match*`) in
@@ -58,7 +58,7 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
                 in
                 let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock)
                 in
-                cont k (Pmakeblock_1))
+                cont k close[normal] my_alloc_region (Pmakeblock_1))
          where k4 =
            ((let prim = %is_int (`*match*_1`) in
              switch prim
@@ -83,19 +83,19 @@ let code inline(never) loopify(never) size(160) newer_version_of(f_0)
                 in
                 let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock)
                 in
-                cont k (Pmakeblock_1))
+                cont k close[normal] my_alloc_region (Pmakeblock_1))
          where k3 =
            let prim = %is_int (`*match*_1`) in
            switch prim
              | 0 -> k2
-             | 1 -> k (0))
+             | 1 -> k close[normal] my_alloc_region (0))
     where k2 =
       let Popaque = %opaque ($camlIncludecore_repro__const_block_0) in
       let Pmakeblock = %block.[`0`].my_alloc_region (Popaque) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlIncludecore_repro__f_2 = closure f_0_1 @f &toplevel.alloc_region in
-apply direct(f_0_1 &toplevel.alloc_region)
+apply direct(f_0_1 &toplevel.alloc_region) [forward close close close]
   ($camlIncludecore_repro__f_2 : _ -> [ 0 | 0 of val ])
     ($camlIncludecore_repro__const_block_1,
      $camlIncludecore_repro__const_block_1)
@@ -103,5 +103,6 @@ apply direct(f_0_1 &toplevel.alloc_region)
   where k1 (param : [ 0 | 0 of val ]) =
     cont k
   where k =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlIncludecore_repro = Block 0 ($camlIncludecore_repro__f_2) in
     cont done ($camlIncludecore_repro)

--- a/testsuite/tests/flambda2/examples/unknown/js.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/js.simplify.reference
@@ -16,19 +16,19 @@ in
 let code of__debug_2 deleted in
 let code loopify(never) size(3) newer_version_of(init_0)
       init_0_1 (x, y) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlJs__Pmakeblock_2)
+  cont k1 pop(regular k1) close[exn] my_alloc_region ($camlJs__Pmakeblock_2)
 in
 let $camlJs__init_7 = closure init_0_1 @init &toplevel.alloc_region in
 let code loopify(never) size(3) newer_version_of(of__unsafe_1)
       of__unsafe_1_1 (a) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlJs__Pmakeblock_4)
+  cont k1 pop(regular k1) close[exn] my_alloc_region ($camlJs__Pmakeblock_4)
 in
 let $camlJs__of__unsafe_8 =
   closure of__unsafe_1_1 @of__unsafe &toplevel.alloc_region
 in
 let code loopify(never) size(3) newer_version_of(of__debug_2)
       of__debug_2_1 (a) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k1 pop(regular k1) ($camlJs__Pmakeblock_6)
+  cont k1 pop(regular k1) close[exn] my_alloc_region ($camlJs__Pmakeblock_6)
 in
 let $camlJs__of__debug_9 =
   closure of__debug_2_1 @of__debug &toplevel.alloc_region
@@ -39,5 +39,6 @@ let $camlJs__Pmakeblock_10 =
            $camlJs__of__debug_9,
            $camlJs__of__unsafe_8)
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlJs = Block 0 (0, $camlJs__Pmakeblock_10) in
 cont done ($camlJs)

--- a/testsuite/tests/flambda2/examples/unknown/lazy_invalid.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/lazy_invalid.simplify.reference
@@ -1,7 +1,7 @@
 let code foo_0 deleted in
 let code `fn[lazy_invalid.ml:13,13--29]_1` deleted in
 let $camlLazy_invalid__immstring_0 = "" in
-apply ccall noalloc
+apply ccall noalloc [forward close close close]
   ($`*extern*`.caml_obj_tag : val -> val)
     ($camlLazy_invalid__immstring_0)
     -> k1 * error
@@ -27,12 +27,12 @@ apply ccall noalloc
             where k1 =
               let Popaque = %opaque ($camlLazy_invalid__immstring_0) in
               apply direct(force_lazy_block_4 &toplevel.alloc_region)
-                     inlined(never)
+                     inlined(never) [forward close close close]
                 $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_4_5
                   (Popaque)
                   -> k * error))
   where k (region_return : val) =
-    (apply ccall
+    (apply ccall [forward close close close]
        ($`*extern*`.caml_alloc_dummy_lazy : val -> val) (0) -> k * error
        where k (t) =
          let code loopify(never) size(1) newer_version_of(foo_0)
@@ -40,7 +40,7 @@ apply ccall noalloc
                  my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
-           cont k (x)
+           cont k close[normal] my_alloc_region (x)
          in
          let $camlLazy_invalid__foo_1 =
            closure foo_0_1 @foo &toplevel.alloc_region
@@ -49,7 +49,7 @@ apply ccall noalloc
                `fn[lazy_invalid.ml:13,13--29]_1_1` (param : imm tagged)
                  my_closure &my_alloc_region my_depth
                  -> k * k1 =
-           apply ccall noalloc
+           apply ccall noalloc [forward close close close]
              ($`*extern*`.caml_obj_tag : val -> val)
                ($camlLazy_invalid__foo_1)
                -> k2 * k1
@@ -68,12 +68,15 @@ apply ccall noalloc
                         where k3 =
                           let prim_2 = %int_comp.eq (tag, 244) in
                           switch prim_2
-                            | 0 -> k ($camlLazy_invalid__foo_1)
+                            | 0 ->
+                              k
+                                close[normal] my_alloc_region
+                                ($camlLazy_invalid__foo_1)
                             | 1 -> k2)
                        where k2 =
                          let Popaque = %opaque ($camlLazy_invalid__foo_1) in
                          apply direct(force_lazy_block_4 &my_alloc_region)
-                                inlined(never)
+                                inlined(never) [close close close close]
                            $CamlinternalLazy.camlCamlinternalLazy__force_lazy_block_4_5
                              (Popaque)
                              -> k * k1))
@@ -86,13 +89,16 @@ apply ccall noalloc
            %lazy.`toplevel`
              ($`camlLazy_invalid__fn[lazy_invalid.ml:13,13--29]_2`)
          in
-         (apply ccall
+         (apply ccall [forward close close close]
             ($`*extern*`.caml_update_dummy_lazy : val * val -> val)
               (t, Pmakelazyblock)
               -> k1 * error
             where k1 (param) =
               cont k
             where k =
+              let `unit` =
+                %close_alloc_region.[`normal`] (toplevel.alloc_region)
+              in
               let $camlLazy_invalid =
                 Block 0 (region_return, $camlLazy_invalid__foo_1, t)
               in

--- a/testsuite/tests/flambda2/examples/unknown/let_symbol_var_inlining.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/let_symbol_var_inlining.simplify.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(3) newer_version_of(f_0)
         -> k * k1
         : imm tagged =
   let int_add = %int_barith.add (n, 42) in
-  cont k (int_add)
+  cont k close[normal] my_alloc_region (int_add)
 in
 let $camlLet_symbol_var_inlining__f_2 =
   closure f_0_1 @f &toplevel.alloc_region
@@ -18,11 +18,12 @@ let code loopify(never) size(5) newer_version_of(g_1)
         -> k * k1
         : imm tagged =
   let int_mul = %int_barith.mul (m, 42) in
-  cont k (int_mul)
+  cont k close[normal] my_alloc_region (int_mul)
 in
 let $camlLet_symbol_var_inlining__g_3 =
   closure g_1_1 @g &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlLet_symbol_var_inlining =
   Block 0 ($Stdlib__List.camlStdlib__List__length_1_15,
            b,

--- a/testsuite/tests/flambda2/examples/unknown/local.raw.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.raw.reference
@@ -7,7 +7,7 @@
          -> k1 * k2
          : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] stack =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 ($camlLocal__const_block_2)
+   cont k1 close[normal] my_alloc_region ($camlLocal__const_block_2)
  in
  let code rec size(35)
        map_local_1 (f : val, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
@@ -20,7 +20,7 @@
     (let untagged = %untag_imm (Pisint) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (0))
+       | 1 -> k1 close[normal] my_alloc_region (0))
       where k4 =
         cont k3)
      where k3 =
@@ -28,19 +28,21 @@
          apply
                 direct(map_local_1
                 &my_alloc_region &my_region &my_ghost_region)
+                [forward close close close]
            (my_closure ~ depth my_depth -> next_depth
             : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
              (f, Pfield)
              -> k3 * k2)
           where k3 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
             ((let Pfield = %block_load.[`0`] (l) in
-              apply &my_alloc_region f (Pfield) -> k3 * k2)
+              apply &my_alloc_region [forward close close close]
+                f (Pfield) -> k3 * k2)
                where k3 (apply_result_1 : val) =
                  let Pmakeblock =
                    %block.[`0`].my_alloc_region.local[my_region]
                      (apply_result_1, apply_result)
                  in
-                 cont k1 (Pmakeblock)))
+                 cont k1 close[normal] my_alloc_region (Pmakeblock)))
  in
  let code rec size(23)
        length_2 (l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
@@ -53,18 +55,18 @@
     (let untagged = %untag_imm (Pisint) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (0))
+       | 1 -> k1 close[normal] my_alloc_region (0))
       where k4 =
         cont k3)
      where k3 =
        ((let Pfield = %block_load.[`1`] (l) in
-         apply direct(length_2 &my_alloc_region)
+         apply direct(length_2 &my_alloc_region) [forward close close close]
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (Pfield)
              -> k3 * k2)
           where k3 (apply_result : imm tagged) =
             let int_add = %int_barith.add (1, apply_result) in
-            cont k1 (int_add))
+            cont k1 close[normal] my_alloc_region (int_add))
  in
  let code size(3)
        `fn[local.ml:32,27--43]_3` (i : imm tagged)
@@ -73,7 +75,7 @@
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let int_add = %int_barith.add (i, 1) in
-   cont k1 (int_add)
+   cont k1 close[normal] my_alloc_region (int_add)
  in
  let code rec loopify(default tailrec) size(28)
        rev_app_4
@@ -88,7 +90,7 @@
     (let untagged = %untag_imm (Pisint) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (l2))
+       | 1 -> k1 close[normal] my_alloc_region (l2))
       where k4 =
         cont k3)
      where k3 =
@@ -98,6 +100,7 @@
        in
        let Pfield_1 = %block_load.[`1`] (l1) in
        apply direct(rev_app_4 &my_alloc_region &my_region &my_ghost_region)
+              [close close close close]
          (my_closure ~ depth my_depth -> next_depth
           : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (Pfield_1, Pmakeblock)
@@ -128,7 +131,8 @@
        let l_1 = %block_load.[`1`] (l) in
        let a = %block_load.[`0`] (l) in
        let acc_1 = %block.[`0`].my_alloc_region.local[my_region] (a, acc) in
-       (apply &my_alloc_region break_here (a) -> k6 * k2
+       (apply &my_alloc_region [forward close close close]
+          break_here (a) -> k6 * k2
           where k6 (apply_result : [ 0 |1 ]) =
             ((let untagged = %untag_imm (apply_result) in
               switch untagged
@@ -142,6 +146,7 @@
             apply
                    direct(find_span_6
                    &my_alloc_region &my_region &my_ghost_region)
+                   [close close close close]
               (my_closure ~ depth my_depth -> next_depth
                : _ ->
                  [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ]
@@ -152,12 +157,12 @@
             let Pmakeblock =
               %block.[`0`].my_alloc_region.local[my_region] (acc_1, l_1)
             in
-            cont k1 (Pmakeblock))
+            cont k1 close[normal] my_alloc_region (Pmakeblock))
      where k3 =
        let Pmakeblock =
          %block.[`0`].my_alloc_region.local[my_region] (acc, 0)
        in
-       cont k1 (Pmakeblock)
+       cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code rec size(39)
        spans_5
@@ -173,13 +178,14 @@
     (let untagged = %untag_imm (Pisint) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (0))
+       | 1 -> k1 close[normal] my_alloc_region (0))
       where k4 =
         cont k3)
      where k3 =
        (apply
                direct(find_span_6
                &my_alloc_region &my_region &my_ghost_region)
+               [forward close close close]
           (find_span ~ depth my_depth -> next_depth
            : _ -> [ 0 of [ 0 | 0 of val * val ] * [ 0 | 0 of val * val ] ])
             (break_here, l, 0)
@@ -191,6 +197,7 @@
               apply
                      direct(spans_5
                      &my_alloc_region &my_region &my_ghost_region)
+                     [forward close close close]
                 (my_closure ~ depth my_depth -> next_depth
                  : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                   (break_here, Pfield)
@@ -202,6 +209,7 @@
                    apply
                           direct(rev_app_4
                           &my_alloc_region &my_region &my_ghost_region)
+                          [forward close close close]
                      (rev_app
                       : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                        (Pfield, 0)
@@ -213,7 +221,7 @@
                         %block.[`0`].my_alloc_region.local[my_region]
                           (apply_result_1, apply_result)
                       in
-                      cont k1 (Pmakeblock))))
+                      cont k1 close[normal] my_alloc_region (Pmakeblock))))
  in
  let code size(25)
        is_even_7 (i : imm tagged)
@@ -228,12 +236,15 @@
      where k5 =
        cont k3
      where k4 =
-       cont k2 pop(regular k2) ($`*predef*`.caml_exn_Division_by_zero)
+       cont k2
+              pop(regular k2)
+              close[exn] my_alloc_region
+              ($`*predef*`.caml_exn_Division_by_zero)
      where k3 =
        let int_mod = %int_barith.mod (i, 2) in
        let prim = %phys_eq (int_mod, 0) in
        let eq = %tag_imm (prim) in
-       cont k1 (eq)
+       cont k1 close[normal] my_alloc_region (eq)
  in
  let $camlLocal__immstring_4 = "local.ml" in
  let $camlLocal__const_block_16 = Block 0 ($camlLocal__immstring_4, 58, 2) in
@@ -263,7 +274,7 @@
  in
  let map_local = closure map_local_1 @map_local &toplevel.alloc_region in
  let length = closure length_2 @length &toplevel.alloc_region in
- apply direct(length_2 &toplevel.alloc_region)
+ apply direct(length_2 &toplevel.alloc_region) [forward close close close]
    (length : _ -> imm tagged) ($camlLocal__const_block_3) -> k3 * error
    where k3 (apply_result : imm tagged) =
      let prim = %phys_eq (apply_result, 1) in
@@ -275,18 +286,23 @@
         where k3 =
           cont k2)
    where k2 =
-     cont error pop(regular error) ($camlLocal__Pmakeblock_6)
+     cont error
+            pop(regular error)
+            close[exn] toplevel.alloc_region
+            ($camlLocal__Pmakeblock_6)
    where k1 (`*match*` : imm tagged) =
      ((let `region` = %begin_region () in
        let ghost_region = %begin_ghost_region () in
        apply
               direct(return_local_0
               &toplevel.alloc_region &`region` &ghost_region)
+              [forward close close close]
          (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
            (0)
            -> k5 * error
          where k5 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
            apply direct(length_2 &toplevel.alloc_region) unroll(3)
+                  [forward close close close]
              (length : _ -> imm tagged) (apply_result) -> k4 * error
          where k4 (apply_result : imm tagged) =
            let prim = %phys_eq (apply_result, 3) in
@@ -298,7 +314,10 @@
               where k4 =
                 cont k3)
          where k3 =
-           cont error pop(regular error) ($camlLocal__Pmakeblock_8)
+           cont error
+                  pop(regular error)
+                  close[exn] toplevel.alloc_region
+                  ($camlLocal__Pmakeblock_8)
          where k2 (region_return : imm tagged) =
            let `unit` = %end_region (`region`) in
            let unit_1 = %end_ghost_region (ghost_region) in
@@ -309,6 +328,7 @@
             apply
                    direct(return_local_0
                    &toplevel.alloc_region &`region` &ghost_region)
+                   [forward close close close]
               (return_local : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                 (0)
                 -> k3 * error
@@ -321,12 +341,14 @@
                   apply
                          direct(map_local_1
                          &toplevel.alloc_region &`region` &ghost_region)
+                         [forward close close close]
                     (map_local
                      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                       (`fn[local.ml:32,27--43]`, ns)
                       -> k3 * error)
                    where k3 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                      (apply direct(length_2 &toplevel.alloc_region)
+                             [forward close close close]
                         (length : _ -> imm tagged) (ms) -> k4 * error
                         where k4 (apply_result : imm tagged) =
                           let prim = %phys_eq (apply_result, 3) in
@@ -340,6 +362,7 @@
                         where k3 =
                           cont error
                                  pop(regular error)
+                                 close[exn] toplevel.alloc_region
                                  ($camlLocal__Pmakeblock_10)))
               where k2 (region_return : imm tagged) =
                 let `unit` = %end_region (`region`) in
@@ -362,6 +385,7 @@
                  apply
                         direct(spans_5
                         &toplevel.alloc_region &`region` &ghost_region)
+                        [forward close close close]
                    (spans : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                      (is_even, $camlLocal__const_block_15)
                      -> k3 * error
@@ -369,6 +393,7 @@
                            (even_spans :
                               [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                      (apply direct(length_2 &toplevel.alloc_region)
+                             [forward close close close]
                         (length : _ -> imm tagged) (even_spans) -> k4 * error
                         where k4 (apply_result : imm tagged) =
                           let prim = %phys_eq (apply_result, 3) in
@@ -382,6 +407,7 @@
                         where k3 =
                           cont error
                                  pop(regular error)
+                                 close[exn] toplevel.alloc_region
                                  ($camlLocal__Pmakeblock_17))
                    where k2 (region_return : imm tagged) =
                      let `unit` = %end_region (`region`) in
@@ -398,7 +424,7 @@
                          find_span,
                          is_even)
                     in
-                    cont k (Pmakeblock)))))
+                    cont k close[normal] toplevel.alloc_region (Pmakeblock)))))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`7`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`7`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/local.simplify.reference
@@ -37,7 +37,7 @@ let code loopify(never) size(1) newer_version_of(return_local_0)
         my_closure &my_alloc_region &my_region &my_ghost_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] stack =
-  cont k ($camlLocal__const_block_2)
+  cont k close[normal] my_alloc_region ($camlLocal__const_block_2)
 in
 let $camlLocal__return_local_18 =
   closure return_local_0_1 @return_local &toplevel.alloc_region
@@ -52,25 +52,27 @@ and code rec loopify(never) size(31) newer_version_of(map_local_1)
   let prim = %is_int (l) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       ((let Pfield = %block_load.[`1`] (l) in
         apply
                direct(map_local_1_1
                &my_alloc_region &my_region &my_ghost_region)
+               [forward close close close]
           ($camlLocal__map_local_19 ~ depth my_depth -> succ my_depth
            : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
             (f, Pfield)
             -> k2 * k1)
          where k2 (apply_result : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
            ((let Pfield = %block_load.[`0`] (l) in
-             apply &my_alloc_region f (Pfield) -> k2 * k1)
+             apply &my_alloc_region [forward close close close]
+               f (Pfield) -> k2 * k1)
               where k2 (apply_result_1 : val) =
                 let Pmakeblock =
                   %block.[`0`].my_alloc_region.local[my_region]
                     (apply_result_1, apply_result)
                 in
-                cont k (Pmakeblock)))
+                cont k close[normal] my_alloc_region (Pmakeblock)))
 in
 let $camlLocal__length_20 =
   closure length_2_1 @length &toplevel.alloc_region
@@ -82,30 +84,34 @@ and code rec loopify(never) size(19) newer_version_of(length_2)
   let prim = %is_int (l) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       ((let Pfield = %block_load.[`1`] (l) in
-        apply direct(length_2_1 &my_alloc_region)
+        apply direct(length_2_1 &my_alloc_region) [forward close close close]
           ($camlLocal__length_20 ~ depth my_depth -> succ my_depth
            : _ -> imm tagged)
             (Pfield)
             -> k2 * k1)
          where k2 (apply_result : imm tagged) =
            let int_add = %int_barith.add (1, apply_result) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
-apply direct(length_2_1 &toplevel.alloc_region)
+apply direct(length_2_1 &toplevel.alloc_region) [forward close close close]
   ($camlLocal__length_20 : _ -> imm tagged)
     ($camlLocal__const_block_3)
     -> k1 * error
   where k1 (apply_result : imm tagged) =
     let prim = %phys_eq (apply_result, 1) in
     switch prim
-      | 0 -> error pop(regular error) ($camlLocal__Pmakeblock_6)
+      | 0 ->
+        error
+          pop(regular error)
+          close[exn] toplevel.alloc_region
+          ($camlLocal__Pmakeblock_6)
       | 1 -> k
   where k =
     (apply direct(length_2_1 &toplevel.alloc_region)
-            inlining_state(depth(30))
+            inlining_state(depth(30)) [forward close close close]
        ($camlLocal__length_20 ~ depth unroll 1 2 -> unroll 0 3
         : _ -> imm tagged)
          (0)
@@ -116,7 +122,11 @@ apply direct(length_2_1 &toplevel.alloc_region)
          let int_add_2 = %int_barith.add (1, int_add_1) in
          let prim = %phys_eq (int_add_2, 3) in
          switch prim
-           | 0 -> error pop(regular error) ($camlLocal__Pmakeblock_8)
+           | 0 ->
+             error
+               pop(regular error)
+               close[exn] toplevel.alloc_region
+               ($camlLocal__Pmakeblock_8)
            | 1 -> k
        where k =
          let `region` = %begin_region () in
@@ -127,7 +137,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
                    -> k2 * k3
                    : imm tagged =
              let int_add = %int_barith.add (i, 1) in
-             cont k2 (int_add)
+             cont k2 close[normal] my_alloc_region (int_add)
            in
            let $`camlLocal__fn[local.ml:32,27--43]_21` =
              closure `fn[local.ml:32,27--43]_3_1` @`fn[local.ml:32,27--43]`
@@ -136,6 +146,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
            apply
                   direct(map_local_1_1
                   &toplevel.alloc_region &`region` &ghost_region)
+                  [forward close close close]
              ($camlLocal__map_local_19
               : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                ($`camlLocal__fn[local.ml:32,27--43]_21`,
@@ -143,12 +154,16 @@ apply direct(length_2_1 &toplevel.alloc_region)
                -> k1 * error)
             where k1 (ms : [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
               (apply direct(length_2_1 &toplevel.alloc_region)
+                      [forward close close close]
                  ($camlLocal__length_20 : _ -> imm tagged) (ms) -> k1 * error
                  where k1 (apply_result : imm tagged) =
                    let prim = %phys_eq (apply_result, 3) in
                    switch prim
                      | 0 ->
-                       error pop(regular error) ($camlLocal__Pmakeblock_10)
+                       error
+                         pop(regular error)
+                         close[exn] toplevel.alloc_region
+                         ($camlLocal__Pmakeblock_10)
                      | 1 -> k)
             where k =
               let `unit` = %end_region (`region`) in
@@ -170,7 +185,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
                     let prim = %is_int (l1_1) in
                     (switch prim
                        | 0 -> k2
-                       | 1 -> k (l2_1)
+                       | 1 -> k close[normal] my_alloc_region (l2_1)
                        where k2 =
                          let Pfield = %block_load.[`0`] (l1_1) in
                          let Pmakeblock =
@@ -205,14 +220,15 @@ apply direct(length_2_1 &toplevel.alloc_region)
                     let Pmakeblock =
                       %block.[`0`].my_alloc_region.local[my_region] (acc, 0)
                     in
-                    cont k (Pmakeblock)
+                    cont k close[normal] my_alloc_region (Pmakeblock)
                   where k2 =
                     let l_1 = %block_load.[`1`] (l) in
                     let a = %block_load.[`0`] (l) in
                     let acc_1 =
                       %block.[`0`].my_alloc_region.local[my_region] (a, acc)
                     in
-                    (apply &my_alloc_region break_here (a) -> k3 * k1
+                    (apply &my_alloc_region [forward close close close]
+                       break_here (a) -> k3 * k1
                        where k3 (param : [ 0 |1 ]) =
                          let unboxed_field = %untag_imm (param) in
                          cont k2 (unboxed_field)
@@ -226,11 +242,14 @@ apply direct(length_2_1 &toplevel.alloc_region)
                                 %block.[`0`].my_alloc_region.local[my_region]
                                   (acc_1, l_1)
                               in
-                              cont k (Pmakeblock)
+                              cont k
+                                     close[normal] my_alloc_region
+                                     (Pmakeblock)
                             where k2 =
                               apply
                                      direct(find_span_6_1
                                      &my_alloc_region &my_region &my_ghost_region)
+                                     [close close close close]
                                 ($camlLocal__find_span_24 ~ depth my_depth -> succ my_depth
                                  : _ ->
                                    [ 0 of [ 0 | 0 of val * val ] *
@@ -249,11 +268,12 @@ apply direct(length_2_1 &toplevel.alloc_region)
                 let prim = %is_int (l) in
                 switch prim
                   | 0 -> k2
-                  | 1 -> k (0)
+                  | 1 -> k close[normal] my_alloc_region (0)
                   where k2 =
                     (apply
                             direct(find_span_6_1
                             &my_alloc_region &my_region &my_ghost_region)
+                            [forward close close close]
                        ($camlLocal__find_span_24 ~ depth my_depth -> succ my_depth
                         : _ ->
                           [ 0 of [ 0 | 0 of val * val ] *
@@ -269,6 +289,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
                            apply
                                   direct(spans_5_1
                                   &my_alloc_region &my_region &my_ghost_region)
+                                  [forward close close close]
                              ($camlLocal__spans_23 ~ depth my_depth -> succ my_depth
                               : _ ->
                                 [ 0 | 0 of val * [ 0 | 0 of val * val ] ]
@@ -283,6 +304,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
                                 apply
                                        direct(rev_app_4_1
                                        &my_alloc_region &my_region &my_ghost_region)
+                                       [forward close close close]
                                   ($camlLocal__rev_app_22
                                    : _ ->
                                      [ 0 | 0 of val * [ 0 | 0 of val * val ]
@@ -299,7 +321,9 @@ apply direct(length_2_1 &toplevel.alloc_region)
                                      %block.[`0`].my_alloc_region.local[my_region]
                                        (apply_result_1, apply_result)
                                    in
-                                   cont k (Pmakeblock))))
+                                   cont k
+                                          close[normal] my_alloc_region
+                                          (Pmakeblock))))
               in
               let code loopify(never) size(9) newer_version_of(is_even_7)
                     is_even_7_1 (i : imm tagged)
@@ -309,7 +333,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
                 let int_mod = %int_barith.mod (i, 2) in
                 let prim = %phys_eq (int_mod, 0) in
                 let eq = %tag_imm (prim) in
-                cont k (eq)
+                cont k close[normal] my_alloc_region (eq)
               in
               let $camlLocal__is_even_25 =
                 closure is_even_7_1 @is_even &toplevel.alloc_region
@@ -319,6 +343,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
               (apply
                       direct(spans_5_1
                       &toplevel.alloc_region &region_1 &ghost_region_1)
+                      [forward close close close]
                  ($camlLocal__spans_23
                   : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
                    ($camlLocal__is_even_25, $camlLocal__const_block_15)
@@ -327,6 +352,7 @@ apply direct(length_2_1 &toplevel.alloc_region)
                          (even_spans :
                             [ 0 | 0 of val * [ 0 | 0 of val * val ] ]) =
                    (apply direct(length_2_1 &toplevel.alloc_region)
+                           [forward close close close]
                       ($camlLocal__length_20 : _ -> imm tagged)
                         (even_spans)
                         -> k1 * error
@@ -336,11 +362,15 @@ apply direct(length_2_1 &toplevel.alloc_region)
                           | 0 ->
                             error
                               pop(regular error)
+                              close[exn] toplevel.alloc_region
                               ($camlLocal__Pmakeblock_17)
                           | 1 -> k)
                  where k =
                    let unit_2 = %end_region (region_1) in
                    let unit_3 = %end_ghost_region (ghost_region_1) in
+                   let unit_4 =
+                     %close_alloc_region.[`normal`] (toplevel.alloc_region)
+                   in
                    let $camlLocal =
                      Block 0 ($camlLocal__return_local_18,
                               $camlLocal__map_local_19,

--- a/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/map_remove.simplify.reference
@@ -21,7 +21,7 @@ let code inline(never) loopify(never) size(9) newer_version_of(bal_0)
           | 0 of [ 0 | 0 of val * imm tagged * val ] * imm tagged *
               [ 0 | 0 of val * imm tagged * val ] ] =
   let Pmakeblock = %block.[`0`].my_alloc_region (l, v, r) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlMap_remove__bal_1 = closure bal_0_1 @bal &toplevel.alloc_region in
 let code loopify(done) size(26) newer_version_of(min_binding_1)
@@ -42,7 +42,11 @@ let code loopify(done) size(26) newer_version_of(min_binding_1)
       let prim = %is_int (param_1) in
       (switch prim
          | 0 -> k2
-         | 1 -> k1 pop(reraise k1) ($`*predef*`.caml_exn_Not_found)
+         | 1 ->
+           k1
+             pop(reraise k1)
+             close[exn] my_alloc_region
+             ($`*predef*`.caml_exn_Not_found)
          where k2 =
            let l = %block_load.[`0`] (param_1) in
            let prim_1 = %is_int (l) in
@@ -51,7 +55,7 @@ let code loopify(done) size(26) newer_version_of(min_binding_1)
               | 1 -> k2
               where k2 =
                 let Pfield = %block_load.[`1`] (param_1) in
-                cont k (Pfield)))
+                cont k close[normal] my_alloc_region (Pfield)))
 in
 let $camlMap_remove__min_binding_2 =
   closure min_binding_1_1 @min_binding &toplevel.alloc_region
@@ -76,7 +80,11 @@ and code rec loopify(never) size(35) newer_version_of(remove_min_binding_2)
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
-    | 1 -> k1 pop(reraise k1) ($camlMap_remove__Pmakeblock_4)
+    | 1 ->
+      k1
+        pop(reraise k1)
+        close[exn] my_alloc_region
+        ($camlMap_remove__Pmakeblock_4)
     where k2 =
       let l = %block_load.[`0`] (param) in
       let prim_1 = %is_int (l) in
@@ -85,11 +93,12 @@ and code rec loopify(never) size(35) newer_version_of(remove_min_binding_2)
          | 1 -> k3
          where k3 =
            let Pfield = %block_load.[`2`] (param) in
-           cont k (Pfield)
+           cont k close[normal] my_alloc_region (Pfield)
          where k2 =
            let Pfield = %block_load.[`2`] (param) in
            let Pfield_1 = %block_load.[`1`] (param) in
            (apply direct(remove_min_binding_2_1 &my_alloc_region)
+                   [forward close close close]
               ($camlMap_remove__remove_min_binding_3 ~ depth my_depth -> succ my_depth
                : _ ->
                  [ 0
@@ -105,6 +114,7 @@ and code rec loopify(never) size(35) newer_version_of(remove_min_binding_2)
                              imm tagged * [ 0 | 0 of val * imm tagged * val ]
                          ]) =
                 apply direct(bal_0_1 &my_alloc_region)
+                       [close close close close]
                   ($camlMap_remove__bal_1
                    : _ ->
                      [ 0
@@ -132,19 +142,21 @@ let code loopify(never) size(34) newer_version_of(merge_3)
   let prim = %is_int (t1) in
   switch prim
     | 0 -> k2
-    | 1 -> k (t2)
+    | 1 -> k close[normal] my_alloc_region (t2)
     where k2 =
       let prim_1 = %is_int (t2) in
       (switch prim_1
          | 0 -> k2
-         | 1 -> k (t1)
+         | 1 -> k close[normal] my_alloc_region (t1)
          where k2 =
            (apply direct(min_binding_1_1 &my_alloc_region)
+                   [forward close close close]
               ($camlMap_remove__min_binding_2 : _ -> imm tagged)
                 (t2)
                 -> k2 * k1
               where k2 (x : imm tagged) =
                 (apply direct(remove_min_binding_2_1 &my_alloc_region)
+                        [forward close close close]
                    ($camlMap_remove__remove_min_binding_3
                     : _ ->
                       [ 0
@@ -160,6 +172,7 @@ let code loopify(never) size(34) newer_version_of(merge_3)
                                   imm tagged *
                                   [ 0 | 0 of val * imm tagged * val ] ]) =
                      apply direct(bal_0_1 &my_alloc_region)
+                            [close close close close]
                        ($camlMap_remove__bal_1
                         : _ ->
                           [ 0
@@ -188,17 +201,17 @@ let code loopify(never) size(30) newer_version_of(remove_4)
   let prim = %is_int (param) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       let l = %block_load.[`0`] (param) in
       let Pfield = %block_load.[`1`] (param) in
       let prim_1 = %int_comp.eq (x, Pfield) in
       (switch prim_1
-         | 0 -> k (l)
+         | 0 -> k close[normal] my_alloc_region (l)
          | 1 -> k2
          where k2 =
            let Pfield_1 = %block_load.[`2`] (param) in
-           apply direct(merge_3_1 &my_alloc_region)
+           apply direct(merge_3_1 &my_alloc_region) [close close close close]
              ($camlMap_remove__merge_5
               : _ ->
                 [ 0
@@ -211,6 +224,7 @@ in
 let $camlMap_remove__remove_6 =
   closure remove_4_1 @remove &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlMap_remove =
   Block 0 ($camlMap_remove__bal_1,
            $camlMap_remove__min_binding_2,

--- a/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/offset.simplify.reference
@@ -11,11 +11,11 @@ let code loopify(never) size(16) newer_version_of(f_2)
   let r = %project_value_slot.[f].[r] (my_closure) in
   (let untagged = %untag_imm (a) in
    switch untagged
-     | 0 -> k (0)
+     | 0 -> k close[normal] my_alloc_region (0)
      | 1 -> k2)
     where k2 =
       let int_add = %int_barith.add (r, x) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code loopify(never) size(20) newer_version_of(g_3)
       g_3_1 (x : imm tagged, y : imm tagged)
@@ -26,12 +26,12 @@ let code loopify(never) size(20) newer_version_of(g_3)
   let s = %project_value_slot.[g].[s] (my_closure) in
   (let untagged = %untag_imm (b) in
    switch untagged
-     | 0 -> k (0)
+     | 0 -> k close[normal] my_alloc_region (0)
      | 1 -> k2)
     where k2 =
       let int_mul = %int_barith.mul (x, y) in
       let int_add = %int_barith.add (s, int_mul) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code rec loopify(never) size(39) newer_version_of(h_4)
       h_4_1 (x : imm tagged, y : imm tagged)
@@ -47,7 +47,7 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
      | 0 -> k2 (0)
      | 1 -> k3)
     where k3 =
-      apply direct(g_3_1 &my_alloc_region)
+      apply direct(g_3_1 &my_alloc_region) [forward close close close]
         (g ~ depth my_depth -> succ my_depth : _ -> imm tagged)
           (x, y)
           -> k2 * k1
@@ -58,7 +58,7 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
           | 1 -> k3)
          where k3 =
            let int_add = %int_barith.add (x, y) in
-           apply direct(f_2_1 &my_alloc_region)
+           apply direct(f_2_1 &my_alloc_region) [forward close close close]
              (f ~ depth my_depth -> succ my_depth : _ -> imm tagged)
                (int_add)
                -> k2 * k1
@@ -66,7 +66,7 @@ let code rec loopify(never) size(39) newer_version_of(h_4)
            let int_add =
              %int_barith.add (staticcatch_result_1, staticcatch_result)
            in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let code inline(always) loopify(never) size(101) newer_version_of(inline_0)
       inline_0_1 (a : imm tagged, b : imm tagged)
@@ -74,14 +74,14 @@ let code inline(always) loopify(never) size(101) newer_version_of(inline_0)
         -> k * k1
         : val =
   apply direct(partial_apply1_44 &my_alloc_region) inlined(never)
-         inlining_state(depth(10))
+         inlining_state(depth(10)) [forward close close close]
     ($Stdlib__Random.camlStdlib__Random__partial_apply1_44_73
      : _ -> imm tagged)
       (10)
       -> k2 * k1
     where k2 (r : imm tagged) =
       (apply direct(partial_apply1_44 &my_alloc_region) inlined(never)
-              inlining_state(depth(10))
+              inlining_state(depth(10)) [forward close close close]
          ($Stdlib__Random.camlStdlib__Random__partial_apply1_44_73
           : _ -> imm tagged)
            (10)
@@ -92,20 +92,20 @@ let code inline(always) loopify(never) size(101) newer_version_of(inline_0)
            and h = closure h_4_1 @h &my_alloc_region
            with { a = a; b = b; r = r; s = s }
            in
-           cont k (h))
+           cont k close[normal] my_alloc_region (h))
 in
 let $camlOffset__inline_1 =
   closure inline_0_1 @`inline` &toplevel.alloc_region
 in
 apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
-       inlining_state(depth(11))
+       inlining_state(depth(11)) [forward close close close]
   ($Stdlib__Random.camlStdlib__Random__partial_apply1_44_73 : _ -> imm tagged
    )
     (10)
     -> k * error
   where k (r : imm tagged) =
     (apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
-            inlining_state(depth(11))
+            inlining_state(depth(11)) [forward close close close]
        ($Stdlib__Random.camlStdlib__Random__partial_apply1_44_73
         : _ -> imm tagged)
          (10)
@@ -116,7 +116,7 @@ apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
                  my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
-           cont k (0)
+           cont k close[normal] my_alloc_region (0)
          in
          let $camlOffset__f_3 =
            closure f_2_2 @f &toplevel.alloc_region
@@ -124,17 +124,20 @@ apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
            closure g_3_2 @g &toplevel.alloc_region
          and $camlOffset__h_5 =
            closure h_4_2 @h &toplevel.alloc_region
-         and code rec loopify(never) size(6) newer_version_of(h_4_1)
+         and code rec loopify(never) size(7) newer_version_of(h_4_1)
                h_4_2 (x : imm tagged, y : imm tagged)
                  my_closure &my_alloc_region my_depth
                  -> k * k1
                  : imm tagged =
-           let int_add = %int_barith.add (x, y) in
-           apply direct(f_2_2 &my_alloc_region) inlining_state(depth(1))
-             ($camlOffset__f_3 ~ depth my_depth -> succ my_depth
-              : _ -> imm tagged)
-               (int_add)
-               -> k * k1
+           (let int_add = %int_barith.add (x, y) in
+            apply direct(f_2_2 &my_alloc_region) inlining_state(depth(1))
+                   [forward close close close]
+              ($camlOffset__f_3 ~ depth my_depth -> succ my_depth
+               : _ -> imm tagged)
+                (int_add)
+                -> k2 * k1)
+             where k2 (staticcatch_result : imm tagged) =
+               cont k close[normal] my_alloc_region (staticcatch_result)
          and code loopify(never) size(4) newer_version_of(f_2_1)
                f_2_2 (x : imm tagged)
                  my_closure &my_alloc_region my_depth
@@ -142,11 +145,12 @@ apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
                  : imm tagged =
            let r_1 = %project_value_slot.[f].[r] ($camlOffset__f_3) in
            let int_add = %int_barith.add (r_1, x) in
-           cont k (int_add)
+           cont k close[normal] my_alloc_region (int_add)
            with { a = 1; b = 0; r = r; s = s }
          in
          (apply direct(partial_apply1_44 &toplevel.alloc_region)
                  inlined(never) inlining_state(depth(11))
+                 [forward close close close]
             ($Stdlib__Random.camlStdlib__Random__partial_apply1_44_73
              : _ -> imm tagged)
               (10)
@@ -154,6 +158,7 @@ apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
             where k (r_1 : imm tagged) =
               (apply direct(partial_apply1_44 &toplevel.alloc_region)
                       inlined(never) inlining_state(depth(11))
+                      [forward close close close]
                  ($Stdlib__Random.camlStdlib__Random__partial_apply1_44_73
                   : _ -> imm tagged)
                    (10)
@@ -164,21 +169,21 @@ apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
                            my_closure &my_alloc_region my_depth
                            -> k * k1
                            : imm tagged =
-                     cont k (0)
+                     cont k close[normal] my_alloc_region (0)
                    in
                    let code loopify(never) size(1) newer_version_of(g_3_1)
                          g_3_3 (x : imm tagged, y : imm tagged)
                            my_closure &my_alloc_region my_depth
                            -> k * k1
                            : imm tagged =
-                     cont k (0)
+                     cont k close[normal] my_alloc_region (0)
                    in
                    let code loopify(never) size(1) newer_version_of(h_4_1)
                          h_4_3 (x : imm tagged, y : imm tagged)
                            my_closure &my_alloc_region my_depth
                            -> k * k1
                            : imm tagged =
-                     cont k (0)
+                     cont k close[normal] my_alloc_region (0)
                    in
                    let $camlOffset__f_6 =
                      closure f_2_3 @f &toplevel.alloc_region
@@ -187,6 +192,9 @@ apply direct(partial_apply1_44 &toplevel.alloc_region) inlined(never)
                    and $camlOffset__h_8 =
                      closure h_4_3 @h &toplevel.alloc_region
                      with { a = 0; b = 0; r = r_1; s = s_1 }
+                   in
+                   let `unit` =
+                     %close_alloc_region.[`normal`] (toplevel.alloc_region)
                    in
                    let $camlOffset =
                      Block 0 ($camlOffset__inline_1,

--- a/testsuite/tests/flambda2/examples/unknown/p.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/p.simplify.reference
@@ -7,14 +7,14 @@ let code inline(never) loopify(never) size(1) newer_version_of(foo_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlP__foo_1 = closure foo_0_1 @foo &toplevel.alloc_region in
 let code loopify(never) size(1) newer_version_of(`fn[p.ml:11,19--31]_2`)
       `fn[p.ml:11,19--31]_2_1` (x)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $`camlP__fn[p.ml:11,19--31]_3` =
   closure `fn[p.ml:11,19--31]_2_1` @`fn[p.ml:11,19--31]`
@@ -25,7 +25,7 @@ let code loopify(never) size(4) newer_version_of(bar_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(foo_0_1 &my_alloc_region)
+  apply direct(foo_0_1 &my_alloc_region) [close close close close]
     ($camlP__foo_1 : _ -> imm tagged)
       ($`camlP__fn[p.ml:11,19--31]_3`, oc, z)
       -> k * k1
@@ -34,10 +34,12 @@ let $camlP__bar_2 = closure bar_1_1 @bar &toplevel.alloc_region in
 let code loopify(never) size(4) newer_version_of(f_3)
       f_3_1 (z) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
   apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(10))
+         [close close close close]
     ($camlP__foo_1 : _ -> imm tagged)
       ($`camlP__fn[p.ml:11,19--31]_3`, 0, z)
       -> k * k1
 in
 let $camlP__f_4 = closure f_3_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlP = Block 0 ($camlP__foo_1, $camlP__bar_2, $camlP__f_4) in
 cont done ($camlP)

--- a/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/protect_refs.simplify.reference
@@ -14,10 +14,11 @@ let code loopify(done) size(22) newer_version_of(iter_0)
       let prim = %is_int (param_1) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (0)
+         | 1 -> k close[normal] my_alloc_region (0)
          where k2 =
            ((let Pfield = %block_load.[`0`] (param_1) in
-             apply &my_alloc_region f_1 (Pfield) -> k3 * k1
+             apply &my_alloc_region [forward close close close]
+               f_1 (Pfield) -> k3 * k1
                where k3 (param_2) =
                  cont k2)
               where k2 =
@@ -34,7 +35,7 @@ let code loopify(never) size(7) newer_version_of(`fn[protect_refs.ml:28,24--50]_
   let Pfield = %block_load.[`1`] (param) in
   let Pfield_1 = %block_load.[`0`] (param) in
   let Psetfield = %block_set.[`0`] (Pfield_1, Pfield) in
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $`camlProtect_refs__fn[protect_refs.ml:28,24--50]_3` =
   closure `fn[protect_refs.ml:28,24--50]_2_1`
@@ -46,13 +47,14 @@ let code loopify(never) size(11) newer_version_of(`fn[protect_refs.ml:29,2--43]_
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   apply direct(iter_0_1 &my_alloc_region) inlining_state(depth(10))
+         [forward close close close]
     ($camlProtect_refs__iter_1 : _ -> imm tagged)
       ($`camlProtect_refs__fn[protect_refs.ml:28,24--50]_3`, refs)
       -> k3 * k1
     where k3 (param : imm tagged) =
       cont k2
     where k2 =
-      apply &my_alloc_region f (0) -> k * k1
+      apply &my_alloc_region [close close close close] f (0) -> k * k1
 in
 let $`camlProtect_refs__fn[protect_refs.ml:29,2--43]_4` =
   closure `fn[protect_refs.ml:29,2--43]_3_1` @`fn[protect_refs.ml:29,2--43]`
@@ -67,6 +69,7 @@ and code inline(never) loopify(never) size(4) newer_version_of(set_mode_pattern_
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   apply direct(`fn[protect_refs.ml:29,2--43]_3_1` &my_alloc_region)
+         [close close close close]
     $`camlProtect_refs__fn[protect_refs.ml:29,2--43]_4`
       ($camlProtect_refs__Pmakeblock_7, f)
       -> k * k1
@@ -81,19 +84,21 @@ in
          my_closure &my_alloc_region my_depth
          -> k1 * k2
          : imm tagged =
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let $`camlProtect_refs__fn[protect_refs.ml:41,26--40]_8` =
    closure `fn[protect_refs.ml:41,26--40]_5_1`
      @`fn[protect_refs.ml:41,26--40]` &toplevel.alloc_region
  in
  apply direct(set_mode_pattern_4_1 &toplevel.alloc_region)
+        [forward close close close]
    ($camlProtect_refs__set_mode_pattern_5 : _ -> imm tagged)
      ($`camlProtect_refs__fn[protect_refs.ml:41,26--40]_8`)
      -> k1 * error
    where k1 (param) =
      cont k)
   where k =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlProtect_refs =
       Block 0 ($camlProtect_refs__iter_1,
                $`camlProtect_refs__fn[protect_refs.ml:29,2--43]_4`,

--- a/testsuite/tests/flambda2/examples/unknown/ray.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/ray.simplify.reference
@@ -10,8 +10,8 @@ let code inline(always) loopify(never) size(14) newer_version_of(min_0)
   let prim_1 = %unbox_num.`float` (x) in
   let prim_2 = %float_comp.le (prim_1, prim) in
   switch prim_2
-    | 0 -> k (y)
-    | 1 -> k (x)
+    | 0 -> k close[normal] my_alloc_region (y)
+    | 1 -> k close[normal] my_alloc_region (x)
 in
 let $camlRay__min_2 = closure min_0_1 @min &toplevel.alloc_region in
 let code inline(always) loopify(never) size(14) newer_version_of(max_1)
@@ -23,8 +23,8 @@ let code inline(always) loopify(never) size(14) newer_version_of(max_1)
   let prim_1 = %unbox_num.`float` (x) in
   let prim_2 = %float_comp.ge (prim_1, prim) in
   switch prim_2
-    | 0 -> k (y)
-    | 1 -> k (x)
+    | 0 -> k close[normal] my_alloc_region (y)
+    | 1 -> k close[normal] my_alloc_region (x)
 in
 let $camlRay__max_3 = closure max_1_1 @max &toplevel.alloc_region in
 let code loopify(never) size(222) newer_version_of(aabb_hit_2)
@@ -74,7 +74,7 @@ let code loopify(never) size(222) newer_version_of(aabb_hit_2)
            let prim_9 = %float_comp.le (unboxed_float_1, unboxed_float) in
            (switch prim_9
               | 0 -> k2
-              | 1 -> k (0)
+              | 1 -> k close[normal] my_alloc_region (0)
               where k2 =
                 let prim_10 = %block_load.`float`.[`1`] (Pfield) in
                 let prim_11 = %block_load.`float`.[`1`] (Pfield_1) in
@@ -117,7 +117,7 @@ let code loopify(never) size(222) newer_version_of(aabb_hit_2)
                           in
                           (switch prim_19
                              | 0 -> k2
-                             | 1 -> k (0)
+                             | 1 -> k close[normal] my_alloc_region (0)
                              where k2 =
                                let prim_20 =
                                  %block_load.`float`.[`2`] (Pfield)
@@ -193,11 +193,14 @@ let code loopify(never) size(222) newer_version_of(aabb_hit_2)
                                            %boolean_not
                                              (float_ordered_and_lessequal)
                                          in
-                                         cont k (Pnot))))))))
+                                         cont k
+                                                close[normal] my_alloc_region
+                                                (Pnot))))))))
 in
 let $camlRay__aabb_hit_4 =
   closure aabb_hit_2_1 @aabb_hit &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlRay =
   Block 0 ($camlRay__min_2, $camlRay__max_3, $camlRay__aabb_hit_4)
 in

--- a/testsuite/tests/flambda2/examples/unknown/test_cmx_offsets2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/test_cmx_offsets2.simplify.reference
@@ -2,5 +2,6 @@ let x =
   %project_value_slot.[f].[x] ($Test_cmx_offsets1.camlTest_cmx_offsets1__f_1)
 in
 let int_add = %int_barith.add (x, 3) in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTest_cmx_offsets2 = Block 0 (int_add) in
 cont done ($camlTest_cmx_offsets2)

--- a/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/test_exn_handler_inlining.simplify.reference
@@ -4,7 +4,7 @@ let code g_1 deleted in
 let code f_3 deleted in
 let code loopify(never) size(1) newer_version_of(id_0)
       id_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $camlTest_exn_handler_inlining__id_1 =
   closure id_0_1 @`id` &toplevel.alloc_region
@@ -20,11 +20,12 @@ let code loopify(never) size(19) newer_version_of(p_2)
     | 1 -> k3
     where k3 =
       let Popaque = %opaque (0) in
-      cont k (Popaque)
+      cont k close[normal] my_alloc_region (Popaque)
     where k2 =
       let Pfield = %block_load.[`1`] (param) in
       let Popaque = %opaque ($camlTest_exn_handler_inlining__id_1) in
-      apply &my_alloc_region Popaque (Pfield) -> k * k1
+      apply &my_alloc_region [close close close close]
+        Popaque (Pfield) -> k * k1
 in
 let $camlTest_exn_handler_inlining__p_3 =
   closure p_2_1 @p &toplevel.alloc_region
@@ -34,7 +35,7 @@ let code loopify(never) size(4) newer_version_of(g_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 | 0 of val * [ 0 | 0 of val * val ] ] =
-  apply direct(p_2_1 &my_alloc_region)
+  apply direct(p_2_1 &my_alloc_region) [close close close close]
     ($camlTest_exn_handler_inlining__p_3
      : _ -> [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
       (y)
@@ -72,11 +73,12 @@ let code loopify(never) size(18) newer_version_of(f_3)
       let c_unboxed0_1 = c_unboxed0 in
       let `unit` = %end_try_region (try_region) in
       let unit_1 = %end_try_ghost_region (try_ghost_region) in
-      cont k (c_unboxed0_1)
+      cont k close[normal] my_alloc_region (c_unboxed0_1)
 in
 let $camlTest_exn_handler_inlining__f_4 =
   closure f_3_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTest_exn_handler_inlining =
   Block 0 ($camlTest_exn_handler_inlining__id_1,
            $camlTest_exn_handler_inlining__g_2,

--- a/testsuite/tests/flambda2/examples/unknown/test_try.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/test_try.simplify.reference
@@ -22,5 +22,7 @@ let try_ghost_region = %begin_try_ghost_region () in
           let unit_1 = %end_try_ghost_region (try_ghost_region_1) in
           cont k)
        where k =
+         let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region)
+         in
          let $camlTest_try = Block 0 () in
          cont done ($camlTest_try))

--- a/testsuite/tests/flambda2/examples/unknown/to_hex.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/to_hex.simplify.reference
@@ -16,7 +16,7 @@ let $camlTo_hex__immstring_1 = "Pervasives.array_bound_error" in
 let $camlTo_hex__Pmakeblock_5 =
   Block 0 ($`*predef*`.caml_exn_Invalid_argument, $camlTo_hex__immstring_0)
 in
-apply ccall
+apply ccall [forward close close close]
   ($`*extern*`.caml_register_named_value : val * val -> val)
     ($camlTo_hex__immstring_1, $camlTo_hex__Pmakeblock_5)
     -> k1 * error
@@ -31,7 +31,7 @@ apply ccall
       let Pmakeblock =
         %block.[`0`].my_alloc_region ($`*predef*`.caml_exn_Failure, s)
       in
-      cont k1 pop(regular k1) (Pmakeblock)
+      cont k1 pop(regular k1) close[exn] my_alloc_region (Pmakeblock)
     in
     let $camlTo_hex__failwith_6 =
       closure failwith_0_1 @failwith &toplevel.alloc_region
@@ -45,12 +45,12 @@ apply ccall
         %block.[`0`].my_alloc_region
           ($`*predef*`.caml_exn_Invalid_argument, s)
       in
-      cont k1 pop(regular k1) (Pmakeblock)
+      cont k1 pop(regular k1) close[exn] my_alloc_region (Pmakeblock)
     in
     let $camlTo_hex__invalid_arg_7 =
       closure invalid_arg_1_1 @invalid_arg &toplevel.alloc_region
     in
-    (apply ccall noalloc
+    (apply ccall noalloc [forward close close close]
        ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
        where k (Pccall) =
          let $camlTo_hex__Exit_8 =
@@ -62,15 +62,15 @@ apply ccall
                  my_closure &my_alloc_region my_depth
                  -> k * k1
                  : val =
-           apply ccall
+           apply ccall [forward close close close]
              ($`*extern*`.caml_lessequal : val * val -> val)
                (x, y)
                -> k2 * k1
              where k2 (Pccall_1) =
                let untagged = %untag_imm (Pccall_1) in
                switch untagged
-                 | 0 -> k (y)
-                 | 1 -> k (x)
+                 | 0 -> k close[normal] my_alloc_region (y)
+                 | 1 -> k close[normal] my_alloc_region (x)
          in
          let $camlTo_hex__min_9 = closure min_2_1 @min &toplevel.alloc_region
          in
@@ -79,15 +79,15 @@ apply ccall
                  my_closure &my_alloc_region my_depth
                  -> k * k1
                  : val =
-           apply ccall
+           apply ccall [forward close close close]
              ($`*extern*`.caml_greaterequal : val * val -> val)
                (x, y)
                -> k2 * k1
              where k2 (Pccall_1) =
                let untagged = %untag_imm (Pccall_1) in
                switch untagged
-                 | 0 -> k (y)
-                 | 1 -> k (x)
+                 | 0 -> k close[normal] my_alloc_region (y)
+                 | 1 -> k close[normal] my_alloc_region (x)
          in
          let $camlTo_hex__max_10 =
            closure max_3_1 @max &toplevel.alloc_region
@@ -100,10 +100,10 @@ apply ccall
            let prim = %int_comp.ge (x, 0) in
            switch prim
              | 0 -> k2
-             | 1 -> k (x)
+             | 1 -> k close[normal] my_alloc_region (x)
              where k2 =
                let int_neg = %int_barith.sub (0, x) in
-               cont k (int_neg)
+               cont k close[normal] my_alloc_region (int_neg)
          in
          let $camlTo_hex__abs_11 =
            closure abs_4_1 @abs &toplevel.alloc_region
@@ -114,7 +114,7 @@ apply ccall
                  -> k * k1
                  : imm tagged =
            let int_xor = %int_barith.xor (x, -1) in
-           cont k (int_xor)
+           cont k close[normal] my_alloc_region (int_xor)
          in
          let $camlTo_hex__lnot_12 =
            closure lnot_5_1 @lnot &toplevel.alloc_region
@@ -153,7 +153,7 @@ apply ccall
               | 1 -> k2 (48))
              where k2 (staticcatch_result : imm tagged) =
                let int_add = %int_barith.add (n, staticcatch_result) in
-               cont k (int_add)
+               cont k close[normal] my_alloc_region (int_add)
          in
          let $camlTo_hex__char_hex_14 =
            closure char_hex_6_1 @char_hex &toplevel.alloc_region
@@ -171,12 +171,13 @@ apply ccall
               | 1 -> k3
               where k3 =
                 apply direct(invalid_arg_1_1 &my_alloc_region)
+                       [forward close close close]
                   ($camlTo_hex__invalid_arg_7 : _ -> imm tagged)
                     ($camlTo_hex__immstring_3)
                     -> never * k1)
              where k2 (prim : imm) =
                let cse_param = prim in
-               (apply ccall
+               (apply ccall [forward close close close]
                   ($`*extern*`.caml_create_bytes : val -> val)
                     (32)
                     -> k2 * k1
@@ -208,6 +209,7 @@ apply ccall
                               let x = %tag_imm (prim_3) in
                               ((let int_lsr = %int_shift.lsr (x, 4i) in
                                 apply direct(char_hex_6_1 &my_alloc_region)
+                                       [forward close close close]
                                   ($camlTo_hex__char_hex_14 : _ -> imm tagged
                                    )
                                     (int_lsr)
@@ -231,6 +233,7 @@ apply ccall
                                      apply
                                             direct(char_hex_6_1
                                             &my_alloc_region)
+                                            [forward close close close]
                                        ($camlTo_hex__char_hex_14
                                         : _ -> imm tagged)
                                          (int_and)
@@ -260,13 +263,21 @@ apply ccall
                                             (for_next_naked, 15L)
                                         in
                                         switch prim_8
-                                          | 0 -> k (result)
+                                          | 0 ->
+                                            k
+                                              close[normal] my_alloc_region
+                                              (result)
                                           | 1 -> k2 (for_next_naked)))
                             where k3 =
-                              cont k1 pop(regular k1) ($camlTo_hex__block_4))))
+                              cont k1
+                                     pop(regular k1)
+                                     close[exn] my_alloc_region
+                                     ($camlTo_hex__block_4))))
          in
          let $camlTo_hex__to_hex_15 =
            closure to_hex_7_1 @to_hex &toplevel.alloc_region
+         in
+         let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region)
          in
          let $camlTo_hex =
            Block 0 ($camlTo_hex__Pmakeblock_13,

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure.simplify.reference
@@ -14,7 +14,7 @@ let code loopify(never) size(7) newer_version_of(`fn[unbox_closure.ml:12,12--25]
   in
   let int_add = %int_barith.add (x, y) in
   let int_add_1 = %int_barith.add (int_add, z) in
-  cont k (int_add_1)
+  cont k close[normal] my_alloc_region (int_add_1)
 in
 let code loopify(never) size(18) newer_version_of(bar_1)
       bar_1_1 (y : imm tagged)
@@ -28,7 +28,7 @@ let code loopify(never) size(18) newer_version_of(bar_1)
       @`fn[unbox_closure.ml:12,12--25]` &my_alloc_region
   with { x = x; y = y }
   in
-  cont k (`fn[unbox_closure.ml:12,12--25]`)
+  cont k close[normal] my_alloc_region (`fn[unbox_closure.ml:12,12--25]`)
 in
 let code loopify(never) size(53) newer_version_of(foobar_0)
       foobar_0_1 (b : imm tagged, x : imm tagged)
@@ -44,15 +44,18 @@ let code loopify(never) size(53) newer_version_of(foobar_0)
      | 0 -> k3
      | 1 -> k4)
     where k4 =
-      apply direct(bar_1_1 &my_alloc_region) (bar : _ -> val) (3) -> k2 * k1
+      apply direct(bar_1_1 &my_alloc_region) [forward close close close]
+        (bar : _ -> val) (3) -> k2 * k1
     where k3 =
-      apply direct(bar_1_1 &my_alloc_region) (bar : _ -> val) (42) -> k2 * k1
+      apply direct(bar_1_1 &my_alloc_region) [forward close close close]
+        (bar : _ -> val) (42) -> k2 * k1
     where k2 (f : val) =
       let `unit` = %end_region (`region`) in
-      apply &my_alloc_region f (x) -> k * k1
+      apply &my_alloc_region [close close close close] f (x) -> k * k1
 in
 let $camlUnbox_closure__foobar_1 =
   closure foobar_0_1 @foobar &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlUnbox_closure = Block 0 ($camlUnbox_closure__foobar_1) in
 cont done ($camlUnbox_closure)

--- a/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/unbox_closure2.simplify.reference
@@ -8,7 +8,7 @@ let code inline(always) loopify(never) size(4) newer_version_of(bar1_2)
         : imm tagged =
   let x = %project_value_slot.[bar1].[x] (my_closure) in
   let int_add = %int_barith.add (x, y) in
-  cont k (int_add)
+  cont k close[normal] my_alloc_region (int_add)
 in
 let code inline(always) loopify(never) size(11) newer_version_of(bar2_1)
       bar2_1_1 (y : imm tagged)
@@ -19,7 +19,7 @@ let code inline(always) loopify(never) size(11) newer_version_of(bar2_1)
   let z = %project_value_slot.[bar2].[z] (my_closure) in
   let int_mul = %int_barith.mul (z, x) in
   let int_mul_1 = %int_barith.mul (int_mul, y) in
-  cont k (int_mul_1)
+  cont k close[normal] my_alloc_region (int_mul_1)
 in
 let code loopify(never) size(64) newer_version_of(foobar_0)
       foobar_0_1 (b : imm tagged, x : imm tagged, z : imm tagged)
@@ -42,10 +42,11 @@ let code loopify(never) size(64) newer_version_of(foobar_0)
       cont k2 (Pmakeblock)
     where k2 (f : [ 0 of val |1 of val ]) =
       let Pfield = %block_load.[`0`] (f) in
-      apply &my_alloc_region Pfield (x) -> k * k1
+      apply &my_alloc_region [close close close close] Pfield (x) -> k * k1
 in
 let $camlUnbox_closure2__foobar_1 =
   closure foobar_0_1 @foobar &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlUnbox_closure2 = Block 0 ($camlUnbox_closure2__foobar_1) in
 cont done ($camlUnbox_closure2)

--- a/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unknown/wrong_allocation_moving.simplify.reference
@@ -9,19 +9,19 @@ let code loopify(never) size(2) newer_version_of(`fn[wrong_allocation_moving.ml:
     %project_value_slot.[`fn[wrong_allocation_moving.ml:21,15--28]`].[y]
       (my_closure)
   in
-  cont k (y)
+  cont k close[normal] my_alloc_region (y)
 in
 let code loopify(never) size(57) newer_version_of(f_0)
       f_0_1 (x : float boxed, foo : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply ccall
+  apply ccall [forward close close close]
     ($`*extern*`.caml_gc_minor_words_unboxed : val -> float) (0) -> k2 * k1
     where k2 (before : float) =
       let prim = %unbox_num.`float` (x) in
       let prim_1 = %bfloat_arith.mul (prim, 0x1p+1) in
       let y = %box_num.`float`.my_alloc_region (prim_1) in
-      (apply ccall
+      (apply ccall [forward close close close]
          ($`*extern*`.caml_gc_minor_words_unboxed : val -> float)
            (0)
            -> k2 * k1
@@ -34,7 +34,7 @@ let code loopify(never) size(57) newer_version_of(f_0)
            with { y = y }
            in
            let Pmakeblock = %block.[`0`].my_alloc_region (y) in
-           apply &my_alloc_region
+           apply &my_alloc_region [close close close close]
              foo
                (Pmakeblock, `fn[wrong_allocation_moving.ml:21,15--28]`, diff)
                -> k * k1)
@@ -42,6 +42,7 @@ in
 let $camlWrong_allocation_moving__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlWrong_allocation_moving =
   Block 0 ($camlWrong_allocation_moving__f_1)
 in

--- a/testsuite/tests/flambda2/examples/unroll.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll.raw.reference
@@ -10,28 +10,30 @@ let $camlUnroll__first_const_0 = Block 0 () in
     (let untagged = %untag_imm (eq) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (1))
+       | 1 -> k1 close[normal] my_alloc_region (1))
       where k4 =
         cont k3)
      where k3 =
        ((let int_sub = %int_barith.sub (n, 1) in
-         apply direct(fact_0 &my_alloc_region)
+         apply direct(fact_0 &my_alloc_region) [forward close close close]
            (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
              (int_sub)
              -> k3 * k2)
           where k3 (apply_result : imm tagged) =
             let int_mul = %int_barith.mul (n, apply_result) in
-            cont k1 (int_mul))
+            cont k1 close[normal] my_alloc_region (int_mul))
  in
  let fact = closure fact_0 @fact &toplevel.alloc_region in
  apply direct(fact_0 &toplevel.alloc_region) unroll(4)
+        [forward close close close]
    (fact : _ -> imm tagged) (6) -> k1 * error
    where k1 (i : imm tagged) =
      (apply direct(fact_0 &toplevel.alloc_region) unroll(7)
+             [forward close close close]
         (fact : _ -> imm tagged) (6) -> k1 * error
         where k1 (j : imm tagged) =
           let Pmakeblock = %block.[`0`].`toplevel` (fact, i, j) in
-          cont k (Pmakeblock)))
+          cont k close[normal] toplevel.alloc_region (Pmakeblock)))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll.simplify.reference
@@ -9,19 +9,20 @@ and code rec loopify(never) size(23) newer_version_of(fact_0)
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2
-    | 1 -> k (1)
+    | 1 -> k close[normal] my_alloc_region (1)
     where k2 =
       ((let int_sub = %int_barith.sub (n, 1) in
-        apply direct(fact_0_1 &my_alloc_region)
+        apply direct(fact_0_1 &my_alloc_region) [forward close close close]
           ($camlUnroll__fact_1 ~ depth my_depth -> succ my_depth
            : _ -> imm tagged)
             (int_sub)
             -> k2 * k1)
          where k2 (apply_result : imm tagged) =
            let int_mul = %int_barith.mul (n, apply_result) in
-           cont k (int_mul))
+           cont k close[normal] my_alloc_region (int_mul))
 in
 apply direct(fact_0_1 &toplevel.alloc_region) inlining_state(depth(40))
+       [forward close close close]
   ($camlUnroll__fact_1 ~ depth unroll 1 3 -> unroll 0 4 : _ -> imm tagged)
     (2)
     -> k * error
@@ -30,5 +31,6 @@ apply direct(fact_0_1 &toplevel.alloc_region) inlining_state(depth(40))
     let int_mul_1 = %int_barith.mul (4, int_mul) in
     let int_mul_2 = %int_barith.mul (5, int_mul_1) in
     let int_mul_3 = %int_barith.mul (6, int_mul_2) in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlUnroll = Block 0 ($camlUnroll__fact_1, int_mul_3, 720) in
     cont done ($camlUnroll)

--- a/testsuite/tests/flambda2/examples/unroll2.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll2.raw.reference
@@ -13,23 +13,24 @@ let $camlUnroll2__first_const_0 = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (x, 1) in
-       apply direct(foo_0 &my_alloc_region)
+       apply direct(foo_0 &my_alloc_region) [close close close close]
          my_closure ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
        let int_add = %int_barith.add (x, 1) in
-       apply direct(foo_0 &my_alloc_region)
+       apply direct(foo_0 &my_alloc_region) [close close close close]
          my_closure ~ depth my_depth -> next_depth (int_add) -> k1 * k2
  in
  let code size(5)
        bar_1 (x : imm tagged) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[bar].[foo] (my_closure) in
-   apply direct(foo_0 &my_alloc_region) unroll(2) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) unroll(2) [close close close close]
+     foo (x) -> k1 * k2
  in
  let foo = closure foo_0 @foo &toplevel.alloc_region in
  let bar = closure bar_1 @bar &toplevel.alloc_region with { foo = foo } in
  let Pmakeblock = %block.[`0`].`toplevel` (foo, bar) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll2.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll2.simplify.reference
@@ -11,13 +11,13 @@ and code rec loopify(never) size(23) newer_version_of(foo_0)
      | 1 -> k3)
     where k3 =
       let int_add = %int_barith.add (x, 1) in
-      apply direct(foo_0_1 &my_alloc_region)
+      apply direct(foo_0_1 &my_alloc_region) [close close close close]
         $camlUnroll2__foo_1 ~ depth my_depth -> succ my_depth
           (int_add)
           -> k * k1
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
-      apply direct(foo_0_1 &my_alloc_region)
+      apply direct(foo_0_1 &my_alloc_region) [close close close close]
         $camlUnroll2__foo_1 ~ depth my_depth -> succ my_depth
           (int_sub)
           -> k * k1
@@ -39,12 +39,14 @@ let code loopify(never) size(61) newer_version_of(bar_1)
          where k4 =
            let int_add_1 = %int_barith.add (int_add, 1) in
            apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
+                  [close close close close]
              $camlUnroll2__foo_1 ~ depth unroll 1 1 -> unroll 0 2
                (int_add_1)
                -> k * k1
          where k3 =
            let int_sub = %int_barith.sub (int_add, 1) in
            apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
+                  [close close close close]
              $camlUnroll2__foo_1 ~ depth unroll 1 1 -> unroll 0 2
                (int_sub)
                -> k * k1)
@@ -58,16 +60,19 @@ let code loopify(never) size(61) newer_version_of(bar_1)
          where k3 =
            let int_add = %int_barith.add (int_sub, 1) in
            apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
+                  [close close close close]
              $camlUnroll2__foo_1 ~ depth unroll 1 1 -> unroll 0 2
                (int_add)
                -> k * k1
          where k2 =
            let int_sub_1 = %int_barith.sub (int_sub, 1) in
            apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(20))
+                  [close close close close]
              $camlUnroll2__foo_1 ~ depth unroll 1 1 -> unroll 0 2
                (int_sub_1)
                -> k * k1)
 in
 let $camlUnroll2__bar_2 = closure bar_1_1 @bar &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlUnroll2 = Block 0 ($camlUnroll2__foo_1, $camlUnroll2__bar_2) in
 cont done ($camlUnroll2)

--- a/testsuite/tests/flambda2/examples/unroll3.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll3.raw.reference
@@ -11,12 +11,12 @@ let $camlUnroll3__first_const_0 = Block 0 () in
     (let untagged = %untag_imm (eq) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (1))
+       | 1 -> k1 close[normal] my_alloc_region (1))
       where k4 =
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(odd_1 &my_alloc_region)
+       apply direct(odd_1 &my_alloc_region) [close close close close]
          (odd ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
@@ -32,12 +32,12 @@ let $camlUnroll3__first_const_0 = Block 0 () in
     (let untagged = %untag_imm (eq) in
      switch untagged
        | 0 -> k4
-       | 1 -> k1 (0))
+       | 1 -> k1 close[normal] my_alloc_region (0))
       where k4 =
         cont k3)
      where k3 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(even_0 &my_alloc_region)
+       apply direct(even_0 &my_alloc_region) [close close close close]
          (even ~ depth my_depth -> next_depth : _ -> imm tagged)
            (int_sub)
            -> k1 * k2
@@ -46,15 +46,17 @@ let $camlUnroll3__first_const_0 = Block 0 () in
  and odd = closure odd_1 @odd &toplevel.alloc_region
  in
  apply direct(even_0 &toplevel.alloc_region) unroll(4)
+        [forward close close close]
    (even : _ -> imm tagged) (3) -> k1 * error
    where k1 (three_is_even : imm tagged) =
      (apply direct(odd_1 &toplevel.alloc_region) unroll(2)
+             [forward close close close]
         (odd : _ -> imm tagged) (4) -> k1 * error
         where k1 (four_is_odd : imm tagged) =
           let Pmakeblock =
             %block.[`0`].`toplevel` (even, odd, three_is_even, four_is_odd)
           in
-          cont k (Pmakeblock)))
+          cont k close[normal] toplevel.alloc_region (Pmakeblock)))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`4`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`4`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll3.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll3.simplify.reference
@@ -11,10 +11,10 @@ and code rec loopify(never) size(18) newer_version_of(odd_1)
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(even_0_1 &my_alloc_region)
+      apply direct(even_0_1 &my_alloc_region) [close close close close]
         ($camlUnroll3__even_1 ~ depth my_depth -> succ my_depth
          : _ -> imm tagged)
           (int_sub)
@@ -27,20 +27,22 @@ and code rec loopify(never) size(18) newer_version_of(even_0)
   let prim = %phys_eq (n, 0) in
   switch prim
     | 0 -> k2
-    | 1 -> k (1)
+    | 1 -> k close[normal] my_alloc_region (1)
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(odd_1_1 &my_alloc_region)
+      apply direct(odd_1_1 &my_alloc_region) [close close close close]
         ($camlUnroll3__odd_2 ~ depth my_depth -> succ my_depth
          : _ -> imm tagged)
           (int_sub)
           -> k * k1
 in
 apply direct(odd_1_1 &toplevel.alloc_region) inlining_state(depth(20))
+       [forward close close close]
   ($camlUnroll3__odd_2 ~ depth unroll 1 1 -> unroll 0 2 : _ -> imm tagged)
     (2)
     -> k * error
   where k (four_is_odd : imm tagged) =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlUnroll3 =
       Block 0 ($camlUnroll3__even_1, $camlUnroll3__odd_2, 0, four_is_odd)
     in

--- a/testsuite/tests/flambda2/examples/unroll4.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.raw.reference
@@ -18,10 +18,11 @@ let $camlUnroll4__first_const_0 = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(odd_2 &my_alloc_region)
+       apply direct(odd_2 &my_alloc_region) [close close close close]
          odd ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
-       apply &my_alloc_region inlined(hint) k (1) -> k1 * k2
+       apply &my_alloc_region inlined(hint) [close close close close]
+         k (1) -> k1 * k2
  and code rec size(31)
        odd_2 (n : imm tagged) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
@@ -39,10 +40,11 @@ let $camlUnroll4__first_const_0 = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (n, 1) in
-       apply direct(even_1 &my_alloc_region)
+       apply direct(even_1 &my_alloc_region) [close close close close]
          even ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
-       apply &my_alloc_region inlined(hint) k (0) -> k1 * k2
+       apply &my_alloc_region inlined(hint) [close close close close]
+         k (0) -> k1 * k2
  in
  let code inline(always) size(93)
        parity_is_0 (p : imm tagged, n : imm tagged, k : val)
@@ -62,27 +64,32 @@ let $camlUnroll4__first_const_0 = Block 0 () in
      where k5 =
        cont k4
      where k4 =
-       apply direct(even_1 &my_alloc_region) unroll(3) even (n) -> k1 * k2
+       apply direct(even_1 &my_alloc_region) unroll(3)
+              [close close close close]
+         even (n) -> k1 * k2
      where k3 =
-       apply direct(odd_2 &my_alloc_region) unroll(4) odd (n) -> k1 * k2
+       apply direct(odd_2 &my_alloc_region) unroll(4)
+              [close close close close]
+         odd (n) -> k1 * k2
  in
  let code inline(always) size(1)
        k_3 (b) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (b)
+   cont k1 close[normal] my_alloc_region (b)
  in
  let parity_is = closure parity_is_0 @parity_is &toplevel.alloc_region in
  let k = closure k_3 @k &toplevel.alloc_region in
- apply direct(parity_is_0 &toplevel.alloc_region)
+ apply direct(parity_is_0 &toplevel.alloc_region) [forward close close close]
    (parity_is : _ -> imm tagged) (0, 1, k) -> k1 * error
    where k1 (one_is_even : imm tagged) =
      (apply direct(parity_is_0 &toplevel.alloc_region)
+             [forward close close close]
         (parity_is : _ -> imm tagged) (1, 4, k) -> k1 * error
         where k1 (four_is_odd : imm tagged) =
           let Pmakeblock =
             %block.[`0`].`toplevel` (parity_is, k, one_is_even, four_is_odd)
           in
-          cont k (Pmakeblock)))
+          cont k close[normal] toplevel.alloc_region (Pmakeblock)))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`4`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`4`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll4.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll4.simplify.reference
@@ -10,10 +10,11 @@ let code rec loopify(never) size(26) newer_version_of(odd_2)
     | 0 -> k2
     | 1 -> k3
     where k3 =
-      apply &my_alloc_region inlined(hint) k (0) -> k * k1
+      apply &my_alloc_region inlined(hint) [close close close close]
+        k (0) -> k * k1
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(even_1_1 &my_alloc_region)
+      apply direct(even_1_1 &my_alloc_region) [close close close close]
         even ~ depth my_depth -> succ my_depth (int_sub) -> k * k1
 and code rec loopify(never) size(26) newer_version_of(even_1)
       even_1_1 (n : imm tagged)
@@ -26,10 +27,11 @@ and code rec loopify(never) size(26) newer_version_of(even_1)
     | 0 -> k2
     | 1 -> k3
     where k3 =
-      apply &my_alloc_region inlined(hint) k (1) -> k * k1
+      apply &my_alloc_region inlined(hint) [close close close close]
+        k (1) -> k * k1
     where k2 =
       let int_sub = %int_barith.sub (n, 1) in
-      apply direct(odd_2_1 &my_alloc_region)
+      apply direct(odd_2_1 &my_alloc_region) [close close close close]
         odd ~ depth my_depth -> succ my_depth (int_sub) -> k * k1
 in
 let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
@@ -51,6 +53,7 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
          | 1 -> k4
          where k4 =
            apply &my_alloc_region inlined(hint) inlining_state(depth(10))
+                  [close close close close]
              k (0) -> k * k1
          where k3 =
            let int_sub = %int_barith.sub (n, 1) in
@@ -60,7 +63,7 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
               | 1 -> k4
               where k4 =
                 apply &my_alloc_region inlined(hint)
-                       inlining_state(depth(20))
+                       inlining_state(depth(20)) [close close close close]
                   k (1) -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
@@ -71,6 +74,7 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                    where k4 =
                      apply &my_alloc_region inlined(hint)
                             inlining_state(depth(30))
+                            [close close close close]
                        k (0) -> k * k1
                    where k3 =
                      let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
@@ -81,11 +85,13 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                         where k4 =
                           apply &my_alloc_region inlined(hint)
                                  inlining_state(depth(40))
+                                 [close close close close]
                             k (1) -> k * k1
                         where k3 =
                           let int_sub_3 = %int_barith.sub (int_sub_2, 1) in
                           apply direct(odd_2_1 &my_alloc_region)
                                  inlining_state(depth(40))
+                                 [close close close close]
                             odd ~ depth 0 -> unroll 0 4 (int_sub_3) -> k * k1))))
     where k2 =
       let prim = %phys_eq (n, 0) in
@@ -94,6 +100,7 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
          | 1 -> k3
          where k3 =
            apply &my_alloc_region inlined(hint) inlining_state(depth(10))
+                  [close close close close]
              k (1) -> k * k1
          where k2 =
            let int_sub = %int_barith.sub (n, 1) in
@@ -103,7 +110,7 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
               | 1 -> k3
               where k3 =
                 apply &my_alloc_region inlined(hint)
-                       inlining_state(depth(20))
+                       inlining_state(depth(20)) [close close close close]
                   k (0) -> k * k1
               where k2 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
@@ -114,11 +121,13 @@ let code inline(always) loopify(never) size(221) newer_version_of(parity_is_0)
                    where k3 =
                      apply &my_alloc_region inlined(hint)
                             inlining_state(depth(30))
+                            [close close close close]
                        k (1) -> k * k1
                    where k2 =
                      let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
                      apply direct(odd_2_1 &my_alloc_region)
                             inlining_state(depth(30))
+                            [close close close close]
                        odd ~ depth 0 -> unroll 0 3 (int_sub_2) -> k * k1)))
 in
 let $camlUnroll4__parity_is_1 =
@@ -126,11 +135,11 @@ let $camlUnroll4__parity_is_1 =
 in
 let code inline(always) loopify(never) size(1) newer_version_of(k_3)
       k_3_1 (b) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (b)
+  cont k close[normal] my_alloc_region (b)
 in
 let $camlUnroll4__k_2 = closure k_3_1 @k &toplevel.alloc_region in
 apply direct(k_3_1 &toplevel.alloc_region) inlined(hint)
-       inlining_state(depth(21))
+       inlining_state(depth(21)) [forward close close close]
   $camlUnroll4__k_2 (0) -> k * error
   where k (one_is_even : imm tagged) =
     ((let $camlUnroll4__even_5 =
@@ -144,10 +153,11 @@ apply direct(k_3_1 &toplevel.alloc_region) inlined(hint)
         let prim = %phys_eq (n, 0) in
         switch prim
           | 0 -> k3
-          | 1 -> k1 (0)
+          | 1 -> k1 close[normal] my_alloc_region (0)
           where k3 =
             let int_sub = %int_barith.sub (n, 1) in
             apply direct(even_1_2 &my_alloc_region) inlining_state(depth(1))
+                   [close close close close]
               $camlUnroll4__even_5 ~ depth my_depth -> succ my_depth
                 (int_sub)
                 -> k1 * k2
@@ -158,18 +168,22 @@ apply direct(k_3_1 &toplevel.alloc_region) inlined(hint)
         let prim = %phys_eq (n, 0) in
         switch prim
           | 0 -> k3
-          | 1 -> k1 (1)
+          | 1 -> k1 close[normal] my_alloc_region (1)
           where k3 =
             let int_sub = %int_barith.sub (n, 1) in
             apply direct(odd_2_2 &my_alloc_region) inlining_state(depth(1))
+                   [close close close close]
               $camlUnroll4__odd_6 ~ depth my_depth -> succ my_depth
                 (int_sub)
                 -> k1 * k2
         with { k = $camlUnroll4__k_2 }
       in
       apply direct(odd_2_2 &toplevel.alloc_region) inlining_state(depth(41))
+             [forward close close close]
         $camlUnroll4__odd_6 ~ depth 0 -> unroll 0 4 (0) -> k * error)
        where k (four_is_odd : imm tagged) =
+         let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region)
+         in
          let $camlUnroll4 =
            Block 0 ($camlUnroll4__parity_is_1,
                     $camlUnroll4__k_2,

--- a/testsuite/tests/flambda2/examples/unroll5.raw.reference
+++ b/testsuite/tests/flambda2/examples/unroll5.raw.reference
@@ -13,11 +13,12 @@ let $camlUnroll5__first_const_0 = Block 0 () in
         cont k4)
      where k4 =
        let int_sub = %int_barith.sub (x, 1) in
-       apply direct(foo_0 &my_alloc_region)
+       apply direct(foo_0 &my_alloc_region) [close close close close]
          my_closure ~ depth my_depth -> next_depth (int_sub) -> k1 * k2
      where k3 =
        let int_add = %int_barith.add (x, 1) in
        apply direct(foo_0 &my_alloc_region) unroll(2)
+              [close close close close]
          my_closure ~ depth my_depth -> next_depth (int_add) -> k1 * k2
  in
  let code size(5)
@@ -26,7 +27,8 @@ let $camlUnroll5__first_const_0 = Block 0 () in
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[test1].[foo] (my_closure) in
-   apply direct(foo_0 &my_alloc_region) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) [close close close close]
+     foo (x) -> k1 * k2
  in
  let code size(5)
        test2_2 (x : imm tagged)
@@ -34,7 +36,8 @@ let $camlUnroll5__first_const_0 = Block 0 () in
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[test2].[foo_1] (my_closure) in
-   apply direct(foo_0 &my_alloc_region) unroll(1) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) unroll(1) [close close close close]
+     foo (x) -> k1 * k2
  in
  let code size(5)
        test3_3 (x : imm tagged)
@@ -42,7 +45,8 @@ let $camlUnroll5__first_const_0 = Block 0 () in
          -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
    let foo = %project_value_slot.[test3].[foo_2] (my_closure) in
-   apply direct(foo_0 &my_alloc_region) unroll(3) foo (x) -> k1 * k2
+   apply direct(foo_0 &my_alloc_region) unroll(3) [close close close close]
+     foo (x) -> k1 * k2
  in
  let foo = closure foo_0 @foo &toplevel.alloc_region in
  let test1 = closure test1_1 @test1 &toplevel.alloc_region
@@ -55,7 +59,7 @@ let $camlUnroll5__first_const_0 = Block 0 () in
  with { foo_2 = foo }
  in
  let Pmakeblock = %block.[`0`].`toplevel` (foo, test1, test2, test3) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`4`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`4`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/examples/unroll5.simplify.reference
+++ b/testsuite/tests/flambda2/examples/unroll5.simplify.reference
@@ -28,14 +28,14 @@ and code rec loopify(never) size(80) newer_version_of(foo_0)
               where k5 =
                 let int_add_2 = %int_barith.add (int_add_1, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(20))
+                       inlining_state(depth(20)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_add_2)
                     -> k * k1
               where k4 =
                 let int_sub = %int_barith.sub (int_add_1, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(20))
+                       inlining_state(depth(20)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_sub)
                     -> k * k1)
@@ -49,20 +49,20 @@ and code rec loopify(never) size(80) newer_version_of(foo_0)
               where k4 =
                 let int_add_1 = %int_barith.add (int_sub, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(20))
+                       inlining_state(depth(20)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_add_1)
                     -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(20))
+                       inlining_state(depth(20)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth my_depth -> succ (succ (unroll 2 (succ my_depth)))
                     (int_sub_1)
                     -> k * k1))
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
-      apply direct(foo_0_1 &my_alloc_region)
+      apply direct(foo_0_1 &my_alloc_region) [close close close close]
         $camlUnroll5__foo_1 ~ depth my_depth -> succ my_depth
           (int_sub)
           -> k * k1
@@ -71,7 +71,8 @@ let code loopify(never) size(4) newer_version_of(test1_1)
       test1_1_1 (x : imm tagged)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply direct(foo_0_1 &my_alloc_region) $camlUnroll5__foo_1 (x) -> k * k1
+  apply direct(foo_0_1 &my_alloc_region) [close close close close]
+    $camlUnroll5__foo_1 (x) -> k * k1
 in
 let $camlUnroll5__test1_2 = closure test1_1_1 @test1 &toplevel.alloc_region
 in
@@ -101,14 +102,14 @@ let code loopify(never) size(80) newer_version_of(test2_2)
               where k5 =
                 let int_add_2 = %int_barith.add (int_add_1, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 1 0 -> unroll 0 3
                     (int_add_2)
                     -> k * k1
               where k4 =
                 let int_sub = %int_barith.sub (int_add_1, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 1 0 -> unroll 0 3
                     (int_sub)
                     -> k * k1)
@@ -122,20 +123,21 @@ let code loopify(never) size(80) newer_version_of(test2_2)
               where k4 =
                 let int_add_1 = %int_barith.add (int_sub, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 1 0 -> unroll 0 3
                     (int_add_1)
                     -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 1 0 -> unroll 0 3
                     (int_sub_1)
                     -> k * k1))
     where k2 =
       let int_sub = %int_barith.sub (x, 1) in
       apply direct(foo_0_1 &my_alloc_region) inlining_state(depth(10))
+             [close close close close]
         $camlUnroll5__foo_1 ~ depth unroll 1 0 -> unroll 0 1
           (int_sub)
           -> k * k1
@@ -168,14 +170,14 @@ let code loopify(never) size(232) newer_version_of(test3_3)
               where k5 =
                 let int_add_2 = %int_barith.add (int_add_1, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 3 0 -> unroll 0 3
                     (int_add_2)
                     -> k * k1
               where k4 =
                 let int_sub = %int_barith.sub (int_add_1, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 3 0 -> unroll 0 3
                     (int_sub)
                     -> k * k1)
@@ -189,14 +191,14 @@ let code loopify(never) size(232) newer_version_of(test3_3)
               where k4 =
                 let int_add_1 = %int_barith.add (int_sub, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 3 0 -> unroll 0 3
                     (int_add_1)
                     -> k * k1
               where k3 =
                 let int_sub_1 = %int_barith.sub (int_sub, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 3 0 -> unroll 0 3
                     (int_sub_1)
                     -> k * k1))
@@ -225,6 +227,7 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                      let int_add_2 = %int_barith.add (int_add_1, 1) in
                      apply direct(foo_0_1 &my_alloc_region)
                             inlining_state(depth(40))
+                            [close close close close]
                        $camlUnroll5__foo_1 ~ depth unroll 2 1 -> unroll 0 4
                          (int_add_2)
                          -> k * k1
@@ -232,6 +235,7 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                      let int_sub_1 = %int_barith.sub (int_add_1, 1) in
                      apply direct(foo_0_1 &my_alloc_region)
                             inlining_state(depth(40))
+                            [close close close close]
                        $camlUnroll5__foo_1 ~ depth unroll 2 1 -> unroll 0 4
                          (int_sub_1)
                          -> k * k1)
@@ -246,6 +250,7 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                      let int_add_1 = %int_barith.add (int_sub_1, 1) in
                      apply direct(foo_0_1 &my_alloc_region)
                             inlining_state(depth(40))
+                            [close close close close]
                        $camlUnroll5__foo_1 ~ depth unroll 2 1 -> unroll 0 4
                          (int_add_1)
                          -> k * k1
@@ -253,6 +258,7 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                      let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
                      apply direct(foo_0_1 &my_alloc_region)
                             inlining_state(depth(40))
+                            [close close close close]
                        $camlUnroll5__foo_1 ~ depth unroll 2 1 -> unroll 0 4
                          (int_sub_2)
                          -> k * k1))
@@ -281,6 +287,7 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                           let int_add_2 = %int_barith.add (int_add_1, 1) in
                           apply direct(foo_0_1 &my_alloc_region)
                                  inlining_state(depth(50))
+                                 [close close close close]
                             $camlUnroll5__foo_1 ~ depth unroll 1 2 -> unroll 0 5
                               (int_add_2)
                               -> k * k1
@@ -288,6 +295,7 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                           let int_sub_2 = %int_barith.sub (int_add_1, 1) in
                           apply direct(foo_0_1 &my_alloc_region)
                                  inlining_state(depth(50))
+                                 [close close close close]
                             $camlUnroll5__foo_1 ~ depth unroll 1 2 -> unroll 0 5
                               (int_sub_2)
                               -> k * k1)
@@ -302,6 +310,7 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                           let int_add_1 = %int_barith.add (int_sub_2, 1) in
                           apply direct(foo_0_1 &my_alloc_region)
                                  inlining_state(depth(50))
+                                 [close close close close]
                             $camlUnroll5__foo_1 ~ depth unroll 1 2 -> unroll 0 5
                               (int_add_1)
                               -> k * k1
@@ -309,19 +318,21 @@ let code loopify(never) size(232) newer_version_of(test3_3)
                           let int_sub_3 = %int_barith.sub (int_sub_2, 1) in
                           apply direct(foo_0_1 &my_alloc_region)
                                  inlining_state(depth(50))
+                                 [close close close close]
                             $camlUnroll5__foo_1 ~ depth unroll 1 2 -> unroll 0 5
                               (int_sub_3)
                               -> k * k1))
               where k2 =
                 let int_sub_2 = %int_barith.sub (int_sub_1, 1) in
                 apply direct(foo_0_1 &my_alloc_region)
-                       inlining_state(depth(30))
+                       inlining_state(depth(30)) [close close close close]
                   $camlUnroll5__foo_1 ~ depth unroll 1 2 -> unroll 0 3
                     (int_sub_2)
                     -> k * k1))
 in
 let $camlUnroll5__test3_4 = closure test3_3_1 @test3 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlUnroll5 =
   Block 0 ($camlUnroll5__foo_1,
            $camlUnroll5__test1_2,

--- a/testsuite/tests/flambda2/examples/value_slot_c.simplify.reference
+++ b/testsuite/tests/flambda2/examples/value_slot_c.simplify.reference
@@ -30,7 +30,8 @@ let code loopify(never) size(59) newer_version_of(f_2)
       let Pfield = %block_load.[`1`] ($Value_slot_b.camlValue_slot_b) in
       cont k2 (Pfield)
     where k2 (g : val) =
-      (apply &my_alloc_region inlined(always) g (3) -> k2 * k1
+      (apply &my_alloc_region inlined(always) [forward close close close]
+         g (3) -> k2 * k1
          where k2 (`*match*` : [ 0 of imm tagged * imm tagged ]) =
            let x = %block_load.[`0`] (`*match*`) in
            ((let prim = %phys_eq (x, 0) in
@@ -41,15 +42,23 @@ let code loopify(never) size(59) newer_version_of(f_2)
                  let prim_1 = %phys_eq (x, 1) in
                  switch prim_1
                    | 0 ->
-                     k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock_7)
+                     k1
+                       pop(regular k1)
+                       close[exn] my_alloc_region
+                       ($camlValue_slot_c__Pmakeblock_7)
                    | 1 -> k2)
               where k2 =
                 let Pfield = %block_load.[`1`] (`*match*`) in
                 let prim = %phys_eq (Pfield, 3) in
                 switch prim
-                  | 0 -> k1 pop(regular k1) ($camlValue_slot_c__Pmakeblock_9)
-                  | 1 -> k (0)))
+                  | 0 ->
+                    k1
+                      pop(regular k1)
+                      close[exn] my_alloc_region
+                      ($camlValue_slot_c__Pmakeblock_9)
+                  | 1 -> k close[normal] my_alloc_region (0)))
 in
 let $camlValue_slot_c__f_10 = closure f_2_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlValue_slot_c = Block 0 ($camlValue_slot_c__f_10) in
 cont done ($camlValue_slot_c)

--- a/testsuite/tests/flambda2/examples/value_slot_use_b.simplify.reference
+++ b/testsuite/tests/flambda2/examples/value_slot_use_b.simplify.reference
@@ -5,18 +5,23 @@
     | 1 -> k2)
    where k2 =
      apply direct(f_0 &toplevel.alloc_region) inlined(always)
+            [forward close close close]
        ($Value_slot_use_a.camlValue_slot_use_a__f_3 : _ -> val)
          (0)
          -> k * error
    where k1 =
      apply direct(f_0 &toplevel.alloc_region) inlined(always)
+            [forward close close close]
        ($Value_slot_use_a.camlValue_slot_use_a__f_3 : _ -> val)
          (1)
          -> k * error)
   where k (g : val) =
-    (apply &toplevel.alloc_region inlined(never) g (2) -> k1 * error
+    (apply &toplevel.alloc_region inlined(never) [forward close close close]
+       g (2) -> k1 * error
        where k1 (param : [ 0 of imm tagged * imm tagged ]) =
          cont k
        where k =
+         let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region)
+         in
          let $camlValue_slot_use_b = Block 0 () in
          cont done ($camlValue_slot_use_b))

--- a/testsuite/tests/flambda2/examples/variant_ah.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_ah.simplify.reference
@@ -7,11 +7,11 @@ let code inline(always) loopify(never) size(18) newer_version_of(maybe_0)
         : [ 0 | 0 of val ] =
   (let untagged = %untag_imm (b) in
    switch untagged
-     | 0 -> k (0)
+     | 0 -> k close[normal] my_alloc_region (0)
      | 1 -> k2)
     where k2 =
       let Pmakeblock = %block.[`0`].my_alloc_region (x) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlVariant_ah__maybe_1 =
   closure maybe_0_1 @maybe &toplevel.alloc_region
@@ -29,13 +29,15 @@ let code loopify(never) size(33) newer_version_of(shouldn't_alloc_1)
          | 0 -> k2
          | 1 -> k3
          where k3 =
-           apply &my_alloc_region g (0) -> k * k1
+           apply &my_alloc_region [close close close close] g (0) -> k * k1
          where k2 =
-           apply &my_alloc_region f (unboxed_field_0_0) -> k * k1)
+           apply &my_alloc_region [close close close close]
+             f (unboxed_field_0_0) -> k * k1)
 in
 let $camlVariant_ah__shouldn't_alloc_2 =
   closure shouldn't_alloc_1_1 @shouldn't_alloc &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlVariant_ah =
   Block 0 ($camlVariant_ah__maybe_1, $camlVariant_ah__shouldn't_alloc_2)
 in

--- a/testsuite/tests/flambda2/examples/variant_unboxed.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_unboxed.simplify.reference
@@ -53,20 +53,25 @@ let code loopify(never) size(47) newer_version_of(foo_0)
       (switch tag
          | 0 -> k2
          | 1 -> k3
-         | 2 -> k1 pop(regular k1) ($camlVariant_unboxed__Pmakeblock_2)
+         | 2 ->
+           k1
+             pop(regular k1)
+             close[exn] my_alloc_region
+             ($camlVariant_unboxed__Pmakeblock_2)
          where k3 =
            let prim = %unbox_num.`float` (unboxed_field_1_1) in
            let prim_1 = %num_conv.[`float`].[`imm`] (prim) in
            let int_of_float = %tag_imm (prim_1) in
            let int_add = %int_barith.add (unboxed_field_1_0, int_of_float) in
-           cont k (int_add)
+           cont k close[normal] my_alloc_region (int_add)
          where k2 =
            let int_add =
              %int_barith.add (unboxed_field_0_0, unboxed_field_0_1)
            in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let $camlVariant_unboxed__foo_3 = closure foo_0_1 @foo &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlVariant_unboxed = Block 0 ($camlVariant_unboxed__foo_3) in
 cont done ($camlVariant_unboxed)

--- a/testsuite/tests/flambda2/examples/variant_unboxing.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variant_unboxing.simplify.reference
@@ -10,8 +10,8 @@ let code loopify(never) size(12) newer_version_of(f1_0)
    cont k2 (untagged, x))
     where k2 (is_int : imm, unboxed_field_0_0) =
       switch is_int
-        | 0 -> k (unboxed_field_0_0)
-        | 1 -> k (1)
+        | 0 -> k close[normal] my_alloc_region (unboxed_field_0_0)
+        | 1 -> k close[normal] my_alloc_region (1)
 in
 let $camlVariant_unboxing__f1_1 = closure f1_0_1 @f1 &toplevel.alloc_region
 in
@@ -103,7 +103,7 @@ let code loopify(never) size(94) newer_version_of(f2_1)
            cont k2 (int_add))
     where k2 (region_return : imm tagged) =
       let `unit` = %end_region (`region`) in
-      cont k (region_return)
+      cont k close[normal] my_alloc_region (region_return)
 in
 let $camlVariant_unboxing__f2_2 = closure f2_1_1 @f2 &toplevel.alloc_region
 in
@@ -138,11 +138,12 @@ let code loopify(never) size(45) newer_version_of(f3_returning_a_2)
              | 1 -> k2 (unboxed_field_1_1))
     where k2 (region_return : imm tagged) =
       let `unit` = %end_region (`region`) in
-      cont k (region_return)
+      cont k close[normal] my_alloc_region (region_return)
 in
 let $camlVariant_unboxing__f3_returning_a_3 =
   closure f3_returning_a_2_1 @f3_returning_a &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlVariant_unboxing =
   Block 0 ($camlVariant_unboxing__f1_1,
            $camlVariant_unboxing__f2_2,

--- a/testsuite/tests/flambda2/examples/variants.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variants.simplify.reference
@@ -11,8 +11,8 @@ let code loopify(never) size(41) newer_version_of(f_0)
     where k5 =
       let untagged = %untag_imm (t) in
       switch untagged
-        | 0 -> k (42)
-        | 1 -> k (0)
+        | 0 -> k close[normal] my_alloc_region (42)
+        | 1 -> k close[normal] my_alloc_region (0)
     where k4 =
       let prim = %get_tag (t) in
       switch prim
@@ -22,11 +22,12 @@ let code loopify(never) size(41) newer_version_of(f_0)
       let Pfield = %block_load.[`1`] (t) in
       let Pfield_1 = %block_load.[`0`] (t) in
       let int_add = %int_barith.add (Pfield_1, Pfield) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
     where k2 =
       let Pfield = %block_load.[`0`] (t) in
-      cont k (Pfield)
+      cont k close[normal] my_alloc_region (Pfield)
 in
 let $camlVariants__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlVariants = Block 0 ($camlVariants__f_1) in
 cont done ($camlVariants)

--- a/testsuite/tests/flambda2/examples/variants_and_if.simplify.reference
+++ b/testsuite/tests/flambda2/examples/variants_and_if.simplify.reference
@@ -1,6 +1,6 @@
 let code f_0 deleted in
 let $camlVariants_and_if__immstring_0 = "Variants_and_if.Foo" in
-apply ccall noalloc
+apply ccall noalloc [forward close close close]
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
     let $camlVariants_and_if__Foo_1 =
@@ -20,15 +20,20 @@ apply ccall noalloc
           let prim = %is_int (t) in
           switch prim
             | 0 -> k2
-            | 1 -> k1 pop(regular k1) ($camlVariants_and_if__Foo_1)
+            | 1 ->
+              k1
+                pop(regular k1)
+                close[exn] my_alloc_region
+                ($camlVariants_and_if__Foo_1)
         where k2 =
           let prim = %is_int (t) in
           switch prim
-            | 0 -> k (2)
-            | 1 -> k (1)
+            | 0 -> k close[normal] my_alloc_region (2)
+            | 1 -> k close[normal] my_alloc_region (1)
     in
     let $camlVariants_and_if__f_2 = closure f_0_1 @f &toplevel.alloc_region
     in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlVariants_and_if =
       Block 0 ($camlVariants_and_if__Foo_1, $camlVariants_and_if__f_2)
     in

--- a/testsuite/tests/flambda2/examples/weird.simplify.reference
+++ b/testsuite/tests/flambda2/examples/weird.simplify.reference
@@ -12,7 +12,11 @@ let code loopify(never) size(35) newer_version_of(f_0)
   (let prim = %get_tag (r) in
    switch prim
      | 0 -> k2
-     | 1 -> k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1474_42))
+     | 1 ->
+       k1
+         pop(reraise k1)
+         close[exn] my_alloc_region
+         ($Stdlib.camlStdlib__Exit1474_42))
     where k2 =
       ((let Popaque = %opaque (0) in
         let untagged = %untag_imm (Popaque) in
@@ -25,9 +29,14 @@ let code loopify(never) size(35) newer_version_of(f_0)
          where k2 (unboxed_field_0_0) =
            let tag = 0i in
            switch tag
-             | 0 -> k (unboxed_field_0_0)
-             | 1 -> k1 pop(regular k1) ($camlWeird__Pmakeblock_3))
+             | 0 -> k close[normal] my_alloc_region (unboxed_field_0_0)
+             | 1 ->
+               k1
+                 pop(regular k1)
+                 close[exn] my_alloc_region
+                 ($camlWeird__Pmakeblock_3))
 in
 let $camlWeird__f_4 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlWeird = Block 0 ($camlWeird__f_4) in
 cont done ($camlWeird)

--- a/testsuite/tests/flambda2/examples/wrong/cse_with_alias_to_param.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/cse_with_alias_to_param.simplify.reference
@@ -2,7 +2,7 @@ let code id_0 deleted in
 let code foo_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(id_0)
       id_0_1 (lam) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (lam)
+  cont k close[normal] my_alloc_region (lam)
 in
 let $camlCse_with_alias_to_param__id_1 =
   closure id_0_1 @`id` &toplevel.alloc_region
@@ -21,18 +21,19 @@ let code loopify(never) size(42) newer_version_of(foo_1)
        cont k2 (Pmakeblock)
      where k3 =
        let Pmakeblock = %block.[`0`].my_alloc_region (v) in
-       apply direct(id_0_1 &my_alloc_region)
+       apply direct(id_0_1 &my_alloc_region) [forward close close close]
          ($camlCse_with_alias_to_param__id_1 : _ -> [ 0 of val ])
            (Pmakeblock)
            -> k2 * k1)
     where k2 (x : [ 0 of val ]) =
       let Pmakeblock = %block.[`0`].my_alloc_region (v) in
       let Pmakeblock_1 = %block.[`0`].my_alloc_region (Pmakeblock, x) in
-      cont k (Pmakeblock_1)
+      cont k close[normal] my_alloc_region (Pmakeblock_1)
 in
 let $camlCse_with_alias_to_param__foo_2 =
   closure foo_1_1 @foo &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCse_with_alias_to_param =
   Block 0 ($camlCse_with_alias_to_param__id_1,
            $camlCse_with_alias_to_param__foo_2)

--- a/testsuite/tests/flambda2/examples/wrong/join_and_aliases.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/join_and_aliases.simplify.reference
@@ -15,7 +15,11 @@ let code loopify(never) size(35) newer_version_of(f_0)
   (let prim = %get_tag (r) in
    switch prim
      | 0 -> k2
-     | 1 -> k1 pop(reraise k1) ($Stdlib.camlStdlib__Exit1474_42))
+     | 1 ->
+       k1
+         pop(reraise k1)
+         close[exn] my_alloc_region
+         ($Stdlib.camlStdlib__Exit1474_42))
     where k2 =
       ((let Popaque = %opaque (0) in
         let untagged = %untag_imm (Popaque) in
@@ -28,9 +32,14 @@ let code loopify(never) size(35) newer_version_of(f_0)
          where k2 (unboxed_field_0_0) =
            let tag = 0i in
            switch tag
-             | 0 -> k (unboxed_field_0_0)
-             | 1 -> k1 pop(regular k1) ($camlJoin_and_aliases__Pmakeblock_3))
+             | 0 -> k close[normal] my_alloc_region (unboxed_field_0_0)
+             | 1 ->
+               k1
+                 pop(regular k1)
+                 close[exn] my_alloc_region
+                 ($camlJoin_and_aliases__Pmakeblock_3))
 in
 let $camlJoin_and_aliases__f_4 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlJoin_and_aliases = Block 0 ($camlJoin_and_aliases__f_4) in
 cont done ($camlJoin_and_aliases)

--- a/testsuite/tests/flambda2/examples/wrong/join_match.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/join_match.simplify.reference
@@ -13,15 +13,15 @@ let code inline(always) loopify(never) size(33) newer_version_of(g_0)
     where k4 =
       let Pfield = %block_load.[`0`] (t) in
       let int_mul = %int_barith.mul (Pfield, 42) in
-      cont k (int_mul)
+      cont k close[normal] my_alloc_region (int_mul)
     where k3 =
       let Pfield = %block_load.[`0`] (t) in
       let int_mul = %int_barith.mul (Pfield, 2) in
-      cont k (int_mul)
+      cont k close[normal] my_alloc_region (int_mul)
     where k2 =
       let Pfield = %block_load.[`0`] (t) in
       let int_add = %int_barith.add (Pfield, 1) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let $camlJoin_match__g_1 = closure g_0_1 @g &toplevel.alloc_region in
 let code loopify(never) size(40) newer_version_of(bar_1)
@@ -41,15 +41,16 @@ let code loopify(never) size(40) newer_version_of(bar_1)
          | 2 -> k4
          where k4 =
            let int_mul = %int_barith.mul (unboxed_field_2_0, 42) in
-           cont k (int_mul)
+           cont k close[normal] my_alloc_region (int_mul)
          where k3 =
            let int_mul = %int_barith.mul (unboxed_field_1_0, 2) in
-           cont k (int_mul)
+           cont k close[normal] my_alloc_region (int_mul)
          where k2 =
            let int_add = %int_barith.add (unboxed_field_0_0, 1) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let $camlJoin_match__bar_2 = closure bar_1_1 @bar &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlJoin_match = Block 0 ($camlJoin_match__g_1, $camlJoin_match__bar_2)
 in
 cont done ($camlJoin_match)

--- a/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/local_exns_to_jumps.simplify.reference
@@ -4,7 +4,7 @@ let code f3_2 deleted in
 let code f4_3 deleted in
 let $camlLocal_exns_to_jumps__immstring_1 = "Local_exns_to_jumps.Exit2" in
 let $camlLocal_exns_to_jumps__immstring_0 = "Local_exns_to_jumps.Exit" in
-apply ccall noalloc
+apply ccall noalloc [forward close close close]
   ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
   where k (Pccall) =
     let $camlLocal_exns_to_jumps__Exit_2 =
@@ -24,7 +24,7 @@ apply ccall noalloc
              where rec k3 (r_unboxed0 : imm tagged) =
                let prim = %int_comp.lt (r_unboxed0, 42) in
                (switch prim
-                  | 0 -> k pop(k2) (0)
+                  | 0 -> k pop(k2) close[normal] my_alloc_region (0)
                   | 1 -> k4
                   where k4 =
                     (apply &my_alloc_region g (r_unboxed0) -> k6 * k2
@@ -47,8 +47,8 @@ apply ccall noalloc
           let unit_1 = %end_try_ghost_region (try_ghost_region) in
           let prim = %phys_eq (`exn`, $camlLocal_exns_to_jumps__Exit_2) in
           switch prim
-            | 0 -> k1 pop(reraise k1) (`exn`)
-            | 1 -> k (42)
+            | 0 -> k1 pop(reraise k1) close[exn] my_alloc_region (`exn`)
+            | 1 -> k close[normal] my_alloc_region (42)
     in
     let $camlLocal_exns_to_jumps__f1_3 =
       closure f1_0_1 @f1 &toplevel.alloc_region
@@ -64,7 +64,7 @@ apply ccall noalloc
         where rec k3 (r_unboxed0 : imm tagged) =
           let prim = %int_comp.lt (r_unboxed0, 42) in
           (switch prim
-             | 0 -> k (0)
+             | 0 -> k close[normal] my_alloc_region (0)
              | 1 -> k4
              where k4 =
                ((let try_region_1 = %begin_try_region () in
@@ -97,7 +97,7 @@ apply ccall noalloc
         where k2 =
           let `unit` = %end_try_region (try_region) in
           let unit_1 = %end_try_ghost_region (try_ghost_region) in
-          cont k (42)
+          cont k close[normal] my_alloc_region (42)
     in
     let $camlLocal_exns_to_jumps__f2_4 =
       closure f2_1_1 @f2 &toplevel.alloc_region
@@ -113,7 +113,7 @@ apply ccall noalloc
         where rec k3 (r_unboxed0 : imm tagged) =
           let prim = %int_comp.lt (r_unboxed0, 42) in
           (switch prim
-             | 0 -> k (0)
+             | 0 -> k close[normal] my_alloc_region (0)
              | 1 -> k4
              where k4 =
                ((let try_region_1 = %begin_try_region () in
@@ -146,12 +146,12 @@ apply ccall noalloc
         where k2 =
           let `unit` = %end_try_region (try_region) in
           let unit_1 = %end_try_ghost_region (try_ghost_region) in
-          cont k (42)
+          cont k close[normal] my_alloc_region (42)
     in
     let $camlLocal_exns_to_jumps__f3_5 =
       closure f3_2_1 @f3 &toplevel.alloc_region
     in
-    (apply ccall noalloc
+    (apply ccall noalloc [forward close close close]
        ($`*extern*`.caml_fresh_oo_id : val -> val) (0) -> k * error
        where k (Pccall_1) =
          let $camlLocal_exns_to_jumps__Exit2_6 =
@@ -169,7 +169,7 @@ apply ccall noalloc
              where rec k3 (r_unboxed0 : imm tagged) =
                let prim = %int_comp.lt (r_unboxed0, 42) in
                (switch prim
-                  | 0 -> k (0)
+                  | 0 -> k close[normal] my_alloc_region (0)
                   | 1 -> k4
                   where k4 =
                     ((let try_region_1 = %begin_try_region () in
@@ -214,10 +214,12 @@ apply ccall noalloc
                let `unit` = %end_try_region (try_region) in
                let unit_1 = %end_try_ghost_region (try_ghost_region) in
                let int_add_2 = %int_barith.add (cse_param_1, cse_param) in
-               cont k (int_add_2)
+               cont k close[normal] my_alloc_region (int_add_2)
          in
          let $camlLocal_exns_to_jumps__f4_7 =
            closure f4_3_1 @f4 &toplevel.alloc_region
+         in
+         let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region)
          in
          let $camlLocal_exns_to_jumps =
            Block 0 ($camlLocal_exns_to_jumps__Exit_2,

--- a/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/opt_flags.simplify.reference
@@ -22,5 +22,6 @@ let $camlOpt_flags__immstring_0 = "foo" in
       | 1 -> k (-1)
   where k (y : imm tagged) =
     let $camlOpt_flags__Pmakeblock_10 = Block 0 (42, y, 1701) in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlOpt_flags = Block 0 ($camlOpt_flags__Pmakeblock_10) in
     cont done ($camlOpt_flags)

--- a/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/static.simplify.reference
@@ -9,8 +9,8 @@ let code loopify(never) size(12) newer_version_of(g_1)
   let x = %project_value_slot.[g].[x] (my_closure) in
   let untagged = %untag_imm (b) in
   switch untagged
-    | 0 -> k (42)
-    | 1 -> k (x)
+    | 0 -> k close[normal] my_alloc_region (42)
+    | 1 -> k close[normal] my_alloc_region (x)
 in
 let code loopify(never) size(10) newer_version_of(h_2)
       h_2_1 (acc : imm tagged, x : imm tagged)
@@ -18,11 +18,12 @@ let code loopify(never) size(10) newer_version_of(h_2)
         -> k * k1
         : imm tagged =
   let g = %project_value_slot.[h].[g] (my_closure) in
-  apply direct(g_1_1 &my_alloc_region) (g : _ -> imm tagged) (0) -> k2 * k1
+  apply direct(g_1_1 &my_alloc_region) [forward close close close]
+    (g : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (acc, x) in
       let int_add_1 = %int_barith.add (int_add, apply_result) in
-      cont k (int_add_1)
+      cont k close[normal] my_alloc_region (int_add_1)
 in
 let code loopify(never) size(58) newer_version_of(f_0)
       f_0_1 (x : imm tagged, l : [ 0 | 0 of val * [ 0 | 0 of val * val ] ])
@@ -36,15 +37,17 @@ let code loopify(never) size(58) newer_version_of(f_0)
       let prim = %is_int (l_1) in
       (switch prim
          | 0 -> k2
-         | 1 -> k (accu)
+         | 1 -> k close[normal] my_alloc_region (accu)
          where k2 =
            let Pfield = %block_load.[`1`] (l_1) in
            ((let Pfield_1 = %block_load.[`0`] (l_1) in
              apply direct(h_2_1 &my_alloc_region) inlining_state(depth(10))
+                    [forward close close close]
                h (accu, Pfield_1) -> k2 * k1)
               where k2 (apply_result) =
                 cont `self` (apply_result, Pfield)))
 in
 let $camlStatic__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlStatic = Block 0 ($camlStatic__f_1) in
 cont done ($camlStatic)

--- a/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
+++ b/testsuite/tests/flambda2/examples/wrong/unused_bucket_switch.simplify.reference
@@ -3,7 +3,7 @@ let $camlUnused_bucket_switch__immstring_0 = "urk" in
 let code f_1 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(opaque_0)
       opaque_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (x)
+  cont k close[normal] my_alloc_region (x)
 in
 let $camlUnused_bucket_switch__opaque_1 =
   closure opaque_0_1 @opaque &toplevel.alloc_region
@@ -23,7 +23,7 @@ let ghost_region = %begin_ghost_region () in
              my_closure &my_alloc_region my_depth
              -> k3 * k4
              : imm tagged =
-       apply direct(opaque_0_1 &my_alloc_region)
+       apply direct(opaque_0_1 &my_alloc_region) [forward close close close]
          ($camlUnused_bucket_switch__opaque_1 : _ -> [ 0 |1 ]) (1) -> k6 * k4
          where k6 (param_1) =
            let unboxed_field = %untag_imm (param_1) in
@@ -32,8 +32,11 @@ let ghost_region = %begin_ghost_region () in
            let naked_immediate = unboxed_field in
            switch naked_immediate
              | 0 ->
-               k4 pop(reraise k4) ($camlUnused_bucket_switch__Pmakeblock_3)
-             | 1 -> k3 (42)
+               k4
+                 pop(reraise k4)
+                 close[exn] my_alloc_region
+                 ($camlUnused_bucket_switch__Pmakeblock_3)
+             | 1 -> k3 close[normal] my_alloc_region (42)
      in
      let $camlUnused_bucket_switch__f_2 =
        closure f_1_1 @f &toplevel.alloc_region
@@ -49,6 +52,7 @@ let ghost_region = %begin_ghost_region () in
   where k (region_return : imm tagged) =
     let `unit` = %end_region (`region`) in
     let unit_1 = %end_ghost_region (ghost_region) in
+    let unit_2 = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlUnused_bucket_switch =
       Block 0 ($camlUnused_bucket_switch__opaque_1, region_return)
     in

--- a/testsuite/tests/flambda2/gadt_simplified_switch.raw.reference
+++ b/testsuite/tests/flambda2/gadt_simplified_switch.raw.reference
@@ -13,10 +13,10 @@
      where k4 =
        let Pfield = %block_load.[`0`] (x) in
        let int_add = %int_barith.add (Pfield, 1) in
-       cont k1 (int_add)
+       cont k1 close[normal] my_alloc_region (int_add)
      where k3 =
        let Pfield = %block_load.[`0`] (x) in
-       cont k1 (Pfield)
+       cont k1 close[normal] my_alloc_region (Pfield)
  in
  let $camlGadt_simplified_switch__immstring_0 = "A" in
  let $camlGadt_simplified_switch__immstring_1 = "B" in
@@ -28,8 +28,14 @@
    let next_depth = rec_info (succ my_depth) in
    let untagged = %untag_imm (x) in
    switch untagged
-     | 0 -> k1 ($camlGadt_simplified_switch__immstring_0)
-     | 1 -> k1 ($camlGadt_simplified_switch__immstring_1)
+     | 0 ->
+       k1
+         close[normal] my_alloc_region
+         ($camlGadt_simplified_switch__immstring_0)
+     | 1 ->
+       k1
+         close[normal] my_alloc_region
+         ($camlGadt_simplified_switch__immstring_1)
  in
  let extract_int = closure extract_int_0 @extract_int &toplevel.alloc_region
  in
@@ -37,7 +43,7 @@
    closure extract_string_1 @extract_string &toplevel.alloc_region
  in
  let Pmakeblock = %block.[`0`].`toplevel` (extract_int, extract_string) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`2`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`2`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.simplify.reference
+++ b/testsuite/tests/flambda2/inlining_cost_of_primitive_on_parameters.simplify.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(8) newer_version_of(f_0)
         : imm tagged =
   let prim = %string_length (x) in
   let Pstringlength = %tag_imm (prim) in
-  cont k (Pstringlength)
+  cont k close[normal] my_alloc_region (Pstringlength)
 in
 let $camlInlining_cost_of_primitive_on_parameters__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
@@ -17,7 +17,7 @@ let code loopify(never) size(4) newer_version_of(g_1)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply direct(f_0_1 &my_alloc_region)
+  apply direct(f_0_1 &my_alloc_region) [close close close close]
     ($camlInlining_cost_of_primitive_on_parameters__f_1 : _ -> imm tagged)
       (x)
       -> k * k1
@@ -25,6 +25,7 @@ in
 let $camlInlining_cost_of_primitive_on_parameters__g_2 =
   closure g_1_1 @g &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlInlining_cost_of_primitive_on_parameters =
   Block 0 ($camlInlining_cost_of_primitive_on_parameters__f_1,
            $camlInlining_cost_of_primitive_on_parameters__g_2)

--- a/testsuite/tests/flambda2/issue5721.simplify.reference
+++ b/testsuite/tests/flambda2/issue5721.simplify.reference
@@ -14,14 +14,16 @@ let code loopify(never) size(33) newer_version_of(main_0)
            | 0 -> k2 (1i)
            | 1 -> k3)
           where k3 =
-            (apply &my_alloc_region f (0) -> k3 * k1
+            (apply &my_alloc_region [forward close close close]
+               f (0) -> k3 * k1
                where k3 (param : imm tagged) =
                  cont k2 (1i))))
     where k2 (join_param : imm) =
       let Pisint = %tag_imm (join_param) in
       let Pnot = %boolean_not (Pisint) in
-      cont k (Pnot)
+      cont k close[normal] my_alloc_region (Pnot)
 in
 let $camlIssue5721__main_1 = closure main_0_1 @main &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlIssue5721 = Block 0 ($camlIssue5721__main_1) in
 cont done ($camlIssue5721)

--- a/testsuite/tests/flambda2/match_on_unboxed_ints.ml
+++ b/testsuite/tests/flambda2/match_on_unboxed_ints.ml
@@ -27,28 +27,29 @@ let code loopify(never) size(60) newer_version_of(map_ints_to_float_constants_0)
     where k3 =
       let prim_1 = %int_comp.`nativeint`.ne (param, 0n) in
       (switch prim_1
-         | 0 -> k (0x0p+0)
+         | 0 -> k close[normal] my_alloc_region (0x0p+0)
          | 1 -> k3
          where k3 =
            let prim_2 = %int_comp.`nativeint`.ne (param, 1n) in
            switch prim_2
-             | 0 -> k (0x1p+0)
-             | 1 -> k (0x1p+2))
+             | 0 -> k close[normal] my_alloc_region (0x1p+0)
+             | 1 -> k close[normal] my_alloc_region (0x1p+2))
     where k2 =
       let prim_1 = %int_comp.`nativeint`.ne (param, 2n) in
       (switch prim_1
-         | 0 -> k (0x1p+1)
+         | 0 -> k close[normal] my_alloc_region (0x1p+1)
          | 1 -> k2
          where k2 =
            let prim_2 = %int_comp.`nativeint`.ne (param, 3n) in
            switch prim_2
-             | 0 -> k (0x1.8p+1)
-             | 1 -> k (0x1p+2))
+             | 0 -> k close[normal] my_alloc_region (0x1.8p+1)
+             | 1 -> k close[normal] my_alloc_region (0x1p+2))
 in
 let $camlTOP1__map_ints_to_float_constants_1 =
   closure map_ints_to_float_constants_0_1 @map_ints_to_float_constants
     &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP1 = Block 0 ($camlTOP1__map_ints_to_float_constants_1) in
 cont done ($camlTOP1)
 |}]
@@ -76,15 +77,16 @@ let code loopify(never) size(14) newer_version_of(map_tagged_ints_to_float_const
   let prim = %int_comp.unsigned.lt (3, param) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0x1p+2)
+    | 1 -> k close[normal] my_alloc_region (0x1p+2)
     where k2 =
       let arg = %array_load.`float` ($camlTOP2__switch_block_5, param) in
-      cont k (arg)
+      cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP2__map_tagged_ints_to_float_constants_4 =
   closure map_tagged_ints_to_float_constants_1_1
     @map_tagged_ints_to_float_constants &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP2 = Block 0 ($camlTOP2__map_tagged_ints_to_float_constants_4) in
 cont done ($camlTOP2)
 |}]
@@ -144,11 +146,13 @@ and code loopify(never) size(88) newer_version_of(match_on_ints_6)
            let prim_2 = %int_comp.`nativeint`.ne (param, 1n) in
            (switch prim_2
               | 0 -> k4
-              | 1 -> k (0)
+              | 1 -> k close[normal] my_alloc_region (0)
               where k4 =
-                apply &my_alloc_region opaque_fun2_1 (0) -> k * k1)
+                apply &my_alloc_region [close close close close]
+                  opaque_fun2_1 (0) -> k * k1)
          where k3 =
-           apply &my_alloc_region opaque_fun1_1 (0) -> k * k1)
+           apply &my_alloc_region [close close close close]
+             opaque_fun1_1 (0) -> k * k1)
     where k2 =
       let prim_1 = %int_comp.`nativeint`.ne (param, 2n) in
       (switch prim_1
@@ -158,11 +162,13 @@ and code loopify(never) size(88) newer_version_of(match_on_ints_6)
            let prim_2 = %int_comp.`nativeint`.ne (param, 3n) in
            (switch prim_2
               | 0 -> k3
-              | 1 -> k (0)
+              | 1 -> k close[normal] my_alloc_region (0)
               where k3 =
-                apply &my_alloc_region opaque_fun4_1 (0) -> k * k1)
+                apply &my_alloc_region [close close close close]
+                  opaque_fun4_1 (0) -> k * k1)
          where k2 =
-           apply &my_alloc_region opaque_fun3_1 (0) -> k * k1)
+           apply &my_alloc_region [close close close close]
+             opaque_fun3_1 (0) -> k * k1)
   with {
     opaque_fun1 = opaque_fun1;
     opaque_fun2 = opaque_fun2;
@@ -170,6 +176,7 @@ and code loopify(never) size(88) newer_version_of(match_on_ints_6)
     opaque_fun4 = opaque_fun4
   }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP7 = Block 0 ($camlTOP7__match_on_ints_20) in
 cont done ($camlTOP7)
 |}]
@@ -215,7 +222,7 @@ and code loopify(never) size(61) newer_version_of(match_on_tagged_ints_7)
   let prim = %int_comp.unsigned.lt (3, param) in
   switch prim
     | 0 -> k2
-    | 1 -> k (0)
+    | 1 -> k close[normal] my_alloc_region (0)
     where k2 =
       ((let untagged = %untag_imm (param) in
         switch untagged
@@ -224,13 +231,17 @@ and code loopify(never) size(61) newer_version_of(match_on_tagged_ints_7)
           | 2 -> k4
           | 3 -> k5)
          where k5 =
-           apply &my_alloc_region opaque_fun4_1 (0) -> k * k1
+           apply &my_alloc_region [close close close close]
+             opaque_fun4_1 (0) -> k * k1
          where k4 =
-           apply &my_alloc_region opaque_fun3_1 (0) -> k * k1
+           apply &my_alloc_region [close close close close]
+             opaque_fun3_1 (0) -> k * k1
          where k3 =
-           apply &my_alloc_region opaque_fun2_1 (0) -> k * k1
+           apply &my_alloc_region [close close close close]
+             opaque_fun2_1 (0) -> k * k1
          where k2 =
-           apply &my_alloc_region opaque_fun1_1 (0) -> k * k1)
+           apply &my_alloc_region [close close close close]
+             opaque_fun1_1 (0) -> k * k1)
   with {
     opaque_fun1 = opaque_fun1;
     opaque_fun2 = opaque_fun2;
@@ -238,6 +249,7 @@ and code loopify(never) size(61) newer_version_of(match_on_tagged_ints_7)
     opaque_fun4 = opaque_fun4
   }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP8 = Block 0 ($camlTOP8__match_on_tagged_ints_23) in
 cont done ($camlTOP8)
 |}]

--- a/testsuite/tests/flambda2/n_way_join_null.raw.reference
+++ b/testsuite/tests/flambda2/n_way_join_null.raw.reference
@@ -16,11 +16,11 @@ let $camlN_way_join_null__first_const_0 = Block 0 () in
       where k4 =
         cont k3 (0))
      where k3 (y) =
-       cont k1 (y)
+       cont k1 close[normal] my_alloc_region (y)
  in
  let main = closure main_0 @main &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (main) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlN_way_join_null = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/n_way_join_null.simplify.reference
+++ b/testsuite/tests/flambda2/n_way_join_null.simplify.reference
@@ -6,10 +6,11 @@ let code loopify(never) size(4) newer_version_of(main_0)
         : imm tagged =
   let prim = %is_null (x) in
   let tagged_scrutinee = %tag_imm (prim) in
-  cont k (tagged_scrutinee)
+  cont k close[normal] my_alloc_region (tagged_scrutinee)
 in
 let $camlN_way_join_null__main_1 =
   closure main_0_1 @main &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlN_way_join_null = Block 0 ($camlN_way_join_null__main_1) in
 cont done ($camlN_way_join_null)

--- a/testsuite/tests/flambda2/n_way_join_preserves_null.raw.reference
+++ b/testsuite/tests/flambda2/n_way_join_preserves_null.raw.reference
@@ -20,18 +20,18 @@ let $camlN_way_join_preserves_null__first_const_0 = Block 0 () in
      where k3 (c : imm tagged) =
        ((let untagged = %untag_imm (c) in
          switch untagged
-           | 0 -> k1 (0)
+           | 0 -> k1 close[normal] my_alloc_region (0)
            | 1 -> k4)
           where k4 =
             cont k3
           where k3 =
             let prim = %phys_ne (bit, 0) in
             let noteq = %tag_imm (prim) in
-            cont k1 (noteq))
+            cont k1 close[normal] my_alloc_region (noteq))
  in
  let f = closure f_0 @f &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (f) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlN_way_join_preserves_null = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/n_way_join_preserves_null.simplify.reference
+++ b/testsuite/tests/flambda2/n_way_join_preserves_null.simplify.reference
@@ -13,16 +13,17 @@ let code loopify(never) size(30) newer_version_of(f_0)
        cont k2 (prim_1))
     where k2 (join_param : imm) =
       (switch join_param
-         | 0 -> k (0)
+         | 0 -> k close[normal] my_alloc_region (0)
          | 1 -> k2
          where k2 =
            let prim = %phys_ne (bit, 0) in
            let noteq = %tag_imm (prim) in
-           cont k (noteq))
+           cont k close[normal] my_alloc_region (noteq))
 in
 let $camlN_way_join_preserves_null__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlN_way_join_preserves_null =
   Block 0 ($camlN_way_join_preserves_null__f_1)
 in

--- a/testsuite/tests/flambda2/rec_info_alias/helper.raw.reference
+++ b/testsuite/tests/flambda2/rec_info_alias/helper.raw.reference
@@ -2,30 +2,35 @@
        f_1 (x) my_closure &my_alloc_region my_depth -> k1 * k2 : imm tagged =
    let next_depth = rec_info (succ my_depth) in
    let y = %project_value_slot.[f].[y] (my_closure) in
-   apply direct(f_1 &my_alloc_region)
+   apply direct(f_1 &my_alloc_region) [forward close close close]
      (my_closure ~ depth my_depth -> next_depth : _ -> imm tagged)
        (x)
        -> k3 * k2
      where k3 (apply_result : imm tagged) =
        let int_add = %int_barith.add (y, apply_result) in
-       cont k1 (int_add)
+       cont k1 close[normal] my_alloc_region (int_add)
  in
  let code size(9)
        g_2 (y) my_closure &my_alloc_region my_depth -> k1 * k2 : imm tagged =
    let f = %project_value_slot.[g].[f] (my_closure) in
    let inlined_dbg = %inlined_apply () in
+   let my_alloc_region_1 =
+     %new_alloc_region.[`normal`[`close`, transfer], `exn`[`close`,
+       transfer], `notrace`[`close`, transfer], div[`close`, transfer]]
+       (my_alloc_region)
+   in
    let my_depth_1 = rec_info my_depth in
    let x = y in
    let my_closure_1 = f in
    let next_depth = rec_info (succ my_depth_1) in
    let y_1 = %project_value_slot.[f].[y] (my_closure_1) in
-   apply direct(f_1 &my_alloc_region)
+   apply direct(f_1 &my_alloc_region_1) [forward close close close]
      (my_closure_1 ~ depth my_depth_1 -> next_depth : _ -> imm tagged)
        (x)
        -> k3 * k2
      where k3 (apply_result : imm tagged) =
        let int_add = %int_barith.add (y_1, apply_result) in
-       cont k1 (int_add)
+       cont k1 close[normal] my_alloc_region_1 (int_add)
  in
  let code inline(always) size(34)
        p_0 (y : imm tagged)
@@ -34,11 +39,11 @@
          : val =
    let f = closure f_1 @f &my_alloc_region with { y = y } in
    let g = closure g_2 @g &my_alloc_region with { f = f } in
-   cont k1 (g)
+   cont k1 close[normal] my_alloc_region (g)
  in
  let $camlHelper__s0 = closure p_0 @p &toplevel.alloc_region in
  let $camlHelper__s1 = Block 0 ($camlHelper__s0) in
- cont k ($camlHelper__s1))
+ cont k close[normal] toplevel.alloc_region ($camlHelper__s1))
   where k define_root_symbol (module_block) =
     let field_0 = $camlHelper__s0 in
     let $camlHelper = Block 0 (field_0) in

--- a/testsuite/tests/flambda2/rec_info_alias/rec_info_alias.simplify.reference
+++ b/testsuite/tests/flambda2/rec_info_alias/rec_info_alias.simplify.reference
@@ -3,22 +3,24 @@ let code rec inline(always) loopify(never) size(8) newer_version_of(f_1_1)
       f_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
   let y = %project_value_slot.[f].[y] (my_closure) in
   apply direct(f_1 &my_alloc_region) inlining_state(depth(1))
+         [forward close close close]
     (my_closure ~ depth my_depth -> succ my_depth : _ -> imm tagged)
       (x)
       -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (y, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code rec loopify(never) size(9) newer_version_of(g_2_1)
       g_2 (y) my_closure &my_alloc_region my_depth -> k * k1 : imm tagged =
   let f = %project_value_slot.[g].[f] (my_closure) in
   let y_1 = %project_value_slot.[f].[y] (f) in
   apply direct(f_1 &my_alloc_region) inlining_state(depth(1))
+         [forward close close close]
     (f ~ depth my_depth -> succ my_depth : _ -> imm tagged) (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (y_1, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code loopify(never) size(34) newer_version_of(h_0)
       h_0_1 (y : imm tagged)
@@ -27,8 +29,9 @@ let code loopify(never) size(34) newer_version_of(h_0)
         : val =
   let f = closure f_1 @f &my_alloc_region with { y = y } in
   let g = closure g_2 @g &my_alloc_region with { f = f } in
-  cont k (g)
+  cont k close[normal] my_alloc_region (g)
 in
 let $camlRec_info_alias__h_1 = closure h_0_1 @h &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlRec_info_alias = Block 0 ($camlRec_info_alias__h_1) in
 cont done ($camlRec_info_alias)

--- a/testsuite/tests/flambda2/removed_operations_of_switch.simplify.reference
+++ b/testsuite/tests/flambda2/removed_operations_of_switch.simplify.reference
@@ -11,27 +11,34 @@ let code loopify(never) size(27) newer_version_of(f_0)
      | 1 -> k3)
     where k3 =
       let Pmakeblock = %block.[`0`].my_alloc_region (x, y) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
     where k2 =
       let Pmakeblock = %block.[`0`].my_alloc_region (y, x) in
-      cont k (Pmakeblock)
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlRemoved_operations_of_switch__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
-let code loopify(never) size(4) newer_version_of(g_1)
+let code loopify(never) size(27) newer_version_of(g_1)
       g_1_1 (b : imm tagged, x, y)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : [ 0 of val * val ] =
-  apply direct(f_0_1 &my_alloc_region)
-    ($camlRemoved_operations_of_switch__f_1 : _ -> [ 0 of val * val ])
-      (b, x, y)
-      -> k * k1
+  (let untagged = %untag_imm (b) in
+   switch untagged
+     | 0 -> k2
+     | 1 -> k3)
+    where k3 =
+      let Pmakeblock = %block.[`0`].my_alloc_region (x, y) in
+      cont k close[normal] my_alloc_region (Pmakeblock)
+    where k2 =
+      let Pmakeblock = %block.[`0`].my_alloc_region (y, x) in
+      cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlRemoved_operations_of_switch__g_2 =
   closure g_1_1 @g &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlRemoved_operations_of_switch =
   Block 0 ($camlRemoved_operations_of_switch__f_1,
            $camlRemoved_operations_of_switch__g_2)

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.raw.reference
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.raw.reference
@@ -7,7 +7,7 @@ let $camlArgument_types_useful__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let Pfield = %block_load.[`0`] (param) in
    let int_add = %int_barith.add (Pfield, 1) in
-   cont k1 (int_add)
+   cont k1 close[normal] my_alloc_region (int_add)
  in
  let code inline(always) size(5)
        unbox_int_and_add_one_wrapper_1 (x : [ 0 of imm tagged ])
@@ -20,6 +20,7 @@ let $camlArgument_types_useful__first_const_0 = Block 0 () in
        (my_closure)
    in
    apply direct(unbox_int_and_add_one_0 &my_alloc_region)
+          [close close close close]
      (unbox_int_and_add_one : _ -> imm tagged) (x) -> k1 * k2
  in
  let code size(11)
@@ -34,6 +35,7 @@ let $camlArgument_types_useful__first_const_0 = Block 0 () in
    in
    let Pmakeblock = %block.[`0`].my_alloc_region (x) in
    apply direct(unbox_int_and_add_one_wrapper_1 &my_alloc_region)
+          [close close close close]
      (unbox_int_and_add_one_wrapper : _ -> imm tagged)
        (Pmakeblock)
        -> k1 * k2
@@ -58,7 +60,7 @@ let $camlArgument_types_useful__first_const_0 = Block 0 () in
       unbox_int_and_add_one_wrapper,
       box_int_then_call_unbox_int_and_add_one_wrapper)
  in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`3`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`3`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/simplify/argument_types_useful.simplify.reference
+++ b/testsuite/tests/flambda2/simplify/argument_types_useful.simplify.reference
@@ -8,7 +8,7 @@ let code loopify(never) size(4) newer_version_of(unbox_int_and_add_one_0)
         : imm tagged =
   let Pfield = %block_load.[`0`] (param) in
   let int_add = %int_barith.add (Pfield, 1) in
-  cont k (int_add)
+  cont k close[normal] my_alloc_region (int_add)
 in
 let $camlArgument_types_useful__unbox_int_and_add_one_1 =
   closure unbox_int_and_add_one_0_1 @unbox_int_and_add_one
@@ -20,6 +20,7 @@ let code inline(always) loopify(never) size(4) newer_version_of(unbox_int_and_ad
         -> k * k1
         : imm tagged =
   apply direct(unbox_int_and_add_one_0_1 &my_alloc_region)
+         [close close close close]
     ($camlArgument_types_useful__unbox_int_and_add_one_1 : _ -> imm tagged)
       (x)
       -> k * k1
@@ -34,12 +35,13 @@ let code loopify(never) size(3) newer_version_of(box_int_then_call_unbox_int_and
         -> k * k1
         : imm tagged =
   let int_add = %int_barith.add (x, 1) in
-  cont k (int_add)
+  cont k close[normal] my_alloc_region (int_add)
 in
 let $camlArgument_types_useful__box_int_then_call_unbox_int_and_add_one_wrapper_3 =
   closure box_int_then_call_unbox_int_and_add_one_wrapper_2_1
     @box_int_then_call_unbox_int_and_add_one_wrapper &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlArgument_types_useful =
   Block 0 ($camlArgument_types_useful__unbox_int_and_add_one_1,
            $camlArgument_types_useful__unbox_int_and_add_one_wrapper_2,

--- a/testsuite/tests/flambda2/simplify/inlining_arguments_meet/inlining_arguments_meet.simplify.with-meet.reference
+++ b/testsuite/tests/flambda2/simplify/inlining_arguments_meet/inlining_arguments_meet.simplify.with-meet.reference
@@ -6,7 +6,7 @@ let code loopify(never) size(4) newer_version_of(h_0)
         -> k * k1
         : imm tagged =
   apply direct(f_with_code_size_between_1_and_10_0 &my_alloc_region)
-         inlining_state(depth(10))
+         inlining_state(depth(10)) [close close close close]
     ($Lib.camlLib__f_with_code_size_between_1_and_10_1 : _ -> imm tagged)
       (x)
       -> k * k1
@@ -23,7 +23,7 @@ let code loopify(never) size(17) newer_version_of(g_with_code_size_between_11_an
   let int_mul_1 = %int_barith.mul (int_mul, y) in
   let int_mul_2 = %int_barith.mul (int_mul_1, y) in
   let int_mul_3 = %int_barith.mul (int_mul_2, y) in
-  cont k (int_mul_3)
+  cont k close[normal] my_alloc_region (int_mul_3)
 in
 let $camlInlining_arguments_meet__g_with_code_size_between_11_and_20_2 =
   closure g_with_code_size_between_11_and_20_3
@@ -36,6 +36,7 @@ let code loopify(never) size(4) newer_version_of(q_1)
         -> k * k1
         : imm tagged =
   apply direct(g_with_code_size_between_11_and_20_3 &my_alloc_region)
+         [close close close close]
     ($camlInlining_arguments_meet__g_with_code_size_between_11_and_20_2
      : _ -> imm tagged)
       (x)
@@ -44,6 +45,7 @@ in
 let $camlInlining_arguments_meet__q_3 =
   closure q_1_1 @q &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlInlining_arguments_meet =
   Block 0 ($camlInlining_arguments_meet__h_1,
            $camlInlining_arguments_meet__g_with_code_size_between_11_and_20_2,

--- a/testsuite/tests/flambda2/simplify/inlining_arguments_meet/inlining_arguments_meet.simplify.without-meet.reference
+++ b/testsuite/tests/flambda2/simplify/inlining_arguments_meet/inlining_arguments_meet.simplify.without-meet.reference
@@ -7,7 +7,7 @@ let code loopify(never) size(9) newer_version_of(h_0)
         : imm tagged =
   let int_mul = %int_barith.mul (x, x) in
   let int_mul_1 = %int_barith.mul (int_mul, x) in
-  cont k (int_mul_1)
+  cont k close[normal] my_alloc_region (int_mul_1)
 in
 let $camlInlining_arguments_meet__h_1 =
   closure h_0_1 @h &toplevel.alloc_region
@@ -21,7 +21,7 @@ let code loopify(never) size(17) newer_version_of(g_with_code_size_between_11_an
   let int_mul_1 = %int_barith.mul (int_mul, y) in
   let int_mul_2 = %int_barith.mul (int_mul_1, y) in
   let int_mul_3 = %int_barith.mul (int_mul_2, y) in
-  cont k (int_mul_3)
+  cont k close[normal] my_alloc_region (int_mul_3)
 in
 let $camlInlining_arguments_meet__g_with_code_size_between_11_and_20_2 =
   closure g_with_code_size_between_11_and_20_3
@@ -37,11 +37,12 @@ let code loopify(never) size(17) newer_version_of(q_1)
   let int_mul_1 = %int_barith.mul (int_mul, x) in
   let int_mul_2 = %int_barith.mul (int_mul_1, x) in
   let int_mul_3 = %int_barith.mul (int_mul_2, x) in
-  cont k (int_mul_3)
+  cont k close[normal] my_alloc_region (int_mul_3)
 in
 let $camlInlining_arguments_meet__q_3 =
   closure q_1_1 @q &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlInlining_arguments_meet =
   Block 0 ($camlInlining_arguments_meet__h_1,
            $camlInlining_arguments_meet__g_with_code_size_between_11_and_20_2,

--- a/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
+++ b/testsuite/tests/flambda2/simplify/naked_immediates_many_relations.ml
@@ -58,13 +58,22 @@ in
             | 1 -> k2
             where k2 =
               switch tag_1
-                | 0 -> error pop(regular error) ($camlTOP3__Pmakeblock_4)
+                | 0 ->
+                  error
+                    pop(regular error)
+                    close[exn] toplevel.alloc_region
+                    ($camlTOP3__Pmakeblock_4)
                 | 1 -> k
             where k1 =
               switch tag_1
                 | 0 -> k
-                | 1 -> error pop(regular error) ($camlTOP3__Pmakeblock_4)))
+                | 1 ->
+                  error
+                    pop(regular error)
+                    close[exn] toplevel.alloc_region
+                    ($camlTOP3__Pmakeblock_4)))
   where k =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlTOP3 = Block 0 (0) in
     cont done ($camlTOP3)
 |}]

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.raw.reference
@@ -6,7 +6,7 @@ let $camlSpeculative_inlining_lifted_constants__first_const_0 = Block 0 () in
          : [ 0 of val * val ] =
    let next_depth = rec_info (succ my_depth) in
    let Pmakeblock = %block.[`0`].my_alloc_region (x, x) in
-   cont k1 (Pmakeblock)
+   cont k1 close[normal] my_alloc_region (Pmakeblock)
  in
  let code size(6)
        v1_1 (param : imm tagged)
@@ -16,12 +16,12 @@ let $camlSpeculative_inlining_lifted_constants__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let f = %project_value_slot.[v1].[f] (my_closure) in
    let one = %project_value_slot.[v1].[one] (my_closure) in
-   apply direct(f_0 &my_alloc_region)
+   apply direct(f_0 &my_alloc_region) [close close close close]
      (f : _ -> [ 0 of imm tagged * imm tagged ]) (one) -> k1 * k2
  in
  let f = closure f_0 @f &toplevel.alloc_region in
  let zero = %opaque (0) in
- apply direct(f_0 &toplevel.alloc_region)
+ apply direct(f_0 &toplevel.alloc_region) [forward close close close]
    (f : _ -> [ 0 of imm tagged * imm tagged ]) (zero) -> k1 * error
    where k1 (v0 : [ 0 of imm tagged * imm tagged ]) =
      let one = %opaque (1) in
@@ -29,7 +29,7 @@ let $camlSpeculative_inlining_lifted_constants__first_const_0 = Block 0 () in
      with { f = f; one = one }
      in
      let Pmakeblock = %block.[`0`].`toplevel` (f, zero, v0, one, v1) in
-     cont k (Pmakeblock))
+     cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`5`].[`0`] (module_block) in
     let field_1 = %block_load.tag[`0`].`size`[`5`].[`1`] (module_block) in

--- a/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_lifted_constants.simplify.reference
@@ -6,13 +6,13 @@ let code loopify(never) size(8) newer_version_of(f_0)
         -> k * k1
         : [ 0 of val * val ] =
   let Pmakeblock = %block.[`0`].my_alloc_region (x, x) in
-  cont k (Pmakeblock)
+  cont k close[normal] my_alloc_region (Pmakeblock)
 in
 let $camlSpeculative_inlining_lifted_constants__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
 let zero = %opaque (0) in
-apply direct(f_0_1 &toplevel.alloc_region)
+apply direct(f_0_1 &toplevel.alloc_region) [forward close close close]
   ($camlSpeculative_inlining_lifted_constants__f_1
    : _ -> [ 0 of imm tagged * imm tagged ])
     (zero)
@@ -30,13 +30,14 @@ apply direct(f_0_1 &toplevel.alloc_region)
         %project_value_slot.[v1].[one]
           ($camlSpeculative_inlining_lifted_constants__v1_3)
       in
-      apply direct(f_0_1 &my_alloc_region)
+      apply direct(f_0_1 &my_alloc_region) [close close close close]
         ($camlSpeculative_inlining_lifted_constants__f_1
          : _ -> [ 0 of imm tagged * imm tagged ])
           (one_1)
           -> k * k1
       with { one = one }
     in
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlSpeculative_inlining_lifted_constants =
       Block 0 ($camlSpeculative_inlining_lifted_constants__f_1,
                zero,

--- a/testsuite/tests/flambda2/speculative_inlining_set_of_closures.simplify.reference
+++ b/testsuite/tests/flambda2/speculative_inlining_set_of_closures.simplify.reference
@@ -8,12 +8,12 @@ let code inline(never) loopify(never) size(15) newer_version_of(use_0)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  apply &my_alloc_region f (0) -> k2 * k1
+  apply &my_alloc_region [forward close close close] f (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
-      (apply &my_alloc_region f (0) -> k2 * k1
+      (apply &my_alloc_region [forward close close close] f (0) -> k2 * k1
          where k2 (apply_result_1 : imm tagged) =
            let int_add = %int_barith.add (apply_result_1, apply_result) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let $camlSpeculative_inlining_set_of_closures__use_1 =
   closure use_0_1 @use &toplevel.alloc_region
@@ -36,7 +36,7 @@ let code loopify(never) size(36) newer_version_of(f_2)
   let int_add_2 = %int_barith.add (int_add_1, int_mul_2) in
   let int_add_3 = %int_barith.add (int_add_2, int_mul_1) in
   let int_add_4 = %int_barith.add (int_add_3, int_mul) in
-  cont k (int_add_4)
+  cont k close[normal] my_alloc_region (int_add_4)
 in
 let code loopify(never) size(48) newer_version_of(g_1)
       g_1_1 (x : imm tagged)
@@ -44,7 +44,7 @@ let code loopify(never) size(48) newer_version_of(g_1)
         -> k * k1
         : imm tagged =
   let f = closure f_2_1 @f &my_alloc_region with { x = x } in
-  apply direct(use_0_1 &my_alloc_region)
+  apply direct(use_0_1 &my_alloc_region) [close close close close]
     ($camlSpeculative_inlining_set_of_closures__use_1 : _ -> imm tagged)
       (f)
       -> k * k1
@@ -69,7 +69,7 @@ let code loopify(never) size(35) newer_version_of(f_2_1)
   let int_add_2 = %int_barith.add (int_add_1, int_mul_2) in
   let int_add_3 = %int_barith.add (int_add_2, int_mul_1) in
   let int_add_4 = %int_barith.add (int_add_3, int_mul) in
-  cont k (int_add_4)
+  cont k close[normal] my_alloc_region (int_add_4)
 in
 let $camlSpeculative_inlining_set_of_closures__f_5 =
   closure f_2_2 @f &toplevel.alloc_region
@@ -81,6 +81,7 @@ let code loopify(never) size(4) newer_version_of(r1_3)
         -> k * k1
         : imm tagged =
   apply direct(use_0_1 &my_alloc_region) inlining_state(depth(10))
+         [close close close close]
     ($camlSpeculative_inlining_set_of_closures__use_1 : _ -> imm tagged)
       ($camlSpeculative_inlining_set_of_closures__f_5)
       -> k * k1
@@ -106,7 +107,7 @@ let code loopify(never) size(36) newer_version_of(f_2_1)
   let int_add_2 = %int_barith.add (int_add_1, int_mul_2) in
   let int_add_3 = %int_barith.add (int_add_2, int_mul_1) in
   let int_add_4 = %int_barith.add (int_add_3, int_mul) in
-  cont k (int_add_4)
+  cont k close[normal] my_alloc_region (int_add_4)
 in
 let code loopify(never) size(48) newer_version_of(r2_4)
       r2_4_1 (param : imm tagged)
@@ -116,6 +117,7 @@ let code loopify(never) size(48) newer_version_of(r2_4)
   let Popaque = %opaque (1) in
   let f = closure f_2_3 @f &my_alloc_region with { x = Popaque } in
   apply direct(use_0_1 &my_alloc_region) inlining_state(depth(10))
+         [close close close close]
     ($camlSpeculative_inlining_set_of_closures__use_1 : _ -> imm tagged)
       (f)
       -> k * k1
@@ -123,6 +125,7 @@ in
 let $camlSpeculative_inlining_set_of_closures__r2_6 =
   closure r2_4_1 @r2 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlSpeculative_inlining_set_of_closures =
   Block 0 ($camlSpeculative_inlining_set_of_closures__use_1,
            $camlSpeculative_inlining_set_of_closures__g_2,

--- a/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
+++ b/testsuite/tests/flambda2/switch_lookup_table_kinds.ml
@@ -42,12 +42,13 @@ let code loopify(never) size(2) newer_version_of(match_tagged_immediate_0)
         -> k * k1
         : imm tagged =
   let arg = %array_load ($camlTOP2__switch_block_3, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP2__match_tagged_immediate_2 =
   closure match_tagged_immediate_0_1 @match_tagged_immediate
     &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP2 = Block 0 ($camlTOP2__match_tagged_immediate_2) in
 cont done ($camlTOP2)
 |}]
@@ -75,12 +76,13 @@ let code loopify(never) size(2) newer_version_of(match_naked_immediate_1)
         -> k * k1
         : imm =
   let arg = %array_load.`int` ($camlTOP4__switch_block_8, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP4__match_naked_immediate_7 =
   closure match_naked_immediate_1_1 @match_naked_immediate
     &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP4 = Block 0 ($camlTOP4__match_naked_immediate_7) in
 cont done ($camlTOP4)
 |}]
@@ -111,11 +113,12 @@ let code loopify(never) size(2) newer_version_of(match_naked_float_2)
         -> k * k1
         : float =
   let arg = %array_load.`float` ($camlTOP5__switch_block_12, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP5__match_naked_float_11 =
   closure match_naked_float_2_1 @match_naked_float &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP5 = Block 0 ($camlTOP5__match_naked_float_11) in
 cont done ($camlTOP5)
 |}]
@@ -146,11 +149,12 @@ let code loopify(never) size(3) newer_version_of(match_naked_float32_3)
         -> k * k1
         : float32 =
   let arg = %array_load.`float32` ($camlTOP6__switch_block_16, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP6__match_naked_float32_15 =
   closure match_naked_float32_3_1 @match_naked_float32 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP6 = Block 0 ($camlTOP6__match_naked_float32_15) in
 cont done ($camlTOP6)
 |}]
@@ -176,11 +180,12 @@ let code loopify(never) size(3) newer_version_of(match_naked_int32_4)
         -> k * k1
         : int32 =
   let arg = %array_load.`int32` ($camlTOP7__switch_block_20, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP7__match_naked_int32_19 =
   closure match_naked_int32_4_1 @match_naked_int32 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP7 = Block 0 ($camlTOP7__match_naked_int32_19) in
 cont done ($camlTOP7)
 |}]
@@ -206,11 +211,12 @@ let code loopify(never) size(2) newer_version_of(match_naked_int64_5)
         -> k * k1
         : int64 =
   let arg = %array_load.`int64` ($camlTOP8__switch_block_24, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP8__match_naked_int64_23 =
   closure match_naked_int64_5_1 @match_naked_int64 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP8 = Block 0 ($camlTOP8__match_naked_int64_23) in
 cont done ($camlTOP8)
 |}]
@@ -236,12 +242,13 @@ let code loopify(never) size(2) newer_version_of(match_naked_nativeint_6)
         -> k * k1
         : nativeint =
   let arg = %array_load.`nativeint` ($camlTOP9__switch_block_28, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP9__match_naked_nativeint_27 =
   closure match_naked_nativeint_6_1 @match_naked_nativeint
     &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP9 = Block 0 ($camlTOP9__match_naked_nativeint_27) in
 cont done ($camlTOP9)
 |}]
@@ -268,11 +275,12 @@ let code loopify(never) size(3) newer_version_of(match_naked_int8_7)
         -> k * k1
         : int8 =
   let arg = %array_load.`int8` ($camlTOP10__switch_block_32, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP10__match_naked_int8_31 =
   closure match_naked_int8_7_1 @match_naked_int8 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP10 = Block 0 ($camlTOP10__match_naked_int8_31) in
 cont done ($camlTOP10)
 |}]
@@ -298,11 +306,12 @@ let code loopify(never) size(3) newer_version_of(match_naked_int16_8)
         -> k * k1
         : int16 =
   let arg = %array_load.`int16` ($camlTOP11__switch_block_36, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP11__match_naked_int16_35 =
   closure match_naked_int16_8_1 @match_naked_int16 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP11 = Block 0 ($camlTOP11__match_naked_int16_35) in
 cont done ($camlTOP11)
 |}]
@@ -337,11 +346,12 @@ let code loopify(never) size(2) newer_version_of(match_symbol_9)
         -> k * k1
         : val =
   let arg = %array_load ($camlTOP12__switch_block_43, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP12__match_symbol_42 =
   closure match_symbol_9_1 @match_symbol &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP12 = Block 0 ($camlTOP12__match_symbol_42) in
 cont done ($camlTOP12)
 |}]
@@ -381,12 +391,13 @@ let code loopify(never) size(2) newer_version_of(match_symbol_or_tagged_immediat
         -> k * k1
         : [ 0 |1 | 0 of imm tagged |1 of val ] =
   let arg = %array_load ($camlTOP14__switch_block_50, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP14__match_symbol_or_tagged_immediate_49 =
   closure match_symbol_or_tagged_immediate_10_1
     @match_symbol_or_tagged_immediate &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP14 = Block 0 ($camlTOP14__match_symbol_or_tagged_immediate_49) in
 cont done ($camlTOP14)
 |}]
@@ -423,12 +434,13 @@ let code loopify(never) size(2) newer_version_of(match_symbol_tagged_or_null_11)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
   let arg = %array_load ($camlTOP15__switch_block_56, t) in
-  cont k (arg)
+  cont k close[normal] my_alloc_region (arg)
 in
 let $camlTOP15__match_symbol_tagged_or_null_55 =
   closure match_symbol_tagged_or_null_11_1 @match_symbol_tagged_or_null
     &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlTOP15 = Block 0 ($camlTOP15__match_symbol_tagged_or_null_55) in
 cont done ($camlTOP15)
 |}]

--- a/testsuite/tests/flambda2/unboxable_local_returning.simplify.reference
+++ b/testsuite/tests/flambda2/unboxable_local_returning.simplify.reference
@@ -8,12 +8,13 @@ let code loopify(never) size(13) stub
      %project_function_slot.[ret_local].[ret_local_unboxed] (my_closure)
    in
    apply &my_alloc_region &my_region &my_ghost_region
+          [forward close close close]
      (ret_local_unboxed : imm tagged -> float) (param) -> k2 * k1)
     where k2 (unboxed_return : float) =
       let boxed_return =
         %box_num.`float`.my_alloc_region.local[my_region] (unboxed_return)
       in
-      cont k (boxed_return)
+      cont k close[normal] my_alloc_region (boxed_return)
 in
 let code ret_heap_3 deleted in
 let code loopify(never) size(13) stub
@@ -24,11 +25,11 @@ let code loopify(never) size(13) stub
   (let ret_heap_unboxed =
      %project_function_slot.[ret_heap].[ret_heap_unboxed] (my_closure)
    in
-   apply &my_alloc_region
+   apply &my_alloc_region [forward close close close]
      (ret_heap_unboxed : imm tagged -> float) (param) -> k2 * k1)
     where k2 (unboxed_return : float) =
       let boxed_return = %box_num.`float`.my_alloc_region (unboxed_return) in
-      cont k (boxed_return)
+      cont k close[normal] my_alloc_region (boxed_return)
 in
 let $camlUnboxable_local_returning__immstring_7 = "ok" in
 let code loopify(never) size(1) newer_version_of(ret_local_1)
@@ -37,7 +38,7 @@ let code loopify(never) size(1) newer_version_of(ret_local_1)
           my_depth
         -> unboxed_return * k
         : float stack =
-  cont unboxed_return (0x1p+0)
+  cont unboxed_return close[normal] my_alloc_region (0x1p+0)
 in
 let $camlUnboxable_local_returning__ret_local_8 =
   closure ret_local_1_1 @ret_local &toplevel.alloc_region
@@ -49,7 +50,7 @@ let code loopify(never) size(1) newer_version_of(ret_heap_3)
         my_unboxed_closure &my_alloc_region my_depth
         -> unboxed_return * k
         : float =
-  cont unboxed_return (0x1p+1)
+  cont unboxed_return close[normal] my_alloc_region (0x1p+1)
 in
 let $camlUnboxable_local_returning__ret_heap_10 =
   closure ret_heap_3_1 @ret_heap &toplevel.alloc_region
@@ -57,12 +58,14 @@ and $camlUnboxable_local_returning__ret_heap_unboxed_11 =
   closure ret_heap_3_2 @ret_heap_unboxed &toplevel.alloc_region
 in
 apply direct(print_endline_47 &toplevel.alloc_region) inlined(never)
+       [forward close close close]
   ($Stdlib.camlStdlib__print_endline_47_98 : _ -> imm tagged)
     ($camlUnboxable_local_returning__immstring_7)
     -> k1 * error
   where k1 (param : imm tagged) =
     cont k
   where k =
+    let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
     let $camlUnboxable_local_returning =
       Block 0 ($camlUnboxable_local_returning__ret_local_8,
                $camlUnboxable_local_returning__ret_heap_10)

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.raw.reference
@@ -7,15 +7,15 @@ let $camlArguments_for_unboxed_closure__first_const_0 = Block 0 () in
    let next_depth = rec_info (succ my_depth) in
    let x = %project_value_slot.[g].[x] (my_closure) in
    let y = %project_value_slot.[g].[y] (my_closure) in
-   apply &my_alloc_region h (y) -> k3 * k2
+   apply &my_alloc_region [forward close close close] h (y) -> k3 * k2
      where k3 (apply_result : imm tagged) =
        let int_add = %int_barith.add (x, apply_result) in
-       cont k1 (int_add)
+       cont k1 close[normal] my_alloc_region (int_add)
  in
  let code inline(never) size(1)
        id_2 (z) my_closure &my_alloc_region my_depth -> k1 * k2 =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (z)
+   cont k1 close[normal] my_alloc_region (z)
  in
  let code inline(never) size(1)
        unused_3 (param)
@@ -23,7 +23,7 @@ let $camlArguments_for_unboxed_closure__first_const_0 = Block 0 () in
          -> k1 * k2
          : imm tagged =
    let next_depth = rec_info (succ my_depth) in
-   cont k1 (0)
+   cont k1 close[normal] my_alloc_region (0)
  in
  let code inline(never) size(6)
        u_4 (param : imm tagged)
@@ -34,6 +34,7 @@ let $camlArguments_for_unboxed_closure__first_const_0 = Block 0 () in
    let g = %project_value_slot.[u].[g] (my_closure) in
    let `id` = %project_value_slot.[u].[`id`] (my_closure) in
    apply direct(g_1 &my_alloc_region) inlined(always)
+          [close close close close]
      (g : _ -> imm tagged) (`id`) -> k1 * k2
  in
  let code size(65)
@@ -52,9 +53,11 @@ let $camlArguments_for_unboxed_closure__first_const_0 = Block 0 () in
     let u = closure u_4 @u &my_alloc_region &`region`
     with { g = g; `id` = `id` }
     in
-    apply direct(u_4 &my_alloc_region) (u : _ -> imm tagged) (0) -> k4 * k2
+    apply direct(u_4 &my_alloc_region) [forward close close close]
+      (u : _ -> imm tagged) (0) -> k4 * k2
       where k4 (apply_result : imm tagged) =
         (apply direct(g_1 &my_alloc_region) inlined(never)
+                [forward close close close]
            (g : _ -> imm tagged) (unused) -> k4 * k2
            where k4 (apply_result_1 : imm tagged) =
              let int_add = %int_barith.add (apply_result_1, apply_result) in
@@ -62,11 +65,11 @@ let $camlArguments_for_unboxed_closure__first_const_0 = Block 0 () in
      where k3 (region_return : imm tagged) =
        let `unit` = %end_region (`region`) in
        let unit_1 = %end_ghost_region (ghost_region) in
-       cont k1 (region_return)
+       cont k1 close[normal] my_alloc_region (region_return)
  in
  let f = closure f_0 @f &toplevel.alloc_region in
  let Pmakeblock = %block.[`0`].`toplevel` (f) in
- cont k (Pmakeblock))
+ cont k close[normal] toplevel.alloc_region (Pmakeblock))
   where k define_root_symbol (module_block) =
     let field_0 = %block_load.tag[`0`].`size`[`1`].[`0`] (module_block) in
     let $camlArguments_for_unboxed_closure = Block 0 (field_0) in

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.reaper.reference
@@ -5,7 +5,7 @@ let code u_4 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(id_2)
       id_2_1 (z) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (z)
+  cont k close[normal] my_alloc_region (z)
 in
 let $camlArguments_for_unboxed_closure__id_2 =
   closure id_2_1 @`id` &toplevel.alloc_region
@@ -21,17 +21,18 @@ let code inline(never) loopify(never) size(7) newer_version_of(u_4)
   let x = g_into_g_field_x in
   let y = g_into_g_field_y in
   apply direct(id_2_1 &my_alloc_region) inlining_state(depth(1))
+         [forward close close close]
     $camlArguments_for_unboxed_closure__id_2 (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code inline(never) loopify(never) size(1) newer_version_of(unused_3)
       unused_3_1 (param)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlArguments_for_unboxed_closure__unused_3 =
   closure unused_3_1 @unused &toplevel.alloc_region
@@ -42,10 +43,11 @@ let code loopify(never) size(9) newer_version_of(g_1)
         -> k * k1
         : imm tagged =
   let x = g_into_my_closure_field_x in
-  apply &my_alloc_region h (poison.val.reaper_unused_argument) -> k2 * k1
+  apply &my_alloc_region [forward close close close]
+    h (poison.val.reaper_unused_argument) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code loopify(never) size(13) newer_version_of(f_0)
       f_0_1 (x : imm tagged, y : imm tagged)
@@ -57,21 +59,23 @@ let code loopify(never) size(13) newer_version_of(f_0)
   let g_into_g_field_y = y in
   let u_into_u_field_g_field_x = g_into_g_field_x in
   let u_into_u_field_g_field_y = g_into_g_field_y in
-  apply direct(u_4_1 &my_alloc_region)
+  apply direct(u_4_1 &my_alloc_region) [forward close close close]
      (u_into_u_field_g_field_y, u_into_u_field_g_field_x) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       (apply direct(g_1_1 &my_alloc_region) inlined(never)
+              [forward close close close]
          
            (g_into_g_field_x, $camlArguments_for_unboxed_closure__unused_3)
            -> k2 * k1
          where k2 (apply_result_1 : imm tagged) =
            let int_add = %int_barith.add (apply_result_1, apply_result) in
            let `unit` = %end_region (`region`) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let $camlArguments_for_unboxed_closure__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlArguments_for_unboxed_closure =
   Block 0 ($camlArguments_for_unboxed_closure__f_1)
 in

--- a/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
+++ b/testsuite/tests/reaper/arguments_for_unboxed_closure.simplify.reference
@@ -5,7 +5,7 @@ let code u_4 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(id_2)
       id_2_1 (z) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (z)
+  cont k close[normal] my_alloc_region (z)
 in
 let $camlArguments_for_unboxed_closure__id_2 =
   closure id_2_1 @`id` &toplevel.alloc_region
@@ -19,19 +19,20 @@ let code inline(never) loopify(never) size(10) newer_version_of(u_4)
   let x = %project_value_slot.[g].[x] (g) in
   let y = %project_value_slot.[g].[y] (g) in
   apply direct(id_2_1 &my_alloc_region) inlining_state(depth(1))
+         [forward close close close]
     ($camlArguments_for_unboxed_closure__id_2 : _ -> imm tagged)
       (y)
       -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code inline(never) loopify(never) size(1) newer_version_of(unused_3)
       unused_3_1 (param)
         my_closure &my_alloc_region my_depth
         -> k * k1
         : imm tagged =
-  cont k (0)
+  cont k close[normal] my_alloc_region (0)
 in
 let $camlArguments_for_unboxed_closure__unused_3 =
   closure unused_3_1 @unused &toplevel.alloc_region
@@ -43,10 +44,10 @@ let code loopify(never) size(11) newer_version_of(g_1)
         : imm tagged =
   let x = %project_value_slot.[g].[x] (my_closure) in
   let y = %project_value_slot.[g].[y] (my_closure) in
-  apply &my_alloc_region h (y) -> k2 * k1
+  apply &my_alloc_region [forward close close close] h (y) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (x, apply_result) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let code loopify(never) size(52) newer_version_of(f_0)
       f_0_1 (x : imm tagged, y : imm tagged)
@@ -60,20 +61,23 @@ let code loopify(never) size(52) newer_version_of(f_0)
   let u = closure u_4_1 @u &my_alloc_region &`region`
   with { g = g; `id` = $camlArguments_for_unboxed_closure__id_2 }
   in
-  apply direct(u_4_1 &my_alloc_region) (u : _ -> imm tagged) (0) -> k2 * k1
+  apply direct(u_4_1 &my_alloc_region) [forward close close close]
+    (u : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       (apply direct(g_1_1 &my_alloc_region) inlined(never)
+              [forward close close close]
          (g : _ -> imm tagged)
            ($camlArguments_for_unboxed_closure__unused_3)
            -> k2 * k1
          where k2 (apply_result_1 : imm tagged) =
            let int_add = %int_barith.add (apply_result_1, apply_result) in
            let `unit` = %end_region (`region`) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let $camlArguments_for_unboxed_closure__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlArguments_for_unboxed_closure =
   Block 0 ($camlArguments_for_unboxed_closure__f_1)
 in

--- a/testsuite/tests/reaper/boxed_number_escape.reaper.local-fields.reference
+++ b/testsuite/tests/reaper/boxed_number_escape.reaper.local-fields.reference
@@ -18,9 +18,10 @@ and code loopify(never) size(14) newer_version_of(escape_0)
   let Psetfield = %block_set.[`0`] (r_1, b) in
   let prim_2 = %num_conv.[`int64`].[`imm`] (prim_1) in
   let int_of_int64 = %tag_imm (prim_2) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
   with { unboxed_field_r = r }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlBoxed_number_escape =
   Block 0 (r, $camlBoxed_number_escape__escape_1)
 in

--- a/testsuite/tests/reaper/boxed_number_escape.reaper.reference
+++ b/testsuite/tests/reaper/boxed_number_escape.reaper.reference
@@ -17,9 +17,10 @@ and code loopify(never) size(14) newer_version_of(escape_0)
   let Psetfield = %block_set.[`0`] (r_1, b) in
   let prim_2 = %num_conv.[`int64`].[`imm`] (prim_1) in
   let int_of_int64 = %tag_imm (prim_2) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
   with { r = r }
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlBoxed_number_escape =
   Block 0 (r, $camlBoxed_number_escape__escape_1)
 in

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.reaper.reference
@@ -2,7 +2,7 @@ let code merge_usages_1 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(merge_usages_1)
       merge_usages_1_1 (u) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (u)
+  cont k close[normal] my_alloc_region (u)
 in
 let $camlBoxed_number_subkind_erasure__merge_usages_2 =
   closure merge_usages_1_1 @merge_usages &toplevel.alloc_region
@@ -30,6 +30,7 @@ let code loopify(never) size(50) newer_version_of(f_0)
       cont k2 (int32_mul, int64_mul)
     where k2 (a : val, b_1 : int64 boxed) =
       (apply direct(merge_usages_1_1 &my_alloc_region)
+              [forward close close close]
          $camlBoxed_number_subkind_erasure__merge_usages_2 (a) -> k4 * k1
          where k4 (function_return_0_merge_usages_1) =
            cont k3
@@ -37,6 +38,7 @@ let code loopify(never) size(50) newer_version_of(f_0)
            cont k2
          where k2 =
            (apply direct(merge_usages_1_1 &my_alloc_region)
+                   [forward close close close]
               $camlBoxed_number_subkind_erasure__merge_usages_2
                 (b_1)
                 -> k2 * k1
@@ -44,11 +46,12 @@ let code loopify(never) size(50) newer_version_of(f_0)
                 let prim = %unbox_num.`int64` (b_2) in
                 let prim_1 = %int_barith.`int64`.add (prim, prim) in
                 let int64_add = %box_num.`int64`.my_alloc_region (prim_1) in
-                cont k (int64_add)))
+                cont k close[normal] my_alloc_region (int64_add)))
 in
 let $camlBoxed_number_subkind_erasure__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlBoxed_number_subkind_erasure =
   Block 0 ($camlBoxed_number_subkind_erasure__f_1)
 in

--- a/testsuite/tests/reaper/boxed_number_subkind_erasure.simplify.reference
+++ b/testsuite/tests/reaper/boxed_number_subkind_erasure.simplify.reference
@@ -2,7 +2,7 @@ let code merge_usages_1 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(merge_usages_1)
       merge_usages_1_1 (u) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (u)
+  cont k close[normal] my_alloc_region (u)
 in
 let $camlBoxed_number_subkind_erasure__merge_usages_2 =
   closure merge_usages_1_1 @merge_usages &toplevel.alloc_region
@@ -34,6 +34,7 @@ let code loopify(never) size(65) newer_version_of(f_0)
       cont k2 (int32_mul, int64_mul)
     where k2 (a : int32 boxed, b_1 : int64 boxed) =
       (apply direct(merge_usages_1_1 &my_alloc_region)
+              [forward close close close]
          ($camlBoxed_number_subkind_erasure__merge_usages_2
           : _ -> int32 boxed)
            (a)
@@ -42,6 +43,7 @@ let code loopify(never) size(65) newer_version_of(f_0)
            cont k2
          where k2 =
            (apply direct(merge_usages_1_1 &my_alloc_region)
+                   [forward close close close]
               ($camlBoxed_number_subkind_erasure__merge_usages_2
                : _ -> int64 boxed)
                 (b_1)
@@ -50,11 +52,12 @@ let code loopify(never) size(65) newer_version_of(f_0)
                 let prim = %unbox_num.`int64` (b_2) in
                 let prim_1 = %int_barith.`int64`.add (prim, prim) in
                 let int64_add = %box_num.`int64`.my_alloc_region (prim_1) in
-                cont k (int64_add)))
+                cont k close[normal] my_alloc_region (int64_add)))
 in
 let $camlBoxed_number_subkind_erasure__f_1 =
   closure f_0_1 @f &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlBoxed_number_subkind_erasure =
   Block 0 ($camlBoxed_number_subkind_erasure__f_1)
 in

--- a/testsuite/tests/reaper/code_size.reaper.reference
+++ b/testsuite/tests/reaper/code_size.reaper.reference
@@ -5,24 +5,25 @@ let code inline(never) loopify(never) size(1) newer_version_of(h_2)
       h_2_1 (Pmakeblock_into_u_field_0)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  cont k (Pmakeblock_into_u_field_0)
+  cont k close[normal] my_alloc_region (Pmakeblock_into_u_field_0)
 in
 let $camlCode_size__h_2 = closure h_2_1 @h &toplevel.alloc_region in
 let code loopify(never) size(6) newer_version_of(g_1)
       g_1_1 (y) my_closure &my_alloc_region my_depth -> k * k1 =
   let x = %project_value_slot.[g].[unboxed_field_x] (my_closure) in
   (let Pmakeblock_into_Pmakeblock_field_0 = x in
-   apply direct(h_2_1 &my_alloc_region)
+   apply direct(h_2_1 &my_alloc_region) [forward close close close]
      $camlCode_size__h_2 (Pmakeblock_into_Pmakeblock_field_0) -> k2 * k1)
     where k2 (`Pmakeblock_into_*match*_field_0`) =
       let Pfield = `Pmakeblock_into_*match*_field_0` in
-      cont k (Pfield)
+      cont k close[normal] my_alloc_region (Pfield)
 in
 let code loopify(never) size(15) newer_version_of(f_0)
       f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : val =
   let g = closure g_1_1 @g &my_alloc_region with { unboxed_field_x = x } in
-  cont k (g)
+  cont k close[normal] my_alloc_region (g)
 in
 let $camlCode_size__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCode_size = Block 0 ($camlCode_size__f_1) in
 cont done ($camlCode_size)

--- a/testsuite/tests/reaper/code_size.simplify.reference
+++ b/testsuite/tests/reaper/code_size.simplify.reference
@@ -3,24 +3,25 @@ let code g_1 deleted in
 let code f_0 deleted in
 let code inline(never) loopify(never) size(1) newer_version_of(h_2)
       h_2_1 (u) my_closure &my_alloc_region my_depth -> k * k1 =
-  cont k (u)
+  cont k close[normal] my_alloc_region (u)
 in
 let $camlCode_size__h_2 = closure h_2_1 @h &toplevel.alloc_region in
 let code loopify(never) size(14) newer_version_of(g_1)
       g_1_1 (y) my_closure &my_alloc_region my_depth -> k * k1 =
   let x = %project_value_slot.[g].[x] (my_closure) in
   (let Pmakeblock = %block.[`0`].my_alloc_region (x, y) in
-   apply direct(h_2_1 &my_alloc_region)
+   apply direct(h_2_1 &my_alloc_region) [forward close close close]
      ($camlCode_size__h_2 : _ -> [ 0 of val * val ]) (Pmakeblock) -> k2 * k1)
     where k2 (`*match*` : [ 0 of val * val ]) =
       let Pfield = %block_load.[`0`] (`*match*`) in
-      cont k (Pfield)
+      cont k close[normal] my_alloc_region (Pfield)
 in
 let code loopify(never) size(23) newer_version_of(f_0)
       f_0_1 (x) my_closure &my_alloc_region my_depth -> k * k1 : val =
   let g = closure g_1_1 @g &my_alloc_region with { x = x } in
-  cont k (g)
+  cont k close[normal] my_alloc_region (g)
 in
 let $camlCode_size__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlCode_size = Block 0 ($camlCode_size__f_1) in
 cont done ($camlCode_size)

--- a/testsuite/tests/reaper/large_no_unbox.reaper.reference
+++ b/testsuite/tests/reaper/large_no_unbox.reaper.reference
@@ -14,7 +14,7 @@ let code inline(never) loopify(never) size(11) newer_version_of(large_2)
   let int_add = %int_barith.add (Pfield_3, Pfield_2) in
   let int_add_1 = %int_barith.add (int_add, Pfield_1) in
   let int_add_2 = %int_barith.add (int_add_1, Pfield) in
-  cont k (int_add_2)
+  cont k close[normal] my_alloc_region (int_add_2)
 in
 let $camlLarge_no_unbox__large_3 =
   closure large_2_1 @large &toplevel.alloc_region
@@ -32,7 +32,7 @@ let code inline(never) loopify(never) size(5) newer_version_of(small_1)
   let Pfield_2 = Pmakeblock_into_param_field_0 in
   let int_add = %int_barith.add (Pfield_2, Pfield_1) in
   let int_add_1 = %int_barith.add (int_add, Pfield) in
-  cont k (int_add_1)
+  cont k close[normal] my_alloc_region (int_add_1)
 in
 let $camlLarge_no_unbox__small_2 =
   closure small_1_1 @small &toplevel.alloc_region
@@ -51,7 +51,7 @@ let code loopify(never) size(36) newer_version_of(f_0)
      %block.[`0`].my_alloc_region.local[`region`]
        (int_add_3, int_add_2, int_add_1, int_add)
    in
-   apply direct(large_2_1 &my_alloc_region)
+   apply direct(large_2_1 &my_alloc_region) [forward close close close]
      ($camlLarge_no_unbox__large_3 : _ -> imm tagged) (Pmakeblock) -> k2 * k1)
     where k2 (apply_result : imm tagged) =
       ((let int_add = %int_barith.add (x, 3) in
@@ -60,7 +60,7 @@ let code loopify(never) size(36) newer_version_of(f_0)
         let Pmakeblock_into_Pmakeblock_field_2 = int_add in
         let Pmakeblock_into_Pmakeblock_field_1 = int_add_1 in
         let Pmakeblock_into_Pmakeblock_field_0 = int_add_2 in
-        apply direct(small_1_1 &my_alloc_region)
+        apply direct(small_1_1 &my_alloc_region) [forward close close close]
           ($camlLarge_no_unbox__small_2 : _ -> imm tagged)
             (Pmakeblock_into_Pmakeblock_field_0,
              Pmakeblock_into_Pmakeblock_field_1,
@@ -69,8 +69,9 @@ let code loopify(never) size(36) newer_version_of(f_0)
          where k2 (apply_result_1 : imm tagged) =
            let int_add = %int_barith.add (apply_result_1, apply_result) in
            let `unit` = %end_region (`region`) in
-           cont k (int_add))
+           cont k close[normal] my_alloc_region (int_add))
 in
 let $camlLarge_no_unbox__f_1 = closure f_0_1 @f &toplevel.alloc_region in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlLarge_no_unbox = Block 0 ($camlLarge_no_unbox__f_1) in
 cont done ($camlLarge_no_unbox)

--- a/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
+++ b/testsuite/tests/reaper/result_types_of_identity.simplify.no-result-types.reference
@@ -15,6 +15,7 @@ let code loopify(never) size(16) newer_version_of(always_0_0)
         -> k * k1
         : imm tagged =
   apply direct(hidden_identity_0 &my_alloc_region) inlined(never)
+         [forward close close close]
     ($Hidden_identity.camlHidden_identity__hidden_identity_1
      : _ -> imm tagged)
       (0)
@@ -23,12 +24,16 @@ let code loopify(never) size(16) newer_version_of(always_0_0)
       let prim = %phys_eq (apply_result, 0) in
       switch prim
         | 0 ->
-          k1 pop(regular k1) ($camlResult_types_of_identity__Pmakeblock_2)
-        | 1 -> k (0)
+          k1
+            pop(regular k1)
+            close[exn] my_alloc_region
+            ($camlResult_types_of_identity__Pmakeblock_2)
+        | 1 -> k close[normal] my_alloc_region (0)
 in
 let $camlResult_types_of_identity__always_0_3 =
   closure always_0_0_1 @always_0 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlResult_types_of_identity =
   Block 0 ($camlResult_types_of_identity__always_0_3)
 in

--- a/testsuite/tests/reaper/result_types_of_identity.simplify.reference
+++ b/testsuite/tests/reaper/result_types_of_identity.simplify.reference
@@ -5,16 +5,18 @@ let code loopify(never) size(5) newer_version_of(always_0_0)
         -> k * k1
         : imm tagged =
   apply direct(hidden_identity_0 &my_alloc_region) inlined(never)
+         [forward close close close]
     ($Hidden_identity.camlHidden_identity__hidden_identity_1
      : _ -> imm tagged)
       (0)
       -> k2 * k1
     where k2 (param_1) =
-      cont k (0)
+      cont k close[normal] my_alloc_region (0)
 in
 let $camlResult_types_of_identity__always_0_3 =
   closure always_0_0_1 @always_0 &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlResult_types_of_identity =
   Block 0 ($camlResult_types_of_identity__always_0_3)
 in

--- a/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.reaper.reference
@@ -26,7 +26,9 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int64_0)
   let prim_1 = int64_of_int_into_x_field_unboxed_int64 in
   let prim_2 = %int_barith.`int64`.add (prim_1, prim) in
   let int64_add_into_int64_add_field_unboxed_int64 = prim_2 in
-  cont k (int64_add_into_int64_add_field_unboxed_int64)
+  cont k
+         close[normal] my_alloc_region
+         (int64_add_into_int64_add_field_unboxed_int64)
 in
 let $camlUnbox_boxed_numbers__add_int64_1 =
   closure add_int64_0_1 @add_int64 &toplevel.alloc_region
@@ -42,7 +44,9 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_int32_1)
   let prim_1 = int32_of_int_into_x_field_unboxed_int32 in
   let prim_2 = %int_barith.`int32`.add (prim_1, prim) in
   let int32_add_into_int32_add_field_unboxed_int32 = prim_2 in
-  cont k (int32_add_into_int32_add_field_unboxed_int32)
+  cont k
+         close[normal] my_alloc_region
+         (int32_add_into_int32_add_field_unboxed_int32)
 in
 let $camlUnbox_boxed_numbers__add_int32_2 =
   closure add_int32_1_1 @add_int32 &toplevel.alloc_region
@@ -58,7 +62,9 @@ let code inline(never) loopify(never) size(2) newer_version_of(add_nativeint_2)
   let prim_1 = nativeint_of_int_into_x_field_unboxed_nativeint in
   let prim_2 = %int_barith.`nativeint`.add (prim_1, prim) in
   let nativeint_add_into_nativeint_add_field_unboxed_nativeint = prim_2 in
-  cont k (nativeint_add_into_nativeint_add_field_unboxed_nativeint)
+  cont k
+         close[normal] my_alloc_region
+         (nativeint_add_into_nativeint_add_field_unboxed_nativeint)
 in
 let $camlUnbox_boxed_numbers__add_nativeint_3 =
   closure add_nativeint_2_1 @add_nativeint &toplevel.alloc_region
@@ -74,7 +80,7 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
    let int64_of_int_into_int64_of_int_field_unboxed_int64_1 = prim_3 in
-   apply direct(add_int64_0_1 &my_alloc_region)
+   apply direct(add_int64_0_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_int64_1 : _ -> int64)
        (int64_of_int_into_int64_of_int_field_unboxed_int64_1,
         int64_of_int_into_int64_of_int_field_unboxed_int64)
@@ -83,7 +89,7 @@ let code loopify(never) size(9) newer_version_of(test_int64_3)
       let prim = int64_add_into_apply_result_field_unboxed_int64 in
       let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
       let int_of_int64 = %tag_imm (prim_1) in
-      cont k (int_of_int64)
+      cont k close[normal] my_alloc_region (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__test_int64_4 =
   closure test_int64_3_1 @test_int64 &toplevel.alloc_region
@@ -99,7 +105,7 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
    let int32_of_int_into_int32_of_int_field_unboxed_int32_1 = prim_3 in
-   apply direct(add_int32_1_1 &my_alloc_region)
+   apply direct(add_int32_1_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_int32_2 : _ -> int32)
        (int32_of_int_into_int32_of_int_field_unboxed_int32_1,
         int32_of_int_into_int32_of_int_field_unboxed_int32)
@@ -108,7 +114,7 @@ let code loopify(never) size(11) newer_version_of(test_int32_4)
       let prim = int32_add_into_apply_result_field_unboxed_int32 in
       let prim_1 = %num_conv.[`int32`].[`imm`] (prim) in
       let int_of_int32 = %tag_imm (prim_1) in
-      cont k (int_of_int32)
+      cont k close[normal] my_alloc_region (int_of_int32)
 in
 let $camlUnbox_boxed_numbers__test_int32_5 =
   closure test_int32_4_1 @test_int32 &toplevel.alloc_region
@@ -129,6 +135,7 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
      prim_3
    in
    apply direct(add_nativeint_2_1 &my_alloc_region)
+          [forward close close close]
      ($camlUnbox_boxed_numbers__add_nativeint_3 : _ -> nativeint)
        (nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint_1,
         nativeint_of_int_into_nativeint_of_int_field_unboxed_nativeint)
@@ -139,7 +146,7 @@ let code loopify(never) size(10) newer_version_of(test_nativeint_5)
       let prim = nativeint_add_into_apply_result_field_unboxed_nativeint in
       let prim_1 = %num_conv.[`nativeint`].[`imm`] (prim) in
       let int_of_nativeint = %tag_imm (prim_1) in
-      cont k (int_of_nativeint)
+      cont k close[normal] my_alloc_region (int_of_nativeint)
 in
 let $camlUnbox_boxed_numbers__test_nativeint_6 =
   closure test_nativeint_5_1 @test_nativeint &toplevel.alloc_region
@@ -155,7 +162,9 @@ let code inline(never) loopify(never) size(3) newer_version_of(add_float_6)
   let prim_1 = float_of_int_into_x_field_unboxed_float in
   let prim_2 = %bfloat_arith.add (prim_1, prim) in
   let float_add_into_float_add_field_unboxed_float = prim_2 in
-  cont k (float_add_into_float_add_field_unboxed_float)
+  cont k
+         close[normal] my_alloc_region
+         (float_add_into_float_add_field_unboxed_float)
 in
 let $camlUnbox_boxed_numbers__add_float_7 =
   closure add_float_6_1 @add_float &toplevel.alloc_region
@@ -171,7 +180,9 @@ let code inline(never) loopify(never) size(3) newer_version_of(add_float32_7)
   let prim_1 = float32_of_int_into_x_field_unboxed_float32 in
   let prim_2 = %bfloat_arith.`float32`.add (prim_1, prim) in
   let float32_add_into_float32_add_field_unboxed_float32 = prim_2 in
-  cont k (float32_add_into_float32_add_field_unboxed_float32)
+  cont k
+         close[normal] my_alloc_region
+         (float32_add_into_float32_add_field_unboxed_float32)
 in
 let $camlUnbox_boxed_numbers__add_float32_8 =
   closure add_float32_7_1 @add_float32 &toplevel.alloc_region
@@ -187,7 +198,7 @@ let code loopify(never) size(12) newer_version_of(test_float_8)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float`] (prim_2) in
    let float_of_int_into_float_of_int_field_unboxed_float_1 = prim_3 in
-   apply direct(add_float_6_1 &my_alloc_region)
+   apply direct(add_float_6_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_float_7 : _ -> float)
        (float_of_int_into_float_of_int_field_unboxed_float_1,
         float_of_int_into_float_of_int_field_unboxed_float)
@@ -196,7 +207,7 @@ let code loopify(never) size(12) newer_version_of(test_float_8)
       let prim = float_add_into_apply_result_field_unboxed_float in
       let prim_1 = %num_conv.[`float`].[`imm`] (prim) in
       let int_of_float = %tag_imm (prim_1) in
-      cont k (int_of_float)
+      cont k close[normal] my_alloc_region (int_of_float)
 in
 let $camlUnbox_boxed_numbers__test_float_9 =
   closure test_float_8_1 @test_float &toplevel.alloc_region
@@ -212,7 +223,7 @@ let code loopify(never) size(12) newer_version_of(test_float32_9)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float32`] (prim_2) in
    let float32_of_int_into_float32_of_int_field_unboxed_float32_1 = prim_3 in
-   apply direct(add_float32_7_1 &my_alloc_region)
+   apply direct(add_float32_7_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_float32_8 : _ -> float32)
        (float32_of_int_into_float32_of_int_field_unboxed_float32_1,
         float32_of_int_into_float32_of_int_field_unboxed_float32)
@@ -221,7 +232,7 @@ let code loopify(never) size(12) newer_version_of(test_float32_9)
       let prim = float32_add_into_apply_result_field_unboxed_float32 in
       let prim_1 = %num_conv.[`float32`].[`imm`] (prim) in
       let int_of_float32 = %tag_imm (prim_1) in
-      cont k (int_of_float32)
+      cont k close[normal] my_alloc_region (int_of_float32)
 in
 let $camlUnbox_boxed_numbers__test_float32_10 =
   closure test_float32_9_1 @test_float32 &toplevel.alloc_region
@@ -237,7 +248,7 @@ let code inline(never) loopify(never) size(3) newer_version_of(read_11)
   let prim = b_into_b_field_unboxed_int64 in
   let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
   let int_of_int64 = %tag_imm (prim_1) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
 in
 let code loopify(never) size(10) newer_version_of(test_value_slot_10)
       test_value_slot_10_1 (n : imm tagged)
@@ -251,12 +262,12 @@ let code loopify(never) size(10) newer_version_of(test_value_slot_10)
   let read_into_read_field_b_field_unboxed_int64 =
     b_into_b_field_unboxed_int64
   in
-  apply direct(read_11_1 &my_alloc_region)
+  apply direct(read_11_1 &my_alloc_region) [forward close close close]
      (read_into_read_field_b_field_unboxed_int64) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let $camlUnbox_boxed_numbers__test_value_slot_11 =
   closure test_value_slot_10_1 @test_value_slot &toplevel.alloc_region
@@ -265,7 +276,7 @@ let code inline(never) loopify(never) size(6) newer_version_of(indirect_14)
       indirect_14_1 (read : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply &my_alloc_region read (0) -> k * k1
+  apply &my_alloc_region [close close close close] read (0) -> k * k1
 in
 let $camlUnbox_boxed_numbers__indirect_13 =
   closure indirect_14_1 @indirect &toplevel.alloc_region
@@ -282,7 +293,7 @@ let code inline(never) loopify(never) size(4) newer_version_of(read_13)
   let prim = b_into_b_field_unboxed_int64 in
   let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
   let int_of_int64 = %tag_imm (prim_1) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
 in
 let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_12)
       test_value_slot_not_unboxed_12_1 (n : imm tagged)
@@ -300,12 +311,12 @@ let code loopify(never) size(22) newer_version_of(test_value_slot_not_unboxed_12
       b_into_b_field_unboxed_int64
   }
   in
-  apply direct(indirect_14_1 &my_alloc_region)
+  apply direct(indirect_14_1 &my_alloc_region) [forward close close close]
     $camlUnbox_boxed_numbers__indirect_13 (read) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_12 =
   closure test_value_slot_not_unboxed_12_1 @test_value_slot_not_unboxed
@@ -322,7 +333,7 @@ let code inline(never) loopify(never) size(3) newer_version_of(pair_first_15)
   let prim = int64_of_int_into_Pfield_field_unboxed_int64 in
   let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
   let int_of_int64 = %tag_imm (prim_1) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__pair_first_14 =
   closure pair_first_15_1 @pair_first &toplevel.alloc_region
@@ -338,7 +349,7 @@ let code loopify(never) size(5) newer_version_of(test_pair_16)
   let Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64 =
     int64_of_int_into_int64_of_int_field_unboxed_int64
   in
-  apply direct(pair_first_15_1 &my_alloc_region)
+  apply direct(pair_first_15_1 &my_alloc_region) [close close close close]
     ($camlUnbox_boxed_numbers__pair_first_14 : _ -> imm tagged)
       (Pmakeblock_into_Pmakeblock_field_0_field_unboxed_int64)
       -> k * k1
@@ -346,6 +357,7 @@ in
 let $camlUnbox_boxed_numbers__test_pair_15 =
   closure test_pair_16_1 @test_pair &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlUnbox_boxed_numbers =
   Block 0 ($camlUnbox_boxed_numbers__test_int64_4,
            $camlUnbox_boxed_numbers__test_int32_5,

--- a/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
+++ b/testsuite/tests/reaper/unbox_boxed_numbers.simplify.reference
@@ -24,7 +24,7 @@ let code inline(never) loopify(never) size(11) newer_version_of(add_int64_0)
   let prim_1 = %unbox_num.`int64` (x) in
   let prim_2 = %int_barith.`int64`.add (prim_1, prim) in
   let int64_add = %box_num.`int64`.my_alloc_region (prim_2) in
-  cont k (int64_add)
+  cont k close[normal] my_alloc_region (int64_add)
 in
 let $camlUnbox_boxed_numbers__add_int64_1 =
   closure add_int64_0_1 @add_int64 &toplevel.alloc_region
@@ -38,7 +38,7 @@ let code inline(never) loopify(never) size(12) newer_version_of(add_int32_1)
   let prim_1 = %unbox_num.`int32` (x) in
   let prim_2 = %int_barith.`int32`.add (prim_1, prim) in
   let int32_add = %box_num.`int32`.my_alloc_region (prim_2) in
-  cont k (int32_add)
+  cont k close[normal] my_alloc_region (int32_add)
 in
 let $camlUnbox_boxed_numbers__add_int32_2 =
   closure add_int32_1_1 @add_int32 &toplevel.alloc_region
@@ -52,7 +52,7 @@ let code inline(never) loopify(never) size(11) newer_version_of(add_nativeint_2)
   let prim_1 = %unbox_num.`nativeint` (x) in
   let prim_2 = %int_barith.`nativeint`.add (prim_1, prim) in
   let nativeint_add = %box_num.`nativeint`.my_alloc_region (prim_2) in
-  cont k (nativeint_add)
+  cont k close[normal] my_alloc_region (nativeint_add)
 in
 let $camlUnbox_boxed_numbers__add_nativeint_3 =
   closure add_nativeint_2_1 @add_nativeint &toplevel.alloc_region
@@ -68,7 +68,7 @@ let code loopify(never) size(21) newer_version_of(test_int64_3)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int64`] (prim_2) in
    let int64_of_int_1 = %box_num.`int64`.my_alloc_region (prim_3) in
-   apply direct(add_int64_0_1 &my_alloc_region)
+   apply direct(add_int64_0_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_int64_1 : _ -> int64 boxed)
        (int64_of_int_1, int64_of_int)
        -> k2 * k1)
@@ -76,7 +76,7 @@ let code loopify(never) size(21) newer_version_of(test_int64_3)
       let prim = %unbox_num.`int64` (apply_result) in
       let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
       let int_of_int64 = %tag_imm (prim_1) in
-      cont k (int_of_int64)
+      cont k close[normal] my_alloc_region (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__test_int64_4 =
   closure test_int64_3_1 @test_int64 &toplevel.alloc_region
@@ -92,7 +92,7 @@ let code loopify(never) size(25) newer_version_of(test_int32_4)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`int32`] (prim_2) in
    let int32_of_int_1 = %box_num.`int32`.my_alloc_region (prim_3) in
-   apply direct(add_int32_1_1 &my_alloc_region)
+   apply direct(add_int32_1_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_int32_2 : _ -> int32 boxed)
        (int32_of_int_1, int32_of_int)
        -> k2 * k1)
@@ -100,7 +100,7 @@ let code loopify(never) size(25) newer_version_of(test_int32_4)
       let prim = %unbox_num.`int32` (apply_result) in
       let prim_1 = %num_conv.[`int32`].[`imm`] (prim) in
       let int_of_int32 = %tag_imm (prim_1) in
-      cont k (int_of_int32)
+      cont k close[normal] my_alloc_region (int_of_int32)
 in
 let $camlUnbox_boxed_numbers__test_int32_5 =
   closure test_int32_4_1 @test_int32 &toplevel.alloc_region
@@ -117,6 +117,7 @@ let code loopify(never) size(22) newer_version_of(test_nativeint_5)
    let prim_3 = %num_conv.[`imm`].[`nativeint`] (prim_2) in
    let nativeint_of_int_1 = %box_num.`nativeint`.my_alloc_region (prim_3) in
    apply direct(add_nativeint_2_1 &my_alloc_region)
+          [forward close close close]
      ($camlUnbox_boxed_numbers__add_nativeint_3 : _ -> nativeint boxed)
        (nativeint_of_int_1, nativeint_of_int)
        -> k2 * k1)
@@ -124,7 +125,7 @@ let code loopify(never) size(22) newer_version_of(test_nativeint_5)
       let prim = %unbox_num.`nativeint` (apply_result) in
       let prim_1 = %num_conv.[`nativeint`].[`imm`] (prim) in
       let int_of_nativeint = %tag_imm (prim_1) in
-      cont k (int_of_nativeint)
+      cont k close[normal] my_alloc_region (int_of_nativeint)
 in
 let $camlUnbox_boxed_numbers__test_nativeint_6 =
   closure test_nativeint_5_1 @test_nativeint &toplevel.alloc_region
@@ -138,7 +139,7 @@ let code inline(never) loopify(never) size(10) newer_version_of(add_float_6)
   let prim_1 = %unbox_num.`float` (x) in
   let prim_2 = %bfloat_arith.add (prim_1, prim) in
   let float_add = %box_num.`float`.my_alloc_region (prim_2) in
-  cont k (float_add)
+  cont k close[normal] my_alloc_region (float_add)
 in
 let $camlUnbox_boxed_numbers__add_float_7 =
   closure add_float_6_1 @add_float &toplevel.alloc_region
@@ -152,7 +153,7 @@ let code inline(never) loopify(never) size(10) newer_version_of(add_float32_7)
   let prim_1 = %unbox_num.fnt32 (x) in
   let prim_2 = %bfloat_arith.`float32`.add (prim_1, prim) in
   let float32_add = %box_num.fnt32.my_alloc_region (prim_2) in
-  cont k (float32_add)
+  cont k close[normal] my_alloc_region (float32_add)
 in
 let $camlUnbox_boxed_numbers__add_float32_8 =
   closure add_float32_7_1 @add_float32 &toplevel.alloc_region
@@ -168,7 +169,7 @@ let code loopify(never) size(23) newer_version_of(test_float_8)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float`] (prim_2) in
    let float_of_int_1 = %box_num.`float`.my_alloc_region (prim_3) in
-   apply direct(add_float_6_1 &my_alloc_region)
+   apply direct(add_float_6_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_float_7 : _ -> float boxed)
        (float_of_int_1, float_of_int)
        -> k2 * k1)
@@ -176,7 +177,7 @@ let code loopify(never) size(23) newer_version_of(test_float_8)
       let prim = %unbox_num.`float` (apply_result) in
       let prim_1 = %num_conv.[`float`].[`imm`] (prim) in
       let int_of_float = %tag_imm (prim_1) in
-      cont k (int_of_float)
+      cont k close[normal] my_alloc_region (int_of_float)
 in
 let $camlUnbox_boxed_numbers__test_float_9 =
   closure test_float_8_1 @test_float &toplevel.alloc_region
@@ -192,7 +193,7 @@ let code loopify(never) size(23) newer_version_of(test_float32_9)
    let prim_2 = %untag_imm (a) in
    let prim_3 = %num_conv.[`imm`].[`float32`] (prim_2) in
    let float32_of_int_1 = %box_num.fnt32.my_alloc_region (prim_3) in
-   apply direct(add_float32_7_1 &my_alloc_region)
+   apply direct(add_float32_7_1 &my_alloc_region) [forward close close close]
      ($camlUnbox_boxed_numbers__add_float32_8 : _ -> float32 boxed)
        (float32_of_int_1, float32_of_int)
        -> k2 * k1)
@@ -200,7 +201,7 @@ let code loopify(never) size(23) newer_version_of(test_float32_9)
       let prim = %unbox_num.fnt32 (apply_result) in
       let prim_1 = %num_conv.[`float32`].[`imm`] (prim) in
       let int_of_float32 = %tag_imm (prim_1) in
-      cont k (int_of_float32)
+      cont k close[normal] my_alloc_region (int_of_float32)
 in
 let $camlUnbox_boxed_numbers__test_float32_10 =
   closure test_float32_9_1 @test_float32 &toplevel.alloc_region
@@ -214,7 +215,7 @@ let code inline(never) loopify(never) size(6) newer_version_of(read_11)
   let prim = %unbox_num.`int64` (b) in
   let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
   let int_of_int64 = %tag_imm (prim_1) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
 in
 let code loopify(never) size(29) newer_version_of(test_value_slot_10)
       test_value_slot_10_1 (n : imm tagged)
@@ -228,12 +229,12 @@ let code loopify(never) size(29) newer_version_of(test_value_slot_10)
   let read = closure read_11_1 @read &my_alloc_region &`region`
   with { b = b }
   in
-  apply direct(read_11_1 &my_alloc_region)
+  apply direct(read_11_1 &my_alloc_region) [forward close close close]
     (read : _ -> imm tagged) (0) -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let $camlUnbox_boxed_numbers__test_value_slot_11 =
   closure test_value_slot_10_1 @test_value_slot &toplevel.alloc_region
@@ -242,7 +243,7 @@ let code inline(never) loopify(never) size(6) newer_version_of(indirect_14)
       indirect_14_1 (read : val)
         my_closure &my_alloc_region my_depth
         -> k * k1 =
-  apply &my_alloc_region read (0) -> k * k1
+  apply &my_alloc_region [close close close close] read (0) -> k * k1
 in
 let $camlUnbox_boxed_numbers__indirect_13 =
   closure indirect_14_1 @indirect &toplevel.alloc_region
@@ -256,7 +257,7 @@ let code inline(never) loopify(never) size(6) newer_version_of(read_13)
   let prim = %unbox_num.`int64` (b) in
   let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
   let int_of_int64 = %tag_imm (prim_1) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
 in
 let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_12)
       test_value_slot_not_unboxed_12_1 (n : imm tagged)
@@ -270,14 +271,14 @@ let code loopify(never) size(29) newer_version_of(test_value_slot_not_unboxed_12
   let read = closure read_13_1 @read_1 &my_alloc_region &`region`
   with { b_1 = b }
   in
-  apply direct(indirect_14_1 &my_alloc_region)
+  apply direct(indirect_14_1 &my_alloc_region) [forward close close close]
     ($camlUnbox_boxed_numbers__indirect_13 : _ -> imm tagged)
       (read)
       -> k2 * k1
     where k2 (apply_result : imm tagged) =
       let int_add = %int_barith.add (apply_result, 1) in
       let `unit` = %end_region (`region`) in
-      cont k (int_add)
+      cont k close[normal] my_alloc_region (int_add)
 in
 let $camlUnbox_boxed_numbers__test_value_slot_not_unboxed_12 =
   closure test_value_slot_not_unboxed_12_1 @test_value_slot_not_unboxed
@@ -292,7 +293,7 @@ let code inline(never) loopify(never) size(6) newer_version_of(pair_first_15)
   let prim = %unbox_num.`int64` (Pfield) in
   let prim_1 = %num_conv.[`int64`].[`imm`] (prim) in
   let int_of_int64 = %tag_imm (prim_1) in
-  cont k (int_of_int64)
+  cont k close[normal] my_alloc_region (int_of_int64)
 in
 let $camlUnbox_boxed_numbers__pair_first_14 =
   closure pair_first_15_1 @pair_first &toplevel.alloc_region
@@ -311,7 +312,7 @@ let code loopify(never) size(23) newer_version_of(test_pair_16)
   let Pmakeblock =
     %block.[`0`].my_alloc_region (int64_of_int_1, int64_of_int)
   in
-  apply direct(pair_first_15_1 &my_alloc_region)
+  apply direct(pair_first_15_1 &my_alloc_region) [close close close close]
     ($camlUnbox_boxed_numbers__pair_first_14 : _ -> imm tagged)
       (Pmakeblock)
       -> k * k1
@@ -319,6 +320,7 @@ in
 let $camlUnbox_boxed_numbers__test_pair_15 =
   closure test_pair_16_1 @test_pair &toplevel.alloc_region
 in
+let `unit` = %close_alloc_region.[`normal`] (toplevel.alloc_region) in
 let $camlUnbox_boxed_numbers =
   Block 0 ($camlUnbox_boxed_numbers__test_int64_4,
            $camlUnbox_boxed_numbers__test_int32_5,


### PR DESCRIPTION
This adds the `New_alloc_region` and `Close_alloc_region` primitives, used to track zero-alloc annotations. The `Close_alloc_region` primitives can be integrated into apply_conts, to avoid them affecting code generation (especially with the simplification of switch expressions). Part of #5278.