### PR TITLE
Dev loop: make the failure paths loud, bounded and recoverable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,32 @@
 
 A fresh worktree needs one complete build and test installation:
 ```sh
-autoconf27
-./configure --prefix="$PWD/_install"
+make dev-configure
 make dev
 ```
 This takes about 5 minutes. Subsequent `make dev` invocations are much faster
 because they use an incremental background watcher.
 
+`configure` is not tracked in git, so every new worktree needs generating it, and
+`configure.ac` requires autoconf >= 2.71 — newer than the `autoconf` on many
+systems, where the one to use is `autoconf27`. `make dev-configure` finds a
+suitable autoconf and configures with `--prefix="$PWD/_install"`; do that by hand
+only if you need different flags.
+
 ## Development loop
 ```sh
 # edit compiler code, then typecheck/build:
 make dev
+# fresh errors from the running watcher, with no build round trip (fastest loop):
+make dev-errors
+# watch a long build's progress:
+make dev-log
 # edit compiler code or a test, then build & run a test:
 make dev-test TEST=typing-local/regression_class_type.ml
 # edit again, test an entire dir:
 make dev-test DIR=typing-local
+# review a test's new output before accepting it:
+make dev-diff TEST=path/to/test.ml
 # promote current outputs as expect goldens
 make dev-promote TEST=path/to/test.ml
 # compile separate files
@@ -27,6 +38,40 @@ make dev-ocamlopt ARGS='file.ml -o file.exe'
 # run the full compiler test suite
 make dev-test-all
 ```
+
+Promote with `make dev-promote`, **never** by copying a `.corrected` file. The
+expect harness runs twice, plain and `-principal`; the second pass writes
+`<test>.ml.corrected.corrected`, so copying `<test>.ml.corrected` silently drops
+the principal-block updates and the parallel suite then fails tests that serial
+spot checks show green. `make dev-diff` always shows the artifact that supersedes.
+
+For one-file experiments the dev compiler can be called directly, which is faster
+and more scriptable than `make dev-ocamlc`:
+```sh
+_build/dev-dune/default/main_native.exe -nostdlib -I _build/dev/runtest/stdlib
+```
+Note that this bypasses `make dev`'s checks, including the stale-stdlib check
+below.
+
+### When things go wrong
+
+- **A build that seems to hang.** `make dev` reports progress every 30s and names
+  `make dev-log`. The watcher's rpc has been seen to wedge — alive, answering
+  pings, never starting the build — so the build is bounded by
+  `DEV_RPC_TIMEOUT` (default 1800s), after which the watcher is restarted and the
+  build retried once, then run directly without the watcher. `make dev-status`
+  shows whether the watcher is idle.
+- **The compiler segfaults, or tests crash for no reason, after a compiler
+  change.** A change to marshaled `.cmi` shapes leaves the previously built
+  stdlib unreadable. `make dev` detects this and tells you to run
+  `make dev-refresh-stdlib`.
+- **A restricted environment where the watcher cannot start** (dune's RPC socket
+  cannot be created, e.g. `bind(): Operation not permitted` in a sandbox): use
+  `make dev NOWATCH=1`, which skips the watcher and rpc entirely. Slower per
+  invocation, works anywhere, and applies to the other `dev-*` targets too.
+- **`ocamlc.byte`-flavoured tests.** The dev test root's `ocamlc.byte` is the boot
+  `main.bc`, built by the host compiler, so it cannot run under the in-tree
+  `ocamlrun`. See `design-docs/dev-loop-improvements.md`.
 
 ## Release builds
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,21 @@ below.
   cannot be created, e.g. `bind(): Operation not permitted` in a sandbox): use
   `make dev NOWATCH=1`, which skips the watcher and rpc entirely. Slower per
   invocation, works anywhere, and applies to the other `dev-*` targets too.
+- **An `expect.opt` test whose result looks too good.** `dev-test` rebuilds an
+  expect-test runner when the selected tests ask for it, and you can check that
+  decision directly:
+  ```sh
+  make dev-runners-needed DIR=codegen     # prints: expectnat
+  ```
+  If a result is suspicious, the manual escape hatch is to refresh the runner
+  yourself before running anything (~3 min, it is a 110M link):
+  ```sh
+  make dev-expect-runners DEV_RUNNERS=expectnat
+  ```
+  Until PR #6794 landed, the native runner was never refreshed at all, so
+  `codegen/*` results under the dev loop before that should not be trusted: a
+  compiler change could be followed by a passing test that had exercised the
+  previous compiler.
 - **A test reported as `skipped` under `make dev-test` that runs elsewhere.** The
   dev test root's `ocamlc.byte` is the boot `main.bc`, built by the host compiler,
   so the in-tree `ocamlrun` cannot execute it. Rather than failing, those actions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,14 @@ below.
   cannot be created, e.g. `bind(): Operation not permitted` in a sandbox): use
   `make dev NOWATCH=1`, which skips the watcher and rpc entirely. Slower per
   invocation, works anywhere, and applies to the other `dev-*` targets too.
-- **`ocamlc.byte`-flavoured tests.** The dev test root's `ocamlc.byte` is the boot
-  `main.bc`, built by the host compiler, so it cannot run under the in-tree
-  `ocamlrun`. See `design-docs/dev-loop-improvements.md`.
+- **A test reported as `skipped` under `make dev-test` that runs elsewhere.** The
+  dev test root's `ocamlc.byte` is the boot `main.bc`, built by the host compiler,
+  so the in-tree `ocamlrun` cannot execute it. Rather than failing, those actions
+  skip with a reason naming the compiler they therefore do not cover. The tests
+  are real and do run under `make dev-test-all`, which uses `_runtest` and the
+  installed bytecode compiler — so a change to bytecode-compiler behaviour needs
+  the full suite, not the fast loop. See
+  `design-docs/dev-loop-improvements-final.md`.
 
 ## Release builds
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 A fresh worktree needs one complete build and test installation:
 ```sh
-make dev-configure
+make dev-configure   # or, by hand: autoconf27 && ./configure --prefix="$PWD/_install"
 make dev
 ```
 This takes about 5 minutes. Subsequent `make dev` invocations are much faster

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -673,7 +673,7 @@ dev-runners-needed:
 	  for runner in expect expectnat; do \
 	    case $$runner in \
 	      expect) pattern='(^|[;[:space:]])expect([;[:space:]]|$$)' ;; \
-	      expectnat) pattern='(^|[;[:space:]])expectnat([;[:space:]]|$$)' ;; \
+	      expectnat) pattern='(^|[;[:space:]])expect\.opt([;[:space:]]|$$)' ;; \
 	    esac; \
 	    if grep -ERq --include='*.ml' "$$pattern" "$$selection"; then \
 	      printf '%s\n' $$runner; \
@@ -697,8 +697,8 @@ dev-selftest:
 	      failures=1; \
 	    fi; \
 	  }; \
-	  check codegen ""; \
-	  check tool-expect-test "expect "; \
+	  check codegen "expectnat "; \
+	  check tool-expect-test "expect expectnat "; \
 	  test $$failures = 0
 
 # Fresh diagnostics straight from the running watcher, without a build round

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -512,25 +512,72 @@ hacking: _build/_bootinstall
 # background process. All public dev commands renew its idle lease and wait
 # for the latest compiler build before using its outputs.
 DEV_IDLE_TIMEOUT ?= 1800
+# How long to wait for a single watcher build before deciding it is wedged.
+# Generous: a cold world-rebuild of the compiler is legitimately many minutes.
+DEV_RPC_TIMEOUT ?= 1800
+# How often to report that a build is still running.
+DEV_HEARTBEAT ?= 30
+# Set NOWATCH=1 to bypass the watcher entirely. Slower, but works where dune's
+# RPC socket cannot be created at all, such as a restricted sandbox.
+NOWATCH ?=
 ARGS ?=
 dev_watcher = python3 tools/dev-watcher.py
 dev_build = _build/dev-dune
 dev_build_flag = --build-dir=$(CURDIR)/$(dev_build)
 dev_boot_targets = $(boot_targets) main.bc
+dev_stdlib = _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib
+dev_compiler = $(dev_build)/default/main_native.exe
+dev_watch_command = $(dune) build $(ws_boot) $(dev_build_flag) -w \
+  --display=short @merlin-support $(dev_boot_targets)
+# The same build, without the watcher: the NOWATCH path and the recovery path
+# taken when the watcher cannot be used.
+dev_direct_command = $(dune) build $(ws_boot) $(dev_build_flag) \
+  --display=short @merlin-support $(dev_boot_targets)
 
 .PHONY: dev dev-start dev-setup dev-runtime dev-check
 .PHONY: dev-test dev-test-all dev-promote
 .PHONY: dev-ocamlc dev-ocamlopt
 .PHONY: dev-expect-runners
-.PHONY: dev-status dev-log dev-stop
+.PHONY: dev-status dev-log dev-stop dev-errors dev-diff
+.PHONY: dev-stdlib-check dev-refresh-stdlib dev-configure
 
 dev-start: _build/_bootinstall
-	@$(dev_watcher) start --idle-timeout $(DEV_IDLE_TIMEOUT) -- \
-	  $(dune) build $(ws_boot) $(dev_build_flag) -w --display=short \
-	  @merlin-support $(dev_boot_targets)
+	@if [ -n "$(NOWATCH)" ]; then exit 0; fi; \
+	 $(dev_watcher) start --idle-timeout $(DEV_IDLE_TIMEOUT) -- \
+	   $(dev_watch_command)
+
+# configure is not tracked in git and configure.ac needs autoconf >= 2.71, which
+# is newer than the autoconf on many systems, so a fresh worktree reliably fails
+# here. Without this check the failure surfaces from the Makefile.config
+# prerequisite of _build/_bootinstall, which says nothing about autoconf.
+dev-configure:
+	@set -eu; \
+	  for candidate in autoconf27 autoconf-2.71 autoconf2.71 autoconf; do \
+	    if command -v $$candidate >/dev/null 2>&1 && \
+	       $$candidate --version 2>/dev/null | head -n 1 | \
+	         awk '{ split($$NF, v, "."); \
+	                exit !(v[1] > 2 || (v[1] == 2 && v[2] >= 71)) }'; then \
+	      found=$$candidate; \
+	      break; \
+	    fi; \
+	  done; \
+	  if [ -z "$${found:-}" ]; then \
+	    echo "dev: no autoconf >= 2.71 on PATH, which configure.ac requires." >&2; \
+	    echo "dev: on these boxes the one to use is usually autoconf27." >&2; \
+	    exit 2; \
+	  fi; \
+	  echo "dev: generating configure with $$found"; \
+	  $$found; \
+	  ./configure --prefix="$$(pwd)/_install"
 
 dev-setup:
 	+@set -eu; \
+	  if [ ! -f Makefile.config ]; then \
+	    echo "dev: Makefile.config is missing, so this worktree is not" >&2; \
+	    echo "dev: configured. Run \`make dev-configure\` (which finds a" >&2; \
+	    echo "dev: suitable autoconf and configures with --prefix=_install)." >&2; \
+	    exit 2; \
+	  fi; \
 	  if [ ! -x _install/bin/ocamlopt.opt ] || \
 	     [ ! -f _runtest/testsuite/Makefile ]; then \
 	    echo "dev: preparing the initial compiler and test installation"; \
@@ -554,21 +601,67 @@ dev-runtime:
 
 dev-check: dev-setup dev-runtime dev-start
 	@set -eu; \
-	  $(dev_watcher) wait-ready --timeout 300 -- \
-	    $(dune) rpc ping --root=. $(dev_build_flag); \
-	  if result="$$( \
-	    $(dune) rpc build $(ws_boot) $(dev_build_flag) \
-	      $(dev_boot_targets) 2>&1 \
-	  )"; then :; else \
-	    printf '%s\n' "$$result"; \
-	    exit 1; \
+	  if [ -n "$(NOWATCH)" ]; then \
+	    echo "dev: building directly (NOWATCH is set; no watcher, no rpc)"; \
+	    $(dev_direct_command); \
+	  else \
+	    $(dev_watcher) build \
+	      --timeout $(DEV_RPC_TIMEOUT) \
+	      --heartbeat $(DEV_HEARTBEAT) \
+	      --ping "$(dune) rpc ping --root=. $(dev_build_flag)" \
+	      --fallback "$(dev_direct_command)" \
+	      --diagnostics "$(dune) diagnostics --root=. $(dev_build_flag)" \
+	      -- $(dune) rpc build $(ws_boot) $(dev_build_flag) \
+	           $(dev_boot_targets); \
+	  fi
+	@$(MAKE) --no-print-directory dev-stdlib-check
+
+# A compiler change can alter the shape of marshaled .cmi files without a magic
+# number bump, which leaves the previously built stdlib unreadable by the
+# compiler that must read it. Nothing in the loop notices, because no stdlib
+# *source* changed: the reader changed. The observed failure is a SIGSEGV in the
+# built compiler, which points nowhere. Predicting this from compiler-source
+# mtimes would rebuild the stdlib on nearly every edit, so detect it instead --
+# compiling one line against the installed stdlib is enough to provoke it.
+dev-stdlib-check:
+	@set -eu; \
+	  if [ ! -x $(dev_compiler) ] || \
+	     [ ! -f $(dev_stdlib)/stdlib.cmi ]; then exit 0; fi; \
+	  scratch=_build/dev/stdlib-check; \
+	  rm -rf $$scratch; mkdir -p $$scratch; \
+	  echo 'let () = Printf.printf "%d" (List.length [Sys.opaque_identity 0])' \
+	    > $$scratch/probe.ml; \
+	  status=0; \
+	  ( ulimit -c 0; \
+	    OCAMLLIB="$$(pwd)/$(dev_stdlib)" TMPDIR="$$(pwd)/$$scratch" \
+	      $(dev_compiler) -c -o $$scratch/probe.cmo $$scratch/probe.ml \
+	      >$$scratch/probe.log 2>&1 \
+	  ) 2>/dev/null || status=$$?; \
+	  if [ $$status = 0 ]; then rm -rf $$scratch; exit 0; fi; \
+	  echo "dev: the compiler cannot read the installed standard library," >&2; \
+	  echo "dev: so a compiler change may have altered .cmi shapes." >&2; \
+	  if [ $$status -gt 128 ]; then \
+	    echo "dev: (it died on signal $$(($$status - 128)), which is what a" >&2; \
+	    echo "dev: stale marshaled .cmi looks like)" >&2; \
 	  fi; \
-	  printf '%s\n' "$$result"; \
-	  if printf '%s\n' "$$result" | grep -qx 'Success'; then \
-	    exit 0; \
-	  fi; \
-	  $(dune) diagnostics --root=. $(dev_build_flag); \
+	  echo "dev: run \`make dev-refresh-stdlib\` to rebuild it." >&2; \
+	  sed 's/^/dev: /' $$scratch/probe.log >&2; \
 	  exit 1
+
+dev-refresh-stdlib:
+	+@$(dev_watcher) stop; \
+	  $(MAKE) --no-print-directory runtime-stdlib
+
+# Check the watcher's own recovery logic against a stub dune. Needs no compiler,
+# so it runs in seconds and does not touch this worktree's watcher.
+dev-selftest:
+	@sh tools/dev-watcher-test.sh
+
+# Fresh diagnostics straight from the running watcher, without a build round
+# trip. This is the tightest error loop the watcher supports.
+dev-errors:
+	@$(dune) diagnostics --root=. $(dev_build_flag) 2>&1 \
+	  | $(dev_watcher) filter-notices
 
 dev: dev-check
 
@@ -617,6 +710,8 @@ dev-test: dev-check
 	  echo "dev: stdlib   = _build/runtime_stdlib_install/lib/ocaml_runtime_stdlib"; \
 	  export OCAMLSRCDIR=$$(pwd)/_build/dev/runtest; \
 	  export CAML_LD_LIBRARY_PATH=$$(pwd)/_build/dev/runtest/stdlib/stublibs; \
+	  export TMPDIR="$${TMPDIR:-$$(pwd)/_build/dev/tmp}"; \
+	  mkdir -p "$$TMPDIR"; \
 	  if $$(which gfortran > /dev/null 2>&1); then \
 	    export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
 	  fi; \
@@ -640,27 +735,79 @@ dev-test-all: dev-check
 	  echo "dev: building the final compiler for the full test suite"; \
 	  $(MAKE) --no-print-directory \
 	    -o boot-compiler -o runtime-stdlib install_for_test; \
-	  $(MAKE) --no-print-directory test-files-parallel
+	  status=0; \
+	  $(MAKE) --no-print-directory test-files-parallel || status=$$?; \
+	  echo "dev: corrected outputs are under _runtest/testsuite/_ocamltest/,"; \
+	  echo "dev: not the _build/dev root the rest of the loop uses."; \
+	  echo "dev: \`make dev-diff TEST=...\` searches both."; \
+	  exit $$status
+
+# A promoting run fails the action it promoted, which aborts the test, so a test
+# with several reference files converges only after several passes. Bounded,
+# because output that is genuinely unstable between the plain and -principal runs
+# never converges and should be reported rather than looped on.
+DEV_PROMOTE_PASSES ?= 3
 
 dev-promote:
 	+@set -eu; \
-	  promote_log=$$(mktemp "$${TMPDIR:-/tmp}/oxcaml-dev-promote.XXXXXX"); \
-	  trap 'rm -f "$$promote_log"' EXIT; \
-	  if $(MAKE) --no-print-directory dev-test PROMOTE=1 \
-	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
-	      $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR)) \
-	      >"$$promote_log" 2>&1; then \
+	  scratch=_build/dev/promote; \
+	  mkdir -p $$scratch; \
+	  promote_log=$$scratch/promote.log; \
+	  pass=1; \
+	  while [ $$pass -le $(DEV_PROMOTE_PASSES) ]; do \
+	    if $(MAKE) --no-print-directory dev-test PROMOTE=1 \
+	        DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
+	        $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR)) \
+	        >"$$promote_log" 2>&1; then \
+	      cat "$$promote_log"; \
+	      exit 0; \
+	    fi; \
 	    cat "$$promote_log"; \
-	    exit 0; \
-	  fi; \
-	  if $(MAKE) --no-print-directory dev-test \
-	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
-	      $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR)); then \
-	    echo "dev: promoted test output"; \
-	    exit 0; \
-	  fi; \
-	  cat "$$promote_log" >&2; \
+	    if $(MAKE) --no-print-directory dev-test \
+	        DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
+	        $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR)); then \
+	      echo "dev: promoted test output (converged after $$pass pass(es))"; \
+	      exit 0; \
+	    fi; \
+	    pass=$$((pass + 1)); \
+	  done; \
+	  echo "dev: promotion did not converge in $(DEV_PROMOTE_PASSES) passes." >&2; \
+	  echo "dev: the usual cause is output that differs between the plain and" >&2; \
+	  echo "dev: -principal runs, which promotion cannot settle: the test needs a" >&2; \
+	  echo "dev: Principal{| ... |} block written by hand." >&2; \
+	  echo "dev: run \`make dev-diff TEST=...\` to see the difference." >&2; \
 	  exit 1
+
+# Show the newest corrected output for a test against its source. Corrected
+# artifacts land in three different places depending on how the test was run, and
+# the -principal pass writes .corrected.corrected, which supersedes .corrected --
+# promoting the latter by hand silently drops the principal updates.
+dev-diff:
+	@set -eu; \
+	  if [ -z "$(TEST)" ]; then \
+	    echo "Usage: make dev-diff TEST=path/to/test.ml" >&2; \
+	    exit 2; \
+	  fi; \
+	  source="testsuite/$(call locate_test,$(TEST))"; \
+	  name=$$(basename "$$source"); \
+	  roots=""; \
+	  for root in _build/dev/runtest/testsuite _runtest/testsuite testsuite; do \
+	    if [ -d $$root ]; then roots="$$roots $$root"; fi; \
+	  done; \
+	  candidates=$$(find $$roots -name "$$name.corrected.corrected" 2>/dev/null); \
+	  if [ -z "$$candidates" ]; then \
+	    candidates=$$(find $$roots -name "$$name.corrected" 2>/dev/null); \
+	  fi; \
+	  if [ -z "$$candidates" ]; then \
+	    echo "dev: no corrected output for $$source." >&2; \
+	    echo "dev: run \`make dev-test TEST=$(TEST)\` first; note that" >&2; \
+	    echo "dev: prepare-test-root discards the previous run's artifacts." >&2; \
+	    exit 1; \
+	  fi; \
+	  newest=$$(ls -t $$candidates | head -1); \
+	  echo "dev: corrected output $$newest"; \
+	  echo "dev: promote it with \`make dev-promote TEST=$(TEST)\`, not by copying."; \
+	  diff -u "$$source" "$$newest" || true
 
 dev-ocamlc: dev-check
 	@echo "dev: compiler = $(dev_build)/default/main_native.exe"

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -729,6 +729,12 @@ dev-test: dev-check
 	    $(if $(TEST),TEST=$(call locate_test,$(TEST))) \
 	    $(if $(DIR),DIR=$(call locate_test,$(DIR)))
 
+# The explicit ocamltest build below matters: install_for_test copies ocamltest
+# from the default build dir, but `-o boot-compiler` tells make that dir is up to
+# date, so a change to ocamltest would silently run the whole suite against the
+# previous harness. The watcher builds ocamltest into _build/dev-dune, which
+# install_for_test does not read. Building that one target takes seconds, unlike
+# the boot compiler that `-o` is there to skip.
 dev-test-all: dev-check
 	+@set -eu; \
 	  if ! parallel --version 2>/dev/null | grep -q 'GNU parallel'; then \
@@ -744,13 +750,30 @@ dev-test-all: dev-check
 	  export TMPDIR="$${TMPDIR:-$$(pwd)/_build/dev/tmp}"; \
 	  mkdir -p "$$TMPDIR"; \
 	  echo "dev: building the final compiler for the full test suite"; \
+	  $(dune) build $(ws_boot) ocamltest/ocamltest.native; \
 	  $(MAKE) --no-print-directory \
 	    -o boot-compiler -o runtime-stdlib install_for_test; \
-	  status=0; \
-	  $(MAKE) --no-print-directory test-files-parallel || status=$$?; \
+	  mkdir -p _build/dev; \
+	  log=_build/dev/test-all.log; \
+	  marker=_build/dev/test-all.status; \
+	  rm -f $$marker; \
+	  { $(MAKE) --no-print-directory test-files-parallel; \
+	    echo $$? >$$marker; } 2>&1 | tee $$log; \
+	  status=$$(cat $$marker); \
 	  echo "dev: corrected outputs are under _runtest/testsuite/_ocamltest/,"; \
 	  echo "dev: not the _build/dev root the rest of the loop uses."; \
 	  echo "dev: \`make dev-diff TEST=...\` searches both."; \
+	  if grep -q 'inconsistent assumptions over interface Stdlib' $$log; then \
+	    echo "dev: Those \"inconsistent assumptions over interface Stdlib\"" >&2; \
+	    echo "dev: failures are almost certainly not real. The main build finds" >&2; \
+	    echo "dev: the stdlib through OCAMLLIB, outside dune's dependency" >&2; \
+	    echo "dev: tracking, so a stdlib *interface* change leaves compiler-libs" >&2; \
+	    echo "dev: compiled against the old Stdlib digest, and install_for_test" >&2; \
+	    echo "dev: exits 0 without fixing it." >&2; \
+	    echo "dev: The known-working recovery is a full \`rm -rf _build\` and" >&2; \
+	    echo "dev: rebuild (~25 minutes). Do not \`rm -rf _build/main\` alone:" >&2; \
+	    echo "dev: that corrupts dune's incremental state and does not heal." >&2; \
+	  fi; \
 	  exit $$status
 
 # A promoting run fails the action it promoted, which aborts the test, so a test

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -540,6 +540,7 @@ dev_direct_command = $(dune) build $(ws_boot) $(dev_build_flag) \
 .PHONY: dev-expect-runners
 .PHONY: dev-status dev-log dev-stop dev-errors dev-diff
 .PHONY: dev-stdlib-check dev-refresh-stdlib dev-configure dev-selftest
