### PR TITLE
Stack 3/6: Bigint for specifications

### DIFF
--- a/design-docs/bigint-final.md
+++ b/design-docs/bigint-final.md
@@ -1,0 +1,70 @@
+# Vox bigint — final report
+
+The bigint piece is built, review-looped, and green.
+
+## Deliverable
+
+Branch `jujacobs/vox/bigint`, clean tree, full suite **2443 passed / 0 failed**:
+
+- `bd81f027df` design doc (`design-docs/bigint.md`, canonical per the new
+  convention)
+- `d08334af83` the module: `stdlib/bigint.{ml,mli}` + wiring
+  (`StdlibModules`, `stdlib.ml(i)`, `dune`, `.depend`) +
+  `testsuite/tests/lib-bigint/`
+- `65b952049f` re-promotes 6 ident-stamp-sensitive expectations (+1 stamp
+  shift from adding a stdlib module; verified pure renumbering)
+- `175af84faf` review-driven test strengthening
+- `2e65664674` review-driven simplifications; `of_string` now raises
+  `Failure`
+
+**Decision to check** (spec left it open): magnitude is `int iarray`, built
+via mutable scratch arrays frozen through a single `trim` — the loops are
+the textbook carry/borrow ones, avoiding vox2's canonicity-on-unwind
+subtlety. Noted in the design doc's Representation section.
+
+## Review loop
+
+4 lanes (codex x2 via `codex exec`, claude x2), design + correctness lenses
+each. **No defect found** — the two correctness lanes independently
+verified the limb overflow bounds (exact fit `radix^2 - 1 = max_int`, zero
+headroom), `min_int` handling, canonicity, and ran an external
+Python-bignum oracle (3292 checks).
+
+Accepted after reproducing:
+
+- `is_zero` / NUL / length-cap coverage gaps (all three mutations
+  previously survived the suite; each now caught — verified by running
+  them)
+- ordering checks were tautologies of the definitions (now checked against
+  the independent decimal oracle over structured boundary values)
+- `to_string` simplified to digit-at-a-time (kills the untestable 32-bit
+  chunk branch, the `assert false`, and the List dep)
+- `Failure` convention for `of_string`, `Int.compare` over a local helper,
+  doc/interface polish (canonicity note on `type t`, runtime-only section
+  header, `compare` contract, `@since`)
+
+Declined as inflation: mul zero fast-path, constructor-collapse refactor,
+chunked parsing, 31-bit test portability (suite now declares its 63-bit
+assumption in its first check), loop merging.
+
+## Open items for the human
+
+1. **Claude headless reviewers couldn't get tool permissions**: the review
+   worktrees resolve to project `/usr/local/home/jujacobs/vox/oxcaml`,
+   which isn't trusted, so `--allowedTools` was ignored; setting
+   `hasTrustDialogAccepted` in `~/.claude.json` from an agent was
+   (reasonably) gated. They ran tool-less over the embedded diff and their
+   proposed experiments were executed by the manager, so the loop stayed
+   dual-model — but trusting that path once (or adding the config entry)
+   gives future claude lanes real worktree access.
+2. **Dev-loop friction**: (a) `dune rpc build` in `dev-check` hung twice
+   after a killed client, surviving watcher idleness — fix each time was
+   killing the rpc client + watcher restart; (b) stdlib **interface**
+   changes don't invalidate main-context compiler-libs (`OCAMLLIB` points
+   at `runtime_stdlib_install`, outside dune's dependency tracking) — the
+   first `dev-test-all` produced 661 bogus "inconsistent assumptions over
+   interface Stdlib" failures until a full `_build` rebuild; note that
+   `rm -rf _build/main` alone corrupts dune's incremental state.
+
+Spec polling: no external edits landed during the run; the doc now travels
+with the branch.

--- a/design-docs/bigint.md
+++ b/design-docs/bigint.md
@@ -1,0 +1,146 @@
+# Vox bigint
+
+An arbitrary-precision signed integer module, in pure OCaml, with a real
+executable implementation.
+
+Specifications need mathematical integers. OCaml `int` is modelled as
+`Bitvec 63`, so `x >= 0` does not imply `x + 1 >= 0`, and a specification that
+wants unbounded arithmetic has nowhere to say so. `Bigint.t` is that place.
+
+This piece is standalone. It depends on nothing else in vox, and nothing else in
+vox depends on it until the translation piece maps its operations to the solver.
+
+## No GMP, and not by preference
+
+Zarith is the standard OCaml answer and it is out of reach here.
+
+- Nothing in the oxcaml tree references zarith or gmp: no `.ml`, `dune`,
+  `.opam` or `configure.ac` hit.
+- Zarith is not in the opam switch, though `libgmp.so` is on the box.
+- No `otherlibs` entry links an external library. The only link flags in the
+  tree are `-ldopt`, `-linkall` and `-lthreadsnat`; `str` carries its own regex
+  C in-tree and `unix` uses libc. A GMP dependency would be the first of its
+  kind and would break bootstrap and cross-compilation.
+- OCaml's own `Num` was removed from the distribution in 4.06, so the project
+  has deliberately stopped shipping a bignum.
+
+Performance is not the reason to want GMP here anyway. The solver never runs
+this code: `Vox_builtin` maps `Bigint.add` by path to SMT `Int` addition, so
+proofs are about mathematical semantics regardless of the implementation. The
+implementation runs only where a specification is executed.
+
+## It lives in core stdlib
+
+Not `otherlibs/stdlib_alpha`, which is otherwise the right home for something
+experimental.
+
+The reason is runtime checking of specifications, which is planned. Runtime
+checks are code the compiler emits into a user's module. If the support lives in
+`stdlib_alpha`, compiler-generated code carries a link dependency the user never
+asked for. This is the same reason `CamlinternalFormat` and `CamlinternalLazy`
+are in stdlib rather than beside them.
+
+It is public rather than `Camlinternal`-prefixed, because specification authors
+write `Bigint.t` in source.
+
+The cost is real: this joins the public stdlib API and touches `StdlibModules`,
+`.depend`, `dune`, `stdlib.ml` and `stdlib.mli`. Worth naming so nobody thinks
+it was chosen for convenience.
+
+## The API is determined by the solver
+
+Every exported operation has to be interpretable as an SMT `Int` operation.
+Anything else becomes an uninterpreted function, and specifications that use it
+silently stop being provable.
+
+    zero one of_int
+    is_zero equal compare lt le gt ge
+    neg abs add sub mul
+
+Note the absences. No division or modulo, which bring partiality on a zero
+divisor and nonlinear reasoning. No exponentiation. vox2 leaves these out too,
+and its `int` division needed a separate constant-divisor restriction on the
+oxsmt path, which is the shape of the trouble.
+
+Adding a convenient function later is a way to create unprovable specifications
+without noticing, so the rule belongs at the top of the `.mli`, not in a commit
+message.
+
+Three functions are runtime-only conveniences with no interpretation, and should
+be marked as not for use in specifications:
+
+    to_int_opt to_string of_string
+
+## Representation
+
+Two constraints. The kind must be `immutable_data`, so the type crosses modes
+and can be used at `@ logical`. And the representation must be canonical.
+
+Sign-magnitude over `int` limbs. Two candidates for the magnitude:
+
+- `int list`, which vox2 uses. Simple and obviously correct.
+- `int iarray`, which is the more idiomatic immutable sequence in OxCaml and
+  better on allocation and locality.
+
+Runtime checking makes the second more attractive than it would otherwise be,
+since checks run in real programs rather than only in spec tests. Either
+satisfies the kind requirement, so this is the implementer's call against how
+much the arithmetic code suffers.
+
+Decision: `int iarray`. The arithmetic builds each magnitude in a mutable
+scratch array and freezes it through a single `trim` helper, so the loops are
+the textbook carry/borrow loops rather than vox2's structural-recursion
+variants, whose canonicity-on-unwind subtlety in `subtract_magnitude` is
+exactly the kind of cleverness this module should not need. Limbs are
+half-word (`radix_bits = (Sys.int_size - 1) / 2`) so limb products with their
+carries fit in `int`.
+
+## Canonicity is an invariant, and it is load-bearing
+
+No leading zero limbs, and zero has sign 0 with an empty magnitude. Canonical
+representation means polymorphic equality agrees with `equal`.
+
+Polymorphic *compare* does not agree with mathematical order, because it
+compares the representation. Document that in the `.mli`; it is the kind of
+thing that silently produces a wrong sort order years later.
+
+## The oracle is not optional
+
+The solver reasons about mathematical integers. Runtime checks run this code. If
+the two disagree, a guarded `assume` can pass at runtime while the obligation it
+was standing in for concerned different numbers. That is a soundness gap in the
+`assume` mechanism, so the implementation's correctness matters even though its
+speed does not.
+
+Test against an independent oracle rather than against itself:
+
+- machine `int` arithmetic for values in range, which covers carries, signs and
+  the boundaries cheaply
+- a deliberately naive decimal-string implementation for large values, written
+  for obviousness rather than speed
+- algebraic properties: commutativity, associativity, distributivity, `sub` as
+  `add` of `neg`, `abs` of `neg`
+
+## Tests
+
+- the canonicity invariant holds after every operation, including the ones that
+  can produce zero: `sub` of equals, `mul` by zero, `neg` of zero
+- oracle agreement on the three fronts above
+- `to_string` and `of_string` round-trip, and `of_string` rejects redundant
+  leading zeroes and bare `-`
+- `to_int_opt` at `min_int` and `max_int`, and one past each
+- comparison is a total order consistent with `equal`
+- polymorphic equality agrees with `equal`, which is the canonicity invariant
+  observed from outside
+
+## Deferred
+
+The mode annotations. vox2's signature is
+`val add : t @ logical -> t @ logical -> t @@ total` throughout, which needs the
+totality piece. Land the module unannotated and add them after.
+
+The `Vox_builtin` mapping from these operations to SMT `Int`, which needs the
+solver interface and the translation piece.
+
+Runtime checking of specifications, which is what makes the executable
+implementation earn its keep, and which is a piece of its own.

--- a/design-docs/bigint.md
+++ b/design-docs/bigint.md
@@ -44,8 +44,10 @@ It is public rather than `Camlinternal`-prefixed, because specification authors
 write `Bigint.t` in source.
 
 The cost is real: this joins the public stdlib API and touches `StdlibModules`,
-`.depend`, `dune`, `stdlib.ml` and `stdlib.mli`. Worth naming so nobody thinks
-it was chosen for convenience.
+`.depend`, `dune`, `stdlib.ml` and `stdlib.mli`. It also permanently claims the
+name `Bigint` in the default-opened namespace, which any third-party code with
+its own `bigint.ml` will feel. Worth naming so nobody thinks it was chosen for
+convenience.
 
 ## The API is determined by the solver
 

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -71,7 +71,7 @@ stdlib__Bigint.cmo : bigint.ml \
     stdlib__Sys.cmi \
     stdlib__String.cmi \
     stdlib.cmi \
