### PR TITLE
Filter nested ikind provenance explanations per axis

### DIFF
--- a/external/merlin/src/ocaml/typing/ikind.ml
+++ b/external/merlin/src/ocaml/typing/ikind.ml
@@ -39,31 +39,60 @@ let fresh_unknown_uid () : Types.Uid.t =
   Types.Uid.mk ~current_unit
 
 module Provenance = struct
-  type id = Id of int
+  module Id : sig
+    type t = private int
+
+    val create : unit -> t
+
+    val equal : t -> t -> bool
+  end = struct
+    type t = int
+
+    let next = ref 0
+
+    let create () =
+      let id = !next in
+      incr next;
+      id
+
+    let equal = Int.equal
+  end
 
   type t =
-    { id : id;
+    { id : Id.t;
       ty : Format_doc.doc;
+          (** The subject as printed in the error message: a type-expression
+              head (["u"], ["'a"]) or a class-of-types phrase (["functions"]).
+          *)
       plural : bool;
+          (** Whether [ty] is a plural phrase, for verb agreement ("functions
+              are ..." vs "[u] is ..."). *)
       source_type_id : int option;
+          (** [Types.get_id] of the type expression this entry was registered
+              for; residual entries sharing it are merged into one message. *)
       is_decl_under_check : bool;
-      parent : id option
+          (** The subject is the declaration whose bound is being checked; such
+              self-occurrences are never reported as causes. *)
+      parent : Id.t option
+          (** The entry for the enclosing subject on the same nesting path, or
+              [None] at the top level. Used to drop a nested entry whose
+              requirement is entailed by an ancestor's. *)
     }
-
-  let next_id = ref 0
 
   let entries : t list ref = ref []
 
-  let equal_id (Id id1) (Id id2) = Int.equal id1 id2
-
-  let name { id = Id id; ty; plural; _ } = Ldd.Name.provenance ~id ~ty ~plural
+  let name { id; ty; plural; _ } =
+    Ldd.Name.provenance ~id:(id :> int) ~ty ~plural
 
   let make ~plural ~source_type_id ~is_decl_under_check ~parent ty =
-    let next = !next_id in
-    next_id := next + 1;
-    let id = Id next in
     let provenance =
-      { id; ty; plural; source_type_id; is_decl_under_check; parent }
+      { id = Id.create ();
+        ty;
+        plural;
+        source_type_id;
+        is_decl_under_check;
+        parent
+      }
     in
     entries := provenance :: !entries;
     provenance
@@ -153,9 +182,9 @@ module Solver = struct
     | Poly of Ldd.node * Ldd.node array
 
   and provenance_ctx =
-    { parent : Provenance.id option;
+    { parent : Provenance.Id.t option;
       decl_uid_under_check : Types.Uid.t option;
-      kinds : (int * Provenance.id option, Ldd.node) Hashtbl.t
+      kinds : (type_id:int * parent:Provenance.Id.t option, Ldd.node) Hashtbl.t
     }
 
   and ctx =
@@ -186,7 +215,8 @@ module Solver = struct
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
-  let with_provenance ?decl_uid_under_check (ctx : ctx) : ctx =
+  let with_provenance ~(decl_uid_under_check : Types.Uid.t option) (ctx : ctx) :
+      ctx =
     { ctx with
       provenance =
         Some { parent = None; decl_uid_under_check; kinds = Hashtbl.create 1 };
@@ -199,13 +229,14 @@ module Solver = struct
   let find_provenance_kind (ctx : ctx) (ty : Types.type_expr) =
     match ctx.provenance with
     | None -> None
-    | Some { parent; kinds } -> Hashtbl.find_opt kinds (Types.get_id ty, parent)
+    | Some { parent; kinds } ->
+      Hashtbl.find_opt kinds (~type_id:(Types.get_id ty), ~parent)
 
   let cache_provenance_kind (ctx : ctx) (ty : Types.type_expr) kind =
     match ctx.provenance with
     | None -> ()
     | Some { parent; kinds } ->
-      Hashtbl.replace kinds (Types.get_id ty, parent) kind
+      Hashtbl.replace kinds (~type_id:(Types.get_id ty), ~parent) kind
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode, name with
@@ -827,7 +858,7 @@ let merge_same_source entries entry =
       in
       List.map
         (fun candidate ->
-          if Provenance.equal_id candidate.provenance.id other.provenance.id
+          if Provenance.Id.equal candidate.provenance.id other.provenance.id
           then merged
           else candidate)
         entries)
@@ -911,7 +942,7 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
       (fun (provenance : Provenance.t) ->
         Hashtbl.add provenances_by_id provenance.id provenance)
       provenances;
-    let exception Missing_provenance_parent of Provenance.id in
+    let exception Missing_provenance_parent of Provenance.Id.t in
     let find_provenance id =
       match Hashtbl.find_opt provenances_by_id id with
       | Some provenance -> provenance
@@ -1518,10 +1549,10 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
     ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
 
-let compute_provenance_bound_polys ?decl_uid_under_check env
+let compute_provenance_bound_polys ~decl_uid_under_check env
     ~(lhs : Solver.ctx -> Ldd.node) (bound : Types.jkind_l) : subcheck_polys =
   compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
-      let ctx = Solver.with_provenance ?decl_uid_under_check ctx in
+      let ctx = Solver.with_provenance ~decl_uid_under_check ctx in
       lhs ctx)
 
 let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
@@ -1640,7 +1671,7 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
           | Ok () -> Error ikind_error
           | Error jkind_error -> Error (Jkind_error jkind_error))
 
-let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
+let check_bound ?(allow_any_crossing = false) ?origin ~decl_uid_under_check
     ~type_equal ~context env ~actual ~bound ~provenance_lhs =
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
@@ -1681,18 +1712,19 @@ let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
         in
         best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
           ~super_jkind:bound ~printing_env:env actual_error (fun () ->
-            compute_provenance_bound_polys ?decl_uid_under_check env
+            compute_provenance_bound_polys ~decl_uid_under_check env
               ~lhs:provenance_lhs bound)
 
 let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
-  check_bound ?origin ~type_equal ~context env ~actual ~bound
-    ~provenance_lhs:(fun ctx -> Solver.kind ~use_tables:true ctx ty)
+  check_bound ?origin ~decl_uid_under_check:None ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs:(fun ctx ->
+      Solver.kind ~use_tables:true ctx ty)
 
 let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
     ~decl ~actual ~bound =
   check_bound ?allow_any_crossing ?origin
-    ~decl_uid_under_check:decl.Types.type_uid ~type_equal ~context env ~actual
-    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
+    ~decl_uid_under_check:(Some decl.Types.type_uid) ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =

--- a/external/merlin/src/ocaml/typing/ikind.ml
+++ b/external/merlin/src/ocaml/typing/ikind.ml
@@ -39,44 +39,72 @@ let fresh_unknown_uid () : Types.Uid.t =
   Types.Uid.mk ~current_unit
 
 module Provenance = struct
+  type id = Id of int
+
+  type t =
+    { id : id;
+      ty : Format_doc.doc;
+      plural : bool;
+      source_type_id : int option;
+      is_decl_under_check : bool;
+      parent : id option
+    }
+
   let next_id = ref 0
 
-  let names : Ldd.Name.t list ref = ref []
+  let entries : t list ref = ref []
 
-  let register_doc ~plural ty : Ldd.Name.t =
-    let id = !next_id in
-    next_id := id + 1;
-    let name = Ldd.Name.provenance ~id ~ty ~plural in
-    names := name :: !names;
-    name
+  let equal_id (Id id1) (Id id2) = Int.equal id1 id2
 
-  let register_text ~plural text =
-    register_doc ~plural (Format_doc.doc_printf "%s" text)
+  let name { id = Id id; ty; plural; _ } = Ldd.Name.provenance ~id ~ty ~plural
 
-  let register (ty : Types.type_expr) : Ldd.Name.t =
+  let make ~plural ~source_type_id ~is_decl_under_check ~parent ty =
+    let next = !next_id in
+    next_id := next + 1;
+    let id = Id next in
+    let provenance =
+      { id; ty; plural; source_type_id; is_decl_under_check; parent }
+    in
+    entries := provenance :: !entries;
+    provenance
+
+  let register ~is_decl_under_check ~parent (ty : Types.type_expr) =
     (* A surviving residual for an occurrence reflects only the head
        constructor's own contribution (the decomposition zeroes anything
        flowing through a separately-tracked inner type or parameter), so
        name the head rather than the full type expression: the constructor
        for [Tconstr], a class-of-types phrase for the built-in shapes. *)
-    let register_type ty =
+    let register_type ~source_type ty =
       Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
-      |> register_doc ~plural:false
+      |> make ~plural:false
+           ~source_type_id:(Some (Types.get_id source_type))
+           ~is_decl_under_check ~parent
+    in
+    let register_text text =
+      make ~plural:true
+        ~source_type_id:(Some (Types.get_id ty))
+        ~is_decl_under_check ~parent
+        (Format_doc.doc_printf "%s" text)
     in
     match Types.get_desc ty with
-    | Types.Tarrow _ -> register_text ~plural:true "functions"
-    | Types.Ttuple _ -> register_text ~plural:true "tuples"
-    | Types.Tunboxed_tuple _ -> register_text ~plural:true "unboxed tuples"
-    | Types.Tobject _ -> register_text ~plural:true "objects"
-    | Types.Tvariant _ -> register_text ~plural:true "polymorphic variants"
-    | Types.Tpackage _ -> register_text ~plural:true "first-class modules"
+    | Types.Tarrow _ -> register_text "functions"
+    | Types.Ttuple _ -> register_text "tuples"
+    | Types.Tunboxed_tuple _ -> register_text "unboxed tuples"
+    | Types.Tobject _ -> register_text "objects"
+    | Types.Tvariant _ -> register_text "polymorphic variants"
+    | Types.Tpackage _ -> register_text "first-class modules"
     | Types.Tconstr (path, _ :: _, _) ->
-      register_type (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
-    | _ -> register_type ty
+      register_type ~source_type:ty
+        (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
+    | _ -> register_type ~source_type:ty ty
 
-  let reset () = names := []
+  let register_phrase ~parent text =
+    make ~plural:true ~source_type_id:None ~is_decl_under_check:false ~parent
+      (Format_doc.doc_printf "%s" text)
 
-  let all_names () = List.rev !names
+  let reset () = entries := []
+
+  let all () = List.rev !entries
 end
 
 (** A kind solver specialized to [Types.Ldd] and [Types.type_expr].
@@ -88,6 +116,12 @@ module Solver = struct
   type mode =
     | Normal
     | Round_up
+
+  let rec uid_is_reliable_identity = function
+    | Types.Uid.Internal -> false
+    | Types.Uid.Unboxed_version uid -> uid_is_reliable_identity uid
+    | Types.Uid.Compilation_unit _ | Types.Uid.Item _ | Types.Uid.Predef _ ->
+      true
 
   (* Hash tables avoiding polymorphic structural comparison on deep values.
      [Btype.TypeHash] keys by the representative of a [type_expr], so
@@ -118,11 +152,17 @@ module Solver = struct
         }
     | Poly of Ldd.node * Ldd.node array
 
+  and provenance_ctx =
+    { parent : Provenance.id option;
+      decl_uid_under_check : Types.Uid.t option;
+      kinds : (int * Provenance.id option, Ldd.node) Hashtbl.t
+    }
+
   and ctx =
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
-      add_provenance : bool;
+      provenance : provenance_ctx option;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -132,22 +172,40 @@ module Solver = struct
   let global_constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t =
     ConstrTbl.create 1
 
-  let create_ctx ~(mode : mode) ~(env : Env.t option) ~add_provenance
+  let create_ctx ~(mode : mode) ~(env : Env.t option)
       ~(lookup_of_env : Env.t -> Path.t -> constr_decl) =
     TyTbl.clear global_ty_to_kind;
     ConstrTbl.clear global_constr_to_coeffs;
     { env;
       lookup_of_env;
       mode;
-      add_provenance;
+      provenance = None;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
-  let reset_for_provenance (ctx : ctx) ~(add_provenance : bool) : ctx =
-    { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
+  let with_provenance ?decl_uid_under_check (ctx : ctx) : ctx =
+    { ctx with
+      provenance =
+        Some { parent = None; decl_uid_under_check; kinds = Hashtbl.create 1 };
+      ty_to_kind = TyTbl.create 1
+    }
+
+  let without_provenance (ctx : ctx) : ctx =
+    { ctx with provenance = None; ty_to_kind = TyTbl.create 1 }
+
+  let find_provenance_kind (ctx : ctx) (ty : Types.type_expr) =
+    match ctx.provenance with
+    | None -> None
+    | Some { parent; kinds } -> Hashtbl.find_opt kinds (Types.get_id ty, parent)
+
+  let cache_provenance_kind (ctx : ctx) (ty : Types.type_expr) kind =
+    match ctx.provenance with
+    | None -> ()
+    | Some { parent; kinds } ->
+      Hashtbl.replace kinds (Types.get_id ty, parent) kind
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode, name with
@@ -159,17 +217,34 @@ module Solver = struct
     let param_id = Types.get_id ty in
     rigid_name ctx (Ldd.Name.param param_id)
 
-  let provenance (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
-    rigid_name ctx (Provenance.register ty)
-
-  let provenance_text (ctx : ctx) (text : string) : Ldd.node =
-    rigid_name ctx (Provenance.register_text ~plural:true text)
+  let provenance_and_child_ctx (ctx : ctx) (ty : Types.type_expr) =
+    match ctx.provenance with
+    | None -> Fun.id, ctx
+    | Some ({ parent; _ } as provenance_ctx) ->
+      let is_decl_under_check =
+        match
+          provenance_ctx.decl_uid_under_check, ctx.env, Types.get_desc ty
+        with
+        | Some decl_uid, Some env, Types.Tconstr (path, _, _)
+          when uid_is_reliable_identity decl_uid -> (
+          match Env.find_type path env with
+          | exception Not_found -> false
+          | decl -> Types.Uid.equal decl_uid decl.type_uid)
+        | None, _, _ | Some _, None, _ | Some _, Some _, _ -> false
+      in
+      let provenance = Provenance.register ~is_decl_under_check ~parent ty in
+      ( (fun poly -> Ldd.meet poly (rigid_name ctx (Provenance.name provenance))),
+        { ctx with
+          provenance = Some { provenance_ctx with parent = Some provenance.id }
+        } )
 
   let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
       : Ldd.node =
-    if ctx.add_provenance
-    then Ldd.meet poly (provenance_text ctx (text ()))
-    else poly
+    match ctx.provenance with
+    | None -> poly
+    | Some { parent; _ } ->
+      let provenance = Provenance.register_phrase ~parent (text ()) in
+      Ldd.meet poly (rigid_name ctx (Provenance.name provenance))
 
   let rec type_may_be_circular (ty : Types.type_expr) : bool =
     match Types.get_desc ty with
@@ -336,28 +411,22 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr ~self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
-      : Ldd.node =
+  and constr ~self_provenance ~arg_ctx (ctx : ctx) (path : Path.t)
+      (args : Types.type_expr list) : Ldd.node =
     let constr_ctx =
-      if ctx.add_provenance
-      then reset_for_provenance ctx ~add_provenance:false
-      else ctx
+      match ctx.provenance with None -> ctx | Some _ -> without_provenance ctx
     in
     let base, coeffs =
       constr_kind constr_ctx ~min_arity:(List.length args) path
     in
-    let base =
-      if ctx.add_provenance
-      then Ldd.meet base (provenance ctx self_ty)
-      else base
-    in
+    let base = self_provenance base in
     let rec loop acc remaining i =
       if i = Array.length coeffs
       then acc
       else
         match remaining with
         | arg :: rest ->
-          let arg_kind = kind ~use_tables:true ctx arg in
+          let arg_kind = kind ~use_tables:true arg_ctx arg in
           loop (Ldd.join acc (Ldd.meet arg_kind coeffs.(i))) rest (i + 1)
         | [] -> failwith "Missing arg"
     in
@@ -468,23 +537,34 @@ module Solver = struct
     else
       match TyTbl.find_opt ctx.ty_to_kind ty with
       | Some kind_poly -> kind_poly
-      | None ->
-        if not use_tables
-        then kind_uncached ctx ty
-        else if type_may_be_circular ty
-        then (
-          let var = Ldd.new_var () in
-          let placeholder = Ldd.node_of_var var in
-          TyTbl.add ctx.ty_to_kind ty placeholder;
-          let kind_rhs = kind_uncached ctx ty in
-          Ldd.solve_lfp var kind_rhs;
-          let kind_inlined = Ldd.inline_solved_vars placeholder in
-          TyTbl.replace ctx.ty_to_kind ty kind_inlined;
-          kind_inlined)
-        else
-          let kind_rhs = kind_uncached ctx ty in
-          TyTbl.add ctx.ty_to_kind ty kind_rhs;
-          kind_rhs
+      | None -> (
+        let cached_provenance_kind =
+          if use_tables then find_provenance_kind ctx ty else None
+        in
+        match cached_provenance_kind with
+        | Some kind_poly -> kind_poly
+        | None ->
+          if not use_tables
+          then kind_uncached ctx ty
+          else if type_may_be_circular ty
+          then (
+            let var = Ldd.new_var () in
+            let placeholder = Ldd.node_of_var var in
+            TyTbl.add ctx.ty_to_kind ty placeholder;
+            let kind_rhs = kind_uncached ctx ty in
+            Ldd.solve_lfp var kind_rhs;
+            let kind_inlined = Ldd.inline_solved_vars placeholder in
+            if Option.is_some ctx.provenance
+            then TyTbl.remove ctx.ty_to_kind ty
+            else TyTbl.replace ctx.ty_to_kind ty kind_inlined;
+            cache_provenance_kind ctx ty kind_inlined;
+            kind_inlined)
+          else
+            let kind_rhs = kind_uncached ctx ty in
+            if Option.is_none ctx.provenance
+            then TyTbl.add ctx.ty_to_kind ty kind_rhs;
+            cache_provenance_kind ctx ty kind_rhs;
+            kind_rhs)
 
   (* Worker for [kind]; does not memoize.
      Only call from [kind] so caching and LFP handling apply. *)
@@ -492,19 +572,24 @@ module Solver = struct
     (* Compute the ikind polynomial for an arbitrary [type_expr]. This is the
        semantic counterpart of [Jkind.jkind_of_type], but expressed in LDD
        form. *)
-    let self_provenance poly =
-      if ctx.add_provenance then Ldd.meet poly (provenance ctx ty) else poly
-    in
     (* [ty] is expected to be representative: no links/substs/fields/nil.
        Provenance is attached only to the contribution introduced by this
        node, not to recursive child contributions. *)
-    match Types.get_desc ty with
+    let desc = Types.get_desc ty in
+    let self_provenance, child_ctx =
+      match desc with
+      | Types.Tlink _ | Types.Tsubst _ | Types.Trepr _ | Types.Tpoly _
+      | Types.Tmod _ | Types.Tfield _ | Types.Tnil ->
+        Fun.id, ctx
+      | _ -> provenance_and_child_ctx ctx ty
+    in
+    match desc with
     | Types.Tvar { name = _name; jkind } | Types.Tunivar { name = _name; jkind }
       ->
       (* Keep a rigid param, but cap it by its annotated jkind. *)
-      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind))
+      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind child_ctx jkind))
     | Types.Tconstr (path, args, _abbrev_memo) ->
-      constr ~self_ty:ty ctx path args
+      constr ~self_provenance ~arg_ctx:child_ctx ctx path args
     | Types.Tmod (ty, mod_bounds) ->
       Ldd.meet
         (kind ~use_tables:true ctx ty)
@@ -513,12 +598,12 @@ module Solver = struct
       (* Boxed tuples: immutable_data base + per-element contributions
          under id modality. *)
       let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
-      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
+      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true child_ctx t)
     | Types.Tunboxed_tuple elts ->
       (* Unboxed tuples: per-element contributions; shallow axes relevant
          only for arity = 1. *)
       Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
-          kind ~use_tables:true ctx t)
+          kind ~use_tables:true child_ctx t)
     | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
       (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
       self_provenance (Ldd.const Axis_lattice.arrow)
@@ -534,11 +619,11 @@ module Solver = struct
          a viable setting in practice. Track removing this workaround as part
          of internal ticket 5746. *)
       kind ~check_principality:false ~use_tables:true ctx ty
-    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind ctx jkind)
+    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind child_ctx jkind)
     | Types.Tobject _ -> self_provenance (Ldd.const Axis_lattice.object_legacy)
     | Types.Tbox t ->
       let base = self_provenance (Ldd.const Axis_lattice.mutable_data) in