+.PHONY: dev-runners-needed
 
 dev-start: _build/_bootinstall
 	@if [ -n "$(NOWATCH)" ]; then exit 0; fi; \
@@ -662,10 +663,43 @@ dev-refresh-stdlib:
 	+@$(dev_watcher) stop; \
 	  $(MAKE) --no-print-directory runtime-stdlib
 
+# Which expect-test runners a selection's tests ask for, decided by the token in
+# their TEST blocks. Separate from the staleness comparison, and printed rather
+# than only used internally, so the decision can be checked: this is exactly the
+# decision that was silently wrong, and nothing could observe it.
+dev-runners-needed:
+	@set -eu; \
+	  selection="testsuite/$(call locate_test,$(if $(TEST),$(TEST),$(DIR)))"; \
+	  for runner in expect expectnat; do \
+	    case $$runner in \
+	      expect) pattern='(^|[;[:space:]])expect([;[:space:]]|$$)' ;; \
+	      expectnat) pattern='(^|[;[:space:]])expectnat([;[:space:]]|$$)' ;; \
+	    esac; \
+	    if grep -ERq --include='*.ml' "$$pattern" "$$selection"; then \
+	      printf '%s\n' $$runner; \
+	    fi; \
+	  done
+
 # Check the watcher's own recovery logic against a stub dune. Needs no compiler,
 # so it runs in seconds and does not touch this worktree's watcher.
 dev-selftest:
 	@sh tools/dev-watcher-test.sh
+	@set -eu; \
+	  echo "== the runners a selection needs come from its TEST-block tokens"; \
+	  failures=0; \
+	  check() { \
+	    actual=$$($(MAKE) --no-print-directory dev-runners-needed DIR=$$1 \
+	      | tr '\n' ' '); \
+	    if [ "$$actual" = "$$2" ]; then \
+	      echo "ok: $$1 needs [$$actual]"; \
+	    else \
+	      echo "FAIL: $$1 needs [$$actual], expected [$$2]"; \
+	      failures=1; \
+	    fi; \
+	  }; \
+	  check codegen ""; \
+	  check tool-expect-test "expect "; \
+	  test $$failures = 0
 
 # Fresh diagnostics straight from the running watcher, without a build round
 # trip. This is the tightest error loop the watcher supports.
@@ -694,17 +728,13 @@ dev-test: dev-check
 	  selection="$(if $(TEST),$(call locate_test,$(TEST)),$(call locate_test,$(DIR)))"; \
 	  selection="testsuite/$$selection"; \
 	  stale_runners=""; \
-	  for runner in expect expectnat; do \
-	    case $$runner in \
-	      expect) pattern='(^|[;[:space:]])expect([;[:space:]]|$$)' ;; \
-	      expectnat) pattern='(^|[;[:space:]])expectnat([;[:space:]]|$$)' ;; \
-	    esac; \
+	  for runner in $$($(MAKE) --no-print-directory dev-runners-needed \
+	      $(if $(TEST),TEST=$(TEST)) $(if $(DIR),DIR=$(DIR))); do \
 	    artifact=_build/main/oxcaml/testsuite/tools/$$runner.exe; \
-	    if grep -ERq --include='*.ml' "$$pattern" "$$selection" && \
-	       { [ ! -x $$artifact ] || \
-	         [ $(dev_build)/default/main_native.exe -nt $$artifact ] || \
-	         find oxcaml/testsuite/tools -type f -newer $$artifact \
-	           -print -quit | grep -q .; }; then \
+	    if [ ! -x $$artifact ] || \
+	       [ $(dev_compiler) -nt $$artifact ] || \
+	       find oxcaml/testsuite/tools -type f -newer $$artifact \
+	         -print -quit | grep -q .; then \
 	      stale_runners="$$stale_runners $$runner"; \
 	    fi; \
 	  done; \

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -540,7 +540,7 @@ dev_direct_command = $(dune) build $(ws_boot) $(dev_build_flag) \
 .PHONY: dev-expect-runners
 .PHONY: dev-status dev-log dev-stop dev-errors dev-diff
 .PHONY: dev-stdlib-check dev-refresh-stdlib dev-configure dev-selftest
-.PHONY: dev-runners-needed
+.PHONY: dev-runners-needed dev-report-skips
 
 dev-start: _build/_bootinstall
 	@if [ -n "$(NOWATCH)" ]; then exit 0; fi; \
@@ -629,6 +629,12 @@ dev-check: dev-setup dev-runtime dev-start
 # mtimes would rebuild the stdlib on nearly every edit, so detect it instead --
 # compiling one line against the installed stdlib is enough to provoke it.
 DEV_SKIP_STDLIB_CHECK ?=
+
+# The dev test root cannot supply a runnable bytecode compiler, so ocamlc.byte and
+# ocamlopt.byte actions skip rather than fail (see design-docs). Clear this to run
+# them for real and find out whether any of them has started working:
+#   make dev-test DIR=... DEV_SKIP_BYTECODE_COMPILERS=
+DEV_SKIP_BYTECODE_COMPILERS ?= 1
 
 dev-stdlib-check:
 	@set -eu; \
@@ -751,14 +757,43 @@ dev-test: dev-check
 	  export CAML_LD_LIBRARY_PATH=$$(pwd)/_build/dev/runtest/stdlib/stublibs; \
 	  export TMPDIR="$${TMPDIR:-$$(pwd)/_build/dev/tmp}"; \
 	  mkdir -p "$$TMPDIR"; \
-	  export OCAMLTEST_SKIP_BYTECODE_COMPILERS=1; \
+	  if [ -n "$(DEV_SKIP_BYTECODE_COMPILERS)" ]; then \
+	    export OCAMLTEST_SKIP_BYTECODE_COMPILERS=1; \
+	  fi; \
 	  if $$(which gfortran > /dev/null 2>&1); then \
 	    export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
 	  fi; \
+	  log=$$(pwd)/_build/dev/test.$$$$.log; \
+	  marker=$$(pwd)/_build/dev/test.$$$$.status; \
+	  trap 'rm -f "$$log" "$$marker"' EXIT; \
 	  cd _build/dev/runtest/testsuite; \
-	  $(MAKE) $(if $(PROMOTE),promote,$(if $(DIR),files-parallel,one)) \
-	    $(if $(TEST),TEST=$(call locate_test,$(TEST))) \
-	    $(if $(DIR),DIR=$(call locate_test,$(DIR)))
+	  { $(MAKE) $(if $(PROMOTE),promote,$(if $(DIR),files-parallel,one)) \
+	      $(if $(TEST),TEST=$(call locate_test,$(TEST))) \
+	      $(if $(DIR),DIR=$(call locate_test,$(DIR))); \
+	    echo $$? >$$marker; } 2>&1 | tee $$log; \
+	  status=$$(cat $$marker); \
+	  $(MAKE) -C $$(pwd)/../../../.. --no-print-directory \
+	    dev-report-skips DEV_SKIP_LOG=$$log; \
+	  exit $$status
+
+# A skipped action inside a multi-action test does not make the test fail, so a
+# test can be reported as passed with one of its branches never run. Say so: the
+# whole point of skipping rather than failing is lost if the gap is invisible in a
+# green run.
+DEV_SKIP_LOG ?=
+dev-report-skips:
+	@set -eu; \
+	  test -n "$(DEV_SKIP_LOG)" || exit 0; \
+	  test -f "$(DEV_SKIP_LOG)" || exit 0; \
+	  skipped=$$(grep -c 'is not runnable under this harness' \
+	    "$(DEV_SKIP_LOG)" || true); \
+	  test "$$skipped" -gt 0 || exit 0; \
+	  echo "dev: $$skipped action(s) skipped: the bytecode compiler"; \
+	  echo "dev: (ocamlc.byte / ocamlopt.byte) cannot run under the dev harness,"; \
+	  echo "dev: so those parts of those tests were not exercised -- including in"; \
+	  echo "dev: any test above that is reported as passed."; \
+	  echo "dev: \`make dev-test-all\` does exercise them, via _runtest."; \
+	  echo "dev: to run them here anyway, add DEV_SKIP_BYTECODE_COMPILERS= ."
 
 # The explicit ocamltest build below matters: install_for_test copies ocamltest
 # from the default build dir, but `-o boot-compiler` tells make that dir is up to

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -883,11 +883,12 @@ dev-promote:
 	    echo "dev: test with more reference files than passes: promotion stops at" >&2; \
 	    echo "dev: the first one it updates. Raise DEV_PROMOTE_PASSES and retry." >&2; \
 	  else \
-	    echo "dev: the last pass promoted nothing, so the output is unstable" >&2; \
-	    echo "dev: rather than merely stale. The usual cause is output that" >&2; \
-	    echo "dev: differs between the plain and -principal runs, which promotion" >&2; \
-	    echo "dev: cannot settle: the test needs a Principal{| ... |} block" >&2; \
-	    echo "dev: written by hand." >&2; \
+	    echo "dev: the last pass promoted nothing, so this is not stale output:" >&2; \
+	    echo "dev: the test is failing for a reason promotion cannot fix. Read the" >&2; \
+	    echo "dev: failure above -- a compile or setup error looks like this too." >&2; \
+	    echo "dev: If the output itself differs between the plain and -principal" >&2; \
+	    echo "dev: runs, promotion cannot settle that either: the test needs a" >&2; \
+	    echo "dev: Principal{| ... |} block written by hand." >&2; \
 	  fi; \
 	  echo "dev: run \`make dev-diff TEST=...\` to see the difference." >&2; \
 	  exit 1

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -721,6 +721,7 @@ dev-test: dev-check
 	  export CAML_LD_LIBRARY_PATH=$$(pwd)/_build/dev/runtest/stdlib/stublibs; \
 	  export TMPDIR="$${TMPDIR:-$$(pwd)/_build/dev/tmp}"; \
 	  mkdir -p "$$TMPDIR"; \
+	  export OCAMLTEST_SKIP_BYTECODE_COMPILERS=1; \
 	  if $$(which gfortran > /dev/null 2>&1); then \
 	    export LIBRARY_PATH=$$(dirname $$(gfortran -print-file-name=libgfortran.a)); \
 	  fi; \

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -539,7 +539,7 @@ dev_direct_command = $(dune) build $(ws_boot) $(dev_build_flag) \
 .PHONY: dev-ocamlc dev-ocamlopt
 .PHONY: dev-expect-runners
 .PHONY: dev-status dev-log dev-stop dev-errors dev-diff
-.PHONY: dev-stdlib-check dev-refresh-stdlib dev-configure
+.PHONY: dev-stdlib-check dev-refresh-stdlib dev-configure dev-selftest
 
 dev-start: _build/_bootinstall
 	@if [ -n "$(NOWATCH)" ]; then exit 0; fi; \
@@ -550,25 +550,29 @@ dev-start: _build/_bootinstall
 # is newer than the autoconf on many systems, so a fresh worktree reliably fails
 # here. Without this check the failure surfaces from the Makefile.config
 # prerequisite of _build/_bootinstall, which says nothing about autoconf.
+# No version parsing: configure.ac's AC_PREREQ([2.71]) already makes a too-old
+# autoconf fail, so trying each candidate and keeping the one that works cannot
+# accept a version that would not have worked. tools/autogen is not used, despite
+# being the wrapper intended for this, because its --warnings=all,error rejects
+# this fork's configure.ac (many AC_RUN_IFELSE cross-compiling warnings).
 dev-configure:
 	@set -eu; \
+	  log=""; \
 	  for candidate in autoconf27 autoconf-2.71 autoconf2.71 autoconf; do \
-	    if command -v $$candidate >/dev/null 2>&1 && \
-	       $$candidate --version 2>/dev/null | head -n 1 | \
-	         awk '{ split($$NF, v, "."); \
-	                exit !(v[1] > 2 || (v[1] == 2 && v[2] >= 71)) }'; then \
-	      found=$$candidate; \
-	      break; \
+	    if ! command -v $$candidate >/dev/null 2>&1; then continue; fi; \
+	    rm -rf autom4te.cache; \
+	    if log=$$($$candidate 2>&1) && [ -f configure ]; then \
+	      echo "dev: generated configure with $$candidate"; \
+	      ./configure --prefix="$$(pwd)/_install"; \
+	      exit 0; \
 	    fi; \
 	  done; \
-	  if [ -z "$${found:-}" ]; then \
-	    echo "dev: no autoconf >= 2.71 on PATH, which configure.ac requires." >&2; \
-	    echo "dev: on these boxes the one to use is usually autoconf27." >&2; \
-	    exit 2; \
-	  fi; \
-	  echo "dev: generating configure with $$found"; \
-	  $$found; \
-	  ./configure --prefix="$$(pwd)/_install"
+	  echo "dev: could not generate configure." >&2; \
+	  echo "dev: configure.ac has AC_PREREQ([2.71]), so an older autoconf fails;" >&2; \
+	  echo "dev: on these boxes the one that works is usually autoconf27." >&2; \
+	  echo "dev: tried autoconf27 autoconf-2.71 autoconf2.71 autoconf." >&2; \
+	  printf '%s\n' "$$log" >&2; \
+	  exit 2
 
 dev-setup:
 	+@set -eu; \
@@ -623,8 +627,11 @@ dev-check: dev-setup dev-runtime dev-start
 # built compiler, which points nowhere. Predicting this from compiler-source
 # mtimes would rebuild the stdlib on nearly every edit, so detect it instead --
 # compiling one line against the installed stdlib is enough to provoke it.
+DEV_SKIP_STDLIB_CHECK ?=
+
 dev-stdlib-check:
 	@set -eu; \
+	  if [ -n "$(DEV_SKIP_STDLIB_CHECK)" ]; then exit 0; fi; \
 	  if [ ! -x $(dev_compiler) ] || \
 	     [ ! -f $(dev_stdlib)/stdlib.cmi ]; then exit 0; fi; \
 	  scratch=_build/dev/stdlib-check; \
@@ -638,15 +645,18 @@ dev-stdlib-check:
 	      >$$scratch/probe.log 2>&1 \
 	  ) 2>/dev/null || status=$$?; \
 	  if [ $$status = 0 ]; then rm -rf $$scratch; exit 0; fi; \
-	  echo "dev: the compiler cannot read the installed standard library," >&2; \
-	  echo "dev: so a compiler change may have altered .cmi shapes." >&2; \
-	  if [ $$status -gt 128 ]; then \
-	    echo "dev: (it died on signal $$(($$status - 128)), which is what a" >&2; \
-	    echo "dev: stale marshaled .cmi looks like)" >&2; \
-	  fi; \
-	  echo "dev: run \`make dev-refresh-stdlib\` to rebuild it." >&2; \
 	  sed 's/^/dev: /' $$scratch/probe.log >&2; \
-	  exit 1
+	  if [ $$status -gt 128 ]; then \
+	    echo "dev: the compiler died on signal $$(($$status - 128)) reading the" >&2; \
+	    echo "dev: installed standard library, which is what a stale marshaled" >&2; \
+	    echo "dev: .cmi looks like: a compiler change may have altered .cmi" >&2; \
+	    echo "dev: shapes. Run \`make dev-refresh-stdlib\` to rebuild it." >&2; \
+	    exit 1; \
+	  fi; \
+	  echo "dev: warning: the compiler failed on a one-line program. That is" >&2; \
+	  echo "dev: most likely your change rather than a stale standard library," >&2; \
+	  echo "dev: so this is a warning; \`make dev-ocamlc\` still works." >&2; \
+	  exit 0
 
 dev-refresh-stdlib:
 	+@$(dev_watcher) stop; \
@@ -660,8 +670,7 @@ dev-selftest:
 # Fresh diagnostics straight from the running watcher, without a build round
 # trip. This is the tightest error loop the watcher supports.
 dev-errors:
-	@$(dune) diagnostics --root=. $(dev_build_flag) 2>&1 \
-	  | $(dev_watcher) filter-notices
+	@$(dune) diagnostics --root=. $(dev_build_flag)
 
 dev: dev-check
 
@@ -732,6 +741,8 @@ dev-test-all: dev-check
 	      DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) >/dev/null || true; \
 	  }; \
 	  trap restart_watcher EXIT; \
+	  export TMPDIR="$${TMPDIR:-$$(pwd)/_build/dev/tmp}"; \
+	  mkdir -p "$$TMPDIR"; \
 	  echo "dev: building the final compiler for the full test suite"; \
 	  $(MAKE) --no-print-directory \
 	    -o boot-compiler -o runtime-stdlib install_for_test; \
@@ -752,8 +763,9 @@ dev-promote:
 	+@set -eu; \
 	  scratch=_build/dev/promote; \
 	  mkdir -p $$scratch; \
-	  promote_log=$$scratch/promote.log; \
+	  promote_log=$$scratch/promote.$$$$.log; \
 	  pass=1; \
+	  promoted=no; \
 	  while [ $$pass -le $(DEV_PROMOTE_PASSES) ]; do \
 	    if $(MAKE) --no-print-directory dev-test PROMOTE=1 \
 	        DEV_IDLE_TIMEOUT=$(DEV_IDLE_TIMEOUT) \
@@ -769,12 +781,25 @@ dev-promote:
 	      echo "dev: promoted test output (converged after $$pass pass(es))"; \
 	      exit 0; \
 	    fi; \
+	    if grep -q '^Promoting ' "$$promote_log"; then \
+	      promoted=yes; \
+	    else \
+	      promoted=no; \
+	    fi; \
 	    pass=$$((pass + 1)); \
 	  done; \
 	  echo "dev: promotion did not converge in $(DEV_PROMOTE_PASSES) passes." >&2; \
-	  echo "dev: the usual cause is output that differs between the plain and" >&2; \
-	  echo "dev: -principal runs, which promotion cannot settle: the test needs a" >&2; \
-	  echo "dev: Principal{| ... |} block written by hand." >&2; \
+	  if [ "$$promoted" = yes ]; then \
+	    echo "dev: the last pass still promoted something, so it is probably a" >&2; \
+	    echo "dev: test with more reference files than passes: promotion stops at" >&2; \
+	    echo "dev: the first one it updates. Raise DEV_PROMOTE_PASSES and retry." >&2; \
+	  else \
+	    echo "dev: the last pass promoted nothing, so the output is unstable" >&2; \
+	    echo "dev: rather than merely stale. The usual cause is output that" >&2; \
+	    echo "dev: differs between the plain and -principal runs, which promotion" >&2; \
+	    echo "dev: cannot settle: the test needs a Principal{| ... |} block" >&2; \
+	    echo "dev: written by hand." >&2; \
+	  fi; \
 	  echo "dev: run \`make dev-diff TEST=...\` to see the difference." >&2; \
 	  exit 1
 

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -816,6 +816,7 @@ dev-test-all: dev-check
 	  export TMPDIR="$${TMPDIR:-$$(pwd)/_build/dev/tmp}"; \
 	  mkdir -p "$$TMPDIR"; \
 	  echo "dev: building the final compiler for the full test suite"; \
+	  echo "dev: refreshing the test harness"; \
 	  $(dune) build $(ws_boot) ocamltest/ocamltest.native; \
 	  $(MAKE) --no-print-directory \
 	    -o boot-compiler -o runtime-stdlib install_for_test; \

--- a/Makefile.common-ox
+++ b/Makefile.common-ox
@@ -788,26 +788,7 @@ dev-diff:
 	    echo "Usage: make dev-diff TEST=path/to/test.ml" >&2; \
 	    exit 2; \
 	  fi; \
-	  source="testsuite/$(call locate_test,$(TEST))"; \
-	  name=$$(basename "$$source"); \
-	  roots=""; \
-	  for root in _build/dev/runtest/testsuite _runtest/testsuite testsuite; do \
-	    if [ -d $$root ]; then roots="$$roots $$root"; fi; \
-	  done; \
-	  candidates=$$(find $$roots -name "$$name.corrected.corrected" 2>/dev/null); \
-	  if [ -z "$$candidates" ]; then \
-	    candidates=$$(find $$roots -name "$$name.corrected" 2>/dev/null); \
-	  fi; \
-	  if [ -z "$$candidates" ]; then \
-	    echo "dev: no corrected output for $$source." >&2; \
-	    echo "dev: run \`make dev-test TEST=$(TEST)\` first; note that" >&2; \
-	    echo "dev: prepare-test-root discards the previous run's artifacts." >&2; \
-	    exit 1; \
-	  fi; \
-	  newest=$$(ls -t $$candidates | head -1); \
-	  echo "dev: corrected output $$newest"; \
-	  echo "dev: promote it with \`make dev-promote TEST=$(TEST)\`, not by copying."; \
-	  diff -u "$$source" "$$newest" || true
+	  $(dev_watcher) diff --test "$(call locate_test,$(TEST))"
 
 dev-ocamlc: dev-check
 	@echo "dev: compiler = $(dev_build)/default/main_native.exe"

--- a/Makefile.config_if_required
+++ b/Makefile.config_if_required
@@ -17,11 +17,18 @@ MAKECMDGOALS ?= defaultentry
 
 CLEAN_TARGET_NAMES=clean partialclean distclean
 
+# Targets that bootstrap the dev loop, or test it without building anything,
+# must be usable before the tree is configured -- configuring is what
+# dev-configure is for, so requiring configuration to reach it is circular.
+UNCONFIGURED_TARGET_NAMES=dev-configure dev-selftest
+
 # Some special targets ('*clean' and 'configure') do not require configuration.
 # REQUIRES_CONFIGURATION is empty if only those targets are requested,
 # and non-empty if configuration is required.
 REQUIRES_CONFIGURATION := $(strip \
-  $(filter-out $(CLEAN_TARGET_NAMES) configure, $(MAKECMDGOALS)))
+  $(filter-out \
+    $(CLEAN_TARGET_NAMES) $(UNCONFIGURED_TARGET_NAMES) configure, \
+    $(MAKECMDGOALS)))
 
 ifneq "$(REQUIRES_CONFIGURATION)" ""
 ifneq "$(origin BUILD_CONFIG_INCLUDED)" "override"

