### PR TITLE
Add flambda2 primitives for bit-counting ops (clz, ctz, popcnt, etc.)

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -106,6 +106,10 @@ let clear_sign_bit arg dbg =
   let mask = Nativeint.lognot (Nativeint.shift_left 1n ((size_int * 8) - 1)) in
   Cop (Cand, [arg; Cconst_natint (mask, dbg)], dbg)
 
+let clear_tag_bit arg dbg =
+  let mask = Nativeint.lognot 1n in
+  Cop (Cand, [arg; Cconst_natint (mask, dbg)], dbg)
+
 let clz bi arg dbg =
   if_operation_supported_bi bi Cclz ~f:(fun () ->
       let res = Cop (Cclz, [make_unsigned_int bi arg dbg], dbg) in
@@ -905,6 +909,10 @@ let transl_builtin name args dbg typ_res =
     popcnt Untagged_int8 (one_arg name args) dbg
   | "caml_nativeint_popcnt_unboxed_to_untagged" ->
     popcnt Unboxed_nativeint (one_arg name args) dbg
+  | "caml_int_ctz_tagged_to_untagged" ->
+    if_operation_supported Cctz ~f:(fun () ->
+        let c = clear_tag_bit (one_arg name args) dbg in
+        sub_int (Cop (Cctz, [c], dbg)) (Cconst_int (1, dbg)) dbg)
   | "caml_int_ctz_untagged_to_untagged" ->
     (* Assuming a 64-bit x86-64 target:
 

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -898,19 +898,28 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
       then extcall ()
       else
         let src_kind : Lambda.extern_repr =
+          (* Bit-counting primitives take [@untagged] or [@unboxed] arguments,
+             except that small integers take the corresponding unboxed type. *)
           match (kind : K.Standard_int.t) with
           | Tagged_immediate -> Same_as_ocaml_repr (Base Scannable)
           | Naked_immediate -> Unboxed_or_untagged_integer Untagged_int
-          | Naked_int8 -> Unboxed_or_untagged_integer Untagged_int8
-          | Naked_int16 -> Unboxed_or_untagged_integer Untagged_int16
           | Naked_int32 -> Unboxed_or_untagged_integer Unboxed_int32
           | Naked_int64 -> Unboxed_or_untagged_integer Unboxed_int64
           | Naked_nativeint -> Unboxed_or_untagged_integer Unboxed_nativeint
+          | Naked_int8 -> Same_as_ocaml_repr (Base Bits8)
+          | Naked_int16 -> Same_as_ocaml_repr (Base Bits16)
         in
-        let arg =
-          external_is_known_unary_primitive ~src_kind
-            ~dst_kind:(Unboxed_or_untagged_integer Untagged_int)
+        let dst_kind : Lambda.extern_repr =
+          (* Bit-counting primitives return naked immediates, except small
+             integers that return at their own kind. *)
+          match (kind : K.Standard_int.t) with
+          | Tagged_immediate | Naked_immediate | Naked_int32 | Naked_int64
+          | Naked_nativeint ->
+            Unboxed_or_untagged_integer Untagged_int
+          | Naked_int8 -> Same_as_ocaml_repr (Base Bits8)
+          | Naked_int16 -> Same_as_ocaml_repr (Base Bits16)
         in
+        let arg = external_is_known_unary_primitive ~src_kind ~dst_kind in
         let prim = P.Unary (Int_bit_counting (kind, op), arg) in
         builtin "bits" prim
     in

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -840,8 +840,37 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
   in
   let call args acc =
     (* Some C primitives have implementations within Flambda itself. *)
-    let[@inline] unboxed_int64_to_and_from_unboxed_float ~src_kind ~dst_kind ~op
-        =
+    let[@local] extcall () =
+      let callee = Simple.symbol call_symbol in
+      let apply =
+        Apply.create ~callee:(Some callee)
+          ~continuation:(Return return_continuation) exn_continuation ~args
+          ~args_arity:param_arity ~return_arity ~call_kind
+          ~return_mode:alloc_mode_app dbg ~inlined:Default_inlined
+          ~inlining_state:(Inlining_state.default ~round:0)
+          ~probe:None ~position:Normal
+          ~relative_history:(Env.relative_history_from_scoped ~loc env)
+      in
+      Expr_with_acc.create_apply acc apply
+    in
+    let[@local] builtin name prim =
+      let result = Variable.create name (P.result_kind' prim) in
+      let result_duid = Flambda_debug_uid.none in
+      let result' = Bound_var.create result result_duid Name_mode.normal in
+      let bindable = Bound_pattern.singleton result' in
+      let acc, return_result =
+        Apply_cont_with_acc.create acc return_continuation
+          ~args:[Simple.var result]
+          ~dbg
+      in
+      let acc, return_result_expr =
+        Expr_with_acc.create_apply_cont acc return_result
+      in
+      Let_with_acc.create acc bindable
+        (Named.create_prim prim dbg)
+        ~body:return_result_expr
+    in
+    let[@inline] external_is_known_unary_primitive ~src_kind ~dst_kind =
       if prim_arity <> 1
       then Misc.fatal_errorf "Expected arity one for %s" prim_native_name
       else
@@ -849,32 +878,41 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
         | [(_, src)], (_, dst)
           when Stdlib.( = ) src src_kind && Stdlib.( = ) dst dst_kind -> (
           match args with
-          | [arg] ->
-            let prim = P.Unary (Reinterpret_64_bit_word op, arg) in
-            let result =
-              Variable.create "reinterpreted" (P.result_kind' prim)
-            in
-            let result_duid = Flambda_debug_uid.none in
-            let result' =
-              Bound_var.create result result_duid Name_mode.normal
-            in
-            let bindable = Bound_pattern.singleton result' in
-            let acc, return_result =
-              Apply_cont_with_acc.create acc return_continuation
-                ~args:[Simple.var result]
-                ~dbg
-            in
-            let acc, return_result_expr =
-              Expr_with_acc.create_apply_cont acc return_result
-            in
-            Let_with_acc.create acc bindable
-              (Named.create_prim prim dbg)
-              ~body:return_result_expr
+          | [arg] -> arg
           | [] | _ :: _ ->
             Misc.fatal_errorf "Expected one arg for %s" prim_native_name)
         | _, _ ->
           Misc.fatal_errorf "Wrong argument and/or result kind(s) for %s"
             prim_native_name
+    in
+    let[@local] unboxed_int64_to_and_from_unboxed_float ~src_kind ~dst_kind ~op
+        =
+      (* This likely should require an [@@builtin] attribute as well, but it
+         doesn't for legacy reasons. *)
+      let arg = external_is_known_unary_primitive ~src_kind ~dst_kind in
+      let prim = P.Unary (Reinterpret_64_bit_word op, arg) in
+      builtin "reinterpreted" prim
+    in
+    let[@local] int_bit_counting kind op =
+      if not prim_c_builtin
+      then extcall ()
+      else
+        let src_kind : Lambda.extern_repr =
+          match (kind : K.Standard_int.t) with
+          | Tagged_immediate -> Same_as_ocaml_repr (Base Scannable)
+          | Naked_immediate -> Unboxed_or_untagged_integer Untagged_int
+          | Naked_int8 -> Unboxed_or_untagged_integer Untagged_int8
+          | Naked_int16 -> Unboxed_or_untagged_integer Untagged_int16
+          | Naked_int32 -> Unboxed_or_untagged_integer Unboxed_int32
+          | Naked_int64 -> Unboxed_or_untagged_integer Unboxed_int64
+          | Naked_nativeint -> Unboxed_or_untagged_integer Unboxed_nativeint
+        in
+        let arg =
+          external_is_known_unary_primitive ~src_kind
+            ~dst_kind:(Unboxed_or_untagged_integer Untagged_int)
+        in
+        let prim = P.Unary (Int_bit_counting (kind, op), arg) in
+        builtin "bits" prim
     in
     match prim_native_name with
     | "caml_int64_float_of_bits_unboxed" ->
@@ -887,18 +925,49 @@ let close_c_call0 acc env ~loc ~let_bound_ids_with_kinds
         ~src_kind:(Unboxed_float Boxed_float64)
         ~dst_kind:(Unboxed_or_untagged_integer Unboxed_int64)
         ~op:Unboxed_float64_as_unboxed_int64
-    | _ ->
-      let callee = Simple.symbol call_symbol in
-      let apply =
-        Apply.create ~callee:(Some callee)
-          ~continuation:(Return return_continuation) exn_continuation ~args
-          ~args_arity:param_arity ~return_arity ~call_kind
-          ~return_mode:alloc_mode_app dbg ~inlined:Default_inlined
-          ~inlining_state:(Inlining_state.default ~round:0)
-          ~probe:None ~position:Normal
-          ~relative_history:(Env.relative_history_from_scoped ~loc env)
-      in
-      Expr_with_acc.create_apply acc apply
+    | "caml_int_clz_tagged_to_untagged" ->
+      int_bit_counting Tagged_immediate Leading_zeros
+    | "caml_int_clz_untagged_to_untagged" ->
+      int_bit_counting Naked_immediate Leading_zeros
+    | "caml_int8_clz_untagged_to_untagged" ->
+      int_bit_counting Naked_int8 Leading_zeros
+    | "caml_int16_clz_untagged_to_untagged" ->
+      int_bit_counting Naked_int16 Leading_zeros
+    | "caml_int32_clz_unboxed_to_untagged" ->
+      int_bit_counting Naked_int32 Leading_zeros
+    | "caml_int64_clz_unboxed_to_untagged" ->
+      int_bit_counting Naked_int64 Leading_zeros
+    | "caml_nativeint_clz_unboxed_to_untagged" ->
+      int_bit_counting Naked_nativeint Leading_zeros
+    | "caml_int_ctz_tagged_to_untagged" ->
+      int_bit_counting Tagged_immediate Trailing_zeros
+    | "caml_int_ctz_untagged_to_untagged" ->
+      int_bit_counting Naked_immediate Trailing_zeros
+    | "caml_int8_ctz_untagged_to_untagged" ->
+      int_bit_counting Naked_int8 Trailing_zeros
+    | "caml_int16_ctz_untagged_to_untagged" ->
+      int_bit_counting Naked_int16 Trailing_zeros
+    | "caml_int32_ctz_unboxed_to_untagged" ->
+      int_bit_counting Naked_int32 Trailing_zeros
+    | "caml_int64_ctz_unboxed_to_untagged" ->
+      int_bit_counting Naked_int64 Trailing_zeros
+    | "caml_nativeint_ctz_unboxed_to_untagged" ->
+      int_bit_counting Naked_nativeint Trailing_zeros
+    | "caml_int_popcnt_tagged_to_untagged" ->
+      int_bit_counting Tagged_immediate Popcount
+    | "caml_int_popcnt_untagged_to_untagged" ->
+      int_bit_counting Naked_immediate Popcount
+    | "caml_int8_popcnt_untagged_to_untagged" ->
+      int_bit_counting Naked_int8 Popcount
+    | "caml_int16_popcnt_untagged_to_untagged" ->
+      int_bit_counting Naked_int16 Popcount
+    | "caml_int32_popcnt_unboxed_to_untagged" ->
+      int_bit_counting Naked_int32 Popcount
+    | "caml_int64_popcnt_unboxed_to_untagged" ->
+      int_bit_counting Naked_int64 Popcount
+    | "caml_nativeint_popcnt_unboxed_to_untagged" ->
+      int_bit_counting Naked_nativeint Popcount
+    | _ -> extcall ()
   in
   let call : Acc.t -> Expr_with_acc.t =
     List.fold_left2

--- a/middle_end/flambda2/numbers/numeric_types.ml
+++ b/middle_end/flambda2/numbers/numeric_types.ml
@@ -84,6 +84,19 @@ struct
 
     let of_float f = of_int (Float.to_int f)
 
+    let leading_zeros i =
+      (* The top [extra_bits] bits are always [0] but must not count as leading
+         zeros. *)
+      let extra_bits = Sys.int_size - num_bits in
+      Misc.Stdlib.Int.leading_zeros (unsigned_to_int i) - extra_bits
+
+    let trailing_zeros i =
+      (* Must set the next bit to [1] for [trailing_zeros zero] to return the
+         correct value. *)
+      Misc.Stdlib.Int.trailing_zeros (unsigned_to_int i lor (1 lsl num_bits))
+
+    let popcount i = Misc.Stdlib.Int.popcount (unsigned_to_int i)
+
     let compare = Int.compare
 
     let equal = Int.equal
@@ -106,7 +119,7 @@ module Int16 = Short_int (struct
 end)
 
 module Int32 = struct
-  include Int32
+  include Misc.Stdlib.Int32
 
   external swap_byte_endianness : t -> t = "%bswap_int32"
 
@@ -146,7 +159,7 @@ module Int32 = struct
 end
 
 module Int64 = struct
-  include Int64
+  include Misc.Stdlib.Int64
 
   external swap_byte_endianness : t -> t = "%bswap_int64"
 

--- a/middle_end/flambda2/numbers/numeric_types.mli
+++ b/middle_end/flambda2/numbers/numeric_types.mli
@@ -49,6 +49,12 @@ module Int8 : sig
 
   val of_float : float -> t
 
+  val leading_zeros : t -> int
+
+  val trailing_zeros : t -> int
+
+  val popcount : t -> int
+
   include Container_types.S with type t := t
 end
 
@@ -73,12 +79,18 @@ module Int16 : sig
 
   val of_float : float -> t
 
+  val leading_zeros : t -> int
+
+  val trailing_zeros : t -> int
+
+  val popcount : t -> int
+
   include Container_types.S with type t := t
 end
 
 module Int32 : sig
   include module type of struct
-    include Int32
+    include Misc.Stdlib.Int32
   end
 
   include Container_types.S with type t := Int32.t
@@ -92,7 +104,7 @@ end
 
 module Int64 : sig
   include module type of struct
-    include Int64
+    include Misc.Stdlib.Int64
   end
 
   include Container_types.S with type t := Int64.t

--- a/middle_end/flambda2/numbers/one_bit_fewer.ml
+++ b/middle_end/flambda2/numbers/one_bit_fewer.ml
@@ -105,6 +105,12 @@ module type S = sig
 
   val shift_right_logical : t -> int -> t
 
+  val leading_zeros : t -> int
+
+  val trailing_zeros : t -> int
+
+  val popcount : t -> int
+
   val max : t -> t -> t
 
   val min : t -> t -> t
@@ -237,6 +243,20 @@ module Make (I : S) : S with type t = I.t = struct
 
   let shift_right_logical t i =
     I.shift_right (I.shift_right_logical (I.shift_left t 1) i) 1
+
+  let leading_zeros t =
+    (* The bottom bit is always [0] after shifting, but it must be [1] for
+       [leading_zeros zero] to return the correct value. *)
+    I.leading_zeros (I.or_ (I.shift_left t 1) I.one)
+
+  let trailing_zeros t =
+    (* The bottom bit is always [0] after shifting but must not count as a
+       trailing zero. *)
+    I.trailing_zeros (I.shift_left t 1) - 1
+
+  let popcount t =
+    (* The bottom bit is always [0] after shifting. *)
+    I.popcount (I.shift_left t 1)
 
   let max = I.max
 

--- a/middle_end/flambda2/numbers/one_bit_fewer.mli
+++ b/middle_end/flambda2/numbers/one_bit_fewer.mli
@@ -91,6 +91,12 @@ module type S = sig
 
   val shift_right_logical : t -> int -> t
 
+  val leading_zeros : t -> int
+
+  val trailing_zeros : t -> int
+
+  val popcount : t -> int
+
   val max : t -> t -> t
 
   val min : t -> t -> t

--- a/middle_end/flambda2/numbers/target_ocaml_int.ml
+++ b/middle_end/flambda2/numbers/target_ocaml_int.ml
@@ -136,6 +136,12 @@ module Int32_base = struct
 
   let shift_right_logical = Int32.shift_right_logical
 
+  let leading_zeros = Misc.Stdlib.Int32.leading_zeros
+
+  let trailing_zeros = Misc.Stdlib.Int32.trailing_zeros
+
+  let popcount = Misc.Stdlib.Int32.popcount
+
   let max x y = if Stdlib.( > ) (Int32.compare x y) 0 then x else y
 
   let min x y = if Stdlib.( < ) (Int32.compare x y) 0 then x else y
@@ -254,6 +260,12 @@ module Int64_base = struct
   let shift_right = Int64.shift_right
 
   let shift_right_logical = Int64.shift_right_logical
+
+  let leading_zeros = Misc.Stdlib.Int64.leading_zeros
+
+  let trailing_zeros = Misc.Stdlib.Int64.trailing_zeros
+
+  let popcount = Misc.Stdlib.Int64.popcount
 
   let max x y = if Stdlib.( > ) (Int64.compare x y) 0 then x else y
 
@@ -578,6 +590,24 @@ let shift_right_logical t i =
   | Int31 x -> Int31 (Int31.shift_right_logical x i)
   | Int32 x -> Int32 (Int32.shift_right_logical x i)
   | Int63 x -> Int63 (Int63.shift_right_logical x i)
+
+let leading_zeros t =
+  match t with
+  | Int31 x -> Int31.leading_zeros x
+  | Int32 x -> Misc.Stdlib.Int32.leading_zeros x
+  | Int63 x -> Int63.leading_zeros x
+
+let trailing_zeros t =
+  match t with
+  | Int31 x -> Int31.trailing_zeros x
+  | Int32 x -> Misc.Stdlib.Int32.trailing_zeros x
+  | Int63 x -> Int63.trailing_zeros x
+
+let popcount t =
+  match t with
+  | Int31 x -> Int31.popcount x
+  | Int32 x -> Misc.Stdlib.Int32.popcount x
+  | Int63 x -> Int63.popcount x
 
 let max t1 t2 = if Stdlib.( < ) (compare t1 t2) 0 then t2 else t1
 

--- a/middle_end/flambda2/numbers/target_ocaml_int.mli
+++ b/middle_end/flambda2/numbers/target_ocaml_int.mli
@@ -181,6 +181,12 @@ val shift_right : t -> int -> t
     [y >= bitsize]. *)
 val shift_right_logical : t -> int -> t
 
+val leading_zeros : t -> int
+
+val trailing_zeros : t -> int
+
+val popcount : t -> int
+
 (** Returns the smaller integer. *)
 val min : t -> t -> t
 

--- a/middle_end/flambda2/numbers/targetint_32_64.ml
+++ b/middle_end/flambda2/numbers/targetint_32_64.ml
@@ -255,6 +255,21 @@ let shift_right_logical t n =
   | Int32 x -> Int32 (Int32.shift_right_logical x n)
   | Int64 x -> Int64 (Int64.shift_right_logical x n)
 
+let leading_zeros t =
+  match t with
+  | Int32 x -> Misc.Stdlib.Int32.leading_zeros x
+  | Int64 x -> Misc.Stdlib.Int64.leading_zeros x
+
+let trailing_zeros t =
+  match t with
+  | Int32 x -> Misc.Stdlib.Int32.trailing_zeros x
+  | Int64 x -> Misc.Stdlib.Int64.trailing_zeros x
+
+let popcount t =
+  match t with
+  | Int32 x -> Misc.Stdlib.Int32.popcount x
+  | Int64 x -> Misc.Stdlib.Int64.popcount x
+
 (* Comparison functions *)
 let compare t1 t2 =
   match t1, t2 with

--- a/middle_end/flambda2/numbers/targetint_32_64.mli
+++ b/middle_end/flambda2/numbers/targetint_32_64.mli
@@ -135,6 +135,12 @@ val shift_right : t -> int -> t
     The result is unspecified if [y < 0] or [y >= bitsize]. *)
 val shift_right_logical : t -> int -> t
 
+val leading_zeros : t -> int
+
+val trailing_zeros : t -> int
+
+val popcount : t -> int
+
 (** Convert the given integer (type [int]) to a target integer (type [t]),
     modulo the target word size. *)
 val of_int : Target_system.Machine_width.t -> int -> t

--- a/middle_end/flambda2/parser/fexpr_prim.ml
+++ b/middle_end/flambda2/parser/fexpr_prim.ml
@@ -77,6 +77,12 @@ let unary_int_arith_op =
     constructor_flag
       (["bswp", Swap_byte_endianness] : (string * P.unary_int_arith_op) list))
 
+let unary_int_bit_counting_op =
+  D.(
+    constructor_flag
+      (["clz", Leading_zeros; "ctz", Trailing_zeros; "popcnt", Popcount]
+        : (string * P.unary_int_bit_counting_op) list))
+
 let binary_int_arith_op =
   D.(
     constructor_flag
@@ -831,6 +837,12 @@ let int_uarith =
     unary "%int_uarith" ~params:(param2 standard_int unary_int_arith_op)
       (fun _ (i, o) -> P.Int_arith (i, o)))
 
+let int_bit_counting =
+  D.(
+    unary "%int_bit_counting"
+      ~params:(param2 standard_int unary_int_bit_counting_op) (fun _ (k, op) ->
+        P.Int_bit_counting (k, op)))
+
 let is_boxed_float =
   D.(unary "%is_boxed_float" ~params:param0 (fun _ () -> P.Is_boxed_float))
 
@@ -1355,6 +1367,7 @@ module OfFlambda = struct
     | Get_tag -> get_tag env ()
     | Is_boxed_float -> is_boxed_float env ()
     | Int_arith (i, o) -> int_uarith env (i, o)
+    | Int_bit_counting (k, op) -> int_bit_counting env (k, op)
     | Int_as_pointer a -> int_as_pointer env a
     | Is_flat_float_array -> is_flat_float_array env ()
     | Is_int _ -> is_int env () (* CR vlaviron: discuss *)

--- a/middle_end/flambda2/reaper/traverse.ml
+++ b/middle_end/flambda2/reaper/traverse.ml
@@ -217,7 +217,7 @@ let traverse_prim denv acc ~bound_pattern (prim : Flambda_primitive.t) ~default
         | Num_conv _ | Boolean_not | Reinterpret_64_bit_word _
         | Reinterpret_boxed_vector | Untag_immediate | Tag_immediate
         | Is_boxed_float | Is_flat_float_array | End_region _ | End_try_region _
-        | Obj_dup _ | Get_header | Peek _ | Make_lazy _ ),
+        | Obj_dup _ | Get_header | Peek _ | Make_lazy _ | Int_bit_counting _ ),
         _ )
   | Binary
       ( ( Block_set _ | Array_load _ | String_or_bigstring_load _

--- a/middle_end/flambda2/simplify/number_adjuncts.ml
+++ b/middle_end/flambda2/simplify/number_adjuncts.ml
@@ -142,6 +142,12 @@ module type Int_number_kind = sig
     val neg : t -> t
 
     val compare_unsigned : t -> t -> int
+
+    val leading_zeros : t -> int
+
+    val trailing_zeros : t -> int
+
+    val popcount : t -> int
   end
 
   include Number_kind_common with module Num := Num

--- a/middle_end/flambda2/simplify/number_adjuncts.mli
+++ b/middle_end/flambda2/simplify/number_adjuncts.mli
@@ -115,6 +115,12 @@ module type Int_number_kind = sig
     val neg : t -> t
 
     val compare_unsigned : t -> t -> int
+
+    val leading_zeros : t -> int
+
+    val trailing_zeros : t -> int
+
+    val popcount : t -> int
   end
 
   include Number_kind_common with module Num := Num

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -330,26 +330,46 @@ module Unary_bit_counting (I : A.Int_number_kind) = struct
     match I.unboxed_prover (DA.typing_env dacc) arg_ty with
     | Known_result ints ->
       assert (not (I.Num.Set.is_empty ints));
-      let machine_width = DE.machine_width (DA.denv dacc) in
       let f =
         match op with
         | Leading_zeros -> I.Num.leading_zeros
         | Trailing_zeros -> I.Num.trailing_zeros
         | Popcount -> I.Num.popcount
       in
-      let possible_results =
-        I.Num.Set.fold
-          (fun int acc ->
-            Target_ocaml_int.Set.add
-              (Target_ocaml_int.of_int machine_width (f int))
-              acc)
-          ints Target_ocaml_int.Set.empty
+      let ty =
+        (* Bit-counting primitives return naked immediates, except small
+           integers that return at their own kind. *)
+        match I.standard_int_kind with
+        | Tagged_immediate | Naked_immediate | Naked_int32 | Naked_int64
+        | Naked_nativeint ->
+          let machine_width = DE.machine_width (DA.denv dacc) in
+          let possible_results =
+            I.Num.Set.fold
+              (fun int acc ->
+                Target_ocaml_int.Set.add
+                  (Target_ocaml_int.of_int machine_width (f int))
+                  acc)
+              ints Target_ocaml_int.Set.empty
+          in
+          T.these_naked_immediates possible_results
+        | Naked_int8 ->
+          let module Int8 = Numeric_types.Int8 in
+          I.Num.Set.fold
+            (fun int acc -> Int8.Set.add (Int8.of_int (f int)) acc)
+            ints Int8.Set.empty
+          |> T.these_naked_int8s
+        | Naked_int16 ->
+          let module Int16 = Numeric_types.Int16 in
+          I.Num.Set.fold
+            (fun int acc -> Int16.Set.add (Int16.of_int (f int)) acc)
+            ints Int16.Set.empty
+          |> T.these_naked_int16s
       in
-      let ty = T.these_naked_immediates possible_results in
       let dacc = DA.add_variable dacc result_var ty in
       SPR.create original_term ~try_reify:true dacc
     | Need_meet ->
-      SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
+      let kind = Named.kind original_term in
+      SPR.create_unknown dacc ~result_var kind ~original_term
     | Invalid -> SPR.create_invalid dacc
 end
 

--- a/middle_end/flambda2/simplify/simplify_unary_primitive.ml
+++ b/middle_end/flambda2/simplify/simplify_unary_primitive.ml
@@ -324,6 +324,45 @@ module Unary_int_arith_naked_int32 = Unary_int_arith (A.For_int32s)
 module Unary_int_arith_naked_int64 = Unary_int_arith (A.For_int64s)
 module Unary_int_arith_naked_nativeint = Unary_int_arith (A.For_nativeints)
 
+module Unary_bit_counting (I : A.Int_number_kind) = struct
+  let simplify (op : P.unary_int_bit_counting_op) dacc ~original_term ~arg:_
+      ~arg_ty ~result_var =
+    match I.unboxed_prover (DA.typing_env dacc) arg_ty with
+    | Known_result ints ->
+      assert (not (I.Num.Set.is_empty ints));
+      let machine_width = DE.machine_width (DA.denv dacc) in
+      let f =
+        match op with
+        | Leading_zeros -> I.Num.leading_zeros
+        | Trailing_zeros -> I.Num.trailing_zeros
+        | Popcount -> I.Num.popcount
+      in
+      let possible_results =
+        I.Num.Set.fold
+          (fun int acc ->
+            Target_ocaml_int.Set.add
+              (Target_ocaml_int.of_int machine_width (f int))
+              acc)
+          ints Target_ocaml_int.Set.empty
+      in
+      let ty = T.these_naked_immediates possible_results in
+      let dacc = DA.add_variable dacc result_var ty in
+      SPR.create original_term ~try_reify:true dacc
+    | Need_meet ->
+      SPR.create_unknown dacc ~result_var K.naked_immediate ~original_term
+    | Invalid -> SPR.create_invalid dacc
+end
+
+module Unary_bit_counting_tagged_immediate =
+  Unary_bit_counting (A.For_tagged_immediates)
+module Unary_bit_counting_naked_immediate =
+  Unary_bit_counting (A.For_naked_immediates)
+module Unary_bit_counting_naked_int8 = Unary_bit_counting (A.For_int8s)
+module Unary_bit_counting_naked_int16 = Unary_bit_counting (A.For_int16s)
+module Unary_bit_counting_naked_int32 = Unary_bit_counting (A.For_int32s)
+module Unary_bit_counting_naked_int64 = Unary_bit_counting (A.For_int64s)
+module Unary_bit_counting_naked_nativeint = Unary_bit_counting (A.For_nativeints)
+
 module Make_simplify_int_conv (N : A.Number_kind) = struct
   let simplify ~(dst : K.Standard_int_or_float.t) dacc ~original_term ~arg
       ~arg_ty ~result_var =
@@ -1039,6 +1078,15 @@ let simplify_unary_primitive dacc original_prim (prim : P.unary_primitive) ~arg
       | Naked_int32 -> Unary_int_arith_naked_int32.simplify op
       | Naked_int64 -> Unary_int_arith_naked_int64.simplify op
       | Naked_nativeint -> Unary_int_arith_naked_nativeint.simplify op)
+    | Int_bit_counting (kind, op) -> (
+      match kind with
+      | Tagged_immediate -> Unary_bit_counting_tagged_immediate.simplify op
+      | Naked_immediate -> Unary_bit_counting_naked_immediate.simplify op
+      | Naked_int8 -> Unary_bit_counting_naked_int8.simplify op
+      | Naked_int16 -> Unary_bit_counting_naked_int16.simplify op
+      | Naked_int32 -> Unary_bit_counting_naked_int32.simplify op
+      | Naked_int64 -> Unary_bit_counting_naked_int64.simplify op
+      | Naked_nativeint -> Unary_bit_counting_naked_nativeint.simplify op)
     | Float_arith (Float64, op) -> simplify_float_arith_op op
     | Float_arith (Float32, op) -> simplify_float32_arith_op op
     | Num_conv { src; dst } -> (

--- a/middle_end/flambda2/terms/code_size.ml
+++ b/middle_end/flambda2/terms/code_size.ml
@@ -74,6 +74,41 @@ let unary_int_prim_size ~machine_width:_ kind op =
       Swap_byte_endianness ) ->
     does_not_need_caml_c_call_extcall_size + 1
 
+let bit_counting_prim_size ~machine_width kind op =
+  (* Note: assumes that the bit-counting primitives (clz, ctz, popcnt) are
+     available as single ops on the target system. *)
+  let module MW = Target_system.Machine_width in
+  match
+    ( (op : Flambda_primitive.unary_int_bit_counting_op),
+      (kind : Flambda_kind.Standard_int.t) )
+  with
+  (* clz *)
+  | Leading_zeros, (Tagged_immediate | Naked_nativeint) -> 1
+  | Leading_zeros, Naked_int32 when MW.is_32_bit machine_width -> 1
+  | Leading_zeros, Naked_int64 when MW.is_64_bit machine_width -> 1
+  | ( Leading_zeros,
+      (Naked_immediate | Naked_int8 | Naked_int16 | Naked_int32 | Naked_int64) )
+    ->
+    1 (* convert to unsigned *) + 1 (* clz *) + 1 (* subtract extra bits *)
+  (* ctz *)
+  | Trailing_zeros, Naked_nativeint -> 1
+  | Trailing_zeros, Naked_int32 when MW.is_32_bit machine_width -> 1
+  | Trailing_zeros, Naked_int64 when MW.is_64_bit machine_width -> 1
+  | ( Trailing_zeros,
+      (Naked_immediate | Naked_int8 | Naked_int16 | Naked_int32 | Naked_int64) )
+    ->
+    1 (* set top bit(s) *) + 1 (* ctz *)
+  | Trailing_zeros, Tagged_immediate ->
+    2 (* clear tag bit *) + 1 (* ctz *) + 1 (* subtract extra bit *)
+  (* popcnt *)
+  | Popcount, Naked_nativeint -> 1
+  | Popcount, Naked_int32 when MW.is_32_bit machine_width -> 1
+  | Popcount, Naked_int64 when MW.is_64_bit machine_width -> 1
+  | Popcount, Tagged_immediate -> 1 (* popcnt *) + 1 (* subtract tag bit *)
+  | Popcount, Naked_immediate -> 1 (* clear sign bit *) + 1 (* popcnt *)
+  | Popcount, (Naked_int8 | Naked_int16 | Naked_int32 | Naked_int64) ->
+    1 (* convert to unsigned *) + 1 (* popcnt *)
+
 let arith_conversion_size ~machine_width src dst =
   match
     ( (src : Flambda_kind.Standard_int_or_float.t),
@@ -426,6 +461,7 @@ let unary_prim_size ~machine_width prim =
   | Int_as_pointer _ -> 1
   | Opaque_identity _ -> 0
   | Int_arith (kind, op) -> unary_int_prim_size ~machine_width kind op
+  | Int_bit_counting (kind, op) -> bit_counting_prim_size ~machine_width kind op
   | Float_arith _ -> 2
   | Num_conv { src; dst } -> arith_conversion_size ~machine_width src dst
   | Boolean_not -> 1

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1608,7 +1608,15 @@ let result_kind_of_unary_primitive p : result_kind =
     Singleton K.value
   | Opaque_identity { middle_end_only = _; kind } -> Singleton kind
   | Int_arith (kind, _) -> Singleton (K.Standard_int.to_kind kind)
-  | Int_bit_counting _ -> Singleton K.naked_immediate
+  | Int_bit_counting (((Naked_int8 | Naked_int16) as kind), _) ->
+    (* Bit-counting primitives return naked immediates, except small integers
+       that return at their own kind. *)
+    Singleton (K.Standard_int.to_kind kind)
+  | Int_bit_counting
+      ( ( Tagged_immediate | Naked_immediate | Naked_int32 | Naked_int64
+        | Naked_nativeint ),
+        _ ) ->
+    Singleton K.naked_immediate
   | Num_conv { src = _; dst } -> Singleton (K.Standard_int_or_float.to_kind dst)
   | Boolean_not -> Singleton K.value
   | Reinterpret_boxed_vector -> Singleton K.value

--- a/middle_end/flambda2/terms/flambda_primitive.ml
+++ b/middle_end/flambda2/terms/flambda_primitive.ml
@@ -1070,6 +1070,18 @@ let print_unary_int_arith_op ppf o =
   let fprintf = Format.fprintf in
   match o with Swap_byte_endianness -> fprintf ppf "bswap"
 
+type unary_int_bit_counting_op =
+  | Leading_zeros
+  | Trailing_zeros
+  | Popcount
+
+let print_unary_int_bit_counting_op ppf o =
+  let fprintf = Format.fprintf in
+  match o with
+  | Leading_zeros -> fprintf ppf "clz"
+  | Trailing_zeros -> fprintf ppf "ctz"
+  | Popcount -> fprintf ppf "popcnt"
+
 type unary_float_arith_op =
   | Abs
   | Neg
@@ -1260,6 +1272,7 @@ type unary_primitive =
       }
   | Int_arith of Flambda_kind.Standard_int.t * unary_int_arith_op
   | Float_arith of float_bitwidth * unary_float_arith_op
+  | Int_bit_counting of Flambda_kind.Standard_int.t * unary_int_bit_counting_op
   | Num_conv of
       { src : Flambda_kind.Standard_int_or_float.t;
         dst : Flambda_kind.Standard_int_or_float.t
@@ -1304,7 +1317,7 @@ let unary_primitive_eligible_for_cse p ~arg =
   | String_length _ -> true
   | Int_as_pointer m -> ( match m with Heap _ -> true | Local _ -> false)
   | Opaque_identity _ -> false
-  | Int_arith _ -> true
+  | Int_arith _ | Int_bit_counting _ -> true
   | Float_arith _ ->
     (* See comment in effects_and_coeffects *)
     Flambda_features.float_const_prop ()
@@ -1359,6 +1372,7 @@ let compare_unary_primitive p1 p2 =
     | Peek _ -> 28
     | Make_lazy _ -> 29
     | Reinterpret_boxed_vector -> 30
+    | Int_bit_counting _ -> 31
   in
   match p1, p2 with
   | ( Block_load { kind = kind1; mut = mut1; field = field1 },
@@ -1403,6 +1417,9 @@ let compare_unary_primitive p1 p2 =
   | Get_tag, Get_tag -> 0
   | String_length kind1, String_length kind2 -> Stdlib.compare kind1 kind2
   | Int_arith (kind1, op1), Int_arith (kind2, op2) ->
+    let c = K.Standard_int.compare kind1 kind2 in
+    if c <> 0 then c else Stdlib.compare op1 op2
+  | Int_bit_counting (kind1, op1), Int_bit_counting (kind2, op2) ->
     let c = K.Standard_int.compare kind1 kind2 in
     if c <> 0 then c else Stdlib.compare op1 op2
   | Num_conv { src = src1; dst = dst1 }, Num_conv { src = src2; dst = dst2 } ->
@@ -1465,7 +1482,7 @@ let compare_unary_primitive p1 p2 =
       | Untag_immediate | Tag_immediate | Project_function_slot _
       | Project_value_slot _ | Is_boxed_float | Is_flat_float_array
       | End_region _ | End_try_region _ | Obj_dup _ | Get_header | Peek _
-      | Make_lazy _ ),
+      | Make_lazy _ | Int_bit_counting _ ),
       _ ) ->
     Stdlib.compare (unary_primitive_numbering p1) (unary_primitive_numbering p2)
 
