### PR TITLE
Improve mode implication inference

### DIFF
--- a/external/merlin/src/analysis/ptyp_of_type.ml
+++ b/external/merlin/src/analysis/ptyp_of_type.ml
@@ -25,10 +25,10 @@ let rec module_type =
         Parsetree.Named
           ( Location.mknoloc (Option.map ~f:Ident.name id),
             module_type type_in,
-            modes param_mode )
+            modes ~arg:true param_mode )
     in
     let out = module_type type_out in
-    Mty.functor_ ~ret_mode:(modes ret_mode) param out
+    Mty.functor_ ~ret_mode:(modes ~arg:false ret_mode) param out
   | Mty_strengthen (mty, path, _aliasability) ->
     Mty.strengthen ~loc:Location.none (module_type mty)
       (Location.mknoloc (Untypeast.lident_of_path path))
@@ -55,8 +55,8 @@ and core_type type_expr =
       | Labelled l -> (Labelled l, core_type type_expr)
       | Optional l -> (Optional l, core_type type_expr)
     in
-    let arg_modes = modes arg_alloc_mode in
-    let ret_modes = modes ret_alloc_mode in
+    let arg_modes = modes ~arg:true arg_alloc_mode in
+    let ret_modes = modes ~arg:false ret_alloc_mode in
     Typ.arrow label type_expr (core_type type_expr_out) arg_modes ret_modes
   | Ttuple type_exprs ->
     let labeled_type_exprs =
@@ -179,9 +179,9 @@ and extension_constructor id { ext_args; ext_ret_type; ext_attributes; _ } =
     ?res:(Option.map ~f:core_type ext_ret_type)
     (var_of_id id)
 
-and modes mode =
+and modes ~arg mode =
   let snapshot = Btype.snapshot () in
-  let mode = Mode.Alloc.zap_to_legacy mode in
+  let mode = Mode.Alloc.zap_to_legacy ~arg mode in
   Btype.backtrack snapshot;
   Out_type.tree_of_modes mode
   |> List.map ~f:(fun mode -> Location.mknoloc (Parsetree.Mode mode))

--- a/external/merlin/src/ocaml/typing/ctype.ml
+++ b/external/merlin/src/ocaml/typing/ctype.ml
@@ -758,8 +758,8 @@ let remove_mode_and_jkind_variables ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-         let _ = Alloc.zap_to_legacy marg in
-         let _ = Alloc.zap_to_legacy mret in
+         let _ = Alloc.zap_to_legacy ~arg:true marg in
+         let _ = Alloc.zap_to_legacy ~arg:false mret in
          go targ; go tret
       | _ -> iter_type_expr go ty
     end