--- a/design-docs/dev-loop-improvements-final.md
+++ b/design-docs/dev-loop-improvements-final.md
@@ -15,6 +15,8 @@ Branch `jujacobs/vox/dev-loop-improvements`, based on `jujacobs/optimize-dev-loo
 | `a7bd9f2024` | fixes from the review loop |
 | `fa727a341c` | `dev-test-all` refreshes the test harness; stdlib-digest diagnosis |
 | `daab428772` / `48892bda89` | RED / GREEN: `ocamlc.byte` tests skip, naming the compiler |
+| `5b051426d2` / `b385cca223` | RED / GREEN: match `expect.opt`, so the native expect runner is refreshed |
+| `c38d1c98f5` | the bytecode-compiler sweep: measurement, visible skip counts, the re-run knob |
 
 Plus this report and its amendments.
 
@@ -206,6 +208,33 @@ simpler and more correct than what I wrote.
   in-tree runtime, i.e. building the bytecode compiler in a context that uses it —
   a build-system change, out of scope here.
 
+  **The sweep, per the ruling.** 548 test files declare `ocamlc.byte` or
+  `ocamlopt.byte` — far beyond my original three directories: 95 in
+  `flambda2/examples`, 39 in `typing-modules-bugs`, 27 in `warnings`, 25 in
+  `typing-recmod`, and so on. Nineteen directories were then measured **both ways**,
+  skip off and skip on (full table in `c38d1c98f5`). The result that decides the
+  design: **the passed count is identical with the skip off and on in every
+  directory**. Nothing that passes is skipped, so the concern behind the ruling —
+  skipping tests that would have passed — does not materialise, and the skip is not
+  masking unrelated failures either (`warnings` keeps its `mnemonics.mll` failure, a
+  lexer test; `tool-ocamlopt-save-ir` keeps one). That is why this stays a per-action
+  decision rather than a checked-in list: the skip is already exactly targeted, and a
+  list would be a second copy of the same fact with a way to go stale.
+
+  **One case did need the ruling's third step.** `typing-layouts-products` goes from
+  27 passed to **31**: four tests there are multi-branch, and their `ocamlc.byte`
+  branch skips while their `native` branches run and pass, so the test reports
+  *passed* with a branch never exercised. No count of skipped *tests* shows that. So
+  `dev-test` now counts skipped **actions** and says what was not covered, naming the
+  compiler and warning that a test reported as passed may be affected. `dev-test-all`
+  needs no such count because it does not set the variable — `_runtest` has the real
+  bytecode compiler — and the message points there.
+
+  **Noticing when a skipped test starts passing** is `DEV_SKIP_BYTECODE_COMPILERS=`,
+  which runs the actions for real in any selection and needs no list to maintain. The
+  measurement above is what a list file would have recorded; its provenance is this
+  report and `c38d1c98f5`, measured 2026-08-14 against branch tip.
+
   **Landed** in `daab428772` (RED) and `48892bda89` (GREEN):
   `OCAMLTEST_SKIP_BYTECODE_COMPILERS` makes the `ocamlc.byte` and `ocamlopt.byte`
   actions skip rather than fail, with a reason naming the compiler —
@@ -296,6 +325,53 @@ speed, and it deserves its own design doc and its own review — which is why it
 kept out of this branch. Whoever picks it up should start by establishing what the
 runner is supposed to be built against and why, not by making the build faster.
 
+## The `expect.opt` runner was never refreshed: `codegen/*` results were vacuous
+
+Reported by another session while using the loop, and it is the same class as the
+stale-harness defect below with a worse blast radius, because the failure mode is a
+*passing* test.
+
+`dev-test` decided whether to rebuild an expect runner by grepping the selected test
+files for the runner's name. For the byte runner that works — the TEST-block token
+really is `expect` (`ocamltest/ocaml_tests.ml:121`). For the native runner it grepped
+for `expectnat`, but the token is `expect.opt` (`ocaml_tests.ml:136`), so the branch
+was dead code and `expectnat.exe` stayed whatever the last full build left behind.
+
+Verified over `testsuite/tests` rather than taken on report:
+
+| token searched for | files containing it |
+| --- | --- |
+| `expectnat` (what the code looked for) | **0** — so the branch could never fire |
+| `expect.opt` (the real spelling) | 43, of which 29 in `codegen/` |
+| `expect` (the byte runner) | 753 — that pattern is right by design, not by luck |
+
+Only 5 of the 43 also carry a bare `expect`, so for the other 38 *neither* runner was
+refreshed. `codegen/` is 29 of its 30 `.ml` tests, which is why **every `codegen/*`
+result under the dev loop before this fix should not be trusted**: a compiler change
+could be followed by a passing test that had exercised the previous compiler. The
+session that found it saw two different mutations produce a byte-identical diff, and
+filed then retracted a false claim about test coverage. `dev-test-all` is unaffected —
+it goes through `_runtest`.
+
+Fixed in `5b051426d2` (RED) / `b385cca223` (GREEN). The fix is one token, but the
+reason it survived is that the decision was unobservable, so it is now split in two
+and the deterministic half is a target: `make dev-runners-needed DIR=codegen` prints
+`expectnat`. `dev-selftest` pins both cases, and the RED→GREEN diff is exactly those
+two expectation lines.
+
+**Cost**, since the worry was that every `codegen/` test would start paying a 110M
+link: measured twice at **~4s** when the main workspace has nothing to rebuild — the
+refresh asks dune, dune answers immediately. The link is only paid after a compiler
+source change, which is precisely when the old behaviour was returning a result from
+the previous compiler. I did not measure that case; the ~3 min figure is the
+reporting session's.
+
+Worth being exact about the trigger, because it is weaker than it looks: it compares
+the runner against the *dev* compiler, while the runner is built by the *main*
+workspace, so it can fire when nothing needs rebuilding (harmless, 4s). What actually
+keeps the runner honest is dune's dependency tracking of main-workspace sources. The
+defect was never a wrong criterion; it was never consulting one.
+
 ## The full suite found a defect nobody had listed
 
 `make dev-test-all` on this branch: **2442 passed, 208 skipped, 1 failed** of 2651
@@ -358,9 +434,22 @@ happened.
 
 ## Verification I did not do
 
-- I did run the full suite, and it earned its keep — see below. What is *not*
-  verified is a second full-suite run after `e95dc422b7`, so the harness-refresh
-  fix is verified only against the single test that exposed it.
+- The full suite was run again at the branch tip: **2444 passed, 208 skipped, 0
+  failed** of 2652 considered, exit 0. So the number matches the tip, and the
+  harness-refresh fix is confirmed by the fixture that exposed it now passing under
+  `_runtest`. The earlier run (2442/208/1) is the one that found that defect.
+- Items 3a, 4d, 4e, 6d, 6e are no longer unexercised:
+  - **3a** — `_build/dev/runtest/ocamlopt` → `ocamlopt.byte` → `boot_ocamlopt.exe`;
+    the path bigint reported as "cannot find file" now exists and resolves to the dev
+    compiler.
+  - **4d** — in a real promote, `Promoting ... to reference` appears before the verify
+    run's output, i.e. chronologically.
+  - **4e** — forced non-convergence by appending `exit 3` to a fixture's driver, with
+    `DEV_PROMOTE_PASSES=2`; the path fires and gives the reworded diagnosis.
+  - **6d** — the artifact-location line fired in the full-suite run above.
+  - **6e** — run under the real system python 3.6.8: `dev watcher: python 3.7 or
+    newer is required (running 3.6.8 from /usr/bin/python3)`, exit 1, instead of an
+    argparse traceback.
 - Items 3a, 4d, 4e, 6d, 6e are landed but not exercised (table above). 4e and 6e
   in particular need a fixture that is genuinely unstable between the plain and
   `-principal` runs, and a python 3.6 interpreter, respectively.

--- a/design-docs/dev-loop-improvements-final.md
+++ b/design-docs/dev-loop-improvements-final.md
@@ -17,6 +17,7 @@ Branch `jujacobs/vox/dev-loop-improvements`, based on `jujacobs/optimize-dev-loo
 | `daab428772` / `48892bda89` | RED / GREEN: `ocamlc.byte` tests skip, naming the compiler |
 | `5b051426d2` / `b385cca223` | RED / GREEN: match `expect.opt`, so the native expect runner is refreshed |
 | `c38d1c98f5` | the bytecode-compiler sweep: measurement, visible skip counts, the re-run knob |
+| `81cdb42bea` | `dev-promote` no longer asserts principal instability for any unpromotable failure |
 
 Plus this report and its amendments.
 
@@ -53,6 +54,8 @@ the failure into an instruction.
 | 6e. python ≥ 3.7 guard | 2/5 | **Exercised** under the system python 3.6.8 |
 | 6f. suppress dune's forwarding notice | 1/5 | **Reversed after review — deleted** |
 | 6g. docs: setup, blessed scratch path, never copy `.corrected` | — | Landed |
+| (found here) `dev-test-all` ran against a stale ocamltest | 0/5 | **Exercised** — a fixture on this branch failed until it was fixed |
+| (reported later) the `expect.opt` runner was never refreshed | — | **Exercised**, red-green; cost measured |
 
 ### The evidence for items 1, 2 and 5
 
@@ -397,7 +400,8 @@ refreshed harness the fixture passes under `_runtest`, where it had failed.
 Two changes on this branch are shared beyond the dev loop and so were the reason
 for running the suite at all: `Makefile.config_if_required` (the configuration gate
 for every target) and `ocamltest/actions_helpers.ml` (promotion for every test).
-Neither caused a failure. The whole `tool-ocamltest` directory also passes, 7/7.
+Neither caused a failure. The whole `tool-ocamltest` directory passes too — 7/7 at
+that point, 8/8 at the tip once the `ocamlc.byte` skip fixture joined it.
 
 ## The `/tmp` rule: what was leaking, and what was left behind
 
@@ -432,12 +436,15 @@ happening repeatedly to wedged runs, and which happened several times during thi
 work. The rule violation was real and is fixed; the accumulation had not yet
 happened.
 
-## Verification I did not do
+## The two gaps flagged earlier are closed
 
-- The full suite was run again at the branch tip: **2444 passed, 208 skipped, 0
-  failed** of 2652 considered, exit 0. So the number matches the tip, and the
-  harness-refresh fix is confirmed by the fixture that exposed it now passing under
-  `_runtest`. The earlier run (2442/208/1) is the one that found that defect.
+- The full suite was run again after items 3b and the `expect.opt` fix had landed:
+  **2444 passed, 208 skipped, 0 failed** of 2652 considered, exit 0. The tree was
+  `c38d1c98f5`; the only later change to code is `81cdb42bea`, one diagnostic string
+  in `dev-promote`, a target the suite does not invoke. The harness-refresh fix is
+  confirmed by the fixture that exposed it now passing under `_runtest`, and the
+  whole `tool-ocamltest` directory passes 8/8, including both new fixtures. The
+  earlier run (2442/208/1) is the one that found that defect.
 - Items 3a, 4d, 4e, 6d, 6e are no longer unexercised:
   - **3a** — `_build/dev/runtest/ocamlopt` → `ocamlopt.byte` → `boot_ocamlopt.exe`;
     the path bigint reported as "cannot find file" now exists and resolves to the dev
@@ -450,9 +457,35 @@ happened.
   - **6e** — run under the real system python 3.6.8: `dev watcher: python 3.7 or
     newer is required (running 3.6.8 from /usr/bin/python3)`, exit 1, instead of an
     argparse traceback.
-- Items 3a, 4d, 4e, 6d, 6e are landed but not exercised (table above). 4e and 6e
-  in particular need a fixture that is genuinely unstable between the plain and
-  `-principal` runs, and a python 3.6 interpreter, respectively.
+## The costly failures were the ones that returned a wrong answer
+
+Worth separating from the friction, because it changes how these items should be
+ranked. The reports mostly describe time lost, and the loudest items are the slow
+ones. But the items that did the most damage are the ones where the loop answered a
+question *incorrectly* and the answer was then believed and repeated:
+
+- **`expect.opt`.** A green test that had exercised the previous compiler. One
+  session saw two different mutations produce a byte-identical diff, then filed and
+  retracted a claim about test coverage that was an artifact of the runner, not of
+  the compiler.
+- **The stale harness.** The full suite reported a changed ocamltest's *pre-change*
+  behaviour, so the suite's answer about a shared file was wrong for 39 minutes'
+  worth of edits, with nothing in the output to say so.
+- **"`dev-test-all` can never be green."** Stated in the source reports, repeated
+  into this piece's own brief as established, and false: the skip flag is exported by
+  `dev-test` only (`Makefile.common-ox:761`, inside `dev-test` from 727;
+  `dev-test-all` begins at 804). Checking it took one grep, and it had already
+  propagated through two layers.
+
+The pattern is why the verification pass over the reports came first: of the
+load-bearing claims checked, 10 held, **5 needed correcting**, and 2 defects nobody
+had reported turned up. It is also why several fixes here are shaped as *making a
+decision observable* rather than as changing the decision —
+`make dev-runners-needed`, the skipped-action count, the artifact-location line. A
+wrong answer that can be checked cheaply stops propagating.
+
+## Verification I did not do
+
 - I did not measure whether the 5s-per-signal escalation grace is right; it makes
   the worst case `2 × (timeout + 10s)` plus the fallback, which is negligible at
   the default 1800s timeout and disproportionate at a very short one.

--- a/design-docs/dev-loop-improvements-final.md
+++ b/design-docs/dev-loop-improvements-final.md
@@ -7,14 +7,25 @@ Branch `jujacobs/vox/dev-loop-improvements`, based on `jujacobs/optimize-dev-loo
 
 | sha | what |
 | --- | --- |
-| `878ec4ed0b` | the design doc: ranking, verification pass over the reports' claims, scope |
-| `8c461894d0` | the tooling: wedge recovery, heartbeat, stale-stdlib detection, NOWATCH, dev-configure, promote fixpoint, dev-diff, dev-errors, ocamlopt links, python guard |
-| `4105336709` | `AGENTS.md`: setup, new targets, failure modes |
-| `88a1362396` | RED: ocamltest `-promote` cannot create a missing reference file |
-| `6b3f460c20` | GREEN: it can, and the expectation diff shows exactly that |
-| `bb21e087d5` | `dev-diff` handles program-output tests |
-| `e7159b3af9` | fixes from the review loop |
-| `e95dc422b7` | `dev-test-all` refreshes the test harness; stdlib-digest diagnosis |
+| `6edb813a48` | the design doc: ranking, verification pass over the reports' claims, scope |
+| `8433611e25` | the tooling: wedge recovery, heartbeat, stale-stdlib detection, NOWATCH, dev-configure, promote fixpoint, dev-diff, dev-errors, ocamlopt links, python guard |
+| `a14da1dabf` | `AGENTS.md`: setup, new targets, failure modes |
+| `d08e0c4d1f` / `de47bdb8d8` | RED / GREEN: ocamltest `-promote` creates a missing reference file |
+| `b87de5e4fe` | `dev-diff` handles program-output tests |
+| `a7bd9f2024` | fixes from the review loop |
+| `fa727a341c` | `dev-test-all` refreshes the test harness; stdlib-digest diagnosis |
+| `daab428772` / `48892bda89` | RED / GREEN: `ocamlc.byte` tests skip, naming the compiler |
+
+Plus this report and its amendments.
+
+Rebased onto **`6f4374f24b`** (`Use autoconf27 in development setup`), so these shas
+supersede the pre-rebase ones; the tree content was verified identical across the
+rebase. The base already changes `AGENTS.md` from `autoconf` to `autoconf27`, so the
+one conflict was resolved in favour of `make dev-configure` with the by-hand form
+kept as a trailing comment — this branch does not duplicate the base's fix. The rest
+of item 6a is still needed, because the doc fix alone does not help a fresh
+worktree: `make dev-configure` and the `Makefile.config` precondition are what turn
+the failure into an instruction.
 
 ## What landed, and whether it was exercised
 
@@ -26,7 +37,7 @@ Branch `jujacobs/vox/dev-loop-improvements`, based on `jujacobs/optimize-dev-loo
 | 1. rpc wedge: heartbeat, timeout, watcher restart + one retry, direct fallback | 5/5 | **Exercised, including a real wedge** |
 | 2. stale `_runtest` stdlib detector + `dev-refresh-stdlib` | 2/5 | **Exercised against a real SIGSEGV**; cure verified |
 | 3a. `ocamlopt`/`ocamlopt.byte` missing from the dev test root | 4/5 | Landed, **not exercised** |
-| 3b. `ocamlc.byte` magic mismatch | 4/5 | **Not done** — see below |
+| 3b. `ocamlc.byte` magic mismatch | 4/5 | **Measured, then landed** — red-green, see below |
 | 4a. `-promote` cannot create a missing reference | 1/5 | **Exercised**, red-green |
 | 4b. promote iterates to a fixpoint | 1/5 | Partly exercised |
 | 4c. `/tmp` scratch → `_build/dev`, `TMPDIR` exported | 1/5 + found | **Exercised** |
@@ -169,9 +180,9 @@ simpler and more correct than what I wrote.
 
 ## Deliberately not done
 
-- **Item 3b, the `ocamlc.byte` magic mismatch (4/5 reports) — measured, and the
-  measurement rules out both candidate fixes.** No code landed for it, but the
-  question is now answered rather than open.
+### Item 3b, resolved by measurement and then landed
+
+**Measured first, and the measurement ruled out the fix I expected to make.**
 
   Baseline, three affected directories: under the dev harness 12 tests fail
   (`formatting` 1, `typing-ocamlc-i` 6, `tool-ocamlc-stop-after` 5); under
@@ -195,14 +206,34 @@ simpler and more correct than what I wrote.
   in-tree runtime, i.e. building the bytecode compiler in a context that uses it —
   a build-system change, out of scope here.
 
-  So the answer to the design doc's open question is the skip-list, now on evidence
-  rather than as a default. ocamltest already has the mechanism:
-  `OCAMLTEST_SKIP_TESTS` (`ocamltest/main.ml:254`), matched against the test
-  filename. I did not implement it, because deciding what the dev harness declares
-  it does not cover is a scoping decision I would rather you make (open question 1).
-  Consequence meanwhile: `dev-test-all` cannot be green, and these tests present as
-  regressions. 3a (the missing `ocamlopt`/`ocamlopt.byte` links) did land, and is a
-  genuinely separate defect from this one.
+  **Landed** in `daab428772` (RED) and `48892bda89` (GREEN):
+  `OCAMLTEST_SKIP_BYTECODE_COMPILERS` makes the `ocamlc.byte` and `ocamlopt.byte`
+  actions skip rather than fail, with a reason naming the compiler —
+  `ocamlc.byte is not runnable under this harness, so this test does not cover it`.
+  It mirrors the existing `native_action`/`no_native_compilers` pattern a few lines
+  above, which already skips actions for a capability the harness lacks, so it is
+  no new mechanism. Implemented per action rather than as a list of test files, so
+  there is no list to go stale and the coverage is the whole suite at once.
+  `dev-test` exports it; `dev-test-all` deliberately does not.
+
+  Measured effect on the three directories: `formatting` 2 passed / 1 skipped / 0
+  failed (was 2/0/1), `typing-ocamlc-i` 0/6/0 (was 0/0/6), `tool-ocamlc-stop-after`
+  0/5/0 (was 0/0/5). So `make dev-test DIR=...` can now be green where it could
+  not be. Scoping verified in both directions: the same tests still run and pass
+  under `_runtest` (`make test-one-no-rebuild DIR=typing-ocamlc-i` → 6 passed, 0
+  skipped).
+
+  **A sixth correction to the reports** came out of this. They say `dev-test-all`
+  "can never be green" on these tests. That is false: `dev-test-all` uses
+  `_runtest`, where `ocamlc.byte` is the real installed bytecode compiler. The
+  full-suite run on this branch had **zero** failures in all three directories, and
+  the affected tests pass there. Only `dev-test` was ever affected. The consequence
+  is worth stating positively: bytecode-compiler behaviour is still covered, by the
+  full suite, and the skip message says so rather than implying the coverage is
+  gone.
+
+  3a (the missing `ocamlopt`/`ocamlopt.byte` links) is a genuinely separate defect
+  and landed earlier.
 - **Item 9's stdlib fingerprinting** stays out of scope for the reasons in the
   design doc. The *detection* the doc promised was initially missing — the claude
   reviewer caught the discrepancy — and is now in `e95dc422b7`: when `dev-test-all`
@@ -213,13 +244,57 @@ simpler and more correct than what I wrote.
 - **Item 7, a single-instance lock** (2/5, not 3/5 as the synthesis said).
   Deferred as planned: `dev-test-all` legitimately holds the loop for 30-40
   minutes, so a naive exclusive lock serialises a reviewer behind it and creates a
-  *new* silent wait. Note that findings 3 above means this branch made the
-  concurrency story better in one way (per-invocation logs) without addressing the
-  underlying absence of a lock.
-- **Item 8** (stale `_runtest` compilerlibs), **item 10** (the expect runner as a
-  second full compiler build — the largest remaining throughput cost, 8-10 min per
-  iteration), **item 11** (a shared dune cache). Reasons in the design doc; item
-  10 is the strongest candidate for the next piece.
+  *new* silent wait. This branch improved the concurrency story in one respect
+  (per-invocation build logs, review finding 3) without addressing the absent lock.
+
+  I was offered a cheap partial win — an advisory notice that prints "another dev
+  command is running (pid N), started Xm ago" and then proceeds — if it fell out of
+  item 1's work. It does not: `build` has no way to know about a sibling dev
+  command, because nothing records one. The watcher lease is renewed by every
+  command and so cannot distinguish one caller from two, and scanning the process
+  table for sibling `dev-watcher.py` processes is the kind of guess that
+  misidentifies a reviewer's worktree. Doing it properly means recording running
+  commands in `_build/dev/`, which is the lock's bookkeeping minus the lock — so it
+  belongs with item 7, not bolted on here.
+
+  Worth recording as evidence for whoever takes it: I hit this myself during this
+  work. Two overlapping `make dev-test` runs interleaved their heartbeats into one
+  log, so the output read as a single build reporting two different elapsed times
+  (`still building (300s...)` next to `still building (330s...)`). I diagnosed it
+  with `ps`, which is exactly what the reports describe. So the notice would have
+  paid for itself even for me, on this branch, with the heartbeat already in place.
+- **Item 8** (stale `_runtest` compilerlibs) and **item 11** (a shared dune cache
+  across worktrees). Reasons in the design doc; item 11 is a measurement task
+  before it is an implementation task.
+
+## Proposed next piece: the expect runner's build cost (item 10)
+
+This is the largest remaining throughput cost in the corpus and the strongest
+candidate for a follow-up, so recording it as a candidate with evidence rather
+than a leftover.
+
+**Evidence.** `feedback-type-formers.md:39-46`: after any compiler change,
+`dev-test` on an expect test pays the fast watcher build *plus* a `main.ws` build
+of `expect.exe` — **~8-10 minutes per iteration** when iterating on parser or
+typing changes together with expectations. That session calls it "the dominant cost
+of the test loop all session" and "the gap between 'fast loop' and 'fast loop
+except for tests'". 1/5 reports, but from the session that did the most
+expectation-heavy work, and it is a throughput cost paid on every iteration rather
+than an incident.
+
+**Where it comes from.** `dev-test` refreshes the runner through
+`dev-expect-runners`, which stops the watcher and runs
+`dune build $(ws_main) oxcaml/testsuite/tools/<runner>.exe`. The staleness check is
+correct and fires when it should; the cost is that the runner is built in the main
+workspace, against the main compiler, not in the boot/dev context the watcher
+already maintains.
+
+**Why it is not a friction fix.** Building the runner in the dev context would make
+it fast, but it changes what the runner links against, and therefore what expect
+tests actually exercise. That is a question about the harness's meaning, not its
+speed, and it deserves its own design doc and its own review — which is why it was
+kept out of this branch. Whoever picks it up should start by establishing what the
+runner is supposed to be built against and why, not by making the build faster.
 
 ## The full suite found a defect nobody had listed
 
@@ -248,6 +323,39 @@ for running the suite at all: `Makefile.config_if_required` (the configuration g
 for every target) and `ocamltest/actions_helpers.ml` (promotion for every test).
 Neither caused a failure. The whole `tool-ocamltest` directory also passes, 7/7.
 
+## The `/tmp` rule: what was leaking, and what was left behind
+
+The exposure was wider than the one `mktemp` in `dev-promote`: ocamltest itself
+calls `Filename.temp_file` at `ocamltest/filecompare.ml:231` — on **every** failing
+test comparison, to hold the diff — and at `ocamltest/actions_helpers.ml:267,309`
+for response files. `Filename.temp_file` honours `TMPDIR` and falls back to `/tmp`,
+so every failing test run under a caller without `TMPDIR` set was writing there.
+Fixed by defaulting `TMPDIR` inside the worktree from `dev-test` and `dev-test-all`,
+and by moving `dev-promote`'s own scratch to `_build/dev`.
+
+**Residue check, since files a service user leaves in a sticky directory cannot be
+removed afterwards.** I audited both directories rather than assuming a cleanup
+fired:
+
+- `/var/tmp` — every entry is root-owned system state (`abrt`, `krb5_0.rcache2`,
+  systemd private dirs, `metrics-config.tar.gz`, `Velociraptor_Buffer.bin`).
+  Nothing of ours, nothing to remove.
+- `/tmp` — no `ocamltest*`, `oxcaml*` or `*dev-promote*` entries at all, confirmed
+  by explicit glob rather than by eye. The `jujacobs`-owned entries there belong to
+  unrelated tooling (`blueprint-worker.log`, `jira_fields_cache.sexp`,
+  `.vscode.all-feature-names-cache.txt`, `exe-server-40358`, `tmux-40358`, krb5
+  credential caches) and the agent-tooling directories `.agents`, `.codex`, `.git`,
+  `dhp.tmp.*` are all **empty**.
+
+So nothing needed cleaning up. The reason is visible in the source and is worth
+recording so the fix is not mistaken for having been urgent in the wrong way:
+ocamltest removes these files on the normal path (`Sys.force_remove` at
+`filecompare.ml:251` and `actions_helpers.ml:304,358`). The leak is therefore
+transient — it only survives when a run is *killed*, which the reports describe
+happening repeatedly to wedged runs, and which happened several times during this
+work. The rule violation was real and is fixed; the accumulation had not yet
+happened.
+
 ## Verification I did not do
 
 - I did run the full suite, and it earned its keep — see below. What is *not*
@@ -262,14 +370,10 @@ Neither caused a failure. The whole `tool-ocamltest` directory also passes, 7/7.
 
 ## Open questions for the owner
 
-1. **Item 3b.** The measurement above removes the choice I thought I had: the
-   `main_native.exe` redirect cannot work, so it is a skip-list or nothing. What I
-   want a ruling on is the scope — skip-list the ~12 tests in the three directories
-   I measured, or sweep the whole suite for `ocamlc.byte`/`ocamlopt.byte` actions
-   first so `dev-test-all` can actually be asserted green? I would do the sweep,
-   since a partial list leaves the full suite red and therefore ignored, which is
-   the status quo. Either way the marker text should name what the dev harness does
-   not cover, so nobody re-does this forensics.
+1. ~~Item 3b~~ — **resolved and landed.** Implementing the skip per *action* rather
+   than as a list of test files made the scope question moot: there is no list to
+   go stale, and the coverage is the whole suite at once. The marker names the
+   compiler, as asked.
 2. **Promotion of a missing reference file.** A missing reference is also how
    ocamltest spells "this output must be empty", and the claude reviewer counted
    **290** tests under `testsuite/tests/` that run an output check with no

--- a/design-docs/dev-loop-improvements-final.md
+++ b/design-docs/dev-loop-improvements-final.md
@@ -1,0 +1,265 @@
+# dev-loop-improvements — final report
+
+Branch `jujacobs/vox/dev-loop-improvements`, based on `jujacobs/optimize-dev-loop`
+@ `6929017cbd`. Plan and evidence base: `design-docs/dev-loop-improvements.md`.
+
+## Commits
+
+| sha | what |
+| --- | --- |
+| `878ec4ed0b` | the design doc: ranking, verification pass over the reports' claims, scope |
+| `8c461894d0` | the tooling: wedge recovery, heartbeat, stale-stdlib detection, NOWATCH, dev-configure, promote fixpoint, dev-diff, dev-errors, ocamlopt links, python guard |
+| `4105336709` | `AGENTS.md`: setup, new targets, failure modes |
+| `88a1362396` | RED: ocamltest `-promote` cannot create a missing reference file |
+| `6b3f460c20` | GREEN: it can, and the expectation diff shows exactly that |
+| `bb21e087d5` | `dev-diff` handles program-output tests |
+| `e7159b3af9` | fixes from the review loop |
+| `e95dc422b7` | `dev-test-all` refreshes the test harness; stdlib-digest diagnosis |
+
+## What landed, and whether it was exercised
+
+"Exercised" means run against the failure it targets. I distinguish that from
+"reasoned through" per item, because three items are only the latter.
+
+| Item | Convergence | State |
+| --- | --- | --- |
+| 1. rpc wedge: heartbeat, timeout, watcher restart + one retry, direct fallback | 5/5 | **Exercised, including a real wedge** |
+| 2. stale `_runtest` stdlib detector + `dev-refresh-stdlib` | 2/5 | **Exercised against a real SIGSEGV**; cure verified |
+| 3a. `ocamlopt`/`ocamlopt.byte` missing from the dev test root | 4/5 | Landed, **not exercised** |
+| 3b. `ocamlc.byte` magic mismatch | 4/5 | **Not done** — see below |
+| 4a. `-promote` cannot create a missing reference | 1/5 | **Exercised**, red-green |
+| 4b. promote iterates to a fixpoint | 1/5 | Partly exercised |
+| 4c. `/tmp` scratch → `_build/dev`, `TMPDIR` exported | 1/5 + found | **Exercised** |
+| 4d. promote log printed before the verify output | 1/5 | Landed, not exercised |
+| 4e. names plain-vs-`-principal` instability | 2/5 | Landed, **not exercised** |
+| 5. `make dev NOWATCH=1` | 1/5 | **Exercised in a real restricted sandbox** |
+| 6a. `make dev-configure` + `Makefile.config` precondition | 5/5 | **Exercised in a fresh worktree** |
+| 6b. `make dev-errors` | 1/5 | Landed, lightly exercised |
+| 6c. `make dev-diff` | 1/5 | **Exercised**, both test kinds |
+| 6d. `dev-test-all` names its artifact location | 1/5 | Landed, not exercised |
+| 6e. python ≥ 3.7 guard | 2/5 | Landed, **not exercised** (needs a 3.6 interpreter) |
+| 6f. suppress dune's forwarding notice | 1/5 | **Reversed after review — deleted** |
+| 6g. docs: setup, blessed scratch path, never copy `.corrected` | — | Landed |
+
+### The evidence for items 1, 2 and 5
+
+**Item 1, in the wild.** A real wedge occurred twice during this work, with the
+signature all five reports describe. Recorded before I killed the first one: the
+`dune rpc build` client had waited **8m56s at 0:00:00 CPU time** while the
+watcher's dune had used 59s of CPU over 17m58s and its log said `Success, waiting
+for filesystem changes...`. On the second occurrence, with
+`DEV_RPC_TIMEOUT=420`, the whole recovery ran unattended
+(`logs/cmi-strong.log`):
+
+    dev: building via the watcher (progress: make dev-log)
+    dev: still building (60s elapsed; progress: make dev-log)
+    ... every 60s ...
+    dev: the build exceeded 420s; stopping it
+    dev: the build timed out after 420s; restarting the watcher and retrying
+    dev: watcher stopped
+    dev: watcher started (idle timeout 1800s)
+    Success
+
+That is a real wedge, not a stub, recovered without intervention.
+
+`make dev-selftest` (`tools/dev-watcher-test.sh`) covers the state machine
+against a stub dune whose `rpc build` hangs, ignores signals, dies, fails or
+succeeds on command: success does not retry; a timeout bounces the watcher and
+retries once, with the watcher really replaced and the abandoned build really
+dead; a signal-ignoring build is still bounded; a persistent wedge falls back and
+propagates the fallback's exit status; `Connection_dead` recovers without waiting
+out the timeout; a genuine build failure reports diagnostics and does not retry.
+It needs no compiler and runs in ~15s. Disabling the timeout makes it hang at the
+wedge case, which is the pre-fix behaviour — the suite is discriminating for the
+thing it exists to check.
+
+**Item 2, against a real segfault.** I made a genuine `.cmi`-shape change by
+swapping two dereferenced fields of `Types.value_description`
+(`val_type`/`val_kind`) — a declaration-order change needing no other edits,
+since record fields are accessed by name — and rebuilt the compiler. The probe
+then died exactly as the reports describe:
+
+    PROBE_EXIT=139           # SIGSEGV
+    dev: the compiler died on signal 11 reading the installed standard library,
+    dev: which is what a stale marshaled .cmi looks like: ...
+    dev: Run `make dev-refresh-stdlib` to rebuild it.
+
+`make dev-refresh-stdlib` then cured it (`REFRESH_EXIT=0`, and the check
+subsequently passed). The probe costs **20ms**, which is the measurement the
+design doc promised; a warm `make dev` is ~0.4s, so it is well under the noise
+floor and does not need a flag.
+
+Worth recording as a falsification: my *first* attempt at this used
+`val_loc`/`val_zero_alloc`, which also changes the marshaled layout but which a
+trivial compile never dereferences — the probe passed. So the detector catches
+shape changes the compiler actually trips over when reading the stdlib, which is
+the class that manifests as a segfault, and not a layout change that stays latent.
+Latent changes can still mislead a larger test. The probe also only reads `.cmi`;
+the equivalent `Cmx_format` failure class is not covered.
+
+**Item 5, in its target environment.** Verified by the codex reviewer, which
+really does run under `workspace-write` — the environment the option exists for:
+cold `make dev NOWATCH=1` passed in 412.58s, warm in 1.43s, with
+`dev-watcher.py status` reporting the watcher stopped and no `_build/dev-dune/.rpc`
+socket; plain `make dev` failed in that sandbox with
+`Unix.Unix_error(Unix.EPERM, "bind", "")` / `Error: bind(): Operation not
+permitted`. That both confirms the claimed cause and shows the fallback works
+where the watcher cannot.
+
+## The review loop
+
+Two reviewers in their own worktrees under `vox/dev-loop/review/`: one claude
+(findings returned as text) and one codex 0.147.0 `gpt-5.6-sol` (`report.md` in
+its worktree). They ran independently and **converged on the same three top
+defects**, each of which defeated a headline claim rather than being a corner
+case. I reproduced every finding before acting on it. Fixes are in `e7159b3af9`.
+
+1. **`make dev-configure` could not be reached in a fresh worktree** — the exact
+   situation it was written for. `Makefile.config_if_required` exempts only the
+   clean goals and `configure` from including the generated
+   `Makefile.build_config`, so make aborted at parse time, before any recipe ran,
+   which also made the `Makefile.config` guard in `dev-setup` dead code. Fixed by
+   exempting `dev-configure` and `dev-selftest`. Now verified end to end in a
+   fresh worktree: exit 0, `configure` and `Makefile.config` created, and
+   `dev-selftest` runs without configuring at all.
+2. **The timeout was not a bound.** `terminate_process_group` escalated SIGINT →
+   SIGTERM and stopped, then waited unconditionally, so a child ignoring both
+   defeated the mechanism — one reviewer measured 121s for a 3s timeout. Fixed
+   with SIGKILL escalation and a bounded wait per step. Same reproduction now
+   returns in 22s where the child would have slept 30s, and the suite has a case
+   for it.
+3. **Concurrent dev commands read each other's build output** through the fixed
+   `_build/dev/rpc-build.log` — and the bad direction is a false green: codex
+   showed a build whose own output was `Failure` exiting 0 because it read a
+   sibling's `Success`. This was a regression introduced by this branch (the
+   output previously lived in a shell variable, i.e. per-process). Fixed by making
+   the log per-invocation; verified with the same two-build reproduction.
+
+Also reproduced and fixed: a watcher that never becomes ready failed instead of
+falling back; `dev-diff` selected artifacts by basename across the whole tree and
+showed an unrelated test's diff (609 test files here share a basename; `test.ml`
+occurs 83 times); `dev-stdlib-check` misattributed any ordinary compiler failure
+to a stale stdlib and hard-failed `dev-check`, which blocked `dev-ocamlc` — the
+tool you would use to investigate; `dev-promote` asserted plain-vs-`-principal`
+instability it had not established; `dev-test-all` did not export `TMPDIR`;
+`watcher-command` recorded a desired rather than a running command; and the first
+failed attempt's output was emitted twice on the cannot-restart path.
+
+**One decision reversed.** Item 6f, suppressing dune's forwarding notice, is
+deleted. Codex constructed a counterexample where the filter dropped a legitimate
+diagnostic that merely contained one of the matched substrings, and the `dev-errors`
+pipe also swallowed dune's exit status. Hiding three lines of known noise is not
+worth hiding output. The self-test now pins the notice being *passed through*, so
+the decision is recorded rather than merely undone.
+
+**One review suggestion falsified.** Both reviewers proposed delegating
+`dev-configure` to `tools/autogen`, the wrapper intended for exactly this, and the
+claude reviewer noted that bypassing it skips its `sed` patches. It does not work
+on this tree: `tools/autogen`'s `--warnings=all,error` rejects this fork's
+`configure.ac` (many `AC_RUN_IFELSE called without default to allow cross
+compiling`). Measured: `tools/autogen autoconf27` exits 1, plain `autoconf27`
+exits 0. So the suggestion is not adopted, and the reason is now a comment in the
+target. Their *other* point was correct and is fixed: my awk version comparison
+failed open — awk with no input records exits 0, and a non-numeric `$NF` compares
+lexicographically — so it accepted a too-old autoconf whenever the version line
+was unusual or absent. Version detection is now gone entirely: `AC_PREREQ([2.71])`
+makes an old autoconf fail by itself, so trying each candidate and keeping the one
+that works cannot accept a version that would not have worked. That is both
+simpler and more correct than what I wrote.
+
+## Deliberately not done
+
+- **Item 3b, the `ocamlc.byte` magic mismatch (4/5 reports) — not done, and this
+  is the largest gap.** The design doc committed to *measuring* rather than
+  deciding: apply the `main_native.exe` redirect and compare per-test pass/fail
+  against `_runtest`. I did not run that comparison, so I did not land either the
+  redirect or a skip marker. 3a (the missing `ocamlopt`/`ocamlopt.byte` links) did
+  land, which unblocks the `ocamlopt.byte` half — a genuinely separate defect, not
+  the magic mismatch. Consequence: `dev-test-all` still cannot be green, and the
+  affected tests still present as regressions rather than saying they are
+  unsupported. Both reviewers flagged this. It needs the measurement, not more
+  reasoning.
+- **Item 9's stdlib fingerprinting** stays out of scope for the reasons in the
+  design doc. The *detection* the doc promised was initially missing — the claude
+  reviewer caught the discrepancy — and is now in `e95dc422b7`: when `dev-test-all`
+  output contains "inconsistent assumptions over interface Stdlib", it prints the
+  cause and the known-working recovery, including that `rm -rf _build/main` alone
+  corrupts dune's incremental state. Not exercised: I did not reproduce the 661-
+  failure state.
+- **Item 7, a single-instance lock** (2/5, not 3/5 as the synthesis said).
+  Deferred as planned: `dev-test-all` legitimately holds the loop for 30-40
+  minutes, so a naive exclusive lock serialises a reviewer behind it and creates a
+  *new* silent wait. Note that findings 3 above means this branch made the
+  concurrency story better in one way (per-invocation logs) without addressing the
+  underlying absence of a lock.
+- **Item 8** (stale `_runtest` compilerlibs), **item 10** (the expect runner as a
+  second full compiler build — the largest remaining throughput cost, 8-10 min per
+  iteration), **item 11** (a shared dune cache). Reasons in the design doc; item
+  10 is the strongest candidate for the next piece.
+
+## The full suite found a defect nobody had listed
+
+`make dev-test-all` on this branch: **2442 passed, 208 skipped, 1 failed** of 2651
+considered. The single failure was the fixture added earlier on this branch, and it
+was not flaky — it had caught a real defect in the loop.
+
+`install_for_test` copies ocamltest from the default build dir, but `dev-test-all`
+passes `-o boot-compiler`, so make treats that dir as up to date; and the watcher
+builds ocamltest into `_build/dev-dune`, which `install_for_test` never reads.
+So **a change to ocamltest is invisible to the full suite**, which runs against the
+previous harness. Measured: `_build/default/ocamltest/ocamltest.native` was 39
+minutes older than the ocamltest source change (10:49:43 vs 11:28:51), and
+`_runtest` received that stale copy; the reference in `_runtest` was correct while
+the result was the pre-fix `reference not created`.
+
+This is the same class as the stale-stdlib and stale-compilerlibs traps the reports
+describe — with the harness itself as the stale artifact — and silent in the same
+way. It only surfaced because a test happened to assert on ocamltest's own
+behaviour. Fixed in `e95dc422b7` by building `ocamltest/ocamltest.native` before
+`install_for_test` (seconds, not a boot-compiler rebuild). Verified: with the
+refreshed harness the fixture passes under `_runtest`, where it had failed.
+
+Two changes on this branch are shared beyond the dev loop and so were the reason
+for running the suite at all: `Makefile.config_if_required` (the configuration gate
+for every target) and `ocamltest/actions_helpers.ml` (promotion for every test).
+Neither caused a failure. The whole `tool-ocamltest` directory also passes, 7/7.
+
+## Verification I did not do
+
+- I did run the full suite, and it earned its keep — see below. What is *not*
+  verified is a second full-suite run after `e95dc422b7`, so the harness-refresh
+  fix is verified only against the single test that exposed it.
+- Items 3a, 4d, 4e, 6d, 6e are landed but not exercised (table above). 4e and 6e
+  in particular need a fixture that is genuinely unstable between the plain and
+  `-principal` runs, and a python 3.6 interpreter, respectively.
+- I did not measure whether the 5s-per-signal escalation grace is right; it makes
+  the worst case `2 × (timeout + 10s)` plus the fallback, which is negligible at
+  the default 1800s timeout and disproportionate at a very short one.
+
+## Open questions for the owner
+
+1. **Item 3b.** My default remains a skip-list with a marker naming what is not
+   covered, over redirecting `ocamlc.byte` to `main_native.exe` (which would make
+   `dev-test-all` green while silently ceasing to test the bytecode compiler).
+   `ocamltest/ocaml_actions.ml:1033` warns that under flambda2 the two "sometimes
+   generate equivalent" output, so the risk is real. The measurement is the next
+   step either way — say if you want the other default.
+2. **Promotion of a missing reference file.** A missing reference is also how
+   ocamltest spells "this output must be empty", and the claude reviewer counted
+   **290** tests under `testsuite/tests/` that run an output check with no
+   `.reference` sibling. So `make dev-promote DIR=...` can now create references
+   for them, converting "asserts empty" into "asserts whatever it produced". I
+   added a comment at the promotion site rather than a mechanism. If you want a
+   guard, the cheap version is for `dev-promote` to list newly *created* reference
+   files at the end, so they get read.
+3. **`dev-stdlib-check` now warns rather than fails** for an ordinary compiler
+   failure, and only errors on death by signal. That keeps `dev-ocamlc` usable
+   mid-refactor, which I think is right, but it means `make dev` can print a
+   warning and still exit 0 with a compiler that cannot compile hello-world.
+4. **Where `diff` lives.** Both reviewers judged that artifact archaeology does
+   not belong in a file called `dev-watcher.py`. I agree and left it, because the
+   better fix they both point at is upstream of it: have `dev-test` pass an
+   explicit `OCAMLTESTDIR` so there are two artifact roots instead of three, which
+   would make `dev-diff` nearly trivial and remove the source-tree root entirely.
+   That is a change to `testsuite/Makefile`'s `exec-one`, shared with the non-dev
+   harness, so I did not make it unasked.

--- a/design-docs/dev-loop-improvements-final.md
+++ b/design-docs/dev-loop-improvements-final.md
@@ -1,7 +1,7 @@
 # dev-loop-improvements — final report
 
 Branch `jujacobs/vox/dev-loop-improvements`, based on `jujacobs/optimize-dev-loop`
-@ `6929017cbd`. Plan and evidence base: `design-docs/dev-loop-improvements.md`.
+@ `6f4374f24b`. Plan and evidence base: `design-docs/dev-loop-improvements.md`.
 
 ## Commits
 
@@ -32,25 +32,25 @@ the failure into an instruction.
 ## What landed, and whether it was exercised
 
 "Exercised" means run against the failure it targets. I distinguish that from
-"reasoned through" per item, because three items are only the latter.
+"reasoned through" per item, because a few items are only the latter.
 
 | Item | Convergence | State |
 | --- | --- | --- |
 | 1. rpc wedge: heartbeat, timeout, watcher restart + one retry, direct fallback | 5/5 | **Exercised, including a real wedge** |
 | 2. stale `_runtest` stdlib detector + `dev-refresh-stdlib` | 2/5 | **Exercised against a real SIGSEGV**; cure verified |
-| 3a. `ocamlopt`/`ocamlopt.byte` missing from the dev test root | 4/5 | Landed, **not exercised** |
+| 3a. `ocamlopt`/`ocamlopt.byte` missing from the dev test root | 4/5 | **Exercised** |
 | 3b. `ocamlc.byte` magic mismatch | 4/5 | **Measured, then landed** — red-green, see below |
 | 4a. `-promote` cannot create a missing reference | 1/5 | **Exercised**, red-green |
 | 4b. promote iterates to a fixpoint | 1/5 | Partly exercised |
 | 4c. `/tmp` scratch → `_build/dev`, `TMPDIR` exported | 1/5 + found | **Exercised** |
-| 4d. promote log printed before the verify output | 1/5 | Landed, not exercised |
-| 4e. names plain-vs-`-principal` instability | 2/5 | Landed, **not exercised** |
+| 4d. promote log printed before the verify output | 1/5 | **Exercised** |
+| 4e. names plain-vs-`-principal` instability | 2/5 | **Exercised**, and reworded after review |
 | 5. `make dev NOWATCH=1` | 1/5 | **Exercised in a real restricted sandbox** |
 | 6a. `make dev-configure` + `Makefile.config` precondition | 5/5 | **Exercised in a fresh worktree** |
 | 6b. `make dev-errors` | 1/5 | Landed, lightly exercised |
 | 6c. `make dev-diff` | 1/5 | **Exercised**, both test kinds |
-| 6d. `dev-test-all` names its artifact location | 1/5 | Landed, not exercised |
-| 6e. python ≥ 3.7 guard | 2/5 | Landed, **not exercised** (needs a 3.6 interpreter) |
+| 6d. `dev-test-all` names its artifact location | 1/5 | **Exercised** in the full-suite run |
+| 6e. python ≥ 3.7 guard | 2/5 | **Exercised** under the system python 3.6.8 |
 | 6f. suppress dune's forwarding notice | 1/5 | **Reversed after review — deleted** |
 | 6g. docs: setup, blessed scratch path, never copy `.corrected` | — | Landed |
 
@@ -125,7 +125,7 @@ Two reviewers in their own worktrees under `vox/dev-loop/review/`: one claude
 (findings returned as text) and one codex 0.147.0 `gpt-5.6-sol` (`report.md` in
 its worktree). They ran independently and **converged on the same three top
 defects**, each of which defeated a headline claim rather than being a corner
-case. I reproduced every finding before acting on it. Fixes are in `e7159b3af9`.
+case. I reproduced every finding before acting on it. Fixes are in `a7bd9f2024`.
 
 1. **`make dev-configure` could not be reached in a fresh worktree** — the exact
    situation it was written for. `Makefile.config_if_required` exempts only the
@@ -265,7 +265,7 @@ simpler and more correct than what I wrote.
   and landed earlier.
 - **Item 9's stdlib fingerprinting** stays out of scope for the reasons in the
   design doc. The *detection* the doc promised was initially missing — the claude
-  reviewer caught the discrepancy — and is now in `e95dc422b7`: when `dev-test-all`
+  reviewer caught the discrepancy — and is now in `fa727a341c`: when `dev-test-all`
   output contains "inconsistent assumptions over interface Stdlib", it prints the
   cause and the known-working recovery, including that `rm -rf _build/main` alone
   corrupts dune's incremental state. Not exercised: I did not reproduce the 661-
@@ -390,7 +390,7 @@ the result was the pre-fix `reference not created`.
 This is the same class as the stale-stdlib and stale-compilerlibs traps the reports
 describe — with the harness itself as the stale artifact — and silent in the same
 way. It only surfaced because a test happened to assert on ocamltest's own
-behaviour. Fixed in `e95dc422b7` by building `ocamltest/ocamltest.native` before
+behaviour. Fixed in `fa727a341c` by building `ocamltest/ocamltest.native` before
 `install_for_test` (seconds, not a boot-compiler rebuild). Verified: with the
 refreshed harness the fixture passes under `_runtest`, where it had failed.
 

--- a/design-docs/dev-loop-improvements-final.md
+++ b/design-docs/dev-loop-improvements-final.md
@@ -169,16 +169,40 @@ simpler and more correct than what I wrote.
 
 ## Deliberately not done
 
-- **Item 3b, the `ocamlc.byte` magic mismatch (4/5 reports) — not done, and this
-  is the largest gap.** The design doc committed to *measuring* rather than
-  deciding: apply the `main_native.exe` redirect and compare per-test pass/fail
-  against `_runtest`. I did not run that comparison, so I did not land either the
-  redirect or a skip marker. 3a (the missing `ocamlopt`/`ocamlopt.byte` links) did
-  land, which unblocks the `ocamlopt.byte` half — a genuinely separate defect, not
-  the magic mismatch. Consequence: `dev-test-all` still cannot be green, and the
-  affected tests still present as regressions rather than saying they are
-  unsupported. Both reviewers flagged this. It needs the measurement, not more
-  reasoning.
+- **Item 3b, the `ocamlc.byte` magic mismatch (4/5 reports) — measured, and the
+  measurement rules out both candidate fixes.** No code landed for it, but the
+  question is now answered rather than open.
+
+  Baseline, three affected directories: under the dev harness 12 tests fail
+  (`formatting` 1, `typing-ocamlc-i` 6, `tool-ocamlc-stop-after` 5); under
+  `_runtest` all 12 pass. So they are purely harness failures, as reported.
+
+  I then applied the candidate fix — point `ocamlc.byte` at `main_native.exe` in
+  `prepare_test_root` — and re-ran: **exactly the same 12 failures**. The reason is
+  visible in the failing command, and it refines the reports' account:
+
+      <runtest>/runtime/ocamlrun <runtest>/ocamlc -use-runtime ... -i -o ... local.ml
+      the file '<runtest>/ocamlc' has not the right magic number:
+        expected Caml1999X583, got
+
+  ocamltest runs `ocamlc` *through* the in-tree `ocamlrun`, so `ocamlc` must be a
+  bytecode image with that runtime's magic. `main.bc` carries trailing magic
+  `Caml1999X036` and a shebang pointing at the opam `ocamlrun`
+  (`~/.opam/5.4.0/bin/ocamlrun`), which is why the unmodified harness reports
+  "got Caml1999X036"; the native executable has no Caml magic at all, which is why
+  the redirect reports "got " and fails identically. **No symlink arrangement can
+  fix this**: the only real fix is producing a `main.bc` whose magic matches the
+  in-tree runtime, i.e. building the bytecode compiler in a context that uses it —
+  a build-system change, out of scope here.
+
+  So the answer to the design doc's open question is the skip-list, now on evidence
+  rather than as a default. ocamltest already has the mechanism:
+  `OCAMLTEST_SKIP_TESTS` (`ocamltest/main.ml:254`), matched against the test
+  filename. I did not implement it, because deciding what the dev harness declares
+  it does not cover is a scoping decision I would rather you make (open question 1).
+  Consequence meanwhile: `dev-test-all` cannot be green, and these tests present as
+  regressions. 3a (the missing `ocamlopt`/`ocamlopt.byte` links) did land, and is a
+  genuinely separate defect from this one.
 - **Item 9's stdlib fingerprinting** stays out of scope for the reasons in the
   design doc. The *detection* the doc promised was initially missing — the claude
   reviewer caught the discrepancy — and is now in `e95dc422b7`: when `dev-test-all`
@@ -238,12 +262,14 @@ Neither caused a failure. The whole `tool-ocamltest` directory also passes, 7/7.
 
 ## Open questions for the owner
 
-1. **Item 3b.** My default remains a skip-list with a marker naming what is not
-   covered, over redirecting `ocamlc.byte` to `main_native.exe` (which would make
-   `dev-test-all` green while silently ceasing to test the bytecode compiler).
-   `ocamltest/ocaml_actions.ml:1033` warns that under flambda2 the two "sometimes
-   generate equivalent" output, so the risk is real. The measurement is the next
-   step either way — say if you want the other default.
+1. **Item 3b.** The measurement above removes the choice I thought I had: the
+   `main_native.exe` redirect cannot work, so it is a skip-list or nothing. What I
+   want a ruling on is the scope — skip-list the ~12 tests in the three directories
+   I measured, or sweep the whole suite for `ocamlc.byte`/`ocamlopt.byte` actions
+   first so `dev-test-all` can actually be asserted green? I would do the sweep,
+   since a partial list leaves the full suite red and therefore ignored, which is
+   the status quo. Either way the marker text should name what the dev harness does
+   not cover, so nobody re-does this forensics.
 2. **Promotion of a missing reference file.** A missing reference is also how
    ocamltest spells "this output must be empty", and the claude reviewer counted
    **290** tests under `testsuite/tests/` that run an output check with no

--- a/design-docs/dev-loop-improvements.md
+++ b/design-docs/dev-loop-improvements.md
@@ -1,0 +1,569 @@
+# dev-loop-improvements
+
+Branch: `jujacobs/vox/dev-loop-improvements`, based on `jujacobs/optimize-dev-loop`
+@ `6929017cbd`.
+
+## Problem
+
+`make dev` and friends (`Makefile.common-ox:511-688`, `tools/dev-watcher.py`) give
+a fast incremental compiler loop built on a persistent `dune --watch` daemon
+driven over dune's RPC. Five agents have now each built one vox piece end to end
+with it — including review loops in separate worktrees — and written up the
+experience. The loop's happy path is unanimously reported as good. Its failure
+paths are not: they are silent, they are indistinguishable from slow-but-working,
+and two classes of them hand you a wrong answer rather than an error.
+
+This piece attacks the failure paths, in order of measured cost to the sessions
+that hit them.
+
+## Evidence base
+
+Five independent session reports, all against `6929017cbd`, in
+`/usr/local/home/jujacobs/vox/dev-loop/`:
+
+| Report | Piece built | Scale of use |
+| --- | --- | --- |
+| `feedback-from-totality-piece.md` | totality/logicality | 1 fresh setup, ~40 watcher cycles, ~80 single tests, 6 full-suite runs, 4 reviewer worktrees |
+| `solver-interface-feedback.md` | solver-interface | 1 initial build, ~6 library rebuilds, ~10 test/promote runs, 3 reviewer worktrees |
+| `feedback-type-formers.md` | type-formers | "hundreds of iterations", parser + `Types`-layout + printer changes |
+| `feedback-erasure-session.md` | erasure | mode-axis change (world rebuilds), 50+ `dev-ocamlc` runs, 2 full-suite runs, 3 reviewer worktrees |
+| `make-dev-feedback-bigint.md` | bigint | fresh worktree, stdlib change, full suite, promotions, 4 sibling worktrees building concurrently |
+
+Convergence counts below are mine, recounted from the reports rather than taken
+from the synthesis I was handed; where they differ I say so.
+
+## Verification pass
+
+Every file:line claim in the five reports and in the owner's synthesis was
+checked against this worktree. Results:
+
+### Confirmed
+
+| Claim | Status |
+| --- | --- |
+| `dev-promote` scratch goes to `/tmp` when `TMPDIR` unset | VERIFIED `Makefile.common-ox:647` |
+| `dev-check` has `wait-ready --timeout 300` for the ping but no timeout on `dune rpc build` | VERIFIED `Makefile.common-ox:557` vs `560` |
+| `dev-runtime` only refreshes on `runtime stdlib otherlibs` source changes (plus `Makefile.config`, `duneconf/runtime_stdlib.ws`) — nothing compiler-side | VERIFIED `Makefile.common-ox:541-553` |
+| `dev-setup` only fires when `_install/bin/ocamlopt.opt` or `_runtest/testsuite/Makefile` are missing; no `Makefile.config` precondition | VERIFIED `Makefile.common-ox:532-539`; the obscure failure comes from `_build/_bootinstall: Makefile.config` at `Makefile.common-ox:204` |
+| `dev-test` runs in `_build/dev/runtest/testsuite`; `dev-test-all` runs `install_for_test` + `test-files-parallel`, which `cd`s to `_runtest/testsuite` | VERIFIED `Makefile.common-ox:618-626`, `641-643`, `452-463` |
+| `dev-check` captures rpc output into a shell variable, so nothing streams | VERIFIED `Makefile.common-ox:559-566` |
+| `one LIST=` treats each line as a `DIR`, not a test file | VERIFIED `testsuite/Makefile:338-342` (`exec-one DIR="$LINE"`) |
+| `dev-watcher.py` needs python ≥ 3.7 (`add_subparsers(..., required=True)`) | VERIFIED `tools/dev-watcher.py:353` |
+| Hand-promoting `.corrected` drops principal-block updates | VERIFIED `ocamltest/ocaml_actions.ml:916-938`: pass 1 writes `<file>.corrected`; if the runner exits 3 ("needs principal") pass 2 runs on that file and the promoted `output` becomes `<file>.corrected.corrected` |
+| No flag exists to suppress dune's "build request is being forwarded" notice | VERIFIED against `dune rpc build --help`, dune 3.23.0 |
+
+### Corrected
+
+Five claims did not survive checking. Each of them would have shaped a fix.
+
+1. **`dev-promote` does *not* exit nonzero after a successful promotion.**
+   The synthesis says it does. `Makefile.common-ox:645-663` already runs
+   `dev-test PROMOTE=1`, and on failure re-runs `dev-test` to verify, printing
+   `dev: promoted test output` and exiting 0. What exits nonzero after
+   promoting is `make dev-test PROMOTE=1` used directly, which is what
+   `feedback-type-formers.md:76` actually reports.
+   Root cause found, and it is not in the Makefile:
+   `ocamltest/actions_helpers.ml:392-398` promotes and *then* still returns
+   `Result.fail_with_reason`. So the fix belongs in ocamltest, and it also
+   explains item 4's "multi-reference tests need promote run twice": the failed
+   action aborts the test before the remaining references are reached.
+
+2. **`ocamlopt.byte` tests do not fail for the magic-number reason.**
+   The synthesis groups `flambda2/` and `layout_poly/` with the `ocamlc.byte`
+   magic mismatch. They are a different, simpler defect:
+   `tools/dev-watcher.py:240-268` lists `ocamlopt` and `ocamlopt.byte` in
+   `overridden` (so the `_runtest` originals are *not* symlinked in) and then
+   only re-creates `ocamlopt.opt`. `ocamltest/ocaml_files.ml:48` resolves the
+   `ocamlopt.byte` action to `$srcdir/ocamlopt`, which therefore does not
+   exist — hence bigint's literal `cannot find file _build/dev/runtest/ocamlopt`.
+   Two defects were conflated; the second is a three-line fix.
+
+3. **There are three artifact locations, not two.** `dev-test-all` →
+   `_runtest/testsuite/_ocamltest/` and `dev-test TEST=` →
+   `_build/dev/runtest/testsuite/_ocamltest/` are both real. But
+   `dev-test PROMOTE=1 DIR=…` routes through `promote` → `one DIR=` →
+   `exec-one`, which sets `OCAMLTESTDIR=$(BASEDIR_HOST)/$(DIR)/_ocamltest`
+   (`testsuite/Makefile:40,351`) — and under the dev root
+   `testsuite/tests/<dir>` is a symlink into the source tree
+   (`tools/dev-watcher.py:329-336`), so that lands **in the source
+   directory**. `dev-test DIR=` without `PROMOTE` uses `files-parallel`, where
+   `OCAMLTESTENV` is empty and artifacts stay in the dev root. This is the
+   exact mechanism behind `solver-interface-feedback.md:73-84`, which reported
+   the symptom correctly but could not name the cause.
+
+4. **"Stale `.corrected` files survive later passing runs" is already false for
+   the dev root.** `prepare_test_root_locked` rebuilds `_build/dev/runtest`
+   from scratch into `runtest.new` and renames it over the old one on *every*
+   `dev-test` (`tools/dev-watcher.py:236-243, 338-343`), which destroys
+   `_build/dev/runtest/testsuite/_ocamltest` wholesale. So the suggested "have
+   `dev-test` delete the test's `_ocamltest` work dir before running" is
+   already satisfied, and I am not building it. Stale artifacts do survive in
+   the two places the dev loop does not own: the source tree (via the
+   `exec-one` path in correction 3) and `_runtest/` (via `dev-test-all`).
+
+5. **The single-instance lock has two reports behind it, not three.**
+   `feedback-type-formers.md:48-58` and `feedback-erasure-session.md:59-65`.
+   `make-dev-feedback-bigint.md:19-21` says the opposite thing about a
+   different axis ("four watchers on one box, no cross-talk"). The item stays,
+   at its real weight.
+
+### Newly found, not in any report
+
+- **ocamltest scatters scratch into `/tmp`** beyond `dev-promote`:
+  `Filename.temp_file` at `ocamltest/filecompare.ml:231` (every diff of a
+  failing test) and `ocamltest/actions_helpers.ml:267,309` (response files).
+  `Filename.temp_file` honours `TMPDIR`, so the dev targets must export it.
+  This is squarely the house `/tmp` rule and is broader than the one `mktemp`
+  the reports found.
+- **`dev-promote` cannot create a missing reference file** for a precise
+  reason: `ocamltest/filecompare.ml:221-228` returns `Unexpected_output` when
+  the reference does not exist, and `ocamltest/actions_helpers.ml:400+` handles
+  that case without ever consulting the `promote` variable — while
+  `Filecompare.promote` (`filecompare.ml:254-257`) opens the reference for
+  writing and would happily create it. So bigint's item 3 is a three-line fix
+  in a branch nobody wired up, not a design limitation.
+
+## Ranked work items
+
+Ranking is by measured cost to the sessions, not by implementation ease. Items
+1-6 are what I intend to land; 7-9 are explicitly deferred with reasons.
+
+---
+
+### 1. The `dune rpc build` wedge, and the silence that hides it
+
+**Evidence.** 5/5 reports. This is the only item every session hit.
+
+- erasure: "~10 times in one session", also hit the review agents in fresh
+  worktrees, estimated 1.5-2h of the session lost.
+- solver-interface: four recurrences, clients killed at 36, 17, 9 and 4 minutes
+  elapsed — ~66 minutes of pure waiting, plus the diagnosis time.
+- bigint: twice, and "sticky" — after the first wedge, later clients also hang.
+- totality: two flavours, both needing manual `make dev-stop`.
+- type-formers: `Connection_dead` twice under load.
+
+Silence is a separate 5/5 item but it is the same fix, so they are bundled: the
+wedge is expensive *because* it is indistinguishable from a legitimate rebuild.
+Sessions diagnosed it by `ps`-ing the daemon's cumulative CPU time. The reports
+are unanimous that a heartbeat naming `make dev-log` would have made this
+self-diagnosing.
+
+There is live evidence on this box right now: two `make dev-test DIR=vox`
+processes in a sibling worktree at 40 and 34 minutes elapsed, 0.0% CPU.
+
+**Decided fix**, in `dev-check`:
+
+1. Echo before the build: `dev: building via the watcher (progress: make dev-log)`.
+2. A heartbeat while the build runs: every `DEV_HEARTBEAT ?= 30` seconds, one
+   line with elapsed time.
+3. Wrap the rpc build in `timeout $(DEV_RPC_TIMEOUT)`, `DEV_RPC_TIMEOUT ?= 1800`,
+   overridable.
+4. On timeout, or on output matching `Connection_dead` / `Connection terminated`:
+   stop the watcher, start it again, and retry exactly once.
+5. If the retry also fails, fall back to a direct `dune build $(ws_boot)
+   $(dev_build_flag) $(dev_boot_targets)` with no rpc at all, so the command
+   completes rather than failing. Say clearly that it fell back.
+
+Retry-once-then-fall-back rather than retry-until-success: an unbounded retry
+loop against a systematically broken watcher is a new silent hang, which is the
+thing being fixed.
+
+**Alternatives rejected.**
+
+- *Watcher writes a `build-result` marker (status + generation counter) that
+  `dev-check` polls*, sidestepping rpc entirely (suggested by
+  solver-interface). This is a bigger change that re-implements the part of
+  dune's RPC semantics we actually depend on — "has the build for the current
+  source generation finished" — with a hand-rolled generation counter that has
+  to be correct against inotify races. It also does not help the first build of
+  a session, where there is no watcher yet. Held in reserve: if timeout + retry
+  turns out to fire routinely rather than rarely, this becomes the right answer
+  and gets its own piece.
+- *CPU-idle watchdog* (suggested by erasure): restart when the daemon has used
+  ~no CPU for N seconds. Rejected as the primary mechanism — a dune legitimately
+  blocked on a slow NFS read or on a sibling worktree's lock also shows 0% CPU,
+  so this would kill healthy builds on a loaded box, which is exactly the box
+  these reports come from. The wall-clock timeout is coarser but cannot
+  misclassify.
+- *Streaming rpc output instead of a heartbeat.* `dune rpc build` reports
+  diagnostics, not progress; the progress lives in the watcher's own log. A
+  heartbeat that points at `make dev-log` is honest about where the information
+  is. Capturing the output is also load-bearing for the `Success` check at
+  `Makefile.common-ox:567`, so streaming means restructuring that too.
+
+**Verification.** Reproducing a wedge on demand is not reliable, so the timeout
+and recovery path get exercised against a stub: a fake `dune` on `PATH` whose
+`rpc build` sleeps forever, with `DEV_RPC_TIMEOUT` set to a few seconds. That
+shows timeout → watcher restart → retry → fallback in order. Separately, the
+heartbeat and the fallback are exercised for real by using this branch's own
+loop for the rest of the piece.
+
+---
+
+### 2. Stale `_runtest` stdlib after a `.cmi`-shape change
+
+**Evidence.** 2/5 reports, and the most expensive per occurrence: both sessions
+that hit it ended up in a debugger.
+
+- totality: `.cmi` shapes changed without a magic bump; the expect runner
+  SIGSEGVs; ~45 min lost bisecting the test file and suspecting solver
+  nontermination.
+- type-formers: changed the `Types` layout with the magic bump deferred; "I was
+  in gdb before realizing the compiler was fine and the cmis were stale".
+  Notes that "every vox piece that touches `Types` will hit this" — which,
+  given what vox is, is a forecast worth taking seriously even at 2/5.
+
+`dev-runtime` cannot catch this: it compares the artifact against
+`runtime stdlib otherlibs` sources only (`Makefile.common-ox:547-549`), and
+here the sources did not change — the *reader* did.
+
+**Decided fix.** Do not predict; detect. After a successful build in
+`dev-check`, and only if the dev compiler exists, compile a one-line file with
+the dev compiler against the installed stdlib, with scratch under
+`_build/dev/smoke/`. On any failure or signal, print one actionable line —
+
+    dev: the compiler cannot read the installed stdlib; a compiler change may
+    dev: have altered .cmi shapes. Run `make dev-refresh-stdlib`.
+
+— and fail. Add `dev-refresh-stdlib` (watcher stop + `runtime-stdlib`) as the
+named cure.
+
+Placement matters and the reports get it slightly wrong. totality suggests
+"after `prepare-test-root` in `dev-test`". But `dev-ocamlc`/`dev-ocamlopt` read
+the same stdlib and erasure used those 50+ times, so the check belongs at the
+end of `dev-check`, which every dev command depends on. It also must run *after*
+the build, not in `dev-runtime`: `dev-check`'s prerequisites are
+`dev-setup dev-runtime dev-start`, so a check in `dev-runtime` would test the
+previous compiler binary, not the one the command is about to use.
+
+**Alternatives rejected.**
+
+- *mtime heuristics over `typing/` / `file_formats/`* (suggested by
+  type-formers). Rejected, and both reports say why: any such witness rebuilds
+  the stdlib on every ordinary `typing/` edit, which is most edits, turning the
+  fast loop into a slow one. type-formers explicitly notes "rebuilding stdlib on
+  every compiler change is too slow".
+- *Bump the cmi magic number.* Not available: the whole failure class exists
+  because the magic bump is deliberately deferred during development.
+- *Print a hint unconditionally* (type-formers' fallback suggestion: "if
+  compiled programs crash after changing Types, run make runtime-stdlib").
+  Rejected: a hint printed on every build is noise that is not read, and the
+  sessions that needed it were looking at a SIGSEGV, not at `make dev`'s
+  output.
+- *Refresh automatically on detection* instead of failing with a message.
+  Tempting, and I may revisit, but `runtime-stdlib` is minutes long and
+  triggering it implicitly from `make dev` reintroduces "a long silent phase
+  you did not ask for", which is item 1. Naming the target keeps the cost
+  visible and voluntary.
+
+**Verification.** Make a real `.cmi`-shape change (add a field to a type that is
+marshaled into cmis) on a scratch commit, rebuild, and show the diagnostic
+fires with this message where the baseline segfaults. Also measure the added
+per-build cost and report it; if it is not comfortably under the noise floor of
+a warm `make dev`, the check moves behind a flag.
+
+---
+
+### 3. `ocamlc.byte` / `ocamlopt.byte` tests under the dev harness
+
+**Evidence.** 4/5 reports (totality, type-formers, erasure, bigint). The cost is
+not one big incident but a recurring tax: the failure presents as a magic-number
+error buried in a test log, every session reclassifies it from scratch, and
+`dev-test-all` can never be green, which devalues the whole full-suite signal.
+Affected: `formatting/`, `tool-ocamlc-stop-after/`, `zero-alloc/cmi_test`,
+`parsetree/test_ppx`, `templates/`, `typing-ocamlc-i/`, and via `ocamlopt.byte`
+`flambda2/` and `layout_poly/`.
+
+Per correction 2 these are two defects:
+
+**3a. `ocamlopt` is simply absent from the dev test root.** Fix: link
+`ocamlopt`/`ocamlopt.byte` alongside the existing `ocamlopt.opt` in
+`prepare_test_root_locked`. Cheap, and it is a plain omission — `ocamlc.byte`
+and `ocamlc` are both created a few lines above.
+
+**3b. `ocamlc.byte` → `main.bc` cannot execute.** `main.bc` is built by the boot
+workspace with the opam host compiler (`Caml1999X036`) but the dev test root's
+`ocamlrun` is the in-tree one (`X583`). Candidate fixes: point `ocamlc.byte` at
+`main_native.exe` (runs, but is no longer a bytecode compiler); build `main.bc`
+against a matching runtime; or skip-list with an explicit "unsupported under dev
+harness" marker.
+
+**Decided fix: measure before choosing.** This is the one item where the answer
+is empirical and I will not decide it from the armchair. The experiment: apply
+3a and the `main_native.exe` variant of 3b, run every affected directory under
+the dev harness, and compare pass/fail per test against the same directories run
+under `_runtest` (the real harness). If the sets agree, the redirect is right and
+the skip-list is unnecessary complexity. If any test genuinely discriminates
+`ocamlc.byte` from `ocamlc.opt` — `ocamltest/ocaml_actions.ml:1033` warns that
+under flambda2 they "sometimes generate equivalent" but not identical output, so
+this is a live risk — then those tests get the explicit skip marker and the rest
+get the redirect. The design doc will record which, with the measurement.
+
+Whichever way it lands, the outcome to insist on is that a test unsupported
+under the dev harness says so in one line, rather than presenting as a
+regression.
+
+---
+
+### 4. `dev-promote`: two real defects and two legibility bugs
+
+**Evidence.** 4/5 reports, though as separate sub-items rather than one
+converged complaint.
+
+**4a. Cannot create a missing reference file** (bigint 3). Root cause verified
+above. Fix in `ocamltest/actions_helpers.ml`: honour `promote` in the
+`Unexpected_output` branch. Red-green testable, and the natural home for the
+fixture is `testsuite/tests/tool-ocamltest/`, which already exists.
+
+**4b. Multi-reference tests need promote run twice** (bigint 4). Same root
+cause: `actions_helpers.ml:397` fails the action *after* promoting, so the test
+aborts before later references are reached. Two candidate fixes — make the
+promoting branch pass, or loop `dev-promote` to a fixpoint. I intend the second.
+Making a promoted check pass silently converts "your output changed" into "no
+news", which is the report signal expect tests exist to give; the two-pass
+"promote, then verify" shape is right, it just needs to be iterated to a
+fixpoint (bounded, 3 attempts) instead of exactly once.
+
+**4c. `/tmp` scratch.** `Makefile.common-ox:647` → `_build/dev/`. Also export
+`TMPDIR` into the test environment so ocamltest's own `Filename.temp_file` uses
+(`filecompare.ml:231`, `actions_helpers.ml:267,309`) stay inside the worktree.
+Binding house rule, and broader than the reports realised.
+
+**4d. Log ordering** (solver-interface 4). The promote log is `cat`ed after the
+verify output, so it reads reverse-chronologically. Print it first.
+
+**4e. Say when output is unstable** (erasure 5, totality's last bullet). When
+promotion does not converge because the plain and `-principal` runs disagree,
+say that in a sentence — `dev: output differs between the plain and -principal
+runs; this test needs a Principal{| … |} block by hand` — instead of only
+printing a diff. erasure records "a puzzled half hour" on exactly this.
+
+Note that 4a and 4b are changes to ocamltest, not to the dev loop, and would
+improve `make promote` for upstream users too.
+
+---
+
+### 5. `make dev NOWATCH=1`
+
+**Evidence.** 1/5 reports (totality 6), and the low count understates it,
+because the sessions that needed it worked around it rather than paying for it.
+Under a `workspace-write` sandbox — which is how codex reviewers run — the
+watcher dies with `bind(): Operation not permitted` because dune's RPC socket
+cannot be created, and there is no fallback. The current workaround is to point
+review agents at a prebuilt runner borrowed from another worktree, which is
+fragile and means reviewers cannot independently build the branch they are
+reviewing. Every future review loop pays this.
+
+**Decided fix.** `NOWATCH=1` makes `dev-start` a no-op and `dev-check` run a
+plain `dune build $(ws_boot) $(dev_build_flag) $(dev_boot_targets)` with no
+`wait-ready`, no rpc, no heartbeat. Slower per invocation, works anywhere.
+`dev-expect-runners` keeps working because its `dev-start` becomes a no-op too.
+
+This composes with item 1's fallback: item 1's fallback is the same `dune build`
+command reached automatically after a failure, so `NOWATCH=1` is that path made
+explicit and unconditional. Implementing them together keeps one code path.
+
+**Verification.** Run `make dev NOWATCH=1` in a worktree with no watcher and
+confirm it builds and that no watcher process or socket appears. Then have a
+codex reviewer, which really does run under `workspace-write`, build the branch
+with it — that is the actual target environment and the only honest test.
+
+---
+
+### 6. Cheap wins with real evidence behind them
+
+Grouped because each is small, but they are not filler — the autoconf item has
+the joint-highest convergence count in the whole corpus.
+
+**6a. Fresh-worktree bootstrap — 5/5 reports.** Every single report mentions it:
+`configure.ac:19` is `AC_PREREQ([2.71])`, the `autoconf` on PATH is 2.69, and
+`configure` is untracked, so every new worktree needs `autoconf27` or a copied
+`configure`. With worktree-per-piece *and* worktree-per-reviewer that is 5-8
+worktrees per piece, and four of the five sessions resorted to copying
+`configure` from a sibling.
+
+Fix: a `dev-configure` target that finds an autoconf ≥ 2.71 on PATH
+(`autoconf27`, `autoconf-2.71`, `autoconf`, checking `--version`) and runs it
+plus `./configure --prefix="$PWD/_install"`; and a `Makefile.config` precondition
+on the dev targets that fails with exactly that hint instead of make's bare
+`No rule to make target 'Makefile.config'` from `Makefile.common-ox:204`.
+
+Rejected: *commit the generated `configure`* (suggested by erasure and bigint) —
+it is a ~100k-line generated artifact that upstream deliberately does not track;
+committing it on a feature branch buys a merge conflict on every rebase. Also
+rejected: *an autoconf shim in `vox/bin`* (suggested by solver-interface) — it
+lives outside the repo, so it does not help a reviewer in a fresh environment,
+which is precisely who gets bitten.
+
+**6b. `make dev-errors` — 1/5 but strongly worded.** erasure calls
+`dune diagnostics --root=. --build-dir=$PWD/_build/dev-dune` against the running
+watcher "the fastest loop of the entire session". `dev-check` already invokes
+exactly this at `Makefile.common-ox:570`; promoting it to a named target is a
+two-line change.
+
+**6c. `make dev-diff TEST=…` — 1/5 (totality 4/5), high leverage.** Find the
+newest corrected artifact across all *three* roots from correction 3, always
+prefer `.corrected.corrected`, print `diff -u` against the source. This is what
+makes "never hand-copy `.corrected`" a realistic instruction rather than a
+prohibition with no substitute.
+
+**6d. Artifact location from `dev-test-all` — 1/5, cost ~20 min.** One line at
+the end naming `_runtest/testsuite/_ocamltest/`. totality re-ran 55 failing
+tests serially for want of it.
+
+**6e. Python version guard — 2/5.** Two lines in `tools/dev-watcher.py:353`'s
+neighbourhood, replacing a bare `argparse` `TypeError` on python 3.6 with
+"python 3.7+ required".
+
+**6f. Suppress dune's "build request is being forwarded" notice — 1/5.** No dune
+flag exists (checked against 3.23.0), so filter the line in `dev-check`.
+
+**6g. Document the blessed scratch path — 1/5.** type-formers found
+`_build/dev-dune/default/main_native.exe -nostdlib -I _build/dev/runtest/stdlib`
+faster and more scriptable than `make dev-ocamlc` for one-file repros. A line in
+`AGENTS.md`, with the caveat that it shares item 2's stale-stdlib exposure —
+which item 2's detector does not cover, because it bypasses `dev-check`.
+
+Also in `AGENTS.md`: "promote with `make dev-promote`, never by copying
+`.corrected`" (totality 5), and the `autoconf27` correction to the setup recipe,
+which currently says plain `autoconf` at `AGENTS.md:7`.
+
+---
+
+## Deferred, with reasons
+
+### 7. Single-instance lock (2/5)
+
+type-formers saw ~15 stuck `make dev-test` processes producing no output until
+`pkill`; erasure saw the expect-runner refresh collide with a restarting watcher
+("Another Dune instance is currently running"). A lock printing "another dev
+command is running (pid N), waiting" would convert both into clear messages.
+
+Deferred, not dismissed. `tools/dev-watcher.py` already has an flock helper
+(`locked()`, line 50) so the mechanism exists, but the scope question is real:
+`dev-test-all` runs for 30-40 minutes and legitimately holds the loop, so a
+naive exclusive lock across all dev commands would serialise a reviewer behind
+it and produce a *new* silent wait. Doing this properly means deciding which
+commands are mutually exclusive and which merely need the watcher steady, and
+that deserves its own thinking rather than being bolted on at the end of this
+piece. Item 1's heartbeat also removes most of the *silence* that made these
+incidents expensive to diagnose, which lowers the urgency. If time remains after
+1-6, this is the next item.
+
+### 8. Stale `_runtest` compilerlibs (1/5)
+
+solver-interface 2: `include ocamlcommon` tests link cmis/cmas from `_runtest`,
+which only `install_for_test` refreshes. Adding a module is loud but cryptic
+(`Unbound module Vox_logic`); *editing* one is silent.
+
+Deferred to a warning at most, and here I disagree with the report's suggested
+fix. It proposes staleness detection against "the typing/parsing/utils sources".
+But the cure is `install_for_test`, which the same report measures at 15-30
+minutes on a loaded box — so a detector that fires on every `typing/` edit
+prescribes a half-hour rebuild on every edit, and will simply be ignored, or
+worse, obeyed. The report's own cheaper variant ("only for tests whose TEST
+block says `include ocamlcommon`") is the right shape, and if I reach it, it
+lands as a warning line scoped to those tests, never as an automatic rebuild.
+Not a promise for this piece.
+
+### 9. Stdlib *interface* change poisoning `_runtest` (1/5)
+
+bigint 1: after `stdlib.mli` changed, main-context compiler-libs stayed compiled
+against the old `Stdlib` digest, producing 661 bogus "inconsistent assumptions
+over interface Stdlib" failures; `install_for_test` exits 0 without fixing it,
+`rm -rf _build/main` corrupts dune's incremental state and does not self-heal,
+and only a full `_build` wipe plus ~25 minutes recovered.
+
+Out of scope for this piece, and I want to be explicit about why, because it is
+the highest-damage single incident in the corpus. The root cause is that
+`main.ws` finds the stdlib via `OCAMLLIB` → `_build/runtime_stdlib_install`
+(`Makefile.common-ox:73`), which is outside dune's dependency tracking. The
+suggested fix — fingerprint the installed stdlib `.cmi` digests and force a
+main-context invalidation when they change — is implementable, but it prescribes
+a ~25 minute rebuild on every stdlib interface change, it only affects
+`install_for_test` / `dev-test-all` rather than the fast loop, and getting the
+invalidation granularity wrong makes the full suite unusable rather than merely
+wrong. The `rm -rf _build/main` non-recovery is a dune bug, not ours.
+
+What is affordable now, and what I will do instead: detection, not healing. When
+`dev-test-all` output contains "inconsistent assumptions over interface Stdlib",
+print one line naming the cause and the known-working recovery (full `_build`
+wipe, ~25 min) — so the next session spends a minute rather than an hour, and
+does not reach for `rm -rf _build/main`. The real fix gets its own piece.
+
+### 10. Expect runner rebuilt as a second full compiler build
+
+type-formers 2, and by that session's own account the dominant cost of its test
+loop: after any compiler change, `dev-test` on an expect test pays the fast
+watcher build *plus* a `main.ws` build of `expect.exe`, ~8-10 minutes per
+iteration.
+
+Explicitly out of scope, and flagged as the strongest candidate for the *next*
+dev-loop piece. This is the largest remaining throughput cost in the corpus, but
+fixing it means building the expect runner in the boot/dev context rather than
+the main workspace, which changes what the runner links against and therefore
+what expect tests are actually testing. That is a correctness question about the
+test harness, not a tooling convenience, and it should not be decided as the
+tenth item of a friction-fixing branch.
+
+### 11. Shared dune cache across worktrees
+
+Raised speculatively by solver-interface and echoed by the owner: each worktree
+carries `_build/dev-dune` plus `_build/main`/`_build/default`, and with 7+
+worktrees on one box that is heavy disk and inotify load, with sibling watchers
+visibly competing. Out of scope. It is a measurement task before it is an
+implementation task, and it was offered as speculation rather than as a reported
+cost.
+
+### Not the dev loop's problem
+
+- The ocamltest `script`-action quirk where defining `stdout`/`stderr` disables
+  redirection for a later `run` action (solver-interface). Real, upstream,
+  already documented in the z3 test's header comment.
+- `dev-test PROMOTE=1 DIR=…` writing `_ocamltest` into the source tree
+  (correction 3) is a genuine defect, but the fix is in `testsuite/Makefile`'s
+  `exec-one`, which is shared with the non-dev harness. I will note it and, if
+  1-6 land with time to spare, fix it by having `dev-test` pass an explicit
+  `OCAMLTESTDIR` under the dev root for every mode — which also collapses three
+  artifact locations to two and makes `dev-diff` simpler.
+
+## Out of scope for this piece, in one list
+
+Items 9 (stdlib interface fingerprinting), 10 (expect runner build cost), 11
+(shared dune cache); the upstream ocamltest `script` quirk; any change to what
+the full test suite asserts; any change to release/`make install` builds; and
+performance work on the watcher itself.
+
+## Verification standard for this piece
+
+Every landed item is exercised against the failure it targets, not only
+reasoned about. Specifically:
+
+- Item 1: stub `dune` whose `rpc build` never returns; show timeout → restart →
+  retry → fallback.
+- Item 2: real `.cmi`-shape change on a scratch commit; show the diagnostic
+  fires where the baseline segfaults; report the added per-build cost.
+- Item 3: pass/fail comparison of affected directories, dev harness vs
+  `_runtest`.
+- Item 4a/4b: red-green fixtures in `testsuite/tests/tool-ocamltest/`, so
+  commit 2's diff to the expectation shows exactly what changed.
+- Item 5: `NOWATCH=1` with no watcher present, then confirmed by a codex
+  reviewer under a real `workspace-write` sandbox.
+- Item 6: exercised by using this branch's loop for the remainder of the work.
+
+The final report (`design-docs/dev-loop-improvements-final.md`) states, per item,
+whether it was exercised or only reasoned through. No check is weakened to make
+a test pass; anything that turns out to be infeasible is reported as such with
+evidence.
+
+## Open questions for the owner
+
+1. Item 3b: if the measurement shows any test genuinely discriminating
+   `ocamlc.byte` from `ocamlc.opt`, the choice is between a skip-list (honest,
+   but `dev-test-all` stays non-green for those tests) and redirecting anyway
+   (green, but the dev harness silently stops testing the bytecode compiler).
+   My default is the skip-list, with the marker text saying exactly what is not
+   covered. Say if you want the other one.
+2. Item 2: the check fails with a message rather than auto-refreshing. If you
+   would rather `make dev` just fix it and eat the minutes, that is a one-line
+   change.

--- a/design-docs/dev-loop-improvements.md
+++ b/design-docs/dev-loop-improvements.md
@@ -269,7 +269,11 @@ a warm `make dev`, the check moves behind a flag.
 **Evidence.** 4/5 reports (totality, type-formers, erasure, bigint). The cost is
 not one big incident but a recurring tax: the failure presents as a magic-number
 error buried in a test log, every session reclassifies it from scratch, and
-`dev-test-all` can never be green, which devalues the whole full-suite signal.
+`make dev-test` can never be green on them. (The reports say `dev-test-all` can
+never be green either, and the synthesis repeats it. That is a sixth correction,
+found while implementing 3b: `dev-test-all` goes through `_runtest` and its
+`ocamlc.byte` is the real installed bytecode compiler, so these tests pass there.
+See the final report.)
 Affected: `formatting/`, `tool-ocamlc-stop-after/`, `zero-alloc/cmi_test`,
 `parsetree/test_ppx`, `templates/`, `typing-ocamlc-i/`, and via `ocamlopt.byte`
 `flambda2/` and `layout_poly/`.

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -409,7 +409,13 @@ let compare_files kind_of_output output_filename reference_filename log
           reference file %s but it is not:\n%s\n"
         output_filename reference_filename unexpected_output_with_banners in
       (* A missing reference is what a brand-new test looks like, so promotion
-         should create it rather than making the author write it by hand. *)
+         should create it rather than making the author write it by hand.
+
+         Note that a missing reference is also how a test spells "this output must
+         be empty", so promoting here turns such a test into one that asserts the
+         output it happened to produce. That is the same hazard promotion always
+         has -- it records what happened rather than what was meant -- but it
+         applies to a file that did not exist before, so review what appears. *)
       promote_if_requested ();
       (Result.fail_with_reason reason, env)
     | Filecompare.Error (commandline, exitcode) ->

--- a/ocamltest/actions_helpers.ml
+++ b/ocamltest/actions_helpers.ml
@@ -379,6 +379,14 @@ let compare_files kind_of_output output_filename reference_filename log
     } in
   let tool =
     Filecompare.make_cmp_tool ~ignore:ignore_header_conf in
+  let promote_if_requested () =
+    if Environments.lookup_as_bool Builtin_variables.promote env = Some true
+    then begin
+      Printf.fprintf log "Promoting %s output %s to reference %s\n%!"
+        kind_of_output output_filename reference_filename;
+      Filecompare.promote files ignore_header_conf;
+    end
+  in
   match Filecompare.check_file ~tool files with
     | Filecompare.Same -> (Result.pass, env)
     | Filecompare.Different ->
@@ -389,12 +397,7 @@ let compare_files kind_of_output output_filename reference_filename log
       let reason =
         Printf.sprintf "%s output %s differs from reference %s: \n%s\n"
         kind_of_output output_filename reference_filename diffstr in
-      if Environments.lookup_as_bool Builtin_variables.promote env = Some true
-      then begin
-        Printf.fprintf log "Promoting %s output %s to reference %s\n%!"
-          kind_of_output output_filename reference_filename;
-        Filecompare.promote files ignore_header_conf;
-      end;
+      promote_if_requested ();
       (Result.fail_with_reason reason, env)
     | Filecompare.Unexpected_output ->
       let banner = String.make 40 '=' in
@@ -405,6 +408,9 @@ let compare_files kind_of_output output_filename reference_filename log
         "The file %s was expected to be empty because there is no \
           reference file %s but it is not:\n%s\n"
         output_filename reference_filename unexpected_output_with_banners in
+      (* A missing reference is what a brand-new test looks like, so promotion
+         should create it rather than making the author write it by hand. *)
+      promote_if_requested ();
       (Result.fail_with_reason reason, env)
     | Filecompare.Error (commandline, exitcode) ->
       let reason = Printf.sprintf "The command %s failed with status %d"

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -27,6 +27,29 @@ let native_action a =
   if Ocamltest_config.native_compiler then a
   else (Actions.update a no_native_compilers)
 
+(* A harness can substitute its own compilers for the installed ones, and may not
+   be able to supply a runnable bytecode compiler: the fast development loop
+   (`make dev-test`) points ocamlc.byte at a boot main.bc carrying the host
+   runtime's magic, which the in-tree ocamlrun refuses. Such tests then present as
+   ordinary failures, so every reader re-derives that from a magic-number error
+   buried in a log. Setting this variable makes them skip instead, and the skip
+   names the compiler that consequently went untested. *)
+let skip_bytecode_compilers =
+  Sys.safe_getenv "OCAMLTEST_SKIP_BYTECODE_COMPILERS" <> ""
+
+let no_bytecode_compiler name _log env =
+  let reason =
+    Printf.sprintf
+      "%s is not runnable under this harness, so this test does not cover it"
+      name
+  in
+  (Result.skip_with_reason reason, env)
+
+let bytecode_compiler_action name a =
+  if skip_bytecode_compilers
+  then Actions.update a (no_bytecode_compiler name)
+  else a
+
 let get_backend_value_from_env env bytecode_var native_var =
   Ocaml_backends.make_backend_function
     (Environments.safe_lookup bytecode_var env)
@@ -516,11 +539,12 @@ let compile (compiler : Ocaml_compilers.compiler) log env =
 (* Compile actions *)
 
 let ocamlc_byte =
-  Actions.make
-    ~name:"ocamlc.byte"
-    ~description:"Compile the program using ocamlc.byte"
-    ~does_something:true
-    (compile Ocaml_compilers.ocamlc_byte)
+  bytecode_compiler_action "ocamlc.byte"
+    (Actions.make
+      ~name:"ocamlc.byte"
+      ~description:"Compile the program using ocamlc.byte"
+      ~does_something:true
+      (compile Ocaml_compilers.ocamlc_byte))
 
 let ocamlc_opt =
   native_action
@@ -532,11 +556,12 @@ let ocamlc_opt =
 
 let ocamlopt_byte =
   native_action
-    (Actions.make
-      ~name:"ocamlopt.byte"
-      ~description:"Compile the program using ocamlopt.byte"
-      ~does_something:true
-      (compile Ocaml_compilers.ocamlopt_byte))
+    (bytecode_compiler_action "ocamlopt.byte"
+      (Actions.make
+        ~name:"ocamlopt.byte"
+        ~description:"Compile the program using ocamlopt.byte"
+        ~does_something:true
+        (compile Ocaml_compilers.ocamlopt_byte)))
 
 let ocamlopt_opt =
   native_action

--- a/testsuite/tests/tool-ocamltest/promote-missing-reference-child.tsl
+++ b/testsuite/tests/tool-ocamltest/promote-missing-reference-child.tsl
@@ -1,0 +1,8 @@
+(* CHILDTEST
+ output = "${test_source_directory}/promote-missing-input";
+ check-program-output;
+*)
+
+(* Run by promote-missing-reference.sh, which copies this file to a .ml in the
+   parent test's build directory so the Make-based drivers do not mistake it for a
+   test of its own. Its reference file deliberately does not exist. *)

--- a/testsuite/tests/tool-ocamltest/promote-missing-reference.ml
+++ b/testsuite/tests/tool-ocamltest/promote-missing-reference.ml
@@ -1,0 +1,17 @@
+(* TEST
+ setup-simple-build-env;
+ set child = "${test_source_directory}/promote-missing-reference-child.tsl";
+ output = "${test_build_directory}/promote-missing-reference.result";
+ script = "sh ${test_source_directory}/promote-missing-reference.sh";
+ script;
+ check-program-output;
+*)
+
+(* This file is a driver, not a program: the work happens in
+   promote-missing-reference.sh, which runs a nested ocamltest with -promote on a
+   test whose reference file does not exist yet, and reports whether promotion
+   created it.
+
+   Promoting a brand-new test's output used to be impossible: check_file returns
+   Unexpected_output when the reference is absent, and that branch never consulted
+   the promote variable, so the reference had to be written by hand. *)

--- a/testsuite/tests/tool-ocamltest/promote-missing-reference.reference
+++ b/testsuite/tests/tool-ocamltest/promote-missing-reference.reference
@@ -1,2 +1,4 @@
 child ocamltest exit: 0
-reference not created
+reference created, contents:
+promoted line one
+promoted line two

--- a/testsuite/tests/tool-ocamltest/promote-missing-reference.reference
+++ b/testsuite/tests/tool-ocamltest/promote-missing-reference.reference
@@ -1,0 +1,2 @@
+child ocamltest exit: 0
+reference not created

--- a/testsuite/tests/tool-ocamltest/promote-missing-reference.sh
+++ b/testsuite/tests/tool-ocamltest/promote-missing-reference.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Run a nested ocamltest with -promote on a test whose reference file does not
+# exist, and report whether promotion created it. Driven by
+# promote-missing-reference.ml, which passes the child's source path in $child.
+
+set -u
+
+copy=child_promote_missing.ml
+reference=child_promote_missing.reference
+
+# The child's output is this file; anything non-empty will do.
+printf 'promoted line one\npromoted line two\n' > promote-missing-input
+
+# CHILDTEST keeps the Make-based drivers from treating the child as a test.
+sed -e 's/CHILDTEST/TEST/' "${child:?child must be set}" > "$copy"
+
+rm -f "$reference"
+
+"${ocamlsrcdir}/ocamltest/ocamltest" -promote "$copy" > child.log 2>&1
+echo "child ocamltest exit: $?"
+
+if [ -f "$reference" ]; then
+  echo "reference created, contents:"
+  cat "$reference"
+else
+  echo "reference not created"
+fi

--- a/testsuite/tests/tool-ocamltest/skip-bytecode-compilers-child.tsl
+++ b/testsuite/tests/tool-ocamltest/skip-bytecode-compilers-child.tsl
@@ -1,0 +1,10 @@
+(* CHILDTEST
+ setup-ocamlc.byte-build-env;
+ ocamlc.byte;
+*)
+
+(* Run by skip-bytecode-compilers.sh, which copies this to a .ml in the parent
+   test's build directory so the Make-based drivers do not treat it as a test of
+   its own. It exists only to reach the ocamlc.byte action. *)
+
+let () = print_string "unreachable when the action is skipped\n"

--- a/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.ml
+++ b/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.ml
@@ -1,0 +1,19 @@
+(* TEST
+ setup-simple-build-env;
+ set child = "${test_source_directory}/skip-bytecode-compilers-child.tsl";
+ output = "${test_build_directory}/skip-bytecode-compilers.result";
+ script = "sh ${test_source_directory}/skip-bytecode-compilers.sh";
+ script;
+ check-program-output;
+*)
+
+(* A driver, not a program: skip-bytecode-compilers.sh runs a nested ocamltest on
+   a child test that uses the ocamlc.byte and ocamlopt.byte actions, with
+   OCAMLTEST_SKIP_BYTECODE_COMPILERS set, and reports how those actions were
+   classified.
+
+   The dev harness (`make dev-test`) points ocamlc.byte at the boot main.bc, which
+   carries the host runtime's magic and so cannot be run by the in-tree ocamlrun.
+   Those tests then present as ordinary failures, and every session re-does the
+   forensics from a magic-number error buried in a log. With the variable set they
+   are skipped instead, and the skip names the compiler that went untested. *)

--- a/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.reference
+++ b/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.reference
@@ -1,0 +1,2 @@
+child ocamltest exit: 0
+ocamlc.byte => failed

--- a/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.reference
+++ b/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.reference
@@ -1,2 +1,3 @@
 child ocamltest exit: 0
-ocamlc.byte => failed
+ocamlc.byte => skipped
+reason: ocamlc.byte is not runnable under this harness, so this test does not cover it

--- a/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.sh
+++ b/testsuite/tests/tool-ocamltest/skip-bytecode-compilers.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Run a nested ocamltest on a child test that uses the ocamlc.byte action, with
+# OCAMLTEST_SKIP_BYTECODE_COMPILERS set, and report how that action was
+# classified. Driven by skip-bytecode-compilers.ml, which passes the child's
+# source path in $child.
+
+set -u
+
+copy=child_skip_bytecode.ml
+
+sed -e 's/CHILDTEST/TEST/' "${child:?child must be set}" > "$copy"
+
+OCAMLTEST_SKIP_BYTECODE_COMPILERS=1 \
+  "${ocamlsrcdir}/ocamltest/ocamltest" "$copy" > child.log 2>&1
+echo "child ocamltest exit: $?"
+
+# Report the classification only, and the reason just for a skip: a failure's
+# reason quotes absolute build paths, which would make the expectation
+# machine-specific.
+classification=$(
+  sed -n 's/.*(ocamlc\.byte) => \([a-z]*\).*/\1/p' child.log | head -n 1
+)
+echo "ocamlc.byte => $classification"
+if [ "$classification" = skipped ]; then
+  sed -n 's/.*(ocamlc\.byte) => skipped (\(.*\))$/reason: \1/p' child.log \
+    | head -n 1
+fi

