### PR TITLE
Do not serialize Cached_level.t

### DIFF
--- a/middle_end/flambda2/types/env/aliases.ml
+++ b/middle_end/flambda2/types/env/aliases.ml
@@ -50,22 +50,6 @@ module Map_to_canonical = struct
           fatal_inconsistent ~func_name:"Aliases.Map_to_canonical.union" elt
             coercion1 coercion2)
       map1 map2
-
-  let ids_for_export t =
-    Name.Map.fold
-      (fun name coercion ids ->
-        Ids_for_export.union ids
-          (Ids_for_export.add_name (Coercion.ids_for_export coercion) name))
-      t Ids_for_export.empty
-
-  let apply_renaming t renaming =
-    Name.Map.fold
-      (fun name coercion t ->
-        Name.Map.add
-          (Renaming.apply_name renaming name)
-          (Coercion.apply_renaming coercion renaming)
-          t)
-      t Name.Map.empty
 end
 
 module Aliases_of_canonical_element : sig
@@ -101,10 +85,6 @@ module Aliases_of_canonical_element : sig
   val inter : t -> t -> t
 
   val compose : t -> then_:Coercion.t -> t
-
-  include Contains_ids.S with type t := t
-
-  val apply_renaming : t -> Renaming.t -> t
 end = struct
   type t =
     { aliases : Map_to_canonical.t Name_mode.Map.t;
@@ -214,27 +194,6 @@ end = struct
     let f m = Name.Map.map_sharing (Coercion.compose_exn ~then_) m in
     let aliases = Name_mode.Map.map_sharing f aliases in
     let all = f all in
-    { aliases; all }
-
-  let ids_for_export { aliases; all } =
-    let aliases =
-      Name_mode.Map.fold
-        (fun _mode map_to_canonical ids ->
-          Ids_for_export.union ids
-            (Map_to_canonical.ids_for_export map_to_canonical))
-        aliases Ids_for_export.empty
-    in
-    let all = Map_to_canonical.ids_for_export all in
-    Ids_for_export.union aliases all
-
-  let apply_renaming { aliases; all } renaming =
-    let aliases =
-      Name_mode.Map.map_sharing
-        (fun map_to_canonical ->
-          Map_to_canonical.apply_renaming map_to_canonical renaming)
-        aliases
-    in
-    let all = Map_to_canonical.apply_renaming all renaming in
     { aliases; all }
 end
 
@@ -996,37 +955,6 @@ let get_aliases t element =
            alias_names_with_coercions_to_canonical));
     Alias_set.create_aliases_of_element ~element ~canonical_element
       ~coercion_from_canonical_to_element ~alias_names_with_coercions_to_element
-
-let apply_renaming
-    { canonical_elements; aliases_of_canonical_names; aliases_of_consts }
-    renaming =
-  let rename_name = Renaming.apply_name renaming in
-  let rename_simple = Renaming.apply_simple renaming in
-  let canonical_elements =
-    Name.Map.fold
-      (fun elt (canonical, coercion) acc ->
-        Name.Map.add (rename_name elt)
-          (rename_simple canonical, Coercion.apply_renaming coercion renaming)
-          acc)
-      canonical_elements Name.Map.empty
-  in
-  let aliases_of_canonical_names =
-    Name.Map.fold
-      (fun canonical aliases acc ->
-        Name.Map.add (rename_name canonical)
-          (Aliases_of_canonical_element.apply_renaming aliases renaming)
-          acc)
-      aliases_of_canonical_names Name.Map.empty
-  in
-  let aliases_of_consts =
-    Reg_width_const.Map.fold
-      (fun const aliases ->
-        Reg_width_const.Map.add
-          (Renaming.apply_const renaming const)
-          (Aliases_of_canonical_element.apply_renaming aliases renaming))
-      aliases_of_consts Reg_width_const.Map.empty
-  in
-  { canonical_elements; aliases_of_canonical_names; aliases_of_consts }
 
 let get_canonical_ignoring_name_mode t name =
   let elt = Simple.name name in

--- a/middle_end/flambda2/types/env/aliases.mli
+++ b/middle_end/flambda2/types/env/aliases.mli
@@ -147,5 +147,3 @@ val add_alias_set :
 val get_aliases : t -> Simple.t -> Alias_set.t
 
 val get_canonical_ignoring_name_mode : t -> Name.t -> Simple.t
