### PR TITLE
Fix placement of lifted constants relative to alias-analysis rebinding lets

### DIFF
--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -582,6 +582,29 @@ let add_lets_around_handler cont at_unit_toplevel uacc handler =
         Continuation.print cont
   in
   let handler, uacc =
+    (* We might need to place lifted constants now, as they could depend on
+       continuation parameters. As such we must also compute the unused
+       parameters after placing any constants! *)
+    if not at_unit_toplevel
+    then handler, uacc
+    else
+      let uacc, lifted_constants_from_body =
+        UA.get_and_clear_lifted_constants uacc
+      in
+      EB.place_lifted_constants uacc
+        ~lifted_constants_from_defining_expr:LCS.empty
+        ~lifted_constants_from_body
+        ~put_bindings_around_body:(fun uacc ~body -> body, uacc)
+        ~body:handler
+  in
+  (* The [lets_to_introduce] rebind parameters that the alias analysis has
+     removed from the continuation. These lets must be placed outside any
+     lifted constants placed above, since such constants can reference the
+     removed parameters, which are not bound anywhere else. Conversely, each
+     let's defining expression is the parameter's canonical dominator, which
+     must be in scope at the continuation's use sites, so it cannot be bound
+     by the lifted constants placed inside. *)
+  let handler, uacc =
     Variable.Lmap.fold
       (fun var bound_to (handler, uacc) ->
         let var_duid = Flambda_debug_uid.none in
@@ -600,22 +623,6 @@ let add_lets_around_handler cont at_unit_toplevel uacc handler =
         in
         handler, uacc)
       continuation_parameters.lets_to_introduce (handler, uacc)
-  in
-  let handler, uacc =
-    (* We might need to place lifted constants now, as they could depend on
-       continuation parameters. As such we must also compute the unused
-       parameters after placing any constants! *)
-    if not at_unit_toplevel
-    then handler, uacc
-    else
-      let uacc, lifted_constants_from_body =
-        UA.get_and_clear_lifted_constants uacc
-      in
-      EB.place_lifted_constants uacc
-        ~lifted_constants_from_defining_expr:LCS.empty
-        ~lifted_constants_from_body
-        ~put_bindings_around_body:(fun uacc ~body -> body, uacc)
-        ~body:handler
   in
   let free_names = UA.name_occurrences uacc in
   let cost_metrics = UA.cost_metrics uacc in

--- a/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
+++ b/middle_end/flambda2/simplify/simplify_let_cont_expr.ml
@@ -598,12 +598,12 @@ let add_lets_around_handler cont at_unit_toplevel uacc handler =
         ~body:handler
   in
   (* The [lets_to_introduce] rebind parameters that the alias analysis has
-     removed from the continuation. These lets must be placed outside any
-     lifted constants placed above, since such constants can reference the
-     removed parameters, which are not bound anywhere else. Conversely, each
-     let's defining expression is the parameter's canonical dominator, which
-     must be in scope at the continuation's use sites, so it cannot be bound
-     by the lifted constants placed inside. *)
+     removed from the continuation. These lets must be placed outside any lifted
+     constants placed above, since such constants can reference the removed
+     parameters, which are not bound anywhere else. Conversely, each let's
+     defining expression is the parameter's canonical dominator, which must be
+     in scope at the continuation's use sites, so it cannot be bound by the
+     lifted constants placed inside. *)
   let handler, uacc =
     Variable.Lmap.fold
       (fun var bound_to (handler, uacc) ->

--- a/testsuite/tests/flambda2/lifted_constant_removed_params.ml
+++ b/testsuite/tests/flambda2/lifted_constant_removed_params.ml
@@ -22,55 +22,31 @@
    that determines which member of an alias class becomes the canonical
    dominator.
 
-   This file was minimized (by chamelon) from real code; the exact shape,
-   including the seemingly redundant matches and opaque calls, is load
-   bearing. *)
+   This file was minimized from real code (patdiff). *)
 
 [@@@ocaml.warning "-6-20-26-27-32-37-39-60"]
 
 external __dummy2__ : unit -> 'a = "%opaque"
-
-external __ignore__ : 'a -> unit = "%ignore"
+external opaque : 'a -> 'a = "%opaque"
 
 module Comparison_result = struct
-  type config = { assume_text : bool }
-
   type t =
     | Binary_different of
         { prev_is_binary : bool
         ; next_is_binary : bool
         }
 
-  let is_binary (s : _) =
-    let (_ : int) =
-      if (__dummy2__ ()) ((__dummy2__ ()) 0) then (__dummy2__ ()) ~length:0 else 0
-    in
-    let rec go i = __dummy2__ () && (__dummy2__ ()) ((__dummy2__ ()) __dummy2__) in
-    go 0
-
-  let create (config : _) ~prev:(_ : _) ~next:(_ : _) ~compare_assuming_text:_ =
+  let[@inline always] create config =
     let prev_is_binary, next_is_binary =
-      match config.assume_text with
+      match config with
       | true -> __dummy2__ ()
-      | false -> is_binary "", __dummy2__ ()
+      | false -> let x =  __dummy2__ () in (x, (__dummy2__ () && __dummy2__ ()))
     in
-    if prev_is_binary || __dummy2__ ()
+    if next_is_binary
     then Binary_different { next_is_binary; prev_is_binary }
     else __dummy2__ ()
 end
 
-module Compare_core = struct
-  module type S_stub = sig end
-
-  module Make (Patdiff_core_arg : S_stub) = struct
-    let diff_strings (config : _) =
-      Comparison_result.create config __dummy2__ __dummy2__ __dummy2__
-  end
-
-  module Patdiff_core_stub : S_stub = struct end
-  module Without_unix = Make (Patdiff_core_stub)
-end
-
 let (_ : Comparison_result.t) =
