### PR TITLE
Refactor: cleanup lowering of %atomic_load_idx and %atomic_set_idx

### DIFF
--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -749,25 +749,17 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
         let element_size = Prim (Lsrint, [word_size; tagged_immediate 3]) in
         Sequence (comp_expr arg, element_size)
       | [] | _ :: _ :: _ -> wrong_arity ~expected:1)
-    | Pget_idx (layout, access) ->
-      let prim =
-        match Lambda.access_atomicity access with
-        | Nonatomic -> Ccall "caml_get_idx_bytecode"
-        | Atomic -> Ccall "caml_get_idx_atomic_bytecode"
-      in
+    | Pget_idx (layout, _) ->
       let elt = Lambda.mixed_block_element_of_layout layout in
-      copy_mixed_block_element elt (binary prim)
-    | Pset_idx (layout, _, atomicity) -> (
+      copy_mixed_block_element elt (binary (Ccall "caml_get_idx_bytecode"))
+    | Pset_idx (layout, _) -> (
       let elt = Lambda.mixed_block_element_of_layout layout in
       match args with
       | [arr; idx; value] ->
-        let prim =
-          match atomicity with
-          | Nonatomic -> Ccall "caml_set_idx_bytecode"
-          | Atomic -> Ccall "caml_set_idx_atomic_bytecode"
-        in
         let copied_value = copy_mixed_block_element elt (comp_expr value) in
-        Prim (prim, [comp_expr arr; comp_expr idx; copied_value])
+        Prim
+          ( Ccall "caml_set_idx_bytecode",
+            [comp_expr arr; comp_expr idx; copied_value] )
       | _ -> wrong_arity ~expected:3)
     | Pget_ptr (layout, _) ->
       let elt = Lambda.mixed_block_element_of_layout layout in
@@ -1002,6 +994,19 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_land_field -> ternary (Ccall "caml_atomic_land_field")
     | Patomic_lor_field -> ternary (Ccall "caml_atomic_lor_field")
     | Patomic_lxor_field -> ternary (Ccall "caml_atomic_lxor_field")
+    | Patomic_load_idx { layout } ->
+      let elt = Lambda.mixed_block_element_of_layout layout in
+      copy_mixed_block_element elt
+        (binary (Ccall "caml_atomic_load_idx_bytecode"))
+    | Patomic_set_idx { layout; _ } -> (
+      let elt = Lambda.mixed_block_element_of_layout layout in
+      match args with
+      | [arr; idx; value] ->
+        let copied_value = copy_mixed_block_element elt (comp_expr value) in
+        Prim
+          ( Ccall "caml_atomic_set_idx_bytecode",
+            [comp_expr arr; comp_expr idx; copied_value] )
+      | _ -> wrong_arity ~expected:3)
     | Patomic_exchange_idx _ ->
       ternary (Ccall "caml_atomic_exchange_idx_bytecode")
     | Patomic_compare_exchange_idx _ ->

--- a/bytecomp/blambda_of_lambda.ml
+++ b/bytecomp/blambda_of_lambda.ml
@@ -1002,6 +1002,19 @@ let rec comp_expr (exp : Lambda.lambda) : Blambda.blambda =
     | Patomic_land_field -> ternary (Ccall "caml_atomic_land_field")
     | Patomic_lor_field -> ternary (Ccall "caml_atomic_lor_field")
     | Patomic_lxor_field -> ternary (Ccall "caml_atomic_lxor_field")
+    | Patomic_exchange_idx _ ->
+      ternary (Ccall "caml_atomic_exchange_idx_bytecode")
+    | Patomic_compare_exchange_idx _ ->
+      n_ary ~arity:4 (Ccall "caml_atomic_compare_exchange_idx_bytecode")
+    | Patomic_compare_set_idx _ ->
+      n_ary ~arity:4 (Ccall "caml_atomic_cas_idx_bytecode")
+    | Patomic_fetch_add_idx ->
+      ternary (Ccall "caml_atomic_fetch_add_idx_bytecode")
+    | Patomic_add_idx -> ternary (Ccall "caml_atomic_add_idx_bytecode")
+    | Patomic_sub_idx -> ternary (Ccall "caml_atomic_sub_idx_bytecode")
+    | Patomic_land_idx -> ternary (Ccall "caml_atomic_land_idx_bytecode")
+    | Patomic_lor_idx -> ternary (Ccall "caml_atomic_lor_idx_bytecode")
+    | Patomic_lxor_idx -> ternary (Ccall "caml_atomic_lxor_idx_bytecode")
     | Pdls_get -> unary (Ccall "caml_domain_dls_get")
     | Ptls_get -> unary (Ccall "caml_domain_tls_get")
     | Pdomain_index -> unary (Ccall "caml_ml_domain_index")

--- a/external/merlin/src/ocaml/typing/primitive.ml
+++ b/external/merlin/src/ocaml/typing/primitive.ml
@@ -961,24 +961,11 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.bits64);
         any
       ]
-    | "%get_idx_atomic" ->
-      check [
-        is (Same_as_ocaml_repr C.scannable);
-        is (Same_as_ocaml_repr C.bits64);
-        is (Same_as_ocaml_repr C.scannable)
-      ]
     | "%set_idx" ->
       check [
         is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.bits64);
         any;
-        is (Same_as_ocaml_repr C.scannable);
-      ]
-    | "%set_idx_atomic" ->
-      check [
-        is (Same_as_ocaml_repr C.scannable);
-        is (Same_as_ocaml_repr C.bits64);
-        is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.scannable);
       ]
     | "%unsafe_array_idx" ->
@@ -1010,6 +997,54 @@ let prim_has_valid_reprs ~loc prim =
       check [
         is (Same_as_ocaml_repr C.word);
         is (Same_as_ocaml_repr C.bits64);
+      ]
+    | "%atomic_load_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_set_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_exchange_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_cas_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_compare_exchange_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_fetch_add_idx"
+    | "%atomic_add_idx"
+    | "%atomic_sub_idx"
+    | "%atomic_land_idx"
+    | "%atomic_lor_idx"
+    | "%atomic_lxor_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
       ]
     | "%unsafe_get_ptr" ->
       check [

--- a/external/merlin/upstream/ocaml_flambda/typing/primitive.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/primitive.ml
@@ -961,24 +961,11 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.bits64);
         any
       ]
-    | "%get_idx_atomic" ->
-      check [
-        is (Same_as_ocaml_repr C.scannable);
-        is (Same_as_ocaml_repr C.bits64);
-        is (Same_as_ocaml_repr C.scannable)
-      ]
     | "%set_idx" ->
       check [
         is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.bits64);
         any;
-        is (Same_as_ocaml_repr C.scannable);
-      ]
-    | "%set_idx_atomic" ->
-      check [
-        is (Same_as_ocaml_repr C.scannable);
-        is (Same_as_ocaml_repr C.bits64);
-        is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.scannable);
       ]
     | "%unsafe_array_idx" ->
