### PR TITLE
Use renamings instead of var to var let bindings for dataflow renamings

### DIFF
--- a/middle_end/flambda2/simplify/rebuilt_expr.ml
+++ b/middle_end/flambda2/simplify/rebuilt_expr.ml
@@ -19,6 +19,8 @@ type t = Expr.t
 
 type rebuilt_expr = t
 
+let apply_renaming = Expr.apply_renaming
+
 let to_expr t are_rebuilding =
   if ART.do_not_rebuild_terms are_rebuilding
   then

--- a/middle_end/flambda2/simplify/rebuilt_expr.mli
+++ b/middle_end/flambda2/simplify/rebuilt_expr.mli
@@ -29,6 +29,8 @@ type t
 
 type rebuilt_expr = t
 
+val apply_renaming : t -> Renaming.t -> t
+
 val print : Are_rebuilding_terms.t -> Format.formatter -> t -> unit
 
 (** This function may only be used when rebuilding terms. *)

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -584,21 +584,37 @@ let add_lets_around_handler cont at_unit_toplevel uacc handler =
   let handler, uacc =
     Variable.Lmap.fold
       (fun var bound_to (handler, uacc) ->
-        let var_duid = Flambda_debug_uid.none in
-        (* CR sspies: [var] can be derived/aliased from a user visible variable.
-           If we can, it would be good to propagate debugging UIDs (or derived
-           UIDs) here in the future. For now, we make due without. See #3967 *)
-        let bound_pattern =
-          Bound_pattern.singleton
-            (Bound_var.create var var_duid Name_mode.normal)
+        let let_bindings () =
+          let var_duid = Flambda_debug_uid.none in
+          (* CR sspies: [var] can be derived/aliased from a user visible
+             variable. If we can, it would be good to propagate debugging UIDs
+             (or derived UIDs) here in the future. For now, we make due without.
+             See #3967 *)
+          let bound_pattern =
+            Bound_pattern.singleton
+              (Bound_var.create var var_duid Name_mode.normal)
+          in
+          let named = Named.create_simple bound_to in
+          let handler, uacc =
+            Expr_builder.create_let_binding uacc bound_pattern named
+              ~free_names_of_defining_expr:(Simple.free_names bound_to)
+              ~cost_metrics_of_defining_expr:Cost_metrics.zero ~body:handler
+          in
+          handler, uacc
         in
-        let named = Named.create_simple bound_to in
-        let handler, uacc =
-          Expr_builder.create_let_binding uacc bound_pattern named
-            ~free_names_of_defining_expr:(Simple.free_names bound_to)
-            ~cost_metrics_of_defining_expr:Cost_metrics.zero ~body:handler
-        in
-        handler, uacc)
+        Simple.pattern_match' bound_to
+          ~const:(fun _ -> let_bindings ())
+          ~symbol:(fun _ ~coercion:_ -> let_bindings ())
+          ~var:(fun bound_to ~coercion ->
+            if Coercion.is_id coercion
+            then
+              let renaming = Renaming.(add_variable empty var bound_to) in
+              let name_occurrences =
+                Name_occurrences.apply_renaming (UA.name_occurrences uacc) renaming
+              in
+              let uacc = UA.with_name_occurrences uacc ~name_occurrences in
+              Rebuilt_expr.apply_renaming handler renaming, uacc
+            else let_bindings ()))
       continuation_parameters.lets_to_introduce (handler, uacc)
   in
   let handler, uacc =


### PR DESCRIPTION
I understand @bclement-ocp 's frustration from https://github.com/oxcaml/oxcaml/pull/6775 . This might be some welcome additional cleanup.

Instead of introducing many `let x = y` bindings, we apply a renaming on variables. This might not be the best place to do that, maybe doing that in the function for building let bindings might be better.