### PR TITLE
Stack 5/6: totality and logicality axes

### DIFF
--- a/design-docs/totality-final.md
+++ b/design-docs/totality-final.md
@@ -1,0 +1,91 @@
+# Totality piece — final report
+
+## Summary
+
+Branch `jujacobs/vox/totality` (worktree `totality/dev`), 4 commits:
+
+- `d5642cb0f6` — the piece: totality/logicality axes end-to-end (lattices,
+  morphisms, coupling registration, surface syntax, kind modifiers, crossing,
+  closure/hereditary/(Rec) rules, primitive allowlist, logicality on mutable
+  projection/mutation; ~880 lines of compiler changes,
+  `testsuite/tests/vox/totality.ml`, and `design-docs/totality.md` with a
+  decision log)
+- `be08ab91e6` — principal-mode baseline promotions
+- `b7cd48b7fe` — review-loop round 1 fixes and pins
+- `c00d624b75` — review-loop round 2: consolidate the lock walk, simplify
+  toplevel pinning
+
+**Tests**: the piece test is green; the full suite is 2438 passed / 5 failed,
+all 5 pre-existing environmental failures (bytecode-ocamlc magic mismatch;
+reproduced on the base branch): `formatting/test_locations.ml`,
+`parsetree/test_ppx.ml`, `templates/basic/test.ml`,
+`tool-ocamlc-stop-after/stop_after_typing_impl.ml`,
+`typing-zero-alloc/cmi_test.ml`.
+
+## Review loop
+
+Two codex + two claude lanes, each in its own worktree off the branch
+(`totality/review/<name>`). codex-general delivered a full report
+(`totality/review/codex-general/report.md`); the codex defect-search lane was
+killed twice by an upstream content filter mid-report but its probe fixtures
+were salvageable and were rerun and triaged; the first claude pair stalled
+>60 minutes and was replaced per the kill rule; the compact retry delivered.
+
+Accepted after reproduction:
+
+- a mutation-caught missing `Pexp_setvar` fixture (no test exercised the
+  instance-variable assignment arm);
+- a disproven decision-log equivalence claim for (Rec) (group-wide floor is
+  observable on non-recursive siblings) — doc fixed, behaviour pinned;
+- one lock-walk mechanism instead of three: `Env.walk_locks_for_totality`
+  reuses `walk_locks`, fixing a latent `Const_closure_lock` skip and gaining
+  the standard used-inside-the-function error context;
+- simpler toplevel pinning (dropped an upward logicality freedom no twin
+  axis has; unannotated bindings are back on the constant-legacy path);
+- table-derived `of_axis_set` instead of hand-computed masks (reviewer
+  checked all 2^13 inputs for equivalence first); stale comments fixed.
+
+Rejected after reproduction: three "blocking soundness holes" (partial
+parameter call, `%apply`/`%revapply`, method send on a parameter) that are
+exactly how the portability twin behaves — capture-based, parameters exempt —
+pinned by fixtures instead of "fixed".
+
+## Decision points needing confirmation
+
+All recorded in the decision log at the end of `design-docs/totality.md`:
+
+1. **Capture-based contract.** `f @ total` may call a `partial` *parameter*;
+   safety is compositional (a total context cannot supply the partial
+   argument — submoding stops partial values at every entry into the total
+   fragment). Twin parity verified: `portable` accepts the same three shapes.
+   One reviewer read `total` as call-oriented; the alternative
+   (application-site constraint at `Pexp_apply`) would also reject the doc's
+   "returned, never applied" recursion test the other way.
+2. **"Total implies stateless" is not implemented.** As annotation
+   defaulting it makes every totality rejection surface as a statefulness
+   error (legacy values violate stateless first) and forces the primitive
+   allowlist to claim statelessness too; the observable content is already
+   delivered by the effect arms plus the logicality bump on captures.
+3. **Known gap, pinned by a fixture**: `module rec M : sig val loop : int ->
+   int @@ total end = struct let loop x = M.loop x end` — the signature
+   claim justifies its own recursive call; termination is inductive, so the
+   self-assumption is unsound (portability tolerates it, being coinductive).
+   Fix (weaken totality modalities in the recursive-approximation
+   environment, the `module rec` analogue of (Rec)) sketched, deferred.
+4. **(Rec) is group-wide**: a non-recursive `and`-sibling is also partial,
+   because the base typechecker gives the group a single mode variable.
+   Per-member precision needs per-binding group mode variables — follow-up.
+5. **`@@ physical` rejected / `nonlogical` spelling** is doc-mandated but
+   breaks the existing convention: `@@ uncontended` and `mod partial` parse
+   today with a redundancy warning rather than erroring.
+6. vox2's `filter_axes_without_kind_modalities` was *not* ported (it would
+   let `type t : value mod total = int -> int` typecheck), and two latent
+   vox2 defects (`less_or_equal` / `get_max_axes` missing the new axes,
+   which made a lone `mod total` invisible to kind printing and equality)
+   are fixed rather than inherited.
+
+## Process note
+
+A test was briefly run in the type-formers worktree before the
+worktree-ownership rule landed; it was killed immediately, was a single
+read-only-ish test run, and their tree was left untouched.

--- a/design-docs/totality.md
+++ b/design-docs/totality.md
@@ -1,0 +1,287 @@
+# Vox totality and logicality axes
+
+Two new mode axes: totality and logicality. Linearity (`many`/`once`) already
+exists in OxCaml and this piece leaves it alone.
+
+    Totality    Total | Partial        comonadic
+    Logicality  Physical | Logical     monadic
+
+`total` says a function terminates and has no effects, so a specification may
+call it. `logical` restricts a value to the parts the logic can talk about:
+reading mutable state through it is rejected, much as it is through a
+`contended` value. A logical value still exists at run time. Erasure, which is
+what removes a value from compilation, is a separate axis in its own piece.
+
+## Lattices and defaults
+
+| axis | min | max | legacy | fragment |
+|---|---|---|---|---|
+| Totality | `Total` | `Partial` | `Partial` | comonadic, `Common_axis_pos` |
+| Logicality | `Physical` | `Logical` | `Physical` | monadic, `Common_axis_neg` |
+
+Both are two-point total orders. Legacy sits at the permissive end of each, so
+every unannotated value is `partial` and `physical` and no existing type changes
+meaning.
+
+`Total <= Partial`, so a total function is accepted where a partial one is
+expected. `Physical <= Logical`, so unrestricted access can be weakened to
+logic-only access and never the reverse. Contention has the same shape, with
+`Uncontended` as the accessible end.
+
+## The axis pair
+
+Totality and logicality are a comonadic/monadic pair, in the same sense as
+portability and contention. The mode system already couples each comonadic axis
+to a monadic partner, in `comonadic_to_monadic_op_max` (`mode.ml:2517`):
+
+    linearity     ->  uniqueness
+    portability   ->  contention
+    totality      ->  logicality
+    statefulness  ->  visibility
+
+`Totality_to_logicality_op` and `Logicality_op_to_totality` sit beside
+`Portability_to_contention_op` and its inverse. This is why the two axes belong
+in one piece: neither does anything alone, and the coupling is a registration in
+an existing table rather than a new rule.
+
+Two consequences, both inherited from the portability and contention twin:
+
+- A `total` closure can only capture `total` values, exactly as a `portable`
+  closure can only capture `portable` ones. This is the ordinary comonadic
+  closure lock.
+- A `total` closure bumps its captures to `logical`, as a `portable` closure
+  bumps its captures to `contended`. Inside a total closure you cannot read
+  mutable state through anything you captured, which is what makes the closure
+  callable from a specification.
+
+The second is what gives logicality its purpose, and it needs no new rule. It
+falls out of `comonadic_to_monadic_op_max` once the pair is registered.
+
+## Surface syntax
+
+Mode position:
+
+    let f (g @ total) = ...
+    let x @ logical = 42
+    val f : 'a @ total -> 'a
+
+Modality position:
+
+    val empty : t @@ total
+    val logical_int : int @@ logical
+
+The names are `total`, `partial`, `physical`, `logical`. In modality position
+the Physical end is spelled `nonlogical`, and `@@ physical` does not exist,
+because the modality parser reads the monadic axis as a join.
+
+Kind modifiers (`mod total`, `mod logical`) are supported.
+
+## Mode crossing
+
+Both axes participate in mode crossing and appear in `Jkind_axis.Axis`.
+
+A type crosses logicality when it has no mutable parts, because the restriction
+is then vacuous. A `logical` `int` may be used where a `physical` `int` is
+expected, and the same holds for arrows. An `int ref` or an `Atomic.t` does not
+cross, so it stays logical and reads through it stay rejected. The negative
+cases carry the meaning of the axis, so cover them first.
+
+A type crosses totality when it has no functions, just like portability.
+
+## Scope of this piece
+
+The axes, their lattices, surface syntax in mode and modality position, mode
+crossing, submoding, printing, and the rules that make `total` mean something.
+
+### What makes a closure partial
+
+Three sources, and only the first is free.
+
+Captured partial values. `ref`, `!` and `:=` are ordinary stdlib values sitting
+at legacy `partial`, so a closure that uses one captures it and becomes partial.
+The comonadic closure lock gives this with no extra rule.
+
+Syntactic effect forms, which have no value to capture: `while`, `for`, mutable
+record field assignment, array element assignment, instance variable assignment.
+Each needs an arm that walks the enclosing closure locks and constrains them to
+`partial`. Upstream already does this for effect handlers, which force enclosing
+functions nonportable and stateful, via `walk_locks_for_legacy_construct`
+(`env.ml:4002`); vox2 adds `constrain_enclosing_totality_partial` beside it
+(`env.ml:4028`). Copy that shape rather than inventing one.
+
+Recursion. A `let rec` self-reference makes the binding partial. With no
+structural recursion check and no decreases clauses, no recursive function is
+total in this piece.
+
+### The hereditary rule
+
+Capture-based propagation misses a local `let rec` inside a total closure,
+because the self-reference never crosses a capture boundary. vox2 closes this
+with an append-only closure-lock stack in `Env`: a function literal nested
+inside a closure demanded total must itself be total, whatever the source of its
+partiality, and walking the stack reaches let-bound literals that the
+expected-mode edge (return, if and argument position) misses
+(`typecore.ml:6790`). Take that approach. It is what makes the discipline hold
+wherever the literal appears rather than only in the positions the expected mode
+reaches.
+
+### The primitive allowlist
+
+For anything interesting to be total, total primitives have to be declared total.
+Otherwise only closures that call nothing qualify.
+
+Three further sources of partiality have no value to capture and no syntactic
+form dedicated to them, so decide whether this piece covers them: a
+non-exhaustive match, which can raise `Match_failure`; division and modulo,
+which raise on a zero divisor; and `assert`. `raise` itself needs no rule, being
+a value left at `partial`.
+
+## Inter-axis implications
+
+Total implies stateless.
+
+## Tests
+
+`testsuite/tests/vox/totality.ml`, expect tests.
+
+- submoding both ways on each axis: `total` accepted where `partial` is
+  expected, `partial` rejected where `total` is expected, and the same pair for
+  physical and logical
+- defaults: an unannotated value is `partial` and `physical`, and prints as it
+  does today
+- crossing positives: a `logical` `int` and a `logical` arrow used at `physical`
+- crossing negatives: a `logical` `int ref` and a `logical` `Atomic.t` stay
+  logical
+- modality position: `val empty : t @@ total`, `val x : int @@ logical`
+- kind modifiers: `mod total` and `mod logical` accepted
+- printing: annotated values print their axis, unannotated values print exactly
+  as before. This is the baseline-churn guard.
+- with the allowlist: `let increment @ total = fun x -> x + 1` accepted, and a
+  closure calling a partial function rejected at `@ total`
+
+The capture bump, which is the pair working:
+
+- a `total` closure capturing a `partial` value, rejected
+- a `total` closure capturing an `int ref` and then reading it, rejected because
+  the capture arrives `logical` and the read needs `physical`
+- the same closure capturing an `int`, accepted, because `int` crosses
+  logicality and the bump is vacuous
+- the portability and contention twin behaving identically on the same
+  fixtures, as a check that the pair was registered rather than special-cased
+
+Effects, each rejected at `@ total`, and each also accepted without the
+annotation so the test discriminates:
+
+- `ref`, `!` and `:=`
+- `while` and `for`
+- mutable record field assignment, array element assignment
+- a closure that captures a partial value from an outer scope
+
+Recursion, which is where the interesting failures are:
+
+- `let rec f x = f x` rejected at `@ total`
+- the boundary case: a top-level recursive function captured into a total
+  closure, rejected because the capture is partial
+- the hereditary case: the same `let rec` written *locally* inside a total
+  closure, where the self-reference never crosses a capture boundary. This is
+  the one capture-based propagation misses, so it is the test that says whether
+  the closure-lock stack works.
+- a let-bound function literal inside a total closure, which the expected-mode
+  edge does not reach
+- mutual recursion, `let rec even x = ... odd x and odd x = ... even x`
+- a recursive function that is only returned, never applied
+
+## Decisions taken during implementation
+
+Points the doc left open or where the implementation departs from vox2, with
+the route taken and why.
+
+- **Hereditary rule: closure-lock walk only.** vox2 carries both an
+  `enclosing_totality` field threaded through `expected_mode` (the
+  expected-mode edge) and the closure-lock walk. The body of a function literal
+  is always typed under its enclosing closure locks, so submoding the literal's
+  totality into every enclosing lock (`type_function`, first value parameter)
+  subsumes the edge; the extra field was dropped.
+
+- **(Rec) as a floor on the group's mode variable.** The recursive group's
+  mode variable has its totality floored at `partial`, so the bound variables
+  are partial both inside the right-hand sides and after the binding. vox2
+  instead builds a separate RHS environment so the after-binding mode is the
+  RHS's derived mode. Observable behaviour is the same: a recursive closure is
+  partial either way, and an arrow-free recursive value (`let rec x = 1`)
+  crosses totality at its use sites, so nothing is lost by the simpler rule.
+
+- **The allowlist** covers `%identity`, integer and float arithmetic, boolean
+  connectives, `%field0_immut`/`%field1_immut` (fst/snd), and
+  `%apply`/`%revapply`. `%divint`/`%modint` are excluded (raise on a zero
+  divisor). Comparisons are excluded (raise on functions, diverge on cyclic
+  values); vox2's machinery admitting comparisons at immediate operand types
+  was not ported — it can be a follow-up if total code needs `=` on ints.
+
+- **`assert` and non-exhaustive matches are partial.** Both can raise
+  (`Assert_failure`, `Match_failure`), both are syntactic with no partial
+  value to capture, so both walk the closure locks like `while` and `for`.
+  Non-exhaustive `let` patterns too. Exception handlers were already forced
+  legacy (hence partial) by `walk_locks_for_legacy_construct`.
+
+- **Reading or writing a mutable field through a `logical` value is rejected
+  in the projection/mutation rule** (`mode_project_mutable`,
+  `mode_mutate_mutable` require `physical`), completing "reading mutable state
+  through it is rejected, much as it is through a contended value". vox2 only
+  rejects reads that pass the ref to a function like `!` (argument submoding);
+  a direct `r.contents` through a logical record slips through there.
+
+- **Mutable-state *creation* is not constrained.** Allocating a mutable record
+  or array literal inside a total closure is allowed; only assignment, loops,
+  raising forms and captures constrain totality. The doc lists assignment
+  forms only, and creation alone neither diverges nor observably affects
+  state. (`ref` itself is partial only because it is an unlisted primitive.)
+
+- **"Total implies stateless" is NOT implemented.** Implementing it as
+  annotation defaulting (the mechanism behind `stateless` implying `portable`)
+  makes every totality rejection surface as a statefulness error — legacy
+  values are both stateful and partial, and the statefulness violation is
+  reported first — and forces the primitive allowlist to also claim
+  statelessness. The observable content of the implication is already
+  delivered: state *writes* force partial syntactically, and state *reads*
+  through captures are blocked by the logicality bump. Flagged for review
+  rather than silently included.
+
+- **`@ partial` on a binding inside a total closure does not force the
+  enclosing closure partial.** The annotation is a bound on the binding, not
+  evidence of partiality; if the body has a real partiality source, that
+  source constrains the enclosing locks itself. vox2 has explicit arms for
+  this; they reject only functions whose bodies are actually total, so they
+  were not ported.
+
+- **Toplevel bindings** stay pinned to legacy except that a `total` or
+  `logical` annotation raises the floor on its axis, and an unannotated
+  binding's logicality is left free upward (so rebinding a logical value
+  works). This mirrors how toplevel bindings interact with `portable` today:
+  the annotation is enforced on the right-hand side, and the printed
+  signature does not show the axis (`val f : int -> int`), but the binding is
+  usable at `total` later in the same unit.
+
+- **Two latent vox2 defects fixed rather than ported**: `Mod_bounds.
+  less_or_equal` and `get_max_axes` in `jkind.ml` enumerate axes by hand and
+  in vox2 miss the two new axes, which made `mod total` invisible to kind
+  printing/equality whenever it was the only modifier. vox2's
+  `filter_axes_without_kind_modalities` in `ikind.ml` (which silently discards
+  totality/logicality disagreements from subkind checks, and would let
+  `type t : value mod total = int -> int` typecheck) was not ported; the new
+  axes participate in subkind checks like every other axis.
+
+- **Baseline shifts accepted during promotion.** (a) Inferred module signatures
+  now include `total` beside `stateless` (same zap-to-strongest rule the
+  existing comonadic axes use). (b) Arrow kinds print `mod ... logical`, since
+  arrows cross logicality. (c) A `mod` list that crosses every old axis no
+  longer prints as `everything`, because `everything` now includes the new
+  axes. (d) `immutable_data with (t @@ immutable)` where `t` has mutable parts
+  is now rejected: the `immutable` visibility modality does not lift
+  logicality, so such a type no longer crosses it. Conservative and sound; a
+  visibility-to-logicality modality implication could relax it later.
+  (e) A degenerate recursive variant whose parameter never occurs in any
+  payload (`type 'a many = Foo of ('a * 'a) many | Leaf`) now crosses
+  contention, which the fixture itself marks as the desired outcome;
+  non-degenerate variants still do not cross (checked with discriminating
+  probes).

--- a/design-docs/totality.md
+++ b/design-docs/totality.md
@@ -205,11 +205,14 @@ the route taken and why.
 
 - **(Rec) as a floor on the group's mode variable.** The recursive group's
   mode variable has its totality floored at `partial`, so the bound variables
-  are partial both inside the right-hand sides and after the binding. vox2
-  instead builds a separate RHS environment so the after-binding mode is the
-  RHS's derived mode. Observable behaviour is the same: a recursive closure is
-  partial either way, and an arrow-free recursive value (`let rec x = 1`)
-  crosses totality at its use sites, so nothing is lost by the simpler rule.
+  are partial both inside the right-hand sides and after the binding. This is
+  deliberately group-wide: the base typechecker gives the whole `let rec`
+  group a single mode variable, so a member that never refers to the group
+  (`let rec a x = a x and b x = x`) also comes out partial (pinned by a test).
+  Per-member precision needs per-binding mode variables for recursive groups,
+  a base-machinery change left as a follow-up; moving such a member out of
+  the group is the workaround. An arrow-free recursive value (`let rec x =
+  1`) still crosses totality at its use sites.
 
 - **The allowlist** covers `%identity`, integer and float arithmetic, boolean
   connectives, `%field0_immut`/`%field1_immut` (fst/snd), and
@@ -285,3 +288,31 @@ the route taken and why.
   contention, which the fixture itself marks as the desired outcome;
   non-degenerate variants still do not cross (checked with discriminating
   probes).
+
+- **Totality is capture-based, exactly like portability.** Parameters are not
+  captures: a total closure may call a `partial` parameter, read mutable
+  state through a parameter, send a message to a parameter object, and the
+  `%apply`/`%revapply` operators are total even though they call their
+  function argument. The guarantee `total` provides is compositional:
+  a total context can only supply total (and logical) arguments — submoding
+  stops partial values at every entry point into the total fragment — so a
+  call graph that lives entirely in the fragment terminates and performs no
+  effects. The alternative reading, where `f @ total` promises termination
+  for arbitrary well-moded arguments, would require constraining the callee's
+  totality into the enclosing locks at every application; that would also
+  diverge from the portability/contention twin, which accepts all three
+  shapes above (pinned by tests). Flagged for explicit confirmation because a
+  reviewer read the axis the other way.
+
+- **KNOWN GAP: recursive modules can claim totality circularly.** In
+  `module rec M : sig val loop : int -> int @@ total end = struct let loop x
+  = M.loop x end`, the body is checked against the declared signature, so the
+  `total` claim justifies its own recursive call and `M.loop` diverges at
+  mode total. The (Rec) floor only covers `let rec`. Portability tolerates
+  this self-assumption (it is a coinductive property); termination does not.
+  The fix is to weaken the totality component of every value modality in the
+  recursive-approximation environment (the analogue of (Rec) for
+  `module rec`), which needs a signature-modality rewriting pass including
+  named module-type expansion — deferred to a follow-up and pinned by a
+  fixture in the test file. Without an explicit `@@ total` claim, recursive
+  module values correctly stay partial.

--- a/design-docs/totality.md
+++ b/design-docs/totality.md
@@ -224,8 +224,11 @@ the route taken and why.
 - **`assert` and non-exhaustive matches are partial.** Both can raise
   (`Assert_failure`, `Match_failure`), both are syntactic with no partial
   value to capture, so both walk the closure locks like `while` and `for`.
-  Non-exhaustive `let` patterns too. Exception handlers were already forced
-  legacy (hence partial) by `walk_locks_for_legacy_construct`.
+  Non-exhaustive `let` patterns too. Effect handlers were already forced
+  legacy (hence partial) by `walk_locks_for_legacy_construct`. `try`/`with`
+  itself is not constrained: catching does not diverge, and anything that can
+  raise inside the body is already partial by the rules above (pinned by a
+  fixture).
 
 - **Reading or writing a mutable field through a `logical` value is rejected
   in the projection/mutation rule** (`mode_project_mutable`,
@@ -258,12 +261,14 @@ the route taken and why.
   were not ported.
 
 - **Toplevel bindings** stay pinned to legacy except that a `total` or
-  `logical` annotation raises the floor on its axis, and an unannotated
-  binding's logicality is left free upward (so rebinding a logical value
-  works). This mirrors how toplevel bindings interact with `portable` today:
-  the annotation is enforced on the right-hand side, and the printed
-  signature does not show the axis (`val f : int -> int`), but the binding is
-  usable at `total` later in the same unit.
+  `logical` annotation pins the binding at that end of its axis instead.
+  Unannotated bindings are pinned at legacy exactly, as before, so rebinding
+  a logical value at toplevel is rejected — the same treatment `contended`
+  gets today (a review round removed an earlier version that left unannotated
+  logicality free upward, a privilege no other monadic axis has). The
+  annotation is enforced on the right-hand side; the toplevel printout does
+  not show `total` (matching `portable` today), though it does show
+  `@@ logical`, whose zap direction is monadic.
 
 - **Two latent vox2 defects fixed rather than ported**: `Mod_bounds.
   less_or_equal` and `get_max_axes` in `jkind.ml` enumerate axes by hand and
@@ -316,3 +321,20 @@ the route taken and why.
   named module-type expansion — deferred to a follow-up and pinned by a
   fixture in the test file. Without an explicit `@@ total` claim, recursive
   module values correctly stay partial.
+
+- **Alternatives raised in review, considered and not taken.**
+  (a) *Application-site totality* (constrain the applied function's totality
+  into the enclosing locks at `Pexp_apply`, instead of the hereditary literal
+  walk): stronger on higher-order calls and would admit building-and-
+  returning a partial closure from a total function, but this doc's own test
+  list requires "a recursive function that is only returned, never applied"
+  to be rejected, and the hereditary rule is what delivers that; switching is
+  a doc-level decision, not piece-level.
+  (b) *Allowing `@@ physical` / dropping `nonlogical`*: the twin axes accept
+  their identity modality with a redundancy warning (`@@ uncontended`,
+  `mod partial` parse today), so the `nonlogical` spelling is a convention
+  break; kept because this doc specifies it, flagged for reconsideration.
+  (c) *Declaring primitive totality in stdlib interfaces* (`@@ total` on the
+  `external`) instead of a compiler allowlist: better long-term (extends to
+  user externals, survives abstraction), deferred to keep this piece free of
+  stdlib churn.