--- a/external/merlin/src/ocaml/typing/mode.ml
+++ b/external/merlin/src/ocaml/typing/mode.ml
@@ -5790,13 +5790,16 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
-  (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
-  let zap_to_legacy ~statefulness =
+  let zap_to_ceil_clamped c m =
+    (match submode m (of_const c) with Ok () | Error _ -> ());
+    zap_to_ceil m
+
+  let zap_to_legacy ~statefulness m =
     match statefulness with
-    | Statefulness.Const.Stateful | Statefulness.Const.Reading
-    | Statefulness.Const.Writing ->
-      zap_to_ceil
-    | Statefulness.Const.Stateless -> zap_to_floor
+    | Statefulness.Const.Stateful -> zap_to_ceil m
+    | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
+    | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
+    | Statefulness.Const.Stateless -> zap_to_floor m
 end
 
 module Uniqueness = struct
@@ -5832,13 +5835,18 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
-  (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
-  let zap_to_legacy ~visibility =
+  let zap_to_floor_clamped c m =
+    (match submode (of_const c) m with Ok () | Error _ -> ());
+    zap_to_floor m
+
+  let zap_to_legacy ~visibility ~arg m =
     match visibility with
-    | Visibility.Const.Read_write | Visibility.Const.Read
+    | Visibility.Const.Read_write -> zap_to_floor m
+    | Visibility.Const.Immutable -> zap_to_ceil m
+    | Visibility.Const.Read ->
+      if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
     | Visibility.Const.Write ->
-      zap_to_floor
-    | Visibility.Const.Immutable -> zap_to_ceil
+      if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
 end
 
 module Forkable = struct
@@ -6179,11 +6187,11 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-  let zap_to_legacy m : Const.t =
+  let zap_to_legacy ~arg m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
     let visibility = proj Visibility m |> Visibility.zap_to_legacy in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy ~visibility
+      proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
     in
     let staticity = proj Staticity m |> Staticity.zap_to_legacy in
     { uniqueness; contention; visibility; staticity }
@@ -6822,8 +6830,8 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.zap_to_floor comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_legacy { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy monadic in
+  let zap_to_legacy ~arg { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy ~arg monadic in
     let comonadic = Comonadic.zap_to_legacy comonadic in
     merge { monadic; comonadic }
 

--- a/external/merlin/src/ocaml/typing/mode_intf.mli
+++ b/external/merlin/src/ocaml/typing/mode_intf.mli
@@ -811,7 +811,19 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-    val zap_to_legacy : lr -> Const.t
+    (** [arg] determines co-/contravariance, and is used to infer the most
+        general mode for implied middle values on monadic axes.\
+
+        Consider:
+
+        {[
+          (* Implies [read shared]. *)
+          let zap_arg_read (x @ read) = ()
+
+          (* Implies [read uncontended]. *)
+          let zap_ret_read x : _ @ read = ()
+        ]} *)
+    val zap_to_legacy : arg:bool -> lr -> Const.t
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->

--- a/external/merlin/src/ocaml/typing/out_type.ml
+++ b/external/merlin/src/ocaml/typing/out_type.ml
@@ -1522,7 +1522,7 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = Alloc.zap_to_legacy mode in
+        let mode = Alloc.zap_to_legacy ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode), tree)
     | Other _ -> tree
   in
@@ -1552,7 +1552,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = Alloc.zap_to_legacy marg in
+        let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -1830,11 +1830,11 @@ and tree_of_ret_typ_mutating acc_mode m ty=
       | Error _ ->
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        let m = Alloc.zap_to_legacy m in
+        let m = Alloc.zap_to_legacy ~arg:false m in
         (Orm_parens (tree_of_modes m), m)
       end
   | _ ->
-    let m = Alloc.zap_to_legacy m in
+    let m = Alloc.zap_to_legacy ~arg:false m in
     (Orm_any (tree_of_modes m), m)
 
 and tree_of_typobject_repr fi =
@@ -2845,7 +2845,9 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
-      let mres = m_res |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let mres =
+        m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
+      in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       let p = best_module_path p in
@@ -2876,7 +2878,9 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
-      let marg = m_arg |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let marg =
+        m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
+      in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/external/merlin/src/ocaml/typing/typecore.ml
+++ b/external/merlin/src/ocaml/typing/typecore.ml
@@ -8283,7 +8283,7 @@ and type_expect_
       let (ty, exp_extra) =
         let alloc_mode =
           Mode.Alloc.Const.Option.value
-            modes.mode_modes
+            (Typemode.apply_mode_implications modes.mode_modes)
             ~default:Mode.Alloc.Const.legacy
         in
         type_constraint env sty alloc_mode
@@ -9390,7 +9390,10 @@ and type_constraint_expect
   =
   fun constraint_arg env expected_mode loc ~loc_arg type_mode constraint_ ty_expected ->
   let ret, ty, exp_extra =
-    let type_mode = Alloc.Const.Option.value ~default:Alloc.Const.legacy type_mode in
+    let type_mode =
+      Alloc.Const.Option.value ~default:Alloc.Const.legacy
+        (Typemode.apply_mode_implications type_mode)
+    in
     match constraint_ with
     | Pcoerce (ty_constrain, ty_coerce) ->
         type_coerce constraint_arg env expected_mode loc ty_constrain ty_coerce

--- a/external/merlin/src/ocaml/typing/typedecl.ml
+++ b/external/merlin/src/ocaml/typing/typedecl.ml
@@ -4827,6 +4827,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
         let modes = Typemode.transl_mode_annots modes in
         let mode =
           modes.mode_modes
+          |> Typemode.apply_mode_implications
           |> Mode.Alloc.Const.(
               Option.value ~default:{legacy with staticity = Static})
           |> Mode.Alloc.of_const

--- a/external/merlin/src/ocaml/typing/typemod.ml
+++ b/external/merlin/src/ocaml/typing/typemod.ml
@@ -2732,6 +2732,7 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
             let tmmode = Typemode.transl_mode_annots smmode in
             let mmode =
               tmmode.mode_modes
+              |> Typemode.apply_mode_implications
               (* CR zqian: mode annotations on rec modules default to legacy for
               now. We can remove this workaround once [module type of] doesn't
               require zapping. *)
@@ -2863,10 +2864,10 @@ let check_nongen_signature env sg =
 
 let remove_functor_mode_variables = function
   | Mty_functor (arg_opt, _, mres) ->
-      Mode.Alloc.zap_to_legacy mres |> ignore;
+      Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy marg |> ignore
+      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
       end
   | _ -> ()
 

--- a/external/merlin/src/ocaml/typing/typemode.ml
+++ b/external/merlin/src/ocaml/typing/typemode.ml
@@ -202,7 +202,7 @@ let enforce_forbidden_modalities ~loc annot_type m =
     raise (Error (loc, Forbidden_modality (annot_type, Global_and_unique)))
   | _ -> ()
 
-let default_mode_annots (annots : Alloc.Const.Option.t) =
+let apply_mode_implications (annots : Alloc.Const.Option.t) =
   (* [forkable] has a different default depending on whether [areality]
      is [global] or [local]. *)
   let forkable =
@@ -256,9 +256,7 @@ let transl_mode_annots annots =
     then raise (Error (loc, Duplicated_axis (Mode, ax)))
     else Alloc.Const.Option.set ax (Some mode) modes_so_far
   in
-  let modes =
-    List.fold_left step Alloc.Const.Option.none annots |> default_mode_annots
-  in
+  let modes = List.fold_left step Alloc.Const.Option.none annots in
   { mode_modes = modes; mode_desc = annots }
 
 let untransl_mode modes =
@@ -547,6 +545,7 @@ let transl_alloc_mode annots =
   let { mode_modes = opt_modes; mode_desc = annots } =
     transl_mode_annots annots
   in
+  let opt_modes = apply_mode_implications opt_modes in
   let modes = Alloc.Const.Option.value opt_modes ~default:Alloc.Const.legacy in
   { mode_modes = modes; mode_desc = annots }
 

--- a/external/merlin/src/ocaml/typing/typemode.mli
+++ b/external/merlin/src/ocaml/typing/typemode.mli
@@ -17,6 +17,9 @@ type modalities =
 *)
 val transl_mode_annots : Parsetree.modes -> Mode.Alloc.Const.Option.t modes
 
+val apply_mode_implications :
+  Mode.Alloc.Const.Option.t -> Mode.Alloc.Const.Option.t
+
 val untransl_mode : _ modes -> Parsetree.modes
 
 (** Interpret mode syntax as alloc mode (on arrow types), where axes are set to

--- a/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ctype.ml
@@ -739,8 +739,8 @@ let remove_mode_and_jkind_variables ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-         let _ = Alloc.zap_to_legacy marg in
-         let _ = Alloc.zap_to_legacy mret in
+         let _ = Alloc.zap_to_legacy ~arg:true marg in
+         let _ = Alloc.zap_to_legacy ~arg:false mret in
          go targ; go tret
       | _ -> iter_type_expr go ty
     end

--- a/external/merlin/upstream/ocaml_flambda/typing/mode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode.ml
@@ -5790,13 +5790,16 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
-  (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
-  let zap_to_legacy ~statefulness =
+  let zap_to_ceil_clamped c m =
+    (match submode m (of_const c) with Ok () | Error _ -> ());
+    zap_to_ceil m
+
+  let zap_to_legacy ~statefulness m =
     match statefulness with
-    | Statefulness.Const.Stateful | Statefulness.Const.Reading
-    | Statefulness.Const.Writing ->
-      zap_to_ceil
-    | Statefulness.Const.Stateless -> zap_to_floor
+    | Statefulness.Const.Stateful -> zap_to_ceil m
+    | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
+    | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
+    | Statefulness.Const.Stateless -> zap_to_floor m
 end
 
 module Uniqueness = struct
@@ -5832,13 +5835,18 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
-  (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
-  let zap_to_legacy ~visibility =
+  let zap_to_floor_clamped c m =
+    (match submode (of_const c) m with Ok () | Error _ -> ());
+    zap_to_floor m
+
+  let zap_to_legacy ~visibility ~arg m =
     match visibility with
-    | Visibility.Const.Read_write | Visibility.Const.Read
+    | Visibility.Const.Read_write -> zap_to_floor m
+    | Visibility.Const.Immutable -> zap_to_ceil m
+    | Visibility.Const.Read ->
+      if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
     | Visibility.Const.Write ->
-      zap_to_floor
-    | Visibility.Const.Immutable -> zap_to_ceil
+      if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
 end
 
 module Forkable = struct
@@ -6179,11 +6187,11 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-  let zap_to_legacy m : Const.t =
+  let zap_to_legacy ~arg m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
     let visibility = proj Visibility m |> Visibility.zap_to_legacy in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy ~visibility
+      proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
     in
     let staticity = proj Staticity m |> Staticity.zap_to_legacy in
     { uniqueness; contention; visibility; staticity }
@@ -6822,8 +6830,8 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.zap_to_floor comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_legacy { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy monadic in
+  let zap_to_legacy ~arg { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy ~arg monadic in
     let comonadic = Comonadic.zap_to_legacy comonadic in
     merge { monadic; comonadic }
 

--- a/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/mode_intf.mli
@@ -811,7 +811,19 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-    val zap_to_legacy : lr -> Const.t
+    (** [arg] determines co-/contravariance, and is used to infer the most
+        general mode for implied middle values on monadic axes.\
+
+        Consider:
+
+        {[
+          (* Implies [read shared]. *)
+          let zap_arg_read (x @ read) = ()
+
+          (* Implies [read uncontended]. *)
+          let zap_ret_read x : _ @ read = ()
+        ]} *)
+    val zap_to_legacy : arg:bool -> lr -> Const.t
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->

--- a/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/out_type.ml
@@ -1412,7 +1412,7 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = Alloc.zap_to_legacy mode in
+        let mode = Alloc.zap_to_legacy ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode), tree)
     | Other _ -> tree
   in
@@ -1442,7 +1442,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = Alloc.zap_to_legacy marg in
+        let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -1709,11 +1709,11 @@ and tree_of_ret_typ_mutating acc_mode m ty=
       | Error _ ->
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        let m = Alloc.zap_to_legacy m in
+        let m = Alloc.zap_to_legacy ~arg:false m in
         (Orm_parens (tree_of_modes m), m)
       end
   | _ ->
-    let m = Alloc.zap_to_legacy m in
+    let m = Alloc.zap_to_legacy ~arg:false m in
     (Orm_any (tree_of_modes m), m)
 
 and tree_of_typobject_repr fi =
@@ -2705,7 +2705,9 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
-      let mres = m_res |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let mres =
+        m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
+      in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       Omty_alias (tree_of_path (Some Module) p)
@@ -2734,7 +2736,9 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
-      let marg = m_arg |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let marg =
+        m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
+      in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typecore.ml
@@ -8046,7 +8046,7 @@ and type_expect_
       let (ty, exp_extra) =
         let alloc_mode =
           Mode.Alloc.Const.Option.value
-            modes.mode_modes
+            (Typemode.apply_mode_implications modes.mode_modes)
             ~default:Mode.Alloc.Const.legacy
         in
         type_constraint env sty alloc_mode
@@ -9117,7 +9117,10 @@ and type_constraint_expect
   =
   fun constraint_arg env expected_mode loc ~loc_arg type_mode constraint_ ty_expected ->
   let ret, ty, exp_extra =
-    let type_mode = Alloc.Const.Option.value ~default:Alloc.Const.legacy type_mode in
+    let type_mode =
+      Alloc.Const.Option.value ~default:Alloc.Const.legacy
+        (Typemode.apply_mode_implications type_mode)
+    in
     match constraint_ with
     | Pcoerce (ty_constrain, ty_coerce) ->
         type_coerce constraint_arg env expected_mode loc ty_constrain ty_coerce

--- a/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typedecl.ml
@@ -4821,6 +4821,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
         let modes = Typemode.transl_mode_annots modes in
         let mode =
           modes.mode_modes
+          |> Typemode.apply_mode_implications
           |> Mode.Alloc.Const.(
               Option.value ~default:{legacy with staticity = Static})
           |> Mode.Alloc.of_const

--- a/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemod.ml
@@ -2710,6 +2710,7 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
             let tmmode = Typemode.transl_mode_annots smmode in
             let mmode =
               tmmode.mode_modes
+              |> Typemode.apply_mode_implications
               (* CR zqian: mode annotations on rec modules default to legacy for
               now. We can remove this workaround once [module type of] doesn't
               require zapping. *)
@@ -2840,10 +2841,10 @@ let check_nongen_signature env sg =
 
 let remove_functor_mode_variables = function
   | Mty_functor (arg_opt, _, mres) ->
-      Mode.Alloc.zap_to_legacy mres |> ignore;
+      Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy marg |> ignore
+      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
       end
   | _ -> ()
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typemode.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemode.ml
@@ -202,7 +202,7 @@ let enforce_forbidden_modalities ~loc annot_type m =
     raise (Error (loc, Forbidden_modality (annot_type, Global_and_unique)))
   | _ -> ()
 
-let default_mode_annots (annots : Alloc.Const.Option.t) =
+let apply_mode_implications (annots : Alloc.Const.Option.t) =
   (* [forkable] has a different default depending on whether [areality]
      is [global] or [local]. *)
   let forkable =
@@ -256,9 +256,7 @@ let transl_mode_annots annots =
     then raise (Error (loc, Duplicated_axis (Mode, ax)))
     else Alloc.Const.Option.set ax (Some mode) modes_so_far
   in
-  let modes =
-    List.fold_left step Alloc.Const.Option.none annots |> default_mode_annots
-  in
+  let modes = List.fold_left step Alloc.Const.Option.none annots in
   { mode_modes = modes; mode_desc = annots }
 
 let untransl_mode modes =
@@ -547,6 +545,7 @@ let transl_alloc_mode annots =
   let { mode_modes = opt_modes; mode_desc = annots } =
     transl_mode_annots annots
   in
+  let opt_modes = apply_mode_implications opt_modes in
   let modes = Alloc.Const.Option.value opt_modes ~default:Alloc.Const.legacy in
   { mode_modes = modes; mode_desc = annots }
 

--- a/external/merlin/upstream/ocaml_flambda/typing/typemode.mli
+++ b/external/merlin/upstream/ocaml_flambda/typing/typemode.mli
@@ -17,6 +17,9 @@ type modalities =
 *)
 val transl_mode_annots : Parsetree.modes -> Mode.Alloc.Const.Option.t modes
 
+val apply_mode_implications :
+  Mode.Alloc.Const.Option.t -> Mode.Alloc.Const.Option.t
+
 val untransl_mode : _ modes -> Parsetree.modes
 
 (** Interpret mode syntax as alloc mode (on arrow types), where axes are set to

--- a/jane/doc/extensions/_05-modes/syntax.md
+++ b/jane/doc/extensions/_05-modes/syntax.md
@@ -303,24 +303,67 @@ specify a mode along the contention axis, the expression behaves as if it contai
 `contended`. This rule still allows you to write e.g. `t @ immutable uncontended`
 if that's what you want; most users will never want this, though.
 
+## How mode implications apply
+
+*Fixed sites* require every axis to be pinned to a specific mode.
+These include:
+
+- modes appearing in types (like in the `f` example above)
+- modes on functor arguments and returns
+- external declarations
+- mode annotations on recursive modules
+
+At fixed sites, an axis you leave unwritten is filled in by an implication from a mode you did write, or, failing that, by the legacy mode.
+
+Everywhere else, a mode annotation constrains only the axes you actually wrote, and the remaining axes are inferred from the code. Those *flexible sites* include:
+
+- function parameters: `fun (x @ local) -> ...`
+- let bindings: `let f @ local = ...`
+- expression constraints: `(e : ty @ local)`
+- return-mode annotations: `let f x : ty @ local = ...`
+- mode constraints on modules
+
+At flexible sites, the implied axes are not pinned. For example, in
+`fun (x @ local) -> ...` the parameter must accept `local` values, but its
+yielding axis is left open: if the parameter is captured by a closure that
+must be `unyielding`, inference can pick `unyielding`. When nothing in the
+program constrains an unwritten axis, it defaults just as it would at a
+fixed site (in particular, `local` still defaults to `yielding` and
+`unforkable`).
+
+Beware of this asymmetry when moving an annotation between positions:
+
+```ocaml
+val f : t @ local -> u     (* argument pinned to yielding *)
+let f (x @ local) = ...    (* yielding mode of x is inferred *)
+```
+
+If you want the pinned behavior at a flexible site, write the implied
+axes explicitly, e.g. `(x @ local yielding)`.
+
+## Implications on modalities
+
 Once we've done this for modes, it would be odd if we didn't also do this
-for modalities. For example, `local` implies `yielding`. Now consider
+for modalities. Consider
 ```ocaml
 type 'a glob = { g : 'a @@ global }
 let unglob (r : 'a glob @ local) : 'a = r.g
 ```
-Because of the mode implication, `r` has mode `local unforkable yielding`.
-The written `global` modality means that `r.g` will have mode `global`
-(corresponding to the unwritten legacy `global` on the return type of `'a`).
-But without a `unyielding` modality, then `r.g` will have mode `yielding`,
+A `local` record such as `r` may also be `yielding`. The written `global`
+modality means that `r.g` will have mode `global` (corresponding to the
+unwritten legacy `global` on the return type of `'a`). But without an
+`unyielding` modality, `r.g` of a `yielding` record would be `yielding`,
 which is not compatible with a return expecting the legacy `unyielding`.
 We thus extend implications to include modalities, such that `global`
 implies `unyielding`, thus getting `unglob` to type-check (because now
 `r.g` will be `unyielding`).
 
-Other implications
-exist, all to lower users' annotation burden, all applying both to modes
-and modalities, according to this table:
+Unlike mode implications, modality implications are not positional: a
+modality expression always describes a complete modality, so its unwritten
+axes are filled in by implications wherever the modality is written.
+
+## The implication table
+
 
 
 | this         | implies this  |
@@ -338,8 +381,9 @@ and modalities, according to this table:
 | `write`      | `corrupted`   |
 | `read_write` | `uncontended` |
 
-These implications exist only in the surface syntax for mode and modality
-expressions. Mode inference does not necessarily follow these implications.
+
+These implications only affect defaults. All combinations on these axes
+are permissible.
 
 ## Global and aliased
 

--- a/testsuite/tests/typing-modes/forkable.ml
+++ b/testsuite/tests/typing-modes/forkable.ml
@@ -227,10 +227,7 @@ val f1 : 'a -> unit = <fun>
 let f2 (x @ local) = exclave_ requires_forkable x
 
 [%%expect{|
-Line 1, characters 48-49:
-1 | let f2 (x @ local) = exclave_ requires_forkable x
-                                                    ^
-Error: This value is "unforkable" but is expected to be "forkable".
+val f2 : 'a @ local forkable -> unit @ local = <fun>
 |}]
 
 let f3 (x @ unforkable) = requires_forkable x

--- a/testsuite/tests/typing-modes/mode_implications.ml
+++ b/testsuite/tests/typing-modes/mode_implications.ml
@@ -363,3 +363,174 @@ let curried (x @ local) (y @ local) =
 [%%expect{|
 val curried : 'a @ local -> 'b @ local unyielding -> unit = <fun>
 |}]
+
+(* Misc tests *)
+
+external use_local_unyielding : 'a @ local unyielding -> unit = "%ignore"
+[%%expect{|
+external use_local_unyielding : 'a @ local unyielding -> unit = "%ignore"
+|}]
+
+module Sig_forces_yielding : sig
+  val f : 'a @ local -> 'b @ local -> unit
+end = struct
+  let f x y = use_local_unyielding x; use_local_unyielding y
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f x y = use_local_unyielding x; use_local_unyielding y
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a -> 'b -> unit end
+       is not included in
+         sig val f : 'a @ local -> 'b @ local -> unit end
+       Values do not match:
+         val f : 'a -> 'b -> unit
+       is not included in
+         val f : 'a @ local -> 'b @ local -> unit
+       The type "'a -> 'b -> unit" is not compatible with the type
+         "'a @ local -> 'b @ local -> unit"
+       Type "'b -> unit" is not compatible with type "'b @ local -> unit"
+|}]
+
+module Zap_before = struct
+  module M = struct
+    let f x : _ @ local = fun () -> x
+  end
+
+  let () = let r = M.f 1 in requires_unyielding r
+end
+[%%expect{|
+module Zap_before :
+  sig module M : sig val f : 'a -> (unit -> 'a) @ local unyielding end end
+|}]
+
+(* [module type of] forces the variables. *)
+
+module Zap_after = struct
+  module M = struct
+    let f x : _ @ local = fun () -> x
+  end
+
+  module type S = module type of M
+
+  let () = let r = M.f 1 in requires_unyielding r
+end
+[%%expect{|
+Line 8, characters 48-49:
+8 |   let () = let r = M.f 1 in requires_unyielding r
+                                                    ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+module Self = struct
+  let f (x @ local) = use_local_unyielding x
+  let g x : _ @ local = fun () -> x
+end
+
+module Self_check : module type of Self = Self
+[%%expect{|
+module Self :
+  sig
+    val f : 'a @ local unyielding -> unit
+    val g : 'a -> (unit -> 'a) @ local
+  end
+module Self_check :
+  sig
+    val f : 'a @ local unyielding -> unit
+    val g : 'a -> (unit -> 'a) @ local @@ stateless
+  end
+|}]
+
+module Functor_arg_stateless (M : Runnable @ stateless) = struct
+  let () = requires_portable M.run
+end
+[%%expect{|
+module Functor_arg_stateless : functor (M : Runnable @ stateless) -> sig end
+|}]
+
+module Functor_arg_unused (M : Runnable @ stateless) = struct end
+
+module Stateless_nonportable : Runnable @ stateless nonportable = struct
+  let run () = ()
+end
+
+module _ = Functor_arg_unused (Stateless_nonportable)
+[%%expect{|
+module Functor_arg_unused : functor (M : Runnable @ stateless) -> sig end
+module Stateless_nonportable : Runnable
+Line 7, characters 11-53:
+7 | module _ = Functor_arg_unused (Stateless_nonportable)
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Modules do not match: sig val run : unit -> unit end @ nonportable
+     is not included in Runnable @ portable
+     Values do not match:
+       val run : unit -> unit (* in a structure at nonportable *)
+     is not included in
+       val run : unit -> unit (* in a structure at portable *)
+     The first is "nonportable"
+     but the second is "portable".
+|}]
+
+module Functor_ret_stateless : sig end -> Runnable @ stateless =
+  functor (M : sig end) -> struct
+    let run () = ()
+  end
+
+module Functor_ret_applied = Functor_ret_stateless (struct end)
+
+let () = requires_portable Functor_ret_applied.run
+[%%expect{|
+module Functor_ret_stateless : sig end -> Runnable @ stateless
+module Functor_ret_applied : Runnable
+|}]
+
+let partial_app_arg_local (g1 : (int @ local -> int -> unit)) =
+  let _ = requires_unyielding (g1 1) in ()
+[%%expect{|
+Line 2, characters 30-36:
+2 |   let _ = requires_unyielding (g1 1) in ()
+                                  ^^^^^^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let partial_app_fn_local (g2 : (int -> int -> unit) @ local) =
+  let _ = requires_unyielding (g2 1) in ()
+[%%expect{|
+Line 2, characters 30-36:
+2 |   let _ = requires_unyielding (g2 1) in ()
+                                  ^^^^^^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+(* Middle comonadic modes infer the best implied mode for the position. *)
+
+let zap_arg_read (x @ read) = ()
+[%%expect{|
+val zap_arg_read : 'a @ read -> unit = <fun>
+|}]
+
+let zap_ret_read x : _ @ read = ()
+[%%expect{|
+val zap_ret_read : 'a -> unit @ read uncontended = <fun>
+|}]
+
+module Zap_clamp_accepts_shared = struct
+  module M = struct
+    let f (x @ read) = ()
+  end
+
+  module type S = module type of M
+
+  let g (y @ read shared) = M.f y
+end
+[%%expect{|
+module Zap_clamp_accepts_shared :
+  sig
+    module M : sig val f : 'a @ read -> unit @@ stateless end
+    module type S = sig val f : 'a @ read -> unit @@ stateless end
+    val g : 'a @ read -> unit
+  end
+|}]

--- a/testsuite/tests/typing-modes/mode_implications.ml
+++ b/testsuite/tests/typing-modes/mode_implications.ml
@@ -168,10 +168,7 @@ val param_local_unconstrained : 'a @ local -> unit = <fun>
 
 let param_local_unyielding (x @ local) = requires_unyielding x
 [%%expect{|
-Line 1, characters 61-62:
-1 | let param_local_unyielding (x @ local) = requires_unyielding x
-                                                                 ^
-Error: This value is "yielding" but is expected to be "unyielding".
+val param_local_unyielding : 'a @ local unyielding -> unit = <fun>
 |}]
 
 let param_explicit_yielding (x @ local yielding) = requires_unyielding x
@@ -186,10 +183,7 @@ let let_local_unyielding () =
   let g @ local = fun () -> () in
   requires_unyielding g
 [%%expect{|
-Line 3, characters 22-23:
-3 |   requires_unyielding g
-                          ^
-Error: This value is "yielding" but is expected to be "unyielding".
+val let_local_unyielding : unit -> unit = <fun>
 |}]
 
 let let_local_still_escapes () =
@@ -209,20 +203,14 @@ let constraint_mode_only () =
   let g = fun () -> () in
   requires_unyielding (g : _ @ local)
 [%%expect{|
-Line 3, characters 22-37:
-3 |   requires_unyielding (g : _ @ local)
-                          ^^^^^^^^^^^^^^^
-Error: This value is "yielding" but is expected to be "unyielding".
+val constraint_mode_only : unit -> unit = <fun>
 |}]
 
 let constraint_type_and_mode () =
   let g = fun () -> () in
   requires_unyielding (g : (unit -> unit) @ local)
 [%%expect{|
-Line 3, characters 22-50:
-3 |   requires_unyielding (g : (unit -> unit) @ local)
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "yielding" but is expected to be "unyielding".
+val constraint_type_and_mode : unit -> unit = <fun>
 |}]
 
 let constraint_type_only () =
@@ -234,10 +222,8 @@ val constraint_type_only : unit -> unit = <fun>
 
 let param_type_and_mode (x : ('a -> 'a) @ local) = requires_unyielding x
 [%%expect{|
-Line 1, characters 71-72:
-1 | let param_type_and_mode (x : ('a -> 'a) @ local) = requires_unyielding x
-                                                                           ^
-Error: This value is "yielding" but is expected to be "unyielding".
+val param_type_and_mode : ('a : any). ('a -> 'a) @ local unyielding -> unit =
+  <fun>
 |}]
 
 let param_read_unconstrained (_x @ read) = ()
@@ -247,10 +233,7 @@ val param_read_unconstrained : 'a @ read -> unit = <fun>
 
 let param_read_uncontended (x @ read) = requires_uncontended x
 [%%expect{|
-Line 1, characters 61-62:
-1 | let param_read_uncontended (x @ read) = requires_uncontended x
-                                                                 ^
-Error: This value is "shared" but is expected to be "uncontended".
+val param_read_uncontended : 'a @ read uncontended -> unit = <fun>
 |}]
 
 let param_reading_unconstrained (f @ reading) = f ()
@@ -260,10 +243,7 @@ val param_reading_unconstrained : (unit -> 'a) @ reading -> 'a = <fun>
 
 let param_reading_portable (f @ reading) = requires_portable f
 [%%expect{|
-Line 1, characters 61-62:
-1 | let param_reading_portable (f @ reading) = requires_portable f
-                                                                 ^
-Error: This value is "shareable" but is expected to be "portable".
+val param_reading_portable : 'a @ reading portable -> unit = <fun>
 |}]
 
 let ret_local_unconstrained x : _ @ local = fun () -> x
@@ -279,10 +259,11 @@ module Ret_local_constrained = struct
     requires_unyielding r
 end
 [%%expect{|
-Line 6, characters 24-25:
-6 |     requires_unyielding r
-                            ^
-Error: This value is "yielding" but is expected to be "unyielding".
+module Ret_local_constrained :
+  sig
+    val f : 'a -> (unit -> 'a) @ local unyielding
+    val use : unit -> unit
+  end
 |}]
 
 let get (x @ read uncontended) = x.contents
@@ -296,20 +277,16 @@ let () = requires_uncontended (get { contents = ref 0 })
 
 let ret_read (x @ read uncontended) : _ @ read = x.contents
 [%%expect{|
-val ret_read : 'a ref @ read uncontended -> 'a @ read = <fun>
+val ret_read : 'a ref @ read uncontended -> 'a @ read uncontended = <fun>
 |}]
 
 let () = requires_uncontended (ret_read { contents = ref 0 })
 [%%expect{|
-Line 1, characters 30-61:
-1 | let () = requires_uncontended (ret_read { contents = ref 0 })
-                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: This value is "shared" but is expected to be "uncontended".
 |}]
 
 let ret_write (x @ write uncontended) : _ @ write = x
 [%%expect{|
-val ret_write : 'a @ write uncontended -> 'a @ write = <fun>
+val ret_write : 'a @ write uncontended -> 'a @ write uncontended = <fun>
 |}]
 
 let infer_arg_visibility x = param_read_unconstrained x
@@ -331,24 +308,8 @@ end = struct
   let f (x @ local) (y @ local) = use_local x; use_local y
 end
 [%%expect{|
-Lines 3-5, characters 6-3:
-3 | ......struct
-4 |   let f (x @ local) (y @ local) = use_local x; use_local y
-5 | end
-Error: Signature mismatch:
-       Modules do not match:
-         sig val f : 'a @ local -> 'b @ local -> unit end
-       is not included in
-         sig
-           val f : 'a @ local unyielding -> 'b @ local unyielding -> unit
-         end
-       Values do not match:
-         val f : 'a @ local -> 'b @ local -> unit
-       is not included in
-         val f : 'a @ local unyielding -> 'b @ local unyielding -> unit
-       The type "'a @ local -> 'b @ local -> unit"
-       is not compatible with the type
-         "'a @ local unyielding -> 'b @ local unyielding -> unit"
+module Sig_forces_unyielding :
+  sig val f : 'a @ local unyielding -> 'b @ local unyielding -> unit end
 |}]
 
 let coerce_stateless (g @ stateless nonportable) =
@@ -357,37 +318,14 @@ let coerce_stateless (g @ stateless nonportable) =
   in
   M.run ()
 [%%expect{|
-Line 3, characters 5-33:
-3 |     (struct let run () = g () end : Runnable @ stateless)
-         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: Signature mismatch:
-       Modules do not match:
-         sig val run : unit -> '_weak1 end @ nonportable
-       is not included in
-         Runnable @ portable
-       Values do not match:
-         val run : unit -> '_weak1 (* in a structure at nonportable *)
-       is not included in
-         val run : unit -> unit (* in a structure at portable *)
-       The first is "nonportable"
-         because it closes over the value "g" at line 3, characters 25-26
-         which is "nonportable".
-       However, the second is "portable".
+val coerce_stateless : (unit -> unit) @ stateless nonportable -> unit = <fun>
 |}]
 
 let annotate_stateless (g @ stateless nonportable) =
   let module M = (struct let run () = g () end @ stateless) in
   M.run ()
 [%%expect{|
-Line 2, characters 18-46:
-2 |   let module M = (struct let run () = g () end @ stateless) in
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The module is "nonportable"
-         because it contains the value "run" defined as the expression at line 2, characters 29-32
-         which is "nonportable"
-         because it closes over the value "g" at line 2, characters 38-39
-         which is "nonportable".
-       However, the module highlighted is expected to be "portable".
+val annotate_stateless : (unit -> 'a) @ stateless nonportable -> 'a = <fun>
 |}]
 
 let coerce_explicit (g @ stateless nonportable) =
@@ -402,19 +340,16 @@ val coerce_explicit : (unit -> unit) @ stateless nonportable -> unit = <fun>
 let ho_yielding (g : _ @ local unyielding -> unit) =
   fun (x @ local) -> g x
 [%%expect{|
-Line 2, characters 23-24:
-2 |   fun (x @ local) -> g x
-                           ^
-Error: This value is "yielding" but is expected to be "unyielding".
+val ho_yielding :
+  ('a @ local unyielding -> unit) -> 'a @ local unyielding -> unit = <fun>
 |}]
 
 let ho_uncontended (g : _ @ uncontended immutable -> unit) =
   fun (x @ read) -> g x
 [%%expect{|
-Line 2, characters 22-23:
-2 |   fun (x @ read) -> g x
-                          ^
-Error: This value is "shared" but is expected to be "uncontended".
+val ho_uncontended :
+  ('a @ immutable uncontended -> unit) -> 'a @ read uncontended -> unit =
+  <fun>
 |}]
 
 let ho_pass (x @ local) f = f x
@@ -426,8 +361,5 @@ let curried (x @ local) (y @ local) =
   requires_unyielding y;
   use_local x
 [%%expect{|
-Line 2, characters 22-23:
-2 |   requires_unyielding y;
-                          ^
-Error: This value is "yielding" but is expected to be "unyielding".
+val curried : 'a @ local -> 'b @ local unyielding -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-modes/mode_implications.ml
+++ b/testsuite/tests/typing-modes/mode_implications.ml
@@ -1,0 +1,433 @@
+(* TEST
+ flags = "-w -220";
+ expect;
+*)
+
+external use_local : 'a @ local -> unit = "%ignore"
+
+external requires_unyielding : 'a @ local unyielding -> unit
+  = "%ignore"
+
+external requires_uncontended : 'a @ uncontended immutable -> unit
+  = "%ignore"
+external requires_portable : 'a @ portable -> unit = "%ignore"
+
+module type Runnable = sig val run : unit -> unit end
+[%%expect{|
+external use_local : 'a @ local -> unit = "%ignore"
+external requires_unyielding : 'a @ local unyielding -> unit = "%ignore"
+external requires_uncontended : 'a @ immutable uncontended -> unit
+  = "%ignore"
+external requires_portable : 'a @ portable -> unit = "%ignore"
+module type Runnable = sig val run : unit -> unit end
+|}]
+
+(* Part 1: fixed mode positions. *)
+
+let arrow_arg_local : (unit -> unit) @ local -> unit =
+  fun g -> requires_unyielding g
+[%%expect{|
+Line 2, characters 31-32:
+2 |   fun g -> requires_unyielding g
+                                   ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+module Arrow_ret_local : sig
+  val f : int -> (unit -> int) @ local
+end = struct
+  let f x = fun () -> x
+end
+[%%expect{|
+module Arrow_ret_local : sig val f : int -> (unit -> int) @ local end
+|}]
+
+let use_arrow_ret_local () =
+  let r = Arrow_ret_local.f 3 in
+  requires_unyielding r
+[%%expect{|
+Line 3, characters 22-23:
+3 |   requires_unyielding r
+                          ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+module Arrow_eq : sig
+  val f : 'a @ local yielding -> unit
+end = struct
+  let f : 'a @ local -> unit = fun _ -> ()
+end
+[%%expect{|
+module Arrow_eq : sig val f : 'a @ local -> unit end
+|}]
+
+let _ = (requires_unyielding : (string -> unit) @ local -> unit)
+[%%expect{|
+Line 1, characters 9-28:
+1 | let _ = (requires_unyielding : (string -> unit) @ local -> unit)
+             ^^^^^^^^^^^^^^^^^^^
+Error: The value "requires_unyielding" has type "'a @ local unyielding -> unit"
+       but an expression was expected of type
+         "(string -> unit) @ local -> unit"
+|}]
+
+let storage = ref ""
+
+let with_effect : ((string -> unit) @ local yielding -> 'a) -> 'a =
+  fun f -> f ((:=) storage)
+
+let run_default : (string -> unit) @ local -> unit =
+  fun f -> f "some string"
+
+let () = with_effect (fun k -> run_default k)
+
+let _ = !storage
+[%%expect{|
+val storage : string ref = {contents = ""}
+val with_effect : ((string -> unit) @ local -> 'a) -> 'a = <fun>
+val run_default : (string -> unit) @ local -> unit = <fun>
+- : string = "some string"
+|}]
+
+let arrow_arg_read : 'a ref @ read -> unit =
+  fun x -> requires_uncontended x
+[%%expect{|
+Line 2, characters 32-33:
+2 |   fun x -> requires_uncontended x
+                                    ^
+Error: This value is "shared" but is expected to be "uncontended".
+|}]
+
+module Arrow_ret_read : sig
+  val peek : 'a ref -> 'a @ read
+end = struct
+  let peek r = r.contents
+end
+[%%expect{|
+module Arrow_ret_read : sig val peek : 'a ref -> 'a @ read end
+|}]
+
+let () = requires_uncontended (Arrow_ret_read.peek (ref (ref 0)))
+[%%expect{|
+Line 1, characters 30-65:
+1 | let () = requires_uncontended (Arrow_ret_read.peek (ref (ref 0)))
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "shared" but is expected to be "uncontended".
+|}]
+
+let arrow_arg_reading : (unit -> unit) @ reading -> unit =
+  fun f -> requires_portable f
+[%%expect{|
+Line 2, characters 29-30:
+2 |   fun f -> requires_portable f
+                                 ^
+Error: This value is "shareable" but is expected to be "portable".
+|}]
+
+let take_reading : (unit -> unit) @ reading -> unit = fun f -> f ()
+
+let pass_nonportable_to_reading () =
+  let np @ nonportable = fun () -> () in
+  take_reading np
+[%%expect{|
+val take_reading : (unit -> unit) @ reading -> unit = <fun>
+Line 5, characters 15-17:
+5 |   take_reading np
+                   ^^
+Error: This value is "nonportable" but is expected to be "shareable".
+|}]
+
+module rec Rec_annotated : Runnable @ stateless = struct
+  let run () = ()
+end
+
+let () = requires_portable (module Rec_annotated : Runnable)
+[%%expect{|
+module rec Rec_annotated : Runnable
+|}]
+
+module rec Rec_plain : Runnable = struct
+  let run () = ()
+end
+
+let () = requires_portable (module Rec_plain : Runnable)
+[%%expect{|
+module rec Rec_plain : Runnable
+Line 5, characters 27-56:
+5 | let () = requires_portable (module Rec_plain : Runnable)
+                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "nonportable" but is expected to be "portable".
+|}]
+
+(* Part 2: flexible sites. *)
+
+let param_local_unconstrained (x @ local) = ()
+[%%expect{|
+val param_local_unconstrained : 'a @ local -> unit = <fun>
+|}]
+
+let param_local_unyielding (x @ local) = requires_unyielding x
+[%%expect{|
+Line 1, characters 61-62:
+1 | let param_local_unyielding (x @ local) = requires_unyielding x
+                                                                 ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let param_explicit_yielding (x @ local yielding) = requires_unyielding x
+[%%expect{|
+Line 1, characters 71-72:
+1 | let param_explicit_yielding (x @ local yielding) = requires_unyielding x
+                                                                           ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let let_local_unyielding () =
+  let g @ local = fun () -> () in
+  requires_unyielding g
+[%%expect{|
+Line 3, characters 22-23:
+3 |   requires_unyielding g
+                          ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let let_local_still_escapes () =
+  let g @ local = fun () -> () in
+  g
+[%%expect{|
+Line 3, characters 2-3:
+3 |   g
+      ^
+Error: This value is "local"
+       but is expected to be "local" to the parent region or "global"
+         because it is a function return value.
+         Hint: Use exclave_ to return a local value.
+|}]
+
+let constraint_mode_only () =
+  let g = fun () -> () in
+  requires_unyielding (g : _ @ local)
+[%%expect{|
+Line 3, characters 22-37:
+3 |   requires_unyielding (g : _ @ local)
+                          ^^^^^^^^^^^^^^^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let constraint_type_and_mode () =
+  let g = fun () -> () in
+  requires_unyielding (g : (unit -> unit) @ local)
+[%%expect{|
+Line 3, characters 22-50:
+3 |   requires_unyielding (g : (unit -> unit) @ local)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let constraint_type_only () =
+  let g = fun () -> () in
+  requires_unyielding (g : unit -> unit)
+[%%expect{|
+val constraint_type_only : unit -> unit = <fun>
+|}]
+
+let param_type_and_mode (x : ('a -> 'a) @ local) = requires_unyielding x
+[%%expect{|
+Line 1, characters 71-72:
+1 | let param_type_and_mode (x : ('a -> 'a) @ local) = requires_unyielding x
+                                                                           ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let param_read_unconstrained (_x @ read) = ()
+[%%expect{|
+val param_read_unconstrained : 'a @ read -> unit = <fun>
+|}]
+
+let param_read_uncontended (x @ read) = requires_uncontended x
+[%%expect{|
+Line 1, characters 61-62:
+1 | let param_read_uncontended (x @ read) = requires_uncontended x
+                                                                 ^
+Error: This value is "shared" but is expected to be "uncontended".
+|}]
+
+let param_reading_unconstrained (f @ reading) = f ()
+[%%expect{|
+val param_reading_unconstrained : (unit -> 'a) @ reading -> 'a = <fun>
+|}]
+
+let param_reading_portable (f @ reading) = requires_portable f
+[%%expect{|
+Line 1, characters 61-62:
+1 | let param_reading_portable (f @ reading) = requires_portable f
+                                                                 ^
+Error: This value is "shareable" but is expected to be "portable".
+|}]
+
+let ret_local_unconstrained x : _ @ local = fun () -> x
+[%%expect{|
+val ret_local_unconstrained : 'a -> (unit -> 'a) @ local = <fun>
+|}]
+
+module Ret_local_constrained = struct
+  let f x : _ @ local = fun () -> x
+
+  let use () =
+    let r = f 3 in
+    requires_unyielding r
+end
+[%%expect{|
+Line 6, characters 24-25:
+6 |     requires_unyielding r
+                            ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let get (x @ read uncontended) = x.contents
+[%%expect{|
+val get : 'a ref @ read uncontended -> 'a @ read uncontended = <fun>
+|}]
+
+let () = requires_uncontended (get { contents = ref 0 })
+[%%expect{|
+|}]
+
+let ret_read (x @ read uncontended) : _ @ read = x.contents
+[%%expect{|
+val ret_read : 'a ref @ read uncontended -> 'a @ read = <fun>
+|}]
+
+let () = requires_uncontended (ret_read { contents = ref 0 })
+[%%expect{|
+Line 1, characters 30-61:
+1 | let () = requires_uncontended (ret_read { contents = ref 0 })
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This value is "shared" but is expected to be "uncontended".
+|}]
+
+let ret_write (x @ write uncontended) : _ @ write = x
+[%%expect{|
+val ret_write : 'a @ write uncontended -> 'a @ write = <fun>
+|}]
+
+let infer_arg_visibility x = param_read_unconstrained x
+[%%expect{|
+val infer_arg_visibility : 'a -> unit = <fun>
+|}]
+
+let call_at_read (y @ read) = infer_arg_visibility y
+[%%expect{|
+Line 1, characters 51-52:
+1 | let call_at_read (y @ read) = infer_arg_visibility y
+                                                       ^
+Error: This value is "read" but is expected to be "read_write".
+|}]
+
+module Sig_forces_unyielding : sig
+  val f : 'a @ local unyielding -> 'b @ local unyielding -> unit
+end = struct
+  let f (x @ local) (y @ local) = use_local x; use_local y
+end
+[%%expect{|
+Lines 3-5, characters 6-3:
+3 | ......struct
+4 |   let f (x @ local) (y @ local) = use_local x; use_local y
+5 | end
+Error: Signature mismatch:
+       Modules do not match:
+         sig val f : 'a @ local -> 'b @ local -> unit end
+       is not included in
+         sig
+           val f : 'a @ local unyielding -> 'b @ local unyielding -> unit
+         end
+       Values do not match:
+         val f : 'a @ local -> 'b @ local -> unit
+       is not included in
+         val f : 'a @ local unyielding -> 'b @ local unyielding -> unit
+       The type "'a @ local -> 'b @ local -> unit"
+       is not compatible with the type
+         "'a @ local unyielding -> 'b @ local unyielding -> unit"
+|}]
+
+let coerce_stateless (g @ stateless nonportable) =
+  let module M =
+    (struct let run () = g () end : Runnable @ stateless)
+  in
+  M.run ()
+[%%expect{|
+Line 3, characters 5-33:
+3 |     (struct let run () = g () end : Runnable @ stateless)
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Signature mismatch:
+       Modules do not match:
+         sig val run : unit -> '_weak1 end @ nonportable
+       is not included in
+         Runnable @ portable
+       Values do not match:
+         val run : unit -> '_weak1 (* in a structure at nonportable *)
+       is not included in
+         val run : unit -> unit (* in a structure at portable *)
+       The first is "nonportable"
+         because it closes over the value "g" at line 3, characters 25-26
+         which is "nonportable".
+       However, the second is "portable".
+|}]
+
+let annotate_stateless (g @ stateless nonportable) =
+  let module M = (struct let run () = g () end @ stateless) in
+  M.run ()
+[%%expect{|
+Line 2, characters 18-46:
+2 |   let module M = (struct let run () = g () end @ stateless) in
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The module is "nonportable"
+         because it contains the value "run" defined as the expression at line 2, characters 29-32
+         which is "nonportable"
+         because it closes over the value "g" at line 2, characters 38-39
+         which is "nonportable".
+       However, the module highlighted is expected to be "portable".
+|}]
+
+let coerce_explicit (g @ stateless nonportable) =
+  let module M =
+    (struct let run () = g () end : Runnable @ stateless nonportable)
+  in
+  M.run ()
+[%%expect{|
+val coerce_explicit : (unit -> unit) @ stateless nonportable -> unit = <fun>
+|}]
+
+let ho_yielding (g : _ @ local unyielding -> unit) =
+  fun (x @ local) -> g x
+[%%expect{|
+Line 2, characters 23-24:
+2 |   fun (x @ local) -> g x
+                           ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]
+
+let ho_uncontended (g : _ @ uncontended immutable -> unit) =
+  fun (x @ read) -> g x
+[%%expect{|
+Line 2, characters 22-23:
+2 |   fun (x @ read) -> g x
+                          ^
+Error: This value is "shared" but is expected to be "uncontended".
+|}]
+
+let ho_pass (x @ local) f = f x
+[%%expect{|
+val ho_pass : 'a @ local -> ('a @ local -> 'b) -> 'b = <fun>
+|}]
+
+let curried (x @ local) (y @ local) =
+  requires_unyielding y;
+  use_local x
+[%%expect{|
+Line 2, characters 22-23:
+2 |   requires_unyielding y;
+                          ^
+Error: This value is "yielding" but is expected to be "unyielding".
+|}]

--- a/testsuite/tests/typing-modes/yielding.ml
+++ b/testsuite/tests/typing-modes/yielding.ml
@@ -213,10 +213,7 @@ val f1 : 'a -> unit = <fun>
 let f2 (x @ local) = exclave_ requires_unyielding x
 
 [%%expect{|
-Line 1, characters 50-51:
-1 | let f2 (x @ local) = exclave_ requires_unyielding x
-                                                      ^
-Error: This value is "yielding" but is expected to be "unyielding".
+val f2 : 'a @ local unyielding -> unit @ local = <fun>
 |}]
 
 let f3 (x @ yielding) = requires_unyielding x

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -739,8 +739,8 @@ let remove_mode_and_jkind_variables ty =
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
       | Tarrow ((_,marg,mret),targ,tret,_) ->
-         let _ = Alloc.zap_to_legacy marg in
-         let _ = Alloc.zap_to_legacy mret in
+         let _ = Alloc.zap_to_legacy ~arg:true marg in
+         let _ = Alloc.zap_to_legacy ~arg:false mret in
          go targ; go tret
       | _ -> iter_type_expr go ty
     end

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -5790,13 +5790,16 @@ module Portability = struct
 
   let legacy = of_const Const.legacy
 
-  (* CR dkalinichenko: ideally, [reading] should zap to [shareable]. *)
-  let zap_to_legacy ~statefulness =
+  let zap_to_ceil_clamped c m =
+    (match submode m (of_const c) with Ok () | Error _ -> ());
+    zap_to_ceil m
+
+  let zap_to_legacy ~statefulness m =
     match statefulness with
-    | Statefulness.Const.Stateful | Statefulness.Const.Reading
-    | Statefulness.Const.Writing ->
-      zap_to_ceil
-    | Statefulness.Const.Stateless -> zap_to_floor
+    | Statefulness.Const.Stateful -> zap_to_ceil m
+    | Statefulness.Const.Reading -> zap_to_ceil_clamped Const.Shareable m
+    | Statefulness.Const.Writing -> zap_to_ceil_clamped Const.Corruptible m
+    | Statefulness.Const.Stateless -> zap_to_floor m
 end
 
 module Uniqueness = struct
@@ -5832,13 +5835,18 @@ module Contention = struct
 
   let legacy = of_const Const.legacy
 
-  (* CR dkalinichenko: ideally, [read] should zap to [shared]. *)
-  let zap_to_legacy ~visibility =
+  let zap_to_floor_clamped c m =
+    (match submode (of_const c) m with Ok () | Error _ -> ());
+    zap_to_floor m
+
+  let zap_to_legacy ~visibility ~arg m =
     match visibility with
-    | Visibility.Const.Read_write | Visibility.Const.Read
+    | Visibility.Const.Read_write -> zap_to_floor m
+    | Visibility.Const.Immutable -> zap_to_ceil m
+    | Visibility.Const.Read ->
+      if arg then zap_to_floor_clamped Const.Shared m else zap_to_floor m
     | Visibility.Const.Write ->
-      zap_to_floor
-    | Visibility.Const.Immutable -> zap_to_ceil
+      if arg then zap_to_floor_clamped Const.Corrupted m else zap_to_floor m
 end
 
 module Forkable = struct
@@ -6179,11 +6187,11 @@ module Monadic = struct
   let min_with ax m =
     S.apply ~hint:Skip Obj.obj (Max_with_simple (ax, Id)) (S.disallow_left m)
 
-  let zap_to_legacy m : Const.t =
+  let zap_to_legacy ~arg m : Const.t =
     let uniqueness = proj Uniqueness m |> Uniqueness.zap_to_legacy in
     let visibility = proj Visibility m |> Visibility.zap_to_legacy in
     let contention =
-      proj Contention m |> Contention.zap_to_legacy ~visibility
+      proj Contention m |> Contention.zap_to_legacy ~visibility ~arg
     in
     let staticity = proj Staticity m |> Staticity.zap_to_legacy in
     { uniqueness; contention; visibility; staticity }
@@ -6822,8 +6830,8 @@ module Value_with (Areality : Areality) = struct
     let comonadic = Comonadic.zap_to_floor comonadic in
     merge { monadic; comonadic }
 
-  let zap_to_legacy { comonadic; monadic } =
-    let monadic = Monadic.zap_to_legacy monadic in
+  let zap_to_legacy ~arg { comonadic; monadic } =
+    let monadic = Monadic.zap_to_legacy ~arg monadic in
     let comonadic = Comonadic.zap_to_legacy comonadic in
     merge { monadic; comonadic }
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -811,7 +811,18 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-    (** [arg] determines co-/contravariance. *)
+    (** [arg] determines co-/contravariance, and is used to infer
+        the most general mode for implied middle values on monadic axes.\
+
+        Consider:
+
+        {[
+          (* Implies [read shared]. *)
+          let zap_arg_read (x @ read) = ()
+
+          (* Implies [read uncontended]. *)
+          let zap_ret_read x : _ @ read = ()
+        ]} *)
     val zap_to_legacy : arg:bool -> lr -> Const.t
 
     val comonadic_to_monadic_min :

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -811,8 +811,8 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-    (** [arg] determines co-/contravariance, and is used to infer
-        the most general mode for implied middle values on monadic axes.\
+    (** [arg] determines co-/contravariance, and is used to infer the most
+        general mode for implied middle values on monadic axes.\
 
         Consider:
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -811,7 +811,8 @@ module type S = sig
     val min_with_monadic :
       'a Monadic.Axis.t -> ('a, 'l * 'r) mode -> ('r * disallowed) t
 
-    val zap_to_legacy : lr -> Const.t
+    (** [arg] determines co-/contravariance. *)
+    val zap_to_legacy : arg:bool -> lr -> Const.t
 
     val comonadic_to_monadic_min :
       ?hint:('r * disallowed) neg Hint.morph ->

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1412,7 +1412,7 @@ let rec tree_of_modal_typexp mode modal ty =
   let not_arrow tree =
     match modal with
     | Arrow_return {mode; _} ->
-        let mode = Alloc.zap_to_legacy mode in
+        let mode = Alloc.zap_to_legacy ~arg:false mode in
         Otyp_ret (Orm_any (tree_of_modes mode), tree)
     | Other _ -> tree
   in
@@ -1442,7 +1442,7 @@ let rec tree_of_modal_typexp mode modal ty =
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
            at legacy, we will be able to omit printing them. *)
-        let arg_mode = Alloc.zap_to_legacy marg in
+        let arg_mode = Alloc.zap_to_legacy ~arg:true marg in
         let t1 =
           if is_optional l then
             match
@@ -1709,11 +1709,11 @@ and tree_of_ret_typ_mutating acc_mode m ty=
       | Error _ ->
         (* In this branch we need to print parens. [m] might have undetermined
         axes and we adopt a similar logic to the [marg] above. *)
-        let m = Alloc.zap_to_legacy m in
+        let m = Alloc.zap_to_legacy ~arg:false m in
         (Orm_parens (tree_of_modes m), m)
       end
   | _ ->
-    let m = Alloc.zap_to_legacy m in
+    let m = Alloc.zap_to_legacy ~arg:false m in
     (Orm_any (tree_of_modes m), m)
 
 and tree_of_typobject_repr fi =
@@ -2705,7 +2705,9 @@ let rec tree_of_modtype ?abbrev = function
         tree_of_functor_parameter ?abbrev param
       in
       let res = wrap_env env (tree_of_modtype ?abbrev) ty_res in
-      let mres = m_res |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let mres =
+        m_res |> Mode.Alloc.zap_to_legacy ~arg:false |> tree_of_modes
+      in
       Omty_functor (param, res, mres))
   | Mty_alias p ->
       Omty_alias (tree_of_path (Some Module) p)
@@ -2734,7 +2736,9 @@ and tree_of_functor_parameter ?abbrev = function
             Some (Ident.name id),
             fun k -> Env.add_module ~arg:true id Mp_present ty_arg k
       in
-      let marg = m_arg |> Mode.Alloc.zap_to_legacy |> tree_of_modes in
+      let marg =
+        m_arg |> Mode.Alloc.zap_to_legacy ~arg:true |> tree_of_modes
+      in
       Some (name, tree_of_modtype ?abbrev ty_arg, marg), env
 
 and tree_of_signature ?abbrev = function

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -8046,7 +8046,7 @@ and type_expect_
       let (ty, exp_extra) =
         let alloc_mode =
           Mode.Alloc.Const.Option.value
-            modes.mode_modes
+            (Typemode.apply_mode_implications modes.mode_modes)
             ~default:Mode.Alloc.Const.legacy
         in
         type_constraint env sty alloc_mode
@@ -9117,7 +9117,10 @@ and type_constraint_expect
   =
   fun constraint_arg env expected_mode loc ~loc_arg type_mode constraint_ ty_expected ->
   let ret, ty, exp_extra =
-    let type_mode = Alloc.Const.Option.value ~default:Alloc.Const.legacy type_mode in
+    let type_mode =
+      Alloc.Const.Option.value ~default:Alloc.Const.legacy
+        (Typemode.apply_mode_implications type_mode)
+    in
     match constraint_ with
     | Pcoerce (ty_constrain, ty_coerce) ->
         type_coerce constraint_arg env expected_mode loc ty_constrain ty_coerce

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4821,6 +4821,7 @@ let transl_value_decl env loc ~modal ~why valdecl =
         let modes = Typemode.transl_mode_annots modes in
         let mode =
           modes.mode_modes
+          |> Typemode.apply_mode_implications
           |> Mode.Alloc.Const.(
               Option.value ~default:{legacy with staticity = Static})
           |> Mode.Alloc.of_const

--- a/typing/typemod.ml
+++ b/typing/typemod.ml
@@ -2710,6 +2710,7 @@ and transl_recmodule_modtypes env ~sig_modalities sdecls =
             let tmmode = Typemode.transl_mode_annots smmode in
             let mmode =
               tmmode.mode_modes
+              |> Typemode.apply_mode_implications
               (* CR zqian: mode annotations on rec modules default to legacy for
               now. We can remove this workaround once [module type of] doesn't
               require zapping. *)
@@ -2840,10 +2841,10 @@ let check_nongen_signature env sg =
 
 let remove_functor_mode_variables = function
   | Mty_functor (arg_opt, _, mres) ->
-      Mode.Alloc.zap_to_legacy mres |> ignore;
+      Mode.Alloc.zap_to_legacy ~arg:false mres |> ignore;
       begin match arg_opt with
       | Unit -> ()
-      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy marg |> ignore
+      | Named (_, _, marg) -> Mode.Alloc.zap_to_legacy ~arg:true marg |> ignore
       end
   | _ -> ()
 

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -202,7 +202,7 @@ let enforce_forbidden_modalities ~loc annot_type m =
     raise (Error (loc, Forbidden_modality (annot_type, Global_and_unique)))
   | _ -> ()
 
-let default_mode_annots (annots : Alloc.Const.Option.t) =
+let apply_mode_implications (annots : Alloc.Const.Option.t) =
   (* [forkable] has a different default depending on whether [areality]
      is [global] or [local]. *)
   let forkable =
@@ -256,9 +256,7 @@ let transl_mode_annots annots =
     then raise (Error (loc, Duplicated_axis (Mode, ax)))
     else Alloc.Const.Option.set ax (Some mode) modes_so_far
   in
-  let modes =
-    List.fold_left step Alloc.Const.Option.none annots |> default_mode_annots
-  in
+  let modes = List.fold_left step Alloc.Const.Option.none annots in
   { mode_modes = modes; mode_desc = annots }
 
 let untransl_mode modes =
@@ -547,6 +545,7 @@ let transl_alloc_mode annots =
   let { mode_modes = opt_modes; mode_desc = annots } =
     transl_mode_annots annots
   in
+  let opt_modes = apply_mode_implications opt_modes in
   let modes = Alloc.Const.Option.value opt_modes ~default:Alloc.Const.legacy in
   { mode_modes = modes; mode_desc = annots }
 

--- a/typing/typemode.mli
+++ b/typing/typemode.mli
@@ -17,6 +17,9 @@ type modalities =
 *)
 val transl_mode_annots : Parsetree.modes -> Mode.Alloc.Const.Option.t modes
 
+val apply_mode_implications :
+  Mode.Alloc.Const.Option.t -> Mode.Alloc.Const.Option.t
+
 val untransl_mode : _ modes -> Parsetree.modes
 
 (** Interpret mode syntax as alloc mode (on arrow types), where axes are set to


### PR DESCRIPTION
Infer implied axes even if the implying axis annotation is present where possible. Allow:

```ocaml
let f (x @ local) = require_unyielding x
```

Unfortunately, we can't do this where inference is not available, for example, in mode annotations on function arrow types. Therefore, distinguish *fixed* mode annotation sites, which pin the implied mode, and *flexible* annotation sites, which allow it to be inferred.

Also, make the implication depend on variance for implications for middle monadic modes.