-  let config = { Comparison_result.assume_text = false } in
-  Compare_core.Without_unix.diff_strings config
+  let config = false in
+  opaque (Comparison_result.create config)

--- a/testsuite/tests/flambda2/lifted_constant_removed_params.ml
+++ b/testsuite/tests/flambda2/lifted_constant_removed_params.ml
@@ -1,0 +1,76 @@
+(* TEST
+ compile_only = "true";
+ flambda2;
+ ocamlopt_flags += " -O3";
+ setup-ocamlopt.byte-build-env;
+ ocamlopt.byte;
+*)
+
+(* Regression test for a bug in the placement of lifted constants relative to
+   the [let]s introduced by the flow analysis to rebind alias-removed
+   continuation parameters (see [Simplify_let_cont_expr.add_lets_around_handler]).
+
+   The alias analysis removes continuation parameters whose canonical
+   dominator is another simple, rebinding them inside the handler with
+   [let param = dominator]. At unit toplevel, lifted constants placed around
+   the same handler can reference such removed parameters. They were
+   previously placed outside the rebinding [let]s, leaving the reference to
+   the removed parameter unbound in the rebuilt term, which tripped the
+   fatal error "The alias analysis marked the param ... as removed, but the
+   free_names indicate it is actually used". Whether the crash manifested
+   was sensitive to name-stamp ordering (e.g. the source file name), since
+   that determines which member of an alias class becomes the canonical
+   dominator.
+
+   This file was minimized (by chamelon) from real code; the exact shape,
+   including the seemingly redundant matches and opaque calls, is load
+   bearing. *)
+
+[@@@ocaml.warning "-6-20-26-27-32-37-39-60"]
+
+external __dummy2__ : unit -> 'a = "%opaque"
+
+external __ignore__ : 'a -> unit = "%ignore"
+
+module Comparison_result = struct
+  type config = { assume_text : bool }
+
+  type t =
+    | Binary_different of
+        { prev_is_binary : bool
+        ; next_is_binary : bool
+        }
+
+  let is_binary (s : _) =
+    let (_ : int) =
+      if (__dummy2__ ()) ((__dummy2__ ()) 0) then (__dummy2__ ()) ~length:0 else 0
+    in
+    let rec go i = __dummy2__ () && (__dummy2__ ()) ((__dummy2__ ()) __dummy2__) in
+    go 0
+
+  let create (config : _) ~prev:(_ : _) ~next:(_ : _) ~compare_assuming_text:_ =
+    let prev_is_binary, next_is_binary =
+      match config.assume_text with
+      | true -> __dummy2__ ()
+      | false -> is_binary "", __dummy2__ ()
+    in
+    if prev_is_binary || __dummy2__ ()
+    then Binary_different { next_is_binary; prev_is_binary }
+    else __dummy2__ ()
+end
+
+module Compare_core = struct
+  module type S_stub = sig end
+
+  module Make (Patdiff_core_arg : S_stub) = struct
+    let diff_strings (config : _) =
+      Comparison_result.create config __dummy2__ __dummy2__ __dummy2__
+  end
+
+  module Patdiff_core_stub : S_stub = struct end
+  module Without_unix = Make (Patdiff_core_stub)
+end
+
+let (_ : Comparison_result.t) =
+  let config = { Comparison_result.assume_text = false } in
+  Compare_core.Without_unix.diff_strings config


### PR DESCRIPTION
## Description

This fixes a compiler crash of the form "The alias analysis marked the param (foo/184382 :: tagged_immediate) as removed, but the free_names indicate it is actually used", raised by the sanity check in `Simplify_let_cont_expr.decide_param_usage_non_recursive` when rebuilding a non-recursive continuation handler at unit toplevel. The crash was originally observed with `-flambda2-match-in-match` but only requires `-O3`, and whether it triggers is sensitive to the source file name, because the choice of canonical dominator within an alias class depends on name ordering.

The flow analysis removes a continuation parameter whose canonical dominator is another simple, and arranges for the parameter to be rebound inside the handler via `lets_to_introduce` (`let p = dom(p)` wrapped around the handler by `add_lets_around_handler`). Separately, at unit toplevel, lifted constants from the handler body are placed around the handler at the same point; as the existing comment notes, they can depend on continuation parameters. Previously the constants were placed after the rebinding lets, i.e. outside them, so a lifted constant that referenced a removed parameter ended up referring to a name that is not bound anywhere in the rebuilt term: the parameter had been removed from the continuation and its rebinding let sat inside the constant's placement. The free-names accounting then correctly reported the removed parameter as used, and the sanity check failed. This is not just a failed assertion: the rebuilt term was genuinely mis-scoped.

The fix swaps the two wrapping steps: lifted constants are placed first, directly around the handler, and the `lets_to_introduce` rebindings are wrapped outermost. This is sound in both directions. Constants may reference removed parameters, which are bound nowhere else, so the rebinding lets must enclose them. Conversely each rebinding let's defining expression is the parameter's canonical dominator, which must already be in scope at the continuation's use sites and is therefore defined above the continuation; it cannot be bound by the constants placed inside, so no dependency runs the other way.

## Testing

A reproducer minimized from real code (patdiff) crashes with `-O3` before this change and compiles after it. That reproducer is included as a compile-only regression test, `testsuite/tests/flambda2/lifted_constant_removed_params.ml`, verified to fail before this change and pass after it (the verification matters because the crash is sensitive to name-stamp ordering, so renaming the file could in principle have defused it). The full testsuite was compiled with the fix applied with `-O3` and with `-O3 -flambda2-match-in-match` with no new failures. The affected function is byte-identical between `oxcaml/main` and the development branch on which the fix was validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