-      Ldd.join base (kind ~use_tables:true ctx t)
+      Ldd.join base (kind ~use_tables:true child_ctx t)
     | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
     | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
     | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
@@ -555,7 +640,7 @@ module Solver = struct
           let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
           Btype.fold_row
             (fun acc ty ->
-              let ty_kind = kind ~use_tables:true ctx ty in
+              let ty_kind = kind ~use_tables:true child_ctx ty in
               Ldd.join acc ty_kind)
             base row
         else
@@ -657,13 +742,20 @@ let axes_in_violation_order ~violating_axes axes =
       List.exists (Jkind_axis.Axis.equal violating_axis) axes)
     violating_axes
 
+type provenance_residual =
+  { provenance : Provenance.t;
+    mode_bounds : Axis_lattice.t;
+    axes : Jkind_axis.Axis.packed list
+  }
+
 type mode_crossing_error =
   { printing_env : Env.t;
     super_jkind : Types.jkind_l;
     sub_poly : Ldd.node;
     super_poly : Ldd.node;
-    provenance_names : Ldd.Name.t list;
-    violating_axes : Jkind_axis.Axis.packed list
+    provenances : Provenance.t list;
+    violating_axes : Jkind_axis.Axis.packed list;
+    provenance_residuals : provenance_residual list option
   }
 
 type subjkind_error =
@@ -677,24 +769,17 @@ let subjkind_error_printing_env = function
 let map_jkind_error result =
   Result.map_error (fun error -> Jkind_error error) result
 
-type provenance_residual =
-  { ty : Format_doc.doc;
-    plural : bool;
-    mode_bounds : Axis_lattice.t;
-    axes : Jkind_axis.Axis.packed list
-  }
-
-let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
-    =
+let add_provenance_residual entries
+    ({ provenance = { ty; plural; _ }; mode_bounds; axes } as entry) =
   (* Deduplicate identical entries (e.g. two fields of type [int ref] under
      the same bound), keeping first-occurrence order. Entries that merely
      share a printed name (e.g. two constructor-local existentials both
      rendered ['a]) can have different requirements and must stay separate. *)
   let duplicate other =
     String.equal
-      (Format_doc.asprintf "%a" Format_doc.pp_doc other.ty)
+      (Format_doc.asprintf "%a" Format_doc.pp_doc other.provenance.ty)
       (Format_doc.asprintf "%a" Format_doc.pp_doc ty)
-    && Bool.equal other.plural plural
+    && Bool.equal other.provenance.plural plural
     && Axis_lattice.equal other.mode_bounds mode_bounds
     && List.length other.axes = List.length axes
     && List.for_all
@@ -703,8 +788,52 @@ let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
   in
   if List.exists duplicate entries then entries else entries @ [entry]
 
-let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
-    =
+let axis_set_of_axes axes =
+  List.fold_left
+    (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+    Jkind_axis.Axis_set.empty axes
+
+let restrict_mode_bounds_to_axes mode_bounds axes =
+  Axis_lattice.join mode_bounds
+    (Axis_lattice.of_axis_set
+       (Jkind_axis.Axis_set.complement (axis_set_of_axes axes)))
+
+let merge_same_source entries entry =
+  match entry.provenance.source_type_id with
+  | None -> entries @ [entry]
+  | Some source_type_id -> (
+    match
+      List.find_opt
+        (fun other ->
+          Option.equal Int.equal other.provenance.source_type_id
+            (Some source_type_id))
+        entries
+    with
+    | None -> entries @ [entry]
+    | Some other ->
+      let axes =
+        List.fold_left
+          (fun axes axis ->
+            if List.exists (Jkind_axis.Axis.equal axis) axes
+            then axes
+            else axes @ [axis])
+          other.axes entry.axes
+      in
+      let merged =
+        { other with
+          mode_bounds = Axis_lattice.meet other.mode_bounds entry.mode_bounds;
+          axes
+        }
+      in
+      List.map
+        (fun candidate ->
+          if Provenance.equal_id candidate.provenance.id other.provenance.id
+          then merged
+          else candidate)
+        entries)
+
+let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
+  let provenance_names = List.map Provenance.name provenances in
   let provenance_vars = List.map Ldd.rigid provenance_names in
   (* For a declaration [type t : bound = rhs], ikind checking compares the
      inferred ikind polynomial for [rhs] against the polynomial for [bound].
@@ -717,9 +846,10 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
        satisfy the required bound?
 
      This is the right question because the provenance variable stands for the
-     mode-crossing behavior we need from the source type. It gives the least
-     restrictive bound that would still make the original lattice comparison
-     pass.
+     mode-crossing behavior we need from the source type. Before rounding, its
+     answer is the least restrictive bound that would make this contribution
+     satisfy the required bound. Rounding down may strengthen that answer when
+     converting it to a concrete mode bound for printing.
 
      We answer the question by first decomposing the provenance-annotated
      polynomial into an untracked base plus one coefficient per provenance
@@ -738,12 +868,14 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
   match Ldd.leq_with_reason base super_poly with
   | _ :: _ -> None
   | [] ->
-    List.combine provenance_names coeffs
-    |> List.filter_map (fun (name, coeff) ->
-        match (name : Ldd.Name.t) with
-        | Atom _ | KAtom _ | Param _ | Unknown _ -> None
-        | Provenance { ty; plural; _ } -> (
-          if is_bot_poly coeff
+    (* Self occurrences stay in the decomposition universe and provenance
+       forest, but are not independent causes to report for their own
+       declaration. Filtering here also prevents them from hiding nested
+       causes as enclosing residuals. *)
+    let entries =
+      List.combine provenances coeffs
+      |> List.filter_map (fun ((provenance : Provenance.t), coeff) ->
+          if provenance.is_decl_under_check || is_bot_poly coeff
           then None
           else
             let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
@@ -763,7 +895,93 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                  axes left to report. *)
               match axes with
               | [] -> None
-              | _ :: _ -> Some { ty; plural; mode_bounds; axes }))
+              | _ :: _ -> Some { provenance; mode_bounds; axes })
+    in
+    (* [raw_bounds_by_id] holds, per surviving raw entry, its requirement
+       restricted to its reported axes (top elsewhere): the exact per-axis
+       VALUES the entry's message will demand of its subject. *)
+    let raw_bounds_by_id = Hashtbl.create (List.length entries) in
+    List.iter
+      (fun entry ->
+        Hashtbl.add raw_bounds_by_id entry.provenance.id
+          (restrict_mode_bounds_to_axes entry.mode_bounds entry.axes))
+      entries;
+    let provenances_by_id = Hashtbl.create (List.length provenances) in
+    List.iter
+      (fun (provenance : Provenance.t) ->
+        Hashtbl.add provenances_by_id provenance.id provenance)
+      provenances;
+    let exception Missing_provenance_parent of Provenance.id in
+    let find_provenance id =
+      match Hashtbl.find_opt provenances_by_id id with
+      | Some provenance -> provenance
+      | None -> raise (Missing_provenance_parent id)
+    in
+    (* An enclosing entry only explains a nested requirement it ENTAILS:
+       same axis and an at-least-as-strong required value. Requirements
+       are kept as a list per ancestor rather than meet-collapsed into a
+       single lattice element: on the diamond axes (portability,
+       contention) the meet of two incomparable ancestor requirements
+       (e.g. shareable and corruptible) would wrongly claim to cover a
+       strictly stronger nested one (portable) that neither ancestor
+       explains. The [parent] links form an acyclic forest, so the walk
+       terminates. *)
+    let covered_bounds_by_id = Hashtbl.create (List.length provenances) in
+    let rec covered_bounds (provenance : Provenance.t) =
+      match Hashtbl.find_opt covered_bounds_by_id provenance.id with
+      | Some bounds -> bounds
+      | None ->
+        let parent_bounds =
+          match provenance.parent with
+          | None -> []
+          | Some parent -> covered_bounds (find_provenance parent)
+        in
+        let bounds =
+          match Hashtbl.find_opt raw_bounds_by_id provenance.id with
+          | None -> parent_bounds
+          | Some own -> own :: parent_bounds
+        in
+        Hashtbl.add covered_bounds_by_id provenance.id bounds;
+        bounds
+    in
+    (* [ancestor] entails [entry] on an axis iff its required value there
+       is below (at least as strong as) the entry's: [co_sub] is bot
+       exactly on those axes. Axes where [ancestor] reports nothing are
+       top after restriction and thus never entail a reported axis. *)
+    let entailed_axes ~ancestor entry =
+      Axis_lattice.co_sub ancestor entry.mode_bounds
+      |> Axis_lattice.non_bot_axes
+      |> List.map Axis_lattice.axis_number_to_axis_packed
+      |> axis_set_of_axes |> Jkind_axis.Axis_set.complement
+    in
+    entries
+    |> List.filter_map (fun entry ->
+        let parent_bounds =
+          match entry.provenance.parent with
+          | None -> []
+          | Some parent -> covered_bounds (find_provenance parent)
+        in
+        let covered =
+          List.fold_left
+            (fun covered ancestor ->
+              Jkind_axis.Axis_set.union covered (entailed_axes ~ancestor entry))
+            Jkind_axis.Axis_set.empty parent_bounds
+        in
+        let axes =
+          List.filter
+            (fun (Jkind_axis.Axis.Pack axis) ->
+              not (Jkind_axis.Axis_set.mem covered axis))
+            entry.axes
+        in
+        match axes with
+        | [] -> None
+        | _ :: _ ->
+          Some
+            { entry with
+              axes;
+              mode_bounds = restrict_mode_bounds_to_axes entry.mode_bounds axes
+            })
+    |> List.fold_left merge_same_source []
     |> List.fold_left add_provenance_residual []
     |> Option.some
 
@@ -772,21 +990,14 @@ let residual_mode_strings { mode_bounds; axes; _ } =
      non-top on other axes; see [axes_in_violation_order]), then let
      [Typemode] drop implied modes (e.g. [aliased] when [global] is
      required) the same way jkind annotations are printed. *)
-  let reported =
-    List.fold_left
-      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
-      Jkind_axis.Axis_set.empty axes
-  in
-  let restricted =
-    Axis_lattice.join mode_bounds
-      (Axis_lattice.of_axis_set (Jkind_axis.Axis_set.complement reported))
-  in
+  let restricted = restrict_mode_bounds_to_axes mode_bounds axes in
   Jkind.Mod_bounds.of_axis_lattice restricted
   |> Typemode.close_implied_mod_bounds
   |> Typemode.untransl_mod_bounds ~verbose:false
   |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let pp_provenance_residual ppf ({ ty; plural; _ } as residual) =
+let pp_provenance_residual ppf
+    ({ provenance = { ty; plural; _ }; _ } as residual) =
   (* Phrase subjects ("mutable fields", "boxed records") are plural noun
      phrases; type-expression subjects read as singular. *)
   let verb = if plural then "are" else "is" in
@@ -810,10 +1021,8 @@ let pp_type_definition_kind_annotation env ppf super_jkind =
     (Jkind.format env) super_jkind
 
 let report_provenance_mode_crossing_error env ppf
-    { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =
-  match
-    provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
-  with
+    { super_jkind; provenance_residuals; _ } =
+  match provenance_residuals with
   | None | Some [] -> None
   | Some [entry] ->
     Some
@@ -1169,8 +1378,8 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
 
 (* Package the above into a full evaluation context. *)
 let create_ctx ~(mode : Solver.mode) ~(env : Env.t option) =
-  Solver.create_ctx ~mode ~env ~add_provenance:false
-    ~lookup_of_env:(fun env path -> lookup_of_env ~env path)
+  Solver.create_ctx ~mode ~env ~lookup_of_env:(fun env path ->
+      lookup_of_env ~env path)
 
 let normalize ~(env : Env.t option) (jkind : Types.jkind_l) : Ldd.node =
   let ctx = create_ctx ~mode:Solver.Normal ~env in
@@ -1309,10 +1518,10 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
     ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
 
-let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
-    (bound : Types.jkind_l) : subcheck_polys =
+let compute_provenance_bound_polys ?decl_uid_under_check env
+    ~(lhs : Solver.ctx -> Ldd.node) (bound : Types.jkind_l) : subcheck_polys =
   compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
-      let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
+      let ctx = Solver.with_provenance ?decl_uid_under_check ctx in
       lhs ctx)
 
 let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
@@ -1327,20 +1536,23 @@ let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
            super_jkind;
            sub_poly;
            super_poly;
-           provenance_names = Provenance.all_names ();
-           violating_axes
+           provenances = Provenance.all ();
+           violating_axes;
+           provenance_residuals = None
          })
 
-let subjkind_error_has_provenance_residuals = function
-  | Jkind_error _ -> false
+let subjkind_error_with_provenance_residuals = function
+  | Jkind_error _ -> None
   | Mode_crossing_error
-      { sub_poly; super_poly; provenance_names; violating_axes; _ } -> (
+      ({ sub_poly; super_poly; provenances; violating_axes; _ } as error) -> (
     match
-      provenance_residuals ~provenance_names ~violating_axes ~sub_poly
-        ~super_poly
+      provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly
     with
-    | None | Some [] -> false
-    | Some (_ :: _) -> true)
+    | None | Some [] -> None
+    | Some (_ :: _ as provenance_residuals) ->
+      Some
+        (Mode_crossing_error
+           { error with provenance_residuals = Some provenance_residuals }))
 
 let same_axis_set axes1 axes2 =
   let of_list =
@@ -1364,25 +1576,29 @@ let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
     | None -> Error error
     | Some fallback_error -> Error fallback_error
   in
-  let provenance_check =
-    match make_polys () with
-    | provenance_polys ->
+  let select_provenance_error () =
+    match
       check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind ~printing_env
-        provenance_polys
+        (make_polys ())
+    with
+    | Ok () -> None
+    | Error provenance_error ->
+      if subjkind_errors_have_same_violating_axes actual_error provenance_error
+      then subjkind_error_with_provenance_residuals provenance_error
+      else None
+  in
+  let provenance_error =
+    match select_provenance_error () with
+    | provenance_error -> provenance_error
     | exception
         ((Misc.Fatal_error _ | Stack_overflow | Out_of_memory | Sys.Break) as exn)
       ->
       raise exn
-    | exception _ -> Ok ()
+    | exception _ -> None
   in
-  match provenance_check with
-  | Ok () -> fallback actual_error
-  | Error provenance_error ->
-    if
-      subjkind_errors_have_same_violating_axes actual_error provenance_error
-      && subjkind_error_has_provenance_residuals provenance_error
-    then Error provenance_error
-    else fallback actual_error
+  match provenance_error with
+  | None -> fallback actual_error
+  | Some provenance_error -> Error provenance_error
 
 let sub_jkind_l ?(allow_any_crossing = false) ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)
@@ -1424,8 +1640,8 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
           | Ok () -> Error ikind_error
           | Error jkind_error -> Error (Jkind_error jkind_error))
 
-let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
-    ~actual ~bound ~provenance_lhs =
+let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
+    ~type_equal ~context env ~actual ~bound ~provenance_lhs =
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
     sub_jkind_l ~allow_any_crossing ?origin ~type_equal ~context env actual
@@ -1465,7 +1681,8 @@ let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
         in
         best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
           ~super_jkind:bound ~printing_env:env actual_error (fun () ->
-            compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
+            compute_provenance_bound_polys ?decl_uid_under_check env
+              ~lhs:provenance_lhs bound)
 
 let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
   check_bound ?origin ~type_equal ~context env ~actual ~bound
@@ -1473,7 +1690,8 @@ let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
 
 let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
     ~decl ~actual ~bound =
-  check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+  check_bound ?allow_any_crossing ?origin
+    ~decl_uid_under_check:decl.Types.type_uid ~type_equal ~context env ~actual
     ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env

