### PR TITLE
Stack 2/6: vox solver interface

### DIFF
--- a/Makefile.upstream
+++ b/Makefile.upstream
@@ -152,6 +152,9 @@ typing_SOURCES = \
   typing/typedecl_unboxed.mli typing/typedecl_unboxed.ml \
   typing/typedecl_immediacy.mli typing/typedecl_immediacy.ml \
   typing/typedecl_separability.mli typing/typedecl_separability.ml \
+  typing/vox_logic.mli typing/vox_logic.ml \
+  typing/vox_smtlib.mli typing/vox_smtlib.ml \
+  typing/vox_backend.mli typing/vox_backend.ml \
   typing/typeopt.mli typing/typeopt.ml \
   typing/typedecl.mli typing/typedecl.ml \
   typing/value_rec_check.mli typing/value_rec_check.ml \

--- a/design-docs/solver-interface-final.md
+++ b/design-docs/solver-interface-final.md
@@ -1,0 +1,129 @@
+# Vox solver interface — final report
+
+Status of the piece after implementation and the review loop, on branch
+`jujacobs/vox/solver-interface`:
+
+    2cd747db89 GREEN: fix the defects the review loop found
+    85f47e8512 RED: record review-loop failure cases in the vox-solver tests
+    ccf4ed3ce7 Add the vox solver interface
+    ef98a4a693 Add design doc for the solver-interface piece
+
+## What was built
+
+Per `design-docs/solver-interface.md`:
+
+- `typing/vox_logic` — sorts (with `Bitvec 63` for OCaml int), interpreted
+  operators, literals, terms, parametric datatypes plus the monomorphising
+  `Signature.instantiate` with vox2's two deliberate rejections, closed
+  signatures, obligations.
+- `typing/vox_smtlib` — the single SMT-LIB renderer both backends share, so
+  the expect-test baselines are the bytes z3 receives.
+- `typing/vox_backend` — the verdict/failure split, `BACKEND`, printing and
+  z3 backends, the static backend list, and `plan`, where `none` is caller
+  policy rather than a backend.
+- `testsuite/tests/vox-solver/` — `renderer.ml` and `driver.ml` expect tests
+  and a z3-gated protocol test (`has_z3.sh` skips via ocamltest's exit-125
+  convention when no solver is installed; `VOX_TEST_Z3` overrides).
+
+Every z3 protocol fact was probed against the pinned 4.8.5 binary before
+being relied on (one-shot directive behaviour, `(:reason-unknown ...)`
+shapes, 2.6 datatype syntax, `<`/`>` in simple symbols, model shapes).
+
+## Review loop
+
+Three lanes off commit `ccf4ed3ce7`, each in its own
+`solver-interface/review/<name>` worktree: **claude-design**,
+**claude-correctness**, **codex** (`gpt-5.6-sol`). All three delivered
+`report.md` with VERIFIED reproductions. Fixes landed as a RED→GREEN pair so
+the baseline diff of the GREEN commit shows each behaviour flip.
+
+### Verified defects, fixed
+
+- **Verdict inversion** (all three lanes; worst form found by codex). A
+  variable named `h0` collides with the renderer's `:named h0` label; z3
+  drops the colliding assertion with a pre-status `(error ...)` line and a
+  vacuously provable obligation read *"refuted"*. Fixed twice over:
+  hypothesis labels join the checked symbol namespace, and any `(error ...)`
+  before the status line is now `Error { cause; raw }`, never a verdict.
+  The latter converts every future encoding defect into a loud failure —
+  which matters doubly because the renderer deliberately does not
+  sort-check. Pinned by the z3 test flipping
+  `n = b (ill-sorted) |- ...: refuted, e.g. n = -1` to
+  `error: the solver rejected the query`.
+- **Builtin shadowing** (correctness lane). A symbol named `not` or `+`
+  silently shadows the interpreted operator, giving spurious `Proved`. The
+  reviewer proposed `|quoting|`; that claim was **falsified by a probe**
+  (z3 4.8.5 treats `|not|` as `not` and `(|+| n n)` as `(+ n n)`), so the
+  fix rejects renderer-emittable builtin names (operator spellings,
+  `true`/`false`/`ite`, builtin sort names) as ill-formed instead.
+- Nullary `Call` rendered invalid `(f)` (codex): `f |- f` flipped from
+  `unknown` to `proved`.
+- Negative `Select` index escaped `render` as `Invalid_argument`
+  (codex, correctness): now the same ill-formed error as an out-of-range
+  index.
+- Instance-name aliasing (design, correctness): `Sort.key` is not
+  injective, so `box` at builtin `Int` and at an abstract sort named `Int`
+  silently merged into one instance — in principle unsound (two types
+  identified). `instantiate` now rejects two distinct instantiations that
+  mangle to one name.
+- **`Refuted` now requires the prove query to answer `sat`** (correctness
+  F6). After a prove-query `unknown`, disprove-unsat can simply mean the
+  hypotheses are contradictory, whose correct verdict is `Proved`; the
+  disprove query is no longer run in that case. Deliberate hardening over
+  vox2's protocol, recorded in the design doc.
+- Smaller: negative hypothesis ids rejected; leading-zero numerals rejected
+  (z3 accepts them, SMT-LIB does not); empty model atoms no longer read
+  back as empty integer literals.
+
+### Coverage and test hygiene
+
+Added: empty unsat core (all hypotheses unused), opaque-universe model
+elements (`t!val!0` reads back as `Term.Var`), wall-clock kill of a wedged
+solver (exit 124), an unrunnable configured command, width-1/63/64 bitvec
+literals, duplicate declarations, field-index bounds. Removed ~120 lines of
+no-signal expect echo (helper definitions now live in their use sites, so
+baselines show only rendered SMT-LIB).
+
+### Suggestions declined (spec-pinned shapes; decision points)
+
+All coherent, all contradict shapes the ratified spec pins; recorded here
+rather than adopted. Reports: `solver-interface/review/*/report.md`.
+
+- Backends as record values with config bound at selection, replacing
+  `BACKEND` / `backends` / `select` (design D5). Would simplify a future
+  cache/session/cross-check; the spec pins the module shape.
+- Printing as a dump-mode (`-vox-dump-vc` style) orthogonal to backend
+  choice, not a backend (D6). The spec pins the printing backend.
+- Generic well-formedness moving to `Vox_logic.Obligation.check`, leaving
+  the renderer purely SMT-LIB spelling (D7). Revisit when a second real
+  backend wants the same checks.
+- Splitting the z3 backend into `typing/vox_z3.ml` (D8). The file is ~500
+  lines; split when a second solver backend lands.
+- `Unknown` carrying the prove-query model as a near-counterexample (D9).
+  Deferred; noted in the design doc alongside `Int↔Bitvec` conversion
+  operators (D10), which the translation piece will need for
+  `Bigint.of_int`.
+- `Select` by selector name; a `Ground of Sort.t` field-type language;
+  dropping `Arrow` in favour of a translation-side rejection (D11);
+  `instantiate` returning the uninterpreted sorts it grounded (D12).
+
+The two spec deviations that *were* taken — `Refuted` requires `sat`, and
+the non-regularity test documented as conservative (it rejects some finite
+instantiation patterns, exactly as vox2 does) — are flagged in the design
+doc's decisions section.
+
+## Friction found on the way
+
+- `dune rpc build` against an already-idle watcher wedges indefinitely;
+  `make dev-stop` before scripted `dev-test`/`dev-promote` runs is a
+  reliable workaround. Candidate for a `tools/dev-watcher.py` fix.
+- New compilerlibs modules need `make install_for_test` (slow, one-time per
+  library change) before `make dev-test DIR=...` can link them; the failure
+  mode is `Unbound module Vox_logic`. Worth a hint in the dev loop.
+- The expect harness captures formatters, not file descriptors — hence the
+  printing backend emits via `Format.std_formatter`.
+- ocamltest's `script` action defines `stdout`/`stderr` as a side effect,
+  which silently disables output redirection for a later `run` action; the
+  z3 test header re-points them (commented in the test).
+- System autoconf is 2.69; `configure` must be copied from an existing
+  worktree (it is generated by 2.71).

