### PR TITLE
Fix failing debug assertion

### DIFF
--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -290,7 +290,6 @@ Caml_inline int stack_cache_bucket (mlsize_t wosize) {
     ++bucket;
     size_bucket_wsz += size_bucket_wsz;
   }
-  CAMLassert(wosize>=size_bucket_wsz/2);
   return -1;
 }
 

--- a/testsuite/tests/effects/stack_cache_bucket.ml
+++ b/testsuite/tests/effects/stack_cache_bucket.ml
@@ -1,0 +1,10 @@
+(* TEST
+   ocamlrunparam += ",Xmain_stack_size=786432,Xfiber_stack_size=262144";
+   no-stack-checks;
+   flags = "-runtime-variant=d";
+   native;
+*)
+
+(* With guard-page stacks, the main stack takes its size from Xmain_stack_size,
+   which may not be a power-of-two multiple of the fiber stack size. This used
+   to trip an assertion in the debug runtime. *)


### PR DESCRIPTION
This assertion assumed that if a stack size is not power-of-two multiple of the default fiber stack size (because it did not match any of the cache buckets), it must be larger than the largest stack cache bucket. 

This is not true for guard-page stacks, since we choose the main/thread/fiber stack size based on an `OCAMLRUNPARAM` variable. The comment on this function implies non-power-of-two-multiple sizes are allowed in general (in which case -1 is returned), so I just deleted the assertion.

Includes a test that hits the assertion under guard pages.