--- a/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
@@ -39,31 +39,60 @@ let fresh_unknown_uid () : Types.Uid.t =
   Types.Uid.mk ~current_unit
 
 module Provenance = struct
-  type id = Id of int
+  module Id : sig
+    type t = private int
+
+    val create : unit -> t
+
+    val equal : t -> t -> bool
+  end = struct
+    type t = int
+
+    let next = ref 0
+
+    let create () =
+      let id = !next in
+      incr next;
+      id
+
+    let equal = Int.equal
+  end
 
   type t =
-    { id : id;
+    { id : Id.t;
       ty : Format_doc.doc;
+          (** The subject as printed in the error message: a type-expression
+              head (["u"], ["'a"]) or a class-of-types phrase (["functions"]).
+          *)
       plural : bool;
+          (** Whether [ty] is a plural phrase, for verb agreement ("functions
+              are ..." vs "[u] is ..."). *)
       source_type_id : int option;
+          (** [Types.get_id] of the type expression this entry was registered
+              for; residual entries sharing it are merged into one message. *)
       is_decl_under_check : bool;
-      parent : id option
+          (** The subject is the declaration whose bound is being checked; such
+              self-occurrences are never reported as causes. *)
+      parent : Id.t option
+          (** The entry for the enclosing subject on the same nesting path, or
+              [None] at the top level. Used to drop a nested entry whose
+              requirement is entailed by an ancestor's. *)
     }
-
-  let next_id = ref 0
 
   let entries : t list ref = ref []
 
-  let equal_id (Id id1) (Id id2) = Int.equal id1 id2
-
-  let name { id = Id id; ty; plural; _ } = Ldd.Name.provenance ~id ~ty ~plural
+  let name { id; ty; plural; _ } =
+    Ldd.Name.provenance ~id:(id :> int) ~ty ~plural
 
   let make ~plural ~source_type_id ~is_decl_under_check ~parent ty =
-    let next = !next_id in
-    next_id := next + 1;
-    let id = Id next in
     let provenance =
-      { id; ty; plural; source_type_id; is_decl_under_check; parent }
+      { id = Id.create ();
+        ty;
+        plural;
+        source_type_id;
+        is_decl_under_check;
+        parent
+      }
     in
     entries := provenance :: !entries;
     provenance
@@ -153,9 +182,9 @@ module Solver = struct
     | Poly of Ldd.node * Ldd.node array
 
   and provenance_ctx =
-    { parent : Provenance.id option;
+    { parent : Provenance.Id.t option;
       decl_uid_under_check : Types.Uid.t option;
-      kinds : (int * Provenance.id option, Ldd.node) Hashtbl.t
+      kinds : (type_id:int * parent:Provenance.Id.t option, Ldd.node) Hashtbl.t
     }
 
   and ctx =
@@ -186,7 +215,8 @@ module Solver = struct
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
-  let with_provenance ?decl_uid_under_check (ctx : ctx) : ctx =
+  let with_provenance ~(decl_uid_under_check : Types.Uid.t option) (ctx : ctx) :
+      ctx =
     { ctx with
       provenance =
         Some { parent = None; decl_uid_under_check; kinds = Hashtbl.create 1 };
@@ -199,13 +229,14 @@ module Solver = struct
   let find_provenance_kind (ctx : ctx) (ty : Types.type_expr) =
     match ctx.provenance with
     | None -> None
-    | Some { parent; kinds } -> Hashtbl.find_opt kinds (Types.get_id ty, parent)
+    | Some { parent; kinds } ->
+      Hashtbl.find_opt kinds (~type_id:(Types.get_id ty), ~parent)
 
   let cache_provenance_kind (ctx : ctx) (ty : Types.type_expr) kind =
     match ctx.provenance with
     | None -> ()
     | Some { parent; kinds } ->
-      Hashtbl.replace kinds (Types.get_id ty, parent) kind
+      Hashtbl.replace kinds (~type_id:(Types.get_id ty), ~parent) kind
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode, name with
@@ -827,7 +858,7 @@ let merge_same_source entries entry =
       in
       List.map
         (fun candidate ->
-          if Provenance.equal_id candidate.provenance.id other.provenance.id
+          if Provenance.Id.equal candidate.provenance.id other.provenance.id
           then merged
           else candidate)
         entries)
@@ -911,7 +942,7 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
       (fun (provenance : Provenance.t) ->
         Hashtbl.add provenances_by_id provenance.id provenance)
       provenances;
-    let exception Missing_provenance_parent of Provenance.id in
+    let exception Missing_provenance_parent of Provenance.Id.t in
     let find_provenance id =
       match Hashtbl.find_opt provenances_by_id id with
       | Some provenance -> provenance
@@ -1518,10 +1549,10 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
     ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
 
-let compute_provenance_bound_polys ?decl_uid_under_check env
+let compute_provenance_bound_polys ~decl_uid_under_check env
     ~(lhs : Solver.ctx -> Ldd.node) (bound : Types.jkind_l) : subcheck_polys =
   compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
-      let ctx = Solver.with_provenance ?decl_uid_under_check ctx in
+      let ctx = Solver.with_provenance ~decl_uid_under_check ctx in
       lhs ctx)
 
 let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
@@ -1640,7 +1671,7 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
           | Ok () -> Error ikind_error
           | Error jkind_error -> Error (Jkind_error jkind_error))
 
-let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
+let check_bound ?(allow_any_crossing = false) ?origin ~decl_uid_under_check
     ~type_equal ~context env ~actual ~bound ~provenance_lhs =
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
@@ -1681,18 +1712,19 @@ let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
         in
         best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
           ~super_jkind:bound ~printing_env:env actual_error (fun () ->
-            compute_provenance_bound_polys ?decl_uid_under_check env
+            compute_provenance_bound_polys ~decl_uid_under_check env
               ~lhs:provenance_lhs bound)
 
 let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
-  check_bound ?origin ~type_equal ~context env ~actual ~bound
-    ~provenance_lhs:(fun ctx -> Solver.kind ~use_tables:true ctx ty)
+  check_bound ?origin ~decl_uid_under_check:None ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs:(fun ctx ->
+      Solver.kind ~use_tables:true ctx ty)
 
 let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
     ~decl ~actual ~bound =
   check_bound ?allow_any_crossing ?origin
-    ~decl_uid_under_check:decl.Types.type_uid ~type_equal ~context env ~actual
-    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
+    ~decl_uid_under_check:(Some decl.Types.type_uid) ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =

--- a/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ikind.ml
@@ -39,44 +39,72 @@ let fresh_unknown_uid () : Types.Uid.t =
   Types.Uid.mk ~current_unit
 
 module Provenance = struct
+  type id = Id of int
+
+  type t =
+    { id : id;
+      ty : Format_doc.doc;
+      plural : bool;
+      source_type_id : int option;
+      is_decl_under_check : bool;
+      parent : id option
+    }
+
   let next_id = ref 0
 
-  let names : Ldd.Name.t list ref = ref []
+  let entries : t list ref = ref []
 
-  let register_doc ~plural ty : Ldd.Name.t =
-    let id = !next_id in
-    next_id := id + 1;
-    let name = Ldd.Name.provenance ~id ~ty ~plural in
-    names := name :: !names;
-    name
+  let equal_id (Id id1) (Id id2) = Int.equal id1 id2
 
-  let register_text ~plural text =
-    register_doc ~plural (Format_doc.doc_printf "%s" text)
+  let name { id = Id id; ty; plural; _ } = Ldd.Name.provenance ~id ~ty ~plural
 
-  let register (ty : Types.type_expr) : Ldd.Name.t =
+  let make ~plural ~source_type_id ~is_decl_under_check ~parent ty =
+    let next = !next_id in
+    next_id := next + 1;
+    let id = Id next in
+    let provenance =
+      { id; ty; plural; source_type_id; is_decl_under_check; parent }
+    in
+    entries := provenance :: !entries;
+    provenance
+
+  let register ~is_decl_under_check ~parent (ty : Types.type_expr) =
     (* A surviving residual for an occurrence reflects only the head
        constructor's own contribution (the decomposition zeroes anything
        flowing through a separately-tracked inner type or parameter), so
        name the head rather than the full type expression: the constructor
        for [Tconstr], a class-of-types phrase for the built-in shapes. *)
-    let register_type ty =
+    let register_type ~source_type ty =
       Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
-      |> register_doc ~plural:false
+      |> make ~plural:false
+           ~source_type_id:(Some (Types.get_id source_type))
+           ~is_decl_under_check ~parent
+    in
+    let register_text text =
+      make ~plural:true
+        ~source_type_id:(Some (Types.get_id ty))
+        ~is_decl_under_check ~parent
+        (Format_doc.doc_printf "%s" text)
     in
     match Types.get_desc ty with
-    | Types.Tarrow _ -> register_text ~plural:true "functions"
-    | Types.Ttuple _ -> register_text ~plural:true "tuples"
-    | Types.Tunboxed_tuple _ -> register_text ~plural:true "unboxed tuples"
-    | Types.Tobject _ -> register_text ~plural:true "objects"
-    | Types.Tvariant _ -> register_text ~plural:true "polymorphic variants"
-    | Types.Tpackage _ -> register_text ~plural:true "first-class modules"
+    | Types.Tarrow _ -> register_text "functions"
+    | Types.Ttuple _ -> register_text "tuples"
+    | Types.Tunboxed_tuple _ -> register_text "unboxed tuples"
+    | Types.Tobject _ -> register_text "objects"
+    | Types.Tvariant _ -> register_text "polymorphic variants"
+    | Types.Tpackage _ -> register_text "first-class modules"
     | Types.Tconstr (path, _ :: _, _) ->
-      register_type (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
-    | _ -> register_type ty
+      register_type ~source_type:ty
+        (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
+    | _ -> register_type ~source_type:ty ty
 
-  let reset () = names := []
+  let register_phrase ~parent text =
+    make ~plural:true ~source_type_id:None ~is_decl_under_check:false ~parent
+      (Format_doc.doc_printf "%s" text)
 
-  let all_names () = List.rev !names
+  let reset () = entries := []
+
+  let all () = List.rev !entries
 end
 
 (** A kind solver specialized to [Types.Ldd] and [Types.type_expr].
@@ -88,6 +116,12 @@ module Solver = struct
   type mode =
     | Normal
     | Round_up
+
+  let rec uid_is_reliable_identity = function
+    | Types.Uid.Internal -> false
+    | Types.Uid.Unboxed_version uid -> uid_is_reliable_identity uid
+    | Types.Uid.Compilation_unit _ | Types.Uid.Item _ | Types.Uid.Predef _ ->
+      true
 
   (* Hash tables avoiding polymorphic structural comparison on deep values.
      [Btype.TypeHash] keys by the representative of a [type_expr], so
@@ -118,11 +152,17 @@ module Solver = struct
         }
     | Poly of Ldd.node * Ldd.node array
 
+  and provenance_ctx =
+    { parent : Provenance.id option;
+      decl_uid_under_check : Types.Uid.t option;
+      kinds : (int * Provenance.id option, Ldd.node) Hashtbl.t
+    }
+
   and ctx =
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
-      add_provenance : bool;
+      provenance : provenance_ctx option;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -132,22 +172,40 @@ module Solver = struct
   let global_constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t =
     ConstrTbl.create 1
 
-  let create_ctx ~(mode : mode) ~(env : Env.t option) ~add_provenance
+  let create_ctx ~(mode : mode) ~(env : Env.t option)
       ~(lookup_of_env : Env.t -> Path.t -> constr_decl) =
     TyTbl.clear global_ty_to_kind;
     ConstrTbl.clear global_constr_to_coeffs;
     { env;
       lookup_of_env;
       mode;
-      add_provenance;
+      provenance = None;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
-  let reset_for_provenance (ctx : ctx) ~(add_provenance : bool) : ctx =
-    { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
+  let with_provenance ?decl_uid_under_check (ctx : ctx) : ctx =
+    { ctx with
+      provenance =
+        Some { parent = None; decl_uid_under_check; kinds = Hashtbl.create 1 };
+      ty_to_kind = TyTbl.create 1
+    }
+
+  let without_provenance (ctx : ctx) : ctx =
+    { ctx with provenance = None; ty_to_kind = TyTbl.create 1 }
+
+  let find_provenance_kind (ctx : ctx) (ty : Types.type_expr) =
+    match ctx.provenance with
+    | None -> None
+    | Some { parent; kinds } -> Hashtbl.find_opt kinds (Types.get_id ty, parent)
+
+  let cache_provenance_kind (ctx : ctx) (ty : Types.type_expr) kind =
+    match ctx.provenance with
+    | None -> ()
+    | Some { parent; kinds } ->
+      Hashtbl.replace kinds (Types.get_id ty, parent) kind
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode, name with
@@ -159,17 +217,34 @@ module Solver = struct
     let param_id = Types.get_id ty in
     rigid_name ctx (Ldd.Name.param param_id)
 
-  let provenance (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
-    rigid_name ctx (Provenance.register ty)
-
-  let provenance_text (ctx : ctx) (text : string) : Ldd.node =
-    rigid_name ctx (Provenance.register_text ~plural:true text)
+  let provenance_and_child_ctx (ctx : ctx) (ty : Types.type_expr) =
+    match ctx.provenance with
+    | None -> Fun.id, ctx
+    | Some ({ parent; _ } as provenance_ctx) ->
+      let is_decl_under_check =
+        match
+          provenance_ctx.decl_uid_under_check, ctx.env, Types.get_desc ty
+        with
+        | Some decl_uid, Some env, Types.Tconstr (path, _, _)
+          when uid_is_reliable_identity decl_uid -> (
+          match Env.find_type path env with
+          | exception Not_found -> false
+          | decl -> Types.Uid.equal decl_uid decl.type_uid)
+        | None, _, _ | Some _, None, _ | Some _, Some _, _ -> false
+      in
+      let provenance = Provenance.register ~is_decl_under_check ~parent ty in
+      ( (fun poly -> Ldd.meet poly (rigid_name ctx (Provenance.name provenance))),
+        { ctx with
+          provenance = Some { provenance_ctx with parent = Some provenance.id }
+        } )
 
   let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
       : Ldd.node =
-    if ctx.add_provenance
-    then Ldd.meet poly (provenance_text ctx (text ()))
-    else poly
+    match ctx.provenance with
+    | None -> poly
+    | Some { parent; _ } ->
+      let provenance = Provenance.register_phrase ~parent (text ()) in
+      Ldd.meet poly (rigid_name ctx (Provenance.name provenance))
 
   let rec type_may_be_circular (ty : Types.type_expr) : bool =
     match Types.get_desc ty with
@@ -336,28 +411,22 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr ~self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
-      : Ldd.node =
+  and constr ~self_provenance ~arg_ctx (ctx : ctx) (path : Path.t)
+      (args : Types.type_expr list) : Ldd.node =
     let constr_ctx =
-      if ctx.add_provenance
-      then reset_for_provenance ctx ~add_provenance:false
-      else ctx
+      match ctx.provenance with None -> ctx | Some _ -> without_provenance ctx
     in
     let base, coeffs =
       constr_kind constr_ctx ~min_arity:(List.length args) path
     in
-    let base =
-      if ctx.add_provenance
-      then Ldd.meet base (provenance ctx self_ty)
-      else base
-    in
+    let base = self_provenance base in
     let rec loop acc remaining i =
       if i = Array.length coeffs
       then acc
       else
         match remaining with
         | arg :: rest ->
-          let arg_kind = kind ~use_tables:true ctx arg in
+          let arg_kind = kind ~use_tables:true arg_ctx arg in
           loop (Ldd.join acc (Ldd.meet arg_kind coeffs.(i))) rest (i + 1)
         | [] -> failwith "Missing arg"
     in
@@ -468,23 +537,34 @@ module Solver = struct
     else
       match TyTbl.find_opt ctx.ty_to_kind ty with
       | Some kind_poly -> kind_poly
-      | None ->
-        if not use_tables
-        then kind_uncached ctx ty
-        else if type_may_be_circular ty
-        then (
-          let var = Ldd.new_var () in
-          let placeholder = Ldd.node_of_var var in
-          TyTbl.add ctx.ty_to_kind ty placeholder;
-          let kind_rhs = kind_uncached ctx ty in
-          Ldd.solve_lfp var kind_rhs;
-          let kind_inlined = Ldd.inline_solved_vars placeholder in
-          TyTbl.replace ctx.ty_to_kind ty kind_inlined;
-          kind_inlined)
-        else
-          let kind_rhs = kind_uncached ctx ty in
-          TyTbl.add ctx.ty_to_kind ty kind_rhs;
-          kind_rhs
+      | None -> (
+        let cached_provenance_kind =
+          if use_tables then find_provenance_kind ctx ty else None
+        in
+        match cached_provenance_kind with
+        | Some kind_poly -> kind_poly
+        | None ->
+          if not use_tables
+          then kind_uncached ctx ty
+          else if type_may_be_circular ty
+          then (
+            let var = Ldd.new_var () in
+            let placeholder = Ldd.node_of_var var in
+            TyTbl.add ctx.ty_to_kind ty placeholder;
+            let kind_rhs = kind_uncached ctx ty in
+            Ldd.solve_lfp var kind_rhs;
+            let kind_inlined = Ldd.inline_solved_vars placeholder in
+            if Option.is_some ctx.provenance
+            then TyTbl.remove ctx.ty_to_kind ty
+            else TyTbl.replace ctx.ty_to_kind ty kind_inlined;
+            cache_provenance_kind ctx ty kind_inlined;
+            kind_inlined)
+          else
+            let kind_rhs = kind_uncached ctx ty in
+            if Option.is_none ctx.provenance
+            then TyTbl.add ctx.ty_to_kind ty kind_rhs;
+            cache_provenance_kind ctx ty kind_rhs;
+            kind_rhs)
 
   (* Worker for [kind]; does not memoize.
      Only call from [kind] so caching and LFP handling apply. *)
@@ -492,19 +572,24 @@ module Solver = struct
     (* Compute the ikind polynomial for an arbitrary [type_expr]. This is the
        semantic counterpart of [Jkind.jkind_of_type], but expressed in LDD
        form. *)
-    let self_provenance poly =
-      if ctx.add_provenance then Ldd.meet poly (provenance ctx ty) else poly
-    in
     (* [ty] is expected to be representative: no links/substs/fields/nil.
        Provenance is attached only to the contribution introduced by this
        node, not to recursive child contributions. *)
-    match Types.get_desc ty with
+    let desc = Types.get_desc ty in
+    let self_provenance, child_ctx =
+      match desc with
+      | Types.Tlink _ | Types.Tsubst _ | Types.Trepr _ | Types.Tpoly _
+      | Types.Tmod _ | Types.Tfield _ | Types.Tnil ->
+        Fun.id, ctx
+      | _ -> provenance_and_child_ctx ctx ty
+    in
+    match desc with
     | Types.Tvar { name = _name; jkind } | Types.Tunivar { name = _name; jkind }
       ->
       (* Keep a rigid param, but cap it by its annotated jkind. *)
-      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind))
+      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind child_ctx jkind))
     | Types.Tconstr (path, args, _abbrev_memo) ->
-      constr ~self_ty:ty ctx path args
+      constr ~self_provenance ~arg_ctx:child_ctx ctx path args
     | Types.Tmod (ty, mod_bounds) ->
       Ldd.meet
         (kind ~use_tables:true ctx ty)
@@ -513,12 +598,12 @@ module Solver = struct
       (* Boxed tuples: immutable_data base + per-element contributions
          under id modality. *)
       let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
-      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
+      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true child_ctx t)
     | Types.Tunboxed_tuple elts ->
       (* Unboxed tuples: per-element contributions; shallow axes relevant
          only for arity = 1. *)
       Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
-          kind ~use_tables:true ctx t)
+          kind ~use_tables:true child_ctx t)
     | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
       (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
       self_provenance (Ldd.const Axis_lattice.arrow)
@@ -534,11 +619,11 @@ module Solver = struct
          a viable setting in practice. Track removing this workaround as part
          of internal ticket 5746. *)
       kind ~check_principality:false ~use_tables:true ctx ty
-    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind ctx jkind)
+    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind child_ctx jkind)
     | Types.Tobject _ -> self_provenance (Ldd.const Axis_lattice.object_legacy)
     | Types.Tbox t ->
       let base = self_provenance (Ldd.const Axis_lattice.mutable_data) in