--- a/testsuite/tests/implicit-types/implicit_kinds.ml
+++ b/testsuite/tests/implicit-types/implicit_kinds.ml
@@ -136,7 +136,8 @@ end
 [%%expect{|
 module Mto_struct :
   sig
-    module type T = sig val id : ('mto : word). 'mto -> 'mto @@ stateless end
+    module type T =
+      sig val id : ('mto : word). 'mto -> 'mto @@ stateless total end
   end
 |}]
 
@@ -168,7 +169,7 @@ Error: Signature mismatch:
              sig
                val pack :
                  ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array
-                 @@ stateless
+                 @@ stateless total
              end
          end
        is not included in
@@ -183,7 +184,7 @@ Error: Signature mismatch:
            sig
              val pack :
                ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array
-               @@ stateless
+               @@ stateless total
            end
        does not match
          module type T =
@@ -195,7 +196,7 @@ Error: Signature mismatch:
          sig
            val pack :
              ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array @@
-             stateless
+             stateless total
          end
        is not equal to
          sig
@@ -205,7 +206,7 @@ Error: Signature mismatch:
        Values do not match:
          val pack :
            ('from_sig : value_maybe_null). 'from_sig -> 'from_sig array @@
-           stateless
+           stateless total
        is not included in
          val pack : ('from_sig : bits64). 'from_sig -> 'from_sig array
        The type "'a -> 'a array" is not compatible with the type "'b -> 'b array"
@@ -233,7 +234,7 @@ module type Sig_default_defines_struct =
         val pack :
           ('from_defined_sig : bits64).
             'from_defined_sig -> 'from_defined_sig array
-          @@ stateless
+          @@ stateless total
       end
   end
 |}]
@@ -844,7 +845,8 @@ end
 [%%expect{|
 module type S28 =
   sig
-    module type Evil = sig val x : ('w : word). 'w -> 'w @@ stateless end
+    module type Evil =
+      sig val x : ('w : word). 'w -> 'w @@ stateless total end
   end
 |}]
 
@@ -860,7 +862,7 @@ end
 
 [%%expect{|
 module type S29 =
-  sig module type VeryEvil = sig val x : int -> int @@ portable end end
+  sig module type VeryEvil = sig val x : int -> int @@ portable total end end
 |}]
 
 (* CR implicit-variables: implement in structures. *)
@@ -1057,7 +1059,8 @@ end
 [%%expect{|
 module type S37 =
   sig
-    module type Inner = sig val id : ('t : word). 't -> unit @@ stateless end
+    module type Inner =
+      sig val id : ('t : word). 't -> unit @@ stateless total end
     val f : ('t : word). 't -> 't
   end
 |}]

--- a/testsuite/tests/parsetree/source_jane_street.ml
+++ b/testsuite/tests/parsetree/source_jane_street.ml
@@ -172,7 +172,8 @@ type t17b : value & value
 type ('a : value mod external_ stateless many unyielding non_float) t18 =
   ('a : value mod immutable global)
 [%%expect{|
-type ('a : value mod everything non_float) t18 = 'a
+type ('a : value non_float mod global many stateless immutable external_) t18 =
+    'a
 |}]
 
 type t = #(int * float#)
@@ -193,7 +194,7 @@ let x () = #( M.Null, M.This "hi" )
 [%%expect{|
 module M :
   sig type 'a t = 'a or_null = Null | This of 'a [@@or_null_reexport] end @@
-  stateless
+  stateless total
 val x : unit -> #('a M.t * string M.t) = <fun>
 |}]
 
@@ -204,7 +205,7 @@ let y () = #( Or_null_names.Nope, Or_null_names.Yep "hi" )
 
 [%%expect{|
 module Or_null_names : sig type 'a t = Nope | Yep of 'a [@@or_null] end @@
-  stateless
+  stateless total
 val y : unit -> #('a Or_null_names.t * string Or_null_names.t) = <fun>
 |}]
 
@@ -675,36 +676,36 @@ module type S = sig end
 module M = struct end
 [%%expect{|
 module type S = sig end
-module M : sig end @@ stateless
+module M : sig end @@ stateless total
 |}]
 
 module F (X : S @ portable) = struct
 end
 [%%expect{|
-module F : functor (X : S @ portable) -> sig end @@ stateless
+module F : functor (X : S @ portable) -> sig end @@ stateless total
 |}]
 
 module F (_ : S @ portable) = struct
 end
 [%%expect{|
-module F : S @ portable -> sig end @@ stateless
+module F : S @ portable -> sig end @@ stateless total
 |}]
 
 module M' = (M : S @ portable)
 [%%expect{|
-module M' : S @@ stateless
+module M' : S @@ stateless total
 |}]
 
 module F (M : S @ portable) : S @ portable = struct
 end
 [%%expect{|
-module F : functor (M : S @ portable) -> S @@ stateless
+module F : functor (M : S @ portable) -> S @@ stateless total
 |}]
 
 module F (M : S @ portable) @ portable = struct
 end
 [%%expect{|
-module F : functor (M : S @ portable) -> sig end @@ stateless
+module F : functor (M : S @ portable) -> sig end @@ stateless total
 |}]
 
 
@@ -713,22 +714,22 @@ module F : functor (M : S @ portable) -> sig end @@ stateless
   be an binary operator *)
 module M' = (M @ portable)
 [%%expect{|
-module M' = M @@ stateless
+module M' = M @@ stateless total
 |}]
 
 module M' = (M : S @ portable)
 [%%expect{|
-module M' : S @@ stateless
+module M' : S @@ stateless total
 |}]
 
 module M @ portable = struct end
 [%%expect{|
-module M : sig end @@ stateless
+module M : sig end @@ stateless total
 |}]
 
 module M : S @ portable = struct end
 [%%expect{|
-module M : S @@ stateless
+module M : S @@ stateless total
 |}]
 
 module type S' = functor () (M : S @ portable) (_ : S @ portable) -> S @ portable
@@ -754,7 +755,7 @@ module type S'' = S @ local -> S -> S
 
 module (F @ portable) () = struct end
 [%%expect{|
-module F : functor () -> sig end @@ stateless
+module F : functor () -> sig end @@ stateless total
 |}]
 
 module (G @ portable) () = F
@@ -767,12 +768,12 @@ module (G @ portable) (F : (S @ unique -> S @ once) @ local) @ contended = struc
 [%%expect{|
 module G :
   functor (F : (S @ unique -> S @ once) @ local) -> sig end @ contended @@
-  stateless
+  stateless total
 |}]
 
 module (G' @ portable) = F
 [%%expect{|
-module G' = F @@ stateless
+module G' = F @@ stateless total
 |}]
 
 module rec (F @ portable) () = struct end
@@ -918,9 +919,9 @@ module type S = sig
 end;;
 
 [%%expect{|
-module F_struct : sig end -> sig end @@ stateless
+module F_struct : sig end -> sig end @@ stateless total
 module type F_sig = sig end -> sig end
-module T : sig end @@ stateless
+module T : sig end @@ stateless total
 module type S = sig end
 |}]
 
@@ -959,17 +960,17 @@ exception Odd
 val x : x:int * y:int = (~x:1, ~y:2)
 val x : x:int * y:int = (~x:1, ~y:2)
 - : x:int * int * z:int * punned:int = (~x:5, 2, ~z:4, ~punned:5)
-val x : x:int * y:int @@ stateless = (~x:1, ~y:2)
-val x : x:int * y:int @@ stateless = (~x:1, ~y:2)
+val x : x:int * y:int @@ stateless total = (~x:1, ~y:2)
+val x : x:int * y:int @@ stateless total = (~x:1, ~y:2)
 |}]
 
 let (~x:x0, ~s, ~(y:int), ..) : (x:int * s:string * y:int * string) =
    (~x: 1, ~s: "a", ~y: 2, "ignore me")
 
 [%%expect{|
-val x0 : int @@ stateless = 1
-val s : string @@ stateless = "a"
-val y : int @@ stateless = 2
+val x0 : int @@ stateless total = 1
+val s : string @@ stateless total = "a"
+val y : int @@ stateless total = 2
 |}]
 
 module M : sig
@@ -989,8 +990,8 @@ module M :
   sig
     val f : (x:int * string) -> x:int * string
     val mk : unit -> x:bool * y:string
-  end @@ stateless
-module X_int_int : sig type t = x:int * int end @@ stateless
+  end @@ stateless total
+module X_int_int : sig type t = x:int * int end @@ stateless total
 |}]
 
 let foo xy k_good k_bad =
@@ -1005,9 +1006,9 @@ let f ((~(x:int),y) : (x:int * int)) : int = x + y
 
 [%%expect{|
 val foo : 'a -> (unit -> 'b) -> (unit -> 'b) -> 'b = <fun>
-val x : int @@ stateless = 1
+val x : int @@ stateless total = 1
 val y : int = 2
-val x : int @@ stateless = 1
+val x : int @@ stateless total = 1
 val y : int = 2
 val f : (foo:int * bar:int) -> int = <fun>
 val f : (x:int * int) -> int = <fun>
@@ -1390,7 +1391,7 @@ module M :
     kind_ immutable = value
     kind_ data = value mod many
     kind_ abstract
-  end @@ stateless
+  end @@ stateless total
 |}]
 
 module type S = sig kind_ k end
@@ -1452,6 +1453,7 @@ module type S2 = S with M
 [%%expect{|
 module type S = sig type t1 type t2 type t3 end
 module M : sig type t1 = int type t2 = K of string type t3 end @@ stateless
+  total
 module type S2 = sig type t1 = M.t1 type t2 = M.t2 type t3 = M.t3 end
 |}]
 
@@ -1558,13 +1560,13 @@ module _ = Base(Name1)(Value1)(Name2)(Value2(Name2_1)(Value2_1)) [@jane.non_eras
 
 [%%expect{|
 module Base : sig end -> sig end -> sig end -> sig end -> sig end @@
-  stateless
-module Name1 : sig end @@ stateless
-module Name2 : sig end @@ stateless
-module Value1 : sig end @@ stateless
-module Value2 : sig end -> sig end -> sig end @@ stateless
-module Name2_1 : sig end @@ stateless
-module Name2_1 : sig end @@ stateless
+  stateless total
+module Name1 : sig end @@ stateless total
+module Name2 : sig end @@ stateless total
+module Value1 : sig end @@ stateless total
+module Value2 : sig end -> sig end -> sig end @@ stateless total
+module Name2_1 : sig end @@ stateless total
+module Name2_1 : sig end @@ stateless total
 Line 9, characters 11-95:
 9 | module _ = Base(Name1)(Value1)(Name2)(Value2(Name2_1)(Value2_1)) [@jane.non_erasable.instances]
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1693,7 +1695,7 @@ module type S = sig
   module Foo = Foo [@foo] @@ nonportable
 end
 [%%expect{|
-module Foo : sig end @@ stateless
+module Foo : sig end @@ stateless total
 module type S = sig module Foo = Foo end
 |}]
 

--- a/testsuite/tests/shadow_include/artificial.ml
+++ b/testsuite/tests/shadow_include/artificial.ml
@@ -63,8 +63,8 @@ end
 module type Extended =
   sig
     type t = Foo.t
-    val to_ : t -> Foo.Bar.t @@ stateless
-    val from : Foo.Bar.t -> t @@ stateless
+    val to_ : t -> Foo.Bar.t @@ stateless total
+    val from : Foo.Bar.t -> t @@ stateless total
     module Bar : sig type t = Foo.Bar.t val int : int end
   end
 |}]

--- a/testsuite/tests/typedtree/module_presence.ml
+++ b/testsuite/tests/typedtree/module_presence.ml
@@ -60,7 +60,7 @@ module type T = sig module Y = X end
               module_type
                 Tmty_alias "X/328"
         ]
-        join_const(unique,uncontended,read_write,static);meet_const(local,once,nonportable,unforkable,yielding,stateful)
+        join_const(unique,uncontended,physical,read_write,static);meet_const(local,once,nonportable,partial,unforkable,yielding,stateful)
         []
 ]
 

--- a/testsuite/tests/typing-jkind-bounds/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics.ml
@@ -53,21 +53,23 @@ kind_ immutable_data =
             non_float
 
 [%%expect{|
-kind_ immutable_data = immutable_data
+kind_ immutable_data =
+value non_float mod forkable unyielding many stateless immutable
 |}]
 
 kind_ sync_data = value mod many contended portable forkable unyielding
                             stateless non_float
 
 [%%expect{|
-kind_ sync_data = sync_data
+kind_ sync_data =
+value non_float mod forkable unyielding many stateless contended
 |}]
 
 kind_ mutable_data = value mod many portable forkable unyielding stateless
                                non_float
 
 [%%expect{|
-kind_ mutable_data = mutable_data
+kind_ mutable_data = value non_float mod forkable unyielding many stateless
 |}]
 
 module type S = sig
@@ -222,7 +224,7 @@ Error: The layout of type "a" is value
 type a : value non_pointer mod global many immutable stateless external_
 type b : value mod contended = a
 [%%expect{|
-type a : immediate
+type a : value non_pointer mod global many stateless immutable external_
 type b = a
 |}]
 
@@ -283,8 +285,15 @@ type d : immediate = c
 [%%expect{|
 type a : immediate
 type b = a
-type c : immediate
-type d = c
+type c : value non_pointer mod global many stateless immutable external_
+Line 4, characters 0-22:
+4 | type d : immediate = c
+    ^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is
+           value non_pointer mod global many stateless immutable external_
+         because of the definition of c at line 3, characters 0-72.
+       But the kind of type "c" must be a subkind of immediate
+         because of the definition of d at line 4, characters 0-22.
 |}]
 
 type a : immediate64
@@ -294,8 +303,15 @@ type d : immediate64 = c
 [%%expect{|
 type a : immediate64
 type b = a
-type c : immediate64
-type d = c
+type c : value non_pointer64 mod global many stateless immutable external64
+Line 4, characters 0-24:
+4 | type d : immediate64 = c
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is
+           value non_pointer64 mod global many stateless immutable external64
+         because of the definition of c at line 3, characters 0-75.
+       But the kind of type "c" must be a subkind of immediate64
+         because of the definition of d at line 4, characters 0-24.
 |}]
 
 type a : float64 = float#
@@ -305,7 +321,7 @@ type d : float64 = c
 [%%expect{|
 type a = float#
 type b = a
-type c : float64 mod everything
+type c : float64 mod global many stateless immutable
 type d = c
 |}]
 
@@ -316,7 +332,7 @@ type d : float32 = c
 [%%expect{|
 type a = float32#
 type b = a
-type c : float32 mod everything
+type c : float32 mod global many stateless immutable
 type d = c
 |}]
 
@@ -1286,7 +1302,8 @@ type ('a : bits32 mod aliased) t = ('a : any mod global)
 type ('a : value mod global) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
-type ('a : value mod everything non_float) t = 'a
+type ('a : value non_float mod global many stateless immutable external_) t =
+    'a
 type 'a t = 'a
 type 'a t = 'a
 type ('a : bits32 mod global) t = 'a

--- a/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/basics_ikinds.ml
@@ -53,21 +53,23 @@ kind_ immutable_data =
             non_float
 
 [%%expect{|
-kind_ immutable_data = immutable_data
+kind_ immutable_data =
+value non_float mod forkable unyielding many stateless immutable
 |}]
 
 kind_ sync_data = value mod many contended portable forkable unyielding
                             stateless non_float
 
 [%%expect{|
-kind_ sync_data = sync_data
+kind_ sync_data =
+value non_float mod forkable unyielding many stateless contended
 |}]
 
 kind_ mutable_data = value mod many portable forkable unyielding stateless
                                non_float
 
 [%%expect{|
-kind_ mutable_data = mutable_data
+kind_ mutable_data = value non_float mod forkable unyielding many stateless
 |}]
 
 module type S = sig
@@ -222,7 +224,7 @@ Error: The layout of type "a" is value
 type a : value non_pointer mod global many immutable stateless external_
 type b : value mod contended = a
 [%%expect{|
-type a : immediate
+type a : value non_pointer mod global many stateless immutable external_
 type b = a
 |}]
 
@@ -283,8 +285,15 @@ type d : immediate = c
 [%%expect{|
 type a : immediate
 type b = a
-type c : immediate
-type d = c
+type c : value non_pointer mod global many stateless immutable external_
+Line 4, characters 0-22:
+4 | type d : immediate = c
+    ^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is
+           value non_pointer mod global many stateless immutable external_
+         because of the definition of c at line 3, characters 0-72.
+       But the kind of type "c" must be a subkind of immediate
+         because of the definition of d at line 4, characters 0-22.
 |}]
 
 type a : immediate64
@@ -294,8 +303,15 @@ type d : immediate64 = c
 [%%expect{|
 type a : immediate64
 type b = a
-type c : immediate64
-type d = c
+type c : value non_pointer64 mod global many stateless immutable external64
+Line 4, characters 0-24:
+4 | type d : immediate64 = c
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "c" is
+           value non_pointer64 mod global many stateless immutable external64
+         because of the definition of c at line 3, characters 0-75.
+       But the kind of type "c" must be a subkind of immediate64
+         because of the definition of d at line 4, characters 0-24.
 |}]
 
 type a : float64 = float#
@@ -305,7 +321,7 @@ type d : float64 = c
 [%%expect{|
 type a = float#
 type b = a
-type c : float64 mod everything
+type c : float64 mod global many stateless immutable
 type d = c
 |}]
 
@@ -316,7 +332,7 @@ type d : float32 = c
 [%%expect{|
 type a = float32#
 type b = a
-type c : float32 mod everything
+type c : float32 mod global many stateless immutable
 type d = c
 |}]
 
@@ -1286,7 +1302,8 @@ type ('a : bits32 mod aliased) t = ('a : any mod global)
 type ('a : value mod global) t = 'a
 type ('a : immediate) t = 'a
 type ('a : immediate) t = 'a
-type ('a : value mod everything non_float) t = 'a
+type ('a : value non_float mod global many stateless immutable external_) t =
+    'a
 type 'a t = 'a
 type 'a t = 'a
 type ('a : bits32 mod global) t = 'a

--- a/testsuite/tests/typing-jkind-bounds/composite.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite.ml
@@ -197,7 +197,9 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with int ≰ mod portable
+         totality: mod total with int ≰ mod total
          statefulness: mod stateless with int ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -350,7 +352,9 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with int ≰ mod portable
+         totality: mod total with int ≰ mod total
          statefulness: mod stateless with int ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]

--- a/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
@@ -192,7 +192,9 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with int ≰ mod portable
+         totality: mod total with int ≰ mod total
          statefulness: mod stateless with int ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -345,7 +347,9 @@ Error: This type "int ref" should be an instance of type "('a : immutable_data)"
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with int ≰ mod portable
+         totality: mod total with int ≰ mod total
          statefulness: mod stateless with int ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]

--- a/testsuite/tests/typing-jkind-bounds/gadt.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt.ml
@@ -153,7 +153,8 @@ Lines 1-3, characters 0-61:
 1 | type 'a t : value mod contended portable =
 2 |   | Shared : ('b : value mod contended portable). 'b  -> 'b t
 3 |   | Unshared : (unit -> 'c) @@ portable               -> 'c t
-Error: The kind of type "t" is value non_float mod immutable portable with 'a
+Error: The kind of type "t" is
+           value non_float mod immutable portable logical with 'a
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of
            value mod portable contended

--- a/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/gadt_ikinds.ml
@@ -186,7 +186,8 @@ Lines 1-3, characters 0-61:
 1 | type 'a t : value mod contended portable =
 2 |   | Shared : ('b : value mod contended portable). 'b  -> 'b t
 3 |   | Unshared : (unit -> 'c) @@ portable               -> 'c t
-Error: The kind of type "t" is value non_float mod immutable portable with 'a
+Error: The kind of type "t" is
+           value non_float mod immutable portable logical with 'a
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of
            value mod portable contended

--- a/testsuite/tests/typing-jkind-bounds/misc.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc.ml
@@ -47,7 +47,8 @@ type t : immutable_data = int -> int
 Line 1, characters 0-36:
 1 | type t : immutable_data = int -> int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int -> int" is value non_float mod aliased immutable
+Error: The kind of type "int -> int" is
+           value non_float mod aliased immutable logical
          because it's a function type.
        But the kind of type "int -> int" must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-36.

--- a/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/misc_ikinds.ml
@@ -47,7 +47,8 @@ type t : immutable_data = int -> int
 Line 1, characters 0-36:
 1 | type t : immutable_data = int -> int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int -> int" is value non_float mod aliased immutable
+Error: The kind of type "int -> int" is
+           value non_float mod aliased immutable logical
          because it's a function type.
        But the kind of type "int -> int" must be a subkind of immutable_data
          because of the definition of t at line 1, characters 0-36.

--- a/testsuite/tests/typing-jkind-bounds/predef.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef.ml
@@ -95,7 +95,8 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) option" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) option is value non_float mod immutable
+       The kind of (unit -> unit) option is
+           value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of (unit -> unit) option must be a subkind of
            value mod portable
@@ -184,6 +185,7 @@ Error: The kind of type "'a ref" is
 
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
 |}]
 
@@ -316,7 +318,8 @@ Line 1, characters 14-33:
                   ^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) list" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) list is value non_float mod immutable
+       The kind of (unit -> unit) list is
+           value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of (unit -> unit) list must be a subkind of
            value mod portable
@@ -527,7 +530,8 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) iarray" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) iarray is value non_float mod immutable
+       The kind of (unit -> unit) iarray is
+           value non_float mod immutable logical
          because it is the primitive value type iarray.
        But the kind of (unit -> unit) iarray must be a subkind of
            value mod portable

--- a/testsuite/tests/typing-jkind-bounds/predef_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/predef_ikinds.ml
@@ -94,7 +94,8 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) option" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) option is value non_float mod immutable
+       The kind of (unit -> unit) option is
+           value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of (unit -> unit) option must be a subkind of
            value mod portable
@@ -183,6 +184,7 @@ Error: The kind of type "'a ref" is
 
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
 |}]
 
@@ -315,7 +317,8 @@ Line 1, characters 14-33:
                   ^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) list" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) list is value non_float mod immutable
+       The kind of (unit -> unit) list is
+           value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of (unit -> unit) list must be a subkind of
            value mod portable
@@ -526,7 +529,8 @@ Line 1, characters 14-35:
                   ^^^^^^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) iarray" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) iarray is value non_float mod immutable
+       The kind of (unit -> unit) iarray is
+           value non_float mod immutable logical
          because it is the primitive value type iarray.
        But the kind of (unit -> unit) iarray must be a subkind of
            value mod portable

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -54,6 +54,8 @@ Error: The kind of type "t" is immutable_data with 'a @@ portable
        The first mode-crosses less than the second along:
          linearity: mod many with 'a ≰ mod many
          contention: mod contended with 'a ≰ mod contended
+         logicality: mod logical with 'a ≰ mod logical
+         totality: mod total with 'a ≰ mod total
          forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
          statefulness: mod stateless with 'a ≰ mod stateless
@@ -107,7 +109,9 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-28.
 
        The first mode-crosses less than the second along:
+         logicality: mod logical with 'a ≰ mod logical
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
          statefulness: mod stateless with 'a ≰ mod stateless
@@ -208,7 +212,8 @@ Line 3, characters 11-25:
                ^^^^^^^^^^^^^^
 Error: This type "(int -> int) u" should be an instance of type
          "('a : immutable_data)"
-       The kind of (int -> int) u is value non_float mod immutable portable
+       The kind of (int -> int) u is
+           value non_float mod immutable portable logical
          because of the definition of u at line 1, characters 0-33.
        But the kind of (int -> int) u must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-28.
@@ -447,5 +452,6 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]

--- a/testsuite/tests/typing-jkind-bounds/printing.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing.ml
@@ -196,7 +196,9 @@ Error: This type "a" = "int ref" should be an instance of type
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with int ≰ mod portable
+         totality: mod total with int ≰ mod total
          statefulness: mod stateless with int ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -234,6 +236,8 @@ Error: This type "(int -> int) u" should be an instance of type
        The first mode-crosses less than the second along:
          linearity: mod many with int -> int ≰ mod many
          contention: mod contended with int -> int ≰ mod contended
+         logicality: mod logical with int -> int ≰ mod logical
+         totality: mod total with int -> int ≰ mod total
          forkable: mod forkable with int -> int ≰ mod forkable
          yielding: mod unyielding with int -> int ≰ mod unyielding
          statefulness: mod stateless with int -> int ≰ mod stateless

--- a/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
@@ -54,6 +54,8 @@ Error: The kind of type "t" is immutable_data with 'a @@ portable
        The first mode-crosses less than the second along:
          linearity: mod many with 'a ≰ mod many
          contention: mod contended with 'a ≰ mod contended
+         logicality: mod logical with 'a ≰ mod logical
+         totality: mod total with 'a ≰ mod total
          forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
          statefulness: mod stateless with 'a ≰ mod stateless
@@ -107,7 +109,9 @@ Error: Signature mismatch:
          because of the definition of t at line 2, characters 2-28.
 
        The first mode-crosses less than the second along:
+         logicality: mod logical with 'a ≰ mod logical
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          forkable: mod forkable with 'a ≰ mod forkable
          yielding: mod unyielding with 'a ≰ mod unyielding
          statefulness: mod stateless with 'a ≰ mod stateless
@@ -208,7 +212,8 @@ Line 3, characters 11-25:
                ^^^^^^^^^^^^^^
 Error: This type "(int -> int) u" should be an instance of type
          "('a : immutable_data)"
-       The kind of (int -> int) u is value non_float mod immutable portable
+       The kind of (int -> int) u is
+           value non_float mod immutable portable logical
          because of the definition of u at line 1, characters 0-33.
        But the kind of (int -> int) u must be a subkind of immutable_data
          because of the definition of t at line 2, characters 0-28.
@@ -447,5 +452,6 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]

--- a/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/printing_ikinds.ml
@@ -196,7 +196,9 @@ Error: This type "a" = "int ref" should be an instance of type
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with int ≰ mod portable
+         totality: mod total with int ≰ mod total
          statefulness: mod stateless with int ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -234,6 +236,8 @@ Error: This type "(int -> int) u" should be an instance of type
        The first mode-crosses less than the second along:
          linearity: mod many with int -> int ≰ mod many
          contention: mod contended with int -> int ≰ mod contended
+         logicality: mod logical with int -> int ≰ mod logical
+         totality: mod total with int -> int ≰ mod total
          forkable: mod forkable with int -> int ≰ mod forkable
          yielding: mod unyielding with int -> int ≰ mod unyielding
          statefulness: mod stateless with int -> int ≰ mod stateless

--- a/testsuite/tests/typing-jkind-bounds/records.ml
+++ b/testsuite/tests/typing-jkind-bounds/records.ml
@@ -162,7 +162,9 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -183,7 +185,7 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -216,7 +218,7 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -331,6 +333,7 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
@@ -339,7 +342,7 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -679,7 +682,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable
@@ -704,7 +707,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
            value mod external_
@@ -799,7 +802,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -161,7 +161,9 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -182,7 +184,7 @@ type t : immutable_data = { x : unit -> unit }
 Line 1, characters 0-46:
 1 | type t : immutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -215,7 +217,7 @@ type t : mutable_data = { x : unit -> unit }
 Line 1, characters 0-44:
 1 | type t : mutable_data = { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -330,6 +332,7 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
@@ -338,7 +341,7 @@ type 'a t : immutable_data with 'a = { x : 'a -> 'a }
 Line 1, characters 0-53:
 1 | type 'a t : immutable_data with 'a = { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed record type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -674,7 +677,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable
@@ -699,7 +702,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
            value mod external_
@@ -794,7 +797,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-22.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable

--- a/testsuite/tests/typing-jkind-bounds/row.ml
+++ b/testsuite/tests/typing-jkind-bounds/row.ml
@@ -269,7 +269,7 @@ Line 1, characters 0-71:
 1 | type trec_fails : immutable_data = [ `C | `D of 'a * unit -> 'a ] as 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "[ `C | `D of 'a * unit -> 'a ] as 'a" is
-           value non_float mod immutable
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `C | `D of 'a * unit -> 'a ] as 'a" must be a subkind of
          immutable_data
@@ -290,7 +290,8 @@ Lines 1-2, characters 0-80:
 2 |   [ `X of 'b | `Y of [ `Z of ('a -> 'b) | `W of 'a | `Loop of 'b ] as 'b ] as 'a
 Error: The kind of type "[ `X of
                             [ `Loop of 'b | `W of 'a | `Z of 'a -> 'b ] as 'b
-                        | `Y of 'b ] as 'a" is value non_float mod immutable
+                        | `Y of 'b ] as 'a" is
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `X of
                                 [ `Loop of 'b | `W of 'a | `Z of 'a -> 'b ]

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -268,7 +268,7 @@ Line 1, characters 0-71:
 1 | type trec_fails : immutable_data = [ `C | `D of 'a * unit -> 'a ] as 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "[ `C | `D of 'a * unit -> 'a ] as 'a" is
-           value non_float mod immutable
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `C | `D of 'a * unit -> 'a ] as 'a" must be a subkind of
          immutable_data
@@ -289,7 +289,8 @@ Lines 1-2, characters 0-80:
 2 |   [ `X of 'b | `Y of [ `Z of ('a -> 'b) | `W of 'a | `Loop of 'b ] as 'b ] as 'a
 Error: The kind of type "[ `X of
                             [ `Loop of 'b | `W of 'a | `Z of 'a -> 'b ] as 'b
-                        | `Y of 'b ] as 'a" is value non_float mod immutable
+                        | `Y of 'b ] as 'a" is
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `X of
                                 [ `Loop of 'b | `W of 'a | `Z of 'a -> 'b ]
@@ -329,13 +330,7 @@ type t3 : value non_float mod everything with [ `A of string] t1 = C of string  
    ikinds regression vs non-ikinds.
    Internal ticket 6481. *)
 [%%expect{|
-Line 1, characters 0-78:
-1 | type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t3" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t3" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t3.
+type t3 = C of string
 |}]
 
 type 'a t1 = [> `A of string | `B of int ] as 'a
@@ -358,13 +353,7 @@ type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] 
    ikinds regression vs non-ikinds.
    Internal ticket 6481. *)
 [%%expect{|
-Line 1, characters 0-96:
-1 | type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t3" is immutable_data
-         because it's a boxed variant type.
-       But the kind of type "t3" must be a subkind of immutable_data
-         because of the annotation on the declaration of the type t3.
+type t3 = C of string
 |}]
 
 module type S = sig

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -331,6 +331,14 @@ type t3 : value non_float mod everything with [ `A of string] t1 = C of string  
    Internal ticket 6481. *)
 [%%expect{|
 type t3 = C of string
+|}, Principal{|
+Line 1, characters 0-78:
+1 | type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t3" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "t3" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t3.
 |}]
 
 type 'a t1 = [> `A of string | `B of int ] as 'a
@@ -354,6 +362,14 @@ type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] 
    Internal ticket 6481. *)
 [%%expect{|
 type t3 = C of string
+|}, Principal{|
+Line 1, characters 0-96:
+1 | type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The kind of type "t3" is immutable_data
+         because it's a boxed variant type.
+       But the kind of type "t3" must be a subkind of immutable_data
+         because of the annotation on the declaration of the type t3.
 |}]
 
 module type S = sig

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics.ml
@@ -596,7 +596,8 @@ type fails : immutable_data = int -> int
 Line 1, characters 0-40:
 1 | type fails : immutable_data = int -> int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int -> int" is value non_float mod aliased immutable
+Error: The kind of type "int -> int" is
+           value non_float mod aliased immutable logical
          because it's a function type.
        But the kind of type "int -> int" must be a subkind of immutable_data
          because of the definition of fails at line 1, characters 0-40.
@@ -607,7 +608,8 @@ type should_fail : immutable_data = [`A of int -> int]
 Line 1, characters 0-54:
 1 | type should_fail : immutable_data = [`A of int -> int]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[ `A of int -> int ]" is value non_float mod immutable
+Error: The kind of type "[ `A of int -> int ]" is
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `A of int -> int ]" must be a subkind of
            immutable_data
@@ -620,7 +622,7 @@ Line 1, characters 0-76:
 1 | type should_also_fail : immutable_data = [`A of int -> int | `B of 'a] as 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "[ `A of int -> int | `B of 'a ] as 'a" is
-           value non_float mod immutable
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `A of int -> int | `B of 'a ] as 'a" must be a subkind of
          immutable_data
@@ -681,7 +683,8 @@ type this_fails : immutable_data = (int -> int) list
 Line 1, characters 0-52:
 1 | type this_fails : immutable_data = (int -> int) list
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "(int -> int) list" is value non_float mod immutable
+Error: The kind of type "(int -> int) list" is
+           value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "(int -> int) list" must be a subkind of
            immutable_data

--- a/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/basics_ikinds.ml
@@ -547,7 +547,8 @@ type fails : immutable_data = int -> int
 Line 1, characters 0-40:
 1 | type fails : immutable_data = int -> int
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "int -> int" is value non_float mod aliased immutable
+Error: The kind of type "int -> int" is
+           value non_float mod aliased immutable logical
          because it's a function type.
        But the kind of type "int -> int" must be a subkind of immutable_data
          because of the definition of fails at line 1, characters 0-40.
@@ -558,7 +559,8 @@ type should_fail : immutable_data = [`A of int -> int]
 Line 1, characters 0-54:
 1 | type should_fail : immutable_data = [`A of int -> int]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "[ `A of int -> int ]" is value non_float mod immutable
+Error: The kind of type "[ `A of int -> int ]" is
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `A of int -> int ]" must be a subkind of
            immutable_data
@@ -571,7 +573,7 @@ Line 1, characters 0-76:
 1 | type should_also_fail : immutable_data = [`A of int -> int | `B of 'a] as 'a
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "[ `A of int -> int | `B of 'a ] as 'a" is
-           value non_float mod immutable
+           value non_float mod immutable logical
          because it's a polymorphic variant type.
        But the kind of type "[ `A of int -> int | `B of 'a ] as 'a" must be a subkind of
          immutable_data
@@ -632,7 +634,8 @@ type this_fails : immutable_data = (int -> int) list
 Line 1, characters 0-52:
 1 | type this_fails : immutable_data = (int -> int) list
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "(int -> int) list" is value non_float mod immutable
+Error: The kind of type "(int -> int) list" is
+           value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "(int -> int) list" must be a subkind of
            immutable_data

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint.ml
@@ -152,6 +152,7 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'b
+         logicality: mod physical ≰ mod logical with 'b
          visibility: mod read_write ≰ mod immutable with 'b
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/constraint_ikinds.ml
@@ -152,6 +152,7 @@ Error: Signature mismatch:
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'b
+         logicality: mod physical ≰ mod logical with 'b
          visibility: mod read_write ≰ mod immutable with 'b
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors.ml
@@ -67,6 +67,7 @@ Error: The kind of type "'a F(Ref).t" is
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
@@ -87,6 +88,7 @@ Error: The kind of type "'a F(Ref).t" is
 
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/functors_ikinds.ml
@@ -67,6 +67,7 @@ Error: The kind of type "'a F(Ref).t" is
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
@@ -87,6 +88,7 @@ Error: The kind of type "'a F(Ref).t" is
 
        The first mode-crosses less than the second along:
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities.ml
@@ -375,9 +375,21 @@ end
 
 module type T = S with type t = t
 [%%expect {|
-type t : immutable_data
+type t : mutable_data mod immutable
 module type S = sig type t : immutable_data end
-module type T = sig type t = t end
+Line 7, characters 16-33:
+7 | module type T = S with type t = t
+                    ^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = t
+       is not included in
+         type t : immutable_data
+       The kind of the first is mutable_data mod immutable
+         because of the definition of t at line 1, characters 0-49.
+       But the kind of the first must be a subkind of immutable_data
+         because of the definition of t at line 4, characters 2-25.
 |}]
 
 (* Test case for bug where type abbreviations incorrectly satisfy modal kinds.

--- a/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/subsumption/modalities_ikinds.ml
@@ -375,9 +375,21 @@ end
 
 module type T = S with type t = t
 [%%expect {|
-type t : immutable_data
+type t : mutable_data mod immutable
 module type S = sig type t : immutable_data end
-module type T = sig type t = t end
+Line 7, characters 16-33:
+7 | module type T = S with type t = t
+                    ^^^^^^^^^^^^^^^^^
+Error: In this "with" constraint, the new definition of "t"
+       does not match its original definition in the constrained signature:
+       Type declarations do not match:
+         type t = t
+       is not included in
+         type t : immutable_data
+       The kind of the first is mutable_data mod immutable
+         because of the definition of t at line 1, characters 0-49.
+       But the kind of the first must be a subkind of immutable_data
+         because of the definition of t at line 4, characters 2-25.
 |}]
 
 (* Test case for bug where type abbreviations incorrectly satisfy modal kinds.

--- a/testsuite/tests/typing-jkind-bounds/variants.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants.ml
@@ -166,7 +166,9 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -187,7 +189,7 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -220,7 +222,7 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -333,6 +335,7 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
@@ -341,7 +344,7 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -680,7 +683,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable
@@ -705,7 +708,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
            value mod external_
@@ -800,7 +803,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -190,7 +190,9 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended
+         logicality: mod physical ≰ mod logical
          portability: mod portable with 'a ≰ mod portable
+         totality: mod total with 'a ≰ mod total
          statefulness: mod stateless with 'a ≰ mod stateless
          visibility: mod read_write ≰ mod immutable
 |}]
@@ -211,7 +213,7 @@ type t : immutable_data = Foo of (unit -> unit)
 Line 1, characters 0-47:
 1 | type t : immutable_data = Foo of (unit -> unit)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data
          because of the annotation on the declaration of the type t.
@@ -244,7 +246,7 @@ type t : mutable_data = Foo of { x : unit -> unit }
 Line 1, characters 0-51:
 1 | type t : mutable_data = Foo of { x : unit -> unit }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of mutable_data
          because of the annotation on the declaration of the type t.
@@ -357,6 +359,7 @@ Error: The kind of type "t" is mutable_data with 'a @@ forkable unyielding many
 
        The first mode-crosses less than the second along:
          contention: mod uncontended ≰ mod contended with 'a
+         logicality: mod physical ≰ mod logical with 'a
          visibility: mod read_write ≰ mod immutable with 'a
 |}]
 
@@ -365,7 +368,7 @@ type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
 Line 1, characters 0-60:
 1 | type 'a t : immutable_data with 'a = Foo of { x : 'a -> 'a }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The kind of type "t" is value non_float mod immutable
+Error: The kind of type "t" is value non_float mod immutable logical
          because it's a boxed variant type.
        But the kind of type "t" must be a subkind of immutable_data with 'a
          because of the annotation on the declaration of the type t.
@@ -700,7 +703,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable
@@ -725,7 +728,7 @@ Line 1, characters 24-28:
                             ^^^^
 Error: The value "func" has type "(unit -> unit) t"
        but an expression was expected of type "('a : value mod external_)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
            value mod external_
@@ -820,7 +823,7 @@ Line 1, characters 14-30:
                   ^^^^^^^^^^^^^^^^
 Error: This type "(unit -> unit) t" should be an instance of type
          "('a : value mod portable)"
-       The kind of (unit -> unit) t is value non_float mod immutable
+       The kind of (unit -> unit) t is value non_float mod immutable logical
          because of the definition of t at line 1, characters 0-21.
        But the kind of (unit -> unit) t must be a subkind of
            value mod portable
@@ -1072,13 +1075,5 @@ let f (x : M.t many) = cross_contended x
 [%%expect {|
 module M : sig type t end
 type 'a many = Foo of ('a * 'a) many | Leaf
-Line 3, characters 39-40:
-3 | let f (x : M.t many) = cross_contended x
-                                           ^
-Error: The value "x" has type "M.t many" but an expression was expected of type
-         "('a : value mod contended)"
-       The kind of M.t many is immutable_data with (M.t * M.t) many
-         because of the definition of many at line 2, characters 0-43.
-       But the kind of M.t many must be a subkind of value mod contended
-         because of the definition of cross_contended at line 9, characters 59-70.
+val f : M.t many -> unit = <fun>
 |}]

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -1076,4 +1076,16 @@ let f (x : M.t many) = cross_contended x
 module M : sig type t end
 type 'a many = Foo of ('a * 'a) many | Leaf
 val f : M.t many -> unit = <fun>
+|}, Principal{|
+module M : sig type t end
+type 'a many = Foo of ('a * 'a) many | Leaf
+Line 3, characters 39-40:
+3 | let f (x : M.t many) = cross_contended x
+                                           ^
+Error: The value "x" has type "M.t many" but an expression was expected of type
+         "('a : value mod contended)"
+       The kind of M.t many is immutable_data with (M.t * M.t) many
+         because of the definition of many at line 2, characters 0-43.
+       But the kind of M.t many must be a subkind of value mod contended
+         because of the definition of cross_contended at line 9, characters 59-70.
 |}]

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity1.ml
@@ -10,12 +10,16 @@ type t
 
 type t : immutable_data
 [%%expect {|
-type t : value non_float mod forkable unyielding many stateless immutable
+type t
+  : value non_float
+      mod forkable unyielding many stateless immutable total logical
 |}]
 
 type t : immediate
 [%%expect {|
-type t : value non_pointer mod global many stateless immutable external_
+type t
+  : value non_pointer
+      mod global many stateless immutable total logical external_
 |}]
 
 type t : float64
@@ -41,12 +45,16 @@ type t : value mod stateless
 type 'a t : immutable_data with 'a
 [%%expect {|
 type 'a t
-  : value non_float mod forkable unyielding many stateless immutable with 'a
+  : value non_float
+      mod forkable unyielding many stateless immutable total logical
+      with 'a
 |}]
 
 type ('a : immutable_data) t
 [%%expect {|
-type ('a : value non_float mod forkable unyielding many stateless immutable)
+type ('a
+     : value non_float
+         mod forkable unyielding many stateless immutable total logical)
      t
 |}]
 
@@ -68,5 +76,7 @@ type 'a t : value mod external_
 type 'a t : immutable_data with 'a @@ external_
 [%%expect {|
 type 'a t
-  : value non_float mod forkable unyielding many stateless immutable with 'a
+  : value non_float
+      mod forkable unyielding many stateless immutable total logical
+      with 'a
 |}]

--- a/testsuite/tests/typing-jkind-bounds/verbosity/verbosity2.ml
+++ b/testsuite/tests/typing-jkind-bounds/verbosity/verbosity2.ml
@@ -21,6 +21,8 @@ type t
           many
           stateless
           immutable
+          total
+          logical
           portable
           contended
           local
@@ -37,6 +39,8 @@ type t
           many
           stateless
           immutable
+          total
+          logical
           forkable
           unyielding
           aliased
@@ -60,6 +64,8 @@ type t
           read_write
           nonportable
           uncontended
+          partial
+          nonlogical
           static
 |}]
 
@@ -76,6 +82,8 @@ type t
           read_write
           nonportable
           uncontended
+          partial
+          nonlogical
           static
           internal
 |}]
@@ -93,6 +101,8 @@ type t
           stateful
           read_write
           uncontended
+          partial
+          nonlogical
           static
           internal
 |}]
@@ -110,6 +120,8 @@ type t
           unique
           read_write
           uncontended
+          partial
+          nonlogical
           static
           internal
 |}]
@@ -123,6 +135,8 @@ type 'a t
           many
           stateless
           immutable
+          total
+          logical
           portable
           contended
           local
@@ -141,6 +155,8 @@ type ('a
              many
              stateless
              immutable
+             total
+             logical
              portable
              contended
              local
@@ -163,6 +179,8 @@ type ('a
              unique
              read_write
              uncontended
+             partial
+             nonlogical
              static
              internal)
      t
@@ -182,6 +200,8 @@ type 'a t
           stateful
           read_write
           uncontended
+          partial
+          nonlogical
           static
       with 'a @@ external_
 |}]
@@ -200,6 +220,8 @@ type 'a t
           read_write
           nonportable
           uncontended
+          partial
+          nonlogical
           static
 |}]
 
@@ -212,6 +234,8 @@ type 'a t
           many
           stateless
           immutable
+          total
+          logical
           portable
           contended
           local

--- a/testsuite/tests/typing-layouts-or-null/custom.ml
+++ b/testsuite/tests/typing-layouts-or-null/custom.ml
@@ -541,7 +541,7 @@ Lines 1-4, characters 0-11:
 3 |   | Nonportable_some of (unit -> unit)
 4 | [@@or_null]
 Error: The kind of type "nonportable_payload" is
-           value_or_null non_float mod aliased immutable
+           value_or_null non_float mod aliased immutable logical
          because an [@@or_null] type gets the kind of or_null
          applied to its payload type.
        But the kind of type "nonportable_payload" must be a subkind of

--- a/testsuite/tests/typing-layouts-or-null/immediate.ml
+++ b/testsuite/tests/typing-layouts-or-null/immediate.ml
@@ -145,7 +145,7 @@ end = struct
 end
 
 [%%expect{|
-module M : sig type t : immediate_or_null end @@ stateless
+module M : sig type t : immediate_or_null end @@ stateless total
 |}]
 
 (* Tests for [immediate64_or_null]. *)
@@ -250,7 +250,7 @@ end = struct
 end
 
 [%%expect{|
-module M64 : sig type t : immediate64_or_null end @@ stateless
+module M64 : sig type t : immediate64_or_null end @@ stateless total
 |}]
 
 module Fails : sig

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2341,7 +2341,8 @@ Lines 1-6, characters 0-30:
 4 |     c : #(int64# * #(float# * (bool -> bool) * 'b ));
 5 |     d : char }
 6 |   constraint 'b = int * string
-Error: The kind of type "record" is value non_float mod immutable with 'a
+Error: The kind of type "record" is
+           value non_float mod immutable logical with 'a
          because it's a boxed record type.
        But the kind of type "record" must be a subkind of value mod portable
          because of the annotation on the declaration of the type record.

--- a/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
+++ b/testsuite/tests/typing-layouts-products/basics_unboxed_records.ml
@@ -764,8 +764,8 @@ Line 1, characters 0-61:
 1 | type q : any mod portable = #{ x : int -> int; y : int -> q }
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: The kind of type "q" is
-           value non_float mod aliased immutable
-           & value non_float mod aliased immutable
+           value non_float mod aliased immutable logical
+           & value non_float mod aliased immutable logical
          because it is an unboxed record.
        But the kind of type "q" must be a subkind of
            any mod portable & any mod portable

--- a/testsuite/tests/typing-layouts/allow_any.ml
+++ b/testsuite/tests/typing-layouts/allow_any.ml
@@ -420,9 +420,9 @@ Error: This variant or record definition does not match that of type "'a t"
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
          the original has: mod forkable unyielding many stateless immutable
-         portable contended with 'a
+         portable contended total logical with 'a
          but this has: mod forkable unyielding many stateless immutable
-         portable contended
+         portable contended total logical
 |}]
 
 type ('a, 'b) arity_2 : immutable_data with 'b = { x : 'a }
@@ -441,9 +441,9 @@ Error: This variant or record definition does not match that of type
        They have different unsafe mode crossing behavior:
        Both specify [@@unsafe_allow_any_mode_crossing], but their bounds are not equal
          the original has: mod forkable unyielding many stateless immutable
-         portable contended with 'b
+         portable contended total logical with 'b
          but this has: mod forkable unyielding many stateless immutable
-         portable contended with 'a
+         portable contended total logical with 'a
 |}]
 
 (* mcomp *)

--- a/testsuite/tests/typing-layouts/basics.ml
+++ b/testsuite/tests/typing-layouts/basics.ml
@@ -2898,7 +2898,9 @@ Line 1, characters 28-32:
 Error: This function application uses an expression with type "'a"
        as a function, but that type has kind "bits64", which cannot
        be the kind of a function.
-       (Functions always have kind "value non_float mod aliased immutable".)
+       (Functions always have kind "value
+                                     non_float
+                                     mod aliased immutable logical".)
 |}]
 
 let f (x : ('a : value mod portable)) = x ()
@@ -2910,7 +2912,9 @@ Line 1, characters 40-44:
 Error: This function application uses an expression with type "'a"
        as a function, but that type has kind "value mod portable", which cannot
        be the kind of a function.
-       (Functions always have kind "value non_float mod aliased immutable".)
+       (Functions always have kind "value
+                                     non_float
+                                     mod aliased immutable logical".)
 |}]
 
 let f (x : ('a : value)) = x ()
@@ -2945,7 +2949,9 @@ Line 9, characters 10-22:
 Error: This function application uses an expression with type "'a"
        as a function, but that type has kind "immediate", which cannot
        be the kind of a function.
-       (Functions always have kind "value non_float mod aliased immutable".)
+       (Functions always have kind "value
+                                     non_float
+                                     mod aliased immutable logical".)
        Hint: Perhaps you have over-applied the function or used an incorrect label.
 |}]
 
@@ -2958,7 +2964,9 @@ Line 1, characters 10-22:
 Error: This function application uses an expression with type "'a"
        as a function, but that type has kind "immediate", which cannot
        be the kind of a function.
-       (Functions always have kind "value non_float mod aliased immutable".)
+       (Functions always have kind "value
+                                     non_float
+                                     mod aliased immutable logical".)
        Hint: Perhaps you have over-applied the function or used an incorrect label.
 |}]
 

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -777,7 +777,7 @@ Line 1, characters 26-40:
 1 | let fails = restricted [| fun () -> "no" |]
                               ^^^^^^^^^^^^^^
 Error:
-       The kind of 'a -> 'b is value non_float mod aliased immutable
+       The kind of 'a -> 'b is value non_float mod aliased immutable logical
          because it's a function type.
        But the kind of 'a -> 'b must be a subkind of
            value_maybe_null mod portable contended

--- a/testsuite/tests/typing-modes/functor.ml
+++ b/testsuite/tests/typing-modes/functor.ml
@@ -70,19 +70,19 @@ module F : S -> T = functor (M : S) -> struct
   let g = M.f
 end
 [%%expect{|
-module F : S -> T @@ stateless
+module F : S -> T @@ stateless total
 |}]
 
 module F (M : S @ portable) (M' : S) = struct
 end
 [%%expect{|
-module F : functor (M : S @ portable) (M' : S) -> sig end @@ stateless
+module F : functor (M : S @ portable) (M' : S) -> sig end @@ stateless total
 |}]
 
 module F (M : S) (M' : S @ portable) @ portable = struct
 end
 [%%expect{|
-module F : functor (M : S) (M' : S @ portable) -> sig end @@ stateless
+module F : functor (M : S) (M' : S @ portable) -> sig end @@ stateless total
 |}]
 
 module F (M : S @ portable) (M' : S @ portable) : T @ portable = struct
@@ -90,6 +90,7 @@ module F (M : S @ portable) (M' : S @ portable) : T @ portable = struct
 end
 [%%expect{|
 module F : functor (M : S @ portable) (M' : S @ portable) -> T @@ stateless
+  total
 |}]
 
 (* In REPL (called "toplevel" in the compiler source code), functors, just like
@@ -110,7 +111,7 @@ module M = struct
     let f () = ()
 end
 [%%expect{|
-module M : sig val f : unit -> unit end @@ stateless
+module M : sig val f : unit -> unit end @@ stateless total
 |}]
 
 module _ @ portable = F(M)
@@ -149,7 +150,7 @@ module Workaround :
   sig
     module F :
       functor (M : S @ portable) -> sig val g : unit -> unit end @ portable
-      @@ stateless nonportable
+      @@ stateless nonportable total
     module M' : sig val g : unit -> unit end
   end @@ portable
 |}]
@@ -165,7 +166,8 @@ module M = struct
     let f' = let r = ref 42 in fun () -> r := 24; ()
 end
 [%%expect{|
-module M : sig val f : unit -> unit @@ stateless val f' : unit -> unit end
+module M :
+  sig val f : unit -> unit @@ stateless total val f' : unit -> unit end
 |}]
 
 (* Note that M is a nonportable module containing both portable and nonportable items.
@@ -307,7 +309,7 @@ end
 [%%expect{|
 module M :
   sig
-    val f : unit -> unit @@ stateless
+    val f : unit -> unit @@ stateless total
     val f' : unit -> unit
     val g : unit -> unit @@ portable
   end
@@ -412,7 +414,7 @@ val f_local : 'a @ local -> unit -> unit = <fun>
 module F (M : S @ local) () = struct end
 [%%expect{|
 module F : functor (M : S @ local) -> (functor () -> sig end) @ local @@
-  stateless
+  stateless total
 |}]
 
 (* Demonstration. *)
@@ -421,7 +423,7 @@ let f_stateful (x @ stateful) () = ()
 module F (M : S @ stateful) () = struct end
 [%%expect{|
 val f_stateful : 'a -> unit -> unit = <fun>
-module F : functor (M : S) () -> sig end @@ stateless
+module F : functor (M : S) () -> sig end @@ stateless total
 |}]
 
 let f_stateful_app (x @ stateful) =
@@ -503,7 +505,7 @@ val f_read_write : 'a -> unit -> unit = <fun>
 
 module F (M : S @ read_write) () = struct end
 [%%expect{|
-module F : functor (M : S) () -> sig end @@ stateless
+module F : functor (M : S) () -> sig end @@ stateless total
 |}]
 
 let f_read_write_app (x @ read_write) =
@@ -588,7 +590,7 @@ val f_read_write_ret : 'a -> unit -> unit = <fun>
 module F (M : S @ read_write) =
   ((functor () -> struct end) : (functor () -> sig end) @ stateless)
 [%%expect{|
-module F : functor (M : S) () -> sig end @@ stateless
+module F : functor (M : S) () -> sig end @@ stateless total
 |}]
 
 let f1 (x1 @ stateful) (x2 @ stateless) (x3 @ stateless) =
@@ -607,7 +609,7 @@ end
 [%%expect{|
 module F1 :
   functor (M1 : S) (M2 : S @ stateless) (M3 : S @ stateless) -> sig end @@
-  stateless
+  stateless total
 |}]
 
 let f1_flip (x2 @ stateless) (x1 @ stateful) = f1 x1 x2
@@ -621,7 +623,7 @@ module F1_flip (M2 : S @ stateless) (M1 : S @ read_write) = F1 (M1) (M2)
 [%%expect{|
 module F1_flip :
   functor (M2 : S @ stateless) (M1 : S) (M3 : S @ stateless) -> sig end @@
-  stateless
+  stateless total
 |}]
 
 (* This example explains why we need the stricter partial application
@@ -666,7 +668,7 @@ end
 [%%expect{|
 module F2 :
   functor (M1 : S @ stateless) (M2 : S) (M3 : S @ stateless) -> sig end @@
-  stateless
+  stateless total
 |}]
 
 let f3 (x1 @ stateless) (x2 @ stateless) (x3 @ stateful) =
@@ -685,7 +687,7 @@ end
 [%%expect{|
 module F3 :
   functor (M1 : S @ stateless) (M2 : S @ stateless) (M3 : S) -> sig end @@
-  stateless
+  stateless total
 |}]
 
 let test1 (_x @ stateful) : (unit -> unit) @ stateless = fun () -> ()
@@ -696,7 +698,7 @@ val test1 : 'a -> (unit -> unit) @ stateless = <fun>
 module F1 (M1 : S @ stateful) : (functor () -> sig end) @ stateless =
   functor () -> struct end
 [%%expect{|
-module F1 : functor (M1 : S) () -> sig end @@ stateless
+module F1 : functor (M1 : S) () -> sig end @@ stateless total
 |}]
 
 let test2 (x @ stateful) : (unit -> unit) @ stateless =
@@ -750,7 +752,7 @@ module type Nonportable_Nonportable = sig module F : functor (M : S) -> T end
 module F (M : Nonportable_Portable) = (M : Portable_Portable)
 [%%expect{|
 module F : functor (M : Nonportable_Portable) -> Portable_Portable @@
-  stateless
+  stateless total
 |}]
 
 module F (M : Portable_Portable) = (M : Nonportable_Portable)
@@ -819,7 +821,7 @@ Error: Signature mismatch:
 module F (M : Portable_Portable) = (M : Portable_Nonportable)
 [%%expect{|
 module F : functor (M : Portable_Portable) -> Portable_Nonportable @@
-  stateless
+  stateless total
 |}]
 
 module F (M : S @ shareable -> S) = (M : S -> S)
@@ -846,12 +848,12 @@ Error: Signature mismatch:
 
 module F (M : S -> S) = (M : S @ shareable -> S)
 [%%expect{|
-module F : functor (M : S -> S) -> S @ shareable -> S @@ stateless
+module F : functor (M : S -> S) -> S @ shareable -> S @@ stateless total
 |}]
 
 module F (M : S -> S @ shareable) = (M : S -> S)
 [%%expect{|
-module F : functor (M : S -> S @ shareable) -> S -> S @@ stateless
+module F : functor (M : S -> S @ shareable) -> S -> S @@ stateless total
 |}]
 
 module F (M : S -> S) = (M : S -> S @ shareable)
@@ -903,12 +905,12 @@ Error: Signature mismatch:
 
 module F (M : T @ immutable -> S) = (M : T -> S)
 [%%expect{|
-module F : functor (M : T @ immutable -> S) -> T -> S @@ stateless
+module F : functor (M : T @ immutable -> S) -> T -> S @@ stateless total
 |}]
 
 module F (M : S -> T) = (M : S -> T @ immutable)
 [%%expect{|
-module F : functor (M : S -> T) -> S -> T @ immutable @@ stateless
+module F : functor (M : S -> T) -> S -> T @ immutable @@ stateless total
 |}]
 
 module F (M : S -> T @ immutable) = (M : S -> T)
@@ -943,6 +945,7 @@ end
 type t' = F(M).t
 [%%expect{|
 module F : functor (X : S @ portable) -> sig type t = int end @@ stateless
+  total
 module M : sig val f : unit -> unit end
 type t' = F(M).t
 |}]
@@ -955,7 +958,7 @@ let (foo @ portable) () =
   let _ : F(M).t = 42 in
   ()
 [%%expect{|
-module F = F @@ stateless nonportable
+module F = F @@ stateless nonportable total
 module M = M
 val foo : unit -> unit = <fun>
 |}]
@@ -983,7 +986,7 @@ end
 [%%expect{|
 module F :
   functor (G : S -> S @ portable) -> sig module H : S -> S @ portable end @@
-  stateless
+  stateless total
 |}]
 
 module F(G : S -> S) = struct
@@ -1037,13 +1040,13 @@ module F(G : S -> S) = struct
 end
 [%%expect{|
 module F : functor (G : S -> S) -> sig module H : S @ portable -> S end @@
-  stateless
+  stateless total
 |}]
 
 module F (M : (S @ portable -> S) -> S) = (M : (S -> S) -> S)
 [%%expect{|
 module F : functor (M : (S @ portable -> S) -> S) -> (S -> S) -> S @@
-  stateless
+  stateless total
 |}]
 
 module F (M : (S -> S) -> S) = (M : (S @ portable -> S) -> S)
@@ -1096,5 +1099,5 @@ Error: Signature mismatch:
 module F (M : (S -> S) -> S) = (M : (S -> S @ portable) -> S)
 [%%expect{|
 module F : functor (M : (S -> S) -> S) -> (S -> S @ portable) -> S @@
-  stateless
+  stateless total
 |}]

--- a/testsuite/tests/typing-modes/incl_modalities.ml
+++ b/testsuite/tests/typing-modes/incl_modalities.ml
@@ -217,7 +217,7 @@ module M :
     module type Foo = sig val foo : 'a -> 'a end
     module type Foo' = Foo
     module type S = sig module N : Foo' end
-  end @@ stateless
+  end @@ stateless total
 module type S' = sig module N : sig val foo : 'a -> 'a @@ portable end end
 |}]
 

--- a/testsuite/tests/typing-modes/md_modalities.ml
+++ b/testsuite/tests/typing-modes/md_modalities.ml
@@ -110,7 +110,7 @@ module type S = sig @@ portable
   module M' = M
 end
 [%%expect{|
-module M : T @@ stateless nonportable
+module M : T @@ stateless nonportable total
 module type S = sig module M' = M end
 |}]
 
@@ -132,7 +132,7 @@ Lines 1-3, characters 15-3:
 3 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig module M' = M @@ stateless nonportable end
+         sig module M' = M @@ stateless nonportable total end
        is not included in
          S
        In module "M'":

--- a/testsuite/tests/typing-modes/module.ml
+++ b/testsuite/tests/typing-modes/module.ml
@@ -23,7 +23,7 @@ end
 val portable_use : 'a @ portable -> unit = <fun>
 module type S = sig val x : 'a -> unit end
 module type SL = sig type 'a t end
-module M : sig type 'a t = int val x : 'a -> unit end @@ stateless
+module M : sig type 'a t = int val x : 'a -> unit end @@ stateless total
 val foo : unit -> unit = <fun>
 module F : functor (X : S) -> sig type t = int val x : 'a -> unit end
 |}]
@@ -161,7 +161,7 @@ module M : S = struct
 end
 [%%expect{|
 module type S = sig val foo : 'a -> 'a val baz : 'a -> 'a @@ portable end
-module M : S @@ stateless nonportable
+module M : S @@ stateless nonportable total
 |}]
 
 let (bar @ portable) () =
@@ -243,7 +243,7 @@ Error: The module "M" is "nonportable"
 module F (X : S @ portable) = struct
 end
 [%%expect{|
-module F : functor (X : S @ portable) -> sig end @@ stateless
+module F : functor (X : S @ portable) -> sig end @@ stateless total
 |}]
 
 module type S = functor () (M : S @ portable) (_ : S @ portable) -> S
@@ -260,8 +260,9 @@ module F () = struct
     let (foo @ once) () = ()
 end
 [%%expect{|
-module F : functor () -> sig val foo : unit -> unit @@ stateless end @ once
-  @@ stateless
+module F :
+  functor () -> sig val foo : unit -> unit @@ stateless total end @ once @@
+  stateless total
 |}]
 
 module type Empty = sig end
@@ -326,13 +327,13 @@ end
 [%%expect{|
 module Test_incl :
   sig
-    module M : sig val foo : 'a -> 'a @@ stateless end
-    module type S = sig val foo : 'a -> 'a @@ stateless end
+    module M : sig val foo : 'a -> 'a @@ stateless total end
+    module type S = sig val foo : 'a -> 'a @@ stateless total end
     module N :
       sig
-        val x : int ref @@ stateless
+        val x : int ref @@ stateless total
         val f : unit -> unit
-        val foo : 'a -> 'a @@ stateless
+        val foo : 'a -> 'a @@ stateless total
       end
   end
 |}]
@@ -393,7 +394,7 @@ end
 [%%expect{|
 module F :
   functor (X : sig val x : int -> int end) -> sig val bar : int -> int end @@
-  stateless
+  stateless total
 |}]
 
 

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -38,7 +38,7 @@ module M = struct
   let foo = {x = "hello"}
 end
 [%%expect{|
-module M : sig val foo : r end @@ stateless
+module M : sig val foo : r end @@ stateless total
 |}]
 
 module type S = sig
@@ -83,7 +83,7 @@ module (M @ uncontended) = struct
     let x @ contended = "hello"
 end
 [%%expect{|
-module M : sig val x : string @@ contended end @@ stateless
+module M : sig val x : string @@ contended end @@ stateless total
 |}]
 
 (* Testing the defaulting behaviour.
@@ -105,8 +105,8 @@ end
 [%%expect{|
 module Module_type_of_comonadic :
   sig
-    module M : sig val x : 'a -> 'a @@ stateless end
-    module type S = sig val x : 'a -> 'a @@ stateless end
+    module M : sig val x : 'a -> 'a @@ stateless total end
+    module type S = sig val x : 'a -> 'a @@ stateless total end
     module M' = M
   end
 |}]
@@ -136,20 +136,20 @@ Lines 8-12, characters 33-5:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val y : int ref @@ stateless
+           val y : int ref @@ stateless total
            val z : 'a -> 'a
            val x : 'a -> 'a
          end @ stateful
        is not included in
          sig
-           val y : int ref @@ stateless
+           val y : int ref @@ stateless total
            val z : 'a -> 'a
-           val x : 'a -> 'a @@ stateless
+           val x : 'a -> 'a @@ stateless total
          end @ stateful
        Values do not match:
          val x : 'a -> 'a (* in a structure at stateful *)
        is not included in
-         val x : 'a -> 'a @@ stateless (* in a structure at stateful *)
+         val x : 'a -> 'a @@ stateless total (* in a structure at stateful *)
        The first is "stateful"
          because it contains a usage (of the value "y" at line 11, characters 29-30)
          which is expected to be "read_write".
@@ -221,14 +221,14 @@ module Module_type_nested :
   sig
     module M :
       sig
-        val x : 'a -> 'a @@ stateless
-        module N : sig val y : string ref @@ stateless end
+        val x : 'a -> 'a @@ stateless total
+        module N : sig val y : string ref @@ stateless total end
       end
     module M' :
       sig
-        val x : 'a -> 'a @@ stateless
-        module N : sig val y : string ref @@ stateless end
-      end @@ stateless contended
+        val x : 'a -> 'a @@ stateless total
+        module N : sig val y : string ref @@ stateless total end
+      end @@ stateless contended total
   end
 |}, Principal{|
 module Module_type_nested :
@@ -261,7 +261,7 @@ end
 [%%expect{|
 module Without_inclusion :
   sig module M : sig val x : 'a -> 'a @@ portable val y : 'a -> 'a end end @@
-  stateless nonportable
+  stateless nonportable total
 |}]
 
 module Without_inclusion = struct
@@ -289,6 +289,7 @@ end
 [%%expect{|
 module Inclusion_fail :
   sig module M : sig val x : string ref end @@ contended end @@ stateless
+  total
 |}]
 
 module Inclusion_fail = struct
@@ -306,11 +307,11 @@ Lines 4-6, characters 22-5:
 6 |   end
 Error: Signature mismatch:
        Modules do not match:
-         sig val x : string ref @@ stateless contended end @ uncontended
+         sig val x : string ref @@ stateless contended total end @ uncontended
        is not included in
          sig val x : string ref end @ uncontended
        Values do not match:
-         val x : string ref @@ stateless contended (* in a structure at uncontended *)
+         val x : string ref @@ stateless contended total (* in a structure at uncontended *)
        is not included in
          val x : string ref (* in a structure at uncontended *)
        The first is "contended"
@@ -359,7 +360,7 @@ end
 (* [M] is inferred to be [portable] in order to type check *)
 [%%expect{|
 module Inclusion_weakens_comonadic :
-  sig module M : sig val x : 'a -> 'a end end @@ stateless
+  sig module M : sig val x : 'a -> 'a end end @@ stateless total
 |}]
 
 module Inclusion_weakens_comonadic = struct
@@ -388,7 +389,7 @@ end
 (* CR layouts v2.8: fix principal case. Internal ticket 5111 *)
 [%%expect{|
 module Inclusion_match : sig module M : sig val x : int ref end end @@
-  stateless
+  stateless total
 |}]
 
 (* [foo] closes over [M.x] instead of [M]. This is better ergonomics. *)
@@ -403,7 +404,7 @@ end
 [%%expect{|
 module Close_over_value :
   sig module M : sig val x : 'a -> 'a end val foo : unit -> unit end @@
-  stateless
+  stateless total
 |}]
 
 (* CR mode-crossing: This is used for the below test in place of a mutable record. *)
@@ -415,7 +416,7 @@ end = struct
   let mk = ()
 end
 [%%expect {|
-module M : sig type t val mk : t @@ portable end @@ stateless
+module M : sig type t val mk : t @@ portable end @@ stateless total
 |}]
 
 module Close_over_value_monadic = struct
@@ -472,7 +473,7 @@ Lines 3-6, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           val x : 'a -> 'a @@ stateless nonportable
+           val x : 'a -> 'a @@ stateless nonportable total
            external length : string -> int = "%string_length"
          end @ nonportable
        is not included in
@@ -553,7 +554,7 @@ module N :
   sig
     module Plain : sig val f : int -> int end
     module type S_plain = sig module M : sig val f : int -> int end end
-  end @@ portable
+  end @@ portable total
 |}]
 
 (* This revised version of that example does not typecheck. It would be nice if
@@ -592,7 +593,7 @@ Lines 13-19, characters 6-3:
 Error: Signature mismatch:
        Modules do not match:
          sig
-           module Plain : sig val f : int -> int end
+           module Plain : sig val f : int -> int end @@ total
            module type S_plain =
              sig module M : sig val f : int -> int end end
          end @ nonportable
@@ -628,7 +629,7 @@ end = struct
   include (struct let foo x = x end : sig val foo : 'a -> 'a end)
 end
 [%%expect{|
-module M : sig val foo : 'a -> 'a @@ global many end @@ stateless
+module M : sig val foo : 'a -> 'a @@ global many end @@ stateless total
 |}]
 
 (* module declaration inclusion check looks at the mode of the enclosing
@@ -640,7 +641,7 @@ end = struct
 end
 [%%expect{|
 module M : sig module N : sig val foo : 'a -> 'a @@ global many end end @@
-  stateless
+  stateless total
 |}]
 
 (* inclusion check should cross modes, if we are comparing modes (instead of
@@ -651,7 +652,7 @@ end = struct
   let foo @ nonportable contended = 42
 end
 [%%expect{|
-module M : sig val foo : int @@ portable end @@ stateless
+module M : sig val foo : int @@ portable end @@ stateless total
 |}]
 
 (* The RHS type (expected type) is used for mode crossing. The following still
@@ -664,7 +665,7 @@ end = struct
   let t @ nonportable contended = 42
 end
 [%%expect{|
-module M : sig type t val t : t @@ portable end @@ stateless
+module M : sig type t val t : t @@ portable end @@ stateless total
 |}]
 
 (* LHS type is a subtype of RHS type, which means more type-level information.
@@ -677,7 +678,7 @@ end = struct
   let t @ nonportable contended = `Foo
 end
 [%%expect{|
-module M : sig val t : [ `Bar | `Foo ] @@ portable end @@ stateless
+module M : sig val t : [ `Bar | `Foo ] @@ portable end @@ stateless total
 |}]
 
 module M : sig
@@ -692,14 +693,14 @@ Lines 3-5, characters 6-3:
 5 | end
 Error: Signature mismatch:
        Modules do not match:
-         sig val t : [> `Foo ] @@ stateless nonportable end @ nonportable
+         sig val t : [> `Foo ] @@ stateless nonportable total end @ nonportable
        is not included in
          sig
            val t : [ `Bar of 'a -> 'a | `Baz of string ref | `Foo ] @@
              portable
          end @ nonportable
        Values do not match:
-         val t : [> `Foo ] @@ stateless nonportable (* in a structure at nonportable *)
+         val t : [> `Foo ] @@ stateless nonportable total (* in a structure at nonportable *)
        is not included in
          val t : [ `Bar of 'a -> 'a | `Baz of string ref | `Foo ] @@ portable (* in a structure at nonportable *)
        The first is "nonportable"
@@ -714,7 +715,7 @@ end
 module F :
   functor (M : sig val foo : 'a -> 'a end) ->
     sig module M' : sig val foo : 'a -> 'a @@ global many end end
-  @@ stateless
+  @@ stateless total
 |}]
 
 (* Similiar for recursive modules *)
@@ -734,12 +735,13 @@ module F (M : sig val f : 'a -> 'a @@ global many end) = struct
 end
 [%%expect{|
 module F : functor (M : sig val f : 'a -> 'a @@ global many end) -> sig end
-  @@ stateless
+  @@ stateless total
 |}]
 
 module G (M : sig val f : 'a -> 'a end) = F(M)
 [%%expect{|
 module G : functor (M : sig val f : 'a -> 'a end) -> sig end @@ stateless
+  total
 |}]
 
 (* Similiar for [include_functor] *)
@@ -749,7 +751,7 @@ module G (M : sig val f : 'a -> 'a end) = struct
 end
 [%%expect{|
 module G : functor (M : sig val f : 'a -> 'a end) -> sig val f : 'a -> 'a end
-  @@ stateless
+  @@ stateless total
 |}]
 
 (* functor declaration inclusion check  looks at the modes of parameter and
@@ -759,7 +761,7 @@ functor (M : sig val foo : 'a -> 'a @@ global many end) -> struct let bar = M.fo
 [%%expect{|
 module F :
   sig val foo : 'a -> 'a end -> sig val bar : 'a -> 'a @@ global many end @@
-  stateless
+  stateless total
 |}]
 
 (* CR zqian: package subtyping doesn't look at the package mode for simplicity.
@@ -955,7 +957,7 @@ end
 [%%expect{|
 module M :
   sig module type F = sig val foo : 'a @@ global many end -> sig end end @@
-  stateless
+  stateless total
 |}]
 
 module M : sig
@@ -967,7 +969,7 @@ end = struct
 end
 [%%expect{|
 module M : sig module type F = sig end -> sig val foo : 'a end end @@
-  stateless
+  stateless total
 |}]
 
 module type T = sig @@ portable
@@ -1014,7 +1016,7 @@ module F (X : SL) : SR = X
 [%%expect{|
 module type SR = sig end
 module type SL = sig end
-module F : functor (X : SL) -> SR @@ stateless
+module F : functor (X : SL) -> SR @@ stateless total
 |}]
 
 
@@ -1028,7 +1030,8 @@ module M_portable = struct
     end
 [%%expect{|
 module M_nonportable : sig val f : unit -> unit end @@ stateless nonportable
-module M_portable : sig val f : unit -> unit end @@ stateless
+  total
+module M_portable : sig val f : unit -> unit end @@ stateless total
 |}]
 
 let (foo @ portable) () =
@@ -1356,7 +1359,7 @@ let (bar @ portable) () =
   k
 [%%expect{|
 module type F = sig end -> sig end
-module F : functor (X : sig end) -> sig end @@ stateless nonportable
+module F : functor (X : sig end) -> sig end @@ stateless nonportable total
 Line 4, characters 18-19:
 4 |   let k = (module F : F) in
                       ^
@@ -1374,7 +1377,7 @@ let (bar @ portable) () =
   k
 [%%expect{|
 module type F = sig end -> sig end
-module F : functor (X : sig end) -> sig end @@ stateless
+module F : functor (X : sig end) -> sig end @@ stateless total
 val bar : unit -> (module F) = <fun>
 |}]
 
@@ -1440,7 +1443,8 @@ let (f @ portable) () =
   ()
 [%%expect{|
 module F : functor (X : sig end) -> sig type t = string end @@ stateless
-module X : sig end @@ stateless
+  total
+module X : sig end @@ stateless total
 val f : unit -> unit = <fun>
 |}]
 
@@ -1525,6 +1529,7 @@ end = struct
 end
 [%%expect{|
 module M : sig module type S = sig module N : sig end end end @@ stateless
+  total
 |}]
 
 (* class makes a structure to be nonportable *)

--- a/testsuite/tests/typing-modes/val_modalities.ml
+++ b/testsuite/tests/typing-modes/val_modalities.ml
@@ -168,12 +168,12 @@ Error: Signature mismatch:
          sig
            val y : int ref
            val z : 'a -> 'a
-           val x : 'a -> 'a @@ stateless
+           val x : 'a -> 'a @@ stateless total
          end @ stateful
        Values do not match:
          val x : 'a -> 'a (* in a structure at stateful *)
        is not included in
-         val x : 'a -> 'a @@ stateless (* in a structure at stateful *)
+         val x : 'a -> 'a @@ stateless total (* in a structure at stateful *)
        The first is "stateful"
          because it contains a usage (of the value "y" at line 11, characters 29-30)
          which is expected to be "read_write".
@@ -235,14 +235,14 @@ module Module_type_nested :
   sig
     module M :
       sig
-        val x : 'a -> 'a @@ stateless
+        val x : 'a -> 'a @@ stateless total
         module N : sig val y : string ref end
       end
     module M' :
       sig
-        val x : 'a -> 'a @@ stateless
+        val x : 'a -> 'a @@ stateless total
         module N : sig val y : string ref end
-      end @@ stateless contended
+      end @@ stateless contended total
   end
 |}]
 

--- a/testsuite/tests/typing-modules/aliases.ml
+++ b/testsuite/tests/typing-modules/aliases.ml
@@ -538,7 +538,8 @@ module A1 : sig end
 module A2 : sig end
 module L1 : sig module X = A1 end
 module L2 : sig module X = A2 end
-module F : functor (L : sig module X : sig end @@ stateless end) -> sig end
+module F :
+  functor (L : sig module X : sig end @@ stateless total end) -> sig end
 module F1 : sig end
 module F2 : sig end
 |}];;
@@ -667,7 +668,7 @@ module type S =
     module P : sig module I = N.I @@ portable end
     module Q :
       sig type wrap' = wrap = W of (Set.Make(Int).t, Set.Make(P.I).t) eq end
-      @@ stateless
+      @@ stateless total
   end
 |}];;
 
@@ -697,7 +698,7 @@ module type S =
       end
     module Q :
       sig type wrap' = wrap = W of (Set.Make(Int).t, Set.Make(N.I).t) eq end
-      @@ stateless
+      @@ stateless total
   end
 |}];;
 
