### PR TITLE
Stack 1/6: a fast development loop for compiler work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,71 +1,134 @@
-# AGENTS.md
+# OxCaml agent guide
 
-This file provides guidance to AI agents when working with code in this repository.
+Do not stage or commit changes unless asked.
 
-# OxCaml Compiler Development Guide
+Use the development commands below while editing. They keep a boot-compiler
+watcher in the background, wait for it before using its output, and report
+compiler errors before running a test or compiler command.
 
-Do not stage or commit your changes unless prompted to.
-Always check that your changes build with both (after configuration, see below):
-1. `make -s boot-compiler` - Quick build check
-2. `make -s test` - Full test suite (required before declaring success)
+## Initial setup
 
-You are working on the OxCaml compiler, a performance-focused fork of OCaml with Jane Street extensions, including the Flambda 2 optimizer and CFG backend.
+A fresh worktree needs one complete build and test installation:
 
-## Key Architecture
-
-**Directory Structure:**
-- `middle_end/flambda2/` - Flambda 2 optimizer implementation
-- `backend/cfg/` - Control Flow Graph backend
-- `driver/` - Compiler driver, including `oxcaml_*` files for OxCaml-specific options
-- `jane/` - Jane Street specific extensions and documentation
-- `testsuite/tests/` - Upstream OCaml test suite
-- `oxcaml/tests/` - OxCaml-specific tests
-
-**Important Files:**
-- `driver/oxcaml_flags.ml` - OxCaml compiler flags definitions
-- `driver/oxcaml_args.ml` - Command-line argument handling
-- Files ending in `.in` require configuration via `./configure`
-
-## Build Commands
-```bash
-make -s boot-compiler         # Quick build (recommended for development)
-make -s                       # Full build
-make -s install               # Install the compiler to $(pwd)/_install
-make -s fmt                   # Auto-format code (always run before committing)
+```sh
+autoconf
+./configure --prefix="$PWD/_install"
+make install
 ```
 
-## Test Commands
-```bash
-make -s test-one TEST=test-dir/path.ml      # Run a single test testsuite/tests/test-dir/path.ml
-make -s test-one DIR=test-dir               # Run all tests in testsuite/tests/test-dir
-make -s promote-one TEST=test-dir/path.ml   # Update expected test output
-make -s test                                # Run all tests
+On the measured Apple Silicon machine, configuration took about 15 seconds and
+the first optimized install took about 4.5 minutes.
+
+## Development loop
+
+Start speculative compilation before editing:
+
+```sh
+make dev
 ```
 
-## Configuration Commands
-```bash
-autoconf                  # Generate configure script
-./configure               # Configure the compiler
+`make dev` returns immediately. Starting it is optional because every command
+below starts or restarts it automatically. The watcher is local to this
+worktree and exits after 30 idle minutes.
+
+Run one test or test directory:
+
+```sh
+make dev-test TEST=typing-local/regression_class_type.ml
+make dev-test DIR=lib-bool
 ```
 
-If the execution of `autoconf` fails because the version is too old, try with `autoconf27` instead.
+Promote a focused test:
 
-Configuration is needed after changing `.in` files or the autoconf script.
+```sh
+make dev-promote TEST=typing-local/regression_class_type.ml
+```
 
-## Development Guidelines
-- Always verify changes build with `make -s boot-compiler`
-- Run `make -s fmt` to ensure code formatting
-- Keep lines under 80 characters
-- Don't add excessive comments unless prompted
-- Don't disable warnings or tests unless prompted
-- Use pattern-matching and functional programming idioms
-- Avoid `assert false` and other unreachable code
-- Rebuild the project often while using the LSP using `make -s boot-compiler`. When
-  you don't rebuild, the LSP may give you stale information from a previous build
+Compile files with the watched compiler:
 
-## Important Notes
+```sh
+make dev-ocamlc ARGS='-c /tmp/probe.ml -o /tmp/probe.cmo'
+make dev-ocamlopt ARGS='/tmp/probe.ml -o /tmp/probe.exe'
+```
 
-- NEVER create files unless absolutely necessary
-- ALWAYS prefer editing existing files
-- NEVER proactively create documentation files (*.md) or README files
-- NEVER stage or commit changes unless explicitly requested
+`ARGS` has the same contents as an `ocamlc` or `ocamlopt` command line. Quote
+it so Make and the shell preserve spaces. These targets select the watched
+compiler and its matching development standard library.
+
+The normal loop is therefore:
+
+```text
+make dev
+edit
+make dev-test TEST=...
+edit
+make dev-test TEST=...
+```
+
+The watcher begins compiling on each save. `dev-test`, `dev-promote`,
+`dev-ocamlc`, and `dev-ocamlopt` wait for the latest saved source state. They
+do not run when that build has a type error.
+
+Existing and newly added tests are read from the live `testsuite/tests` tree.
+No `_runtest` refresh is needed. Standard-library and runtime edits are also
+detected; the next development command refreshes those components before
+continuing.
+
+Expect tests embed compiler libraries in their runner. `dev-test` detects
+`expect` and `expectnat` actions and refreshes a stale runner automatically.
+The watcher uses an isolated Dune build directory, so it does not invalidate
+the main Dune context. A measured runner refresh after a compiler edit took
+about 38 seconds.
+
+The development test root intentionally has no `ocamlopt.byte`. Use the normal
+final-compiler test path for a test that explicitly requires the
+bytecode-hosted native compiler.
+
+Useful recovery commands are:
+
+```sh
+make dev-status
+make dev-log
+make dev-stop
+```
+
+Do not run another Dune or ordinary Make build while the watcher is active.
+Use `make dev-stop` first. The development commands coordinate with the
+watcher themselves.
+
+## Final validation
+
+The development compiler is an unoptimized boot compiler. It is intended for
+fast typechecking and functional tests, not final validation.
+
+Use the final compiler when testing self-hosting, bytecode-only compiler
+variants, release behavior, compiler performance, benchmarks, or memtraces:
+
+```sh
+make dev-stop
+make install
+make test-one TEST=test-dir/path.ml
+```
+
+Use targeted tests while iterating. Run `make test` only for broad changes or
+when asked. On the measured machine, a small warm `dev-test` took about one
+second, while the complete test suite took about 6 minutes 43 seconds.
+
+Always benchmark or memtrace with the compiler produced by `make install`,
+never with the boot compiler. Configure without `--enable-dev` for performance
+measurements.
+
+Run `make fmt` before committing when the changed files are covered by the
+formatter. Do not disable warnings or tests unless asked.
+
+## Repository map
+
+- `middle_end/flambda2/`: Flambda 2 optimizer
+- `backend/cfg/`: CFG backend
+- `driver/`: compiler drivers and OxCaml command-line handling
+- `jane/`: Jane Street extensions and documentation
+- `testsuite/tests/`: upstream OCaml tests
+- `oxcaml/tests/`: OxCaml-specific tests
+
+Files ending in `.in` require configuration after they change. Keep lines
+under 80 characters and prefer the existing functional OCaml style.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,19 @@ make dev-test TEST=typing-local/regression_class_type.ml
 make dev-test DIR=lib-bool
 ```
 