--- a/tools/dev-watcher-test.sh
+++ b/tools/dev-watcher-test.sh
@@ -12,7 +12,9 @@
 set -eu
 
 root=$(cd "$(dirname "$0")/.." && pwd)
-scratch=$root/_build/dev/watcher-test
+# Per-process, so two runs of this suite -- or two reviewers in one worktree --
+# cannot delete each other's scratch mid-test.
+scratch=$root/_build/dev/watcher-test.$$
 export TMPDIR=$scratch
 
 failures=0
@@ -42,7 +44,15 @@ case "$1 ${2-}" in
         printf 'certain command line arguments may be ignored.\n'
         printf 'Success\n'
         exit 0 ;;
-      hang) exec sleep 600 ;;
+      # 601, distinct from the watcher's own `sleep 600`, so the tests can tell an
+      # abandoned build from a healthy watcher.
+      # Record the pid so the tests can check this build really died, rather than
+      # matching on a command line, which would also match a sibling worktree
+      # running this same suite.
+      hang) echo $$ >> "$HANGS"; exec sleep 601 ;;
+      # Ignores the polite signals, so only SIGKILL ends it. Without escalation a
+      # wedged build like this makes the timeout unbounded.
+      stubborn) echo $$ >> "$HANGS"; trap '' INT TERM; exec sleep 601 ;;
       dead)
         echo 'Error: Server returned error: Connection terminated (error' \
              'kind: Connection_dead)'