@@ -859,11 +860,11 @@ Lines 4-6, characters 6-3:
 6 | end..
 Error: Signature mismatch:
        Modules do not match:
-         sig module type S = sig module N = X.N @@ stateless end end
+         sig module type S = sig module N = X.N @@ stateless total end end
        is not included in
          sig module type S = sig module N = X.N end end
        Module type declarations do not match:
-         module type S = sig module N = X.N @@ stateless end
+         module type S = sig module N = X.N @@ stateless total end
        does not match
          module type S = sig module N = X.N end
        The second module type is not included in the first
@@ -871,7 +872,7 @@ Error: Signature mismatch:
        Module types do not match:
          sig module N = X.N end
        is not equal to
-         sig module N = X.N @@ stateless end
+         sig module N = X.N @@ stateless total end
        At position "module type S = <here>"
        Modalities on N do not match:
        The second is stateless and the first is not.

--- a/testsuite/tests/typing-modules/nondep_private_abbrev.ml
+++ b/testsuite/tests/typing-modules/nondep_private_abbrev.ml
@@ -150,5 +150,6 @@ module I : functor (X : sig end) -> sig type t = Priv(X).t end
 
 module IndirectPriv = I(struct end);;
 [%%expect{|
-module IndirectPriv : sig type t : value non_float mod immutable with int end
+module IndirectPriv :
+  sig type t : value non_float mod immutable logical with int end
 |}]