-
-val apply_renaming : t -> Renaming.t -> t

--- a/middle_end/flambda2/types/env/cached_level.ml
+++ b/middle_end/flambda2/types/env/cached_level.ml
@@ -86,72 +86,27 @@ let find_symbol_projection t var =
 let clean_for_export t ~reachable_names =
   (* Names coming from other compilation units or unreachable are removed *)
   let current_compilation_unit = Current_unit.get_cu_exn () in
-  let names_to_types =
-    Name.Map.filter_map
-      (fun name (ty, binding_time_and_mode) ->
-        if
-          Name_occurrences.mem_name reachable_names name
-          && Compilation_unit.equal
-               (Name.compilation_unit name)
-               current_compilation_unit
-        then (
-          let binding_time_and_mode =
-            if Name.is_var name
-            then Binding_time.With_name_mode.imported_variables
-            else binding_time_and_mode
-          in
-          (match Type_grammar.get_alias_opt ty with
-          | None -> ()
-          | Some alias ->
-            Misc.fatal_errorf "Remaining alias after cleanup: %a -> %a@."
-              Name.print name Simple.print alias);
-          Some (ty, binding_time_and_mode))
-        else None)
-      t.names_to_types
-  in
-  let aliases = Aliases.empty in
-  { t with names_to_types; aliases }
-
-let apply_renaming { names_to_types; aliases; symbol_projections } renaming =
-  let names_to_types =
-    Name.Map.fold
-      (fun name (ty, binding_time_and_mode) acc ->
-        Name.Map.add
-          (Renaming.apply_name renaming name)
-          (Type_grammar.apply_renaming ty renaming, binding_time_and_mode)
-          acc)
-      names_to_types Name.Map.empty
-  in
-  let aliases = Aliases.apply_renaming aliases renaming in
-  let symbol_projections =
-    Variable.Map.fold
-      (fun var proj acc ->
-        Variable.Map.add
-          (Renaming.apply_variable renaming var)
-          (Symbol_projection.apply_renaming proj renaming)
-          acc)
-      symbol_projections Variable.Map.empty
-  in
-  { names_to_types; aliases; symbol_projections }
-
-let merge t1 t2 =
-  let names_to_types =
-    Name.Map.disjoint_union t1.names_to_types t2.names_to_types
-  in
-  let aliases = Aliases.empty in
-  let symbol_projections =
-    Variable.Map.union_total_shared
-      (fun var proj1 proj2 ->
-        if Symbol_projection.equal proj1 proj2
-        then proj1
-        else
-          Misc.fatal_errorf
-            "Cannot merge symbol projections for %a:@ %a@ and@ %a"
-            Variable.print var Symbol_projection.print proj1
-            Symbol_projection.print proj2)
-      t1.symbol_projections t2.symbol_projections
-  in
-  { names_to_types; aliases; symbol_projections }
+  Name.Map.filter_map
+    (fun name (ty, binding_time_and_mode) ->
+      if
+        Name_occurrences.mem_name reachable_names name
+        && Compilation_unit.equal
+             (Name.compilation_unit name)
+             current_compilation_unit
+      then (
+        let binding_time_and_mode =
+          if Name.is_var name
+          then Binding_time.With_name_mode.imported_variables
+          else binding_time_and_mode
+        in
+        (match Type_grammar.get_alias_opt ty with
+        | None -> ()
+        | Some alias ->
+          Misc.fatal_errorf "Remaining alias after cleanup: %a -> %a@."
+            Name.print name Simple.print alias);
+        Some (ty, binding_time_and_mode))
+      else None)
+    t.names_to_types
 
 let canonicalise t simple =
   Simple.pattern_match simple
@@ -175,34 +130,3 @@ let remove_unused_value_slots_and_shortcut_aliases
       names_to_types
   in
   { names_to_types; aliases; symbol_projections }