@@ -1010,6 +997,54 @@ let prim_has_valid_reprs ~loc prim =
       check [
         is (Same_as_ocaml_repr C.word);
         is (Same_as_ocaml_repr C.bits64);
+      ]
+    | "%atomic_load_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_set_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_exchange_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_cas_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_compare_exchange_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_fetch_add_idx"
+    | "%atomic_add_idx"
+    | "%atomic_sub_idx"
+    | "%atomic_land_idx"
+    | "%atomic_lor_idx"
+    | "%atomic_lxor_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
       ]
     | "%unsafe_get_ptr" ->
       check [

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -45,14 +45,6 @@ type has_initializer =
   | With_initializer
   | Uninitialized
 
-type atomic_flag = Asttypes.atomic_flag
-
-type access_flag = Asttypes.access_flag
-
-let access_atomicity : access_flag -> atomic_flag = function
-  | Immutable_access | Mutable_access -> Nonatomic
-  | Atomic_access -> Atomic
-
 include (struct
 
   type locality_mode =
@@ -457,6 +449,10 @@ type primitive =
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
+  | Patomic_load_idx of
+    { layout : layout }
+  | Patomic_set_idx of
+    { layout : layout; mode : modify_mode }
   | Patomic_exchange_idx of
     { layout : layout; mode : modify_mode }
   | Patomic_compare_exchange_idx of
@@ -500,8 +496,8 @@ type primitive =
   (* Poll for runtime actions *)
   | Ppoll
   | Pcpu_relax
-  | Pget_idx of layout * access_flag
-  | Pset_idx of layout * modify_mode * atomic_flag
+  | Pget_idx of layout * Asttypes.mutable_flag
+  | Pset_idx of layout * modify_mode
   | Pget_ptr of layout * Asttypes.mutable_flag
   | Pset_ptr of layout * modify_mode
   | Pget_ext_ptr of layout * Asttypes.mutable_flag
@@ -2951,6 +2947,8 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
+  | Patomic_load_idx _
+  | Patomic_set_idx _
   | Patomic_exchange_idx _
   | Patomic_compare_exchange_idx _
   | Patomic_compare_set_idx _
@@ -3156,6 +3154,7 @@ let primitive_can_raise prim =
   | Patomic_sub_field  | Patomic_land_field | Patomic_lor_field
   | Patomic_lxor_field  | Patomic_load_field _ | Patomic_load_mixed_field _
   | Patomic_set_field _ | Patomic_set_mixed_field _
+  | Patomic_load_idx _ | Patomic_set_idx _
   | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
   | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
   | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx
@@ -3664,6 +3663,8 @@ let primitive_result_layout (p : primitive) =
     layout_any_value
   | Patomic_compare_set_field _
   | Patomic_fetch_add_field -> layout_int
+  | Patomic_load_idx { layout } -> layout
+  | Patomic_set_idx _ -> layout_unit
   | Patomic_exchange_idx { layout; _ } -> layout
   | Patomic_compare_exchange_idx { layout; _ } -> layout
   | Patomic_compare_set_idx _

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -457,6 +457,18 @@ type primitive =
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
+  | Patomic_exchange_idx of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_exchange_idx of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_set_idx of
+    { layout : layout; mode : modify_mode }
+  | Patomic_fetch_add_idx
+  | Patomic_add_idx
+  | Patomic_sub_idx
+  | Patomic_land_idx
+  | Patomic_lor_idx
+  | Patomic_lxor_idx
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)
@@ -2939,6 +2951,15 @@ let primitive_may_allocate : primitive -> locality_mode option = function
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
+  | Patomic_exchange_idx _
+  | Patomic_compare_exchange_idx _
+  | Patomic_compare_set_idx _
+  | Patomic_fetch_add_idx
+  | Patomic_add_idx
+  | Patomic_sub_idx
+  | Patomic_land_idx
+  | Patomic_lor_idx
+  | Patomic_lxor_idx
   | Pdls_get
   | Ptls_get
   | Pdomain_index
@@ -3134,7 +3155,11 @@ let primitive_can_raise prim =
   | Patomic_compare_set_field _ | Patomic_fetch_add_field  | Patomic_add_field
   | Patomic_sub_field  | Patomic_land_field | Patomic_lor_field
   | Patomic_lxor_field  | Patomic_load_field _ | Patomic_load_mixed_field _
-  | Patomic_set_field _ | Patomic_set_mixed_field _ -> false
+  | Patomic_set_field _ | Patomic_set_mixed_field _
+  | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
+  | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
+  | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx
+  | Patomic_lxor_idx -> false
   | Pwith_stack | Pwith_stack_preemptible
   | Pperform | Pcontinue | Pdiscontinue
   | Pdiscontinue_with_backtrace
@@ -3639,6 +3664,10 @@ let primitive_result_layout (p : primitive) =
     layout_any_value
   | Patomic_compare_set_field _
   | Patomic_fetch_add_field -> layout_int
+  | Patomic_exchange_idx { layout; _ } -> layout
+  | Patomic_compare_exchange_idx { layout; _ } -> layout
+  | Patomic_compare_set_idx _
+  | Patomic_fetch_add_idx -> layout_int
   | Pdls_get | Ptls_get -> layout_any_value
   | Pdomain_index -> layout_unboxed_int Untagged_int
   | Patomic_add_field
@@ -3646,6 +3675,11 @@ let primitive_result_layout (p : primitive) =
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
+  | Patomic_add_idx
+  | Patomic_sub_idx
+  | Patomic_land_idx
+  | Patomic_lor_idx
+  | Patomic_lxor_idx
   | Ppoll -> layout_unit
   | Pcpu_relax -> layout_unit
   | Preinterpret_tagged_int63_as_unboxed_int64 -> layout_unboxed_int64

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -55,12 +55,6 @@ type modify_mode = private
   | Modify_heap
   | Modify_maybe_stack
 
-type atomic_flag = Asttypes.atomic_flag
-
-type access_flag = Asttypes.access_flag
-
-val access_atomicity : access_flag -> atomic_flag
-
 val alloc_heap : locality_mode
 
 val alloc_local : locality_mode
@@ -432,6 +426,8 @@ type primitive =
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
+  | Patomic_load_idx of { layout : layout }
+  | Patomic_set_idx of { layout : layout; mode : modify_mode }
   | Patomic_exchange_idx of
     { layout : layout; mode : modify_mode }
   | Patomic_compare_exchange_idx of
@@ -493,8 +489,8 @@ type primitive =
   | Ppoll
   (* Arch-specific pause. Without poll insertion, also acts as a [Ppoll]. *)
   | Pcpu_relax
-  | Pget_idx of layout * access_flag
-  | Pset_idx of layout * modify_mode * atomic_flag
+  | Pget_idx of layout * Asttypes.mutable_flag
+  | Pset_idx of layout * modify_mode
   | Pget_ptr of layout * Asttypes.mutable_flag
   | Pset_ptr of layout * modify_mode
   (* External pointer primitives: like [Pget_ptr]/[Pset_ptr] but take only the

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -432,6 +432,18 @@ type primitive =
   | Patomic_land_field
   | Patomic_lor_field
   | Patomic_lxor_field
+  | Patomic_exchange_idx of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_exchange_idx of
+    { layout : layout; mode : modify_mode }
+  | Patomic_compare_set_idx of
+    { layout : layout; mode : modify_mode }
+  | Patomic_fetch_add_idx
+  | Patomic_add_idx
+  | Patomic_sub_idx
+  | Patomic_land_idx
+  | Patomic_lor_idx
+  | Patomic_lxor_idx
   (* Inhibition of optimisation *)
   | Popaque of layout
   (* Statically-defined probes *)

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -925,6 +925,13 @@ let primitive ppf = function
   | Patomic_land_field -> fprintf ppf "atomic_land_field"
   | Patomic_lor_field -> fprintf ppf "atomic_lor_field"
   | Patomic_lxor_field -> fprintf ppf "atomic_lxor_field"
+  | Patomic_load_idx {layout = l} ->
+      fprintf ppf "atomic_load_idx %a"
+        layout l
+  | Patomic_set_idx {layout = l; mode} ->
+      fprintf ppf "atomic_set_idx%s %a"
+        (modify_mode mode)
+        layout l
   | Patomic_exchange_idx {layout = l; mode} ->
       fprintf ppf "atomic_exchange_idx%s %a"
         (modify_mode mode)
@@ -977,20 +984,13 @@ let primitive ppf = function
   | Ppoke layout ->
       fprintf ppf "(poke@ %a)"
         peek_or_poke layout
-  | Pget_idx (l, Atomic_access) ->
-      fprintf ppf "(get_idx_atomic@ %a)"
-        layout l
-  | Pget_idx (l, Mutable_access) ->
+  | Pget_idx (l, Mutable) ->
       fprintf ppf "(get_idx@ %a)"
         layout l
-  | Pget_idx (l, Immutable_access) ->
+  | Pget_idx (l, Immutable) ->
       fprintf ppf "(get_idx_imm@ %a)"
         layout l
-  | Pset_idx (l, mode, Atomic) ->
-      fprintf ppf "(set_idx_atomic%s@ %a)"
-        (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
-        layout l
-  | Pset_idx (l, mode, Nonatomic) ->
+  | Pset_idx (l, mode) ->
       fprintf ppf "(set_idx%s@ %a)"
         (match mode with Modify_heap -> "" | Modify_maybe_stack -> "_local")
         layout l
@@ -1163,6 +1163,8 @@ let name_of_primitive = function
   | Patomic_land_field -> "Patomic_land_field"
   | Patomic_lor_field -> "Patomic_lor_field"
   | Patomic_lxor_field -> "Patomic_lxor_field"
+  | Patomic_load_idx _ -> "Patomic_load_idx"
+  | Patomic_set_idx _ -> "Patomic_set_idx"
   | Patomic_exchange_idx _ -> "Patomic_exchange_idx"
   | Patomic_compare_exchange_idx _ -> "Patomic_compare_exchange_idx"
   | Patomic_compare_set_idx _ -> "Patomic_compare_set_idx"

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -925,6 +925,24 @@ let primitive ppf = function
   | Patomic_land_field -> fprintf ppf "atomic_land_field"
   | Patomic_lor_field -> fprintf ppf "atomic_lor_field"
   | Patomic_lxor_field -> fprintf ppf "atomic_lxor_field"
+  | Patomic_exchange_idx {layout = l; mode} ->
+      fprintf ppf "atomic_exchange_idx%s %a"
+        (modify_mode mode)
+        layout l
+  | Patomic_compare_exchange_idx {layout = l; mode} ->
+      fprintf ppf "atomic_compare_exchange_idx%s %a"
+        (modify_mode mode)
+        layout l
+  | Patomic_compare_set_idx {layout = l; mode} ->
+      fprintf ppf "atomic_compare_set_idx%s %a"
+        (modify_mode mode)
+        layout l
+  | Patomic_fetch_add_idx -> fprintf ppf "atomic_fetch_add_idx"
+  | Patomic_add_idx -> fprintf ppf "atomic_add_idx"
+  | Patomic_sub_idx -> fprintf ppf "atomic_sub_idx"
+  | Patomic_land_idx -> fprintf ppf "atomic_land_idx"
+  | Patomic_lor_idx -> fprintf ppf "atomic_lor_idx"
+  | Patomic_lxor_idx -> fprintf ppf "atomic_lxor_idx"
   | Popaque _ -> fprintf ppf "opaque"
   | Pdls_get -> fprintf ppf "dls_get"
   | Ppoll -> fprintf ppf "poll"
@@ -1145,6 +1163,15 @@ let name_of_primitive = function
   | Patomic_land_field -> "Patomic_land_field"
   | Patomic_lor_field -> "Patomic_lor_field"
   | Patomic_lxor_field -> "Patomic_lxor_field"
+  | Patomic_exchange_idx _ -> "Patomic_exchange_idx"
+  | Patomic_compare_exchange_idx _ -> "Patomic_compare_exchange_idx"
+  | Patomic_compare_set_idx _ -> "Patomic_compare_set_idx"
+  | Patomic_fetch_add_idx -> "Patomic_fetch_add_idx"
+  | Patomic_add_idx -> "Patomic_add_idx"
+  | Patomic_sub_idx -> "Patomic_sub_idx"
+  | Patomic_land_idx -> "Patomic_land_idx"
+  | Patomic_lor_idx -> "Patomic_lor_idx"
+  | Patomic_lxor_idx -> "Patomic_lxor_idx"
   | Pcpu_relax -> "Pcpu_relax"
   | Popaque _ -> "Popaque"
   | Pwith_stack -> "Pwith_stack"

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -562,8 +562,11 @@ and fracture_prim lambda prim args loc =
   | Patomic_set_mixed_field _ | Patomic_exchange_field _
   | Patomic_compare_exchange_field _ | Patomic_compare_set_field _
   | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
-  | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field | Popaque _
-  | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Punbox_unit
+  | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
+  | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
+  | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
+  | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
+  | Popaque _ | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Punbox_unit
   | Punbox_vector _ | Pbox_vector _ | Punbox_mask | Pbox_mask _ | Pjoin_vec256
   | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
   | Preinterpret_tuple_as_boxed_vector _

--- a/lambda/slambda_fracture.ml
+++ b/lambda/slambda_fracture.ml
@@ -566,10 +566,10 @@ and fracture_prim lambda prim args loc =
   | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
   | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
   | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
-  | Popaque _ | Pprobe_is_enabled _ | Pobj_dup | Pobj_magic _ | Punbox_unit
-  | Punbox_vector _ | Pbox_vector _ | Punbox_mask | Pbox_mask _ | Pjoin_vec256
-  | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
-  | Preinterpret_tuple_as_boxed_vector _
+  | Patomic_load_idx _ | Patomic_set_idx _ | Popaque _ | Pprobe_is_enabled _
+  | Pobj_dup | Pobj_magic _ | Punbox_unit | Punbox_vector _ | Pbox_vector _
+  | Punbox_mask | Pbox_mask _ | Pjoin_vec256 | Psplit_vec256
+  | Preinterpret_boxed_vector_as_tuple _ | Preinterpret_tuple_as_boxed_vector _
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64 | Parray_to_iarray
   | Parray_of_iarray | Pget_header _ | Ppeek _ | Ppoke _ | Pdls_get | Ptls_get

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -537,6 +537,21 @@ and eval_prim env prim =
   | Pset_ext_ptr (old_layout, mode) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pset_ext_ptr (new_layout, mode)
+  | Patomic_exchange_idx { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_exchange_idx { layout = new_layout; mode }
+  | Patomic_compare_exchange_idx { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_compare_exchange_idx { layout = new_layout; mode }
+  | Patomic_compare_set_idx { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_compare_set_idx { layout = new_layout; mode }
   | Pbytes_to_string | Pbytes_of_string | Pignore | Pgetglobal _ | Pgetpredef _
   | Pmakefloatblock _ | Pmakeufloatblock _ | Pmakelazyblock _ | Pfield _
   | Pfield_computed _ | Psetfield _ | Psetfield_computed _ | Pfloatfield _
@@ -575,9 +590,11 @@ and eval_prim env prim =
   | Patomic_compare_exchange_field _ | Patomic_compare_set_field _
   | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
   | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
-  | Pprobe_is_enabled _ | Pobj_dup | Punbox_unit | Punbox_vector _
-  | Pbox_vector _ | Punbox_mask | Pbox_mask _ | Pjoin_vec256 | Psplit_vec256
-  | Preinterpret_boxed_vector_as_tuple _ | Preinterpret_tuple_as_boxed_vector _
+  | Patomic_fetch_add_idx | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx
+  | Patomic_lor_idx | Patomic_lxor_idx | Pprobe_is_enabled _ | Pobj_dup
+  | Punbox_unit | Punbox_vector _ | Pbox_vector _ | Punbox_mask | Pbox_mask _
+  | Pjoin_vec256 | Psplit_vec256 | Preinterpret_boxed_vector_as_tuple _
+  | Preinterpret_tuple_as_boxed_vector _
   | Preinterpret_unboxed_int64_as_tagged_int63
   | Preinterpret_tagged_int63_as_unboxed_int64 | Parray_to_iarray
   | Parray_of_iarray | Pget_header _ | Ppeek _ | Ppoke _ | Pdls_get | Ptls_get

--- a/lambda/slambdaeval.ml
+++ b/lambda/slambdaeval.ml
@@ -517,14 +517,12 @@ and eval_prim env prim =
   | Pobj_magic old_layout ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pobj_magic new_layout
-  | Pget_idx (old_layout, access) ->
+  | Pget_idx (old_layout, mut) ->
     let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout then prim else Pget_idx (new_layout, access)
-  | Pset_idx (old_layout, mode, atomicity) ->
+    if new_layout == old_layout then prim else Pget_idx (new_layout, mut)
+  | Pset_idx (old_layout, mode) ->
     let new_layout = eval_layout env old_layout in
-    if new_layout == old_layout
-    then prim
-    else Pset_idx (new_layout, mode, atomicity)
+    if new_layout == old_layout then prim else Pset_idx (new_layout, mode)
   | Pget_ptr (old_layout, mut) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pget_ptr (new_layout, mut)
@@ -537,6 +535,16 @@ and eval_prim env prim =
   | Pset_ext_ptr (old_layout, mode) ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout then prim else Pset_ext_ptr (new_layout, mode)
+  | Patomic_load_idx { layout = old_layout } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_load_idx { layout = new_layout }
+  | Patomic_set_idx { layout = old_layout; mode } ->
+    let new_layout = eval_layout env old_layout in
+    if new_layout == old_layout
+    then prim
+    else Patomic_set_idx { layout = new_layout; mode }
   | Patomic_exchange_idx { layout = old_layout; mode } ->
     let new_layout = eval_layout env old_layout in
     if new_layout == old_layout
@@ -630,7 +638,9 @@ let assert_primitive_contains_no_splices (prim : Lambda.primitive) =
   | Popaque layout | Pobj_magic layout ->
     assert_layout_contains_no_splices layout
   | Pget_idx (layout, _)
-  | Pset_idx (layout, _, _)
+  | Pset_idx (layout, _)
+  | Patomic_load_idx { layout }
+  | Patomic_set_idx { layout; _ }
   | Pget_ptr (layout, _)
   | Pset_ptr (layout, _)
   | Pget_ext_ptr (layout, _)

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -919,6 +919,10 @@ let rec choice ctx t =
     | Patomic_lor_field | Patomic_lxor_field
     | Patomic_load_field _ | Patomic_load_mixed_field _
     | Patomic_set_field _ | Patomic_set_mixed_field _
+    | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
+    | Patomic_compare_set_idx _ | Patomic_fetch_add_idx
+    | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx
+    | Patomic_lor_idx | Patomic_lxor_idx
     | Pcpu_relax
     | Punbox_vector _ | Pbox_vector (_, _)
     | Punbox_mask | Pbox_mask _

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -919,6 +919,7 @@ let rec choice ctx t =
     | Patomic_lor_field | Patomic_lxor_field
     | Patomic_load_field _ | Patomic_load_mixed_field _
     | Patomic_set_field _ | Patomic_set_mixed_field _
+    | Patomic_load_idx _ | Patomic_set_idx _
     | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
     | Patomic_compare_set_idx _ | Patomic_fetch_add_idx
     | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -1251,16 +1251,15 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%get_idx_imm" ->
       (* This primitive requires the indexed data to be truly immutable,
          which the compiler will rely upon when performing optimizations *)
-      Primitive(Pget_idx (layout, Immutable_access), 2)
+      Primitive(Pget_idx (layout, Immutable), 2)
     | "%get_idx" ->
       (* Whenever it's safe to use the "_imm" counterpart to this primitive
-         (just above), it's also safe to use this one. Marking the primitive
-         as [Mutable_access] just restricts the optimizations that can be
-         performed. *)
-      Primitive(Pget_idx (layout, Mutable_access), 2)
+         (just above), it's also safe to use this one. Marking the primitive as
+         [Mutable] just restricts the optimizations that can be performed. *)
+      Primitive(Pget_idx (layout, Mutable), 2)
     | "%set_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
-      Primitive(Pset_idx (layout, get_first_arg_mode (), Nonatomic), 3)
+      Primitive(Pset_idx (layout, get_first_arg_mode ()), 3)
     | "%unsafe_array_idx" ->
       Primitive(Pmake_idx_array
         (Punspecializedarray, Ptagged_int_index,
@@ -1994,9 +1993,9 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
   | Atomic (Compare_exchange _ as op, Idx_like (Idx, _)), [_; _; _; v] ->
     let l = layout_of_ty_for_idx_set env loc v in
     Some (Atomic (op, Idx_like (Idx, l)))
-  | Primitive (Pset_idx (_, m, a), arity), (_ :: _ :: p3 :: _) ->
+  | Primitive (Pset_idx (_, m), arity), (_ :: _ :: p3 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p3 in
-    Some (Primitive (Pset_idx (l, m, a), arity))
+    Some (Primitive (Pset_idx (l, m), arity))
   | Primitive (Pset_ptr (_, m), arity), (_ :: p2 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p2 in
     Some (Primitive (Pset_ptr (l, m), arity))
@@ -2261,8 +2260,8 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
     end
     | Idx_like (Idx, layout) -> begin
         match op with
-        | Load -> Pget_idx (layout, Atomic_access)
-        | Set mode -> Pset_idx (layout, mode, Atomic)
+        | Load -> Patomic_load_idx { layout }
+        | Set mode -> Patomic_set_idx { layout; mode }
         | Exchange mode -> Patomic_exchange_idx { layout; mode }
         | Compare_exchange mode ->
           Patomic_compare_exchange_idx { layout; mode }
@@ -2729,6 +2728,7 @@ let lambda_primitive_needs_event_after = function
   | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
   | Patomic_load_field _ | Patomic_load_mixed_field _
   | Patomic_set_field _ | Patomic_set_mixed_field _
+  | Patomic_load_idx _ | Patomic_set_idx _
   | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
   | Patomic_compare_set_idx _ | Patomic_fetch_add_idx
   | Patomic_add_idx | Patomic_sub_idx

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -111,6 +111,7 @@ type atomic_kind =
   | Ref   (* operation on an atomic reference (takes only a pointer) *)
   | Field (* operation on an atomic field (takes a pointer and an offset) *)
   | Loc   (* operation on a first-class field (takes a (pointer, offset) pair *)
+  | Idx of layout (* operation on an idx_atomic (takes a pointer and an idx) *)
 
 type atomic_op =
   | Load
@@ -1136,45 +1137,76 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%atomic_load" -> Atomic(Load, Ref, Pointer)
     | "%atomic_load_field" -> Atomic(Load, Field, Pointer)
     | "%atomic_load_loc" -> Atomic(Load, Loc, Pointer)
+    | "%atomic_load_idx" -> Atomic(Load, Idx layout, Pointer)
     | "%atomic_set" -> Atomic(Set (get_first_arg_mode ()), Ref, Pointer)
     | "%atomic_set_field" -> Atomic(Set (get_first_arg_mode ()), Field, Pointer)
     | "%atomic_set_loc" -> Atomic(Set (get_first_arg_mode ()), Loc, Pointer)
+    | "%atomic_set_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Set (get_first_arg_mode ()), Idx layout, Pointer)
     | "%atomic_exchange" ->
       Atomic(Exchange (get_first_arg_mode ()), Ref, Pointer)
     | "%atomic_exchange_field" ->
       Atomic(Exchange (get_first_arg_mode ()), Field, Pointer)
     | "%atomic_exchange_loc" ->
       Atomic(Exchange (get_first_arg_mode ()), Loc, Pointer)
+    | "%atomic_exchange_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Exchange (get_first_arg_mode ()), Idx layout, Pointer)
     | "%atomic_compare_exchange" ->
       Atomic(Compare_exchange (get_first_arg_mode ()), Ref, Pointer)
     | "%atomic_compare_exchange_field" ->
       Atomic(Compare_exchange (get_first_arg_mode ()), Field, Pointer)
     | "%atomic_compare_exchange_loc" ->
       Atomic(Compare_exchange (get_first_arg_mode ()), Loc, Pointer)
+    | "%atomic_compare_exchange_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Compare_exchange (get_first_arg_mode ()), Idx layout, Pointer)
     | "%atomic_cas" ->
       Atomic(Compare_and_set (get_first_arg_mode ()), Ref, Pointer)
     | "%atomic_cas_field" ->
       Atomic(Compare_and_set (get_first_arg_mode ()), Field, Pointer)
     | "%atomic_cas_loc" ->
       Atomic(Compare_and_set (get_first_arg_mode ()), Loc, Pointer)
+    | "%atomic_cas_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Compare_and_set (get_first_arg_mode ()), Idx layout, Pointer)
     | "%atomic_fetch_add" -> Atomic(Fetch_add, Ref, Immediate)
     | "%atomic_fetch_add_field" -> Atomic(Fetch_add, Field, Immediate)
     | "%atomic_fetch_add_loc" -> Atomic(Fetch_add, Loc, Immediate)
+    | "%atomic_fetch_add_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Fetch_add, Idx layout, Immediate)
     | "%atomic_add" -> Atomic(Add, Ref, Immediate)
     | "%atomic_add_field" -> Atomic(Add, Field, Immediate)
     | "%atomic_add_loc" -> Atomic(Add, Loc, Immediate)
+    | "%atomic_add_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Add, Idx layout, Immediate)
     | "%atomic_sub" -> Atomic(Sub, Ref, Immediate)
     | "%atomic_sub_field" -> Atomic(Sub, Field, Immediate)
     | "%atomic_sub_loc" -> Atomic(Sub, Loc, Immediate)
+    | "%atomic_sub_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Sub, Idx layout, Immediate)
     | "%atomic_land" -> Atomic(Land, Ref, Immediate)
     | "%atomic_land_field" -> Atomic(Land, Field, Immediate)
     | "%atomic_land_loc" -> Atomic(Land, Loc, Immediate)
+    | "%atomic_land_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Land, Idx layout, Immediate)
     | "%atomic_lor" -> Atomic(Lor, Ref, Immediate)
     | "%atomic_lor_field" -> Atomic(Lor, Field, Immediate)
     | "%atomic_lor_loc" -> Atomic(Lor, Loc, Immediate)
+    | "%atomic_lor_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Lor, Idx layout, Immediate)
     | "%atomic_lxor" -> Atomic(Lxor, Ref, Immediate)
     | "%atomic_lxor_field" -> Atomic(Lxor, Field, Immediate)
     | "%atomic_lxor_loc" -> Atomic(Lxor, Loc, Immediate)
+    | "%atomic_lxor_idx" ->
+      let layout = List.nth (get_arg_layouts ()) 2 in
+      Atomic(Lxor, Idx layout, Immediate)
     | "%cpu_relax" -> Primitive (Pcpu_relax, 1)
     | "%with_stack" -> Primitive (Pwith_stack, 5)
     | "%with_stack_preemptible" -> Primitive (Pwith_stack_preemptible, 6)
@@ -1217,14 +1249,9 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
          as [Mutable_access] just restricts the optimizations that can be
          performed. *)
       Primitive(Pget_idx (layout, Mutable_access), 2)
-    | "%get_idx_atomic" ->
-      Primitive(Pget_idx (layout, Atomic_access), 2)
     | "%set_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
       Primitive(Pset_idx (layout, get_first_arg_mode (), Nonatomic), 3)
-    | "%set_idx_atomic" ->
-      let layout = List.nth (get_arg_layouts ()) 2 in
-      Primitive(Pset_idx (layout, get_first_arg_mode (), Atomic), 3)
     | "%unsafe_array_idx" ->
       Primitive(Pmake_idx_array
         (Punspecializedarray, Ptagged_int_index,
@@ -1946,6 +1973,14 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     (match fst (maybe_pointer_type env v) with
     | Pointer -> None
     | Immediate -> Some (Atomic (op, kind, Immediate)))
+  | Atomic (Set _ as op, Idx _, Pointer), [_; _; v]
+  | Atomic (Exchange _ as op, Idx _, Pointer), [_; _; v]
+  | Atomic (Compare_and_set _ as op, Idx _, Pointer), [_; _; _; v]
+  | Atomic (Compare_exchange _ as op, Idx _, Pointer), [_; _; _; v] ->
+    let l = layout_of_ty_for_idx_set env loc v in
+    (* no need to refine [Pointer] -- [idx_atomic] operations look at
+       [layout] instead *)
+    Some (Atomic (op, Idx l, Pointer))
   | Primitive (Pset_idx (_, m, a), arity), (_ :: _ :: p3 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p3 in
     Some (Primitive (Pset_idx (l, m, a), arity))
@@ -2179,7 +2214,7 @@ let atomic_arity op (kind : atomic_kind) =
   let extra_kind_arity =
     match kind with
     | Ref | Loc -> 0
-    | Field -> 1
+    | Field | Idx _ -> 1
   in
   arity_of_op + extra_kind_arity
 
@@ -2195,20 +2230,39 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
         first, rest
   in
   let prim =
-    match op with
-    | Load -> Patomic_load_field { immediate_or_pointer }
-    | Set mode -> Patomic_set_field { immediate_or_pointer; mode }
-    | Exchange mode -> Patomic_exchange_field { immediate_or_pointer; mode }
-    | Compare_exchange mode ->
-      Patomic_compare_exchange_field { immediate_or_pointer; mode }
-    | Compare_and_set mode ->
-      Patomic_compare_set_field { immediate_or_pointer; mode }
-    | Fetch_add -> Patomic_fetch_add_field
-    | Add -> Patomic_add_field
-    | Sub -> Patomic_sub_field
-    | Land -> Patomic_land_field
-    | Lor -> Patomic_lor_field
-    | Lxor -> Patomic_lxor_field
+    match kind with
+    | Ref | Loc | Field -> begin
+        match op with
+        | Load -> Patomic_load_field { immediate_or_pointer }
+        | Set mode -> Patomic_set_field { immediate_or_pointer; mode }
+        | Exchange mode -> Patomic_exchange_field { immediate_or_pointer; mode }
+        | Compare_exchange mode ->
+          Patomic_compare_exchange_field { immediate_or_pointer; mode }
+        | Compare_and_set mode ->
+          Patomic_compare_set_field { immediate_or_pointer; mode }
+        | Fetch_add -> Patomic_fetch_add_field
+        | Add -> Patomic_add_field
+        | Sub -> Patomic_sub_field
+        | Land -> Patomic_land_field
+        | Lor -> Patomic_lor_field
+        | Lxor -> Patomic_lxor_field
+    end
+    | Idx layout -> begin
+        match op with
+        | Load -> Pget_idx (layout, Atomic_access)
+        | Set mode -> Pset_idx (layout, mode, Atomic)
+        | Exchange mode -> Patomic_exchange_idx { layout; mode }
+        | Compare_exchange mode ->
+          Patomic_compare_exchange_idx { layout; mode }
+        | Compare_and_set mode ->
+          Patomic_compare_set_idx { layout; mode }
+        | Fetch_add -> Patomic_fetch_add_idx
+        | Add -> Patomic_add_idx
+        | Sub -> Patomic_sub_idx
+        | Land -> Patomic_land_idx
+        | Lor -> Patomic_lor_idx
+        | Lxor -> Patomic_lxor_idx
+    end
   in
   match kind with
   | Ref ->
@@ -2225,6 +2279,13 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
            [Lprim(%atomic_exchange_field, [ptr; ofs; v])]
          becomes
            [Lprim(caml_atomic_exchange_field, [ptr; ofs; v])] *)
+      Lprim (prim, args, loc)
+  | Idx _ ->
+      (* the primitive application
+           [Lprim(%atomic_exchange_idx, [ptr; idx; v])]
+         becomes
+           [Lprim(caml_atomic_exchange_field, [ptr; ofs; v])]
+         where [ofs] is the field offset corresponding to [idx]. *)
       Lprim (prim, args, loc)
   | Loc ->
       (* the primitive application
@@ -2665,6 +2726,10 @@ let lambda_primitive_needs_event_after = function
   | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
   | Patomic_load_field _ | Patomic_load_mixed_field _
   | Patomic_set_field _ | Patomic_set_mixed_field _
+  | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
+  | Patomic_compare_set_idx _ | Patomic_fetch_add_idx
+  | Patomic_add_idx | Patomic_sub_idx
+  | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
   | Pcpu_relax | Pctconst _ | Pint_as_pointer _ | Popaque _
   | Pdls_get
   | Ptls_get

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -107,11 +107,17 @@ type loc_kind =
   | Loc_POS
   | Loc_FUNCTION
 
-type atomic_kind =
+type atomic_field_kind =
   | Ref   (* operation on an atomic reference (takes only a pointer) *)
   | Field (* operation on an atomic field (takes a pointer and an offset) *)
   | Loc   (* operation on a first-class field (takes a (pointer, offset) pair *)
-  | Idx of layout (* operation on an idx_atomic (takes a pointer and an idx) *)
+
+type atomic_idx_kind =
+  | Idx (* operation on an idx_atomic (takes a pointer and an idx) *)
+
+type atomic_kind =
+  | Field_like of atomic_field_kind * immediate_or_pointer
+  | Idx_like of atomic_idx_kind * layout
 
 type atomic_op =
   | Load
@@ -143,7 +149,7 @@ type prim =
   | Identity
   | Apply of Lambda.region_close * Lambda.layout
   | Revapply of Lambda.region_close * Lambda.layout
-  | Atomic of atomic_op * atomic_kind * Lambda.immediate_or_pointer
+  | Atomic of atomic_op * atomic_kind
   | Peek of Lambda.peek_or_poke option
   | Poke of Lambda.peek_or_poke option
     (* For [Peek] and [Poke] the [option] is [None] until the primitive
@@ -675,6 +681,7 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
       (fun (_, repr) -> Lambda.layout_of_extern_repr repr)
       lambda_prim.prim_native_repr_args
   in
+  let int_layout = Pvalue { raw_kind = Pintval; nullable = Non_nullable } in
   let prim = match p.prim_name with
     | "%identity" -> Identity
     | "%bytes_to_string" -> Primitive (Pbytes_to_string, 1)
@@ -1134,79 +1141,81 @@ let lookup_primitive_unspecialized loc ~poly_mode ~poly_sort pos p =
     | "%unbox_mask" -> Primitive(Punbox_mask, 1)
     | "%box_mask" -> Primitive(Pbox_mask mode, 1)
     | "%get_header" -> Primitive (Pget_header mode, 1)
-    | "%atomic_load" -> Atomic(Load, Ref, Pointer)
-    | "%atomic_load_field" -> Atomic(Load, Field, Pointer)
-    | "%atomic_load_loc" -> Atomic(Load, Loc, Pointer)
-    | "%atomic_load_idx" -> Atomic(Load, Idx layout, Pointer)
-    | "%atomic_set" -> Atomic(Set (get_first_arg_mode ()), Ref, Pointer)
-    | "%atomic_set_field" -> Atomic(Set (get_first_arg_mode ()), Field, Pointer)
-    | "%atomic_set_loc" -> Atomic(Set (get_first_arg_mode ()), Loc, Pointer)
+    | "%atomic_load" -> Atomic(Load, Field_like (Ref, Pointer))
+    | "%atomic_load_field" -> Atomic(Load, Field_like (Field, Pointer))
+    | "%atomic_load_loc" -> Atomic(Load, Field_like (Loc, Pointer))
+    | "%atomic_load_idx" -> Atomic(Load, Idx_like (Idx, layout))
+    | "%atomic_set" ->
+      Atomic(Set (get_first_arg_mode ()), Field_like (Ref, Pointer))
+    | "%atomic_set_field" ->
+      Atomic(Set (get_first_arg_mode ()), Field_like (Field, Pointer))
+    | "%atomic_set_loc" ->
+      Atomic(Set (get_first_arg_mode ()), Field_like (Loc, Pointer))
     | "%atomic_set_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Set (get_first_arg_mode ()), Idx layout, Pointer)
+      Atomic(Set (get_first_arg_mode ()), Idx_like (Idx, layout))
     | "%atomic_exchange" ->
-      Atomic(Exchange (get_first_arg_mode ()), Ref, Pointer)
+      Atomic(Exchange (get_first_arg_mode ()), Field_like (Ref, Pointer))
     | "%atomic_exchange_field" ->
-      Atomic(Exchange (get_first_arg_mode ()), Field, Pointer)
+      Atomic(Exchange (get_first_arg_mode ()), Field_like (Field, Pointer))
     | "%atomic_exchange_loc" ->
-      Atomic(Exchange (get_first_arg_mode ()), Loc, Pointer)
+      Atomic(Exchange (get_first_arg_mode ()), Field_like (Loc, Pointer))
     | "%atomic_exchange_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Exchange (get_first_arg_mode ()), Idx layout, Pointer)
+      Atomic(Exchange (get_first_arg_mode ()), Idx_like (Idx, layout))
     | "%atomic_compare_exchange" ->
-      Atomic(Compare_exchange (get_first_arg_mode ()), Ref, Pointer)
+      Atomic(Compare_exchange (get_first_arg_mode ()),
+             Field_like (Ref, Pointer))
     | "%atomic_compare_exchange_field" ->
-      Atomic(Compare_exchange (get_first_arg_mode ()), Field, Pointer)
+      Atomic(Compare_exchange (get_first_arg_mode ()),
+             Field_like (Field, Pointer))
     | "%atomic_compare_exchange_loc" ->
-      Atomic(Compare_exchange (get_first_arg_mode ()), Loc, Pointer)
+      Atomic(Compare_exchange (get_first_arg_mode ()),
+             Field_like (Loc, Pointer))
     | "%atomic_compare_exchange_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Compare_exchange (get_first_arg_mode ()), Idx layout, Pointer)
+      Atomic(Compare_exchange (get_first_arg_mode ()), Idx_like (Idx, layout))
     | "%atomic_cas" ->
-      Atomic(Compare_and_set (get_first_arg_mode ()), Ref, Pointer)
+      Atomic(Compare_and_set (get_first_arg_mode ()), Field_like (Ref, Pointer))
     | "%atomic_cas_field" ->
-      Atomic(Compare_and_set (get_first_arg_mode ()), Field, Pointer)
+      Atomic(Compare_and_set (get_first_arg_mode ()),
+             Field_like (Field, Pointer))
     | "%atomic_cas_loc" ->
-      Atomic(Compare_and_set (get_first_arg_mode ()), Loc, Pointer)
+      Atomic(Compare_and_set (get_first_arg_mode ()), Field_like (Loc, Pointer))
     | "%atomic_cas_idx" ->
       let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Compare_and_set (get_first_arg_mode ()), Idx layout, Pointer)
-    | "%atomic_fetch_add" -> Atomic(Fetch_add, Ref, Immediate)
-    | "%atomic_fetch_add_field" -> Atomic(Fetch_add, Field, Immediate)
-    | "%atomic_fetch_add_loc" -> Atomic(Fetch_add, Loc, Immediate)
+      Atomic(Compare_and_set (get_first_arg_mode ()), Idx_like (Idx, layout))
+    | "%atomic_fetch_add" -> Atomic(Fetch_add, Field_like (Ref, Immediate))
+    | "%atomic_fetch_add_field" ->
+      Atomic(Fetch_add, Field_like (Field, Immediate))
+    | "%atomic_fetch_add_loc" -> Atomic(Fetch_add, Field_like (Loc, Immediate))
     | "%atomic_fetch_add_idx" ->
-      let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Fetch_add, Idx layout, Immediate)
-    | "%atomic_add" -> Atomic(Add, Ref, Immediate)
-    | "%atomic_add_field" -> Atomic(Add, Field, Immediate)
-    | "%atomic_add_loc" -> Atomic(Add, Loc, Immediate)
+      Atomic(Fetch_add, Idx_like (Idx, int_layout))
+    | "%atomic_add" -> Atomic(Add, Field_like (Ref, Immediate))
+    | "%atomic_add_field" -> Atomic(Add, Field_like (Field, Immediate))
+    | "%atomic_add_loc" -> Atomic(Add, Field_like (Loc, Immediate))
     | "%atomic_add_idx" ->
-      let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Add, Idx layout, Immediate)
-    | "%atomic_sub" -> Atomic(Sub, Ref, Immediate)
-    | "%atomic_sub_field" -> Atomic(Sub, Field, Immediate)
-    | "%atomic_sub_loc" -> Atomic(Sub, Loc, Immediate)
+      Atomic(Add, Idx_like (Idx, int_layout))
+    | "%atomic_sub" -> Atomic(Sub, Field_like (Ref, Immediate))
+    | "%atomic_sub_field" -> Atomic(Sub, Field_like (Field, Immediate))
+    | "%atomic_sub_loc" -> Atomic(Sub, Field_like (Loc, Immediate))
     | "%atomic_sub_idx" ->
-      let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Sub, Idx layout, Immediate)
-    | "%atomic_land" -> Atomic(Land, Ref, Immediate)
-    | "%atomic_land_field" -> Atomic(Land, Field, Immediate)
-    | "%atomic_land_loc" -> Atomic(Land, Loc, Immediate)
+      Atomic(Sub, Idx_like (Idx, int_layout))
+    | "%atomic_land" -> Atomic(Land, Field_like (Ref, Immediate))
+    | "%atomic_land_field" -> Atomic(Land, Field_like (Field, Immediate))
+    | "%atomic_land_loc" -> Atomic(Land, Field_like (Loc, Immediate))
     | "%atomic_land_idx" ->
-      let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Land, Idx layout, Immediate)
-    | "%atomic_lor" -> Atomic(Lor, Ref, Immediate)
-    | "%atomic_lor_field" -> Atomic(Lor, Field, Immediate)
-    | "%atomic_lor_loc" -> Atomic(Lor, Loc, Immediate)
+      Atomic(Land, Idx_like (Idx, int_layout))
+    | "%atomic_lor" -> Atomic(Lor, Field_like (Ref, Immediate))
+    | "%atomic_lor_field" -> Atomic(Lor, Field_like (Field, Immediate))
+    | "%atomic_lor_loc" -> Atomic(Lor, Field_like (Loc, Immediate))
     | "%atomic_lor_idx" ->
-      let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Lor, Idx layout, Immediate)
-    | "%atomic_lxor" -> Atomic(Lxor, Ref, Immediate)
-    | "%atomic_lxor_field" -> Atomic(Lxor, Field, Immediate)
-    | "%atomic_lxor_loc" -> Atomic(Lxor, Loc, Immediate)
+      Atomic(Lor, Idx_like (Idx, int_layout))
+    | "%atomic_lxor" -> Atomic(Lxor, Field_like (Ref, Immediate))
+    | "%atomic_lxor_field" -> Atomic(Lxor, Field_like (Field, Immediate))
+    | "%atomic_lxor_loc" -> Atomic(Lxor, Field_like (Loc, Immediate))
     | "%atomic_lxor_idx" ->
-      let layout = List.nth (get_arg_layouts ()) 2 in
-      Atomic(Lxor, Idx layout, Immediate)
+      Atomic(Lxor, Idx_like (Idx, int_layout))
     | "%cpu_relax" -> Primitive (Pcpu_relax, 1)
     | "%with_stack" -> Primitive (Pwith_stack, 5)
     | "%with_stack_preemptible" -> Primitive (Pwith_stack_preemptible, 6)
@@ -1944,14 +1953,14 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
     | None -> None
     | Some contents_layout -> Some (Poke (Some contents_layout))
   )
-  | Atomic (Load, (Ref | Loc as kind), Pointer), _ ->
+  | Atomic (Load, Field_like ((Ref | Loc) as kind, Pointer)), _ ->
     (match is_function_type env ty with
     | None -> None
     | Some (_, rhs) ->
       match fst (maybe_pointer_type env rhs) with
       | Pointer -> None
-      | Immediate -> Some (Atomic (Load, kind, Immediate)))
-  | Atomic (Load, Field, Pointer), _ ->
+      | Immediate -> Some (Atomic (Load, Field_like (kind, Immediate))))
+  | Atomic (Load, Field_like (Field, Pointer)), _ ->
     (match is_function_type env ty with
     | None -> None
     | Some (_, ty) ->
@@ -1960,27 +1969,31 @@ let specialize_primitive env loc ty ~has_constant_constructor prim =
       | Some (_, rhs) ->
         match fst (maybe_pointer_type env rhs) with
         | Pointer -> None
-        | Immediate -> Some (Atomic (Load, Field, Immediate)))
-  | Atomic (Set _ as op, (Ref | Loc as kind), Pointer), [_; v]
-  | Atomic (Set _ as op, (Field as kind), Pointer), [_; _; v]
-  | Atomic (Exchange _ as op, (Ref | Loc as kind), Pointer), [_; v]
-  | Atomic (Exchange _ as op, (Field as kind), Pointer), [_; _; v]
-  | Atomic (Compare_and_set _ as op, (Ref | Loc as kind), Pointer), [_; _; v]
-  | Atomic (Compare_and_set _ as op, (Field as kind), Pointer), [_; _; _; v]
-  | Atomic (Compare_exchange _ as op, (Ref | Loc as kind), Pointer), [_; _; v]
-  | Atomic (Compare_exchange _ as op, (Field as kind), Pointer), [_; _; _; v] ->
+        | Immediate ->
+          Some (Atomic (Load, Field_like (Field, Immediate))))
+  | Atomic (Set _ as op, Field_like ((Ref | Loc) as kind, Pointer)), [_; v]
+  | Atomic (Set _ as op, Field_like (Field as kind, Pointer)), [_; _; v]
+  | Atomic (Exchange _ as op, Field_like ((Ref | Loc) as kind, Pointer)),
+      [_; v]
+  | Atomic (Exchange _ as op, Field_like (Field as kind, Pointer)), [_; _; v]
+  | Atomic (Compare_and_set _ as op,
+      Field_like ((Ref | Loc) as kind, Pointer)), [_; _; v]
+  | Atomic (Compare_and_set _ as op, Field_like (Field as kind, Pointer)),
+      [_; _; _; v]
+  | Atomic (Compare_exchange _ as op,
+      Field_like ((Ref | Loc) as kind, Pointer)), [_; _; v]
+  | Atomic (Compare_exchange _ as op, Field_like (Field as kind, Pointer)),
+      [_; _; _; v] ->
     (* Checking [v] is sufficient for CAS: we only need the contents' type. *)
     (match fst (maybe_pointer_type env v) with
     | Pointer -> None
-    | Immediate -> Some (Atomic (op, kind, Immediate)))
-  | Atomic (Set _ as op, Idx _, Pointer), [_; _; v]
-  | Atomic (Exchange _ as op, Idx _, Pointer), [_; _; v]
-  | Atomic (Compare_and_set _ as op, Idx _, Pointer), [_; _; _; v]
-  | Atomic (Compare_exchange _ as op, Idx _, Pointer), [_; _; _; v] ->
+    | Immediate -> Some (Atomic (op, Field_like (kind, Immediate))))
+  | Atomic (Set _ as op, Idx_like (Idx, _)), [_; _; v]
+  | Atomic (Exchange _ as op, Idx_like (Idx, _)), [_; _; v]
+  | Atomic (Compare_and_set _ as op, Idx_like (Idx, _)), [_; _; _; v]
+  | Atomic (Compare_exchange _ as op, Idx_like (Idx, _)), [_; _; _; v] ->
     let l = layout_of_ty_for_idx_set env loc v in
-    (* no need to refine [Pointer] -- [idx_atomic] operations look at
-       [layout] instead *)
-    Some (Atomic (op, Idx l, Pointer))
+    Some (Atomic (op, Idx_like (Idx, l)))
   | Primitive (Pset_idx (_, m, a), arity), (_ :: _ :: p3 :: _) ->
     let l = layout_of_ty_for_idx_set env loc p3 in
     Some (Primitive (Pset_idx (l, m, a), arity))
@@ -2213,13 +2226,12 @@ let atomic_arity op (kind : atomic_kind) =
   in
   let extra_kind_arity =
     match kind with
-    | Ref | Loc -> 0
-    | Field | Idx _ -> 1
+    | Field_like ((Ref | Loc), _) -> 0
+    | Field_like (Field, _) | Idx_like (Idx, _) -> 1
   in
   arity_of_op + extra_kind_arity
 
-let lambda_of_atomic prim_name loc op (kind : atomic_kind)
-                     immediate_or_pointer args =
+let lambda_of_atomic prim_name loc op (kind : atomic_kind) args =
   if List.length args <> atomic_arity op kind then
     raise (Error (to_location loc, Wrong_arity_builtin_primitive prim_name)) ;
   let split = function
@@ -2231,7 +2243,7 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
   in
   let prim =
     match kind with
-    | Ref | Loc | Field -> begin
+    | Field_like (_, immediate_or_pointer) -> begin
         match op with
         | Load -> Patomic_load_field { immediate_or_pointer }
         | Set mode -> Patomic_set_field { immediate_or_pointer; mode }
@@ -2247,7 +2259,7 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
         | Lor -> Patomic_lor_field
         | Lxor -> Patomic_lxor_field
     end
-    | Idx layout -> begin
+    | Idx_like (Idx, layout) -> begin
         match op with
         | Load -> Pget_idx (layout, Atomic_access)
         | Set mode -> Pset_idx (layout, mode, Atomic)
@@ -2265,7 +2277,7 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
     end
   in
   match kind with
-  | Ref ->
+  | Field_like (Ref, _) ->
       (* the primitive application
            [Lprim(%atomic_exchange, [ref; v])]
          becomes
@@ -2274,20 +2286,7 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
       let ref_arg, rest = split args in
       let args = ref_arg :: tagged_immediate 0  :: rest in
       Lprim (prim, args, loc)
-  | Field ->
-      (* the primitive application
-           [Lprim(%atomic_exchange_field, [ptr; ofs; v])]
-         becomes
-           [Lprim(caml_atomic_exchange_field, [ptr; ofs; v])] *)
-      Lprim (prim, args, loc)
-  | Idx _ ->
-      (* the primitive application
-           [Lprim(%atomic_exchange_idx, [ptr; idx; v])]
-         becomes
-           [Lprim(caml_atomic_exchange_field, [ptr; ofs; v])]
-         where [ofs] is the field offset corresponding to [idx]. *)
-      Lprim (prim, args, loc)
-  | Loc ->
+  | Field_like (Loc, _) ->
       (* the primitive application
            [Lprim(%atomic_exchange_loc, [(ptr, ofs); v])]
          becomes
@@ -2299,7 +2298,7 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
               Lprim(caml_atomic_exchange_field, [Field(p, 0); Field(p, 1); v]))]
       *)
       let loc_arg, rest = split args in
-      match loc_arg with
+      begin match loc_arg with
       | Lprim (Pmakeblock _, [ptr; ofs], _argloc) ->
           let args = ptr :: ofs :: rest in
           Lprim (prim, args, loc)
@@ -2315,6 +2314,10 @@ let lambda_of_atomic prim_name loc op (kind : atomic_kind)
           Llet (
             Strict, Pvalue { raw_kind = Pgenval; nullable = Non_nullable},
             varg, Lambda.debug_uid_none, loc_arg, Lprim (prim, args, loc))
+      end
+  | Field_like (Field, _)
+  | Idx_like _ ->
+      Lprim (prim, args, loc)
 
 let caml_restore_raw_backtrace =
   Lambda.simple_prim_on_values ~name:"caml_restore_raw_backtrace" ~arity:2
@@ -2435,8 +2438,8 @@ let lambda_of_prim prim_name prim ~yielding loc args arg_exps =
           [exn; Lconst (Const_immstring msg)],
           loc)],
         loc)
-  | Atomic (op, kind, imm_or_ptr), args ->
-      lambda_of_atomic prim_name loc op kind imm_or_ptr args
+  | Atomic (op, kind), args ->
+      lambda_of_atomic prim_name loc op kind args
   | (Raise _ | Raise_with_backtrace
     | Lazy_force _ | Loc _ | Primitive _ | Sys_argv | Comparison _
     | Send _ | Send_self _ | Send_cache _ | Frame_pointers | Identity
@@ -2475,7 +2478,7 @@ let check_primitive_arity loc p =
     | Frame_pointers -> p.prim_arity = 0
     | Identity | Peek _ -> p.prim_arity = 1
     | Apply _ | Revapply _ | Poke _ -> p.prim_arity = 2
-    | Atomic (op, kind, _) -> p.prim_arity = atomic_arity op kind
+    | Atomic (op, kind) -> p.prim_arity = atomic_arity op kind
     | Unsupported _ -> true
   in
   if not ok then raise(Error(loc, Wrong_arity_builtin_primitive p.prim_name))

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -320,6 +320,11 @@ let compute_static_size lam =
     | Patomic_land_field
     | Patomic_lor_field
     | Patomic_lxor_field
+    | Patomic_add_idx
+    | Patomic_sub_idx
+    | Patomic_land_idx
+    | Patomic_lor_idx
+    | Patomic_lxor_idx
     | Pcpu_relax ->
         (* Unit-returning primitives. Most of these are only generated from
            external declarations and not special-cased by [Value_rec_check],
@@ -467,6 +472,10 @@ let compute_static_size lam =
     | Patomic_compare_exchange_field _
     | Patomic_compare_set_field _
     | Patomic_fetch_add_field
+    | Patomic_exchange_idx _
+    | Patomic_compare_exchange_idx _
+    | Patomic_compare_set_idx _
+    | Patomic_fetch_add_idx
     | Popaque _
     | Pdls_get
     | Ptls_get

--- a/lambda/value_rec_compiler.ml
+++ b/lambda/value_rec_compiler.ml
@@ -472,6 +472,8 @@ let compute_static_size lam =
     | Patomic_compare_exchange_field _
     | Patomic_compare_set_field _
     | Patomic_fetch_add_field
+    | Patomic_load_idx _
+    | Patomic_set_idx _
     | Patomic_exchange_idx _
     | Patomic_compare_exchange_idx _
     | Patomic_compare_set_idx _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1318,10 +1318,11 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Patomic_compare_exchange_field _ | Patomic_compare_set_field _
       | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
       | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
-      | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
-      | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
-      | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
-      | Pdls_get | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
+      | Patomic_load_idx _ | Patomic_set_idx _ | Patomic_exchange_idx _
+      | Patomic_compare_exchange_idx _ | Patomic_compare_set_idx _
+      | Patomic_fetch_add_idx | Patomic_add_idx | Patomic_sub_idx
+      | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx | Pdls_get
+      | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
       | Patomic_load_mixed_field _ | Patomic_set_field _
       | Patomic_set_mixed_field _ | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _

--- a/middle_end/flambda2/from_lambda/closure_conversion.ml
+++ b/middle_end/flambda2/from_lambda/closure_conversion.ml
@@ -1317,8 +1317,11 @@ let close_primitive acc env ~let_bound_ids_with_kinds named
       | Pget_ext_ptr _ | Pset_ext_ptr _ | Patomic_exchange_field _
       | Patomic_compare_exchange_field _ | Patomic_compare_set_field _
       | Patomic_fetch_add_field | Patomic_add_field | Patomic_sub_field
-      | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field | Pdls_get
-      | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
+      | Patomic_land_field | Patomic_lor_field | Patomic_lxor_field
+      | Patomic_exchange_idx _ | Patomic_compare_exchange_idx _
+      | Patomic_compare_set_idx _ | Patomic_fetch_add_idx | Patomic_add_idx
+      | Patomic_sub_idx | Patomic_land_idx | Patomic_lor_idx | Patomic_lxor_idx
+      | Pdls_get | Ptls_get | Pdomain_index | Ppoll | Patomic_load_field _
       | Patomic_load_mixed_field _ | Patomic_set_field _
       | Patomic_set_mixed_field _ | Preinterpret_tagged_int63_as_unboxed_int64
       | Preinterpret_unboxed_int64_as_tagged_int63 | Ppeek _ | Ppoke _

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1904,6 +1904,18 @@ let convert_pset_indirect ~machine_width ~dbg primitive write_offset_kind layout
     let new_value = List.hd new_values in
     [Ternary (Atomic_set_field (field_kind, mode), ptr, field, new_value)]
 
+let convert_atomic_idx_field ~machine_width primitive dbg layout ~idx =
+  needs_64_bit_target primitive dbg;
+  let offsets = block_index_access_offsets ~machine_width layout idx in
+  let kinds =
+    Flambda_arity.unarize
+      (Flambda_arity.from_lambda_list [layout] ~machine_width)
+  in
+  let offset, full_kind = check_single_element offsets kinds in
+  let field_kind = P.Block_access_field_kind.from_kind full_kind in
+  let field = tagged_field_index_of_offset ~machine_width offset in
+  field, field_kind
+
 let string_or_bytes_checks (size : Flambda_primitive.string_accessor_width)
     unsafe =
   if unsafe
@@ -3420,6 +3432,73 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [Ternary (Atomic_field_int_arith Or, atomic, field, i)]
   | Patomic_lxor_field, [[atomic]; [field]; [i]] ->
     [Ternary (Atomic_field_int_arith Xor, atomic, field, i)]
+  | Patomic_exchange_idx { layout; mode }, [[ptr]; [idx]; [new_value]] ->
+    let field, field_kind =
+      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    in
+    [ Ternary
+        ( Atomic_exchange_field
+            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+          ptr,
+          field,
+          new_value ) ]
+  | ( Patomic_compare_exchange_idx { layout; mode },
+      [[ptr]; [idx]; [comparison_value]; [new_value]] ) ->
+    let field, field_kind =
+      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    in
+    [ Quaternary
+        ( Atomic_compare_exchange_field
+            { atomic_kind = field_kind;
+              args_kind = field_kind;
+              mode = Alloc_mode.For_assignments.from_lambda mode
+            },
+          ptr,
+          field,
+          comparison_value,
+          new_value ) ]
+  | ( Patomic_compare_set_idx { layout; mode },
+      [[ptr]; [idx]; [old_value]; [new_value]] ) ->
+    let field, field_kind =
+      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    in
+    [ Quaternary
+        ( Atomic_compare_and_set_field
+            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+          ptr,
+          field,
+          old_value,
+          new_value ) ]
+  | Patomic_fetch_add_idx, [[ptr]; [idx]; [i]] ->
+    let field, _ =
+      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_field_int_arith Fetch_add, ptr, field, i)]
+  | Patomic_add_idx, [[ptr]; [idx]; [i]] ->
+    let field, _ =
+      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_field_int_arith Add, ptr, field, i)]
+  | Patomic_sub_idx, [[ptr]; [idx]; [i]] ->
+    let field, _ =
+      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_field_int_arith Sub, ptr, field, i)]
+  | Patomic_land_idx, [[ptr]; [idx]; [i]] ->
+    let field, _ =
+      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_field_int_arith And, ptr, field, i)]
+  | Patomic_lor_idx, [[ptr]; [idx]; [i]] ->
+    let field, _ =
+      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_field_int_arith Or, ptr, field, i)]
+  | Patomic_lxor_idx, [[ptr]; [idx]; [i]] ->
+    let field, _ =
+      convert_atomic_idx_field ~machine_width prim dbg L.layout_int ~idx
+    in
+    [Ternary (Atomic_field_int_arith Xor, ptr, field, i)]
   | Pcpu_relax, _ -> [Nullary Cpu_relax]
   | Pdls_get, _ -> [Nullary Dls_get]
   | Ptls_get, _ -> [Nullary Tls_get]