--- a/testsuite/tests/typing-modules/pr7726.ml
+++ b/testsuite/tests/typing-modules/pr7726.ml
@@ -62,7 +62,7 @@ module M :
   end
 module type S =
   sig
-    module F : functor (X : T) -> T @@ stateless
+    module F : functor (X : T) -> T @@ stateless total
     module rec Fixed : sig type t = F(Fixed).t end
   end
 module Id : functor (X : T) -> sig type t = X.t end

--- a/testsuite/tests/typing-modules/pr7787.ml
+++ b/testsuite/tests/typing-modules/pr7787.ml
@@ -37,7 +37,7 @@ end = struct
 end;;
 [%%expect{|
 module rec M : sig val go : unit -> int end
-and T2 : sig module N = T.N @@ portable end
+and T2 : sig module N = T.N @@ portable total end
 |}]
 
 let () = ignore (M.go ())

--- a/testsuite/tests/typing-unique/rbtree.ml
+++ b/testsuite/tests/typing-unique/rbtree.ml
@@ -503,7 +503,7 @@ module Make_Okasaki :
       val balance_left : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
       val balance_right : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
       val ins : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
-      val set_black : ('a, 'b) tree -> ('a, 'b) tree @@ stateless
+      val set_black : ('a, 'b) tree -> ('a, 'b) tree @@ stateless total
       val insert : Ord.t -> 'a -> (Ord.t, 'a) tree -> (Ord.t, 'a) tree
     end
 Line 110, characters 16-52:

--- a/testsuite/tests/typing-warnings/pr7553.ml
+++ b/testsuite/tests/typing-warnings/pr7553.ml
@@ -48,5 +48,6 @@ Line 4, characters 6-12:
           ^^^^^^
 Warning 33 [unused-open]: unused open "A".
 
-module rec D : sig module M : sig module X : sig end @@ stateless end end
+module rec D :
+  sig module M : sig module X : sig end @@ stateless total end end
 |}]

--- a/testsuite/tests/typing-zero-alloc/signatures.ml
+++ b/testsuite/tests/typing-zero-alloc/signatures.ml
@@ -866,7 +866,7 @@ end
 [%%expect{|
 module M_base_for_mto : sig val f : int -> int [@@zero_alloc] end
 module type S_base_mto =
-  sig val f : int -> int @@ portable [@@zero_alloc] end
+  sig val f : int -> int @@ portable total [@@zero_alloc] end
 module M_mto_base_good : S_base_mto
 Lines 11-13, characters 37-3:
 11 | .....................................struct
@@ -880,7 +880,7 @@ Error: Signature mismatch:
        Values do not match:
          val f : int -> int [@@zero_alloc opt]
        is not included in
-         val f : int -> int @@ portable [@@zero_alloc]
+         val f : int -> int @@ portable total [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
@@ -901,7 +901,7 @@ end
 [%%expect{|
 module M_strict_for_mto : sig val f : int -> int [@@zero_alloc strict] end
 module type S_strict_mto =
-  sig val f : int -> int @@ portable [@@zero_alloc strict] end
+  sig val f : int -> int @@ portable total [@@zero_alloc strict] end
 module M_mto_strict_good : S_strict_mto
 Lines 11-13, characters 41-3:
 11 | .........................................struct
@@ -915,7 +915,7 @@ Error: Signature mismatch:
        Values do not match:
          val f : int -> int [@@zero_alloc]
        is not included in
-         val f : int -> int @@ portable [@@zero_alloc strict]
+         val f : int -> int @@ portable total [@@zero_alloc strict]
        The former provides a weaker "zero_alloc" guarantee than the latter.
 |}]
 
@@ -940,10 +940,10 @@ module type S_no_nrn = module type of M_nrn_for_mto
 [%%expect{|
 module M_assume_for_mto : sig val f : int -> int * int [@@zero_alloc] end
 module type S_no_assume =
-  sig val f : int -> int * int @@ portable [@@zero_alloc] end
+  sig val f : int -> int * int @@ portable total [@@zero_alloc] end
 module M_nrn_for_mto : sig val f : int -> int * int [@@zero_alloc] end
 module type S_no_nrn =
-  sig val f : int -> int * int @@ portable [@@zero_alloc] end
+  sig val f : int -> int * int @@ portable total [@@zero_alloc] end
 |}]
 
 (**********************************************)
@@ -1051,8 +1051,8 @@ module type S = module type of M_infer2
 [%%expect{|
 module type S =
   sig
-    val f : 'a -> 'a @@ stateless [@@zero_alloc strict]
-    val g : 'a -> 'a @@ stateless [@@zero_alloc]
+    val f : 'a -> 'a @@ stateless total [@@zero_alloc strict]
+    val g : 'a -> 'a @@ stateless total [@@zero_alloc]
   end
 |}]
 
@@ -1133,7 +1133,7 @@ module M_explicit_arity_2 : sig type t = int -> int val f : int -> t end
 module type S =
   sig
     type t = int -> int
-    val f : int -> t @@ stateless [@@zero_alloc arity 2]
+    val f : int -> t @@ stateless total [@@zero_alloc arity 2]
   end
 |}]
 
@@ -1153,7 +1153,7 @@ end
 module type S = module type of M_for_mto
 [%%expect{|
 module M_for_mto : sig val f : int -> int end
-module type S = sig val f : int -> int @@ portable end
+module type S = sig val f : int -> int @@ portable total end
 |}]
 
 (* [S] itself is fixed. *)
@@ -1164,11 +1164,11 @@ Line 1, characters 61-62:
                                                                  ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : int -> int @@ portable end
+         sig val f : int -> int @@ portable total end
        is not included in
          sig val f : int -> int [@@zero_alloc] end
        Values do not match:
-         val f : int -> int @@ portable
+         val f : int -> int @@ portable total
        is not included in
          val f : int -> int [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.
@@ -1185,18 +1185,18 @@ module type S' = module type of M_for_mto
 module F' (X : S') : sig val[@zero_alloc] f : int -> int end = X
 module F (X : S) : sig val[@zero_alloc] f : int -> int end = X
 [%%expect{|
-module type S' = sig val f : int -> int @@ portable [@@zero_alloc] end
+module type S' = sig val f : int -> int @@ portable total [@@zero_alloc] end
 module F' : functor (X : S') -> sig val f : int -> int [@@zero_alloc] end
 Line 7, characters 61-62:
 7 | module F (X : S) : sig val[@zero_alloc] f : int -> int end = X
                                                                  ^
 Error: Signature mismatch:
        Modules do not match:
-         sig val f : int -> int @@ portable end
+         sig val f : int -> int @@ portable total end
        is not included in
          sig val f : int -> int [@@zero_alloc] end
        Values do not match:
-         val f : int -> int @@ portable
+         val f : int -> int @@ portable total
        is not included in
          val f : int -> int [@@zero_alloc]
        The former provides a weaker "zero_alloc" guarantee than the latter.

--- a/testsuite/tests/vox/totality.ml
+++ b/testsuite/tests/vox/totality.ml
@@ -299,7 +299,10 @@ let uses_while @ total = fun () -> while false do () done
 Line 1, characters 35-57:
 1 | let uses_while @ total = fun () -> while false do () done
                                        ^^^^^^^^^^^^^^^^^^^^^^
-Error: The function is "partial" but is expected to be "total".
+Error: The function is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 25-57
+         which is expected to be "total".
 |}]
 let uses_while = fun () -> while false do () done
 [%%expect{|
@@ -311,7 +314,10 @@ let uses_for @ total = fun () -> for _i = 0 to 10 do () done
 Line 1, characters 33-60:
 1 | let uses_for @ total = fun () -> for _i = 0 to 10 do () done
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The function is "partial" but is expected to be "total".
+Error: The function is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 23-60
+         which is expected to be "total".
 |}]
 let uses_for = fun () -> for _i = 0 to 10 do () done
 [%%expect{|
@@ -325,7 +331,10 @@ type mrec = { mutable x : int; }
 Line 2, characters 46-54:
 2 | let uses_setfield @ total = fun (r : mrec) -> r.x <- 1
                                                   ^^^^^^^^
-Error: The function is "partial" but is expected to be "total".
+Error: The function is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 2, characters 28-54
+         which is expected to be "total".
 |}]
 let uses_setfield = fun (r : mrec) -> r.x <- 1
 [%%expect{|
@@ -364,7 +373,10 @@ let uses_assert @ total = fun x -> assert (x > 0)
 Line 1, characters 35-49:
 1 | let uses_assert @ total = fun x -> assert (x > 0)
                                        ^^^^^^^^^^^^^^
-Error: The function is "partial" but is expected to be "total".
+Error: The function is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 26-49
+         which is expected to be "total".
 |}]
 let uses_assert = fun x -> assert (x > 0)
 [%%expect{|
@@ -383,7 +395,10 @@ Warning 8 [partial-match]: this pattern-matching is not exhaustive.
 Line 1, characters 52-76:
 1 | let partial_match @ total = fun (x : int option) -> match x with Some y -> y
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^
-Error: The function is "partial" but is expected to be "total".
+Error: The function is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 28-76
+         which is expected to be "total".
 |}]
 let exhaustive_match @ total = fun (x : int option) ->
   match x with Some y -> y | None -> 0
@@ -433,7 +448,19 @@ end
 Line 3, characters 51-57:
 3 |   method set_via_total = let f @ total = fun () -> v <- 1 in f ()
                                                        ^^^^^^
-Error: The function is "partial" but is expected to be "total".
+Error: The function is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 3, characters 41-57
+         which is expected to be "total".
+|}]
+
+(* [try] itself is not an effect form: catching does not diverge, and a body
+   that could raise is already partial. *)
+exception E
+let uses_try @ total = fun () -> try 1 with E -> 2
+[%%expect{|
+exception E
+val uses_try : unit -> int = <fun>
 |}]
 
 (* ------------------------------------------------------------------ *)
@@ -474,6 +501,8 @@ Line 2, characters 17-19:
 Error: The value "go" is "partial"
        but is expected to be "total"
          because it is used inside the function at line 2, characters 13-21
+         which is expected to be "total"
+         because it is used inside the function at lines 1-3, characters 24-6
          which is expected to be "total".
 |}]
 
@@ -528,6 +557,8 @@ Line 2, characters 49-52:
 Error: The value "odd" is "partial"
        but is expected to be "total"
          because it is used inside the function at line 2, characters 15-60
+         which is expected to be "total"
+         because it is used inside the function at lines 1-4, characters 21-9
          which is expected to be "total".
 |}]
 