@@ -1497,6 +1514,7 @@ let print_unary_primitive ppf p =
     fprintf ppf "@[(Opaque_identity@ (middle_end_only %b) (kind %a))@]"
       middle_end_only K.print kind
   | Int_arith (_k, o) -> print_unary_int_arith_op ppf o
+  | Int_bit_counting (_k, o) -> print_unary_int_bit_counting_op ppf o
   | Num_conv { src; dst } ->
     fprintf ppf "Num_conv_%a_to_%a"
       Flambda_kind.Standard_int_or_float.print_lowercase src
@@ -1551,6 +1569,7 @@ let arg_kind_of_unary_primitive p =
   | Int_as_pointer _ -> K.value
   | Opaque_identity { middle_end_only = _; kind } -> kind
   | Int_arith (kind, _) -> K.Standard_int.to_kind kind
+  | Int_bit_counting (kind, _) -> K.Standard_int.to_kind kind
   | Num_conv { src; dst = _ } -> K.Standard_int_or_float.to_kind src
   | Boolean_not -> K.value
   | Reinterpret_boxed_vector -> K.value
@@ -1589,6 +1608,7 @@ let result_kind_of_unary_primitive p : result_kind =
     Singleton K.value
   | Opaque_identity { middle_end_only = _; kind } -> Singleton kind
   | Int_arith (kind, _) -> Singleton (K.Standard_int.to_kind kind)