+Run the entire test suite with the final compiler and GNU Parallel:
+
+```sh
+make dev-test-all
+```
+
+`dev-test-all` validates the watched compiler, stops the watcher to avoid CPU
+contention, incrementally builds the final compiler, recreates the normal test
+installation, and runs the full suite. It restarts the watcher before returning,
+including after a build or test failure. It requires GNU Parallel rather than
+silently falling back to a slow sequential run. Use this for broad validation,
+not for the normal edit loop.
+
 Promote a focused test:
 
 ```sh
@@ -111,8 +124,13 @@ make test-one TEST=test-dir/path.ml
 ```
 
 Use targeted tests while iterating. Run `make test` only for broad changes or
-when asked. On the measured machine, a small warm `dev-test` took about one
-second, while the complete test suite took about 6 minutes 43 seconds.
+when asked. `make dev-test-all` is the faster full-suite path after development
+edits. On the measured machine, a small warm `dev-test` took about one second,
+warm final-compiler preparation took about 10 seconds, and the complete parallel
+test execution took about 6 minutes 43 seconds, for about 6 minutes 53 seconds
+end to end when warm. After a compiler edit that caused a broad final rebuild,
+`dev-test-all` took about 10 minutes 19 seconds end to end. For a
+bootstrap-sensitive change, use ordinary `make test` instead.
 
 Always benchmark or memtrace with the compiler produced by `make install`,
 never with the boot compiler. Configure without `--enable-dev` for performance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,26 @@ make dev-test-all
 
 Benchmark and memtrace only with the compiler produced by `make install`, never
 the development boot compiler.
+
+## Review loop
+
+When the user asks you to review loop, that means that you launch several claude and codex agents to review the changes. Don't take their suggestions at face value: carefully triage which issues are real and important, and which aren't, with respect to the original goal. We want to avoid overcomplicating the code as a result of the review loop. The agents themselves should focus on:
+* Whether this is the simplest way to do it - AI coding can result in overcomplicated code and diffs that are not optimally small. It is very important to keep the code small and elegant for long term code health. Key question: is this the simplest, most elegant way to do it?
+* Is the architecture right? Is everything in the right place? Is there duplicated functionality? Is there a way to do it with less code?
+* What are the alternative ways of doing it? Is there a better way?
+* Whether there are bugs, ideally proved by a failing test case / repro. Triage whether you agree that the behavior is actually a bug or not.
+* Whether there is important missing test coverage, ideally proved by a mutation that currently makes no test fail - it's also important to curtail test growth: the test suite should be compact, and each test should add separate value.
+* In general: the key question is whether an expert human software engineer would critique the changeset as-is.
+
+It is very important that review agents have their own worktree to build and run experiments and develop tests.
+Once you have the review reports, try to ground claims in experimental reality as much as possible. Reproduce suggested issues. Try out suggested refactorings. Only accept if grounded reality shows that it is a real issue or real improvement.
+
+## Worktree structure
+
+Set up a directory named after the change/branch, and in that directory make a worktree called dev, and a subfolder called review where the worktrees of review agents live.
+
+## Design docs and specs
+
+Each change has a design doc, specified by the human. These live in the repo itself, in the design-docs folder. If that folder doesn't exist yet, make it. The design doc should be named after the branch.
+
+If, during development, you come across a decision point where the design doc is ambiguous or simply doesn't specify which route to take, then first decide (1) is there an arguably best route (2) does the decision actually matter much. Only if there is no clear best route, note at the end of the design doc in concise style which route you took and why, and which alternatives you considered, and also notify me so that I can help check if that's the right decision.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ When the user asks you to review loop, that means that you launch several claude
 It is very important that review agents have their own worktree to build and run experiments and develop tests.
 Once you have the review reports, try to ground claims in experimental reality as much as possible. Reproduce suggested issues. Try out suggested refactorings. Only accept if grounded reality shows that it is a real issue or real improvement.
 
+Try to get the deliverable in the best shape of the highest quality. Use of subagents is almost free compared to human software engineering time, so use them well. The biggest danger is not bugs: the biggest danger is is wrong design decisions. Significant agent effort should be spent on evaluating whether the design decisions are optimal, because otherwise we end up in a morass of slop and progress will slowly grind to a halt. We want to keep the project maximally healthy. If you need human help, don't hesitate to ask for it.
+
 ## Worktree structure
 
 Set up a directory named after the change/branch, and in that directory make a worktree called dev, and a subfolder called review where the worktrees of review agents live.
@@ -55,3 +57,7 @@ Set up a directory named after the change/branch, and in that directory make a w
 Each change has a design doc, specified by the human. These live in the repo itself, in the design-docs folder. If that folder doesn't exist yet, make it. The design doc should be named after the branch.
 
 If, during development, you come across a decision point where the design doc is ambiguous or simply doesn't specify which route to take, then first decide (1) is there an arguably best route (2) does the decision actually matter much. Only if there is no clear best route, note at the end of the design doc in concise style which route you took and why, and which alternatives you considered, and also notify me so that I can help check if that's the right decision.
+
+## Friction
+
+If you notice friction or other problems that could be fixed by going up a meta level and fixing the setup or tooling or appraoch, try to fix that!

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,152 +1,34 @@
 # OxCaml agent guide
 
-Do not stage or commit changes unless asked.
-
-Use the development commands below while editing. They keep a boot-compiler
-watcher in the background, wait for it before using its output, and report
-compiler errors before running a test or compiler command.
-
 ## Initial setup
 
 A fresh worktree needs one complete build and test installation:
-
 ```sh
 autoconf
 ./configure --prefix="$PWD/_install"
-make install
-```
-
-On the measured Apple Silicon machine, configuration took about 15 seconds and
-the first optimized install took about 4.5 minutes.
-
-## Development loop
-
-Start speculative compilation before editing:
-
-```sh
 make dev
 ```
+This takes about 5 minutes. Subsequent `make dev` invocations are much faster
+because they use an incremental background watcher.
 
-`make dev` returns immediately. Starting it is optional because every command
-below starts or restarts it automatically. The watcher is local to this
-worktree and exits after 30 idle minutes.
-
-Run one test or test directory:
-
+## Development loop
 ```sh
+# edit compiler code, then typecheck/build:
+make dev
+# edit compiler code or a test, then build & run a test:
 make dev-test TEST=typing-local/regression_class_type.ml
-make dev-test DIR=lib-bool
-```
-
-Run the entire test suite with the final compiler and GNU Parallel:
-
-```sh
+# edit again, test an entire dir:
+make dev-test DIR=typing-local
+# promote current outputs as expect goldens
+make dev-promote TEST=path/to/test.ml
+# compile separate files
+make dev-ocamlc ARGS='-c file.ml'
+make dev-ocamlopt ARGS='file.ml -o file.exe'
+# run the full compiler test suite
 make dev-test-all
 ```
 
-`dev-test-all` validates the watched compiler, stops the watcher to avoid CPU
-contention, incrementally builds the final compiler, recreates the normal test
-installation, and runs the full suite. It restarts the watcher before returning,
-including after a build or test failure. It requires GNU Parallel rather than
-silently falling back to a slow sequential run. Use this for broad validation,
-not for the normal edit loop.
+## Release builds
 
-Promote a focused test:
-
-```sh
-make dev-promote TEST=typing-local/regression_class_type.ml
-```
-
-Compile files with the watched compiler:
-
-```sh
-make dev-ocamlc ARGS='-c /tmp/probe.ml -o /tmp/probe.cmo'
-make dev-ocamlopt ARGS='/tmp/probe.ml -o /tmp/probe.exe'
-```
-
-`ARGS` has the same contents as an `ocamlc` or `ocamlopt` command line. Quote
-it so Make and the shell preserve spaces. These targets select the watched
-compiler and its matching development standard library.
-
-The normal loop is therefore:
-
-```text
-make dev
-edit
-make dev-test TEST=...
-edit
-make dev-test TEST=...
-```
-
-The watcher begins compiling on each save. `dev-test`, `dev-promote`,
-`dev-ocamlc`, and `dev-ocamlopt` wait for the latest saved source state. They
-do not run when that build has a type error.
-
-Existing and newly added tests are read from the live `testsuite/tests` tree.
-No `_runtest` refresh is needed. Standard-library and runtime edits are also
-detected; the next development command refreshes those components before
-continuing.
-
-Expect tests embed compiler libraries in their runner. `dev-test` detects
-`expect` and `expectnat` actions and refreshes a stale runner automatically.
-The watcher uses an isolated Dune build directory, so it does not invalidate
-the main Dune context. A measured runner refresh after a compiler edit took
-about 38 seconds.
-
-The development test root intentionally has no `ocamlopt.byte`. Use the normal
-final-compiler test path for a test that explicitly requires the
-bytecode-hosted native compiler.
-
-Useful recovery commands are:
-
-```sh
-make dev-status
-make dev-log
-make dev-stop
-```
-
-Do not run another Dune or ordinary Make build while the watcher is active.
-Use `make dev-stop` first. The development commands coordinate with the
-watcher themselves.
-
-## Final validation
-
-The development compiler is an unoptimized boot compiler. It is intended for
-fast typechecking and functional tests, not final validation.
-
-Use the final compiler when testing self-hosting, bytecode-only compiler
-variants, release behavior, compiler performance, benchmarks, or memtraces:
-
-```sh
-make dev-stop
-make install
-make test-one TEST=test-dir/path.ml
-```
-
-Use targeted tests while iterating. Run `make test` only for broad changes or
-when asked. `make dev-test-all` is the faster full-suite path after development
-edits. On the measured machine, a small warm `dev-test` took about one second,
-warm final-compiler preparation took about 10 seconds, and the complete parallel
-test execution took about 6 minutes 43 seconds, for about 6 minutes 53 seconds
-end to end when warm. After a compiler edit that caused a broad final rebuild,
-`dev-test-all` took about 10 minutes 19 seconds end to end. For a
-bootstrap-sensitive change, use ordinary `make test` instead.
-
-Always benchmark or memtrace with the compiler produced by `make install`,
-never with the boot compiler. Configure without `--enable-dev` for performance
-measurements.
-
-Run `make fmt` before committing when the changed files are covered by the
-formatter. Do not disable warnings or tests unless asked.
-
-## Repository map
-
-- `middle_end/flambda2/`: Flambda 2 optimizer
-- `backend/cfg/`: CFG backend
-- `driver/`: compiler drivers and OxCaml command-line handling
-- `jane/`: Jane Street extensions and documentation
-- `testsuite/tests/`: upstream OCaml tests
-- `oxcaml/tests/`: OxCaml-specific tests
-
-Files ending in `.in` require configuration after they change. Keep lines
-under 80 characters and prefer the existing functional OCaml style.
+Benchmark and memtrace only with the compiler produced by `make install`, never
+the development boot compiler.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 A fresh worktree needs one complete build and test installation:
 ```sh
-autoconf
+autoconf27
 ./configure --prefix="$PWD/_install"
 make dev
 ```

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ endif
 
 .PHONY: clean
 clean:
+	$(if $(filter 1,$(V)),,@)python3 tools/dev-watcher.py stop
 	$(if $(filter 1,$(V)),,@)set -eu; \
 	  dirs="$(CLEAN_DIRS)"; \
 	  if [ -z "$$dirs" ]; then echo "Refusing to clean empty directory list" >&2; exit 1; fi; \
@@ -99,7 +100,7 @@ clean:
 	    case "$$dir" in ""|"/"|".") echo "Refusing to clean $$dir" >&2; exit 1;; esac; \
 	  done; \
 	  ws_list="$(CLEAN_DUNE_WORKSPACES)"; \
