### PR TITLE
Lazy import of int ids

### DIFF
--- a/middle_end/flambda2/algorithms/table_by_int_id.ml
+++ b/middle_end/flambda2/algorithms/table_by_int_id.ml
@@ -103,4 +103,19 @@ struct
   let find t id =
     assert (Id.flags id = E.flags);
     HT.find t id
+
+  (* We serialize a table using the exact same format we use in memory, except
+     that we only store the data for the exported elements. *)
+  type serializable = E.t HT.t
+
+  let export t ~iter =
+    let exported = HT.create 0 in
+    iter (fun id -> HT.replace exported id (find t id));
+    exported
+
+  let import t id =
+    assert (Id.flags id = E.flags);
+    try HT.find t id
+    with Not_found ->
+      Misc.fatal_error "Id was not exported from this compilation unit."
 end

--- a/middle_end/flambda2/algorithms/table_by_int_id.mli
+++ b/middle_end/flambda2/algorithms/table_by_int_id.mli
@@ -44,4 +44,10 @@ end) : sig
   val add : t -> E.t -> Id.t
 
   val find : t -> Id.t -> E.t
+
+  type serializable
+
+  val export : t -> iter:((Id.t -> unit) -> unit) -> serializable
+
+  val import : serializable -> Id.t -> E.t
 end

--- a/middle_end/flambda2/cmx/exported_code.ml
+++ b/middle_end/flambda2/cmx/exported_code.ml
@@ -103,17 +103,13 @@ let ids_for_export t =
         (Code_or_metadata.ids_for_export code_or_metadata))
     t Ids_for_export.empty
 