--- a/testsuite/tests/vox/totality.ml
+++ b/testsuite/tests/vox/totality.ml
@@ -1,0 +1,494 @@
+(* TEST
+ expect;
+*)
+
+(* Tests for the totality and logicality mode axes.
+
+   Totality (comonadic): total < partial, legacy partial.
+   Logicality (monadic): physical < logical, legacy physical.
+   The two are a comonadic/monadic pair like portability and contention. *)
+
+(* ------------------------------------------------------------------ *)
+(* Submoding both ways on each axis. *)
+
+let f (g @ total) = g 0
+let g_total @ total = fun x -> x + 1
+let _ = f g_total (* total accepted where partial is expected, via [f]'s use *)
+[%%expect{|
+val f : (int -> 'a) @ total -> 'a = <fun>
+val g_total : int -> int = <fun>
+- : int = 1
+|}]
+
+(* partial rejected where total is expected *)
+let g_partial = fun x -> x + 1
+let _ = f g_partial
+[%%expect{|
+val g_partial : int -> int = <fun>
+Line 2, characters 10-19:
+2 | let _ = f g_partial
+              ^^^^^^^^^
+Error: This value is "partial" but is expected to be "total".
+|}]
+
+(* physical accepted where logical is expected *)
+let uses_logical (_x @ logical) = ()
+let phys = 42
+let _ = uses_logical phys
+[%%expect{|
+val uses_logical : 'a @ logical -> unit = <fun>
+val phys : int = 42
+- : unit = ()
+|}]
+
+(* logical rejected where physical is expected, on a type that does not
+   cross logicality *)
+let wants_physical (x @ physical) = ignore x
+let use_logical_ref (r @ logical) = wants_physical r
+[%%expect{|
+val wants_physical : 'a -> unit = <fun>
+Line 2, characters 51-52:
+2 | let use_logical_ref (r @ logical) = wants_physical r
+                                                       ^
+Error: This value is "logical" but is expected to be "physical".
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* Defaults: an unannotated value is partial and physical, and prints as it
+   does today. *)
+
+let unannotated = fun x -> x
+[%%expect{|
+val unannotated : 'a -> 'a = <fun>
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* Crossing positives: a logical int and a logical arrow used at physical. *)
+
+let cross_int (x : int @ logical) = wants_physical x
+let cross_arrow (f : (int -> int) @ logical) = wants_physical f
+[%%expect{|
+val cross_int : int @ logical -> unit = <fun>
+val cross_arrow : (int -> int) @ logical -> unit = <fun>
+|}]
+
+(* Crossing negatives: an int ref and an Atomic.t stay logical. *)
+
+let no_cross_ref (r : int ref @ logical) = wants_physical r
+[%%expect{|
+Line 1, characters 58-59:
+1 | let no_cross_ref (r : int ref @ logical) = wants_physical r
+                                                              ^
+Error: This value is "logical" but is expected to be "physical".
+|}]
+
+let no_cross_atomic (a : int Atomic.t @ logical) = wants_physical a
+[%%expect{|
+Line 1, characters 66-67:
+1 | let no_cross_atomic (a : int Atomic.t @ logical) = wants_physical a
+                                                                      ^
+Error: This value is "logical" but is expected to be "physical".
+|}]
+
+(* A type crosses totality when it has no functions. *)
+let cross_totality_int (x : int) = f (fun _ -> x)
+[%%expect{|
+val cross_totality_int : int -> int = <fun>
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* Modality position. *)
+
+module M : sig
+  val empty : int list @@ total
+  val logical_int : int @@ logical
+end = struct
+  let empty @ total = []
+  let logical_int @ logical = 42
+end
+[%%expect{|
+module M :
+  sig val empty : int list @@ total val logical_int : int @@ logical end
+|}]
+
+(* [@@ physical] does not exist; the Physical end is spelled [nonlogical]. *)
+module type S = sig
+  val x : int @@ physical
+end
+[%%expect{|
+Line 2, characters 17-25:
+2 |   val x : int @@ physical
+                     ^^^^^^^^
+Error: Unrecognized modality physical.
+|}]
+
+module type S = sig
+  val x : int ref @@ nonlogical
+end
+[%%expect{|
+Line 2, characters 21-31:
+2 |   val x : int ref @@ nonlogical
+                         ^^^^^^^^^^
+Warning 220 [redundant-modality]: This modality is redundant.
+
+module type S = sig val x : int ref end
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* Kind modifiers. *)
+
+type t_total : value mod total
+type t_logical : value mod logical
+[%%expect{|
+type t_total : value mod total
+type t_logical : value mod logical
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* The allowlist: primitives on the allowlist are total. *)
+
+let increment @ total = fun x -> x + 1
+[%%expect{|
+val increment : int -> int = <fun>
+|}]
+
+(* A closure calling a partial function is rejected at [@ total]. *)
+let calls_partial @ total = fun () -> g_partial 0
+[%%expect{|
+Line 1, characters 38-47:
+1 | let calls_partial @ total = fun () -> g_partial 0
+                                          ^^^^^^^^^
+Error: The value "g_partial" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 28-49
+         which is expected to be "total".
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* The capture bump: the pair working together. *)
+
+(* A total closure capturing a partial value: rejected.  The parameter must
+   be pinned partial, otherwise inference strengthens it to total. *)
+let capture_partial (h @ partial) =
+  f (fun x -> h (); x)
+[%%expect{|
+Line 2, characters 14-15:
+2 |   f (fun x -> h (); x)
+                  ^
+Error: The value "h" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 2, characters 4-22
+         which is expected to be "total".
+|}]
+
+(* A total closure capturing an int ref and reading it: the capture arrives
+   logical, and the read needs physical.  The read is a direct mutable-field
+   projection; going through [!] would instead report [!] itself as partial. *)
+let capture_ref (r : int ref) =
+  f (fun _ -> r.contents)
+[%%expect{|
+Line 2, characters 14-15:
+2 |   f (fun _ -> r.contents)
+                  ^
+Error: This value is "logical"
+         because it is used inside the function at line 2, characters 4-25
+         which is expected to be "total".
+       However, the highlighted expression is expected to be "physical"
+         because its mutable field "contents" is being read.
+|}]
+
+(* The same closure capturing an int: accepted, because int crosses
+   logicality. *)
+let capture_int (n : int) =
+  f (fun _ -> n)
+[%%expect{|
+val capture_int : int -> int = <fun>
+|}]
+
+(* The portability/contention twin behaves identically on the same fixture:
+   a portable closure capturing an int ref and reading it is rejected because
+   the capture arrives contended. *)
+let wants_portable (g : (int -> int) @ portable) = g 0
+let capture_ref_portable (r : int ref) =
+  wants_portable (fun _ -> r.contents)
+[%%expect{|
+val wants_portable : (int -> int) @ portable -> int = <fun>
+Line 3, characters 27-28:
+3 |   wants_portable (fun _ -> r.contents)
+                               ^
+Error: This value is "contended"
+         because it is used inside the function at line 3, characters 17-38
+         which is expected to be "portable".
+       However, the highlighted expression is expected to be "shared" or "uncontended"
+         because its mutable field "contents" is being read.
+|}]
+
+(* Reading or writing a mutable field through a logical value is rejected,
+   much as through a contended value. *)
+let read_logical (r @ logical) = (r : int ref).contents
+[%%expect{|
+Line 1, characters 34-35:
+1 | let read_logical (r @ logical) = (r : int ref).contents
+                                      ^
+Error: This value is "logical"
+       but is expected to be "physical"
+         because its mutable field "contents" is being read.
+|}]
+
+let write_logical (r @ logical) = (r : int ref).contents <- 1
+[%%expect{|
+Line 1, characters 35-36:
+1 | let write_logical (r @ logical) = (r : int ref).contents <- 1
+                                       ^
+Error: This value is "logical"
+       but is expected to be "physical"
+         because its mutable field "contents" is being written.
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* Effects: each rejected at [@ total], and accepted without the
+   annotation. *)
+
+let uses_ref @ total = fun () -> ref 0
+[%%expect{|
+Line 1, characters 33-36:
+1 | let uses_ref @ total = fun () -> ref 0
+                                     ^^^
+Error: The value "ref" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 23-38
+         which is expected to be "total".
+|}]
+let uses_ref = fun () -> ref 0
+[%%expect{|
+val uses_ref : unit -> int ref = <fun>
+|}]
+
+let uses_deref @ total = fun (r : int ref) -> !r
+[%%expect{|
+Line 1, characters 46-47:
+1 | let uses_deref @ total = fun (r : int ref) -> !r
+                                                  ^
+Error: The value "(!)" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 25-48
+         which is expected to be "total".
+|}]
+let uses_deref = fun (r : int ref) -> !r
+[%%expect{|
+val uses_deref : int ref -> int = <fun>
+|}]
+
+let uses_assign @ total = fun (r : int ref) -> r := 1
+[%%expect{|
+Line 1, characters 49-51:
+1 | let uses_assign @ total = fun (r : int ref) -> r := 1
+                                                     ^^
+Error: The value "(:=)" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 26-53
+         which is expected to be "total".
+|}]
+let uses_assign = fun (r : int ref) -> r := 1
+[%%expect{|
+val uses_assign : int ref -> unit = <fun>
+|}]
+
+let uses_while @ total = fun () -> while false do () done
+[%%expect{|
+Line 1, characters 35-57:
+1 | let uses_while @ total = fun () -> while false do () done
+                                       ^^^^^^^^^^^^^^^^^^^^^^
+Error: The function is "partial" but is expected to be "total".
+|}]
+let uses_while = fun () -> while false do () done
+[%%expect{|
+val uses_while : unit -> unit = <fun>
+|}]
+
+let uses_for @ total = fun () -> for _i = 0 to 10 do () done
+[%%expect{|
+Line 1, characters 33-60:
+1 | let uses_for @ total = fun () -> for _i = 0 to 10 do () done
+                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The function is "partial" but is expected to be "total".
+|}]
+let uses_for = fun () -> for _i = 0 to 10 do () done
+[%%expect{|
+val uses_for : unit -> unit = <fun>
+|}]
+
+type mrec = { mutable x : int }
+let uses_setfield @ total = fun (r : mrec) -> r.x <- 1
+[%%expect{|
+type mrec = { mutable x : int; }
+Line 2, characters 46-54:
+2 | let uses_setfield @ total = fun (r : mrec) -> r.x <- 1
+                                                  ^^^^^^^^
+Error: The function is "partial" but is expected to be "total".
+|}]
+let uses_setfield = fun (r : mrec) -> r.x <- 1
+[%%expect{|
+val uses_setfield : mrec -> unit = <fun>
+|}]
+
+let uses_array_set @ total = fun (a : int array) -> a.(0) <- 1
+[%%expect{|
+Line 1, characters 52-62:
+1 | let uses_array_set @ total = fun (a : int array) -> a.(0) <- 1
+                                                        ^^^^^^^^^^
+Error: The value "Array.set" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 29-62
+         which is expected to be "total".
+|}]
+let uses_array_set = fun (a : int array) -> a.(0) <- 1
+[%%expect{|
+val uses_array_set : int array -> unit = <fun>
+|}]
+
+(* A closure capturing a partial value from an outer scope. *)
+let outer_partial (h @ partial) @ total = fun () -> fun () -> h ()
+[%%expect{|
+Line 1, characters 62-63:
+1 | let outer_partial (h @ partial) @ total = fun () -> fun () -> h ()
+                                                                  ^
+Error: The value "h" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 42-66
+         which is expected to be "total".
+|}]
+
+let uses_assert @ total = fun x -> assert (x > 0)
+[%%expect{|
+Line 1, characters 35-49:
+1 | let uses_assert @ total = fun x -> assert (x > 0)
+                                       ^^^^^^^^^^^^^^
+Error: The function is "partial" but is expected to be "total".
+|}]
+let uses_assert = fun x -> assert (x > 0)
+[%%expect{|
+val uses_assert : int -> unit = <fun>
+|}]
+
+(* A non-exhaustive match can raise [Match_failure]. *)
+let partial_match @ total = fun (x : int option) -> match x with Some y -> y
+[%%expect{|
+Line 1, characters 52-76:
+1 | let partial_match @ total = fun (x : int option) -> match x with Some y -> y
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^^
+Warning 8 [partial-match]: this pattern-matching is not exhaustive.
+  Here is an example of a case that is not matched: "None"
+
+Line 1, characters 52-76:
+1 | let partial_match @ total = fun (x : int option) -> match x with Some y -> y
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^^
+Error: The function is "partial" but is expected to be "total".
+|}]
+let exhaustive_match @ total = fun (x : int option) ->
+  match x with Some y -> y | None -> 0
+[%%expect{|
+val exhaustive_match : int option -> int = <fun>
+|}]
+
+(* ------------------------------------------------------------------ *)
+(* Recursion. *)
+
+let rec looper x = looper x
+let _ = f looper
+[%%expect{|
+val looper : 'a -> 'b = <fun>
+Line 2, characters 10-16:
+2 | let _ = f looper
+              ^^^^^^
+Error: This value is "partial" but is expected to be "total".
+|}]
+
+(* The boundary case: a top-level recursive function captured into a total
+   closure. *)
+let capture_rec @ total = fun x -> looper x
+[%%expect{|
+Line 1, characters 35-41:
+1 | let capture_rec @ total = fun x -> looper x
+                                       ^^^^^^
+Error: The value "looper" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 26-43
+         which is expected to be "total".
+|}]
+
+(* The hereditary case: the same [let rec] written locally inside a total
+   closure, where the self-reference never crosses a capture boundary. *)
+let local_rec @ total = fun () ->
+  let rec go x = go x in
+  go 0
+[%%expect{|
+Line 2, characters 17-19:
+2 |   let rec go x = go x in
+                     ^^
+Error: The value "go" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 2, characters 13-21
+         which is expected to be "total".
+|}]
+
+(* A let-bound function literal inside a total closure, which the
+   expected-mode edge does not reach: the literal itself is fine (and total),
+   so this is accepted. *)
+let let_bound_literal @ total = fun () ->
+  let id = fun x -> x in
+  id 0
+[%%expect{|
+val let_bound_literal : unit -> int = <fun>
+|}]
+
+(* ... but a let-bound literal with a partial body is rejected. *)
+let let_bound_partial @ total = fun () ->
+  let bad = fun () -> ref 0 in
+  bad
+[%%expect{|
+Line 2, characters 22-25:
+2 |   let bad = fun () -> ref 0 in
+                          ^^^
+Error: The value "ref" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at lines 1-3, characters 32-5
+         which is expected to be "total".
+|}]
+
+(* Mutual recursion.  Written with [match] rather than [=] so that the only
+   partiality source is the recursion itself. *)
+let mutual @ total = fun () ->
+  let rec even x = match x with 0 -> true | n -> odd (n - 1)
+  and odd x = match x with 0 -> false | n -> even (n - 1) in
+  even 10
+[%%expect{|
+Line 2, characters 49-52:
+2 |   let rec even x = match x with 0 -> true | n -> odd (n - 1)
+                                                     ^^^
+Error: The value "odd" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 2, characters 15-60
+         which is expected to be "total".
+|}]
+
+(* A recursive function that is only returned, never applied, still makes the
+   closure partial: the closure returns a partial value it captured. *)
+let returns_rec @ total = fun () -> looper
+[%%expect{|
+Line 1, characters 36-42:
+1 | let returns_rec @ total = fun () -> looper
+                                        ^^^^^^
+Error: The value "looper" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 26-42
+         which is expected to be "total".
+|}]
+
+(* An arrow-free recursive value crosses totality at its use sites. *)
+let rec one = 1
+let use_one @ total = fun () -> one
+[%%expect{|
+val one : int = 1
+val use_one : unit -> int = <fun>
+|}]

--- a/testsuite/tests/vox/totality.ml
+++ b/testsuite/tests/vox/totality.ml
@@ -392,6 +392,51 @@ val exhaustive_match : int option -> int = <fun>
 |}]
 
 (* ------------------------------------------------------------------ *)
+(* Totality is capture-based: parameters are not captures.  A total closure
+   may call a partial parameter, read mutable state through a parameter, or
+   send a message to a parameter object.  Termination of calls from the total
+   fragment still follows compositionally, because a total context can only
+   supply total (and logical) arguments.  The portability/contention twin
+   behaves identically on all three shapes. *)
+
+let calls_partial_param @ total = fun (h @ partial) -> h ()
+let calls_nonportable_param @ portable = fun (h @ nonportable) -> h ()
+[%%expect{|
+val calls_partial_param : (unit -> 'a) -> 'a = <fun>
+val calls_nonportable_param : (unit -> 'a) -> 'a = <fun>
+|}]
+
+let reads_param @ total = fun (r : int ref) -> r.contents
+[%%expect{|
+val reads_param : int ref -> int = <fun>
+|}]
+
+(* ... but a total context cannot supply the partial argument such a function
+   would need to go wrong. *)
+let _ @ total = fun () -> calls_partial_param g_partial
+[%%expect{|
+Line 1, characters 46-55:
+1 | let _ @ total = fun () -> calls_partial_param g_partial
+                                                  ^^^^^^^^^
+Error: The value "g_partial" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 1, characters 16-55
+         which is expected to be "total".
+|}]
+
+(* Instance-variable assignment constrains enclosing closures. *)
+class has_ivar = object
+  val mutable v = 0
+  method set_via_total = let f @ total = fun () -> v <- 1 in f ()
+end
+[%%expect{|
+Line 3, characters 51-57:
+3 |   method set_via_total = let f @ total = fun () -> v <- 1 in f ()
+                                                       ^^^^^^
+Error: The function is "partial" but is expected to be "total".
+|}]
+
+(* ------------------------------------------------------------------ *)
 (* Recursion. *)
 
 let rec looper x = looper x
@@ -456,6 +501,20 @@ Error: The value "ref" is "partial"
          which is expected to be "total".
 |}]
 
+(* The whole recursive group sits at partial, including a member that never
+   refers to the group: the group shares one mode variable. *)
+let rec rec_member x = rec_member x
+and plain_member x = x
+let _ = f plain_member
+[%%expect{|
+val rec_member : 'a -> 'b = <fun>
+val plain_member : 'a -> 'a = <fun>
+Line 3, characters 10-22:
+3 | let _ = f plain_member
+              ^^^^^^^^^^^^
+Error: This value is "partial" but is expected to be "total".
+|}]
+
 (* Mutual recursion.  Written with [match] rather than [=] so that the only
    partiality source is the recursion itself. *)
 let mutual @ total = fun () ->
@@ -482,6 +541,38 @@ Line 1, characters 36-42:
 Error: The value "looper" is "partial"
        but is expected to be "total"
          because it is used inside the function at line 1, characters 26-42
+         which is expected to be "total".
+|}]
+
+(* KNOWN GAP (see the design doc's decision log): a recursive module's
+   signature can claim [@@ total] and the claim justifies its own recursive
+   call, because the body is checked against the declared signature.
+   Termination is inductive, so this self-assumption is unsound; fixing it
+   needs the recursive-approximation environment to weaken totality
+   modalities, a follow-up. This fixture pins the current behaviour so the
+   fix shows up as a diff here. *)
+module rec MRec : sig val loop : int -> int @@ total end = struct
+  let loop x = MRec.loop x
+end
+let uses_rec_module @ total = fun () -> MRec.loop 0
+[%%expect{|
+module rec MRec : sig val loop : int -> int @@ total end
+val uses_rec_module : unit -> int = <fun>
+|}]
+
+(* Without the modality claim, the recursive module's value stays partial. *)
+module rec NRec : sig val loop : int -> int end = struct
+  let loop x = NRec.loop x
+end
+let uses_rec_module2 @ total = fun () -> NRec.loop 0
+[%%expect{|
+module rec NRec : sig val loop : int -> int end
+Line 4, characters 41-50:
+4 | let uses_rec_module2 @ total = fun () -> NRec.loop 0
+                                             ^^^^^^^^^
+Error: The value "NRec.loop" is "partial"
+       but is expected to be "total"
+         because it is used inside the function at line 4, characters 31-52
          which is expected to be "total".
 |}]
 

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -14,8 +14,8 @@
 
 (* Axis lattice: efficient bitfield encoding of jkind axes.
 
-   This module packs 11 axes into an OCaml immediate-sized integer. The axes
-   are indexed 0-10 and their values are ordered from most restrictive (0) to
+   This module packs 13 axes into an OCaml immediate-sized integer. The axes
+   are indexed 0-12 and their values are ordered from most restrictive (0) to
    least restrictive (max).
 
    Axis layout (index, name, values from level 0 to max):
@@ -23,16 +23,18 @@
    1. Uniqueness (monadic): Aliased -> Unique
    2. Linearity: Many -> Once
    3. Contention (monadic): Contended -> Corrupted / Shared -> Uncontended
-   4. Portability: Portable -> Shareable / Corruptible -> Nonportable
-   5. Forkable: Forkable -> Unforkable
-   6. Yielding: Unyielding -> Yielding
-   7. Statefulness: Stateless -> Writing / Reading -> Stateful
-   8. Visibility (monadic): Immutable -> Read / Write -> Read_write
-   9. Staticity (monadic): Dynamic -> Static
-   10. Externality: External -> External64 -> Internal
+   4. Logicality (monadic): Logical -> Physical
+   5. Portability: Portable -> Shareable / Corruptible -> Nonportable
+   6. Totality: Total -> Partial
+   7. Forkable: Forkable -> Unforkable
+   8. Yielding: Unyielding -> Yielding
+   9. Statefulness: Stateless -> Writing / Reading -> Stateful
+   10. Visibility (monadic): Immutable -> Read / Write -> Read_write
+   11. Staticity (monadic): Dynamic -> Static
+   12. Externality: External -> External64 -> Internal
 
-   Axes 0-9 are modal axes (affect mode-crossing).
-   Axis 10 is the only non-modal axis (externality).
+   Axes 0-11 are modal axes (affect mode-crossing).
+   Axis 12 is the only non-modal axis (externality).
 
    Each 2-valued axis uses 1 bit. The 3-valued chain axes and 4-valued diamond
    axes use 2 bits.

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -66,7 +66,9 @@ let axis_shapes =
       | Modal (Monadic Uniqueness) -> Chain2
       | Modal (Comonadic Linearity) -> Chain2
       | Modal (Monadic Contention) -> Diamond4
+      | Modal (Monadic Logicality) -> Chain2
       | Modal (Comonadic Portability) -> Diamond4
+      | Modal (Comonadic Totality) -> Chain2
       | Modal (Comonadic Forkable) -> Chain2
       | Modal (Comonadic Yielding) -> Chain2
       | Modal (Comonadic Statefulness) -> Diamond4
@@ -193,13 +195,12 @@ let of_axis_set (set : Jkind_axis.Axis_set.t) : t =
   let lo =
     set land 0x001
     lor ((set land 0x00E) lsl 1)
-    lor ((set land 0x010) lsl 2)
-    lor ((set land 0x0E0) lsl 3)
-    lor ((set land 0x100) lsl 4)
-    lor ((set land 0x600) lsl 5)
-    lor ((set land 0x1800) lsl 6)
+    lor ((set land 0x030) lsl 2)
+    lor ((set land 0x3C0) lsl 3)
+    lor ((set land 0x400) lsl 4)
+    lor ((set land 0x1800) lsl 5)
   in
-  lo lor ((lo land 0x49451) lsl 1)
+  lo lor ((lo land 0x25091) lsl 1)
 
 (* IK-only: compute relevant axes of a constant modality, mirroring
    Jkind.relevant_axes_of_modality. *)
@@ -253,6 +254,16 @@ module Levels = struct
     | Mode.Contention.Const.Corrupted -> 1
     | Mode.Contention.Const.Shared -> 2
     | Mode.Contention.Const.Uncontended -> 3
+
+  let level_of_logicality_monadic (x : Mode.Logicality.Const.t) : int =
+    match x with
+    | Mode.Logicality.Const.Logical -> 0
+    | Mode.Logicality.Const.Physical -> 1
+
+  let level_of_totality (x : Mode.Totality.Const.t) : int =
+    match x with
+    | Mode.Totality.Const.Total -> 0
+    | Mode.Totality.Const.Partial -> 1
 
   let level_of_forkable (x : Mode.Forkable.Const.t) : int =
     match x with
@@ -314,6 +325,16 @@ module Levels = struct
     | 3 -> Mode.Contention.Const.Uncontended
     | _ -> invalid_arg "Axis_lattice.contention_of_level_monadic"
 
+  let logicality_of_level_monadic = function
+    | 0 -> Mode.Logicality.Const.Logical
+    | 1 -> Mode.Logicality.Const.Physical
+    | _ -> invalid_arg "Axis_lattice.logicality_of_level_monadic"
+
+  let totality_of_level = function
+    | 0 -> Mode.Totality.Const.Total
+    | 1 -> Mode.Totality.Const.Partial
+    | _ -> invalid_arg "Axis_lattice.totality_of_level"
+
   let forkable_of_level = function
     | 0 -> Mode.Forkable.Const.Forkable
     | 1 -> Mode.Forkable.Const.Unforkable
@@ -362,26 +383,32 @@ let linearity (x : t) : Mode.Linearity.Const.t =
 let contention (x : t) : Mode.Contention.Const.t =
   Levels.contention_of_level_monadic (get_axis x ~axis:3)
 
+let logicality (x : t) : Mode.Logicality.Const.t =
+  Levels.logicality_of_level_monadic (get_axis x ~axis:4)
+
 let portability (x : t) : Mode.Portability.Const.t =
-  Levels.portability_of_level (get_axis x ~axis:4)
+  Levels.portability_of_level (get_axis x ~axis:5)
+
+let totality (x : t) : Mode.Totality.Const.t =
+  Levels.totality_of_level (get_axis x ~axis:6)
 
 let forkable (x : t) : Mode.Forkable.Const.t =
-  Levels.forkable_of_level (get_axis x ~axis:5)
+  Levels.forkable_of_level (get_axis x ~axis:7)
 
 let yielding (x : t) : Mode.Yielding.Const.t =
-  Levels.yielding_of_level (get_axis x ~axis:6)
+  Levels.yielding_of_level (get_axis x ~axis:8)
 
 let statefulness (x : t) : Mode.Statefulness.Const.t =
-  Levels.statefulness_of_level (get_axis x ~axis:7)
+  Levels.statefulness_of_level (get_axis x ~axis:9)
 
 let visibility (x : t) : Mode.Visibility.Const.t =
-  Levels.visibility_of_level_monadic (get_axis x ~axis:8)
+  Levels.visibility_of_level_monadic (get_axis x ~axis:10)
 
 let staticity (x : t) : Mode.Staticity.const =
-  Levels.staticity_of_level_monadic (get_axis x ~axis:9)
+  Levels.staticity_of_level_monadic (get_axis x ~axis:11)
 
 let externality (x : t) : Jkind_axis.Externality.t =
-  Levels.externality_of_level (get_axis x ~axis:10)
+  Levels.externality_of_level (get_axis x ~axis:12)
 
 let set_areality (a : Mode.Regionality.Const.t) (x : t) : t =
   set_axis x ~axis:0 ~level:(Levels.level_of_areality a)
@@ -395,26 +422,32 @@ let set_linearity (l : Mode.Linearity.Const.t) (x : t) : t =
 let set_contention (c : Mode.Contention.Const.t) (x : t) : t =
   set_axis x ~axis:3 ~level:(Levels.level_of_contention_monadic c)
 
+let set_logicality (g : Mode.Logicality.Const.t) (x : t) : t =
+  set_axis x ~axis:4 ~level:(Levels.level_of_logicality_monadic g)
+
 let set_portability (p : Mode.Portability.Const.t) (x : t) : t =
-  set_axis x ~axis:4 ~level:(Levels.level_of_portability p)
+  set_axis x ~axis:5 ~level:(Levels.level_of_portability p)
+
+let set_totality (t : Mode.Totality.Const.t) (x : t) : t =
+  set_axis x ~axis:6 ~level:(Levels.level_of_totality t)
 
 let set_forkable (f : Mode.Forkable.Const.t) (x : t) : t =
-  set_axis x ~axis:5 ~level:(Levels.level_of_forkable f)
+  set_axis x ~axis:7 ~level:(Levels.level_of_forkable f)
 
 let set_yielding (y : Mode.Yielding.Const.t) (x : t) : t =
-  set_axis x ~axis:6 ~level:(Levels.level_of_yielding y)
+  set_axis x ~axis:8 ~level:(Levels.level_of_yielding y)
 
 let set_statefulness (s : Mode.Statefulness.Const.t) (x : t) : t =
-  set_axis x ~axis:7 ~level:(Levels.level_of_statefulness s)
+  set_axis x ~axis:9 ~level:(Levels.level_of_statefulness s)
 
 let set_visibility (v : Mode.Visibility.Const.t) (x : t) : t =
-  set_axis x ~axis:8 ~level:(Levels.level_of_visibility_monadic v)
+  set_axis x ~axis:10 ~level:(Levels.level_of_visibility_monadic v)
 
 let set_staticity (s : Mode.Staticity.const) (x : t) : t =
-  set_axis x ~axis:9 ~level:(Levels.level_of_staticity_monadic s)
+  set_axis x ~axis:11 ~level:(Levels.level_of_staticity_monadic s)
 
 let set_externality (e : Jkind_axis.Externality.t) (x : t) : t =
-  set_axis x ~axis:10 ~level:(Levels.level_of_externality e)
+  set_axis x ~axis:12 ~level:(Levels.level_of_externality e)
 
 let to_mode_crossing (x : t) : Mode.Crossing.t =
   let open Mode.Crossing in
@@ -426,6 +459,9 @@ let to_mode_crossing (x : t) : Mode.Crossing.t =
       ~contention:
         (Monadic.Atom.Modality
            (Mode.Modality.Monadic.Atom.Join_const (contention x)))
+      ~logicality:
+        (Monadic.Atom.Modality
+           (Mode.Modality.Monadic.Atom.Join_const (logicality x)))
       ~visibility:
         (Monadic.Atom.Modality
            (Mode.Modality.Monadic.Atom.Join_const (visibility x)))
@@ -444,6 +480,9 @@ let to_mode_crossing (x : t) : Mode.Crossing.t =
       ~portability:
         (Comonadic.Atom.Modality
            (Mode.Modality.Comonadic.Atom.Meet_const (portability x)))
+      ~totality:
+        (Comonadic.Atom.Modality
+           (Mode.Modality.Comonadic.Atom.Meet_const (totality x)))
       ~forkable:
         (Comonadic.Atom.Modality
            (Mode.Modality.Comonadic.Atom.Meet_const (forkable x)))
@@ -456,12 +495,14 @@ let to_mode_crossing (x : t) : Mode.Crossing.t =
   in
   { monadic; comonadic }
 
-let create ~areality ~linearity ~uniqueness ~portability ~contention ~forkable
-    ~yielding ~statefulness ~visibility ~staticity ~externality =
+let create ~areality ~linearity ~uniqueness ~portability ~contention ~totality
+    ~logicality ~forkable ~yielding ~statefulness ~visibility ~staticity
+    ~externality =
   bot |> set_areality areality |> set_uniqueness uniqueness
   |> set_linearity linearity |> set_contention contention
   |> set_portability portability
-  |> set_forkable forkable |> set_yielding yielding
+  |> set_totality totality |> set_logicality logicality |> set_forkable forkable
+  |> set_yielding yielding
   |> set_statefulness statefulness
   |> set_visibility visibility |> set_staticity staticity
   |> set_externality externality
@@ -471,39 +512,40 @@ let nonfloat_value : t =
   create ~areality:Mode.Regionality.Const.max
     ~linearity:Mode.Linearity.Const.max ~uniqueness:Mode.Uniqueness.Const.Unique
     ~portability:Mode.Portability.Const.max
+    ~totality:Mode.Totality.Const.Partial
     ~contention:Mode.Contention.Const.Uncontended
-    ~forkable:Mode.Forkable.Const.max ~yielding:Mode.Yielding.Const.max
-    ~statefulness:Mode.Statefulness.Const.max
+    ~logicality:Mode.Logicality.Const.Physical ~forkable:Mode.Forkable.Const.max
+    ~yielding:Mode.Yielding.Const.max ~statefulness:Mode.Statefulness.Const.max
     ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
 let immutable_data : t =
   create ~areality:Mode.Regionality.Const.max
     ~linearity:Mode.Linearity.Const.min ~uniqueness:Mode.Uniqueness.Const.Unique
-    ~portability:Mode.Portability.Const.min
+    ~portability:Mode.Portability.Const.min ~totality:Mode.Totality.Const.Total
     ~contention:Mode.Contention.Const.Contended
-    ~forkable:Mode.Forkable.Const.min ~yielding:Mode.Yielding.Const.min
-    ~statefulness:Mode.Statefulness.Const.min
+    ~logicality:Mode.Logicality.Const.Logical ~forkable:Mode.Forkable.Const.min
+    ~yielding:Mode.Yielding.Const.min ~statefulness:Mode.Statefulness.Const.min
     ~visibility:Mode.Visibility.Const.Immutable ~staticity:Mode.Staticity.Static
     ~externality:Jkind_axis.Externality.max
 
 let mutable_data : t =
   create ~areality:Mode.Regionality.Const.max
     ~linearity:Mode.Linearity.Const.min ~uniqueness:Mode.Uniqueness.Const.Unique
-    ~portability:Mode.Portability.Const.min
+    ~portability:Mode.Portability.Const.min ~totality:Mode.Totality.Const.Total
     ~contention:Mode.Contention.Const.Uncontended
-    ~forkable:Mode.Forkable.Const.min ~yielding:Mode.Yielding.Const.min
-    ~statefulness:Mode.Statefulness.Const.min
+    ~logicality:Mode.Logicality.Const.Physical ~forkable:Mode.Forkable.Const.min
+    ~yielding:Mode.Yielding.Const.min ~statefulness:Mode.Statefulness.Const.min
     ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
 let sync_data : t =
   create ~areality:Mode.Regionality.Const.max
     ~linearity:Mode.Linearity.Const.min ~uniqueness:Mode.Uniqueness.Const.Unique
-    ~portability:Mode.Portability.Const.min
+    ~portability:Mode.Portability.Const.min ~totality:Mode.Totality.Const.Total
     ~contention:Mode.Contention.Const.Contended
-    ~forkable:Mode.Forkable.Const.min ~yielding:Mode.Yielding.Const.min
-    ~statefulness:Mode.Statefulness.Const.min
+    ~logicality:Mode.Logicality.Const.Physical ~forkable:Mode.Forkable.Const.min
+    ~yielding:Mode.Yielding.Const.min ~statefulness:Mode.Statefulness.Const.min
     ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
@@ -511,9 +553,10 @@ let value : t =
   create ~areality:Mode.Regionality.Const.max
     ~linearity:Mode.Linearity.Const.max ~uniqueness:Mode.Uniqueness.Const.Unique
     ~portability:Mode.Portability.Const.max
+    ~totality:Mode.Totality.Const.Partial
     ~contention:Mode.Contention.Const.Uncontended
-    ~forkable:Mode.Forkable.Const.min ~yielding:Mode.Yielding.Const.max
-    ~statefulness:Mode.Statefulness.Const.max
+    ~logicality:Mode.Logicality.Const.Physical ~forkable:Mode.Forkable.Const.min
+    ~yielding:Mode.Yielding.Const.max ~statefulness:Mode.Statefulness.Const.max
     ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
@@ -522,9 +565,10 @@ let arrow : t =
     ~linearity:Mode.Linearity.Const.max
     ~uniqueness:Mode.Uniqueness.Const.Aliased
     ~portability:Mode.Portability.Const.max
+    ~totality:Mode.Totality.Const.Partial
     ~contention:Mode.Contention.Const.Contended
-    ~forkable:Mode.Forkable.Const.max ~yielding:Mode.Yielding.Const.max
-    ~statefulness:Mode.Statefulness.Const.max
+    ~logicality:Mode.Logicality.Const.Logical ~forkable:Mode.Forkable.Const.max
+    ~yielding:Mode.Yielding.Const.max ~statefulness:Mode.Statefulness.Const.max
     ~visibility:Mode.Visibility.Const.Immutable ~staticity:Mode.Staticity.Static
     ~externality:Jkind_axis.Externality.max
 
@@ -532,21 +576,29 @@ let immediate : t =
   create ~areality:Mode.Regionality.Const.min
     ~linearity:Mode.Linearity.Const.min
     ~uniqueness:Mode.Uniqueness.Const.Aliased
-    ~portability:Mode.Portability.Const.min
+    ~portability:Mode.Portability.Const.min ~totality:Mode.Totality.Const.Total
     ~contention:Mode.Contention.Const.Contended
-    ~forkable:Mode.Forkable.Const.min ~yielding:Mode.Yielding.Const.min
-    ~statefulness:Mode.Statefulness.Const.min
+    ~logicality:Mode.Logicality.Const.Logical ~forkable:Mode.Forkable.Const.min
+    ~yielding:Mode.Yielding.Const.min ~statefulness:Mode.Statefulness.Const.min
     ~visibility:Mode.Visibility.Const.Immutable ~staticity:Mode.Staticity.Static
     ~externality:Jkind_axis.Externality.min
 
 let object_legacy : t =
-  let ({ linearity; areality; portability; forkable; yielding; statefulness }
+  let ({ linearity;
+         areality;
+         portability;
+         totality;
+         forkable;
+         yielding;
+         statefulness
+       }
         : Mode.Value.Comonadic.Const.t) =
     Mode.Value.Comonadic.Const.legacy
   in
   create ~linearity ~areality ~uniqueness:Mode.Uniqueness.Const.Aliased
-    ~portability ~contention:Mode.Contention.Const.Uncontended ~forkable
-    ~yielding ~statefulness ~visibility:Mode.Visibility.Const.Read_write
+    ~portability ~totality ~contention:Mode.Contention.Const.Uncontended
+    ~logicality:Mode.Logicality.Const.Physical ~forkable ~yielding ~statefulness
+    ~visibility:Mode.Visibility.Const.Read_write
     ~staticity:Mode.Staticity.Static ~externality:Jkind_axis.Externality.max
 
 let axis_number_to_axis_packed (axis_number : int) : Jkind_axis.Axis.packed =

--- a/typing/axis_lattice.ml
+++ b/typing/axis_lattice.ml
@@ -110,7 +110,7 @@ type t = int
 
 let bot : t = 0
 
-(* For this layout top happens to be all 20 bits set: 0xF_FFFF. *)
+(* For this layout top happens to be all 19 bits set: 0x7_FFFF. *)
 let top : t = Array.fold_left ( lor ) 0 axis_mask
 
 let join (a : t) (b : t) : t = a lor b
@@ -193,16 +193,14 @@ let co_sub (a : t) (b : t) : t =
 
 (* Build a mask from a set of relevant axes. *)
 let of_axis_set (set : Jkind_axis.Axis_set.t) : t =
+  (* Not hot: derive from the layout tables so that adding an axis needs no
+     recomputed constants. *)
   let set : int = Obj.magic set in
-  let lo =
-    set land 0x001
-    lor ((set land 0x00E) lsl 1)
-    lor ((set land 0x030) lsl 2)
-    lor ((set land 0x3C0) lsl 3)
-    lor ((set land 0x400) lsl 4)
-    lor ((set land 0x1800) lsl 5)
-  in
-  lo lor ((lo land 0x25091) lsl 1)
+  let acc = ref 0 in
+  for i = 0 to num_axes - 1 do
+    if set land (1 lsl i) <> 0 then acc := !acc lor axis_mask.(i)
+  done;
+  !acc
 
 (* IK-only: compute relevant axes of a constant modality, mirroring
    Jkind.relevant_axes_of_modality. *)

--- a/typing/axis_lattice.mli
+++ b/typing/axis_lattice.mli
@@ -47,6 +47,8 @@ val create :
   uniqueness:Mode.Uniqueness.Const.t ->
   portability:Mode.Portability.Const.t ->
   contention:Mode.Contention.Const.t ->
+  totality:Mode.Totality.Const.t ->
+  logicality:Mode.Logicality.Const.t ->
   forkable:Mode.Forkable.Const.t ->
   yielding:Mode.Yielding.Const.t ->
   statefulness:Mode.Statefulness.Const.t ->
@@ -64,6 +66,10 @@ val uniqueness : t -> Mode.Uniqueness.Const.t
 val portability : t -> Mode.Portability.Const.t
 
 val contention : t -> Mode.Contention.Const.t
+
+val totality : t -> Mode.Totality.Const.t
+
+val logicality : t -> Mode.Logicality.Const.t
 
 val forkable : t -> Mode.Forkable.Const.t
 

--- a/typing/btype.ml
+++ b/typing/btype.ml
@@ -934,6 +934,8 @@ module Jkind0 = struct
     let uniqueness = Crossing.Axis.Monadic Uniqueness
     let portability = Crossing.Axis.Comonadic Portability
     let contention = Crossing.Axis.Monadic Contention
+    let totality = Crossing.Axis.Comonadic Totality
+    let logicality = Crossing.Axis.Monadic Logicality
     let forkable = Crossing.Axis.Comonadic Forkable
     let yielding = Crossing.Axis.Comonadic Yielding
     let statefulness = Crossing.Axis.Comonadic Statefulness
@@ -966,6 +968,8 @@ module Jkind0 = struct
       let uniqueness = modal uniqueness in
       let portability = modal portability in
       let contention = modal contention in
+      let totality = modal totality in
+      let logicality = modal logicality in
       let forkable = modal forkable in
       let yielding = modal yielding in
       let statefulness = modal statefulness in
@@ -977,11 +981,12 @@ module Jkind0 = struct
         else t.externality
       in
       let monadic =
-        Crossing.Monadic.create ~uniqueness ~contention ~visibility ~staticity
+        Crossing.Monadic.create ~uniqueness ~contention ~logicality ~visibility
+          ~staticity
       in
       let comonadic =
-        Crossing.Comonadic.create ~regionality ~linearity ~portability ~yielding
-          ~forkable ~statefulness
+        Crossing.Comonadic.create ~regionality ~linearity ~portability ~totality
+          ~yielding ~forkable ~statefulness
       in
       let crossing : Mode.Crossing.t = { monadic; comonadic } in
       {
@@ -1003,6 +1008,8 @@ module Jkind0 = struct
       let uniqueness = modal uniqueness in
       let portability = modal portability in
       let contention = modal contention in
+      let totality = modal totality in
+      let logicality = modal logicality in
       let forkable = modal forkable in
       let yielding = modal yielding in
       let statefulness = modal statefulness in
@@ -1014,11 +1021,12 @@ module Jkind0 = struct
         else t.externality
       in
       let monadic =
-        Crossing.Monadic.create ~uniqueness ~contention ~visibility ~staticity
+        Crossing.Monadic.create ~uniqueness ~contention ~logicality ~visibility
+          ~staticity
       in
       let comonadic =
-        Crossing.Comonadic.create ~regionality ~linearity ~portability ~yielding
-          ~forkable ~statefulness
+        Crossing.Comonadic.create ~regionality ~linearity ~portability ~totality
+          ~yielding ~forkable ~statefulness
       in
       let crossing : Mode.Crossing.t = { monadic; comonadic } in
       {
@@ -1038,6 +1046,8 @@ module Jkind0 = struct
       modal uniqueness &&
       modal portability &&
       modal contention &&
+      modal totality &&
+      modal logicality &&
       modal forkable &&
       modal yielding &&
       modal statefulness &&
@@ -1055,8 +1065,9 @@ module Jkind0 = struct
     let for_arrow =
       let crossing =
         Crossing.create ~linearity:false ~regionality:false ~uniqueness:true
-          ~portability:false ~contention:true ~forkable:false ~yielding:false
-          ~statefulness:false ~visibility:true ~staticity:false
+          ~portability:false ~totality:false ~contention:true ~logicality:true
+          ~forkable:false ~yielding:false ~statefulness:false ~visibility:true
+          ~staticity:false
       in
       create crossing ~externality:Externality.max
 
@@ -1098,6 +1109,10 @@ module Jkind0 = struct
 
     let contention_const t = extract_monadic contention t
 
+    let totality_const t = extract_comonadic totality t
+
+    let logicality_const t = extract_monadic logicality t
+
     let forkable_const t = extract_comonadic forkable t
 
     let yielding_const t = extract_comonadic yielding t
@@ -1112,6 +1127,7 @@ module Jkind0 = struct
       Axis_lattice.create ~areality:(areality_const t)
         ~linearity:(linearity_const t) ~uniqueness:(uniqueness_const t)
         ~portability:(portability_const t) ~contention:(contention_const t)
+        ~totality:(totality_const t) ~logicality:(logicality_const t)
         ~forkable:(forkable_const t) ~yielding:(yielding_const t)
         ~statefulness:(statefulness_const t) ~visibility:(visibility_const t)
         ~staticity:(staticity_const t) ~externality:(externality t)
@@ -1456,8 +1472,9 @@ module Jkind0 = struct
         let open Mod_bounds in
         let crossing =
           Crossing.create ~regionality:false ~linearity:true ~portability:true
-            ~forkable:true ~yielding:true ~uniqueness:false ~contention:true
-            ~statefulness:true ~visibility:true ~staticity:false
+            ~totality:true ~forkable:true ~yielding:true ~uniqueness:false
+            ~contention:true ~logicality:true ~statefulness:true
+            ~visibility:true ~staticity:false
         in
         create crossing ~externality:Externality.max
 
@@ -1498,9 +1515,10 @@ module Jkind0 = struct
               mod_bounds =
                 (let crossing =
                    Crossing.create ~regionality:false ~linearity:false
-                     ~portability:true ~forkable:false ~yielding:false
-                     ~uniqueness:false ~contention:true ~statefulness:true
-                     ~visibility:true ~staticity:false
+                     ~portability:true ~totality:true ~forkable:false
+                     ~yielding:false ~uniqueness:false ~contention:true
+                     ~logicality:true ~statefulness:true ~visibility:true
+                     ~staticity:false
                  in
                  create crossing ~externality:Externality.max);
               with_bounds = No_with_bounds
@@ -1512,8 +1530,9 @@ module Jkind0 = struct
         let open Mod_bounds in
         let crossing =
           Crossing.create ~regionality:false ~linearity:true ~portability:true
-            ~forkable:true ~yielding:true ~uniqueness:false ~contention:true
-            ~statefulness:true ~visibility:false ~staticity:false
+            ~totality:true ~forkable:true ~yielding:true ~uniqueness:false
+            ~contention:true ~logicality:false ~statefulness:true
+            ~visibility:false ~staticity:false
         in
         create crossing ~externality:Externality.max
 
@@ -1547,8 +1566,9 @@ module Jkind0 = struct
         let open Mod_bounds in
         let crossing =
           Crossing.create ~regionality:false ~linearity:true ~portability:true
-            ~forkable:true ~yielding:true ~contention:false ~uniqueness:false
-            ~statefulness:true ~visibility:false ~staticity:false
+            ~totality:true ~forkable:true ~yielding:true ~contention:false
+            ~logicality:false ~uniqueness:false ~statefulness:true
+            ~visibility:false ~staticity:false
         in
         create crossing ~externality:Externality.max
 
@@ -2581,8 +2601,9 @@ module Jkind0 = struct
     let for_float ident =
       let crossing =
         Mode.Crossing.create ~regionality:false ~linearity:true
-          ~portability:true ~forkable:true ~yielding:true ~uniqueness:false
-          ~contention:true ~statefulness:true ~visibility:true ~staticity:false
+          ~portability:true ~totality:true ~forkable:true ~yielding:true
+          ~uniqueness:false ~contention:true ~logicality:true ~statefulness:true
+          ~visibility:true ~staticity:false
       in
       let mod_bounds =
         Mod_bounds.create crossing ~externality:Mod_bounds.Externality.max

--- a/typing/ctype.ml
+++ b/typing/ctype.ml
@@ -6310,10 +6310,12 @@ let mode_crossing_structure_memaddr =
   Mode.Crossing.create
     ~uniqueness:false
     ~contention:true
+    ~logicality:false
     ~visibility:true
     ~regionality:false
     ~linearity:true
     ~portability:true
+    ~totality:true
     ~forkable:true
     ~yielding:true
     ~statefulness:true
@@ -6324,10 +6326,12 @@ let mode_crossing_functor =
   Mode.Crossing.create
     ~uniqueness:true
     ~contention:true
+    ~logicality:true
     ~visibility:true
     ~regionality:false
     ~linearity:false
     ~portability:false
+    ~totality:false
     ~forkable:false
     ~yielding:false
     ~statefulness:false
@@ -8905,8 +8909,8 @@ let exn_constructor_crossing env lid ~args locks =
       None ((Mode.Value.(disallow_right min)), locks)
   in
   (* Exceptions cross contention and visibility on the monadic side, and
-     portability and statefulness on the comonadic side, so we project those
-     axes. *)
+     portability, totality, and statefulness on the comonadic side, so we
+     project those axes. *)
   let monadic_mode = vmode.monadic in
   let monadic =
     [ monadic_mode
@@ -8925,6 +8929,9 @@ let exn_constructor_crossing env lid ~args locks =
     [ comonadic_source
       |> Mode.Value.Comonadic.proj Portability
       |> Mode.Value.Comonadic.max_with Portability;
+      comonadic_source
+      |> Mode.Value.Comonadic.proj Totality
+      |> Mode.Value.Comonadic.max_with Totality;
       comonadic_source
       |> Mode.Value.Comonadic.proj Statefulness
       |> Mode.Value.Comonadic.max_with Statefulness

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3799,21 +3799,19 @@ let walk_locks_for_legacy_construct ~env pp =
        (Mode.Value.disallow_right Mode.Value.legacy) None locks
       : Mode.Value.l)
 
-let constrain_enclosing_totality_at_least ~env pp totality =
+(** Registers a use of a construct whose totality is [totality] (a loop, a
+    mutable assignment, or a nested function literal), constraining every
+    enclosing closure lock as if a value at that totality — and otherwise at
+    the bottom of every axis — were used at the pinpoint. In particular a
+    partial construct forces every enclosing closure to be partial, the same
+    way effect handlers force enclosing closures to legacy above. *)
+let walk_locks_for_totality ~env pp totality =
   let locks = IdTbl.get_all_locks env.values in
   let _stage_locks, locks = partition_locks locks in
-  List.iter
-    (function
-      | Closure_lock (_, comonadic) ->
-        Mode.Totality.submode_err pp
-          totality
-          (Mode.Value.Comonadic.proj Mode.Axis.Totality comonadic)
-      | Const_closure_lock _ | Region_lock | Exclave_lock | Unboxed_lock -> ())
-    locks
-
-let constrain_enclosing_totality_partial ~env pp =
-  constrain_enclosing_totality_at_least ~env pp
-    (Mode.Totality.of_const Mode.Totality.Const.Partial)
+  ignore
+    (walk_locks ~errors:true ~env ~pp
+       (Mode.Value.min_with_comonadic Totality totality) None locks
+      : Mode.Value.l)
 
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
   and [locks] which is the locks between the declaration and the usage (either

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -3799,6 +3799,22 @@ let walk_locks_for_legacy_construct ~env pp =
        (Mode.Value.disallow_right Mode.Value.legacy) None locks
       : Mode.Value.l)
 
+let constrain_enclosing_totality_at_least ~env pp totality =
+  let locks = IdTbl.get_all_locks env.values in
+  let _stage_locks, locks = partition_locks locks in
+  List.iter
+    (function
+      | Closure_lock (_, comonadic) ->
+        Mode.Totality.submode_err pp
+          totality
+          (Mode.Value.Comonadic.proj Mode.Axis.Totality comonadic)
+      | Const_closure_lock _ | Region_lock | Exclave_lock | Unboxed_lock -> ())
+    locks
+
+let constrain_enclosing_totality_partial ~env pp =
+  constrain_enclosing_totality_at_least ~env pp
+    (Mode.Totality.of_const Mode.Totality.Const.Partial)
+
 (** Takes [m0] which is the parameter of [let mutable x] at declaration site,
   and [locks] which is the locks between the declaration and the usage (either
   reading or writing) of [x], and:

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -322,17 +322,18 @@ val walk_locks : env:t -> loc:Location.t -> Longident.t ->
     stateful. *)
 val walk_locks_for_legacy_construct : env:t -> Mode.Hint.pinpoint -> unit
 
-(** Constrains the totality of every enclosing closure to be at least the given
-    totality (i.e. submodes [totality] into each enclosing closure lock).  Used
-    for the (Hereditary) discipline: a nested function literal's totality must be
-    below every enclosing closure's totality, so a partial nested closure forces
-    its enclosing closures partial. *)
-val constrain_enclosing_totality_at_least :
-  env:t -> Mode.Hint.pinpoint -> Mode.Totality.l -> unit
-
-(** Constrains the totality of every enclosing closure to be partial. *)
-val constrain_enclosing_totality_partial :
-  env:t -> Mode.Hint.pinpoint -> unit
+(** Registers a use of a construct whose totality is [totality] (a loop, a
+    mutable assignment, or a nested function literal), constraining every
+    enclosing closure lock as if a value at that totality — and otherwise at
+    the bottom of every axis — were used at the pinpoint.  This is the
+    (Hereditary) discipline: a nested literal's totality must be below every
+    enclosing closure's totality, and a partial construct forces every
+    enclosing closure partial. *)
+val walk_locks_for_totality :
+  env:t ->
+  Mode.Hint.pinpoint ->
+  (Allowance.allowed * 'r) Mode.Totality.t ->
+  unit
 
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -322,6 +322,18 @@ val walk_locks : env:t -> loc:Location.t -> Longident.t ->
     stateful. *)
 val walk_locks_for_legacy_construct : env:t -> Mode.Hint.pinpoint -> unit
 
+(** Constrains the totality of every enclosing closure to be at least the given
+    totality (i.e. submodes [totality] into each enclosing closure lock).  Used
+    for the (Hereditary) discipline: a nested function literal's totality must be
+    below every enclosing closure's totality, so a partial nested closure forces
+    its enclosing closures partial. *)
+val constrain_enclosing_totality_at_least :
+  env:t -> Mode.Hint.pinpoint -> Mode.Totality.l -> unit
+
+(** Constrains the totality of every enclosing closure to be partial. *)
+val constrain_enclosing_totality_partial :
+  env:t -> Mode.Hint.pinpoint -> unit
+
 val lookup_value:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
   Path.t * value_description * mode_with_locks

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -513,7 +513,9 @@ module Mod_bounds = struct
     @@ Sub_result.combine (modal_less_or_equal (Monadic Uniqueness))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Linearity))
     @@ Sub_result.combine (modal_less_or_equal (Monadic Contention))
+    @@ Sub_result.combine (modal_less_or_equal (Monadic Logicality))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Portability))
+    @@ Sub_result.combine (modal_less_or_equal (Comonadic Totality))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Forkable))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Yielding))
     @@ Sub_result.combine (modal_less_or_equal (Comonadic Statefulness))
@@ -545,7 +547,9 @@ module Mod_bounds = struct
     |> add_crossing_if (Comonadic Linearity)
     |> add_crossing_if (Monadic Uniqueness)
     |> add_crossing_if (Comonadic Portability)
+    |> add_crossing_if (Comonadic Totality)
     |> add_crossing_if (Monadic Contention)
+    |> add_crossing_if (Monadic Logicality)
     |> add_crossing_if (Comonadic Forkable)
     |> add_crossing_if (Comonadic Yielding)
     |> add_crossing_if (Comonadic Statefulness)
@@ -1242,6 +1246,8 @@ module Base_and_axes = struct
                     (value_for_axis ~axis:(Modal (Monadic Uniqueness)))
                   ~contention:
                     (value_for_axis ~axis:(Modal (Monadic Contention)))
+                  ~logicality:
+                    (value_for_axis ~axis:(Modal (Monadic Logicality)))
                   ~visibility:
                     (value_for_axis ~axis:(Modal (Monadic Visibility)))
                   ~staticity:(value_for_axis ~axis:(Modal (Monadic Staticity)))
@@ -1254,6 +1260,7 @@ module Base_and_axes = struct
                     (value_for_axis ~axis:(Modal (Comonadic Linearity)))
                   ~portability:
                     (value_for_axis ~axis:(Modal (Comonadic Portability)))
+                  ~totality:(value_for_axis ~axis:(Modal (Comonadic Totality)))
                   ~forkable:(value_for_axis ~axis:(Modal (Comonadic Forkable)))
                   ~yielding:(value_for_axis ~axis:(Modal (Comonadic Yielding)))
                   ~statefulness:
@@ -2514,6 +2521,7 @@ let for_object =
         (* Since [global] implies [aliased] in presence of borrowing,
            objects also cross uniqueness. *)
       ~contention:(Crossing.Per_axis.max (Crossing.Axis.Monadic Contention))
+      ~logicality:(Crossing.Per_axis.max (Crossing.Axis.Monadic Logicality))
       ~visibility:(Crossing.Per_axis.max (Crossing.Axis.Monadic Visibility))
       ~staticity:(Crossing.Per_axis.max (Crossing.Axis.Monadic Staticity))
   in

--- a/typing/jkind_axis.ml
+++ b/typing/jkind_axis.ml
@@ -140,7 +140,9 @@ module Axis = struct
       Pack (Modal (Monadic Uniqueness));
       Pack (Modal (Comonadic Linearity));
       Pack (Modal (Monadic Contention));
+      Pack (Modal (Monadic Logicality));
       Pack (Modal (Comonadic Portability));
+      Pack (Modal (Comonadic Totality));
       Pack (Modal (Comonadic Forkable));
       Pack (Modal (Comonadic Yielding));
       Pack (Modal (Comonadic Statefulness));
@@ -258,14 +260,16 @@ module Axis_set = struct
     | Modal (Monadic Uniqueness) -> 1
     | Modal (Comonadic Linearity) -> 2
     | Modal (Monadic Contention) -> 3
-    | Modal (Comonadic Portability) -> 4
-    | Modal (Comonadic Forkable) -> 5
-    | Modal (Comonadic Yielding) -> 6
-    | Modal (Comonadic Statefulness) -> 7
-    | Modal (Monadic Visibility) -> 8
-    | Modal (Monadic Staticity) -> 9
+    | Modal (Monadic Logicality) -> 4
+    | Modal (Comonadic Portability) -> 5
+    | Modal (Comonadic Totality) -> 6
+    | Modal (Comonadic Forkable) -> 7
+    | Modal (Comonadic Yielding) -> 8
+    | Modal (Comonadic Statefulness) -> 9
+    | Modal (Monadic Visibility) -> 10
+    | Modal (Monadic Staticity) -> 11
     (* CR-soon zqian: call [Mode.Crossing.Axis.index] for modal axes *)
-    | Nonmodal Externality -> 10
+    | Nonmodal Externality -> 12
 
   let[@inline] axis_mask ax = 1 lsl axis_index ax
 
@@ -289,7 +293,9 @@ module Axis_set = struct
     |> set_axis (Modal (Monadic Uniqueness))
     |> set_axis (Modal (Comonadic Linearity))
     |> set_axis (Modal (Monadic Contention))
+    |> set_axis (Modal (Monadic Logicality))
     |> set_axis (Modal (Comonadic Portability))
+    |> set_axis (Modal (Comonadic Totality))
     |> set_axis (Modal (Comonadic Forkable))
     |> set_axis (Modal (Comonadic Yielding))
     |> set_axis (Modal (Comonadic Statefulness))

--- a/typing/mode.ml
+++ b/typing/mode.ml
@@ -615,6 +615,30 @@ module Lattices = struct
       | Nonportable -> Fmt.fprintf ppf "nonportable"
   end
 
+  module Totality = struct
+    type t =
+      | Total
+      | Partial
+
+    include Total (struct
+      type nonrec t = t
+
+      let min = Total
+
+      let max = Partial
+
+      let ord = function Total -> 0 | Partial -> 1
+    end)
+
+    let legacy = Partial
+
+    let all = lazy [Total; Partial]
+
+    let print ppf = function
+      | Total -> Fmt.fprintf ppf "total"
+      | Partial -> Fmt.fprintf ppf "partial"
+  end
+
   module Contention = struct
     (* Changes to this type must consider the implementation of [Diamond]. *)
     type t =
@@ -644,6 +668,30 @@ module Lattices = struct
       | Corrupted -> Fmt.fprintf ppf "corrupted"
       | Shared -> Fmt.fprintf ppf "shared"
       | Uncontended -> Fmt.fprintf ppf "uncontended"
+  end
+
+  module Logicality = struct
+    type t =
+      | Physical
+      | Logical
+
+    include Total (struct
+      type nonrec t = t
+
+      let min = Physical
+
+      let max = Logical
+
+      let ord = function Physical -> 0 | Logical -> 1
+    end)
+
+    let legacy = Physical
+
+    let all = lazy [Physical; Logical]
+
+    let print ppf = function
+      | Physical -> Fmt.fprintf ppf "physical"
+      | Logical -> Fmt.fprintf ppf "logical"
   end
 
   module Forkable = struct
@@ -783,6 +831,7 @@ module Lattices = struct
   type monadic =
     { uniqueness : Uniqueness.t;
       contention : Contention.t;
+      logicality : Logicality.t;
       visibility : Visibility.t;
       staticity : Staticity.t
     }
@@ -793,23 +842,26 @@ module Lattices = struct
     let min =
       let uniqueness = Uniqueness.min in
       let contention = Contention.min in
+      let logicality = Logicality.min in
       let visibility = Visibility.min in
       let staticity = Staticity.min in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     let max =
       let uniqueness = Uniqueness.max in
       let contention = Contention.max in
+      let logicality = Logicality.max in
       let visibility = Visibility.max in
       let staticity = Staticity.max in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     let legacy =
       let uniqueness = Uniqueness.legacy in
       let contention = Contention.legacy in
+      let logicality = Logicality.legacy in
       let visibility = Visibility.legacy in
       let staticity = Staticity.legacy in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     (** All product values, including every combination of axis values. *)
     let all =
@@ -818,9 +870,10 @@ module Lattices = struct
          let ( let+ ) xs f = List.map f xs in
          let* uniqueness = Lazy.force Uniqueness.all in
          let* contention = Lazy.force Contention.all in
+         let* logicality = Lazy.force Logicality.all in
          let* visibility = Lazy.force Visibility.all in
          let+ staticity = Lazy.force Staticity.all in
-         { uniqueness; contention; visibility; staticity })
+         { uniqueness; contention; logicality; visibility; staticity })
 
     (* CR-someday ageorges: the following code manually enumerates axes. It would be nice
        to use the later definition of Lattices.Monadic.Axis.all *)
@@ -836,6 +889,8 @@ module Lattices = struct
                 { base with uniqueness });
                (let+ contention = Lazy.force Contention.all in
                 { base with contention });