-      Ldd.join base (kind ~use_tables:true ctx t)
+      Ldd.join base (kind ~use_tables:true child_ctx t)
     | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
     | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
     | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
@@ -555,7 +640,7 @@ module Solver = struct
           let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
           Btype.fold_row
             (fun acc ty ->
-              let ty_kind = kind ~use_tables:true ctx ty in
+              let ty_kind = kind ~use_tables:true child_ctx ty in
               Ldd.join acc ty_kind)
             base row
         else
@@ -657,13 +742,20 @@ let axes_in_violation_order ~violating_axes axes =
       List.exists (Jkind_axis.Axis.equal violating_axis) axes)
     violating_axes
 
+type provenance_residual =
+  { provenance : Provenance.t;
+    mode_bounds : Axis_lattice.t;
+    axes : Jkind_axis.Axis.packed list
+  }
+
 type mode_crossing_error =
   { printing_env : Env.t;
     super_jkind : Types.jkind_l;
     sub_poly : Ldd.node;
     super_poly : Ldd.node;
-    provenance_names : Ldd.Name.t list;
-    violating_axes : Jkind_axis.Axis.packed list
+    provenances : Provenance.t list;
+    violating_axes : Jkind_axis.Axis.packed list;
+    provenance_residuals : provenance_residual list option
   }
 
 type subjkind_error =
@@ -677,24 +769,17 @@ let subjkind_error_printing_env = function
 let map_jkind_error result =
   Result.map_error (fun error -> Jkind_error error) result
 
-type provenance_residual =
-  { ty : Format_doc.doc;
-    plural : bool;
-    mode_bounds : Axis_lattice.t;
-    axes : Jkind_axis.Axis.packed list
-  }
-
-let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
-    =
+let add_provenance_residual entries
+    ({ provenance = { ty; plural; _ }; mode_bounds; axes } as entry) =
   (* Deduplicate identical entries (e.g. two fields of type [int ref] under
      the same bound), keeping first-occurrence order. Entries that merely
      share a printed name (e.g. two constructor-local existentials both
      rendered ['a]) can have different requirements and must stay separate. *)
   let duplicate other =
     String.equal
-      (Format_doc.asprintf "%a" Format_doc.pp_doc other.ty)
+      (Format_doc.asprintf "%a" Format_doc.pp_doc other.provenance.ty)
       (Format_doc.asprintf "%a" Format_doc.pp_doc ty)
-    && Bool.equal other.plural plural
+    && Bool.equal other.provenance.plural plural
     && Axis_lattice.equal other.mode_bounds mode_bounds
     && List.length other.axes = List.length axes
     && List.for_all
@@ -703,8 +788,52 @@ let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
   in
   if List.exists duplicate entries then entries else entries @ [entry]
 
-let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
-    =
+let axis_set_of_axes axes =
+  List.fold_left
+    (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+    Jkind_axis.Axis_set.empty axes
+
+let restrict_mode_bounds_to_axes mode_bounds axes =
+  Axis_lattice.join mode_bounds
+    (Axis_lattice.of_axis_set
+       (Jkind_axis.Axis_set.complement (axis_set_of_axes axes)))
+
+let merge_same_source entries entry =
+  match entry.provenance.source_type_id with
+  | None -> entries @ [entry]
+  | Some source_type_id -> (
+    match
+      List.find_opt
+        (fun other ->
+          Option.equal Int.equal other.provenance.source_type_id
+            (Some source_type_id))
+        entries
+    with
+    | None -> entries @ [entry]
+    | Some other ->
+      let axes =
+        List.fold_left
+          (fun axes axis ->
+            if List.exists (Jkind_axis.Axis.equal axis) axes
+            then axes
+            else axes @ [axis])
+          other.axes entry.axes
+      in
+      let merged =
+        { other with
+          mode_bounds = Axis_lattice.meet other.mode_bounds entry.mode_bounds;
+          axes
+        }
+      in
+      List.map
+        (fun candidate ->
+          if Provenance.equal_id candidate.provenance.id other.provenance.id
+          then merged
+          else candidate)
+        entries)
+
+let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
+  let provenance_names = List.map Provenance.name provenances in
   let provenance_vars = List.map Ldd.rigid provenance_names in
   (* For a declaration [type t : bound = rhs], ikind checking compares the
      inferred ikind polynomial for [rhs] against the polynomial for [bound].
@@ -717,9 +846,10 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
        satisfy the required bound?
 
      This is the right question because the provenance variable stands for the
-     mode-crossing behavior we need from the source type. It gives the least
-     restrictive bound that would still make the original lattice comparison
-     pass.
+     mode-crossing behavior we need from the source type. Before rounding, its
+     answer is the least restrictive bound that would make this contribution
+     satisfy the required bound. Rounding down may strengthen that answer when
+     converting it to a concrete mode bound for printing.
 
      We answer the question by first decomposing the provenance-annotated
      polynomial into an untracked base plus one coefficient per provenance
@@ -738,12 +868,14 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
   match Ldd.leq_with_reason base super_poly with
   | _ :: _ -> None
   | [] ->
-    List.combine provenance_names coeffs
-    |> List.filter_map (fun (name, coeff) ->
-        match (name : Ldd.Name.t) with
-        | Atom _ | KAtom _ | Param _ | Unknown _ -> None
-        | Provenance { ty; plural; _ } -> (
-          if is_bot_poly coeff
+    (* Self occurrences stay in the decomposition universe and provenance
+       forest, but are not independent causes to report for their own
+       declaration. Filtering here also prevents them from hiding nested
+       causes as enclosing residuals. *)
+    let entries =
+      List.combine provenances coeffs
+      |> List.filter_map (fun ((provenance : Provenance.t), coeff) ->
+          if provenance.is_decl_under_check || is_bot_poly coeff
           then None
           else
             let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
@@ -763,7 +895,93 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                  axes left to report. *)
               match axes with
               | [] -> None
-              | _ :: _ -> Some { ty; plural; mode_bounds; axes }))
+              | _ :: _ -> Some { provenance; mode_bounds; axes })
+    in
+    (* [raw_bounds_by_id] holds, per surviving raw entry, its requirement
+       restricted to its reported axes (top elsewhere): the exact per-axis
+       VALUES the entry's message will demand of its subject. *)
+    let raw_bounds_by_id = Hashtbl.create (List.length entries) in
+    List.iter
+      (fun entry ->
+        Hashtbl.add raw_bounds_by_id entry.provenance.id
+          (restrict_mode_bounds_to_axes entry.mode_bounds entry.axes))
+      entries;
+    let provenances_by_id = Hashtbl.create (List.length provenances) in
+    List.iter
+      (fun (provenance : Provenance.t) ->
+        Hashtbl.add provenances_by_id provenance.id provenance)
+      provenances;
+    let exception Missing_provenance_parent of Provenance.id in
+    let find_provenance id =
+      match Hashtbl.find_opt provenances_by_id id with
+      | Some provenance -> provenance
+      | None -> raise (Missing_provenance_parent id)
+    in
+    (* An enclosing entry only explains a nested requirement it ENTAILS:
+       same axis and an at-least-as-strong required value. Requirements
+       are kept as a list per ancestor rather than meet-collapsed into a
+       single lattice element: on the diamond axes (portability,
+       contention) the meet of two incomparable ancestor requirements
+       (e.g. shareable and corruptible) would wrongly claim to cover a
+       strictly stronger nested one (portable) that neither ancestor
+       explains. The [parent] links form an acyclic forest, so the walk
+       terminates. *)
+    let covered_bounds_by_id = Hashtbl.create (List.length provenances) in
+    let rec covered_bounds (provenance : Provenance.t) =
+      match Hashtbl.find_opt covered_bounds_by_id provenance.id with
+      | Some bounds -> bounds
+      | None ->
+        let parent_bounds =
+          match provenance.parent with
+          | None -> []
+          | Some parent -> covered_bounds (find_provenance parent)
+        in
+        let bounds =
+          match Hashtbl.find_opt raw_bounds_by_id provenance.id with
+          | None -> parent_bounds
+          | Some own -> own :: parent_bounds
+        in
+        Hashtbl.add covered_bounds_by_id provenance.id bounds;
+        bounds
+    in
+    (* [ancestor] entails [entry] on an axis iff its required value there
+       is below (at least as strong as) the entry's: [co_sub] is bot
+       exactly on those axes. Axes where [ancestor] reports nothing are
+       top after restriction and thus never entail a reported axis. *)
+    let entailed_axes ~ancestor entry =
+      Axis_lattice.co_sub ancestor entry.mode_bounds
+      |> Axis_lattice.non_bot_axes
+      |> List.map Axis_lattice.axis_number_to_axis_packed
+      |> axis_set_of_axes |> Jkind_axis.Axis_set.complement
+    in
+    entries
+    |> List.filter_map (fun entry ->
+        let parent_bounds =
+          match entry.provenance.parent with
+          | None -> []
+          | Some parent -> covered_bounds (find_provenance parent)
+        in
+        let covered =
+          List.fold_left
+            (fun covered ancestor ->
+              Jkind_axis.Axis_set.union covered (entailed_axes ~ancestor entry))
+            Jkind_axis.Axis_set.empty parent_bounds
+        in
+        let axes =
+          List.filter
+            (fun (Jkind_axis.Axis.Pack axis) ->
+              not (Jkind_axis.Axis_set.mem covered axis))
+            entry.axes
+        in
+        match axes with
+        | [] -> None
+        | _ :: _ ->
+          Some
+            { entry with
+              axes;
+              mode_bounds = restrict_mode_bounds_to_axes entry.mode_bounds axes
+            })
+    |> List.fold_left merge_same_source []
     |> List.fold_left add_provenance_residual []
     |> Option.some
 
@@ -772,21 +990,14 @@ let residual_mode_strings { mode_bounds; axes; _ } =
      non-top on other axes; see [axes_in_violation_order]), then let
      [Typemode] drop implied modes (e.g. [aliased] when [global] is
      required) the same way jkind annotations are printed. *)
-  let reported =
-    List.fold_left
-      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
-      Jkind_axis.Axis_set.empty axes
-  in
-  let restricted =
-    Axis_lattice.join mode_bounds
-      (Axis_lattice.of_axis_set (Jkind_axis.Axis_set.complement reported))
-  in
+  let restricted = restrict_mode_bounds_to_axes mode_bounds axes in
   Jkind.Mod_bounds.of_axis_lattice restricted
   |> Typemode.close_implied_mod_bounds
   |> Typemode.untransl_mod_bounds ~verbose:false
   |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let pp_provenance_residual ppf ({ ty; plural; _ } as residual) =
+let pp_provenance_residual ppf
+    ({ provenance = { ty; plural; _ }; _ } as residual) =
   (* Phrase subjects ("mutable fields", "boxed records") are plural noun
      phrases; type-expression subjects read as singular. *)
   let verb = if plural then "are" else "is" in
@@ -810,10 +1021,8 @@ let pp_type_definition_kind_annotation env ppf super_jkind =
     (Jkind.format env) super_jkind
 
 let report_provenance_mode_crossing_error env ppf
-    { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =
-  match
-    provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
-  with
+    { super_jkind; provenance_residuals; _ } =
+  match provenance_residuals with
   | None | Some [] -> None
   | Some [entry] ->
     Some
@@ -1169,8 +1378,8 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
 
 (* Package the above into a full evaluation context. *)
 let create_ctx ~(mode : Solver.mode) ~(env : Env.t option) =
-  Solver.create_ctx ~mode ~env ~add_provenance:false
-    ~lookup_of_env:(fun env path -> lookup_of_env ~env path)
+  Solver.create_ctx ~mode ~env ~lookup_of_env:(fun env path ->
+      lookup_of_env ~env path)
 
 let normalize ~(env : Env.t option) (jkind : Types.jkind_l) : Ldd.node =
   let ctx = create_ctx ~mode:Solver.Normal ~env in
@@ -1309,10 +1518,10 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
     ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
 
-let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
-    (bound : Types.jkind_l) : subcheck_polys =
+let compute_provenance_bound_polys ?decl_uid_under_check env
+    ~(lhs : Solver.ctx -> Ldd.node) (bound : Types.jkind_l) : subcheck_polys =
   compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
-      let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
+      let ctx = Solver.with_provenance ?decl_uid_under_check ctx in
       lhs ctx)
 
 let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
@@ -1327,20 +1536,23 @@ let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
            super_jkind;
            sub_poly;
            super_poly;
-           provenance_names = Provenance.all_names ();
-           violating_axes
+           provenances = Provenance.all ();
+           violating_axes;
+           provenance_residuals = None
          })
 
-let subjkind_error_has_provenance_residuals = function
-  | Jkind_error _ -> false
+let subjkind_error_with_provenance_residuals = function
+  | Jkind_error _ -> None
   | Mode_crossing_error
-      { sub_poly; super_poly; provenance_names; violating_axes; _ } -> (
+      ({ sub_poly; super_poly; provenances; violating_axes; _ } as error) -> (
     match
-      provenance_residuals ~provenance_names ~violating_axes ~sub_poly
-        ~super_poly
+      provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly
     with
-    | None | Some [] -> false
-    | Some (_ :: _) -> true)
+    | None | Some [] -> None
+    | Some (_ :: _ as provenance_residuals) ->
+      Some
+        (Mode_crossing_error
+           { error with provenance_residuals = Some provenance_residuals }))
 
 let same_axis_set axes1 axes2 =
   let of_list =
@@ -1364,25 +1576,29 @@ let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
     | None -> Error error
     | Some fallback_error -> Error fallback_error
   in
-  let provenance_check =
-    match make_polys () with
-    | provenance_polys ->
+  let select_provenance_error () =
+    match
       check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind ~printing_env
-        provenance_polys
+        (make_polys ())
+    with
+    | Ok () -> None
+    | Error provenance_error ->
+      if subjkind_errors_have_same_violating_axes actual_error provenance_error
+      then subjkind_error_with_provenance_residuals provenance_error
+      else None
+  in
+  let provenance_error =
+    match select_provenance_error () with
+    | provenance_error -> provenance_error
     | exception
         ((Misc.Fatal_error | Stack_overflow | Out_of_memory | Sys.Break) as exn)
       ->
       raise exn
-    | exception _ -> Ok ()
+    | exception _ -> None
   in
-  match provenance_check with
-  | Ok () -> fallback actual_error
-  | Error provenance_error ->
-    if
-      subjkind_errors_have_same_violating_axes actual_error provenance_error
-      && subjkind_error_has_provenance_residuals provenance_error
-    then Error provenance_error
-    else fallback actual_error
+  match provenance_error with
+  | None -> fallback actual_error
+  | Some provenance_error -> Error provenance_error
 
 let sub_jkind_l ?(allow_any_crossing = false) ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)
@@ -1424,8 +1640,8 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
           | Ok () -> Error ikind_error
           | Error jkind_error -> Error (Jkind_error jkind_error))
 
-let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
-    ~actual ~bound ~provenance_lhs =
+let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
+    ~type_equal ~context env ~actual ~bound ~provenance_lhs =
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
     sub_jkind_l ~allow_any_crossing ?origin ~type_equal ~context env actual
@@ -1465,7 +1681,8 @@ let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
         in
         best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
           ~super_jkind:bound ~printing_env:env actual_error (fun () ->
-            compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
+            compute_provenance_bound_polys ?decl_uid_under_check env
+              ~lhs:provenance_lhs bound)
 
 let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
   check_bound ?origin ~type_equal ~context env ~actual ~bound
@@ -1473,7 +1690,8 @@ let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
 
 let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
     ~decl ~actual ~bound =
-  check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
+  check_bound ?allow_any_crossing ?origin
+    ~decl_uid_under_check:decl.Types.type_uid ~type_equal ~context env ~actual
     ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -1984,9 +1984,7 @@ Line 4, characters 0-77:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod portable contended,
-       because
-       - 'a is not mod portable
-       - b is not mod portable
+       because b is not mod portable.
 |}]
 
 type 'a t : value mod contended portable with 'a