+  | Int_bit_counting _ -> Singleton K.naked_immediate
   | Num_conv { src = _; dst } -> Singleton (K.Standard_int_or_float.to_kind dst)
   | Boolean_not -> Singleton K.value
   | Reinterpret_boxed_vector -> Singleton K.value
@@ -1665,6 +1685,7 @@ let effects_and_coeffects_of_unary_primitive p : Effects_and_coeffects.t =
   | Opaque_identity _ ->
     Arbitrary_effects, Has_coeffects, Strict, Can't_move_before_any_branch
   | Int_arith (_, Swap_byte_endianness)
+  | Int_bit_counting (_, (Leading_zeros | Trailing_zeros | Popcount))
   | Num_conv _ | Boolean_not | Reinterpret_64_bit_word _
   | Reinterpret_boxed_vector ->
     No_effects, No_coeffects, Strict, Can't_move_before_any_branch
@@ -1745,7 +1766,7 @@ let unary_classify_for_printing p =
   | String_length _ | Get_tag -> Destructive
   | Is_int _ | Is_null | Opaque_identity _ | Int_arith _ | Num_conv _
   | Boolean_not | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector
-  | Float_arith _ ->
+  | Float_arith _ | Int_bit_counting _ ->
     Neither
   | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate ->
     Destructive