+               (let+ logicality = Lazy.force Logicality.all in
+                { base with logicality });
                (let+ visibility = Lazy.force Visibility.all in
                 { base with visibility });
                (let+ staticity = Lazy.force Staticity.all in
@@ -846,6 +901,7 @@ module Lattices = struct
     let le m1 m2 =
       let { uniqueness = uniqueness1;
             contention = contention1;
+            logicality = logicality1;
             visibility = visibility1;
             staticity = staticity1
           } =
@@ -853,6 +909,7 @@ module Lattices = struct
       in
       let { uniqueness = uniqueness2;
             contention = contention2;
+            logicality = logicality2;
             visibility = visibility2;
             staticity = staticity2
           } =
@@ -860,12 +917,14 @@ module Lattices = struct
       in
       Uniqueness.le uniqueness1 uniqueness2
       && Contention.le contention1 contention2
+      && Logicality.le logicality1 logicality2
       && Visibility.le visibility1 visibility2
       && Staticity.le staticity1 staticity2
 
     let equal m1 m2 =
       let { uniqueness = uniqueness1;
             contention = contention1;
+            logicality = logicality1;
             visibility = visibility1;
             staticity = staticity1
           } =
@@ -873,6 +932,7 @@ module Lattices = struct
       in
       let { uniqueness = uniqueness2;
             contention = contention2;
+            logicality = logicality2;
             visibility = visibility2;
             staticity = staticity2
           } =
@@ -880,6 +940,7 @@ module Lattices = struct
       in
       Uniqueness.equal uniqueness1 uniqueness2
       && Contention.equal contention1 contention2
+      && Logicality.equal logicality1 logicality2
       && Visibility.equal visibility1 visibility2
       && Staticity.equal staticity1 staticity2
 
@@ -892,42 +953,50 @@ module Lattices = struct
         if c <> 0
         then c
         else
-          let c = Visibility.compare_total m1.visibility m2.visibility in
+          let c = Logicality.compare_total m1.logicality m2.logicality in
           if c <> 0
           then c
-          else Staticity.compare_total m1.staticity m2.staticity
+          else
+            let c = Visibility.compare_total m1.visibility m2.visibility in
+            if c <> 0
+            then c
+            else Staticity.compare_total m1.staticity m2.staticity
 
     let join m1 m2 =
       let uniqueness = Uniqueness.join m1.uniqueness m2.uniqueness in
       let contention = Contention.join m1.contention m2.contention in
+      let logicality = Logicality.join m1.logicality m2.logicality in
       let visibility = Visibility.join m1.visibility m2.visibility in
       let staticity = Staticity.join m1.staticity m2.staticity in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     let meet m1 m2 =
       let uniqueness = Uniqueness.meet m1.uniqueness m2.uniqueness in
       let contention = Contention.meet m1.contention m2.contention in
+      let logicality = Logicality.meet m1.logicality m2.logicality in
       let visibility = Visibility.meet m1.visibility m2.visibility in
       let staticity = Staticity.meet m1.staticity m2.staticity in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     let subtract m1 m2 =
       let uniqueness = Uniqueness.subtract m1.uniqueness m2.uniqueness in
       let contention = Contention.subtract m1.contention m2.contention in
+      let logicality = Logicality.subtract m1.logicality m2.logicality in
       let visibility = Visibility.subtract m1.visibility m2.visibility in
       let staticity = Staticity.subtract m1.staticity m2.staticity in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     let print ppf m =
-      Fmt.fprintf ppf "%a,%a,%a,%a" Uniqueness.print m.uniqueness
-        Contention.print m.contention Visibility.print m.visibility
-        Staticity.print m.staticity
+      Fmt.fprintf ppf "%a,%a,%a,%a,%a" Uniqueness.print m.uniqueness
+        Contention.print m.contention Logicality.print m.logicality
+        Visibility.print m.visibility Staticity.print m.staticity
   end
 
   type 'areality comonadic_with =
     { areality : 'areality;
       linearity : Linearity.t;
       portability : Portability.t;
+      totality : Totality.t;
       forkable : Forkable.t;
       yielding : Yielding.t;
       statefulness : Statefulness.t
@@ -940,28 +1009,52 @@ module Lattices = struct
       let areality = Areality.min in
       let linearity = Linearity.min in
       let portability = Portability.min in
+      let totality = Totality.min in
       let forkable = Forkable.min in
       let yielding = Yielding.min in
       let statefulness = Statefulness.min in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let max =
       let areality = Areality.max in
       let linearity = Linearity.max in
       let portability = Portability.max in
+      let totality = Totality.max in
       let forkable = Forkable.max in
       let yielding = Yielding.max in
       let statefulness = Statefulness.max in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let legacy =
       let areality = Areality.legacy in
       let linearity = Linearity.legacy in
       let portability = Portability.legacy in
+      let totality = Totality.legacy in
       let forkable = Forkable.legacy in
       let yielding = Yielding.legacy in
       let statefulness = Statefulness.legacy in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     (** All product values, including every combination of axis values. *)
     let all =
@@ -971,10 +1064,18 @@ module Lattices = struct
          let* areality = Lazy.force Areality.all in
          let* linearity = Lazy.force Linearity.all in
          let* portability = Lazy.force Portability.all in
+         let* totality = Lazy.force Totality.all in
          let* forkable = Lazy.force Forkable.all in
          let* yielding = Lazy.force Yielding.all in
          let+ statefulness = Lazy.force Statefulness.all in
-         { areality; linearity; portability; forkable; yielding; statefulness })
+         { areality;
+           linearity;
+           portability;
+           totality;
+           forkable;
+           yielding;
+           statefulness
+         })
 
     (* CR-someday ageorges: the following code manually enumerates axes. It would be nice
        to use the later definition of Lattices.Comonadic_with.Axis.all *)
@@ -992,6 +1093,8 @@ module Lattices = struct
                 { base with linearity });
                (let+ portability = Lazy.force Portability.all in
                 { base with portability });