-    stdlib__List.cmi \
+    stdlib__Int.cmi \
     stdlib__Iarray.cmi \
     stdlib__Char.cmi \
     stdlib__Buffer.cmi \
@@ -81,7 +81,7 @@ stdlib__Bigint.cmx : bigint.ml \
     stdlib__Sys.cmx \
     stdlib__String.cmx \
     stdlib.cmx \
-    stdlib__List.cmx \
+    stdlib__Int.cmx \
     stdlib__Iarray.cmx \
     stdlib__Char.cmx \
     stdlib__Buffer.cmx \

--- a/stdlib/.depend
+++ b/stdlib/.depend
@@ -67,6 +67,28 @@ stdlib__Bigarray.cmx : bigarray.ml \
 stdlib__Bigarray.cmi : bigarray.mli \
     stdlib.cmi \
     stdlib__Complex.cmi
+stdlib__Bigint.cmo : bigint.ml \
+    stdlib__Sys.cmi \
+    stdlib__String.cmi \
+    stdlib.cmi \
+    stdlib__List.cmi \
+    stdlib__Iarray.cmi \
+    stdlib__Char.cmi \
+    stdlib__Buffer.cmi \
+    stdlib__Array.cmi \
+    stdlib__Bigint.cmi
+stdlib__Bigint.cmx : bigint.ml \
+    stdlib__Sys.cmx \
+    stdlib__String.cmx \
+    stdlib.cmx \
+    stdlib__List.cmx \
+    stdlib__Iarray.cmx \
+    stdlib__Char.cmx \
+    stdlib__Buffer.cmx \
+    stdlib__Array.cmx \
+    stdlib__Bigint.cmi
+stdlib__Bigint.cmi : bigint.mli \
+    stdlib.cmi
 stdlib__Bool.cmo : bool.ml \
     stdlib.cmi \
     stdlib__Bool.cmi

--- a/stdlib/StdlibModules
+++ b/stdlib/StdlibModules
@@ -72,6 +72,7 @@ STDLIB_MODULE_BASENAMES = \
   stack \
   queue \
   buffer \
+  bigint \
   camlinternalFormat \
   printf \
   arg \

--- a/stdlib/bigint.ml
+++ b/stdlib/bigint.ml
@@ -1,0 +1,282 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2026 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Sign-magnitude representation with immutable, least-significant-first,
+   half-word limbs.  Half-word limbs keep every limb product, with its
+   carries, within [max_int], so the arithmetic below never overflows.
+
+   The representation is canonical: no leading zero limbs, and zero has
+   sign 0 with an empty magnitude.  Canonicity is load-bearing: it is what
+   makes polymorphic equality agree with [equal].  Every magnitude is
+   built by [trim], which is the one place that enforces it. *)
+
+let radix_bits = (Sys.int_size - 1) / 2
+let radix = 1 lsl radix_bits
+let mask = radix - 1
+
+type t : immutable_data =
+  { sign : int  (* -1, 0 or 1; 0 exactly for zero *)
+  ; mag : int iarray  (* each limb in [0, radix); no leading zero limb *)
+  }
+
+let zero = { sign = 0; mag = Iarray.init 0 (fun _ -> 0) }
+
+(* Freeze a scratch magnitude, dropping leading zero limbs. *)
+let trim scratch =
+  let length = ref (Array.length scratch) in
+  while !length > 0 && scratch.(!length - 1) = 0 do
+    length := !length - 1
+  done;
+  Iarray.init !length (fun index -> scratch.(index))
+
+(* [make sign mag] assembles a value from a possibly-empty magnitude,
+   forcing sign 0 on the empty one. *)
+let make sign mag =
+  if Iarray.length mag = 0 then zero else { sign; mag }
+
+let is_zero value = value.sign = 0
+
+let int_compare (left : int) right =
+  if left < right then -1 else if left > right then 1 else 0
+
+let compare_magnitude left right =
+  let left_length = Iarray.length left in
+  let right_length = Iarray.length right in
+  if left_length <> right_length
+  then int_compare left_length right_length
+  else begin
+    let rec from index =
+      if index < 0
+      then 0
+      else begin
+        let order =
+          int_compare (Iarray.get left index) (Iarray.get right index)
+        in
+        if order <> 0 then order else from (index - 1)
+      end
+    in
+    from (left_length - 1)
+  end
+
+let compare left right =
+  if left.sign <> right.sign
+  then int_compare left.sign right.sign
+  else if left.sign >= 0
+  then compare_magnitude left.mag right.mag
+  else compare_magnitude right.mag left.mag
+
+let equal left right = compare left right = 0
+let lt left right = compare left right < 0
+let le left right = compare left right <= 0
+let gt left right = compare left right > 0
+let ge left right = compare left right >= 0
+
+let neg value = make (-value.sign) value.mag
+let abs value = make 1 value.mag
+
+let add_magnitude left right =
+  let left_length = Iarray.length left in
+  let right_length = Iarray.length right in
+  let length =
+    (if left_length > right_length then left_length else right_length) + 1
+  in
+  let scratch = Array.make length 0 in
+  let carry = ref 0 in
+  for index = 0 to length - 1 do
+    let left_limb = if index < left_length then Iarray.get left index else 0 in
+    let right_limb =
+      if index < right_length then Iarray.get right index else 0
+    in
+    let sum = left_limb + right_limb + !carry in
+    scratch.(index) <- sum land mask;
+    carry := sum lsr radix_bits
+  done;
+  (* The final carry landed in the extra limb, so [!carry] is 0 here. *)
+  trim scratch
+
+(* [left] must be at least [right]. *)
+let subtract_magnitude left right =
+  let left_length = Iarray.length left in
+  let right_length = Iarray.length right in
+  let scratch = Array.make left_length 0 in
+  let borrow = ref 0 in
+  for index = 0 to left_length - 1 do
+    let right_limb =
+      if index < right_length then Iarray.get right index else 0
+    in
+    let difference = Iarray.get left index - right_limb - !borrow in
+    if difference < 0
+    then begin
+      scratch.(index) <- difference + radix;
+      borrow := 1
+    end
+    else begin
+      scratch.(index) <- difference;
+      borrow := 0
+    end
+  done;
+  trim scratch
+
+(* Schoolbook multiplication.  Every intermediate value is at most
+   (radix - 1)^2 + 2 * (radix - 1) = radix^2 - 1 <= max_int. *)
+let multiply_magnitude left right =
+  let left_length = Iarray.length left in
+  let right_length = Iarray.length right in
+  let scratch = Array.make (left_length + right_length) 0 in
+  for left_index = 0 to left_length - 1 do
+    let left_limb = Iarray.get left left_index in
+    let carry = ref 0 in
+    for right_index = 0 to right_length - 1 do
+      let product =
+        (left_limb * Iarray.get right right_index)
+        + scratch.(left_index + right_index)
+        + !carry
+      in
+      scratch.(left_index + right_index) <- product land mask;
+      carry := product lsr radix_bits
+    done;
+    scratch.(left_index + right_length) <- !carry
+  done;
+  trim scratch
+
+let add left right =
+  if left.sign = 0
+  then right
+  else if right.sign = 0
+  then left
+  else if left.sign = right.sign
+  then make left.sign (add_magnitude left.mag right.mag)
+  else begin
+    let magnitude_order = compare_magnitude left.mag right.mag in
+    if magnitude_order >= 0
+    then make left.sign (subtract_magnitude left.mag right.mag)
+    else make right.sign (subtract_magnitude right.mag left.mag)
+  end
+
+let sub left right = add left (neg right)
+
+let mul left right =
+  make (left.sign * right.sign) (multiply_magnitude left.mag right.mag)
+
+let of_int integer =
+  if integer = 0
+  then zero
+  else begin
+    (* Peel limbs from the negated value: [-max_int] is representable but
+       [-min_int] is not, so the loop works on non-positive numbers.
+       Three limbs always suffice: 3 * radix_bits >= Sys.int_size. *)
+    let scratch = Array.make 3 0 in
+    let remaining = ref (if integer < 0 then integer else -integer) in
+    let index = ref 0 in
+    while !remaining <> 0 do
+      scratch.(!index) <- -(!remaining mod radix);
+      remaining := !remaining / radix;
+      index := !index + 1
+    done;
+    { sign = (if integer < 0 then -1 else 1); mag = trim scratch }
+  end
+
+let one = of_int 1
+let min_int_bigint = of_int min_int
+let max_int_bigint = of_int max_int
+
+let to_int_opt value =
+  if lt value min_int_bigint || gt value max_int_bigint
+  then None
+  else begin
+    (* In range, so folding up the negated value stays within
+       [min_int, 0] and cannot overflow. *)
+    let rec negated index acc =
+      if index < 0
+      then acc
+      else negated (index - 1) ((acc * radix) - Iarray.get value.mag index)
+    in
+    let negated_value = negated (Iarray.length value.mag - 1) 0 in
+    Some (if value.sign < 0 then negated_value else -negated_value)
+  end
+
+(* Decimal conversion peels [decimal_chunk_width] digits at a time.  The
+   chunk is sized so that the division step's intermediate value,
+   (decimal_chunk - 1) * radix + mask, stays within [max_int]. *)
+let decimal_chunk, decimal_chunk_width =
+  if Sys.int_size <= 32 then 10_000, 4 else 1_000_000_000, 9
+
+(* Divide a magnitude by a small positive integer; quotient and remainder. *)
+let divide_magnitude_small magnitude divisor =
+  let length = Iarray.length magnitude in
+  let scratch = Array.make length 0 in
+  let remainder = ref 0 in
+  for index = length - 1 downto 0 do
+    let current = (!remainder * radix) + Iarray.get magnitude index in
+    scratch.(index) <- current / divisor;
+    remainder := current mod divisor
+  done;
+  trim scratch, !remainder
+
+let to_string value =
+  if value.sign = 0
+  then "0"
+  else begin
+    let rec chunks magnitude collected =
+      if Iarray.length magnitude = 0
+      then collected
+      else begin
+        let quotient, chunk =
+          divide_magnitude_small magnitude decimal_chunk
+        in
+        chunks quotient (chunk :: collected)
+      end
+    in
+    match chunks value.mag [] with
+    | [] -> assert false (* a nonzero value has a nonempty magnitude *)
+    | most_significant :: rest ->
+      let buffer = Buffer.create 32 in
+      if value.sign < 0 then Buffer.add_char buffer '-';
+      Buffer.add_string buffer (string_of_int most_significant);
+      List.iter
+        (fun chunk ->
+          let digits = string_of_int chunk in
+          for _ = String.length digits + 1 to decimal_chunk_width do
+            Buffer.add_char buffer '0'
+          done;
+          Buffer.add_string buffer digits)
+        rest;
+      Buffer.contents buffer
+  end
+
+let of_string string =
+  let reject reason = invalid_arg ("Bigint.of_string: " ^ reason) in
+  let length = String.length string in
+  if length = 0 then reject "empty string";
+  let negative = string.[0] = '-' in
+  let first = if negative then 1 else 0 in
+  if first >= length then reject "no digits";
+  String.iteri
+    (fun index character ->
+      if index >= first && not ('0' <= character && character <= '9')
+      then reject "non-digit character")
+    string;
+  if string.[first] = '0' && length - first > 1
+  then reject "redundant leading zero";
+  if negative && string.[first] = '0' then reject "negative zero";
+  let ten = of_int 10 in
+  let magnitude = ref zero in
+  for index = first to length - 1 do
+    magnitude :=
+      add
+        (mul !magnitude ten)
+        (of_int (Char.code string.[index] - Char.code '0'))
+  done;
+  if negative then neg !magnitude else !magnitude