@@ -51,7 +61,7 @@ case "$1 ${2-}" in
     esac ;;
 esac
 case "$1" in
-  build) echo "FALLBACK BUILD RAN"; exit 0 ;;
+  build) echo "FALLBACK BUILD RAN"; exit "${FALLBACK_STATUS-0}" ;;
   diagnostics) echo "DIAGNOSTICS RAN"; exit 0 ;;
 esac
 echo "stub dune: unexpected arguments: $*" >&2
@@ -59,6 +69,8 @@ exit 99
 STUB
   chmod +x "$scratch/bin/dune"
   export COUNTER=$scratch/build-count
+  export HANGS=$scratch/hung-pids
+  : > "$HANGS"
   export PATH=$scratch/bin:$PATH
 }
 
@@ -71,6 +83,7 @@ watcher() {
 # on the prefix being scoped.
 start_stub_watcher() {
   : > "$COUNTER"
+  : > "$HANGS"
   unset BUILD_1 BUILD_2 BUILD_3 BUILD_4 BUILD_5 || true
   BUILD_DEFAULT=${1-success}
   export BUILD_DEFAULT
@@ -129,6 +142,38 @@ expect_build_count() {
   fi
 }
 
+watcher_pid() {
+  cat "$scratch/_build/dev/watcher.pid" 2>/dev/null || echo none
+}
+
+# The recovery path is defined by two effects, not by its messages: the watcher is
+# really replaced, and the abandoned build really dies.
+expect_watcher_replaced() {
+  if [ "$1" != "$(watcher_pid)" ] && [ "$(watcher_pid)" != none ]; then
+    echo "  ok: watcher was replaced ($1 -> $(watcher_pid))"
+  else
+    echo "  FAIL: watcher not replaced (was $1, now $(watcher_pid))"
+    failures=$((failures + 1))
+  fi
+}
+
+expect_no_abandoned_builds() {
+  stragglers=0
+  while read -r pid; do
+    [ -n "$pid" ] || continue
+    if kill -0 "$pid" 2>/dev/null; then
+      stragglers=$((stragglers + 1))
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done < "$HANGS"
+  if [ "$stragglers" -eq 0 ]; then
+    echo "  ok: no abandoned build processes"
+  else
+    echo "  FAIL: $stragglers abandoned build process(es) left behind"
+    failures=$((failures + 1))
+  fi
+}
+
 setup
 trap 'watcher stop >/dev/null 2>&1 || true' EXIT
 
@@ -137,19 +182,30 @@ start_stub_watcher success
 run_build 0 "success"
 expect_output "Success"
 expect_build_count 1
-# The forwarding notice and the bare "Warning:" that introduces it are dropped.
-expect_no_output "being forwarded"
-expect_no_output "Warning:"
+# Dune's rpc forwarding notice is passed through rather than filtered. Suppressing
+# it needed matching on substrings, which could hide a real diagnostic that
+# happened to contain one; three lines of noise is the cheaper problem.
+expect_output "being forwarded"
 
 echo "== a wedged build times out, bounces the watcher, and retries once"
 start_stub_watcher success
 behaviour 1 hang
+before=$(watcher_pid)
 run_build 0 "timeout then retry" --timeout 2 --heartbeat 1
 expect_output "exceeded 2s"
 expect_output "restarting the watcher and retrying"
 expect_output "Success"
 expect_build_count 2
 expect_no_output "FALLBACK BUILD RAN"
+expect_watcher_replaced "$before"
+expect_no_abandoned_builds
+
+echo "== a build that ignores SIGINT and SIGTERM is still bounded"
+start_stub_watcher stubborn
+run_build 0 "stubborn build" --timeout 2 --heartbeat 1
+expect_output "building directly"
+expect_output "FALLBACK BUILD RAN"
+expect_no_abandoned_builds
 
 echo "== a heartbeat is printed while a build is running"
 start_stub_watcher success
@@ -166,6 +222,13 @@ expect_output "FALLBACK BUILD RAN"
 # Exactly two rpc attempts, then the fallback: retrying without a bound would
 # be a new silent hang.
 expect_build_count 2
+
+echo "== a failing direct build reports its own exit status"
+start_stub_watcher hang
+FALLBACK_STATUS=7 export FALLBACK_STATUS
+run_build 7 "fallback status" --timeout 2 --heartbeat 1
+expect_output "FALLBACK BUILD RAN"
+unset FALLBACK_STATUS
 
 echo "== a dead connection is recovered without waiting for the timeout"
 start_stub_watcher success

--- a/tools/dev-watcher-test.sh
+++ b/tools/dev-watcher-test.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+# Exercise `dev-watcher.py build`'s recovery from a wedged watcher.
+#
+# The failure this guards against is an rpc client that waits forever against a
+# watcher that is alive and answers pings but never starts the build. That is not
+# reproducible on demand, so it is simulated: the tests run against a stub
+# `dune` whose `rpc build` hangs, dies, fails or succeeds on command, in a
+# throwaway root so no real watcher is touched.
+#
+# Run from the repo root: sh tools/dev-watcher-test.sh
+
+set -eu
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+scratch=$root/_build/dev/watcher-test
+export TMPDIR=$scratch
+
+failures=0
+
+setup() {
+  rm -rf "$scratch"
+  mkdir -p "$scratch/tools" "$scratch/bin"
+  cp "$root/tools/dev-watcher.py" "$scratch/tools/dev-watcher.py"
+  cat > "$scratch/bin/dune" <<'STUB'
+#!/bin/sh
+# Stub dune. Successive `rpc build` calls behave as BUILD_1, BUILD_2, ...
+# falling back to BUILD_DEFAULT.
+case "$1 ${2-}" in
+  "rpc ping") exit 0 ;;
+  "rpc build")
+    count=$(cat "$COUNTER" 2>/dev/null || echo 0)
+    count=$((count + 1))
+    echo "$count" > "$COUNTER"
+    eval "behaviour=\${BUILD_$count-}"
+    [ -n "$behaviour" ] || behaviour=$BUILD_DEFAULT
+    case "$behaviour" in
+      success)
+        # Reproduce dune's three-line rpc forwarding notice verbatim.
+        printf 'Warning:\n'
+        printf 'Your build request is being forwarded to a running Dune '
+        printf 'instance. Note that\n'
+        printf 'certain command line arguments may be ignored.\n'
+        printf 'Success\n'
+        exit 0 ;;
+      hang) exec sleep 600 ;;
+      dead)
+        echo 'Error: Server returned error: Connection terminated (error' \
+             'kind: Connection_dead)'
+        exit 1 ;;
+      failure) printf 'Failure\n'; exit 0 ;;
+    esac ;;
+esac
+case "$1" in
+  build) echo "FALLBACK BUILD RAN"; exit 0 ;;
+  diagnostics) echo "DIAGNOSTICS RAN"; exit 0 ;;
+esac
+echo "stub dune: unexpected arguments: $*" >&2
+exit 99
+STUB
+  chmod +x "$scratch/bin/dune"
+  export COUNTER=$scratch/build-count
+  export PATH=$scratch/bin:$PATH
+}
+
+watcher() {
+  python3 "$scratch/tools/dev-watcher.py" "$@"
+}
+
+# A `VAR=value function` prefix persists in the calling shell under POSIX sh, so
+# each case must clear the previous one's behaviours explicitly rather than rely
+# on the prefix being scoped.
+start_stub_watcher() {
+  : > "$COUNTER"
+  unset BUILD_1 BUILD_2 BUILD_3 BUILD_4 BUILD_5 || true
+  BUILD_DEFAULT=${1-success}
+  export BUILD_DEFAULT
+  watcher start --idle-timeout 60 -- sleep 600 >/dev/null
+}
+
+behaviour() {
+  eval "export BUILD_$1=\$2"
+}
+
+# run_build <expected status> <name>; remaining args are `build` arguments.
+run_build() {
+  expected=$1; name=$2; shift 2
+  status=0
+  watcher build \
+    --ping "dune rpc ping" \
+    --fallback "dune build" \
+    --diagnostics "dune diagnostics" \
+    "$@" -- dune rpc build > "$scratch/out" 2>&1 || status=$?
+  if [ "$status" != "$expected" ]; then
+    echo "FAIL: $name: expected exit $expected, got $status"
+    sed 's/^/    /' "$scratch/out"
+    failures=$((failures + 1))
+    return 0
+  fi
+  echo "ok: $name (exit $status)"
+}
+
+expect_output() {
+  if grep -qF "$1" "$scratch/out"; then
+    echo "  ok: output contains '$1'"
+  else
+    echo "  FAIL: output does not contain '$1'"
+    sed 's/^/    /' "$scratch/out"
+    failures=$((failures + 1))
+  fi
+}
+
+expect_no_output() {
+  if grep -qF "$1" "$scratch/out"; then
+    echo "  FAIL: output should not contain '$1'"
+    sed 's/^/    /' "$scratch/out"
+    failures=$((failures + 1))
+  else
+    echo "  ok: output omits '$1'"
+  fi
+}
+
+expect_build_count() {
+  actual=$(cat "$COUNTER")
+  if [ "$actual" = "$1" ]; then
+    echo "  ok: made $actual rpc build attempt(s)"
+  else
+    echo "  FAIL: expected $1 rpc build attempt(s), made $actual"
+    failures=$((failures + 1))
+  fi
+}
+
+setup
+trap 'watcher stop >/dev/null 2>&1 || true' EXIT
+
+echo "== a successful build stays quiet and does not retry"
+start_stub_watcher success
+run_build 0 "success"
+expect_output "Success"
+expect_build_count 1
+# The forwarding notice and the bare "Warning:" that introduces it are dropped.
+expect_no_output "being forwarded"
+expect_no_output "Warning:"
+
+echo "== a wedged build times out, bounces the watcher, and retries once"
+start_stub_watcher success
+behaviour 1 hang
+run_build 0 "timeout then retry" --timeout 2 --heartbeat 1
+expect_output "exceeded 2s"
+expect_output "restarting the watcher and retrying"
+expect_output "Success"
+expect_build_count 2
+expect_no_output "FALLBACK BUILD RAN"
+
+echo "== a heartbeat is printed while a build is running"
+start_stub_watcher success
+behaviour 1 hang
+run_build 0 "heartbeat" --timeout 3 --heartbeat 1
+expect_output "still building"
+expect_output "progress: make dev-log"
+
+echo "== a persistently wedged watcher falls back to a direct build"
+start_stub_watcher hang
+run_build 0 "fallback" --timeout 2 --heartbeat 1
+expect_output "building directly"
+expect_output "FALLBACK BUILD RAN"
+# Exactly two rpc attempts, then the fallback: retrying without a bound would
+# be a new silent hang.
+expect_build_count 2
+
+echo "== a dead connection is recovered without waiting for the timeout"
+start_stub_watcher success
+behaviour 1 dead
+run_build 0 "connection died" --timeout 600 --heartbeat 300
+expect_output "lost its connection to the watcher"
+expect_output "Success"
+expect_build_count 2
+
+echo "== a genuine build failure reports diagnostics and does not retry"
+start_stub_watcher failure
+run_build 1 "build failure" --timeout 60
+expect_output "DIAGNOSTICS RAN"
+expect_build_count 1
+expect_no_output "FALLBACK BUILD RAN"
+
+watcher stop >/dev/null 2>&1 || true
+rm -rf "$scratch"
+
+if [ "$failures" = 0 ]; then
+  echo "all dev-watcher build tests passed"
+else
+  echo "$failures dev-watcher build check(s) failed"
+  exit 1
+fi