--- a/testsuite/tests/typing-jkind-bounds/rectypes_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/rectypes_ikinds.ml
@@ -12,3 +12,19 @@ type 'a u = int constraint 'a = 'a * 'a
 [%%expect{|
 type 'a u = int constraint 'a = 'a * 'a
 |}]
+
+type bad : value
+type other : value
+type v : value mod contended = { x : (bad * other ref * 'a as 'a) }
+[%%expect {|
+type bad
+type other
+Line 3, characters 0-67:
+3 | type v : value mod contended = { x : (bad * other ref * 'a as 'a) }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
+       because
+       - bad is not mod contended
+       - ref is not mod contended
+|}]

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -839,8 +839,8 @@ Error: The kind of type "t" is immutable_data with bad outer
          because of the annotation on the declaration of the type t.
 |}]
 
-(* A self-recursive declaration currently lists itself as a cause
-   alongside the genuine carrier. *)
+(* A self-recursive declaration does not list itself as a cause; only
+   the genuine carrier is reported. *)
 type t : value mod portable = Leaf of (int -> int) | Node of t
 [%%expect {|
 Line 1, characters 0-62:
@@ -852,9 +852,8 @@ Error: The kind of type "t" is value non_float mod immutable
          because of the annotation on the declaration of the type t.
 |}]
 
-(* Mutually-recursive pair where the SIBLING (not self) is the carrier:
-   [t] reports both its self-occurrence and the group-mate [u]. Any
-   change to self-reporting must keep the [u] line. *)
+(* Mutually-recursive pair where the sibling (not self) is the carrier:
+   [t]'s self-occurrence is not reported, but the group-mate [u] is. *)
 type t : value mod portable = A of t | B of u
 and u = C of (int -> int)
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -745,6 +745,42 @@ Error: The kind of type "c" is
          portability: mod portable with 'a with t ≰ mod portable
 |}]
 
+(* Ancestor and descendant requirements can differ in VALUE on the same
+   axis: [outer]'s own portability requirement is only [corruptible],
+   while the nested [bad] must be fully [portable]. Portability is a
+   diamond (portable < {shareable, corruptible} < nonportable), so
+   neither requirement covers the other and both must be reported. *)
+type 'a outer : value mod shareable with 'a
+type bad : value
+type t : value mod portable = { x : bad outer }
+[%%expect {|
+type 'a outer : value mod shareable with 'a
+type bad
+Line 3, characters 0-47:
+3 | type t : value mod portable = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with bad outer
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Same on the contention diamond. *)
+type 'a outer : value mod shared with 'a
+type bad : value
+type t : value mod contended = { x : bad outer }
+[%%expect {|
+type 'a outer : value mod shared with 'a
+type bad
+Line 3, characters 0-48:
+3 | type t : value mod contended = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with bad outer
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -881,6 +881,42 @@ Error: The kind of type "t2" is value non_float mod immutable
          because of the annotation on the declaration of the type t2.
 |}]
 
+(* Chain-3 axis (externality), equal-value suppression: both subjects
+   require exactly [external64], so the enclosing subject entails the
+   nested one. *)
+type ('a : value) outer : value with 'a
+type bad : value
+type t : value mod external64 = { x : bad outer }
+[%%expect {|
+type 'a outer
+type bad
+Line 3, characters 0-49:
+3 | type t : value mod external64 = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with bad outer
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod external64
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Chain-3 entailment where the enclosing subject does not report the
+   axis at all: the nested [external64] requirement must survive. *)
+type ('a : value) outer2 : value mod external64 with 'a
+type bad2 : value
+type t2 : value mod portable external64 = { x : bad2 outer2 }
+[%%expect {|
+type 'a outer2 : value mod external64 with 'a
+type bad2
+Line 3, characters 0-61:
+3 | type t2 : value mod portable external64 = { x : bad2 outer2 }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t2" is immutable_data with bad2 outer2
+         because it's a boxed record type.
+       But the kind of type "t2" must be a subkind of
+           value mod portable external64
+         because of the annotation on the declaration of the type t2.
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -839,6 +839,48 @@ Error: The kind of type "t" is immutable_data with bad outer
          because of the annotation on the declaration of the type t.
 |}]
 
+(* A self-recursive declaration currently lists itself as a cause
+   alongside the genuine carrier. *)
+type t : value mod portable = Leaf of (int -> int) | Node of t
+[%%expect {|
+Line 1, characters 0-62:
+1 | type t : value mod portable = Leaf of (int -> int) | Node of t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value non_float mod immutable
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Mutually-recursive pair where the SIBLING (not self) is the carrier:
+   [t] reports both its self-occurrence and the group-mate [u]. Any
+   change to self-reporting must keep the [u] line. *)
+type t : value mod portable = A of t | B of u
+and u = C of (int -> int)
+[%%expect {|
+Line 1, characters 0-45:
+1 | type t : value mod portable = A of t | B of u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is value non_float mod immutable
+         because it's a boxed variant type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Sibling-only carrier (no self-occurrence in [t2]): a group-mate
+   subject is not self. *)
+type t2 : value mod portable = K of u2
+and u2 = L of (int -> int)
+[%%expect {|
+Line 1, characters 0-38:
+1 | type t2 : value mod portable = K of u2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t2" is value non_float mod immutable
+         because it's a boxed variant type.
+       But the kind of type "t2" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t2.
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -657,6 +657,94 @@ Error: The kind of type "c" is mutable_data with 'a
          because of the annotation on the declaration of the type c.
 |}]
 
+type t : value mod contended
+type 'a b = Foo of t * 'a
+type 'a c : value mod portable contended = { direct : 'a; nested : 'a b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of t * 'a
+Line 3, characters 0-73:
+3 | type 'a c : value mod portable contended = { direct : 'a; nested : 'a b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is immutable_data with 'a with t
+         because it's a boxed record type.
+       But the kind of type "c" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type c.
+|}]
+
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+type 'a c : value mod portable contended = { b : 'a b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+Line 3, characters 0-55:
+3 | type 'a c : value mod portable contended = { b : 'a b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is immutable_data with 'a with t
+         because it's a boxed record type.
+       But the kind of type "c" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type c.
+|}]
+
+(* Same as above with ['a := int]: even with a fully-crossing parameter,
+   [c] still fails portability via [t] inside [b], so [b] must be blamed. *)
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+type c : value mod portable contended = { b : int b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+Line 3, characters 0-53:
+3 | type c : value mod portable contended = { b : int b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is immutable_data with t
+         because it's a boxed record type.
+       But the kind of type "c" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type c.
+|}]
+
+type bad : value
+type t : value mod contended = { x : (bad * int) ref }
+[%%expect {|
+type bad
+Line 2, characters 0-54:
+2 | type t : value mod contended = { x : (bad * int) ref }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is
+           mutable_data with bad @@ forkable unyielding many
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+
+       The first mode-crosses less than the second along:
+         contention: mod uncontended ≰ mod contended
+|}]
+
+type t : value mod contended
+type 'a b = Foo of t * 'a
+type 'a c : value mod portable contended = { x : ('a ref * int) b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of t * 'a
+Line 3, characters 0-67:
+3 | type 'a c : value mod portable contended = { x : ('a ref * int) b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is
+           mutable_data with 'a @@ forkable unyielding many with t
+         because it's a boxed record type.
+       But the kind of type "c" must be a subkind of
+           value mod portable contended
+         because of the annotation on the declaration of the type c.
+
+       The first mode-crosses less than the second along:
+         contention: mod uncontended ≰ mod contended
+         portability: mod portable with 'a with t ≰ mod portable
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics.ml
@@ -747,9 +747,10 @@ Error: The kind of type "c" is
 
 (* Ancestor and descendant requirements can differ in VALUE on the same
    axis: [outer]'s own portability requirement is only [corruptible],
-   while the nested [bad] must be fully [portable]. Portability is a
-   diamond (portable < {shareable, corruptible} < nonportable), so
-   neither requirement covers the other and both must be reported. *)
+   while the nested [bad] must be fully [portable]. On the portability
+   diamond (portable < {shareable, corruptible} < nonportable) the
+   enclosing, weaker requirement does not entail the nested, stronger
+   one, so both must be reported. *)
 type 'a outer : value mod shareable with 'a
 type bad : value
 type t : value mod portable = { x : bad outer }
@@ -778,6 +779,63 @@ Line 3, characters 0-48:
 Error: The kind of type "t" is immutable_data with bad outer
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of value mod contended
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Two enclosing subjects on one path with incomparable requirements
+   (corruptible and shareable) do not jointly cover a nested subject that
+   must be fully portable: entailment is tested against each enclosing
+   requirement separately, never against their combination. *)
+type 'a o1 : value mod shareable with 'a
+type 'a o2 : value mod corruptible with 'a
+type bad : value
+type t : value mod portable = { x : bad o2 o1 }
+[%%expect {|
+type 'a o1 : value mod shareable with 'a
+type 'a o2 : value mod corruptible with 'a
+type bad
+Line 4, characters 0-47:
+4 | type t : value mod portable = { x : bad o2 o1 }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with bad o2 o1
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* A strictly stronger enclosing requirement suppresses a weaker nested
+   one (not only an equal one). *)
+type 'a outer : value with 'a
+type bad : value mod shareable
+type t : value mod portable = { x : bad outer }
+[%%expect {|
+type 'a outer
+type bad : value mod shareable
+Line 3, characters 0-47:
+3 | type t : value mod portable = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with bad outer
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of value mod portable
+         because of the annotation on the declaration of the type t.
+|}]
+
+(* Partial per-axis coverage: the enclosing subject covers the nested
+   contention requirement but not the stronger nested portability one,
+   so the nested subject keeps exactly the uncovered axis. *)
+type 'a outer : value mod shareable with 'a
+type bad : value
+type t : value mod portable contended = { x : bad outer }
+[%%expect {|
+type 'a outer : value mod shareable with 'a
+type bad
+Line 3, characters 0-57:
+3 | type t : value mod portable contended = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t" is immutable_data with bad outer
+         because it's a boxed record type.
+       But the kind of type "t" must be a subkind of
+           value mod portable contended
          because of the annotation on the declaration of the type t.
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -727,6 +727,40 @@ Error: This type definition does not satisfy its kind annotation
        - ref is not mod contended
 |}]
 
+(* Ancestor and descendant requirements can differ in VALUE on the same
+   axis: [outer]'s own portability requirement is only [corruptible],
+   while the nested [bad] must be fully [portable]. Portability is a
+   diamond (portable < {shareable, corruptible} < nonportable), so
+   neither requirement covers the other and both must be reported. *)
+type 'a outer : value mod shareable with 'a
+type bad : value
+type t : value mod portable = { x : bad outer }
+[%%expect {|
+type 'a outer : value mod shareable with 'a
+type bad
+Line 3, characters 0-47:
+3 | type t : value mod portable = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
+       because outer is not mod corruptible.
+|}]
+
+(* Same on the contention diamond. *)
+type 'a outer : value mod shared with 'a
+type bad : value
+type t : value mod contended = { x : bad outer }
+[%%expect {|
+type 'a outer : value mod shared with 'a
+type bad
+Line 3, characters 0-48:
+3 | type t : value mod contended = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
+       because outer is not mod corrupted.
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -863,6 +863,44 @@ Error: This type definition does not satisfy its kind annotation
        because u2 is not mod portable.
 |}]
 
+(* Chain-3 axis (externality), equal-value suppression: both subjects
+   require exactly [external64], so the enclosing subject entails the
+   nested one. *)
+type ('a : value) outer : value with 'a
+type bad : value
+type t : value mod external64 = { x : bad outer }
+[%%expect {|
+type 'a outer
+type bad
+Line 3, characters 0-49:
+3 | type t : value mod external64 = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod external64,
+       because
+       - boxed records are not mod external64
+       - outer is not mod external64
+|}]
+
+(* Chain-3 entailment where the enclosing subject does not report the
+   axis at all: the nested [external64] requirement must survive. *)
+type ('a : value) outer2 : value mod external64 with 'a
+type bad2 : value
+type t2 : value mod portable external64 = { x : bad2 outer2 }
+[%%expect {|
+type 'a outer2 : value mod external64 with 'a
+type bad2
+Line 3, characters 0-61:
+3 | type t2 : value mod portable external64 = { x : bad2 outer2 }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable external64,
+       because
+       - boxed records are not mod external64
+       - outer2 is not mod portable
+       - bad2 is not mod external64
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -824,6 +824,49 @@ Error: This type definition does not satisfy its kind annotation
        - bad is not mod portable
 |}]
 
+(* A self-recursive declaration currently lists itself as a cause
+   alongside the genuine carrier. *)
+type t : value mod portable = Leaf of (int -> int) | Node of t
+[%%expect {|
+Line 1, characters 0-62:
+1 | type t : value mod portable = Leaf of (int -> int) | Node of t
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
+       because
+       - functions are not mod portable
+       - t is not mod portable
+|}]
+
+(* Mutually-recursive pair where the SIBLING (not self) is the carrier:
+   [t] reports both its self-occurrence and the group-mate [u]. Any
+   change to self-reporting must keep the [u] line. *)
+type t : value mod portable = A of t | B of u
+and u = C of (int -> int)
+[%%expect {|
+Line 1, characters 0-45:
+1 | type t : value mod portable = A of t | B of u
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
+       because
+       - t is not mod portable
+       - u is not mod portable
+|}]
+
+(* Sibling-only carrier (no self-occurrence in [t2]): a group-mate
+   subject is not self. *)
+type t2 : value mod portable = K of u2
+and u2 = L of (int -> int)
+[%%expect {|
+Line 1, characters 0-38:
+1 | type t2 : value mod portable = K of u2
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
+       because u2 is not mod portable.
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -729,9 +729,10 @@ Error: This type definition does not satisfy its kind annotation
 
 (* Ancestor and descendant requirements can differ in VALUE on the same
    axis: [outer]'s own portability requirement is only [corruptible],
-   while the nested [bad] must be fully [portable]. Portability is a
-   diamond (portable < {shareable, corruptible} < nonportable), so
-   neither requirement covers the other and both must be reported. *)
+   while the nested [bad] must be fully [portable]. On the portability
+   diamond (portable < {shareable, corruptible} < nonportable) the
+   enclosing, weaker requirement does not entail the nested, stronger
+   one, so both must be reported. *)
 type 'a outer : value mod shareable with 'a
 type bad : value
 type t : value mod portable = { x : bad outer }
@@ -763,6 +764,64 @@ Error: This type definition does not satisfy its kind annotation
        because
        - outer is not mod corrupted
        - bad is not mod contended
+|}]
+
+(* Two enclosing subjects on one path with incomparable requirements
+   (corruptible and shareable) do not jointly cover a nested subject that
+   must be fully portable: entailment is tested against each enclosing
+   requirement separately, never against their combination. *)
+type 'a o1 : value mod shareable with 'a
+type 'a o2 : value mod corruptible with 'a
+type bad : value
+type t : value mod portable = { x : bad o2 o1 }
+[%%expect {|
+type 'a o1 : value mod shareable with 'a
+type 'a o2 : value mod corruptible with 'a
+type bad
+Line 4, characters 0-47:
+4 | type t : value mod portable = { x : bad o2 o1 }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
+       because
+       - o1 is not mod corruptible
+       - o2 is not mod shareable
+       - bad is not mod portable
+|}]
+
+(* A strictly stronger enclosing requirement suppresses a weaker nested
+   one (not only an equal one). *)
+type 'a outer : value with 'a
+type bad : value mod shareable
+type t : value mod portable = { x : bad outer }
+[%%expect {|
+type 'a outer
+type bad : value mod shareable
+Line 3, characters 0-47:
+3 | type t : value mod portable = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable,
+       because outer is not mod portable.
+|}]
+
+(* Partial per-axis coverage: the enclosing subject covers the nested
+   contention requirement but not the stronger nested portability one,
+   so the nested subject keeps exactly the uncovered axis. *)
+type 'a outer : value mod shareable with 'a
+type bad : value
+type t : value mod portable contended = { x : bad outer }
+[%%expect {|
+type 'a outer : value mod shareable with 'a
+type bad
+Line 3, characters 0-57:
+3 | type t : value mod portable contended = { x : bad outer }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - outer is not mod corruptible contended
+       - bad is not mod portable
 |}]
 
 (* GADTs: only the offending constructor's payload is reported. *)

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -824,8 +824,8 @@ Error: This type definition does not satisfy its kind annotation
        - bad is not mod portable
 |}]
 
-(* A self-recursive declaration currently lists itself as a cause
-   alongside the genuine carrier. *)
+(* A self-recursive declaration does not list itself as a cause; only
+   the genuine carrier is reported. *)
 type t : value mod portable = Leaf of (int -> int) | Node of t
 [%%expect {|
 Line 1, characters 0-62:
@@ -836,9 +836,8 @@ Error: This type definition does not satisfy its kind annotation
        because functions are not mod portable.
 |}]
 
-(* Mutually-recursive pair where the SIBLING (not self) is the carrier:
-   [t] reports both its self-occurrence and the group-mate [u]. Any
-   change to self-reporting must keep the [u] line. *)
+(* Mutually-recursive pair where the sibling (not self) is the carrier:
+   [t]'s self-occurrence is not reported, but the group-mate [u] is. *)
 type t : value mod portable = A of t | B of u
 and u = C of (int -> int)
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -651,6 +651,66 @@ Error: This type definition does not satisfy its kind annotation
        - 'a is not mod portable
 |}]
 
+type t : value mod contended
+type 'a b = Foo of t * 'a
+type 'a c : value mod portable contended = { direct : 'a; nested : 'a b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of t * 'a
+Line 3, characters 0-73:
+3 | type 'a c : value mod portable contended = { direct : 'a; nested : 'a b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - 'a is not mod portable contended
+       - b is not mod portable
+|}]
+
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+type 'a c : value mod portable contended = { b : 'a b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+Line 3, characters 0-55:
+3 | type 'a c : value mod portable contended = { b : 'a b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - b is not mod portable
+       - 'a is not mod contended
+|}]
+
+type bad : value
+type t : value mod contended = { x : (bad * int) ref }
+[%%expect {|
+type bad
+Line 2, characters 0-54:
+2 | type t : value mod contended = { x : (bad * int) ref }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod contended,
+       because ref is not mod contended.
+|}]
+
+type t : value mod contended
+type 'a b = Foo of t * 'a
+type 'a c : value mod portable contended = { x : ('a ref * int) b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of t * 'a
+Line 3, characters 0-67:
+3 | type 'a c : value mod portable contended = { x : ('a ref * int) b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because
+       - b is not mod portable
+       - ref is not mod contended
+|}]
+
 (* GADTs: only the offending constructor's payload is reported. *)
 type _ t : value mod contended =
   | I : int -> int t

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -683,6 +683,22 @@ Error: This type definition does not satisfy its kind annotation
        - 'a is not mod contended
 |}]
 