--- a/stdlib/bigint.ml
+++ b/stdlib/bigint.ml
@@ -20,7 +20,8 @@
    The representation is canonical: no leading zero limbs, and zero has
    sign 0 with an empty magnitude.  Canonicity is load-bearing: it is what
    makes polymorphic equality agree with [equal].  Every magnitude is
-   built by [trim], which is the one place that enforces it. *)
+   built by [trim], which drops leading zero limbs, and every value by
+   [make], which forces sign 0 on the empty magnitude. *)
 
 let radix_bits = (Sys.int_size - 1) / 2
 let radix = 1 lsl radix_bits
@@ -48,21 +49,18 @@ let make sign mag =
 
 let is_zero value = value.sign = 0
 
-let int_compare (left : int) right =
-  if left < right then -1 else if left > right then 1 else 0
-
 let compare_magnitude left right =
   let left_length = Iarray.length left in
   let right_length = Iarray.length right in
   if left_length <> right_length
-  then int_compare left_length right_length
+  then Int.compare left_length right_length
   else begin
     let rec from index =
       if index < 0
       then 0
       else begin
         let order =
-          int_compare (Iarray.get left index) (Iarray.get right index)
+          Int.compare (Iarray.get left index) (Iarray.get right index)
         in
         if order <> 0 then order else from (index - 1)
       end
@@ -72,7 +70,7 @@ let compare_magnitude left right =
 
 let compare left right =
   if left.sign <> right.sign
-  then int_compare left.sign right.sign
+  then Int.compare left.sign right.sign
   else if left.sign >= 0
   then compare_magnitude left.mag right.mag
   else compare_magnitude right.mag left.mag
@@ -130,7 +128,9 @@ let subtract_magnitude left right =
   trim scratch
 
 (* Schoolbook multiplication.  Every intermediate value is at most
-   (radix - 1)^2 + 2 * (radix - 1) = radix^2 - 1 <= max_int. *)
+   (radix - 1)^2 + 2 * (radix - 1) = radix^2 - 1 <= max_int -- an exact
+   fit, with zero headroom when Sys.int_size is odd, so no term can be
+   added to the inner sum. *)
 let multiply_magnitude left right =
   let left_length = Iarray.length left in
   let right_length = Iarray.length right in
@@ -147,6 +147,8 @@ let multiply_magnitude left right =
       scratch.(left_index + right_index) <- product land mask;
       carry := product lsr radix_bits
     done;
+    (* A store, not an accumulate: the previous outer iteration's final
+       carry landed one position lower, so this slot is still 0. *)
     scratch.(left_index + right_length) <- !carry
   done;
   trim scratch
@@ -185,7 +187,7 @@ let of_int integer =
       remaining := !remaining / radix;
       index := !index + 1
     done;
-    { sign = (if integer < 0 then -1 else 1); mag = trim scratch }
+    make (if integer < 0 then -1 else 1) (trim scratch)
   end
 
 let one = of_int 1
@@ -207,21 +209,16 @@ let to_int_opt value =
     Some (if value.sign < 0 then negated_value else -negated_value)
   end
 
-(* Decimal conversion peels [decimal_chunk_width] digits at a time.  The
-   chunk is sized so that the division step's intermediate value,
-   (decimal_chunk - 1) * radix + mask, stays within [max_int]. *)
-let decimal_chunk, decimal_chunk_width =
-  if Sys.int_size <= 32 then 10_000, 4 else 1_000_000_000, 9
-
-(* Divide a magnitude by a small positive integer; quotient and remainder. *)
-let divide_magnitude_small magnitude divisor =
+(* Divide a magnitude by ten; quotient magnitude and remainder digit.  The
+   intermediate value is at most 9 * radix + mask, well within [max_int]. *)
+let divide_magnitude_by_ten magnitude =
   let length = Iarray.length magnitude in
   let scratch = Array.make length 0 in
   let remainder = ref 0 in
   for index = length - 1 downto 0 do
     let current = (!remainder * radix) + Iarray.get magnitude index in
-    scratch.(index) <- current / divisor;
-    remainder := current mod divisor
+    scratch.(index) <- current / 10;
+    remainder := current mod 10
   done;
   trim scratch, !remainder
 
@@ -229,35 +226,21 @@ let to_string value =
   if value.sign = 0
   then "0"
   else begin
-    let rec chunks magnitude collected =
-      if Iarray.length magnitude = 0
-      then collected
-      else begin
-        let quotient, chunk =
-          divide_magnitude_small magnitude decimal_chunk
-        in
-        chunks quotient (chunk :: collected)
-      end
-    in
-    match chunks value.mag [] with
-    | [] -> assert false (* a nonzero value has a nonempty magnitude *)
-    | most_significant :: rest ->
-      let buffer = Buffer.create 32 in
-      if value.sign < 0 then Buffer.add_char buffer '-';
-      Buffer.add_string buffer (string_of_int most_significant);
-      List.iter
-        (fun chunk ->
-          let digits = string_of_int chunk in
-          for _ = String.length digits + 1 to decimal_chunk_width do
-            Buffer.add_char buffer '0'
-          done;
-          Buffer.add_string buffer digits)
-        rest;
-      Buffer.contents buffer
+    (* Decimal digits fall out least significant first; reverse at the end. *)
+    let buffer = Buffer.create 32 in
+    let magnitude = ref value.mag in
+    while Iarray.length !magnitude > 0 do
+      let quotient, digit = divide_magnitude_by_ten !magnitude in
+      Buffer.add_char buffer (Char.chr (Char.code '0' + digit));
+      magnitude := quotient
+    done;
+    if value.sign < 0 then Buffer.add_char buffer '-';
+    let length = Buffer.length buffer in
+    String.init length (fun index -> Buffer.nth buffer (length - 1 - index))
   end
 
 let of_string string =
-  let reject reason = invalid_arg ("Bigint.of_string: " ^ reason) in
+  let reject reason = failwith ("Bigint.of_string: " ^ reason) in
   let length = String.length string in
   if length = 0 then reject "empty string";
   let negative = string.[0] = '-' in

--- a/stdlib/bigint.mli
+++ b/stdlib/bigint.mli
@@ -1,0 +1,69 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                         The OCaml programmers                          *)
+(*                                                                        *)
+(*   Copyright 2026 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Arbitrary-precision signed integers.
+
+    Values are mathematical integers: arithmetic does not wrap at the
+    bounds of the machine [int] type.  This is the executable counterpart
+    of the mathematical-integer sort that specification checking reasons
+    about.
+
+    Interface rule: every operation exported here, other than the three
+    marked as runtime-only, must be interpretable as an SMT [Int]
+    operation.  An operation without an interpretation becomes an
+    uninterpreted function, and specifications that use it silently stop
+    being provable.  That is why there is no division, modulo or
+    exponentiation.  Do not add a convenient function here without also
+    giving it a solver interpretation. *)
+
+type t : immutable_data
+
+val zero : t
+val one : t
+val of_int : int -> t
+
+val is_zero : t -> bool
+
+(** The representation is canonical, so polymorphic equality agrees with
+    [equal].  Polymorphic ordering does not agree with mathematical
+    order, because it compares the representation; use [compare], [lt],
+    [le], [gt] or [ge] instead. *)
+val equal : t -> t -> bool
+
+val compare : t -> t -> int
+val lt : t -> t -> bool
+val le : t -> t -> bool
+val gt : t -> t -> bool
+val ge : t -> t -> bool
+
+val neg : t -> t
+val abs : t -> t
+val add : t -> t -> t
+val sub : t -> t -> t
+val mul : t -> t -> t
+
+(** The remaining operations are runtime-only conveniences with no solver
+    interpretation.  Do not use them in specifications. *)
+
+(** [to_int_opt value] is [Some integer] exactly when [value] is
+    representable as a machine [int]. *)
+val to_int_opt : t -> int option
+
+(** Canonical decimal notation: an optional leading minus followed by
+    decimal digits with no redundant leading zeroes.  [to_string]
+    produces it and [of_string] accepts exactly it, raising
+    [Invalid_argument] on anything else. *)
+val to_string : t -> string
+val of_string : string -> t

--- a/stdlib/bigint.mli
+++ b/stdlib/bigint.mli
@@ -20,29 +20,34 @@
     of the mathematical-integer sort that specification checking reasons
     about.
 
-    Interface rule: every operation exported here, other than the three
-    marked as runtime-only, must be interpretable as an SMT [Int]
-    operation.  An operation without an interpretation becomes an
+    Interface rule: every operation exported here, other than the
+    runtime-only conversions at the end, must be interpretable as an SMT
+    [Int] operation.  An operation without an interpretation becomes an
     uninterpreted function, and specifications that use it silently stop
     being provable.  That is why there is no division, modulo or
     exponentiation.  Do not add a convenient function here without also
-    giving it a solver interpretation. *)
+    giving it a solver interpretation.
+
+    @since 5.4 *)
 
 type t : immutable_data
+(** The representation is canonical, so polymorphic equality agrees with
+    [equal] and [Hashtbl.hash] is consistent with it.  Polymorphic
+    ordering does not agree with mathematical order, because it compares
+    the representation; use [compare], [lt], [le], [gt] or [ge]
+    instead. *)
 
 val zero : t
 val one : t
 val of_int : int -> t
 
 val is_zero : t -> bool
-
-(** The representation is canonical, so polymorphic equality agrees with
-    [equal].  Polymorphic ordering does not agree with mathematical
-    order, because it compares the representation; use [compare], [lt],
-    [le], [gt] or [ge] instead. *)
 val equal : t -> t -> bool
 
+(** [compare] implements the mathematical order and returns [-1], [0]
+    or [1]. *)
 val compare : t -> t -> int
+
 val lt : t -> t -> bool
 val le : t -> t -> bool
 val gt : t -> t -> bool
@@ -54,8 +59,10 @@ val add : t -> t -> t
 val sub : t -> t -> t
 val mul : t -> t -> t
 
-(** The remaining operations are runtime-only conveniences with no solver
-    interpretation.  Do not use them in specifications. *)
+(** {1 Runtime-only conversions}
+
+    These have no solver interpretation.  Do not use them in
+    specifications. *)
 
 (** [to_int_opt value] is [Some integer] exactly when [value] is
     representable as a machine [int]. *)
