### PR TITLE
int{8,16} popcnt/clz/ctz do not need sign extension

### DIFF
--- a/backend/cmm_builtins.ml
+++ b/backend/cmm_builtins.ml
@@ -1246,7 +1246,13 @@ let builtin_sign_extends = function
   | "caml_ext_pointer_load_signed_int32" | "caml_ext_pointer_load_unboxed_int32"
   | "caml_int32_shift_right_by_int32_unboxed" | "caml_csel_int32_unboxed"
   | "caml_int16_shift_right_by_int16_untagged"
-  | "caml_int8_shift_right_by_int8_untagged" ->
+  | "caml_int8_shift_right_by_int8_untagged"
+  (* popcnt/clz/ctz are never negative. *)
+  | "caml_int8_popcnt_untagged_to_untagged"
+  | "caml_int16_popcnt_untagged_to_untagged"
+  | "caml_int8_clz_untagged_to_untagged" | "caml_int16_clz_untagged_to_untagged"
+  | "caml_int8_ctz_untagged_to_untagged" | "caml_int16_ctz_untagged_to_untagged"
+    ->
     true
   | _ -> false
 

--- a/testsuite/tests/codegen/int8_u.ml
+++ b/testsuite/tests/codegen/int8_u.ml
@@ -613,8 +613,6 @@ let popcount x = Int8_u.popcount x
 popcount:
   andl  $255, %eax
   popcnt %rax, %rax
-  salq  $56, %rax
-  sarq  $56, %rax
   ret
 |}]
 
@@ -623,8 +621,6 @@ let ctz x = Int8_u.ctz x
 ctz:
   orq   $256, %rax
   tzcnt %rax, %rax
-  salq  $56, %rax
-  sarq  $56, %rax
   ret
 |}]
 
@@ -634,8 +630,6 @@ clz:
   andl  $255, %eax
   lzcnt %rax, %rax
   addq  $-56, %rax
-  salq  $56, %rax
-  sarq  $56, %rax
   ret
 |}]
 


### PR DESCRIPTION
They never return negative values.

Note that the test for Int16 does not change because it does not use `caml_int16_{popcnt,clz,ctz}_untagged_to_untagged` but instead `caml_popcnt_int16` / `caml_lzcnt_int16` / `caml_bmi_tzcnt_int16` that are handled in `simd_selection`.

This makes #6738 a little bit nicer.