-
-let free_function_slots_and_value_slots
-    { names_to_types; aliases = _; symbol_projections } =
-  let from_projections =
-    Variable.Map.fold
-      (fun _var proj free_names ->
-        Name_occurrences.union free_names
-          (Name_occurrences.restrict_to_value_slots_and_function_slots
-             (Symbol_projection.free_names proj)))
-      symbol_projections Name_occurrences.empty
-  in
-  Name.Map.fold
-    (fun _name (ty, _binding_time) free_names ->
-      let free_names_of_ty = Type_grammar.free_names ty in
-      Name_occurrences.union free_names
-        (Name_occurrences.restrict_to_value_slots_and_function_slots
-           free_names_of_ty))
-    names_to_types from_projections
-
-let ids_for_export t =
-  if not (Aliases.is_empty t.aliases)
-  then
-    Misc.fatal_error
-      "Aliases structure must be empty for export; did you forget to call \
-       [clean_for_export]?";
-  Name.Map.fold
-    (fun name (typ, _binding_time_and_mode) ids ->
-      Ids_for_export.add_name
-        (Ids_for_export.union ids (Type_grammar.ids_for_export typ))
-        name)
-    (names_to_types t) Ids_for_export.empty

--- a/middle_end/flambda2/types/env/cached_level.mli
+++ b/middle_end/flambda2/types/env/cached_level.mli
@@ -43,17 +43,12 @@ val find_symbol_projection : t -> Variable.t -> Symbol_projection.t option
 
 val symbol_projections : t -> Symbol_projection.t Variable.Map.t
 
-val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
-
-val apply_renaming : t -> Renaming.t -> t
-
-include Contains_ids.S with type t := t
-
-val merge : t -> t -> t
+val clean_for_export :
+  t ->
+  reachable_names:Name_occurrences.t ->
+  (Type_grammar.t * Binding_time.With_name_mode.t) Name.Map.t
 
 val remove_unused_value_slots_and_shortcut_aliases :
   t -> used_value_slots:Value_slot.Set.t -> t
 
 val canonicalise : t -> Simple.t -> Simple.t
-
-val free_function_slots_and_value_slots : t -> Name_occurrences.t

--- a/middle_end/flambda2/types/env/typing_env.ml
+++ b/middle_end/flambda2/types/env/typing_env.ml
@@ -38,7 +38,10 @@ module One_level : sig
 
   val is_empty : t -> bool
 
-  val clean_for_export : t -> reachable_names:Name_occurrences.t -> t
+  val clean_for_export :
+    t ->
+    reachable_names:Name_occurrences.t ->
+    (TG.t * Binding_time.With_name_mode.t) Name.Map.t
 
   val remove_unused_value_slots_and_shortcut_aliases :
     t -> used_value_slots:Value_slot.Set.t -> t
@@ -86,10 +89,7 @@ end = struct
   let is_empty t = TEL.is_empty t.level
 
   let clean_for_export t ~reachable_names =
-    { t with
-      just_after_level =
-        Cached_level.clean_for_export t.just_after_level ~reachable_names
-    }
+    Cached_level.clean_for_export t.just_after_level ~reachable_names
 
   let remove_unused_value_slots_and_shortcut_aliases t ~used_value_slots =
     let just_after_level =
@@ -122,7 +122,7 @@ type t =
 and serializable =
   { defined_symbols_without_equations : Symbol.t list;
     code_age_relation : Code_age_relation.t;
-    just_after_level : Cached_level.t
+    names_to_types : (Type_grammar.t * Binding_time.With_name_mode.t) Name.Map.t
   }
 
 type typing_env = t
@@ -173,19 +173,17 @@ let [@ocamlformat "disable"] print ppf
       Aliases.print (aliases t)
 
 let [@ocamlformat "disable"] print_serializable ppf
-    { defined_symbols_without_equations; code_age_relation; just_after_level } =
+    { defined_symbols_without_equations; code_age_relation; names_to_types } =
   Format.fprintf ppf
     "@[<hov 1>(\
         @[<hov 1>(defined_symbols_without_equations@ (%a))@]@ \
         @[<hov 1>(code_age_relation@ %a)@]@ \
         @[<hov 1>(type_equations@ %a)@]@ \
-        @[<hov 1>(aliases@ %a)@]\
         )@]"
     (Format.pp_print_list ~pp_sep:Format.pp_print_space Symbol.print) defined_symbols_without_equations
     Code_age_relation.print code_age_relation
     (Name.Map.print (fun ppf (ty, _bt_and_mode) -> TG.print ppf ty))