-	  if [ -n "$(strip $(CLEAN_DUNE_BIN))" ]; then \
+	  if [ -n "$(strip $(CLEAN_DUNE_BIN))" ] && [ -d _build ]; then \
 	    for ws in $$ws_list; do \
 	      if [ -f $$ws ]; then \
 	        if ! "$(strip $(CLEAN_DUNE_BIN))" clean --root=. --workspace=$$ws; then \

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -482,6 +482,139 @@ promote-one-no-rebuild:
 hacking: _build/_bootinstall
 	$(dune) build $(ws_boot) -w @merlin-support $(boot_targets)
 
+# The development watcher starts eagerly, but is managed as a worktree-local
+# background process. All public dev commands renew its idle lease and wait
+# for the latest compiler build before using its outputs.
+DEV_IDLE_TIMEOUT ?= 1800
+ARGS ?=
+dev_watcher = python3 tools/dev-watcher.py
+dev_build = _build/dev-dune
+dev_build_flag = --build-dir=$(CURDIR)/$(dev_build)
+dev_boot_targets = $(boot_targets) main.bc
+
+.PHONY: dev dev-runtime dev-check dev-test dev-promote dev-ocamlc dev-ocamlopt
+.PHONY: dev-expect-runners
+.PHONY: dev-status dev-log dev-stop
+
+dev: _build/_bootinstall
+	@$(dev_watcher) start --idle-timeout $(DEV_IDLE_TIMEOUT) -- \
+	  $(dune) build $(ws_boot) $(dev_build_flag) -w --display=short \
+	  @merlin-support $(dev_boot_targets)
+
+dev-runtime:
+	+@set -eu; \
+	  artifact=_build/runtime_stdlib_install/lib/ocaml_runtime_stdlib/stdlib.cma; \
+	  if [ ! -f $$artifact ] || \
+	     [ Makefile.config -nt $$artifact ] || \
+	     [ duneconf/runtime_stdlib.ws -nt $$artifact ] || \
+	     find runtime stdlib otherlibs \
+	       \( -type d \( -name test -o -name tests \) -prune \) -o \
+	       \( -type f -newer $$artifact -print -quit \) | grep -q .; then \
+	    echo "dev: refreshing the runtime and standard library"; \
+	    $(dev_watcher) stop; \
+	    $(MAKE) runtime-stdlib; \
+	  fi
+
+dev-check: dev-runtime dev
+	@set -eu; \
+	  $(dev_watcher) wait-ready --timeout 300 -- \
+	    $(dune) rpc ping --root=. $(dev_build_flag); \
+	  if result="$$( \
+	    $(dune) rpc build $(ws_boot) $(dev_build_flag) \
+	      $(dev_boot_targets) 2>&1 \
+	  )"; then :; else \
+	    printf '%s\n' "$$result"; \
+	    exit 1; \
+	  fi; \
+	  printf '%s\n' "$$result"; \
+	  if printf '%s\n' "$$result" | grep -qx 'Success'; then \
+	    exit 0; \
+	  fi; \
+	  $(dune) diagnostics --root=. $(dev_build_flag); \
+	  exit 1
+
+DEV_RUNNERS ?=
+dev-expect-runners:
+	@test -n "$(DEV_RUNNERS)" || \
+	  { echo "dev: no expect-test runner selected" >&2; exit 2; }
+	@$(dev_watcher) stop
+	$(dune) build $(ws_main) \
+	  $(addprefix oxcaml/testsuite/tools/,$(addsuffix .exe,$(DEV_RUNNERS)))
+	@$(MAKE) --no-print-directory dev DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT)
+
+dev-test: dev-check
+	+@set -eu; \
+	  if [ -z "$(TEST)$(DIR)" ]; then \
+	    echo "Usage: make dev-test TEST=path/to/test.ml" >&2; \
+	    echo "   or: make dev-test DIR=path/to/test-directory" >&2; \
+	    exit 2; \
+	  fi; \
+	  selection="$(if $(TEST),$(call locate_test,$(TEST)),$(call locate_test,$(DIR)))"; \
+	  selection="testsuite/$$selection"; \
+	  stale_runners=""; \
+	  for runner in expect expectnat; do \
+	    case $$runner in \
+	      expect) pattern='(^|[;[:space:]])expect([;[:space:]]|$$)' ;; \
+	      expectnat) pattern='(^|[;[:space:]])expectnat([;[:space:]]|$$)' ;; \
+	    esac; \
+	    artifact=_build/main/oxcaml/testsuite/tools/$$runner.exe; \
+	    if grep -ERq --include='*.ml' "$$pattern" "$$selection" && \
+	       { [ ! -x $$artifact ] || \
+	         [ $(dev_build)/default/main_native.exe -nt $$artifact ] || \
+	         find oxcaml/testsuite/tools -type f -newer $$artifact \
+	           -print -quit | grep -q .; }; then \
+	      stale_runners="$$stale_runners $$runner"; \
+	    fi; \
+	  done; \
+	  if [ -n "$$stale_runners" ]; then \
+	    echo "dev: refreshing expect-test runner(s):$$stale_runners"; \
+	    $(MAKE) --no-print-directory dev-expect-runners \
+	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
+	      DEV_RUNNERS="$$stale_runners"; \
+	  fi; \
+	  $(dev_watcher) prepare-test-root; \
+	  echo "dev: compiler = $(dev_build)/default/main_native.exe"; \
+	  echo "dev: stdlib   = _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib"; \
+	  export OCAMLSRCDIR=$$(pwd)/_build/dev/runtest; \
+	  export CAML_LD_LIBRARY_PATH=$$(pwd)/_build/dev/runtest/stdlib/stublibs; \
+	  if $$(which gfortran > /dev/null 2>&1); then \
+	    export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
+	  fi; \
+	  cd _build/dev/runtest/testsuite; \
+	  $(MAKE) one \
+	    $(if $(TEST),TEST=$(call locate_test,$(TEST))) \
+	    $(if $(DIR),DIR=$(call locate_test,$(DIR)))
+
+dev-promote:
+	+@$(MAKE) --no-print-directory dev-test PROMOTE=1 \
+	  DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
+	  $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR))
+
+dev-ocamlc: dev-check
+	@echo "dev: compiler = $(dev_build)/default/main_native.exe"
+	@echo "dev: stdlib   = _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib"
+	@OCAMLLIB="$$(pwd)/_build/runtime_stdlib_install/lib/ocaml_runtime_stdlib" \
+	  $(dev_build)/default/main_native.exe $(ARGS)
+
+dev-ocamlopt: dev-check
+	@echo "dev: compiler = $(dev_build)/default/boot_ocamlopt.exe"
+	@echo "dev: stdlib   = _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib"
+	@OCAMLLIB="$$(pwd)/_build/runtime_stdlib_install/lib/ocaml_runtime_stdlib" \
+	  $(dev_build)/default/boot_ocamlopt.exe $(ARGS)
+
+dev-status:
+	@$(dev_watcher) status
+
+dev-log:
+	@if [ -f _build/dev/watcher.log ]; then \
+	  tail -n 100 _build/dev/watcher.log; \
+	else \
+	  echo "dev: no watcher log"; \
+	fi
+
+dev-stop:
+	@$(dev_watcher) stop
+
 # The `hacking-emacs-poller` and `hacking-emacs-builder` targets make it
 # possible to run the polling build with Emacs's `M-x compile`.  You should run
 # `make hacking-emacs-poller` in your terminal from the root directory of the

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -496,15 +496,25 @@ dev_build = _build/dev-dune
 dev_build_flag = --build-dir=$(CURDIR)/$(dev_build)
 dev_boot_targets = $(boot_targets) main.bc
 