--- a/tools/dev-watcher.py
+++ b/tools/dev-watcher.py
@@ -2,13 +2,23 @@
 
 import argparse
 import fcntl
+import json
 import os
 from pathlib import Path
+import shlex
 import shutil
 import signal
 import subprocess
 import sys
 import time
+
+
+if sys.version_info < (3, 7):
+    raise SystemExit(
+        "dev watcher: python 3.7 or newer is required "
+        f"(running {sys.version.split()[0]} from {sys.executable}); "
+        "put a newer python3 first on PATH"
+    )
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -19,6 +29,19 @@ LEASE_FILE = STATE / "last-used"
 TIMEOUT_FILE = STATE / "idle-timeout"
 LOG_FILE = STATE / "watcher.log"
 LOCK_FILE = STATE / "lock"
+WATCHER_COMMAND_FILE = STATE / "watcher-command"
+BUILD_LOG_FILE = STATE / "rpc-build.log"
+
+# Dune prints a three-line warning on every rpc-forwarded command, which is
+# noise once known. There is no dune flag to suppress it (checked against 3.23),
+# so match its body and the bare "Warning:" that introduces it.
+FORWARDING_NOTICE = (
+    "build request is being forwarded",
+    "certain command line arguments may be ignored",
+)
+
+# What a dune rpc client says when the watcher's RPC server has gone away.
+CONNECTION_FAILURES = ("Connection_dead", "Connection terminated")
 
 
 def read_pid(path):