+(* Same as above with ['a := int]: even with a fully-crossing parameter,
+   [c] still fails portability via [t] inside [b], so [b] must be blamed. *)
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+type c : value mod portable contended = { b : int b }
+[%%expect {|
+type t : value mod contended
+type 'a b = Foo of (t * 'a) | Next of 'a b
+Line 3, characters 0-53:
+3 | type c : value mod portable contended = { b : int b }
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This type definition does not satisfy its kind annotation
+         value mod portable contended,
+       because b is not mod portable.
+|}]
+
 type bad : value
 type t : value mod contended = { x : (bad * int) ref }
 [%%expect {|

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -743,7 +743,9 @@ Line 3, characters 0-47:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod portable,
-       because outer is not mod corruptible.
+       because
+       - outer is not mod corruptible
+       - bad is not mod portable
 |}]
 
 (* Same on the contention diamond. *)
@@ -758,7 +760,9 @@ Line 3, characters 0-48:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod contended,
-       because outer is not mod corrupted.
+       because
+       - outer is not mod corrupted
+       - bad is not mod contended
 |}]
 
 (* GADTs: only the offending constructor's payload is reported. *)

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -833,9 +833,7 @@ Line 1, characters 0-62:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod portable,
-       because
-       - functions are not mod portable
-       - t is not mod portable
+       because functions are not mod portable.
 |}]
 
 (* Mutually-recursive pair where the SIBLING (not self) is the carrier:
@@ -849,9 +847,7 @@ Line 1, characters 0-45:
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This type definition does not satisfy its kind annotation
          value mod portable,
-       because
-       - t is not mod portable
-       - u is not mod portable
+       because u is not mod portable.
 |}]
 
 (* Sibling-only carrier (no self-occurrence in [t2]): a group-mate

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -39,44 +39,69 @@ let fresh_unknown_uid () : Types.Uid.t =
   Types.Uid.mk ~current_unit
 
 module Provenance = struct
+  type id = Id of int
+
+  type t =
+    { id : id;
+      ty : Format_doc.doc;
+      plural : bool;
+      source_type_id : int option;
+      parent : id option
+    }
+
   let next_id = ref 0
 
-  let names : Ldd.Name.t list ref = ref []
+  let entries : t list ref = ref []
 
-  let register_doc ~plural ty : Ldd.Name.t =
-    let id = !next_id in
-    next_id := id + 1;
-    let name = Ldd.Name.provenance ~id ~ty ~plural in
-    names := name :: !names;
-    name
+  let equal_id (Id id1) (Id id2) = Int.equal id1 id2
 
-  let register_text ~plural text =
-    register_doc ~plural (Format_doc.doc_printf "%s" text)
+  let name { id = Id id; ty; plural; _ } = Ldd.Name.provenance ~id ~ty ~plural
 
-  let register (ty : Types.type_expr) : Ldd.Name.t =
+  let make ~plural ~source_type_id ~parent ty =
+    let next = !next_id in
+    next_id := next + 1;
+    let id = Id next in
+    let provenance = { id; ty; plural; source_type_id; parent } in
+    entries := provenance :: !entries;
+    provenance
+
+  let register ~parent (ty : Types.type_expr) =
     (* A surviving residual for an occurrence reflects only the head
        constructor's own contribution (the decomposition zeroes anything
        flowing through a separately-tracked inner type or parameter), so
        name the head rather than the full type expression: the constructor
        for [Tconstr], a class-of-types phrase for the built-in shapes. *)
-    let register_type ty =
+    let register_type ~source_type ty =
       Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
-      |> register_doc ~plural:false
+      |> make ~plural:false
+           ~source_type_id:(Some (Types.get_id source_type))
+           ~parent
+    in
+    let register_text text =
+      make ~plural:true
+        ~source_type_id:(Some (Types.get_id ty))
+        ~parent
+        (Format_doc.doc_printf "%s" text)
     in
     match Types.get_desc ty with
-    | Types.Tarrow _ -> register_text ~plural:true "functions"
-    | Types.Ttuple _ -> register_text ~plural:true "tuples"
-    | Types.Tunboxed_tuple _ -> register_text ~plural:true "unboxed tuples"
-    | Types.Tobject _ -> register_text ~plural:true "objects"
-    | Types.Tvariant _ -> register_text ~plural:true "polymorphic variants"
-    | Types.Tpackage _ -> register_text ~plural:true "first-class modules"
+    | Types.Tarrow _ -> register_text "functions"
+    | Types.Ttuple _ -> register_text "tuples"
+    | Types.Tunboxed_tuple _ -> register_text "unboxed tuples"
+    | Types.Tobject _ -> register_text "objects"
+    | Types.Tvariant _ -> register_text "polymorphic variants"
+    | Types.Tpackage _ -> register_text "first-class modules"
     | Types.Tconstr (path, _ :: _, _) ->
-      register_type (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
-    | _ -> register_type ty
+      register_type ~source_type:ty
+        (Btype.newgenty (Types.Tconstr (path, [], ref Types.Mnil)))
+    | _ -> register_type ~source_type:ty ty
 
-  let reset () = names := []
+  let register_phrase ~parent text =
+    make ~plural:true ~source_type_id:None ~parent
+      (Format_doc.doc_printf "%s" text)
 
-  let all_names () = List.rev !names
+  let reset () = entries := []
+
+  let all () = List.rev !entries
 end
 
 (** A kind solver specialized to [Types.Ldd] and [Types.type_expr].
@@ -118,11 +143,16 @@ module Solver = struct
         }
     | Poly of Ldd.node * Ldd.node array
 
+  and provenance_ctx =
+    { parent : Provenance.id option;
+      kinds : (int * Provenance.id option, Ldd.node) Hashtbl.t
+    }
+
   and ctx =
     { env : Env.t option;
       lookup_of_env : Env.t -> Path.t -> constr_decl;
       mode : mode;
-      add_provenance : bool;
+      provenance : provenance_ctx option;
       ty_to_kind : Ldd.node TyTbl.t;
       constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t
     }
@@ -132,22 +162,39 @@ module Solver = struct
   let global_constr_to_coeffs : (Ldd.node * Ldd.node array) ConstrTbl.t =
     ConstrTbl.create 1
 
-  let create_ctx ~(mode : mode) ~(env : Env.t option) ~add_provenance
+  let create_ctx ~(mode : mode) ~(env : Env.t option)
       ~(lookup_of_env : Env.t -> Path.t -> constr_decl) =
     TyTbl.clear global_ty_to_kind;
     ConstrTbl.clear global_constr_to_coeffs;
     { env;
       lookup_of_env;
       mode;
-      add_provenance;
+      provenance = None;
       ty_to_kind = global_ty_to_kind;
       constr_to_coeffs = global_constr_to_coeffs
     }
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
-  let reset_for_provenance (ctx : ctx) ~(add_provenance : bool) : ctx =
-    { ctx with add_provenance; ty_to_kind = TyTbl.create 1 }
+  let with_provenance (ctx : ctx) : ctx =
+    { ctx with
+      provenance = Some { parent = None; kinds = Hashtbl.create 1 };
+      ty_to_kind = TyTbl.create 1
+    }
+
+  let without_provenance (ctx : ctx) : ctx =
+    { ctx with provenance = None; ty_to_kind = TyTbl.create 1 }
+
+  let find_provenance_kind (ctx : ctx) (ty : Types.type_expr) =
+    match ctx.provenance with
+    | None -> None
+    | Some { parent; kinds } -> Hashtbl.find_opt kinds (Types.get_id ty, parent)
+
+  let cache_provenance_kind (ctx : ctx) (ty : Types.type_expr) kind =
+    match ctx.provenance with
+    | None -> ()
+    | Some { parent; kinds } ->
+      Hashtbl.replace kinds (Types.get_id ty, parent) kind
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode, name with
@@ -159,17 +206,23 @@ module Solver = struct
     let param_id = Types.get_id ty in
     rigid_name ctx (Ldd.Name.param param_id)
 
-  let provenance (ctx : ctx) (ty : Types.type_expr) : Ldd.node =
-    rigid_name ctx (Provenance.register ty)
-
-  let provenance_text (ctx : ctx) (text : string) : Ldd.node =
-    rigid_name ctx (Provenance.register_text ~plural:true text)
+  let provenance_and_child_ctx (ctx : ctx) (ty : Types.type_expr) =
+    match ctx.provenance with
+    | None -> Fun.id, ctx
+    | Some ({ parent; _ } as provenance_ctx) ->
+      let provenance = Provenance.register ~parent ty in
+      ( (fun poly -> Ldd.meet poly (rigid_name ctx (Provenance.name provenance))),
+        { ctx with
+          provenance = Some { provenance_ctx with parent = Some provenance.id }
+        } )
 
   let with_provenance_text (ctx : ctx) (text : unit -> string) (poly : Ldd.node)
       : Ldd.node =
-    if ctx.add_provenance
-    then Ldd.meet poly (provenance_text ctx (text ()))
-    else poly
+    match ctx.provenance with
+    | None -> poly
+    | Some { parent; _ } ->
+      let provenance = Provenance.register_phrase ~parent (text ()) in
+      Ldd.meet poly (rigid_name ctx (Provenance.name provenance))
 
   let rec type_may_be_circular (ty : Types.type_expr) : bool =
     match Types.get_desc ty with
@@ -336,28 +389,22 @@ module Solver = struct
         base_poly, coeffs_poly)
 
   (* Apply a constructor polynomial to argument types. *)
-  and constr ~self_ty (ctx : ctx) (path : Path.t) (args : Types.type_expr list)
-      : Ldd.node =
+  and constr ~self_provenance ~arg_ctx (ctx : ctx) (path : Path.t)
+      (args : Types.type_expr list) : Ldd.node =
     let constr_ctx =
-      if ctx.add_provenance
-      then reset_for_provenance ctx ~add_provenance:false
-      else ctx
+      match ctx.provenance with None -> ctx | Some _ -> without_provenance ctx
     in
     let base, coeffs =
       constr_kind constr_ctx ~min_arity:(List.length args) path
     in
-    let base =
-      if ctx.add_provenance
-      then Ldd.meet base (provenance ctx self_ty)
-      else base
-    in
+    let base = self_provenance base in
     let rec loop acc remaining i =
       if i = Array.length coeffs
       then acc
       else
         match remaining with
         | arg :: rest ->
-          let arg_kind = kind ~use_tables:true ctx arg in
+          let arg_kind = kind ~use_tables:true arg_ctx arg in
           loop (Ldd.join acc (Ldd.meet arg_kind coeffs.(i))) rest (i + 1)
         | [] -> failwith "Missing arg"
     in
@@ -468,23 +515,34 @@ module Solver = struct
     else
       match TyTbl.find_opt ctx.ty_to_kind ty with
       | Some kind_poly -> kind_poly
-      | None ->
-        if not use_tables
-        then kind_uncached ctx ty
-        else if type_may_be_circular ty
-        then (
-          let var = Ldd.new_var () in
-          let placeholder = Ldd.node_of_var var in
-          TyTbl.add ctx.ty_to_kind ty placeholder;
-          let kind_rhs = kind_uncached ctx ty in
-          Ldd.solve_lfp var kind_rhs;
-          let kind_inlined = Ldd.inline_solved_vars placeholder in
-          TyTbl.replace ctx.ty_to_kind ty kind_inlined;
-          kind_inlined)
-        else
-          let kind_rhs = kind_uncached ctx ty in
-          TyTbl.add ctx.ty_to_kind ty kind_rhs;
-          kind_rhs
+      | None -> (
+        let cached_provenance_kind =
+          if use_tables then find_provenance_kind ctx ty else None
+        in
+        match cached_provenance_kind with
+        | Some kind_poly -> kind_poly
+        | None ->
+          if not use_tables
+          then kind_uncached ctx ty
+          else if type_may_be_circular ty
+          then (
+            let var = Ldd.new_var () in
+            let placeholder = Ldd.node_of_var var in
+            TyTbl.add ctx.ty_to_kind ty placeholder;
+            let kind_rhs = kind_uncached ctx ty in
+            Ldd.solve_lfp var kind_rhs;
+            let kind_inlined = Ldd.inline_solved_vars placeholder in
+            if Option.is_some ctx.provenance
+            then TyTbl.remove ctx.ty_to_kind ty
+            else TyTbl.replace ctx.ty_to_kind ty kind_inlined;
+            cache_provenance_kind ctx ty kind_inlined;
+            kind_inlined)
+          else
+            let kind_rhs = kind_uncached ctx ty in
+            if Option.is_none ctx.provenance
+            then TyTbl.add ctx.ty_to_kind ty kind_rhs;
+            cache_provenance_kind ctx ty kind_rhs;
+            kind_rhs)
 
   (* Worker for [kind]; does not memoize.
      Only call from [kind] so caching and LFP handling apply. *)
@@ -492,19 +550,24 @@ module Solver = struct
     (* Compute the ikind polynomial for an arbitrary [type_expr]. This is the
        semantic counterpart of [Jkind.jkind_of_type], but expressed in LDD
        form. *)
-    let self_provenance poly =
-      if ctx.add_provenance then Ldd.meet poly (provenance ctx ty) else poly
-    in
     (* [ty] is expected to be representative: no links/substs/fields/nil.
        Provenance is attached only to the contribution introduced by this
        node, not to recursive child contributions. *)
-    match Types.get_desc ty with
+    let desc = Types.get_desc ty in
+    let self_provenance, child_ctx =
+      match desc with
+      | Types.Tlink _ | Types.Tsubst _ | Types.Trepr _ | Types.Tpoly _
+      | Types.Tmod _ | Types.Tfield _ | Types.Tnil ->
+        Fun.id, ctx
+      | _ -> provenance_and_child_ctx ctx ty
+    in
+    match desc with
     | Types.Tvar { name = _name; jkind } | Types.Tunivar { name = _name; jkind }
       ->
       (* Keep a rigid param, but cap it by its annotated jkind. *)
-      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind ctx jkind))
+      self_provenance (Ldd.meet (rigid ctx ty) (ckind_of_jkind child_ctx jkind))
     | Types.Tconstr (path, args, _abbrev_memo) ->
-      constr ~self_ty:ty ctx path args
+      constr ~self_provenance ~arg_ctx:child_ctx ctx path args
     | Types.Tmod (ty, mod_bounds) ->
       Ldd.meet
         (kind ~use_tables:true ctx ty)
@@ -513,12 +576,12 @@ module Solver = struct
       (* Boxed tuples: immutable_data base + per-element contributions
          under id modality. *)
       let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
-      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true ctx t)
+      Ldd.sum elts ~base ~f:(fun (_lbl, t) -> kind ~use_tables:true child_ctx t)
     | Types.Tunboxed_tuple elts ->
       (* Unboxed tuples: per-element contributions; shallow axes relevant
          only for arity = 1. *)
       Ldd.sum elts ~base:Ldd.bot ~f:(fun (_lbl, t) ->
-          kind ~use_tables:true ctx t)
+          kind ~use_tables:true child_ctx t)
     | Types.Tarrow (_lbl, _t1, _t2, _commu) ->
       (* Arrows use the dedicated per-axis bounds (no with-bounds). *)
       self_provenance (Ldd.const Axis_lattice.arrow)
@@ -534,11 +597,11 @@ module Solver = struct
          a viable setting in practice. Track removing this workaround as part
          of internal ticket 5746. *)
       kind ~check_principality:false ~use_tables:true ctx ty
-    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind ctx jkind)
+    | Types.Tof_kind jkind -> self_provenance (ckind_of_jkind child_ctx jkind)
     | Types.Tobject _ -> self_provenance (Ldd.const Axis_lattice.object_legacy)
     | Types.Tbox t ->
       let base = self_provenance (Ldd.const Axis_lattice.mutable_data) in
-      Ldd.join base (kind ~use_tables:true ctx t)
+      Ldd.join base (kind ~use_tables:true child_ctx t)
     | Types.Tfield _ -> failwith "Tfield shouldn't appear in kind"
     | Types.Tnil -> failwith "Tnil shouldn't appear in kind"
     | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ ->
@@ -555,7 +618,7 @@ module Solver = struct
           let base = self_provenance (Ldd.const Axis_lattice.immutable_data) in
           Btype.fold_row
             (fun acc ty ->
-              let ty_kind = kind ~use_tables:true ctx ty in
+              let ty_kind = kind ~use_tables:true child_ctx ty in
               Ldd.join acc ty_kind)
             base row
         else
@@ -662,7 +725,7 @@ type mode_crossing_error =
     super_jkind : Types.jkind_l;
     sub_poly : Ldd.node;
     super_poly : Ldd.node;
-    provenance_names : Ldd.Name.t list;
+    provenances : Provenance.t list;
     violating_axes : Jkind_axis.Axis.packed list
   }
 
@@ -678,23 +741,22 @@ let map_jkind_error result =
   Result.map_error (fun error -> Jkind_error error) result
 
 type provenance_residual =