+               (let+ totality = Lazy.force Totality.all in
+                { base with totality });
                (let+ forkable = Lazy.force Forkable.all in
                 { base with forkable });
                (let+ yielding = Lazy.force Yielding.all in
@@ -1005,6 +1108,7 @@ module Lattices = struct
       let { areality = areality1;
             linearity = linearity1;
             portability = portability1;
+            totality = totality1;
             forkable = forkable1;
             yielding = yielding1;
             statefulness = statefulness1
@@ -1014,6 +1118,7 @@ module Lattices = struct
       let { areality = areality2;
             linearity = linearity2;
             portability = portability2;
+            totality = totality2;
             forkable = forkable2;
             yielding = yielding2;
             statefulness = statefulness2
@@ -1023,6 +1128,7 @@ module Lattices = struct
       Areality.le areality1 areality2
       && Linearity.le linearity1 linearity2
       && Portability.le portability1 portability2
+      && Totality.le totality1 totality2
       && Forkable.le forkable1 forkable2
       && Yielding.le yielding1 yielding2
       && Statefulness.le statefulness1 statefulness2
@@ -1031,6 +1137,7 @@ module Lattices = struct
       let { areality = areality1;
             linearity = linearity1;
             portability = portability1;
+            totality = totality1;
             forkable = forkable1;
             yielding = yielding1;
             statefulness = statefulness1
@@ -1040,6 +1147,7 @@ module Lattices = struct
       let { areality = areality2;
             linearity = linearity2;
             portability = portability2;
+            totality = totality2;
             forkable = forkable2;
             yielding = yielding2;
             statefulness = statefulness2
@@ -1049,6 +1157,7 @@ module Lattices = struct
       Areality.equal areality1 areality2
       && Linearity.equal linearity1 linearity2
       && Portability.equal portability1 portability2
+      && Totality.equal totality1 totality2
       && Forkable.equal forkable1 forkable2
       && Yielding.equal yielding1 yielding2
       && Statefulness.equal statefulness1 statefulness2
@@ -1066,47 +1175,75 @@ module Lattices = struct
           if c <> 0
           then c
           else
-            let c = Forkable.compare_total m1.forkable m2.forkable in
+            let c = Totality.compare_total m1.totality m2.totality in
             if c <> 0
             then c
             else
-              let c = Yielding.compare_total m1.yielding m2.yielding in
+              let c = Forkable.compare_total m1.forkable m2.forkable in
               if c <> 0
               then c
-              else Statefulness.compare_total m1.statefulness m2.statefulness
+              else
+                let c = Yielding.compare_total m1.yielding m2.yielding in
+                if c <> 0
+                then c
+                else Statefulness.compare_total m1.statefulness m2.statefulness
 
     let join m1 m2 =
       let areality = Areality.join m1.areality m2.areality in
       let linearity = Linearity.join m1.linearity m2.linearity in
       let portability = Portability.join m1.portability m2.portability in
+      let totality = Totality.join m1.totality m2.totality in
       let forkable = Forkable.join m1.forkable m2.forkable in
       let yielding = Yielding.join m1.yielding m2.yielding in
       let statefulness = Statefulness.join m1.statefulness m2.statefulness in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let meet m1 m2 =
       let areality = Areality.meet m1.areality m2.areality in
       let linearity = Linearity.meet m1.linearity m2.linearity in
       let portability = Portability.meet m1.portability m2.portability in
+      let totality = Totality.meet m1.totality m2.totality in
       let forkable = Forkable.meet m1.forkable m2.forkable in
       let yielding = Yielding.meet m1.yielding m2.yielding in
       let statefulness = Statefulness.meet m1.statefulness m2.statefulness in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let imply m1 m2 =
       let areality = Areality.imply m1.areality m2.areality in
       let linearity = Linearity.imply m1.linearity m2.linearity in
       let portability = Portability.imply m1.portability m2.portability in
+      let totality = Totality.imply m1.totality m2.totality in
       let forkable = Forkable.imply m1.forkable m2.forkable in
       let yielding = Yielding.imply m1.yielding m2.yielding in
       let statefulness = Statefulness.imply m1.statefulness m2.statefulness in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let print ppf m =
-      Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a" Areality.print m.areality
+      Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a,%a" Areality.print m.areality
         Linearity.print m.linearity Portability.print m.portability
-        Forkable.print m.forkable Yielding.print m.yielding Statefulness.print
-        m.statefulness
+        Totality.print m.totality Forkable.print m.forkable Yielding.print
+        m.yielding Statefulness.print m.statefulness
   end
   [@@inline]
 
@@ -1152,6 +1289,7 @@ module Lattices = struct
   *)
   module Uniqueness_op = Opposite (Uniqueness)
   module Contention_op = Opposite (Contention)
+  module Logicality_op = Opposite (Logicality)
   module Visibility_op = Opposite (Visibility)
   module Staticity_op = Opposite (Staticity)
   module Monadic_op = Opposite (Monadic)
@@ -1164,10 +1302,12 @@ module Lattices = struct
     | Uniqueness_op : Uniqueness_op.t obj
     | Linearity : Linearity.t obj
     | Portability : Portability.t obj
+    | Totality : Totality.t obj
     | Forkable : Forkable.t obj
     | Yielding : Yielding.t obj
     | Statefulness : Statefulness.t obj
     | Contention_op : Contention_op.t obj
+    | Logicality_op : Logicality_op.t obj
     | Visibility_op : Visibility_op.t obj
     | Staticity_op : Staticity_op.t obj
     | Monadic_op : Monadic_op.t obj
@@ -1188,8 +1328,9 @@ module Lattices = struct
     | Locality -> Locality
     | Regionality -> Regionality
     | Uniqueness_op | Linearity | Monadic_op | Comonadic_with_regionality
-    | Comonadic_with_locality | Contention_op | Visibility_op | Portability
-    | Forkable | Yielding | Statefulness | Staticity_op ->
+    | Comonadic_with_locality | Contention_op | Logicality_op | Visibility_op
+    | Portability | Totality | Forkable | Yielding | Statefulness | Staticity_op
+      ->
       assert false
 
   let comonadic_with_obj : type a. a obj -> a comonadic_with obj =
@@ -1201,10 +1342,12 @@ module Lattices = struct
     | Uniqueness_op -> true
     | Linearity -> false
     | Portability -> false
+    | Totality -> false
     | Forkable -> false
     | Yielding -> false
     | Statefulness -> false
     | Contention_op -> true
+    | Logicality_op -> true
     | Visibility_op -> true
     | Staticity_op -> true
     | Monadic_op -> true
@@ -1218,10 +1361,12 @@ module Lattices = struct
     | Uniqueness_op -> Fmt.fprintf ppf "Uniqueness_op"
     | Linearity -> Fmt.fprintf ppf "Linearity"
     | Portability -> Fmt.fprintf ppf "Portability"
+    | Totality -> Fmt.fprintf ppf "Totality"
     | Forkable -> Fmt.fprintf ppf "Forkable"
     | Yielding -> Fmt.fprintf ppf "Yielding"
     | Statefulness -> Fmt.fprintf ppf "Statefulness"
     | Contention_op -> Fmt.fprintf ppf "Contention_op"
+    | Logicality_op -> Fmt.fprintf ppf "Logicality_op"
     | Visibility_op -> Fmt.fprintf ppf "Visibility_op"
     | Staticity_op -> Fmt.fprintf ppf "Staticity_op"
     | Monadic_op -> Fmt.fprintf ppf "Monadic_op"
@@ -1233,12 +1378,14 @@ module Lattices = struct
     | Regionality -> Regionality.min
     | Uniqueness_op -> Uniqueness_op.min
     | Contention_op -> Contention_op.min
+    | Logicality_op -> Logicality_op.min
     | Visibility_op -> Visibility_op.min
     | Forkable -> Forkable.min
     | Yielding -> Yielding.min
     | Statefulness -> Statefulness.min
     | Linearity -> Linearity.min
     | Portability -> Portability.min
+    | Totality -> Totality.min
     | Staticity_op -> Staticity_op.min
     | Monadic_op -> Monadic_op.min
     | Comonadic_with_locality -> Comonadic_with_locality.min
@@ -1249,9 +1396,11 @@ module Lattices = struct
     | Regionality -> Regionality.max
     | Uniqueness_op -> Uniqueness_op.max
     | Contention_op -> Contention_op.max
+    | Logicality_op -> Logicality_op.max
     | Visibility_op -> Visibility_op.max
     | Linearity -> Linearity.max
     | Portability -> Portability.max
+    | Totality -> Totality.max
     | Forkable -> Forkable.max
     | Yielding -> Yielding.max
     | Statefulness -> Statefulness.max
@@ -1267,9 +1416,11 @@ module Lattices = struct
     | Regionality -> Regionality.le a b
     | Uniqueness_op -> Uniqueness_op.le a b
     | Contention_op -> Contention_op.le a b
+    | Logicality_op -> Logicality_op.le a b
     | Visibility_op -> Visibility_op.le a b
     | Linearity -> Linearity.le a b
     | Portability -> Portability.le a b
+    | Totality -> Totality.le a b
     | Forkable -> Forkable.le a b
     | Yielding -> Yielding.le a b
     | Statefulness -> Statefulness.le a b
@@ -1285,9 +1436,11 @@ module Lattices = struct
     | Regionality -> Regionality.compare_total a b
     | Uniqueness_op -> Uniqueness_op.compare_total a b
     | Contention_op -> Contention_op.compare_total a b
+    | Logicality_op -> Logicality_op.compare_total a b
     | Visibility_op -> Visibility_op.compare_total a b
     | Linearity -> Linearity.compare_total a b
     | Portability -> Portability.compare_total a b
+    | Totality -> Totality.compare_total a b
     | Forkable -> Forkable.compare_total a b
     | Yielding -> Yielding.compare_total a b
     | Statefulness -> Statefulness.compare_total a b
@@ -1303,9 +1456,11 @@ module Lattices = struct
     | Regionality -> Regionality.equal a b
     | Uniqueness_op -> Uniqueness_op.equal a b
     | Contention_op -> Contention_op.equal a b
+    | Logicality_op -> Logicality_op.equal a b
     | Visibility_op -> Visibility_op.equal a b
     | Linearity -> Linearity.equal a b
     | Portability -> Portability.equal a b
+    | Totality -> Totality.equal a b
     | Forkable -> Forkable.equal a b
     | Yielding -> Yielding.equal a b
     | Statefulness -> Statefulness.equal a b
@@ -1321,9 +1476,11 @@ module Lattices = struct
     | Regionality -> Regionality.join a b
     | Uniqueness_op -> Uniqueness_op.join a b
     | Contention_op -> Contention_op.join a b
+    | Logicality_op -> Logicality_op.join a b
     | Visibility_op -> Visibility_op.join a b
     | Linearity -> Linearity.join a b
     | Portability -> Portability.join a b
+    | Totality -> Totality.join a b
     | Forkable -> Forkable.join a b
     | Yielding -> Yielding.join a b
     | Statefulness -> Statefulness.join a b
@@ -1339,9 +1496,11 @@ module Lattices = struct
     | Regionality -> Regionality.meet a b
     | Uniqueness_op -> Uniqueness_op.meet a b
     | Contention_op -> Contention_op.meet a b
+    | Logicality_op -> Logicality_op.meet a b
     | Visibility_op -> Visibility_op.meet a b
     | Linearity -> Linearity.meet a b
     | Portability -> Portability.meet a b
+    | Totality -> Totality.meet a b
     | Forkable -> Forkable.meet a b
     | Yielding -> Yielding.meet a b
     | Statefulness -> Statefulness.meet a b
@@ -1357,9 +1516,11 @@ module Lattices = struct
     | Regionality -> Regionality.imply a b
     | Uniqueness_op -> Uniqueness_op.imply a b
     | Contention_op -> Contention_op.imply a b
+    | Logicality_op -> Logicality_op.imply a b
     | Visibility_op -> Visibility_op.imply a b
     | Linearity -> Linearity.imply a b
     | Portability -> Portability.imply a b
+    | Totality -> Totality.imply a b
     | Forkable -> Forkable.imply a b
     | Yielding -> Yielding.imply a b
     | Statefulness -> Statefulness.imply a b
@@ -1374,9 +1535,11 @@ module Lattices = struct
     | Regionality -> Regionality.print
     | Uniqueness_op -> Uniqueness_op.print
     | Contention_op -> Contention_op.print
+    | Logicality_op -> Logicality_op.print
     | Visibility_op -> Visibility_op.print
     | Linearity -> Linearity.print
     | Portability -> Portability.print
+    | Totality -> Totality.print
     | Forkable -> Forkable.print
     | Yielding -> Yielding.print
     | Statefulness -> Statefulness.print
@@ -1391,9 +1554,11 @@ module Lattices = struct
     | Regionality -> Regionality.min
     | Uniqueness_op -> Uniqueness_op.min
     | Contention_op -> Contention_op.min
+    | Logicality_op -> Logicality_op.min
     | Visibility_op -> Visibility_op.min
     | Linearity -> Linearity.min
     | Portability -> Portability.min
+    | Totality -> Totality.min
     | Forkable -> Forkable.min
     | Yielding -> Yielding.min
     | Statefulness -> Statefulness.min
@@ -1420,6 +1585,9 @@ module Lattices = struct
     | Portability, Portability -> 0
     | Portability, _ -> -1
     | _, Portability -> 1
+    | Totality, Totality -> 0
+    | Totality, _ -> -1
+    | _, Totality -> 1
     | Forkable, Forkable -> 0
     | Forkable, _ -> -1
     | _, Forkable -> 1
@@ -1432,6 +1600,9 @@ module Lattices = struct
     | Contention_op, Contention_op -> 0
     | Contention_op, _ -> -1
     | _, Contention_op -> 1
+    | Logicality_op, Logicality_op -> 0
+    | Logicality_op, _ -> -1
+    | _, Logicality_op -> 1
     | Visibility_op, Visibility_op -> 0
     | Visibility_op, _ -> -1
     | _, Visibility_op -> 1
@@ -1454,19 +1625,21 @@ module Lattices = struct
     | Uniqueness_op, Uniqueness_op -> Misc.Is_eq
     | Linearity, Linearity -> Misc.Is_eq
     | Portability, Portability -> Misc.Is_eq
+    | Totality, Totality -> Misc.Is_eq
     | Forkable, Forkable -> Misc.Is_eq
     | Yielding, Yielding -> Misc.Is_eq
     | Statefulness, Statefulness -> Misc.Is_eq
     | Contention_op, Contention_op -> Misc.Is_eq
+    | Logicality_op, Logicality_op -> Misc.Is_eq
     | Visibility_op, Visibility_op -> Misc.Is_eq
     | Staticity_op, Staticity_op -> Misc.Is_eq
     | Monadic_op, Monadic_op -> Misc.Is_eq
     | Comonadic_with_regionality, Comonadic_with_regionality -> Misc.Is_eq
     | Comonadic_with_locality, Comonadic_with_locality -> Misc.Is_eq
     | ( ( Locality | Regionality | Uniqueness_op | Linearity | Portability
-        | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
-        | Staticity_op | Monadic_op | Comonadic_with_regionality
-        | Comonadic_with_locality ),
+        | Totality | Forkable | Yielding | Statefulness | Contention_op
+        | Logicality_op | Visibility_op | Staticity_op | Monadic_op
+        | Comonadic_with_regionality | Comonadic_with_locality ),
         _ ) ->
       Misc.Is_not_eq
 end
@@ -1482,9 +1655,11 @@ module Lattices_mono = struct
       | Linearity : ('areality comonadic_with, Linearity.t) t
       | Statefulness : ('areality comonadic_with, Statefulness.t) t
       | Portability : ('areality comonadic_with, Portability.t) t
+      | Totality : ('areality comonadic_with, Totality.t) t
       | Uniqueness : (Monadic_op.t, Uniqueness_op.t) t
       | Visibility : (Monadic_op.t, Visibility_op.t) t
       | Contention : (Monadic_op.t, Contention_op.t) t
+      | Logicality : (Monadic_op.t, Logicality_op.t) t
       | Staticity : (Monadic_op.t, Staticity_op.t) t
 
     let print : type p r. _ -> (p, r) t -> unit =
@@ -1492,8 +1667,10 @@ module Lattices_mono = struct
       | Areality -> Fmt.fprintf ppf "locality"
       | Linearity -> Fmt.fprintf ppf "linearity"
       | Portability -> Fmt.fprintf ppf "portability"
+      | Totality -> Fmt.fprintf ppf "totality"
       | Uniqueness -> Fmt.fprintf ppf "uniqueness"
       | Contention -> Fmt.fprintf ppf "contention"
+      | Logicality -> Fmt.fprintf ppf "logicality"
       | Forkable -> Fmt.fprintf ppf "forkable"
       | Yielding -> Fmt.fprintf ppf "yielding"
       | Statefulness -> Fmt.fprintf ppf "statefulness"
@@ -1506,15 +1683,18 @@ module Lattices_mono = struct
       | Areality, Areality -> Is_eq
       | Linearity, Linearity -> Is_eq
       | Portability, Portability -> Is_eq
+      | Totality, Totality -> Is_eq
       | Uniqueness, Uniqueness -> Is_eq
       | Contention, Contention -> Is_eq
+      | Logicality, Logicality -> Is_eq
       | Forkable, Forkable -> Is_eq
       | Yielding, Yielding -> Is_eq
       | Statefulness, Statefulness -> Is_eq
       | Visibility, Visibility -> Is_eq
       | Staticity, Staticity -> Is_eq
-      | ( ( Areality | Linearity | Uniqueness | Portability | Contention
-          | Forkable | Yielding | Statefulness | Visibility | Staticity ),
+      | ( ( Areality | Linearity | Uniqueness | Portability | Totality
+          | Contention | Logicality | Forkable | Yielding | Statefulness
+          | Visibility | Staticity ),
           _ ) ->
         Is_not_eq
 
@@ -1529,7 +1709,9 @@ module Lattices_mono = struct
       | Visibility -> 6
       | Portability -> 7
       | Contention -> 8
-      | Staticity -> 9
+      | Totality -> 9
+      | Logicality -> 10
+      | Staticity -> 11
 
     (** Compare two axes in implication order. If A implies B, then A is before
         B. This is also observed by [printtyp]. *)
@@ -1542,11 +1724,13 @@ module Lattices_mono = struct
       | Areality -> t.areality
       | Linearity -> t.linearity
       | Portability -> t.portability
+      | Totality -> t.totality
       | Forkable -> t.forkable
       | Yielding -> t.yielding
       | Statefulness -> t.statefulness
       | Uniqueness -> t.uniqueness
       | Contention -> t.contention
+      | Logicality -> t.logicality
       | Visibility -> t.visibility
       | Staticity -> t.staticity
 
@@ -1556,11 +1740,13 @@ module Lattices_mono = struct
       | Areality -> { t with areality = r }
       | Linearity -> { t with linearity = r }
       | Portability -> { t with portability = r }
+      | Totality -> { t with totality = r }
       | Forkable -> { t with forkable = r }
       | Yielding -> { t with yielding = r }
       | Statefulness -> { t with statefulness = r }
       | Uniqueness -> { t with uniqueness = r }
       | Contention -> { t with contention = r }
+      | Logicality -> { t with logicality = r }
       | Visibility -> { t with visibility = r }
       | Staticity -> { t with staticity = r }
 
@@ -1573,19 +1759,25 @@ module Lattices_mono = struct
           From Yielding;
           From Linearity;
           From Statefulness;
-          From Portability ]
+          From Portability;
+          From Totality ]
       | Comonadic_with_regionality ->
         [ From Areality;
           From Forkable;
           From Yielding;
           From Linearity;
           From Statefulness;
-          From Portability ]
+          From Portability;
+          From Totality ]
       | Monadic_op ->
-        [From Uniqueness; From Visibility; From Contention; From Staticity]
+        [ From Uniqueness;
+          From Visibility;
+          From Contention;
+          From Logicality;
+          From Staticity ]
       | Locality | Regionality | Uniqueness_op | Linearity | Portability
-      | Forkable | Yielding | Statefulness | Contention_op | Visibility_op
-      | Staticity_op ->
+      | Totality | Forkable | Yielding | Statefulness | Contention_op
+      | Logicality_op | Visibility_op | Staticity_op ->
         []
 
     type 'b to_ = To : 'a obj * ('a, 'b) t -> 'b to_
@@ -1603,6 +1795,9 @@ module Lattices_mono = struct
       | Portability ->
         [ To (Comonadic_with_locality, Portability);
           To (Comonadic_with_regionality, Portability) ]
+      | Totality ->
+        [ To (Comonadic_with_locality, Totality);
+          To (Comonadic_with_regionality, Totality) ]
       | Forkable ->
         [ To (Comonadic_with_locality, Forkable);
           To (Comonadic_with_regionality, Forkable) ]
@@ -1613,6 +1808,7 @@ module Lattices_mono = struct
         [ To (Comonadic_with_locality, Statefulness);
           To (Comonadic_with_regionality, Statefulness) ]
       | Contention_op -> [To (Monadic_op, Contention)]
+      | Logicality_op -> [To (Monadic_op, Logicality)]
       | Visibility_op -> [To (Monadic_op, Visibility)]
       | Staticity_op -> [To (Monadic_op, Staticity)]
 
@@ -1631,9 +1827,11 @@ module Lattices_mono = struct
       | Linearity -> Comonadic (obj, ax)
       | Statefulness -> Comonadic (obj, ax)
       | Portability -> Comonadic (obj, ax)
+      | Totality -> Comonadic (obj, ax)
       | Uniqueness -> Monadic ax
       | Visibility -> Monadic ax
       | Contention -> Monadic ax
+      | Logicality -> Monadic ax
       | Staticity -> Monadic ax
   end
 
@@ -1645,10 +1843,12 @@ module Lattices_mono = struct
       Obj Uniqueness_op;
       Obj Linearity;
       Obj Portability;
+      Obj Totality;
       Obj Forkable;
       Obj Yielding;
       Obj Statefulness;
       Obj Contention_op;
+      Obj Logicality_op;
       Obj Visibility_op;
       Obj Staticity_op;
       Obj Monadic_op;
@@ -1664,10 +1864,12 @@ module Lattices_mono = struct
       | Uniqueness_op -> Uniqueness.all
       | Linearity -> Linearity.all
       | Portability -> Portability.all
+      | Totality -> Totality.all
       | Forkable -> Forkable.all
       | Yielding -> Yielding.all
       | Statefulness -> Statefulness.all
       | Contention_op -> Contention.all
+      | Logicality_op -> Logicality.all
       | Visibility_op -> Visibility.all
       | Staticity_op -> Staticity.all
       | Monadic_op -> if full then Monadic.all else Monadic.spanning_elements
@@ -2013,6 +2215,8 @@ module Lattices_mono = struct
           (Visibility_op.t, Statefulness.t, 'l * 'r) t
       | Statefulness_to_visibility_op :
           (Statefulness.t, Visibility_op.t, 'l * 'r) t
+      | Totality_to_logicality_op : (Totality.t, Logicality_op.t, 'l * 'r) t
+      | Logicality_op_to_totality : (Logicality_op.t, Totality.t, 'l * 'r) t
       | Monadic_op_to_comonadic_min :
           (Monadic_op.t, 'a comonadic_with, 'l * disallowed) t
           (** Dualize the monadic fragment to the comonadic fragment. The
@@ -2043,6 +2247,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> Portability_to_contention_op
       | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
       | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
+      | Totality_to_logicality_op -> Totality_to_logicality_op
+      | Logicality_op_to_totality -> Logicality_op_to_totality
       | Monadic_op_to_comonadic_min -> Monadic_op_to_comonadic_min
       | Comonadic_to_monadic_op_min a -> Comonadic_to_monadic_op_min a
 
@@ -2057,6 +2263,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> Portability_to_contention_op
       | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
       | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
+      | Totality_to_logicality_op -> Totality_to_logicality_op
+      | Logicality_op_to_totality -> Logicality_op_to_totality
       | Comonadic_to_monadic_op_max a -> Comonadic_to_monadic_op_max a
       | Monadic_op_to_comonadic_max -> Monadic_op_to_comonadic_max
 
@@ -2071,6 +2279,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> Portability_to_contention_op
       | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
       | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
+      | Totality_to_logicality_op -> Totality_to_logicality_op
+      | Logicality_op_to_totality -> Logicality_op_to_totality
       | Monadic_op_to_comonadic_min -> Monadic_op_to_comonadic_min
       | Comonadic_to_monadic_op_min a -> Comonadic_to_monadic_op_min a
       | Monadic_op_to_comonadic_max -> Monadic_op_to_comonadic_max
@@ -2087,6 +2297,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> Portability_to_contention_op
       | Visibility_op_to_statefulness -> Visibility_op_to_statefulness
       | Statefulness_to_visibility_op -> Statefulness_to_visibility_op
+      | Totality_to_logicality_op -> Totality_to_logicality_op
+      | Logicality_op_to_totality -> Logicality_op_to_totality
       | Monadic_op_to_comonadic_min -> Monadic_op_to_comonadic_min
       | Comonadic_to_monadic_op_min a -> Comonadic_to_monadic_op_min a
       | Monadic_op_to_comonadic_max -> Monadic_op_to_comonadic_max
@@ -2101,6 +2313,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> Portability
       | Visibility_op_to_statefulness -> Visibility_op
       | Statefulness_to_visibility_op -> Statefulness
+      | Totality_to_logicality_op -> Totality
+      | Logicality_op_to_totality -> Logicality_op
       | Monadic_op_to_comonadic_min -> Monadic_op
       | Comonadic_to_monadic_op_min ar -> areality_comonadic_obj ar
       | Monadic_op_to_comonadic_max -> Monadic_op
@@ -2135,6 +2349,12 @@ module Lattices_mono = struct
       | Statefulness_to_visibility_op, Statefulness_to_visibility_op -> 0
       | Statefulness_to_visibility_op, _ -> .
       | _, Statefulness_to_visibility_op -> .
+      | Totality_to_logicality_op, Totality_to_logicality_op -> 0
+      | Totality_to_logicality_op, _ -> .
+      | _, Totality_to_logicality_op -> .
+      | Logicality_op_to_totality, Logicality_op_to_totality -> 0
+      | Logicality_op_to_totality, _ -> .
+      | _, Logicality_op_to_totality -> .
       | Monadic_op_to_comonadic_min, Monadic_op_to_comonadic_min -> 0
       | Monadic_op_to_comonadic_min, _ -> -1
       | _, Monadic_op_to_comonadic_min -> 1
@@ -2182,6 +2402,12 @@ module Lattices_mono = struct
         Misc.Is_eq
       | Statefulness_to_visibility_op, _ -> .
       | _, Statefulness_to_visibility_op -> .
+      | Totality_to_logicality_op, Totality_to_logicality_op -> Misc.Is_eq
+      | Totality_to_logicality_op, _ -> .
+      | _, Totality_to_logicality_op -> .
+      | Logicality_op_to_totality, Logicality_op_to_totality -> Misc.Is_eq
+      | Logicality_op_to_totality, _ -> .
+      | _, Logicality_op_to_totality -> .
       | Monadic_op_to_comonadic_min, Monadic_op_to_comonadic_min -> Misc.Is_eq
       | Monadic_op_to_comonadic_min, _ -> Misc.Is_not_eq
       | _, Monadic_op_to_comonadic_min -> Misc.Is_not_eq
@@ -2217,6 +2443,8 @@ module Lattices_mono = struct
         Fmt.fprintf ppf "visibility_op_to_statefulness"
       | Statefulness_to_visibility_op ->
         Fmt.fprintf ppf "statefulnes_to_visibility_op"
+      | Totality_to_logicality_op -> Fmt.fprintf ppf "totality_to_logicality_op"
+      | Logicality_op_to_totality -> Fmt.fprintf ppf "logicality_op_to_totality"
       | Monadic_op_to_comonadic_min ->
         Fmt.fprintf ppf "monadic_op_to_comonadic_min"
       | Comonadic_to_monadic_op_min _ ->
@@ -2258,6 +2486,14 @@ module Lattices_mono = struct
       | Statefulness.Reading -> Visibility.Read
       | Statefulness.Stateful -> Visibility.Read_write
 
+    let totality_to_logicality_op = function
+      | Totality.Total -> Logicality.Logical
+      | Totality.Partial -> Logicality.Physical
+
+    let logicality_op_to_totality = function
+      | Logicality.Logical -> Totality.Total
+      | Logicality.Physical -> Totality.Partial
+
     let monadic_op_to_comonadic_min : type a.
         a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
      fun obj m ->
@@ -2268,19 +2504,28 @@ module Lattices_mono = struct
       in
       let linearity = uniqueness_op_to_linearity m.uniqueness in
       let portability = contention_op_to_portability m.contention in
+      let totality = logicality_op_to_totality m.logicality in
       let forkable = Forkable.min in
       let yielding = Yielding.min in
       let statefulness = visibility_op_to_statefulness m.visibility in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let comonadic_to_monadic_op_min : type a.
         a areality -> a comonadic_with -> Monadic_op.t =
      fun _ m ->
       let uniqueness = linearity_to_uniqueness_op m.linearity in
       let contention = portability_to_contention_op m.portability in
+      let logicality = totality_to_logicality_op m.totality in
       let visibility = statefulness_to_visibility_op m.statefulness in
       let staticity = Staticity_op.min in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     let monadic_op_to_comonadic_max : type a.
         a comonadic_with obj -> Monadic_op.t -> a comonadic_with =
@@ -2292,19 +2537,28 @@ module Lattices_mono = struct
       in
       let linearity = uniqueness_op_to_linearity m.uniqueness in
       let portability = contention_op_to_portability m.contention in
+      let totality = logicality_op_to_totality m.logicality in
       let forkable = Forkable.max in
       let yielding = Yielding.max in
       let statefulness = visibility_op_to_statefulness m.visibility in
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
 
     let comonadic_to_monadic_op_max : type a.
         a areality -> a comonadic_with -> Monadic_op.t =
      fun _ m ->
       let uniqueness = linearity_to_uniqueness_op m.linearity in
       let contention = portability_to_contention_op m.portability in
+      let logicality = totality_to_logicality_op m.totality in
       let visibility = statefulness_to_visibility_op m.statefulness in
       let staticity = Staticity_op.max in
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
 
     let apply : type a b d. b obj -> (a, b, d) t -> a -> b =
      fun dst f a ->
@@ -2319,6 +2573,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> portability_to_contention_op a
       | Visibility_op_to_statefulness -> visibility_op_to_statefulness a
       | Statefulness_to_visibility_op -> statefulness_to_visibility_op a
+      | Totality_to_logicality_op -> totality_to_logicality_op a
+      | Logicality_op_to_totality -> logicality_op_to_totality a
       | Monadic_op_to_comonadic_min -> monadic_op_to_comonadic_min dst a
       | Comonadic_to_monadic_op_min ar -> comonadic_to_monadic_op_min ar a
       | Monadic_op_to_comonadic_max -> monadic_op_to_comonadic_max dst a
@@ -2336,6 +2592,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> Contention_op_to_portability
       | Visibility_op_to_statefulness -> Statefulness_to_visibility_op
       | Statefulness_to_visibility_op -> Visibility_op_to_statefulness
+      | Totality_to_logicality_op -> Logicality_op_to_totality
+      | Logicality_op_to_totality -> Totality_to_logicality_op
       | Monadic_op_to_comonadic_min ->
         Comonadic_to_monadic_op_max (comonadic_obj_areality dst)
       | Comonadic_to_monadic_op_min _ -> Monadic_op_to_comonadic_max
@@ -2352,6 +2610,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op -> Contention_op_to_portability
       | Visibility_op_to_statefulness -> Statefulness_to_visibility_op
       | Statefulness_to_visibility_op -> Visibility_op_to_statefulness
+      | Totality_to_logicality_op -> Logicality_op_to_totality
+      | Logicality_op_to_totality -> Totality_to_logicality_op
       | Monadic_op_to_comonadic_max ->
         Comonadic_to_monadic_op_min (comonadic_obj_areality dst)
       | Comonadic_to_monadic_op_max _ -> Monadic_op_to_comonadic_min
@@ -2380,6 +2640,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op as m -> Allowed_right m
       | Visibility_op_to_statefulness as m -> Allowed_right m
       | Statefulness_to_visibility_op as m -> Allowed_right m
+      | Totality_to_logicality_op as m -> Allowed_right m
+      | Logicality_op_to_totality as m -> Allowed_right m
       | Monadic_op_to_comonadic_min -> Not_allowed_right
       | Comonadic_to_monadic_op_min _ -> Not_allowed_right
       | Monadic_op_to_comonadic_max as m -> Allowed_right m
@@ -2410,6 +2672,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op as m -> Allowed_left m
       | Visibility_op_to_statefulness as m -> Allowed_left m
       | Statefulness_to_visibility_op as m -> Allowed_left m
+      | Totality_to_logicality_op as m -> Allowed_left m
+      | Logicality_op_to_totality as m -> Allowed_left m
       | Monadic_op_to_comonadic_min as m -> Allowed_left m
       | Comonadic_to_monadic_op_min a ->
         Allowed_left (Comonadic_to_monadic_op_min a)
@@ -2437,6 +2701,7 @@ module Lattices_mono = struct
       | Uniqueness_op_to_linearity | Linearity_to_uniqueness_op
       | Contention_op_to_portability | Portability_to_contention_op
       | Visibility_op_to_statefulness | Statefulness_to_visibility_op
+      | Totality_to_logicality_op | Logicality_op_to_totality
       | Monadic_op_to_comonadic_min | Comonadic_to_monadic_op_min _
       | Monadic_op_to_comonadic_max | Comonadic_to_monadic_op_max _ ->
         (* The following proof depends on the fact that [Core_morph.t] preserves binary
@@ -2511,6 +2776,7 @@ module Lattices_mono = struct
       | Linearity -> Proj_id (Linearity, src)
       | Statefulness -> Proj_id (Statefulness, src)
       | Portability -> Proj_id (Portability, src)
+      | Totality -> Proj_id (Totality, src)
       | Areality -> Proj_core (Locality_restricted lm1, Areality, src)
 
     let compose_projection_core : type a b p d.
@@ -2526,6 +2792,8 @@ module Lattices_mono = struct
         Proj_core (Visibility_op_to_statefulness, Visibility, Monadic_op)
       | Monadic_op_to_comonadic_min, Portability ->
         Proj_core (Contention_op_to_portability, Contention, Monadic_op)
+      | Monadic_op_to_comonadic_min, Totality ->
+        Proj_core (Logicality_op_to_totality, Logicality, Monadic_op)
       | Comonadic_to_monadic_op_min areality, Uniqueness ->
         Proj_core
           ( Linearity_to_uniqueness_op,
@@ -2541,6 +2809,9 @@ module Lattices_mono = struct
           ( Portability_to_contention_op,
             Portability,
             areality_comonadic_obj areality )
+      | Comonadic_to_monadic_op_min areality, Logicality ->
+        Proj_core
+          (Totality_to_logicality_op, Totality, areality_comonadic_obj areality)
       | Comonadic_to_monadic_op_min areality, Staticity ->
         Proj_const_min (areality_comonadic_obj areality)
       | Monadic_op_to_comonadic_max, Areality -> Proj_const_max Monadic_op
@@ -2552,6 +2823,8 @@ module Lattices_mono = struct
         Proj_core (Visibility_op_to_statefulness, Visibility, Monadic_op)
       | Monadic_op_to_comonadic_max, Portability ->
         Proj_core (Contention_op_to_portability, Contention, Monadic_op)
+      | Monadic_op_to_comonadic_max, Totality ->
+        Proj_core (Logicality_op_to_totality, Logicality, Monadic_op)
       | Comonadic_to_monadic_op_max areality, Uniqueness ->
         Proj_core
           ( Linearity_to_uniqueness_op,
@@ -2567,6 +2840,9 @@ module Lattices_mono = struct
           ( Portability_to_contention_op,
             Portability,
             areality_comonadic_obj areality )
+      | Comonadic_to_monadic_op_max areality, Logicality ->
+        Proj_core
+          (Totality_to_logicality_op, Totality, areality_comonadic_obj areality)
       | Comonadic_to_monadic_op_max areality, Staticity ->
         Proj_const_max (areality_comonadic_obj areality)
       | Locality_full lm, (_ as ax0) -> compose_projection_locality_full ax0 lm
@@ -2624,6 +2900,13 @@ module Lattices_mono = struct
         | Regional_to_local | Locality_as_regionality | Regional_to_global
         | Regional_to_local_regionality | Regional_to_global_regionality ->
           And_max_id Portability)
+      | Totality -> (
+        match lm1 with
+        | Local_to_regional -> Disallowed
+        | Local_to_regional_regionality -> Disallowed
+        | Regional_to_local | Locality_as_regionality | Regional_to_global
+        | Regional_to_local_regionality | Regional_to_global_regionality ->
+          And_max_id Totality)
       | Areality -> And_max_core (Areality, Locality_restricted lm1)
 
     let compose_core_max_with : type b c q r.
@@ -2634,6 +2917,8 @@ module Lattices_mono = struct
       match (m0 : (b, c, disallowed * r) t), (ax1 : (b, q) Axis.t) with
       | Comonadic_to_monadic_op_max _, Portability ->
         And_max_core (Contention, Portability_to_contention_op)
+      | Comonadic_to_monadic_op_max _, Totality ->
+        And_max_core (Logicality, Totality_to_logicality_op)
       | Comonadic_to_monadic_op_max _, Statefulness ->
         And_max_core (Visibility, Statefulness_to_visibility_op)
       | Comonadic_to_monadic_op_max _, Linearity ->
@@ -2644,6 +2929,8 @@ module Lattices_mono = struct
       | Monadic_op_to_comonadic_max, Staticity -> Const_max_core
       | Monadic_op_to_comonadic_max, Contention ->
         And_max_core (Portability, Contention_op_to_portability)
+      | Monadic_op_to_comonadic_max, Logicality ->
+        And_max_core (Totality, Logicality_op_to_totality)
       | Monadic_op_to_comonadic_max, Visibility ->
         And_max_core (Statefulness, Visibility_op_to_statefulness)
       | Monadic_op_to_comonadic_max, Uniqueness ->
@@ -2675,6 +2962,7 @@ module Lattices_mono = struct
       | Linearity -> And_min_id Linearity
       | Statefulness -> And_min_id Statefulness
       | Portability -> And_min_id Portability
+      | Totality -> And_min_id Totality
       | Areality -> And_min_core (Areality, Locality_restricted lm1)
 
     let compose_core_min_with : type b c q l.
@@ -2685,6 +2973,8 @@ module Lattices_mono = struct
       match (m0 : (b, c, l * disallowed) t), (ax1 : (b, q) Axis.t) with
       | Comonadic_to_monadic_op_min _, Portability ->
         And_min_core (Contention, Portability_to_contention_op)
+      | Comonadic_to_monadic_op_min _, Totality ->
+        And_min_core (Logicality, Totality_to_logicality_op)
       | Comonadic_to_monadic_op_min _, Statefulness ->
         And_min_core (Visibility, Statefulness_to_visibility_op)
       | Comonadic_to_monadic_op_min _, Linearity ->
@@ -2695,6 +2985,8 @@ module Lattices_mono = struct
       | Monadic_op_to_comonadic_min, Staticity -> Const_min_core
       | Monadic_op_to_comonadic_min, Contention ->
         And_min_core (Portability, Contention_op_to_portability)
+      | Monadic_op_to_comonadic_min, Logicality ->
+        And_min_core (Totality, Logicality_op_to_totality)
       | Monadic_op_to_comonadic_min, Visibility ->
         And_min_core (Statefulness, Visibility_op_to_statefulness)
       | Monadic_op_to_comonadic_min, Uniqueness ->
@@ -2759,6 +3051,10 @@ module Lattices_mono = struct
         Morph Monadic_op_to_comonadic_max
       | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
         Morph (Comonadic_to_monadic_op_max (comonadic_obj_areality src))
+      | Totality_to_logicality_op, Totality, Logicality, _, _ ->
+        Morph (Comonadic_to_monadic_op_max (comonadic_obj_areality src))
+      | Logicality_op_to_totality, Logicality, Totality, _, _ ->
+        Morph Monadic_op_to_comonadic_max
       | Locality_restricted lm, Areality, Areality, _, _ ->
         Morph (Locality_full (Locality_morph.disallow_left lm))
       | _, _, _, _, _ -> .
@@ -2789,6 +3085,10 @@ module Lattices_mono = struct
         Morph Monadic_op_to_comonadic_min
       | Statefulness_to_visibility_op, Statefulness, Visibility, _, _ ->
         Morph (Comonadic_to_monadic_op_min (comonadic_obj_areality src))
+      | Totality_to_logicality_op, Totality, Logicality, _, _ ->
+        Morph (Comonadic_to_monadic_op_min (comonadic_obj_areality src))
+      | Logicality_op_to_totality, Logicality, Totality, _, _ ->
+        Morph Monadic_op_to_comonadic_min
       | Locality_restricted lm, Areality, Areality, _, _ ->
         Morph (Locality_full (Locality_morph.disallow_right lm))
       | _, _, _, _, _ -> .
@@ -2808,10 +3108,12 @@ module Lattices_mono = struct
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
+      | Totality -> [To Logicality_op_to_totality]
       | Forkable -> []
       | Yielding -> []
       | Statefulness -> [To Visibility_op_to_statefulness]
       | Contention_op -> [To Portability_to_contention_op]
+      | Logicality_op -> [To Totality_to_logicality_op]
       | Visibility_op -> [To Statefulness_to_visibility_op]
       | Staticity_op -> []
       | Monadic_op ->
@@ -2836,10 +3138,12 @@ module Lattices_mono = struct
       | Uniqueness_op -> [To Linearity_to_uniqueness_op]
       | Linearity -> [To Uniqueness_op_to_linearity]
       | Portability -> [To Contention_op_to_portability]
+      | Totality -> [To Logicality_op_to_totality]
       | Forkable -> []
       | Yielding -> []
       | Statefulness -> [To Visibility_op_to_statefulness]
       | Contention_op -> [To Portability_to_contention_op]
+      | Logicality_op -> [To Totality_to_logicality_op]
       | Visibility_op -> [To Statefulness_to_visibility_op]
       | Staticity_op -> []
       | Monadic_op ->
@@ -2864,6 +3168,8 @@ module Lattices_mono = struct
     | Linearity, Comonadic_with_regionality -> Linearity
     | Portability, Comonadic_with_locality -> Portability
     | Portability, Comonadic_with_regionality -> Portability
+    | Totality, Comonadic_with_locality -> Totality
+    | Totality, Comonadic_with_regionality -> Totality
     | Forkable, Comonadic_with_locality -> Forkable
     | Forkable, Comonadic_with_regionality -> Forkable
     | Yielding, Comonadic_with_locality -> Yielding
@@ -2872,6 +3178,7 @@ module Lattices_mono = struct
     | Statefulness, Comonadic_with_regionality -> Statefulness
     | Uniqueness, Monadic_op -> Uniqueness_op
     | Contention, Monadic_op -> Contention_op
+    | Logicality, Monadic_op -> Logicality_op
     | Visibility, Monadic_op -> Visibility_op
     | Staticity, Monadic_op -> Staticity_op
 
@@ -3222,6 +3529,8 @@ module Lattices_mono = struct
       | Portability_to_contention_op, Contention_op_to_portability -> Id
       | Visibility_op_to_statefulness, Statefulness_to_visibility_op -> Id
       | Statefulness_to_visibility_op, Visibility_op_to_statefulness -> Id
+      | Totality_to_logicality_op, Logicality_op_to_totality -> Id
+      | Logicality_op_to_totality, Totality_to_logicality_op -> Id
       | Comonadic_to_monadic_op_min areality, Monadic_op_to_comonadic_min ->
         let c =
           match areality with
@@ -4151,6 +4460,8 @@ module Lattices_mono = struct
 
   let morphs_to_portability = morphs_to_obj Portability
 
+  let morphs_to_totality = morphs_to_obj Totality
+
   let morphs_to_forkable = morphs_to_obj Forkable
 
   let morphs_to_yielding = morphs_to_obj Yielding
@@ -4158,6 +4469,8 @@ module Lattices_mono = struct
   let morphs_to_statefulness = morphs_to_obj Statefulness
 
   let morphs_to_contention_op = morphs_to_obj Contention_op
+
+  let morphs_to_logicality_op = morphs_to_obj Logicality_op
 
   let morphs_to_visibility_op = morphs_to_obj Visibility_op
 
@@ -4177,10 +4490,12 @@ module Lattices_mono = struct
     | Uniqueness_op -> force_by_coverage ~full morphs_to_uniqueness_op
     | Linearity -> force_by_coverage ~full morphs_to_linearity
     | Portability -> force_by_coverage ~full morphs_to_portability
+    | Totality -> force_by_coverage ~full morphs_to_totality
     | Forkable -> force_by_coverage ~full morphs_to_forkable
     | Yielding -> force_by_coverage ~full morphs_to_yielding
     | Statefulness -> force_by_coverage ~full morphs_to_statefulness
     | Contention_op -> force_by_coverage ~full morphs_to_contention_op
+    | Logicality_op -> force_by_coverage ~full morphs_to_logicality_op
     | Visibility_op -> force_by_coverage ~full morphs_to_visibility_op
     | Staticity_op -> force_by_coverage ~full morphs_to_staticity_op
     | Monadic_op -> force_by_coverage ~full morphs_to_monadic_op
@@ -4223,12 +4538,15 @@ module Lattices_mono = struct
       | Portability_to_contention_op, _ -> .
       | Visibility_op_to_statefulness, _ -> .
       | Statefulness_to_visibility_op, _ -> .
+      | Totality_to_logicality_op, _ -> .
+      | Logicality_op_to_totality, _ -> .
       | Locality_full _, (Areality as ax) -> Axis ax
       | Locality_full _, (Forkable as ax) -> Axis ax
       | Locality_full _, (Yielding as ax) -> Axis ax
       | Locality_full _, (Linearity as ax) -> Axis ax
       | Locality_full _, (Statefulness as ax) -> Axis ax
       | Locality_full _, (Portability as ax) -> Axis ax
+      | Locality_full _, (Totality as ax) -> Axis ax
       | Locality_full _, _ -> .
       | Monadic_op_to_comonadic_min, Areality -> None_responsible
       | Monadic_op_to_comonadic_min, Forkable -> None_responsible
@@ -4236,9 +4554,11 @@ module Lattices_mono = struct
       | Monadic_op_to_comonadic_min, Linearity -> Axis Uniqueness
       | Monadic_op_to_comonadic_min, Statefulness -> Axis Visibility
       | Monadic_op_to_comonadic_min, Portability -> Axis Contention
+      | Monadic_op_to_comonadic_min, Totality -> Axis Logicality
       | Comonadic_to_monadic_op_min _, Uniqueness -> Axis Linearity
       | Comonadic_to_monadic_op_min _, Visibility -> Axis Statefulness
       | Comonadic_to_monadic_op_min _, Contention -> Axis Portability
+      | Comonadic_to_monadic_op_min _, Logicality -> Axis Totality
       | Comonadic_to_monadic_op_min _, Staticity -> None_responsible
       | Monadic_op_to_comonadic_max, Areality -> None_responsible
       | Monadic_op_to_comonadic_max, Forkable -> None_responsible
@@ -4246,9 +4566,11 @@ module Lattices_mono = struct
       | Monadic_op_to_comonadic_max, Linearity -> Axis Uniqueness
       | Monadic_op_to_comonadic_max, Statefulness -> Axis Visibility
       | Monadic_op_to_comonadic_max, Portability -> Axis Contention
+      | Monadic_op_to_comonadic_max, Totality -> Axis Logicality
       | Comonadic_to_monadic_op_max _, Uniqueness -> Axis Linearity
       | Comonadic_to_monadic_op_max _, Visibility -> Axis Statefulness
       | Comonadic_to_monadic_op_max _, Contention -> Axis Portability
+      | Comonadic_to_monadic_op_max _, Logicality -> Axis Totality
       | Comonadic_to_monadic_op_max _, Staticity -> None_responsible
 
     let rec find_responsible_axis_proj_simple : type a b b_ax l r.
@@ -4409,6 +4731,7 @@ let erase_hints () = S.erase_hints ()
 type monadic = C.monadic =
   { uniqueness : C.Uniqueness.t;
     contention : C.Contention.t;
+    logicality : C.Logicality.t;
     visibility : C.Visibility.t;
     staticity : C.Staticity.t
   }
@@ -4417,6 +4740,7 @@ type 'a comonadic_with = 'a C.comonadic_with =
   { areality : 'a;
     linearity : C.Linearity.t;
     portability : C.Portability.t;
+    totality : C.Totality.t;
     forkable : C.Forkable.t;
     yielding : C.Yielding.t;
     statefulness : C.Statefulness.t
@@ -5799,6 +6123,22 @@ module Portability = struct
     | Statefulness.Const.Stateless -> zap_to_floor
 end
 
+module Totality = struct
+  module Const = C.Totality
+
+  module Obj = struct
+    type const = Const.t
+
+    let obj : _ C.obj = C.Totality
+  end
+
+  include Comonadic_gen (Obj)
+
+  let legacy = of_const Const.legacy
+
+  let zap_to_legacy = zap_to_ceil
+end
+
 module Uniqueness = struct
   module Const = C.Uniqueness
 
@@ -5839,6 +6179,22 @@ module Contention = struct
     | Visibility.Const.Write ->
       zap_to_floor
     | Visibility.Const.Immutable -> zap_to_ceil
+end
+
+module Logicality = struct
+  module Const = C.Logicality
+
+  module Obj = struct
+    type const = Const.t
+
+    let obj = C.Logicality_op
+  end
+
+  include Monadic_gen (Obj)
+
+  let legacy = of_const Const.legacy
+
+  let zap_to_legacy = zap_to_floor
 end
 
 module Forkable = struct
@@ -5947,6 +6303,7 @@ module Comonadic_with (Areality : Areality) = struct
       [ P Areality;
         P Linearity;
         P Portability;
+        P Totality;
         P Forkable;
         P Yielding;
         P Statefulness ]
@@ -6034,10 +6391,18 @@ module Comonadic_with (Areality : Areality) = struct
     let portability =
       proj Portability m |> Portability.zap_to_legacy ~statefulness
     in
+    let totality = proj Totality m |> Totality.zap_to_legacy in
     let global = Areality.Const.equal areality Areality.Const.legacy in
     let forkable = proj Forkable m |> Forkable.zap_to_legacy ~global in
     let yielding = proj Yielding m |> Yielding.zap_to_legacy ~global in
-    { areality; linearity; portability; forkable; yielding; statefulness }
+    { areality;
+      linearity;
+      portability;
+      totality;
+      forkable;
+      yielding;
+      statefulness
+    }
 
   let legacy = of_const Const.legacy
 
@@ -6100,7 +6465,7 @@ module Monadic = struct
     let proj = Axis.proj
 
     let all =
-      [P Uniqueness; P Contention; P Visibility; P Staticity]
+      [P Uniqueness; P Contention; P Logicality; P Visibility; P Staticity]
       |> List.sort (fun (P ax1) (P ax2) -> compare ax1 ax2)
   end
 
@@ -6185,8 +6550,9 @@ module Monadic = struct
     let contention =
       proj Contention m |> Contention.zap_to_legacy ~visibility
     in
+    let logicality = proj Logicality m |> Logicality.zap_to_legacy in
     let staticity = proj Staticity m |> Staticity.zap_to_legacy in
-    { uniqueness; contention; visibility; staticity }
+    { uniqueness; contention; logicality; visibility; staticity }
 
   let legacy = of_const Const.legacy
 
@@ -6277,7 +6643,7 @@ module Value_with (Areality : Areality) = struct
 
   (* CR-soon zqian: make a functor [Mode.Value.Const.Make] to generalize over any type
      operator applied on each mode constants. *)
-  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
+  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l) modes =
     { areality : 'a;
       linearity : 'b;
       uniqueness : 'c;
@@ -6287,45 +6653,66 @@ module Value_with (Areality : Areality) = struct
       yielding : 'g;
       statefulness : 'h;
       visibility : 'i;
-      staticity : 'j
+      staticity : 'j;
+      totality : 'k;
+      logicality : 'l
     }
 
   let split
       { areality;
         linearity;
         portability;
+        totality;
         forkable;
         yielding;
         statefulness;
         uniqueness;
         contention;
+        logicality;
         visibility;
         staticity
       } =
     let monadic : Monadic.Const.t =
-      { uniqueness; contention; visibility; staticity }
+      { uniqueness; contention; logicality; visibility; staticity }
     in
     let comonadic : Comonadic.Const.t =
-      { areality; linearity; portability; forkable; yielding; statefulness }
+      { areality;
+        linearity;
+        portability;
+        totality;
+        forkable;
+        yielding;
+        statefulness
+      }
     in
     { comonadic; monadic }
 
   let merge { comonadic; monadic } =
-    let ({ areality; linearity; portability; forkable; yielding; statefulness }
+    let ({ areality;
+           linearity;
+           portability;
+           totality;
+           forkable;
+           yielding;
+           statefulness
+         }
           : Comonadic.Const.t) =
       comonadic
     in
-    let ({ uniqueness; contention; visibility; staticity } : Monadic.Const.t) =
+    let ({ uniqueness; contention; logicality; visibility; staticity }
+          : Monadic.Const.t) =
       monadic
     in
     { areality;
       linearity;
       portability;
+      totality;
       forkable;
       yielding;
       statefulness;
       uniqueness;
       contention;
+      logicality;
       visibility;
       staticity
     }
@@ -6372,7 +6759,9 @@ module Value_with (Areality : Areality) = struct
         Yielding.Const.t,
         Statefulness.Const.t,
         Visibility.Const.t,
-        Staticity.Const.t )
+        Staticity.Const.t,
+        Totality.Const.t,
+        Logicality.Const.t )
       modes
 
     let min =
@@ -6437,7 +6826,9 @@ module Value_with (Areality : Areality) = struct
           Yielding.Const.t option,
           Statefulness.Const.t option,
           Visibility.Const.t option,
-          Staticity.Const.t option )
+          Staticity.Const.t option,
+          Totality.Const.t option,
+          Logicality.Const.t option )
         modes
 
       let none =
@@ -6450,7 +6841,9 @@ module Value_with (Areality : Areality) = struct
           yielding = None;
           statefulness = None;
           visibility = None;
-          staticity = None
+          staticity = None;
+          totality = None;
+          logicality = None
         }
 
       let value opt ~default =
@@ -6462,8 +6855,12 @@ module Value_with (Areality : Areality) = struct
         let portability =
           Option.value opt.portability ~default:default.portability
         in
+        let totality = Option.value opt.totality ~default:default.totality in
         let contention =
           Option.value opt.contention ~default:default.contention
+        in
+        let logicality =
+          Option.value opt.logicality ~default:default.logicality
         in
         let yielding = Option.value opt.yielding ~default:default.yielding in
         let forkable = Option.value opt.forkable ~default:default.forkable in
@@ -6478,7 +6875,9 @@ module Value_with (Areality : Areality) = struct
           uniqueness;
           linearity;
           portability;
+          totality;
           contention;
+          logicality;
           forkable;
           yielding;
           statefulness;
@@ -6492,6 +6891,7 @@ module Value_with (Areality : Areality) = struct
           match ax with
           | Uniqueness -> t.uniqueness
           | Contention -> t.contention
+          | Logicality -> t.logicality
           | Visibility -> t.visibility
           | Staticity -> t.staticity)
         | Comonadic ax -> (
@@ -6499,6 +6899,7 @@ module Value_with (Areality : Areality) = struct
           | Areality -> t.areality
           | Linearity -> t.linearity
           | Portability -> t.portability
+          | Totality -> t.totality
           | Forkable -> t.forkable
           | Yielding -> t.yielding
           | Statefulness -> t.statefulness)
@@ -6509,6 +6910,7 @@ module Value_with (Areality : Areality) = struct
           match ax with
           | Uniqueness -> { t with uniqueness = a }
           | Contention -> { t with contention = a }
+          | Logicality -> { t with logicality = a }
           | Visibility -> { t with visibility = a }
           | Staticity -> { t with staticity = a })
         | Comonadic ax -> (
@@ -6516,6 +6918,7 @@ module Value_with (Areality : Areality) = struct
           | Areality -> { t with areality = a }
           | Linearity -> { t with linearity = a }
           | Portability -> { t with portability = a }
+          | Totality -> { t with totality = a }
           | Yielding -> { t with yielding = a }
           | Forkable -> { t with forkable = a }
           | Statefulness -> { t with statefulness = a })
@@ -6530,13 +6933,15 @@ module Value_with (Areality : Areality) = struct
             yielding;
             statefulness;
             visibility;
-            staticity
+            staticity;
+            totality;
+            logicality
           } =
         let option_print print ppf = function
           | None -> Fmt.fprintf ppf "None"
           | Some a -> Fmt.fprintf ppf "Some %a" print a
         in
-        Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a,%a,%a,%a,%a"
+        Fmt.fprintf ppf "%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a,%a"
           (option_print Areality.Const.print)
           areality
           (option_print Linearity.Const.print)
@@ -6557,6 +6962,10 @@ module Value_with (Areality : Areality) = struct
           visibility
           (option_print Staticity.Const.print)
           staticity
+          (option_print Totality.Const.print)
+          totality
+          (option_print Logicality.Const.print)
+          logicality
     end
 
     let diff m1 m2 =
@@ -6568,6 +6977,8 @@ module Value_with (Areality : Areality) = struct
         diff Portability.Const.le m1.portability m2.portability
       in
       let contention = diff Contention.Const.le m1.contention m2.contention in
+      let totality = diff Totality.Const.le m1.totality m2.totality in
+      let logicality = diff Logicality.Const.le m1.logicality m2.logicality in
       let forkable = diff Forkable.Const.le m1.forkable m2.forkable in
       let yielding = diff Yielding.Const.le m1.yielding m2.yielding in
       let statefulness =
@@ -6580,6 +6991,8 @@ module Value_with (Areality : Areality) = struct
         uniqueness;
         portability;
         contention;
+        totality;
+        logicality;
         forkable;
         yielding;
         statefulness;
@@ -6879,8 +7292,10 @@ module Const = struct
       ({ areality;
          linearity;
          portability;
+         totality;
          uniqueness;
          contention;
+         logicality;
          forkable;
          yielding;
          statefulness;
@@ -6892,8 +7307,10 @@ module Const = struct
     { areality;
       linearity;
       portability;
+      totality;
       uniqueness;
       contention;
+      logicality;
       forkable;
       yielding;
       statefulness;
@@ -6908,11 +7325,13 @@ module Const = struct
       | Comonadic Areality -> Left Refl
       | Comonadic Linearity -> Right (Comonadic Linearity)
       | Comonadic Portability -> Right (Comonadic Portability)
+      | Comonadic Totality -> Right (Comonadic Totality)
       | Comonadic Forkable -> Right (Comonadic Forkable)
       | Comonadic Yielding -> Right (Comonadic Yielding)
       | Comonadic Statefulness -> Right (Comonadic Statefulness)
       | Monadic Uniqueness -> Right (Monadic Uniqueness)
       | Monadic Contention -> Right (Monadic Contention)
+      | Monadic Logicality -> Right (Monadic Logicality)
       | Monadic Visibility -> Right (Monadic Visibility)
       | Monadic Staticity -> Right (Monadic Staticity)
 
@@ -7442,7 +7861,8 @@ module Modality = struct
         Value.Comonadic.Const.Per_axis.le ax a b
 
     let print (type a) (ax : a Axis.t) ppf (t : a) =
-      match ax, t with
+      match[@warning "-4"] ax, t with
+      | Monadic Logicality, Join_const Physical -> Fmt.fprintf ppf "nonlogical"
       | Comonadic ax, Meet_const t ->
         Value.Comonadic.Const.Per_axis.print ax ppf t
       | Monadic ax, Join_const t -> Value.Monadic.Const.Per_axis.print ax ppf t
@@ -7665,9 +8085,12 @@ module Crossing = struct
 
     let create ~uniqueness:(Atom.Modality (Join_const uniqueness))
         ~contention:(Atom.Modality (Join_const contention))
+        ~logicality:(Atom.Modality (Join_const logicality))
         ~visibility:(Atom.Modality (Join_const visibility))
         ~staticity:(Atom.Modality (Join_const staticity)) =
-      Modality (Join_const { uniqueness; contention; visibility; staticity })
+      Modality
+        (Join_const
+           { uniqueness; contention; logicality; visibility; staticity })
 
     let modality m (Modality t) = Modality (Modality.Const.concat ~then_:t m)
 
@@ -7745,6 +8168,7 @@ module Crossing = struct
     let create ~regionality:(Atom.Modality (Meet_const areality))
         ~linearity:(Atom.Modality (Meet_const linearity))
         ~portability:(Atom.Modality (Meet_const portability))
+        ~totality:(Atom.Modality (Meet_const totality))
         ~forkable:(Atom.Modality (Meet_const forkable))
         ~yielding:(Atom.Modality (Meet_const yielding))
         ~statefulness:(Atom.Modality (Meet_const statefulness)) =
@@ -7753,6 +8177,7 @@ module Crossing = struct
            { areality;
              linearity;
              portability;
+             totality;
              statefulness;
              forkable;
              yielding
@@ -7998,7 +8423,8 @@ module Crossing = struct
       { monadic; comonadic = (Comonadic.set [@inlined hint]) ax a comonadic }
 
   let create ~regionality ~linearity ~uniqueness ~portability ~contention
-      ~forkable ~yielding ~statefulness ~visibility ~staticity =
+      ~totality ~logicality ~forkable ~yielding ~statefulness ~visibility
+      ~staticity =
     let comonadic b ax =
       if b then Per_axis.min (Comonadic ax) else Per_axis.max (Comonadic ax)
     in
@@ -8010,17 +8436,19 @@ module Crossing = struct
     let uniqueness = monadic uniqueness Uniqueness in
     let portability = comonadic portability Portability in
     let contention = monadic contention Contention in
+    let totality = comonadic totality Totality in
+    let logicality = monadic logicality Logicality in
     let forkable = comonadic forkable Forkable in
     let yielding = comonadic yielding Yielding in
     let statefulness = comonadic statefulness Statefulness in
     let visibility = monadic visibility Visibility in
     let staticity = monadic staticity Staticity in
     let monadic =
-      Monadic.create ~uniqueness ~contention ~visibility ~staticity
+      Monadic.create ~uniqueness ~contention ~logicality ~visibility ~staticity
     in
     let comonadic =
-      Comonadic.create ~regionality ~linearity ~portability ~yielding ~forkable
-        ~statefulness
+      Comonadic.create ~regionality ~linearity ~portability ~totality ~yielding
+        ~forkable ~statefulness
     in
     { monadic; comonadic }
 

--- a/typing/mode_intf.mli
+++ b/typing/mode_intf.mli
@@ -463,6 +463,18 @@ module type S = sig
     include Common_axis_pos with module Const := Const
   end
 
+  module Totality : sig
+    module Const : sig
+      type t =
+        | Total
+        | Partial
+
+      include Const with type t := t
+    end
+
+    include Common_axis_pos with module Const := Const
+  end
+
   module Uniqueness : sig
     module Const : sig
       type t =
@@ -486,6 +498,18 @@ module type S = sig
         | Corrupted
         | Shared
         | Contended
+
+      include Const with type t := t
+    end
+
+    include Common_axis_neg with module Const := Const
+  end
+
+  module Logicality : sig
+    module Const : sig
+      type t =
+        | Physical
+        | Logical
 
       include Const with type t := t
     end
@@ -582,6 +606,7 @@ module type S = sig
     { areality : 'a;
       linearity : Linearity.Const.t;
       portability : Portability.Const.t;
+      totality : Totality.Const.t;
       forkable : Forkable.Const.t;
       yielding : Yielding.Const.t;
       statefulness : Statefulness.Const.t
@@ -590,6 +615,7 @@ module type S = sig
   type monadic =
     { uniqueness : Uniqueness.Const.t;
       contention : Contention.Const.t;
+      logicality : Logicality.Const.t;
       visibility : Visibility.Const.t;
       staticity : Staticity.Const.t
     }
@@ -606,9 +632,11 @@ module type S = sig
       | Linearity : ('areality comonadic_with, Linearity.Const.t) t
       | Statefulness : ('areality comonadic_with, Statefulness.Const.t) t
       | Portability : ('areality comonadic_with, Portability.Const.t) t
+      | Totality : ('areality comonadic_with, Totality.Const.t) t
       | Uniqueness : (monadic, Uniqueness.Const.t) t
       | Visibility : (monadic, Visibility.Const.t) t
       | Contention : (monadic, Contention.Const.t) t
+      | Logicality : (monadic, Logicality.Const.t) t
       | Staticity : (monadic, Staticity.Const.t) t
 
     val print : Fmt.formatter -> ('p, 'r) t -> unit
@@ -669,7 +697,7 @@ module type S = sig
       include Axis with type 'a t := 'a t
     end
 
-    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j) modes =
+    type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'l) modes =
       { areality : 'a;
         linearity : 'b;
         uniqueness : 'c;
@@ -679,7 +707,9 @@ module type S = sig
         yielding : 'g;
         statefulness : 'h;
         visibility : 'i;
-        staticity : 'j
+        staticity : 'j;
+        totality : 'k;
+        logicality : 'l
       }
 
     module Const : sig
@@ -695,7 +725,9 @@ module type S = sig
               Yielding.Const.t,
               Statefulness.Const.t,
               Visibility.Const.t,
-              Staticity.Const.t )
+              Staticity.Const.t,
+              Totality.Const.t,
+              Logicality.Const.t )
             modes
 
       module Option : sig
@@ -711,7 +743,9 @@ module type S = sig
             Yielding.Const.t option,
             Statefulness.Const.t option,
             Visibility.Const.t option,
-            Staticity.Const.t option )
+            Staticity.Const.t option,
+            Totality.Const.t option,
+            Logicality.Const.t option )
           modes
 
         val none : t
@@ -1116,6 +1150,7 @@ module type S = sig
       val create :
         uniqueness:Uniqueness.Const.t Atom.t ->
         contention:Contention.Const.t Atom.t ->
+        logicality:Logicality.Const.t Atom.t ->
         visibility:Visibility.Const.t Atom.t ->
         staticity:Staticity.Const.t Atom.t ->
         t
@@ -1143,6 +1178,7 @@ module type S = sig
         regionality:Regionality.Const.t Atom.t ->
         linearity:Linearity.Const.t Atom.t ->
         portability:Portability.Const.t Atom.t ->
+        totality:Totality.Const.t Atom.t ->
         forkable:Forkable.Const.t Atom.t ->
         yielding:Yielding.Const.t Atom.t ->
         statefulness:Statefulness.Const.t Atom.t ->
@@ -1185,6 +1221,8 @@ module type S = sig
       uniqueness:bool ->
       portability:bool ->
       contention:bool ->
+      totality:bool ->
+      logicality:bool ->
       forkable:bool ->
       yielding:bool ->
       statefulness:bool ->

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -676,6 +676,36 @@ let mode_strictly_local expected_mode =
 let mode_coerce mode expected_mode =
   mode_morph (fun m -> Value.meet [m; mode]) expected_mode
 
+(* For anything interesting to be total, total primitives must be declared
+   total; otherwise only closures that call nothing qualify.  These neither
+   diverge nor raise nor touch mutable state.  [%divint] and [%modint] are
+   deliberately absent: they raise on a zero divisor.  Comparisons are also
+   absent: polymorphic comparison can raise on functions and diverge on cyclic
+   values. *)
+let primitive_is_total = function
+  | "%identity"
+  | "%negint" | "%succint" | "%predint"
+  | "%addint" | "%subint" | "%mulint"
+  | "%andint" | "%orint" | "%xorint"
+  | "%lslint" | "%lsrint" | "%asrint"
+  | "%negfloat" | "%absfloat"
+  | "%addfloat" | "%subfloat" | "%mulfloat" | "%divfloat"
+  | "%floatofint" | "%intoffloat"
+  | "%boolnot" | "%sequand" | "%sequor"
+  | "%field0_immut" | "%field1_immut"
+  | "%apply" | "%revapply" -> true
+  | _ -> false
+
+let total_primitive_mode mode =
+  mode |> Value.meet_const_with Totality Totality.Const.Total
+
+(* Syntactic effect forms ([while], [for], mutable assignment, forcing a lazy)
+   have no partial value to capture, so each constrains the totality of every
+   enclosing closure to partial by walking the closure locks, in the same way
+   [Env.walk_locks_for_legacy_construct] does for effect handlers. *)
+let constrain_enclosing_totality ~loc env =
+  Env.constrain_enclosing_totality_partial ~env (loc, Function)
+
 let mode_lazy expected_mode =
   let mode =
     Value.{
@@ -688,8 +718,13 @@ let mode_lazy expected_mode =
     mode_coerce (Value.of_const ~hint_comonadic:Lazy_allocated_on_heap mode)
       expected_mode
   in
+  (* [~totality:false] couples the lazy to its thunk: forcing runs the whole
+     thunk, so a partial body has to make the lazy partial.  [~portability:true]
+     decouples because a lazy's portability is that of its forced result, not of
+     values merely used inside the thunk. *)
   let mode_crossing =
     Crossing.create ~linearity:true ~portability:true
+      ~totality:false ~logicality:false
       ~regionality:false ~uniqueness:false ~contention:false ~statefulness:false
       ~visibility:false ~forkable:false ~yielding:false ~staticity:false
   in
@@ -1277,7 +1312,8 @@ let mode_project_mutable mut_name =
   let mode =
     { Value.Const.max with
       visibility = Visibility.Const.Read;
-      contention = Contention.Const.Shared }
+      contention = Contention.Const.Shared;
+      logicality = Logicality.Const.Physical }
     |> Value.of_const ~hint_monadic:(Mutable_read mut_name)
   in
   mode_default mode
@@ -1287,7 +1323,8 @@ let mode_mutate_mutable mut_name =
   let mode =
     { Value.Const.max with
       visibility = Write;
-      contention = Corrupted }
+      contention = Corrupted;
+      logicality = Logicality.Const.Physical }
     |> Value.of_const ~hint_monadic:(Mutable_write mut_name)
   in
   mode_default mode
@@ -3980,6 +4017,9 @@ and type_pat_aux
            pat_unique_barrier = Unique_barrier.not_computed () }
   | Ppat_lazy sp1 ->
       submode ~loc ~env:!!penv alloc_mode.mode mode_force_lazy;
+      (* Matching a [lazy] pattern forces the thunk, which runs arbitrary
+         code. *)
+      constrain_enclosing_totality ~loc !!penv;
       let nv = solve_Ppat_lazy loc penv expected_ty in
       let alloc_mode = global_pat_mode alloc_mode in
       let p1 =
@@ -6344,6 +6384,15 @@ let split_function_ty
     match is_first_val_param with
     | false -> env
     | true ->
+        (* (Hereditary): a function literal nested inside a closure demanded
+           total must itself be total, whatever the source of its partiality.
+           Submoding this literal's totality into every enclosing closure lock
+           reaches let-bound literals that the expected-mode edge (return, if
+           and argument position) misses.  [env] here still holds only the
+           enclosing closure locks; this literal's own lock is added below. *)
+        Env.constrain_enclosing_totality_at_least ~env (loc_fun, Function)
+          (Alloc.proj_comonadic Totality alloc_mode
+           |> Totality.disallow_right);
         let env =
           Env.add_closure_lock
             (loc, Function)
@@ -6572,7 +6621,36 @@ let vb_pat_constraint
 let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
   let pat_mode, exp_mode =
     if force_toplevel
-    then simple_pat_mode Value.legacy, mode_legacy
+    then begin
+      (* Toplevel bindings are pinned to legacy, except that a [total] or
+         [logical] annotation raises the floor on its axis (so the binding is
+         usable at that mode later), and an unannotated binding's logicality is
+         left free between [physical] and [logical] so that rebinding a logical
+         value stays possible. *)
+      let mode_annots = mode_annots_from_pat spat in
+      let lower = Value.Const.legacy in
+      let lower =
+        match mode_annots.mode_modes.totality with
+        | Some Totality.Const.Total ->
+            { lower with totality = Totality.Const.Total }
+        | Some Partial | None -> lower
+      in
+      let lower =
+        match mode_annots.mode_modes.logicality with
+        | Some Logicality.Const.Logical ->
+            { lower with logicality = Logicality.Const.Logical }
+        | Some Physical | None -> lower
+      in
+      let upper =
+        match mode_annots.mode_modes.logicality with
+        | None -> { lower with logicality = Logicality.Const.Logical }
+        | Some _ -> lower
+      in
+      let mode = Value.newvar () in
+      Value.submode_exn (Value.of_const lower) mode;
+      Value.submode_exn mode (Value.of_const upper);
+      simple_pat_mode mode, mode_default mode
+    end
     else match rec_mode_var with
     | None -> begin
         match pat_tuple_arity spat with
@@ -7728,6 +7806,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_setfield(srecord, lid, snewval) ->
+      constrain_enclosing_totality ~loc env;
       let (record, _, rmode, label, expected_type, ambiguity) =
         type_label_access Legacy env srecord Env.Mutation lid in
       let ty_record =
@@ -7982,6 +8061,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_while(scond, sbody) ->
+      constrain_enclosing_totality ~loc env;
       let env =
         Env.add_const_closure_lock ~ghost:true (loc, Loop)
           {Value.Comonadic.Const.max with linearity = Many} env
@@ -8011,6 +8091,7 @@ and type_expect_
         exp_attributes = sexp.pexp_attributes;
         exp_env = env }
   | Pexp_for(param, slow, shigh, dir, sbody) ->
+      constrain_enclosing_totality ~loc env;
       let for_from =
         type_expect env (mode_region Value.max) slow
           (mk_expected ~explanation:For_loop_start_index Predef.type_int)
@@ -8173,6 +8254,7 @@ and type_expect_
               exp_env = env }
         end
   | Pexp_setvar (lab, snewval) ->
+      constrain_enclosing_totality ~loc env;
       let desc =
         match Env.lookup_settable_variable ~loc lab.txt env with
         | Instance_variable (path, Mutable, cl_num,ty) ->
@@ -8313,6 +8395,8 @@ and type_expect_
         exp_env = env }
 
   | Pexp_assert (e) ->
+      (* [assert] can raise [Assert_failure]. *)
+      constrain_enclosing_totality ~loc env;
       let cond =
         type_expect env mode_max e
           (mk_expected ~explanation:Assert_condition Predef.type_bool)
@@ -8781,6 +8865,7 @@ and type_expect_
         ~attributes:sexp.pexp_attributes
         comp
   | Pexp_overwrite (exp1, exp2) ->
+      constrain_enclosing_totality ~loc env;
       if not (Language_extension.is_enabled Overwriting) then
         raise (Typetexp.Error (loc, env, Unsupported_extension Overwriting));
       if not (can_be_overwritten exp2.pexp_desc) then
@@ -9221,6 +9306,16 @@ and type_ident env ?(recarg=Rejected) lid =
   Therefore, we need to cross modes upon look-up. Ideally that should be done in
   [Env], but that is difficult due to cyclic dependency between jkind and env. *)
   let mode = cross_left env desc.val_type mode in