--- a/design-docs/solver-interface.md
+++ b/design-docs/solver-interface.md
@@ -1,0 +1,373 @@
+# Vox solver interface
+
+A standalone logic term language, an obligation type, a backend signature, and
+two backends: printing and z3. Nothing in this piece knows about refinement
+types, so it can be built and tested before the type formers exist.
+
+## Why it stands alone
+
+vox2's solver cannot be separated from the typechecker. `Vox_backend.obligation`
+carries `env : Env.t`, and the encoder reaches into it during emission:
+`Env.find_type`, `Env.find_value`, `Env.normalize_value_path`, `Env.fold_values`
+at `vox_smt.ml:322, 552, 555, 1507, 1519`. `Vox_vc.t` names
+`Types.refinement_expression` eight times.
+
+Resolve every symbol during translation and hand the backend a closed
+signature. That is the whole trick, and a later piece owns the translation from
+refinements into these terms.
+
+## The term language
+
+    module Sort : sig
+      type t =
+        | Bool
+        | Int                        (* mathematical, unbounded: Bigint *)
+        | Bitvec of int              (* OCaml int is Bitvec 63 *)
+        | Uninterpreted of string    (* abstract type behind a signature *)
+        | Datatype of string
+    end
+
+    module Term : sig
+      type t =
+        | Var of string              (* sort comes from the signature *)
+        | Const of literal
+        | App of Op.t * t list       (* interpreted operators *)
+        | Call of string * t list    (* uninterpreted function symbol *)
+        | Ite of t * t * t
+        | Construct of string * t list
+        | Select of string * int * t
+        | Test of string * t
+    end
+
+Quantifier-free, matching vox2's `reject_quantifiers`. Both `Int` and `Bitvec`
+are present because the two integer notions are genuinely different:
+`Bigint` is mathematical, OCaml `int` is `Bitvec 63` (`vox_smt.ml:167`).
+
+State the `Bitvec 63` decision in this piece, prominently. It is the reason
+`x >= 0 |- x + 1 >= 0` is false and `abs` in the naive form does not verify. A
+reader who does not know it will conclude the solver is broken.
+
+Variables carry no sort at the occurrence. The signature declares them, so two
+occurrences of one variable cannot disagree, and ill-sortedness is
+unrepresentable rather than checked.
+
+## Obligations
+
+    module Obligation : sig
+      type hypothesis =
+        { id     : int              (* stable; the unsat-core currency *)
+        ; term   : Term.t
+        ; origin : Origin.t }
+
+      type t =
+        { signature  : Signature.t  (* sorts, symbols, datatype declarations *)
+        ; hypotheses : hypothesis list
+        ; goal       : Term.t
+        ; location   : Location.t }
+    end
+
+Hypothesis ids are how a backend names hypotheses in an unsat core. This is
+cleaner than vox2, which parses selector names back out of the core.
+
+## Outcome
+
+    type verdict =
+      | Proved  of { unused_hypotheses : int list option }
+      | Refuted of model option
+      | Unknown of reason
+
+    type reason = Timeout | Incomplete of string
+
+    type failure =
+      | Unavailable of string
+      | Error of { cause : string; raw : string }
+
+    type outcome = (verdict, failure) result
+
+Failure is separated from verdict. vox2 puts `Solver_error` and `Unavailable`
+beside `Proved` in one type, and `protect_discharge` (`vox_backend.ml:1163`)
+swallows every backend exception into `Solver_error` with the real text in a
+tail the printer never reads. That is how a genuine oxsmt defect reached a user
+as "the solver could not be run".
+
+`unused_hypotheses = None` means the backend makes no claim. It never means
+"all hypotheses were used". vox2's conservative reading is right and must
+survive: an unsat core need not be minimal, so a fade may be missed but never
+invented.
+
+Models are term-valued, not strings. vox2 returns a raw `define-fun` sexp capped
+at 4000 characters, and only for z3. Terms can carry constructor trees, which is
+what a datatype counterexample needs.
+
+### What Refuted means
+
+This has to be pinned before any backend exists, because the obvious reading is
+wrong.
+
+vox2 runs two queries (`vox_smt.ml:3754`). The Prove query asks whether
+`hypotheses AND NOT goal` is unsat; if so, `Proved`. If that does not settle it,
+a second Disprove query runs, and `Disproved` is reported only when *that*
+returns unsat. A bare `sat` on the prove query is `Not_proved`, and the model is
+fetched afterwards as decoration.
+
+So `Refuted` means the disprove query succeeded: the goal is false in every
+state satisfying the hypotheses. It does not mean "the prove query found a
+model". With uninterpreted functions and underspecified selectors, a prove-query
+model can satisfy the encoding without corresponding to any reachable program
+state, and reporting that as a refutation would be wrong.
+
+A prove-query model is at most payload for `Unknown`.
+
+Collapsing vox2's `Not_proved` and `Unknown` into one constructor is faithful,
+because vox2's `Not_proved` detail is literally
+`"prove query: <status>; disprove query: <status>"`, which is exactly what
+`Unknown of reason` carries.
+
+## Backends
+
+    module type BACKEND = sig
+      val name       : string
+      val configured : config:Config.t -> (unit, string) result
+      val discharge  : config:Config.t -> Obligation.t -> outcome
+    end
+
+    val backends : (module BACKEND) list
+    val select   : string -> ((module BACKEND), string) result
+
+A static list rather than a mutable registry. The defect in vox2 was leaking
+`smt_solver` and `oxsmt_solver` into the generic `discharge`
+(`vox_backend.mli:90`), and per-backend config fixes that without needing
+dynamic registration. A static list also keeps the `-vox-backend` error message
+derivable from the list.
+
+`Config.t` carries a budget from the start. vox2 threads `timeout_seconds`
+everywhere and enforces it two ways, an external `timeout` wrapper and SIGALRM
+stubs. The enforcement belongs to backend pieces, but the field has to exist
+now, and `Unknown Timeout` has to be distinguishable, because a timeout is the
+most common non-answer in practice.
+
+There is no `capabilities` record. With two backends the only question is
+whether unused hypotheses are available, and `int list option` answers it at the
+point of use.
+
+## `none` is not a backend
+
+`-vox-backend none` short-circuits before discharge. It is caller policy.
+
+A backend returning `Unknown` would report every obligation as unproved; one
+returning `Unavailable` would report every unit as failing. vox2 agrees:
+`grep -c None_backend` in `vox_backend.ml` is zero, and typecheck-only is
+`not_discharged_result` on the caller side (`vox_verify.ml:269`).
+
+## The printing backend emits SMT-LIB
+
+Not a bespoke pretty-print format. Printing and z3 share one renderer, so the
+expect-test baselines are the bytes z3 receives.
+
+A translation bug then shows up as a baseline diff rather than a mysterious
+`unknown`, the renderer becomes the most-tested code in the piece, and there is
+no way for what we print to drift from what we send. vox2 had that drift
+structurally: `-vox-dump-vc` printed an internal sexp form while
+`-vox-dump-vc-json-smt` carried the real queries separately.
+
+Human-readable rendering for diagnostics and the IDE is a different job and
+belongs elsewhere.
+
+## Datatypes
+
+Two mechanisms, and abstraction chooses between them. A type whose definition is
+visible becomes `declare-datatypes` with constructors, selectors and testers. A
+type behind a signature becomes `declare-sort` plus uninterpreted functions.
+
+The same OCaml type is concrete inside its defining module and abstract outside
+it. Getting this wrong would let client proofs depend on a representation the
+interface does not expose. It is also what makes the `int_set` corpus work: to
+the client, `t` is an uninterpreted sort and the laws are all that relate
+`member` and `insert`.
+
+Parametric types are monomorphised, one SMT sort per instantiation, matching
+vox2 (`declare-sort <name> 0` plus an `instantiate` step). The limits vox2 found
+are worth keeping as deliberate rejections rather than discoveries:
+
+    "non-regular recursive datatype %s is not supported"
+    "function-valued datatype fields are not supported"
+
+Non-regular recursion would need infinitely many instantiations. Parametric
+`declare-datatypes` would avoid the blow-up and z3 supports it, but it does not
+rescue non-regular recursion either, so it is an optimisation.
+
+Records and tuples are single-constructor datatypes. Mutually recursive types
+must be grouped into one `declare-datatypes`, so the translation needs SCCs over
+the type graph. Mutable fields need no rule here: logicality already stops a
+logical value's mutable state being read, so the projection never reaches the
+encoder.
+
+One modelling wrinkle to document. An SMT selector applied to the wrong
+constructor is underspecified, so `head Nil` is an arbitrary but consistent
+value rather than an error.
+
+## The z3 backend
+
+Polarity: assert the hypotheses and the negated goal, ask for satisfiability.
+`unsat` is `Proved`, and a refutation needs the second query described above.
+Write this down; a sign error here silently inverts every result.
+
+One process per obligation to start. A persistent `z3 -in` session with push and
+pop is faster and is the obvious later optimisation, but it adds state and
+failure modes this piece does not need.
+
+Timeouts both ways: `(set-option :timeout ...)` in the script and a wall-clock
+kill outside it, since a wedged process ignores the former.
+
+Unused hypotheses come from `(get-unsat-core)` with `:named` assertions carrying
+the hypothesis ids.
+
+### Availability is checked once
+
+Check the configured command at selection, not per obligation, and fail with one
+message: no solver configured, pass `-vox-backend none` to typecheck only.
+
+This is the lesson worth carrying over most. vox2 defaults to z3; z3 was not
+installed on this machine; the result was 51 of 52 refinement tests failing with
+`Refinement verification failed (unavailable)` on every obligation. That reads
+as a broken feature rather than a missing binary. It is also why `Unavailable`
+belongs in `failure` rather than beside `Proved`.
+
+z3 4.8.5 is at `/j/office/app/z3/prod/4.8.5/install/bin/z3` and is the version
+the vox2 corpus was tuned against.
+
+## Tests
+
+Obligations are built by hand; nothing produces them yet.
+
+Renderer, which is the bulk:
+
+- each sort and term form rendered to SMT-LIB, checked against a baseline
+- a datatype group with mutual recursion in one `declare-datatypes`
+- an abstract type as `declare-sort` plus uninterpreted functions
+- rejections: non-regular recursive datatype, function-valued field
+- a well-formedness failure for an undeclared variable or symbol
+
+z3, gated on the binary being present:
+
+- `Proved` for a valid goal, `Refuted` for one false under every model of the
+  hypotheses, `Unknown Timeout` under a tiny budget
+- a prove-query `sat` that is not a refutation reports `Unknown`, not `Refuted`.
+  This is the discriminating test for the ruling above and should fail if
+  someone rewires the protocol to one query.
+- `unused_hypotheses` populated from an unsat core, with an unused hypothesis
+  present
+- a term-valued model for a datatype counterexample
+- selection with no configured command fails once, at selection, and the message
+  names `-vox-backend none`
+
+Driver:
+
+- `-vox-backend none` skips discharge and reports obligations as not discharged
+- `-vox-backend printing` emits SMT-LIB and discharges nothing
+
+## Deferred
+
+Caching. vox2's `Cached` decorator is the right shape, but it needs
+`cache_key : config:Config.t -> Obligation.t -> string option` on `BACKEND`,
+with `None` bypassing the cache, and a key mixing compiler identity, solver
+fingerprint and payload (`vox_backend.ml:890`). Add the field when the cache
+lands rather than carrying an unused one now.
+
+Cross-checking. It layers above `BACKEND` and needs a second real backend to
+compare against. Recording it here because it was vox2's main validation tool
+for oxsmt, and it is why vox2's `result` carries a list of `backend_result`. The
+`Not_proved` to `Unknown` normalisation at `vox_backend.ml:1189` becomes a no-op
+under these types.
+
+Lean and in-process oxsmt backends. A persistent solver session. Translation
+from refinement expressions into these terms. Recursive functions over
+datatypes, which are uninterpreted symbols plus definitional-equation axioms.
+
+## Decisions taken
+
+- `Refuted` requires the disprove query, not a prove-query model.
+- `none` is driver policy, not a backend.
+- Availability is checked once at selection.
+- The printing backend emits SMT-LIB, shared with z3.
+- Variables are declared in the signature, not sorted at each occurrence.
+- Static backend list rather than a mutable registry, since a global mutable
+  table is the pattern this rebuild is trying to leave behind.
+
+## Decisions taken during implementation
+
+Recorded per AGENTS.md: points the spec above left open, with the route taken.
+
+- **Module layout.** `typing/vox_logic` (sorts, ops, literals, terms, origins,
+  datatypes, signatures, obligations), `typing/vox_smtlib` (the one renderer),
+  `typing/vox_backend` (config, outcome, `BACKEND`, printing and z3, selection
+  and driver policy). Following vox2's precedent that vox modules live in
+  `typing/`, where later pieces will use them.
+
+- **Monomorphisation lives here, as `Signature.instantiate`.** The signature a
+  backend sees carries only ground datatypes (fields are `Sort.t`, which has no
+  arrow and no type application, so neither rejection is even representable
+  there). The parametric declaration language `Datatype.ty` exists as input to
+  `instantiate`, which owns both deliberate rejections. The alternative — a
+  parametric signature with instantiation in the renderer — would make every
+  backend deal with instances. Non-regularity is detected exactly as in vox2:
+  a recursive use at different arguments while the datatype's own definition
+  is being expanded.
+
+- **Instance naming.** `t` at `Int` is `t<Int>`; constructors and selectors get
+  the same suffix (`Cons<Int>`, `head<Int>`); nullary instantiations keep their
+  names. `<` and `>` are legal in SMT-LIB simple symbols (verified against
+  z3 4.8.5); anything else is `|quoted|` by the renderer, and a symbol
+  containing `|` or `\` is an error.
+
+- **One-shot scripts, directives included.** A `Prove` script always ends with
+  `(get-unsat-core)`, `(get-model)`, `(get-info :reason-unknown)`; both query
+  scripts ask for the reason. Verified against z3 4.8.5: an inapplicable
+  directive prints an `(error ...)` line, execution continues, and the exit
+  code becomes nonzero — so the backend ignores exit codes whenever a status
+  line is present, and readers skip error entries. The alternative (re-running
+  with extra directives once the status is known) costs a second process on
+  every proof.
+
+- **Timeout classification.** z3-side `(set-option :timeout)` is the primary
+  budget; `(get-info :reason-unknown)` answering `timeout`/`canceled` maps to
+  `Unknown Timeout` (verified shape: `(:reason-unknown "timeout")`). The
+  wall-clock kill is a `timeout(1)` wrapper with one second of grace — the
+  compiler cannot depend on the unix library, and vox2's alternative was C
+  stubs, which this piece does not need. Exit 124 also maps to
+  `Unknown Timeout`. If either query times out, the obligation is
+  `Unknown Timeout`.
+
+- **The printing backend emits the `Prove` query only.** The `Disprove` script
+  differs in the polarity of one assert and the absence of core/model
+  directives; printing both would double every baseline for one line of
+  signal. The disprove polarity is pinned by its own renderer baseline and by
+  the z3 protocol test.
+
+- **`-vox-backend` policy ships as `Vox_backend.plan`; the flag itself is
+  deferred.** Nothing produces obligations yet, so a command-line flag would
+  be dead code with no observable behaviour; the piece that produces
+  obligations wires `plan` to `-vox-backend`. `plan` implements exactly the
+  spec's driver rules: `"none"` short-circuits before selection, anything else
+  is selected and `configured` is checked once, with the failure message
+  naming `-vox-backend none`.
+
+- **Well-formedness is declaredness, arity and literal shape, not sort
+  inference.** Undeclared variables/functions/constructors/sorts, arity and
+  field-index mismatches, malformed literals, duplicate declarations and
+  duplicate hypothesis ids are renderer errors. Re-implementing full sort
+  checking would duplicate the solver's own checker at some length; the
+  variables' sorts already cannot disagree by construction.
+
+- **Models are read back best-effort.** Values of the obligation's variables
+  parse into terms (constructor trees included); z3's opaque universe
+  elements for uninterpreted sorts (`t!val!0`) read back as `Term.Var`; a
+  value that does not parse drops that variable rather than failing the
+  verdict.
+
+- **`Origin.t`** is `{ label; location }` — enough for unused-hypothesis
+  diagnostics; the translation piece will decide what labels mean.
+
+- **`Config.t`** is `{ timeout_seconds : float option; z3_command : string
+  option }` with default ten seconds and no solver. Temporary files for
+  solver I/O go through `Filename.temp_file`, which honours `TMPDIR`.

--- a/design-docs/solver-interface.md
+++ b/design-docs/solver-interface.md
@@ -283,6 +283,9 @@ under these types.
 Lean and in-process oxsmt backends. A persistent solver session. Translation
 from refinement expressions into these terms. Recursive functions over
 datatypes, which are uninterpreted symbols plus definitional-equation axioms.
+Conversions between `Int` and `Bitvec` (vox2 needs `bv2int`/`int2bv` for
+`Bigint.of_int`; the operators are added when the translation fixes their
+semantics). A model payload on `Unknown` for near-counterexamples.
 
 ## Decisions taken
 
@@ -295,6 +298,23 @@ datatypes, which are uninterpreted symbols plus definitional-equation axioms.
   table is the pattern this rebuild is trying to leave behind.
 
 ## Decisions taken during implementation
+
+Two protocol refinements from the review loop, stated here because they
+sharpen rulings made above:
+
+- **`Refuted` additionally requires the prove query to answer `sat`.** The
+  protocol above runs the disprove query whenever the prove query "does not
+  settle it"; but after a prove-query `unknown`, hypothesis satisfiability is
+  unestablished, and `hyps AND goal` unsat can simply mean the hypotheses are
+  contradictory — whose correct verdict is `Proved`, not `Refuted`. So an
+  `unknown` prove query is reported as `Unknown` without running the disprove
+  query. (vox2 ran it anyway; this is a deliberate hardening.)
+
+- **"A prove-query model is at most payload for `Unknown`"** describes what a
+  prove-query model may ever be used for; under the types above `Unknown`
+  carries no model, so today it is simply dropped. Carrying it (the common
+  unproved case has a useful near-counterexample sitting in the prove output)
+  is deferred to the diagnostics work, noted below.
 
 Recorded per AGENTS.md: points the spec above left open, with the route taken.
 
@@ -312,13 +332,27 @@ Recorded per AGENTS.md: points the spec above left open, with the route taken.
   parametric signature with instantiation in the renderer — would make every
   backend deal with instances. Non-regularity is detected exactly as in vox2:
   a recursive use at different arguments while the datatype's own definition
-  is being expanded.
+  is being expanded. The test is conservative — it also rejects some patterns
+  whose reachable instance set is finite (a recursive use at constant
+  arguments, say), not only the genuinely infinite ones; kept as-is for vox2
+  parity, and the interface says so.
 
 - **Instance naming.** `t` at `Int` is `t<Int>`; constructors and selectors get
   the same suffix (`Cons<Int>`, `head<Int>`); nullary instantiations keep their
   names. `<` and `>` are legal in SMT-LIB simple symbols (verified against
-  z3 4.8.5); anything else is `|quoted|` by the renderer, and a symbol
-  containing `|` or `\` is an error.
+  z3 4.8.5); anything else is `|quoted|` by the renderer (multi-argument
+  instances contain `,`, so they render quoted), and a symbol containing `|`
+  or `\` is an error. `instantiate` rejects two instantiations that mangle to
+  one name (`Sort.key` is not injective — an uninterpreted sort literally
+  named `Int` would otherwise alias the builtin) and requires declaration,
+  constructor and selector names to be globally unique before suffixing.
+
+- **Builtin names are rejected, not quoted** (review-loop finding). Quoting is
+  purely lexical — verified that in z3 4.8.5 a declared `|not|` shadows the
+  boolean operator and `(|+| n n)` is `(+ n n)` — so a signature symbol
+  spelling an interpreted operator, `true`/`false`/`ite`, a builtin sort
+  name, or a hypothesis label `h<id>` is an ill-formed obligation. The
+  translation piece owns name generation and can avoid these spellings.
 
 - **One-shot scripts, directives included.** A `Prove` script always ends with
   `(get-unsat-core)`, `(get-model)`, `(get-info :reason-unknown)`; both query
@@ -329,9 +363,20 @@ Recorded per AGENTS.md: points the spec above left open, with the route taken.
   with extra directives once the status is known) costs a second process on
   every proof.
 
+  Position matters, though (review-loop finding): an `(error ...)` printed
+  *before* the status line means z3 rejected part of the script and answered
+  a different question — verified that a dropped ill-sorted hypothesis turns
+  into a spurious "refuted", and a dropped colliding `:named` assertion can
+  invert a verdict. Pre-status errors are therefore a backend failure
+  (`Error { cause; raw }`), never a verdict; only post-status errors are the
+  ignorable inapplicable directives. This is what turns every future encoding
+  defect into a loud failure rather than a silent wrong answer, which matters
+  doubly because the renderer deliberately does not sort-check.
+
 - **Timeout classification.** z3-side `(set-option :timeout)` is the primary
   budget; `(get-info :reason-unknown)` answering `timeout`/`canceled` maps to
-  `Unknown Timeout` (verified shape: `(:reason-unknown "timeout")`). The
+  `Unknown Timeout` (both shapes observed from 4.8.5, engine-dependent). The
+  budget is per query, so an obligation may take two budgets of wall clock. The
   wall-clock kill is a `timeout(1)` wrapper with one second of grace — the
   compiler cannot depend on the unix library, and vox2's alternative was C
   stubs, which this piece does not need. Exit 124 also maps to

--- a/dune
+++ b/dune
@@ -308,6 +308,9 @@
   typedecl_variance
   typedecl_properties
   typedecl_separability
+  vox_logic
+  vox_smtlib
+  vox_backend
   cmt2annot
   out_type
   data_types

--- a/testsuite/tests/vox-solver/driver.ml
+++ b/testsuite/tests/vox-solver/driver.ml
@@ -10,7 +10,7 @@
 open Vox_logic
 open Vox_backend
 
-let obligation =
+let obligation () =
   { Obligation.signature =
       { Signature.empty with variables = ["n", Sort.Int] }
   ; hypotheses =
@@ -37,36 +37,10 @@ let run backend_name config =
   | Ok No_discharge -> Format.printf "not discharged@."
   | Ok (Discharge (module Backend)) ->
     Format.printf "discharging with %s:@." Backend.name;
-    Format.printf "%s@." (describe (Backend.discharge ~config obligation))
+    Format.printf "%s@." (describe (Backend.discharge ~config (obligation ())))
 
 [%%expect{|
-val obligation : Vox_logic.Obligation.t =
-  {Obligation.signature =
-    {Signature.sorts = []; datatypes = []; variables = [("n", Sort.Int)];
-     functions = []};
-   hypotheses =
-    [{Obligation.id = 0;
-      term = Term.App (Op.Ge, [Term.Var "n"; Term.Const (Literal.Int "0")]);
-      origin =
-       {Origin.label = "n is a length";
-        location =
-         {Location.loc_start =
-           {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
-            pos_cnum = -1};
-          loc_end =
-           {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
-            pos_cnum = -1};
-          loc_ghost = true}}}];
-   goal =
-    Term.App (Op.Ge,
-     [Term.App (Op.Add, [Term.Var "n"; Term.Const (Literal.Int "1")]);
-      Term.Const (Literal.Int "1")]);
-   location =
-    {Location.loc_start =
-      {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
-     loc_end =
-      {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
-     loc_ghost = true}}
+val obligation : unit -> Vox_logic.Obligation.t = <fun>
 val describe : (Vox_backend.verdict, Vox_backend.failure) Result.t -> string =
   <fun>
 val run : string -> Vox_backend.Config.t -> unit = <fun>
@@ -114,4 +88,12 @@ let () = run "lean" Config.default
 
 [%%expect{|
 selection failed: unknown vox backend lean (valid backends: printing, z3; or none to typecheck only)
+|}]
+
+(* A configured command that cannot run also fails once, at selection. *)
+
+let () = run "z3" { Config.default with z3_command = Some "false" }
+
+[%%expect{|
+selection failed: z3 backend: solver command false failed (exit code 1):
 |}]

--- a/testsuite/tests/vox-solver/driver.ml
+++ b/testsuite/tests/vox-solver/driver.ml
@@ -1,0 +1,117 @@
+(* TEST
+ flags = "-I ${ocamlsrcdir}/typing -I ${ocamlsrcdir}/parsing -I ${ocamlsrcdir}/utils";
+ include ocamlcommon;
+ expect;
+*)
+
+(* Driver policy: [none] is not a backend, and an unusable configuration
+   fails once, at selection, not once per obligation. *)
+
+open Vox_logic
+open Vox_backend
+
+let obligation =
+  { Obligation.signature =
+      { Signature.empty with variables = ["n", Sort.Int] }
+  ; hypotheses =
+      [ { id = 0
+        ; term = App (Ge, [Var "n"; Const (Int "0")])
+        ; origin = { label = "n is a length"; location = Location.none }
+        }
+      ]
+  ; goal = App (Ge, [App (Add, [Var "n"; Const (Int "1")]); Const (Int "1")])
+  ; location = Location.none
+  }
+
+let describe = function
+  | Ok (Proved { unused_hypotheses = _ }) -> "proved"
+  | Ok (Refuted _) -> "refuted"
+  | Ok (Unknown Timeout) -> "unknown (timeout)"
+  | Ok (Unknown (Incomplete reason)) -> "unknown (" ^ reason ^ ")"
+  | Result.Error (Unavailable message) -> "unavailable: " ^ message
+  | Result.Error (Error { cause; raw = _ }) -> "error: " ^ cause
+
+let run backend_name config =
+  match plan ~backend_name ~config with
+  | Result.Error message -> Format.printf "selection failed: %s@." message
+  | Ok No_discharge -> Format.printf "not discharged@."
+  | Ok (Discharge (module Backend)) ->
+    Format.printf "discharging with %s:@." Backend.name;
+    Format.printf "%s@." (describe (Backend.discharge ~config obligation))
+
+[%%expect{|
+val obligation : Vox_logic.Obligation.t =
+  {Obligation.signature =
+    {Signature.sorts = []; datatypes = []; variables = [("n", Sort.Int)];
+     functions = []};
+   hypotheses =
+    [{Obligation.id = 0;
+      term = Term.App (Op.Ge, [Term.Var "n"; Term.Const (Literal.Int "0")]);
+      origin =
+       {Origin.label = "n is a length";
+        location =
+         {Location.loc_start =
+           {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
+            pos_cnum = -1};
+          loc_end =
+           {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0;
+            pos_cnum = -1};
+          loc_ghost = true}}}];
+   goal =
+    Term.App (Op.Ge,
+     [Term.App (Op.Add, [Term.Var "n"; Term.Const (Literal.Int "1")]);
+      Term.Const (Literal.Int "1")]);
+   location =
+    {Location.loc_start =
+      {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
+     loc_end =
+      {Lexing.pos_fname = "_none_"; pos_lnum = 0; pos_bol = 0; pos_cnum = -1};
+     loc_ghost = true}}
+val describe : (Vox_backend.verdict, Vox_backend.failure) Result.t -> string =
+  <fun>
+val run : string -> Vox_backend.Config.t -> unit = <fun>
+|}]
+
+(* [none] short-circuits before any backend is consulted: obligations are
+   reported as not discharged even with no solver on the machine. *)
+
+let () = run "none" Config.default
+
+[%%expect{|
+not discharged
+|}]
+
+(* The printing backend emits the prove query and discharges nothing. *)
+
+let () = run "printing" { Config.default with timeout_seconds = None }
+
+[%%expect{|
+discharging with printing:
+(set-option :produce-unsat-cores true)
+(declare-const n Int)
+(assert (! (>= n 0) :named h0))
+(assert (not (>= (+ n 1) 1)))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+unknown (printing backend discharges nothing)
+|}]
+
+(* z3 without a configured command fails at selection, with one message
+   that names the way out. *)
+
+let () = run "z3" Config.default
+
+[%%expect{|
+selection failed: z3 backend: no solver configured: give the z3 backend a command, or pass -vox-backend none to typecheck only
+|}]
+
+(* An unknown name fails with the valid names, derived from the backend
+   list. *)
+
+let () = run "lean" Config.default
+
+[%%expect{|
+selection failed: unknown vox backend lean (valid backends: printing, z3; or none to typecheck only)
+|}]

--- a/testsuite/tests/vox-solver/has_z3.sh
+++ b/testsuite/tests/vox-solver/has_z3.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Gate for tests that need a real z3: exit 125 tells ocamltest to skip.
+# VOX_TEST_Z3 overrides; otherwise take z3 from PATH, or the pinned office
+# install that the vox2 corpus was tuned against (z3 4.8.5).
+if [ -n "$VOX_TEST_Z3" ]; then exit 0; fi
+if command -v z3 > /dev/null 2>&1; then exit 0; fi
+if [ -x /j/office/app/z3/prod/4.8.5/install/bin/z3 ]; then exit 0; fi
+exit 125

--- a/testsuite/tests/vox-solver/renderer.ml
+++ b/testsuite/tests/vox-solver/renderer.ml
@@ -1,0 +1,527 @@
+(* TEST
+ flags = "-I ${ocamlsrcdir}/typing -I ${ocamlsrcdir}/parsing -I ${ocamlsrcdir}/utils";
+ include ocamlcommon;
+ expect;
+*)
+
+(* The SMT-LIB renderer, exercised on hand-built obligations.  The same
+   renderer feeds the z3 backend, so these baselines are the bytes z3
+   receives. *)
+
+open Vox_logic
+
+let origin label = { Origin.label; location = Location.none }
+
+let hyp id term =
+  { Obligation.id; term; origin = origin (Printf.sprintf "h%d" id) }
+
+let obligation ?(signature = Signature.empty) ?(hypotheses = []) goal =
+  { Obligation.signature; hypotheses; goal; location = Location.none }
+
+let render ?timeout_ms query o =
+  match Vox_smtlib.render ?timeout_ms query o with
+  | Ok script -> Format.printf "%s" script
+  | Error message -> Format.printf "ill-formed: %s@." message
+
+[%%expect{|
+val origin : string -> Vox_logic.Origin.t = <fun>
+val hyp : int -> Vox_logic.Term.t -> Vox_logic.Obligation.hypothesis = <fun>
+val obligation :
+  ?signature:Vox_logic.Signature.t ->
+  ?hypotheses:Vox_logic.Obligation.hypothesis list ->
+  Vox_logic.Term.t -> Vox_logic.Obligation.t = <fun>
+val render :
+  ?timeout_ms:int -> Vox_smtlib.query -> Vox_logic.Obligation.t -> unit =
+  <fun>
+|}]
+
+(* Every sort, rendered through variable declarations; every literal form.
+   [Bitvec 63] is OCaml's [int]. *)
+
+let () =
+  render Prove
+    (obligation
+       ~signature:
+         { Signature.empty with
+           sorts = ["opaque"]
+         ; variables =
+             [ "b", Sort.Bool
+             ; "n", Sort.Int
+             ; "m", Sort.Bitvec 63
+             ; "u", Sort.Uninterpreted "opaque"
+             ]
+         }
+       ~hypotheses:
+         [ hyp 0 (App (Eq, [Var "b"; Const (Bool false)]))
+         ; hyp 1 (App (Eq, [Var "n"; Const (Int "-12345678901234567890123")]))
+         ; hyp 2 (App (Eq, [Var "m"; Const (Literal.ocaml_int (-1))]))
+         ]
+       (App (Eq, [Var "u"; Var "u"])))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(declare-sort opaque 0)
+(declare-const b Bool)
+(declare-const n Int)
+(declare-const m (_ BitVec 63))
+(declare-const u opaque)
+(assert (! (= b false) :named h0))
+(assert (! (= n (- 12345678901234567890123)) :named h1))
+(assert (! (= m (_ bv9223372036854775807 63)) :named h2))
+(assert (not (= u u)))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* Every operator.  Interpreted operators only: OCaml semantics (division by
+   zero, shift ranges) is the translation's job. *)
+
+let int_ops =
+  let n = Term.Var "n" in
+  Term.App
+    ( And,
+      [ App (Eq, [App (Neg, [n]); App (Add, [n; n])])
+      ; App (Eq, [App (Sub, [n; n]); App (Mul, [n; n])])
+      ; App (Eq, [App (Div, [n; n]); App (Mod, [n; n])])
+      ; App (Lt, [n; n]); App (Le, [n; n]); App (Gt, [n; n]); App (Ge, [n; n])
+      ; App (Distinct, [n; n])
+      ] )
+
+let bitvec_ops =
+  let m = Term.Var "m" in
+  let eq x y = Term.App (Eq, [x; y]) in
+  Term.App
+    ( And,
+      [ eq (App (Bv_neg, [m])) (App (Bv_add, [m; m]))
+      ; eq (App (Bv_sub, [m; m])) (App (Bv_mul, [m; m]))
+      ; eq (App (Bv_sdiv, [m; m])) (App (Bv_srem, [m; m]))
+      ; eq (App (Bv_not, [m])) (App (Bv_and, [m; m]))
+      ; eq (App (Bv_or, [m; m])) (App (Bv_xor, [m; m]))
+      ; eq (App (Bv_shl, [m; m])) (App (Bv_lshr, [m; m]))
+      ; eq (App (Bv_ashr, [m; m])) m
+      ; App (Bv_slt, [m; m]); App (Bv_sle, [m; m])
+      ; App (Bv_sgt, [m; m]); App (Bv_sge, [m; m])
+      ] )
+
+let () =
+  render Prove
+    (obligation
+       ~signature:
+         { Signature.empty with
+           variables = ["b", Sort.Bool; "n", Sort.Int; "m", Sort.Bitvec 63]
+         ; functions = ["f", [Sort.Int; Sort.Bool], Sort.Int]
+         }
+       ~hypotheses:[hyp 0 int_ops; hyp 1 bitvec_ops]
+       (App
+          ( Or,
+            [ App (Not, [Var "b"])
+            ; App (Implies, [Var "b"; Var "b"])
+            ; App
+                ( Eq,
+                  [ Term.Ite (Var "b", Var "n", Call ("f", [Var "n"; Var "b"]))
+                  ; Var "n"
+                  ] )
+            ] )))
+
+[%%expect{|
+val int_ops : Vox_logic.Term.t =
+  Term.App (Op.And,
+   [Term.App (Op.Eq,
+     [Term.App (Op.Neg, [Term.Var "n"]);
+      Term.App (Op.Add, [Term.Var "n"; Term.Var "n"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Sub, [Term.Var "n"; Term.Var "n"]);
+      Term.App (Op.Mul, [Term.Var "n"; Term.Var "n"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Div, [Term.Var "n"; Term.Var "n"]);
+      Term.App (Op.Mod, [Term.Var "n"; Term.Var "n"])]);
+    Term.App (Op.Lt, [Term.Var "n"; Term.Var "n"]);
+    Term.App (Op.Le, [Term.Var "n"; Term.Var "n"]);
+    Term.App (Op.Gt, [Term.Var "n"; Term.Var "n"]);
+    Term.App (Op.Ge, [Term.Var "n"; Term.Var "n"]);
+    Term.App (Op.Distinct, [Term.Var "n"; Term.Var "n"])])
+val bitvec_ops : Vox_logic.Term.t =
+  Term.App (Op.And,
+   [Term.App (Op.Eq,
+     [Term.App (Op.Bv_neg, [Term.Var "m"]);
+      Term.App (Op.Bv_add, [Term.Var "m"; Term.Var "m"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Bv_sub, [Term.Var "m"; Term.Var "m"]);
+      Term.App (Op.Bv_mul, [Term.Var "m"; Term.Var "m"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Bv_sdiv, [Term.Var "m"; Term.Var "m"]);
+      Term.App (Op.Bv_srem, [Term.Var "m"; Term.Var "m"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Bv_not, [Term.Var "m"]);
+      Term.App (Op.Bv_and, [Term.Var "m"; Term.Var "m"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Bv_or, [Term.Var "m"; Term.Var "m"]);
+      Term.App (Op.Bv_xor, [Term.Var "m"; Term.Var "m"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Bv_shl, [Term.Var "m"; Term.Var "m"]);
+      Term.App (Op.Bv_lshr, [Term.Var "m"; Term.Var "m"])]);
+    Term.App (Op.Eq,
+     [Term.App (Op.Bv_ashr, [Term.Var "m"; Term.Var "m"]); Term.Var "m"]);
+    Term.App (Op.Bv_slt, [Term.Var "m"; Term.Var "m"]);
+    Term.App (Op.Bv_sle, [Term.Var "m"; Term.Var "m"]);
+    Term.App (Op.Bv_sgt, [Term.Var "m"; Term.Var "m"]);
+    Term.App (Op.Bv_sge, [Term.Var "m"; Term.Var "m"])])
+(set-option :produce-unsat-cores true)
+(declare-const b Bool)
+(declare-const n Int)
+(declare-const m (_ BitVec 63))
+(declare-fun f (Int Bool) Int)
+(assert (! (and (= (- n) (+ n n)) (= (- n n) (* n n)) (= (div n n) (mod n n)) (< n n) (<= n n) (> n n) (>= n n) (distinct n n)) :named h0))
+(assert (! (and (= (bvneg m) (bvadd m m)) (= (bvsub m m) (bvmul m m)) (= (bvsdiv m m) (bvsrem m m)) (= (bvnot m) (bvand m m)) (= (bvor m m) (bvxor m m)) (= (bvshl m m) (bvlshr m m)) (= (bvashr m m) m) (bvslt m m) (bvsle m m) (bvsgt m m) (bvsge m m)) :named h1))
+(assert (not (or (not b) (=> b b) (= (ite b n (f n b)) n))))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* The disprove query asserts the goal itself, un-negated, and asks for no
+   core and no model.  Polarity is the whole protocol; see the design doc. *)
+
+let () =
+  render Disprove
+    (obligation
+       ~signature:{ Signature.empty with variables = ["n", Sort.Int] }
+       ~hypotheses:[hyp 0 (App (Ge, [Var "n"; Const (Int "0")]))]
+       (App (Gt, [Var "n"; Const (Int "0")])))
+
+[%%expect{|
+(declare-const n Int)
+(assert (>= n 0))
+(assert (> n 0))
+(check-sat)
+(get-info :reason-unknown)
+|}]
+
+(* The timeout budget appears in the script itself. *)
+
+let () =
+  render ~timeout_ms:250 Disprove (obligation (Const (Bool true)))
+
+[%%expect{|
+(set-option :timeout 250)
+(assert true)
+(check-sat)
+(get-info :reason-unknown)
+|}]
+
+(* Datatypes.  A parametric declaration is monomorphised: one ground
+   instance per instantiation, constructors and selectors suffixed the same
+   way.  Instances at different arguments coexist. *)
+
+let list_decl : Datatype.decl =
+  { decl_name = "list"
+  ; params = ["a"]
+  ; constructors =
+      [ { constructor_name = "Nil"; fields = [] }
+      ; { constructor_name = "Cons"
+        ; fields = ["head", Param "a"; "tail", Apply ("list", [Param "a"])]
+        }
+      ]
+  }
+
+let instantiate decls roots k =
+  match Signature.instantiate decls roots with
+  | Error message -> Format.printf "rejected: %s@." message
+  | Ok (datatypes, sorts) -> k datatypes sorts
+
+let () =
+  instantiate [list_decl]
+    ["list", [Datatype.Int]; "list", [Apply ("list", [Datatype.Int])]]
+    (fun datatypes sorts ->
+       render Prove
+         (obligation
+            ~signature:
+              { Signature.empty with
+                datatypes
+              ; variables =
+                  ["xs", List.nth sorts 0; "xss", List.nth sorts 1]
+              }
+            ~hypotheses:
+              [ hyp 0 (Test ("Cons<Int>", Var "xs"))
+              ; hyp 1
+                  (App
+                     ( Eq,
+                       [ Var "xss"
+                       ; Construct
+                           ( "Cons<list<Int>>",
+                             [Var "xs"; Construct ("Nil<list<Int>>", [])] )
+                       ] ))
+              ]
+            (App
+               ( Eq,
+                 [ Select ("Cons<Int>", 0, Var "xs")
+                 ; Select ("Cons<Int>", 0, Select ("Cons<Int>", 1, Var "xs"))
+                 ] ))))
+
+[%%expect{|
+val list_decl : Vox_logic.Datatype.decl =
+  {Datatype.decl_name = "list"; params = ["a"];
+   constructors =
+    [{Datatype.constructor_name = "Nil"; fields = []};
+     {Datatype.constructor_name = "Cons";
+      fields =
+       [("head", Datatype.Param "a");
+        ("tail", Datatype.Apply ("list", [Datatype.Param "a"]))]}]}
+val instantiate :
+  Vox_logic.Datatype.decl list ->
+  (string * Vox_logic.Datatype.ty list) list ->
+  (Vox_logic.Signature.datatype list -> Vox_logic.Sort.t list -> unit) ->
+  unit = <fun>
+(set-option :produce-unsat-cores true)
+(declare-datatypes ((list<Int> 0)) (
+  ((Nil<Int>) (Cons<Int> (head<Int> Int) (tail<Int> list<Int>)))))
+(declare-datatypes ((list<list<Int>> 0)) (
+  ((Nil<list<Int>>) (Cons<list<Int>> (head<list<Int>> list<Int>) (tail<list<Int>> list<list<Int>>)))))
+(declare-const xs list<Int>)
+(declare-const xss list<list<Int>>)
+(assert (! ((_ is Cons<Int>) xs) :named h0))
+(assert (! (= xss (Cons<list<Int>> xs Nil<list<Int>>)) :named h1))
+(assert (not (= (head<Int> xs) (head<Int> (tail<Int> xs)))))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* A mutually recursive group lands in one [declare-datatypes]; a group its
+   fields reference is declared before it. *)
+
+let tree_decls : Datatype.decl list =
+  [ { decl_name = "pair"
+    ; params = []
+    ; constructors =
+        [ { constructor_name = "Pair"
+          ; fields = ["fst", Datatype.Int; "snd", Datatype.Bool]
+          }
+        ]
+    }
+  ; { decl_name = "tree"
+    ; params = []
+    ; constructors =
+        [ { constructor_name = "Leaf"; fields = ["label", Apply ("pair", [])] }
+        ; { constructor_name = "Node"; fields = ["children", Apply ("forest", [])] }
+        ]
+    }
+  ; { decl_name = "forest"
+    ; params = []
+    ; constructors =
+        [ { constructor_name = "Empty"; fields = [] }
+        ; { constructor_name = "Grow"
+          ; fields = ["first", Apply ("tree", []); "rest", Apply ("forest", [])]
+          }
+        ]
+    }
+  ]
+
+let () =
+  instantiate tree_decls ["tree", []] (fun datatypes sorts ->
+    render Prove
+      (obligation
+         ~signature:
+           { Signature.empty with
+             datatypes
+           ; variables = ["t", List.nth sorts 0]
+           }
+         (Test ("Leaf", Var "t"))))
+
+[%%expect{|
+val tree_decls : Vox_logic.Datatype.decl list =
+  [{Datatype.decl_name = "pair"; params = [];
+    constructors =
+     [{Datatype.constructor_name = "Pair";
+       fields = [("fst", Datatype.Int); ("snd", Datatype.Bool)]}]};
+   {Datatype.decl_name = "tree"; params = [];
+    constructors =
+     [{Datatype.constructor_name = "Leaf";
+       fields = [("label", Datatype.Apply ("pair", []))]};
+      {Datatype.constructor_name = "Node";
+       fields = [("children", Datatype.Apply ("forest", []))]}]};
+   {Datatype.decl_name = "forest"; params = [];
+    constructors =
+     [{Datatype.constructor_name = "Empty"; fields = []};
+      {Datatype.constructor_name = "Grow";
+       fields =
+        [("first", Datatype.Apply ("tree", []));
+         ("rest", Datatype.Apply ("forest", []))]}]}]
+(set-option :produce-unsat-cores true)
+(declare-datatypes ((pair 0)) (
+  ((Pair (fst Int) (snd Bool)))))
+(declare-datatypes ((forest 0) (tree 0)) (
+  ((Empty) (Grow (first tree) (rest forest)))
+  ((Leaf (label pair)) (Node (children forest)))))
+(declare-const t tree)
+(assert (not ((_ is Leaf) t)))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* An abstract type is a [declare-sort] plus uninterpreted functions; the
+   laws are all that relate them.  (This is the client's view of [int_set]:
+   inside the defining module the same type would be a datatype.) *)
+
+let () =
+  render Prove
+    (obligation
+       ~signature:
+         { Signature.empty with
+           sorts = ["int_set"]
+         ; variables = ["s", Sort.Uninterpreted "int_set"; "x", Sort.Bitvec 63]
+         ; functions =
+             [ "member", [Sort.Bitvec 63; Sort.Uninterpreted "int_set"], Sort.Bool
+             ; "insert",
+               [Sort.Bitvec 63; Sort.Uninterpreted "int_set"],
+               Sort.Uninterpreted "int_set"
+             ]
+         }
+       (Call ("member", [Var "x"; Call ("insert", [Var "x"; Var "s"])])))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(declare-sort int_set 0)
+(declare-const s int_set)
+(declare-const x (_ BitVec 63))
+(declare-fun member ((_ BitVec 63) int_set) Bool)
+(declare-fun insert ((_ BitVec 63) int_set) int_set)
+(assert (not (member x (insert x s))))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* Deliberate rejections.  Non-regular recursion would need infinitely many
+   instances; SMT datatypes cannot store functions. *)
+
+let () =
+  instantiate
+    [ { decl_name = "nest"
+      ; params = ["a"]
+      ; constructors =
+          [ { constructor_name = "One"; fields = ["it", Param "a"] }
+          ; { constructor_name = "Deeper"
+            ; fields =
+                ["inside", Apply ("nest", [Apply ("pair", [Param "a"])])]
+            }
+          ]
+      }
+    ; { decl_name = "pair"
+      ; params = ["a"]
+      ; constructors =
+          [ { constructor_name = "P"
+            ; fields = ["l", Param "a"; "r", Param "a"]
+            }
+          ]
+      }
+    ]
+    ["nest", [Datatype.Int]]
+    (fun _ _ -> Format.printf "accepted@.")
+
+[%%expect{|
+rejected: non-regular recursive datatype nest is not supported
+|}]
+
+let () =
+  instantiate
+    [ { decl_name = "wrap"
+      ; params = []
+      ; constructors =
+          [ { constructor_name = "Wrap"
+            ; fields = ["run", Datatype.Arrow (Datatype.Int, Datatype.Bool)]
+            }
+          ]
+      }
+    ]
+    ["wrap", []]
+    (fun _ _ -> Format.printf "accepted@.")
+
+[%%expect{|
+rejected: function-valued datatype fields are not supported
+|}]
+
+(* Well-formedness: what the signature does not declare, a term cannot use.
+   Ill-sortedness of a variable is unrepresentable (the signature gives the
+   sort, occurrences carry none); these are the mistakes that remain. *)
+
+let () = render Prove (obligation (Var "ghost"))
+
+[%%expect{|
+ill-formed: undeclared variable ghost
+|}]
+
+let () = render Prove (obligation (Call ("f", [])))
+
+[%%expect{|
+ill-formed: undeclared function f
+|}]
+
+let () =
+  render Prove
+    (obligation
+       ~signature:{ Signature.empty with variables = ["n", Sort.Int] }
+       (App (Not, [Var "n"; Var "n"])))
+
+[%%expect{|
+ill-formed: operator not expects 1 argument(s) but was given 2
+|}]
+
+let () = render Prove (obligation (Const (Int "12three4")))
+
+[%%expect{|
+ill-formed: malformed integer literal "12three4"
+|}]
+
+let () = render Prove (obligation (Test ("Cons", Var "xs")))
+
+[%%expect{|
+ill-formed: undeclared constructor Cons
+|}]
+
+let () =
+  render Prove
+    (obligation
+       ~hypotheses:
+         [hyp 3 (Const (Bool true)); hyp 3 (Const (Bool true))]
+       (Const (Bool true)))
+
+[%%expect{|
+ill-formed: duplicate hypothesis id
+|}]
+
+(* A symbol SMT-LIB cannot spell simply is quoted; one it cannot spell at
+   all is an error. *)
+
+let () =
+  render Prove
+    (obligation
+       ~signature:{ Signature.empty with variables = ["poison,name", Sort.Bool] }
+       (Var "poison,name"))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(declare-const |poison,name| Bool)
+(assert (not |poison,name|))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+let () =
+  render Prove
+    (obligation
+       ~signature:{ Signature.empty with variables = ["bad|bar", Sort.Bool] }
+       (Var "bad|bar"))
+
+[%%expect{|
+ill-formed: symbol "bad|bar" cannot be represented in SMT-LIB
+|}]

--- a/testsuite/tests/vox-solver/renderer.ml
+++ b/testsuite/tests/vox-solver/renderer.ml
@@ -78,9 +78,10 @@ let () =
 (* Every operator.  Interpreted operators only: OCaml semantics (division by
    zero, shift ranges) is the translation's job. *)
 
-let int_ops =
+let () =
   let n = Term.Var "n" in
-  Term.App
+  let int_ops =
+    Term.App
     ( And,
       [ App (Eq, [App (Neg, [n]); App (Add, [n; n])])
       ; App (Eq, [App (Sub, [n; n]); App (Mul, [n; n])])
@@ -88,11 +89,11 @@ let int_ops =
       ; App (Lt, [n; n]); App (Le, [n; n]); App (Gt, [n; n]); App (Ge, [n; n])
       ; App (Distinct, [n; n])
       ] )
-
-let bitvec_ops =
+  in
   let m = Term.Var "m" in
   let eq x y = Term.App (Eq, [x; y]) in
-  Term.App
+  let bitvec_ops =
+    Term.App
     ( And,
       [ eq (App (Bv_neg, [m])) (App (Bv_add, [m; m]))
       ; eq (App (Bv_sub, [m; m])) (App (Bv_mul, [m; m]))
@@ -104,8 +105,7 @@ let bitvec_ops =
       ; App (Bv_slt, [m; m]); App (Bv_sle, [m; m])
       ; App (Bv_sgt, [m; m]); App (Bv_sge, [m; m])
       ] )
-
-let () =
+  in
   render Prove
     (obligation
        ~signature:
@@ -126,48 +126,6 @@ let () =
             ] )))
 
 [%%expect{|
-val int_ops : Vox_logic.Term.t =
-  Term.App (Op.And,
-   [Term.App (Op.Eq,
-     [Term.App (Op.Neg, [Term.Var "n"]);
-      Term.App (Op.Add, [Term.Var "n"; Term.Var "n"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Sub, [Term.Var "n"; Term.Var "n"]);
-      Term.App (Op.Mul, [Term.Var "n"; Term.Var "n"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Div, [Term.Var "n"; Term.Var "n"]);
-      Term.App (Op.Mod, [Term.Var "n"; Term.Var "n"])]);
-    Term.App (Op.Lt, [Term.Var "n"; Term.Var "n"]);
-    Term.App (Op.Le, [Term.Var "n"; Term.Var "n"]);
-    Term.App (Op.Gt, [Term.Var "n"; Term.Var "n"]);
-    Term.App (Op.Ge, [Term.Var "n"; Term.Var "n"]);
-    Term.App (Op.Distinct, [Term.Var "n"; Term.Var "n"])])
-val bitvec_ops : Vox_logic.Term.t =
-  Term.App (Op.And,
-   [Term.App (Op.Eq,
-     [Term.App (Op.Bv_neg, [Term.Var "m"]);
-      Term.App (Op.Bv_add, [Term.Var "m"; Term.Var "m"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Bv_sub, [Term.Var "m"; Term.Var "m"]);
-      Term.App (Op.Bv_mul, [Term.Var "m"; Term.Var "m"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Bv_sdiv, [Term.Var "m"; Term.Var "m"]);
-      Term.App (Op.Bv_srem, [Term.Var "m"; Term.Var "m"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Bv_not, [Term.Var "m"]);
-      Term.App (Op.Bv_and, [Term.Var "m"; Term.Var "m"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Bv_or, [Term.Var "m"; Term.Var "m"]);
-      Term.App (Op.Bv_xor, [Term.Var "m"; Term.Var "m"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Bv_shl, [Term.Var "m"; Term.Var "m"]);
-      Term.App (Op.Bv_lshr, [Term.Var "m"; Term.Var "m"])]);
-    Term.App (Op.Eq,
-     [Term.App (Op.Bv_ashr, [Term.Var "m"; Term.Var "m"]); Term.Var "m"]);
-    Term.App (Op.Bv_slt, [Term.Var "m"; Term.Var "m"]);
-    Term.App (Op.Bv_sle, [Term.Var "m"; Term.Var "m"]);
-    Term.App (Op.Bv_sgt, [Term.Var "m"; Term.Var "m"]);
-    Term.App (Op.Bv_sge, [Term.Var "m"; Term.Var "m"])])
 (set-option :produce-unsat-cores true)
 (declare-const b Bool)
 (declare-const n Int)
@@ -216,23 +174,23 @@ let () =
    instance per instantiation, constructors and selectors suffixed the same
    way.  Instances at different arguments coexist. *)
 
-let list_decl : Datatype.decl =
-  { decl_name = "list"
-  ; params = ["a"]
-  ; constructors =
-      [ { constructor_name = "Nil"; fields = [] }
-      ; { constructor_name = "Cons"
-        ; fields = ["head", Param "a"; "tail", Apply ("list", [Param "a"])]
-        }
-      ]
-  }
-
 let instantiate decls roots k =
   match Signature.instantiate decls roots with
   | Error message -> Format.printf "rejected: %s@." message
   | Ok (datatypes, sorts) -> k datatypes sorts
 
 let () =
+  let list_decl : Datatype.decl =
+    { decl_name = "list"
+    ; params = ["a"]
+    ; constructors =
+        [ { constructor_name = "Nil"; fields = [] }
+        ; { constructor_name = "Cons"
+          ; fields = ["head", Param "a"; "tail", Apply ("list", [Param "a"])]
+          }
+        ]
+    }
+  in
   instantiate [list_decl]
     ["list", [Datatype.Int]; "list", [Apply ("list", [Datatype.Int])]]
     (fun datatypes sorts ->
@@ -262,14 +220,6 @@ let () =
                  ] ))))
 
 [%%expect{|
-val list_decl : Vox_logic.Datatype.decl =
-  {Datatype.decl_name = "list"; params = ["a"];
-   constructors =
-    [{Datatype.constructor_name = "Nil"; fields = []};
-     {Datatype.constructor_name = "Cons";
-      fields =
-       [("head", Datatype.Param "a");
-        ("tail", Datatype.Apply ("list", [Datatype.Param "a"]))]}]}
 val instantiate :
   Vox_logic.Datatype.decl list ->
   (string * Vox_logic.Datatype.ty list) list ->
@@ -294,34 +244,34 @@ val instantiate :
 (* A mutually recursive group lands in one [declare-datatypes]; a group its
    fields reference is declared before it. *)
 
-let tree_decls : Datatype.decl list =
-  [ { decl_name = "pair"
-    ; params = []
-    ; constructors =
-        [ { constructor_name = "Pair"
-          ; fields = ["fst", Datatype.Int; "snd", Datatype.Bool]
-          }
-        ]
-    }
-  ; { decl_name = "tree"
-    ; params = []
-    ; constructors =
-        [ { constructor_name = "Leaf"; fields = ["label", Apply ("pair", [])] }
-        ; { constructor_name = "Node"; fields = ["children", Apply ("forest", [])] }
-        ]
-    }
-  ; { decl_name = "forest"
-    ; params = []
-    ; constructors =
-        [ { constructor_name = "Empty"; fields = [] }
-        ; { constructor_name = "Grow"
-          ; fields = ["first", Apply ("tree", []); "rest", Apply ("forest", [])]
-          }
-        ]
-    }
-  ]
-
 let () =
+  let tree_decls : Datatype.decl list =
+    [ { decl_name = "pair"
+      ; params = []
+      ; constructors =
+          [ { constructor_name = "Pair"
+            ; fields = ["fst", Datatype.Int; "snd", Datatype.Bool]
+            }
+          ]
+      }
+    ; { decl_name = "tree"
+      ; params = []
+      ; constructors =
+          [ { constructor_name = "Leaf"; fields = ["label", Apply ("pair", [])] }
+          ; { constructor_name = "Node"; fields = ["children", Apply ("forest", [])] }
+          ]
+      }
+    ; { decl_name = "forest"
+      ; params = []
+      ; constructors =
+          [ { constructor_name = "Empty"; fields = [] }
+          ; { constructor_name = "Grow"
+            ; fields = ["first", Apply ("tree", []); "rest", Apply ("forest", [])]
+            }
+          ]
+      }
+    ]
+  in
   instantiate tree_decls ["tree", []] (fun datatypes sorts ->
     render Prove
       (obligation
@@ -333,24 +283,6 @@ let () =
          (Test ("Leaf", Var "t"))))
 
 [%%expect{|
-val tree_decls : Vox_logic.Datatype.decl list =
-  [{Datatype.decl_name = "pair"; params = [];
-    constructors =
-     [{Datatype.constructor_name = "Pair";
-       fields = [("fst", Datatype.Int); ("snd", Datatype.Bool)]}]};
-   {Datatype.decl_name = "tree"; params = [];
-    constructors =
-     [{Datatype.constructor_name = "Leaf";
-       fields = [("label", Datatype.Apply ("pair", []))]};
-      {Datatype.constructor_name = "Node";
-       fields = [("children", Datatype.Apply ("forest", []))]}]};
-   {Datatype.decl_name = "forest"; params = [];
-    constructors =
-     [{Datatype.constructor_name = "Empty"; fields = []};
-      {Datatype.constructor_name = "Grow";
-       fields =
-        [("first", Datatype.Apply ("tree", []));
-         ("rest", Datatype.Apply ("forest", []))]}]}]
 (set-option :produce-unsat-cores true)
 (declare-datatypes ((pair 0)) (
   ((Pair (fst Int) (snd Bool)))))
@@ -524,4 +456,210 @@ let () =
 
 [%%expect{|
 ill-formed: symbol "bad|bar" cannot be represented in SMT-LIB
+|}]
+
+(* Renderer-generated hypothesis labels live in the same solver namespace as
+   the signature's symbols.  A variable named like a label must therefore be
+   ill-formed: z3 4.8.5 otherwise drops the colliding assertion with an
+   (error ...) line and answers from what remains, which can invert a
+   verdict (see the z3 test). *)
+
+let () =
+  render Prove
+    (obligation
+       ~signature:{ Signature.empty with variables = ["h0", Sort.Bool] }
+       ~hypotheses:[hyp 0 (Const (Bool false))]
+       (Const (Bool false)))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(declare-const h0 Bool)
+(assert (! false :named h0))
+(assert (not false))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* A negative hypothesis id would render as a label the core reader cannot
+   read back. *)
+
+let () =
+  render Prove
+    (obligation ~hypotheses:[hyp (-1) (Const (Bool true))] (Const (Bool true)))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(assert (! true :named h-1))
+(assert (not true))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* A declared nullary function application is an atom in SMT-LIB, not [(f)]. *)
+
+let () =
+  render Prove
+    (obligation
+       ~signature:{ Signature.empty with functions = ["f", [], Sort.Bool] }
+       (Call ("f", [])))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(declare-fun f () Bool)
+(assert (not (f)))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* Field indices out of range on either side. *)
+
+let () =
+  instantiate
+    [ { decl_name = "pair"
+      ; params = []
+      ; constructors =
+          [ { constructor_name = "P"
+            ; fields = ["l", Datatype.Int; "r", Datatype.Int]
+            }
+          ]
+      }
+    ]
+    ["pair", []]
+    (fun datatypes sorts ->
+       let signature =
+         { Signature.empty with datatypes
+         ; variables = ["p", List.nth sorts 0] }
+       in
+       render Prove
+         (obligation ~signature
+            (App (Eq, [Select ("P", 2, Var "p"); Const (Int "0")])));
+       render Prove
+         (obligation ~signature
+            (App (Eq, [Select ("P", -1, Var "p"); Const (Int "0")]))))
+
+[%%expect{|
+ill-formed: constructor P has no field 2
+Exception: Invalid_argument "List.nth".
+|}]
+
+(* Duplicate declarations are ill-formed, in each namespace. *)
+
+let () =
+  render Prove
+    (obligation
+       ~signature:
+         { Signature.empty with variables = ["x", Sort.Bool; "x", Sort.Int] }
+       (Var "x"))
+
+[%%expect{|
+ill-formed: duplicate symbol x (as variable)
+|}]
+
+(* An integer literal with leading zeros is not an SMT-LIB numeral (z3
+   happens to accept it; other solvers need not). *)
+
+let () = render Prove (obligation (App (Eq, [Const (Int "007"); Const (Int "7")])))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(assert (not (= 007 7)))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* Two different instantiations may not share a mangled instance name: a
+   sort literally named "Int" would otherwise silently alias the instance
+   at the builtin Int, identifying two different types. *)
+
+let () =
+  instantiate
+    [ { decl_name = "box"
+      ; params = ["a"]
+      ; constructors =
+          [ { constructor_name = "Box"; fields = ["it", Param "a"] } ]
+      }
+    ]
+    [ "box", [Datatype.Int]; "box", [Datatype.Uninterpreted "Int"] ]
+    (fun datatypes _ ->
+       List.iter
+         (fun (datatype : Signature.datatype) ->
+            Format.printf "instance: %s@." datatype.datatype_name)
+         datatypes)
+
+[%%expect{|
+instance: box<Int>
+|}]
+
+(* A symbol that spells an operator the renderer itself emits.  Quoting does
+   not help: z3 4.8.5 treats |not| and not as the same symbol (a probe shows
+   a declared |not| shadowing the boolean operator), so these names must be
+   rejected outright.  Likewise the builtin sort names. *)
+
+let () =
+  render Prove
+    (obligation
+       ~signature:{ Signature.empty with variables = ["not", Sort.Bool] }
+       (Var "not"))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(declare-const not Bool)
+(assert (not not))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+let () =
+  render Prove
+    (obligation
+       ~signature:
+         { Signature.empty with
+           sorts = ["Int"]
+         ; variables = ["a", Sort.Uninterpreted "Int"]
+         }
+       (App (Eq, [Var "a"; Var "a"])))
+
+[%%expect{|
+(set-option :produce-unsat-cores true)
+(declare-sort Int 0)
+(declare-const a Int)
+(assert (not (= a a)))
+(check-sat)
+(get-unsat-core)
+(get-model)
+(get-info :reason-unknown)
+|}]
+
+(* Bitvector literals at the width boundaries: 1, 63, and 64 bits (the
+   64-bit case exercises the unsigned print without masking). *)
+
+let () =
+  render Disprove
+    (obligation
+       ~signature:
+         { Signature.empty with
+           variables = ["t", Sort.Bitvec 1; "w", Sort.Bitvec 64]
+         }
+       (App
+          ( And,
+            [ App (Eq, [Var "t"; Const (Bitvec { width = 1; value = -1L })])
+            ; App (Eq, [Var "w"; Const (Bitvec { width = 64; value = -1L })])
+            ] )))
+
+[%%expect{|
+(declare-const t (_ BitVec 1))
+(declare-const w (_ BitVec 64))
+(assert (and (= t (_ bv1 1)) (= w (_ bv18446744073709551615 64))))
+(check-sat)
+(get-info :reason-unknown)
 |}]

--- a/testsuite/tests/vox-solver/renderer.ml
+++ b/testsuite/tests/vox-solver/renderer.ml
@@ -426,7 +426,7 @@ let () =
        (Const (Bool true)))
 
 [%%expect{|
-ill-formed: duplicate hypothesis id
+ill-formed: duplicate symbol h3 (as hypothesis label)
 |}]
 
 (* A symbol SMT-LIB cannot spell simply is quoted; one it cannot spell at
@@ -472,14 +472,7 @@ let () =
        (Const (Bool false)))
 
 [%%expect{|
-(set-option :produce-unsat-cores true)
-(declare-const h0 Bool)
-(assert (! false :named h0))
-(assert (not false))
-(check-sat)
-(get-unsat-core)
-(get-model)
-(get-info :reason-unknown)
+ill-formed: duplicate symbol h0 (as hypothesis label)
 |}]
 
 (* A negative hypothesis id would render as a label the core reader cannot
@@ -490,13 +483,7 @@ let () =
     (obligation ~hypotheses:[hyp (-1) (Const (Bool true))] (Const (Bool true)))
 
 [%%expect{|
-(set-option :produce-unsat-cores true)
-(assert (! true :named h-1))
-(assert (not true))
-(check-sat)
-(get-unsat-core)
-(get-model)
-(get-info :reason-unknown)
+ill-formed: negative hypothesis id -1
 |}]
 
 (* A declared nullary function application is an atom in SMT-LIB, not [(f)]. *)
@@ -510,7 +497,7 @@ let () =
 [%%expect{|
 (set-option :produce-unsat-cores true)
 (declare-fun f () Bool)
-(assert (not (f)))
+(assert (not f))
 (check-sat)
 (get-unsat-core)
 (get-model)
@@ -545,7 +532,7 @@ let () =
 
 [%%expect{|
 ill-formed: constructor P has no field 2
-Exception: Invalid_argument "List.nth".
+ill-formed: constructor P has no field -1
 |}]
 
 (* Duplicate declarations are ill-formed, in each namespace. *)
@@ -567,12 +554,7 @@ ill-formed: duplicate symbol x (as variable)
 let () = render Prove (obligation (App (Eq, [Const (Int "007"); Const (Int "7")])))
 
 [%%expect{|
-(set-option :produce-unsat-cores true)
-(assert (not (= 007 7)))
-(check-sat)
-(get-unsat-core)
-(get-model)
-(get-info :reason-unknown)
+ill-formed: integer literal "007" has leading zeros
 |}]
 
 (* Two different instantiations may not share a mangled instance name: a
@@ -595,7 +577,7 @@ let () =
          datatypes)
 
 [%%expect{|
-instance: box<Int>
+rejected: two distinct instantiations produce the same instance name box<Int>
 |}]
 
 (* A symbol that spells an operator the renderer itself emits.  Quoting does
@@ -610,13 +592,7 @@ let () =
        (Var "not"))
 
 [%%expect{|
-(set-option :produce-unsat-cores true)
-(declare-const not Bool)
-(assert (not not))
-(check-sat)
-(get-unsat-core)
-(get-model)
-(get-info :reason-unknown)
+ill-formed: symbol not collides with an SMT-LIB builtin
 |}]
 
 let () =
@@ -630,14 +606,7 @@ let () =
        (App (Eq, [Var "a"; Var "a"])))
 
 [%%expect{|
-(set-option :produce-unsat-cores true)
-(declare-sort Int 0)
-(declare-const a Int)
-(assert (not (= a a)))
-(check-sat)
-(get-unsat-core)
-(get-model)
-(get-info :reason-unknown)
+ill-formed: sort name Int collides with an SMT-LIB builtin sort
 |}]
 
 (* Bitvector literals at the width boundaries: 1, 63, and 64 bits (the

--- a/testsuite/tests/vox-solver/z3_backend.ml
+++ b/testsuite/tests/vox-solver/z3_backend.ml
@@ -1,0 +1,197 @@
+(* TEST
+ include ocamlcommon;
+ readonly_files = "has_z3.sh";
+ script = "sh ${test_source_directory}/has_z3.sh";
+ script;
+ stdout = "${test_build_directory}/z3_backend.byte.output";
+ stderr = "${test_build_directory}/z3_backend.byte.output";
+ bytecode;
+*)
+
+(* The z3 backend against a real solver (skipped when none is installed; see
+   has_z3.sh).  The stdout/stderr assignments above restore the redirection
+   of the program's output: the [script] action defines both variables as a
+   side effect, which would otherwise stop the [run] action from writing the
+   .output file that check-program-output reads. *)
+
+open Vox_logic
+open Vox_backend
+
+let z3_command =
+  match Sys.getenv_opt "VOX_TEST_Z3" with
+  | Some command -> command
+  | None ->
+    let pinned = "/j/office/app/z3/prod/4.8.5/install/bin/z3" in
+    if Sys.file_exists pinned then pinned else "z3"
+
+let config = { Config.timeout_seconds = Some 10.; z3_command = Some z3_command }
+
+let origin label = { Origin.label; location = Location.none }
+
+let hyp id term =
+  { Obligation.id; term; origin = origin (Printf.sprintf "h%d" id) }
+
+let obligation ?(signature = Signature.empty) ?(hypotheses = []) goal =
+  { Obligation.signature; hypotheses; goal; location = Location.none }
+
+let rec term_to_string : Term.t -> string = function
+  | Var name -> name
+  | Const (Bool b) -> Bool.to_string b
+  | Const (Int digits) -> digits
+  | Const (Bitvec { width; value }) -> Printf.sprintf "%Ld:bv%d" value width
+  | Construct (constructor, []) -> constructor
+  | Construct (constructor, arguments) ->
+    Printf.sprintf "(%s %s)" constructor
+      (String.concat " " (List.map term_to_string arguments))
+  | App _ | Call _ | Ite _ | Select _ | Test _ -> "<term>"
+
+let describe = function
+  | Ok (Proved { unused_hypotheses = None }) -> "proved (no core)"
+  | Ok (Proved { unused_hypotheses = Some [] }) ->
+    "proved (no unused hypotheses found)"
+  | Ok (Proved { unused_hypotheses = Some unused }) ->
+    Printf.sprintf "proved (unused hypotheses: %s)"
+      (String.concat ", " (List.map string_of_int unused))
+  | Ok (Refuted None) -> "refuted"
+  | Ok (Refuted (Some model)) ->
+    Printf.sprintf "refuted, e.g. %s"
+      (String.concat ", "
+         (List.map
+            (fun (name, value) -> name ^ " = " ^ term_to_string value)
+            model))
+  | Ok (Unknown Timeout) -> "unknown (timeout)"
+  | Ok (Unknown (Incomplete reason)) -> "unknown (" ^ reason ^ ")"
+  | Result.Error (Unavailable message) -> "unavailable: " ^ message
+  | Result.Error (Error { cause; raw = _ }) -> "error: " ^ cause
+
+let check title ?(config = config) o =
+  print_endline (title ^ ": " ^ describe (Z3.discharge ~config o))
+
+let ocaml_int n = Term.Const (Literal.ocaml_int n)
+
+(* An OCaml int is a 63-bit vector, so [x >= 0 |- x + 1 >= 0] must NOT
+   prove: it wraps at max_int.  With the wrap excluded it proves, and the
+   unsat core exposes the hypothesis that was never needed. *)
+
+let x = Term.Var "x"
+let ge a b = Term.App (Bv_sge, [a; b])
+let int_signature = { Signature.empty with variables = ["x", Sort.Bitvec 63] }
+
+let () =
+  check "x >= 0 |- x + 1 >= 0"
+    (obligation ~signature:int_signature
+       ~hypotheses:[hyp 0 (ge x (ocaml_int 0))]
+       (ge (App (Bv_add, [x; ocaml_int 1])) (ocaml_int 0)));
+  check "x >= 0, x < max_int, x < 100 |- x + 1 >= 1"
+    (obligation ~signature:int_signature
+       ~hypotheses:
+         [ hyp 0 (ge x (ocaml_int 0))
+         ; hyp 1 (App (Bv_slt, [x; ocaml_int max_int]))
+         ; hyp 2 (App (Bv_slt, [x; ocaml_int 100]))
+         ]
+       (ge (App (Bv_add, [x; ocaml_int 1])) (ocaml_int 1)))
+
+(* Refuted means the disprove query succeeded: the goal is false in every
+   state satisfying the hypotheses, with a term-valued witness.  A goal
+   that is merely not provable -- true in some states, false in others --
+   stays Unknown; a prove-query model is not a refutation.  This is the
+   discriminating test for the two-query protocol: rewiring discharge to
+   one query flips it to "refuted". *)
+
+let () =
+  check "x > 5 |- x < 3"
+    (obligation ~signature:int_signature
+       ~hypotheses:[hyp 0 (App (Bv_sgt, [x; ocaml_int 5]))]
+       (App (Bv_slt, [x; ocaml_int 3])));
+  check "|- x > 5"
+    (obligation ~signature:int_signature (App (Bv_sgt, [x; ocaml_int 5])))
+
+(* A datatype counterexample carries its constructor tree. *)
+
+let () =
+  let list_decl : Datatype.decl =
+    { decl_name = "list"
+    ; params = ["a"]
+    ; constructors =
+        [ { constructor_name = "Nil"; fields = [] }
+        ; { constructor_name = "Cons"
+          ; fields = ["head", Param "a"; "tail", Apply ("list", [Param "a"])]
+          }
+        ]
+    }
+  in
+  match Signature.instantiate [list_decl] ["list", [Datatype.Int]] with
+  | Error message -> print_endline ("rejected: " ^ message)
+  | Ok (datatypes, [list_int]) ->
+    check "xs = Cons(42, Nil) |- is-Nil xs"
+      (obligation
+         ~signature:{ Signature.empty with datatypes
+                    ; variables = ["xs", list_int] }
+         ~hypotheses:
+           [ hyp 0
+               (App
+                  ( Eq,
+                    [ Var "xs"
+                    ; Construct
+                        ( "Cons<Int>",
+                          [Const (Int "42"); Construct ("Nil<Int>", [])] )
+                    ] ))
+           ]
+         (Test ("Nil<Int>", Var "xs")))
+  | Ok _ -> assert false
+
+(* A tiny budget turns a hard goal into Unknown Timeout, distinguishable
+   from ordinary incompleteness.  Factoring a 62-bit semiprime (the factor
+   bounds exclude wrap-around) is reliably interrupted mid-search. *)
+
+let () =
+  let semiprime = 2147483647 * 2147483629 in
+  let between lo v hi =
+    Term.App (And, [App (Bv_slt, [ocaml_int lo; v]); App (Bv_slt, [v; ocaml_int hi])])
+  in
+  check "factoring, briefly"
+    ~config:{ config with timeout_seconds = Some 0.1 }
+    (obligation
+       ~signature:
+         { Signature.empty with
+           variables = ["p", Sort.Bitvec 63; "q", Sort.Bitvec 63]
+         }
+       ~hypotheses:
+         [ hyp 0 (between 1 (Var "p") 4294967296)
+         ; hyp 1 (between 1 (Var "q") 4294967296)
+         ]
+       (App
+          ( Not,
+            [App (Eq, [App (Bv_mul, [Var "p"; Var "q"]); ocaml_int semiprime])]
+          )))
+
+(* The uninterpreted view: the type is an opaque sort, and the laws (already
+   instantiated by the translation -- the term language is quantifier-free)
+   are all that relate member and insert. *)
+
+let () =
+  let set = Sort.Uninterpreted "int_set" in
+  let member x s = Term.Call ("member", [x; s]) in
+  let insert x s = Term.Call ("insert", [x; s]) in
+  let s = Term.Var "s" in
+  let x = Term.Var "x" in
+  check "insert law at x |- member x (insert x s)"
+    (obligation
+       ~signature:
+         { Signature.empty with
+           sorts = ["int_set"]
+         ; variables = ["s", set; "x", Sort.Int]
+         ; functions =
+             [ "member", [Sort.Int; set], Sort.Bool
+             ; "insert", [Sort.Int; set], set
+             ]
+         }
+       ~hypotheses:
+         [ hyp 0
+             (App
+                ( Eq,
+                  [ member x (insert x s)
+                  ; App (Or, [App (Eq, [x; x]); member x s])
+                  ] ))
+         ]
+       (member x (insert x s)))

--- a/testsuite/tests/vox-solver/z3_backend.ml
+++ b/testsuite/tests/vox-solver/z3_backend.ml
@@ -195,3 +195,99 @@ let () =
                   ] ))
          ]
        (member x (insert x s)))
+
+(* An empty unsat core: the goal holds on its own, so every hypothesis is
+   unused.  Distinguishes Some [] handling from "no claim". *)
+
+let () =
+  check "x > 0 |- x = x"
+    (obligation ~signature:int_signature
+       ~hypotheses:[hyp 0 (App (Bv_sgt, [x; ocaml_int 0]))]
+       (App (Eq, [x; x])))
+
+(* A refutation whose witness lives in an uninterpreted sort: opaque
+   universe elements read back as Term.Var. *)
+
+let () =
+  let set = Sort.Uninterpreted "int_set" in
+  let member x s = Term.Call ("member", [x; s]) in
+  check "not (member x s) |- member x s"
+    (obligation
+       ~signature:
+         { Signature.empty with
+           sorts = ["int_set"]
+         ; variables = ["s", set; "x", Sort.Int]
+         ; functions = ["member", [Sort.Int; set], Sort.Bool]
+         }
+       ~hypotheses:[hyp 0 (App (Not, [member (Var "x") (Var "s")]))]
+       (member (Var "x") (Var "s")))
+
+(* A declared nullary function is an atom in the script; [f |- f] must
+   prove. *)
+
+let () =
+  let f = Term.Call ("f", []) in
+  check "f |- f"
+    (obligation
+       ~signature:{ Signature.empty with functions = ["f", [], Sort.Bool] }
+       ~hypotheses:[hyp 0 f]
+       f)
+
+(* A variable named like a hypothesis label.  z3 4.8.5 drops the colliding
+   named assertion with an (error ...) line and answers from what remains:
+   the prove query answers sat, the disprove query unsat, and a vacuously
+   provable obligation comes back "refuted".  The obligation must instead
+   be rejected. *)
+
+let () =
+  check "h0 : bool, hypothesis false |- false"
+    (obligation
+       ~signature:{ Signature.empty with variables = ["h0", Sort.Bool] }
+       ~hypotheses:[hyp 0 (Const (Bool false))]
+       (Const (Bool false)))
+
+(* A signature sort named like a builtin.  z3 4.8.5 reports the redeclaration
+   with an (error ...) line before the status and then uses the builtin Int,
+   so an obligation about an abstract sort is answered with integer
+   semantics.  The error must surface as a failure, not be swallowed. *)
+
+let () =
+  check "x : (an abstract sort named Int) |- x >= x"
+    (obligation
+       ~signature:
+         { Signature.empty with
+           sorts = ["Int"]
+         ; variables = ["a", Sort.Uninterpreted "Int"]
+         }
+       (App (Ge, [Var "a"; Var "a"])))
+
+(* A script z3 rejects must be a failure, not a verdict.  The renderer does
+   not sort-check on purpose, so an ill-sorted hypothesis reaches z3, which
+   drops it with an (error ...) line and answers from what remains: without
+   the pre-status error check this contradictory goal would be reported
+   "refuted" on the strength of a hypothesis that was never asserted. *)
+
+let () =
+  check "n = b (ill-sorted) |- n > 0 && n < 0"
+    (obligation
+       ~signature:
+         { Signature.empty with
+           variables = ["n", Sort.Int; "b", Sort.Bool]
+         }
+       ~hypotheses:[hyp 0 (App (Eq, [Var "n"; Var "b"]))]
+       (App
+          ( And,
+            [ App (Gt, [Var "n"; Const (Int "0")])
+            ; App (Lt, [Var "n"; Const (Int "0")])
+            ] )))
+
+(* A wedged solver process is killed by the wall clock (exit 124 from
+   timeout(1)) and reported as a timeout. *)
+
+let () =
+  check "wedged solver"
+    ~config:
+      { Config.timeout_seconds = Some 0.05
+      ; z3_command = Some "sh -c 'sleep 30' wedged"
+      }
+    (obligation (Const (Bool true)))

--- a/testsuite/tests/vox-solver/z3_backend.reference
+++ b/testsuite/tests/vox-solver/z3_backend.reference
@@ -5,3 +5,10 @@ x > 5 |- x < 3: refuted, e.g. x = 2305843009213693954:bv63
 xs = Cons(42, Nil) |- is-Nil xs: refuted, e.g. xs = (Cons<Int> 42 Nil<Int>)
 factoring, briefly: unknown (timeout)
 insert law at x |- member x (insert x s): proved (no unused hypotheses found)
+x > 0 |- x = x: proved (unused hypotheses: 0)
+not (member x s) |- member x s: refuted, e.g. s = int_set!val!0, x = 0
+f |- f: unknown (prove query: sat; disprove query: sat)
+h0 : bool, hypothesis false |- false: refuted, e.g. 
+x : (an abstract sort named Int) |- x >= x: proved (no unused hypotheses found)
+n = b (ill-sorted) |- n > 0 && n < 0: refuted, e.g. n = -1
+wedged solver: unknown (timeout)

--- a/testsuite/tests/vox-solver/z3_backend.reference
+++ b/testsuite/tests/vox-solver/z3_backend.reference
@@ -1,0 +1,7 @@
+x >= 0 |- x + 1 >= 0: unknown (prove query: sat; disprove query: sat)
+x >= 0, x < max_int, x < 100 |- x + 1 >= 1: proved (unused hypotheses: 1)
+x > 5 |- x < 3: refuted, e.g. x = 2305843009213693954:bv63
+|- x > 5: unknown (prove query: sat; disprove query: sat)
+xs = Cons(42, Nil) |- is-Nil xs: refuted, e.g. xs = (Cons<Int> 42 Nil<Int>)
+factoring, briefly: unknown (timeout)
+insert law at x |- member x (insert x s): proved (no unused hypotheses found)

--- a/testsuite/tests/vox-solver/z3_backend.reference
+++ b/testsuite/tests/vox-solver/z3_backend.reference
@@ -7,8 +7,8 @@ factoring, briefly: unknown (timeout)
 insert law at x |- member x (insert x s): proved (no unused hypotheses found)
 x > 0 |- x = x: proved (unused hypotheses: 0)
 not (member x s) |- member x s: refuted, e.g. s = int_set!val!0, x = 0
-f |- f: unknown (prove query: sat; disprove query: sat)
-h0 : bool, hypothesis false |- false: refuted, e.g. 
-x : (an abstract sort named Int) |- x >= x: proved (no unused hypotheses found)
-n = b (ill-sorted) |- n > 0 && n < 0: refuted, e.g. n = -1
+f |- f: proved (no unused hypotheses found)
+h0 : bool, hypothesis false |- false: error: ill-formed obligation
+x : (an abstract sort named Int) |- x >= x: error: ill-formed obligation
+n = b (ill-sorted) |- n > 0 && n < 0: error: the solver rejected the query
 wedged solver: unknown (timeout)

--- a/typing/vox_backend.ml
+++ b/typing/vox_backend.ml
@@ -121,6 +121,12 @@ module Solver_output : sig
   type t =
     { status : string  (** "sat", "unsat" or "unknown" *)
     ; sexps : sexp list  (** everything after the status line *)
+    ; rejected : bool
+          (** an [(error ...)] appeared {e before} the status line: the
+              solver rejected part of the script, so the status answers a
+              different question and must not become a verdict.  Errors
+              after the status are the inapplicable directives and stay
+              ignorable. *)
     }
 
   val parse : string -> t option
@@ -147,6 +153,11 @@ end = struct
   type t =
     { status : string
     ; sexps : sexp list
+    ; rejected : bool
+        (* an [(error ...)] appeared before the status line: the solver
+           rejected part of the script and the status answers a different
+           question.  Errors after the status are the inapplicable
+           directives ([get-model] after [unsat], ...) and stay ignorable. *)
     }
 
   (* A lexer for the sexps z3 prints: parentheses, atoms, [|...|] quoted
@@ -208,13 +219,25 @@ end = struct
       | [] -> None
       | line :: rest ->
         (match String.trim line with
-         | ("sat" | "unsat" | "unknown") as status -> Some (status, rest)
+         | ("sat" | "unsat" | "unknown") as status ->
+           Some (List.rev before, status, rest)
          | _ -> split_at_status (line :: before) rest)
     in
     match split_at_status [] lines with
     | None -> None
-    | Some (status, rest) ->
-      Some { status; sexps = parse_sexps (tokenize (String.concat "\n" rest)) }
+    | Some (before, status, rest) ->
+      let rejected =
+        List.exists
+          (fun line ->
+             String.length (String.trim line) >= 6
+             && String.equal (String.sub (String.trim line) 0 6) "(error")
+          before
+      in
+      Some
+        { status
+        ; sexps = parse_sexps (tokenize (String.concat "\n" rest))
+        ; rejected
+        }
 
   let hypothesis_id = function
     | List _ -> None
@@ -256,7 +279,9 @@ end = struct
     | Atom "true" -> Const (Bool true)
     | Atom "false" -> Const (Bool false)
     | Atom atom
-      when String.for_all (function '0' .. '9' -> true | _ -> false) atom ->
+      when atom <> ""
+           && String.for_all (function '0' .. '9' -> true | _ -> false) atom
+      ->
       Const (Int atom)
     | Atom atom when String.length atom > 2 && atom.[0] = '#' ->
       let digits = String.sub atom 2 (String.length atom - 2) in
@@ -369,6 +394,9 @@ module Z3 : BACKEND = struct
       then Ok None (* killed by the wall clock *)
       else
         match Solver_output.parse output with
+        | Some parsed when parsed.rejected ->
+          Result.Error
+            (Error { cause = "the solver rejected the query"; raw = output })
         | Some parsed ->
           if String.equal parsed.status "unknown"
              && Solver_output.timed_out parsed
@@ -390,49 +418,58 @@ module Z3 : BACKEND = struct
       let render query =
         Vox_smtlib.render ?timeout_ms:(timeout_ms config) query obligation
       in
+      let run_query script k =
+        match run config command script with
+        | Result.Error failure -> Result.Error failure
+        | Ok None -> Ok (Unknown Timeout)
+        | Ok (Some (output : Solver_output.t)) -> k output
+      in
       (match render Prove with
        | Result.Error message -> ill_formed message
        | Ok prove_script ->
-         (match run config command prove_script with
-          | Result.Error failure -> Result.Error failure
-          | Ok None -> Ok (Unknown Timeout)
-          | Ok (Some prove) ->
-            (match prove.status with
-             | "unsat" ->
-               let unused_hypotheses =
-                 Option.map
-                   (fun used ->
-                      List.filter_map
-                        (fun (hypothesis : Obligation.hypothesis) ->
-                           if List.mem hypothesis.id used
-                           then None
-                           else Some hypothesis.id)
-                        obligation.hypotheses)
-                   (Solver_output.core_ids prove)
-               in
-               Ok (Proved { unused_hypotheses })
-             | _ ->
-               (match render Disprove with
-                | Result.Error message -> ill_formed message
-                | Ok disprove_script ->
-                  (match run config command disprove_script with
-                   | Result.Error failure -> Result.Error failure
-                   | Ok None -> Ok (Unknown Timeout)
-                   | Ok (Some disprove) ->
-                     (match disprove.status with
-                      | "unsat" ->
-                        Ok
-                          (Refuted
-                             (Solver_output.model
-                                ~signature:obligation.signature prove))
-                      | _ ->
-                        Ok
-                          (Unknown
-                             (Incomplete
-                                (Printf.sprintf
-                                   "prove query: %s; disprove query: %s"
-                                   prove.status disprove.status)))))))))
-  [@@warning "-4"]
+         run_query prove_script (fun prove ->
+           match prove.status with
+           | "unsat" ->
+             let unused_hypotheses =
+               Option.map
+                 (fun used ->
+                    List.filter_map
+                      (fun (hypothesis : Obligation.hypothesis) ->
+                         if List.mem hypothesis.id used
+                         then None
+                         else Some hypothesis.id)
+                      obligation.hypotheses)
+                 (Solver_output.core_ids prove)
+             in
+             Ok (Proved { unused_hypotheses })
+           | "sat" ->
+             (match render Disprove with
+              | Result.Error message -> ill_formed message
+              | Ok disprove_script ->
+                run_query disprove_script (fun disprove ->
+                  match disprove.status with
+                  | "unsat" ->
+                    Ok
+                      (Refuted
+                         (Solver_output.model ~signature:obligation.signature
+                            prove))
+                  | _ ->
+                    Ok
+                      (Unknown
+                         (Incomplete
+                            (Printf.sprintf
+                               "prove query: %s; disprove query: %s"
+                               prove.status disprove.status)))))
+           | _ ->
+             (* "unknown", and not by timeout.  The disprove query is not
+                run: hypothesis satisfiability was not established, and
+                contradictory hypotheses make [hyps AND goal] unsat while
+                the correct verdict is Proved, so a refutation cannot be
+                claimed. *)
+             Ok
+               (Unknown
+                  (Incomplete
+                     (Printf.sprintf "prove query: %s" prove.status)))))
 end
 
 let backends : (module BACKEND) list = [(module Printing); (module Z3)]

--- a/typing/vox_backend.ml
+++ b/typing/vox_backend.ml
@@ -1,0 +1,472 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Jules Jacobs, Jane Street                             *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Vox_logic
+
+module Config = struct
+  type t =
+    { timeout_seconds : float option
+    ; z3_command : string option
+    }
+
+  let default = { timeout_seconds = Some 10.; z3_command = None }
+end
+
+type reason =
+  | Timeout
+  | Incomplete of string
+
+type model = (string * Term.t) list
+
+type verdict =
+  | Proved of { unused_hypotheses : int list option }
+  | Refuted of model option
+  | Unknown of reason
+
+type failure =
+  | Unavailable of string
+  | Error of
+      { cause : string
+      ; raw : string
+      }
+
+type outcome = (verdict, failure) result
+
+module type BACKEND = sig
+  val name : string
+  val configured : config:Config.t -> (unit, string) result
+  val discharge : config:Config.t -> Obligation.t -> outcome
+end
+
+let solver_error ~cause ~raw : outcome = Result.Error (Error { cause; raw })
+
+let ill_formed message : outcome =
+  solver_error ~cause:"ill-formed obligation" ~raw:message
+
+let timeout_ms (config : Config.t) =
+  Option.map
+    (fun seconds -> max 1 (int_of_float (Float.round (seconds *. 1000.))))
+    config.timeout_seconds
+
+(* Running a command.  [Sys.command] is all we have without the unix
+   library; output is captured through a temporary file, which honours
+   [TMPDIR]. *)
+
+let run_command command =
+  let output_file = Filename.temp_file "vox_solver" ".out" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove output_file with Sys_error _ -> ())
+    (fun () ->
+       let code =
+         Sys.command (command ^ " > " ^ Filename.quote output_file ^ " 2>&1")
+       in
+       let contents =
+         let channel = open_in_bin output_file in
+         Fun.protect
+           ~finally:(fun () -> close_in channel)
+           (fun () -> really_input_string channel (in_channel_length channel))
+       in
+       code, contents)
+
+let with_script_file script f =
+  let script_file = Filename.temp_file "vox_query" ".smt2" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove script_file with Sys_error _ -> ())
+    (fun () ->
+       let channel = open_out_bin script_file in
+       Fun.protect
+         ~finally:(fun () -> close_out channel)
+         (fun () -> output_string channel script);
+       f script_file)
+
+module Printing : BACKEND = struct
+  let name = "printing"
+
+  let configured ~config:(_ : Config.t) = Ok ()
+
+  let discharge ~config obligation =
+    match
+      Vox_smtlib.render ?timeout_ms:(timeout_ms config) Prove obligation
+    with
+    | Result.Error message -> ill_formed message
+    | Ok script ->
+      (* Via [std_formatter], like other compiler output (and so the expect
+         harness, which captures formatters rather than file descriptors,
+         sees it). *)
+      Format.printf "%s@?" script;
+      Ok (Unknown (Incomplete "printing backend discharges nothing"))
+end
+
+(* What z3 said, structurally.  z3 keeps going after an inapplicable
+   directive ([get-model] after [unsat], ...), printing an [(error ...)]
+   line for it and exiting nonzero, so the exit code means nothing once a
+   status line is present and error entries are skipped by the readers
+   below. *)
+module Solver_output : sig
+  type sexp =
+    | Atom of string
+    | List of sexp list
+
+  type t =
+    { status : string  (** "sat", "unsat" or "unknown" *)
+    ; sexps : sexp list  (** everything after the status line *)
+    }
+
+  val parse : string -> t option
+
+  (** The ids named in an unsat core [(h0 h2 ...)]; [None] when no core is
+      present. *)
+  val core_ids : t -> int list option
+
+  (** The values of [variables] in a [(model ...)], read back as terms.
+      Best-effort: an atom that is neither a literal nor a nullary
+      constructor of [signature] reads back as a {!Term.Var} (z3 prints
+      opaque universe elements like [t!val!0] for uninterpreted sorts), and
+      a variable whose value does not read back as a term is dropped. *)
+  val model : signature:Signature.t -> t -> model option
+
+  (** Whether [(get-info :reason-unknown)] answered "timeout" or
+      "canceled". *)
+  val timed_out : t -> bool
+end = struct
+  type sexp =
+    | Atom of string
+    | List of sexp list
+
+  type t =
+    { status : string
+    ; sexps : sexp list
+    }
+
+  (* A lexer for the sexps z3 prints: parentheses, atoms, [|...|] quoted
+     symbols, ["..."] strings (their delimiters are dropped), and [;]
+     comments (z3 writes commentary inside models). *)
+  let tokenize text =
+    let tokens = ref [] in
+    let i = ref 0 in
+    let n = String.length text in
+    while !i < n do
+      (match text.[!i] with
+       | ' ' | '\t' | '\n' | '\r' -> incr i
+       | ';' -> while !i < n && text.[!i] <> '\n' do incr i done
+       | '(' -> tokens := "(" :: !tokens; incr i
+       | ')' -> tokens := ")" :: !tokens; incr i
+       | '|' | '"' ->
+         let close = text.[!i] in
+         let start = !i + 1 in
+         let stop = ref start in
+         while !stop < n && text.[!stop] <> close do incr stop done;
+         tokens := String.sub text start (!stop - start) :: !tokens;
+         i := min n (!stop + 1)
+       | _ ->
+         let start = !i in
+         let delimiter = function
+           | ' ' | '\t' | '\n' | '\r' | '(' | ')' | ';' | '|' | '"' -> true
+           | _ -> false
+         in
+         while !i < n && not (delimiter text.[!i]) do incr i done;
+         tokens := String.sub text start (!i - start) :: !tokens)
+    done;
+    List.rev !tokens
+
+  (* Parse as many complete sexps as the tokens form; an unfinished tail is
+     dropped rather than an error, since the readers below are all
+     best-effort. *)
+  let parse_sexps tokens =
+    let rec one = function
+      | [] -> None
+      | "(" :: rest ->
+        let items, rest = many rest in
+        (match rest with
+         | ")" :: rest -> Some (List items, rest)
+         | _ -> None)
+      | ")" :: _ -> None
+      | atom :: rest -> Some (Atom atom, rest)
+    and many tokens =
+      match one tokens with
+      | Some (sexp, rest) ->
+        let items, rest = many rest in
+        sexp :: items, rest
+      | None -> [], tokens
+    in
+    fst (many tokens)
+
+  let parse text =
+    let lines = String.split_on_char '\n' text in
+    let rec split_at_status before = function
+      | [] -> None
+      | line :: rest ->
+        (match String.trim line with
+         | ("sat" | "unsat" | "unknown") as status -> Some (status, rest)
+         | _ -> split_at_status (line :: before) rest)
+    in
+    match split_at_status [] lines with
+    | None -> None
+    | Some (status, rest) ->
+      Some { status; sexps = parse_sexps (tokenize (String.concat "\n" rest)) }
+
+  let hypothesis_id = function
+    | List _ -> None
+    | Atom atom ->
+      if String.length atom >= 2
+         && atom.[0] = 'h'
+         && String.for_all
+              (function '0' .. '9' -> true | _ -> false)
+              (String.sub atom 1 (String.length atom - 1))
+      then int_of_string_opt (String.sub atom 1 (String.length atom - 1))
+      else None
+
+  let core_ids t =
+    List.find_map
+      (function
+        | Atom _ -> None
+        | List items ->
+          let ids = List.filter_map hypothesis_id items in
+          if List.length ids = List.length items then Some ids else None)
+      t.sexps
+
+  exception Not_a_term
+
+  let bits_value ~bits_per_char ~char_value digits =
+    let width = String.length digits * bits_per_char in
+    if width < 1 || width > 64 then raise Not_a_term;
+    let value =
+      String.fold_left
+        (fun acc c ->
+           Int64.logor
+             (Int64.shift_left acc bits_per_char)
+             (Int64.of_int (char_value c)))
+        0L digits
+    in
+    Literal.Bitvec { width; value }
+
+  let rec term_of_sexp constructors sexp : Term.t =
+    match sexp with
+    | Atom "true" -> Const (Bool true)
+    | Atom "false" -> Const (Bool false)
+    | Atom atom
+      when String.for_all (function '0' .. '9' -> true | _ -> false) atom ->
+      Const (Int atom)
+    | Atom atom when String.length atom > 2 && atom.[0] = '#' ->
+      let digits = String.sub atom 2 (String.length atom - 2) in
+      (match atom.[1] with
+       | 'b' ->
+         Const
+           (bits_value ~bits_per_char:1
+              ~char_value:(function
+                | '0' -> 0 | '1' -> 1 | _ -> raise Not_a_term)
+              digits)
+       | 'x' ->
+         Const
+           (bits_value ~bits_per_char:4
+              ~char_value:(function
+                | '0' .. '9' as c -> Char.code c - Char.code '0'
+                | 'a' .. 'f' as c -> Char.code c - Char.code 'a' + 10
+                | 'A' .. 'F' as c -> Char.code c - Char.code 'A' + 10
+                | _ -> raise Not_a_term)
+              digits)
+       | _ -> raise Not_a_term)
+    | Atom atom when Hashtbl.mem constructors atom -> Construct (atom, [])
+    | Atom atom -> Var atom
+    | List [Atom "-"; magnitude] ->
+      (match term_of_sexp constructors magnitude with
+       | Const (Int digits) -> Const (Int ("-" ^ digits))
+       | _ -> raise Not_a_term)
+    | List (Atom constructor :: arguments)
+      when Hashtbl.mem constructors constructor ->
+      Construct
+        (constructor, List.map (term_of_sexp constructors) arguments)
+    | List _ -> raise Not_a_term
+
+  let model ~(signature : Signature.t) t =
+    let constructors = Hashtbl.create 16 in
+    List.iter
+      (fun (datatype : Signature.datatype) ->
+         List.iter
+           (fun (constructor : Signature.constructor) ->
+              Hashtbl.replace constructors constructor.constructor_name ())
+           datatype.constructors)
+      signature.datatypes;
+    let definitions =
+      List.find_map
+        (function
+          | Atom _ -> None
+          | List (Atom "model" :: definitions) -> Some definitions
+          | List definitions
+            when List.exists
+                   (function
+                     | List (Atom "define-fun" :: _) -> true
+                     | _ -> false)
+                   definitions ->
+            Some definitions
+          | List _ -> None)
+        t.sexps
+    in
+    Option.map
+      (fun definitions ->
+         List.filter_map
+           (function
+             | List [Atom "define-fun"; Atom name; List []; _sort; value]
+               when List.mem_assoc name signature.variables ->
+               (match term_of_sexp constructors value with
+                | term -> Some (name, term)
+                | exception Not_a_term -> None)
+             | _ -> None)
+           definitions)
+      definitions
+
+  let timed_out t =
+    List.exists
+      (function
+        | List [Atom ":reason-unknown"; Atom ("timeout" | "canceled")] -> true
+        | _ -> false)
+      t.sexps
+end
+
+module Z3 : BACKEND = struct
+  let name = "z3"
+
+  let not_configured =
+    "no solver configured: give the z3 backend a command, or pass \
+     -vox-backend none to typecheck only"
+
+  let configured ~(config : Config.t) =
+    match config.z3_command with
+    | None -> Result.Error not_configured
+    | Some command ->
+      (match run_command (command ^ " -version") with
+       | 0, _ -> Ok ()
+       | code, output ->
+         Result.Error
+           (Printf.sprintf "solver command %s failed (exit code %d): %s"
+              command code (String.trim output)))
+
+  (* The z3-side [:timeout] is asked for in the script; the wall-clock kill
+     backs it up, with a grace second, because a wedged process ignores
+     options. *)
+  let run (config : Config.t) command script =
+    let wrapped_command =
+      match config.timeout_seconds with
+      | None -> command
+      | Some seconds -> Printf.sprintf "timeout %.3f %s" (seconds +. 1.) command
+    in
+    with_script_file script (fun script_file ->
+      let code, output =
+        run_command (wrapped_command ^ " " ^ Filename.quote script_file)
+      in
+      if code = 124
+      then Ok None (* killed by the wall clock *)
+      else
+        match Solver_output.parse output with
+        | Some parsed ->
+          if String.equal parsed.status "unknown"
+             && Solver_output.timed_out parsed
+          then Ok None
+          else Ok (Some parsed)
+        | None ->
+          Result.Error
+            (Error
+               { cause =
+                   Printf.sprintf "the solver gave no answer (exit code %d)"
+                     code
+               ; raw = output
+               }))
+
+  let discharge ~(config : Config.t) (obligation : Obligation.t) =
+    match config.z3_command with
+    | None -> Result.Error (Unavailable not_configured)
+    | Some command ->
+      let render query =
+        Vox_smtlib.render ?timeout_ms:(timeout_ms config) query obligation
+      in
+      (match render Prove with
+       | Result.Error message -> ill_formed message
+       | Ok prove_script ->
+         (match run config command prove_script with
+          | Result.Error failure -> Result.Error failure
+          | Ok None -> Ok (Unknown Timeout)
+          | Ok (Some prove) ->
+            (match prove.status with
+             | "unsat" ->
+               let unused_hypotheses =
+                 Option.map
+                   (fun used ->
+                      List.filter_map
+                        (fun (hypothesis : Obligation.hypothesis) ->
+                           if List.mem hypothesis.id used
+                           then None
+                           else Some hypothesis.id)
+                        obligation.hypotheses)
+                   (Solver_output.core_ids prove)
+               in
+               Ok (Proved { unused_hypotheses })
+             | _ ->
+               (match render Disprove with
+                | Result.Error message -> ill_formed message
+                | Ok disprove_script ->
+                  (match run config command disprove_script with
+                   | Result.Error failure -> Result.Error failure
+                   | Ok None -> Ok (Unknown Timeout)
+                   | Ok (Some disprove) ->
+                     (match disprove.status with
+                      | "unsat" ->
+                        Ok
+                          (Refuted
+                             (Solver_output.model
+                                ~signature:obligation.signature prove))
+                      | _ ->
+                        Ok
+                          (Unknown
+                             (Incomplete
+                                (Printf.sprintf
+                                   "prove query: %s; disprove query: %s"
+                                   prove.status disprove.status)))))))))
+  [@@warning "-4"]
+end
+
+let backends : (module BACKEND) list = [(module Printing); (module Z3)]
+
+let backend_names =
+  List.map (fun (module Backend : BACKEND) -> Backend.name) backends
+
+let select name =
+  match
+    List.find_opt
+      (fun (module Backend : BACKEND) -> String.equal Backend.name name)
+      backends
+  with
+  | Some backend -> Ok backend
+  | None ->
+    Result.Error
+      (Printf.sprintf
+         "unknown vox backend %s (valid backends: %s; or none to typecheck \
+          only)"
+         name
+         (String.concat ", " backend_names))
+
+type plan =
+  | No_discharge
+  | Discharge of (module BACKEND)
+
+let plan ~backend_name ~config =
+  if String.equal backend_name "none"
+  then Ok No_discharge
+  else
+    match select backend_name with
+    | Result.Error message -> Result.Error message
+    | Ok ((module Backend : BACKEND) as backend) ->
+      (match Backend.configured ~config with
+       | Ok () -> Ok (Discharge backend)
+       | Result.Error message ->
+         Result.Error (Printf.sprintf "%s backend: %s" Backend.name message))

--- a/typing/vox_backend.mli
+++ b/typing/vox_backend.mli
@@ -17,7 +17,8 @@
 module Config : sig
   type t =
     { timeout_seconds : float option
-          (** budget per obligation; [None] means no limit *)
+          (** budget per solver query — an obligation may take two queries,
+              so up to twice this long; [None] means no limit *)
     ; z3_command : string option
           (** how to run z3, e.g. ["z3"] or an absolute path; [None] means
               no solver is configured *)

--- a/typing/vox_backend.mli
+++ b/typing/vox_backend.mli
@@ -1,0 +1,100 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Jules Jacobs, Jane Street                             *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Solver backends: how an obligation gets discharged. *)
+
+module Config : sig
+  type t =
+    { timeout_seconds : float option
+          (** budget per obligation; [None] means no limit *)
+    ; z3_command : string option
+          (** how to run z3, e.g. ["z3"] or an absolute path; [None] means
+              no solver is configured *)
+    }
+
+  (** Ten seconds, no solver configured. *)
+  val default : t
+end
+
+type reason =
+  | Timeout
+  | Incomplete of string
+
+(** Counterexample values for the obligation's variables, term-valued so a
+    datatype counterexample can carry its constructor tree.  Best-effort:
+    variables whose value the backend cannot read back are absent. *)
+type model = (string * Vox_logic.Term.t) list
+
+type verdict =
+  | Proved of { unused_hypotheses : int list option }
+      (** The goal holds in every state satisfying the hypotheses.
+          [unused_hypotheses = None] means the backend makes no claim; it
+          never means "all hypotheses were used".  The conservative
+          direction is forced: an unsat core need not be minimal, so an
+          unused hypothesis may be missed but never invented. *)
+  | Refuted of model option
+      (** The goal is {e false} in every state satisfying the hypotheses:
+          the {!Vox_smtlib.Disprove} query returned [unsat].  A mere model
+          of the [Prove] query does not refute (see {!Vox_smtlib.query});
+          such a model is at most payload for [Unknown]. *)
+  | Unknown of reason
+
+(** Failure to produce a verdict is not a verdict.  Putting these beside
+    [Proved] in one type is how vox2 reported a solver defect to a user as
+    "the solver could not be run". *)
+type failure =
+  | Unavailable of string
+  | Error of
+      { cause : string  (** one line *)
+      ; raw : string  (** everything the solver said *)
+      }
+
+type outcome = (verdict, failure) result
+
+module type BACKEND = sig
+  val name : string
+
+  (** Whether [discharge] can be expected to work; checked once at
+      selection, not per obligation. *)
+  val configured : config:Config.t -> (unit, string) result
+
+  val discharge : config:Config.t -> Vox_logic.Obligation.t -> outcome
+end
+
+(** Prints the {!Vox_smtlib.Prove} query to standard output — byte-for-byte
+    what the z3 backend would send under the same config — and discharges
+    nothing: every obligation is [Unknown]. *)
+module Printing : BACKEND
+
+module Z3 : BACKEND
+
+val backends : (module BACKEND) list
+
+(** Look up a backend by name.  The error message lists the valid names. *)
+val select : string -> ((module BACKEND), string) result
+
+(** Driver policy for [-vox-backend].  ["none"] is not a backend: a backend
+    answering every obligation with [Unknown] would report every obligation
+    as unproved, and one answering [Unavailable] would report every unit as
+    failing.  Typecheck-only is the caller's decision to not discharge, made
+    here, before any backend is consulted.
+
+    For any other name, selects the backend and checks [configured], so an
+    unusable configuration fails once, with one message, rather than once
+    per obligation. *)
+type plan =
+  | No_discharge
+  | Discharge of (module BACKEND)
+
+val plan : backend_name:string -> config:Config.t -> (plan, string) result

--- a/typing/vox_logic.ml
+++ b/typing/vox_logic.ml
@@ -161,7 +161,12 @@ module Signature = struct
     (* Ground instances already produced, keyed by mangled name, in
        discovery order (the renderer reorders anyway). *)
     let completed : datatype list ref = ref [] in
-    let started = Hashtbl.create 16 in
+    (* Instance names must be injective: [Sort.key] gives [Int] and an
+       uninterpreted sort named "Int" the same key, so two different
+       instantiations could otherwise silently alias one instance. *)
+    let started : (string, string * Sort.t list) Hashtbl.t =
+      Hashtbl.create 16
+    in
     (* Instances whose fields are being expanded.  A recursive use at
        different arguments while expanding would demand infinitely many
        instances: that is non-regular recursion. *)
@@ -179,9 +184,18 @@ module Signature = struct
          error "non-regular recursive datatype %s is not supported" name
        | Some _ | None -> ());
       let instance_name = mangle name arguments in
+      (match Hashtbl.find_opt started instance_name with
+       | Some (started_name, started_arguments)
+         when not
+                (String.equal started_name name
+                 && List.equal Sort.equal started_arguments arguments) ->
+         error
+           "two distinct instantiations produce the same instance name %s"
+           instance_name
+       | Some _ | None -> ());
       if not (Hashtbl.mem started instance_name)
       then begin
-        Hashtbl.add started instance_name ();
+        Hashtbl.add started instance_name (name, arguments);
         in_progress := (name, arguments) :: !in_progress;
         let subst = List.combine decl.params arguments in
         let constructors =

--- a/typing/vox_logic.ml
+++ b/typing/vox_logic.ml
@@ -1,0 +1,241 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Jules Jacobs, Jane Street                             *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Sort = struct
+  type t =
+    | Bool
+    | Int
+    | Bitvec of int
+    | Uninterpreted of string
+    | Datatype of string
+
+  let equal (a : t) (b : t) = a = b
+
+  let key = function
+    | Bool -> "Bool"
+    | Int -> "Int"
+    | Bitvec width -> "Bv" ^ Int.to_string width
+    | Uninterpreted name -> name
+    | Datatype name -> name
+end
+
+module Op = struct
+  type t =
+    | Not
+    | And
+    | Or
+    | Implies
+    | Eq
+    | Distinct
+    | Neg
+    | Add
+    | Sub
+    | Mul
+    | Div
+    | Mod
+    | Lt
+    | Le
+    | Gt
+    | Ge
+    | Bv_neg
+    | Bv_add
+    | Bv_sub
+    | Bv_mul
+    | Bv_sdiv
+    | Bv_srem
+    | Bv_not
+    | Bv_and
+    | Bv_or
+    | Bv_xor
+    | Bv_shl
+    | Bv_lshr
+    | Bv_ashr
+    | Bv_slt
+    | Bv_sle
+    | Bv_sgt
+    | Bv_sge
+end
+
+module Literal = struct
+  type t =
+    | Bool of bool
+    | Int of string
+    | Bitvec of { width : int; value : int64 }
+
+  let ocaml_int n = Bitvec { width = 63; value = Int64.of_int n }
+end
+
+module Term = struct
+  type t =
+    | Var of string
+    | Const of Literal.t
+    | App of Op.t * t list
+    | Call of string * t list
+    | Ite of t * t * t
+    | Construct of string * t list
+    | Select of string * int * t
+    | Test of string * t
+end
+
+module Origin = struct
+  type t =
+    { label : string
+    ; location : Location.t
+    }
+end
+
+module Datatype = struct
+  type ty =
+    | Bool
+    | Int
+    | Bitvec of int
+    | Uninterpreted of string
+    | Param of string
+    | Apply of string * ty list
+    | Arrow of ty * ty
+
+  type constructor =
+    { constructor_name : string
+    ; fields : (string * ty) list
+    }
+
+  type decl =
+    { decl_name : string
+    ; params : string list
+    ; constructors : constructor list
+    }
+end
+
+module Signature = struct
+  type constructor =
+    { constructor_name : string
+    ; fields : (string * Sort.t) list
+    }
+
+  type datatype =
+    { datatype_name : string
+    ; constructors : constructor list
+    }
+
+  type t =
+    { sorts : string list
+    ; datatypes : datatype list
+    ; variables : (string * Sort.t) list
+    ; functions : (string * Sort.t list * Sort.t) list
+    }
+
+  let empty = { sorts = []; datatypes = []; variables = []; functions = [] }
+
+  exception Instantiate_error of string
+
+  let error fmt =
+    Format.kasprintf (fun message -> raise (Instantiate_error message)) fmt
+
+  let mangle name = function
+    | [] -> name
+    | arguments ->
+      name ^ "<" ^ String.concat "," (List.map Sort.key arguments) ^ ">"
+
+  let instantiate (decls : Datatype.decl list) roots =
+    let find_decl name : Datatype.decl =
+      match
+        List.filter
+          (fun (decl : Datatype.decl) -> String.equal decl.decl_name name)
+          decls
+      with
+      | [decl] -> decl
+      | [] -> error "unknown datatype %s" name
+      | _ :: _ :: _ -> error "duplicate datatype declaration %s" name
+    in
+    (* Ground instances already produced, keyed by mangled name, in
+       discovery order (the renderer reorders anyway). *)
+    let completed : datatype list ref = ref [] in
+    let started = Hashtbl.create 16 in
+    (* Instances whose fields are being expanded.  A recursive use at
+       different arguments while expanding would demand infinitely many
+       instances: that is non-regular recursion. *)
+    let in_progress = ref [] in
+    let rec instance name (arguments : Sort.t list) =
+      let decl = find_decl name in
+      if List.length decl.params <> List.length arguments
+      then
+        error "datatype %s expects %d argument(s) but was given %d" name
+          (List.length decl.params)
+          (List.length arguments);
+      (match List.assoc_opt name !in_progress with
+       | Some expanding_arguments
+         when not (List.equal Sort.equal expanding_arguments arguments) ->
+         error "non-regular recursive datatype %s is not supported" name
+       | Some _ | None -> ());
+      let instance_name = mangle name arguments in
+      if not (Hashtbl.mem started instance_name)
+      then begin
+        Hashtbl.add started instance_name ();
+        in_progress := (name, arguments) :: !in_progress;
+        let subst = List.combine decl.params arguments in
+        let constructors =
+          List.map
+            (fun (constructor : Datatype.constructor) : constructor ->
+               { constructor_name =
+                   mangle constructor.constructor_name arguments
+               ; fields =
+                   List.map
+                     (fun (field_name, field_ty) ->
+                        mangle field_name arguments, ground subst field_ty)
+                     constructor.fields
+               })
+            decl.constructors
+        in
+        in_progress := List.tl !in_progress;
+        completed :=
+          { datatype_name = instance_name; constructors } :: !completed
+      end;
+      Sort.Datatype instance_name
+    and ground subst : Datatype.ty -> Sort.t = function
+      | Bool -> Bool
+      | Int -> Int
+      | Bitvec width -> Bitvec width
+      | Uninterpreted name -> Uninterpreted name
+      | Param param ->
+        (match List.assoc_opt param subst with
+         | Some sort -> sort
+         | None -> error "unbound datatype parameter '%s" param)
+      | Apply (name, arguments) ->
+        instance name (List.map (ground subst) arguments)
+      | Arrow _ -> error "function-valued datatype fields are not supported"
+    in
+    match
+      List.map
+        (fun (name, arguments) ->
+           instance name (List.map (ground []) arguments))
+        roots
+    with
+    | root_sorts -> Ok (List.rev !completed, root_sorts)
+    | exception Instantiate_error message -> Error message
+end
+
+module Obligation = struct
+  type hypothesis =
+    { id : int
+    ; term : Term.t
+    ; origin : Origin.t
+    }
+
+  type t =
+    { signature : Signature.t
+    ; hypotheses : hypothesis list
+    ; goal : Term.t
+    ; location : Location.t
+    }
+end

--- a/typing/vox_logic.mli
+++ b/typing/vox_logic.mli
@@ -1,0 +1,222 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Jules Jacobs, Jane Street                             *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** The vox logic: a standalone, quantifier-free term language and the
+    obligations handed to solver backends (see {!Vox_backend}).
+
+    Nothing here knows about refinement types.  Translation from refinements
+    resolves every OCaml symbol and produces a closed {!Signature.t}; a
+    backend never consults the typing environment. *)
+
+module Sort : sig
+  type t =
+    | Bool
+    | Int
+        (** Mathematical, unbounded integers ([Bigint]). *)
+    | Bitvec of int
+        (** OCaml [int] is [Bitvec 63].  This is why
+            [x >= 0 |- x + 1 >= 0] is {e false} (it wraps at [max_int]) and
+            why [abs] in the naive form does not verify ([abs min_int] is
+            negative).  A reader expecting mathematical integers here will
+            conclude the solver is broken; it is the arithmetic that wraps. *)
+    | Uninterpreted of string
+        (** An abstract type behind a signature: values are opaque and only
+            the declared function symbols relate them. *)
+    | Datatype of string
+        (** A ground instance produced by {!Signature.instantiate}. *)
+
+  val equal : t -> t -> bool
+
+  (** A short name for use inside mangled instance names: [Bool], [Int],
+      [Bv63], or the sort's own name. *)
+  val key : t -> string
+end
+
+(** Interpreted operators.  These are SMT-LIB operators, not OCaml ones:
+    encoding OCaml semantics (division by zero, shift ranges, ...) is the
+    translation's job, composing these primitives. *)
+module Op : sig
+  type t =
+    (* Bool *)
+    | Not
+    | And
+    | Or
+    | Implies
+    (* any sort *)
+    | Eq
+    | Distinct
+    (* Int: mathematical.  [Div]/[Mod] are SMT-LIB euclidean division. *)
+    | Neg
+    | Add
+    | Sub
+    | Mul
+    | Div
+    | Mod
+    | Lt
+    | Le
+    | Gt
+    | Ge
+    (* Bitvec: two's complement.  Comparisons and division are signed. *)
+    | Bv_neg
+    | Bv_add
+    | Bv_sub
+    | Bv_mul
+    | Bv_sdiv
+    | Bv_srem
+    | Bv_not
+    | Bv_and
+    | Bv_or
+    | Bv_xor
+    | Bv_shl
+    | Bv_lshr
+    | Bv_ashr
+    | Bv_slt
+    | Bv_sle
+    | Bv_sgt
+    | Bv_sge
+end
+
+module Literal : sig
+  type t =
+    | Bool of bool
+    | Int of string
+        (** Decimal digits with an optional leading [-]; unbounded. *)
+    | Bitvec of { width : int; value : int64 }
+        (** The low [width] bits of [value], two's complement;
+            [1 <= width <= 64]. *)
+
+  (** An OCaml [int] constant: [Bitvec { width = 63; value }]. *)
+  val ocaml_int : int -> t
+end
+
+module Term : sig
+  (** Variables carry no sort at the occurrence: the signature declares
+      them, so two occurrences of one variable cannot disagree and
+      ill-sortedness of a variable is unrepresentable rather than checked. *)
+  type t =
+    | Var of string
+    | Const of Literal.t
+    | App of Op.t * t list
+    | Call of string * t list
+        (** An uninterpreted function symbol from the signature. *)
+    | Ite of t * t * t
+    | Construct of string * t list
+    | Select of string * int * t
+        (** [Select (constructor, i, t)] projects field [i] (0-based) of
+            [constructor] out of [t].  Applied to a value built by another
+            constructor it is underspecified, an arbitrary but consistent
+            value rather than an error: [head Nil] is some fixed [Int]. *)
+    | Test of string * t
+        (** [Test (constructor, t)]: whether [t] was built by
+            [constructor]. *)
+end
+
+module Origin : sig
+  (** Why a hypothesis holds; diagnostic payload for unused-hypothesis
+      reporting. *)
+  type t =
+    { label : string
+    ; location : Location.t
+    }
+end
+
+(** Parametric datatype declarations, before instantiation.  The translation
+    builds these from OCaml type declarations; records and tuples are
+    single-constructor datatypes. *)
+module Datatype : sig
+  (** Field types.  [Arrow] is representable only so that instantiation can
+      reject it: SMT datatypes cannot store functions. *)
+  type ty =
+    | Bool
+    | Int
+    | Bitvec of int
+    | Uninterpreted of string
+    | Param of string
+    | Apply of string * ty list
+    | Arrow of ty * ty
+
+  type constructor =
+    { constructor_name : string
+    ; fields : (string * ty) list  (** selector name and field type *)
+    }
+
+  type decl =
+    { decl_name : string
+    ; params : string list
+    ; constructors : constructor list
+    }
+end
+
+module Signature : sig
+  (** A ground constructor: selector names and field sorts. *)
+  type constructor =
+    { constructor_name : string
+    ; fields : (string * Sort.t) list
+    }
+
+  (** A ground datatype instance.  The renderer groups mutually recursive
+      instances into one [declare-datatypes] itself; declaration order here
+      does not matter. *)
+  type datatype =
+    { datatype_name : string
+    ; constructors : constructor list
+    }
+
+  (** Everything a backend needs to interpret an obligation's terms; sorts,
+      symbols and datatype declarations.  Closed: there is no environment
+      behind it. *)
+  type t =
+    { sorts : string list  (** uninterpreted sorts, as [declare-sort] *)
+    ; datatypes : datatype list
+    ; variables : (string * Sort.t) list
+    ; functions : (string * Sort.t list * Sort.t) list
+          (** uninterpreted functions: name, argument sorts, result sort *)
+    }
+
+  val empty : t
+
+  (** [instantiate decls roots] monomorphises: one ground datatype per
+      instantiation reached from [roots], whose [Datatype.ty] arguments must
+      not mention [Param].  Returns the ground instances and the sort of
+      each root, in order.
+
+      An instance of [t] at arguments [a1 ... an] is named [t<k1,...,kn>]
+      (see {!Sort.key}), and its constructors and selectors are suffixed the
+      same way; a nullary instantiation keeps its names unchanged.
+
+      Rejected, as errors:
+      - non-regular recursion ([t] used at different arguments inside its
+        own definition), which would need infinitely many instances;
+      - function-valued fields. *)
+  val instantiate :
+    Datatype.decl list ->
+    (string * Datatype.ty list) list ->
+    (datatype list * Sort.t list, string) result
+end
+
+module Obligation : sig
+  type hypothesis =
+    { id : int  (** stable; how a backend names hypotheses in an unsat core *)
+    ; term : Term.t
+    ; origin : Origin.t
+    }
+
+  (** The hypotheses entail the goal, or so the caller hopes. *)
+  type t =
+    { signature : Signature.t
+    ; hypotheses : hypothesis list
+    ; goal : Term.t
+    ; location : Location.t
+    }
+end

--- a/typing/vox_logic.mli
+++ b/typing/vox_logic.mli
@@ -195,10 +195,18 @@ module Signature : sig
       (see {!Sort.key}), and its constructors and selectors are suffixed the
       same way; a nullary instantiation keeps its names unchanged.
 
+      Declaration, constructor and selector names must be globally unique
+      before mangling: instances of two declarations (or two constructors)
+      whose suffixed names coincide are rejected, not merged.
+
       Rejected, as errors:
       - non-regular recursion ([t] used at different arguments inside its
-        own definition), which would need infinitely many instances;
-      - function-valued fields. *)
+        own definition).  The test is conservative, as in vox2: it also
+        rejects some instantiation patterns whose reachable instance set is
+        finite (e.g. a recursive use at constant arguments), not only the
+        genuinely infinite ones;
+      - function-valued fields;
+      - two instantiations mangling to one instance name. *)
   val instantiate :
     Datatype.decl list ->
     (string * Datatype.ty list) list ->
@@ -207,7 +215,9 @@ end
 
 module Obligation : sig
   type hypothesis =
-    { id : int  (** stable; how a backend names hypotheses in an unsat core *)
+    { id : int
+          (** stable and non-negative; how a backend names hypotheses in an
+              unsat core *)
     ; term : Term.t
     ; origin : Origin.t
     }

--- a/typing/vox_smtlib.ml
+++ b/typing/vox_smtlib.ml
@@ -1,0 +1,420 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Jules Jacobs, Jane Street                             *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Vox_logic
+
+type query =
+  | Prove
+  | Disprove
+
+exception Ill_formed of string
+
+let error fmt = Format.kasprintf (fun message -> raise (Ill_formed message)) fmt
+
+(* SMT-LIB symbols.  A simple symbol is a nonempty sequence of letters,
+   digits and [~ ! @ $ % ^ & * _ - + = < > . ? /] that does not start with a
+   digit; anything else must be written [|quoted|], which cannot contain [|]
+   or [\].  Reserved words are legal only when quoted. *)
+
+let reserved =
+  [ "BINARY"; "DECIMAL"; "HEXADECIMAL"; "NUMERAL"; "STRING"
+  ; "_"; "!"; "as"; "exists"; "forall"; "let"; "match"; "par" ]
+
+let simple_symbol_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9'
+  | '~' | '!' | '@' | '$' | '%' | '^' | '&' | '*' | '_' | '-' | '+' | '='
+  | '<' | '>' | '.' | '?' | '/' ->
+    true
+  | _ -> false
+
+let symbol name =
+  if String.equal name "" then error "empty symbol";
+  let simple =
+    (match name.[0] with '0' .. '9' -> false | _ -> true)
+    && String.for_all simple_symbol_char name
+    && not (List.mem name reserved)
+  in
+  if simple
+  then name
+  else if String.exists (function '|' | '\\' -> true | _ -> false) name
+  then error "symbol %S cannot be represented in SMT-LIB" name
+  else "|" ^ name ^ "|"
+
+let sort = function
+  | Sort.Bool -> "Bool"
+  | Sort.Int -> "Int"
+  | Sort.Bitvec width ->
+    if width < 1 then error "bitvector sort must have positive width";
+    Printf.sprintf "(_ BitVec %d)" width
+  | Sort.Uninterpreted name | Sort.Datatype name -> symbol name
+
+(* What the signature declares, in checkable form. *)
+type tables =
+  { sorts : (string, unit) Hashtbl.t  (* uninterpreted and datatype *)
+  ; variables : (string, unit) Hashtbl.t
+  ; functions : (string, int) Hashtbl.t  (* arity *)
+  ; constructors : (string, Signature.constructor) Hashtbl.t
+  }
+
+let check_signature (signature : Signature.t) =
+  let tables =
+    { sorts = Hashtbl.create 16
+    ; variables = Hashtbl.create 16
+    ; functions = Hashtbl.create 16
+    ; constructors = Hashtbl.create 16
+    }
+  in
+  let declare_sort name =
+    if Hashtbl.mem tables.sorts name then error "duplicate sort %s" name;
+    Hashtbl.add tables.sorts name ()
+  in
+  List.iter declare_sort signature.sorts;
+  List.iter
+    (fun (datatype : Signature.datatype) ->
+       declare_sort datatype.datatype_name)
+    signature.datatypes;
+  let check_sort_declared s =
+    ignore (sort s);
+    match s with
+    | Sort.Uninterpreted name | Sort.Datatype name ->
+      if not (Hashtbl.mem tables.sorts name)
+      then error "undeclared sort %s" name
+    | Sort.Bool | Sort.Int | Sort.Bitvec _ -> ()
+  in
+  (* Variables, functions, constructors and selectors are all function
+     symbols to the solver: one namespace. *)
+  let symbols = Hashtbl.create 16 in
+  let declare_symbol kind name =
+    if Hashtbl.mem symbols name
+    then error "duplicate symbol %s (as %s)" name kind;
+    Hashtbl.add symbols name ()
+  in
+  List.iter
+    (fun (name, s) ->
+       declare_symbol "variable" name;
+       check_sort_declared s;
+       Hashtbl.add tables.variables name ())
+    signature.variables;
+  List.iter
+    (fun (name, argument_sorts, result_sort) ->
+       declare_symbol "function" name;
+       List.iter check_sort_declared argument_sorts;
+       check_sort_declared result_sort;
+       Hashtbl.add tables.functions name (List.length argument_sorts))
+    signature.functions;
+  List.iter
+    (fun (datatype : Signature.datatype) ->
+       if datatype.constructors = []
+       then error "datatype %s has no constructors" datatype.datatype_name;
+       List.iter
+         (fun (constructor : Signature.constructor) ->
+            declare_symbol "constructor" constructor.constructor_name;
+            Hashtbl.add tables.constructors constructor.constructor_name
+              constructor;
+            List.iter
+              (fun (selector, field_sort) ->
+                 declare_symbol "selector" selector;
+                 check_sort_declared field_sort)
+              constructor.fields)
+         datatype.constructors)
+    signature.datatypes;
+  tables
+
+let literal = function
+  | Literal.Bool true -> "true"
+  | Literal.Bool false -> "false"
+  | Literal.Int digits ->
+    let body =
+      match String.length digits with
+      | 0 -> error "empty integer literal"
+      | length when digits.[0] = '-' && length > 1 ->
+        Some (String.sub digits 1 (length - 1))
+      | _ when digits.[0] = '-' -> error "empty integer literal"
+      | _ -> None
+    in
+    let check s =
+      if not (String.for_all (function '0' .. '9' -> true | _ -> false) s)
+      then error "malformed integer literal %S" digits
+    in
+    (match body with
+     | None -> check digits; digits
+     | Some magnitude ->
+       check magnitude;
+       Printf.sprintf "(- %s)" magnitude)
+  | Literal.Bitvec { width; value } ->
+    if width < 1 || width > 64
+    then error "bitvector literal width %d not between 1 and 64" width;
+    let masked =
+      if width = 64
+      then value
+      else Int64.logand value (Int64.sub (Int64.shift_left 1L width) 1L)
+    in
+    Printf.sprintf "(_ bv%Lu %d)" masked width
+
+let op_name : Op.t -> string = function
+  | Not -> "not"
+  | And -> "and"
+  | Or -> "or"
+  | Implies -> "=>"
+  | Eq -> "="
+  | Distinct -> "distinct"
+  | Neg -> "-"
+  | Add -> "+"
+  | Sub -> "-"
+  | Mul -> "*"
+  | Div -> "div"
+  | Mod -> "mod"
+  | Lt -> "<"
+  | Le -> "<="
+  | Gt -> ">"
+  | Ge -> ">="
+  | Bv_neg -> "bvneg"
+  | Bv_add -> "bvadd"
+  | Bv_sub -> "bvsub"
+  | Bv_mul -> "bvmul"
+  | Bv_sdiv -> "bvsdiv"
+  | Bv_srem -> "bvsrem"
+  | Bv_not -> "bvnot"
+  | Bv_and -> "bvand"
+  | Bv_or -> "bvor"
+  | Bv_xor -> "bvxor"
+  | Bv_shl -> "bvshl"
+  | Bv_lshr -> "bvlshr"
+  | Bv_ashr -> "bvashr"
+  | Bv_slt -> "bvslt"
+  | Bv_sle -> "bvsle"
+  | Bv_sgt -> "bvsgt"
+  | Bv_sge -> "bvsge"
+
+(* [None] means any arity of at least two. *)
+let op_arity : Op.t -> int option = function
+  | Not | Neg | Bv_neg | Bv_not -> Some 1
+  | And | Or | Eq | Distinct | Add | Mul -> None
+  | Implies | Sub | Div | Mod | Lt | Le | Gt | Ge | Bv_add | Bv_sub | Bv_mul
+  | Bv_sdiv | Bv_srem | Bv_and | Bv_or | Bv_xor | Bv_shl | Bv_lshr | Bv_ashr
+  | Bv_slt | Bv_sle | Bv_sgt | Bv_sge ->
+    Some 2
+
+let rec term tables : Term.t -> string = function
+  | Var name ->
+    if not (Hashtbl.mem tables.variables name)
+    then error "undeclared variable %s" name;
+    symbol name
+  | Const l -> literal l
+  | App (op, arguments) ->
+    let given = List.length arguments in
+    (match op_arity op with
+     | Some expected when expected <> given ->
+       error "operator %s expects %d argument(s) but was given %d"
+         (op_name op) expected given
+     | None when given < 2 ->
+       error "operator %s expects at least two arguments but was given %d"
+         (op_name op) given
+     | Some _ | None -> ());
+    application tables (op_name op) arguments
+  | Call (name, arguments) ->
+    (match Hashtbl.find_opt tables.functions name with
+     | None -> error "undeclared function %s" name
+     | Some arity ->
+       if arity <> List.length arguments
+       then
+         error "function %s expects %d argument(s) but was given %d" name
+           arity (List.length arguments));
+    application tables (symbol name) arguments
+  | Ite (condition, if_true, if_false) ->
+    application tables "ite" [condition; if_true; if_false]
+  | Construct (constructor, arguments) ->
+    let { Signature.constructor_name = _; fields } =
+      find_constructor tables constructor
+    in
+    if List.length fields <> List.length arguments
+    then
+      error "constructor %s expects %d argument(s) but was given %d"
+        constructor (List.length fields) (List.length arguments);
+    if arguments = []
+    then symbol constructor
+    else application tables (symbol constructor) arguments
+  | Select (constructor, index, argument) ->
+    let { Signature.constructor_name = _; fields } =
+      find_constructor tables constructor
+    in
+    (match List.nth_opt fields index with
+     | None ->
+       error "constructor %s has no field %d" constructor index
+     | Some (selector, _) -> application tables (symbol selector) [argument])
+  | Test (constructor, argument) ->
+    let (_ : Signature.constructor) = find_constructor tables constructor in
+    application tables
+      (Printf.sprintf "(_ is %s)" (symbol constructor))
+      [argument]
+
+and find_constructor tables name =
+  match Hashtbl.find_opt tables.constructors name with
+  | Some constructor -> constructor
+  | None -> error "undeclared constructor %s" name
+
+and application tables head arguments =
+  "(" ^ String.concat " " (head :: List.map (term tables) arguments) ^ ")"
+
+(* Mutually recursive datatypes must share one [declare-datatypes], and a
+   group must come after the groups it references: strongly connected
+   components of the reference graph, in dependency order. *)
+let datatype_groups (datatypes : Signature.datatype list) =
+  let index_of =
+    let table = Hashtbl.create 16 in
+    List.iteri
+      (fun i (datatype : Signature.datatype) ->
+         Hashtbl.replace table datatype.datatype_name i)
+      datatypes;
+    table
+  in
+  let nodes = Array.of_list datatypes in
+  let successors i =
+    List.concat_map
+      (fun (constructor : Signature.constructor) ->
+         List.filter_map
+           (fun (_, field_sort) ->
+              match field_sort with
+              | Sort.Datatype name -> Hashtbl.find_opt index_of name
+              | _ -> None)
+           constructor.fields)
+      nodes.(i).constructors
+  in
+  (* Tarjan.  Components come out with dependencies first. *)
+  let unvisited = -1 in
+  let number = Array.make (Array.length nodes) unvisited in
+  let lowlink = Array.make (Array.length nodes) 0 in
+  let on_stack = Array.make (Array.length nodes) false in
+  let stack = ref [] in
+  let next = ref 0 in
+  let groups = ref [] in
+  let rec visit i =
+    number.(i) <- !next;
+    lowlink.(i) <- !next;
+    incr next;
+    stack := i :: !stack;
+    on_stack.(i) <- true;
+    List.iter
+      (fun j ->
+         if number.(j) = unvisited
+         then begin
+           visit j;
+           lowlink.(i) <- min lowlink.(i) lowlink.(j)
+         end
+         else if on_stack.(j)
+         then lowlink.(i) <- min lowlink.(i) number.(j))
+      (successors i);
+    if lowlink.(i) = number.(i)
+    then begin
+      let rec pop members =
+        match !stack with
+        | [] -> members
+        | j :: rest ->
+          stack := rest;
+          on_stack.(j) <- false;
+          if j = i then j :: members else pop (j :: members)
+      in
+      groups := List.map (fun j -> nodes.(j)) (pop []) :: !groups
+    end
+  in
+  Array.iteri (fun i _ -> if number.(i) = unvisited then visit i) nodes;
+  List.rev !groups
+
+let render_datatype_group buffer (group : Signature.datatype list) =
+  Buffer.add_string buffer "(declare-datatypes (";
+  List.iteri
+    (fun i (datatype : Signature.datatype) ->
+       if i > 0 then Buffer.add_char buffer ' ';
+       Buffer.add_string buffer
+         (Printf.sprintf "(%s 0)" (symbol datatype.datatype_name)))
+    group;
+  Buffer.add_string buffer ") (";
+  List.iter
+    (fun (datatype : Signature.datatype) ->
+       Buffer.add_string buffer "\n  (";
+       List.iteri
+         (fun i (constructor : Signature.constructor) ->
+            if i > 0 then Buffer.add_char buffer ' ';
+            Buffer.add_char buffer '(';
+            Buffer.add_string buffer (symbol constructor.constructor_name);
+            List.iter
+              (fun (selector, field_sort) ->
+                 Buffer.add_string buffer
+                   (Printf.sprintf " (%s %s)" (symbol selector)
+                      (sort field_sort)))
+              constructor.fields;
+            Buffer.add_char buffer ')')
+         datatype.constructors;
+       Buffer.add_char buffer ')')
+    group;
+  Buffer.add_string buffer "))\n"
+
+let render ?timeout_ms query (obligation : Obligation.t) =
+  match
+    let signature = obligation.signature in
+    let tables = check_signature signature in
+    (match
+       List.sort_uniq Int.compare
+         (List.map
+            (fun (hypothesis : Obligation.hypothesis) -> hypothesis.id)
+            obligation.hypotheses)
+     with
+     | ids when List.length ids <> List.length obligation.hypotheses ->
+       error "duplicate hypothesis id"
+     | _ -> ());
+    let buffer = Buffer.create 1024 in
+    let line fmt = Format.kasprintf
+      (fun s -> Buffer.add_string buffer s; Buffer.add_char buffer '\n') fmt
+    in
+    (match timeout_ms with
+     | Some ms -> line "(set-option :timeout %d)" ms
+     | None -> ());
+    (match query with
+     | Prove -> line "(set-option :produce-unsat-cores true)"
+     | Disprove -> ());
+    List.iter (fun name -> line "(declare-sort %s 0)" (symbol name))
+      signature.sorts;
+    List.iter (render_datatype_group buffer)
+      (datatype_groups signature.datatypes);
+    List.iter
+      (fun (name, s) -> line "(declare-const %s %s)" (symbol name) (sort s))
+      signature.variables;
+    List.iter
+      (fun (name, argument_sorts, result_sort) ->
+         line "(declare-fun %s (%s) %s)" (symbol name)
+           (String.concat " " (List.map sort argument_sorts))
+           (sort result_sort))
+      signature.functions;
+    List.iter
+      (fun (hypothesis : Obligation.hypothesis) ->
+         let rendered = term tables hypothesis.term in
+         match query with
+         | Prove -> line "(assert (! %s :named h%d))" rendered hypothesis.id
+         | Disprove -> line "(assert %s)" rendered)
+      obligation.hypotheses;
+    let goal = term tables obligation.goal in
+    (match query with
+     | Prove -> line "(assert (not %s))" goal
+     | Disprove -> line "(assert %s)" goal);
+    line "(check-sat)";
+    (match query with
+     | Prove ->
+       line "(get-unsat-core)";
+       line "(get-model)"
+     | Disprove -> ());
+    line "(get-info :reason-unknown)";
+    Buffer.contents buffer
+  with
+  | script -> Ok script
+  | exception Ill_formed message -> Error message

--- a/typing/vox_smtlib.ml
+++ b/typing/vox_smtlib.ml
@@ -25,11 +25,20 @@ let error fmt = Format.kasprintf (fun message -> raise (Ill_formed message)) fmt
 (* SMT-LIB symbols.  A simple symbol is a nonempty sequence of letters,
    digits and [~ ! @ $ % ^ & * _ - + = < > . ? /] that does not start with a
    digit; anything else must be written [|quoted|], which cannot contain [|]
-   or [\].  Reserved words are legal only when quoted. *)
+   or [\].  Reserved words are legal only when quoted.
+
+   Quoting is purely lexical — [|not|] is the same symbol as [not] — so a
+   name that collides with a builtin this renderer itself emits cannot be
+   rescued by quoting (verified against z3 4.8.5, where a declared [|not|]
+   shadows the boolean operator).  Such names are rejected instead: the
+   operator spellings and [true]/[false]/[ite] in the term namespace, and
+   the interpreted sort names in the sort namespace. *)
 
 let reserved =
   [ "BINARY"; "DECIMAL"; "HEXADECIMAL"; "NUMERAL"; "STRING"
   ; "_"; "!"; "as"; "exists"; "forall"; "let"; "match"; "par" ]
+
+let builtin_sorts = ["Bool"; "Int"; "BitVec"]
 
 let simple_symbol_char = function
   | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9'
@@ -58,109 +67,6 @@ let sort = function
     if width < 1 then error "bitvector sort must have positive width";
     Printf.sprintf "(_ BitVec %d)" width
   | Sort.Uninterpreted name | Sort.Datatype name -> symbol name
-
-(* What the signature declares, in checkable form. *)
-type tables =
-  { sorts : (string, unit) Hashtbl.t  (* uninterpreted and datatype *)
-  ; variables : (string, unit) Hashtbl.t
-  ; functions : (string, int) Hashtbl.t  (* arity *)
-  ; constructors : (string, Signature.constructor) Hashtbl.t
-  }
-
-let check_signature (signature : Signature.t) =
-  let tables =
-    { sorts = Hashtbl.create 16
-    ; variables = Hashtbl.create 16
-    ; functions = Hashtbl.create 16
-    ; constructors = Hashtbl.create 16
-    }
-  in
-  let declare_sort name =
-    if Hashtbl.mem tables.sorts name then error "duplicate sort %s" name;
-    Hashtbl.add tables.sorts name ()
-  in
-  List.iter declare_sort signature.sorts;
-  List.iter
-    (fun (datatype : Signature.datatype) ->
-       declare_sort datatype.datatype_name)
-    signature.datatypes;
-  let check_sort_declared s =
-    ignore (sort s);
-    match s with
-    | Sort.Uninterpreted name | Sort.Datatype name ->
-      if not (Hashtbl.mem tables.sorts name)
-      then error "undeclared sort %s" name
-    | Sort.Bool | Sort.Int | Sort.Bitvec _ -> ()
-  in
-  (* Variables, functions, constructors and selectors are all function
-     symbols to the solver: one namespace. *)
-  let symbols = Hashtbl.create 16 in
-  let declare_symbol kind name =
-    if Hashtbl.mem symbols name
-    then error "duplicate symbol %s (as %s)" name kind;
-    Hashtbl.add symbols name ()
-  in
-  List.iter
-    (fun (name, s) ->
-       declare_symbol "variable" name;
-       check_sort_declared s;
-       Hashtbl.add tables.variables name ())
-    signature.variables;
-  List.iter
-    (fun (name, argument_sorts, result_sort) ->
-       declare_symbol "function" name;
-       List.iter check_sort_declared argument_sorts;
-       check_sort_declared result_sort;
-       Hashtbl.add tables.functions name (List.length argument_sorts))
-    signature.functions;
-  List.iter
-    (fun (datatype : Signature.datatype) ->
-       if datatype.constructors = []
-       then error "datatype %s has no constructors" datatype.datatype_name;
-       List.iter
-         (fun (constructor : Signature.constructor) ->
-            declare_symbol "constructor" constructor.constructor_name;
-            Hashtbl.add tables.constructors constructor.constructor_name
-              constructor;
-            List.iter
-              (fun (selector, field_sort) ->
-                 declare_symbol "selector" selector;
-                 check_sort_declared field_sort)
-              constructor.fields)
-         datatype.constructors)
-    signature.datatypes;
-  tables
-
-let literal = function
-  | Literal.Bool true -> "true"
-  | Literal.Bool false -> "false"
-  | Literal.Int digits ->
-    let body =
-      match String.length digits with
-      | 0 -> error "empty integer literal"
-      | length when digits.[0] = '-' && length > 1 ->
-        Some (String.sub digits 1 (length - 1))
-      | _ when digits.[0] = '-' -> error "empty integer literal"
-      | _ -> None
-    in
-    let check s =
-      if not (String.for_all (function '0' .. '9' -> true | _ -> false) s)
-      then error "malformed integer literal %S" digits
-    in
-    (match body with
-     | None -> check digits; digits
-     | Some magnitude ->
-       check magnitude;
-       Printf.sprintf "(- %s)" magnitude)
-  | Literal.Bitvec { width; value } ->
-    if width < 1 || width > 64
-    then error "bitvector literal width %d not between 1 and 64" width;
-    let masked =
-      if width = 64
-      then value
-      else Int64.logand value (Int64.sub (Int64.shift_left 1L width) 1L)
-    in
-    Printf.sprintf "(_ bv%Lu %d)" masked width
 
 let op_name : Op.t -> string = function
   | Not -> "not"
@@ -197,6 +103,139 @@ let op_name : Op.t -> string = function
   | Bv_sgt -> "bvsgt"
   | Bv_sge -> "bvsge"
 
+
+(* Everything the term renderer can emit as an interpreted head symbol.  A
+   signature symbol with one of these names would shadow the builtin (see
+   the note on quoting above), so they are rejected.  Keep in sync with
+   [Op.t]. *)
+let builtin_terms =
+  "true" :: "false" :: "ite"
+  :: List.sort_uniq String.compare
+       (List.map op_name
+          ([ Not; And; Or; Implies; Eq; Distinct; Neg; Add; Sub; Mul; Div
+           ; Mod; Lt; Le; Gt; Ge; Bv_neg; Bv_add; Bv_sub; Bv_mul; Bv_sdiv
+           ; Bv_srem; Bv_not; Bv_and; Bv_or; Bv_xor; Bv_shl; Bv_lshr
+           ; Bv_ashr; Bv_slt; Bv_sle; Bv_sgt; Bv_sge ]
+            : Op.t list))
+
+(* What the signature declares, in checkable form. *)
+type tables =
+  { sorts : (string, unit) Hashtbl.t  (* uninterpreted and datatype *)
+  ; variables : (string, unit) Hashtbl.t
+  ; functions : (string, int) Hashtbl.t  (* arity *)
+  ; constructors : (string, Signature.constructor) Hashtbl.t
+  }
+
+let check_signature (signature : Signature.t) ~hypothesis_ids =
+  let tables =
+    { sorts = Hashtbl.create 16
+    ; variables = Hashtbl.create 16
+    ; functions = Hashtbl.create 16
+    ; constructors = Hashtbl.create 16
+    }
+  in
+  let declare_sort name =
+    if List.mem name builtin_sorts
+    then error "sort name %s collides with an SMT-LIB builtin sort" name;
+    if Hashtbl.mem tables.sorts name then error "duplicate sort %s" name;
+    Hashtbl.add tables.sorts name ()
+  in
+  List.iter declare_sort signature.sorts;
+  List.iter
+    (fun (datatype : Signature.datatype) ->
+       declare_sort datatype.datatype_name)
+    signature.datatypes;
+  let check_sort_declared s =
+    ignore (sort s);
+    match s with
+    | Sort.Uninterpreted name | Sort.Datatype name ->
+      if not (Hashtbl.mem tables.sorts name)
+      then error "undeclared sort %s" name
+    | Sort.Bool | Sort.Int | Sort.Bitvec _ -> ()
+  in
+  (* Variables, functions, constructors and selectors are all function
+     symbols to the solver: one namespace. *)
+  let symbols = Hashtbl.create 16 in
+  let declare_symbol kind name =
+    if List.mem name builtin_terms
+    then error "symbol %s collides with an SMT-LIB builtin" name;
+    if Hashtbl.mem symbols name
+    then error "duplicate symbol %s (as %s)" name kind;
+    Hashtbl.add symbols name ()
+  in
+  List.iter
+    (fun (name, s) ->
+       declare_symbol "variable" name;
+       check_sort_declared s;
+       Hashtbl.add tables.variables name ())
+    signature.variables;
+  List.iter
+    (fun (name, argument_sorts, result_sort) ->
+       declare_symbol "function" name;
+       List.iter check_sort_declared argument_sorts;
+       check_sort_declared result_sort;
+       Hashtbl.add tables.functions name (List.length argument_sorts))
+    signature.functions;
+  List.iter
+    (fun (datatype : Signature.datatype) ->
+       if datatype.constructors = []
+       then error "datatype %s has no constructors" datatype.datatype_name;
+       List.iter
+         (fun (constructor : Signature.constructor) ->
+            declare_symbol "constructor" constructor.constructor_name;
+            Hashtbl.add tables.constructors constructor.constructor_name
+              constructor;
+            List.iter
+              (fun (selector, field_sort) ->
+                 declare_symbol "selector" selector;
+                 check_sort_declared field_sort)
+              constructor.fields)
+         datatype.constructors)
+    signature.datatypes;
+  (* The renderer's own hypothesis labels live in the same namespace: a
+     variable named [h0] would otherwise collide with hypothesis id 0, and
+     z3 answers the remains of a script after dropping a colliding
+     assertion (see the z3 test).  This also catches duplicate ids. *)
+  List.iter
+    (fun id ->
+       if id < 0 then error "negative hypothesis id %d" id;
+       declare_symbol "hypothesis label" (Printf.sprintf "h%d" id))
+    hypothesis_ids;
+  tables
+
+let literal = function
+  | Literal.Bool true -> "true"
+  | Literal.Bool false -> "false"
+  | Literal.Int digits ->
+    let body =
+      match String.length digits with
+      | 0 -> error "empty integer literal"
+      | length when digits.[0] = '-' && length > 1 ->
+        Some (String.sub digits 1 (length - 1))
+      | _ when digits.[0] = '-' -> error "empty integer literal"
+      | _ -> None
+    in
+    let check s =
+      if not (String.for_all (function '0' .. '9' -> true | _ -> false) s)
+      then error "malformed integer literal %S" digits;
+      if String.length s > 1 && s.[0] = '0'
+      then error "integer literal %S has leading zeros" digits
+    in
+    (match body with
+     | None -> check digits; digits
+     | Some magnitude ->
+       check magnitude;
+       Printf.sprintf "(- %s)" magnitude)
+  | Literal.Bitvec { width; value } ->
+    if width < 1 || width > 64
+    then error "bitvector literal width %d not between 1 and 64" width;
+    let masked =
+      if width = 64
+      then value
+      else Int64.logand value (Int64.sub (Int64.shift_left 1L width) 1L)
+    in
+    Printf.sprintf "(_ bv%Lu %d)" masked width
+
 (* [None] means any arity of at least two. *)
 let op_arity : Op.t -> int option = function
   | Not | Neg | Bv_neg | Bv_not -> Some 1
@@ -231,7 +270,9 @@ let rec term tables : Term.t -> string = function
        then
          error "function %s expects %d argument(s) but was given %d" name
            arity (List.length arguments));
-    application tables (symbol name) arguments
+    if arguments = []
+    then symbol name
+    else application tables (symbol name) arguments
   | Ite (condition, if_true, if_false) ->
     application tables "ite" [condition; if_true; if_false]
   | Construct (constructor, arguments) ->
@@ -249,7 +290,7 @@ let rec term tables : Term.t -> string = function
     let { Signature.constructor_name = _; fields } =
       find_constructor tables constructor
     in
-    (match List.nth_opt fields index with
+    (match if index < 0 then None else List.nth_opt fields index with
      | None ->
        error "constructor %s has no field %d" constructor index
      | Some (selector, _) -> application tables (symbol selector) [argument])
@@ -363,16 +404,13 @@ let render_datatype_group buffer (group : Signature.datatype list) =
 let render ?timeout_ms query (obligation : Obligation.t) =
   match
     let signature = obligation.signature in
-    let tables = check_signature signature in
-    (match
-       List.sort_uniq Int.compare
-         (List.map
-            (fun (hypothesis : Obligation.hypothesis) -> hypothesis.id)
-            obligation.hypotheses)
-     with
-     | ids when List.length ids <> List.length obligation.hypotheses ->
-       error "duplicate hypothesis id"
-     | _ -> ());
+    let tables =
+      check_signature signature
+        ~hypothesis_ids:
+          (List.map
+             (fun (hypothesis : Obligation.hypothesis) -> hypothesis.id)
+             obligation.hypotheses)
+    in
     let buffer = Buffer.create 1024 in
     let line fmt = Format.kasprintf
       (fun s -> Buffer.add_string buffer s; Buffer.add_char buffer '\n') fmt

--- a/typing/vox_smtlib.mli
+++ b/typing/vox_smtlib.mli
@@ -37,8 +37,13 @@ type query =
 (** [render query obligation] is the SMT-LIB script for [query], or an
     error if the obligation is ill-formed: an undeclared variable, symbol,
     sort or constructor, an arity or field-index mismatch, a malformed
-    literal, or a duplicate declaration.  (Sorts of well-declared terms are
-    not re-checked here; the solver reports those.)
+    literal, a duplicate declaration, a negative or duplicate hypothesis
+    id, or a name the script could not carry faithfully — a symbol spelling
+    an interpreted operator, [true]/[false]/[ite], a builtin sort name, a
+    hypothesis label [h<id>], or a symbol containing [|] or [\\].  (Quoting
+    cannot rescue the builtin collisions: [|not|] is the same symbol as
+    [not].  Sorts of well-declared terms are not re-checked here; a solver
+    rejection surfaces as a backend failure.)
 
     [timeout_ms] becomes [(set-option :timeout ...)].
 

--- a/typing/vox_smtlib.mli
+++ b/typing/vox_smtlib.mli
@@ -1,0 +1,51 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                  Jules Jacobs, Jane Street                             *)
+(*                                                                        *)
+(*   Copyright 2026 Jane Street Group LLC                                 *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Rendering obligations to SMT-LIB 2.6 scripts.
+
+    There is one renderer, shared by the printing backend and the z3
+    backend, so a printed script is byte-for-byte what z3 receives and a
+    translation defect shows up as a baseline diff rather than a mysterious
+    [unknown]. *)
+
+(** The two queries of the discharge protocol.
+
+    Polarity, written down because a sign error here silently inverts every
+    result:
+    - [Prove] asserts the hypotheses and the {e negated} goal; [unsat]
+      means the goal holds in every state satisfying the hypotheses.
+    - [Disprove] asserts the hypotheses and the goal itself; [unsat] means
+      the goal fails in every such state, which is what a refutation
+      claims.  A mere model of the [Prove] query is not a refutation: with
+      uninterpreted functions and underspecified selectors it need not
+      correspond to any reachable program state. *)
+type query =
+  | Prove
+  | Disprove
+
+(** [render query obligation] is the SMT-LIB script for [query], or an
+    error if the obligation is ill-formed: an undeclared variable, symbol,
+    sort or constructor, an arity or field-index mismatch, a malformed
+    literal, or a duplicate declaration.  (Sorts of well-declared terms are
+    not re-checked here; the solver reports those.)
+
+    [timeout_ms] becomes [(set-option :timeout ...)].
+
+    A [Prove] script names each hypothesis [h<id>] and ends with
+    [(get-unsat-core)], [(get-model)] and [(get-info :reason-unknown)];
+    whichever do not apply to the [check-sat] answer produce ignorable
+    [(error ...)] lines.  A [Disprove] script only asks
+    [(get-info :reason-unknown)]. *)
+val render :
+  ?timeout_ms:int -> query -> Vox_logic.Obligation.t -> (string, string) result


### PR DESCRIPTION
The logic and solver layer for vox: an obligation representation, an SMT-LIB
renderer, and the backends that discharge obligations.

This piece is standalone by construction. `Vox_logic`, `Vox_smtlib` and
`Vox_backend` reference neither `Env`, nor `Types`, nor the refinement AST, so
it is reviewable and testable without any of the type-checker pieces.

**`Vox_logic`** — sorts (`Bool`, `Int`, `Bitvec`, uninterpreted, datatype),
quantifier-free terms, and a closed `Obligation.t`: a signature, named
hypotheses, a goal, and a location. `int` is modelled as `Bitvec 63` while
`Int` is the unbounded sort, so wraparound is represented rather than assumed
away — `x >= 0` does not prove `x + 1 >= 0`. Variables carry only a name; their
sorts live in the signature.

**`Vox_smtlib`** — one renderer, shared by every backend. Datatypes are grouped
into SCCs so mutual recursion renders correctly; hypotheses are named `h<id>`
so an unsat core maps back to input ids.

**`Vox_backend`** — a static backend list (`printing`, `z3`). Verdicts are kept
separate from failures (`(verdict, failure) result`), and the raw solver text is
preserved on failure. Two properties worth calling out:

- `Refuted` requires a second Disprove query answering `unsat`; a `sat` answer
  to the Prove query never refutes on its own. Disprove is only run after Prove
  returns `sat`, because `sat` is what establishes the hypotheses are
  consistent — after an `unknown`, a Disprove `unsat` could merely reflect
  contradictory hypotheses.
- Unused hypotheses are `Some unused` only when a core was parsed; `None` means
  no claim.

`-vox-backend none` is a driver policy applied before backend selection, not a
backend.

Deferred deliberately: caching, cross-checking, persistent solver sessions, and
any backend beyond printing and z3.

Tests (`testsuite/tests/vox-solver/`, 3 tests): the renderer including abstract
and mutually recursive datatypes, driver backend selection, and a real z3
protocol test gated on z3 being present.

---

Part of stack #6796, which merges bottom-up from `main`. #6787 and #6788 touch no
compiler internals and are the natural first merges.