@@ -3581,7 +3660,9 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Punboxed_nativeint_array_set_vec _ | Patomic_set_field _
       | Patomic_exchange_field _ | Patomic_fetch_add_field | Patomic_add_field
       | Patomic_sub_field | Patomic_land_field | Patomic_lxor_field
-      | Patomic_lor_field | Pset_idx _ ),
+      | Patomic_lor_field | Patomic_exchange_idx _ | Patomic_fetch_add_idx
+      | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx | Patomic_lxor_idx
+      | Patomic_lor_idx | Pset_idx _ ),
       ( []
       | [_]
       | [_; _]
@@ -3593,7 +3674,8 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       "Closure_conversion.convert_primitive: Wrong arity for ternary primitive \
        %a (%a)"
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
-  | ( (Patomic_compare_exchange_field _ | Patomic_compare_set_field _),
+  | ( ( Patomic_compare_exchange_field _ | Patomic_compare_set_field _
+      | Patomic_compare_exchange_idx _ | Patomic_compare_set_idx _ ),
       ( []
       | [_]
       | [_; _]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1835,11 +1835,6 @@ let tagged_field_index_of_offset ~machine_width offset : H.simple_or_prim =
   Prim
     (Unary (Num_conv { src = Naked_int64; dst = Tagged_immediate }, Prim index))
 
-let access_flag_of_mutable_flag : Asttypes.mutable_flag -> L.access_flag =
-  function
-  | Immutable -> Immutable_access
-  | Mutable -> Mutable_access
-
 let check_single_element offsets kinds =
   let offset, full_kind =
     match offsets, kinds with
@@ -1865,60 +1860,36 @@ let convert_atomic_idx_field ~machine_width primitive dbg layout ~idx =
   field, field_kind
 
 let convert_pget_indirect ~machine_width ~dbg primitive layout
-    (access : L.access_flag) ~ptr ~idx : H.expr_primitive list =
+    (mut : Asttypes.mutable_flag) ~ptr ~idx : H.expr_primitive list =
   needs_64_bit_target primitive dbg;
-  match Lambda.access_atomicity access with
-  | Nonatomic ->
-    let offsets, kinds =
-      block_index_access_offsets_and_kinds ~machine_width layout idx
-    in
-    let mut =
-      match access with
-      | Immutable_access -> Asttypes.Immutable
-      | Mutable_access -> Asttypes.Mutable
-      | Atomic_access ->
-        Misc.fatal_error "convert_pget_indirect: expected nonatomic access"
-    in
-    let reads =
-      List.map2
-        (fun kind offset ->
-          H.Binary (Read_offset (kind, mut), ptr, Prim offset))
-        kinds offsets
-    in
-    [H.maybe_create_unboxed_product reads]
-  | Atomic ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width primitive dbg layout ~idx
-    in
-    [Binary (Atomic_load_field field_kind, ptr, field)]
+  let offsets, kinds =
+    block_index_access_offsets_and_kinds ~machine_width layout idx
+  in
+  let reads =
+    List.map2
+      (fun kind offset -> H.Binary (Read_offset (kind, mut), ptr, Prim offset))
+      kinds offsets
+  in
+  [H.maybe_create_unboxed_product reads]
 
 let convert_pset_indirect ~machine_width ~dbg primitive write_offset_kind layout
-    mode (atomicity : L.atomic_flag) ~ptr ~idx ~new_values :
-    H.expr_primitive list =
+    mode ~ptr ~idx ~new_values : H.expr_primitive list =
   needs_64_bit_target primitive dbg;
   let mode = Alloc_mode.For_assignments.from_lambda mode in
-  match atomicity with
-  | Nonatomic ->
-    let offsets, kinds =
-      block_index_access_offsets_and_kinds ~machine_width layout idx
-    in
-    let writes =
-      Misc.Stdlib.List.map3
-        (fun kind offset new_value ->
-          H.Ternary
-            ( Write_offset (write_offset_kind, kind, mode),
-              ptr,
-              Prim offset,
-              new_value ))
-        kinds offsets new_values
-    in
-    [H.Sequence writes]
-  | Atomic ->
-    let field, field_kind =
-      convert_atomic_idx_field ~machine_width primitive dbg layout ~idx
-    in
-    let new_value = List.hd new_values in
-    [Ternary (Atomic_set_field (field_kind, mode), ptr, field, new_value)]
+  let offsets, kinds =
+    block_index_access_offsets_and_kinds ~machine_width layout idx
+  in
+  let writes =
+    Misc.Stdlib.List.map3
+      (fun kind offset new_value ->
+        H.Ternary
+          ( Write_offset (write_offset_kind, kind, mode),
+            ptr,
+            Prim offset,
+            new_value ))
+      kinds offsets new_values
+  in
+  [H.Sequence writes]
 
 let string_or_bytes_checks (size : Flambda_primitive.string_accessor_width)
     unsafe =
@@ -3436,6 +3407,21 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
     [Ternary (Atomic_field_int_arith Or, atomic, field, i)]
   | Patomic_lxor_field, [[atomic]; [field]; [i]] ->
     [Ternary (Atomic_field_int_arith Xor, atomic, field, i)]
+  | Patomic_load_idx { layout }, [[ptr]; [idx]] ->
+    let field, field_kind =
+      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    in
+    [Binary (Atomic_load_field field_kind, ptr, field)]
+  | Patomic_set_idx { layout; mode }, [[ptr]; [idx]; [new_value]] ->
+    let field, field_kind =
+      convert_atomic_idx_field ~machine_width prim dbg layout ~idx
+    in
+    [ Ternary
+        ( Atomic_set_field
+            (field_kind, Alloc_mode.For_assignments.from_lambda mode),
+          ptr,
+          field,
+          new_value ) ]
   | Patomic_exchange_idx { layout; mode }, [[ptr]; [idx]; [new_value]] ->
     let field, field_kind =
       convert_atomic_idx_field ~machine_width prim dbg layout ~idx
@@ -3531,23 +3517,21 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
   | Ppoke layout, [[ptr]; [new_value]] ->
     let kind = standard_int_or_float_of_peek_or_poke layout in
     [Binary (Poke kind, ptr, new_value)]
-  | Pget_idx (layout, access), [[ptr]; [idx]] ->
-    convert_pget_indirect ~machine_width ~dbg prim layout access ~ptr ~idx
+  | Pget_idx (layout, mut), [[ptr]; [idx]] ->
+    convert_pget_indirect ~machine_width ~dbg prim layout mut ~ptr ~idx
   | Pget_ptr (layout, mut), [[ptr; idx]] ->
-    convert_pget_indirect ~machine_width ~dbg prim layout
-      (access_flag_of_mutable_flag mut)
-      ~ptr ~idx
+    convert_pget_indirect ~machine_width ~dbg prim layout mut ~ptr ~idx
   | Pget_ptr _, [([] | [_] | _ :: _ :: _ :: _)] ->
     Misc.fatal_errorf
       "Closure_convertion.convert_primitive: The argument to Pget_ptr should \
        be an unboxed product of length 2"
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
-  | Pset_idx (layout, mode, atomicity), [[ptr]; [idx]; new_values] ->
-    convert_pset_indirect ~machine_width ~dbg prim Into_block layout mode
-      atomicity ~ptr ~idx ~new_values
+  | Pset_idx (layout, mode), [[ptr]; [idx]; new_values] ->
+    convert_pset_indirect ~machine_width ~dbg prim Into_block layout mode ~ptr
+      ~idx ~new_values
   | Pset_ptr (layout, mode), [[ptr; idx]; new_values] ->
     convert_pset_indirect ~machine_width ~dbg prim Into_block_or_off_heap layout
-      mode Nonatomic ~ptr ~idx ~new_values
+      mode ~ptr ~idx ~new_values
   | Pset_ptr _, [([] | [_] | _ :: _ :: _ :: _); _] ->
     Misc.fatal_errorf
       "Closure_convertion.convert_primitive: The first argument to Pset_ptr \
@@ -3555,13 +3539,12 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       Printlambda.primitive prim H.print_list_of_lists_of_simple_or_prim args
   | Pget_ext_ptr (layout, mut), [[idx]] ->
     let null_base = H.Simple (Simple.const Reg_width_const.const_null) in
-    convert_pget_indirect ~machine_width ~dbg prim layout
-      (access_flag_of_mutable_flag mut)
-      ~ptr:null_base ~idx
+    convert_pget_indirect ~machine_width ~dbg prim layout mut ~ptr:null_base
+      ~idx
   | Pset_ext_ptr (layout, mode), [[idx]; new_values] ->
     let null_base = H.Simple (Simple.const Reg_width_const.const_null) in
     convert_pset_indirect ~machine_width ~dbg prim Into_block_or_off_heap layout
-      mode Nonatomic ~ptr:null_base ~idx ~new_values
+      mode ~ptr:null_base ~idx ~new_values
   | (Praise _ | Pccall _), _ ->
     Misc.fatal_errorf
       "Closure_conversion.convert_primitive: Primitive %a (%a) shouldn't be \
@@ -3628,7 +3611,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Patomic_load_field _ | Patomic_set_mixed_field _ | Ppoke _
       | Pphys_equal _
       | Pscalar (Binary _)
-      | Pget_idx _ | Pset_ptr _ | Pset_ext_ptr _ ),
+      | Patomic_load_idx _ | Pget_idx _ | Pset_ptr _ | Pset_ext_ptr _ ),
       ( []
       | [_]
       | _ :: _ :: _ :: _
@@ -3666,7 +3649,7 @@ let convert_lprim ~(machine_width : Target_system.Machine_width.t) ~big_endian
       | Patomic_sub_field | Patomic_land_field | Patomic_lxor_field
       | Patomic_lor_field | Patomic_exchange_idx _ | Patomic_fetch_add_idx
       | Patomic_add_idx | Patomic_sub_idx | Patomic_land_idx | Patomic_lxor_idx
-      | Patomic_lor_idx | Pset_idx _ ),
+      | Patomic_lor_idx | Patomic_set_idx _ | Pset_idx _ ),
       ( []
       | [_]
       | [_; _]

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1844,16 +1844,28 @@ let check_single_element offsets kinds =
     Misc.fatal_error "check_single_element: expected value for atomic op";
   offset, full_kind
 
-let convert_pget_indirect ~machine_width ~dbg primitive layout
-    (access : L.access_flag) ~ptr ~idx : H.expr_primitive list =
+let convert_atomic_idx_field ~machine_width primitive dbg layout ~idx =
   needs_64_bit_target primitive dbg;
   let offsets = block_index_access_offsets ~machine_width layout idx in
   let kinds =
     Flambda_arity.unarize
       (Flambda_arity.from_lambda_list [layout] ~machine_width)
   in
+  let offset, full_kind = check_single_element offsets kinds in
+  let field_kind = P.Block_access_field_kind.from_kind full_kind in
+  let field = tagged_field_index_of_offset ~machine_width offset in
+  field, field_kind
+
+let convert_pget_indirect ~machine_width ~dbg primitive layout
+    (access : L.access_flag) ~ptr ~idx : H.expr_primitive list =
+  needs_64_bit_target primitive dbg;
   match Lambda.access_atomicity access with
   | Nonatomic ->
+    let offsets = block_index_access_offsets ~machine_width layout idx in
+    let kinds =
+      Flambda_arity.unarize
+        (Flambda_arity.from_lambda_list [layout] ~machine_width)
+    in
     let mut =
       match access with
       | Immutable_access -> Asttypes.Immutable
@@ -1869,9 +1881,9 @@ let convert_pget_indirect ~machine_width ~dbg primitive layout
     in
     [H.maybe_create_unboxed_product reads]
   | Atomic ->
-    let offset, full_kind = check_single_element offsets kinds in
-    let field_kind = P.Block_access_field_kind.from_kind full_kind in
-    let field = tagged_field_index_of_offset ~machine_width offset in
+    let field, field_kind =
+      convert_atomic_idx_field ~machine_width primitive dbg layout ~idx
+    in
     [Binary (Atomic_load_field field_kind, ptr, field)]
 
 let convert_pset_indirect ~machine_width ~dbg primitive write_offset_kind layout
@@ -1879,13 +1891,13 @@ let convert_pset_indirect ~machine_width ~dbg primitive write_offset_kind layout
     H.expr_primitive list =
   needs_64_bit_target primitive dbg;
   let mode = Alloc_mode.For_assignments.from_lambda mode in
-  let offsets = block_index_access_offsets ~machine_width layout idx in
-  let kinds =
-    Flambda_arity.unarize
-      (Flambda_arity.from_lambda_list [layout] ~machine_width)
-  in
   match atomicity with
   | Nonatomic ->
+    let offsets = block_index_access_offsets ~machine_width layout idx in
+    let kinds =
+      Flambda_arity.unarize
+        (Flambda_arity.from_lambda_list [layout] ~machine_width)
+    in
     let writes =
       Misc.Stdlib.List.map3
         (fun kind offset new_value ->
@@ -1898,23 +1910,11 @@ let convert_pset_indirect ~machine_width ~dbg primitive write_offset_kind layout
     in
     [H.Sequence writes]
   | Atomic ->
-    let offset, full_kind = check_single_element offsets kinds in
-    let field_kind = P.Block_access_field_kind.from_kind full_kind in
-    let field = tagged_field_index_of_offset ~machine_width offset in
+    let field, field_kind =
+      convert_atomic_idx_field ~machine_width primitive dbg layout ~idx
+    in
     let new_value = List.hd new_values in
     [Ternary (Atomic_set_field (field_kind, mode), ptr, field, new_value)]
-
-let convert_atomic_idx_field ~machine_width primitive dbg layout ~idx =
-  needs_64_bit_target primitive dbg;
-  let offsets = block_index_access_offsets ~machine_width layout idx in
-  let kinds =
-    Flambda_arity.unarize
-      (Flambda_arity.from_lambda_list [layout] ~machine_width)
-  in
-  let offset, full_kind = check_single_element offsets kinds in
-  let field_kind = P.Block_access_field_kind.from_kind full_kind in
-  let field = tagged_field_index_of_offset ~machine_width offset in
-  field, field_kind
 
 let string_or_bytes_checks (size : Flambda_primitive.string_accessor_width)
     unsafe =

--- a/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2/from_lambda/lambda_to_flambda_primitives.ml
@@ -1760,10 +1760,14 @@ let extract_block_index_offset ~machine_width idx =
 
 (* Given an index that points to data of some layout, produce the list of
    offsets needed to access each element *)
-let block_index_access_offsets ~machine_width layout idx =
+let block_index_access_offsets_and_kinds ~machine_width layout idx =
   assert (Target_system.is_64_bit ());
   let mbe = L.mixed_block_element_of_layout layout in
   let cts = MPB.count mbe in
+  let kinds =
+    Flambda_arity.unarize
+      (Flambda_arity.from_lambda_list [layout] ~machine_width)
+  in
   if MPB.has_value_and_flat cts
   then
     let offset = extract_block_index_offset ~machine_width idx in
@@ -1799,7 +1803,10 @@ let block_index_access_offsets ~machine_width layout idx =
       let prim = add offset offset_from_offset in
       MPB.add to_left (MPB.count mbe), prim
     in
-    snd (List.fold_left_map f MPB.zero (L.mixed_block_element_leaves mbe))
+    let offsets =
+      snd (List.fold_left_map f MPB.zero (L.mixed_block_element_leaves mbe))
+    in
+    offsets, kinds
   else
     let f (to_left : MPB.t) (mbe : unit L.mixed_block_element) =
       let summand =
@@ -1810,9 +1817,12 @@ let block_index_access_offsets ~machine_width layout idx =
       let prim = H.Binary (Int_arith (Naked_int64, Add), idx, summand) in
       MPB.add to_left (MPB.count mbe), prim
     in
-    snd (List.fold_left_map f MPB.zero (L.mixed_block_element_leaves mbe))
+    let offsets =
+      snd (List.fold_left_map f MPB.zero (L.mixed_block_element_leaves mbe))
+    in
+    offsets, kinds
 
-(* [block_index_access_offsets] produces untagged byte offsets, but
+(* [block_index_access_offsets_and_kinds] produces untagged byte offsets, but
    [Atomic_load_field] and [Atomic_set_field] expect a tagged word index. *)
 let tagged_field_index_of_offset ~machine_width offset : H.simple_or_prim =
   let log2_size_addr =
@@ -1846,10 +1856,8 @@ let check_single_element offsets kinds =
 
 let convert_atomic_idx_field ~machine_width primitive dbg layout ~idx =
   needs_64_bit_target primitive dbg;
-  let offsets = block_index_access_offsets ~machine_width layout idx in
-  let kinds =
-    Flambda_arity.unarize
-      (Flambda_arity.from_lambda_list [layout] ~machine_width)
+  let offsets, kinds =
+    block_index_access_offsets_and_kinds ~machine_width layout idx
   in
   let offset, full_kind = check_single_element offsets kinds in
   let field_kind = P.Block_access_field_kind.from_kind full_kind in
@@ -1861,10 +1869,8 @@ let convert_pget_indirect ~machine_width ~dbg primitive layout
   needs_64_bit_target primitive dbg;
   match Lambda.access_atomicity access with
   | Nonatomic ->
-    let offsets = block_index_access_offsets ~machine_width layout idx in
-    let kinds =
-      Flambda_arity.unarize
-        (Flambda_arity.from_lambda_list [layout] ~machine_width)
+    let offsets, kinds =
+      block_index_access_offsets_and_kinds ~machine_width layout idx
     in
     let mut =
       match access with
@@ -1893,10 +1899,8 @@ let convert_pset_indirect ~machine_width ~dbg primitive write_offset_kind layout
   let mode = Alloc_mode.For_assignments.from_lambda mode in
   match atomicity with
   | Nonatomic ->
-    let offsets = block_index_access_offsets ~machine_width layout idx in
-    let kinds =
-      Flambda_arity.unarize
-        (Flambda_arity.from_lambda_list [layout] ~machine_width)
+    let offsets, kinds =
+      block_index_access_offsets_and_kinds ~machine_width layout idx
     in
     let writes =
       Misc.Stdlib.List.map3

--- a/otherlibs/stdlib_stable/idx_atomic.ml
+++ b/otherlibs/stdlib_stable/idx_atomic.ml
@@ -17,12 +17,52 @@
 type ('a : value_or_null, 'b : value_or_null) t : bits64 mod everything =
   ('a, 'b) idx_atomic
 
-external get
-  : ('a : value_or_null) ('b : value_or_null).
-  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> ('b[@local_opt])
-  = "%get_idx_atomic"
+external get :
+  ('a : value_or_null) ('b : value_or_null).
+  'a @ local -> ('a, 'b) t -> 'b = "%atomic_load_idx"
 
-external set
-  : ('a : value_or_null) ('b : value_or_null).
-  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> 'b -> unit
-  = "%set_idx_atomic"
+external set :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> unit = "%atomic_set_idx"
+
+external exchange :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> 'b
+  = "%atomic_exchange_idx"
+
+external compare_and_set :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> 'b -> bool
+  = "%atomic_cas_idx"
+
+external compare_exchange :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> 'b -> 'b
+  = "%atomic_compare_exchange_idx"
+
+external fetch_and_add :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> int
+  = "%atomic_fetch_add_idx"
+
+external add :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_add_idx"
+
+external sub :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_sub_idx"
+
+external logand :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_land_idx"
+
+external logor :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_lor_idx"
+
+external logxor :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_lxor_idx"
+
+let incr a i = add a i 1
+let decr a i = sub a i 1

--- a/otherlibs/stdlib_stable/idx_atomic.mli
+++ b/otherlibs/stdlib_stable/idx_atomic.mli
@@ -18,17 +18,81 @@
 type ('a : value_or_null, 'b : value_or_null) t : bits64 mod everything =
   ('a, 'b) idx_atomic
 
-(** [get a i] uses the index [i] to access [a] atomically. *)
-external get
-  : ('a : value_or_null) ('b : value_or_null).
-  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> ('b[@local_opt])
-  = "%get_idx_atomic"
+(** [get a i] gets [a] at index [i] atomically.
 
-(** [set a i v] uses the index [i] to set [a] to [v] atomically.
+    It can take [a] locally and return its result globally because atomic
+    indices can only be created to elements with the [global] modality. *)
+external get :
+  ('a : value_or_null) ('b : value_or_null).
+  'a @ local -> ('a, 'b) t -> 'b = "%atomic_load_idx"
+
+(** [set a i v] sets [a] at index [i] to [v] atomically.
 
     It can take [a] locally and [v] globally because atomic indices can only be
     created to elements with the [global] modality. *)
-external set
-  : ('a : value_or_null) ('b : value_or_null).
-  ('a[@local_opt]) -> ('a, 'b) idx_atomic -> 'b -> unit
-  = "%set_idx_atomic"
+external set :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> unit = "%atomic_set_idx"
+
+(** [exchange a i v] sets [a] at index [i] to [v] atomically and returns the
+    previous value. *)
+external exchange :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> 'b = "%atomic_exchange_idx"
+
+(** [compare_and_set a i seen v] sets [a] at index [i] to [v] only if the
+    value of [a] at index [i] is physically equal to [seen]. The comparison
+    and the set occur atomically.
+
+    Returns [true] if the set occurred and [false] otherwise. *)
+external compare_and_set :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> 'b -> bool = "%atomic_cas_idx"
+
+(** [compare_exchange a i seen v] sets [a] at index [i] to [v] only if the
+    value of [a] at index [i] is physically equal to [seen]. The comparison
+    and the set occur atomically.
+
+    Returns the previous value of [a] at index [i], or the current
+    (unchanged) value if the comparison failed. *)
+external compare_exchange :
+  ('a : value_or_null) ('b : value_or_null).
+  ('a[@local_opt]) -> ('a, 'b) t -> 'b -> 'b -> 'b
+  = "%atomic_compare_exchange_idx"
+
+(** [fetch_and_add a i n] atomically increments [a] at index [i] by [n], and
+    returns the current value (before the increment). *)
+external fetch_and_add :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> int
+  = "%atomic_fetch_add_idx"
+
+(** [add a i n] atomically adds [n] onto [a] at index [i]. *)
+external add :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_add_idx"
+
+(** [sub a i n] atomically subtracts [n] from [a] at index [i]. *)
+external sub :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_sub_idx"
+
+(** [logand a i n] atomically bitwise-ands [n] onto [a] at index [i]. *)
+external logand :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_land_idx"
+
+(** [logor a i n] atomically bitwise-ors [n] onto [a] at index [i]. *)
+external logor :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_lor_idx"
+
+(** [logxor a i n] atomically bitwise-xors [n] onto [a] at index [i]. *)
+external logxor :
+  ('a : value_or_null). 'a @ local -> ('a, int) t -> int -> unit
+  = "%atomic_lxor_idx"
+
+(** [incr a i] atomically increments [a] at index [i] by [1]. *)
+val incr : ('a : value_or_null). 'a @ local -> ('a, int) t -> unit
+
+(** [decr a i] atomically decrements [a] at index [i] by [1]. *)
+val decr : ('a : value_or_null). 'a @ local -> ('a, int) t -> unit

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -1120,11 +1120,18 @@ CAMLprim value caml_get_idx_bytecode(value base, value idx)
   CAMLreturn (res);
 }
 
-CAMLprim value caml_get_idx_atomic_bytecode(value base, value idx) {
-  CAMLparam2 (base, idx);
+Caml_inline void check_atomic_idx(value base, value idx)
+{
   CAMLassert (Tag_val(idx) == 0);
   CAMLassert (Wosize_val(idx) == 1); /* Nested atomic accesses not supported */
   CAMLassert (Tag_val(base) != Double_array_tag);
+  (void)base;
+  (void)idx;
+}
+
+CAMLprim value caml_get_idx_atomic_bytecode(value base, value idx) {
+  CAMLparam2 (base, idx);
+  check_atomic_idx(base, idx);
   CAMLreturn (caml_atomic_load_field(base, Field(idx, 0)));
 }
 
@@ -1154,11 +1161,78 @@ CAMLprim value caml_set_idx_bytecode(value base, value idx, value v)
 CAMLprim value caml_set_idx_atomic_bytecode(value base, value idx, value v)
 {
   CAMLparam3 (base, idx, v);
-  CAMLassert (Tag_val(idx) == 0);
-  CAMLassert (Wosize_val(idx) == 1); /* Nested atomic accesses not supported */
-  CAMLassert (Tag_val(base) != Double_array_tag);
+  check_atomic_idx(base, idx);
   caml_atomic_exchange_field(base, Field(idx, 0), v);
   CAMLreturn (Val_unit);
+}
+
+CAMLprim value caml_atomic_exchange_idx_bytecode(value base, value idx,
+                                                 value v)
+{
+  CAMLparam3 (base, idx, v);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_exchange_field(base, Field(idx, 0), v));
+}
+
+CAMLprim value caml_atomic_compare_exchange_idx_bytecode(value base, value idx,
+                                                         value oldv,
+                                                         value newv)
+{
+  CAMLparam4 (base, idx, oldv, newv);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_compare_exchange_field(base, Field(idx, 0),
+                                                 oldv, newv));
+}
+
+CAMLprim value caml_atomic_cas_idx_bytecode(value base, value idx,
+                                            value oldv, value newv)
+{
+  CAMLparam4 (base, idx, oldv, newv);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_cas_field(base, Field(idx, 0), oldv, newv));
+}
+
+CAMLprim value caml_atomic_fetch_add_idx_bytecode(value base, value idx,
+                                                  value incr)
+{
+  CAMLparam3 (base, idx, incr);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_fetch_add_field(base, Field(idx, 0), incr));
+}
+
+CAMLprim value caml_atomic_add_idx_bytecode(value base, value idx, value incr)
+{
+  CAMLparam3 (base, idx, incr);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_add_field(base, Field(idx, 0), incr));
+}
+
+CAMLprim value caml_atomic_sub_idx_bytecode(value base, value idx, value incr)
+{
+  CAMLparam3 (base, idx, incr);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_sub_field(base, Field(idx, 0), incr));
+}
+
+CAMLprim value caml_atomic_land_idx_bytecode(value base, value idx, value incr)
+{
+  CAMLparam3 (base, idx, incr);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_land_field(base, Field(idx, 0), incr));
+}
+
+CAMLprim value caml_atomic_lor_idx_bytecode(value base, value idx, value incr)
+{
+  CAMLparam3 (base, idx, incr);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_lor_field(base, Field(idx, 0), incr));
+}
+
+CAMLprim value caml_atomic_lxor_idx_bytecode(value base, value idx, value incr)
+{
+  CAMLparam3 (base, idx, incr);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_lxor_field(base, Field(idx, 0), incr));
 }
 
 CAMLprim value caml_get_ptr_bytecode(value ptr)

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -1129,12 +1129,6 @@ Caml_inline void check_atomic_idx(value base, value idx)
   (void)idx;
 }
 
-CAMLprim value caml_get_idx_atomic_bytecode(value base, value idx) {
-  CAMLparam2 (base, idx);
-  check_atomic_idx(base, idx);
-  CAMLreturn (caml_atomic_load_field(base, Field(idx, 0)));
-}
-
 CAMLprim value caml_set_idx_bytecode(value base, value idx, value v)
 {
   CAMLparam3 (base, idx, v);
@@ -1158,12 +1152,18 @@ CAMLprim value caml_set_idx_bytecode(value base, value idx, value v)
   CAMLreturn (Val_unit);
 }
 
-CAMLprim value caml_set_idx_atomic_bytecode(value base, value idx, value v)
+CAMLprim value caml_atomic_load_idx_bytecode(value base, value idx)
+{
+  CAMLparam2 (base, idx);
+  check_atomic_idx(base, idx);
+  CAMLreturn (caml_atomic_load_field(base, Field(idx, 0)));
+}
+
+CAMLprim value caml_atomic_set_idx_bytecode(value base, value idx, value v)
 {
   CAMLparam3 (base, idx, v);
   check_atomic_idx(base, idx);
-  caml_atomic_exchange_field(base, Field(idx, 0), v);
-  CAMLreturn (Val_unit);
+  CAMLreturn (caml_atomic_set_field(base, Field(idx, 0), v));
 }
 
 CAMLprim value caml_atomic_exchange_idx_bytecode(value base, value idx,

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -49,6 +49,14 @@ CAMLextern void caml_initialize (volatile value *, value);
 CAMLextern value caml_atomic_load_field (value, value);
 CAMLextern value caml_atomic_exchange_field (value, value, value);
 CAMLextern value caml_atomic_cas_field (value, value, value, value);
+CAMLextern value caml_atomic_compare_exchange_field (value, value,
+                                                     value, value);
+CAMLextern value caml_atomic_fetch_add_field (value, value, value);
+CAMLextern value caml_atomic_add_field (value, value, value);
+CAMLextern value caml_atomic_sub_field (value, value, value);
+CAMLextern value caml_atomic_land_field (value, value, value);
+CAMLextern value caml_atomic_lor_field (value, value, value);
+CAMLextern value caml_atomic_lxor_field (value, value, value);
 CAMLextern value caml_check_urgent_gc (value);
 
 /* Donate [size] bytes at [base] to the major heap, as an "extent"

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -47,6 +47,7 @@ CAMLextern void caml_modify (volatile value *, value);
 CAMLextern void caml_modify_local (value obj, intnat i, value val);
 CAMLextern void caml_initialize (volatile value *, value);
 CAMLextern value caml_atomic_load_field (value, value);
+CAMLextern value caml_atomic_set_field (value, value, value);
 CAMLextern value caml_atomic_exchange_field (value, value, value);
 CAMLextern value caml_atomic_cas_field (value, value, value, value);
 CAMLextern value caml_atomic_compare_exchange_field (value, value,

--- a/testsuite/tests/records-and-block-indices/idx_atomic.ml
+++ b/testsuite/tests/records-and-block-indices/idx_atomic.ml
@@ -29,6 +29,90 @@ module Basic = struct
     ()
 end
 
+(* test read-modify-write operations using block indices *)
+
+module Rmw = struct
+  type t = { mutable x: int [@atomic]; mutable y: string [@atomic] }
+
+  let () =
+    Printf.printf "== idx_atomic read-modify-write ==\n";
+    let t = { x = 1; y = "one" } in
+    Printf.printf "exchange (.x) 2 = %d\n" (Idx_atomic.exchange t (.x) 2);
+    Printf.printf "exchange (.y) two = %s\n" (Idx_atomic.exchange t (.y) "two");
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    Printf.printf "compare_and_set (.x) 2 3 = %b\n"
+      (Idx_atomic.compare_and_set t (.x) 2 3);
+    Printf.printf "compare_and_set (.x) 2 4 = %b\n"
+      (Idx_atomic.compare_and_set t (.x) 2 4);
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    let y = Idx_atomic.get t (.y) in
+    Printf.printf "compare_and_set (.y) y three = %b\n"
+      (Idx_atomic.compare_and_set t (.y) y "three");
+    Printf.printf "(.y) = %s\n" (Idx_atomic.get t (.y));
+    Printf.printf "compare_exchange (.x) 3 5 = %d\n"
+      (Idx_atomic.compare_exchange t (.x) 3 5);
+    Printf.printf "compare_exchange (.x) 3 6 = %d\n"
+      (Idx_atomic.compare_exchange t (.x) 3 6);
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "fetch_and_add (.x) 10 = %d\n"
+      (Idx_atomic.fetch_and_add t (.x) 10);
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "add (.x) 4\n"; Idx_atomic.add t (.x) 4;
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "sub (.x) 5\n"; Idx_atomic.sub t (.x) 5;
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "logand (.x) 6\n"; Idx_atomic.logand t (.x) 6;
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "logor (.x) 9\n"; Idx_atomic.logor t (.x) 9;
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "logxor (.x) 3\n"; Idx_atomic.logxor t (.x) 3;
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "incr (.x)\n"; Idx_atomic.incr t (.x);
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    Printf.printf "decr (.x)\n"; Idx_atomic.decr t (.x);
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    ()
+end
+
+(* test read-modify-write operations on a mixed record *)
+
+module RmwMixed = struct
+  type t = { x: int64#; mutable y: int [@atomic]; z: int64# }
+
+  let () =
+    Printf.printf "== idx_atomic read-modify-write (mixed record) ==\n";
+    let t = { x = #42L; y = 1; z = #67L } in
+    Printf.printf "exchange (.y) 2 = %d\n" (Idx_atomic.exchange t (.y) 2);
+    Printf.printf "compare_and_set (.y) 2 3 = %b\n"
+      (Idx_atomic.compare_and_set t (.y) 2 3);
+    Printf.printf "fetch_and_add (.y) 10 = %d\n"
+      (Idx_atomic.fetch_and_add t (.y) 10);
+    Printf.printf "(.x) = %Ld\n" (Int64_u.to_int64 t.x);
+    Printf.printf "(.y) = %d\n" (Idx_atomic.get t (.y));
+    Printf.printf "(.z) = %Ld\n" (Int64_u.to_int64 t.z);
+    ()
+end
+
+(* test read-modify-write operations on a stack-allocated record *)
+
+module RmwStack = struct
+  type t = { mutable x: int [@atomic] }
+
+  let () =
+    Printf.printf "== idx_atomic read-modify-write (stack-allocated record) ==\n";
+    let t = stack_ { x = 1 } in
+    Printf.printf "exchange (.x) 2 = %d\n" (Idx_atomic.exchange t (.x) 2);
+    Printf.printf "compare_and_set (.x) 2 3 = %b\n"
+      (Idx_atomic.compare_and_set t (.x) 2 3);
+    Printf.printf "compare_exchange (.x) 3 4 = %d\n"
+      (Idx_atomic.compare_exchange t (.x) 3 4);
+    Printf.printf "fetch_and_add (.x) 10 = %d\n"
+      (Idx_atomic.fetch_and_add t (.x) 10);
+    Printf.printf "(.x) = %d\n" (Idx_atomic.get t (.x));
+    ()
+end
+
 (* test reading/writing unboxed singleton record *)
 
 module UnboxedSingleton = struct

--- a/testsuite/tests/records-and-block-indices/idx_atomic.reference
+++ b/testsuite/tests/records-and-block-indices/idx_atomic.reference
@@ -5,6 +5,48 @@
 (.y) <- four
 (.x) = 3
 (.y) = four
+== idx_atomic read-modify-write ==
+exchange (.x) 2 = 1
+exchange (.y) two = one
+(.x) = 2
+(.y) = two
+compare_and_set (.x) 2 3 = true
+compare_and_set (.x) 2 4 = false
+(.x) = 3
+compare_and_set (.y) y three = true
+(.y) = three
+compare_exchange (.x) 3 5 = 3
+compare_exchange (.x) 3 6 = 5
+(.x) = 5
+fetch_and_add (.x) 10 = 5
+(.x) = 15
+add (.x) 4
+(.x) = 19
+sub (.x) 5
+(.x) = 14
+logand (.x) 6
+(.x) = 6
+logor (.x) 9
+(.x) = 15
+logxor (.x) 3
+(.x) = 12
+incr (.x)
+(.x) = 13
+decr (.x)
+(.x) = 12
+== idx_atomic read-modify-write (mixed record) ==
+exchange (.y) 2 = 1
+compare_and_set (.y) 2 3 = true
+fetch_and_add (.y) 10 = 3
+(.x) = 42
+(.y) = 13
+(.z) = 67
+== idx_atomic read-modify-write (stack-allocated record) ==
+exchange (.x) 2 = 1
+compare_and_set (.x) 2 3 = true
+compare_exchange (.x) 3 4 = 3
+fetch_and_add (.x) 10 = 4
+(.x) = 14
 == idx_atomic with unboxed singleton ==
 (.x) = #{y = 1}
 (.x.#y) = 1

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -213,7 +213,7 @@ let () = assert (atomic_lxor_field_calls () = 0)
 
 (* build a test function for a particular atomic call *)
 let gen_test ~fn ~fn_calls ~reset_fn_calls =
-  let test ~(call_pos : [%call_pos]) ~expected f =
+  let test ~(call_pos : [%call_pos]) ~expected (f : unit -> unit) =
     total_atomic_reset ();
     reset_fn_calls ();
     f ();
@@ -340,10 +340,10 @@ module Atomic_locality = struct
       ignore (Atomic.exchange t "bar")
     );
     test_atomic_compare_exchange_field ~expected:1 (fun () ->
-      Atomic.compare_exchange t "foo" "bar"
+      ignore (Atomic.compare_exchange t "foo" "bar")
     );
     test_atomic_cas_field ~expected:1 (fun () ->
-      Atomic.compare_and_set t "foo" "bar"
+      ignore (Atomic.compare_and_set t "foo" "bar")
     )
 
   (* atomic in local record *)
@@ -356,10 +356,10 @@ module Atomic_locality = struct
       ignore (Atomic.exchange t "bar")
     );
     test_atomic_compare_exchange_field_local ~expected:1 (fun () ->
-      Atomic.compare_exchange t "foo" "bar"
+      ignore (Atomic.compare_exchange t "foo" "bar")
     );
     test_atomic_cas_field_local ~expected:1 (fun () ->
-      Atomic.compare_and_set t "foo" "bar"
+      ignore (Atomic.compare_and_set t "foo" "bar")
     )
 end
 
@@ -377,10 +377,10 @@ module Atomic_loc_locality = struct
       ignore (Atomic.Loc.exchange loc "bar")
     );
     test_atomic_compare_exchange_field ~expected:1 (fun () ->
-      Atomic.Loc.compare_exchange loc "foo" "bar"
+      ignore (Atomic.Loc.compare_exchange loc "foo" "bar")
     );
     test_atomic_cas_field ~expected:1 (fun () ->
-      Atomic.Loc.compare_and_set loc "foo" "bar"
+      ignore (Atomic.Loc.compare_and_set loc "foo" "bar")
     )
 
   (* atomic in local record *)
@@ -394,10 +394,10 @@ module Atomic_loc_locality = struct
       ignore (Atomic.Loc.exchange loc "bar")
     );
     test_atomic_compare_exchange_field_local ~expected:1 (fun () ->
-      Atomic.Loc.compare_exchange loc "foo" "bar"
+      ignore (Atomic.Loc.compare_exchange loc "foo" "bar")
     );
     test_atomic_cas_field_local ~expected:1 (fun () ->
-      Atomic.Loc.compare_and_set loc "foo" "bar"
+      ignore (Atomic.Loc.compare_and_set loc "foo" "bar")
     )
 end
 
@@ -432,10 +432,10 @@ module Atomic_field_locality = struct
       ignore (atomic_exchange_field t 0 "bar")
     );
     test_atomic_compare_exchange_field ~expected:1 (fun () ->
-      atomic_compare_exchange_field t 0 "foo" "bar"
+      ignore (atomic_compare_exchange_field t 0 "foo" "bar")
     );
     test_atomic_cas_field ~expected:1 (fun () ->
-      atomic_compare_and_set_field t 0 "foo" "bar"
+      ignore (atomic_compare_and_set_field t 0 "foo" "bar")
     )
 
   (* atomic in local record *)
@@ -448,9 +448,9 @@ module Atomic_field_locality = struct
       ignore (atomic_exchange_field t 0 "bar")
     );
     test_atomic_compare_exchange_field_local ~expected:1 (fun () ->
-      atomic_compare_exchange_field t 0 "foo" "bar"
+      ignore (atomic_compare_exchange_field t 0 "foo" "bar")
     );
     test_atomic_cas_field_local ~expected:1 (fun () ->
-      atomic_compare_and_set_field t 0 "foo" "bar"
+      ignore (atomic_compare_and_set_field t 0 "foo" "bar")
     )
 end

--- a/testsuite/tests/typing-layouts-caml-modify/atomics.ml
+++ b/testsuite/tests/typing-layouts-caml-modify/atomics.ml
@@ -261,6 +261,36 @@ let test_atomic_cas_field_local =
     ~fn_calls:atomic_cas_field_local_calls
     ~reset_fn_calls:atomic_cas_field_local_reset
 
+let test_atomic_fetch_add_field =
+  gen_test ~fn:"atomic_fetch_add_field"
+    ~fn_calls:atomic_fetch_add_field_calls
+    ~reset_fn_calls:atomic_fetch_add_field_reset
+
+let test_atomic_add_field =
+  gen_test ~fn:"atomic_add_field"
+    ~fn_calls:atomic_add_field_calls
+    ~reset_fn_calls:atomic_add_field_reset
+
+let test_atomic_sub_field =
+  gen_test ~fn:"atomic_sub_field"
+    ~fn_calls:atomic_sub_field_calls
+    ~reset_fn_calls:atomic_sub_field_reset
+
+let test_atomic_land_field =
+  gen_test ~fn:"atomic_land_field"
+    ~fn_calls:atomic_land_field_calls
+    ~reset_fn_calls:atomic_land_field_reset
+
+let test_atomic_lor_field =
+  gen_test ~fn:"atomic_lor_field"
+    ~fn_calls:atomic_lor_field_calls
+    ~reset_fn_calls:atomic_lor_field_reset
+
+let test_atomic_lxor_field =
+  gen_test ~fn:"atomic_lxor_field"
+    ~fn_calls:atomic_lxor_field_calls
+    ~reset_fn_calls:atomic_lxor_field_reset
+
 (* Patomic_set_field skips runtime call for immediates. *)
 module Set_field = struct
   type t = { mutable imm: int [@atomic]; mutable ptr: string [@atomic] }
@@ -325,6 +355,52 @@ module Set_idx_atomic_mixed = struct
     test_atomic_exchange_field ~expected:1 (fun () ->
       let idx = (.ptr) in
       Idx_atomic.set t idx "four";
+      ignore (Sys.opaque_identity t)
+    )
+end
+
+(* Idx_atomic read-modify-write operations skip runtime calls for
+   immediates. *)
+module Rmw_idx_atomic_imm = struct
+  type t = { mutable imm: int [@atomic] }
+
+  let () =
+    let t = { imm = 1 } in
+    let idx = (.imm) in
+    test_atomic_exchange_field ~expected:0 (fun () ->
+      ignore (Idx_atomic.exchange t idx 2);
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_cas_field ~expected:0 (fun () ->
+      ignore (Idx_atomic.compare_and_set t idx 2 3);
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_compare_exchange_field ~expected:0 (fun () ->
+      ignore (Idx_atomic.compare_exchange t idx 3 4);
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_fetch_add_field ~expected:0 (fun () ->
+      ignore (Idx_atomic.fetch_and_add t idx 1);
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_add_field ~expected:0 (fun () ->
+      Idx_atomic.add t idx 1;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_sub_field ~expected:0 (fun () ->
+      Idx_atomic.sub t idx 1;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_land_field ~expected:0 (fun () ->
+      Idx_atomic.logand t idx 1;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_lor_field ~expected:0 (fun () ->
+      Idx_atomic.logor t idx 1;
+      ignore (Sys.opaque_identity t)
+    );
+    test_atomic_lxor_field ~expected:0 (fun () ->
+      Idx_atomic.logxor t idx 1;
       ignore (Sys.opaque_identity t)
     )
 end
@@ -410,6 +486,15 @@ module Atomic_idx_locality = struct
     let idx = (.contents) in
     test_atomic_exchange_field ~expected:1 (fun () ->
       Idx_atomic.set t idx "bar"
+    );
+    test_atomic_exchange_field ~expected:1 (fun () ->
+      ignore (Idx_atomic.exchange t idx "bar")
+    );
+    test_atomic_compare_exchange_field ~expected:1 (fun () ->
+      ignore (Idx_atomic.compare_exchange t idx "foo" "bar")
+    );
+    test_atomic_cas_field ~expected:1 (fun () ->
+      ignore (Idx_atomic.compare_and_set t idx "foo" "bar")
     )
 
   (* atomic in local record *)
@@ -418,6 +503,15 @@ module Atomic_idx_locality = struct
     let idx = (.contents) in
     test_atomic_exchange_field_local ~expected:1 (fun () ->
       Idx_atomic.set t idx "bar"
+    );
+    test_atomic_exchange_field_local ~expected:1 (fun () ->
+      ignore (Idx_atomic.exchange t idx "bar")
+    );
+    test_atomic_compare_exchange_field_local ~expected:1 (fun () ->
+      ignore (Idx_atomic.compare_exchange t idx "foo" "bar")
+    );
+    test_atomic_cas_field_local ~expected:1 (fun () ->
+      ignore (Idx_atomic.compare_and_set t idx "foo" "bar")
     )
 end
 

--- a/typing/primitive.ml
+++ b/typing/primitive.ml
@@ -961,24 +961,11 @@ let prim_has_valid_reprs ~loc prim =
         is (Same_as_ocaml_repr C.bits64);
         any
       ]
-    | "%get_idx_atomic" ->
-      check [
-        is (Same_as_ocaml_repr C.scannable);
-        is (Same_as_ocaml_repr C.bits64);
-        is (Same_as_ocaml_repr C.scannable)
-      ]
     | "%set_idx" ->
       check [
         is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.bits64);
         any;
-        is (Same_as_ocaml_repr C.scannable);
-      ]
-    | "%set_idx_atomic" ->
-      check [
-        is (Same_as_ocaml_repr C.scannable);
-        is (Same_as_ocaml_repr C.bits64);
-        is (Same_as_ocaml_repr C.scannable);
         is (Same_as_ocaml_repr C.scannable);
       ]
     | "%unsafe_array_idx" ->
@@ -1010,6 +997,54 @@ let prim_has_valid_reprs ~loc prim =
       check [
         is (Same_as_ocaml_repr C.word);
         is (Same_as_ocaml_repr C.bits64);
+      ]
+    | "%atomic_load_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_set_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_exchange_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_cas_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_compare_exchange_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
+      ]
+    | "%atomic_fetch_add_idx"
+    | "%atomic_add_idx"
+    | "%atomic_sub_idx"
+    | "%atomic_land_idx"
+    | "%atomic_lor_idx"
+    | "%atomic_lxor_idx" ->
+      check [
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.bits64);
+        is (Same_as_ocaml_repr C.scannable);
+        is (Same_as_ocaml_repr C.scannable);
       ]
     | "%unsafe_get_ptr" ->
       check [


### PR DESCRIPTION
Addresses internal ticket 7719.

In #6473 we implemented the missing `idx_atomic` operations and lamented that `get`/`set` lowered through `Pget`/`Pset` rather than `Patomic_*_idx` primitives like everything else.

This PR rectifies that by:
- Making `Pget_idx` and `Pset_idx` once again handle only nonatomic loads/stores through block indices
- Introducing `Patomic_load_idx` and `Patomic_set_idx` primitives

This PR is *almost* a pure refactor. Caveats:

- Generated native code should be identical.
- Generated bytecode will use updated function names but behave identically:
  - `caml_get_idx_atomic_bytecode` -> `caml_atomic_load_idx_bytecode`
  - `caml_set_idx_atomic_bytecode` -> `caml_atomic_set_idx_bytecode`
  - This is more consistent with existing atomic runtime function names.

Note that our existing test cases pass without any changes.