-.PHONY: dev dev-runtime dev-check dev-test dev-test-all dev-promote
+.PHONY: dev dev-start dev-setup dev-runtime dev-check
+.PHONY: dev-test dev-test-all dev-promote
 .PHONY: dev-ocamlc dev-ocamlopt
 .PHONY: dev-expect-runners
 .PHONY: dev-status dev-log dev-stop
 
-dev: _build/_bootinstall
+dev-start: _build/_bootinstall
 	@$(dev_watcher) start --idle-timeout $(DEV_IDLE_TIMEOUT) -- \
 	  $(dune) build $(ws_boot) $(dev_build_flag) -w --display=short \
 	  @merlin-support $(dev_boot_targets)
+
+dev-setup:
+	+@set -eu; \
+	  if [ ! -x _install/bin/ocamlopt.opt ] || \
+	     [ ! -f _runtest/testsuite/Makefile ]; then \
+	    echo "dev: preparing the initial compiler and test installation"; \
+	    $(dev_watcher) stop; \
+	    $(MAKE) --no-print-directory install_for_test; \
+	  fi
 
 dev-runtime:
 	+@set -eu; \
@@ -520,7 +530,7 @@ dev-runtime:
 	    $(MAKE) runtime-stdlib; \
 	  fi
 
-dev-check: dev-runtime dev
+dev-check: dev-setup dev-runtime dev-start
 	@set -eu; \
 	  $(dev_watcher) wait-ready --timeout 300 -- \
 	    $(dune) rpc ping --root=. $(dev_build_flag); \
@@ -538,6 +548,8 @@ dev-check: dev-runtime dev
 	  $(dune) diagnostics --root=. $(dev_build_flag); \
 	  exit 1
 
+dev: dev-check
+
 DEV_RUNNERS ?=
 dev-expect-runners:
 	@test -n "$(DEV_RUNNERS)" || \
@@ -545,7 +557,8 @@ dev-expect-runners:
 	@$(dev_watcher) stop
 	$(dune) build $(ws_main) \
 	  $(addprefix oxcaml/testsuite/tools/,$(addsuffix .exe,$(DEV_RUNNERS)))
-	@$(MAKE) --no-print-directory dev DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT)
+	@$(MAKE) --no-print-directory dev-start \
+	  DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT)
 
 dev-test: dev-check
 	+@set -eu; \
@@ -586,7 +599,7 @@ dev-test: dev-check
 	    export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
 	  fi; \
 	  cd _build/dev/runtest/testsuite; \
-	  $(MAKE) one \
+	  $(MAKE) $(if $(PROMOTE),promote,one) \
 	    $(if $(TEST),TEST=$(call locate_test,$(TEST))) \
 	    $(if $(DIR),DIR=$(call locate_test,$(DIR)))
 
@@ -598,7 +611,7 @@ dev-test-all: dev-check
 	  fi; \
 	  $(dev_watcher) stop; \
 	  restart_watcher() { \
-	    $(MAKE) --no-print-directory dev \
+	    $(MAKE) --no-print-directory dev-start \
 	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) >/dev/null || true; \
 	  }; \
 	  trap restart_watcher EXIT; \
@@ -608,9 +621,24 @@ dev-test-all: dev-check
 	  $(MAKE) --no-print-directory test-no-rebuild
 
 dev-promote:
-	+@$(MAKE) --no-print-directory dev-test PROMOTE=1 \
-	  DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
-	  $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR))
+	+@set -eu; \
+	  promote_log=$$(mktemp "$${TMPDIR:-/tmp}/oxcaml-dev-promote.XXXXXX"); \
+	  trap 'rm -f "$$promote_log"' EXIT; \
+	  if $(MAKE) --no-print-directory dev-test PROMOTE=1 \
+	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
+	      $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR)) \
+	      >"$$promote_log" 2>&1; then \
+	    cat "$$promote_log"; \
+	    exit 0; \
+	  fi; \
+	  if $(MAKE) --no-print-directory dev-test \
+	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
+	      $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR)); then \
+	    echo "dev: promoted test output"; \
+	    exit 0; \
+	  fi; \
+	  cat "$$promote_log" >&2; \
+	  exit 1
 
 dev-ocamlc: dev-check
 	@echo "dev: compiler = $(dev_build)/default/main_native.exe"

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -440,6 +440,28 @@ test-no-rebuild:
                fi \
              fi)
 
