### PR TITLE
Get rid of useless [let x = x] bindings from dataflow

### DIFF
--- a/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_apply_cont_expr.ml
@@ -40,20 +40,25 @@ let inline_linearly_used_continuation uacc ~params:params' ~handler
       (RE.print (UA.are_rebuilding_terms uacc))
       handler;
   let bindings_outermost_first =
-    ListLabels.map2 params args ~f:(fun param arg ->
-        let let_bound =
-          let param_var, param_uid = BP.var_and_uid param in
-          Bound_var.create param_var param_uid Name_mode.normal
-          |> Bound_pattern.singleton
-        in
+    ListLabels.map2 params args
+      ~f:(fun param arg : Expr_builder.binding_to_place ->
+        let param_var, param_uid = BP.var_and_uid param in
         let named = Named.create_simple arg in
-        let machine_width = UE.machine_width (UA.uenv uacc) in
-        Expr_builder.Keep_binding
-          { let_bound;
-            simplified_defining_expr =
-              Simplified_named.create ~machine_width named;
-            original_defining_expr = Some named
-          })
+        (* Get rid of useless [let x = x] bindings from dataflow. *)
+        if Simple.equal arg (Simple.var param_var)
+        then Delete_binding { original_defining_expr = Some named }
+        else
+          let let_bound =
+            Bound_var.create param_var param_uid Name_mode.normal
+            |> Bound_pattern.singleton
+          in
+          let machine_width = UE.machine_width (UA.uenv uacc) in
+          Keep_binding
+            { let_bound;
+              simplified_defining_expr =
+                Simplified_named.create ~machine_width named;
+              original_defining_expr = Some named
+            })
   in
   let expr, uacc =
     let uacc =

--- a/testsuite/tests/flambda2/examples/cse_minus.simplify.reference
+++ b/testsuite/tests/flambda2/examples/cse_minus.simplify.reference
@@ -22,12 +22,11 @@ let code loopify(never) size(43) newer_version_of(f_0)
       | 0 -> k3
       | 1 -> k4 (int_sub))
      where k4 (int_sub_1) =
-       let int_sub_2 = int_sub_1 in
-       let Parrayrefs = %array_load.mut (table_1, int_sub_2) in
+       let Parrayrefs = %array_load.mut (table_1, int_sub_1) in
        let prim = %phys_eq (Parrayrefs, 0) in
        switch prim
          | 0 -> k1 pop(regular k1) ($camlCse_minus__Pmakeblock_4)
-         | 1 -> k2 (int_sub_2)
+         | 1 -> k2 (int_sub_1)
      where k3 =
        cont k1 pop(regular k1) ($camlCse_minus__block_1))
     where k2 (int_sub) =


### PR DESCRIPTION
These have been annoying me for a while and I finally stumbled upon the place where they are generated, so, they are gone now.