@@ -63,7 +70,7 @@ val to_int_opt : t -> int option
 
 (** Canonical decimal notation: an optional leading minus followed by
     decimal digits with no redundant leading zeroes.  [to_string]
-    produces it and [of_string] accepts exactly it, raising
-    [Invalid_argument] on anything else. *)
+    produces it and [of_string] accepts exactly it, raising [Failure]
+    on anything else. *)
 val to_string : t -> string
 val of_string : string -> t

--- a/stdlib/dune
+++ b/stdlib/dune
@@ -76,6 +76,8 @@
   effect.mli
   bigarray.ml
   bigarray.mli
+  bigint.ml
+  bigint.mli
   bool.ml
   bool.mli
   buffer.ml
@@ -258,6 +260,11 @@
   .stdlib.objs/byte/stdlib__Bigarray.cmsi
   .stdlib.objs/byte/stdlib__Bigarray.cmt
   .stdlib.objs/byte/stdlib__Bigarray.cmti
+  .stdlib.objs/byte/stdlib__Bigint.cmi
+  .stdlib.objs/byte/stdlib__Bigint.cms
+  .stdlib.objs/byte/stdlib__Bigint.cmsi
+  .stdlib.objs/byte/stdlib__Bigint.cmt
+  .stdlib.objs/byte/stdlib__Bigint.cmti
   .stdlib.objs/byte/stdlib__Bool.cmi
   .stdlib.objs/byte/stdlib__Bool.cms
   .stdlib.objs/byte/stdlib__Bool.cmsi
@@ -624,6 +631,7 @@
   .stdlib.objs/native/stdlib__Float.cmx
   .stdlib.objs/native/stdlib__Fun.cmx
   .stdlib.objs/native/stdlib__Bigarray.cmx
+  .stdlib.objs/native/stdlib__Bigint.cmx
   .stdlib.objs/native/stdlib__Array.cmx
   .stdlib.objs/native/stdlib__Iarray.cmx
   .stdlib.objs/native/stdlib__Int32.cmx

--- a/stdlib/stdlib.ml
+++ b/stdlib/stdlib.ml
@@ -622,6 +622,7 @@ module ArrayLabels    = ArrayLabels
 module Atomic         = Atomic
 module Backoff        = Backoff
 module Bigarray       = Bigarray
+module Bigint         = Bigint
 module Bool           = Bool
 module Buffer         = Buffer
 module Bytes          = Bytes

--- a/stdlib/stdlib.mli
+++ b/stdlib/stdlib.mli
@@ -1390,6 +1390,7 @@ module ArrayLabels    = ArrayLabels
 module Atomic         = Atomic
 module Backoff        = Backoff
 module Bigarray       = Bigarray
+module Bigint         = Bigint
 module Bool           = Bool
 module Buffer         = Buffer
 module Bytes          = Bytes

--- a/testsuite/tests/atomic-locs/record_fields.ml
+++ b/testsuite/tests/atomic-locs/record_fields.ml
@@ -17,7 +17,7 @@ module Atomic = struct
   end
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Atomic/329"
+(apply (field_imm 1 (global Toploop!)) "Atomic/330"
   (let (Loc = (makeblock 0)) (makeblock 0 Loc)))
 module Atomic :
   sig
@@ -55,7 +55,7 @@ module Basic = struct
     Atomic.Loc.compare_and_set (get_loc r) oldv newv
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Basic/367"
+(apply (field_imm 1 (global Toploop!)) "Basic/368"
   (let
     (get = (function {nlocal = 0} r (atomic_load_field_ptr r 1))
      get_imm = (function {nlocal = 0} r : int (atomic_load_field_imm r 1))
@@ -189,7 +189,7 @@ end : sig
   type t = { mutable x : int [@atomic] }
 end)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Ok/408" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Ok/409" (makeblock 0))
 module Ok : sig type t = { mutable x : int [@atomic]; } end
 |}];;
 