@@ -60,31 +83,50 @@ def clean_stale_state():
         CHILD_PID_FILE.unlink(missing_ok=True)
 
 
-def start(args):
-    if not args.command:
+def save_watcher_command(command, idle_timeout):
+    STATE.mkdir(parents=True, exist_ok=True)
+    WATCHER_COMMAND_FILE.write_text(
+        json.dumps({"command": list(command), "idle_timeout": idle_timeout})
+        + "\n"
+    )
+
+
+def load_watcher_command():
+    try:
+        saved = json.loads(WATCHER_COMMAND_FILE.read_text())
+    except (FileNotFoundError, ValueError):
+        return None
+    if not saved.get("command"):
+        return None
+    return saved["command"], saved.get("idle_timeout", 1800)
+
+
+def start_watcher(command, idle_timeout):
+    if not command:
         raise SystemExit("dev watcher: missing watcher command")
     with locked():
         clean_stale_state()
+        save_watcher_command(command, idle_timeout)
         pid = read_pid(PID_FILE)
         if alive(pid):
-            touch_lease(args.idle_timeout)
+            touch_lease(idle_timeout)
             return
 
-        touch_lease(args.idle_timeout)
+        touch_lease(idle_timeout)
         if LOG_FILE.exists() and LOG_FILE.stat().st_size > 1_000_000:
             LOG_FILE.write_bytes(b"")
         log = LOG_FILE.open("ab", buffering=0)