-    (Cached_level.names_to_types just_after_level)
-    Aliases.print (Cached_level.aliases just_after_level)
+    names_to_types
 
 module Meet_or_join_env_base : sig
   type t
@@ -330,10 +328,7 @@ let binding_time_resolver resolver name =
       (Printexc.raw_backtrace_to_string (Printexc.get_raw_backtrace ()))
   | None -> raise Binding_time_resolver_failure
   | Some t -> (
-    match
-      Name.Map.find_or_null name
-        (Cached_level.names_to_types t.just_after_level)
-    with
+    match Name.Map.find_or_null name t.names_to_types with
     | Null ->
       Misc.fatal_errorf "Binding time resolver cannot find name %a in:@ %a"
         Name.print name print_serializable t
@@ -449,9 +444,7 @@ let find_with_binding_time_and_mode' t name kind =
             check_optional_kind_matches name ty kind;
             ty, Binding_time.With_name_mode.imported_variables)
       | Some t -> (
-        match
-          Name.Map.find name (Cached_level.names_to_types t.just_after_level)
-        with
+        match Name.Map.find name t.names_to_types with
         | exception Not_found ->
           Name.pattern_match name
             ~symbol:(fun symbol ->
@@ -1105,14 +1098,12 @@ end = struct
   type t = serializable
 
   let create (env : Pre_serializable.t) ~reachable_names : t =
-    let current_level =
+    let names_to_types =
       One_level.clean_for_export env.current_level ~reachable_names
     in
     let code_age_relation =
       Code_age_relation.clean_for_export env.code_age_relation ~reachable_names
     in
-    let just_after_level = One_level.just_after_level current_level in
-    let names_to_types = Cached_level.names_to_types just_after_level in
     let defined_symbols_without_equations =
       Symbol.Set.fold
         (fun symbol defined_symbols_without_equations ->
@@ -1123,13 +1114,13 @@ end = struct
           else defined_symbols_without_equations)
         env.defined_symbols []
     in
-    { defined_symbols_without_equations; code_age_relation; just_after_level }
+    { defined_symbols_without_equations; code_age_relation; names_to_types }
 
   let predefined_exceptions symbols : t =
     let defined_symbols_without_equations = Symbol.Set.elements symbols in
     { defined_symbols_without_equations;
       code_age_relation = Code_age_relation.empty;
-      just_after_level = Cached_level.empty
+      names_to_types = Name.Map.empty
     }
 
   let create_from_closure_conversion_approx ~machine_width
@@ -1152,36 +1143,46 @@ end = struct
         MTC.static_closure_with_this_code ~this_function_slot:function_slot
           ~closure_symbol:symbol ~code_id
     in
-    let just_after_level =
+    let names_to_types =
       Symbol.Map.fold
         (fun sym approx cached ->
-          Cached_level.add_or_replace_binding cached (Name.symbol sym)
-            (type_from_approx approx) Binding_time.symbols Name_mode.normal)
-        symbols Cached_level.empty
+          Name.Map.add (Name.symbol sym)
+            (type_from_approx approx, Binding_time.With_name_mode.symbols)
+            cached)
+        symbols Name.Map.empty
     in
-    { defined_symbols_without_equations; code_age_relation; just_after_level }
+    { defined_symbols_without_equations; code_age_relation; names_to_types }
 
-  let free_function_slots_and_value_slots t =
-    Cached_level.free_function_slots_and_value_slots t.just_after_level
+  let free_function_slots_and_value_slots
+      { names_to_types;
+        defined_symbols_without_equations = _;
+        code_age_relation = _
+      } =
+    Name.Map.fold
+      (fun _name (ty, _binding_time) free_names ->
+        let free_names_of_ty = Type_grammar.free_names ty in
+        Name_occurrences.union free_names
+          (Name_occurrences.restrict_to_value_slots_and_function_slots
+             free_names_of_ty))
+      names_to_types Name_occurrences.empty
 
   let print = print_serializable
 
   let ids_for_export
-      { defined_symbols_without_equations; code_age_relation; just_after_level }
-      =
+      { defined_symbols_without_equations; code_age_relation; names_to_types } =
     Ids_for_export.create
       ~symbols:(Symbol.Set.of_list defined_symbols_without_equations)
       ~code_ids:(Code_age_relation.all_code_ids_for_export code_age_relation)
       ()
-    |> Ids_for_export.union (Cached_level.ids_for_export just_after_level)
-    |> Variable.Map.fold
-         (fun var proj ids ->
-           Ids_for_export.add_variable ids var
-           |> Ids_for_export.union (Symbol_projection.ids_for_export proj))
-         (Cached_level.symbol_projections just_after_level)
+    |> Name.Map.fold
+         (fun name (typ, _binding_time_and_mode) ids ->
+           Ids_for_export.add_name
+             (Ids_for_export.union ids (Type_grammar.ids_for_export typ))
+             name)
+         names_to_types
 
   let apply_renaming
-      { defined_symbols_without_equations; code_age_relation; just_after_level }
+      { defined_symbols_without_equations; code_age_relation; names_to_types }
       renaming =
     let defined_symbols_without_equations =
       List.map
@@ -1191,10 +1192,16 @@ end = struct
     let code_age_relation =
       Code_age_relation.apply_renaming code_age_relation renaming
     in
-    let just_after_level =
-      Cached_level.apply_renaming just_after_level renaming
+    let names_to_types =
+      Name.Map.fold
+        (fun name (ty, binding_time_and_mode) acc ->
+          Name.Map.add
+            (Renaming.apply_name renaming name)
+            (Type_grammar.apply_renaming ty renaming, binding_time_and_mode)
+            acc)
+        names_to_types Name.Map.empty
     in
-    { defined_symbols_without_equations; code_age_relation; just_after_level }
+    { defined_symbols_without_equations; code_age_relation; names_to_types }
 
   let merge (t1 : t) (t2 : t) : t =
     let defined_symbols_without_equations =
@@ -1204,10 +1211,10 @@ end = struct
     let code_age_relation =
       Code_age_relation.union t1.code_age_relation t2.code_age_relation
     in
-    let just_after_level =
-      Cached_level.merge t1.just_after_level t2.just_after_level
+    let names_to_types =
+      Name.Map.disjoint_union t1.names_to_types t2.names_to_types
     in
-    { defined_symbols_without_equations; code_age_relation; just_after_level }
+    { defined_symbols_without_equations; code_age_relation; names_to_types }
 
   let extract_symbol_approx env symbol find_code =
     let rec type_to_approx (ty : Type_grammar.t) : _ Value_approximation.t =
@@ -1321,8 +1328,7 @@ end = struct
       | Rec_info _ | Region _ -> assert false
     in
     let symbol_ty, _binding_time_and_mode =
-      Name.Map.find (Name.symbol symbol)
-        (Cached_level.names_to_types env.just_after_level)
+      Name.Map.find (Name.symbol symbol) env.names_to_types
     in
     type_to_approx symbol_ty
 end

--- a/testsuite/tests/tool-ocamlobjinfo/question.reference
+++ b/testsuite/tests/tool-ocamlobjinfo/question.reference
@@ -64,10 +64,7 @@ Typing env:
          (closure_types
           ((function_slot_components_by_index
             {([0m[38;5;31;1m(answer/0 ∷ [0m[38;5;37;1m𝕍[0m[38;5;31;1m)[0m (Val ([0m[38;5;160;1m=[0m [0m[38;5;111;1m[0m[38;5;98;1mQuestion.camlQuestion__answer_1[0m[38;5;111;1m[0m)))})))
-         (value_slot_types ((value_slot_components_by_index {})))))})))})
- (aliases
-  ((canonical_elements {}) (aliases_of_canonical_names {})
-   (aliases_of_consts {}))))
+         (value_slot_types ((value_slot_components_by_index {})))))})))}) )
 
 Currying functions:
 Apply functions:


### PR DESCRIPTION
We currently serialize a `Cached_level.t` as part of the `Typing_env.serializable`, but we actually only care about its `name_to_types` field.

Making that explicit allows to simplify things in preparation of delaying the renaming of serializable typing envs, and gets rid of quite a bit of code as a bonus.