@@ -1781,7 +1802,7 @@ let free_names_unary_primitive p =
   | Reinterpret_64_bit_word _ | Reinterpret_boxed_vector | Float_arith _
   | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
   | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
-  | End_try_region _ | Get_header
+  | End_try_region _ | Get_header | Int_bit_counting _
   | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
     Name_occurrences.empty
 
@@ -1830,7 +1851,7 @@ let apply_renaming_unary_primitive p renaming =
   | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
   | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
   | End_try_region _ | Project_function_slot _ | Project_value_slot _
-  | Get_header
+  | Get_header | Int_bit_counting _
   | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
     p
 
@@ -1849,7 +1870,7 @@ let ids_for_export_unary_primitive p =
   | Array_length _ | Bigarray_length _ | Unbox_number _ | Untag_immediate
   | Tag_immediate | Is_boxed_float | Is_flat_float_array | End_region _
   | End_try_region _ | Project_function_slot _ | Project_value_slot _
-  | Get_header
+  | Get_header | Int_bit_counting _
   | Peek (_ : Flambda_kind.Standard_int_or_float.t) ->
     Ids_for_export.empty
 

--- a/middle_end/flambda2/terms/flambda_primitive.mli
+++ b/middle_end/flambda2/terms/flambda_primitive.mli
@@ -399,6 +399,11 @@ type unary_int_arith_op = Swap_byte_endianness
 (* CR mshinwell/jvanburen: we should consider splitting this swapping primitive
    into two, based on the semantics *)
 
