### PR TITLE
Stack 4/6: refinement type formers

### DIFF
--- a/chamelon/compat/compat.ox.ml
+++ b/chamelon/compat/compat.ox.ml
@@ -49,7 +49,7 @@ let mkTvar name = Tvar { name; jkind = dummy_jkind }
 
 let mkTarrow (label, t1, t2, comm) =
   let label = Typetexp.transl_label label None in
-  Tarrow ((label, Alloc.legacy, Alloc.legacy), t1, t2, comm)
+  Tarrow ((label, None, Alloc.legacy, Alloc.legacy), t1, t2, comm)
 
 type texp_ident_identifier = ident_kind * unique_use
 

--- a/chamelon/lib/minimizer/dummy.ml
+++ b/chamelon/lib/minimizer/dummy.ml
@@ -66,7 +66,7 @@ let unit_typ =
 let default_mode = Typemode.transl_alloc_mode []
 
 let a_to_unit =
-  { ctyp_desc = Ttyp_arrow (Nolabel, a_typ, default_mode, unit_typ, default_mode);
+  { ctyp_desc = Ttyp_arrow (Nolabel, None, a_typ, default_mode, unit_typ, default_mode);
     ctyp_type =
       Btype.newty2 ~level:0
         (mkTarrow (Nolabel, a_typ.ctyp_type, unit_typ.ctyp_type, commu_ok));
@@ -76,7 +76,7 @@ let a_to_unit =
   }
 
 let unit_to_a =
-  { ctyp_desc = Ttyp_arrow (Nolabel, unit_typ, default_mode, a_typ, default_mode);
+  { ctyp_desc = Ttyp_arrow (Nolabel, None, unit_typ, default_mode, a_typ, default_mode);
     ctyp_type =
       Btype.newty2 ~level:0
         (mkTarrow (Nolabel, unit_typ.ctyp_type, a_typ.ctyp_type, commu_ok));

--- a/design-docs/type-formers-final.md
+++ b/design-docs/type-formers-final.md
@@ -1,0 +1,80 @@
+# Type formers: final report
+
+Status: implemented, review-looped twice, green on the full test suite.
+Branch `jujacobs/vox/type-formers`, three commits, 69 files, +2799/-168.
+
+## What landed
+
+- `24bc7ffacc` — the feature. `Ptyp_refine` and `arrow_arg_name`
+  (`Pan_nolabel`/`Pan_name`/`Pan_tilde`/`Pan_optional`) in the parsetree;
+  `Trefine` plus the resolved total-subset predicate mirror in `Types`;
+  the binder ident in `arrow_desc`; the occurrence test in
+  `parsing/vox_binding.ml`; predicate operations in `typing/vox_rexp.ml`;
+  rigid `unify`/`eqtype`/`moregen` with alpha-equivalence via a
+  `univar_pairs`-style binder stack; `Subst` freshening; printing via
+  `Otyp_refine` + `Pprintast`, with `~`-escape decided on the converted
+  output; warning 230 for mixed arrows; expect tests, a `.cmi` round-trip
+  test, and an empty-`{}` RED fixture.
+- `41d8b7a761` — first review round fixes. First-class value-path
+  substitution in `Subst`/`Env` (same-signature references survive `.cmi`
+  import); predicates print from substituted paths; partial application
+  keeps the binder; string constants compare without their locations;
+  predicate-local binders scope into interior types; quotations get a
+  located error; `nondep_type` refuses to erase predicate-mentioned
+  modules; typed outcometree constructors (`Binder`/`Tilde_labelled`);
+  `Ttyp_refine` carries the source predicate; printer binder renaming
+  deleted.
+- `449fa54bf6` — verification round. Constructor paths are resolved,
+  substituted and printed (a functor application prints `AC.C`, not a
+  dangling `X.C`), and consuming a dependent parameter — applying it, or
+  defining a `fun` against a dependent annotation — is rejected with a
+  located error instead of letting the type escape its binder.
+
+## Review loop
+
+Two codex and two claude reviewers, each in its own worktree under
+`type-formers/review/<name>/` (codex reports at
+`type-formers/review/*/report.md`), followed by a codex verification pass
+over the fix round, which reproduced and confirmed every fix and found no
+regression in the new `Subst.values` map, the outcometree constructors,
+the omitted-binder threading, or the renaming removal.
+`make dev-test-all`: 2445 passed / 0 failed, after both rounds.
+
+## Decisions to check (AGENTS.md: notify on ambiguous-spec choices)
+
+All are recorded with rationale in `design-docs/type-formers.md`; these
+are the ones worth a human look:
+
+1. **The hole is not a name**: `int{ _ > 0 }` ≠ `n:int{ n > 0 }` —
+   strict syntactic alpha-equivalence, no hole/name normalization.
+2. **`Trefine` carries no name**; the value's name always lives on the
+   arrow (`arrow_desc` binder; `~x:` is a domain-only binder). The
+   spec's "the refined type carries the value's name" is realized this
+   way to make "binds once" structural.
+3. **Dependent-arrow consumption is rejected** until the elimination
+   piece: the verification round argued the binder escape violated the
+   printing contract, and the rejection replaced a pinned-escape
+   behaviour.
+4. Smaller: `~x:` scopes over the whole argument type; class arrows and
+   tuple labels never bind; record labels in predicates stay longidents
+   (the compiler has no label-path representation); `ref`/`!`/`:=` are
+   rejected by bare name only.
+
+## Caveats and follow-ups
+
+- Dev-loop friction worth fixing separately: `dev-runtime` does not
+  refresh `runtime_stdlib_install` when the compiler itself changes, so
+  a `Types` layout change (no `.cmi` magic bump yet, per spec) silently
+  corrupts imports — symptom is segfaults, cure is `make runtime-stdlib`.
+- `ocamlc.byte`-style tests (including `vox/roundtrip` and
+  `vox/empty-predicate` here) cannot run under the dev harness (runtime
+  magic mismatch, preexisting); they were verified manually with the dev
+  compiler and will run in full CI.
+- During the first round the headless claude reviewers ran read-only
+  (the session's permission mode refused `claude -p` with shell access),
+  so their findings were file:line-grounded while codex did the executed
+  repros; a scoped permission rule (`Bash(claude -p --allowedTools:*)`)
+  has since been added for future loops.
+- Deferred by the spec and untouched: introduction/elimination rules,
+  signature matching beyond identity, subtyping/coercion, VC generation,
+  solvers, `.cmi` magic bump, extension gating, vendored merlin.

--- a/design-docs/type-formers.md
+++ b/design-docs/type-formers.md
@@ -268,12 +268,13 @@ which route was taken and why, and what was considered.
   (`Types.refinement_expression`) resolves value names — bound names to
   idents, free names to paths via `Env.lookup_value` — but carries no
   types except those written in the source (`Rexp_constraint`).
-  Constructor and record-label names are checked for existence at
-  translation and stored as longidents; resolving them to descriptions
-  would drag `constructor_description`s (and their types) into the type
-  graph, and no rule consumes them yet. Consequence to revisit in a later
-  piece: a module renaming via `Subst` rewrites value paths but not
-  constructor names.
+  Constructors resolve to paths too (`Pextra_ty (type_path, Pcstr_ty
+  name)`, or the constructor's own path for extension constructors), which
+  `Subst.type_path` rewrites, so functor application and signature
+  prefixing keep them meaningful. Record labels have no path
+  representation in the compiler; field names are checked for existence
+  and stay longidents — a known gap should a predicate project a field of
+  a functor-parameter record.
 - **The predicate sublanguage, concretely.** Idents, constants,
   application, labeled tuples, constructors, record field access,
   `if`/`then`/`else`, single non-recursive `let x = e in e`, `fun x -> e`,
@@ -296,19 +297,16 @@ which route was taken and why, and what was considered.
   conversion time and printed by `Pprintast`. Interior types are rendered
   through the type printer and re-parsed with `Parse.core_type`, so paths
   and nested refinements print consistently with the enclosing output.
-  The label slot of `Otyp_arrow` is the printed name slot verbatim
-  (`Labelled "x"` for a binder, `Labelled "~x"` for an escaped label);
-  outcometree consumers that pattern-match labels see strings, which is
-  what they print. The alternative — new outcometree label constructors —
-  touches every outcometree consumer for the same output.
+  The name slot of `Otyp_arrow` is typed: `Binder` and `Tilde_labelled`
+  are outcometree `arg_label` constructors (initially this was a string
+  convention inside `Labelled`; the first review round pointed out that
+  the honest representation costs three small consumers).
 - **When `~` is printed.** Only when needed: a label prints bare unless
-  its name occurs in a refinement predicate in scope (its own binder, an
-  outer binder with the same printed name, or a free identifier printed as
-  that bare name), in which case re-parsing would turn it into a binder
-  and the printer escapes it. This can over-escape in corner cases (an
-  occurrence bound by a deeper arrow); the output still re-parses to the
-  same type. Positional binders are renamed (`x` → `x1`) when they collide
-  with an enclosing binder still in scope.
+  re-parsing the converted output would turn it into a binder
+  (`out_label_needs_escape`, which runs the occurrence test's scoping
+  rules on the artifact that is actually printed). Binder names print as
+  written; the printer does not rename binders — see the review-round
+  decisions below.
 - **Unification and the binder.** The binder ident is not part of type
   identity. `unify`, `eqtype` and `moregen` pair the two binders on a
   stack (mirroring `univar_pairs`) and compare predicates
@@ -377,10 +375,13 @@ Decisions and accepted costs recorded here:
   string conventions inside `Labelled`.
 - **Dependent arrows survive partial application**: the omitted-parameter
   record carries the binder and every arrow reconstruction in `Typecore`
-  preserves it. Whether *applying* a dependent arrow should be allowed at
-  all is an elimination-rule question for a later piece; today the domain
-  type escapes its binder and the escaped occurrence prints under the
-  binder's name (pinned by a test).
+  preserves it. *Consuming* a dependent parameter — applying it to an
+  argument, or defining a `fun` against a dependent annotation
+  (`Ctype.filter_arrow`) — is rejected with a located error
+  (`Unsupported_dependent_arrow`): it would let the domain or codomain
+  escape the binder's scope, producing types that print as unparseable
+  source. The elimination and introduction rules of a later piece will
+  replace the rejection.
 - **Predicate-local binders scope into interior types** (and therefore
   into refinements nested in them), matching the occurrence test.
 - **Refinements in quotations are a located error**, not a fatal error:

--- a/design-docs/type-formers.md
+++ b/design-docs/type-formers.md
@@ -310,13 +310,16 @@ which route was taken and why, and what was considered.
   same type. Positional binders are renamed (`x` → `x1`) when they collide
   with an enclosing binder still in scope.
 - **Unification and the binder.** The binder ident is not part of type
-  identity. `unify`/`eqtype` pair the two binders on a stack (mirroring
-  `univar_pairs`) and compare predicates alpha-equivalently
-  (`Vox_rexp.equal`); a one-sided binder is ignored at the arrow and can
-  only be followed by a predicate mismatch at the refinements themselves.
-  `moregen`, `mcomp` beyond payload compatibility, and `subtype` have no
-  refinement rules — signature matching and coercions are later pieces —
-  so they fall into their generic mismatch cases.
+  identity. `unify`, `eqtype` and `moregen` pair the two binders on a
+  stack (mirroring `univar_pairs`) and compare predicates
+  alpha-equivalently (`Vox_rexp.equal`); a one-sided binder is ignored at
+  the arrow and can only be followed by a predicate mismatch at the
+  refinements themselves. `moregen` has the *identity* arm only — a
+  toplevel `let` of a refined-function type includes its own signature —
+  with no weakening; `mcomp` beyond payload compatibility and `subtype`
+  have no refinement rules, so they fall into their generic mismatch
+  cases. Signature matching beyond identity and coercions are later
+  pieces.
 - **Class types.** Refinements are permitted in every `core_type`,
   including class arrow domains, but class arrows keep today's label
   grammar and never bind: a name used in a refinement there is simply
@@ -343,3 +346,55 @@ which route was taken and why, and what was considered.
   written name from the printed form or thread arrow context into
   predicate comparison; both cost more than the distinction is worth while
   refinements are inert. Revisit if it bites once refinements are used.
+
+
+## Decisions from the first review round
+
+Four reviewers (two claude, two codex) reviewed commit `24bc7ffacc`; the
+verified defects they found are fixed and their repros pinned as tests.
+Decisions and accepted costs recorded here:
+
+- **Value paths are substituted first-class.** `Subst` gained a `values`
+  map (`add_value`), used by signature prefixing (`Env.prefix_idents`) and
+  binder renaming (`rename_bound_idents`), because a predicate referencing
+  a value of its own signature must be re-prefixed on `.cmi` import, and
+  `value_path` alone is a no-op on `Pident`. Printing renders free idents
+  from the (substituted) path through the printer's path machinery, not
+  from the stored source longident — the longident is kept only as
+  documentation of what was written.
+- **`Ttyp_refine` carries the source predicate expression** (precedent:
+  `Parsetree.jkind_annotation` in the typedtree). `Untypeast` returns it
+  verbatim, and only `Out_type` reconstructs surface syntax from the
+  resolved predicate. The interior-type render-and-reparse remains in
+  `Out_type` only.
+- **The printer does not rename binders.** Binder names print as written
+  (`Ident.name`); the only capture-avoidance mechanism is `~`-escaping of
+  labels, decided on the converted output. Renaming was reachable only
+  from graphs no source can produce, and it could itself capture a free
+  identifier of the chosen name.
+- **The outcometree name slot is typed**: `Binder of string` and
+  `Tilde_labelled of string` are outcometree `arg_label` constructors, not
+  string conventions inside `Labelled`.
+- **Dependent arrows survive partial application**: the omitted-parameter
+  record carries the binder and every arrow reconstruction in `Typecore`
+  preserves it. Whether *applying* a dependent arrow should be allowed at
+  all is an elimination-rule question for a later piece; today the domain
+  type escapes its binder and the escaped occurrence prints under the
+  binder's name (pinned by a test).
+- **Predicate-local binders scope into interior types** (and therefore
+  into refinements nested in them), matching the occurrence test.
+- **Refinements in quotations are a located error**, not a fatal error:
+  they are reachable from valid source. Neighbouring unimplemented
+  quotation forms keep their fatal errors; that is the quotation
+  feature's own convention.
+- **`nondep_type` refuses to erase a module mentioned by a predicate**
+  (`Nondep_cannot_erase`), like packages do.
+- **Known accepted costs** (measured against the spec's "simplest" bar,
+  kept deliberately): the occurrence test walks the arrow's syntax once
+  per bare name (types are small; a one-pass free-name-set computation is
+  the alternative if this ever shows up in profiles); the printer's escape
+  check walks the converted output per plain-labelled arrow; `ref`, `!`
+  and `:=` are rejected by bare name only, so qualified or rebound
+  spellings pass name resolution — the predicate sublanguage is
+  *syntactically* total, and real totality checking is a later piece's
+  job.

--- a/design-docs/type-formers.md
+++ b/design-docs/type-formers.md
@@ -1,0 +1,345 @@
+# Vox type formers
+
+We add one type former and one binding rule:
+
+    t{ predicate }       -- refinement of t; the value is _
+    x:t -> b             -- x names the value and scopes over b
+
+Examples:
+
+    int{ _ >= 0 }                                  -- the hole _ is the int itself
+    x:int{ x > 0 } -> int{ _ >= x }                -- x scopes over the codomain
+    unit{ invariant tree = true }                  -- a proposition; no name needed
+    val sub : s:string -> int{ _ < length s } -> char
+
+Refinements are `Trefine` nodes in the type graph, not side tables. The refined
+type carries the value's name, its payload type t, and the predicate expression
+p. The predicate has the same shape as an ordinary OxCaml expression
+(Typedtree), except it is a second version of the type of expressions for inside
+the type language, plus it only allows the subset of expressions that are total
+(e.g. tuples yes, ref no, let yes, while no).
+
+The dependent function type is not a new type former. Instead we add an optional
+binder to the existing function type. We use the same ident-based binding
+mechanism as `Tpoly`, NOT De Bruijn or locally nameless.
+
+## Labels and binders
+
+OCaml has exactly one name-before-type slot in the type grammar (`arg_label ::=
+optlabel | LIDENT COLON | empty`) and labels own it. There is no lighter free
+spelling for a binder — the alternatives are heavier (parens) or misleading — so
+we share the slot, and decide by use:
+
+For `x:T -> b`:
+
+- `x` is a **positional binder** iff `x` occurs free in a refinement in `T` or
+  in `b`. The argument is then not labelled and the call site is unchanged:
+  `f v`. The binder scopes over `T`'s own refinement and over `b`.
+- Otherwise `x:T` is an ordinary labelled argument, exactly as today.
+- `~x:T` is always a label, whatever occurs anywhere. This spelling is new
+  (TILDE does not appear in the type grammar today, only in patterns and
+  expressions) and matches how labels are written in terms and at call sites.
+- `_` denotes the value of the refinement it appears in, and is always
+  available.
+
+All four combinations are spellable, and the choice of spelling is the signal:
+
+    int{ _ > 0 }       -- positional, hole
+    n:int{ n > 0 }     -- positional, named
+    x:int{ _ > 0 }     -- labelled, hole
+    ~x:int{ x > 0 }    -- labelled, named
+
+Using the name is what makes it a binder. That is what keeps a name available
+whenever one reads better than the hole — `m:matrix{ rows m = cols m }` rather
+than `matrix{ rows _ = cols _ }` — without a carve-out for the argument's own
+refinement.
+
+Backward compatibility follows: existing code contains no refinements, so no
+name can occur in one, so every existing `x:T` stays a label. `~x:T` did not
+parse before, so no existing code uses it.
+
+The intended end state is the uniform rule *bare `x:` binds, `~x:` labels*. The
+third bullet is a compatibility shim for the existing tree; new code can write
+`~x:` for labels from the start and converge on it.
+
+Consequences to accept:
+
+- A single arrow can mix conventions: in `x:int -> y:int -> int{ _ >= x }`, `x`
+  is positional and `y` is labelled, and reading the convention requires
+  scanning the whole type. Warn when one arrow ends up mixed.
+- Retrofitting a spec onto an existing labelled function turns it positional as
+  soon as the spec uses the name — including in the argument's own refinement —
+  so this fires readily when specifying labelled APIs. The fix is one edit at
+  the definition (`~x:`, or use `_`), and the breakage is a compile error at the
+  call sites, not silent. Writing `~x:` on labelled APIs from the start avoids
+  it entirely.
+- Optional and position parameters never bind: the argument may be absent, so
+  "the value of this parameter" is not defined. `?x:T` is always a label, and
+  its refinement uses `_`.
+- Binders under `Tpoly` are allowed. Open question to settle during
+  implementation: whether the value binder scopes inside or outside the type
+  quantifier, and whether `Tpoly`'s alpha-renaming freshens the value binder as
+  well as the type variables. `Subst` will freshen two kinds of binder in one
+  node and the order matters for capture.
+
+The occurrence test decides a label, which is part of the type, so it runs
+before name resolution: a syntactic free-occurrence check over the parsetree of
+`T` and `b`, respecting binders introduced inside predicates (a predicate's own
+`let`, `match` cases, nested arrows). This is the only genuinely novel logic in
+the piece and the label/binder rule inherits any edge case it has, so implement
+and test it first rather than last.
+
+## Scope of this piece
+
+No typing rules. Refinements are parsed, translated, printed and carried through
+the type graph, and are otherwise inert: nothing is checked, nothing is stripped,
+no verification condition is generated, no solver is involved.
+
+A refined type is rigid and behaves like any other type. There is no
+introduction rule and no elimination rule yet, so this piece can declare and
+print refined types but cannot apply or consume a value of one:
+`let f (x : int{ _ > 0 }) = x + 1` does not typecheck, and neither does `f 5`.
+That is expected here; the rules land in a later piece. Fixtures must therefore
+declare, annotate and print rather than use.
+
+## Positions
+
+A refinement is a type former: permitted in every `core_type` position, with no
+exceptions. Restrictions that do not fall out of the semantics are not worth
+their cost — they have to be specified, implemented, tested and explained, and
+each one is a guess that gets baked in.
+
+Type-declaration right-hand sides are included deliberately. `type wf = tree{ inv _ }`
+is the main thing standing between the precondition/postcondition shape and
+unreadable signatures, since most preconditions are named predicates.
+
+## Equality and unification
+
+- Refinements are rigid: never inferred, never solved for.
+- `int{p}` and `int` do not unify. One-sided refinement is a clash.
+- Two refined types are equal iff payloads are equal and predicates are
+  syntactically alpha-equivalent — no normalization, no entailment, no solver.
+- A predicate's interior types are updated by substitution like any other type.
+  `Subst` freshens binder stamps on import; `Btype` does not.
+- Type variables inside a predicate are live in the generic type-graph
+  traversal: `Btype`'s fold and map descend into the predicate, so levels,
+  generalization and the occur check reach them. They behave as they would
+  anywhere else in the type.
+
+## Erasure
+
+The payload determines layout, jkind and runtime representation. Refinements
+never reach lambda. Use "payload" consistently, in prose and in the field name.
+
+## Syntax
+
+- `t{p}` binds at atomic_type precedence, so `int{ _ > 0 } list` is
+  `(int{ _ > 0 }) list`.
+- `int {p}` and `int{p}` are the same; no whitespace sensitivity.
+- The predicate sublanguage is a fixed closed subset enforced by construction in
+  the Types mirror, not by a check on an unrestricted AST.
+- Non-total forms (while, ref, assignment, sequencing) are rejected at
+  translation with a form-specific message, not a generic parse error.
+- Surface parsetree gains real `Ptyp_` constructors. No extension-node encoding.
+
+## Printing
+
+- The printed form is canonical source and round-trips.
+- A binder is printed only when it is mentioned; otherwise `t{p}` with `_`.
+- Printing must reproduce the label/binder distinction it read, including `~x:`.
+- Error messages show the refinement, not the bare payload.
+
+## How complete to be
+
+Split by whether an arm encodes a decision.
+
+Structural arms have one sensible implementation — descend into payload, view
+type, and the predicate's interior types. There is no decision to defer and they
+run on every path, including printing and error reporting. Write them:
+
+- parser, parsetree, `ast_helper`/`ast_mapper`/`ast_iterator`
+- `typetexp` translation, including the occurrence test
+- `Btype` fold/map/iter
+- `Subst` — runs as soon as a refinement appears in a signature, which the
+  round-trip test requires
+- `out_type`/`oprint`/`outcometree`, `printtyped`, `untypeast`, `pprintast`
+- `Ctype`: structural equality, the rigid clash, `expand_head` → `Cannot_expand`
+- `cmi_format`
+
+Relational arms encode rules a later piece owns. Leaving them unimplemented is
+the specification: subtyping, seal-context matching, expected-type weakening,
+coercion, unification arms beyond the rigid clash.
+
+Two kinds of unimplemented, and the difference matters:
+
+- Unreachable from well-formed source in this piece → `Misc.fatal_error`.
+- Reachable from valid source but unspecified → a real located error. A crash on
+  valid input is a bug even in a work-in-progress piece.
+
+Because refinements are allowed in every position, more arms are reachable than
+you might expect. Classify each `Trefine` arm deliberately rather than reaching
+for `assert false`.
+
+## Tests
+
+`vox/type-formers.ml` expect tests. Round-trip printing is necessary but weak —
+it can pass while the type is semantically wrong — so also:
+
+- the four spellings, each checked for both the refinement and the calling
+  convention: `int{ _ > 0 }`, `n:int{ n > 0 }`, `x:int{ _ > 0 }`,
+  `~x:int{ x > 0 }`
+- a name occurring only in a *later* refinement (`x:int -> int{ _ >= x }`) binds
+- `x:int{ x > 0 } -> int{ _ >= x }` binds once, not twice
+- a mixed arrow, checking the warning fires
+- occurrence-test edge cases: a name shadowed by a predicate's own `let` or
+  `match` binder, and a name occurring only inside a nested arrow's refinement
+- `?x:int{ _ > 0 }` stays a label and does not bind
+- alpha-equivalence: differently-named binders compare and print as expected
+- `.cmi` round-trip: write a refined signature, read it back, print it. The
+  cheapest guard on the representation, and where a `Subst` or `Btype` gap shows
+  up first.
+- rejection cases as RED fixtures: unbound name in a predicate, `while` in a
+  predicate, empty `{}`
+- printing in error messages, not only at the toplevel
+- refinements across positions — a record field, a constructor argument, a type
+  declaration right-hand side — each with a `.cmi` round-trip
+- a recursive type declaration whose predicate mentions the type being defined,
+  to pin whatever the occur check does
+
+## Deferred to later pieces
+
+Introduction and elimination rules, including whether a refined type is usable
+where its payload is expected; module sealing and signature matching;
+verification condition generation; solver interfaces; naming the result of an
+arrow (`_` suffices for now, and `-> z:t{p}` is free syntax if it is ever
+wanted); rollout concerns (extension gating, `.cmi` magic bump, the vendored
+merlin copy, keeping refinement-free printing byte-identical).
+
+## Decisions taken
+
+Recorded per AGENTS.md: where the design had a real fork, which route and why.
+
+- **Sharing the label slot** rather than adding a parenthesised binder form.
+  `(x : t)` was the alternative. It never changes a calling convention, but it
+  puts parens on every argument a postcondition mentions, which in the
+  precondition/postcondition shape is most of them. Sharing the slot keeps the
+  common case light; the cost is mixed conventions within an arrow and the
+  retrofit edit, both listed above.
+- **`~x:` for explicit labels** rather than `(x:t)`. `~` is the label marker
+  everywhere else in the language, whereas `(x : t)` in terms is a *positional*
+  parameter, so parens-means-label would invert the existing intuition. `~x:`
+  also gives a convergence path to a uniform rule.
+- **Keeping `_`** rather than requiring a name everywhere. `unit{p}` is a
+  proposition whose value is irrelevant, and naming it is pure noise.
+- **The occurrence test covers the argument's own refinement**, not only the
+  rest of the arrow. Excluding it would have made `n:int{ n > 0 }` a labelled
+  argument, so a positional argument could only be refined through `_` — forcing
+  the hole exactly where a name reads better. The cost is that the convention
+  flips more readily on retrofit, mitigated by `~x:`.
+
+## Decisions taken during implementation
+
+Recorded per AGENTS.md: points where this document was ambiguous or silent,
+which route was taken and why, and what was considered.
+
+- **Where the value's name lives.** The document says the refined type
+  carries the value's name. In the implementation `Trefine` carries only
+  payload and predicate; the hole `_` is its own predicate form
+  (`Rexp_hole`, meaning "the value of the innermost enclosing refinement"),
+  and every *name* for the value is an arrow binder: `arrow_desc` carries
+  an `Ident.t option` which for `x:T -> U` scopes over the predicates of
+  both sides and for `~x:T -> U` scopes over the predicates of `T` only.
+  This is what makes `x:int{ x > 0 } -> int{ _ >= x }` bind once — there is
+  no second, per-refinement binder to alpha-rename or to capture. The
+  alternative (a binder ident on every `Trefine`, holes as references to
+  it) needs freshening and pairing machinery on every refinement for no
+  observable difference. The binder is `Some` only when some predicate
+  mentions it.
+- **Scope of `~x:`.** Fixed to: all refinement predicates within the
+  argument's type, not just its top-level refinement, and never the
+  codomain. This is the domain-only restriction of the positional binder's
+  scope, so `~x:(int{ x > 0 } * int)` works and there is no special case
+  for "the argument's own refinement".
+- **Scope of a positional binder over its own domain.** The document says
+  the binder scopes over "T's own refinement and over b" while the
+  occurrence test looks at refinements anywhere in `T`; the implementation
+  scopes the binder over all of `T` and `b`, matching the test.
+- **Predicates are resolved, not typed.** The mirror
+  (`Types.refinement_expression`) resolves value names — bound names to
+  idents, free names to paths via `Env.lookup_value` — but carries no
+  types except those written in the source (`Rexp_constraint`).
+  Constructor and record-label names are checked for existence at
+  translation and stored as longidents; resolving them to descriptions
+  would drag `constructor_description`s (and their types) into the type
+  graph, and no rule consumes them yet. Consequence to revisit in a later
+  piece: a module renaming via `Subst` rewrites value paths but not
+  constructor names.
+- **The predicate sublanguage, concretely.** Idents, constants,
+  application, labeled tuples, constructors, record field access,
+  `if`/`then`/`else`, single non-recursive `let x = e in e`, `fun x -> e`,
+  `match` with variable/wildcard/constant/tuple/constructor/alias
+  patterns, and type constraints. Non-total forms (`while`, `for`,
+  sequencing, assignment, arrays, `try`, `assert`, `lazy`, `ref`/`!`/`:=`
+  as bare identifiers) are rejected with the totality message; total but
+  unsupported forms (records, or-patterns, recursive or multiple `let`,
+  coercions, objects, …) get a located "not supported" error, so nothing
+  reachable from source crashes.
+- **Binders under `Tpoly`** (open question in the document): the value
+  binder scopes inside the type quantifier — the binder is introduced at
+  the arrow, which sits under the `Tpoly` node, and predicates are
+  translated in the same pass, so `'a. x:'a t{ p x } -> …` just works.
+  `Tpoly` alpha-renaming does not freshen value binders; `Subst` freshens
+  all predicate binder stamps (and rewrites references) whenever a type is
+  copied, which covers import. `Btype`'s generic copies keep stamps.
+- **Printing pipeline.** `Otyp_refine of out_type * Parsetree.expression`:
+  the predicate is untyped back to surface syntax (`Vox_rexp.untype`) at
+  conversion time and printed by `Pprintast`. Interior types are rendered
+  through the type printer and re-parsed with `Parse.core_type`, so paths
+  and nested refinements print consistently with the enclosing output.
+  The label slot of `Otyp_arrow` is the printed name slot verbatim
+  (`Labelled "x"` for a binder, `Labelled "~x"` for an escaped label);
+  outcometree consumers that pattern-match labels see strings, which is
+  what they print. The alternative — new outcometree label constructors —
+  touches every outcometree consumer for the same output.
+- **When `~` is printed.** Only when needed: a label prints bare unless
+  its name occurs in a refinement predicate in scope (its own binder, an
+  outer binder with the same printed name, or a free identifier printed as
+  that bare name), in which case re-parsing would turn it into a binder
+  and the printer escapes it. This can over-escape in corner cases (an
+  occurrence bound by a deeper arrow); the output still re-parses to the
+  same type. Positional binders are renamed (`x` → `x1`) when they collide
+  with an enclosing binder still in scope.
+- **Unification and the binder.** The binder ident is not part of type
+  identity. `unify`/`eqtype` pair the two binders on a stack (mirroring
+  `univar_pairs`) and compare predicates alpha-equivalently
+  (`Vox_rexp.equal`); a one-sided binder is ignored at the arrow and can
+  only be followed by a predicate mismatch at the refinements themselves.
+  `moregen`, `mcomp` beyond payload compatibility, and `subtype` have no
+  refinement rules — signature matching and coercions are later pieces —
+  so they fall into their generic mismatch cases.
+- **Class types.** Refinements are permitted in every `core_type`,
+  including class arrow domains, but class arrows keep today's label
+  grammar and never bind: a name used in a refinement there is simply
+  unbound (ordinary error). Class types are legacy; extending the binder
+  rule to them buys nothing today.
+- **Labeled tuples.** Tuple labels (`x:int * y:bool`) are not subject to
+  the binder rule; a tuple component's label never binds in refinements.
+  The document only gives the rule for arrows.
+- **The mixed-arrow warning** is number 230, `vox-mixed-arrow-conventions`,
+  and fires once per arrow chain (the maximal spine translated together),
+  when the chain contains both a positional binder and a bare-spelled
+  label. `~`-spelled and optional labels don't count against mixing: they
+  are self-describing.
+- **`varify_constructors`** (the `let f : 'a. …` path) does not descend
+  into predicates; type variables in predicate interior types are not
+  varified. Interior types are otherwise fully live in the graph (levels,
+  generalization, occur check) through `Btype.fold_type_expr`.
+- **The hole is not a name.** `int{ _ > 0 }` and `n:int{ n > 0 }` are
+  different types: `Rexp_hole` and a binder reference are syntactically
+  different predicates, and equality is syntactic alpha-equivalence with no
+  normalization. The alternatives — normalizing a binder's occurrences in
+  its own domain refinement to holes, or a context-dependent equality that
+  identifies the hole with the enclosing arrow's binder — either erase the
+  written name from the printed form or thread arrow context into
+  predicate comparison; both cost more than the distinction is worth while
+  refinements are inert. Revisit if it bites once refinements are used.

--- a/dune
+++ b/dune
@@ -185,6 +185,7 @@
   ast_helper
   camlinternalMenhirLib
   ast_iterator
+  vox_binding
   parser
   lexer
   parse
@@ -248,6 +249,7 @@
   shape_reduce
   zero_alloc
   types
+  vox_rexp
   btype
   oprint
   subst

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -290,7 +290,7 @@ let iter_on_occurrences
       | Ttyp_unboxed_tuple _
       | Ttyp_quote _ | Ttyp_splice _ | Ttyp_of_kind _
       | Ttyp_alias _ | Ttyp_variant _ | Ttyp_poly _ | Ttyp_call_pos
-      | Ttyp_repr _ | Ttyp_newlayout _ -> ());
+      | Ttyp_repr _ | Ttyp_newlayout _ | Ttyp_refine _ -> ());
       default_iterator.typ sub ct);
 
   pat =

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2701,9 +2701,10 @@ let type_for_annotation ~env ~loc typ =
               tpt_txt = mkloc (Untypeast.lident_of_path pack_path) loc
             }
         | Trefine _ ->
-          fatal_errorf
-            "Translquote [at %a]: no support for refinement types"
-            Location.print_loc_in_lowercase loc
+          (* Reachable from valid source; quotation of refinements is not
+             yet specified. *)
+          Location.raise_errorf ~loc
+            "Refinement types are not yet supported in quotations"
         | Tlink _ | Tsubst _ | Tfield _ | Tnil ->
           fatal_errorf
             "Translquote [at %a]:@ Unexpected type expression@ in a quoted \
@@ -3025,7 +3026,10 @@ and quote_core_type ~scopes ty =
   | Ttyp_quote ty -> Type.quote loc (quote_core_type ~scopes ty) |> Type.wrap
   | Ttyp_splice _ -> Type.var loc None |> Type.wrap
   | Ttyp_refine _ ->
-    fatal_error "Translquote: Ttyp_refine not implemented."
+    (* Reachable from valid source; quotation of refinements is not yet
+       specified. *)
+    Location.raise_errorf ~loc:ty.ctyp_loc
+      "Refinement types are not yet supported in quotations"
   | Ttyp_repr _ -> fatal_error "Translquote: Ttyp_repr not implemented."
   | Ttyp_newlayout _ ->
     fatal_error "Translquote: Ttyp_newlayout not implemented."

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2623,9 +2623,10 @@ let type_for_annotation ~env ~loc typ =
         | Tunivar _ ->
           let name, jkind_annotation = unwrap_univar ty |> Option.get in
           Ttyp_var (Some name, jkind_annotation)
-        | Tarrow ((arg_label, _, _), ty, ty', _) ->
+        | Tarrow ((arg_label, binder, _, _), ty, ty', _) ->
           Ttyp_arrow
             ( arg_label,
+              binder,
               go ty,
               Typemode.transl_alloc_mode [],
               go ty',
@@ -2699,6 +2700,10 @@ let type_for_annotation ~env ~loc typ =
               tpt_type = Mty_ident pack_path;
               tpt_txt = mkloc (Untypeast.lident_of_path pack_path) loc
             }
+        | Trefine _ ->
+          fatal_errorf
+            "Translquote [at %a]: no support for refinement types"
+            Location.print_loc_in_lowercase loc
         | Tlink _ | Tsubst _ | Tfield _ | Tnil ->
           fatal_errorf
             "Translquote [at %a]:@ Unexpected type expression@ in a quoted \
@@ -2884,7 +2889,7 @@ and quote_core_type ~scopes ty =
         var
     in
     Type.var loc (Some var) |> Type.wrap
-  | Ttyp_arrow (arg_lab, ty1, ms1, ty2, ms2) ->
+  | Ttyp_arrow (arg_lab, _binder, ty1, ms1, ty2, ms2) ->
     let lab = quote_arg_label loc arg_lab
     and ty1 = quote_core_type ~scopes ty1
     and ms1 = quote_modes loc ms1
@@ -3019,6 +3024,8 @@ and quote_core_type ~scopes ty =
     Type.package loc mod_type with_types |> Type.wrap
   | Ttyp_quote ty -> Type.quote loc (quote_core_type ~scopes ty) |> Type.wrap
   | Ttyp_splice _ -> Type.var loc None |> Type.wrap
+  | Ttyp_refine _ ->
+    fatal_error "Translquote: Ttyp_refine not implemented."
   | Ttyp_repr _ -> fatal_error "Translquote: Ttyp_repr not implemented."
   | Ttyp_newlayout _ ->
     fatal_error "Translquote: Ttyp_newlayout not implemented."
@@ -3408,6 +3415,7 @@ and quote_expression_extra ~env ~scopes _stage extra lambda =
             { ctyp_desc =
                 Ttyp_arrow
                   ( arg_lbl,
+                    None,
                     (match sch with
                     | Some sch ->
                       type_for_annotation ~env ~loc:(to_location loc) sch

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -513,7 +513,8 @@ let remove_option typ =
     | Tvariant _
     | Tpackage _
     | Tof_kind _
-    | Tbox _ -> t
+    | Tbox _
+    | Trefine _ -> t
     | Tlink t2 -> trim (get_desc t2)
     | Tsubst _ -> assert false
   in

--- a/ocamldoc/odoc_str.ml
+++ b/ocamldoc/odoc_str.ml
@@ -47,7 +47,7 @@ let rec is_arrow_type t =
   | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ | Types.Tbox _
   | Types.Trepr _
   | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _
-  | Types.Tof_kind _ -> false
+  | Types.Tof_kind _ | Types.Trefine _ -> false
   | Types.Tsubst _ -> assert false
 
 
@@ -61,7 +61,7 @@ let rec need_parent t =
   | Types.Tquote _ | Types.Tsplice _ | Types.Tquote_eval _ | Types.Trepr _
   | Types.Tbox _
   | Types.Tfield _ | Types.Tnil | Types.Tvariant _ | Types.Tpackage _
-  | Types.Tof_kind _ -> false
+  | Types.Tof_kind _ | Types.Trefine _ -> false
   | Types.Tsubst _ -> assert false
 
 let print_type_scheme ppf t =

--- a/ocamldoc/odoc_value.ml
+++ b/ocamldoc/odoc_value.ml
@@ -63,7 +63,7 @@ let update_value_parameters_text v =
 let parameter_list_from_arrows typ =
   let rec iter t =
     match Types.get_desc t with
-      Types.Tarrow ((l,_,_), t1, t2, _) ->
+      Types.Tarrow ((l,_,_,_), t1, t2, _) ->
         (l, t1) :: (iter t2)
     | Types.Tlink texp
     | Types.Tpoly (texp, _) | Types.Trepr (texp, _) -> iter texp
@@ -82,7 +82,8 @@ let parameter_list_from_arrows typ =
     | Types.Tpackage _
     | Types.Tvariant _
     | Types.Tof_kind _
-    | Types.Tbox _ ->
+    | Types.Tbox _
+    | Types.Trefine _ ->
         []
     | Types.Tsubst _ ->
         assert false

--- a/otherlibs/dynlink/dune
+++ b/otherlibs/dynlink/dune
@@ -100,6 +100,7 @@
   docstrings
   lexer
   camlinternalMenhirLib
+  parse
   parser_types
   parser
   printast
@@ -136,6 +137,8 @@
   ldd
   axis_lattice
   value_rec_types
+  vox_binding
+  vox_rexp
   btype
   lazy_backtrack
   hash_consed
@@ -338,6 +341,9 @@
 
 (copy_files ../../typing/mode.ml)
 
+(copy_files ../../parsing/parse.ml)
+(copy_files ../../parsing/vox_binding.ml)
+(copy_files ../../typing/vox_rexp.ml)
 (copy_files ../../typing/btype.ml)
 
 (copy_files ../../typing/typemode.ml)
@@ -541,6 +547,9 @@
 
 (copy_files ../../typing/mode.mli)
 
+(copy_files ../../parsing/parse.mli)
+(copy_files ../../parsing/vox_binding.mli)
+(copy_files ../../typing/vox_rexp.mli)
 (copy_files ../../typing/btype.mli)
 
 (copy_files ../../typing/typemode.mli)
@@ -736,6 +745,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Diffing_with_keys.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Ast_helper.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Ast_iterator.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Vox_binding.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Builtin_attributes.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Pprintast.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Load_path.cmo
@@ -758,6 +768,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Scalar.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Primitive.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Oprint.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Vox_rexp.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Btype.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Typemode.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Predef.cmo
@@ -772,6 +783,7 @@
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__CamlinternalMenhirLib.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Parser_types.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Parser.cmo
+  .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Parse.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Persistent_env.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Type_shape.cmo
   .dynlink_compilerlibs.objs/byte/dynlink_compilerlibs__Env.cmo
@@ -871,6 +883,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Syntaxerr.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Ast_helper.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Ast_iterator.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Vox_binding.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Builtin_attributes.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Pprintast.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Load_path.cmx
@@ -893,6 +906,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Scalar.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Primitive.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Oprint.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Vox_rexp.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Btype.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Typemode.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Predef.cmx
@@ -907,6 +921,7 @@
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__CamlinternalMenhirLib.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Parser_types.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Parser.cmx
+  .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Parse.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Persistent_env.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Type_shape.cmx
   .dynlink_compilerlibs.objs/native/dynlink_compilerlibs__Env.cmx

--- a/parsing/ast_helper.ml
+++ b/parsing/ast_helper.ml
@@ -83,6 +83,7 @@ module Typ = struct
   let quote ?loc ?attrs t = mk ?loc ?attrs (Ptyp_quote t)
   let splice ?loc ?attrs t = mk ?loc ?attrs (Ptyp_splice t)
   let repr ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_repr (a, b))
+  let refine ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_refine (a, b))
   let newlayout ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_newlayout (a, b))
   let of_kind ?loc ?attrs a = mk ?loc ?attrs (Ptyp_of_kind a)
 
@@ -153,6 +154,11 @@ module Typ = struct
             Ptyp_repr (var_lst, loop core_type)
         | Ptyp_newlayout (var_lst, core_type) ->
             Ptyp_newlayout (var_lst, loop core_type)
+        | Ptyp_refine (core_type, predicate) ->
+            (* The predicate is untouched: refinements are rigid and the
+               types appearing inside predicates are not subject to
+               varification. *)
+            Ptyp_refine (loop core_type, predicate)
         | Ptyp_extension (s, arg) ->
             Ptyp_extension (s, arg)
       in

--- a/parsing/ast_helper.mli
+++ b/parsing/ast_helper.mli
@@ -73,8 +73,8 @@ module Typ :
     val any: ?loc:loc -> ?attrs:attrs -> jkind_annotation option -> core_type
     val var: ?loc:loc -> ?attrs:attrs -> string -> jkind_annotation option
       -> core_type
-    val arrow: ?loc:loc -> ?attrs:attrs -> arg_label -> core_type -> core_type ->
-      mode with_loc list -> mode with_loc list -> core_type
+    val arrow: ?loc:loc -> ?attrs:attrs -> arrow_arg_name -> core_type
+      -> core_type -> mode with_loc list -> mode with_loc list -> core_type
     val tuple: ?loc:loc -> ?attrs:attrs -> (string option * core_type) list
                -> core_type
     val unboxed_tuple: ?loc:loc -> ?attrs:attrs
@@ -96,6 +96,7 @@ module Typ :
     val splice : ?loc:loc -> ?attrs:attrs -> core_type -> core_type
     val of_kind : ?loc:loc -> ?attrs:attrs -> jkind_annotation -> core_type
     val repr: ?loc:loc -> ?attrs:attrs -> str list -> core_type -> core_type
+    val refine: ?loc:loc -> ?attrs:attrs -> core_type -> expression -> core_type
     val newlayout:
       ?loc:loc -> ?attrs:attrs -> str list -> core_type -> core_type
     val extension: ?loc:loc -> ?attrs:attrs -> extension -> core_type

--- a/parsing/ast_iterator.ml
+++ b/parsing/ast_iterator.ml
@@ -144,7 +144,11 @@ module T = struct
     match desc with
     | Ptyp_any jkind
     | Ptyp_var (_, jkind) -> Option.iter (sub.jkind_annotation sub) jkind
-    | Ptyp_arrow (_lab, t1, t2, m1, m2) ->
+    | Ptyp_arrow (lab, t1, t2, m1, m2) ->
+        (match lab with
+         | Pan_nolabel -> ()
+         | Pan_name name | Pan_tilde name | Pan_optional name ->
+             iter_loc sub name);
         sub.typ sub t1; sub.typ sub t2;
         sub.modes sub m1; sub.modes sub m2
     | Ptyp_tuple tyl -> List.iter (fun (_, e) -> sub.typ sub e) tyl
@@ -174,6 +178,7 @@ module T = struct
         sub.jkind_annotation sub jkind
     | Ptyp_repr (_, t) -> sub.typ sub t
     | Ptyp_newlayout (_, t) -> sub.typ sub t
+    | Ptyp_refine (t, predicate) -> sub.typ sub t; sub.expr sub predicate
     | Ptyp_extension x -> sub.extension sub x
 
   let iter_type_declaration sub

--- a/parsing/ast_mapper.ml
+++ b/parsing/ast_mapper.ml
@@ -183,6 +183,13 @@ module T = struct
         let jkind = map_opt (sub.jkind_annotation sub) jkind in
         var ~loc ~attrs s jkind
     | Ptyp_arrow (lab, t1, t2, m1, m2) ->
+        let lab =
+          match lab with
+          | Pan_nolabel -> Pan_nolabel
+          | Pan_name name -> Pan_name (map_loc sub name)
+          | Pan_tilde name -> Pan_tilde (map_loc sub name)
+          | Pan_optional name -> Pan_optional (map_loc sub name)
+        in
         arrow ~loc ~attrs lab (sub.typ sub t1) (sub.typ sub t2) (sub.modes sub m1) (sub.modes sub m2)
     | Ptyp_tuple tyl ->
         tuple ~loc ~attrs (List.map (fun (l, t) -> l, sub.typ sub t) tyl)
@@ -224,6 +231,8 @@ module T = struct
         repr ~loc ~attrs (List.map (map_loc sub) lvars) (sub.typ sub t)
     | Ptyp_newlayout (lvars, t) ->
         newlayout ~loc ~attrs (List.map (map_loc sub) lvars) (sub.typ sub t)
+    | Ptyp_refine (t, predicate) ->
+        refine ~loc ~attrs (sub.typ sub t) (sub.expr sub predicate)
     | Ptyp_extension x -> extension ~loc ~attrs (sub.extension sub x)
 
   let map_type_declaration sub

--- a/parsing/depend.ml
+++ b/parsing/depend.ml
@@ -93,6 +93,11 @@ let handle_extension ext =
   | _ ->
     ()
 
+(* Forward declaration: refinement predicates [T{P}] are expressions, and
+   [add_type] is defined before [add_expr]. *)
+let add_expr_fwd : (bound_map -> Parsetree.expression -> unit) ref =
+  ref (fun _ _ -> assert false)
+
 let rec add_type bv ty =
   match ty.ptyp_desc with
     Ptyp_any jkind
@@ -128,6 +133,7 @@ let rec add_type bv ty =
   | Ptyp_of_kind jkind -> add_jkind bv jkind
   | Ptyp_repr(_, t) -> add_type bv t
   | Ptyp_newlayout(_, t) -> add_type bv t
+  | Ptyp_refine(t, p) -> add_type bv t; !add_expr_fwd bv p
   | Ptyp_extension e -> handle_extension e
 
 and add_package_type bv ptyp =
@@ -765,3 +771,5 @@ and add_class_field bv pcf =
 
 and add_class_declaration bv decl =
   add_class_expr bv decl.pci_expr
+
+let () = add_expr_fwd := add_expr

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4655,7 +4655,7 @@ function_type:
 
 strict_function_or_labeled_tuple_type:
   | mktyp(
-      label = arg_label
+      label = arrow_arg_name
       domain_with_modes = with_optional_mode_expr(extra_rhs(param_type))
       MINUSGREATER
       codomain = strict_function_or_labeled_tuple_type
@@ -4664,7 +4664,7 @@ strict_function_or_labeled_tuple_type:
     )
     { $1 }
   | mktyp(
-      label = arg_label
+      label = arrow_arg_name
       domain_with_modes = with_optional_mode_expr(extra_rhs(param_type))
       MINUSGREATER
       codomain_with_modes = with_optional_mode_expr(tuple_type)
@@ -4689,21 +4689,21 @@ strict_function_or_labeled_tuple_type:
      Apparently, this is sufficient for menhir to be able to delay a decision
      about which of the above module type cases we are in.  *)
   | mktyp(
-      label = LIDENT COLON
+      label = mkrhs(LIDENT) COLON
       tuple_with_modes = with_optional_mode_expr(proper_tuple_type)
       MINUSGREATER
       codomain = strict_function_or_labeled_tuple_type
          {
            let (tuple, tuple_loc), arg_modes = tuple_with_modes in
            let ty, ltys = tuple in
-           let label = Labelled label in
+           let label = Pan_name label in
            let domain = mktyp ~loc:tuple_loc (Ptyp_tuple ((None, ty) :: ltys)) in
            let domain = extra_rhs_core_type domain ~pos:(snd tuple_loc) in
            Ptyp_arrow(label, domain, codomain, arg_modes, []) }
     )
     { $1 }
   | mktyp(
-      label = LIDENT COLON
+      label = mkrhs(LIDENT) COLON
       tuple_with_modes = with_optional_mode_expr(proper_tuple_type)
       MINUSGREATER
       codomain_with_modes = with_optional_mode_expr(tuple_type)
@@ -4711,7 +4711,7 @@ strict_function_or_labeled_tuple_type:
          { let (tuple, tuple_loc), arg_modes = tuple_with_modes in
            let (codomain, codomain_loc), ret_modes = codomain_with_modes in
            let ty, ltys = tuple in
-           let label = Labelled label in
+           let label = Pan_name label in
            let domain = mktyp ~loc:tuple_loc (Ptyp_tuple ((None, ty) :: ltys)) in
            let domain = extra_rhs_core_type domain ~pos:(snd tuple_loc) in
            Ptyp_arrow(label,
@@ -4740,6 +4740,26 @@ strict_function_or_labeled_tuple_type:
       { $1 }
   | /* empty */
       { Nolabel }
+;
+
+(* The name slot of an arrow type.  A bare [x:] is a positional binder or a
+   label depending on whether [x] occurs in a refinement (decided during
+   translation); [~x:] is always a label; [?x:] is always an optional
+   label. *)
+%inline strict_arrow_arg_name:
+  | label = mkrhs(optlabel)
+      { Pan_optional label }
+  | label = mkrhs(LIDENT) COLON
+      { Pan_name label }
+  | label = mkrhs(LABEL)
+      { Pan_tilde label }
+;
+
+%inline arrow_arg_name:
+  | strict_arrow_arg_name
+      { $1 }
+  | /* empty */
+      { Pan_nolabel }
 ;
 /* Legacy mode annotations */
 %inline mode_legacy:
@@ -4981,6 +5001,10 @@ spliceable_type:
 atomic_type:
   | type_ = delimited_type
       { type_ }
+  | payload = atomic_type LBRACE predicate = seq_expr RBRACE
+      { mktyp ~loc:$sloc (Ptyp_refine (payload, predicate)) }
+  | atomic_type LBRACE seq_expr error
+      { unclosed "{" $loc($2) "}" $loc($4) }
   | mktyp( /* begin mktyp group */
       tys = actual_type_parameters
       tid = mkrhs(type_longident)

--- a/parsing/parser.mly
+++ b/parsing/parser.mly
@@ -4689,21 +4689,20 @@ strict_function_or_labeled_tuple_type:
      Apparently, this is sufficient for menhir to be able to delay a decision
      about which of the above module type cases we are in.  *)
   | mktyp(
-      label = mkrhs(LIDENT) COLON
+      label = arrow_tuple_domain_name
       tuple_with_modes = with_optional_mode_expr(proper_tuple_type)
       MINUSGREATER
       codomain = strict_function_or_labeled_tuple_type
          {
            let (tuple, tuple_loc), arg_modes = tuple_with_modes in
            let ty, ltys = tuple in
-           let label = Pan_name label in
            let domain = mktyp ~loc:tuple_loc (Ptyp_tuple ((None, ty) :: ltys)) in
            let domain = extra_rhs_core_type domain ~pos:(snd tuple_loc) in
            Ptyp_arrow(label, domain, codomain, arg_modes, []) }
     )
     { $1 }
   | mktyp(
-      label = mkrhs(LIDENT) COLON
+      label = arrow_tuple_domain_name
       tuple_with_modes = with_optional_mode_expr(proper_tuple_type)
       MINUSGREATER
       codomain_with_modes = with_optional_mode_expr(tuple_type)
@@ -4711,7 +4710,6 @@ strict_function_or_labeled_tuple_type:
          { let (tuple, tuple_loc), arg_modes = tuple_with_modes in
            let (codomain, codomain_loc), ret_modes = codomain_with_modes in
            let ty, ltys = tuple in
-           let label = Pan_name label in
            let domain = mktyp ~loc:tuple_loc (Ptyp_tuple ((None, ty) :: ltys)) in
            let domain = extra_rhs_core_type domain ~pos:(snd tuple_loc) in
            Ptyp_arrow(label,
@@ -4746,20 +4744,25 @@ strict_function_or_labeled_tuple_type:
    label depending on whether [x] occurs in a refinement (decided during
    translation); [~x:] is always a label; [?x:] is always an optional
    label. *)
-%inline strict_arrow_arg_name:
+%inline arrow_arg_name:
   | label = mkrhs(optlabel)
       { Pan_optional label }
   | label = mkrhs(LIDENT) COLON
       { Pan_name label }
   | label = mkrhs(LABEL)
       { Pan_tilde label }
-;
-
-%inline arrow_arg_name:
-  | strict_arrow_arg_name
-      { $1 }
   | /* empty */
       { Pan_nolabel }
+;
+
+(* The name slot of an arrow whose domain is an unparenthesised tuple
+   ([x:t1 * t2 -> u]); split out to keep the labeled-tuple disambiguation
+   rules above manageable. *)
+%inline arrow_tuple_domain_name:
+  | label = mkrhs(LIDENT) COLON
+      { Pan_name label }
+  | label = mkrhs(LABEL)
+      { Pan_tilde label }
 ;
 /* Legacy mode annotations */
 %inline mode_legacy:

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -115,14 +115,16 @@ and core_type_desc =
   | Ptyp_any of jkind_annotation option (** [_] or [_ : k] *)
   | Ptyp_var of string * jkind_annotation option
     (** A type variable such as ['a] or ['a : k] *)
-  | Ptyp_arrow of arg_label * core_type * core_type * modes * modes
-      (** [Ptyp_arrow(lbl, T1, T2, M1, M2)] represents:
-            - [T1 @ M1 -> T2 @ M2]    when [lbl] is
-                                     {{!arg_label.Nolabel}[Nolabel]},
-            - [~l:(T1 @ M1) -> (T2 @ M2)] when [lbl] is
-                                     {{!arg_label.Labelled}[Labelled]},
-            - [?l:(T1 @ M1) -> (T2 @ M2)] when [lbl] is
-                                     {{!arg_label.Optional}[Optional]}.
+  | Ptyp_arrow of arrow_arg_name * core_type * core_type * modes * modes
+      (** [Ptyp_arrow(arg, T1, T2, M1, M2)] represents:
+            - [T1 @ M1 -> T2 @ M2]    when [arg] is
+                                     {{!arrow_arg_name.Pan_nolabel}[Pan_nolabel]},
+            - [l:(T1 @ M1) -> (T2 @ M2)] when [arg] is
+                                     {{!arrow_arg_name.Pan_name}[Pan_name]},
+            - [~l:(T1 @ M1) -> (T2 @ M2)] when [arg] is
+                                     {{!arrow_arg_name.Pan_tilde}[Pan_tilde]},
+            - [?l:(T1 @ M1) -> (T2 @ M2)] when [arg] is
+                                     {{!arrow_arg_name.Pan_optional}[Pan_optional]}.
          *)
   | Ptyp_tuple of (string option * core_type) list
       (** [Ptyp_tuple(tl)] represents a product type:
@@ -224,7 +226,24 @@ and core_type_desc =
   | Ptyp_splice of core_type (** [$T] *)
   | Ptyp_of_kind of jkind_annotation (** [(type : k)] *)
   | Ptyp_repr of string loc list * core_type
+  | Ptyp_refine of core_type * expression
+      (** [T{ P }]: the refinement of the payload type [T] by the predicate
+          [P].  The predicate is an ordinary expression; the restriction to
+          total forms is enforced at translation, not here.  Within [P], the
+          hole [_] denotes the refined value. *)
   | Ptyp_extension of extension  (** [[%id]]. *)
+
+(** The name slot of an arrow type, [Ptyp_arrow].  A bare name [x:T -> U] is
+    a positional binder if [x] occurs free in a refinement predicate in [T]
+    or [U] (see {!Vox_binding.classify}), and the ordinary label [x]
+    otherwise.  [~x:T -> U] is always the label [x]; the spelling is new and
+    the tilde must be preserved for re-parsing.  [?x:T -> U] is always the
+    optional label [x] and never binds. *)
+and arrow_arg_name =
+  | Pan_nolabel  (** [T -> U] *)
+  | Pan_name of string loc  (** [x:T -> U]: binder or label by occurrence *)
+  | Pan_tilde of string loc  (** [~x:T -> U]: always the label [x] *)
+  | Pan_optional of string loc  (** [?x:T -> U] *)
 
 and arg_label = Asttypes.arg_label =
     Nolabel

--- a/parsing/parsetree.mli
+++ b/parsing/parsetree.mli
@@ -235,7 +235,7 @@ and core_type_desc =
 
 (** The name slot of an arrow type, [Ptyp_arrow].  A bare name [x:T -> U] is
     a positional binder if [x] occurs free in a refinement predicate in [T]
-    or [U] (see {!Vox_binding.classify}), and the ordinary label [x]
+    or [U] (see {!Vox_binding.name_used_in_refinement}), and the ordinary label [x]
     otherwise.  [~x:T -> U] is always the label [x]; the spelling is new and
     the tilde must be preserved for re-parsing.  [?x:T -> U] is always the
     optional label [x] and never binds. *)

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -489,6 +489,21 @@ and core_type1_with_optional_modes pty ctxt f (c, m) =
   | _ :: _ ->
     pp f "%a%a" (core_type1 ctxt) c optional_at_modes m
 
+and type_with_arrow_arg_name ctxt f (name, c, mode) =
+  match name with
+  | Pan_nolabel ->
+    core_type1_with_optional_modes core_type1 ctxt f (c, mode)
+    (* otherwise parenthesize *)
+  | Pan_name s ->
+    pp f "%a:%a" ident_of_name s.txt
+      (core_type1_with_optional_modes core_type1 ctxt) (c, mode)
+  | Pan_tilde s ->
+    pp f "~%a:%a" ident_of_name s.txt
+      (core_type1_with_optional_modes core_type1 ctxt) (c, mode)
+  | Pan_optional s ->
+    pp f "?%a:%a" ident_of_name s.txt
+      (core_type1_with_optional_modes core_type1 ctxt) (c, mode)
+
 and type_with_label ctxt f (label, c, mode) =
   match label with
   | Nolabel    ->
@@ -565,7 +580,7 @@ and core_type ctxt f x =
   else match x.ptyp_desc with
     | Ptyp_arrow (l, ct1, ct2, m1, m2) ->
         pp f "@[<2>%a@;->@;%a@]" (* FIXME remove parens later *)
-          (type_with_label ctxt) (l,ct1,m1) (return_type ctxt) (ct2,m2)
+          (type_with_arrow_arg_name ctxt) (l,ct1,m1) (return_type ctxt) (ct2,m2)
     | Ptyp_alias (ct, s, j) ->
         pp f "@[<2>%a@;as@;%a@]" (core_type1 ctxt) ct
           tyvar_loc_option_jkind (s, j)
@@ -685,6 +700,9 @@ and core_type1 ctxt f x =
         pp f "@[<hov2><[%a]>@]" (core_type ctxt) t
     | Ptyp_splice t ->
         pp f "@[<hov2>$(%a)@]" (core_type ctxt) t
+    | Ptyp_refine (payload, predicate) ->
+        pp f "@[<hov2>%a{ %a }@]" (core_type1 ctxt) payload
+          (expression reset_ctxt) predicate
     | Ptyp_extension e -> extension ctxt f e
     | (Ptyp_arrow _ | Ptyp_alias _ | Ptyp_poly _ | Ptyp_repr _
       | Ptyp_newlayout _ | Ptyp_of_kind _) ->
@@ -1235,6 +1253,7 @@ and simple_expr ctxt f x =
                (list (expression (under_semi ctxt)) ~sep:";@;") xs
          | `simple x -> constr f x
          | _ -> assert false)
+    | Pexp_hole -> pp f "_"
     | Pexp_ident li ->
         value_longident_loc f li
     (* (match view_fixity_of_exp x with *)

--- a/parsing/printast.ml
+++ b/parsing/printast.ml
@@ -147,6 +147,12 @@ let arg_label i ppf = function
   | Optional s -> line i ppf "Optional \"%s\"\n" s
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
 
+let arrow_arg_name i ppf = function
+  | Pan_nolabel -> line i ppf "Pan_nolabel\n"
+  | Pan_name s -> line i ppf "Pan_name \"%s\"\n" s.txt
+  | Pan_tilde s -> line i ppf "Pan_tilde \"%s\"\n" s.txt
+  | Pan_optional s -> line i ppf "Pan_optional \"%s\"\n" s.txt
+
 let modality i ppf modality =
   line i ppf "modality %a\n" fmt_string_loc
     (Location.map (fun (Modality x) -> x) modality)
@@ -182,7 +188,7 @@ let rec core_type i ppf x =
       jkind_annotation_opt (i+1) ppf jkind
   | Ptyp_arrow (l, ct1, ct2, m1, m2) ->
       line i ppf "Ptyp_arrow\n";
-      arg_label i ppf l;
+      arrow_arg_name i ppf l;
       core_type i ppf ct1;
       modes i ppf m1;
       core_type i ppf ct2;
@@ -242,6 +248,10 @@ let rec core_type i ppf x =
       core_type i ppf t
   | Ptyp_of_kind jkind ->
       line i ppf "Ptyp_of_kind %a\n" (jkind_annotation (i + 1)) jkind
+  | Ptyp_refine (ct, predicate) ->
+      line i ppf "Ptyp_refine\n";
+      core_type i ppf ct;
+      expression i ppf predicate
   | Ptyp_repr (lvars, ct) ->
       line i ppf "Ptyp_repr\n";
       list i reprvar ppf lvars;

--- a/parsing/vox_binding.ml
+++ b/parsing/vox_binding.ml
@@ -144,8 +144,9 @@ and child_walker name =
     typ = (fun _ t -> walk_type name t);
     expr = (fun _ e -> walk_pred name e);
     pat = (fun _ p -> default_walk_pat name p);
-    (* Attribute payloads are not part of the type. *)
-    attribute = (fun _ _ -> ())
+    (* Attribute and extension payloads are not part of the type. *)
+    attribute = (fun _ _ -> ());
+    extension = (fun _ _ -> ())
   }
 
 let name_used_in_refinement name tys =
@@ -157,11 +158,3 @@ let name_used_in_predicate name pred =
   match walk_pred name pred with
   | () -> false
   | exception Found -> true
-
-type bare_name_classification =
-  | Positional_binder
-  | Ordinary_label
-
-let classify_bare_name name ~domain ~codomain =
-  if name_used_in_refinement name [ domain; codomain ] then Positional_binder
-  else Ordinary_label

--- a/parsing/vox_binding.ml
+++ b/parsing/vox_binding.ml
@@ -1,0 +1,167 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Copyright 2026 Jane Street Group LLC                                  *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Parsetree
+
+(* The whole module is a free-occurrence check for one name at a time.  The
+   walk raises [Found] at the first free occurrence of the name inside a
+   refinement predicate; shadowing is implemented by not descending into
+   the scope of a binder for the same name. *)
+
+exception Found
+
+(* Does [pat] bind [name]?  (Or-patterns bind the same set on both sides,
+   so scanning every variable is correct.) *)
+let pattern_binds name pat =
+  let exception Binds in
+  let it =
+    { Ast_iterator.default_iterator with
+      pat =
+        (fun sub p ->
+          (match p.ppat_desc with
+           | Ppat_var s | Ppat_alias (_, s) when s.txt = name -> raise Binds
+           | _ -> ());
+          Ast_iterator.default_iterator.pat sub p);
+      (* Binding is a matter of the pattern itself; do not look at
+         attribute payloads or interior expressions/types. *)
+      attribute = (fun _ _ -> ());
+      expr = (fun _ _ -> ());
+      typ = (fun _ _ -> ())
+    }
+  in
+  match it.pat it pat with () -> false | exception Binds -> true
+
+(* [walk_type] looks for refinements and checks their predicates;
+   occurrences of the name outside a refinement predicate do not count.
+   [walk_pred] looks for free occurrences of the name, we are already
+   inside a predicate. *)
+
+let rec walk_type name ty =
+  match ty.ptyp_desc with
+  | Ptyp_refine (payload, predicate) ->
+      walk_type name payload;
+      walk_pred name predicate
+  | Ptyp_arrow (arg, domain, codomain, _, _) -> (
+      match arg with
+      | Pan_name s when s.txt = name ->
+          (* If the name occurs free in a refinement in [domain] or
+             [codomain], this nested arrow binds it there; either way no
+             occurrence escapes to the enclosing scope. *)
+          ()
+      | Pan_tilde s when s.txt = name ->
+          (* [~x:] names the value of its own argument inside the
+             argument's refinements, but does not scope over the
+             codomain. *)
+          walk_type name codomain
+      | Pan_nolabel | Pan_name _ | Pan_tilde _ | Pan_optional _ ->
+          walk_type name domain;
+          walk_type name codomain)
+  | _ -> default_walk_type name ty
+
+and default_walk_type name ty =
+  let it = child_walker name in
+  Ast_iterator.default_iterator.typ it ty
+
+and walk_pred name e =
+  match e.pexp_desc with
+  | Pexp_ident { txt = Longident.Lident s; _ } -> if s = name then raise Found
+  | Pexp_let (_, rec_flag, vbs, body) ->
+      let bound = List.exists (fun vb -> pattern_binds name vb.pvb_pat) vbs in
+      let walk_bound_expr vb =
+        (* Constraint types inside the pattern are walked in either case:
+           they are types, and refinements within them can mention the
+           name. *)
+        default_walk_pat name vb.pvb_pat;
+        match rec_flag with
+        | Nonrecursive -> walk_pred name vb.pvb_expr
+        | Recursive -> if not bound then walk_pred name vb.pvb_expr
+      in
+      List.iter walk_bound_expr vbs;
+      if not bound then walk_pred name body
+  | Pexp_function (params, constraint_, body) ->
+      let bound =
+        List.fold_left
+          (fun bound param ->
+            match param.pparam_desc with
+            | Pparam_val (_, default, pat) ->
+                (* The default expression is evaluated outside the scope of
+                   the parameters bound so far only in principle; being
+                   conservative here is fine because optional-argument
+                   defaults are not part of the predicate sublanguage. *)
+                (match default with
+                 | Some d when not bound -> walk_pred name d
+                 | _ -> ());
+                default_walk_pat name pat;
+                bound || pattern_binds name pat
+            | Pparam_newtype _ -> bound)
+          false params
+      in
+      (match constraint_.ret_type_constraint with
+       | Some (Pconstraint t) -> walk_type name t
+       | Some (Pcoerce (t_opt, t)) ->
+           Option.iter (walk_type name) t_opt;
+           walk_type name t
+       | None -> ());
+      if not bound then
+        match body with
+        | Pfunction_body body -> walk_pred name body
+        | Pfunction_cases (cases, _, _) -> List.iter (walk_case name) cases
+      else ()
+  | Pexp_match (scrutinee, cases) | Pexp_try (scrutinee, cases) ->
+      walk_pred name scrutinee;
+      List.iter (walk_case name) cases
+  | Pexp_constraint (inner, ty_opt, _) ->
+      walk_pred name inner;
+      Option.iter (walk_type name) ty_opt
+  | _ ->
+      let it = child_walker name in
+      Ast_iterator.default_iterator.expr it e
+
+and walk_case name case =
+  default_walk_pat name case.pc_lhs;
+  if not (pattern_binds name case.pc_lhs) then begin
+    Option.iter (walk_pred name) case.pc_guard;
+    walk_pred name case.pc_rhs
+  end
+
+(* Walk only the interior types of a pattern (constraint annotations),
+   where nested refinements can occur. *)
+and default_walk_pat name pat =
+  let it = child_walker name in
+  Ast_iterator.default_iterator.pat it pat
+
+and child_walker name =
+  { Ast_iterator.default_iterator with
+    typ = (fun _ t -> walk_type name t);
+    expr = (fun _ e -> walk_pred name e);
+    pat = (fun _ p -> default_walk_pat name p);
+    (* Attribute payloads are not part of the type. *)
+    attribute = (fun _ _ -> ())
+  }
+
+let name_used_in_refinement name tys =
+  match List.iter (walk_type name) tys with
+  | () -> false
+  | exception Found -> true
+
+let name_used_in_predicate name pred =
+  match walk_pred name pred with
+  | () -> false
+  | exception Found -> true
+
+type bare_name_classification =
+  | Positional_binder
+  | Ordinary_label
+
+let classify_bare_name name ~domain ~codomain =
+  if name_used_in_refinement name [ domain; codomain ] then Positional_binder
+  else Ordinary_label

--- a/parsing/vox_binding.mli
+++ b/parsing/vox_binding.mli
@@ -32,14 +32,3 @@ val name_used_in_refinement : string -> Parsetree.core_type list -> bool
     already inside a refinement)?  Used by the printers to decide when a
     printed label must be escaped as [~x:]. *)
 val name_used_in_predicate : string -> Parsetree.expression -> bool
-
-type bare_name_classification =
-  | Positional_binder
-  | Ordinary_label
-
-(** Classify the bare name [x] of [x:domain -> codomain]. *)
-val classify_bare_name :
-  string ->
-  domain:Parsetree.core_type ->
-  codomain:Parsetree.core_type ->
-  bare_name_classification

--- a/parsing/vox_binding.mli
+++ b/parsing/vox_binding.mli
@@ -1,0 +1,45 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Copyright 2026 Jane Street Group LLC                                  *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** The occurrence test for the name slot of arrow types.
+
+    In [x:T -> U], the bare name [x] is a positional binder if [x] occurs
+    free in a refinement predicate within [T] or [U], and the ordinary label
+    [x] otherwise.  The test is purely syntactic and runs on the parsetree,
+    before name resolution.  It respects the binders introduced inside
+    predicates ([let], [fun] parameters, [match] cases) and the binders
+    introduced by nested arrows.
+
+    This module is the single implementation of that test; translation
+    ([Typetexp]), type approximation ([Typecore]) and printing back to
+    source ([Untypeast], to decide when a label must be escaped as [~x:])
+    all go through it. *)
+
+(** Does [name] occur free in a refinement predicate within one of the given
+    types? *)
+val name_used_in_refinement : string -> Parsetree.core_type list -> bool
+
+(** Does [name] occur free in the given predicate expression (which is
+    already inside a refinement)?  Used by the printers to decide when a
+    printed label must be escaped as [~x:]. *)
+val name_used_in_predicate : string -> Parsetree.expression -> bool
+
+type bare_name_classification =
+  | Positional_binder
+  | Ordinary_label
+
+(** Classify the bare name [x] of [x:domain -> codomain]. *)
+val classify_bare_name :
+  string ->
+  domain:Parsetree.core_type ->
+  codomain:Parsetree.core_type ->
+  bare_name_classification

--- a/printer/printast_with_mappings.ml
+++ b/printer/printast_with_mappings.ml
@@ -167,6 +167,13 @@ let arg_label i ppf = function
   | Labelled s -> line i ppf "Labelled \"%s\"\n" s
 ;;
 
+let arrow_arg_name i ppf = function
+  | Pan_nolabel -> line i ppf "Pan_nolabel\n"
+  | Pan_name s -> line i ppf "Pan_name \"%s\"\n" s.txt
+  | Pan_tilde s -> line i ppf "Pan_tilde \"%s\"\n" s.txt
+  | Pan_optional s -> line i ppf "Pan_optional \"%s\"\n" s.txt
+;;
+
 let modality i ppf modality =
   line i ppf "modality %a\n" fmt_string_loc
     (Location.map (fun (Modality x) -> x) modality)
@@ -203,7 +210,7 @@ let rec core_type i ppf x =
       jkind_annotation_opt (i+1) ppf jkind
   | Ptyp_arrow (l, ct1, ct2, m1, m2) ->
       line i ppf "Ptyp_arrow\n";
-      arg_label i ppf l;
+      arrow_arg_name i ppf l;
       core_type i ppf ct1;
       core_type i ppf ct2;
       modes i ppf m1;
@@ -261,6 +268,10 @@ let rec core_type i ppf x =
   | Ptyp_splice t ->
       line i ppf "Ptyp_splice\n";
       core_type i ppf t
+  | Ptyp_refine (ct, predicate) ->
+      line i ppf "Ptyp_refine\n";
+      core_type i ppf ct;
+      expression i ppf predicate
   | Ptyp_repr (lv, ct) ->
       line i ppf "Ptyp_repr\n";
       list i reprvar ppf lv;

--- a/testsuite/tests/parsetree/locations_test.compilers.reference
+++ b/testsuite/tests/parsetree/locations_test.compilers.reference
@@ -263,7 +263,7 @@ Ptop_def
               ]
               core_type (//toplevel//[2,1+16]..[2,1+22])
                 Ptyp_arrow
-                Nolabel
+                Pan_nolabel
                 core_type (//toplevel//[2,1+16]..[2,1+17])
                   Ptyp_var a
                 core_type (//toplevel//[2,1+21]..[2,1+22])
@@ -287,7 +287,7 @@ Ptop_def
                     Pexp_ident "x" (//toplevel//[2,1+34]..[2,1+35])
               core_type (//toplevel//[2,1+16]..[2,1+22])
                 Ptyp_arrow
-                Nolabel
+                Pan_nolabel
                 core_type (//toplevel//[2,1+16]..[2,1+17])
                   Ptyp_constr "a" (//toplevel//[2,1+16]..[2,1+17])
                   []
@@ -337,7 +337,7 @@ Ptop_def
                                 Pexp_ident "x" (//toplevel//[4,46+13]..[4,46+14])
                           core_type (//toplevel//[3,16+21]..[3,16+27])
                             Ptyp_arrow
-                            Nolabel
+                            Pan_nolabel
                             core_type (//toplevel//[3,16+21]..[3,16+22])
                               Ptyp_constr "a" (//toplevel//[3,16+21]..[3,16+22])
                               []
@@ -352,7 +352,7 @@ Ptop_def
                           ]
                           core_type (//toplevel//[3,16+21]..[3,16+27])
                             Ptyp_arrow
-                            Nolabel
+                            Pan_nolabel
                             core_type (//toplevel//[3,16+21]..[3,16+22])
                               Ptyp_var a
                             core_type (//toplevel//[3,16+26]..[3,16+27])

--- a/testsuite/tests/parsing/attributes.compilers.reference
+++ b/testsuite/tests/parsing/attributes.compilers.reference
@@ -338,7 +338,7 @@
                 attribute "foo"
                   []
                 Ptyp_arrow
-                Nolabel
+                Pan_nolabel
                 core_type (attributes.ml[59,812+19]..[59,812+23])
                   Ptyp_constr "unit" (attributes.ml[59,812+19]..[59,812+23])
                   []

--- a/testsuite/tests/parsing/extensions.compilers.reference
+++ b/testsuite/tests/parsing/extensions.compilers.reference
@@ -166,7 +166,7 @@
           Ptyp_extension "foo"
           core_type (extensions.ml[16,344+29]..[16,344+35])
             Ptyp_arrow
-            Nolabel
+            Pan_nolabel
             core_type (extensions.ml[16,344+29]..[16,344+30])
               Ptyp_constr "t" (extensions.ml[16,344+29]..[16,344+30])
               []

--- a/testsuite/tests/vox/empty-predicate/empty_predicate.compilers.reference
+++ b/testsuite/tests/vox/empty-predicate/empty_predicate.compilers.reference
@@ -1,0 +1,4 @@
+File "empty_predicate.ml", line 9, characters 16-17:
+9 | type bad = int{ }
+                    ^
+Error: Syntax error

--- a/testsuite/tests/vox/empty-predicate/empty_predicate.ml
+++ b/testsuite/tests/vox/empty-predicate/empty_predicate.ml
@@ -1,0 +1,9 @@
+(* TEST
+ setup-ocamlc.byte-build-env;
+ ocamlc_byte_exit_status = "2";
+ ocamlc.byte;
+ check-ocamlc.byte-output;
+*)
+
+(* An empty predicate is a syntax error, not an empty refinement. *)
+type bad = int{ }

--- a/testsuite/tests/vox/roundtrip/roundtrip_defs.mli
+++ b/testsuite/tests/vox/roundtrip/roundtrip_defs.mli
@@ -12,3 +12,9 @@ val labelled : ~x:int{ x > 0 } -> unit
 type wf = { size : int{ _ >= 0 } }
 
 type pos = Pos of int{ _ > 0 }
+
+(* A predicate referencing a value of the same signature: import must
+   rewrite the path. *)
+val positive : int -> bool
+
+type p = int{ positive _ }

--- a/testsuite/tests/vox/roundtrip/roundtrip_defs.mli
+++ b/testsuite/tests/vox/roundtrip/roundtrip_defs.mli
@@ -1,0 +1,14 @@
+(* Refined declarations that cross a .cmi boundary: written here, read back
+   and printed by the test. *)
+
+type nat = int{ _ >= 0 }
+
+type dep = x:int{ x > 0 } -> int{ _ >= x }
+
+val sub : s:string -> int{ _ < String.length s } -> char
+
+val labelled : ~x:int{ x > 0 } -> unit
+
+type wf = { size : int{ _ >= 0 } }
+
+type pos = Pos of int{ _ > 0 }

--- a/testsuite/tests/vox/roundtrip/test.ml
+++ b/testsuite/tests/vox/roundtrip/test.ml
@@ -22,6 +22,8 @@ module Roundtrip_defs :
     val labelled : ~x:int{ x > 0 } -> unit
     type wf = { size : int{ _ >= 0 }; }
     type pos = Pos of int{ _ > 0 }
+    val positive : int -> bool
+    type p = int{ positive _ }
   end
 |}]
 
@@ -35,4 +37,10 @@ val l : (x:int{ x > 0 } -> int{ _ >= x }) list = []
 let l : int{ _ >= 0 } list = ([] : Roundtrip_defs.nat list);;
 [%%expect{|
 val l : int{ _ >= 0 } list = []
+|}]
+
+(* A same-signature value reference is prefixed on import *)
+let l : int{ Roundtrip_defs.positive _ } list = ([] : Roundtrip_defs.p list);;
+[%%expect{|
+val l : int{ Roundtrip_defs.positive _ } list = []
 |}]

--- a/testsuite/tests/vox/roundtrip/test.ml
+++ b/testsuite/tests/vox/roundtrip/test.ml
@@ -1,0 +1,38 @@
+(* TEST
+ readonly_files = "roundtrip_defs.mli";
+ setup-ocamlc.byte-build-env;
+ module = "roundtrip_defs.mli";
+ ocamlc.byte;
+ expect;
+*)
+
+(* Write a refined signature to a .cmi, read it back, print it.  The
+   cheapest guard on the representation: a [Subst] or [Btype] gap shows up
+   here first. *)
+
+#directory "ocamlc.byte";;
+
+#show Roundtrip_defs;;
+[%%expect{|
+module Roundtrip_defs :
+  sig
+    type nat = int{ _ >= 0 }
+    type dep = x:int{ x > 0 } -> int{ _ >= x }
+    val sub : s:string -> int{ _ < (String.length s) } -> char
+    val labelled : ~x:int{ x > 0 } -> unit
+    type wf = { size : int{ _ >= 0 }; }
+    type pos = Pos of int{ _ > 0 }
+  end
+|}]
+
+(* The imported types are the same types: unification across the .cmi,
+   with binders freshened on import *)
+let l : (x:int{ x > 0 } -> int{ _ >= x }) list = ([] : Roundtrip_defs.dep list);;
+[%%expect{|
+val l : (x:int{ x > 0 } -> int{ _ >= x }) list = []
+|}]
+
+let l : int{ _ >= 0 } list = ([] : Roundtrip_defs.nat list);;
+[%%expect{|
+val l : int{ _ >= 0 } list = []
+|}]

--- a/testsuite/tests/vox/type-formers.ml
+++ b/testsuite/tests/vox/type-formers.ml
@@ -387,11 +387,41 @@ val mk : (~x:int{ x > 0 } -> y:int -> unit) -> ~x:int{ x > 0 } -> unit =
   <fun>
 |}]
 
-(* Applying a dependent arrow lets the domain type escape its binder; the
-   escaped occurrence prints under the binder's name.  Elimination rules —
-   including whether this should be rejected or substituted — belong to a
-   later piece; this pins the current, inert behaviour. *)
+(* Consuming a dependent parameter is rejected: it would let the rest of
+   the arrow escape the binder's scope.  The elimination rules belong to a
+   later piece. *)
 let apply (f : x:int{ x > 0 } -> unit) v = f v;;
 [%%expect{|
-val apply : (x:int{ x > 0 } -> unit) -> int{ x > 0 } -> unit = <fun>
+Line 1, characters 45-46:
+1 | let apply (f : x:int{ x > 0 } -> unit) v = f v;;
+                                                 ^
+Error: Functions with a dependent arrow type cannot be defined or
+       applied yet: the introduction and elimination rules for
+       refinements are not implemented.
+|}]
+
+(* ... and so is defining a function against a dependent annotation *)
+let f : x:int{ x > 0 } -> unit = fun v -> ();;
+[%%expect{|
+Line 1, characters 33-44:
+1 | let f : x:int{ x > 0 } -> unit = fun v -> ();;
+                                     ^^^^^^^^^^^
+Error: Functions with a dependent arrow type cannot be defined or
+       applied yet: the introduction and elimination rules for
+       refinements are not implemented.
+|}]
+
+(* Constructors in predicates are resolved paths: a functor application
+   substitutes them like values *)
+module FC (X : sig type t = C end) = struct
+  type u = int{ match X.C with X.C -> true }
+end
+module AC = struct type t = C end
+module RC = FC (AC);;
+[%%expect{|
+module FC :
+  functor (X : sig type t = C end) ->
+    sig type u = int{ match X.C with | X.C -> true } end
+module AC : sig type t = C end
+module RC : sig type u = int{ match AC.C with | AC.C -> true } end
 |}]

--- a/testsuite/tests/vox/type-formers.ml
+++ b/testsuite/tests/vox/type-formers.ml
@@ -153,6 +153,48 @@ type opt = ?x:int{ _ > 0 } -> unit -> unit;;
 type opt = ?x:int{ _ > 0 } -> unit -> unit
 |}]
 
+type bad = ?x:int{ x > 0 } -> unit -> unit;;
+[%%expect{|
+Line 1, characters 19-20:
+1 | type bad = ?x:int{ x > 0 } -> unit -> unit;;
+                       ^
+Error: Unbound value "x"
+|}]
+
+(* [~x:] scopes over the whole argument, and only the argument *)
+type tilde_tuple = ~x:(int{ x > 0 } * int) -> unit;;
+[%%expect{|
+type tilde_tuple = ~x:int{ x > 0 } * int -> unit
+|}]
+
+type bad = ~x:int -> int{ _ >= x };;
+[%%expect{|
+Line 1, characters 31-32:
+1 | type bad = ~x:int -> int{ _ >= x };;
+                                   ^
+Error: Unbound value "x"
+|}]
+
+(* A positional binder scopes over refinements anywhere in its domain *)
+type nested_domain = x:(int{ x > 0 } * int) -> unit;;
+[%%expect{|
+type nested_domain = x:int{ x > 0 } * int -> unit
+|}]
+
+(* A [fun] parameter in the predicate shadows the name, so [x] stays a
+   label *)
+type still_label = x:int list{ List.for_all (fun x -> x > 0) _ } -> unit;;
+[%%expect{|
+type still_label = x:int list{ List.for_all (fun x -> x > 0) _ } -> unit
+|}]
+
+(* A predicate-local binder is in scope in nested refinements through a
+   constraint type *)
+type local_nested = int{ (fun x -> (x : int{ x = 0 })) 0 = 0 };;
+[%%expect{|
+type local_nested = int{ ((fun x -> (x : int{ x = 0 })) 0) = 0 }
+|}]
+
 (* Mixed arrow: a positional binder and a bare-spelled label in one
    chain warns *)
 type mixed = x:int -> y:int -> int{ _ >= x };;
@@ -202,13 +244,32 @@ Error: Unbound value "n"
 |}]
 
 (* Rejections: non-total forms *)
-type bad = int{ while true do () done; true };;
+type bad = int{ while true do () done };;
 [%%expect{|
-Line 1, characters 16-43:
-1 | type bad = int{ while true do () done; true };;
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Line 1, characters 16-37:
+1 | type bad = int{ while true do () done };;
+                    ^^^^^^^^^^^^^^^^^^^^^
+Error: While loops are not allowed in a refinement predicate:
+       predicates must be total.
+|}]
+
+type bad = int{ (); true };;
+[%%expect{|
+Line 1, characters 16-24:
+1 | type bad = int{ (); true };;
+                    ^^^^^^^^
 Error: Sequencing is not allowed in a refinement predicate:
        predicates must be total.
+|}]
+
+(* Total but not yet part of the predicate sublanguage: a real located
+   error, not a crash *)
+type bad = int{ { contents = 1 } = _ };;
+[%%expect{|
+Line 1, characters 16-32:
+1 | type bad = int{ { contents = 1 } = _ };;
+                    ^^^^^^^^^^^^^^^^
+Error: A record expression is not supported in refinement predicates.
 |}]
 
 type bad = unit{ ref true };;
@@ -254,6 +315,58 @@ type wft = t tree{ well_formed (_ : t tree) }
 and t = int
 |}]
 
+(* String constants compare by contents, not by where they were
+   written *)
+type s = string{ _ = "a" }
+let l : s list = ([] : string{ _ = "a" } list);;
+[%%expect{|
+type s = string{ _ = "a" }
+val l : s list = []
+|}]
+
+(* Type variables inside a predicate are live in the type graph:
+   instantiating the declaration substitutes them *)
+type 'a t = int{ (_ : 'a list) = [] }
+let l : int t list = ([] : int{ (_ : int list) = [] } list);;
+[%%expect{|
+type 'a t = int{ (_ : 'a list) = [] }
+val l : int t list = []
+|}]
+
+(* A self-referential predicate, to pin what the occur check does *)
+type u = int{ (_ : u) = _ };;
+[%%expect{|
+Line 1, characters 0-27:
+1 | type u = int{ (_ : u) = _ };;
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The type abbreviation "u" is cyclic:
+         "u" = "int{ (_ : u) = _ }",
+         "int{ (_ : u) = _ }" contains "u"
+|}]
+
+(* Predicates print resolved names: a functor application substitutes the
+   value path *)
+module F (X : sig val p : int end) = struct
+  type t = int{ _ > X.p }
+end
+module A = struct let p = 0 end
+module R = F (A);;
+[%%expect{|
+module F :
+  functor (X : sig val p : int end) -> sig type t = int{ _ > X.p } end
+module A : sig val p : int end
+module R : sig type t = int{ _ > A.p } end
+|}]
+
+(* A label whose name is a value mentioned in a refinement is escaped, so
+   the printed form re-parses to the same type *)
+let x = 0
+type esc = ~x:int -> int{ x > 0 };;
+[%%expect{|
+val x : int = 0
+type esc = ~x:int -> int{ x > 0 }
+|}]
+
 (* --- Inertness ------------------------------------------------------- *)
 
 (* No introduction rule: a refined type cannot be consumed or produced *)
@@ -264,4 +377,21 @@ Line 1, characters 27-28:
                                ^
 Error: The value "x" has type "int{ _ > 0 }"
        but an expression was expected of type "int"
+|}]
+
+(* Partial application preserves the binder of an omitted argument *)
+let mk (g : ~x:int{ x > 0 } -> y:int -> unit) : ~x:int{ x > 0 } -> unit =
+  g ~y:0;;
+[%%expect{|
+val mk : (~x:int{ x > 0 } -> y:int -> unit) -> ~x:int{ x > 0 } -> unit =
+  <fun>
+|}]
+
+(* Applying a dependent arrow lets the domain type escape its binder; the
+   escaped occurrence prints under the binder's name.  Elimination rules —
+   including whether this should be rejected or substituted — belong to a
+   later piece; this pins the current, inert behaviour. *)
+let apply (f : x:int{ x > 0 } -> unit) v = f v;;
+[%%expect{|
+val apply : (x:int{ x > 0 } -> unit) -> int{ x > 0 } -> unit = <fun>
 |}]

--- a/testsuite/tests/vox/type-formers.ml
+++ b/testsuite/tests/vox/type-formers.ml
@@ -1,0 +1,267 @@
+(* TEST
+ expect;
+*)
+
+(* Vox type formers: refinement types [t{p}] and the dependent-arrow
+   binder.  This piece is inert: refinements parse, translate, print and
+   travel through the type graph, but there are no introduction or
+   elimination rules yet, so these tests declare, annotate and print
+   rather than use. *)
+
+(* --- The four spellings --------------------------------------------- *)
+
+(* positional, hole *)
+type t1 = int{ _ > 0 } -> unit;;
+[%%expect{|
+type t1 = int{ _ > 0 } -> unit
+|}]
+
+(* positional, named: using the name is what makes it a binder *)
+type t2 = n:int{ n > 0 } -> unit;;
+[%%expect{|
+type t2 = n:int{ n > 0 } -> unit
+|}]
+
+(* labelled, hole: [x] does not occur in a refinement, so it stays a
+   label *)
+type t3 = x:int{ _ > 0 } -> unit;;
+[%%expect{|
+type t3 = x:int{ _ > 0 } -> unit
+|}]
+
+(* labelled, named: [~x:] is always a label, and the name refers to the
+   argument's own value in its own refinement *)
+type t4 = ~x:int{ x > 0 } -> unit;;
+[%%expect{|
+type t4 = ~x:int{ x > 0 } -> unit
+|}]
+
+(* --- Calling conventions -------------------------------------------- *)
+
+(* The binder is positional: the calling convention is unchanged, so the
+   type unifies with itself spelled through a hole-free alias. *)
+type pos_conv = int{ _ > 0 } -> unit
+let l : pos_conv list = ([] : (int{ _ > 0 } -> unit) list);;
+[%%expect{|
+type pos_conv = int{ _ > 0 } -> unit
+val l : pos_conv list = []
+|}]
+
+(* The hole and a named binder are different predicates: equality is
+   syntactic alpha-equivalence, with no normalization between [_] and a
+   name for the same value. *)
+let l : (n:int{ n > 0 } -> unit) list = ([] : (int{ _ > 0 } -> unit) list);;
+[%%expect{|
+Line 1, characters 40-74:
+1 | let l : (n:int{ n > 0 } -> unit) list = ([] : (int{ _ > 0 } -> unit) list);;
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "(int{ _ > 0 } -> unit) list"
+       but an expression was expected of type "(n:int{ n > 0 } -> unit) list"
+       Type "int{ _ > 0 }" is not compatible with type "int{ n > 0 }"
+|}]
+
+(* A bare name that binds is not a label: labelled functions do not
+   unify with it. *)
+let l : (n:int{ n > 0 } -> unit) list = ([] : (n:int -> unit) list);;
+[%%expect{|
+Line 1, characters 40-67:
+1 | let l : (n:int{ n > 0 } -> unit) list = ([] : (n:int -> unit) list);;
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "(n:int -> unit) list"
+       but an expression was expected of type "(n:int{ n > 0 } -> unit) list"
+       The first argument is labeled "n",
+       but an unlabeled argument was expected
+|}]
+
+(* [~x:] is a label: it unifies with the same label *)
+let l : (~x:int{ x > 0 } -> unit) list = ([] : (~x:int{ x > 0 } -> unit) list);;
+[%%expect{|
+val l : (~x:int{ x > 0 } -> unit) list = []
+|}]
+
+(* --- Binding --------------------------------------------------------- *)
+
+(* A name occurring only in a later refinement binds *)
+type later = x:int -> int{ _ >= x };;
+[%%expect{|
+type later = x:int -> int{ _ >= x }
+|}]
+
+(* One binder for both the argument's own refinement and the codomain *)
+type once = x:int{ x > 0 } -> int{ _ >= x };;
+[%%expect{|
+type once = x:int{ x > 0 } -> int{ _ >= x }
+|}]
+
+(* Alpha-equivalence: differently-named binders compare equal *)
+let l : (x:int{ x > 0 } -> int{ _ >= x }) list =
+  ([] : (y:int{ y > 0 } -> int{ _ >= y }) list);;
+[%%expect{|
+val l : (x:int{ x > 0 } -> int{ _ >= x }) list = []
+|}]
+
+(* ... but different predicates do not *)
+let l : (x:int{ x > 0 } -> int{ _ >= x }) list =
+  ([] : (y:int{ y > 1 } -> int{ _ >= y }) list);;
+[%%expect{|
+Line 2, characters 2-47:
+2 |   ([] : (y:int{ y > 1 } -> int{ _ >= y }) list);;
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: This expression has type "(y:int{ y > 1 } -> int{ _ >= y }) list"
+       but an expression was expected of type
+         "(x:int{ x > 0 } -> int{ _ >= x }) list"
+       Type "int{ y > 1 }" is not compatible with type "int{ x > 0 }"
+|}]
+
+(* One-sided refinement is a clash *)
+let l : int{ _ > 0 } list = ([] : int list);;
+[%%expect{|
+Line 1, characters 28-43:
+1 | let l : int{ _ > 0 } list = ([] : int list);;
+                                ^^^^^^^^^^^^^^^
+Error: This expression has type "int list"
+       but an expression was expected of type "int{ _ > 0 } list"
+       Type "int" is not compatible with type "int{ _ > 0 }"
+|}]
+
+(* --- The occurrence test -------------------------------------------- *)
+
+(* A name shadowed by a predicate's own [let] does not bind *)
+type shadow_let = x:int{ let x = 1 in x > 0 } -> unit;;
+[%%expect{|
+type shadow_let = x:int{ let x = 1 in x > 0 } -> unit
+|}]
+
+(* A name shadowed by a [match] case binder does not bind *)
+type shadow_match =
+  x:int option{ match _ with Some x -> x > 0 | None -> true } -> unit;;
+[%%expect{|
+type shadow_match =
+    x:int option{ match _ with | Some x -> x > 0 | None -> true } -> unit
+|}]
+
+(* A name occurring only inside a nested arrow's refinement does not
+   escape that arrow *)
+type nested = x:int -> (x:int -> int{ _ >= x }) -> unit;;
+[%%expect{|
+type nested = x:int -> (x:int -> int{ _ >= x }) -> unit
+|}]
+
+(* Optional parameters never bind *)
+type opt = ?x:int{ _ > 0 } -> unit -> unit;;
+[%%expect{|
+type opt = ?x:int{ _ > 0 } -> unit -> unit
+|}]
+
+(* Mixed arrow: a positional binder and a bare-spelled label in one
+   chain warns *)
+type mixed = x:int -> y:int -> int{ _ >= x };;
+[%%expect{|
+Line 1, characters 13-44:
+1 | type mixed = x:int -> y:int -> int{ _ >= x };;
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 230 [vox-mixed-arrow-conventions]: This arrow type mixes positional value binders and bare-spelled
+  labels; reading it requires scanning the whole type.
+  Spell the labels with a tilde ("~x:") to make the convention explicit.
+
+type mixed = x:int -> y:int -> int{ _ >= x }
+|}]
+
+(* --- Predicates ------------------------------------------------------ *)
+
+(* Predicates are ordinary expressions: applications, field access,
+   let, fun, match, if, tuples, constants, constructors *)
+type pred_apply = s:string -> int{ _ < String.length s } -> char;;
+[%%expect{|
+type pred_apply = s:string -> int{ _ < (String.length s) } -> char
+|}]
+
+type pred_fun = int list{ List.for_all (fun x -> x > 0) _ };;
+[%%expect{|
+type pred_fun = int list{ List.for_all (fun x -> x > 0) _ }
+|}]
+
+type pred_if = int{ if _ > 0 then _ < 10 else _ > -10 };;
+[%%expect{|
+type pred_if = int{ if _ > 0 then _ < 10 else _ > (-10) }
+|}]
+
+(* A proposition on unit; no name needed *)
+type prop = unit{ 1 + 1 = 2 };;
+[%%expect{|
+type prop = unit{ (1 + 1) = 2 }
+|}]
+
+(* Rejections: unbound name *)
+type bad = int{ _ > n };;
+[%%expect{|
+Line 1, characters 20-21:
+1 | type bad = int{ _ > n };;
+                        ^
+Error: Unbound value "n"
+|}]
+
+(* Rejections: non-total forms *)
+type bad = int{ while true do () done; true };;
+[%%expect{|
+Line 1, characters 16-43:
+1 | type bad = int{ while true do () done; true };;
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: Sequencing is not allowed in a refinement predicate:
+       predicates must be total.
+|}]
+
+type bad = unit{ ref true };;
+[%%expect{|
+Line 1, characters 17-20:
+1 | type bad = unit{ ref true };;
+                     ^^^
+Error: References are not allowed in a refinement predicate:
+       predicates must be total.
+|}]
+
+(* --- Positions ------------------------------------------------------- *)
+
+(* Record fields, constructor arguments, type declaration bodies *)
+type wf = { size : int{ _ >= 0 }; mutable used : int };;
+[%%expect{|
+type wf = { size : int{ _ >= 0 }; mutable used : int; }
+|}]
+
+type pos = Pos of int{ _ > 0 } | Neg of int{ _ < 0 };;
+[%%expect{|
+type pos = Pos of int{ _ > 0 } | Neg of int{ _ < 0 }
+|}]
+
+type nat = int{ _ >= 0 };;
+[%%expect{|
+type nat = int{ _ >= 0 }
+|}]
+
+(* A recursive declaration whose predicate mentions the type being
+   defined, through an interior type *)
+type 'a tree = Leaf | Node of 'a tree * 'a * 'a tree
+let well_formed (_ : 'a tree) = true;;
+[%%expect{|
+type 'a tree = Leaf | Node of 'a tree * 'a * 'a tree
+val well_formed : 'a tree -> bool = <fun>
+|}]
+
+type wft = t tree{ well_formed (_ : t tree) }
+and t = int;;
+[%%expect{|
+type wft = t tree{ well_formed (_ : t tree) }
+and t = int
+|}]
+
+(* --- Inertness ------------------------------------------------------- *)
+
+(* No introduction rule: a refined type cannot be consumed or produced *)
+let f (x : int{ _ > 0 }) = x + 1;;
+[%%expect{|
+Line 1, characters 27-28:
+1 | let f (x : int{ _ > 0 }) = x + 1;;
+                               ^
+Error: The value "x" has type "int{ _ > 0 }"
+       but an expression was expected of type "int"
+|}]

--- a/toplevel/byte/trace.ml
+++ b/toplevel/byte/trace.ml
@@ -67,7 +67,7 @@ let print_label ppf l =
 
 let rec instrument_result env name ppf clos_typ =
   match get_desc (Ctype.expand_head env clos_typ) with
-  | Tarrow((l,_,_), t1, t2, _) ->
+  | Tarrow((l,_,_,_), t1, t2, _) ->
       let starred_name =
         match name with
         | Lident s -> Lident(s ^ "*" )
@@ -110,7 +110,7 @@ let _ = Dummy
 
 let instrument_closure env name ppf clos_typ =
   match get_desc (Ctype.expand_head env clos_typ) with
-  | Tarrow((l,_,_), t1, t2, _) ->
+  | Tarrow((l,_,_,_), t1, t2, _) ->
       let trace_res = instrument_result env name ppf t2 in
       (fun actual_code closure arg ->
         if not !may_trace then begin

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -393,6 +393,9 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
               Oval_stuff "<poly>"
           | Tarrow _ ->
               Oval_stuff "<fun>"
+          | Trefine { ref_payload; _ } ->
+              (* The payload determines the runtime representation. *)
+              tree_of_val depth obj ref_payload
           | Ttuple(labeled_tys) ->
               Oval_tuple (tree_of_labeled_val_list 0 depth obj labeled_tys)
           | Tunboxed_tuple(labeled_tys) ->

--- a/toplevel/topprinters.ml
+++ b/toplevel/topprinters.ml
@@ -17,7 +17,7 @@
 
 let type_arrow ta tb =
   let arrow_desc =
-    Types.Nolabel,Mode.Alloc.legacy,Mode.Alloc.legacy
+    Types.Nolabel,None,Mode.Alloc.legacy,Mode.Alloc.legacy
   in
   Ctype.newty
     (Tarrow (arrow_desc, Ctype.newmono ta, tb, Types.commu_var ()))
@@ -84,7 +84,7 @@ let match_simple_printer_type env ty ~is_old_style =
 let filter_arrow env ty =
   let ty = Ctype.expand_head env ty in
   match Types.get_desc ty with
-  | Tarrow ((lbl,_,_), l, r, _) when not (Btype.is_omittable lbl) -> Some (l, r)
+  | Tarrow ((lbl,_,_,_), l, r, _) when not (Btype.is_omittable lbl) -> Some (l, r)
   | _ -> None
 
 let extract_last_arrow env ty =

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -371,6 +371,9 @@ let fold_type_expr f init ty =
     List.fold_left (fun result (_n, ty) -> f result ty) init pack.pack_cstrs
   | Tof_kind _ -> init
   | Tbox ty -> f init ty
+  | Trefine { ref_payload; ref_pred } ->
+      let result = f init ref_payload in
+      Vox_rexp.fold_types f result ref_pred
 
 let iter_type_expr f ty =
   fold_type_expr (fun () v -> f v) () ty
@@ -615,6 +618,11 @@ let rec copy_type_desc ?(keep_names=false) f = function
         pack_cstrs = List.map (fun (n, ty) -> (n, f ty)) pack.pack_cstrs}
   | Tof_kind jk -> Tof_kind jk
   | Tbox ty -> Tbox (f ty)
+  | Trefine { ref_payload; ref_pred } ->
+      (* Binder stamps are kept: [Subst] freshens them on import, generic
+         copies do not. *)
+      Trefine { ref_payload = f ref_payload;
+                ref_pred = Vox_rexp.map ~type_expr:f ref_pred }
 
 (* TODO: rename to [module Copy_scope] *)
 module For_copy : sig

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -5767,6 +5767,10 @@ type filter_arrow_failure =
       }
   | Not_a_function
   | Jkind_error of type_expr * Jkind.Violation.t
+  | Dependent_arrow
+    (* The arrow carries a value binder; decomposing it would let the
+       domain or codomain escape the binder's scope.  The introduction and
+       elimination rules for refinements are a later piece. *)
 
 exception Filter_arrow_failed of filter_arrow_failure
 
@@ -5834,7 +5838,8 @@ let filter_arrow env t l ~force_tpoly =
       end;
       link_type t t';
       arrow_desc
-  | Tarrow((l', _, arg_mode, ret_mode), ty_arg, ty_ret, _) ->
+  | Tarrow((l', binder, arg_mode, ret_mode), ty_arg, ty_ret, _) ->
+      if binder <> None then raise (Filter_arrow_failed Dependent_arrow);
       if l = l' || !Clflags.classic && l = Nolabel &&
         equivalent_with_nolabels l l'
       then

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -8493,6 +8493,19 @@ let rec nondep_type_rec ?(expand_private=false) env ids ty =
                *)
             with Cannot_expand -> raise exn
           end
+      | Trefine { ref_payload = _; ref_pred }
+        when Vox_rexp.find_value_path (Path.find_free_opt ids) ref_pred
+             <> None ->
+          (* A predicate mentioning the erased module cannot be kept: the
+             value path has no meaning without it. *)
+          let id =
+            match
+              Vox_rexp.find_value_path (Path.find_free_opt ids) ref_pred
+            with
+            | Some id -> id
+            | None -> assert false
+          in
+          raise (Nondep_cannot_erase id)
       | Tpackage pack when Path.exists_free ids pack.pack_path ->
           let p' = normalize_package_path env pack.pack_path in
           begin match Path.find_free_opt ids p' with

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -738,7 +738,7 @@ let remove_mode_and_jkind_variables ty =
       match get_desc ty with
       | Tvar { jkind } -> Jkind.default_to_scannable jkind
       | Tunivar { jkind } -> Jkind.default_to_scannable jkind
-      | Tarrow ((_,marg,mret),targ,tret,_) ->
+      | Tarrow ((_,_,marg,mret),targ,tret,_) ->
          let _ = Alloc.zap_to_legacy marg in
          let _ = Alloc.zap_to_legacy mret in
          go targ; go tret
@@ -1040,7 +1040,8 @@ let rec copy_spine copy_scope ty =
   | Tsplice _
   | Tquote_eval _
   | Tof_kind _
-  | Tbox _ -> ty
+  | Tbox _
+  | Trefine _ -> ty
   | ( Tarrow _ | Tpoly _ | Trepr _ | Ttuple _ | Tunboxed_tuple _ | Tpackage _
     | Tconstr _ | Tmod _ ) as desc ->
       let level = get_level ty in
@@ -2031,7 +2032,7 @@ let curry_mode alloc arg : Alloc.Const.t =
 
 let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
   match locals, get_desc ty with
-  | l :: locals, Tarrow ((lbl,marg,mret),arg,ret,commu) ->
+  | l :: locals, Tarrow ((lbl,binder,marg,mret),arg,ret,commu) ->
      let marg = with_locality_and_forkable_yielding
       (prim_mode' (Some (mvar_l, mvar_y)) l) marg
      in
@@ -2050,7 +2051,7 @@ let rec instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ty =
           mret'
      in
      let ret = instance_prim_locals locals mvar_l mvar_y macc (loc, yld) ret in
-     newty2 ~level:(get_level ty) (Tarrow ((lbl,marg,mret),arg,ret, commu))
+     newty2 ~level:(get_level ty) (Tarrow ((lbl,binder,marg,mret),arg,ret, commu))
   | _ :: _, _ -> assert false
   | [], _ ->
      ty
@@ -2464,6 +2465,8 @@ and try_reduce_quote_eval env t =
   let try_reduce_poly env t = if is_Tpoly t then try_reduce_once env t else t in
   match get_desc t with
   | Tvar _ | Tunivar _ -> raise Cannot_expand
+  (* Refinements are rigid; quoted refined types do not reduce further. *)
+  | Trefine _ -> raise Cannot_expand
   (* [<[t1 -> t2]> eval]  ==>  [<[t1]> eval -> <[t2]> eval] *)
   | Tarrow (a, t1, t2, c) ->
     (* Reduce the parameter type's [Tpoly] immediately *)
@@ -2666,7 +2669,7 @@ let rec extract_concrete_typedecl env ty =
   | Tquote_eval ty -> extract_concrete_typedecl (incr_stage env) ty
   | Tbox ty -> extract_concrete_typedecl env ty
   | Tarrow _ | Ttuple _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
-  | Tvariant _ | Tpackage _ | Tof_kind _ -> Has_no_typedecl
+  | Tvariant _ | Tpackage _ | Tof_kind _ | Trefine _ -> Has_no_typedecl
   | Tvar _ | Tunivar _ -> May_have_typedecl
   | Tlink _ | Tsubst _ -> assert false
 
@@ -2703,7 +2706,7 @@ let prim_params_yielding env ty ~arity =
     if n <= 0 then Some acc
     else
       match get_desc (expand_head_opt env ty) with
-      | Tarrow ((_, marg, _), _, ret, _) ->
+      | Tarrow ((_, _, marg, _), _, ret, _) ->
         let yielding =
           Yielding.disallow_right (Alloc.proj_comonadic Yielding marg)
         in
@@ -2863,6 +2866,9 @@ let contained_without_boxing env ty =
   | Tpoly (ty, _) -> [ty]
   | Tmod (ty, _) -> [ty]
   | Trepr (_, _) ->  Misc.fatal_error "Ctype.contained_without_boxing: repr"
+  | Trefine { ref_payload; _ } ->
+    (* The payload determines the runtime representation. *)
+    [ref_payload]
   | Tvar _ | Tarrow _ | Ttuple _ | Tobject _ | Tfield _ | Tnil | Tlink _
   | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ | Tof_kind _ | Tbox _
   | Tquote _ | Tsplice _ | Tquote_eval _ -> []
@@ -3125,6 +3131,9 @@ and estimate_type_jkind ~expand_components ~ignore_mod_bounds env ty =
     |> estimate_type_jkind ~expand_components ~ignore_mod_bounds env
   | Trepr (ty, _sort_vars) ->
     estimate_type_jkind ~expand_components ~ignore_mod_bounds env ty
+  | Trefine { ref_payload; _ } ->
+    (* The payload determines layout, jkind and runtime representation. *)
+    estimate_type_jkind ~expand_components ~ignore_mod_bounds env ref_payload
   | Tof_kind jkind ->
     (* A [Tof_kind] is substitued for existential [Tvar]s or [Tunivar]s bound in
        a [Tpoly] that would escape their scope. In both cases, we can never
@@ -4039,6 +4048,24 @@ let univars_escape env univar_pairs vl ty =
 
 let univar_pairs = ref []
 
+(* Pairing of dependent-arrow binders, for alpha-equivalence of refinement
+   predicates below them.  Mirrors [univar_pairs]: the comparison functions
+   push a pair while they descend under two arrows whose binders are being
+   identified, and [Vox_rexp.equal] consults the stack. *)
+let arrow_binder_pairs : (Ident.t * Ident.t) list ref = ref []
+
+let with_arrow_binder_pair b1 b2 f =
+  match b1, b2 with
+  | Some id1, Some id2 ->
+      let old = !arrow_binder_pairs in
+      arrow_binder_pairs := (id1, id2) :: old;
+      Misc.try_finally f ~always:(fun () -> arrow_binder_pairs := old)
+  | (Some _ | None), (Some _ | None) ->
+      (* A binder exists only if some predicate mentions it, so a one-sided
+         binder can only be followed by a predicate mismatch; nothing to
+         record. *)
+      f ()
+
 let with_univar_pairs pairs f =
   let old = !univar_pairs in
   univar_pairs := pairs;
@@ -4430,10 +4457,15 @@ let rec mcomp type_pairs env t1 t2 =
             with Not_found -> ()
             end
         (* Rigid cases -- neither side is flexible nor aliasable *)
-        | (Tarrow ((l1,_,_), t1, u1, _), Tarrow ((l2,_,_), t2, u2, _), _, _)
+        | (Tarrow ((l1,_,_,_), t1, u1, _), Tarrow ((l2,_,_,_), t2, u2, _), _, _)
           when compatible_labels ~in_pattern_mode:true l1 l2 ->
             mcomp type_pairs env t1 t2;
             mcomp type_pairs env u1 u2;
+        | (Trefine r1, Trefine r2, _, _) ->
+            (* Only the payloads are compared: returning without raising
+               means "possibly compatible", which is always sound, and the
+               predicates carry no head structure to refute. *)
+            mcomp type_pairs env r1.ref_payload r2.ref_payload
         | (Ttuple tl1, Ttuple tl2, _, _) ->
             mcomp_labeled_list type_pairs env tl1 tl2
         (*
@@ -5131,17 +5163,27 @@ and unify3 uenv t1 t1' t2 t2' =
     end;
     try
       begin match (d1, d2) with
-        (Tarrow ((l1,a1,r1), t1, u1, c1), Tarrow ((l2,a2,r2), t2, u2, c2)) ->
+        (Tarrow ((l1,b1,a1,r1), t1, u1, c1), Tarrow ((l2,b2,a2,r2), t2, u2, c2)) ->
           eq_labels Unify ~in_pattern_mode:(in_pattern_mode uenv) l1 l2;
           unify_alloc_mode_for Unify a1 a2;
           unify_alloc_mode_for Unify r1 r2;
-          unify uenv t1 t2; unify uenv u1 u2;
+          with_arrow_binder_pair b1 b2
+            (fun () -> unify uenv t1 t2; unify uenv u1 u2);
           begin match is_commu_ok c1, is_commu_ok c2 with
           | false, true -> set_commu_ok c1
           | true, false -> set_commu_ok c2
           | false, false -> link_commu ~inside:c1 c2
           | true, true -> ()
           end
+      | (Trefine r1, Trefine r2) ->
+          (* Refinements are rigid: payloads unify, predicates must be
+             syntactically alpha-equivalent.  One-sided refinement falls
+             into the mismatch case below. *)
+          unify uenv r1.ref_payload r2.ref_payload;
+          let type_eq ty1 ty2 = unify uenv ty1 ty2; true in
+          if not (Vox_rexp.equal ~type_eq ~pairs:!arrow_binder_pairs
+                    r1.ref_pred r2.ref_pred)
+          then raise_unexplained_for Unify
       | (Ttuple labeled_tl1, Ttuple labeled_tl2) ->
           unify_labeled_list uenv labeled_tl1 labeled_tl2
       | (Tunboxed_tuple labeled_tl1, Tunboxed_tuple labeled_tl2) ->
@@ -5764,7 +5806,7 @@ let filter_arrow env t l ~force_tpoly =
     let arg_mode = Alloc.newvar () in
     let ret_mode = Alloc.newvar () in
     let t' =
-      newty2 ~level (Tarrow ((l, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok))
+      newty2 ~level (Tarrow ((l, None, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok))
     in
     t', { ty_arg; arg_mode; ty_ret; ret_mode }
   in
@@ -5792,7 +5834,7 @@ let filter_arrow env t l ~force_tpoly =
       end;
       link_type t t';
       arrow_desc
-  | Tarrow((l', arg_mode, ret_mode), ty_arg, ty_ret, _) ->
+  | Tarrow((l', _, arg_mode, ret_mode), ty_arg, ty_ret, _) ->
       if l = l' || !Clflags.classic && l = Nolabel &&
         equivalent_with_nolabels l l'
       then
@@ -6423,9 +6465,10 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
               instantiating [t2], which we do not wish to do *)
               check_type_jkind_exn env Moregen t2 (Jkind.disallow_left jkind);
               link_type t1' t2
-          | (Tarrow ((l1,a1,r1), t1, u1, _),
-             Tarrow ((l2,a2,r2), t2, u2, _)) ->
+          | (Tarrow ((l1,b1,a1,r1), t1, u1, _),
+             Tarrow ((l2,b2,a2,r2), t2, u2, _)) ->
               eq_labels Moregen ~in_pattern_mode:false l1 l2;
+              with_arrow_binder_pair b1 b2 @@ fun () ->
               moregen inst_nongen (neg_variance variance) type_pairs env t1 t2;
               moregen inst_nongen variance type_pairs env u1 u2;
               (* [t2] and [u2] is the user-written interface, which we deem as
@@ -6435,6 +6478,19 @@ let rec moregen inst_nongen variance type_pairs env t1 t2 =
               crossing. Similar for [u1] and [u2]. *)
               moregen_alloc_mode env t2 ~is_ret:false (neg_variance variance) a1 a2;
               moregen_alloc_mode env u2 ~is_ret:true variance r1 r2
+          | (Trefine r1, Trefine r2) ->
+              (* Refinements are rigid: the payloads are compared and the
+                 predicates must be syntactically alpha-equivalent.  There
+                 is no weakening — that is a later piece. *)
+              moregen inst_nongen variance type_pairs env
+                r1.ref_payload r2.ref_payload;
+              let type_eq ty1 ty2 =
+                moregen inst_nongen variance type_pairs env ty1 ty2;
+                true
+              in
+              if not (Vox_rexp.equal ~type_eq ~pairs:!arrow_binder_pairs
+                        r1.ref_pred r2.ref_pred)
+              then raise_unexplained_for Moregen
           | (Ttuple labeled_tl1, Ttuple labeled_tl2) ->
               moregen_labeled_list inst_nongen variance type_pairs env
                 labeled_tl1 labeled_tl2
@@ -6948,13 +7004,25 @@ let rec eqtype rename type_pairs subst env ~do_jkind_check t1 t2 =
           match (get_desc t1', get_desc t2') with
             (Tvar { jkind = k1 }, Tvar { jkind = k2 }) when rename ->
               eqtype_subst env type_pairs subst t1' k1 t2' k2 ~do_jkind_check
-          | (Tarrow ((l1,a1,r1), t1, u1, _),
-             Tarrow ((l2,a2,r2), t2, u2, _)) ->
+          | (Tarrow ((l1,b1,a1,r1), t1, u1, _),
+             Tarrow ((l2,b2,a2,r2), t2, u2, _)) ->
               eq_labels Equality ~in_pattern_mode:false l1 l2;
+              with_arrow_binder_pair b1 b2 @@ fun () ->
               eqtype rename type_pairs subst env t1 t2 ~do_jkind_check:true;
               eqtype rename type_pairs subst env u1 u2 ~do_jkind_check:true;
               eqtype_alloc_mode a1 a2;
               eqtype_alloc_mode r1 r2
+          | (Trefine r1, Trefine r2) ->
+              eqtype rename type_pairs subst env
+                r1.ref_payload r2.ref_payload ~do_jkind_check:true;
+              let type_eq ty1 ty2 =
+                eqtype rename type_pairs subst env ty1 ty2
+                  ~do_jkind_check:true;
+                true
+              in
+              if not (Vox_rexp.equal ~type_eq ~pairs:!arrow_binder_pairs
+                        r1.ref_pred r2.ref_pred)
+              then raise_unexplained_for Equality
           | (Ttuple labeled_tl1, Ttuple labeled_tl2) ->
               eqtype_labeled_list rename type_pairs subst env labeled_tl1
                 labeled_tl2
@@ -7555,7 +7623,10 @@ let rec build_subtype env (visited : transient_expr list)
           (t, Unchanged)
       else
         (t, Unchanged)
-  | Tarrow((l,a,r), t1, t2, _) ->
+  | Trefine _ ->
+      (* Subtyping rules for refinements belong to a later piece. *)
+      (t, Unchanged)
+  | Tarrow((l,binder,a,r), t1, t2, _) ->
       let tt = Transient_expr.repr t in
       if memq_warn tt visited then (t, Unchanged) else
       let visited = tt :: visited in
@@ -7592,7 +7663,7 @@ let rec build_subtype env (visited : transient_expr list)
       in
       let c = max_change c1 (max_change c2 (max_change c3 c4)) in
       if c > Unchanged
-      then (newty (Tarrow((l,a',r'), t1', t2', commu_ok)), c)
+      then (newty (Tarrow((l,binder,a',r'), t1', t2', commu_ok)), c)
       else (t, Unchanged)
   | Ttuple labeled_tlist ->
       build_subtype_tuple env visited loops posi level t labeled_tlist
@@ -7831,8 +7902,8 @@ let rec subtype_rec env trace t1 t2 cstrs =
     match (get_desc t1, get_desc t2) with
       (Tvar _, _) | (_, Tvar _) ->
         (trace, t1, t2, !univar_pairs)::cstrs
-    | (Tarrow((l1,a1,r1), t1, u1, _),
-       Tarrow((l2,a2,r2), t2, u2, _))
+    | (Tarrow((l1,_,a1,r1), t1, u1, _),
+       Tarrow((l2,_,a2,r2), t2, u2, _))
       when compatible_labels ~in_pattern_mode:false l1 l2 ->
         let cstrs =
           subtype_rec

--- a/typing/ctype.mli
+++ b/typing/ctype.mli
@@ -428,6 +428,9 @@ type filter_arrow_failure =
       }
   | Not_a_function
   | Jkind_error of type_expr * Jkind.Violation.t
+  | Dependent_arrow
+    (** The arrow carries a value binder; using it as a function is not
+        supported until the refinement introduction/elimination piece. *)
 
 exception Filter_arrow_failed of filter_arrow_failure
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -2229,7 +2229,9 @@ let prefix_idents root prefixing_sub sg =
     | Sig_value(id, _, _) as item :: rem ->
       let p = Pdot(root, Ident.name id) in
       prefix_idents root
-        ((item, p) :: items_and_paths) prefixing_sub rem
+        ((item, p) :: items_and_paths)
+        (Subst.add_value id p prefixing_sub)
+        rem
     | Sig_type(id, td, rs, vis) :: rem ->
       let p = Pdot(root, Ident.name id) in
       prefix_idents root

--- a/typing/gprinttyp.ml
+++ b/typing/gprinttyp.ml
@@ -677,8 +677,10 @@ module Digraph = struct
     let std_edge = edge std in
     match desc with
     | Types.Tvar { name; _ } -> mk "%a" Pp.pretty_var name
-    | Types.Tarrow ((l,_,_),t1,t2,_) ->
+    | Types.Tarrow ((l,_,_,_),t1,t2,_) ->
        mk "→%a" Pp.exponent_of_label l |> numbered [t1; t2]
+    | Types.Trefine r ->
+        mk "{...}" |> numbered [r.ref_payload]
     | Types.Ttuple tl ->
         mk "*" |> labeled_edges params id tl
     | Types.Tunboxed_tuple tl ->

--- a/typing/ikind.ml
+++ b/typing/ikind.ml
@@ -450,6 +450,9 @@ module Solver = struct
       | Types.Tlink _ -> failwith "Tlink shouldn't appear in kind"
       | Types.Tsubst _ -> failwith "Tsubst shouldn't appear in kind"
       | Types.Trepr (ty, _sort_vars) -> kind ~use_tables:true ctx ty
+      | Types.Trefine { ref_payload; _ } ->
+        (* The payload determines the kind. *)
+        kind ~use_tables:true ctx ref_payload
       | Types.Tpoly (ty, univars) ->
         (* CR ikinds: this is sound but not fully precise.
           Internal ticket 5746. *)

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -1177,7 +1177,7 @@ module Base_and_axes = struct
              belong in the next case. What is the right behaviour here? *)
           | Tquote _ | Tsplice _ | Tquote_eval _ -> Skip
           | Tvar _ | Tarrow _ | Tunboxed_tuple _ | Tobject _ | Tfield _ | Tnil
-          | Tunivar _ | Tpackage _ | Tof_kind _ | Tbox _ ->
+          | Tunivar _ | Tpackage _ | Tof_kind _ | Tbox _ | Trefine _ ->
             (* these cases either cannot be infinitely recursive or their jkinds
                do not have with_bounds *)
             (* CR layouts v2.8: Some of these might get with-bounds someday. We

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -352,7 +352,8 @@ let print_out_modalities ppf l =
 let print_arg_label_and_out_type ppf (lbl : arg_label) ty ~print_type =
   match lbl with
   | Nolabel -> print_type ppf ty
-  | Labelled l -> fprintf ppf "%a:%a" print_lident l print_type ty
+  | Labelled l | Binder l -> fprintf ppf "%a:%a" print_lident l print_type ty
+  | Tilde_labelled l -> fprintf ppf "~%a:%a" print_lident l print_type ty
   | Position l -> fprintf ppf "%a:[%%call_pos]" print_lident l
   | Optional l -> fprintf ppf "?%a:%a" print_lident l print_type ty
 

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -440,6 +440,10 @@ and print_simple_out_type ppf =
   function
     Otyp_class (id, tyl) ->
       fprintf ppf "@[%a#%a@]" print_typargs tyl print_ident id
+  | Otyp_refine (payload, predicate) ->
+      fprintf ppf "@[<hov 2>%a{ %a }@]"
+        print_simple_out_type payload
+        (Format_doc.deprecated Pprintast.expression) predicate
   | Otyp_constr (id, tyl) ->
       pp_open_box ppf 0;
       print_typargs ppf tyl;

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1578,25 +1578,41 @@ let rec tree_of_modal_typexp mode modal ty =
           | ct -> ct
           | exception _ -> Ast_helper.Typ.any None
         in
+        (* Names render through the printer's path machinery, so that
+           shortening and substitution are reflected. *)
+        let rec longident : Outcometree.out_ident -> Longident.t = function
+          | Oide_ident { printed_name } -> Lident printed_name
+          | Oide_dot (id, s) ->
+              Ldot (Location.mknoloc (longident id), Location.mknoloc s)
+          | Oide_apply (a, b) ->
+              Lapply
+                (Location.mknoloc (longident a),
+                 Location.mknoloc (longident b))
+          | Oide_hash id -> longident id
+        in
         let value_ident path =
-          (* Through the printer's path machinery, so that shortening and
-             substitution are reflected. *)
-          let rec longident : Outcometree.out_ident -> Longident.t = function
-            | Oide_ident { printed_name } -> Lident printed_name
-            | Oide_dot (id, s) ->
-                Ldot (Location.mknoloc (longident id), Location.mknoloc s)
-            | Oide_apply (a, b) ->
-                Lapply
-                  (Location.mknoloc (longident a),
-                   Location.mknoloc (longident b))
-            | Oide_hash id -> longident id
-          in
           Location.mknoloc (longident (tree_of_path (Some Value) path))
+        in
+        let constructor_ident path =
+          (* A constructor is qualified by the module of its type. *)
+          match (path : Path.t) with
+          | Pextra_ty (tp, Pcstr_ty name) -> (
+              match tp with
+              | Pdot (m, _) | Pextra_ty (Pdot (m, _), _) ->
+                  Location.mknoloc
+                    (Longident.Ldot
+                       (Location.mknoloc
+                          (longident (tree_of_path (Some Module) m)),
+                        Location.mknoloc name))
+              | _ -> Location.mknoloc (Longident.Lident name))
+          | path ->
+              (* extension constructor *)
+              Location.mknoloc (longident (tree_of_path None path))
         in
         Otyp_refine
           (payload,
-           Vox_rexp.untype ~var_name:Ident.name ~value_ident ~core_type
-             ref_pred)
+           Vox_rexp.untype ~var_name:Ident.name ~value_ident
+             ~constructor_ident ~core_type ref_pred)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)
     | Tunboxed_tuple labeled_tyl ->

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1303,29 +1303,6 @@ let outcome_label : Types.arg_label -> Outcometree.arg_label = function
   | Optional l -> Optional l
   | Position l -> Position l
 
-(* Dependent-arrow binders in scope during conversion: the ident and the
-   name chosen for printing.  A positional binder is renamed when its name
-   collides with an enclosing binder still in scope. *)
-let refinement_binders : (Ident.t * string) list ref = ref []
-
-let refinement_binder_name id =
-  match List.assq_opt id !refinement_binders with
-  | Some name -> name
-  | None -> Ident.name id
-
-let choose_refinement_binder_name id =
-  let taken name =
-    List.exists (fun (_, n) -> String.equal n name) !refinement_binders
-  in
-  let base = Ident.name id in
-  if not (taken base) then base
-  else
-    let rec pick i =
-      let candidate = base ^ string_of_int i in
-      if taken candidate then pick (i + 1) else candidate
-    in
-    pick 1
-
 (* Does some refinement predicate reachable from [tys] satisfy [f]?  The
    walk goes through payloads, predicates' interior types and ordinary
    structure, and is guarded against cycles. *)
@@ -1360,16 +1337,15 @@ let out_label_needs_escape name t1 t2 =
     | Otyp_arrow (slot, _, dom, ret) ->
         let shadows s = String.equal s name in
         (match slot with
-         | Labelled s when shadows s ->
+         | (Labelled s | Binder s) when shadows s ->
              (* a bare slot [name:] re-binds occurrences below it *)
              ()
-         | Labelled s
-           when String.length s > 0 && s.[0] = '~'
-                && shadows (String.sub s 1 (String.length s - 1)) ->
+         | Tilde_labelled s when shadows s ->
              (* [~name:] shadows its own domain only *)
              walk ret
          | Position s when shadows s -> ()
-         | Nolabel | Labelled _ | Optional _ | Position _ ->
+         | Nolabel | Labelled _ | Binder _ | Tilde_labelled _ | Optional _
+         | Position _ ->
              walk dom; walk ret)
     | Otyp_ret (_, t) | Otyp_alias { aliased = t; _ } | Otyp_mod (t, _)
     | Otyp_poly (_, t) | Otyp_newlayout (_, t) | Otyp_repr (_, t)
@@ -1534,16 +1510,12 @@ let rec tree_of_modal_typexp mode modal ty =
               Some id
           | Some _ | None -> None
         in
-        let pre_lab, bound_name =
+        let pre_lab =
           match l, binder with
-          | Nolabel, Some id ->
-              let name = choose_refinement_binder_name id in
-              Some (Outcometree.Labelled name), Some (id, name)
-          | Labelled lbl, Some id ->
-              (* The name of a [~x:] binder is the label itself; it cannot
-                 collide, because its scope is the argument's own
-                 refinements, where the label shadows everything else. *)
-              Some (Outcometree.Labelled ("~" ^ lbl)), Some (id, lbl)
+          | Nolabel, Some id -> Some (Outcometree.Binder (Ident.name id))
+          | Labelled lbl, Some _ ->
+              (* The name of a [~x:] binder is the label itself. *)
+              Some (Outcometree.Tilde_labelled lbl)
           | (Optional _ | Position _), Some _ ->
               Misc.fatal_error
                 "Out_type.tree_of_typexp: binder on an optional or position \
@@ -1551,14 +1523,8 @@ let rec tree_of_modal_typexp mode modal ty =
           | _, None ->
               (* For a plain label the spelling is decided below, on the
                  converted output. *)
-              None, None
+              None
         in
-        protect_refs
-          [ R (refinement_binders,
-               (match bound_name with
-                | Some binding -> binding :: !refinement_binders
-                | None -> !refinement_binders)) ]
-        @@ fun () ->
         (* [marg] will contain undetermined axes. It would be imprecise if we
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
@@ -1591,7 +1557,7 @@ let rec tree_of_modal_typexp mode modal ty =
                  binder. *)
               match lab with
               | Labelled lbl when out_label_needs_escape lbl t1 t2 ->
-                  Labelled ("~" ^ lbl)
+                  Tilde_labelled lbl
               | lab -> lab
         in
         Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
@@ -1612,9 +1578,24 @@ let rec tree_of_modal_typexp mode modal ty =
           | ct -> ct
           | exception _ -> Ast_helper.Typ.any None
         in
+        let value_ident path =
+          (* Through the printer's path machinery, so that shortening and
+             substitution are reflected. *)
+          let rec longident : Outcometree.out_ident -> Longident.t = function
+            | Oide_ident { printed_name } -> Lident printed_name
+            | Oide_dot (id, s) ->
+                Ldot (Location.mknoloc (longident id), Location.mknoloc s)
+            | Oide_apply (a, b) ->
+                Lapply
+                  (Location.mknoloc (longident a),
+                   Location.mknoloc (longident b))
+            | Oide_hash id -> longident id
+          in
+          Location.mknoloc (longident (tree_of_path (Some Value) path))
+        in
         Otyp_refine
           (payload,
-           Vox_rexp.untype ~var_name:refinement_binder_name ~core_type
+           Vox_rexp.untype ~var_name:Ident.name ~value_ident ~core_type
              ref_pred)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)

--- a/typing/out_type.ml
+++ b/typing/out_type.ml
@@ -1303,6 +1303,97 @@ let outcome_label : Types.arg_label -> Outcometree.arg_label = function
   | Optional l -> Optional l
   | Position l -> Position l
 
+(* Dependent-arrow binders in scope during conversion: the ident and the
+   name chosen for printing.  A positional binder is renamed when its name
+   collides with an enclosing binder still in scope. *)
+let refinement_binders : (Ident.t * string) list ref = ref []
+
+let refinement_binder_name id =
+  match List.assq_opt id !refinement_binders with
+  | Some name -> name
+  | None -> Ident.name id
+
+let choose_refinement_binder_name id =
+  let taken name =
+    List.exists (fun (_, n) -> String.equal n name) !refinement_binders
+  in
+  let base = Ident.name id in
+  if not (taken base) then base
+  else
+    let rec pick i =
+      let candidate = base ^ string_of_int i in
+      if taken candidate then pick (i + 1) else candidate
+    in
+    pick 1
+
+(* Does some refinement predicate reachable from [tys] satisfy [f]?  The
+   walk goes through payloads, predicates' interior types and ordinary
+   structure, and is guarded against cycles. *)
+let exists_refinement_pred f tys =
+  let exception Found in
+  let visited = Hashtbl.create 8 in
+  let rec walk ty =
+    let id = get_id ty in
+    if not (Hashtbl.mem visited id) then begin
+      Hashtbl.add visited id ();
+      (match get_desc ty with
+       | Trefine { ref_pred; _ } -> if f ref_pred then raise Found
+       | _ -> ());
+      Btype.iter_type_expr walk ty
+    end
+  in
+  match List.iter walk tys with () -> false | exception Found -> true
+
+(* Would the bare label [name] capture an occurrence on re-parse?  This
+   runs on the converted output — the artifact that will actually be
+   re-parsed — and mirrors the occurrence test's scoping: an arrow whose
+   printed name slot is [name] shadows it below (bare slots capture,
+   [~name] shadows its domain only), and predicate-local binders shadow
+   inside predicates ([Vox_binding.name_used_in_predicate]). *)
+let out_label_needs_escape name t1 t2 =
+  let exception Found in
+  let rec walk (t : Outcometree.out_type) =
+    match t with
+    | Otyp_refine (payload, pred) ->
+        if Vox_binding.name_used_in_predicate name pred then raise Found;
+        walk payload
+    | Otyp_arrow (slot, _, dom, ret) ->
+        let shadows s = String.equal s name in
+        (match slot with
+         | Labelled s when shadows s ->
+             (* a bare slot [name:] re-binds occurrences below it *)
+             ()
+         | Labelled s
+           when String.length s > 0 && s.[0] = '~'
+                && shadows (String.sub s 1 (String.length s - 1)) ->
+             (* [~name:] shadows its own domain only *)
+             walk ret
+         | Position s when shadows s -> ()
+         | Nolabel | Labelled _ | Optional _ | Position _ ->
+             walk dom; walk ret)
+    | Otyp_ret (_, t) | Otyp_alias { aliased = t; _ } | Otyp_mod (t, _)
+    | Otyp_poly (_, t) | Otyp_newlayout (_, t) | Otyp_repr (_, t)
+    | Otyp_attribute (t, _) | Otyp_quote t | Otyp_splice t
+    | Otyp_jkind_annot (t, _) ->
+        walk t
+    | Otyp_tuple lts | Otyp_unboxed_tuple lts ->
+        List.iter (fun (_, t) -> walk t) lts
+    | Otyp_constr (_, ts) | Otyp_class (_, ts) -> List.iter walk ts
+    | Otyp_manifest (ta, tb) -> walk ta; walk tb
+    | Otyp_object { fields; _ } -> List.iter (fun (_, t) -> walk t) fields
+    | Otyp_variant (var, _, _) ->
+        (match var with
+         | Ovar_fields fields ->
+             List.iter (fun (_, _, ts) -> List.iter walk ts) fields
+         | Ovar_typ t -> walk t)
+    | Otyp_module { opack_cstrs; _ } ->
+        List.iter (fun (_, t) -> walk t) opack_cstrs
+    | Otyp_stuff _ | Otyp_var _ | Otyp_abstract | Otyp_open | Otyp_sum _
+    | Otyp_record _ | Otyp_record_unboxed_product _
+    | Otyp_of_kind _ -> ()
+  in
+  match walk t1; walk t2 with () -> false | exception Found -> true
+
 (** Un-interpret modalities back to outcome tree. Takes the mutability and
     attributes on the field and removes mutable-implied modalities
     accordingly. *)
@@ -1428,11 +1519,46 @@ let rec tree_of_modal_typexp mode modal ty =
         let non_gen = is_non_gen mode ty in
         let name_gen = Variable_names.new_var_name ~non_gen ty in
         Otyp_var (non_gen, Variable_names.name_of_type name_gen tty)
-    | Tarrow ((l, marg, mret), ty1, ty2, _) ->
-        let lab =
-          if !print_labels || is_omittable l then outcome_label l
-          else Nolabel
+    | Tarrow ((l, binder, marg, mret), ty1, ty2, _) ->
+        (* The label slot of the outcome arrow is the printed name slot: a
+           dependent-arrow binder prints as [x:], and a label that would
+           re-parse as a binder is escaped as [~x:]. *)
+        let binder_scope =
+          match l with Nolabel -> [ty1; ty2] | _ -> [ty1]
         in
+        let binder =
+          match binder with
+          | Some id
+            when exists_refinement_pred (Vox_rexp.mentions_ident id)
+                   binder_scope ->
+              Some id
+          | Some _ | None -> None
+        in
+        let pre_lab, bound_name =
+          match l, binder with
+          | Nolabel, Some id ->
+              let name = choose_refinement_binder_name id in
+              Some (Outcometree.Labelled name), Some (id, name)
+          | Labelled lbl, Some id ->
+              (* The name of a [~x:] binder is the label itself; it cannot
+                 collide, because its scope is the argument's own
+                 refinements, where the label shadows everything else. *)
+              Some (Outcometree.Labelled ("~" ^ lbl)), Some (id, lbl)
+          | (Optional _ | Position _), Some _ ->
+              Misc.fatal_error
+                "Out_type.tree_of_typexp: binder on an optional or position \
+                 argument"
+          | _, None ->
+              (* For a plain label the spelling is decided below, on the
+                 converted output. *)
+              None, None
+        in
+        protect_refs
+          [ R (refinement_binders,
+               (match bound_name with
+                | Some binding -> binding :: !refinement_binders
+                | None -> !refinement_binders)) ]
+        @@ fun () ->
         (* [marg] will contain undetermined axes. It would be imprecise if we
            don't print anything for those axes, since user would interpret that
            as legacy. The best we can do is to zap to legacy and if they do land
@@ -1453,7 +1579,43 @@ let rec tree_of_modal_typexp mode modal ty =
         let acc_mode = curry_mode alloc_mode arg_mode in
         let modal = Arrow_return {acc = acc_mode; mode = mret} in
         let t2 = tree_of_modal_typexp mode modal ty2 in
+        let lab =
+          match pre_lab with
+          | Some lab -> lab
+          | None ->
+              let lab =
+                if !print_labels || is_omittable l then outcome_label l
+                else Nolabel
+              in
+              (* Escape a label whose bare spelling would re-parse as a
+                 binder. *)
+              match lab with
+              | Labelled lbl when out_label_needs_escape lbl t1 t2 ->
+                  Labelled ("~" ^ lbl)
+              | lab -> lab
+        in
         Otyp_arrow (lab, tree_of_modes arg_mode, t1, t2)
+    | Trefine { ref_payload; ref_pred } ->
+        let payload = tree_of_typexp mode Alloc.Const.legacy ref_payload in
+        let core_type ty =
+          (* Render an interior type through the printer and re-parse it as
+             source syntax, so that paths, variable names and nested
+             refinements are printed consistently with the enclosing
+             output. *)
+          let rendered =
+            Format_doc.asprintf "%t"
+              (fun ppf ->
+                !Oprint.out_type ppf
+                  (tree_of_typexp mode Alloc.Const.legacy ty))
+          in
+          match Parse.core_type (Lexing.from_string rendered) with
+          | ct -> ct
+          | exception _ -> Ast_helper.Typ.any None
+        in
+        Otyp_refine
+          (payload,
+           Vox_rexp.untype ~var_name:refinement_binder_name ~core_type
+             ref_pred)
     | Ttuple labeled_tyl ->
         Otyp_tuple (tree_of_labeled_typlist mode labeled_tyl)
     | Tunboxed_tuple labeled_tyl ->

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -128,7 +128,14 @@ and out_type =
   | Otyp_open
   | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
   | Otyp_arrow of arg_label * out_arg_mode * out_type * out_type
-  (** INVARIANT: the [out_type] for the return must be [Otyp_ret]. *)
+  (** INVARIANT: the [out_type] for the return must be [Otyp_ret].
+
+      The label string is the printed name slot verbatim: a dependent-arrow
+      binder is [Labelled "x"], and a label escaped so that it does not
+      re-parse as a binder is [Labelled "~x"]. *)
+  | Otyp_refine of out_type * Parsetree.expression
+  (** [T{ P }]: a refinement type.  The predicate is carried as surface
+      syntax, produced by [Out_type], and printed with [Pprintast]. *)
   | Otyp_class of out_ident * out_type list
   | Otyp_constr of out_ident * out_type list
   | Otyp_manifest of out_type * out_type

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -81,6 +81,12 @@ type arg_label =
   | Labelled of string
   | Optional of string
   | Position of string
+  | Binder of string
+      (** The value binder of a dependent arrow: prints as [x:], not a
+          label. *)
+  | Tilde_labelled of string
+      (** A label printed [~x:], so that it does not re-parse as a
+          binder. *)
 
 type out_mode = string
 
@@ -128,11 +134,7 @@ and out_type =
   | Otyp_open
   | Otyp_alias of {non_gen:bool; aliased:out_type; alias:string}
   | Otyp_arrow of arg_label * out_arg_mode * out_type * out_type
-  (** INVARIANT: the [out_type] for the return must be [Otyp_ret].
-
-      The label string is the printed name slot verbatim: a dependent-arrow
-      binder is [Labelled "x"], and a label escaped so that it does not
-      re-parse as a binder is [Labelled "~x"]. *)
+  (** INVARIANT: the [out_type] for the return must be [Otyp_ret]. *)
   | Otyp_refine of out_type * Parsetree.expression
   (** [T{ P }]: a refinement type.  The predicate is carried as surface
       syntax, produced by [Out_type], and printed with [Pprintast]. *)

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -437,14 +437,7 @@ let rec core_type i ppf x =
   | Ttyp_refine (ct, pred) ->
       line i ppf "Ttyp_refine\n";
       core_type i ppf ct;
-      (* The predicate is resolved syntax shared with the type graph; print
-         it back as source. *)
-      line (i+1) ppf "predicate %a\n"
-        (fun ppf pred ->
-          Pprintast.expression ppf
-            (Vox_rexp.untype ~var_name:Ident.name
-               ~core_type:(fun _ -> Ast_helper.Typ.any None) pred))
-        pred
+      line (i+1) ppf "predicate %a\n" Pprintast.expression pred
   | Ttyp_repr (lv, ct) ->
       line i ppf "Ttyp_repr%a\n"
         (fun ppf -> List.iter (typevar_no_jkind ~print_quote:true ppf)) lv;

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -372,9 +372,12 @@ let rec core_type i ppf x =
   | Ttyp_var (s, jkind) ->
       line i ppf "Ttyp_var %s\n" (Option.value ~default:"_" s);
       option i jkind_annotation ppf jkind
-  | Ttyp_arrow (l, ct1, m1, ct2, m2) ->
+  | Ttyp_arrow (l, binder, ct1, m1, ct2, m2) ->
       line i ppf "Ttyp_arrow\n";
       arg_label i ppf l;
+      (match binder with
+       | None -> ()
+       | Some id -> line (i+1) ppf "binder %a\n" fmt_ident id);
       core_type i ppf ct1;
       alloc_modes i ppf m1;
       core_type i ppf ct2;
@@ -431,6 +434,17 @@ let rec core_type i ppf x =
   | Ttyp_splice t ->
       line i ppf "Ttyp_splice\n";
       core_type i ppf t
+  | Ttyp_refine (ct, pred) ->
+      line i ppf "Ttyp_refine\n";
+      core_type i ppf ct;
+      (* The predicate is resolved syntax shared with the type graph; print
+         it back as source. *)
+      line (i+1) ppf "predicate %a\n"
+        (fun ppf pred ->
+          Pprintast.expression ppf
+            (Vox_rexp.untype ~var_name:Ident.name
+               ~core_type:(fun _ -> Ast_helper.Typ.any None) pred))
+        pred
   | Ttyp_repr (lv, ct) ->
       line i ppf "Ttyp_repr%a\n"
         (fun ppf -> List.iter (typevar_no_jkind ~print_quote:true ppf)) lv;

--- a/typing/rawprinttyp.ml
+++ b/typing/rawprinttyp.ml
@@ -107,13 +107,15 @@ and raw_type_desc ppf ty =
     Tvar { name; jkind } ->
       fprintf ppf "Tvar (@,%a,@,%a)"
         print_name name (Format_doc.compat (Jkind.format env)) jkind
-  | Tarrow((l,arg,ret),t1,t2,c) ->
+  | Tarrow((l,_binder,arg,ret),t1,t2,c) ->
       fprintf ppf "@[<hov1>Tarrow((\"%s\",%a,%a),@,%a,@,%a,@,%s)@]"
         (string_of_label l)
         (Format_doc.compat (Alloc.print ~verbose:true ())) arg
         (Format_doc.compat (Alloc.print ~verbose:true ())) ret
         raw_type t1 raw_type t2
         (if is_commu_ok c then "Cok" else "Cunknown")
+  | Trefine { ref_payload; ref_pred = _ } ->
+      fprintf ppf "@[<1>Trefine@,%a@]" raw_type ref_payload
   | Ttuple tl ->
       fprintf ppf "@[<1>Ttuple@,%a@]" labeled_type_list tl
   | Tunboxed_tuple tl ->

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -618,7 +618,7 @@ let jkind_const_desc s
   | Layout _ -> jkind
 
 (* Similar to [Ctype.nondep_type_rec]. *)
-let rec typexp copy_scope s ty =
+let rec typexp copy_scope s rename ty =
   let should_duplicate_vars =
     match s.additional_action with
     | Duplicate_variables | Prepare_for_saving _ -> true
@@ -678,7 +678,7 @@ let rec typexp copy_scope s ty =
         | _ -> assert false
       else match desc with
       | Tconstr (p, args, _abbrev) ->
-         let args = List.map (typexp copy_scope s) args in
+         let args = List.map (typexp copy_scope s rename) args in
          begin match Path.Map.find p s.types with
          | exception Not_found -> Tconstr(type_path s p, args, ref Mnil)
          | Path _ -> Tconstr(type_path s p, args, ref Mnil)
@@ -689,17 +689,17 @@ let rec typexp copy_scope s ty =
           Tpackage {
             pack_path = modtype_path s pack_path;
             pack_cstrs =
-              List.map (fun (n, ty) -> (n, typexp copy_scope s ty)) pack_cstrs;
+              List.map (fun (n, ty) -> (n, typexp copy_scope s rename ty)) pack_cstrs;
           }
       | Tobject (t1, name) ->
-          let t1' = typexp copy_scope s t1 in
+          let t1' = typexp copy_scope s rename t1 in
           let name' =
             match !name with
             | None -> None
             | Some (p, tl) ->
                 if to_subst_by_type_function s p
                 then None
-                else Some (type_path s p, List.map (typexp copy_scope s) tl)
+                else Some (type_path s p, List.map (typexp copy_scope s rename) tl)
           in
           Tobject (t1', ref name')
       | Tvariant row ->
@@ -722,7 +722,7 @@ let rec typexp copy_scope s ty =
                 match mored with
                   Tsubst (ty, None) -> ty
                 | Tconstr _ | Tquote _ | Tsplice _ | Tnil | Tof_kind _ ->
-                    typexp copy_scope s more
+                    typexp copy_scope s rename more
                 | Tunivar _ | Tvar _ ->
                     if should_duplicate_vars then newpersty mored
                     else if dup && is_Tvar more then newgenty mored
@@ -735,7 +735,7 @@ let rec typexp copy_scope s ty =
               (* TODO: check if more' can be eliminated *)
               (* Return a new copy *)
               let row =
-                copy_row (typexp copy_scope s) true row (not dup) more' in
+                copy_row (typexp copy_scope s rename) true row (not dup) more' in
               match row_name row with
               | Some (p, tl) ->
                   let name =
@@ -747,22 +747,38 @@ let rec typexp copy_scope s ty =
                   Tvariant row
           end
       | Tfield(_label, kind, _t1, t2) when field_kind_repr kind = Fabsent ->
-          Tlink (typexp copy_scope s t2)
-      | Tarrow ((label, marg, mret), arg, ret, comm) ->
+          Tlink (typexp copy_scope s rename t2)
+      | Tarrow ((label, binder, marg, mret), arg, ret, comm) ->
           let marg, mret =
             match s.additional_action with
             | Prepare_for_saving { prepare_mode; _ } ->
               prepare_mode marg, prepare_mode mret
             | _ -> marg, mret
           in
-          let arg = typexp copy_scope s arg in
-          let ret = typexp copy_scope s ret in
+          (* Freshen the binder stamp; the references in the refinement
+             predicates below are rewritten through [rename]. *)
+          let rename, binder =
+            match binder with
+            | None -> rename, None
+            | Some id ->
+                let id' = Ident.rename id in
+                Ident.Map.add id id' rename, Some id'
+          in
+          let arg = typexp copy_scope s rename arg in
+          let ret = typexp copy_scope s rename ret in
           let comm = copy_commu comm in
-          Tarrow ((label, marg, mret), arg, ret, comm)
+          Tarrow ((label, binder, marg, mret), arg, ret, comm)
+      | Trefine { ref_payload; ref_pred } ->
+          Trefine
+            { ref_payload = typexp copy_scope s rename ref_payload;
+              ref_pred =
+                Vox_rexp.map ~rename ~freshen:true
+                  ~value_path:(value_path s)
+                  ~type_expr:(typexp copy_scope s rename) ref_pred }
       | Tof_kind jk -> Tof_kind (jkind copy_scope s jk)
       | Tmod (ty, mod_bounds) ->
-          Tmod (typexp copy_scope s ty, mod_bounds)
-      | _ -> copy_type_desc (typexp copy_scope s) desc
+          Tmod (typexp copy_scope s rename ty, mod_bounds)
+      | _ -> copy_type_desc (typexp copy_scope s rename) desc
     in
     Transient_expr.set_stub_desc ty' desc;
     ty'
@@ -776,7 +792,7 @@ and jkind : 'l 'r. _ -> _ -> ('l * 'r) jkind -> ('l * 'r) jkind =
     | Duplicate_variables | No_action -> jkind
   in
   (* CR-soon layouts aivaskovic: get rid of map_type_expr *)
-  let jkind = Jkind.map_type_expr (typexp copy_scope s) jkind in
+  let jkind = Jkind.map_type_expr (typexp copy_scope s Ident.Map.empty) jkind in
   let jkind_desc = jkind_desc s jkind.jkind in
   if jkind_desc == jkind.jkind then jkind
   else { jkind with jkind = jkind_desc }
@@ -789,7 +805,7 @@ and jkind : 'l 'r. _ -> _ -> ('l * 'r) jkind -> ('l * 'r) jkind =
 *)
 let typexp copy_scope s loc ty =
   location_for_jkind_check_errors := loc;
-  typexp copy_scope s ty
+  typexp copy_scope s Ident.Map.empty ty
 
 let jkind copy_scope s loc jk =
   location_for_jkind_check_errors := loc;

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -785,6 +785,7 @@ let rec typexp copy_scope s rename ty =
               ref_pred =
                 Vox_rexp.map ~rename ~freshen:true
                   ~value_path:(value_path s)
+                  ~constructor_path:(type_path s)
                   ~type_expr:(typexp copy_scope s rename) ref_pred }
       | Tof_kind jk -> Tof_kind (jkind copy_scope s rename jk)
       | Tmod (ty, mod_bounds) ->

--- a/typing/subst.ml
+++ b/typing/subst.ml
@@ -73,6 +73,10 @@ type s =
     modules: Path.t Path.Map.t;
     modtypes: module_type Path.Map.t;
     jkinds: kind_replacement Path.Map.t;
+    values: Path.t Path.Map.t;
+    (* Value paths only occur in types inside refinement predicates
+       ([Rexp_ident]); this map is what keeps them meaningful across
+       signature prefixing and binder renaming. *)
 
     additional_action: additional_action;
     sort_var_mapping: sort_map;
@@ -110,6 +114,7 @@ let identity =
     modules = Path.Map.empty;
     modtypes = Path.Map.empty;
     jkinds = Path.Map.empty;
+    values = Path.Map.empty;
     additional_action = No_action;
     sort_var_mapping = Nothing;
     loc = None;
@@ -152,6 +157,9 @@ let add_type id p s =
 
 let add_module id p s =
   { s with modules = Path.Map.add (Pident id) p s.modules; last_compose = None }
+
+let add_value id p s =
+  { s with values = Path.Map.add (Pident id) p s.values; last_compose = None }
 
 let add_modtype_gen p ty s =
   { s with modtypes = Path.Map.add p ty s.modtypes; last_compose = None }
@@ -407,10 +415,13 @@ let jkind_path s path =
 
 (* For values, extension constructors, classes and class types *)
 let value_path s path =
-  match path with
-  | Pident _ -> path
-  | Pdot(p, n) -> Pdot(module_path s p, n)
-  | Papply _ | Pextra_ty _ -> fatal_error "Subst.value_path"
+  match Path.Map.find path s.values with
+  | p -> p
+  | exception Not_found ->
+      match path with
+      | Pident _ -> path
+      | Pdot(p, n) -> Pdot(module_path s p, n)
+      | Papply _ | Pextra_ty _ -> fatal_error "Subst.value_path"
 
 let rec type_path s path =
   match Path.Map.find path s.types with
@@ -628,7 +639,7 @@ let rec typexp copy_scope s rename ty =
   match desc with
     Tvar { jkind = jk } | Tunivar { jkind = jk } ->
       let desc, jkind_changed =
-        let jk' = jkind copy_scope s jk in
+        let jk' = jkind copy_scope s rename jk in
         if jk == jk' then desc, false else
           let desc =
             match desc with
@@ -775,7 +786,7 @@ let rec typexp copy_scope s rename ty =
                 Vox_rexp.map ~rename ~freshen:true
                   ~value_path:(value_path s)
                   ~type_expr:(typexp copy_scope s rename) ref_pred }
-      | Tof_kind jk -> Tof_kind (jkind copy_scope s jk)
+      | Tof_kind jk -> Tof_kind (jkind copy_scope s rename jk)
       | Tmod (ty, mod_bounds) ->
           Tmod (typexp copy_scope s rename ty, mod_bounds)
       | _ -> copy_type_desc (typexp copy_scope s rename) desc
@@ -783,8 +794,8 @@ let rec typexp copy_scope s rename ty =
     Transient_expr.set_stub_desc ty' desc;
     ty'
 
-and jkind : 'l 'r. _ -> _ -> ('l * 'r) jkind -> ('l * 'r) jkind =
-  fun copy_scope s jkind ->
+and jkind : 'l 'r. _ -> _ -> _ -> ('l * 'r) jkind -> ('l * 'r) jkind =
+  fun copy_scope s rename jkind ->
   let jkind =
     match s.additional_action with
     | Prepare_for_saving { prepare_jkind; _ } ->
@@ -792,7 +803,7 @@ and jkind : 'l 'r. _ -> _ -> ('l * 'r) jkind -> ('l * 'r) jkind =
     | Duplicate_variables | No_action -> jkind
   in
   (* CR-soon layouts aivaskovic: get rid of map_type_expr *)
-  let jkind = Jkind.map_type_expr (typexp copy_scope s Ident.Map.empty) jkind in
+  let jkind = Jkind.map_type_expr (typexp copy_scope s rename) jkind in
   let jkind_desc = jkind_desc s jkind.jkind in
   if jkind_desc == jkind.jkind then jkind
   else { jkind with jkind = jkind_desc }
@@ -809,7 +820,7 @@ let typexp copy_scope s loc ty =
 
 let jkind copy_scope s loc jk =
   location_for_jkind_check_errors := loc;
-  jkind copy_scope s jk
+  jkind copy_scope s Ident.Map.empty jk
 
 (*
    Always make a copy of the type. If this is not done, type levels
@@ -1175,7 +1186,10 @@ let rename_bound_idents scoping s sg =
     | Sig_value(id, vd, vis) :: rest ->
         (* scope doesn't matter for value identifiers. *)
         let id' = rename_ident s id in
-        rename_bound_idents s (Sig_value(id', vd, vis) :: sg) rest
+        rename_bound_idents
+          (add_value id (Pident id') s)
+          (Sig_value(id', vd, vis) :: sg)
+          rest
     | Sig_typext(id, ec, es, vis) :: rest ->
         let id' = rename id in
         rename_bound_idents s (Sig_typext(id',ec,es,vis) :: sg) rest
@@ -1358,6 +1372,7 @@ and compose s1 s2 =
           modules = merge_path_maps (module_path s2) s1.modules s2.modules;
           modtypes = merge_path_maps (modtype Keep s2) s1.modtypes s2.modtypes;
           jkinds = merge_path_maps (jkind_replacement s2) s1.jkinds s2.jkinds;
+          values = merge_path_maps (value_path s2) s1.values s2.values;
           additional_action = begin
             match s1.additional_action, s2.additional_action with
             | action, No_action | No_action, action -> action

--- a/typing/subst.mli
+++ b/typing/subst.mli
@@ -50,6 +50,8 @@ val unsafe: t -> unsafe subst
 
 val add_type: Ident.t -> Path.t -> 'k subst -> 'k subst
 val add_module: Ident.t -> Path.t -> 'k subst -> 'k subst
+(* Value paths occur in types only inside refinement predicates. *)
+val add_value: Ident.t -> Path.t -> 'k subst -> 'k subst
 val add_modtype: Ident.t -> Path.t -> 'k subst -> 'k subst
 val add_jkind: Ident.t -> Path.t -> t -> t
 

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -747,11 +747,15 @@ let typ sub {ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes; _} =
   match ctyp_desc with
   | Ttyp_var (_, jkind) ->
       Option.iter (sub.jkind_annotation sub) jkind
-  | Ttyp_arrow (_, ct1, ma1, ct2, ma2) ->
+  | Ttyp_arrow (_, _, ct1, ma1, ct2, ma2) ->
       sub.typ sub ct1;
       sub.modes sub ma1;
       sub.typ sub ct2;
       sub.modes sub ma2
+  | Ttyp_refine (payload, _pred) ->
+      (* The predicate is resolved syntax shared with the type graph, not a
+         typedtree fragment; there is nothing typedtree-shaped to visit. *)
+      sub.typ sub payload
   | Ttyp_tuple list -> List.iter (fun (_, t) -> sub.typ sub t) list
   | Ttyp_unboxed_tuple list -> List.iter (fun (_, t) -> sub.typ sub t) list
   | Ttyp_constr (_, lid, list) ->

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -753,8 +753,8 @@ let typ sub {ctyp_loc; ctyp_desc; ctyp_env; ctyp_attributes; _} =
       sub.typ sub ct2;
       sub.modes sub ma2
   | Ttyp_refine (payload, _pred) ->
-      (* The predicate is resolved syntax shared with the type graph, not a
-         typedtree fragment; there is nothing typedtree-shaped to visit. *)
+      (* The predicate is the source expression; the resolved form lives in
+         the type graph.  There is nothing typedtree-shaped to visit. *)
       sub.typ sub payload
   | Ttyp_tuple list -> List.iter (fun (_, t) -> sub.typ sub t) list
   | Ttyp_unboxed_tuple list -> List.iter (fun (_, t) -> sub.typ sub t) list

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -1054,9 +1054,13 @@ let typ sub x =
     | (Ttyp_var (_,None) | Ttyp_call_pos) as d -> d
     | Ttyp_var (s, Some jkind) ->
         Ttyp_var (s, Some (sub.jkind_annotation sub jkind))
-    | Ttyp_arrow (label, ct1, ma1, ct2, ma2) ->
-        Ttyp_arrow (label, sub.typ sub ct1, sub.modes sub ma1,
+    | Ttyp_arrow (label, binder, ct1, ma1, ct2, ma2) ->
+        Ttyp_arrow (label, binder, sub.typ sub ct1, sub.modes sub ma1,
                     sub.typ sub ct2, sub.modes sub ma2)
+    | Ttyp_refine (payload, pred) ->
+        (* The predicate is resolved syntax shared with the type graph, not
+           a typedtree fragment. *)
+        Ttyp_refine (sub.typ sub payload, pred)
     | Ttyp_tuple list ->
         Ttyp_tuple (List.map (fun (label, t) -> label, sub.typ sub t) list)
     | Ttyp_unboxed_tuple list ->

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -1058,8 +1058,8 @@ let typ sub x =
         Ttyp_arrow (label, binder, sub.typ sub ct1, sub.modes sub ma1,
                     sub.typ sub ct2, sub.modes sub ma2)
     | Ttyp_refine (payload, pred) ->
-        (* The predicate is resolved syntax shared with the type graph, not
-           a typedtree fragment. *)
+        (* The predicate is the source expression; the resolved form lives
+           in the type graph. *)
         Ttyp_refine (sub.typ sub payload, pred)
     | Ttyp_tuple list ->
         Ttyp_tuple (List.map (fun (label, t) -> label, sub.typ sub t) list)

--- a/typing/type_shape.ml
+++ b/typing/type_shape.ml
@@ -246,6 +246,9 @@ module Type_shape = struct
             (* CR layout-polymorphism aivaskovic: sort variables do not
                influence the type shape. *)
             of_type_expr_go ~depth ~visited type_expr subst shape_for_constr
+          | Trefine { ref_payload; _ } ->
+            (* The payload determines the runtime representation. *)
+            of_type_expr_go ~depth ~visited ref_payload subst shape_for_constr
           | Tunboxed_tuple exprs ->
             Shape.unboxed_tuple (of_expr_list (List.map snd exprs))
           | Tobject _ | Tnil | Tfield _ ->
@@ -269,7 +272,7 @@ module Type_shape = struct
                 | Tpoly (_, _)
                 | Trepr (_, _)
                 | Tpackage _ | Tquote _ | Tsplice _ | Tquote_eval _ | Tof_kind _
-                | Tbox _ ->
+                | Tbox _ | Trefine _ ->
                   assert false
               in
               Misc.fatal_errorf

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -196,7 +196,7 @@ let rec constructor_type constr cty =
   | Cty_signature _ ->
       constr
   | Cty_arrow (l, ty, cty) ->
-      let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
+      let arrow_desc = l, None, Mode.Alloc.legacy, Mode.Alloc.legacy in
       let ty = Ctype.newmono ty in
       Ctype.newty
         (Tarrow (arrow_desc, ty, constructor_type constr cty, commu_ok))
@@ -962,7 +962,7 @@ and class_field_second_pass cl_num sign met_env field =
         (fun () ->
            let ty = Btype.method_type label.txt sign in
            let self_type = sign.Types.csig_self in
-           let arrow_desc = Nolabel, Mode.Alloc.legacy, Mode.Alloc.legacy in
+           let arrow_desc = Nolabel, None, Mode.Alloc.legacy, Mode.Alloc.legacy in
            let self_param_type = Btype.newgenty (Tpoly(self_type, [])) in
            let meth_type =
              Typecore.mk_expected (Btype.newgenty
@@ -982,7 +982,7 @@ and class_field_second_pass cl_num sign met_env field =
         (fun () ->
            let unit_type = Ctype.instance Predef.type_unit in
            let self_param_type = Ctype.newmono sign.Types.csig_self in
-           let arrow_desc = Nolabel, Mode.Alloc.legacy, Mode.Alloc.legacy in
+           let arrow_desc = Nolabel, None, Mode.Alloc.legacy, Mode.Alloc.legacy in
            let meth_type =
              Typecore.mk_expected (Ctype.newty
                (Tarrow (arrow_desc, self_param_type, unit_type, commu_ok)))
@@ -1592,7 +1592,7 @@ let rec approx_declaration cl =
            classes to work with jkinds *)
       in
       let arg = Ctype.newmono arg in
-      let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
+      let arrow_desc = l, None, Mode.Alloc.legacy, Mode.Alloc.legacy in
       Ctype.newty
         (Tarrow (arrow_desc, arg, approx_declaration cl, commu_ok))
   | Pcl_let (_, _, cl) ->
@@ -1612,7 +1612,7 @@ let rec approx_description ct =
            relax jkinds in classes *)
       in
       let arg = Ctype.newmono arg in
-      let arrow_desc = l, Mode.Alloc.legacy, Mode.Alloc.legacy in
+      let arrow_desc = l, None, Mode.Alloc.legacy, Mode.Alloc.legacy in
       Ctype.newty
         (Tarrow (arrow_desc, arg, approx_description ct, commu_ok))
   | _ -> Ctype.newvar (Jkind.Builtin.value ~why:Object)

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -315,6 +315,7 @@ type error =
   | Exclave_returns_not_local
   | Unboxed_int_literals_not_supported
   | Function_type_not_rep of type_expr * Jkind.Violation.t
+  | Unsupported_dependent_arrow
   | Function_type_escapes_partial_match of
       { ty : type_expr;
         match_loc : Location.t;
@@ -365,6 +366,7 @@ let error_of_filter_arrow_failure ~explanation ~first ty_fun
       else Too_many_arguments(ty_fun, explanation)
     end
   | Jkind_error (ty, err) -> Function_type_not_rep (ty, err)
+  | Dependent_arrow -> Unsupported_dependent_arrow
 
 (* Forward declaration, to be filled in by Typemod.type_module *)
 
@@ -4964,7 +4966,10 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
                               { some_args_ok; ty_fun; jkind }))
               end;
               (sort_arg, mode_arg, ty_arg_mono, mode_ret, ty_res)
-        | Tarrow ((l, _, mode_arg, mode_ret), ty_arg, ty_res, _)
+        | Tarrow ((l, Some _, _, _), _, _, _)
+          when labels_match ~param:l ~arg:lbl ->
+            raise (Error (sarg.pexp_loc, env, Unsupported_dependent_arrow))
+        | Tarrow ((l, None, mode_arg, mode_ret), ty_arg, ty_res, _)
           when labels_match ~param:l ~arg:lbl ->
             let sort_arg =
               match
@@ -5103,6 +5108,12 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs
             let arg =
               match arg_opt with
               | Some (sarg, l', ~commuted) ->
+                  (* Consuming a dependent parameter would let the rest of
+                     the arrow escape the binder's scope; the elimination
+                     rules are a later piece. *)
+                  if arg_binder <> None then
+                    raise (Error (sarg.pexp_loc, env,
+                                  Unsupported_dependent_arrow));
                   let wrapped_in_some = optional && not (is_optional l') in
                   if wrapped_in_some then
                     may_warn sarg.pexp_loc
@@ -11972,6 +11983,11 @@ and type_n_ary_function
                     fatal_error
                       "Jkind_error not expected as this point; this should \
                        have been caught when the function was typechecked."
+                | Dependent_arrow ->
+                    fatal_error
+                      "Dependent_arrow not expected at this point; this \
+                       should have been caught when the function was \
+                       typechecked."
               in
               let err =
                 Function_arity_type_clash
@@ -13571,6 +13587,11 @@ let report_error ~loc env =
         (Jkind.Violation.report_with_offender
            ~offender:(fun ppf -> Printtyp.type_expr ppf ty)
            env) violation
+  | Unsupported_dependent_arrow ->
+      Location.errorf ~loc
+        "@[Functions with a dependent arrow type cannot be defined or@ \
+         applied yet: the introduction and elimination rules for@ \
+         refinements are not implemented.@]"
   | Function_type_escapes_partial_match { ty; match_loc; kind; why } ->
       let what =
         match kind with `Argument -> "argument" | `Result -> "result"

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4670,7 +4670,7 @@ let rec list_labels_aux env visited ls ty_fun =
   if TypeSet.mem ty visited then
     List.rev ls, false
   else match get_desc ty with
-    | Tarrow ((l,_,_), _, ty_res, _) ->
+    | Tarrow ((l,_,_,_), _, ty_res, _) ->
         list_labels_aux env (TypeSet.add ty visited) (l::ls) ty_res
     | _ ->
         List.rev ls, is_Tvar ty
@@ -4874,7 +4874,7 @@ let remaining_function_type_for_error ty_ret mode_ret rev_args =
          | Arg (Eliminated_optional_arg
                   { mode_fun; ty_arg; mode_arg; level; _ })
          | Omitted { mode_fun; ty_arg; mode_arg; level } ->
-             let arrow_desc = lbl, mode_arg, mode_ret in
+             let arrow_desc = lbl, None, mode_arg, mode_ret in
              let ty_ret =
                newty2 ~level
                  (Tarrow (arrow_desc, ty_arg, ty_ret, commu_ok))
@@ -4936,7 +4936,7 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
                   Warnings.Ignored_extra_argument;
               let mode_arg = Alloc.newvar () in
               let mode_ret = Alloc.newvar () in
-              let kind = (lbl, mode_arg, mode_ret) in
+              let kind = (lbl, None, mode_arg, mode_ret) in
               begin try
                 unify env ty_fun
                   (newty (Tarrow(kind,ty_arg,ty_res,commu_var ())));
@@ -4955,7 +4955,7 @@ let collect_unknown_apply_args env funct ty_fun0 mode_fun rev_args sargs
                               { some_args_ok; ty_fun; jkind }))
               end;
               (sort_arg, mode_arg, ty_arg_mono, mode_ret, ty_res)
-        | Tarrow ((l, mode_arg, mode_ret), ty_arg, ty_res, _)
+        | Tarrow ((l, _, mode_arg, mode_ret), ty_arg, ty_res, _)
           when labels_match ~param:l ~arg:lbl ->
             let sort_arg =
               match
@@ -5031,7 +5031,7 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs
         ret_tvar
     | Some (ad, arrow_kind) ->
       begin
-        let (l, mode_arg, mode_ret) = ad in
+        let (l, _, mode_arg, mode_ret) = ad in
         let name = label_name l
         and optional = is_optional l
         and omittable = is_omittable l in
@@ -5133,7 +5133,7 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let args = (lbl, Arg (exp, sort), sch) :: args in
              (ty_ret, mode_ret, open_args, closed_args, args)
          | Omitted { mode_fun; ty_arg; mode_arg; level; sort_arg } ->
-             let arrow_desc = (lbl, mode_arg, mode_ret) in
+             let arrow_desc = (lbl, None, mode_arg, mode_ret) in
              let sort_ret =
                match type_sort ~why:Function_result ~fixed:false env ty_ret with
                | Ok sort -> sort
@@ -5550,7 +5550,10 @@ let approx_type_default () = newvar (Jkind.Builtin.any ~why:Dummy_jkind)
 let rec approx_type env sty =
   match sty.ptyp_desc with
   | Ptyp_arrow (p, ({ ptyp_desc = Ptyp_poly _ } as arg_sty), sty, arg_mode, _) ->
-      let p = Typetexp.transl_label p (Some arg_sty) in
+      let p =
+        Typetexp.transl_arrow_arg_label p ~domain:arg_sty ~codomain:sty
+          (Some arg_sty)
+      in
       (* CR layouts v5: value requirement here to be relaxed *)
       if is_optional p then newvar Predef.option_argument_jkind
       else begin
@@ -5565,11 +5568,14 @@ let rec approx_type env sty =
         let ret = approx_type env sty in
         let marg = Alloc.of_const arg_mode.mode_modes in
         let mret = Alloc.newvar () in
-        newty (Tarrow ((p,marg,mret), arg_ty.ctyp_type, ret, commu_ok))
+        newty (Tarrow ((p,None,marg,mret), arg_ty.ctyp_type, ret, commu_ok))
       end
   | Ptyp_arrow (p, arg_sty, sty, arg_mode, _) ->
       let arg_mode = Typemode.transl_alloc_mode arg_mode in
-      let p = Typetexp.transl_label p (Some arg_sty) in
+      let p =
+        Typetexp.transl_arrow_arg_label p ~domain:arg_sty ~codomain:sty
+          (Some arg_sty)
+      in
       let arg =
         if is_optional p
         then type_option (newvar Predef.option_argument_jkind)
@@ -5578,7 +5584,7 @@ let rec approx_type env sty =
       let ret = approx_type env sty in
       let marg = Alloc.of_const arg_mode.mode_modes in
       let mret = Alloc.newvar () in
-      newty (Tarrow ((p,marg,mret), newmono arg, ret, commu_ok))
+      newty (Tarrow ((p,None,marg,mret), newmono arg, ret, commu_ok))
   | Ptyp_tuple args ->
       newty (Ttuple (List.map (fun (l, t) -> l, approx_type env t) args))
   | Ptyp_constr (lid, ctl) ->
@@ -6128,10 +6134,10 @@ type apply_prim =
   | Revapply
 let check_apply_prim_type prim typ =
   match get_desc typ with
-  | Tarrow ((Nolabel,_,_),a,b,_) when tpoly_is_mono a ->
+  | Tarrow ((Nolabel,_,_,_),a,b,_) when tpoly_is_mono a ->
       let a = tpoly_get_mono a in
       begin match get_desc b with
-      | Tarrow((Nolabel,_,_),c,d,_) when tpoly_is_mono c ->
+      | Tarrow((Nolabel,_,_,_),c,d,_) when tpoly_is_mono c ->
           let c = tpoly_get_mono c in
           let f, x, res =
             match prim with
@@ -6139,7 +6145,7 @@ let check_apply_prim_type prim typ =
             | Revapply -> c, a, d
           in
           begin match get_desc f with
-          | Tarrow((Nolabel,_,_),fl,fr,_) ->
+          | Tarrow((Nolabel,_,_,_),fl,fr,_) ->
               let fl = tpoly_get_mono fl in
               is_Tvar fl && is_Tvar fr && is_Tvar x && is_Tvar res
               && Types.eq_type fl x && Types.eq_type fr res
@@ -8502,7 +8508,7 @@ and type_expect_
             loop slet.pbop_pat (newvar initial_jkind) initial_sort sands
           in
           let ty_func_result, body_sort = new_rep_var ~why:Function_result () in
-          let arrow_desc = Nolabel, Alloc.legacy, Alloc.legacy in
+          let arrow_desc = Nolabel, None, Alloc.legacy, Alloc.legacy in
           let ty_func =
             newty (Tarrow(arrow_desc, newmono ty_params, ty_func_result,
                           commu_ok))
@@ -9523,7 +9529,8 @@ and type_function
         instance
           (newgenty
              (Tarrow
-                ((typed_arg_label, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
+                ((typed_arg_label, None, arg_mode, ret_mode), ty_arg, ty_ret,
+                 commu_ok)))
       in
       (* This is quadratic, as it operates over the entire tail of the
          type for each new parameter. Now that functions are n-ary, we
@@ -10152,15 +10159,15 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     let lv = get_level expty in
     let lv' = get_level expty' in
     match get_desc expty', get_desc expty with
-    | Tarrow((l, marg, mret), ty_arg', ty_res', _),
+    | Tarrow((l, binder, marg, mret), ty_arg', ty_res', _),
       Tarrow(_, ty_arg,  ty_res,  _)
       when lv' = generic_level || not !Clflags.principal ->
       let ty_res', ty_res, changed = loosen_arrow_modes ty_res' ty_res in
       let mret, changed' = Alloc.newvar_below mret in
       let marg, changed'' = Alloc.newvar_above marg in
       if changed || changed' || changed'' then
-        newty2 ~level:lv' (Tarrow((l, marg, mret), ty_arg', ty_res', commu_ok)),
-        newty2 ~level:lv  (Tarrow((l, marg, mret), ty_arg,  ty_res,  commu_ok)),
+        newty2 ~level:lv' (Tarrow((l, binder, marg, mret), ty_arg', ty_res', commu_ok)),
+        newty2 ~level:lv  (Tarrow((l, binder, marg, mret), ty_arg,  ty_res,  commu_ok)),
         true
       else
         ty', ty, false
@@ -10186,7 +10193,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     let work () =
       let te = expand_head env ty_expected' in
       match get_desc te with
-        Tarrow((Nolabel,_,_),_,ty_res0,_) ->
+        Tarrow((Nolabel,_,_,_),_,ty_res0,_) ->
           Some (no_labels ty_res0, get_level te)
       | _ -> None
     in
@@ -10214,7 +10221,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       in
       let rec make_args args ty_fun =
         match get_desc (expand_head env ty_fun) with
-        | Tarrow ((l,_marg,_mret),ty_arg,ty_fun,_) when is_optional l ->
+        | Tarrow ((l,_,_marg,_mret),ty_arg,ty_fun,_) when is_optional l ->
             let ty =
               type_option_none env (instance (tpoly_get_mono ty_arg))
                 sarg.pexp_loc
@@ -10222,10 +10229,10 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
             (* CR layouts v5: change value assumption below when we allow
                non-values in structures. *)
             make_args ((l, Arg (ty, Jkind.Sort.scannable)) :: args) ty_fun
-        | Tarrow ((l,_marg,_mret),_,ty_fun,_) when is_position l ->
+        | Tarrow ((l,_,_marg,_mret),_,ty_fun,_) when is_position l ->
             let arg = src_pos (Location.ghostify sarg.pexp_loc) [] env in
             make_args ((l, Arg (arg, Jkind.Sort.scannable)) :: args) ty_fun
-        | Tarrow ((l,_,_),_,ty_res',_) when l = Nolabel || !Clflags.classic ->
+        | Tarrow ((l,_,_,_),_,ty_res',_) when l = Nolabel || !Clflags.classic ->
             List.rev args, ty_fun, no_labels ty_res'
         | Tvar _ ->  List.rev args, ty_fun, false
         |  _ -> [], texp.exp_type, false
@@ -10242,7 +10249,7 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
       and ty_fun = instance ty_fun' in
       let marg, ty_arg, mret, ty_res =
         match get_desc (expand_head env ty_expected) with
-          Tarrow((Nolabel,marg,mret),ty_arg,ty_res,_) ->
+          Tarrow((Nolabel,_,marg,mret),ty_arg,ty_res,_) ->
            marg, ty_arg, mret, ty_res
         | _ -> assert false
       in
@@ -11317,7 +11324,7 @@ and type_function_cases_expect
     let ty_fun =
       instance
         (newgenty
-           (Tarrow ((Nolabel, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
+           (Tarrow ((Nolabel, None, arg_mode, ret_mode), ty_arg, ty_ret, commu_ok)))
     in
     unify_exp_types loc env ty_fun (instance ty_expected);
     let param , param_uid = name_cases "param" cases in
@@ -11824,7 +11831,7 @@ and type_andops env sarg sands expected_sort expected_ty =
             let ty_result, op_result_sort =
               new_rep_var ~why:Function_result ()
             in
-            let arrow_desc = (Nolabel, Alloc.legacy, Alloc.legacy) in
+            let arrow_desc = (Nolabel, None, Alloc.legacy, Alloc.legacy) in
             let ty_rest_fun =
               newty (Tarrow(arrow_desc, newmono ty_arg, ty_result, commu_ok)) in
             let ty_op =
@@ -11931,7 +11938,7 @@ and type_n_ary_function
                       let new_mode_var () = Mode.Alloc.newvar () in
                       (newty
                          (Tarrow
-                            ( (arg_label, new_mode_var (), new_mode_var ())
+                            ( (arg_label, None, new_mode_var (), new_mode_var ())
                             , new_ty_var Function_argument
                             , new_ty_var Function_result
                             , commu_ok )));
@@ -12641,7 +12648,7 @@ let escaping_submode_reason_hint =
     let get_non_local_arity ty =
       let rec loop sureness n ty =
         match get_desc ty with
-        | Tarrow ((_, _, res_mode), _, res_ty, _) ->
+        | Tarrow ((_, _, _, res_mode), _, res_ty, _) ->
           begin match
             Locality.Guts.check_const (Alloc.proj_comonadic Areality res_mode)
           with

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -4739,7 +4739,11 @@ type untyped_omitted_param =
     ty_arg : type_expr;
     mode_arg : Alloc.lr;
     level: int;
-    sort_arg : Jkind.sort }
+    sort_arg : Jkind.sort;
+    arg_binder : Ident.t option
+    (* The dependent-arrow binder of the omitted parameter: [ty_arg]'s
+       refinements may reference it, so reconstructed arrows must carry
+       it. *) }
 
 let is_partial_apply args =
   List.exists
@@ -4867,22 +4871,27 @@ let remaining_function_type_for_error ty_ret mode_ret rev_args =
   let ty_ret, _, _ =
     List.fold_left
       (fun (ty_ret, mode_ret, closed_args) (lbl, arg) ->
+         let rebuild ~arg_binder ~mode_fun ~ty_arg ~mode_arg ~level =
+           let arrow_desc = lbl, arg_binder, mode_arg, mode_ret in
+           let ty_ret =
+             newty2 ~level
+               (Tarrow (arrow_desc, ty_arg, ty_ret, commu_ok))
+           in
+           let mode_ret, _ =
+             Alloc.newvar_above (Alloc.join (mode_fun :: closed_args))
+           in
+           (ty_ret, mode_ret, closed_args)
+         in
          match arg with
          | Arg (Unknown_arg { mode_arg; _ } | Known_arg { mode_arg; _ }) ->
              let closed_args = mode_arg :: closed_args in
              (ty_ret, mode_ret, closed_args)
          | Arg (Eliminated_optional_arg
-                  { mode_fun; ty_arg; mode_arg; level; _ })
-         | Omitted { mode_fun; ty_arg; mode_arg; level } ->
-             let arrow_desc = lbl, None, mode_arg, mode_ret in
-             let ty_ret =
-               newty2 ~level
-                 (Tarrow (arrow_desc, ty_arg, ty_ret, commu_ok))
-             in
-             let mode_ret, _ =
-               Alloc.newvar_above (Alloc.join (mode_fun :: closed_args))
-             in
-             (ty_ret, mode_ret, closed_args))
+                  { mode_fun; ty_arg; mode_arg; level; _ }) ->
+             (* Optional parameters never bind. *)
+             rebuild ~arg_binder:None ~mode_fun ~ty_arg ~mode_arg ~level
+         | Omitted { mode_fun; ty_arg; mode_arg; level; arg_binder; _ } ->
+             rebuild ~arg_binder ~mode_fun ~ty_arg ~mode_arg ~level)
       (ty_ret, mode_ret, []) rev_args
   in
   ty_ret
@@ -5031,7 +5040,7 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs
         ret_tvar
     | Some (ad, arrow_kind) ->
       begin
-        let (l, _, mode_arg, mode_ret) = ad in
+        let (l, arg_binder, mode_arg, mode_ret) = ad in
         let name = label_name l
         and optional = is_optional l
         and omittable = is_omittable l in
@@ -5113,7 +5122,8 @@ let collect_apply_args env funct ignore_labels ty_fun ty_fun0 mode_fun sargs
                      over it. *)
                   may_warn funct.exp_loc
                     (Warnings.Non_principal_labels "commuted an argument");
-                  Omitted { mode_fun; ty_arg; mode_arg; level = lv; sort_arg }
+                  Omitted { mode_fun; ty_arg; mode_arg; level = lv;
+                            sort_arg; arg_binder }
                 end
             in
             loop ty_ret ty_ret0 mode_ret ((l, arg) :: rev_args) remaining_sargs
@@ -5132,8 +5142,9 @@ let type_omitted_parameters_and_build_result_type expected_mode env loc ty_ret
              let open_args = (exp, marg) :: open_args in
              let args = (lbl, Arg (exp, sort), sch) :: args in
              (ty_ret, mode_ret, open_args, closed_args, args)
-         | Omitted { mode_fun; ty_arg; mode_arg; level; sort_arg } ->
-             let arrow_desc = (lbl, None, mode_arg, mode_ret) in
+         | Omitted { mode_fun; ty_arg; mode_arg; level; sort_arg;
+                     arg_binder } ->
+             let arrow_desc = (lbl, arg_binder, mode_arg, mode_ret) in
              let sort_ret =
                match type_sort ~why:Function_result ~fixed:false env ty_ret with
                | Ok sort -> sort
@@ -10159,14 +10170,16 @@ and type_argument ?explanation ?recarg ~overwrite env (mode : expected_mode) sar
     let lv = get_level expty in
     let lv' = get_level expty' in
     match get_desc expty', get_desc expty with
-    | Tarrow((l, binder, marg, mret), ty_arg', ty_res', _),
-      Tarrow(_, ty_arg,  ty_res,  _)
+    | Tarrow((l, binder', marg, mret), ty_arg', ty_res', _),
+      Tarrow((_, binder, _, _), ty_arg,  ty_res,  _)
       when lv' = generic_level || not !Clflags.principal ->
       let ty_res', ty_res, changed = loosen_arrow_modes ty_res' ty_res in
       let mret, changed' = Alloc.newvar_below mret in
       let marg, changed'' = Alloc.newvar_above marg in
       if changed || changed' || changed'' then
-        newty2 ~level:lv' (Tarrow((l, binder, marg, mret), ty_arg', ty_res', commu_ok)),
+        (* Each rebuilt arrow keeps its own binder: the refinements under
+           it reference that ident. *)
+        newty2 ~level:lv' (Tarrow((l, binder', marg, mret), ty_arg', ty_res', commu_ok)),
         newty2 ~level:lv  (Tarrow((l, binder, marg, mret), ty_arg,  ty_res,  commu_ok)),
         true
       else

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -361,6 +361,7 @@ type error =
   | Exclave_returns_not_local
   | Unboxed_int_literals_not_supported
   | Function_type_not_rep of type_expr * Jkind.Violation.t
+  | Unsupported_dependent_arrow
   | Function_type_escapes_partial_match of
       { ty : type_expr;
         match_loc : Location.t;

--- a/typing/typedecl.ml
+++ b/typing/typedecl.ml
@@ -4512,7 +4512,7 @@ let rec parse_native_repr_attributes env core_type ty rmode
   with
   | Ptyp_arrow _, Tarrow _, Native_repr_attr_present kind  ->
     raise (Error (core_type.ptyp_loc, Cannot_unbox_or_untag_type kind))
-  | Ptyp_arrow (_, ct1, ct2, _, _), Tarrow ((_,marg,mret), t1, t2, _), _
+  | Ptyp_arrow (_, ct1, ct2, _, _), Tarrow ((_,_,marg,mret), t1, t2, _), _
     when not (Builtin_attributes.has_curry core_type.ptyp_attributes) ->
     let t1, _ = Btype.tpoly_get_poly t1 in
     let repr_arg =

--- a/typing/typedecl_separability.ml
+++ b/typing/typedecl_separability.ml
@@ -153,6 +153,7 @@ let rec immediate_subtypes : type_expr -> type_expr list = fun ty ->
   | Tvar _ | Tunivar _ -> []
   | Tof_kind _ -> []
   | Tpoly (pty, _) -> [pty]
+  | Trefine { ref_payload; _ } -> [ref_payload]
   | Trepr (_, _) -> Misc.fatal_error "immediate_subtypes: Trepr"
   | Tconstr (_path, tys, _) -> tys
 
@@ -469,6 +470,9 @@ let check_type
        under a separating type constructor. *)
     | (Tpoly(pty,_)       , m      ) ->
         check_type hyps pty m
+    (* The payload determines the memory representation. *)
+    | (Trefine r          , m      ) ->
+        check_type hyps r.ref_payload m
     | (Trepr(_pty,_)       , _m    ) ->
         assert false
     | (Tunivar(_)         , _      ) -> empty

--- a/typing/typedecl_variance.ml
+++ b/typing/typedecl_variance.ml
@@ -118,6 +118,13 @@ let compute_variance env visited vari ty =
         compute_same (row_more row)
     | Tpoly (ty, _) | Trepr (ty, _) ->
         compute_same ty
+    | Trefine { ref_payload; ref_pred } ->
+        (* Refinements are rigid — they only ever equal alpha-equivalent
+           refinements — so occurrences under them are treated like package
+           constraints, i.e. invariantly. *)
+        let v = Variance.(compose vari full) in
+        compute_variance_rec env v ref_payload;
+        Vox_rexp.iter_types (compute_variance_rec env v) ref_pred
     | Tvar _ | Tnil | Tlink _ | Tunivar _ | Tof_kind _ -> ()
     | Tpackage pack ->
         let v = Variance.(compose vari full) in

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -885,10 +885,11 @@ and core_type_desc =
   | Ttyp_quote of core_type
   | Ttyp_splice of core_type
   | Ttyp_repr of string list * core_type
-  | Ttyp_refine of core_type * Types.refinement_expression
-      (** [T{ P }].  The predicate is the resolved form shared with the
-          type graph; there is no separately-typed predicate because
-          refinements are inert in this piece. *)
+  | Ttyp_refine of core_type * Parsetree.expression
+      (** [T{ P }].  The predicate is kept as the source expression: the
+          resolved form lives in the type graph ([ctyp_type]), and there is
+          no separately-typed predicate because refinements are inert in
+          this piece. *)
   | Ttyp_newlayout of string loc list * core_type
   | Ttyp_of_kind of Parsetree.jkind_annotation
   | Ttyp_call_pos

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -863,8 +863,14 @@ and core_type =
 
 and core_type_desc =
   | Ttyp_var of string option * Parsetree.jkind_annotation option
-  | Ttyp_arrow of arg_label * core_type * Mode.Alloc.Const.t modes *
-                  core_type * Mode.Alloc.Const.t modes
+  | Ttyp_arrow of arg_label * Ident.t option * core_type *
+                  Mode.Alloc.Const.t modes * core_type *
+                  Mode.Alloc.Const.t modes
+      (** The [Ident.t option] is the value binder of a dependent arrow;
+          see {!Types.arrow_desc}.  When the label is [Nolabel] it was
+          spelled [x:T -> U] and binds over both sides; when the label is
+          [Labelled x] it was spelled [~x:T -> U] and binds over the domain
+          only. *)
   | Ttyp_tuple of (string option * core_type) list
   | Ttyp_unboxed_tuple of (string option * core_type) list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list
@@ -879,6 +885,10 @@ and core_type_desc =
   | Ttyp_quote of core_type
   | Ttyp_splice of core_type
   | Ttyp_repr of string list * core_type
+  | Ttyp_refine of core_type * Types.refinement_expression
+      (** [T{ P }].  The predicate is the resolved form shared with the
+          type graph; there is no separately-typed predicate because
+          refinements are inert in this piece. *)
   | Ttyp_newlayout of string loc list * core_type
   | Ttyp_of_kind of Parsetree.jkind_annotation
   | Ttyp_call_pos

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1324,10 +1324,11 @@ and core_type_desc =
   | Ttyp_quote of core_type
   | Ttyp_splice of core_type
   | Ttyp_repr of string list * core_type
-  | Ttyp_refine of core_type * Types.refinement_expression
-      (** [T{ P }].  The predicate is the resolved form shared with the
-          type graph; there is no separately-typed predicate because
-          refinements are inert in this piece. *)
+  | Ttyp_refine of core_type * Parsetree.expression
+      (** [T{ P }].  The predicate is kept as the source expression: the
+          resolved form lives in the type graph ([ctyp_type]), and there is
+          no separately-typed predicate because refinements are inert in
+          this piece. *)
   | Ttyp_newlayout of string loc list * core_type
       (** [Ttyp_newlayout (vars, ty)] represents layout-polymorphic types in
           which [vars] are generalised sort variables.

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -1302,8 +1302,14 @@ and core_type =
 
 and core_type_desc =
   | Ttyp_var of string option * Parsetree.jkind_annotation option
-  | Ttyp_arrow of arg_label * core_type * Mode.Alloc.Const.t modes *
-                  core_type * Mode.Alloc.Const.t modes
+  | Ttyp_arrow of arg_label * Ident.t option * core_type *
+                  Mode.Alloc.Const.t modes * core_type *
+                  Mode.Alloc.Const.t modes
+      (** The [Ident.t option] is the value binder of a dependent arrow;
+          see {!Types.arrow_desc}.  When the label is [Nolabel] it was
+          spelled [x:T -> U] and binds over both sides; when the label is
+          [Labelled x] it was spelled [~x:T -> U] and binds over the domain
+          only. *)
   | Ttyp_tuple of (string option * core_type) list
   | Ttyp_unboxed_tuple of (string option * core_type) list
   | Ttyp_constr of Path.t * Longident.t loc * core_type list
@@ -1318,6 +1324,10 @@ and core_type_desc =
   | Ttyp_quote of core_type
   | Ttyp_splice of core_type
   | Ttyp_repr of string list * core_type
+  | Ttyp_refine of core_type * Types.refinement_expression
+      (** [T{ P }].  The predicate is the resolved form shared with the
+          type graph; there is no separately-typed predicate because
+          refinements are inert in this piece. *)
   | Ttyp_newlayout of string loc list * core_type
       (** [Ttyp_newlayout (vars, ty)] represents layout-polymorphic types in
           which [vars] are generalised sort variables.

--- a/typing/typeopt.ml
+++ b/typing/typeopt.ml
@@ -51,17 +51,22 @@ exception Error of Location.t * error
 (* CR external-mode: Don't disregard modalities when using [scrape_ty] to reason
    about the runtime properties of a type - in particular, in
    [maybe_pointer_ty], when checking whether a type crosses externality. *)
-let scrape_ty env ty =
+let rec scrape_ty env ty =
   let ty =
     match get_desc ty with
     | Tpoly(ty, _) -> ty
     | _ -> ty
   in
   match get_desc ty with
+  | Trefine { ref_payload; _ } ->
+      (* The payload of a refinement determines its runtime
+         representation. *)
+      scrape_ty env ref_payload
   | Tconstr _
   | Tquote _ | Tsplice _ | Tquote_eval _ ->
       let ty = Ctype.expand_head_opt env ty in
       begin match get_desc ty with
+      | Trefine { ref_payload; _ } -> scrape_ty env ref_payload
       | Tconstr (p, _, _) ->
           begin match find_unboxed_type (Env.find_type p env) with
           | Some _ -> begin
@@ -275,6 +280,8 @@ let classify ~classify_product env ty layout : _ classification =
   | Tlink _ | Tsubst _ | Tpoly _ | Tfield _ | Tunboxed_tuple _
   | Trepr _ ->
       assert false
+  | Trefine _ ->
+      Misc.fatal_error "Typeopt.classify: Trefine after scrape_ty"
   end
   | Base (Float64, _) -> Unboxed_float Unboxed_float64
   | Base (Float32, _) -> Unboxed_float Unboxed_float32
@@ -888,6 +895,8 @@ and value_kind_mixed_block_field env ~loc ~visited ~depth ~num_nodes_visited
         | Tquote _ | Tsplice _ | Tquote_eval _ | Tof_kind _ | Tbox _ ->
           unknown ()
         | Trepr _ -> Misc.fatal_error "value_kind_mixed_block_field: Trepr"
+        | Trefine _ ->
+          Misc.fatal_error "value_kind_mixed_block_field: Trefine after scrape_ty"
         end
     in
     let (_, num_nodes_visited), kinds =

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -166,6 +166,54 @@ and type_desc =
   | Tpackage of package
   | Tof_kind of jkind_lr
   | Tbox of type_expr
+  | Trefine of refinement_desc
+
+and refinement_desc =
+  { ref_payload : type_expr;
+    ref_pred : refinement_expression }
+
+and refinement_expression =
+  { rexp_desc : refinement_expression_desc;
+    rexp_loc : Location.t }
+
+and refinement_expression_desc =
+  | Rexp_hole
+  | Rexp_var of Ident.t
+  | Rexp_ident of Path.t * Longident.t loc
+  | Rexp_constant of Parsetree.constant
+  | Rexp_apply of
+      refinement_expression * (Asttypes.arg_label * refinement_expression) list
+  | Rexp_tuple of (string option * refinement_expression) list
+  | Rexp_construct of Longident.t loc * refinement_expression option
+  | Rexp_field of refinement_expression * Longident.t loc
+  | Rexp_ifthenelse of
+      refinement_expression * refinement_expression
+      * refinement_expression option
+  | Rexp_let of refinement_binding * refinement_expression
+  | Rexp_fun of Ident.t * refinement_expression
+  | Rexp_match of refinement_expression * refinement_case list
+  | Rexp_constraint of refinement_expression * type_expr
+
+and refinement_binding =
+  { rb_ident : Ident.t;
+    rb_expr : refinement_expression }
+
+and refinement_case =
+  { rc_lhs : refinement_pattern;
+    rc_guard : refinement_expression option;
+    rc_rhs : refinement_expression }
+
+and refinement_pattern =
+  { rpat_desc : refinement_pattern_desc;
+    rpat_loc : Location.t }
+
+and refinement_pattern_desc =
+  | Rpat_any
+  | Rpat_var of Ident.t
+  | Rpat_constant of Parsetree.constant
+  | Rpat_tuple of (string option * refinement_pattern) list
+  | Rpat_construct of Longident.t loc * refinement_pattern option
+  | Rpat_alias of refinement_pattern * Ident.t
 
 and arg_label =
   | Nolabel
@@ -174,7 +222,7 @@ and arg_label =
   | Position of string
 
 and arrow_desc =
-  arg_label * Mode.Alloc.lr * Mode.Alloc.lr
+  arg_label * Ident.t option * Mode.Alloc.lr * Mode.Alloc.lr
 
 and package =
     { pack_path : Path.t;
@@ -1361,6 +1409,7 @@ let best_effort_compare_type_expr te1 te2 =
         | Tsplice _
         | Tquote_eval _
         | Tbox _
+        | Trefine _
         (* CR layouts v2.8: we can actually see Tsubst here in certain cases, eg during
            [Ctype.copy] when copying the types inside of with_bounds. We also can't
            compare Tsubst structurally, because the Tsubsts that are created in

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -184,7 +184,7 @@ and refinement_expression_desc =
   | Rexp_apply of
       refinement_expression * (Asttypes.arg_label * refinement_expression) list
   | Rexp_tuple of (string option * refinement_expression) list
-  | Rexp_construct of Longident.t loc * refinement_expression option
+  | Rexp_construct of Path.t * Longident.t loc * refinement_expression option
   | Rexp_field of refinement_expression * Longident.t loc
   | Rexp_ifthenelse of
       refinement_expression * refinement_expression
@@ -212,7 +212,7 @@ and refinement_pattern_desc =
   | Rpat_var of Ident.t
   | Rpat_constant of Parsetree.constant
   | Rpat_tuple of (string option * refinement_pattern) list
-  | Rpat_construct of Longident.t loc * refinement_pattern option
+  | Rpat_construct of Path.t * Longident.t loc * refinement_pattern option
   | Rpat_alias of refinement_pattern * Ident.t
 
 and arg_label =

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -329,7 +329,10 @@ and refinement_expression_desc =
   | Rexp_apply of
       refinement_expression * (Asttypes.arg_label * refinement_expression) list
   | Rexp_tuple of (string option * refinement_expression) list
-  | Rexp_construct of Longident.t loc * refinement_expression option
+  | Rexp_construct of Path.t * Longident.t loc * refinement_expression option
+  (** The path is [Pextra_ty (type_path, Pcstr_ty name)] for an ordinary
+      constructor and the constructor's own path for an extension
+      constructor, so that substitution keeps it meaningful. *)
   | Rexp_field of refinement_expression * Longident.t loc
   | Rexp_ifthenelse of
       refinement_expression * refinement_expression
@@ -359,7 +362,7 @@ and refinement_pattern_desc =
   | Rpat_var of Ident.t
   | Rpat_constant of Parsetree.constant
   | Rpat_tuple of (string option * refinement_pattern) list
-  | Rpat_construct of Longident.t loc * refinement_pattern option
+  | Rpat_construct of Path.t * Longident.t loc * refinement_pattern option
   | Rpat_alias of refinement_pattern * Ident.t
 
 (** This is used in the Typedtree. It is distinct from

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -286,6 +286,82 @@ and type_desc =
   | Tbox of type_expr
   (** [Tbox ty] ==> [ty box] *)
 
+  | Trefine of refinement_desc
+  (** [Trefine { ref_payload; ref_pred }] ==> [ref_payload{ ref_pred }]
+
+      A refinement type.  The payload determines the layout, jkind and
+      runtime representation; refinements never reach lambda.  Refinements
+      are rigid: they are never inferred and never solved for, [t{p}] and
+      [t] do not unify, and two refined types are equal iff their payloads
+      are equal and their predicates are syntactically alpha-equivalent. *)
+
+(** A refinement type: the payload type and the predicate over the refined
+    value. *)
+and refinement_desc =
+  { ref_payload : type_expr;
+    ref_pred : refinement_expression }
+
+(** A refinement predicate.  This is a second version of the type of
+    expressions for inside the type language: the same shape as ordinary
+    expressions, restricted by construction to the total sublanguage (no
+    loops, no references, no assignment, no sequencing).  Value names are
+    resolved — bound names ([Rexp_var]) are the arrow binders and the
+    predicate's own binders, free names ([Rexp_ident]) are looked up in the
+    environment when the type is translated — but the predicate is not
+    typechecked in any other way; the typing rules for refinements belong
+    to a later piece.  The interior types ([Rexp_constraint]) are ordinary
+    types in the type graph: generic traversals ([Btype], [Subst]) descend
+    into them. *)
+and refinement_expression =
+  { rexp_desc : refinement_expression_desc;
+    rexp_loc : Location.t }
+
+and refinement_expression_desc =
+  | Rexp_hole
+  (** [_]: the value of the innermost enclosing refinement. *)
+  | Rexp_var of Ident.t
+  (** A bound name: an arrow binder, or a binder introduced inside the
+      predicate by [Rexp_let], [Rexp_fun] or [Rexp_match]. *)
+  | Rexp_ident of Path.t * Longident.t loc
+  (** A free name, resolved when the type was translated.  The longident
+      is kept for printing. *)
+  | Rexp_constant of Parsetree.constant
+  | Rexp_apply of
+      refinement_expression * (Asttypes.arg_label * refinement_expression) list
+  | Rexp_tuple of (string option * refinement_expression) list
+  | Rexp_construct of Longident.t loc * refinement_expression option
+  | Rexp_field of refinement_expression * Longident.t loc
+  | Rexp_ifthenelse of
+      refinement_expression * refinement_expression
+      * refinement_expression option
+  | Rexp_let of refinement_binding * refinement_expression
+  (** [let x = e1 in e2]; only single, non-recursive variable bindings. *)
+  | Rexp_fun of Ident.t * refinement_expression
+  (** [fun x -> e]; only single, unlabelled variable parameters. *)
+  | Rexp_match of refinement_expression * refinement_case list
+  | Rexp_constraint of refinement_expression * type_expr
+
+and refinement_binding =
+  { rb_ident : Ident.t;
+    rb_expr : refinement_expression }
+
+and refinement_case =
+  { rc_lhs : refinement_pattern;
+    rc_guard : refinement_expression option;
+    rc_rhs : refinement_expression }
+
+and refinement_pattern =
+  { rpat_desc : refinement_pattern_desc;
+    rpat_loc : Location.t }
+
+and refinement_pattern_desc =
+  | Rpat_any
+  | Rpat_var of Ident.t
+  | Rpat_constant of Parsetree.constant
+  | Rpat_tuple of (string option * refinement_pattern) list
+  | Rpat_construct of Longident.t loc * refinement_pattern option
+  | Rpat_alias of refinement_pattern * Ident.t
+
 (** This is used in the Typedtree. It is distinct from
     {{!Asttypes.arg_label}[arg_label]} because Position argument labels are
     discovered through typechecking. *)
@@ -295,8 +371,16 @@ and arg_label =
   | Optional of string (** [?label:T -> ...] *)
   | Position of string (** [label:[%call_pos] -> ...] *)
 
+(** The second component is the optional value binder of a dependent arrow:
+    in [x:T -> U] where [x] occurs in a refinement in [T] or [U], the ident
+    binds [x] over the refinement predicates of both [T] and [U]; in
+    [~x:T -> U] where [x] occurs in a refinement in [T], the label is kept
+    and the ident binds [x] over the refinement predicates of [T] only.
+    The binder is [Some] only when it is referenced by some predicate.
+    Binder names are not part of type identity: equality is up to
+    alpha-conversion. *)
 and arrow_desc =
-  arg_label * Mode.Alloc.lr * Mode.Alloc.lr
+  arg_label * Ident.t option * Mode.Alloc.lr * Mode.Alloc.lr
 
 (** [package] corresponds to the type of a first-class module *)
 and package =

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -877,6 +877,22 @@ let get_type_param_name styp =
   | Ptyp_var (name, _) -> Some name
   | _ -> Misc.fatal_error "non-type-variable in get_type_param_name"
 
+(* The path under which a constructor referenced by a refinement predicate
+   is recorded: the constructor path of an extension constructor, and
+   [Pextra_ty (type_path, Pcstr_ty name)] for an ordinary constructor.
+   Both are rewritten by [Subst.type_path], which is what keeps the
+   reference meaningful across signature prefixing and functor
+   application. *)
+let refinement_constructor_path (cstr : Data_types.constructor_description) =
+  match cstr.cstr_tag with
+  | Extension p -> p
+  | Ordinary _ | Null -> (
+      match get_desc cstr.cstr_res with
+      | Tconstr (p, _, _) -> Path.Pextra_ty (p, Pcstr_ty cstr.cstr_name)
+      | _ ->
+          Misc.fatal_error
+            "Typetexp.refinement_constructor_path: malformed constructor")
+
 (* Dependent-arrow binders currently in scope, for resolving names inside
    refinement predicates.  The dynamic extent of translating an arrow's
    domain and codomain is exactly the binder's lexical scope, so a
@@ -1504,12 +1520,12 @@ and transl_refinement_predicate env ~policy ~row_context locals sexp
       mk (Rexp_tuple
             (List.map (fun (lbl, c) -> lbl, transl locals c) components))
   | Pexp_construct (lid, arg) ->
-      (* Resolve, to reject unbound names here rather than in a later
-         piece; the predicate keeps the source name. *)
-      ignore
-        (Env.lookup_constructor ~loc:lid.loc Env.Positive lid.txt env
-         : _ * _);
-      mk (Rexp_construct (lid, Option.map (transl locals) arg))
+      let cstr, _ =
+        Env.lookup_constructor ~loc:lid.loc Env.Positive lid.txt env
+      in
+      mk (Rexp_construct
+            (refinement_constructor_path cstr, lid,
+             Option.map (transl locals) arg))
   | Pexp_field (e, lid) ->
       ignore
         (Env.lookup_label ~record_form:Legacy ~loc:lid.loc Env.Projection
@@ -1626,9 +1642,9 @@ and transl_refinement_pattern env locals pat =
       locals, mk (Rpat_tuple components)
   | Ppat_tuple (_, Open) -> unsupported "A partial tuple pattern"
   | Ppat_construct (lid, arg) ->
-      ignore
-        (Env.lookup_constructor ~loc:lid.loc Env.Pattern lid.txt env
-         : _ * _);
+      let cstr, _ =
+        Env.lookup_constructor ~loc:lid.loc Env.Pattern lid.txt env
+      in
       let locals, arg =
         match arg with
         | None -> locals, None
@@ -1637,7 +1653,7 @@ and transl_refinement_pattern env locals pat =
             locals, Some p
         | Some (_ :: _, _) -> unsupported "An existential type binding"
       in
-      locals, mk (Rpat_construct (lid, arg))
+      locals, mk (Rpat_construct (refinement_constructor_path cstr, lid, arg))
   | Ppat_alias (p, name) ->
       let locals, p = transl_refinement_pattern env locals p in
       let id = Ident.create_local name.txt in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -921,14 +921,14 @@ let decide_arrow_arg_name (arg : Parsetree.arrow_arg_name)
       { aan_label = Labelled name.txt; aan_binder = binder;
         aan_bare_label = false }
   | Pan_name name ->
-      match Vox_binding.classify_bare_name name.txt ~domain ~codomain with
-      | Positional_binder ->
-          { aan_label = Nolabel;
-            aan_binder = Some (name.txt, `Domain_and_codomain);
-            aan_bare_label = false }
-      | Ordinary_label ->
-          { aan_label = Labelled name.txt; aan_binder = None;
-            aan_bare_label = true }
+      if Vox_binding.name_used_in_refinement name.txt [domain; codomain]
+      then
+        { aan_label = Nolabel;
+          aan_binder = Some (name.txt, `Domain_and_codomain);
+          aan_bare_label = false }
+      else
+        { aan_label = Labelled name.txt; aan_binder = None;
+          aan_bare_label = true }
 
 let rec extract_params styp =
   match styp.ptyp_desc with
@@ -1443,7 +1443,7 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
         newty (Trefine { ref_payload = payload_cty.ctyp_type;
                          ref_pred = pred })
       in
-      ctyp (Ttyp_refine (payload_cty, pred)) ty
+      ctyp (Ttyp_refine (payload_cty, spred)) ty
   | Ptyp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
 
@@ -1466,6 +1466,17 @@ and transl_refinement_predicate env ~policy ~row_context locals sexp
   in
   let transl locals sexp =
     transl_refinement_predicate env ~policy ~row_context locals sexp
+  in
+  (* Interior types are translated with the predicate's own binders added
+     to the ambient scope, so that refinements nested inside them can
+     mention them (locals shadow arrow binders). *)
+  let transl_interior_type locals ty =
+    Misc.protect_refs
+      [ Misc.R (refinement_scope,
+                Misc.Stdlib.String.Map.union
+                  (fun _ _outer local -> Some local)
+                  !refinement_scope locals) ]
+      (fun () -> transl_type env ~policy ~row_context Alloc.Const.legacy ty)
   in
   match sexp.pexp_desc with
   | Pexp_hole -> mk Rexp_hole
@@ -1550,9 +1561,7 @@ and transl_refinement_predicate env ~policy ~row_context locals sexp
             ret_type_constraint = None } -> body
         | { ret_type_constraint = Some (Pconstraint ty);
             mode_annotations = []; ret_mode_annotations = [] } ->
-            let cty =
-              transl_type env ~policy ~row_context Alloc.Const.legacy ty
-            in
+            let cty = transl_interior_type locals ty in
             { rexp_desc = Rexp_constraint (body, cty.ctyp_type);
               rexp_loc = loc }
         | _ -> unsupported "This function constraint"
@@ -1565,7 +1574,7 @@ and transl_refinement_predicate env ~policy ~row_context locals sexp
                (transl_refinement_case env ~policy ~row_context locals)
                cases))
   | Pexp_constraint (e, Some ty, []) ->
-      let cty = transl_type env ~policy ~row_context Alloc.Const.legacy ty in
+      let cty = transl_interior_type locals ty in
       mk (Rexp_constraint (transl locals e, cty.ctyp_type))
   | Pexp_constraint _ -> unsupported "This form of constraint"
   | Pexp_while _ -> not_total "While loops are"
@@ -1582,8 +1591,6 @@ and transl_refinement_predicate env ~policy ~row_context locals sexp
   | _ -> unsupported "This expression form"
 
 and transl_refinement_case env ~policy ~row_context locals case =
-  (match case.pc_lhs.ppat_desc with
-   | _ -> ());
   let locals, rc_lhs =
     transl_refinement_pattern env locals case.pc_lhs
   in

--- a/typing/typetexp.ml
+++ b/typing/typetexp.ml
@@ -111,6 +111,8 @@ type error =
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
   | Val_poly_and_layout
+  | Refinement_predicate_not_total of string
+  | Refinement_predicate_unsupported of string
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error
@@ -875,9 +877,63 @@ let get_type_param_name styp =
   | Ptyp_var (name, _) -> Some name
   | _ -> Misc.fatal_error "non-type-variable in get_type_param_name"
 
+(* Dependent-arrow binders currently in scope, for resolving names inside
+   refinement predicates.  The dynamic extent of translating an arrow's
+   domain and codomain is exactly the binder's lexical scope, so a
+   [protect_refs]-managed reference suffices; compare [TyVarEnv]. *)
+let refinement_scope : Ident.t Misc.Stdlib.String.Map.t ref =
+  ref Misc.Stdlib.String.Map.empty
+
+let with_refinement_binder binder f =
+  match binder with
+  | None -> f ()
+  | Some (name, id) ->
+      Misc.protect_refs
+        [ Misc.R (refinement_scope,
+                  Misc.Stdlib.String.Map.add name id !refinement_scope) ]
+        f
+
+(* The decided form of the name slot of one arrow. *)
+type arrow_argument_name =
+  { aan_label : Parsetree.arg_label;  (* before [%call_pos] resolution *)
+    aan_binder : (string * [ `Domain_and_codomain | `Domain_only ]) option;
+    aan_bare_label : bool
+    (* a bare [x:T] that the occurrence test decided is a label *) }
+
+let decide_arrow_arg_name (arg : Parsetree.arrow_arg_name)
+    ~(domain : Parsetree.core_type) ~(codomain : Parsetree.core_type) =
+  match arg with
+  | Pan_nolabel ->
+      { aan_label = Nolabel; aan_binder = None; aan_bare_label = false }
+  | Pan_optional name ->
+      (* Optional parameters never bind: the argument may be absent, so
+         "the value of this parameter" is not defined. *)
+      { aan_label = Optional name.txt; aan_binder = None;
+        aan_bare_label = false }
+  | Pan_tilde name ->
+      (* Always the label; the name is additionally available as the value
+         of the argument inside the argument's own refinements. *)
+      let binder =
+        if Vox_binding.name_used_in_refinement name.txt [domain]
+        then Some (name.txt, `Domain_only)
+        else None
+      in
+      { aan_label = Labelled name.txt; aan_binder = binder;
+        aan_bare_label = false }
+  | Pan_name name ->
+      match Vox_binding.classify_bare_name name.txt ~domain ~codomain with
+      | Positional_binder ->
+          { aan_label = Nolabel;
+            aan_binder = Some (name.txt, `Domain_and_codomain);
+            aan_bare_label = false }
+      | Ordinary_label ->
+          { aan_label = Labelled name.txt; aan_binder = None;
+            aan_bare_label = true }
+
 let rec extract_params styp =
   match styp.ptyp_desc with
-  | Ptyp_arrow (l, a, r, ma, mr) ->
+  | Ptyp_arrow (arg, a, r, ma, mr) ->
+      let arg = decide_arrow_arg_name arg ~domain:a ~codomain:r in
       let arg_mode = Typemode.transl_alloc_mode ma in
       let ret_mode = Typemode.transl_alloc_mode mr in
       let params, ret, ret_mode =
@@ -886,7 +942,7 @@ let rec extract_params styp =
           extract_params r
         | _ -> [], r, ret_mode
       in
-      (l, arg_mode, a) :: params, ret, ret_mode
+      (arg, arg_mode, a) :: params, ret, ret_mode
   | _ -> assert false
 
 let check_arg_type styp =
@@ -908,6 +964,12 @@ let transl_label (label : Parsetree.arg_label)
   | Labelled l, _ -> Labelled l
   | Optional l, _ -> Optional l
   | Nolabel, _ -> Nolabel
+
+(* The label of an arrow, for callers that do not translate the arrow
+   itself (e.g. type approximation in [Typecore]). *)
+let transl_arrow_arg_label arg ~domain ~codomain arg_opt =
+  let decided = decide_arrow_arg_name arg ~domain ~codomain in
+  transl_label decided.aan_label arg_opt
 
 (* Parallel to [transl_label_from_expr]. *)
 let transl_label_from_pat (label : Parsetree.arg_label)
@@ -989,15 +1051,38 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       ctyp desc typ
   | Ptyp_arrow _ ->
       let args, ret, ret_mode = extract_params styp in
+      (* Reading a mixed arrow requires scanning the whole type to tell
+         binders from labels; warn once per chain. *)
+      let has_positional_binder =
+        List.exists
+          (fun (arg, _, _) ->
+            match arg.aan_binder with
+            | Some (_, `Domain_and_codomain) -> true
+            | Some (_, `Domain_only) | None -> false)
+          args
+      and has_bare_label =
+        List.exists (fun (arg, _, _) -> arg.aan_bare_label) args
+      in
+      if has_positional_binder && has_bare_label then
+        Location.prerr_warning styp.ptyp_loc
+          Warnings.Vox_mixed_arrow_conventions;
       let rec loop acc_mode args =
         match args with
-        | (l, arg_mode, arg) :: rest ->
-          check_arg_type arg;
-          let l = transl_label l (Some arg) in
+        | (arg, arg_mode, sarg) :: rest ->
+          check_arg_type sarg;
+          let l = transl_label arg.aan_label (Some sarg) in
+          let binder =
+            Option.map
+              (fun (name, scope) -> name, Ident.create_local name, scope)
+              arg.aan_binder
+          in
+          let binder_ident = Option.map (fun (_, id, _) -> id) binder in
+          let in_scope = Option.map (fun (name, id, _) -> name, id) binder in
           let arg_cty =
+            with_refinement_binder in_scope @@ fun () ->
             if Btype.is_position l then
               ctyp Ttyp_call_pos (newconstr Predef.path_lexing_position [])
-            else transl_type env ~policy ~row_context arg_mode.mode_modes arg
+            else transl_type env ~policy ~row_context arg_mode.mode_modes sarg
           in
           let acc_mode = curry_mode acc_mode arg_mode.mode_modes in
           let ret_mode =
@@ -1006,7 +1091,15 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             | _ :: _ ->
               { mode_modes = acc_mode; mode_desc = [] }
           in
-          let ret_cty = loop acc_mode rest in
+          let in_scope_of_rest =
+            match binder with
+            | Some (name, id, `Domain_and_codomain) -> Some (name, id)
+            | Some (_, _, `Domain_only) | None -> None
+          in
+          let ret_cty =
+            with_refinement_binder in_scope_of_rest @@ fun () ->
+            loop acc_mode rest
+          in
           let arg_ty = arg_cty.ctyp_type in
           let arg_ty =
             if Btype.is_Tpoly arg_ty then arg_ty else newmono arg_ty
@@ -1015,19 +1108,20 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
             if not (Btype.is_optional l) then arg_ty
             else begin
               if not (Btype.tpoly_is_mono arg_ty) then
-                raise (Error (arg.ptyp_loc, env, Polymorphic_optional_param));
+                raise (Error (sarg.ptyp_loc, env, Polymorphic_optional_param));
               newmono
                 (newconstr Predef.path_option [Btype.tpoly_get_mono arg_ty])
             end
           in
           let arg_mode_desc = Alloc.of_const arg_mode.mode_modes in
           let ret_mode_desc = Alloc.of_const ret_mode.mode_modes in
-          let arrow_desc = (l, arg_mode_desc, ret_mode_desc) in
+          let arrow_desc = (l, binder_ident, arg_mode_desc, ret_mode_desc) in
           let ty =
             newty (Tarrow(arrow_desc, arg_ty, ret_cty.ctyp_type, commu_ok))
           in
           ctyp
-            (Ttyp_arrow (l, arg_cty, arg_mode, ret_cty, ret_mode))
+            (Ttyp_arrow (l, binder_ident, arg_cty, arg_mode, ret_cty,
+                         ret_mode))
             ty
         | [] -> transl_type env ~policy ~row_context ret_mode.mode_modes ret
       in
@@ -1339,8 +1433,211 @@ and transl_type_aux env ~row_context ~aliased ~policy mode styp =
       let new_env = Env.enter_splice ~loc env in
       let cty = transl_type new_env ~policy ~row_context mode t in
       ctyp (Ttyp_splice cty) (newty (Tsplice cty.ctyp_type))
+  | Ptyp_refine (spayload, spred) ->
+      let payload_cty = transl_type env ~policy ~row_context mode spayload in
+      let pred =
+        transl_refinement_predicate env ~policy ~row_context
+          Misc.Stdlib.String.Map.empty spred
+      in
+      let ty =
+        newty (Trefine { ref_payload = payload_cty.ctyp_type;
+                         ref_pred = pred })
+      in
+      ctyp (Ttyp_refine (payload_cty, pred)) ty
   | Ptyp_extension ext ->
       raise (Error_forward (Builtin_attributes.error_of_extension ext))
+
+(* Translation of refinement predicates.  The predicate keeps the shape of
+   the source expression; the sublanguage is the total subset, enforced
+   here by construction.  Value names are resolved: [locals] are the
+   predicate's own binders, [refinement_scope] the dependent-arrow binders,
+   and everything else is looked up in the environment.  Beyond name
+   resolution, nothing is checked: the typing rules for refinements belong
+   to a later piece. *)
+and transl_refinement_predicate env ~policy ~row_context locals sexp
+    : refinement_expression =
+  let loc = sexp.pexp_loc in
+  let mk rexp_desc = { rexp_desc; rexp_loc = loc } in
+  let not_total form =
+    raise (Error (loc, env, Refinement_predicate_not_total form))
+  in
+  let unsupported what =
+    raise (Error (loc, env, Refinement_predicate_unsupported what))
+  in
+  let transl locals sexp =
+    transl_refinement_predicate env ~policy ~row_context locals sexp
+  in
+  match sexp.pexp_desc with
+  | Pexp_hole -> mk Rexp_hole
+  | Pexp_ident { txt = Longident.Lident name; _ }
+    when Misc.Stdlib.String.Map.mem name locals ->
+      mk (Rexp_var (Misc.Stdlib.String.Map.find name locals))
+  | Pexp_ident { txt = Longident.Lident name; _ }
+    when Misc.Stdlib.String.Map.mem name !refinement_scope ->
+      mk (Rexp_var (Misc.Stdlib.String.Map.find name !refinement_scope))
+  | Pexp_ident { txt = Longident.Lident "ref"; _ } ->
+      not_total "References are"
+  | Pexp_ident { txt = Longident.Lident ":="; _ } ->
+      not_total "Assignments are"
+  | Pexp_ident { txt = Longident.Lident "!"; _ } ->
+      not_total "Dereferences are"
+  | Pexp_ident lid ->
+      let path, _, _ = Env.lookup_value ~loc:lid.loc lid.txt env in
+      mk (Rexp_ident (path, lid))
+  | Pexp_constant const -> mk (Rexp_constant const)
+  | Pexp_apply (fn, args) ->
+      mk (Rexp_apply
+            (transl locals fn,
+             List.map (fun (lbl, arg) -> lbl, transl locals arg) args))
+  | Pexp_tuple components ->
+      mk (Rexp_tuple
+            (List.map (fun (lbl, c) -> lbl, transl locals c) components))
+  | Pexp_construct (lid, arg) ->
+      (* Resolve, to reject unbound names here rather than in a later
+         piece; the predicate keeps the source name. *)
+      ignore
+        (Env.lookup_constructor ~loc:lid.loc Env.Positive lid.txt env
+         : _ * _);
+      mk (Rexp_construct (lid, Option.map (transl locals) arg))
+  | Pexp_field (e, lid) ->
+      ignore
+        (Env.lookup_label ~record_form:Legacy ~loc:lid.loc Env.Projection
+           lid.txt env
+         : _ Data_types.gen_label_description);
+      mk (Rexp_field (transl locals e, lid))
+  | Pexp_ifthenelse (cond, ifso, ifnot) ->
+      mk (Rexp_ifthenelse
+            (transl locals cond,
+             transl locals ifso,
+             Option.map (transl locals) ifnot))
+  | Pexp_let (Mutable, _, _, _) -> not_total "Mutable bindings are"
+  | Pexp_let (Immutable, Recursive, _, _) ->
+      unsupported "A recursive binding"
+  | Pexp_let (Immutable, Nonrecursive, [ vb ], body) -> begin
+      match vb.pvb_pat.ppat_desc with
+      | Ppat_var name ->
+          let rb_expr = transl locals vb.pvb_expr in
+          let id = Ident.create_local name.txt in
+          let locals = Misc.Stdlib.String.Map.add name.txt id locals in
+          mk (Rexp_let ({ rb_ident = id; rb_expr }, transl locals body))
+      | _ -> unsupported "This binding pattern"
+    end
+  | Pexp_let (Immutable, Nonrecursive, _, _) ->
+      unsupported "A multiple binding"
+  | Pexp_function (params, constraint_, body) ->
+      let locals, params =
+        List.fold_left_map
+          (fun locals param ->
+            match param.pparam_desc with
+            | Pparam_val (Nolabel, None, { ppat_desc = Ppat_var name; _ }) ->
+                let id = Ident.create_local name.txt in
+                Misc.Stdlib.String.Map.add name.txt id locals, id
+            | Pparam_val _ | Pparam_newtype _ ->
+                raise (Error (param.pparam_loc, env,
+                              Refinement_predicate_unsupported
+                                "This function parameter")))
+          locals params
+      in
+      let body =
+        match body with
+        | Pfunction_body body -> transl locals body
+        | Pfunction_cases _ ->
+            unsupported "A function defined by cases"
+      in
+      let body =
+        match constraint_ with
+        | { mode_annotations = []; ret_mode_annotations = [];
+            ret_type_constraint = None } -> body
+        | { ret_type_constraint = Some (Pconstraint ty);
+            mode_annotations = []; ret_mode_annotations = [] } ->
+            let cty =
+              transl_type env ~policy ~row_context Alloc.Const.legacy ty
+            in
+            { rexp_desc = Rexp_constraint (body, cty.ctyp_type);
+              rexp_loc = loc }
+        | _ -> unsupported "This function constraint"
+      in
+      List.fold_right (fun id body -> mk (Rexp_fun (id, body))) params body
+  | Pexp_match (scrutinee, cases) ->
+      mk (Rexp_match
+            (transl locals scrutinee,
+             List.map
+               (transl_refinement_case env ~policy ~row_context locals)
+               cases))
+  | Pexp_constraint (e, Some ty, []) ->
+      let cty = transl_type env ~policy ~row_context Alloc.Const.legacy ty in
+      mk (Rexp_constraint (transl locals e, cty.ctyp_type))
+  | Pexp_constraint _ -> unsupported "This form of constraint"
+  | Pexp_while _ -> not_total "While loops are"
+  | Pexp_for _ -> not_total "For loops are"
+  | Pexp_sequence _ -> not_total "Sequencing is"
+  | Pexp_setfield _ | Pexp_setvar _ -> not_total "Assignment is"
+  | Pexp_array _ -> not_total "Arrays are"
+  | Pexp_try _ -> not_total "Exception handlers are"
+  | Pexp_assert _ -> not_total "Assertions are"
+  | Pexp_lazy _ -> not_total "Lazy expressions are"
+  | Pexp_letexception _ -> not_total "Exception declarations are"
+  | Pexp_record _ | Pexp_record_unboxed_product _ ->
+      unsupported "A record expression"
+  | _ -> unsupported "This expression form"
+
+and transl_refinement_case env ~policy ~row_context locals case =
+  (match case.pc_lhs.ppat_desc with
+   | _ -> ());
+  let locals, rc_lhs =
+    transl_refinement_pattern env locals case.pc_lhs
+  in
+  { rc_lhs;
+    rc_guard =
+      Option.map
+        (transl_refinement_predicate env ~policy ~row_context locals)
+        case.pc_guard;
+    rc_rhs =
+      transl_refinement_predicate env ~policy ~row_context locals
+        case.pc_rhs }
+
+and transl_refinement_pattern env locals pat =
+  let loc = pat.ppat_loc in
+  let mk rpat_desc = { rpat_desc; rpat_loc = loc } in
+  let unsupported what =
+    raise (Error (loc, env, Refinement_predicate_unsupported what))
+  in
+  match pat.ppat_desc with
+  | Ppat_any -> locals, mk Rpat_any
+  | Ppat_var name ->
+      let id = Ident.create_local name.txt in
+      Misc.Stdlib.String.Map.add name.txt id locals, mk (Rpat_var id)
+  | Ppat_constant const -> locals, mk (Rpat_constant const)
+  | Ppat_tuple (components, Closed) ->
+      let locals, components =
+        List.fold_left_map
+          (fun locals (lbl, p) ->
+            let locals, p = transl_refinement_pattern env locals p in
+            locals, (lbl, p))
+          locals components
+      in
+      locals, mk (Rpat_tuple components)
+  | Ppat_tuple (_, Open) -> unsupported "A partial tuple pattern"
+  | Ppat_construct (lid, arg) ->
+      ignore
+        (Env.lookup_constructor ~loc:lid.loc Env.Pattern lid.txt env
+         : _ * _);
+      let locals, arg =
+        match arg with
+        | None -> locals, None
+        | Some ([], p) ->
+            let locals, p = transl_refinement_pattern env locals p in
+            locals, Some p
+        | Some (_ :: _, _) -> unsupported "An existential type binding"
+      in
+      locals, mk (Rpat_construct (lid, arg))
+  | Ppat_alias (p, name) ->
+      let locals, p = transl_refinement_pattern env locals p in
+      let id = Ident.create_local name.txt in
+      Misc.Stdlib.String.Map.add name.txt id locals,
+      mk (Rpat_alias (p, id))
+  | Ppat_or _ -> unsupported "An or-pattern"
+  | _ -> unsupported "This pattern form"
 
 and transl_type_var env ~policy ~row_context attrs loc name jkind_annot_opt =
   let print_name = "'" ^ name in
@@ -2102,6 +2399,15 @@ let report_error_doc loc env = function
          value descriptions introduced using %a.@]"
         Style.inline_code "layout_"
         Style.inline_code "val poly_"
+  | Refinement_predicate_not_total form ->
+      Location.errorf ~loc
+        "@[%s not allowed in a refinement predicate:@ predicates must be \
+         total.@]"
+        form
+  | Refinement_predicate_unsupported what ->
+      Location.errorf ~loc
+        "@[%s is not supported in refinement predicates.@]"
+        what
 
 let () =
   Location.register_error_of_exn

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -78,7 +78,7 @@ val transl_label :
 
 (** The label of an arrow type, for callers that do not translate the
     arrow itself: decides bare names by the occurrence test
-    ({!Vox_binding.classify_bare_name}) and then behaves as
+    ({!Vox_binding.name_used_in_refinement}) and then behaves as
     {!transl_label}. *)
 val transl_arrow_arg_label :
         Parsetree.arrow_arg_name ->

--- a/typing/typetexp.mli
+++ b/typing/typetexp.mli
@@ -76,6 +76,15 @@ val valid_tyvar_name : string -> bool
 val transl_label :
         Parsetree.arg_label -> Parsetree.core_type option -> Types.arg_label
 
+(** The label of an arrow type, for callers that do not translate the
+    arrow itself: decides bare names by the occurrence test
+    ({!Vox_binding.classify_bare_name}) and then behaves as
+    {!transl_label}. *)
+val transl_arrow_arg_label :
+        Parsetree.arrow_arg_name ->
+        domain:Parsetree.core_type -> codomain:Parsetree.core_type ->
+        Parsetree.core_type option -> Types.arg_label
+
 (** Produces a Typedtree argument label, as well as the pattern corresponding
     to the argument. [transl_label lbl pat] is equal to:
 
@@ -203,6 +212,8 @@ type error =
     { name : string; explicit_jkind : jkind_lr; implicit_jkind : jkind_lr }
   | Lpoly_unsupported
   | Val_poly_and_layout
+  | Refinement_predicate_not_total of string
+  | Refinement_predicate_unsupported of string
 
 exception Error of Location.t * Env.t * error
 

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -1113,11 +1113,39 @@ let core_type sub ct =
   let desc = match ct.ctyp_desc with
       Ttyp_var (None, jkind) -> Ptyp_any jkind
     | Ttyp_var (Some s, jkind) -> Ptyp_var (s, jkind)
-    | Ttyp_arrow (arg_label, ct1, modes1, ct2, modes2) ->
+    | Ttyp_arrow (arg_label, binder, ct1, modes1, ct2, modes2) ->
         let modes1 = Typemode.untransl_mode modes1 in
         let modes2 = Typemode.untransl_mode modes2 in
-        Ptyp_arrow
-          (label arg_label, sub.typ sub ct1, sub.typ sub ct2, modes1, modes2)
+        let ct1 = sub.typ sub ct1 and ct2 = sub.typ sub ct2 in
+        let name =
+          match binder, label arg_label with
+          | Some id, Nolabel ->
+              (* A positional binder: it re-binds on re-parse because it was
+                 created only when the name occurs in a refinement. *)
+              Pan_name (mknoloc (Ident.name id))
+          | _, Nolabel -> Pan_nolabel
+          | _, Optional l -> Pan_optional (mknoloc l)
+          | _, Labelled l ->
+              (* Escape the label whenever its bare spelling would re-parse
+                 as a binder. *)
+              if Vox_binding.name_used_in_refinement l [ct1; ct2]
+              then Pan_tilde (mknoloc l)
+              else Pan_name (mknoloc l)
+        in
+        Ptyp_arrow (name, ct1, ct2, modes1, modes2)
+    | Ttyp_refine (payload, pred) ->
+        let core_type_of_type_expr ty =
+          (* Interior types live in the type graph, not in the typedtree;
+             render and re-parse them. *)
+          let rendered = Format.asprintf "%a" Printtyp.type_expr ty in
+          match Parse.core_type (Lexing.from_string rendered) with
+          | ct -> ct
+          | exception _ -> Ast_helper.Typ.any None
+        in
+        Ptyp_refine
+          (sub.typ sub payload,
+           Vox_rexp.untype ~var_name:Ident.name
+             ~core_type:core_type_of_type_expr pred)
     | Ttyp_tuple list ->
         Ptyp_tuple (List.map (fun (l, typ) -> l, sub.typ sub typ) list)
     | Ttyp_unboxed_tuple list ->

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -1134,18 +1134,7 @@ let core_type sub ct =
         in
         Ptyp_arrow (name, ct1, ct2, modes1, modes2)
     | Ttyp_refine (payload, pred) ->
-        let core_type_of_type_expr ty =
-          (* Interior types live in the type graph, not in the typedtree;
-             render and re-parse them. *)
-          let rendered = Format.asprintf "%a" Printtyp.type_expr ty in
-          match Parse.core_type (Lexing.from_string rendered) with
-          | ct -> ct
-          | exception _ -> Ast_helper.Typ.any None
-        in
-        Ptyp_refine
-          (sub.typ sub payload,
-           Vox_rexp.untype ~var_name:Ident.name
-             ~core_type:core_type_of_type_expr pred)
+        Ptyp_refine (sub.typ sub payload, pred)
     | Ttyp_tuple list ->
         Ptyp_tuple (List.map (fun (l, typ) -> l, sub.typ sub typ) list)
     | Ttyp_unboxed_tuple list ->

--- a/typing/vicuna_traverse_typed_tree.ml
+++ b/typing/vicuna_traverse_typed_tree.ml
@@ -155,6 +155,8 @@ let classify env ty : classification =
       raise (Vicuna_unsupported (Other "Unexpected type constructor Trepr"))
     | Tbox _ ->
       raise (Vicuna_unsupported (Other "Unexpected type constructor Tbox"))
+    | Trefine _ ->
+      raise (Vicuna_unsupported (Other "Unexpected type constructor Trefine"))
 
 type can_be_float_array =
   | YesFloatArray
@@ -182,6 +184,9 @@ let rec value_kind env (subst : value_shape Subst.t) ~visited ~depth ty :
   in
   let scty = scrape_ty env ty in
   match get_desc scty with
+  | Trefine _ ->
+    Misc.fatal_error
+      "Vicuna_traverse_typed_tree.value_kind: Trefine after scrape_ty"
   | Tmod _ ->
     Misc.fatal_error "Vicuna_traverse_typed_tree.value_kind: unexpected Tmod"
   | Tconstr (p, _, _) when Path.same p Predef.path_int -> Imm
@@ -423,7 +428,7 @@ let rec split_external_type (ct : core_type) :
     (core_type * bool) list * core_type =
   match ct.ctyp_desc with
   | Ttyp_poly (_, ct) -> split_external_type ct
-  | Ttyp_arrow (lab, arg, _, cont, _) -> (
+  | Ttyp_arrow (lab, _, arg, _, cont, _) -> (
     let args, ret = split_external_type cont in
     match lab with
     | Nolabel | Labelled _ -> (arg, false) :: args, ret

--- a/typing/vox_rexp.ml
+++ b/typing/vox_rexp.ml
@@ -139,6 +139,15 @@ let map ?(rename = Ident.Map.empty) ?(freshen = false) ?value_path ~type_expr
 
 (* Alpha-equivalence *)
 
+(* [Pconst_string] carries the location of the string contents inside the
+   description; it is not part of the syntax and must not be part of type
+   identity. *)
+let constant_equal (c1 : Parsetree.constant) (c2 : Parsetree.constant) =
+  match c1.pconst_desc, c2.pconst_desc with
+  | Pconst_string (s1, _, d1), Pconst_string (s2, _, d2) ->
+      String.equal s1 s2 && Option.equal String.equal d1 d2
+  | desc1, desc2 -> desc1 = desc2
+
 let equal ~type_eq ~pairs rexp1 rexp2 =
   (* [pairs] pairs the binders of the left predicate with the binders of
      the right one, innermost first. *)
@@ -157,8 +166,7 @@ let equal ~type_eq ~pairs rexp1 rexp2 =
     | Rexp_hole, Rexp_hole -> true
     | Rexp_var id1, Rexp_var id2 -> var_eq pairs id1 id2
     | Rexp_ident (p1, _), Rexp_ident (p2, _) -> Path.same p1 p2
-    | Rexp_constant c1, Rexp_constant c2 ->
-        c1.pconst_desc = c2.pconst_desc
+    | Rexp_constant c1, Rexp_constant c2 -> constant_equal c1 c2
     | Rexp_apply (f1, args1), Rexp_apply (f2, args2) ->
         eq pairs f1 f2
         && List.compare_lengths args1 args2 = 0
@@ -204,7 +212,7 @@ let equal ~type_eq ~pairs rexp1 rexp2 =
     | Rpat_any, Rpat_any -> Some pairs
     | Rpat_var id1, Rpat_var id2 -> Some ((id1, id2) :: pairs)
     | Rpat_constant c1, Rpat_constant c2 ->
-        if c1.pconst_desc = c2.pconst_desc then Some pairs else None
+        if constant_equal c1 c2 then Some pairs else None
     | Rpat_tuple c1, Rpat_tuple c2 ->
         if List.compare_lengths c1 c2 = 0 then
           List.fold_left2
@@ -232,7 +240,7 @@ let equal ~type_eq ~pairs rexp1 rexp2 =
 
 (* Back to surface syntax *)
 
-let untype ~var_name ~core_type rexp =
+let untype ~var_name ~value_ident ~core_type rexp =
   let open Ast_helper in
   let lid_of_name name = Location.mknoloc (Longident.Lident name) in
   let rec untype_rexp rexp =
@@ -240,7 +248,11 @@ let untype ~var_name ~core_type rexp =
     match rexp.rexp_desc with
     | Rexp_hole -> Exp.mk ~loc Pexp_hole
     | Rexp_var id -> Exp.ident ~loc (lid_of_name (var_name id))
-    | Rexp_ident (_, lid) -> Exp.ident ~loc lid
+    | Rexp_ident (path, _) ->
+        (* Render from the resolved path: the source longident may not
+           resolve at the printing site, and substitution rewrites only the
+           path. *)
+        Exp.ident ~loc (value_ident path)
     | Rexp_constant const -> Exp.constant ~loc const
     | Rexp_apply (fn, args) ->
         Exp.apply ~loc (untype_rexp fn)
@@ -325,6 +337,23 @@ let exists_rexp pred rexp =
     | Rexp_constraint (e, _) -> walk e
   in
   match walk rexp with () -> false | exception Found -> true
+
+let find_value_path (f : Path.t -> 'a option) rexp : 'a option =
+  let result = ref None in
+  ignore
+    (exists_rexp
+       (fun r ->
+         match r.rexp_desc with
+         | Rexp_ident (path, _) -> (
+             match f path with
+             | Some _ as found ->
+                 result := found;
+                 true
+             | None -> false)
+         | _ -> false)
+       rexp
+     : bool);
+  !result
 
 let mentions_ident id rexp =
   exists_rexp

--- a/typing/vox_rexp.ml
+++ b/typing/vox_rexp.ml
@@ -25,7 +25,7 @@ let rec fold_types f acc rexp =
       List.fold_left
         (fun acc (_, component) -> fold_types f acc component)
         acc components
-  | Rexp_construct (_, arg) ->
+  | Rexp_construct (_, _, arg) ->
       Option.fold ~none:acc ~some:(fold_types f acc) arg
   | Rexp_field (e, _) -> fold_types f acc e
   | Rexp_ifthenelse (cond, ifso, ifnot) ->
@@ -48,8 +48,8 @@ let iter_types f rexp = fold_types (fun () ty -> f ty) () rexp
 
 (* Rebuilding *)
 
-let map ?(rename = Ident.Map.empty) ?(freshen = false) ?value_path ~type_expr
-    rexp =
+let map ?(rename = Ident.Map.empty) ?(freshen = false) ?value_path
+    ?constructor_path ~type_expr rexp =
   let rename_var rename id =
     match Ident.Map.find_opt id rename with Some id' -> id' | None -> id
   in
@@ -77,8 +77,11 @@ let map ?(rename = Ident.Map.empty) ?(freshen = false) ?value_path ~type_expr
       | Rexp_tuple components ->
           Rexp_tuple
             (List.map (fun (lbl, c) -> lbl, map_rexp rename c) components)
-      | Rexp_construct (lid, arg) ->
-          Rexp_construct (lid, Option.map (map_rexp rename) arg)
+      | Rexp_construct (path, lid, arg) ->
+          let path =
+            match constructor_path with Some f -> f path | None -> path
+          in
+          Rexp_construct (path, lid, Option.map (map_rexp rename) arg)
       | Rexp_field (e, lid) -> Rexp_field (map_rexp rename e, lid)
       | Rexp_ifthenelse (cond, ifso, ifnot) ->
           Rexp_ifthenelse
@@ -119,7 +122,10 @@ let map ?(rename = Ident.Map.empty) ?(freshen = false) ?value_path ~type_expr
               rename components
           in
           rename, Rpat_tuple components
-      | Rpat_construct (lid, arg) ->
+      | Rpat_construct (path, lid, arg) ->
+          let path =
+            match constructor_path with Some f -> f path | None -> path
+          in
           let rename, arg =
             match arg with
             | None -> rename, None
@@ -127,7 +133,7 @@ let map ?(rename = Ident.Map.empty) ?(freshen = false) ?value_path ~type_expr
                 let rename, p = map_pat rename p in
                 rename, Some p
           in
-          rename, Rpat_construct (lid, arg)
+          rename, Rpat_construct (path, lid, arg)
       | Rpat_alias (p, id) ->
           let rename, p = map_pat rename p in
           let rename, id = bind rename id in
@@ -178,8 +184,8 @@ let equal ~type_eq ~pairs rexp1 rexp2 =
         && List.for_all2
              (fun (l1, e1) (l2, e2) -> l1 = l2 && eq pairs e1 e2)
              c1 c2
-    | Rexp_construct (lid1, arg1), Rexp_construct (lid2, arg2) ->
-        lid1.txt = lid2.txt
+    | Rexp_construct (p1, _, arg1), Rexp_construct (p2, _, arg2) ->
+        Path.same p1 p2
         && Option.equal (eq pairs) arg1 arg2
     | Rexp_field (e1, lid1), Rexp_field (e2, lid2) ->
         lid1.txt = lid2.txt && eq pairs e1 e2
@@ -221,8 +227,8 @@ let equal ~type_eq ~pairs rexp1 rexp2 =
                   if l1 = l2 then eq_pat pairs p1 p2 else None))
             (Some pairs) c1 c2
         else None
-    | Rpat_construct (lid1, arg1), Rpat_construct (lid2, arg2) ->
-        if lid1.txt = lid2.txt then
+    | Rpat_construct (c1, _, arg1), Rpat_construct (c2, _, arg2) ->
+        if Path.same c1 c2 then
           match arg1, arg2 with
           | None, None -> Some pairs
           | Some p1, Some p2 -> eq_pat pairs p1 p2
@@ -240,7 +246,7 @@ let equal ~type_eq ~pairs rexp1 rexp2 =
 
 (* Back to surface syntax *)
 
-let untype ~var_name ~value_ident ~core_type rexp =
+let untype ~var_name ~value_ident ~constructor_ident ~core_type rexp =
   let open Ast_helper in
   let lid_of_name name = Location.mknoloc (Longident.Lident name) in
   let rec untype_rexp rexp =
@@ -260,8 +266,9 @@ let untype ~var_name ~value_ident ~core_type rexp =
     | Rexp_tuple components ->
         Exp.tuple ~loc
           (List.map (fun (lbl, c) -> lbl, untype_rexp c) components)
-    | Rexp_construct (lid, arg) ->
-        Exp.construct ~loc lid (Option.map untype_rexp arg)
+    | Rexp_construct (path, _, arg) ->
+        Exp.construct ~loc (constructor_ident path)
+          (Option.map untype_rexp arg)
     | Rexp_field (e, lid) -> Exp.field ~loc (untype_rexp e) lid
     | Rexp_ifthenelse (cond, ifso, ifnot) ->
         Exp.ifthenelse ~loc (untype_rexp cond) (untype_rexp ifso)
@@ -301,8 +308,8 @@ let untype ~var_name ~value_ident ~core_type rexp =
         Pat.tuple ~loc
           (List.map (fun (lbl, p) -> lbl, untype_pat p) components)
           Asttypes.Closed
-    | Rpat_construct (lid, arg) ->
-        Pat.construct ~loc lid
+    | Rpat_construct (path, _, arg) ->
+        Pat.construct ~loc (constructor_ident path)
           (Option.map (fun p -> [], untype_pat p) arg)
     | Rpat_alias (p, id) ->
         Pat.alias ~loc (untype_pat p) (Location.mknoloc (var_name id))
@@ -321,7 +328,7 @@ let exists_rexp pred rexp =
         walk fn;
         List.iter (fun (_, arg) -> walk arg) args
     | Rexp_tuple components -> List.iter (fun (_, c) -> walk c) components
-    | Rexp_construct (_, arg) -> Option.iter walk arg
+    | Rexp_construct (_, _, arg) -> Option.iter walk arg
     | Rexp_field (e, _) -> walk e
     | Rexp_ifthenelse (cond, ifso, ifnot) ->
         walk cond; walk ifso; Option.iter walk ifnot
@@ -340,16 +347,29 @@ let exists_rexp pred rexp =
 
 let find_value_path (f : Path.t -> 'a option) rexp : 'a option =
   let result = ref None in
+  let check path =
+    match f path with
+    | Some _ as found ->
+        result := found;
+        true
+    | None -> false
+  in
   ignore
     (exists_rexp
        (fun r ->
          match r.rexp_desc with
-         | Rexp_ident (path, _) -> (
-             match f path with
-             | Some _ as found ->
-                 result := found;
-                 true
-             | None -> false)
+         | Rexp_ident (path, _) | Rexp_construct (path, _, _) -> check path
+         | Rexp_match (_, cases) ->
+             let rec pat_path p =
+               match p.rpat_desc with
+               | Rpat_construct (path, _, arg) ->
+                   check path
+                   || Option.fold ~none:false ~some:pat_path arg
+               | Rpat_alias (p, _) -> pat_path p
+               | Rpat_tuple ps -> List.exists (fun (_, p) -> pat_path p) ps
+               | Rpat_any | Rpat_var _ | Rpat_constant _ -> false
+             in
+             List.exists (fun c -> pat_path c.rc_lhs) cases
          | _ -> false)
        rexp
      : bool);

--- a/typing/vox_rexp.ml
+++ b/typing/vox_rexp.ml
@@ -1,0 +1,335 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Copyright 2026 Jane Street Group LLC                                  *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+open Types
+
+(* Folding over interior types *)
+
+let rec fold_types f acc rexp =
+  match rexp.rexp_desc with
+  | Rexp_hole | Rexp_var _ | Rexp_ident _ | Rexp_constant _ -> acc
+  | Rexp_apply (fn, args) ->
+      List.fold_left
+        (fun acc (_, arg) -> fold_types f acc arg)
+        (fold_types f acc fn) args
+  | Rexp_tuple components ->
+      List.fold_left
+        (fun acc (_, component) -> fold_types f acc component)
+        acc components
+  | Rexp_construct (_, arg) ->
+      Option.fold ~none:acc ~some:(fold_types f acc) arg
+  | Rexp_field (e, _) -> fold_types f acc e
+  | Rexp_ifthenelse (cond, ifso, ifnot) ->
+      let acc = fold_types f acc cond in
+      let acc = fold_types f acc ifso in
+      Option.fold ~none:acc ~some:(fold_types f acc) ifnot
+  | Rexp_let ({ rb_ident = _; rb_expr }, body) ->
+      fold_types f (fold_types f acc rb_expr) body
+  | Rexp_fun (_, body) -> fold_types f acc body
+  | Rexp_match (scrutinee, cases) ->
+      List.fold_left (fold_types_case f) (fold_types f acc scrutinee) cases
+  | Rexp_constraint (e, ty) -> f (fold_types f acc e) ty
+
+and fold_types_case f acc { rc_lhs = _; rc_guard; rc_rhs } =
+  (* Patterns carry no interior types. *)
+  let acc = Option.fold ~none:acc ~some:(fold_types f acc) rc_guard in
+  fold_types f acc rc_rhs
+
+let iter_types f rexp = fold_types (fun () ty -> f ty) () rexp
+
+(* Rebuilding *)
+
+let map ?(rename = Ident.Map.empty) ?(freshen = false) ?value_path ~type_expr
+    rexp =
+  let rename_var rename id =
+    match Ident.Map.find_opt id rename with Some id' -> id' | None -> id
+  in
+  let bind rename id =
+    if freshen then
+      let id' = Ident.rename id in
+      Ident.Map.add id id' rename, id'
+    else rename, id
+  in
+  let rec map_rexp rename rexp =
+    let rexp_desc =
+      match rexp.rexp_desc with
+      | Rexp_hole -> Rexp_hole
+      | Rexp_var id -> Rexp_var (rename_var rename id)
+      | Rexp_ident (path, lid) ->
+          let path =
+            match value_path with Some f -> f path | None -> path
+          in
+          Rexp_ident (path, lid)
+      | Rexp_constant _ as desc -> desc
+      | Rexp_apply (fn, args) ->
+          Rexp_apply
+            ( map_rexp rename fn,
+              List.map (fun (lbl, arg) -> lbl, map_rexp rename arg) args )
+      | Rexp_tuple components ->
+          Rexp_tuple
+            (List.map (fun (lbl, c) -> lbl, map_rexp rename c) components)
+      | Rexp_construct (lid, arg) ->
+          Rexp_construct (lid, Option.map (map_rexp rename) arg)
+      | Rexp_field (e, lid) -> Rexp_field (map_rexp rename e, lid)
+      | Rexp_ifthenelse (cond, ifso, ifnot) ->
+          Rexp_ifthenelse
+            ( map_rexp rename cond,
+              map_rexp rename ifso,
+              Option.map (map_rexp rename) ifnot )
+      | Rexp_let ({ rb_ident; rb_expr }, body) ->
+          let rb_expr = map_rexp rename rb_expr in
+          let rename, rb_ident = bind rename rb_ident in
+          Rexp_let ({ rb_ident; rb_expr }, map_rexp rename body)
+      | Rexp_fun (param, body) ->
+          let rename, param = bind rename param in
+          Rexp_fun (param, map_rexp rename body)
+      | Rexp_match (scrutinee, cases) ->
+          Rexp_match (map_rexp rename scrutinee, List.map (map_case rename) cases)
+      | Rexp_constraint (e, ty) ->
+          Rexp_constraint (map_rexp rename e, type_expr ty)
+    in
+    { rexp with rexp_desc }
+  and map_case rename { rc_lhs; rc_guard; rc_rhs } =
+    let rename, rc_lhs = map_pat rename rc_lhs in
+    { rc_lhs;
+      rc_guard = Option.map (map_rexp rename) rc_guard;
+      rc_rhs = map_rexp rename rc_rhs }
+  and map_pat rename pat =
+    let rename, rpat_desc =
+      match pat.rpat_desc with
+      | (Rpat_any | Rpat_constant _) as desc -> rename, desc
+      | Rpat_var id ->
+          let rename, id = bind rename id in
+          rename, Rpat_var id
+      | Rpat_tuple components ->
+          let rename, components =
+            List.fold_left_map
+              (fun rename (lbl, p) ->
+                let rename, p = map_pat rename p in
+                rename, (lbl, p))
+              rename components
+          in
+          rename, Rpat_tuple components
+      | Rpat_construct (lid, arg) ->
+          let rename, arg =
+            match arg with
+            | None -> rename, None
+            | Some p ->
+                let rename, p = map_pat rename p in
+                rename, Some p
+          in
+          rename, Rpat_construct (lid, arg)
+      | Rpat_alias (p, id) ->
+          let rename, p = map_pat rename p in
+          let rename, id = bind rename id in
+          rename, Rpat_alias (p, id)
+    in
+    rename, { pat with rpat_desc }
+  in
+  map_rexp rename rexp
+
+(* Alpha-equivalence *)
+
+let equal ~type_eq ~pairs rexp1 rexp2 =
+  (* [pairs] pairs the binders of the left predicate with the binders of
+     the right one, innermost first. *)
+  let var_eq pairs id1 id2 =
+    let rec find = function
+      | [] -> Ident.same id1 id2
+      | (l, r) :: rest ->
+          if Ident.same id1 l then Ident.same id2 r
+          else if Ident.same id2 r then false
+          else find rest
+    in
+    find pairs
+  in
+  let rec eq pairs rexp1 rexp2 =
+    match rexp1.rexp_desc, rexp2.rexp_desc with
+    | Rexp_hole, Rexp_hole -> true
+    | Rexp_var id1, Rexp_var id2 -> var_eq pairs id1 id2
+    | Rexp_ident (p1, _), Rexp_ident (p2, _) -> Path.same p1 p2
+    | Rexp_constant c1, Rexp_constant c2 ->
+        c1.pconst_desc = c2.pconst_desc
+    | Rexp_apply (f1, args1), Rexp_apply (f2, args2) ->
+        eq pairs f1 f2
+        && List.compare_lengths args1 args2 = 0
+        && List.for_all2
+             (fun (l1, a1) (l2, a2) -> l1 = l2 && eq pairs a1 a2)
+             args1 args2
+    | Rexp_tuple c1, Rexp_tuple c2 ->
+        List.compare_lengths c1 c2 = 0
+        && List.for_all2
+             (fun (l1, e1) (l2, e2) -> l1 = l2 && eq pairs e1 e2)
+             c1 c2
+    | Rexp_construct (lid1, arg1), Rexp_construct (lid2, arg2) ->
+        lid1.txt = lid2.txt
+        && Option.equal (eq pairs) arg1 arg2
+    | Rexp_field (e1, lid1), Rexp_field (e2, lid2) ->
+        lid1.txt = lid2.txt && eq pairs e1 e2
+    | Rexp_ifthenelse (c1, t1, e1), Rexp_ifthenelse (c2, t2, e2) ->
+        eq pairs c1 c2 && eq pairs t1 t2 && Option.equal (eq pairs) e1 e2
+    | Rexp_let (b1, body1), Rexp_let (b2, body2) ->
+        eq pairs b1.rb_expr b2.rb_expr
+        && eq ((b1.rb_ident, b2.rb_ident) :: pairs) body1 body2
+    | Rexp_fun (p1, body1), Rexp_fun (p2, body2) ->
+        eq ((p1, p2) :: pairs) body1 body2
+    | Rexp_match (s1, cases1), Rexp_match (s2, cases2) ->
+        eq pairs s1 s2
+        && List.compare_lengths cases1 cases2 = 0
+        && List.for_all2 (eq_case pairs) cases1 cases2
+    | Rexp_constraint (e1, ty1), Rexp_constraint (e2, ty2) ->
+        eq pairs e1 e2 && type_eq ty1 ty2
+    | ( ( Rexp_hole | Rexp_var _ | Rexp_ident _ | Rexp_constant _
+        | Rexp_apply _ | Rexp_tuple _ | Rexp_construct _ | Rexp_field _
+        | Rexp_ifthenelse _ | Rexp_let _ | Rexp_fun _ | Rexp_match _
+        | Rexp_constraint _ ), _ ) ->
+        false
+  and eq_case pairs case1 case2 =
+    match eq_pat pairs case1.rc_lhs case2.rc_lhs with
+    | None -> false
+    | Some pairs ->
+        Option.equal (eq pairs) case1.rc_guard case2.rc_guard
+        && eq pairs case1.rc_rhs case2.rc_rhs
+  and eq_pat pairs pat1 pat2 =
+    match pat1.rpat_desc, pat2.rpat_desc with
+    | Rpat_any, Rpat_any -> Some pairs
+    | Rpat_var id1, Rpat_var id2 -> Some ((id1, id2) :: pairs)
+    | Rpat_constant c1, Rpat_constant c2 ->
+        if c1.pconst_desc = c2.pconst_desc then Some pairs else None
+    | Rpat_tuple c1, Rpat_tuple c2 ->
+        if List.compare_lengths c1 c2 = 0 then
+          List.fold_left2
+            (fun pairs (l1, p1) (l2, p2) ->
+              Option.bind pairs (fun pairs ->
+                  if l1 = l2 then eq_pat pairs p1 p2 else None))
+            (Some pairs) c1 c2
+        else None
+    | Rpat_construct (lid1, arg1), Rpat_construct (lid2, arg2) ->
+        if lid1.txt = lid2.txt then
+          match arg1, arg2 with
+          | None, None -> Some pairs
+          | Some p1, Some p2 -> eq_pat pairs p1 p2
+          | None, Some _ | Some _, None -> None
+        else None
+    | Rpat_alias (p1, id1), Rpat_alias (p2, id2) ->
+        Option.map
+          (fun pairs -> (id1, id2) :: pairs)
+          (eq_pat pairs p1 p2)
+    | ( ( Rpat_any | Rpat_var _ | Rpat_constant _ | Rpat_tuple _
+        | Rpat_construct _ | Rpat_alias _ ), _ ) ->
+        None
+  in
+  eq pairs rexp1 rexp2
+
+(* Back to surface syntax *)
+
+let untype ~var_name ~core_type rexp =
+  let open Ast_helper in
+  let lid_of_name name = Location.mknoloc (Longident.Lident name) in
+  let rec untype_rexp rexp =
+    let loc = rexp.rexp_loc in
+    match rexp.rexp_desc with
+    | Rexp_hole -> Exp.mk ~loc Pexp_hole
+    | Rexp_var id -> Exp.ident ~loc (lid_of_name (var_name id))
+    | Rexp_ident (_, lid) -> Exp.ident ~loc lid
+    | Rexp_constant const -> Exp.constant ~loc const
+    | Rexp_apply (fn, args) ->
+        Exp.apply ~loc (untype_rexp fn)
+          (List.map (fun (lbl, arg) -> lbl, untype_rexp arg) args)
+    | Rexp_tuple components ->
+        Exp.tuple ~loc
+          (List.map (fun (lbl, c) -> lbl, untype_rexp c) components)
+    | Rexp_construct (lid, arg) ->
+        Exp.construct ~loc lid (Option.map untype_rexp arg)
+    | Rexp_field (e, lid) -> Exp.field ~loc (untype_rexp e) lid
+    | Rexp_ifthenelse (cond, ifso, ifnot) ->
+        Exp.ifthenelse ~loc (untype_rexp cond) (untype_rexp ifso)
+          (Option.map untype_rexp ifnot)
+    | Rexp_let ({ rb_ident; rb_expr }, body) ->
+        Exp.let_ ~loc Immutable Nonrecursive
+          [ Vb.mk
+              (Pat.var (Location.mknoloc (var_name rb_ident)))
+              (untype_rexp rb_expr) ]
+          (untype_rexp body)
+    | Rexp_fun (param, body) ->
+        Exp.function_ ~loc
+          [ { pparam_desc =
+                Pparam_val
+                  ( Asttypes.Nolabel, None,
+                    Pat.var (Location.mknoloc (var_name param)) );
+              pparam_loc = Location.none } ]
+          { mode_annotations = [];
+            ret_mode_annotations = [];
+            ret_type_constraint = None }
+          (Pfunction_body (untype_rexp body))
+    | Rexp_match (scrutinee, cases) ->
+        Exp.match_ ~loc (untype_rexp scrutinee) (List.map untype_case cases)
+    | Rexp_constraint (e, ty) ->
+        Exp.constraint_ ~loc (untype_rexp e) (Some (core_type ty)) []
+  and untype_case { rc_lhs; rc_guard; rc_rhs } =
+    Exp.case (untype_pat rc_lhs)
+      ?guard:(Option.map untype_rexp rc_guard)
+      (untype_rexp rc_rhs)
+  and untype_pat pat =
+    let loc = pat.rpat_loc in
+    match pat.rpat_desc with
+    | Rpat_any -> Pat.any ~loc ()
+    | Rpat_var id -> Pat.var ~loc (Location.mknoloc (var_name id))
+    | Rpat_constant const -> Pat.constant ~loc const
+    | Rpat_tuple components ->
+        Pat.tuple ~loc
+          (List.map (fun (lbl, p) -> lbl, untype_pat p) components)
+          Asttypes.Closed
+    | Rpat_construct (lid, arg) ->
+        Pat.construct ~loc lid
+          (Option.map (fun p -> [], untype_pat p) arg)
+    | Rpat_alias (p, id) ->
+        Pat.alias ~loc (untype_pat p) (Location.mknoloc (var_name id))
+  in
+  untype_rexp rexp
+
+(* Occurrence checks used by the printer *)
+
+let exists_rexp pred rexp =
+  let exception Found in
+  let rec walk rexp =
+    if pred rexp then raise Found;
+    match rexp.rexp_desc with
+    | Rexp_hole | Rexp_var _ | Rexp_ident _ | Rexp_constant _ -> ()
+    | Rexp_apply (fn, args) ->
+        walk fn;
+        List.iter (fun (_, arg) -> walk arg) args
+    | Rexp_tuple components -> List.iter (fun (_, c) -> walk c) components
+    | Rexp_construct (_, arg) -> Option.iter walk arg
+    | Rexp_field (e, _) -> walk e
+    | Rexp_ifthenelse (cond, ifso, ifnot) ->
+        walk cond; walk ifso; Option.iter walk ifnot
+    | Rexp_let ({ rb_expr; _ }, body) -> walk rb_expr; walk body
+    | Rexp_fun (_, body) -> walk body
+    | Rexp_match (scrutinee, cases) ->
+        walk scrutinee;
+        List.iter
+          (fun { rc_guard; rc_rhs; _ } ->
+            Option.iter walk rc_guard;
+            walk rc_rhs)
+          cases
+    | Rexp_constraint (e, _) -> walk e
+  in
+  match walk rexp with () -> false | exception Found -> true
+
+let mentions_ident id rexp =
+  exists_rexp
+    (fun r ->
+      match r.rexp_desc with
+      | Rexp_var id' -> Ident.same id id'
+      | _ -> false)
+    rexp

--- a/typing/vox_rexp.mli
+++ b/typing/vox_rexp.mli
@@ -1,0 +1,59 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*  Copyright 2026 Jane Street Group LLC                                  *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Generic operations on refinement predicates ({!Types.refinement_expression}).
+
+    A predicate is resolved syntax: the only pieces of it that live in the
+    type graph proper are its interior types (the types of
+    [Rexp_constraint] nodes and of nested refinements within them).  The
+    traversals below visit exactly those; the callers decide what to do
+    with them. *)
+
+open Types
+
+(** Fold over the interior types of a predicate. *)
+val fold_types :
+  ('a -> type_expr -> 'a) -> 'a -> refinement_expression -> 'a
+
+val iter_types : (type_expr -> unit) -> refinement_expression -> unit
+
+(** Rebuild a predicate.  [type_expr] is applied to interior types.
+    If [freshen] is set, every binder ident introduced inside the predicate
+    is renamed to a fresh stamp ([Subst] freshens binder stamps on import;
+    [Btype] does not).  [rename] maps externally-bound idents (arrow
+    binders); [value_path] rewrites the paths of free idents. *)
+val map :
+  ?rename:Ident.t Ident.Map.t ->
+  ?freshen:bool ->
+  ?value_path:(Path.t -> Path.t) ->
+  type_expr:(type_expr -> type_expr) ->
+  refinement_expression -> refinement_expression
+
+(** Syntactic alpha-equivalence.  [type_eq] compares interior types;
+    [pairs] gives the pairing of externally-bound idents (the arrow binders
+    of the two types being compared). *)
+val equal :
+  type_eq:(type_expr -> type_expr -> bool) ->
+  pairs:(Ident.t * Ident.t) list ->
+  refinement_expression -> refinement_expression -> bool
+
+(** Back to surface syntax, for printing.  [var_name] chooses the printed
+    name of a bound ident (the printer renames binders to avoid capture);
+    [core_type] renders an interior type.  Holes print as [_] via
+    [Pexp_hole]. *)
+val untype :
+  var_name:(Ident.t -> string) ->
+  core_type:(type_expr -> Parsetree.core_type) ->
+  refinement_expression -> Parsetree.expression
+
+(** Does the predicate mention the given bound ident? *)
+val mentions_ident : Ident.t -> refinement_expression -> bool

--- a/typing/vox_rexp.mli
+++ b/typing/vox_rexp.mli
@@ -47,13 +47,20 @@ val equal :
   refinement_expression -> refinement_expression -> bool
 
 (** Back to surface syntax, for printing.  [var_name] chooses the printed
-    name of a bound ident (the printer renames binders to avoid capture);
-    [core_type] renders an interior type.  Holes print as [_] via
-    [Pexp_hole]. *)
+    name of a bound ident; [value_ident] renders a free ident from its
+    resolved (possibly substituted) path; [core_type] renders an interior
+    type.  Holes print as [_] via [Pexp_hole]. *)
 val untype :
   var_name:(Ident.t -> string) ->
+  value_ident:(Path.t -> Longident.t Location.loc) ->
   core_type:(type_expr -> Parsetree.core_type) ->
   refinement_expression -> Parsetree.expression
 
 (** Does the predicate mention the given bound ident? *)
 val mentions_ident : Ident.t -> refinement_expression -> bool
+
+(** The first free value path in the predicate for which [f] answers, if
+    any.  Interior types are not scanned here; the caller scans the type
+    graph. *)
+val find_value_path :
+  (Path.t -> 'a option) -> refinement_expression -> 'a option

--- a/typing/vox_rexp.mli
+++ b/typing/vox_rexp.mli
@@ -35,6 +35,7 @@ val map :
   ?rename:Ident.t Ident.Map.t ->
   ?freshen:bool ->
   ?value_path:(Path.t -> Path.t) ->
+  ?constructor_path:(Path.t -> Path.t) ->
   type_expr:(type_expr -> type_expr) ->
   refinement_expression -> refinement_expression
 
@@ -53,14 +54,15 @@ val equal :
 val untype :
   var_name:(Ident.t -> string) ->
   value_ident:(Path.t -> Longident.t Location.loc) ->
+  constructor_ident:(Path.t -> Longident.t Location.loc) ->
   core_type:(type_expr -> Parsetree.core_type) ->
   refinement_expression -> Parsetree.expression
 
 (** Does the predicate mention the given bound ident? *)
 val mentions_ident : Ident.t -> refinement_expression -> bool
 
-(** The first free value path in the predicate for which [f] answers, if
-    any.  Interior types are not scanned here; the caller scans the type
-    graph. *)
+(** The first free value or constructor path in the predicate for which
+    [f] answers, if any.  Interior types are not scanned here; the caller
+    scans the type graph. *)
 val find_value_path :
   (Path.t -> 'a option) -> refinement_expression -> 'a option

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -170,6 +170,7 @@ type t =
   | Useless_valpoly                         (* 219 *)
   | Redundant_modality                      (* 220 *)
   | Unused_alert_disable of string          (* 221 *)
+  | Vox_mixed_arrow_conventions             (* 230 *)
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
    the numbers of existing warnings.
@@ -273,6 +274,7 @@ let number = function
   | Useless_valpoly -> 219
   | Redundant_modality -> 220
   | Unused_alert_disable _ -> 221
+  | Vox_mixed_arrow_conventions -> 230
 ;;
 (* DO NOT REMOVE the ;; above: it is used by
    the testsuite/ests/warnings/mnemonics.mll test to determine where
@@ -714,6 +716,11 @@ let descriptions = [
     names = ["unused-alert-disable"];
     description = "An attribute disabling an alert did not suppress any\n\
     \    occurrence of that alert.";
+    since = since 5 4 };
+  { number = 230;
+    names = ["vox-mixed-arrow-conventions"];
+    description = "An arrow type mixes positional value binders and\n\
+    \    bare-spelled labels.";
     since = since 5 4 };
 ]
 
@@ -1618,6 +1625,11 @@ let message = function
       msg "This attribute disables alert %a,@ \
            but it did not suppress any occurrence of the alert."
         Style.inline_code name
+  | Vox_mixed_arrow_conventions ->
+      msg "This arrow type mixes positional value binders and bare-spelled@ \
+           labels; reading it requires scanning the whole type.@ Spell the \
+           labels with a tilde (%a) to make the convention explicit."
+        Style.inline_code "~x:"
 ;;
 
 let nerrors = ref 0

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -173,6 +173,7 @@ type t =
   | Useless_valpoly                         (* 219 *)
   | Redundant_modality                      (* 220 *)
   | Unused_alert_disable of string          (* 221 *)
+  | Vox_mixed_arrow_conventions             (* 230 *)
 
 type alert = {kind:string; message:string; def:loc; use:loc}
 


### PR DESCRIPTION
The refinement type former: `t{ predicate }` as a real type in the type graph,
threaded through the compiler's structural passes.

This piece is deliberately **inert**. Refinements are rigid and carry no typing
rules: nothing is proved, nothing is discharged, and a refined value cannot be
consumed. What it establishes is representation, substitution, printing, and
`.cmi` round-tripping — the parts that are painful to retrofit.

**Syntax.** `t{ p }` is the sole refinement spelling. `_` denotes the value being
refined and is always available:

```ocaml
int{ _ >= 0 }
x:int{ x > 0 } -> int{ _ >= x }
unit{ invariant tree = true }
val sub : s:string -> int{ _ < length s } -> char
```

**Binders.** OCaml has exactly one name-before-type slot and labels own it, so
the slot is shared and the decision is by use. In `x:T -> b`, `x` is a
positional binder exactly when `x` occurs free in a refinement in `T` or in `b`
— the argument is then unlabelled and call sites are unchanged. Otherwise `x:T`
is an ordinary label, exactly as today. `~x:T` is always a label whatever
occurs; that spelling did not previously parse, so no existing code uses it.
Backward compatibility follows without a special case: existing code contains no
refinements, so no name can occur in one, so every existing `x:T` stays a label.

The dependent arrow is not a new type former — the existing function type gains
one optional `Ident.t`, using the same ident-based binding mechanism as `Tpoly`.
Binder names are not part of type identity; equality is up to alpha-conversion.

**Structural completeness.** Refinements are permitted in every `core_type`
position, and `Btype` fold/map, `Subst`, unification, `moregen`, printing and
untyping all descend through both the payload and the predicate's interior
types. Predicates are `Typedtree`-shaped but restricted to total expressions.

Applying a dependent arrow, and decomposing one to type a function definition,
produce located errors: both need the elimination and introduction rules that a
later piece adds. Partial application that omits the dependent parameter keeps
its binder and still works.

Tests: `testsuite/tests/vox/type-formers.ml`, plus a `.cmi` round-trip fixture
and an empty-predicate syntax-error fixture.

---

Part of stack #6796, which merges bottom-up from `main`. #6787 and #6788 touch no
compiler internals and are the natural first merges.