+.PHONY: test-files-parallel
+test-files-parallel:
+	if [ "$(middle_end)" = "flambda2" ]; then \
+	  for path in `cd testsuite; ls -1 -d tests/*`; do \
+	    if [[ -d "testsuite/$$path" ]] && ! grep -q "^  $$path " oxcaml/testsuite/flambda2-test-list; then \
+	      echo "  $$path"; \
+	    fi; \
+	  done > _runtest/flambda2-test-list; \
+	fi
+	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
+	 export CAML_LD_LIBRARY_PATH=$$(pwd)/_runtest/lib/ocaml/stublibs; \
+	 if $$(which gfortran > /dev/null 2>&1); then \
+	   export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
+	 fi; \
+	 cd _runtest/testsuite; \
+	 if [ "$(middle_end)" = "flambda2" ]; then \
+	   $(MAKE) --no-print-directory files-parallel \
+	     FILE=$$(pwd)/../flambda2-test-list; \
+	 else \
+	   $(MAKE) --no-print-directory files-parallel DIR=tests; \
+	 fi)
+
 promote-failed:
 	(export OCAMLSRCDIR=$$(pwd)/_runtest; \
 	 export CAML_LD_LIBRARY_PATH=$$(pwd)/_runtest/lib/ocaml/stublibs; \
@@ -599,7 +621,7 @@ dev-test: dev-check
 	    export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
 	  fi; \
 	  cd _build/dev/runtest/testsuite; \
-	  $(MAKE) $(if $(PROMOTE),promote,one) \
+	  $(MAKE) $(if $(PROMOTE),promote,$(if $(DIR),files-parallel,one)) \
 	    $(if $(TEST),TEST=$(call locate_test,$(TEST))) \
 	    $(if $(DIR),DIR=$(call locate_test,$(DIR)))
 
@@ -618,7 +640,7 @@ dev-test-all: dev-check
 	  echo "dev: building the final compiler for the full test suite"; \
 	  $(MAKE) --no-print-directory \
 	    -o boot-compiler -o runtime-stdlib install_for_test; \
-	  $(MAKE) --no-print-directory test-no-rebuild
+	  $(MAKE) --no-print-directory test-files-parallel
 
 dev-promote:
 	+@set -eu; \

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -406,6 +406,10 @@ install_for_test: install
 	mkdir _runtest/ocamltest
 	cp $(boot_build)/ocamltest/ocamltest.native _runtest/ocamltest/ocamltest
 test: install_for_test
+	$(MAKE) test-no-rebuild
+
+.PHONY: test-no-rebuild
+test-no-rebuild:
 	if [ "$(middle_end)" = "flambda2" ]; then \
 	  for path in `cd testsuite; ls -1 -d tests/*`; do \
 	    if [[ -d "testsuite/$$path" ]] && ! grep -q "^  $$path " oxcaml/testsuite/flambda2-test-list; then \
@@ -492,7 +496,8 @@ dev_build = _build/dev-dune
 dev_build_flag = --build-dir=$(CURDIR)/$(dev_build)
 dev_boot_targets = $(boot_targets) main.bc
 
-.PHONY: dev dev-runtime dev-check dev-test dev-promote dev-ocamlc dev-ocamlopt
+.PHONY: dev dev-runtime dev-check dev-test dev-test-all dev-promote
+.PHONY: dev-ocamlc dev-ocamlopt
 .PHONY: dev-expect-runners
 .PHONY: dev-status dev-log dev-stop
 
@@ -584,6 +589,23 @@ dev-test: dev-check
 	  $(MAKE) one \
 	    $(if $(TEST),TEST=$(call locate_test,$(TEST))) \
 	    $(if $(DIR),DIR=$(call locate_test,$(DIR)))
+
+dev-test-all: dev-check
+	+@set -eu; \
+	  if ! parallel --version 2>/dev/null | grep -q 'GNU parallel'; then \
+	    echo "dev: GNU Parallel is required for dev-test-all" >&2; \
+	    exit 2; \
+	  fi; \
+	  $(dev_watcher) stop; \
+	  restart_watcher() { \
+	    $(MAKE) --no-print-directory dev \
+	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) >/dev/null || true; \
+	  }; \
+	  trap restart_watcher EXIT; \
+	  echo "dev: building the final compiler for the full test suite"; \
+	  $(MAKE) --no-print-directory \
+	    -o boot-compiler -o runtime-stdlib install_for_test; \
+	  $(MAKE) --no-print-directory test-no-rebuild
 
 dev-promote:
 	+@$(MAKE) --no-print-directory dev-test PROMOTE=1 \

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -275,6 +275,43 @@ list-parallel: lib tools
 	 | tee $(TESTLOG)
 	@$(MAKE) report
 
+# Run each test file as a separate GNU Parallel job. This gives better load
+# balancing than [list-parallel], which runs all files in a directory in one
+# serial job.
+.PHONY: files-parallel
+files-parallel: lib tools
+	@if [ "$(words $(DIR) $(FILE))" != 1 ]; then \
+	  echo "Specify exactly one of DIR or FILE."; \
+	  exit 1; \
+	fi
+	@echo | parallel >/dev/null 2>/dev/null \
+	 || (echo "Unable to run the GNU parallel tool;";\
+	     echo "You should install it before using files-parallel.";\
+	     exit 1)
+	@echo | parallel --gnu --no-notice >/dev/null 2>/dev/null \
+	 || (echo "Your 'parallel' tool seems incompatible with GNU parallel.";\
+	     echo "This target requires GNU parallel.";\
+	     exit 1)
+	@(if [ -n "$(DIR)" ]; then echo "$(DIR)"; else cat "$(FILE)"; fi) \
+	 | while $(IFS_LINE) read -r requested_dir; do \
+	     requested_dir=$${requested_dir#  }; \
+	     $(ocamltest) -find-test-dirs "$$requested_dir"; \
+	   done \
+	 | while $(IFS_LINE) read -r test_dir; do \
+	     $(ocamltest) -list-tests "$$test_dir" \
+	       | while $(IFS_LINE) read -r test_file; do \
+	           case "$$test_file" in *.corrected) continue;; esac; \
+	           echo "$$test_dir/$$test_file"; \
+	         done; \
+	   done \
+	 | parallel --gnu --no-notice --keep-order $(J_ARGUMENT) \
+	     'test_path={}; test_dir="$${test_path%/*}"; \
+	      echo "Running tests from '\''$$test_dir'\'' ..."; \
+	      TERM=dumb $(OCAMLTESTENV) $(ocamltest) $(OCAMLTESTFLAGS) \
+	        "$$test_path"' \
+	 | tee $(TESTLOG)
+	@$(MAKE) report
+
 .PHONY: one
 one:
 	@case "$(words $(DIR) $(LIST) $(TEST))" in \