+type unary_int_bit_counting_op =
+  | Leading_zeros
+  | Trailing_zeros
+  | Popcount
+
 (** Naked float unary arithmetic operations. *)
 type unary_float_arith_op =
   | Abs
@@ -455,6 +460,7 @@ type unary_primitive =
       }
   | Int_arith of Flambda_kind.Standard_int.t * unary_int_arith_op
   | Float_arith of float_bitwidth * unary_float_arith_op
+  | Int_bit_counting of Flambda_kind.Standard_int.t * unary_int_bit_counting_op
   | Num_conv of
       { src : Flambda_kind.Standard_int_or_float.t;
         dst : Flambda_kind.Standard_int_or_float.t

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -901,6 +901,40 @@ let unary_float_arith_primitive _env dbg width op arg =
   | Float32, Abs -> C.float32_abs ~dbg arg
   | Float32, Neg -> C.float32_neg ~dbg arg
 
+let unary_int_bit_counting_primitive _env dbg kind op arg =
+  (* CR-someday bclement: It is a bit weird that we are converting back these
+     primitives to C calls. These were initially lowered to primitives in
+     cmm_builtins.ml, but we now do the recognition earlier (in
+     closure_conversion.ml) and it is easier to not change the cmm code paths
+     too much, but we should get rid of the extcalls and simply lower the
+     primitives here instead of in cmm_builtins.ml
+
+     While it looks like this could create external calls to C functions that
+     were not mentioned by the user, the primitives can only come from the
+     corresponding C extcall in the first place (see closure_conversion.ml). *)
+  let prim_name =
+    match (op : P.unary_int_bit_counting_op) with
+    | Leading_zeros -> "clz"
+    | Trailing_zeros -> "ctz"
+    | Popcount -> "popcnt"
+  in
+  let pf fmt = Format.asprintf fmt prim_name in
+  let ext_name =
+    match (kind : K.Standard_int.t) with
+    | Tagged_immediate -> pf "caml_int_%s_tagged_to_untagged"
+    | Naked_immediate -> pf "caml_int_%s_untagged_to_untagged"
+    | Naked_int8 -> pf "caml_int8_%s_untagged_to_untagged"
+    | Naked_int16 -> pf "caml_int16_%s_untagged_to_untagged"
+    | Naked_int32 -> pf "caml_int32_%s_unboxed_to_untagged"
+    | Naked_int64 -> pf "caml_int64_%s_unboxed_to_untagged"
+    | Naked_nativeint -> pf "caml_nativeint_%s_unboxed_to_untagged"
+  in
+  (C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:true
+     ~effects:No_effects ~coeffects:No_coeffects
+     ~ty_args:[C.exttype_of_kind (K.Standard_int.to_kind kind)]
+     ext_name Cmm.typ_int [arg])
+    .extcall
+
 let arithmetic_conversion dbg src dst arg =
   if K.Standard_int_or_float.equal src dst
   then None, arg
@@ -1207,6 +1241,8 @@ let unary_primitive env res dbg f (_arg_simple : Simple.t option)
     None, res, unary_int_arith_primitive env dbg kind op arg
   | Float_arith (width, op) ->
     None, res, unary_float_arith_primitive env dbg width op arg
+  | Int_bit_counting (kind, op) ->
+    None, res, unary_int_bit_counting_primitive env dbg kind op arg
   | Num_conv { src; dst } ->
     let extra, expr = arithmetic_conversion dbg src dst arg in
     extra, res, expr

--- a/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
+++ b/middle_end/flambda2/to_cmm/to_cmm_primitive.ml
@@ -901,7 +901,7 @@ let unary_float_arith_primitive _env dbg width op arg =
   | Float32, Abs -> C.float32_abs ~dbg arg
   | Float32, Neg -> C.float32_neg ~dbg arg
 
-let unary_int_bit_counting_primitive _env dbg kind op arg =
+let unary_int_bit_counting_primitive _env dbg (kind : K.Standard_int.t) op arg =
   (* CR-someday bclement: It is a bit weird that we are converting back these
      primitives to C calls. These were initially lowered to primitives in
      cmm_builtins.ml, but we now do the recognition earlier (in
@@ -920,7 +920,7 @@ let unary_int_bit_counting_primitive _env dbg kind op arg =
   in
   let pf fmt = Format.asprintf fmt prim_name in
   let ext_name =
-    match (kind : K.Standard_int.t) with
+    match kind with
     | Tagged_immediate -> pf "caml_int_%s_tagged_to_untagged"
     | Naked_immediate -> pf "caml_int_%s_untagged_to_untagged"
     | Naked_int8 -> pf "caml_int8_%s_untagged_to_untagged"
@@ -929,11 +929,23 @@ let unary_int_bit_counting_primitive _env dbg kind op arg =
     | Naked_int64 -> pf "caml_int64_%s_unboxed_to_untagged"
     | Naked_nativeint -> pf "caml_nativeint_%s_unboxed_to_untagged"
   in
-  (C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:true
-     ~effects:No_effects ~coeffects:No_coeffects
-     ~ty_args:[C.exttype_of_kind (K.Standard_int.to_kind kind)]
-     ext_name Cmm.typ_int [arg])
-    .extcall
+  let { C.extcall; builtin_sign_extends } =
+    C.extcall ~dbg ~alloc:false ~returns:true ~is_c_builtin:true
+      ~effects:No_effects ~coeffects:No_coeffects
+      ~ty_args:[C.exttype_of_kind (K.Standard_int.to_kind kind)]
+      ext_name Cmm.typ_int [arg]
+  in
+  (* Small integer primitives return small integers and might need sign
+     extension. See also comment in [To_cmm_expr]. *)
+  if builtin_sign_extends
+  then extcall
+  else
+    match kind with
+    | Naked_int8 -> C.sign_extend ~bits:8 ~dbg extcall
+    | Naked_int16 -> C.sign_extend ~bits:16 ~dbg extcall
+    | Tagged_immediate | Naked_immediate | Naked_int32 | Naked_int64
+    | Naked_nativeint ->
+      extcall
 
 let arithmetic_conversion dbg src dst arg =
   if K.Standard_int_or_float.equal src dst

--- a/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
+++ b/middle_end/flambda2/to_jsir/to_jsir_primitive.ml
@@ -220,6 +220,25 @@ let unary_exn ~env ~res (f : Flambda_primitive.unary_primitive) x =
         | Naked_int8 -> assert false
       in
       use_prim' (Extern extern_name))
+  | Int_bit_counting (kind, op) ->
+    let prim_name =
+      match op with
+      | Leading_zeros -> "clz"
+      | Trailing_zeros -> "ctz"
+      | Popcount -> "popcnt"
+    in
+    let extern_name =
+      let pf fmt = Format.asprintf fmt prim_name in
+      match kind with
+      | Naked_int32 -> pf "caml_int32_%s_unboxed_to_untagged"
+      | Naked_int64 -> pf "caml_int64_%s_unboxed_to_untagged"
+      | Naked_nativeint -> pf "caml_nativeint_%s_unboxed_to_untagged"
+      | Naked_int8 -> pf "caml_int8_%s_untagged_to_untagged"
+      | Naked_int16 -> pf "caml_int16_%s_untagged_to_untagged"
+      | Naked_immediate -> pf "caml_int_%s_untagged_to_untagged"
+      | Tagged_immediate -> pf "caml_int_%s_tagged_to_untagged"
+    in
+    use_prim' (Extern extern_name)
   | Float_arith (bitwidth, op) ->
     let op_name = match op with Abs -> "abs" | Neg -> "neg" in
     let extern_name = with_float_suffix ~bitwidth op_name in

--- a/testsuite/tests/codegen/builtins.ml
+++ b/testsuite/tests/codegen/builtins.ml
@@ -24,13 +24,10 @@ clz_tagged:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let clz_tagged_const () = Builtins.int_clz 6
 [%%expect_asm X86_64{|
 clz_tagged_const:
-  movl  $13, %eax
-  lzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $121, %eax
   ret
 |}]
 
@@ -44,13 +41,10 @@ clz64:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let clz64_const () = Builtins.int64_clz (Int64.of_int 6)
 [%%expect_asm X86_64{|
 clz64_const:
-  movl  $6, %eax
-  lzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $123, %eax
   ret
 |}]
 
@@ -67,14 +61,10 @@ clz32:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let clz32_const () = Builtins.int32_clz (Int32.of_int 6)
 [%%expect_asm X86_64{|
 clz32_const:
-  movl  $6, %eax
-  movl  %eax, %eax
-  lzcnt %rax, %rax
-  leaq  -63(%rax,%rax), %rax
+  movl  $59, %eax
   ret
 |}]
 
@@ -89,13 +79,10 @@ clz_native:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let clz_native_const () = Builtins.nativeint_clz (Nativeint.of_int 6)
 [%%expect_asm X86_64{|
 clz_native_const:
-  movl  $6, %eax
-  lzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $123, %eax
   ret
 |}]
 
@@ -114,15 +101,10 @@ ctz_int:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let ctz_int_const () = Builtins.int_ctz 6
 [%%expect_asm X86_64{|
 ctz_int_const:
-  movl  $1, %eax
-  salq  $63, %rax
-  orq   $6, %rax
-  tzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $3, %eax
   ret
 |}]
 
@@ -136,13 +118,10 @@ ctz64:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let ctz64_const () = Builtins.int64_ctz (Int64.of_int 6)
 [%%expect_asm X86_64{|
 ctz64_const:
-  movl  $6, %eax
-  tzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $3, %eax
   ret
 |}]
 
@@ -159,14 +138,10 @@ ctz32:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let ctz32_const () = Builtins.int32_ctz (Int32.of_int 6)
 [%%expect_asm X86_64{|
 ctz32_const:
-  movabsq $4294967296, %rax
-  orq   $6, %rax
-  tzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $3, %eax
   ret
 |}]
 
@@ -181,13 +156,10 @@ ctz_native:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let ctz_native_const () = Builtins.nativeint_ctz (Nativeint.of_int 6)
 [%%expect_asm X86_64{|
 ctz_native_const:
-  movl  $6, %eax
-  tzcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $3, %eax
   ret
 |}]
 
@@ -201,13 +173,10 @@ popcnt_tagged:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let popcnt_tagged_const () = Builtins.int_popcnt 6
 [%%expect_asm X86_64{|
 popcnt_tagged_const:
-  movl  $13, %eax
-  popcnt %rax, %rax
-  leaq  -1(%rax,%rax), %rax
+  movl  $5, %eax
   ret
 |}]
 
@@ -221,13 +190,10 @@ popcnt64:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let popcnt64_const () = Builtins.int64_popcnt (Int64.of_int 6)
 [%%expect_asm X86_64{|
 popcnt64_const:
-  movl  $6, %eax
-  popcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $5, %eax
   ret
 |}]
 
@@ -243,14 +209,10 @@ popcnt32:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let popcnt32_const () = Builtins.int32_popcnt (Int32.of_int 6)
 [%%expect_asm X86_64{|
 popcnt32_const:
-  movl  $6, %eax
-  movl  %eax, %eax
-  popcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $5, %eax
   ret
 |}]
 
@@ -265,14 +227,11 @@ popcnt_native:
   ret
 |}]
 
-(* CR ttebbi: The constant call should be folded. *)
 let popcnt_native_const () =
   Builtins.nativeint_popcnt (Nativeint.of_int 6)
 [%%expect_asm X86_64{|
 popcnt_native_const:
-  movl  $6, %eax
-  popcnt %rax, %rax
-  leaq  1(%rax,%rax), %rax
+  movl  $5, %eax
   ret
 |}]
 

--- a/testsuite/tests/flambda2/simplify/bit_counting_ops.ml
+++ b/testsuite/tests/flambda2/simplify/bit_counting_ops.ml
@@ -25,17 +25,27 @@ module Int8 = struct
   let min_int = 0x80s
   let max_int = 0x7Fs
 
-  external leading_zeros : (t [@unboxed]) -> (int [@untagged]) =
+  external leading_zeros : int8# -> int8# =
     "" "caml_int8_clz_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external trailing_zeros : (t [@unboxed]) -> (int [@untagged]) =
+  external trailing_zeros : int8# -> int8# =
     "" "caml_int8_ctz_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external popcount : (t [@unboxed]) -> (int [@untagged]) =
+  external popcount : int8# -> int8# =
     "" "caml_int8_popcnt_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external untag : t -> int8# = "%int8#_of_int8"
+  external tag_as_int : int8# -> int = "%int_of_int8#"
+
+  let wrap f n = tag_as_int (f (untag n))
+  [@@inline]
+
+  let leading_zeros n = wrap leading_zeros n
+  let trailing_zeros n = wrap trailing_zeros n
+  let popcount n = wrap popcount n
 end
 
 module Int16 = struct
@@ -54,17 +64,27 @@ module Int16 = struct
   let min_int = 0x8000S
   let max_int = 0x7FFFS
 
-  external leading_zeros : (t [@unboxed]) -> (int [@untagged]) =
+  external leading_zeros : int16# -> int16# =
     "" "caml_int16_clz_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external trailing_zeros : (t [@unboxed]) -> (int [@untagged]) =
+  external trailing_zeros : int16# -> int16# =
     "" "caml_int16_ctz_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
 
-  external popcount : (t [@unboxed]) -> (int [@untagged]) =
+  external popcount : int16# -> int16# =
     "" "caml_int16_popcnt_untagged_to_untagged"
   [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external untag : t -> int16# = "%int16#_of_int16"
+  external tag_as_int : int16# -> int = "%int_of_int16#"
+
+  let wrap f n = tag_as_int (f (untag n))
+  [@@inline]
+
+  let leading_zeros n = wrap leading_zeros n
+  let trailing_zeros n = wrap trailing_zeros n
+  let popcount n = wrap popcount n
 end
 
 module Int32 = struct

--- a/testsuite/tests/flambda2/simplify/bit_counting_ops.ml
+++ b/testsuite/tests/flambda2/simplify/bit_counting_ops.ml
@@ -1,0 +1,269 @@
+(* TEST
+   compile_only = "true";
+   flambda2;
+   setup-ocamlopt.byte-build-env;
+   ocamlopt.byte with dump-simplify;
+   check-fexpr-dump;
+ *)
+
+(* This whole file (with the .mli) should simplify down to nothing as we
+   constant-fold all the tests. *)
+
+module Int8 = struct
+  type t = int8
+
+  let size = 8
+
+  external to_int : t -> int = "%int_of_int8"
+  external format_int : string -> int -> string = "caml_format_int"
+  let[@inline] to_string x = format_int "%d" (to_int x)
+
+  let zero = 0s
+  let one = 1s
+  let minus_one = -1s
+  let minus_two = -2s
+  let min_int = 0x80s
+  let max_int = 0x7Fs
+
+  external leading_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int8_clz_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external trailing_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int8_ctz_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external popcount : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int8_popcnt_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+end
+
+module Int16 = struct
+  type t = int16
+
+  let size = 16
+
+  external to_int : t -> int = "%int_of_int16"
+  external format_int : string -> int -> string = "caml_format_int"
+  let[@inline] to_string x = format_int "%d" (to_int x)
+
+  let zero = 0S
+  let one = 1S
+  let minus_one = -1S
+  let minus_two = -2S
+  let min_int = 0x8000S
+  let max_int = 0x7FFFS
+
+  external leading_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int16_clz_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external trailing_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int16_ctz_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external popcount : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int16_popcnt_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+end
+
+module Int32 = struct
+  type t = int32
+
+  let size = 32
+
+  external format : string -> int32 -> string = "caml_int32_format"
+  let[@inline] to_string n = format "%d" n
+
+  let zero = 0l
+  let one = 1l
+  let minus_one = -1l
+  let minus_two = -2l
+  let min_int = 0x80000000l
+  let max_int = 0x7FFFFFFFl
+
+  external leading_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int32_clz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external trailing_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int32_ctz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external popcount : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int32_popcnt_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+end
+
+module Int64 = struct
+  type t = int64
+
+  let size = 64
+
+  external format : string -> int64 -> string = "caml_int64_format"
+  let[@inline] to_string n = format "%d" n
+
+  let zero = 0L
+  let one = 1L
+  let minus_one = -1L
+  let minus_two = -2L
+  let min_int = 0x8000000000000000L
+  let max_int = 0x7FFFFFFFFFFFFFFFL
+
+  external leading_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int64_clz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external trailing_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int64_ctz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external popcount : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_int64_popcnt_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+end
+
+module Nativeint = struct
+  type t = nativeint
+
+  let size = Sys.word_size
+
+  external format : string -> nativeint -> string = "caml_nativeint_format"
+  let[@inline] to_string n = format "%d" n
+
+  let zero = 0n
+  let one = 1n
+  let minus_one = -1n
+  let minus_two = -2n
+  external shift_left: nativeint -> int -> nativeint = "%nativeint_lsl"
+  let min_int = shift_left 1n (size - 1)
+  external sub: nativeint -> nativeint -> nativeint = "%nativeint_sub"
+  let max_int = sub min_int 1n
+
+  external leading_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_nativeint_clz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external trailing_zeros : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_nativeint_ctz_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external popcount : (t [@unboxed]) -> (int [@untagged]) =
+    "" "caml_nativeint_popcnt_unboxed_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+end
+
+module Immediate = struct
+  type t = int
+
+  let size = Sys.int_size
+
+  external format_int : string -> int -> string = "caml_format_int"
+  let[@inline] to_string x = format_int "%d" x
+
+  let zero = 0
+  let one = 1
+  let minus_one = -1
+  let minus_two = -2
+  external shift_right_logical : int -> int -> int = "%lsrint"
+  let max_int = shift_right_logical (-1) 1
+  external add : int -> int -> int = "%addint"
+  let min_int = add max_int 1
+end
+
+module Naked_immediate = struct
+  include Immediate
+
+  external leading_zeros : (t [@untagged]) -> (int [@untagged]) =
+    "" "caml_int_clz_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external trailing_zeros : (t [@untagged]) -> (int [@untagged]) =
+    "" "caml_int_ctz_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external popcount : (t [@untagged]) -> (int [@untagged]) =
+    "" "caml_int_popcnt_untagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+end
+
+module Tagged_immediate = struct
+  include Immediate
+
+  external leading_zeros : t -> (int [@untagged]) =
+    "" "caml_int_clz_tagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external trailing_zeros : t -> (int [@untagged]) =
+    "" "caml_int_ctz_tagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+
+  external popcount : t -> (int [@untagged]) =
+    "" "caml_int_popcnt_tagged_to_untagged"
+  [@@noalloc] [@@builtin] [@@no_effects] [@@no_coeffects]
+end
+
+module Test(I : sig
+  type t
+
+  val to_string : t -> string
+
+  val size : int
+  val zero : t
+  val one : t
+  val minus_one : t
+  val minus_two : t
+  val min_int : t
+  val max_int : t
+
+
+  val leading_zeros : t -> int
+  val trailing_zeros : t -> int
+  val popcount : t -> int
+end) = struct
+  open I
+
+  let[@inline] check name fn lhs rhs =
+    let fn_lhs = (fn [@inlined hint]) lhs in
+    if fn_lhs <> rhs
+    then (Format.kasprintf [@inlined never]) failwith "%s(%s): expected %d but got %d" name (to_string lhs) fn_lhs rhs
+
+  let[@inline] check_leading_zeros lhs rhs =
+    check "leading_zeros" leading_zeros lhs rhs
+
+  let[@inline] check_trailing_zeros lhs rhs =
+    check "trailing_zeros" trailing_zeros lhs rhs
+
+  let[@inline] check_popcount lhs rhs =
+    check "popcount" popcount lhs rhs
+
+  let () =
+    check_leading_zeros zero size;
+    check_leading_zeros one (size - 1);
+    check_leading_zeros minus_one 0;
+    check_leading_zeros minus_two 0;
+    check_leading_zeros min_int 0;
+    check_leading_zeros max_int 1;
+    check_trailing_zeros zero size;
+    check_trailing_zeros one 0;
+    check_trailing_zeros minus_one 0;
+    check_trailing_zeros minus_two 1;
+    check_trailing_zeros min_int (size - 1);
+    check_trailing_zeros max_int 0;
+    check_popcount zero 0;
+    check_popcount one 1;
+    check_popcount minus_one size;
+    check_popcount minus_two (size - 1);
+    check_popcount min_int 1;
+    check_popcount max_int (size - 1);
+    ()
+end
+[@@inline]
+
+module _ = Test(Int8)
+module _ = Test(Int16)
+module _ = Test(Int32)
+module _ = Test(Int64)
+module _ = Test(Nativeint)
+module _ = Test(Naked_immediate)
+module _ = Test(Tagged_immediate)

--- a/testsuite/tests/flambda2/simplify/bit_counting_ops.simplify.reference
+++ b/testsuite/tests/flambda2/simplify/bit_counting_ops.simplify.reference
@@ -1,0 +1,2 @@
+let $camlBit_counting_ops = Block 0 () in
+cont done ($camlBit_counting_ops)

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -575,6 +575,165 @@ module Stdlib = struct
     include Int
     let min (a : int) (b : int) = min a b
     let max (a : int) (b : int) = max a b
+
+    (* Number of leading zeros.  Hacker's Delight (2 ed.), algorithm 5.12 *)
+
+    let leading_zeros x =
+      let x = ref x and n = ref Sys.int_size in
+      if Sys.int_size > 32 then begin
+        let y = shift_right_logical !x 32 in
+        if y <> 0 then (n := !n - 32; x := y)
+      end;
+      let y = shift_right_logical !x 16 in
+      if y <> 0 then (n := !n - 16; x := y);
+      let y = shift_right_logical !x  8 in
+      if y <> 0 then (n := !n -  8; x := y);
+      let y = shift_right_logical !x  4 in
+      if y <> 0 then (n := !n -  4; x := y);
+      let y = shift_right_logical !x 2 in
+      if y <> 0 then (n := !n -  2; x := y);
+      let y = shift_right_logical !x 1 in
+      if y <> 0 then !n - 2 else !n - !x
+
+    (* Number of trailing zeros.  Hacker's Delight (2 ed.), algorithm 5.21 *)
+
+    let trailing_zeros x =
+      if x = 0 then Sys.int_size else begin
+        let x = ref x and n = ref (Sys.int_size - 1) in
+        if Sys.int_size > 32 then begin
+          let y = shift_left !x 32 in
+          if y <> 0 then (n := !n - 32; x := y)
+        end;
+        let y = shift_left !x 16 in
+        if y <> 0 then (n := !n - 16; x := y);
+        let y = shift_left !x  8 in
+        if y <> 0 then (n := !n -  8; x := y);
+        let y = shift_left !x  4 in
+        if y <> 0 then (n := !n -  4; x := y);
+        let y = shift_left !x  2 in
+        if y <> 0 then (n := !n -  2; x := y);
+        let y = shift_left !x  1 in
+        if y <> 0 then !n - 1 else !n
+      end
+
+    (* Population count.  Hacker's Delight (2 ed.), algorithm 5.2 *)
+
+    external int64_to_int : int64 -> int = "%int64_to_int"
+    let cst1 = int64_to_int 0x5555_5555_5555_5555L
+    let cst2 = int64_to_int 0x3333_3333_3333_3333L
+    let cst3 = int64_to_int 0x0F0F_0F0F_0F0F_0F0FL
+
+    let popcount x =
+      let x = sub x (logand (shift_right_logical x 1) cst1) in
+      let x = add (logand x cst2)
+                  (logand (shift_right_logical x 2) cst2) in
+      let x = logand (add x (shift_right_logical x 4)) cst3 in
+      let x = add x (shift_right_logical x 8) in
+      let x = add x (shift_right_logical x 16) in
+      if Sys.int_size > 32 then begin
+        let x = add x (shift_right_logical x 32) in
+        x land 0x7F
+      end else
+        x land 0x3F
+  end
+
+  module Int32 = struct
+    include Int32
+
+    (* Number of leading zeros.  Hacker's Delight (2 ed.), algorithm 5.12 *)
+
+    let leading_zeros x =
+      let x = ref x and n = ref 32 in
+      let y = shift_right_logical !x 16 in
+      if y <> 0l then (n := !n - 16; x := y);
+      let y = shift_right_logical !x  8 in
+      if y <> 0l then (n := !n -  8; x := y);
+      let y = shift_right_logical !x  4 in
+      if y <> 0l then (n := !n -  4; x := y);
+      let y = shift_right_logical !x 2 in
+      if y <> 0l then (n := !n -  2; x := y);
+      let y = shift_right_logical !x 1 in
+      if y <> 0l then !n - 2 else !n - to_int !x
+
+    (* Number of trailing zeros.  Hacker's Delight (2 ed.), algorithm 5.21 *)
+
+    let trailing_zeros x =
+      if x = 0l then 32 else begin
+        let x = ref x and n = ref 31 in
+        let y = shift_left !x 16 in
+        if y <> 0l then (n := !n - 16; x := y);
+        let y = shift_left !x  8 in
+        if y <> 0l then (n := !n -  8; x := y);
+        let y = shift_left !x  4 in
+        if y <> 0l then (n := !n -  4; x := y);
+        let y = shift_left !x  2 in
+        if y <> 0l then (n := !n -  2; x := y);
+        let y = shift_left !x  1 in
+        if y <> 0l then !n - 1 else !n
+      end
+
+    (* Population count.  Hacker's Delight (2 ed.), algorithm 5.2 *)
+
+    let popcount x =
+      let x = sub x (logand (shift_right_logical x 1) 0x5555_5555l) in
+      let x = add (logand x 0x3333_3333l)
+                  (logand (shift_right_logical x 2) 0x3333_3333l) in
+      let x = logand (add x (shift_right_logical x 4)) 0x0F0F_0F0Fl in
+      let x = add x (shift_right_logical x 8) in
+      let x = add x (shift_right_logical x 16) in
+      to_int x land 0x3F
+  end
+
+  module Int64 = struct
+    include Int64
+
+    (* Number of leading zeros.  Hacker's Delight (2 ed.), algorithm 5.12 *)
+
+    let leading_zeros x =
+      let x = ref x and n = ref 64 in
+      let y = shift_right_logical !x 32 in
+      if y <> 0L then (n := !n - 32; x := y);
+      let y = shift_right_logical !x 16 in
+      if y <> 0L then (n := !n - 16; x := y);
+      let y = shift_right_logical !x  8 in
+      if y <> 0L then (n := !n -  8; x := y);
+      let y = shift_right_logical !x  4 in
+      if y <> 0L then (n := !n -  4; x := y);
+      let y = shift_right_logical !x 2 in
+      if y <> 0L then (n := !n -  2; x := y);
+      let y = shift_right_logical !x 1 in
+      if y <> 0L then !n - 2 else !n - to_int !x
+
+    (* Number of trailing zeros.  Hacker's Delight (2 ed.), algorithm 5.21 *)
+
+    let trailing_zeros x =
+      if x = 0L then 64 else begin
+        let x = ref x and n = ref 63 in
+        let y = shift_left !x 32 in
+        if y <> 0L then (n := !n - 32; x := y);
+        let y = shift_left !x 16 in
+        if y <> 0L then (n := !n - 16; x := y);
+        let y = shift_left !x  8 in
+        if y <> 0L then (n := !n -  8; x := y);
+        let y = shift_left !x  4 in
+        if y <> 0L then (n := !n -  4; x := y);
+        let y = shift_left !x  2 in
+        if y <> 0L then (n := !n -  2; x := y);
+        let y = shift_left !x  1 in
+        if y <> 0L then !n - 1 else !n
+      end
+
+    (* Population count.  Hacker's Delight (2 ed.), algorithm 5.2 *)
+
+    let popcount x =
+      let x = sub x (logand (shift_right_logical x 1) 0x5555_5555_5555_5555L) in
+      let x = add (logand x 0x3333_3333_3333_3333L)
+                  (logand (shift_right_logical x 2) 0x3333_3333_3333_3333L) in
+      let x = logand (add x (shift_right_logical x 4)) 0x0F0F_0F0F_0F0F_0F0FL in
+      let x = add x (shift_right_logical x 8) in
+      let x = add x (shift_right_logical x 16) in
+      let x = add x (shift_right_logical x 32) in
+      to_int x land 0x7F
   end
 
   external compare : 'a -> 'a -> int = "%compare"

--- a/utils/misc.mli
+++ b/utils/misc.mli
@@ -354,6 +354,29 @@ module Stdlib : sig
 
     val min : t -> t -> t
     val max : t -> t -> t
+
+    (* CR bclement: these are in the upstream stdlib in 5.5 *)
+    val leading_zeros : t -> int
+    val trailing_zeros : t -> int
+    val popcount : t -> int
+  end
+
+  module Int32 : sig
+    include module type of Int32
+
+    (* CR bclement: these are in the upstream stdlib in 5.5 *)
+    val leading_zeros : t -> int
+    val trailing_zeros : t -> int
+    val popcount : t -> int
+  end
+
+  module Int64 : sig
+    include module type of Int64
+
+    (* CR bclement: these are in the upstream stdlib in 5.5 *)
+    val leading_zeros : t -> int
+    val trailing_zeros : t -> int
+    val popcount : t -> int
   end
 
   external compare : 'a -> 'a -> int = "%compare"


### PR DESCRIPTION
Alternative to #6726 (I'll add the other primitives from that PR in a follow-up).