-  { ty : Format_doc.doc;
-    plural : bool;
+  { provenance : Provenance.t;
     mode_bounds : Axis_lattice.t;
     axes : Jkind_axis.Axis.packed list
   }
 
-let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
-    =
+let add_provenance_residual entries
+    ({ provenance = { ty; plural; _ }; mode_bounds; axes } as entry) =
   (* Deduplicate identical entries (e.g. two fields of type [int ref] under
      the same bound), keeping first-occurrence order. Entries that merely
      share a printed name (e.g. two constructor-local existentials both
      rendered ['a]) can have different requirements and must stay separate. *)
   let duplicate other =
     String.equal
-      (Format_doc.asprintf "%a" Format_doc.pp_doc other.ty)
+      (Format_doc.asprintf "%a" Format_doc.pp_doc other.provenance.ty)
       (Format_doc.asprintf "%a" Format_doc.pp_doc ty)
-    && Bool.equal other.plural plural
+    && Bool.equal other.provenance.plural plural
     && Axis_lattice.equal other.mode_bounds mode_bounds
     && List.length other.axes = List.length axes
     && List.for_all
@@ -703,8 +765,52 @@ let add_provenance_residual entries ({ ty; plural; mode_bounds; axes } as entry)
   in
   if List.exists duplicate entries then entries else entries @ [entry]
 
-let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
-    =
+let axis_set_of_axes axes =
+  List.fold_left
+    (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
+    Jkind_axis.Axis_set.empty axes
+
+let restrict_mode_bounds_to_axes mode_bounds axes =
+  Axis_lattice.join mode_bounds
+    (Axis_lattice.of_axis_set
+       (Jkind_axis.Axis_set.complement (axis_set_of_axes axes)))
+
+let merge_same_source entries entry =
+  match entry.provenance.source_type_id with
+  | None -> entries @ [entry]
+  | Some source_type_id -> (
+    match
+      List.find_opt
+        (fun other ->
+          Option.equal Int.equal other.provenance.source_type_id
+            (Some source_type_id))
+        entries
+    with
+    | None -> entries @ [entry]
+    | Some other ->
+      let axes =
+        List.fold_left
+          (fun axes axis ->
+            if List.exists (Jkind_axis.Axis.equal axis) axes
+            then axes
+            else axes @ [axis])
+          other.axes entry.axes
+      in
+      let merged =
+        { other with
+          mode_bounds = Axis_lattice.meet other.mode_bounds entry.mode_bounds;
+          axes
+        }
+      in
+      List.map
+        (fun candidate ->
+          if Provenance.equal_id candidate.provenance.id other.provenance.id
+          then merged
+          else candidate)
+        entries)
+
+let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
+  let provenance_names = List.map Provenance.name provenances in
   let provenance_vars = List.map Ldd.rigid provenance_names in
   (* For a declaration [type t : bound = rhs], ikind checking compares the
      inferred ikind polynomial for [rhs] against the polynomial for [bound].
@@ -738,11 +844,9 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
   match Ldd.leq_with_reason base super_poly with
   | _ :: _ -> None
   | [] ->
-    List.combine provenance_names coeffs
-    |> List.filter_map (fun (name, coeff) ->
-        match (name : Ldd.Name.t) with
-        | Atom _ | KAtom _ | Param _ | Unknown _ -> None
-        | Provenance { ty; plural; _ } -> (
+    let entries =
+      List.combine provenances coeffs
+      |> List.filter_map (fun (provenance, coeff) ->
           if is_bot_poly coeff
           then None
           else
@@ -763,7 +867,60 @@ let provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
                  axes left to report. *)
               match axes with
               | [] -> None
-              | _ :: _ -> Some { ty; plural; mode_bounds; axes }))
+              | _ :: _ -> Some { provenance; mode_bounds; axes })
+    in
+    let raw_axes_by_id = Hashtbl.create (List.length entries) in
+    List.iter
+      (fun entry ->
+        Hashtbl.add raw_axes_by_id entry.provenance.id
+          (axis_set_of_axes entry.axes))
+      entries;
+    let provenances_by_id = Hashtbl.create (List.length provenances) in
+    List.iter
+      (fun (provenance : Provenance.t) ->
+        Hashtbl.add provenances_by_id provenance.id provenance)
+      provenances;
+    let covered_axes_by_id = Hashtbl.create (List.length provenances) in
+    let rec covered_axes (provenance : Provenance.t) =
+      match Hashtbl.find_opt covered_axes_by_id provenance.id with
+      | Some axes -> axes
+      | None ->
+        let parent_axes =
+          match provenance.parent with
+          | None -> Jkind_axis.Axis_set.empty
+          | Some parent -> covered_axes (Hashtbl.find provenances_by_id parent)
+        in
+        let own_axes =
+          Option.value
+            (Hashtbl.find_opt raw_axes_by_id provenance.id)
+            ~default:Jkind_axis.Axis_set.empty
+        in
+        let axes = Jkind_axis.Axis_set.union parent_axes own_axes in
+        Hashtbl.add covered_axes_by_id provenance.id axes;
+        axes
+    in
+    entries
+    |> List.filter_map (fun entry ->
+        let parent_axes =
+          match entry.provenance.parent with
+          | None -> Jkind_axis.Axis_set.empty
+          | Some parent -> covered_axes (Hashtbl.find provenances_by_id parent)
+        in
+        let axes =
+          List.filter
+            (fun (Jkind_axis.Axis.Pack axis) ->
+              not (Jkind_axis.Axis_set.mem parent_axes axis))
+            entry.axes
+        in
+        match axes with
+        | [] -> None
+        | _ :: _ ->
+          Some
+            { entry with
+              axes;
+              mode_bounds = restrict_mode_bounds_to_axes entry.mode_bounds axes
+            })
+    |> List.fold_left merge_same_source []
     |> List.fold_left add_provenance_residual []
     |> Option.some
 
@@ -772,21 +929,14 @@ let residual_mode_strings { mode_bounds; axes; _ } =
      non-top on other axes; see [axes_in_violation_order]), then let
      [Typemode] drop implied modes (e.g. [aliased] when [global] is
      required) the same way jkind annotations are printed. *)
-  let reported =
-    List.fold_left
-      (fun set (Jkind_axis.Axis.Pack axis) -> Jkind_axis.Axis_set.add set axis)
-      Jkind_axis.Axis_set.empty axes
-  in
-  let restricted =
-    Axis_lattice.join mode_bounds
-      (Axis_lattice.of_axis_set (Jkind_axis.Axis_set.complement reported))
-  in
+  let restricted = restrict_mode_bounds_to_axes mode_bounds axes in
   Jkind.Mod_bounds.of_axis_lattice restricted
   |> Typemode.close_implied_mod_bounds
   |> Typemode.untransl_mod_bounds ~verbose:false
   |> List.map (fun { Location.txt = Parsetree.Mode s; _ } -> s)
 
-let pp_provenance_residual ppf ({ ty; plural; _ } as residual) =
+let pp_provenance_residual ppf
+    ({ provenance = { ty; plural; _ }; _ } as residual) =
   (* Phrase subjects ("mutable fields", "boxed records") are plural noun
      phrases; type-expression subjects read as singular. *)
   let verb = if plural then "are" else "is" in
@@ -810,9 +960,9 @@ let pp_type_definition_kind_annotation env ppf super_jkind =
     (Jkind.format env) super_jkind
 
 let report_provenance_mode_crossing_error env ppf
-    { super_jkind; sub_poly; super_poly; provenance_names; violating_axes; _ } =
+    { super_jkind; sub_poly; super_poly; provenances; violating_axes; _ } =
   match
-    provenance_residuals ~provenance_names ~violating_axes ~sub_poly ~super_poly
+    provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly
   with
   | None | Some [] -> None
   | Some [entry] ->
@@ -1169,8 +1319,8 @@ let lookup_of_env ~(env : Env.t) (path : Path.t) : Solver.constr_decl =
 
 (* Package the above into a full evaluation context. *)
 let create_ctx ~(mode : Solver.mode) ~(env : Env.t option) =
-  Solver.create_ctx ~mode ~env ~add_provenance:false
-    ~lookup_of_env:(fun env path -> lookup_of_env ~env path)
+  Solver.create_ctx ~mode ~env ~lookup_of_env:(fun env path ->
+      lookup_of_env ~env path)
 
 let normalize ~(env : Env.t option) (jkind : Types.jkind_l) : Ldd.node =
   let ctx = create_ctx ~mode:Solver.Normal ~env in
@@ -1312,7 +1462,7 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
 let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
     (bound : Types.jkind_l) : subcheck_polys =
   compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
-      let ctx = Solver.reset_for_provenance ctx ~add_provenance:true in
+      let ctx = Solver.with_provenance ctx in
       lhs ctx)
 
 let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
@@ -1327,17 +1477,16 @@ let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
            super_jkind;
            sub_poly;
            super_poly;
-           provenance_names = Provenance.all_names ();
+           provenances = Provenance.all ();
            violating_axes
          })
 
 let subjkind_error_has_provenance_residuals = function
   | Jkind_error _ -> false
-  | Mode_crossing_error
-      { sub_poly; super_poly; provenance_names; violating_axes; _ } -> (
+  | Mode_crossing_error { sub_poly; super_poly; provenances; violating_axes; _ }
+    -> (
     match
-      provenance_residuals ~provenance_names ~violating_axes ~sub_poly
-        ~super_poly
+      provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly
     with
     | None | Some [] -> false
     | Some (_ :: _) -> true)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -720,13 +720,20 @@ let axes_in_violation_order ~violating_axes axes =
       List.exists (Jkind_axis.Axis.equal violating_axis) axes)
     violating_axes
 
+type provenance_residual =
+  { provenance : Provenance.t;
+    mode_bounds : Axis_lattice.t;
+    axes : Jkind_axis.Axis.packed list
+  }
+
 type mode_crossing_error =
   { printing_env : Env.t;
     super_jkind : Types.jkind_l;
     sub_poly : Ldd.node;
     super_poly : Ldd.node;
     provenances : Provenance.t list;
-    violating_axes : Jkind_axis.Axis.packed list
+    violating_axes : Jkind_axis.Axis.packed list;
+    provenance_residuals : provenance_residual list option
   }
 
 type subjkind_error =
@@ -739,12 +746,6 @@ let subjkind_error_printing_env = function
 
 let map_jkind_error result =
   Result.map_error (fun error -> Jkind_error error) result
-
-type provenance_residual =
-  { provenance : Provenance.t;
-    mode_bounds : Axis_lattice.t;
-    axes : Jkind_axis.Axis.packed list
-  }
 
 let add_provenance_residual entries
     ({ provenance = { ty; plural; _ }; mode_bounds; axes } as entry) =
@@ -989,10 +990,8 @@ let pp_type_definition_kind_annotation env ppf super_jkind =
     (Jkind.format env) super_jkind
 
 let report_provenance_mode_crossing_error env ppf
-    { super_jkind; sub_poly; super_poly; provenances; violating_axes; _ } =
-  match
-    provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly
-  with
+    { super_jkind; provenance_residuals; _ } =
+  match provenance_residuals with
   | None | Some [] -> None
   | Some [entry] ->
     Some
@@ -1507,18 +1506,22 @@ let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
            sub_poly;
            super_poly;
            provenances = Provenance.all ();
-           violating_axes
+           violating_axes;
+           provenance_residuals = None
          })
 
-let subjkind_error_has_provenance_residuals = function
-  | Jkind_error _ -> false
-  | Mode_crossing_error { sub_poly; super_poly; provenances; violating_axes; _ }
-    -> (
+let subjkind_error_with_provenance_residuals = function
+  | Jkind_error _ -> None
+  | Mode_crossing_error
+      ({ sub_poly; super_poly; provenances; violating_axes; _ } as error) -> (
     match
       provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly
     with
-    | None | Some [] -> false
-    | Some (_ :: _) -> true)
+    | None | Some [] -> None
+    | Some (_ :: _ as provenance_residuals) ->
+      Some
+        (Mode_crossing_error
+           { error with provenance_residuals = Some provenance_residuals }))
 
 let same_axis_set axes1 axes2 =
   let of_list =
@@ -1558,8 +1561,10 @@ let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
   | Error provenance_error ->
     if
       subjkind_errors_have_same_violating_axes actual_error provenance_error
-      && subjkind_error_has_provenance_residuals provenance_error
-    then Error provenance_error
+    then
+      match subjkind_error_with_provenance_residuals provenance_error with
+      | None -> fallback actual_error
+      | Some provenance_error -> Error provenance_error
     else fallback actual_error
 
 let sub_jkind_l ?(allow_any_crossing = false) ?origin

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -39,31 +39,60 @@ let fresh_unknown_uid () : Types.Uid.t =
   Types.Uid.mk ~current_unit
 
 module Provenance = struct
-  type id = Id of int
+  module Id : sig
+    type t = private int
+
+    val create : unit -> t
+
+    val equal : t -> t -> bool
+  end = struct
+    type t = int
+
+    let next = ref 0
+
+    let create () =
+      let id = !next in
+      incr next;
+      id
+
+    let equal = Int.equal
+  end
 
   type t =