-let apply_renaming code_id_map renaming t =
-  if Renaming.is_identity renaming && Code_id.Map.is_empty code_id_map
+let apply_renaming code_id_importer renaming t =
+  if Renaming.is_identity renaming
   then t
   else
     Code_id.Map.fold
       (fun code_id code_or_metadata all_code ->
-        let code_id =
-          match Code_id.Map.find code_id code_id_map with
-          | exception Not_found -> code_id
-          | code_id -> code_id
-        in
+        let code_id = Code_id.import code_id_importer code_id in
         let code_or_metadata =
           Code_or_metadata.apply_renaming code_or_metadata renaming
         in

--- a/middle_end/flambda2/cmx/exported_code.mli
+++ b/middle_end/flambda2/cmx/exported_code.mli
@@ -19,7 +19,7 @@ type raw
 
 include Contains_ids.S with type t := t
 
-val apply_renaming : Code_id.t Code_id.Map.t -> Renaming.t -> t -> t
+val apply_renaming : Code_id.importer -> Renaming.t -> t -> t
 
 val print : Format.formatter -> t -> unit
 

--- a/middle_end/flambda2/cmx/flambda_cmx_format.ml
+++ b/middle_end/flambda2/cmx/flambda_cmx_format.ml
@@ -17,12 +17,12 @@
 (** Contents of middle-end-specific portion of .cmx files when using Flambda. *)
 
 type table_data =
-  { symbols : (Symbol.t * Symbol.exported) list;
-    variables : (Variable.t * Variable.exported) list;
-    simples : (Simple.t * Simple.exported) list;
-    consts : (Reg_width_const.t * Reg_width_const.exported) list;
-    code_ids : (Code_id.t * Code_id.exported) list;
-    continuations : (Continuation.t * Continuation.exported) list
+  { symbols : Symbol.importer;
+    variables : Variable.importer;
+    simples : Simple.importer;
+    consts : Reg_width_const.importer;
+    code_ids : Code_id.importer;
+    continuations : Continuation.importer
   }
 
 type t0 =
@@ -54,38 +54,12 @@ let create_raw ~final_typing_env ~all_code ~exported_offsets ~used_value_slots
   let exported_ids =
     Ids_for_export.union typing_env_exported_ids all_code_exported_ids
   in
-  let symbols =
-    Symbol.Set.fold
-      (fun symbol symbols -> (symbol, Symbol.export symbol) :: symbols)
-      exported_ids.symbols []
-  in
-  let variables =
-    Variable.Set.fold
-      (fun variable variables ->
-        (variable, Variable.export variable) :: variables)
-      exported_ids.variables []
-  in
-  let simples =
-    Simple.Set.fold
-      (fun simple simples -> (simple, Simple.export simple) :: simples)
-      exported_ids.simples []
-  in
-  let consts =
-    Reg_width_const.Set.fold
-      (fun const consts -> (const, Reg_width_const.export const) :: consts)
-      exported_ids.consts []
-  in
-  let code_ids =
-    Code_id.Set.fold
-      (fun code_id code_ids -> (code_id, Code_id.export code_id) :: code_ids)
-      exported_ids.code_ids []
-  in
-  let continuations =
-    Continuation.Set.fold
-      (fun continuation continuations ->
-        (continuation, Continuation.export continuation) :: continuations)
-      exported_ids.continuations []
-  in
+  let symbols = Symbol.export exported_ids.symbols in
+  let variables = Variable.export exported_ids.variables in
+  let simples = Simple.export exported_ids.simples in
+  let consts = Reg_width_const.export exported_ids.consts in
+  let code_ids = Code_id.export exported_ids.code_ids in
+  let continuations = Continuation.export exported_ids.continuations in
   let table_data =
     { symbols; variables; simples; consts; code_ids; continuations }
   in
@@ -105,59 +79,13 @@ let create_raw ~final_typing_env ~all_code ~exported_offsets ~used_value_slots
   in
   to_raw ~sections t
 
-module Make_importer (S : sig
-  type t
-
-  type exported
-
-  val import : exported -> t
-
-  include Container_types.S with type t := t
-end) : sig
-  val import : (S.t * S.exported) list -> S.t S.Map.t
-end = struct
-  let import from_table_data =
-    (* The returned map gives the hash collisions. *)
-    List.fold_left
-      (fun import_map (key, exported) ->
-        let new_key = S.import exported in
-        if key == new_key then import_map else S.Map.add key new_key import_map)
-      S.Map.empty from_table_data
-end
-[@@inline always]
-
-module Symbol_importer = Make_importer (Symbol)
-module Variable_importer = Make_importer (Variable)
-module Simple_importer = Make_importer (Simple)
-module Const_importer = Make_importer (Reg_width_const)
-module Code_id_importer = Make_importer (Code_id)
-module Continuation_importer = Make_importer (Continuation)
-
 let import_typing_env_and_code0 ~sections t =
-  let symbols =
-    Profile.record_call ~accumulate:true "import_symbols" (fun () ->
-        Symbol_importer.import t.table_data.symbols)
-  in
-  let variables =
-    Profile.record_call ~accumulate:true "import_variables" (fun () ->
-        Variable_importer.import t.table_data.variables)
-  in
-  let simples =
-    Profile.record_call ~accumulate:true "import_simples" (fun () ->
-        Simple_importer.import t.table_data.simples)
-  in
-  let consts =
-    Profile.record_call ~accumulate:true "import_consts" (fun () ->
-        Const_importer.import t.table_data.consts)
-  in
-  let code_ids =
-    Profile.record_call ~accumulate:true "import_code_ids" (fun () ->
-        Code_id_importer.import t.table_data.code_ids)
-  in
-  let continuations =
-    Profile.record_call ~accumulate:true "import_continuations" (fun () ->
-        Continuation_importer.import t.table_data.continuations)
-  in
+  let symbols = t.table_data.symbols in
+  let variables = t.table_data.variables in
+  let simples = t.table_data.simples in
+  let consts = t.table_data.consts in
+  let code_ids = t.table_data.code_ids in
+  let continuations = t.table_data.continuations in
   let used_value_slots = t.used_value_slots in
   let original_compilation_unit = t.original_compilation_unit in
   let renaming =

--- a/middle_end/flambda2/identifiers/continuation.ml
+++ b/middle_end/flambda2/identifiers/continuation.ml
@@ -102,8 +102,6 @@ end
 
 type t = Id.t
 
-type exported = Data.t
-
 module Table = Table_by_int_id.Make (Data)
 
 let grand_table_of_continuations = ref (Table.create ())
@@ -172,6 +170,10 @@ module Set = Tree.Set
 module Map = Tree.Map
 module Lmap = Lmap.Make (T)
 
-let export t = find_data t
+type importer = Table.serializable
 
-let import data = Table.add !grand_table_of_continuations data
+let export conts =
+  Table.export !grand_table_of_continuations ~iter:(fun f -> Set.iter f conts)
+
+let import importer t =
+  Table.add !grand_table_of_continuations (Table.import importer t)

--- a/middle_end/flambda2/identifiers/continuation.mli
+++ b/middle_end/flambda2/identifiers/continuation.mli
@@ -18,7 +18,7 @@
 
 type t = private Table_by_int_id.Id.t
 
-type exported
+type importer
 
 include Container_types.S with type t := t
 
@@ -48,9 +48,9 @@ val name_stamp : t -> int
 
 val sort : t -> Sort.t
 
-val export : t -> exported
+val export : Set.t -> importer
 
-val import : exported -> t
+val import : importer -> t -> t
 
 val initialise : unit -> unit
 

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -835,25 +835,25 @@ module Simple = struct
   let export simples =
     Table.export !grand_table_of_simples ~iter:(fun f -> Set.iter f simples)
 
-  let pattern_match_imported importer t ~name_not_imported:name
-      ~const_not_imported:const =
+  let import importer t ~import_const ~import_symbol ~import_var =
     let flags = Id.flags t in
     if flags = var_flags
-    then (name [@inlined hint]) (Name.var t) ~coercion:Coercion.id
+    then (import_var [@inlined hint]) t
     else if flags = symbol_flags
-    then (name [@inlined hint]) (Name.symbol t) ~coercion:Coercion.id
+    then (import_symbol [@inlined hint]) t
     else if flags = const_flags
-    then (const [@inlined hint]) t
+    then (import_const [@inlined hint]) t
     else if flags = simple_flags
     then
       let { Simple_data.simple = t; coercion } = Table.import importer t in
+      let coercion = Coercion.map_depth_variables coercion ~f:import_var in
       let flags = Id.flags t in
       if flags = var_flags
-      then (name [@inlined hint]) (Name.var t) ~coercion
+      then with_coercion ((import_var [@inlined hint]) t) coercion
       else if flags = symbol_flags
-      then (name [@inlined hint]) (Name.symbol t) ~coercion
+      then with_coercion ((import_symbol [@inlined hint]) t) coercion
       else if flags = const_flags
-      then (const [@inlined hint]) t
+      then (import_const [@inlined hint]) t
       else assert false
     else assert false
 end

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -835,7 +835,8 @@ module Simple = struct
   let export simples =
     Table.export !grand_table_of_simples ~iter:(fun f -> Set.iter f simples)
 
-  let import importer t ~name ~const =
+  let pattern_match_imported importer t ~name_not_imported:name
+      ~const_not_imported:const =
     let flags = Id.flags t in
     if flags = var_flags
     then (name [@inlined hint]) (Name.var t) ~coercion:Coercion.id

--- a/middle_end/flambda2/identifiers/int_ids.ml
+++ b/middle_end/flambda2/identifiers/int_ids.ml
@@ -369,8 +369,6 @@ end
 module Const = struct
   type t = Id.t
 
-  type exported = Const_data.t
-
   module Table = Table_by_int_id.Make (Const_data)
 
   let grand_table_of_constants = ref (Table.create ())
@@ -467,15 +465,17 @@ module Const = struct
   module Set = Tree.Set
   module Map = Tree.Map
 
-  let export t = find_data t
+  type importer = Table.serializable
 
-  let import (data : exported) = create data
+  let export consts =
+    Table.export !grand_table_of_constants ~iter:(fun f -> Set.iter f consts)
+
+  let import importer t =
+    Table.add !grand_table_of_constants (Table.import importer t)
 end
 
 module Variable = struct
   type t = Id.t
-
-  type exported = Variable_data.t
 
   module Table = Table_by_int_id.Make (Variable_data)
 
@@ -549,15 +549,17 @@ module Variable = struct
   module Map = Tree.Map
   module Lmap = Lmap.Make (T)
 
-  let export t = find_data t
+  type importer = Table.serializable
 
-  let import (data : exported) = Table.add !grand_table_of_variables data
+  let export vars =
+    Table.export !grand_table_of_variables ~iter:(fun f -> Set.iter f vars)
+
+  let import importer t =
+    Table.add !grand_table_of_variables (Table.import importer t)
 end
 
 module Symbol = struct
   type t = Id.t
-
-  type exported = Symbol_data.t
 
   module Table = Table_by_int_id.Make (Symbol_data)
 
@@ -626,9 +628,13 @@ module Symbol = struct
   module Set = Tree.Set
   module Map = Tree.Map
 
-  let export t = find_data t
+  type importer = Table.serializable
 
-  let import (data : exported) = Table.add !grand_table_of_symbols data
+  let export symbols =
+    Table.export !grand_table_of_symbols ~iter:(fun f -> Set.iter f symbols)
+
+  let import importer t =
+    Table.add !grand_table_of_symbols (Table.import importer t)
 end
 
 module Name = struct
@@ -713,8 +719,6 @@ end
 
 module Simple = struct
   type t = Id.t
-
-  type exported = Simple_data.t
 
   module Table = Table_by_int_id.Make (Simple_data)
 
@@ -826,20 +830,35 @@ module Simple = struct
   module Set = Tree.Set
   module Map = Tree.Map
 
-  let export t = find_data t
+  type importer = Table.serializable
 
-  let import (data : exported) =
-    (* Note: We do not import the underlying name or const. This is done on
-       purpose, to make the import process simpler and well-defined, but means
-       that the real import functions (in Renaming) are responsible for
-       importing the underlying name/const. *)
-    Table.add !grand_table_of_simples data
+  let export simples =
+    Table.export !grand_table_of_simples ~iter:(fun f -> Set.iter f simples)
+
+  let import importer t ~name ~const =
+    let flags = Id.flags t in
+    if flags = var_flags
+    then (name [@inlined hint]) (Name.var t) ~coercion:Coercion.id
+    else if flags = symbol_flags
+    then (name [@inlined hint]) (Name.symbol t) ~coercion:Coercion.id
+    else if flags = const_flags
+    then (const [@inlined hint]) t
+    else if flags = simple_flags
+    then
+      let { Simple_data.simple = t; coercion } = Table.import importer t in
+      let flags = Id.flags t in
+      if flags = var_flags
+      then (name [@inlined hint]) (Name.var t) ~coercion
+      else if flags = symbol_flags
+      then (name [@inlined hint]) (Name.symbol t) ~coercion
+      else if flags = const_flags
+      then (const [@inlined hint]) t
+      else assert false
+    else assert false
 end
 
 module Code_id = struct
   type t = Id.t
-
-  type exported = Code_id_data.t
 
   module Table = Table_by_int_id.Make (Code_id_data)
 
@@ -931,9 +950,13 @@ module Code_id = struct
       (fun older newer invert_map -> Map.add newer older invert_map)
       map Map.empty
 
-  let export t = find_data t
+  type importer = Table.serializable
 
-  let import (data : exported) = Table.add !grand_table_of_code_ids data
+  let export symbols =
+    Table.export !grand_table_of_code_ids ~iter:(fun f -> Set.iter f symbols)
+
+  let import importer t =
+    Table.add !grand_table_of_code_ids (Table.import importer t)
 end
 
 module Code_id_or_symbol = struct

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -225,11 +225,12 @@ module Simple : sig
 
   val export : Set.t -> importer
 
-  val import :
+  (* The imported only holds those [Simple]s with [Coercion]. *)
+  val pattern_match_imported :
     importer ->
     t ->
-    name:(Name.t -> coercion:Coercion.t -> 'a) ->
-    const:(Const.t -> 'a) ->
+    name_not_imported:(Name.t -> coercion:Coercion.t -> 'a) ->
+    const_not_imported:(Const.t -> 'a) ->
     'a
 end
 

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -21,7 +21,7 @@
 module Const : sig
   type t = private Table_by_int_id.Id.t
 
-  type exported
+  type importer
 
   include Container_types.S with type t := t
 
@@ -101,15 +101,15 @@ module Const : sig
 
   val descr : t -> Descr.t
 
-  val export : t -> exported
+  val export : Set.t -> importer
 
-  val import : exported -> t
+  val import : importer -> t -> t
 end
 
 module Variable : sig
   type t = private Table_by_int_id.Id.t
 
-  type exported
+  type importer
 
   include Container_types.S_plus_iterator with type t := t
 
@@ -127,15 +127,15 @@ module Variable : sig
 
   val user_visible : t -> bool
 
-  val export : t -> exported
+  val export : Set.t -> importer
 
-  val import : exported -> t
+  val import : importer -> t -> t
 end
 
 module Symbol : sig
   type t = private Table_by_int_id.Id.t
 
-  type exported
+  type importer
 
   include Container_types.S_plus_iterator with type t := t
 
@@ -156,9 +156,9 @@ module Symbol : sig
 
   val linkage_name_as_string : t -> string
 
-  val export : t -> exported
+  val export : Set.t -> importer
 
-  val import : exported -> t
+  val import : importer -> t -> t
 
   val external_symbols_compilation_unit : unit -> Compilation_unit.t
 end
@@ -190,7 +190,7 @@ module Coercion :
 module Simple : sig
   type t = private Table_by_int_id.Id.t
 
-  type exported
+  type importer
 
   include Container_types.S_plus_iterator with type t := t
 
@@ -223,15 +223,20 @@ module Simple : sig
      [same s (with_coercion s coercion)] returns true *)
   val same : t -> t -> bool
 
-  val export : t -> exported
+  val export : Set.t -> importer
 
-  val import : exported -> t
+  val import :
+    importer ->
+    t ->
+    name:(Name.t -> coercion:Coercion.t -> 'a) ->
+    const:(Const.t -> 'a) ->
+    'a
 end
 
 module Code_id : sig
   type t = private Table_by_int_id.Id.t
 
-  type exported
+  type importer
 
   include Container_types.S with type t := t
 
@@ -257,9 +262,9 @@ module Code_id : sig
 
   val invert_map : t Map.t -> t Map.t
 
-  val export : t -> exported
+  val export : Set.t -> importer
 
-  val import : exported -> t
+  val import : importer -> t -> t
 end
 
 module Code_id_or_symbol : sig

--- a/middle_end/flambda2/identifiers/int_ids.mli
+++ b/middle_end/flambda2/identifiers/int_ids.mli
@@ -225,13 +225,13 @@ module Simple : sig
 
   val export : Set.t -> importer
 
-  (* The imported only holds those [Simple]s with [Coercion]. *)
-  val pattern_match_imported :
+  val import :
     importer ->
     t ->
-    name_not_imported:(Name.t -> coercion:Coercion.t -> 'a) ->
-    const_not_imported:(Const.t -> 'a) ->
-    'a
+    import_const:(Const.t -> Const.t) ->
+    import_symbol:(Symbol.t -> Symbol.t) ->
+    import_var:(Variable.t -> Variable.t) ->
+    t
 end
 
 module Code_id : sig

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -41,7 +41,7 @@ module Import_map : sig
   val symbol : t -> Symbol.t -> Symbol.t
 
   val simple :
-    t -> Simple.t -> import_variable:(Variable.t -> Variable.t) -> Simple.t
+    t -> Simple.t -> import_var:(Variable.t -> Variable.t) -> Simple.t
 
   val code_id : t -> Code_id.t -> Code_id.t
 
@@ -99,22 +99,12 @@ end = struct
 
   let continuation t orig = Continuation.import t.continuations orig
 
-  let simple t simple ~import_variable =
+  let simple t simple ~import_var =
     (* Constants and symbols are never permuted, only freshened upon import. *)
-    let[@inline always] name_not_imported old_name ~coercion:old_coercion =
-      let new_name =
-        Name.pattern_match old_name
-          ~symbol:(fun orig -> Name.symbol (symbol t orig))
-          ~var:(fun orig -> Name.var (import_variable orig))
-      in
-      let new_coercion =
-        Coercion.map_depth_variables old_coercion ~f:(fun dv ->
-            import_variable dv)
-      in
-      Simple.with_coercion (Simple.name new_name) new_coercion
-    in
-    Simple.pattern_match_imported t.simples simple ~name_not_imported
-      ~const_not_imported:(fun cst -> Simple.const (const t cst))
+    Simple.import t.simples simple
+      ~import_const:(fun orig -> const t orig)
+      ~import_symbol:(fun orig -> symbol t orig)
+      ~import_var
 
   let value_slot_is_used t var =
     if Value_slot.in_compilation_unit var t.original_compilation_unit
@@ -291,7 +281,7 @@ let apply_simple t simple =
   | Some import_map ->
     (* This is a bit tricky -- we want to be able to use [apply_variable] here
        so the variables in [Import_map.simple] cannot have been imported yet. *)
-    Import_map.simple import_map simple ~import_variable:(fun var ->
+    Import_map.simple import_map simple ~import_var:(fun var ->
         apply_variable t var)
 
 let value_slot_is_used t value_slot =

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -26,12 +26,12 @@ module Import_map : sig
   type t
 
   val create :
-    symbols:Symbol.t Symbol.Map.t ->
-    variables:Variable.t Variable.Map.t ->
-    simples:Simple.t Simple.Map.t ->
-    consts:Const.t Const.Map.t ->
-    code_ids:Code_id.t Code_id.Map.t ->
-    continuations:Continuation.t Continuation.Map.t ->
+    symbols:Symbol.importer ->
+    variables:Variable.importer ->
+    simples:Simple.importer ->
+    consts:Const.importer ->
+    code_ids:Code_id.importer ->
+    continuations:Continuation.importer ->
     used_value_slots:Value_slot.Set.t ->
     original_compilation_unit:Compilation_unit.t ->
     t
@@ -42,7 +42,12 @@ module Import_map : sig
 
   val symbol : t -> Symbol.t -> Symbol.t
 
-  val simple : t -> Simple.t -> Simple.t
+  val simple :
+    t ->
+    Simple.t ->
+    name:(Name.t -> coercion:Coercion.t -> 'a) ->
+    const:(Const.t -> 'a) ->
+    'a
 
   val code_id : t -> Code_id.t -> Code_id.t
 
@@ -51,12 +56,12 @@ module Import_map : sig
   val value_slot_is_used : t -> Value_slot.t -> bool
 end = struct
   type t =
-    { symbols : Symbol.t Symbol.Map.t;
-      variables : Variable.t Variable.Map.t;
-      simples : Simple.t Simple.Map.t;
-      consts : Const.t Const.Map.t;
-      code_ids : Code_id.t Code_id.Map.t;
-      continuations : Continuation.t Continuation.Map.t;
+    { symbols : Symbol.importer;
+      variables : Variable.importer;
+      simples : Simple.importer;
+      consts : Const.importer;
+      code_ids : Code_id.importer;
+      continuations : Continuation.importer;
       used_value_slots : Value_slot.Set.t;
       (* CR vlaviron: [used_value_slots] is here because we need to rewrite the
          types to remove occurrences of unused value slots, as otherwise the
@@ -90,24 +95,20 @@ end = struct
       original_compilation_unit
     }
 
-  let rename map orig ~find =
-    match find orig map with a -> a | exception Not_found -> orig
+  let symbol t orig = Symbol.import t.symbols orig
 
-  let symbol t orig = rename t.symbols orig ~find:Symbol.Map.find
+  let variable t orig = Variable.import t.variables orig
 
-  let variable t orig = rename t.variables orig ~find:Variable.Map.find
+  let const t orig = Const.import t.consts orig
 
-  let const t orig = rename t.consts orig ~find:Const.Map.find
+  let code_id t orig = Code_id.import t.code_ids orig
 
-  let code_id t orig = rename t.code_ids orig ~find:Code_id.Map.find
+  let continuation t orig = Continuation.import t.continuations orig
 
-  let continuation t orig =
-    rename t.continuations orig ~find:Continuation.Map.find
-
-  let simple t simple =
+  let simple t simple ~name ~const =
     (* [t.simples] only holds those [Simple]s with [Coercion] (analogously to
-       the grand table of [Simple]s, see reg_width_things.ml). *)
-    rename t.simples simple ~find:Simple.Map.find
+       the grand table of [Simple]s, see int_ids.ml). *)
+    Simple.import t.simples simple ~name ~const
 
   let value_slot_is_used t var =
     if Value_slot.in_compilation_unit var t.original_compilation_unit
@@ -303,25 +304,31 @@ let apply_const t cst =
   | Some import_map -> Import_map.const import_map cst
 
 let apply_simple t simple =
-  let simple =
-    match t.import_map with
-    | None -> simple
-    | Some import_map -> Import_map.simple import_map simple
-  in
-  let[@inline always] name old_name ~coercion:old_coercion =
-    let new_name = apply_name t old_name in
-    let new_coercion =
-      Coercion.map_depth_variables old_coercion ~f:(fun dv ->
-          apply_variable t dv)
-    in
-    if old_name == new_name && old_coercion == new_coercion
-    then simple
-    else Simple.with_coercion (Simple.name new_name) new_coercion
-  in
   (* Constants are never permuted, only freshened upon import. *)
-  Simple.pattern_match simple ~name ~const:(fun cst ->
-      assert (not (Simple.has_coercion simple));
-      Simple.const (apply_const t cst))
+  let[@inline always] const cst = Simple.const (apply_const t cst) in
+  match t.import_map with
+  | None ->
+    let[@inline always] name old_name ~coercion:old_coercion =
+      let new_name = apply_name t old_name in
+      let new_coercion =
+        Coercion.map_depth_variables old_coercion ~f:(fun dv ->
+            apply_variable t dv)
+      in
+      if old_name == new_name && old_coercion == new_coercion
+      then simple
+      else Simple.with_coercion (Simple.name new_name) new_coercion
+    in
+    Simple.pattern_match simple ~name ~const
+  | Some import_map ->
+    let[@inline always] name old_name ~coercion:old_coercion =
+      let new_name = apply_name t old_name in
+      let new_coercion =
+        Coercion.map_depth_variables old_coercion ~f:(fun dv ->
+            apply_variable t dv)
+      in
+      Simple.with_coercion (Simple.name new_name) new_coercion
+    in
+    Import_map.simple import_map simple ~name ~const
 
 let value_slot_is_used t value_slot =
   match t.import_map with

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -16,8 +16,6 @@
 
 module Continuations = Permutation.Make [@inlined hint] (Continuation)
 module Variables = Permutation.Make [@inlined hint] (Variable)
-module Code_ids = Permutation.Make [@inlined hint] (Code_id)
-module Symbols = Permutation.Make [@inlined hint] (Symbol)
 module Coercion = Int_ids.Coercion
 module Const = Reg_width_const
 module Simple = Int_ids.Simple
@@ -43,10 +41,7 @@ module Import_map : sig
   val symbol : t -> Symbol.t -> Symbol.t
 
   val simple :
-    t ->
-    Simple.t ->
-    import_name:(Name.t -> coercion:Coercion.t -> Simple.t) ->
-    Simple.t
+    t -> Simple.t -> import_variable:(Variable.t -> Variable.t) -> Simple.t
 
   val code_id : t -> Code_id.t -> Code_id.t
 
@@ -104,11 +99,22 @@ end = struct
 
   let continuation t orig = Continuation.import t.continuations orig
 
-  let simple t simple ~import_name =
-    (* Constants are never permuted, only freshened upon import. *)
-    Simple.pattern_match_imported t.simples simple
-      ~name_not_imported:import_name ~const_not_imported:(fun cst ->
-        Simple.const (const t cst))
+  let simple t simple ~import_variable =
+    (* Constants and symbols are never permuted, only freshened upon import. *)
+    let[@inline always] name_not_imported old_name ~coercion:old_coercion =
+      let new_name =
+        Name.pattern_match old_name
+          ~symbol:(fun orig -> Name.symbol (symbol t orig))
+          ~var:(fun orig -> Name.var (import_variable orig))
+      in
+      let new_coercion =
+        Coercion.map_depth_variables old_coercion ~f:(fun dv ->
+            import_variable dv)
+      in
+      Simple.with_coercion (Simple.name new_name) new_coercion
+    in
+    Simple.pattern_match_imported t.simples simple ~name_not_imported
+      ~const_not_imported:(fun cst -> Simple.const (const t cst))
 
   let value_slot_is_used t var =
     if Value_slot.in_compilation_unit var t.original_compilation_unit
@@ -120,16 +126,12 @@ end
 type t =
   { continuations : Continuations.t;
     variables : Variables.t;
-    code_ids : Code_ids.t;
-    symbols : Symbols.t;
     import_map : Import_map.t option
   }
 
 let empty =
   { continuations = Continuations.empty;
     variables = Variables.empty;
-    code_ids = Code_ids.empty;
-    symbols = Symbols.empty;
     import_map = None
   }
 
@@ -147,22 +149,17 @@ let create_import_map ~symbols ~variables ~simples ~consts ~code_ids
 let has_import_map t = Option.is_some t.import_map
 
 let [@ocamlformat "disable"] print ppf
-      { continuations; variables; code_ids; symbols; import_map = _; } =
+      { continuations; variables; import_map = _; } =
   Format.fprintf ppf "@[<hov 1>(\
       @[<hov 1>(continuations@ %a)@]@ \
       @[<hov 1>(variables@ %a)@])@ \
-      @[<hov 1>(code_ids@ %a)@])@ \
-      @[<hov 1>(symbols@ %a)@])@ \
       @]"
     Continuations.print continuations
     Variables.print variables
-    Code_ids.print code_ids
-    Symbols.print symbols
 
-let is_identity { continuations; variables; code_ids; symbols; import_map } =
+let is_identity { continuations; variables; import_map } =
   Continuations.is_empty continuations
   && Variables.is_empty variables
-  && Code_ids.is_empty code_ids && Symbols.is_empty symbols
   &&
   match import_map with
   | None -> true
@@ -176,22 +173,16 @@ let compose0
     ~second:
       ({ continuations = continuations2;
          variables = variables2;
-         code_ids = code_ids2;
-         symbols = symbols2;
          import_map = import_map2
        } as second)
     ~first:
       ({ continuations = continuations1;
          variables = variables1;
-         code_ids = code_ids1;
-         symbols = symbols1;
          import_map = import_map1
        } as first) =
   { continuations =
       Continuations.compose ~second:continuations2 ~first:continuations1;
     variables = Variables.compose ~second:variables2 ~first:variables1;
-    code_ids = Code_ids.compose ~second:code_ids2 ~first:code_ids1;
-    symbols = Symbols.compose ~second:symbols2 ~first:symbols1;
     (* The process of simplification of terms together with the collection of
        [Ids_for_export] from types, prior to writing of .cmx files, should
        ensure that only [first] (and not [second]) has an import map. *)
@@ -236,21 +227,10 @@ let apply_variable_set t vars =
       Variable.Set.add var result)
     vars Variable.Set.empty
 
-let add_symbol t symbol1 symbol2 =
-  { t with symbols = Symbols.compose_one ~first:t.symbols symbol1 symbol2 }
-
-let add_fresh_symbol t symbol1 ~guaranteed_fresh:symbol2 =
-  { t with
-    symbols = Symbols.compose_one_fresh t.symbols symbol1 ~fresh:symbol2
-  }
-
 let apply_symbol t symbol =
-  let symbol =
-    match t.import_map with
-    | None -> symbol
-    | Some import_map -> Import_map.symbol import_map symbol
-  in
-  Symbols.apply t.symbols symbol
+  match t.import_map with
+  | None -> symbol
+  | Some import_map -> Import_map.symbol import_map symbol
 
 let apply_symbol_set t symbols =
   Symbol.Set.fold
@@ -282,21 +262,10 @@ let apply_continuation t k =
   in
   Continuations.apply t.continuations k
 
-let add_code_id t code_id1 code_id2 =
-  { t with code_ids = Code_ids.compose_one ~first:t.code_ids code_id1 code_id2 }
-
-let add_fresh_code_id t code_id1 ~guaranteed_fresh:code_id2 =
-  { t with
-    code_ids = Code_ids.compose_one_fresh t.code_ids code_id1 ~fresh:code_id2
-  }
-
 let apply_code_id t code_id =
-  let code_id =
-    match t.import_map with
-    | None -> code_id
-    | Some import_map -> Import_map.code_id import_map code_id
-  in
-  Code_ids.apply t.code_ids code_id
+  match t.import_map with
+  | None -> code_id
+  | Some import_map -> Import_map.code_id import_map code_id
 
 let apply_const t cst =
   match t.import_map with
@@ -320,18 +289,10 @@ let apply_simple t simple =
     in
     Simple.pattern_match simple ~name ~const
   | Some import_map ->
-    (* This is a bit tricky -- we want to be able to use [apply_name] and
-       [apply_variable] here, so the names and coercions returned by
-       [Import_map.simple] cannot have been imported yet. *)
-    let[@inline always] import_name old_name ~coercion:old_coercion =
-      let new_name = apply_name t old_name in
-      let new_coercion =
-        Coercion.map_depth_variables old_coercion ~f:(fun dv ->
-            apply_variable t dv)
-      in
-      Simple.with_coercion (Simple.name new_name) new_coercion
-    in
-    Import_map.simple import_map simple ~import_name
+    (* This is a bit tricky -- we want to be able to use [apply_variable] here
+       so the variables in [Import_map.simple] cannot have been imported yet. *)
+    Import_map.simple import_map simple ~import_variable:(fun var ->
+        apply_variable t var)
 
 let value_slot_is_used t value_slot =
   match t.import_map with

--- a/middle_end/flambda2/nominal/renaming.ml
+++ b/middle_end/flambda2/nominal/renaming.ml
@@ -45,9 +45,8 @@ module Import_map : sig
   val simple :
     t ->
     Simple.t ->
-    name:(Name.t -> coercion:Coercion.t -> 'a) ->
-    const:(Const.t -> 'a) ->
-    'a
+    import_name:(Name.t -> coercion:Coercion.t -> Simple.t) ->
+    Simple.t
 
   val code_id : t -> Code_id.t -> Code_id.t
 
@@ -105,10 +104,11 @@ end = struct
 
   let continuation t orig = Continuation.import t.continuations orig
 
-  let simple t simple ~name ~const =
-    (* [t.simples] only holds those [Simple]s with [Coercion] (analogously to
-       the grand table of [Simple]s, see int_ids.ml). *)
-    Simple.import t.simples simple ~name ~const
+  let simple t simple ~import_name =
+    (* Constants are never permuted, only freshened upon import. *)
+    Simple.pattern_match_imported t.simples simple
+      ~name_not_imported:import_name ~const_not_imported:(fun cst ->
+        Simple.const (const t cst))
 
   let value_slot_is_used t var =
     if Value_slot.in_compilation_unit var t.original_compilation_unit
@@ -304,10 +304,10 @@ let apply_const t cst =
   | Some import_map -> Import_map.const import_map cst
 
 let apply_simple t simple =
-  (* Constants are never permuted, only freshened upon import. *)
-  let[@inline always] const cst = Simple.const (apply_const t cst) in
   match t.import_map with
   | None ->
+    (* Constants are never permuted, only freshened upon import. *)
+    let[@inline always] const cst = Simple.const (apply_const t cst) in
     let[@inline always] name old_name ~coercion:old_coercion =
       let new_name = apply_name t old_name in
       let new_coercion =
@@ -320,7 +320,10 @@ let apply_simple t simple =
     in
     Simple.pattern_match simple ~name ~const
   | Some import_map ->
-    let[@inline always] name old_name ~coercion:old_coercion =
+    (* This is a bit tricky -- we want to be able to use [apply_name] and
+       [apply_variable] here, so the names and coercions returned by
+       [Import_map.simple] cannot have been imported yet. *)
+    let[@inline always] import_name old_name ~coercion:old_coercion =
       let new_name = apply_name t old_name in
       let new_coercion =
         Coercion.map_depth_variables old_coercion ~f:(fun dv ->
@@ -328,7 +331,7 @@ let apply_simple t simple =
       in
       Simple.with_coercion (Simple.name new_name) new_coercion
     in
-    Import_map.simple import_map simple ~name ~const
+    Import_map.simple import_map simple ~import_name
 
 let value_slot_is_used t value_slot =
   match t.import_map with

--- a/middle_end/flambda2/nominal/renaming.mli
+++ b/middle_end/flambda2/nominal/renaming.mli
@@ -60,10 +60,7 @@ val apply_variable : t -> Variable.t -> Variable.t
 
 val apply_variable_set : t -> Variable.Set.t -> Variable.Set.t
 
-val add_symbol : t -> Symbol.t -> Symbol.t -> t
-
-val add_fresh_symbol : t -> Symbol.t -> guaranteed_fresh:Symbol.t -> t
-
+(* This is only used by the importing code. We don't permute symbols. *)
 val apply_symbol : t -> Symbol.t -> Symbol.t
 
 val apply_symbol_set : t -> Symbol.Set.t -> Symbol.Set.t
@@ -77,10 +74,7 @@ val add_fresh_continuation :
 
 val apply_continuation : t -> Continuation.t -> Continuation.t
 
-val add_code_id : t -> Code_id.t -> Code_id.t -> t
-
-val add_fresh_code_id : t -> Code_id.t -> guaranteed_fresh:Code_id.t -> t
-
+(* This is only used by the importing code. We don't permute code ids. *)
 val apply_code_id : t -> Code_id.t -> Code_id.t
 
 (* This is only used by the importing code. We don't permute constants. *)

--- a/middle_end/flambda2/nominal/renaming.mli
+++ b/middle_end/flambda2/nominal/renaming.mli
@@ -34,12 +34,12 @@ val print : Format.formatter -> t -> unit
 val is_identity : t -> bool
 
 val create_import_map :
-  symbols:Symbol.t Symbol.Map.t ->
-  variables:Variable.t Variable.Map.t ->
-  simples:Simple.t Simple.Map.t ->
-  consts:Reg_width_const.t Reg_width_const.Map.t ->
-  code_ids:Code_id.t Code_id.Map.t ->
-  continuations:Continuation.t Continuation.Map.t ->
+  symbols:Symbol.importer ->
+  variables:Variable.importer ->
+  simples:Simple.importer ->
+  consts:Reg_width_const.importer ->
+  code_ids:Code_id.importer ->
+  continuations:Continuation.importer ->
   used_value_slots:Value_slot.Set.t ->
   original_compilation_unit:Compilation_unit.t ->
   t


### PR DESCRIPTION
Currently, we store a pair of `(int id, data)` for all the exported int-based identifiers (variables, symbols, continuations, etc.) in cmx files, and we import that data into the grand tables for the current compilation unit upon loading the cmx.

We do this even though we often need only a fairly small fraction (on the compiler code base, this is around 5%) of these imported identifiers, but we still spend quite a bit of time (still on the compiler code base, 1-2% of the total compilation time) re-interning the exported data eagerly upon loading cmx files.

This patch makes the importing lazy: we now export cleaned copies of the grand tables (with only the exported identifiers) and only import the actual data into the grand table for the compilation unit when a variable is seen by a renaming.

On my machine, this improves the total compilation time (as measured by `-dprofile`) by ~1% (and the time spent in flambda2 by ~4%) when building a reference commit. The impact on cmx size is minimal (on the compiler code base, it reduces the size of cmxes by ~0.1%).