@@ -258,7 +258,7 @@ module Inline_record = struct
   let test : t -> int = fun (A r) -> r.x
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record/452"
+(apply (field_imm 1 (global Toploop!)) "Inline_record/453"
   (let
     (test =
        (function {nlocal = 0} param : int (atomic_load_field_imm param 0)))
@@ -280,7 +280,7 @@ module Extension_with_inline_record = struct
   let () = assert (test (A { x = 42 }) = 42)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/464"
+(apply (field_imm 1 (global Toploop!)) "Extension_with_inline_record/465"
   (let
     (A =
        (makeblock_unique 248 "Extension_with_inline_record.A"
@@ -374,7 +374,7 @@ Warning 214 [atomic-float-record-boxed]: This record contains atomic float field
   which prevents the float record optimization.
   The fields of this record will be boxed instead of being
   represented as a flat float array.
-(apply (field_imm 1 (global Toploop!)) "Float_records/529"
+(apply (field_imm 1 (global Toploop!)) "Float_records/530"
   (let
     (mk_flat =
        (function {nlocal = 0} x[value<float>] y[value<float>]
@@ -594,7 +594,7 @@ Line 5, characters 14-19:
 Warning 9 [missing-record-field-pattern]: the following labels are not bound
   in this record pattern: "y".
   Either bind these labels explicitly or add "; _" to the pattern.
-(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/622"
+(apply (field_imm 1 (global Toploop!)) "Pattern_matching_wildcard/623"
   (let
     (warning = (function {nlocal = 0} param : int (field_int 0 param))
      allowed = (function {nlocal = 0} param : int (field_int 0 param))
@@ -635,7 +635,7 @@ module Functional_update_ok = struct
   let allowed t = { t with y = 42 }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/642"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_ok/643"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -655,7 +655,7 @@ module Functional_update_copy_ok = struct
   let allowed t = { t with y = t.y }
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/654"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_copy_ok/655"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -689,7 +689,7 @@ module Functional_update_multi_ok = struct
   let allowed t = { t with y = 42; z = 67 } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/674"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_ok/675"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -713,7 +713,7 @@ module Functional_update_multi_copy_ok = struct
   let allowed t = { t with y = t.y; z = t.z } (* no implicit atomic loads *)
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/689"
+(apply (field_imm 1 (global Toploop!)) "Functional_update_multi_copy_ok/690"
   (let
     (allowed =
        (function {nlocal = 0} t
@@ -742,7 +742,7 @@ end
 
 let project (t : Mixed_blocks.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/700" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks/701" (makeblock 0))
 module Mixed_blocks :
   sig
     type t = { padding : #(int * int * int); mutable field : int [@atomic]; }
@@ -786,7 +786,7 @@ end
 
 let project (t : Mixed_blocks_2.t) = t.field
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/714" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_2/715" (makeblock 0))
 module Mixed_blocks_2 :
   sig
     type t = { mutable field : int [@atomic]; padding : #(int * int * int); }
@@ -832,7 +832,7 @@ module Mixed_blocks_rec = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/731" (makeblock 0))
+(apply (field_imm 1 (global Toploop!)) "Mixed_blocks_rec/732" (makeblock 0))
 module Mixed_blocks_rec :
   sig
     type t = { padding : u; mutable field : int [@atomic]; }
@@ -940,7 +940,7 @@ module Atomic_float_with_float_hash = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/765"
+(apply (field_imm 1 (global Toploop!)) "Atomic_float_with_float_hash/766"
   (let
     (disallowed =
        (function {nlocal = 0} t : float
@@ -961,7 +961,7 @@ module Inline_record_atomic_in_mixed = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/778"
+(apply (field_imm 1 (global Toploop!)) "Inline_record_atomic_in_mixed/779"
   (let
     (disallowed =
        (function {nlocal = 0} t : int

--- a/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
+++ b/testsuite/tests/flambda2/array_element_kind_meet.simplify.reference
@@ -15,16 +15,16 @@ let code loopify(never) size(52) newer_version_of(sum_0)
       let prim_1 = %untag_imm (for_stop) in
       let for_stop_naked = %num_conv.[`imm`].[`int64`] (prim_1) in
       (cont k2 (0L, 0)
-         where rec k2 (for_counter_naked : int64, r_478_unboxed0) =
+         where rec k2 (for_counter_naked : int64, r_479_unboxed0) =
            let prim_2 = %num_conv.[`int64`].[`imm`] (for_counter_naked) in
            let i = %tag_imm (prim_2) in
            let ifnot_result = %array_load.mut (Pfield, i) in
            ((let prim_3 = %is_int (ifnot_result) in
              switch prim_3
                | 0 -> k4
-               | 1 -> k3 (r_478_unboxed0)
+               | 1 -> k3 (r_479_unboxed0)
                where k4 =
-                 let int_add = %int_barith.add (r_478_unboxed0, 1) in
+                 let int_add = %int_barith.add (r_479_unboxed0, 1) in
                  cont k3 (int_add))
               where k3 (return_val0) =
                 let for_next_naked =

--- a/testsuite/tests/layout_poly/cross_module_static/cross_module_static_lib.objinfo.reference
+++ b/testsuite/tests/layout_poly/cross_module_static/cross_module_static_lib.objinfo.reference
@@ -20,21 +20,21 @@ Static data:
     (closure ⟨env⟩ layout_2 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 1} closure/333[L]
-           (function {nlocal = 0} x/318[$layout_2] : $layout_2 x/318))⟫ });
+        ⟪(function {nlocal = 1} closure/334[L]
+           (function {nlocal = 0} x/319[$layout_2] : $layout_2 x/319))⟫ });
     (closure ⟨env⟩ layout_11 layout_12 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 1} closure/334[L]
-           (function {nlocal = 0} x/321[$layout_11] y/322[$layout_12]
+        ⟪(function {nlocal = 1} closure/335[L]
+           (function {nlocal = 0} x/322[$layout_11] y/323[$layout_12]
              : #($layout_11, $layout_12)
-             (make_unboxed_product #($layout_11, $layout_12) x/321 y/322)))⟫ });
+             (make_unboxed_product #($layout_11, $layout_12) x/322 y/323)))⟫ });
     [ (missing); ];
     (closure ⟨env⟩ layout_16 ->
       { c = (missing)
       ; r =
-        ⟪(function {nlocal = 1} closure/335[L]
-           (let (calls/332 =a (mixedfield 0  (*) closure/335))
-             (function {nlocal = 0} x/326[$layout_16] : $layout_16
-               (seq (+:=1 calls/332) x/326))))⟫ });
+        ⟪(function {nlocal = 1} closure/336[L]
+           (let (calls/333 =a (mixedfield 0  (*) closure/336))
+             (function {nlocal = 0} x/327[$layout_16] : $layout_16
+               (seq (+:=1 calls/333) x/327))))⟫ });
     ]

--- a/testsuite/tests/layout_poly/cross_module_static/cross_module_static_relay.objinfo.reference
+++ b/testsuite/tests/layout_poly/cross_module_static/cross_module_static_relay.objinfo.reference
@@ -23,7 +23,7 @@ Static data:
       (let (#body/3 =
          { c = (missing)
          ; r =
-           ⟪(function {nlocal = 0} x/318[$layout_6] : $layout_6
+           ⟪(function {nlocal = 0} x/319[$layout_6] : $layout_6
               $(let (#body/2 =
                   { c = (missing)
                   ; r =
@@ -36,8 +36,8 @@ Static data:
                             ⟪(apply[L] $#app/1
                                (field_imm 0
                                  (global static Cross_module_static_lib!)))⟫ })
-                       x/318)⟫ })
+                       x/319)⟫ })
                  { c = #body/2.c; r = ⟪(region $#body/2)⟫ }))⟫ })
         { c = #body/3.c
-        ; r = ⟪(function {nlocal = 1} closure/325[L] $#body/3)⟫ }));
+        ; r = ⟪(function {nlocal = 1} closure/326[L] $#body/3)⟫ }));
     ]

--- a/testsuite/tests/lib-bigint/test.ml
+++ b/testsuite/tests/lib-bigint/test.ml
@@ -1,0 +1,388 @@
+(* TEST
+   bytecode;
+   native;
+*)
+
+(* Bigint is checked against independent oracles: machine [int] arithmetic
+   for values in range, and a naive decimal-string implementation for large
+   values.  The naive implementation is written for obviousness, not speed:
+   numbers are strings of decimal digits, and the algorithms are the
+   schoolbook ones, digit by digit. *)
+
+let checks = ref 0
+
+let check description condition =
+  incr checks;
+  if not condition then failwith ("Bigint check failed: " ^ description)
+
+(* ---- The naive decimal oracle ---------------------------------------- *)
+
+module Oracle = struct
+  (* A number is a sign and a string of decimal digits without leading
+     zeroes; magnitude "0" always has sign 1. *)
+  type t = { negative : bool; digits : string }
+
+  let of_string string =
+    let negative = string.[0] = '-' in
+    let digits =
+      if negative then String.sub string 1 (String.length string - 1)
+      else string
+    in
+    if digits = "0" then { negative = false; digits } else { negative; digits }
+
+  let to_string { negative; digits } =
+    if negative then "-" ^ digits else digits
+
+  let digit string index = Char.code string.[index] - Char.code '0'
+
+  let strip_leading_zeroes string =
+    let length = String.length string in
+    let first = ref 0 in
+    while !first < length - 1 && string.[!first] = '0' do incr first done;
+    String.sub string !first (length - !first)
+
+  (* Magnitude comparison: longer means larger, otherwise lexicographic. *)
+  let compare_digits left right =
+    let by_length = compare (String.length left) (String.length right) in
+    if by_length <> 0 then by_length else compare left right
+
+  (* Schoolbook addition, right to left with a carry. *)
+  let add_digits left right =
+    let width = 1 + max (String.length left) (String.length right) in
+    let at string index =
+      (* index counted from the right *)
+      if index < String.length string
+      then digit string (String.length string - 1 - index)
+      else 0
+    in
+    let result = Bytes.make width '0' in
+    let carry = ref 0 in
+    for index = 0 to width - 1 do
+      let sum = at left index + at right index + !carry in
+      Bytes.set result (width - 1 - index) (Char.chr (Char.code '0' + sum mod 10));
+      carry := sum / 10
+    done;
+    strip_leading_zeroes (Bytes.to_string result)
+
+  (* Schoolbook subtraction, [left] at least [right], with a borrow. *)
+  let sub_digits left right =
+    let width = String.length left in
+    let at string index =
+      if index < String.length string
+      then digit string (String.length string - 1 - index)
+      else 0
+    in
+    let result = Bytes.make width '0' in
+    let borrow = ref 0 in
+    for index = 0 to width - 1 do
+      let difference = at left index - at right index - !borrow in
+      let difference, next_borrow =
+        if difference < 0 then difference + 10, 1 else difference, 0
+      in
+      Bytes.set result (width - 1 - index)
+        (Char.chr (Char.code '0' + difference));
+      borrow := next_borrow
+    done;
+    strip_leading_zeroes (Bytes.to_string result)
+
+  (* Schoolbook multiplication: multiply by one digit at a time and add up
+     the shifted partial products. *)
+  let mul_digits left right =
+    let mul_one_digit string d =
+      if d = 0 then "0"
+      else begin
+        let width = String.length string + 1 in
+        let result = Bytes.make width '0' in
+        let carry = ref 0 in
+        for index = 0 to String.length string - 1 do
+          let product =
+            (digit string (String.length string - 1 - index) * d) + !carry
+          in
+          Bytes.set result (width - 1 - index)
+            (Char.chr (Char.code '0' + product mod 10));
+          carry := product / 10
+        done;
+        Bytes.set result 0 (Char.chr (Char.code '0' + !carry));
+        strip_leading_zeroes (Bytes.to_string result)
+      end
+    in
+    let total = ref "0" in
+    String.iteri
+      (fun index _ ->
+        let partial = mul_one_digit left (digit right index) in
+        let shift = String.length right - 1 - index in
+        let shifted =
+          if partial = "0" then partial
+          else partial ^ String.make shift '0'
+        in
+        total := add_digits !total shifted)
+      right;
+    !total
+
+  let compare left right =
+    match left.negative, right.negative with
+    | false, true -> 1
+    | true, false -> -1
+    | false, false -> compare_digits left.digits right.digits
+    | true, true -> compare_digits right.digits left.digits
+
+  let neg value =
+    if value.digits = "0" then value
+    else { value with negative = not value.negative }
+
+  let abs value = { value with negative = false }
+
+  let add left right =
+    if left.negative = right.negative
+    then { negative = left.negative; digits = add_digits left.digits right.digits }
+    else begin
+      match compare_digits left.digits right.digits with
+      | 0 -> { negative = false; digits = "0" }
+      | order when order > 0 ->
+        { negative = left.negative; digits = sub_digits left.digits right.digits }
+      | _ ->
+        { negative = right.negative; digits = sub_digits right.digits left.digits }
+    end
+
+  let sub left right = add left (neg right)
+
+  let mul left right =
+    let digits = mul_digits left.digits right.digits in
+    { negative = left.negative <> right.negative && digits <> "0"; digits }
+end
+
+(* ---- Deterministic pseudo-random decimal strings ---------------------- *)
+
+let random_state = ref 1_234_567
+
+let random bound =
+  random_state := ((!random_state * 75) + 74) mod 65_537;
+  !random_state mod bound
+
+let random_decimal max_digits =
+  if random 20 = 0
+  then "0"
+  else begin
+    let digits = 1 + random max_digits in
+    let buffer = Buffer.create (digits + 1) in
+    if random 2 = 0 then Buffer.add_char buffer '-';
+    Buffer.add_char buffer (Char.chr (Char.code '1' + random 9));
+    for _ = 2 to digits do
+      Buffer.add_char buffer (Char.chr (Char.code '0' + random 10))
+    done;
+    Buffer.contents buffer
+  end
+
+(* ---- Machine-int oracle for values in range --------------------------- *)
+
+(* Boundary values: around zero, around the limb boundaries for half-word
+   limbs of any plausible size, and around the int bounds. *)
+let interesting_ints =
+  let around pivot = [ pivot - 1; pivot; pivot + 1 ] in
+  List.concat
+    [ around 0
+    ; around (1 lsl 15)
+    ; around (1 lsl 16)
+    ; around (1 lsl 30)
+    ; around (1 lsl 31)
+    ; List.map (fun n -> -n) (around (1 lsl 30))
+    ; List.map (fun n -> -n) (around (1 lsl 31))
+    ; [ min_int; min_int + 1; max_int - 1; max_int ]
+    ]
+
+let check_machine_int_oracle () =
+  let no_overflow_add a b =
+    (* a + b representable *)
+    if b >= 0 then a <= max_int - b else a >= min_int - b
+  in
+  List.iter
+    (fun a ->
+      let big_a = Bigint.of_int a in
+      check "of_int round-trip" (Bigint.to_int_opt big_a = Some a);
+      check "of_int/of_string agree"
+        (Bigint.equal big_a (Bigint.of_string (string_of_int a)));
+      check "to_string agrees with string_of_int"
+        (String.equal (Bigint.to_string big_a) (string_of_int a));
+      if a <> min_int then begin
+        check "neg" (Bigint.to_int_opt (Bigint.neg big_a) = Some (-a));
+        check "abs" (Bigint.to_int_opt (Bigint.abs big_a) = Some (Stdlib.abs a))
+      end;
+      List.iter
+        (fun b ->
+          let big_b = Bigint.of_int b in
+          if no_overflow_add a b
+          then
+            check "add" (Bigint.to_int_opt (Bigint.add big_a big_b) = Some (a + b));
+          if no_overflow_add a (-b) && b <> min_int
+          then
+            check "sub" (Bigint.to_int_opt (Bigint.sub big_a big_b) = Some (a - b));
+          (* Small factors only, so the product is representable. *)
+          let small n = -(1 lsl 31) < n && n < 1 lsl 31 in
+          if small a && small b
+          then
+            check "mul" (Bigint.to_int_opt (Bigint.mul big_a big_b) = Some (a * b));
+          check "compare"
+            (Bigint.compare big_a big_b = Stdlib.compare (a : int) b))
+        interesting_ints)
+    interesting_ints
+
+(* ---- Decimal oracle for large values ---------------------------------- *)
+
+let check_decimal_oracle () =
+  let agree description operation oracle_operation left right =
+    let via_bigint =
+      Bigint.to_string
+        (operation (Bigint.of_string left) (Bigint.of_string right))
+    in
+    let via_oracle =
+      Oracle.to_string
+        (oracle_operation (Oracle.of_string left) (Oracle.of_string right))
+    in
+    check description (String.equal via_bigint via_oracle)
+  in
+  for _ = 1 to 300 do
+    let left = random_decimal 60 in
+    let right = random_decimal 60 in
+    agree "oracle add" Bigint.add Oracle.add left right;
+    agree "oracle sub" Bigint.sub Oracle.sub left right;
+    agree "oracle mul" Bigint.mul Oracle.mul left right;
+    check "oracle compare"
+      (Bigint.compare (Bigint.of_string left) (Bigint.of_string right)
+       = Oracle.compare (Oracle.of_string left) (Oracle.of_string right))
+  done
+
+(* ---- Algebraic properties --------------------------------------------- *)
+
+let check_algebraic_properties () =
+  let ( + ) = Bigint.add
+  and ( - ) = Bigint.sub
+  and ( * ) = Bigint.mul in
+  for _ = 1 to 300 do
+    let a = Bigint.of_string (random_decimal 40) in
+    let b = Bigint.of_string (random_decimal 40) in
+    let c = Bigint.of_string (random_decimal 40) in
+    check "add commutes" (Bigint.equal (a + b) (b + a));
+    check "add associates" (Bigint.equal ((a + b) + c) (a + (b + c)));
+    check "mul commutes" (Bigint.equal (a * b) (b * a));
+    check "mul associates" (Bigint.equal ((a * b) * c) (a * (b * c)));
+    check "mul distributes" (Bigint.equal (a * (b + c)) ((a * b) + (a * c)));
+    check "sub is add of neg" (Bigint.equal (a - b) (a + Bigint.neg b));
+    check "abs of neg" (Bigint.equal (Bigint.abs (Bigint.neg a)) (Bigint.abs a));
+    check "neg of neg" (Bigint.equal (Bigint.neg (Bigint.neg a)) a);
+    check "add zero" (Bigint.equal (a + Bigint.zero) a);
+    check "mul one" (Bigint.equal (a * Bigint.one) a)
+  done
+
+(* ---- Canonicity, observed through polymorphic equality ---------------- *)
+
+let check_canonicity () =
+  (* Operations that produce zero must produce the canonical zero. *)
+  let a = Bigint.of_string "123456789012345678901234567890" in
+  check "sub of equals is canonical zero" (Bigint.sub a a = Bigint.zero);
+  check "mul by zero is canonical zero" (Bigint.mul a Bigint.zero = Bigint.zero);
+  check "neg of zero is canonical zero" (Bigint.neg Bigint.zero = Bigint.zero);
+  check "abs of zero is canonical zero" (Bigint.abs Bigint.zero = Bigint.zero);
+  check "of_int zero is canonical zero" (Bigint.of_int 0 = Bigint.zero);
+  check "is_zero of computed zero" (Bigint.is_zero (Bigint.sub a a));
+  (* Equal values reached by different routes are structurally equal. *)
+  for _ = 1 to 300 do
+    let x = Bigint.of_string (random_decimal 40) in
+    let y = Bigint.of_string (random_decimal 40) in
+    check "poly equality agrees with equal"
+      ((x = y) = Bigint.equal x y);
+    check "add then sub is structurally the argument"
+      (Bigint.sub (Bigint.add x y) y = x);
+    check "different routes, same structure"
+      (Bigint.add x y = Bigint.add y x)
+  done
+
+(* ---- Ordering ---------------------------------------------------------- *)
+
+let check_ordering () =
+  let bigints =
+    List.map Bigint.of_string
+      (List.sort_uniq Stdlib.compare
+         (List.init 60 (fun _ -> random_decimal 30)))
+  in
+  List.iter
+    (fun x ->
+      List.iter
+        (fun y ->
+          let order = Bigint.compare x y in
+          check "compare consistent with equal"
+            ((order = 0) = Bigint.equal x y);
+          check "compare antisymmetric" (Bigint.compare y x = -order);
+          check "lt" (Bigint.lt x y = (order < 0));
+          check "le" (Bigint.le x y = (order <= 0));
+          check "gt" (Bigint.gt x y = (order > 0));
+          check "ge" (Bigint.ge x y = (order >= 0)))
+        bigints)
+    bigints;
+  (* Transitivity on a small subset of triples. *)
+  let subset = List.filteri (fun index _ -> index < 12) bigints in
+  List.iter
+    (fun x ->
+      List.iter
+        (fun y ->
+          List.iter
+            (fun z ->
+              if Bigint.le x y && Bigint.le y z
+              then check "le transitive" (Bigint.le x z))
+            subset)
+        subset)
+    subset
+
+(* ---- Strings ----------------------------------------------------------- *)
+
+let check_strings () =
+  let round_trips =
+    [ "0"; "1"; "-1"; "10"; "-10"
+    ; "2147483647"; "2147483648"; "2147483649"
+    ; "4611686018427387903"; "4611686018427387904"
+    ; "-4611686018427387904"
+    ; "9223372036854775807"; "-9223372036854775808"
+    ; "123456789012345678901234567890"
+    ; "-999999999999999999999999999999999999"
+    ]
+  in
+  List.iter
+    (fun string ->
+      check "round-trip"
+        (String.equal (Bigint.to_string (Bigint.of_string string)) string))
+    round_trips;
+  for _ = 1 to 300 do
+    let string = random_decimal 200 in
+    check "random round-trip"
+      (String.equal (Bigint.to_string (Bigint.of_string string)) string)
+  done;
+  List.iter
+    (fun string ->
+      check "invalid string rejected"
+        (match Bigint.of_string string with
+         | _ -> false
+         | exception Invalid_argument _ -> true))
+    [ ""; "-"; "00"; "01"; "-0"; "-00"; "-01"; "+1"; " 1"; "1 "; "1x"; "--1" ]
+
+(* ---- Machine bounds ---------------------------------------------------- *)
+
+let check_int_bounds () =
+  List.iter
+    (fun n -> check "in range" (Bigint.to_int_opt (Bigint.of_int n) = Some n))
+    [ min_int; min_int + 1; -1; 0; 1; max_int - 1; max_int ];
+  check "one past max_int"
+    (Bigint.to_int_opt (Bigint.add (Bigint.of_int max_int) Bigint.one) = None);
+  check "one past min_int"
+    (Bigint.to_int_opt (Bigint.sub (Bigint.of_int min_int) Bigint.one) = None);
+  check "far out of range"
+    (Bigint.to_int_opt (Bigint.of_string "123456789012345678901234567890")
+     = None)
+
+let () =
+  check_machine_int_oracle ();
+  check_decimal_oracle ();
+  check_algebraic_properties ();
+  check_canonicity ();
+  check_ordering ();
+  check_strings ();
+  check_int_bounds ();
+  Printf.printf "Bigint: %d checks passed\n" !checks

--- a/testsuite/tests/lib-bigint/test.ml
+++ b/testsuite/tests/lib-bigint/test.ml
@@ -377,7 +377,7 @@ let check_strings () =
       check ("invalid string rejected " ^ String.escaped string)
         (match Bigint.of_string string with
          | _ -> false
-         | exception Invalid_argument _ -> true))
+         | exception Failure _ -> true))
     [ ""; "-"; "00"; "01"; "-0"; "-00"; "-01"; "+1"; " 1"; "1 "; "1x"; "--1"
     ; "1\000"; "\0001"; "1\n"; "\t1"; "1e5"; "0x1"; "1_000"; "- 1" ]
 

--- a/testsuite/tests/lib-bigint/test.ml
+++ b/testsuite/tests/lib-bigint/test.ml
@@ -7,7 +7,10 @@
    for values in range, and a naive decimal-string implementation for large
    values.  The naive implementation is written for obviousness, not speed:
    numbers are strings of decimal digits, and the algorithms are the
-   schoolbook ones, digit by digit. *)
+   schoolbook ones, digit by digit.
+
+   The suite assumes a 63-bit [int] (the first check enforces it): the
+   boundary constants below bake in the 31-bit limb width. *)
 
 let checks = ref 0
 
@@ -19,7 +22,8 @@ let check description condition =
 
 module Oracle = struct
   (* A number is a sign and a string of decimal digits without leading
-     zeroes; magnitude "0" always has sign 1. *)
+     zeroes; magnitude "0" always has sign 1.  Inputs are assumed
+     well-formed: this oracle parses nothing and validates nothing. *)
   type t = { negative : bool; digits : string }
 
   let of_string string =
@@ -35,6 +39,12 @@ module Oracle = struct
 
   let digit string index = Char.code string.[index] - Char.code '0'
 
+  (* The digit at [index] counted from the right, or 0 past the end. *)
+  let digit_from_right string index =
+    if index < String.length string
+    then digit string (String.length string - 1 - index)
+    else 0
+
   let strip_leading_zeroes string =
     let length = String.length string in
     let first = ref 0 in
@@ -49,16 +59,10 @@ module Oracle = struct
   (* Schoolbook addition, right to left with a carry. *)
   let add_digits left right =
     let width = 1 + max (String.length left) (String.length right) in
-    let at string index =
-      (* index counted from the right *)
-      if index < String.length string
-      then digit string (String.length string - 1 - index)
-      else 0
-    in
     let result = Bytes.make width '0' in
     let carry = ref 0 in
     for index = 0 to width - 1 do
-      let sum = at left index + at right index + !carry in
+      let sum = digit_from_right left index + digit_from_right right index + !carry in
       Bytes.set result (width - 1 - index) (Char.chr (Char.code '0' + sum mod 10));
       carry := sum / 10
     done;
@@ -67,15 +71,12 @@ module Oracle = struct
   (* Schoolbook subtraction, [left] at least [right], with a borrow. *)
   let sub_digits left right =
     let width = String.length left in
-    let at string index =
-      if index < String.length string
-      then digit string (String.length string - 1 - index)
-      else 0
-    in
     let result = Bytes.make width '0' in
     let borrow = ref 0 in
     for index = 0 to width - 1 do
-      let difference = at left index - at right index - !borrow in
+      let difference =
+        digit_from_right left index - digit_from_right right index - !borrow
+      in
       let difference, next_borrow =
         if difference < 0 then difference + 10, 1 else difference, 0
       in
@@ -95,9 +96,7 @@ module Oracle = struct
         let result = Bytes.make width '0' in
         let carry = ref 0 in
         for index = 0 to String.length string - 1 do
-          let product =
-            (digit string (String.length string - 1 - index) * d) + !carry
-          in
+          let product = (digit_from_right string index * d) + !carry in
           Bytes.set result (width - 1 - index)
             (Char.chr (Char.code '0' + product mod 10));
           carry := product / 10
@@ -153,6 +152,8 @@ end
 
 (* ---- Deterministic pseudo-random decimal strings ---------------------- *)
 
+(* A tiny LCG: quality is irrelevant, determinism is the point (the
+   reference file records one fixed run). *)
 let random_state = ref 1_234_567
 
 let random bound =
@@ -175,8 +176,8 @@ let random_decimal max_digits =
 
 (* ---- Machine-int oracle for values in range --------------------------- *)
 
-(* Boundary values: around zero, around the limb boundaries for half-word
-   limbs of any plausible size, and around the int bounds. *)
+(* Boundary values: around zero, around the limb boundary, and around the
+   int bounds. *)
 let interesting_ints =
   let around pivot = [ pivot - 1; pivot; pivot + 1 ] in
   List.concat
@@ -199,10 +200,11 @@ let check_machine_int_oracle () =
     (fun a ->
       let big_a = Bigint.of_int a in
       check "of_int round-trip" (Bigint.to_int_opt big_a = Some a);
-      check "of_int/of_string agree"
-        (Bigint.equal big_a (Bigint.of_string (string_of_int a)));
+      check "of_int/of_string agree structurally"
+        (big_a = Bigint.of_string (string_of_int a));
       check "to_string agrees with string_of_int"
         (String.equal (Bigint.to_string big_a) (string_of_int a));
+      check "is_zero" (Bigint.is_zero big_a = (a = 0));
       if a <> min_int then begin
         check "neg" (Bigint.to_int_opt (Bigint.neg big_a) = Some (-a));
         check "abs" (Bigint.to_int_opt (Bigint.abs big_a) = Some (Stdlib.abs a))
@@ -229,7 +231,7 @@ let check_machine_int_oracle () =
 (* ---- Decimal oracle for large values ---------------------------------- *)
 
 let check_decimal_oracle () =
-  let agree description operation oracle_operation left right =
+  let agree name operation oracle_operation left right =
     let via_bigint =
       Bigint.to_string
         (operation (Bigint.of_string left) (Bigint.of_string right))
@@ -238,7 +240,7 @@ let check_decimal_oracle () =
       Oracle.to_string
         (oracle_operation (Oracle.of_string left) (Oracle.of_string right))
     in
-    check description (String.equal via_bigint via_oracle)
+    check (name ^ " " ^ left ^ " " ^ right) (String.equal via_bigint via_oracle)
   in
   for _ = 1 to 300 do
     let left = random_decimal 60 in
@@ -246,9 +248,14 @@ let check_decimal_oracle () =
     agree "oracle add" Bigint.add Oracle.add left right;
     agree "oracle sub" Bigint.sub Oracle.sub left right;
     agree "oracle mul" Bigint.mul Oracle.mul left right;
-    check "oracle compare"
+    check ("oracle compare " ^ left ^ " " ^ right)
       (Bigint.compare (Bigint.of_string left) (Bigint.of_string right)
-       = Oracle.compare (Oracle.of_string left) (Oracle.of_string right))
+       = Oracle.compare (Oracle.of_string left) (Oracle.of_string right));
+    check ("equal agrees with string equality " ^ left ^ " " ^ right)
+      (Bigint.equal (Bigint.of_string left) (Bigint.of_string right)
+       = String.equal left right);
+    check ("is_zero via string " ^ left)
+      (Bigint.is_zero (Bigint.of_string left) = String.equal left "0")
   done
 
 (* ---- Algebraic properties --------------------------------------------- *)
@@ -284,53 +291,58 @@ let check_canonicity () =
   check "abs of zero is canonical zero" (Bigint.abs Bigint.zero = Bigint.zero);
   check "of_int zero is canonical zero" (Bigint.of_int 0 = Bigint.zero);
   check "is_zero of computed zero" (Bigint.is_zero (Bigint.sub a a));
+  (* An add whose result magnitude shrinks from three limbs to one. *)
+  let big = Bigint.of_string "4611686018427387904" in      (* 2^62 *)
+  let almost = Bigint.of_string "-4611686018427387903" in  (* -(2^62 - 1) *)
+  check "add shrinks to canonical one" (Bigint.add big almost = Bigint.one);
   (* Equal values reached by different routes are structurally equal. *)
   for _ = 1 to 300 do
     let x = Bigint.of_string (random_decimal 40) in
     let y = Bigint.of_string (random_decimal 40) in
-    check "poly equality agrees with equal"
-      ((x = y) = Bigint.equal x y);
     check "add then sub is structurally the argument"
       (Bigint.sub (Bigint.add x y) y = x);
     check "different routes, same structure"
       (Bigint.add x y = Bigint.add y x)
   done
 
-(* ---- Ordering ---------------------------------------------------------- *)
+(* ---- Ordering, against the independent oracle -------------------------- *)
 
 let check_ordering () =
-  let bigints =
-    List.map Bigint.of_string
-      (List.sort_uniq Stdlib.compare
-         (List.init 60 (fun _ -> random_decimal 30)))
+  (* Structured values: zero, small, both sides of the limb boundary,
+     shared prefixes, the machine-int bounds and one past them. *)
+  let values =
+    [ "0"; "1"; "-1"; "2"; "-2"
+    ; "2147483647"; "2147483648"; "2147483649"
+    ; "-2147483647"; "-2147483648"; "-2147483649"
+    ; "12345"; "123456"; "-12345"; "-123456"
+    ; "4611686018427387903"; "-4611686018427387904"
+    ; "4611686018427387904"; "-4611686018427387905"
+    ; "99999999999999999999999999999999999999"
+    ]
   in
   List.iter
-    (fun x ->
+    (fun left ->
       List.iter
-        (fun y ->
-          let order = Bigint.compare x y in
-          check "compare consistent with equal"
-            ((order = 0) = Bigint.equal x y);
-          check "compare antisymmetric" (Bigint.compare y x = -order);
-          check "lt" (Bigint.lt x y = (order < 0));
-          check "le" (Bigint.le x y = (order <= 0));
-          check "gt" (Bigint.gt x y = (order > 0));
-          check "ge" (Bigint.ge x y = (order >= 0)))
-        bigints)
-    bigints;
-  (* Transitivity on a small subset of triples. *)
-  let subset = List.filteri (fun index _ -> index < 12) bigints in
-  List.iter
-    (fun x ->
-      List.iter
-        (fun y ->
-          List.iter
-            (fun z ->
-              if Bigint.le x y && Bigint.le y z
-              then check "le transitive" (Bigint.le x z))
-            subset)
-        subset)
-    subset
+        (fun right ->
+          let x = Bigint.of_string left and y = Bigint.of_string right in
+          let order =
+            Oracle.compare (Oracle.of_string left) (Oracle.of_string right)
+          in
+          let name property = property ^ " " ^ left ^ " " ^ right in
+          check (name "compare") (Bigint.compare x y = order);
+          check (name "equal") (Bigint.equal x y = (order = 0));
+          check (name "lt") (Bigint.lt x y = (order < 0));
+          check (name "le") (Bigint.le x y = (order <= 0));
+          check (name "gt") (Bigint.gt x y = (order > 0));
+          check (name "ge") (Bigint.ge x y = (order >= 0)))
+        values)
+    values;
+  (* The .mli warns that polymorphic ordering is not mathematical order;
+     pin the documented disagreement (limbs [1; 1] vs [0; 2]). *)
+  let small = Bigint.of_string "2147483649" in
+  let large = Bigint.of_string "4294967296" in
+  check "poly compare disagrees with mathematical order"
+    (Stdlib.compare small large > 0 && Bigint.lt small large)
 
 (* ---- Strings ----------------------------------------------------------- *)
 
@@ -341,27 +353,33 @@ let check_strings () =
     ; "4611686018427387903"; "4611686018427387904"
     ; "-4611686018427387904"
     ; "9223372036854775807"; "-9223372036854775808"
+    ; "1000000000"; "1000000000000000000"
     ; "123456789012345678901234567890"
     ; "-999999999999999999999999999999999999"
     ]
   in
   List.iter
     (fun string ->
-      check "round-trip"
+      check ("round-trip " ^ string)
         (String.equal (Bigint.to_string (Bigint.of_string string)) string))
     round_trips;
   for _ = 1 to 300 do
     let string = random_decimal 200 in
-    check "random round-trip"
+    check ("random round-trip " ^ string)
       (String.equal (Bigint.to_string (Bigint.of_string string)) string)
   done;
+  (* Arbitrary precision means arbitrary: one deep value. *)
+  let nines = String.make 5_000 '9' in
+  check "long round-trip"
+    (String.equal (Bigint.to_string (Bigint.of_string nines)) nines);
   List.iter
     (fun string ->
-      check "invalid string rejected"
+      check ("invalid string rejected " ^ String.escaped string)
         (match Bigint.of_string string with
          | _ -> false
          | exception Invalid_argument _ -> true))
-    [ ""; "-"; "00"; "01"; "-0"; "-00"; "-01"; "+1"; " 1"; "1 "; "1x"; "--1" ]
+    [ ""; "-"; "00"; "01"; "-0"; "-00"; "-01"; "+1"; " 1"; "1 "; "1x"; "--1"
+    ; "1\000"; "\0001"; "1\n"; "\t1"; "1e5"; "0x1"; "1_000"; "- 1" ]
 
 (* ---- Machine bounds ---------------------------------------------------- *)
 
@@ -373,11 +391,27 @@ let check_int_bounds () =
     (Bigint.to_int_opt (Bigint.add (Bigint.of_int max_int) Bigint.one) = None);
   check "one past min_int"
     (Bigint.to_int_opt (Bigint.sub (Bigint.of_int min_int) Bigint.one) = None);
+  check "one past max_int via mul"
+    (Bigint.to_int_opt
+       (Bigint.mul (Bigint.of_int (1 lsl 31)) (Bigint.of_int (1 lsl 31)))
+     = None);
+  (* abs and neg leave the machine range at min_int. *)
+  let min_int_magnitude =
+    let s = string_of_int min_int in
+    String.sub s 1 (String.length s - 1)
+  in
+  check "abs of min_int"
+    (String.equal
+       (Bigint.to_string (Bigint.abs (Bigint.of_int min_int)))
+       min_int_magnitude);
+  check "neg of min_int is out of range"
+    (Bigint.to_int_opt (Bigint.neg (Bigint.of_int min_int)) = None);
   check "far out of range"
     (Bigint.to_int_opt (Bigint.of_string "123456789012345678901234567890")
      = None)
 
 let () =
+  check "the suite assumes a 63-bit int" (Sys.int_size = 63);
   check_machine_int_oracle ();
   check_decimal_oracle ();
   check_algebraic_properties ();
@@ -385,4 +419,5 @@ let () =
   check_ordering ();
   check_strings ();
   check_int_bounds ();
-  Printf.printf "Bigint: %d checks passed\n" !checks
+  if !checks < 1_000 then failwith "Bigint: suspiciously few checks ran";
+  print_string "Bigint: all checks passed\n"

--- a/testsuite/tests/lib-bigint/test.reference
+++ b/testsuite/tests/lib-bigint/test.reference
@@ -1,1 +1,1 @@
-Bigint: 28802 checks passed
+Bigint: all checks passed

--- a/testsuite/tests/lib-bigint/test.reference
+++ b/testsuite/tests/lib-bigint/test.reference
@@ -1,0 +1,1 @@
+Bigint: 28802 checks passed

--- a/testsuite/tests/typedtree/module_presence.ml
+++ b/testsuite/tests/typedtree/module_presence.ml
@@ -8,7 +8,7 @@ module X = struct end
 [
   structure_item
     Tstr_module (Present)
-    X/326
+    X/327
       module_expr
         Tmod_structure
         []
@@ -22,7 +22,7 @@ module X = struct end [@foo]
 [
   structure_item
     Tstr_module (Present)
-    X/327
+    X/328
       module_expr
         attribute "foo"
           []
@@ -38,9 +38,9 @@ module Y = X
 [
   structure_item
     Tstr_module (Absent)
-    Y/328
+    Y/329
       module_expr
-        Tmod_ident "X/327"
+        Tmod_ident "X/328"
 ]
 
 module Y = X
@@ -50,15 +50,15 @@ module type T = sig module Y = X end
 [%%expect{|
 [
   structure_item
-    Tstr_modtype "T/330"
+    Tstr_modtype "T/331"
       module_type
         Tmty_signature
         [
           signature_item
             Tsig_module (Absent)
-            Y/329
+            Y/330
               module_type
-                Tmty_alias "X/327"
+                Tmty_alias "X/328"
         ]
         join_const(unique,uncontended,read_write,static);meet_const(local,once,nonportable,unforkable,yielding,stateful)
         []

--- a/testsuite/tests/typing-layouts-or-null/non_float_array.ml
+++ b/testsuite/tests/typing-layouts-or-null/non_float_array.ml
@@ -57,7 +57,7 @@ end = struct
 end
 
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "X/403"
+(apply (field_imm 1 (global Toploop!)) "X/404"
   (let
     (x1 =[value<(consts ()) (non_consts ([0: *, value<int>]))>]
        [0: "first" 1]
@@ -80,7 +80,7 @@ let () =
 
 [%%expect{|
 (let
-  (X =? (apply (field_imm 0 (global Toploop!)) "X/403")
+  (X =? (apply (field_imm 0 (global Toploop!)) "X/404")
    *match* =[value<int>]
      (let (xs =[value<addrarray>] (caml_array_make 4 (field_imm 0 X)))
        (seq (array.set[addr indexed by int] xs 1 (field_imm 1 X))

--- a/testsuite/tests/typing-modes/yielding_lambda.ml
+++ b/testsuite/tests/typing-modes/yielding_lambda.ml
@@ -13,7 +13,7 @@ end
 let[@inline never] yield (_ : Yielding.t @ yielding) = ()
 let[@inline never] add x y = x + y
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Yielding/332"
+(apply (field_imm 1 (global Toploop!)) "Yielding/333"
   (let (with_ = (function {nlocal = 0} f never_inline (apply[yielding] f 0)))
     (makeblock 0 with_)))
 module Yielding : sig type t val with_ : (t @ yielding -> 'r) -> 'r end
@@ -41,7 +41,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -59,7 +59,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -76,7 +76,7 @@ let () = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -93,7 +93,7 @@ let (_ : int) = Yielding.with_ (fun y ->
 (let
   (add =? (apply (field_imm 0 (global Toploop!)) "add")
    yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (seq (apply add 2 2) (apply[yielding] yield y) (applynontail add 4 4)))))
@@ -119,7 +119,7 @@ end = struct
   ;;
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "List/438"
+(apply (field_imm 1 (global Toploop!)) "List/439"
   (letrec
     (map
        (function {nlocal = 2} f[L]
@@ -183,8 +183,8 @@ let f (l : int list) =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   List =? (apply (field_imm 0 (global Toploop!)) "List/438")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   List =? (apply (field_imm 0 (global Toploop!)) "List/439")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    f =
      (function {nlocal = 0}
        l[value<
@@ -227,8 +227,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   List =? (apply (field_imm 0 (global Toploop!)) "List/438")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   List =? (apply (field_imm 0 (global Toploop!)) "List/439")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -483,7 +483,7 @@ let (_ : int) =
   end
 ;;
 [%%expect{|
-(let (Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
+(let (Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (let
@@ -530,7 +530,7 @@ let (_ : int) =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int
       (let
@@ -573,7 +573,7 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -608,17 +608,17 @@ module F (X : sig val n : int end) = struct let m = X.n + 1 end
 module N = struct let n = 41 end
 module R = F(N)
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "F/857"
+(apply (field_imm 1 (global Toploop!)) "F/858"
   (function {nlocal = 0} X is_a_functor never_loop
     (let (m =[value<int>] (%int_add (field_imm 0 X) 1)) (makeblock 0 m))))
 module F : functor (X : sig val n : int end) -> sig val m : int end
-(apply (field_imm 1 (global Toploop!)) "N/862"
+(apply (field_imm 1 (global Toploop!)) "N/863"
   (let (n =[value<int>] 41) (makeblock 0 n)))
 module N : sig val n : int end
 (let
-  (N =? (apply (field_imm 0 (global Toploop!)) "N/862")
-   F =? (apply (field_imm 0 (global Toploop!)) "F/857"))
-  (apply (field_imm 1 (global Toploop!)) "R/864" (apply F N)))
+  (N =? (apply (field_imm 0 (global Toploop!)) "N/863")
+   F =? (apply (field_imm 0 (global Toploop!)) "F/858"))
+  (apply (field_imm 1 (global Toploop!)) "R/865" (apply F N)))
 module R : sig val m : int end
 |}]
 
@@ -629,7 +629,7 @@ module Yf (X : sig val f : unit -> unit end @ yielding) = struct
   let g () = X.f ()
 end
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Yf/870"
+(apply (field_imm 1 (global Toploop!)) "Yf/871"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -647,8 +647,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/870")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/871")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -674,13 +674,13 @@ let h () =
   let module R = Yf (M) in
   R.g ()
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "M/883"
+(apply (field_imm 1 (global Toploop!)) "M/884"
   (let (f = (function {nlocal = 0} param[value<int>] : int 0))
     (makeblock 0 f)))
 module M : sig val f : unit -> unit end
 (let
-  (M =? (apply (field_imm 0 (global Toploop!)) "M/883")
-   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/870")
+  (M =? (apply (field_imm 0 (global Toploop!)) "M/884")
+   Yf =? (apply (field_imm 0 (global Toploop!)) "Yf/871")
    h =
      (function {nlocal = 0} param[value<int>] : int
        (let (R = (apply Yf M)) (apply[yielding] (field_imm 0 R) 0))))
@@ -697,7 +697,7 @@ let () =
     let module R = Uf (struct let f () = yield y end) in
     R.g ())
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Uf/894"
+(apply (field_imm 1 (global Toploop!)) "Uf/895"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -736,8 +736,8 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   M =? (apply (field_imm 0 (global Toploop!)) "M/883")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   M =? (apply (field_imm 0 (global Toploop!)) "M/884")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -767,7 +767,7 @@ let () =
 [%%expect{|
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -877,15 +877,15 @@ class d = object inherit c as super method n = super#m end
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!)) (opaque [0: #"m"])
            c_init))))
-  (apply (field_imm 1 (global Toploop!)) "c/956" c))
+  (apply (field_imm 1 (global Toploop!)) "c/957" c))
 class c : object method m : int end
 (let
-  (c =? (apply (field_imm 0 (global Toploop!)) "c/956")
+  (c =? (apply (field_imm 0 (global Toploop!)) "c/957")
    mk = (function {nlocal = 0} param[value<int>] (apply (field_mut 0 c) 0)))
   (apply (field_imm 1 (global Toploop!)) "mk" mk))
 val mk : unit -> c = <fun>
 (let
-  (c =? (apply (field_imm 0 (global Toploop!)) "c/956")
+  (c =? (apply (field_imm 0 (global Toploop!)) "c/957")
    shared =a (opaque [0: #"m"])
    shared =a (opaque [0: #"n" #"m"])
    d =?
@@ -921,7 +921,7 @@ val mk : unit -> c = <fun>
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!))
            (opaque [0: #"m" #"n"]) d_init))))
-  (apply (field_imm 1 (global Toploop!)) "d/984" d))
+  (apply (field_imm 1 (global Toploop!)) "d/985" d))
 class d : object method m : int method n : int end
 |}]
 
@@ -975,12 +975,12 @@ end
 [%%expect{|
 0
 module type S = sig type t val x : t end
-(apply (field_imm 1 (global Toploop!)) "F/1032"
+(apply (field_imm 1 (global Toploop!)) "F/1033"
   (function {nlocal = 0} M is_a_functor never_loop
     (let (y = (field_imm 0 M)) (makeblock 0 y))))
 module F : functor (M : S) -> sig val y : M.t end
-(let (F =? (apply (field_imm 0 (global Toploop!)) "F/1032"))
-  (apply (field_imm 1 (global Toploop!)) "M/1040"
+(let (F =? (apply (field_imm 0 (global Toploop!)) "F/1033"))
+  (apply (field_imm 1 (global Toploop!)) "M/1041"
     (let (x =[value<int>] 42 include = (apply F (makeblock 0 x)))
       (makeblock 0 x (field_imm 0 include)))))
 module M : sig type t = int val x : int val y : int end
@@ -1000,7 +1000,7 @@ let () =
     end in
     M.g ())
 [%%expect{|
-(apply (field_imm 1 (global Toploop!)) "Gf/1047"
+(apply (field_imm 1 (global Toploop!)) "Gf/1048"
   (function {nlocal = 0} X is_a_functor never_loop
     (let
       (g =
@@ -1012,8 +1012,8 @@ module Gf :
     sig val g : unit -> unit end @ yielding
 (let
   (yield =? (apply (field_imm 0 (global Toploop!)) "yield")
-   Gf =? (apply (field_imm 0 (global Toploop!)) "Gf/1047")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332")
+   Gf =? (apply (field_imm 0 (global Toploop!)) "Gf/1048")
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333")
    *match* =[value<int>]
      (apply (field_imm 0 Yielding)
        (function {nlocal = 0} y : int
@@ -1084,7 +1084,7 @@ let (_ : int) = Yielding.with_ (fun y -> o#uses y)
 [%%expect{|
 (let
   (o =? (apply (field_imm 0 (global Toploop!)) "o")
-   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/332"))
+   Yielding =? (apply (field_imm 0 (global Toploop!)) "Yielding/333"))
   (apply (field_imm 0 Yielding)
     (function {nlocal = 0} y : int (send[yielding] o -844262836 y))))
 - : int = 0
@@ -1124,6 +1124,6 @@ end
                       class)))))))
        (opaque
          (apply (field_imm 18 (global CamlinternalOO!)) shared c2_init))))
-  (apply (field_imm 1 (global Toploop!)) "c2/1096" c2))
+  (apply (field_imm 1 (global Toploop!)) "c2/1097" c2))
 class c2 : object method call_m : int method m : int -> int end
 |}]


### PR DESCRIPTION
`Bigint`: arbitrary-precision signed integers in `stdlib`, the surface type for
the unbounded `Int` sort in specifications.

This is a real implementation rather than a type-checker-only symbol, because
specifications should be runnable — the runtime-checking work later needs to
evaluate a predicate, not just translate it.

```ocaml
type t : immutable_data
```

The representation is canonical, so polymorphic equality agrees with
`Bigint.equal` and `Hashtbl.hash` is consistent with it. Polymorphic *ordering*
does not, since it compares the representation; `compare` implements the
mathematical order.

The API is what specifications need: `zero`, `one`, `of_int`, `is_zero`,
`equal`, `compare`, `lt`/`le`/`gt`/`ge`, `neg`, `abs`, `add`, `sub`, `mul`, plus
`to_int_opt`, `to_string` and `of_string` for the runtime boundary.
`of_string` raises `Failure` on malformed input, matching the rest of the
stdlib.

The absences are deliberate and documented at the top of the `.mli`: no division
or modulo, which introduce partiality on a zero divisor and nonlinear reasoning,
and no exponentiation. Adding a convenient function later is an easy way to
start writing unprovable specifications without noticing, so the constraint
belongs in the interface rather than in a commit message.

Tests: `testsuite/tests/lib-bigint/test.ml`, checked against an oracle across
add/sub/mul/compare and the string round trip, including sign and carry
boundary cases.

---

Part of stack #6796, which merges bottom-up from `main`. #6787 and #6788 touch no
compiler internals and are the natural first merges.