-    { id : id;
+    { id : Id.t;
       ty : Format_doc.doc;
+          (** The subject as printed in the error message: a type-expression
+              head (["u"], ["'a"]) or a class-of-types phrase (["functions"]).
+          *)
       plural : bool;
+          (** Whether [ty] is a plural phrase, for verb agreement ("functions
+              are ..." vs "[u] is ..."). *)
       source_type_id : int option;
+          (** [Types.get_id] of the type expression this entry was registered
+              for; residual entries sharing it are merged into one message. *)
       is_decl_under_check : bool;
-      parent : id option
+          (** The subject is the declaration whose bound is being checked; such
+              self-occurrences are never reported as causes. *)
+      parent : Id.t option
+          (** The entry for the enclosing subject on the same nesting path, or
+              [None] at the top level. Used to drop a nested entry whose
+              requirement is entailed by an ancestor's. *)
     }
-
-  let next_id = ref 0
 
   let entries : t list ref = ref []
 
-  let equal_id (Id id1) (Id id2) = Int.equal id1 id2
-
-  let name { id = Id id; ty; plural; _ } = Ldd.Name.provenance ~id ~ty ~plural
+  let name { id; ty; plural; _ } =
+    Ldd.Name.provenance ~id:(id :> int) ~ty ~plural
 
   let make ~plural ~source_type_id ~is_decl_under_check ~parent ty =
-    let next = !next_id in
-    next_id := next + 1;
-    let id = Id next in
     let provenance =
-      { id; ty; plural; source_type_id; is_decl_under_check; parent }
+      { id = Id.create ();
+        ty;
+        plural;
+        source_type_id;
+        is_decl_under_check;
+        parent
+      }
     in
     entries := provenance :: !entries;
     provenance
@@ -153,9 +182,9 @@ module Solver = struct
     | Poly of Ldd.node * Ldd.node array
 
   and provenance_ctx =
-    { parent : Provenance.id option;
+    { parent : Provenance.Id.t option;
       decl_uid_under_check : Types.Uid.t option;
-      kinds : (int * Provenance.id option, Ldd.node) Hashtbl.t
+      kinds : (type_id:int * parent:Provenance.Id.t option, Ldd.node) Hashtbl.t
     }
 
   and ctx =
@@ -186,7 +215,8 @@ module Solver = struct
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
-  let with_provenance ?decl_uid_under_check (ctx : ctx) : ctx =
+  let with_provenance ~(decl_uid_under_check : Types.Uid.t option) (ctx : ctx) :
+      ctx =
     { ctx with
       provenance =
         Some { parent = None; decl_uid_under_check; kinds = Hashtbl.create 1 };
@@ -199,13 +229,14 @@ module Solver = struct
   let find_provenance_kind (ctx : ctx) (ty : Types.type_expr) =
     match ctx.provenance with
     | None -> None
-    | Some { parent; kinds } -> Hashtbl.find_opt kinds (Types.get_id ty, parent)
+    | Some { parent; kinds } ->
+      Hashtbl.find_opt kinds (~type_id:(Types.get_id ty), ~parent)
 
   let cache_provenance_kind (ctx : ctx) (ty : Types.type_expr) kind =
     match ctx.provenance with
     | None -> ()
     | Some { parent; kinds } ->
-      Hashtbl.replace kinds (Types.get_id ty, parent) kind
+      Hashtbl.replace kinds (~type_id:(Types.get_id ty), ~parent) kind
 
   let rigid_name (ctx : ctx) (name : Ldd.Name.t) : Ldd.node =
     match ctx.mode, name with
@@ -827,7 +858,7 @@ let merge_same_source entries entry =
       in
       List.map
         (fun candidate ->
-          if Provenance.equal_id candidate.provenance.id other.provenance.id
+          if Provenance.Id.equal candidate.provenance.id other.provenance.id
           then merged
           else candidate)
         entries)
@@ -911,7 +942,7 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
       (fun (provenance : Provenance.t) ->
         Hashtbl.add provenances_by_id provenance.id provenance)
       provenances;
-    let exception Missing_provenance_parent of Provenance.id in
+    let exception Missing_provenance_parent of Provenance.Id.t in
     let find_provenance id =
       match Hashtbl.find_opt provenances_by_id id with
       | Some provenance -> provenance
@@ -1518,10 +1549,10 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
     ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
 
-let compute_provenance_bound_polys ?decl_uid_under_check env
+let compute_provenance_bound_polys ~decl_uid_under_check env
     ~(lhs : Solver.ctx -> Ldd.node) (bound : Types.jkind_l) : subcheck_polys =
   compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
-      let ctx = Solver.with_provenance ?decl_uid_under_check ctx in
+      let ctx = Solver.with_provenance ~decl_uid_under_check ctx in
       lhs ctx)
 
 let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
@@ -1640,7 +1671,7 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
           | Ok () -> Error ikind_error
           | Error jkind_error -> Error (Jkind_error jkind_error))
 
-let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
+let check_bound ?(allow_any_crossing = false) ?origin ~decl_uid_under_check
     ~type_equal ~context env ~actual ~bound ~provenance_lhs =
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
@@ -1681,18 +1712,19 @@ let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
         in
         best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
           ~super_jkind:bound ~printing_env:env actual_error (fun () ->
-            compute_provenance_bound_polys ?decl_uid_under_check env
+            compute_provenance_bound_polys ~decl_uid_under_check env
               ~lhs:provenance_lhs bound)
 
 let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
-  check_bound ?origin ~type_equal ~context env ~actual ~bound
-    ~provenance_lhs:(fun ctx -> Solver.kind ~use_tables:true ctx ty)
+  check_bound ?origin ~decl_uid_under_check:None ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs:(fun ctx ->
+      Solver.kind ~use_tables:true ctx ty)
 
 let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
     ~decl ~actual ~bound =
   check_bound ?allow_any_crossing ?origin
-    ~decl_uid_under_check:decl.Types.type_uid ~type_equal ~context env ~actual
-    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
+    ~decl_uid_under_check:(Some decl.Types.type_uid) ~type_equal ~context env
+    ~actual ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -884,6 +884,12 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
       (fun (provenance : Provenance.t) ->
         Hashtbl.add provenances_by_id provenance.id provenance)
       provenances;
+    let exception Missing_provenance_parent of Provenance.id in
+    let find_provenance id =
+      match Hashtbl.find_opt provenances_by_id id with
+      | Some provenance -> provenance
+      | None -> raise (Missing_provenance_parent id)
+    in
     (* An enclosing entry only explains a nested requirement it ENTAILS:
        same axis and an at-least-as-strong required value. Requirements
        are kept as a list per ancestor rather than meet-collapsed into a
@@ -901,8 +907,7 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
         let parent_bounds =
           match provenance.parent with
           | None -> []
-          | Some parent ->
-            covered_bounds (Hashtbl.find provenances_by_id parent)
+          | Some parent -> covered_bounds (find_provenance parent)
         in
         let bounds =
           match Hashtbl.find_opt raw_bounds_by_id provenance.id with
@@ -927,8 +932,7 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
         let parent_bounds =
           match entry.provenance.parent with
           | None -> []
-          | Some parent ->
-            covered_bounds (Hashtbl.find provenances_by_id parent)
+          | Some parent -> covered_bounds (find_provenance parent)
         in
         let covered =
           List.fold_left
@@ -1545,27 +1549,30 @@ let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
     | None -> Error error
     | Some fallback_error -> Error fallback_error
   in
-  let provenance_check =
-    match make_polys () with
-    | provenance_polys ->
+  let select_provenance_error () =
+    match
       check_mode_crossing_polys ~origin ~sub_jkind ~super_jkind ~printing_env
-        provenance_polys
+        (make_polys ())
+    with
+    | Ok () -> None
+    | Error provenance_error ->
+      if
+        subjkind_errors_have_same_violating_axes actual_error provenance_error
+      then subjkind_error_with_provenance_residuals provenance_error
+      else None
+  in
+  let provenance_error =
+    match select_provenance_error () with
+    | provenance_error -> provenance_error
     | exception
         ((Misc.Fatal_error | Stack_overflow | Out_of_memory | Sys.Break) as exn)
       ->
       raise exn
-    | exception _ -> Ok ()
+    | exception _ -> None
   in
-  match provenance_check with
-  | Ok () -> fallback actual_error
-  | Error provenance_error ->
-    if
-      subjkind_errors_have_same_violating_axes actual_error provenance_error
-    then
-      match subjkind_error_with_provenance_residuals provenance_error with
-      | None -> fallback actual_error
-      | Some provenance_error -> Error provenance_error
-    else fallback actual_error
+  match provenance_error with
+  | None -> fallback actual_error
+  | Some provenance_error -> Error provenance_error
 
 let sub_jkind_l ?(allow_any_crossing = false) ?origin
     ~(type_equal : Types.type_expr -> Types.type_expr -> bool)

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -46,6 +46,7 @@ module Provenance = struct
       ty : Format_doc.doc;
       plural : bool;
       source_type_id : int option;
+      is_decl_under_check : bool;
       parent : id option
     }
 
@@ -57,15 +58,17 @@ module Provenance = struct
 
   let name { id = Id id; ty; plural; _ } = Ldd.Name.provenance ~id ~ty ~plural
 
-  let make ~plural ~source_type_id ~parent ty =
+  let make ~plural ~source_type_id ~is_decl_under_check ~parent ty =
     let next = !next_id in
     next_id := next + 1;
     let id = Id next in
-    let provenance = { id; ty; plural; source_type_id; parent } in
+    let provenance =
+      { id; ty; plural; source_type_id; is_decl_under_check; parent }
+    in
     entries := provenance :: !entries;
     provenance
 
-  let register ~parent (ty : Types.type_expr) =
+  let register ~is_decl_under_check ~parent (ty : Types.type_expr) =
     (* A surviving residual for an occurrence reflects only the head
        constructor's own contribution (the decomposition zeroes anything
        flowing through a separately-tracked inner type or parameter), so
@@ -75,11 +78,13 @@ module Provenance = struct
       Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
       |> make ~plural:false
            ~source_type_id:(Some (Types.get_id source_type))
+           ~is_decl_under_check
            ~parent
     in
     let register_text text =
       make ~plural:true
         ~source_type_id:(Some (Types.get_id ty))
+        ~is_decl_under_check
         ~parent
         (Format_doc.doc_printf "%s" text)
     in
@@ -96,7 +101,7 @@ module Provenance = struct
     | _ -> register_type ~source_type:ty ty
 
   let register_phrase ~parent text =
-    make ~plural:true ~source_type_id:None ~parent
+    make ~plural:true ~source_type_id:None ~is_decl_under_check:false ~parent
       (Format_doc.doc_printf "%s" text)
 
   let reset () = entries := []
@@ -113,6 +118,12 @@ module Solver = struct
   type mode =
     | Normal
     | Round_up
+
+  let rec uid_is_reliable_identity = function
+    | Types.Uid.Internal -> false
+    | Types.Uid.Unboxed_version uid -> uid_is_reliable_identity uid
+    | Types.Uid.Compilation_unit _ | Types.Uid.Item _ | Types.Uid.Predef _ ->
+      true
 
   (* Hash tables avoiding polymorphic structural comparison on deep values.
      [Btype.TypeHash] keys by the representative of a [type_expr], so
@@ -145,6 +156,7 @@ module Solver = struct
 
   and provenance_ctx =
     { parent : Provenance.id option;
+      decl_uid_under_check : Types.Uid.t option;
       kinds : (int * Provenance.id option, Ldd.node) Hashtbl.t
     }
 
@@ -176,9 +188,10 @@ module Solver = struct
 
   let reset_for_mode (ctx : ctx) ~(mode : mode) : ctx = { ctx with mode }
 
-  let with_provenance (ctx : ctx) : ctx =
+  let with_provenance ?decl_uid_under_check (ctx : ctx) : ctx =
     { ctx with
-      provenance = Some { parent = None; kinds = Hashtbl.create 1 };
+      provenance =
+        Some { parent = None; decl_uid_under_check; kinds = Hashtbl.create 1 };
       ty_to_kind = TyTbl.create 1
     }
 
@@ -210,7 +223,20 @@ module Solver = struct
     match ctx.provenance with
     | None -> Fun.id, ctx
     | Some ({ parent; _ } as provenance_ctx) ->
-      let provenance = Provenance.register ~parent ty in
+      let is_decl_under_check =
+        match
+          provenance_ctx.decl_uid_under_check, ctx.env, Types.get_desc ty
+        with
+        | Some decl_uid, Some env, Types.Tconstr (path, _, _)
+          when uid_is_reliable_identity decl_uid -> (
+          match Env.find_type path env with
+          | exception Not_found -> false
+          | decl -> Types.Uid.equal decl_uid decl.type_uid)
+        | None, _, _ | Some _, None, _ | Some _, Some _, _ -> false
+      in
+      let provenance =
+        Provenance.register ~is_decl_under_check ~parent ty
+      in
       ( (fun poly -> Ldd.meet poly (rigid_name ctx (Provenance.name provenance))),
         { ctx with
           provenance = Some { provenance_ctx with parent = Some provenance.id }
@@ -846,10 +872,14 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
   match Ldd.leq_with_reason base super_poly with
   | _ :: _ -> None
   | [] ->
+    (* Self occurrences stay in the decomposition universe and provenance
+       forest, but are not independent causes to report for their own
+       declaration. Filtering here also prevents them from hiding nested
+       causes as enclosing residuals. *)
     let entries =
       List.combine provenances coeffs
-      |> List.filter_map (fun (provenance, coeff) ->
-          if is_bot_poly coeff
+      |> List.filter_map (fun ((provenance : Provenance.t), coeff) ->
+          if provenance.is_decl_under_check || is_bot_poly coeff
           then None
           else
             let mode_bounds = Ldd.imply coeff super_poly |> Ldd.round_down in
@@ -1492,10 +1522,10 @@ let compute_subcheck_polys ~context:_ env (sub : ('l1 * 'r1) Types.jkind)
     ~lhs_floor:(Some (fun ctx -> Solver.mod_bounds_floor_of_jkind ctx sub))
     ~lhs:(fun ctx -> Solver.ckind_of_jkind ctx sub)
 
-let compute_provenance_bound_polys env ~(lhs : Solver.ctx -> Ldd.node)
-    (bound : Types.jkind_l) : subcheck_polys =
+let compute_provenance_bound_polys ?decl_uid_under_check env
+    ~(lhs : Solver.ctx -> Ldd.node) (bound : Types.jkind_l) : subcheck_polys =
   compute_bound_polys env bound ~lhs_floor:None ~lhs:(fun ctx ->
-      let ctx = Solver.with_provenance ctx in
+      let ctx = Solver.with_provenance ?decl_uid_under_check ctx in
       lhs ctx)
 
 let check_mode_crossing_polys ~origin:_ ~sub_jkind:_ ~super_jkind ~printing_env
@@ -1615,8 +1645,8 @@ let sub_jkind_l ?(allow_any_crossing = false) ?origin
           | Ok () -> Error ikind_error
           | Error jkind_error -> Error (Jkind_error jkind_error))
 
-let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
-    ~actual ~bound ~provenance_lhs =
+let check_bound ?(allow_any_crossing = false) ?origin ?decl_uid_under_check
+    ~type_equal ~context env ~actual ~bound ~provenance_lhs =
   if not (enable_sub_jkind_l && !Clflags.ikinds)
   then
     sub_jkind_l ~allow_any_crossing ?origin ~type_equal ~context env actual
@@ -1656,7 +1686,8 @@ let check_bound ?(allow_any_crossing = false) ?origin ~type_equal ~context env
         in
         best_effort_provenance_error ~fallback_error ~origin ~sub_jkind:actual
           ~super_jkind:bound ~printing_env:env actual_error (fun () ->
-            compute_provenance_bound_polys env ~lhs:provenance_lhs bound)
+            compute_provenance_bound_polys ?decl_uid_under_check env
+              ~lhs:provenance_lhs bound)
 
 let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
   check_bound ?origin ~type_equal ~context env ~actual ~bound
@@ -1664,8 +1695,10 @@ let check_type_expr_bound ?origin ~type_equal ~context env ~ty ~actual ~bound =
 
 let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
     ~decl ~actual ~bound =
-  check_bound ?allow_any_crossing ?origin ~type_equal ~context env ~actual
-    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
+  check_bound ?allow_any_crossing ?origin
+    ~decl_uid_under_check:decl.Types.type_uid ~type_equal ~context env ~actual
+    ~bound
+    ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -824,9 +824,10 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
        satisfy the required bound?
 
      This is the right question because the provenance variable stands for the
-     mode-crossing behavior we need from the source type. It gives the least
-     restrictive bound that would still make the original lattice comparison
-     pass.
+     mode-crossing behavior we need from the source type. Before rounding, its
+     answer is the least restrictive bound that would make this contribution
+     satisfy the required bound. Rounding down may strengthen that answer when
+     converting it to a concrete mode bound for printing.
 
      We answer the question by first decomposing the provenance-annotated
      polynomial into an untracked base plus one coefficient per provenance

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -78,14 +78,12 @@ module Provenance = struct
       Format_doc.doc_printf "@[<hov>%a@]" Jkind.format_type_expr ty
       |> make ~plural:false
            ~source_type_id:(Some (Types.get_id source_type))
-           ~is_decl_under_check
-           ~parent
+           ~is_decl_under_check ~parent
     in
     let register_text text =
       make ~plural:true
         ~source_type_id:(Some (Types.get_id ty))
-        ~is_decl_under_check
-        ~parent
+        ~is_decl_under_check ~parent
         (Format_doc.doc_printf "%s" text)
     in
     match Types.get_desc ty with
@@ -234,9 +232,7 @@ module Solver = struct
           | decl -> Types.Uid.equal decl_uid decl.type_uid)
         | None, _, _ | Some _, None, _ | Some _, Some _, _ -> false
       in
-      let provenance =
-        Provenance.register ~is_decl_under_check ~parent ty
-      in
+      let provenance = Provenance.register ~is_decl_under_check ~parent ty in
       ( (fun poly -> Ldd.meet poly (rigid_name ctx (Provenance.name provenance))),
         { ctx with
           provenance = Some { provenance_ctx with parent = Some provenance.id }
@@ -1587,8 +1583,7 @@ let best_effort_provenance_error ~fallback_error ~origin ~sub_jkind ~super_jkind
     with
     | Ok () -> None
     | Error provenance_error ->
-      if
-        subjkind_errors_have_same_violating_axes actual_error provenance_error
+      if subjkind_errors_have_same_violating_axes actual_error provenance_error
       then subjkind_error_with_provenance_residuals provenance_error
       else None
   in
@@ -1697,8 +1692,7 @@ let check_type_decl_bound ?allow_any_crossing ?origin ~type_equal ~context env
     ~decl ~actual ~bound =
   check_bound ?allow_any_crossing ?origin
     ~decl_uid_under_check:decl.Types.type_uid ~type_equal ~context env ~actual
-    ~bound
-    ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
+    ~bound ~provenance_lhs:(fun ctx -> type_decl_rhs_kind_poly ctx decl)
 
 let crossing_of_jkind ~(context : Jkind.jkind_context) env
     (jkind : ('l * 'r) Types.jkind) : Mode.Crossing.t =

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -869,47 +869,76 @@ let provenance_residuals ~provenances ~violating_axes ~sub_poly ~super_poly =
               | [] -> None
               | _ :: _ -> Some { provenance; mode_bounds; axes })
     in
-    let raw_axes_by_id = Hashtbl.create (List.length entries) in
+    (* [raw_bounds_by_id] holds, per surviving raw entry, its requirement
+       restricted to its reported axes (top elsewhere): the exact per-axis
+       VALUES the entry's message will demand of its subject. *)
+    let raw_bounds_by_id = Hashtbl.create (List.length entries) in
     List.iter
       (fun entry ->
-        Hashtbl.add raw_axes_by_id entry.provenance.id
-          (axis_set_of_axes entry.axes))
+        Hashtbl.add raw_bounds_by_id entry.provenance.id
+          (restrict_mode_bounds_to_axes entry.mode_bounds entry.axes))
       entries;
     let provenances_by_id = Hashtbl.create (List.length provenances) in
     List.iter
       (fun (provenance : Provenance.t) ->
         Hashtbl.add provenances_by_id provenance.id provenance)
       provenances;
-    let covered_axes_by_id = Hashtbl.create (List.length provenances) in
-    let rec covered_axes (provenance : Provenance.t) =
-      match Hashtbl.find_opt covered_axes_by_id provenance.id with
-      | Some axes -> axes
+    (* An enclosing entry only explains a nested requirement it ENTAILS:
+       same axis and an at-least-as-strong required value. Requirements
+       are kept as a list per ancestor rather than meet-collapsed into a
+       single lattice element: on the diamond axes (portability,
+       contention) the meet of two incomparable ancestor requirements
+       (e.g. shareable and corruptible) would wrongly claim to cover a
+       strictly stronger nested one (portable) that neither ancestor
+       explains. The [parent] links form an acyclic forest, so the walk
+       terminates. *)
+    let covered_bounds_by_id = Hashtbl.create (List.length provenances) in
+    let rec covered_bounds (provenance : Provenance.t) =
+      match Hashtbl.find_opt covered_bounds_by_id provenance.id with
+      | Some bounds -> bounds
       | None ->
-        let parent_axes =
+        let parent_bounds =
           match provenance.parent with
-          | None -> Jkind_axis.Axis_set.empty
-          | Some parent -> covered_axes (Hashtbl.find provenances_by_id parent)
+          | None -> []
+          | Some parent ->
+            covered_bounds (Hashtbl.find provenances_by_id parent)
         in
-        let own_axes =
-          Option.value
-            (Hashtbl.find_opt raw_axes_by_id provenance.id)
-            ~default:Jkind_axis.Axis_set.empty
+        let bounds =
+          match Hashtbl.find_opt raw_bounds_by_id provenance.id with
+          | None -> parent_bounds
+          | Some own -> own :: parent_bounds
         in
-        let axes = Jkind_axis.Axis_set.union parent_axes own_axes in
-        Hashtbl.add covered_axes_by_id provenance.id axes;
-        axes
+        Hashtbl.add covered_bounds_by_id provenance.id bounds;
+        bounds
+    in
+    (* [ancestor] entails [entry] on an axis iff its required value there
+       is below (at least as strong as) the entry's: [co_sub] is bot
+       exactly on those axes. Axes where [ancestor] reports nothing are
+       top after restriction and thus never entail a reported axis. *)
+    let entailed_axes ~ancestor entry =
+      Axis_lattice.co_sub ancestor entry.mode_bounds
+      |> Axis_lattice.non_bot_axes
+      |> List.map Axis_lattice.axis_number_to_axis_packed
+      |> axis_set_of_axes |> Jkind_axis.Axis_set.complement
     in
     entries
     |> List.filter_map (fun entry ->
-        let parent_axes =
+        let parent_bounds =
           match entry.provenance.parent with
-          | None -> Jkind_axis.Axis_set.empty
-          | Some parent -> covered_axes (Hashtbl.find provenances_by_id parent)
+          | None -> []
+          | Some parent ->
+            covered_bounds (Hashtbl.find provenances_by_id parent)
+        in
+        let covered =
+          List.fold_left
+            (fun covered ancestor ->
+              Jkind_axis.Axis_set.union covered (entailed_axes ~ancestor entry))
+            Jkind_axis.Axis_set.empty parent_bounds
         in
         let axes =
           List.filter
             (fun (Jkind_axis.Axis.Pack axis) ->
-              not (Jkind_axis.Axis_set.mem parent_axes axis))
+              not (Jkind_axis.Axis_set.mem covered axis))
             entry.axes
         in
         match axes with


### PR DESCRIPTION
Stacked on #6262.

For:

```ocaml
type t : value mod contended
type 'a b = Foo of t * 'a
type 'a c : value mod portable contended = { b : 'a b }
```

#6262 can report portability on both `b` and the nested `'a`. This PR tracks enclosing provenance per occurrence and removes only axes already explained by an enclosing item:

```text
- b is not mod portable
- 'a is not mod contended
```