--- a/tools/dev-watcher.py
+++ b/tools/dev-watcher.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+
+import argparse
+import fcntl
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE = ROOT / "_build" / "dev"
+PID_FILE = STATE / "watcher.pid"
+CHILD_PID_FILE = STATE / "dune.pid"
+LEASE_FILE = STATE / "last-used"
+TIMEOUT_FILE = STATE / "idle-timeout"
+LOG_FILE = STATE / "watcher.log"
+LOCK_FILE = STATE / "lock"
+
+
+def read_pid(path):
+    try:
+        return int(path.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def alive(pid):
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def touch_lease(idle_timeout=None):
+    STATE.mkdir(parents=True, exist_ok=True)
+    LEASE_FILE.touch()
+    if idle_timeout is not None:
+        TIMEOUT_FILE.write_text(f"{idle_timeout}\n")
+
+
+def locked():
+    STATE.mkdir(parents=True, exist_ok=True)
+    lock = LOCK_FILE.open("a+")
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    return lock
+
+
+def clean_stale_state():
+    if not alive(read_pid(PID_FILE)):
+        PID_FILE.unlink(missing_ok=True)
+        CHILD_PID_FILE.unlink(missing_ok=True)
+
+
+def start(args):
+    if not args.command:
+        raise SystemExit("dev watcher: missing watcher command")
+    with locked():
+        clean_stale_state()
+        pid = read_pid(PID_FILE)
+        if alive(pid):
+            touch_lease(args.idle_timeout)
+            return
+
+        touch_lease(args.idle_timeout)
+        if LOG_FILE.exists() and LOG_FILE.stat().st_size > 1_000_000:
+            LOG_FILE.write_bytes(b"")
+        log = LOG_FILE.open("ab", buffering=0)
+        command = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "supervise",
+            "--idle-timeout",
+            str(args.idle_timeout),
+            "--",
+            *args.command,
+        ]
+        supervisor = subprocess.Popen(
+            command,
+            cwd=ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            close_fds=True,
+        )
+        PID_FILE.write_text(f"{supervisor.pid}\n")
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if alive(read_pid(CHILD_PID_FILE)):
+            print(f"dev: watcher started (idle timeout {args.idle_timeout}s)")
+            return
+        if not alive(supervisor.pid):
+            break
+        time.sleep(0.05)
+    raise SystemExit(f"dev watcher failed to start; see {LOG_FILE}")
+
+
+def terminate_process_group(child):
+    if child.poll() is not None:
+        return
+    try:
+        os.killpg(child.pid, signal.SIGINT)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and child.poll() is None:
+        time.sleep(0.05)
+    if child.poll() is None:
+        try:
+            os.killpg(child.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+
+
+def supervise(args):
+    stopping = False
+
+    def request_stop(_signum, _frame):
+        nonlocal stopping
+        stopping = True
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+
+    environment = os.environ.copy()
+    environment.pop("MAKEFLAGS", None)
+    environment.pop("MFLAGS", None)
+    child = subprocess.Popen(
+        args.command,
+        cwd=ROOT,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+        env=environment,
+    )
+    CHILD_PID_FILE.write_text(f"{child.pid}\n")
+
+    try:
+        while child.poll() is None:
+            try:
+                idle_for = time.time() - LEASE_FILE.stat().st_mtime
+            except FileNotFoundError:
+                idle_for = args.idle_timeout
+            try:
+                idle_timeout = int(TIMEOUT_FILE.read_text().strip())
+            except (FileNotFoundError, ValueError):
+                idle_timeout = args.idle_timeout
+            if stopping or idle_for >= idle_timeout:
+                terminate_process_group(child)
+                break
+            time.sleep(min(1, idle_timeout))
+        return child.wait()
+    finally:
+        with locked():
+            if read_pid(PID_FILE) == os.getpid():
+                PID_FILE.unlink(missing_ok=True)
+                CHILD_PID_FILE.unlink(missing_ok=True)
+
+
+def stop(_args):
+    with locked():
+        clean_stale_state()
+        pid = read_pid(PID_FILE)
+        if pid is None:
+            return
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            clean_stale_state()
+            return
+
+    deadline = time.monotonic() + 7
+    while time.monotonic() < deadline and alive(pid):
+        time.sleep(0.05)
+    if alive(pid):
+        raise SystemExit(f"dev watcher {pid} did not stop")
+    print("dev: watcher stopped")
+
+
+def status(_args):
+    clean_stale_state()
+    pid = read_pid(PID_FILE)
+    if not alive(pid):
+        print("dev: watcher is stopped")
+        return 1
+    age = int(time.time() - LEASE_FILE.stat().st_mtime)
+    print(f"dev: watcher is running (pid {pid}, idle {age}s)")
+    return 0
+
+
+def wait_ready(args):
+    deadline = time.monotonic() + args.timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            args.command,
+            cwd=ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            return 0
+        if not alive(read_pid(PID_FILE)):
+            raise SystemExit(f"dev watcher exited; see {LOG_FILE}")
+        time.sleep(0.1)
+    raise SystemExit(f"dev watcher did not become ready; see {LOG_FILE}")
+
+
+def link(source, destination):
+    destination.symlink_to(
+        source.resolve(), target_is_directory=source.is_dir()
+    )
+
+
+def prepare_test_root_locked():
+    source_root = ROOT / "_runtest"
+    runtime_stdlib = (
+        ROOT
+        / "_build/runtime_stdlib_install/lib/ocaml_runtime_stdlib"
+    )
+    if not source_root.is_dir() or not runtime_stdlib.is_dir():
+        raise SystemExit(
+            "dev: run `make install` once before using development tests"
+        )
+
+    destination = STATE / "runtest"
+    temporary = STATE / "runtest.new"
+    shutil.rmtree(temporary, ignore_errors=True)
+    temporary.mkdir(parents=True)
+
+    overridden = {
+        "ocamlc",
+        "ocamlc.byte",
+        "ocamlc.opt",
+        "ocamlopt",
+        "ocamlopt.byte",
+        "ocamlopt.opt",
+        "ocamlrun",
+        "ocamlrund",
+        "ocamlruni",
+        "ocamltest",
+        "runtime",
+        "stdlib",
+        "testsuite",
+    }
+    for entry in source_root.iterdir():
+        if entry.name not in overridden:
+            link(entry, temporary / entry.name)
+
+    link(ROOT / "_build/dev-dune/default/main.bc", temporary / "ocamlc.byte")
+    (temporary / "ocamlc").symlink_to("ocamlc.byte")
+    link(
+        ROOT / "_build/dev-dune/default/main_native.exe",
+        temporary / "ocamlc.opt",
+    )
+    link(
+        ROOT / "_build/dev-dune/default/boot_ocamlopt.exe",
+        temporary / "ocamlopt.opt",
+    )
+    for name in ("ocamlrun", "ocamlrund", "ocamlruni"):
+        link(
+            ROOT / f"_build/runtime_stdlib_install/bin/{name}",
+            temporary / name,
+        )
+    stdlib = temporary / "stdlib"
+    stdlib.mkdir()
+    for entry in runtime_stdlib.iterdir():
+        if entry.name != "stublibs":
+            link(entry, stdlib / entry.name)
+
+    stublibs = stdlib / "stublibs"
+    stublibs.mkdir()
+    dev_stubs = {
+        stub.name: stub
+        for stub in (ROOT / "_build/dev-dune/default").rglob("dll*.so")
+    }
+    for stub in (source_root / "stdlib/stublibs").iterdir():
+        if stub.name not in dev_stubs:
+            link(stub, stublibs / stub.name)
+    for name, stub in dev_stubs.items():
+        link(stub, stublibs / name)
+
+    runtime = temporary / "runtime"
+    runtime.mkdir()
+    for entry in (source_root / "runtime").iterdir():
+        if entry.name not in {
+            "caml", "ocamlrun", "ocamlrund", "ocamlruni", "threads.h"
+        }:
+            link(entry, runtime / entry.name)
+    (runtime / "caml").symlink_to("../stdlib/caml")
+    link(ROOT / "runtime/caml/threads.h", runtime / "threads.h")
+    for name in ("ocamlrun", "ocamlrund", "ocamlruni"):
+        (runtime / name).symlink_to(f"../{name}")
+
+    ocamltest = temporary / "ocamltest"
+    ocamltest.mkdir()
+    link(
+        ROOT / "_build/dev-dune/default/ocamltest/ocamltest.native",
+        ocamltest / "ocamltest",
+    )
+
+    source_testsuite = source_root / "testsuite"
+    testsuite = temporary / "testsuite"
+    testsuite.mkdir()
+    for entry in source_testsuite.iterdir():
+        if entry.name not in {"tests", "tools"}:
+            link(entry, testsuite / entry.name)
+
+    source_tools = source_testsuite / "tools"
+    tools = testsuite / "tools"
+    tools.mkdir()
+    for entry in source_tools.iterdir():
+        if entry.name not in {"expect", "expectnat"}:
+            link(entry, tools / entry.name)
+    for name in ("expect", "expectnat"):
+        executable = ROOT / f"_build/main/oxcaml/testsuite/tools/{name}.exe"
+        if executable.exists():
+            link(executable, tools / name)
+
+    tests = testsuite / "tests"
+    tests.mkdir()
+    replacements = {"asmcomp", "asmgen", "lib-extensions"}
+    for entry in (ROOT / "testsuite/tests").iterdir():
+        if entry.name not in replacements:
+            link(entry, tests / entry.name)
+    for name in replacements:
+        link(ROOT / "oxcaml/testsuite/tests" / name, tests / name)
+
+    old = STATE / "runtest.old"
+    shutil.rmtree(old, ignore_errors=True)
+    if destination.exists():
+        destination.rename(old)
+    temporary.rename(destination)
+    shutil.rmtree(old, ignore_errors=True)
+
+
+def prepare_test_root(_args):
+    with locked():
+        prepare_test_root_locked()
+
+
+def parser():
+    result = argparse.ArgumentParser()
+    commands = result.add_subparsers(dest="action", required=True)
+
+    start_parser = commands.add_parser("start")
+    start_parser.add_argument("--idle-timeout", type=int, required=True)
+    start_parser.add_argument("command", nargs=argparse.REMAINDER)
+    start_parser.set_defaults(function=start)
+
+    supervise_parser = commands.add_parser("supervise")
+    supervise_parser.add_argument("--idle-timeout", type=int, required=True)
+    supervise_parser.add_argument("command", nargs=argparse.REMAINDER)
+    supervise_parser.set_defaults(function=supervise)
+
+    stop_parser = commands.add_parser("stop")
+    stop_parser.set_defaults(function=stop)
+
+    status_parser = commands.add_parser("status")
+    status_parser.set_defaults(function=status)
+
+    ready_parser = commands.add_parser("wait-ready")
+    ready_parser.add_argument("--timeout", type=int, default=300)
+    ready_parser.add_argument("command", nargs=argparse.REMAINDER)
+    ready_parser.set_defaults(function=wait_ready)
+
+    touch_parser = commands.add_parser("touch")
+    touch_parser.set_defaults(function=lambda _args: touch_lease())
+
+    test_root_parser = commands.add_parser("prepare-test-root")
+    test_root_parser.set_defaults(function=prepare_test_root)
+    return result
+
+
+def main():
+    args = parser().parse_args()
+    has_separator = (
+        args.action in {"start", "supervise", "wait-ready"}
+        and args.command[:1] == ["--"]
+    )
+    if has_separator:
+        args.command = args.command[1:]
+    result = args.function(args)
+    return result if isinstance(result, int) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A persistent-watcher development loop for compiler work, plus the agent workflow
documentation that goes with it. This is the base of the Stack: the five vox
pieces above it were built and tested with these targets.

- `make dev` — incremental compiler build through a long-lived dune watcher
  (`tools/dev-watcher.py`), driven over dune RPC. Warm rebuilds of a single
  `typing/` file land in well under a minute.
- `make dev-test TEST=… | DIR=…` — run testsuite files against the dev
  compiler, in both plain and `-principal` modes. `make dev-promote` writes
  expect blocks and `.reference` files back into the source tree directly.
- `make dev-test-all` — full suite, parallelised at file granularity, with a
  pass/skip/fail summary.
- `make dev-ocamlc` / `make dev-ocamlopt ARGS=…` — one-off compiles with the
  dev compiler, for smoke tests and `-dlambda` / `-dcmm` inspection.
- `make dev-log` / `dev-status` / `dev-stop` — watcher inspection and
  lifecycle.

Commands are synchronous and self-configuring: each starts the watcher if it
isn't running and renews its idle lease, so daemon lifecycle needs no thought
in the common case.

`AGENTS.md` gains the dev loop, the review-loop workflow, and the design-doc
convention.

Five sessions have now used this loop to build a piece each, and reported back
on it. The convergent findings — chiefly that a wedged `dune rpc build` has no
timeout, and that `_runtest` artifacts can go stale after a compiler change
without any diagnostic — are being addressed in a follow-up piece rather than
held against this one.

---

Part of stack #6796, which merges bottom-up from `main`. #6787 and #6788 touch no
compiler internals and are the natural first merges.