+  (* Total primitives are declared total here: primitives sit at legacy
+     [partial] like every other value, and the allowlist is what lets a total
+     closure call them. *)
+  let mode =
+    match desc.val_kind with
+    | Val_prim { prim_name; _ } when primitive_is_total prim_name ->
+        total_primitive_mode mode
+    | Val_reg _ | Val_mut _ | Val_prim _ | Val_ivar _ | Val_self _
+    | Val_anc _ -> mode
+  in
   (* There can be locks between the definition and a use of a value. For
   example, if a function closes over a value, there will be Closure_lock between
   the value's definition and the value's use in the function. Walking the locks
@@ -11221,8 +11316,16 @@ and map_half_typed_cases
   if val_cases = [] && exn_cases <> [] then
     raise (Error (loc, env, No_value_clauses));
   let partial =
-    if check_if_total then
-      check_partial ~lev env ty_arg_check loc val_cases
+    if check_if_total then begin
+      let partial = check_partial ~lev env ty_arg_check loc val_cases in
+      (* A non-exhaustive match can raise [Match_failure], so it constrains
+         the enclosing closures to partial, like the other syntactic effect
+         forms. *)
+      (match partial with
+       | Partial -> constrain_enclosing_totality ~loc env
+       | Total -> ());
+      partial
+    end
     else
       Partial
   in
@@ -11455,6 +11558,17 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
         Some m
     | Nonrecursive -> None
   in
+  (* (Rec): inside the right-hand sides of a [let rec], the bound variables sit
+     at [partial], so a recursive closure captures itself at partial and comes
+     out partial.  Crossing stays type-directed: an arrow-free recursive value
+     (e.g. [let rec x = 1]) still crosses to total at its use sites. *)
+  Option.iter
+    (fun m ->
+      Value.submode_exn
+        (Value.of_const
+           { Value.Const.min with totality = Totality.Const.Partial })
+        m)
+    rec_mode_var;
   let spatl = List.map vb_pat_constraint spat_sexp_list in
   let spatl =
     List.map (pat_modes ~force_toplevel rec_mode_var ~is_lpoly) spatl
@@ -11588,8 +11702,11 @@ and type_let ?check ?check_strict ?(force_toplevel = false)
           Builtin_attributes.warning_scope ~ppwarning:false attrs
             (fun () ->
               let case = Parmatch.typed_case (case pat exp) in
-              ignore(check_partial env pat.pat_type pat.pat_loc
-                       [case] : Typedtree.partial)
+              (match check_partial env pat.pat_type pat.pat_loc [case] with
+               | Partial ->
+                   (* A non-exhaustive let pattern can raise [Match_failure]. *)
+                   constrain_enclosing_totality ~loc:pat.pat_loc env
+               | Total -> ())
             )
         )
         mode_pat_typ_list

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -704,7 +704,8 @@ let total_primitive_mode mode =
    enclosing closure to partial by walking the closure locks, in the same way
    [Env.walk_locks_for_legacy_construct] does for effect handlers. *)
 let constrain_enclosing_totality ~loc env =
-  Env.constrain_enclosing_totality_partial ~env (loc, Function)
+  Env.walk_locks_for_totality ~env (loc, Function)
+    (Totality.of_const Totality.Const.Partial)
 
 let mode_lazy expected_mode =
   let mode =
@@ -6390,9 +6391,8 @@ let split_function_ty
            reaches let-bound literals that the expected-mode edge (return, if
            and argument position) misses.  [env] here still holds only the
            enclosing closure locks; this literal's own lock is added below. *)
-        Env.constrain_enclosing_totality_at_least ~env (loc_fun, Function)
-          (Alloc.proj_comonadic Totality alloc_mode
-           |> Totality.disallow_right);
+        Env.walk_locks_for_totality ~env (loc_fun, Function)
+          (Alloc.proj_comonadic Totality alloc_mode);
         let env =
           Env.add_closure_lock
             (loc, Function)
@@ -6623,32 +6623,24 @@ let pat_modes ~force_toplevel rec_mode_var ~is_lpoly (attrs, spat) =
     if force_toplevel
     then begin
       (* Toplevel bindings are pinned to legacy, except that a [total] or
-         [logical] annotation raises the floor on its axis (so the binding is
-         usable at that mode later), and an unannotated binding's logicality is
-         left free between [physical] and [logical] so that rebinding a logical
-         value stays possible. *)
+         [logical] annotation moves the binding to that end of its axis, so
+         the binding is usable at that mode later in the unit.  Unannotated
+         bindings stay at legacy exactly, as before. *)
       let mode_annots = mode_annots_from_pat spat in
-      let lower = Value.Const.legacy in
-      let lower =
+      let pinned = Value.Const.legacy in
+      let pinned =
         match mode_annots.mode_modes.totality with
         | Some Totality.Const.Total ->
-            { lower with totality = Totality.Const.Total }
-        | Some Partial | None -> lower
+            { pinned with totality = Totality.Const.Total }
+        | Some Partial | None -> pinned
       in
-      let lower =
+      let pinned =
         match mode_annots.mode_modes.logicality with
         | Some Logicality.Const.Logical ->
-            { lower with logicality = Logicality.Const.Logical }
-        | Some Physical | None -> lower
+            { pinned with logicality = Logicality.Const.Logical }
+        | Some Physical | None -> pinned
       in
-      let upper =
-        match mode_annots.mode_modes.logicality with
-        | None -> { lower with logicality = Logicality.Const.Logical }
-        | Some _ -> lower
-      in
-      let mode = Value.newvar () in
-      Value.submode_exn (Value.of_const lower) mode;
-      Value.submode_exn mode (Value.of_const upper);
+      let mode = Value.of_const pinned in
       simple_pat_mode mode, mode_default mode
     end
     else match rec_mode_var with

--- a/typing/typemode.ml
+++ b/typing/typemode.ml
@@ -80,6 +80,10 @@ module Mode_axis_pair = struct
     | "corruptible" -> comonadic Portability Corruptible
     | "shareable" -> comonadic Portability Shareable
     | "portable" -> comonadic Portability Portable
+    | "total" -> comonadic Totality Total
+    | "partial" -> comonadic Totality Partial
+    | "physical" -> monadic Logicality Physical
+    | "logical" -> monadic Logicality Logical
     | "contended" -> monadic Contention Contended
     | "corrupted" -> monadic Contention Corrupted
     | "shared" -> monadic Contention Shared
@@ -105,11 +109,18 @@ module Modality_axis_pair = struct
   type t = Modality.atom
 
   let of_string s : t =
-    match[@warning "-18"]
-      Mode_axis_pair.to_value (Mode_axis_pair.of_string s)
-    with
-    | Atom (Monadic ax, mode) -> Atom (Monadic ax, Join_const mode)
-    | Atom (Comonadic ax, mode) -> Atom (Comonadic ax, Meet_const mode)
+    (* The modality parser reads a monadic axis as a join, so the Physical end
+       of logicality is spelled [nonlogical] and [physical] does not exist in
+       modality position. *)
+    match[@warning "-18"] s with
+    | "nonlogical" -> Modality.Atom (Monadic Logicality, Join_const Physical)
+    | "physical" -> raise Not_found
+    | _ -> (
+      match[@warning "-18"]
+        Mode_axis_pair.to_value (Mode_axis_pair.of_string s)
+      with
+      | Atom (Monadic ax, mode) -> Atom (Monadic ax, Join_const mode)
+      | Atom (Comonadic ax, mode) -> Atom (Comonadic ax, Meet_const mode))
 end
 
 module Nonmodal_axis_pair = struct
@@ -269,24 +280,14 @@ let untransl_mode modes =
   in
   List.map untransl_annot modes.mode_desc
 
-let mode_annot_to_modality_annot mode_annot =
-  Location.map
-    (fun mode : Modality.atom ->
-      let (Atom (ax, mode)) = Mode_axis_pair.to_value mode in
-      match[@warning "-18"] ax with
-      | Comonadic ax -> Atom (Comonadic ax, Meet_const mode)
-      | Monadic ax -> Atom (Monadic ax, Join_const mode))
-    mode_annot
-
 let transl_modality ~maturity { txt = Parsetree.Modality modality; loc } =
   Language_extension.assert_enabled ~loc Mode maturity;
-  let mode =
-    try Mode_axis_pair.(of_string modality)
+  let atom =
+    try Modality_axis_pair.of_string modality
     with Not_found ->
       raise (Error (loc, Unrecognized_modifier (Modality, modality)))
   in
-  let mode_annot = { txt = mode; loc } in
-  mode_annot_to_modality_annot mode_annot
+  { txt = atom; loc }
 
 let untransl_modality =
   Location.map (fun (Atom (ax, t) : Modality.atom) : Parsetree.modality ->


### PR DESCRIPTION
Two mode axes, added as a comonadic/monadic pair:

| axis | min | max | legacy | fragment |
|---|---|---|---|---|
| Totality | `Total` | `Partial` | `Partial` | comonadic |
| Logicality | `Physical` | `Logical` | `Physical` | monadic |

`total` says a function terminates and has no effects, so a specification may
call it. `logical` restricts a value to the parts the logic can talk about:
reading mutable state through it is rejected, much as it is through a
`contended` value. A logical value still exists at run time — removing a value
from compilation is the separate erasure axis, in the piece above this one.

Legacy sits at the permissive end of both axes, so every unannotated value is
`partial` and `physical` and no existing type changes meaning.

**Why one piece.** The two axes are a pair in the same sense as portability and
contention, and the coupling is a registration in the existing
`comonadic_to_monadic_op_max` table rather than a new rule. Neither axis does
anything useful alone, so they land together:

- A `total` closure may only capture `total` values, exactly as a `portable`
  closure may only capture `portable` ones — the ordinary comonadic closure
  lock.
- A `total` closure bumps its captures to `logical`, as a `portable` closure
  bumps its captures to `contended`. Inside a total closure you cannot read
  mutable state through a capture, which is what makes the closure callable from
  a specification.

**What `total` rules out.** Non-termination and observable state: `ref`, `!`,
`:=`, `while` and `for`, with recursive calls restricted. No structural-recursion
check or `decreases` clauses — a `letrec` rule only.

Tests: `testsuite/tests/vox/totality.ml`, plus promoted principal-mode baselines
across the existing suite for the two new axes.

One known gap has a failing test queued rather than being fixed here: `@@
immutable` no longer lifts logicality, because `Typemode.implied_modalities` maps
`Visibility Immutable` to `Contention Contended` but nothing into `Logicality`.
The comonadic counterpart must *not* be added — `Stateless -> Total` would be
unsound, since a stateless function can still diverge — so the two axis pairs are
legitimately asymmetric there.

---

Part of stack #6796, which merges bottom-up from `main`. #6787 and #6788 touch no
compiler internals and are the natural first merges.