-        command = [
+        supervisor_command = [
             sys.executable,
             str(Path(__file__).resolve()),
             "supervise",
             "--idle-timeout",
-            str(args.idle_timeout),
+            str(idle_timeout),
             "--",
-            *args.command,
+            *command,
         ]
         supervisor = subprocess.Popen(
-            command,
+            supervisor_command,
             cwd=ROOT,
             stdin=subprocess.DEVNULL,
             stdout=log,
@@ -97,12 +139,16 @@ def start(args):
     deadline = time.monotonic() + 5
     while time.monotonic() < deadline:
         if alive(read_pid(CHILD_PID_FILE)):
-            print(f"dev: watcher started (idle timeout {args.idle_timeout}s)")
+            print(f"dev: watcher started (idle timeout {idle_timeout}s)")
             return
         if not alive(supervisor.pid):
             break
         time.sleep(0.05)
     raise SystemExit(f"dev watcher failed to start; see {LOG_FILE}")
+
+
+def start(args):
+    start_watcher(args.command, args.idle_timeout)
 
 
 def terminate_process_group(child):
@@ -166,7 +212,7 @@ def supervise(args):
                 CHILD_PID_FILE.unlink(missing_ok=True)
 
 
-def stop(_args):
+def stop_watcher():
     with locked():
         clean_stale_state()
         pid = read_pid(PID_FILE)
@@ -186,6 +232,10 @@ def stop(_args):
     print("dev: watcher stopped")
 
 
+def stop(_args):
+    stop_watcher()
+
+
 def status(_args):
     clean_stale_state()
     pid = read_pid(PID_FILE)
@@ -197,11 +247,11 @@ def status(_args):
     return 0
 
 
-def wait_ready(args):
-    deadline = time.monotonic() + args.timeout
+def await_ready(command, timeout):
+    deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         result = subprocess.run(
-            args.command,
+            command,
             cwd=ROOT,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
@@ -213,6 +263,147 @@ def wait_ready(args):
             raise SystemExit(f"dev watcher exited; see {LOG_FILE}")
         time.sleep(0.1)
     raise SystemExit(f"dev watcher did not become ready; see {LOG_FILE}")
+
+
+def wait_ready(args):
+    return await_ready(args.command, args.timeout)
+
+
+def announce(message):
+    print(f"dev: {message}", flush=True)
+
+
+def run_with_heartbeat(command, timeout, heartbeat):
+    """Run [command], capturing its combined output into BUILD_LOG_FILE while
+    printing a heartbeat so a long build is distinguishable from a wedged one.
+    Returns (exit status, output), with a status of None on timeout."""
+    BUILD_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with BUILD_LOG_FILE.open("wb") as sink:
+        child = subprocess.Popen(
+            command,
+            cwd=ROOT,
+            stdin=subprocess.DEVNULL,
+            stdout=sink,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        start_time = time.monotonic()
+        next_heartbeat = start_time + heartbeat
+        timed_out = False
+        while child.poll() is None:
+            now = time.monotonic()
+            if timeout and now - start_time >= timeout:
+                announce(f"the build exceeded {timeout}s; stopping it")
+                terminate_process_group(child)
+                child.wait()
+                timed_out = True
+                break
+            if heartbeat and now >= next_heartbeat:
+                announce(
+                    f"still building ({int(now - start_time)}s elapsed; "
+                    "progress: make dev-log)"
+                )
+                next_heartbeat = now + heartbeat
+            time.sleep(0.2)
+    output = BUILD_LOG_FILE.read_text(errors="replace")
+    return (None if timed_out else child.returncode), output
+
+
+def emit(output):
+    lines = output.splitlines()
+    noise = [
+        any(fragment in line for fragment in FORWARDING_NOTICE)
+        for line in lines
+    ]
+    for index, line in enumerate(lines):
+        introduces_noise = (
+            line.strip() == "Warning:"
+            and index + 1 < len(lines)
+            and noise[index + 1]
+        )
+        if introduces_noise:
+            noise[index] = True
+    for line, is_noise in zip(lines, noise):
+        if not is_noise:
+            print(line, flush=True)
+
+
+def filter_notices(_args):
+    emit(sys.stdin.read())
+
+
+def lost_connection(output):
+    return any(failure in output for failure in CONNECTION_FAILURES)
+
+
+def restart_watcher(ping, ready_timeout):
+    saved = load_watcher_command()
+    if saved is None:
+        announce("no saved watcher command, so the watcher cannot be restarted")
+        return False
+    command, idle_timeout = saved
+    try:
+        stop_watcher()
+        start_watcher(command, idle_timeout)
+        if ping:
+            await_ready(ping, ready_timeout)
+    except SystemExit as failure:
+        announce(f"restarting the watcher failed: {failure}")
+        return False
+    return True
+
+
+def attempt_rpc_build(args):
+    status, output = run_with_heartbeat(
+        args.command, args.timeout, args.heartbeat
+    )
+    if status is None:
+        return None, output, f"timed out after {args.timeout}s"
+    if lost_connection(output):
+        return None, output, "lost its connection to the watcher"
+    return status, output, None
+
+
+def build(args):
+    """Build through the watcher's RPC, recovering from a wedged watcher.
+
+    The observed failure is an rpc client that waits forever against a watcher
+    that is alive and answers pings but never starts the build. So: bound the
+    wait, bounce the watcher and retry exactly once, and if that also fails
+    build directly. Retrying without a bound would just be a new silent hang.
+    """
+    touch_lease()
+    if args.ping:
+        await_ready(args.ping, args.ready_timeout)
+    announce("building via the watcher (progress: make dev-log)")
+    status, output, failure = attempt_rpc_build(args)
+
+    if failure is not None:
+        announce(f"the build {failure}; restarting the watcher and retrying")
+        emit(output)
+        if restart_watcher(args.ping, args.ready_timeout):
+            status, output, failure = attempt_rpc_build(args)
+        else:
+            failure = "could not restart the watcher"
+        if failure is not None:
+            announce(f"the build {failure}; building directly instead")
+            emit(output)
+            return build_directly(args.fallback)
+
+    emit(output)
+    if status == 0 and "Success" in output.splitlines():
+        return 0
+    if args.diagnostics:
+        subprocess.run(args.diagnostics, cwd=ROOT)
+    return 1
+
+
+def build_directly(fallback):
+    if not fallback:
+        announce("no direct build command was given")
+        return 1
+    announce("building directly (no watcher, no rpc; slower)")
+    return subprocess.run(fallback, cwd=ROOT).returncode
 
 
 def link(source, destination):
@@ -266,6 +457,14 @@ def prepare_test_root_locked():
         ROOT / "_build/dev-dune/default/boot_ocamlopt.exe",
         temporary / "ocamlopt.opt",
     )
+    # ocamltest resolves its "ocamlopt.byte" action to $srcdir/ocamlopt
+    # (ocamltest/ocaml_files.ml), so without these the whole flavour fails with
+    # "cannot find file .../ocamlopt" rather than running against the dev build.
+    link(
+        ROOT / "_build/dev-dune/default/boot_ocamlopt.exe",
+        temporary / "ocamlopt.byte",
+    )
+    (temporary / "ocamlopt").symlink_to("ocamlopt.byte")
     for name in ("ocamlrun", "ocamlrund", "ocamlruni"):
         link(
             ROOT / f"_build/runtime_stdlib_install/bin/{name}",
@@ -373,8 +572,21 @@ def parser():
     ready_parser.add_argument("command", nargs=argparse.REMAINDER)
     ready_parser.set_defaults(function=wait_ready)
 
+    build_parser = commands.add_parser("build")
+    build_parser.add_argument("--timeout", type=int, default=1800)
+    build_parser.add_argument("--heartbeat", type=int, default=30)
+    build_parser.add_argument("--ready-timeout", type=int, default=300)
+    build_parser.add_argument("--ping", type=shlex.split, default=[])
+    build_parser.add_argument("--fallback", type=shlex.split, default=[])
+    build_parser.add_argument("--diagnostics", type=shlex.split, default=[])
+    build_parser.add_argument("command", nargs=argparse.REMAINDER)
+    build_parser.set_defaults(function=build)
+
     touch_parser = commands.add_parser("touch")
     touch_parser.set_defaults(function=lambda _args: touch_lease())
+
+    filter_parser = commands.add_parser("filter-notices")
+    filter_parser.set_defaults(function=filter_notices)
 
     test_root_parser = commands.add_parser("prepare-test-root")
     test_root_parser.set_defaults(function=prepare_test_root)
@@ -384,7 +596,7 @@ def parser():
 def main():
     args = parser().parse_args()
     has_separator = (
-        args.action in {"start", "supervise", "wait-ready"}
+        args.action in {"start", "supervise", "wait-ready", "build"}
         and args.command[:1] == ["--"]
     )
     if has_separator:

--- a/tools/dev-watcher.py
+++ b/tools/dev-watcher.py
@@ -30,15 +30,6 @@ TIMEOUT_FILE = STATE / "idle-timeout"
 LOG_FILE = STATE / "watcher.log"
 LOCK_FILE = STATE / "lock"
 WATCHER_COMMAND_FILE = STATE / "watcher-command"
-BUILD_LOG_FILE = STATE / "rpc-build.log"
-
-# Dune prints a three-line warning on every rpc-forwarded command, which is
-# noise once known. There is no dune flag to suppress it (checked against 3.23),
-# so match its body and the bare "Warning:" that introduces it.
-FORWARDING_NOTICE = (
-    "build request is being forwarded",
-    "certain command line arguments may be ignored",
-)
 
 # What a dune rpc client says when the watcher's RPC server has gone away.
 CONNECTION_FAILURES = ("Connection_dead", "Connection terminated")
@@ -106,13 +97,15 @@ def start_watcher(command, idle_timeout):
         raise SystemExit("dev watcher: missing watcher command")
     with locked():
         clean_stale_state()
-        save_watcher_command(command, idle_timeout)
         pid = read_pid(PID_FILE)
         if alive(pid):
             touch_lease(idle_timeout)
             return
 
         touch_lease(idle_timeout)
+        # Recorded only when this call is the one that starts the watcher, so the
+        # file always describes the command the running watcher is executing.
+        save_watcher_command(command, idle_timeout)
         if LOG_FILE.exists() and LOG_FILE.stat().st_size > 1_000_000:
             LOG_FILE.write_bytes(b"")
         log = LOG_FILE.open("ab", buffering=0)
@@ -151,20 +144,32 @@ def start(args):
     start_watcher(args.command, args.idle_timeout)
 
 
-def terminate_process_group(child):
-    if child.poll() is not None:
-        return
+def signal_process_group(child, number):
     try:
-        os.killpg(child.pid, signal.SIGINT)
+        os.killpg(child.pid, number)
     except ProcessLookupError:
-        return
-    deadline = time.monotonic() + 5
+        pass
+
+
+def await_exit(child, seconds):
+    deadline = time.monotonic() + seconds
     while time.monotonic() < deadline and child.poll() is None:
         time.sleep(0.05)
-    if child.poll() is None:
-        try:
-            os.killpg(child.pid, signal.SIGTERM)
-        except ProcessLookupError:
+    return child.poll() is not None
+
+
+def terminate_process_group(child):
+    """Stop [child]'s process group, escalating to SIGKILL.
+
+    Escalating matters: a child that ignores SIGINT and SIGTERM would otherwise
+    make a bounded wait unbounded, which is the failure this whole mechanism
+    exists to avoid.
+    """
+    for number in (signal.SIGINT, signal.SIGTERM, signal.SIGKILL):
+        if child.poll() is not None:
+            return
+        signal_process_group(child, number)
+        if await_exit(child, 5):
             return
 
 
@@ -274,62 +279,52 @@ def announce(message):
 
 
 def run_with_heartbeat(command, timeout, heartbeat):
-    """Run [command], capturing its combined output into BUILD_LOG_FILE while
-    printing a heartbeat so a long build is distinguishable from a wedged one.
-    Returns (exit status, output), with a status of None on timeout."""
-    BUILD_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with BUILD_LOG_FILE.open("wb") as sink:
-        child = subprocess.Popen(
-            command,
-            cwd=ROOT,
-            stdin=subprocess.DEVNULL,
-            stdout=sink,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-        )
-        start_time = time.monotonic()
-        next_heartbeat = start_time + heartbeat
-        timed_out = False
-        while child.poll() is None:
-            now = time.monotonic()
-            if timeout and now - start_time >= timeout:
-                announce(f"the build exceeded {timeout}s; stopping it")
-                terminate_process_group(child)
-                child.wait()
-                timed_out = True
-                break
-            if heartbeat and now >= next_heartbeat:
-                announce(
-                    f"still building ({int(now - start_time)}s elapsed; "
-                    "progress: make dev-log)"
-                )
-                next_heartbeat = now + heartbeat
-            time.sleep(0.2)
-    output = BUILD_LOG_FILE.read_text(errors="replace")
+    """Run [command], capturing its combined output while printing a heartbeat so
+    a long build is distinguishable from a wedged one. Returns (exit status,
+    output), with a status of None on timeout."""
+    # Per invocation, not a fixed path: two dev commands in one worktree would
+    # otherwise truncate and read each other's output, and a build that read a
+    # sibling's "Success" would report success it never achieved.
+    log_file = STATE / f"rpc-build.{os.getpid()}.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with log_file.open("wb") as sink:
+            child = subprocess.Popen(
+                command,
+                cwd=ROOT,
+                stdin=subprocess.DEVNULL,
+                stdout=sink,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+            start_time = time.monotonic()
+            next_heartbeat = start_time + heartbeat
+            timed_out = False
+            while child.poll() is None:
+                now = time.monotonic()
+                if timeout and now - start_time >= timeout:
+                    announce(f"the build exceeded {timeout}s; stopping it")
+                    terminate_process_group(child)
+                    # The child may have exited on its own just as the deadline
+                    # passed, in which case its result is real.
+                    timed_out = child.poll() != 0
+                    break
+                if heartbeat and now >= next_heartbeat:
+                    announce(
+                        f"still building ({int(now - start_time)}s elapsed; "
+                        "progress: make dev-log)"
+                    )
+                    next_heartbeat = now + heartbeat
+                time.sleep(0.2)
+        output = log_file.read_text(errors="replace")
+    finally:
+        log_file.unlink(missing_ok=True)
     return (None if timed_out else child.returncode), output
 
 
 def emit(output):
-    lines = output.splitlines()
-    noise = [
-        any(fragment in line for fragment in FORWARDING_NOTICE)
-        for line in lines
-    ]
-    for index, line in enumerate(lines):
-        introduces_noise = (
-            line.strip() == "Warning:"
-            and index + 1 < len(lines)
-            and noise[index + 1]
-        )
-        if introduces_noise:
-            noise[index] = True
-    for line, is_noise in zip(lines, noise):
-        if not is_noise:
-            print(line, flush=True)
-
-
-def filter_notices(_args):
-    emit(sys.stdin.read())
+    sys.stdout.write(output)
+    sys.stdout.flush()
 
 
 def lost_connection(output):
@@ -374,7 +369,13 @@ def build(args):
     """
     touch_lease()
     if args.ping:
-        await_ready(args.ping, args.ready_timeout)
+        try:
+            await_ready(args.ping, args.ready_timeout)
+        except SystemExit as unready:
+            # A watcher that never becomes ready is exactly the case the
+            # fallback exists for, so do not fail here.
+            announce(f"the watcher is not ready ({unready}); building directly")
+            return build_directly(args.fallback)
     announce("building via the watcher (progress: make dev-log)")
     status, output, failure = attempt_rpc_build(args)
 
@@ -383,11 +384,12 @@ def build(args):
         emit(output)
         if restart_watcher(args.ping, args.ready_timeout):
             status, output, failure = attempt_rpc_build(args)
+            if failure is not None:
+                emit(output)
         else:
             failure = "could not restart the watcher"
         if failure is not None:
             announce(f"the build {failure}; building directly instead")
-            emit(output)
             return build_directly(args.fallback)
 
     emit(output)
@@ -417,14 +419,34 @@ def newest(paths):
     return max(paths, key=lambda path: path.stat().st_mtime)
 
 
-def find_artifacts(patterns):
+def within(path, parts):
+    """Whether [parts] occurs as a contiguous run of directories in [path]."""
+    candidate = path.parts
+    return any(
+        candidate[index:index + len(parts)] == parts
+        for index in range(len(candidate) - len(parts) + 1)
+    )
+
+
+def find_artifacts(directory, patterns):
+    """Newest artifact matching one of [patterns], from within the test's own
+    directory under each artifact root.
+
+    Scoping to that directory is not optional: 609 of this tree's test files share
+    a basename with a test elsewhere (test.ml alone occurs 83 times), so a
+    basename search across the roots readily finds an unrelated test's output. The
+    directory is matched anywhere in the path rather than as a prefix, because
+    each root nests it differently and ocamltest adds a per-test level.
+    """
+    parts = Path(directory).parts
     for pattern in patterns:
         found = [
             path
             for root in ARTIFACT_ROOTS
-            if (ROOT / root).is_dir()
-            for path in (ROOT / root).rglob(pattern)
-            if path.is_file()
+            for base in [ROOT / root]
+            if base.is_dir()
+            for path in base.rglob(pattern)
+            if path.is_file() and within(path, parts)
         ]
         if found:
             return newest(found)
@@ -439,17 +461,24 @@ def diff(args):
     the latter by hand drops the principal updates silently.
     """
     source = ROOT / "testsuite" / args.test
+    if not source.is_file():
+        announce(f"no such test: {source}")
+        return 2
     stem = source.name.rsplit(".", 1)[0]
+    # args.test is "tests/<dir>/<file>.ml"; artifacts sit under the same
+    # "tests/<dir>" path within whichever root ran the test.
+    directory = str(Path(args.test).parent)
 
     corrected = find_artifacts(
-        [f"{source.name}.corrected.corrected", f"{source.name}.corrected"]
+        directory,
+        [f"{source.name}.corrected.corrected", f"{source.name}.corrected"],
     )
     if corrected is not None:
         announce(f"corrected output {corrected.relative_to(ROOT)}")
         announce("promote with `make dev-promote`, never by copying this file")
         return show_diff(source, corrected)
 
-    output = find_artifacts([f"{stem}.output", f"{stem}.result"])
+    output = find_artifacts(directory, [f"{stem}.output", f"{stem}.result"])
     if output is None:
         announce(f"no fresh output for {source.relative_to(ROOT)}")
         announce("run `make dev-test TEST=...` first; note that prepare-test-root")
@@ -648,9 +677,6 @@ def parser():
 
     touch_parser = commands.add_parser("touch")
     touch_parser.set_defaults(function=lambda _args: touch_lease())
-
-    filter_parser = commands.add_parser("filter-notices")
-    filter_parser.set_defaults(function=filter_notices)
 
     diff_parser = commands.add_parser("diff")
     diff_parser.add_argument("--test", required=True)

--- a/tools/dev-watcher.py
+++ b/tools/dev-watcher.py
@@ -406,6 +406,70 @@ def build_directly(fallback):
     return subprocess.run(fallback, cwd=ROOT).returncode
 
 
+# Where a test's fresh output can end up. dev-test uses the dev root; dev-test-all
+# uses _runtest; and the promote path for a whole directory runs ocamltest with
+# OCAMLTESTDIR under the test's own directory, which the dev root symlinks back
+# into the source tree.
+ARTIFACT_ROOTS = ("_build/dev/runtest/testsuite", "_runtest/testsuite", "testsuite")
+
+
+def newest(paths):
+    return max(paths, key=lambda path: path.stat().st_mtime)
+
+
+def find_artifacts(patterns):
+    for pattern in patterns:
+        found = [
+            path
+            for root in ARTIFACT_ROOTS
+            if (ROOT / root).is_dir()
+            for path in (ROOT / root).rglob(pattern)
+            if path.is_file()
+        ]
+        if found:
+            return newest(found)
+    return None
+
+
+def diff(args):
+    """Show a test's newest fresh output against what it is compared to.
+
+    Expect tests are the subtle case: the -principal pass writes
+    <test>.corrected.corrected, which supersedes <test>.corrected, so promoting
+    the latter by hand drops the principal updates silently.
+    """
+    source = ROOT / "testsuite" / args.test
+    stem = source.name.rsplit(".", 1)[0]
+
+    corrected = find_artifacts(
+        [f"{source.name}.corrected.corrected", f"{source.name}.corrected"]
+    )
+    if corrected is not None:
+        announce(f"corrected output {corrected.relative_to(ROOT)}")
+        announce("promote with `make dev-promote`, never by copying this file")
+        return show_diff(source, corrected)
+
+    output = find_artifacts([f"{stem}.output", f"{stem}.result"])
+    if output is None:
+        announce(f"no fresh output for {source.relative_to(ROOT)}")
+        announce("run `make dev-test TEST=...` first; note that prepare-test-root")
+        announce("discards the previous run's artifacts")
+        return 1
+
+    announce(f"program output {output.relative_to(ROOT)}")
+    reference = source.parent / f"{stem}.reference"
+    if not reference.is_file():
+        announce(f"no reference {reference.relative_to(ROOT)} yet; the output is:")
+        print(output.read_text(errors="replace"), end="")
+        return 0
+    return show_diff(reference, output)
+
+
+def show_diff(reference, output):
+    subprocess.run(["diff", "-u", str(reference), str(output)], cwd=ROOT)
+    return 0
+
+
 def link(source, destination):
     destination.symlink_to(
         source.resolve(), target_is_directory=source.is_dir()
@@ -587,6 +651,10 @@ def parser():
 
     filter_parser = commands.add_parser("filter-notices")
     filter_parser.set_defaults(function=filter_notices)
+
+    diff_parser = commands.add_parser("diff")
+    diff_parser.add_argument("--test", required=True)
+    diff_parser.set_defaults(function=diff)
 
     test_root_parser = commands.add_parser("prepare-test-root")
     test_root_parser.set_defaults(function=prepare_test_root)


### PR DESCRIPTION
Acts on five independent experience reports from sessions that each built one
piece of a compiler project using the loop added in #6786. The reports converge
hard, and convergence set the priority: the `dune rpc build` wedge was hit by all
five, stale `_runtest` artifacts by four, and the silence that made both
expensive by all five.

Companion to #6786 rather than part of the vox stack — this is tooling only and
independent of the language pieces, so it branches off the same base.

## The failure paths are now loud, bounded and recoverable

- **The wedge.** `dune rpc build` could hang forever against a watcher that had
  already logged success; `wait-ready` had a timeout, the build call did not.
  Now: heartbeat every 60s, `DEV_RPC_TIMEOUT` (default 1800s, overridable),
  then stop the watcher, restart it, retry once, and fall back to a direct
  `dune build`. Three independent in-the-wild recoveries during development,
  one of them a client sitting 8m56s at 0:00:00 CPU.
- **Timeouts are bounds.** Killing escalates SIGINT → SIGTERM → SIGKILL across
  the process group with a bounded wait per step, so a child that ignores a
  signal cannot extend the deadline.
- **Stale `_runtest` stdlib.** A compiler change can alter marshaled `.cmi`
  shapes with no magic bump, leaving the previously built stdlib unreadable by
  the compiler that has to read it; the observed failure was a SIGSEGV that
  points nowhere, and two sessions reached for a debugger. A 20ms one-line
  compile after each successful build detects it and names the cure
  (`make dev-refresh-stdlib`). Verified against a real SIGSEGV produced by
  swapping two *dereferenced* fields of `Types.value_description` — and the
  recorded limit is as useful as the detector: swapping fields a trivial
  compile never dereferences changes the marshaled layout without tripping it,
  so this catches the segfaulting class, not latent layout drift.
- **Stale test harness.** Found by a new fixture here, and by none of the five
  reports: `install_for_test` copies ocamltest from `_build/default`, but
  `dev-test-all` builds it into `_build/dev-dune`, so **an ocamltest change was
  invisible to the full suite** — measured 39 minutes stale.
- **No more false greens.** Concurrent dev commands shared one build-output
  log, and the dangerous direction was a build whose own result was `Failure`
  exiting 0 on a sibling's `Success`. The log is now per-invocation.
- **Scratch stays inside the worktree.** ocamltest writes temporary files for
  every failing-test diff; `TMPDIR` is now defaulted under `_build/dev` from
  both `dev-test` and `dev-test-all`. ocamltest removes these on the normal
  path, so the leak only survived killed runs — which happened repeatedly
  while developing this branch.

## New and changed targets

`make dev-configure` (fresh worktrees need `autoconf27`, not the 2.69 on PATH —
four of five sessions hand-copied `configure` from a sibling worktree),
`dev-refresh-stdlib`, `dev-diff`, `dev-errors`, `dev-selftest`,
`dev-stdlib-check`. `make dev NOWATCH=1` skips the watcher and rpc entirely for
sandboxes where dune cannot bind its socket — measured cold 412s / warm 1.43s in
exactly that environment, which is why review agents no longer need a runner
borrowed from another worktree.

`ocamltest -promote` can now create a missing reference file instead of failing
with the real hint buried in a log. Committed RED then GREEN, so the second
commit's diff to the expectation shows precisely what changed.

## Bytecode-compiler test actions are now skipped, not failed

`ocamlc.byte`-flavoured tests cannot run under the *fast loop*, and the
measurement says no arrangement of symlinks will fix it: ocamltest runs
`ocamlrun <ocamlc>`, `main.bc` carries magic `Caml1999X036` with a shebang to the
opam `ocamlrun`, and the in-tree runtime expects `Caml1999X583`
(`utils/config.common.ml:32`). Redirecting to a native binary produces exactly
the same 12 failures, because a native binary has no Caml trailer at all.

So the action is skipped with a reason that names what is not covered, following
the existing `no_native_compilers` pattern. Also committed RED then GREEN; the
expectation diff *is* the behaviour change:

```
-ocamlc.byte => failed
+ocamlc.byte => skipped
+reason: ocamlc.byte is not runnable under this harness, so this test does not cover it
```

Skipping per *action* rather than per test file means there is no list to go
stale. The flag is exported by `dev-test` only: `dev-test-all` runs through
`_runtest`, where `ocamlc.byte` is the real installed bytecode compiler and these
tests pass. So the gap is the fast loop's, not the suite's — a point the source
reports had backwards.

A sweep found **548** test files declaring `ocamlc.byte`/`ocamlopt.byte`, so the
originally reported dozen was a corner of it. Nineteen directories were then
measured with the skip off and on: **the passed count is identical in every
one**, so nothing that passes is being skipped, and unrelated failures are not
being masked. Set `DEV_SKIP_BYTECODE_COMPILERS=` to run the actions for real in
any selection.

The measurement also turned up something a count of skipped *tests* cannot show.
`typing-layouts-products` reports 27 passed with the skip on and 31 with it off,
because four of its tests are multi-branch: the `ocamlc.byte` branch skips while
the `native` branches pass, so the test reports **passed with a branch never
exercised**. `dev-test` therefore counts skipped *actions* and says so, naming
the compiler and warning that a test reported as passed may be affected.

## The native expect runner is refreshed again

The staleness check grepped test files for a runner's own name, `expectnat`,
but the TEST-block token is `expect.opt`. Counted over `testsuite/tests`:
`expectnat` appears in **0** files, `expect.opt` in **43** (29 of them in
`codegen/`), `expect` in **753**. So the native branch could never fire, and
because `expect` does not match `expect.opt` either, 38 of those 43 tests
refreshed **neither** runner — they ran against whatever the last full build
left behind, reporting green regardless of the compiler under test.

Fixed, and committed RED then GREEN. Rather than patch one token, the decision
was made observable first: `make dev-runners-needed DIR=…` prints which runners
a selection asks for, which is a pure function of test-file contents and so
checkable, unlike the mtime half. The RED→GREEN diff is exactly the two
expectations moving, `codegen needs []` → `codegen needs [expectnat ]`. That
refactor is the real fix for why this survived so long: the decision was
unobservable.

Cost, measured rather than assumed: **~4s** when the main workspace has nothing
to rebuild. The 110M link is paid only after a compiler source change — which is
precisely when the old behaviour was handing back the previous compiler's
answer.

## Deliberately not done

Reasons in `design-docs/dev-loop-improvements.md`: a single-instance lock (a
naive one serialises a reviewer behind a 30-40 minute `dev-test-all`, creating a
new silent wait — though two overlapping runs did interleave heartbeats into one
log during this work, so the advisory half would have paid for itself);
staleness detection for `_runtest` compilerlibs (prescribing a 15-30 minute
`install_for_test` on every `typing/` edit is worse than the trap);
stdlib-digest invalidation (detected and explained, not repaired); and caching
the expect runner's second full compiler build, which is the largest remaining
throughput cost but changes what expect tests link against, so it is a
harness-correctness decision and is written up as the proposed next piece.

## Verification

`make dev-selftest`, `tool-ocamltest` 8/8, and a full suite run at
`c38d1c98f5`: **2444 passed, 208 skipped, 0 failed** of 2652, exit 0. The only
later change to code is a single diagnostic string inside `dev-promote`, a target
the suite never invokes; the rest is documentation. A review loop with one claude and one codex reviewer
found three defects that defeated this branch's own headline claims, all
reproduced before being fixed: `dev-configure` was unreachable in a fresh
worktree (the exact case it was for), the timeout was not a bound, and the shared
log's false green. One earlier decision was reversed on a reviewer's
counterexample — filtering dune's forwarding notice also dropped real diagnostics
and swallowed dune's exit status, so it is gone and the self-test pins the notice
being passed through. Per-item honesty about what was exercised and what was only
reasoned through is in `design-docs/dev-loop-improvements-final.md`.

---

Part of the same effort as stack #6796, but not an entry in it.