### PR TITLE
Occurs check for sort variables

### DIFF
--- a/external/merlin/src/ocaml/typing/jkind.ml
+++ b/external/merlin/src/ocaml/typing/jkind.ml
@@ -428,6 +428,7 @@ module Layout = struct
         | Var _ ->
           let sort_var_str = Fmt.asprintf "%a" Sort.format s in
           pp_string_list ppf (sort_var_str :: Scannable_axes.to_string_list sa)
+        | Product _ when nested -> Fmt.fprintf ppf "(%a)" Sort.format s
         (* definitely never scannable *)
         | Base _ | Product _ | Univar _ -> Fmt.fprintf ppf "%a" Sort.format s)
       | Product ts ->

--- a/external/merlin/src/ocaml/typing/jkind_types.ml
+++ b/external/merlin/src/ocaml/typing/jkind_types.ml
@@ -846,6 +846,13 @@ module Sort = struct
     | Equal_mutated_second -> Equal_mutated_first
     | (Unequal | Equal_no_mutation | Equal_mutated_both) as r -> r
 
+  let rec var_occurs v = function
+    | Var v' -> (
+      v == v'
+      || match v'.contents with None -> false | Some s -> var_occurs v s)
+    | Base _ | Univar _ -> false
+    | Product ts -> List.exists (var_occurs v) ts
+
   let[@inline] sorts_of_product s =
     (* In the equate functions, it's useful to pass around lists of sorts inside
        the product constructor they came from to avoid re-allocating it if we
@@ -920,8 +927,11 @@ module Sort = struct
     | Some s1 -> equate_sort_product s1 s2
     | None when is_rigidvar v1 -> Unequal
     | None ->
-      set v1 (Some s2);
-      Equal_mutated_first
+      if var_occurs v1 s2
+      then Unequal
+      else (
+        set v1 (Some s2);
+        Equal_mutated_first)
 
   and equate_sort_product s1 s2 =
     match s1 with

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind.ml
@@ -428,6 +428,7 @@ module Layout = struct
         | Var _ ->
           let sort_var_str = Fmt.asprintf "%a" Sort.format s in
           pp_string_list ppf (sort_var_str :: Scannable_axes.to_string_list sa)
+        | Product _ when nested -> Fmt.fprintf ppf "(%a)" Sort.format s
         (* definitely never scannable *)
         | Base _ | Product _ | Univar _ -> Fmt.fprintf ppf "%a" Sort.format s)
       | Product ts ->

--- a/external/merlin/upstream/ocaml_flambda/typing/jkind_types.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/jkind_types.ml
@@ -846,6 +846,13 @@ module Sort = struct
     | Equal_mutated_second -> Equal_mutated_first
     | (Unequal | Equal_no_mutation | Equal_mutated_both) as r -> r
 
+  let rec var_occurs v = function
+    | Var v' -> (
+      v == v'
+      || match v'.contents with None -> false | Some s -> var_occurs v s)
+    | Base _ | Univar _ -> false
+    | Product ts -> List.exists (var_occurs v) ts
+
   let[@inline] sorts_of_product s =
     (* In the equate functions, it's useful to pass around lists of sorts inside
        the product constructor they came from to avoid re-allocating it if we
@@ -920,8 +927,11 @@ module Sort = struct
     | Some s1 -> equate_sort_product s1 s2
     | None when is_rigidvar v1 -> Unequal
     | None ->
-      set v1 (Some s2);
-      Equal_mutated_first
+      if var_occurs v1 s2
+      then Unequal
+      else (
+        set v1 (Some s2);
+        Equal_mutated_first)
 
   and equate_sort_product s1 s2 =
     match s1 with

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -790,12 +790,26 @@ Error:
 (* Occurs check prevents cyclic sorts *)
 
 (* At applications of this function, ['a] and ['b] share a sort variable *)
-(* CR rtjoa: This crashes the compiler with a stack overflow, by constructing
-   a cyclic sort. *)
 external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
 [@@layout_poly]
 
+(* CR layouts: Improve this error message *)
 (* The return type would need sort ['s1 = 's1 & value] *)
 let bad (x : 'c) : #('c * string) = magic_any x
 [%%expect{|
+external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
+  [@@layout_poly]
+Line 6, characters 36-47:
+6 | let bad (x : 'c) : #('c * string) = magic_any x
+                                        ^^^^^^^^^^^
+Error: This expression has type
+         "('a : '_representable_layout_2 & value_or_null)"
+       but an expression was expected of type "#('c * string)"
+       The layout of #('c * string) is
+           '_representable_layout_3 & value & value non_float
+         because it is an unboxed tuple.
+       But the layout of #('c * string) must be representable
+         because it's the layout polymorphic type in an external declaration
+         ([@layout_poly] forces all variables of layout 'any' to be
+         representable at call sites).
 |}]

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -806,7 +806,7 @@ Error: This expression has type
          "('a : '_representable_layout_2 & value_or_null)"
        but an expression was expected of type "#('c * string)"
        The layout of #('c * string) is
-           '_representable_layout_3 & value & value non_float
+           ('_representable_layout_3 & value) & value non_float
          because it is an unboxed tuple.
        But the layout of #('c * string) must be representable
          because it's the layout polymorphic type in an external declaration

--- a/testsuite/tests/typing-layouts/layout_poly.ml
+++ b/testsuite/tests/typing-layouts/layout_poly.ml
@@ -785,3 +785,17 @@ Error:
          ([@layout_poly] forces all variables of layout 'any' to be
          representable at call sites).
 |}]
+
+(**************************************)
+(* Occurs check prevents cyclic sorts *)
+
+(* At applications of this function, ['a] and ['b] share a sort variable *)
+(* CR rtjoa: This crashes the compiler with a stack overflow, by constructing
+   a cyclic sort. *)
+external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
+[@@layout_poly]
+
+(* The return type would need sort ['s1 = 's1 & value] *)
+let bad (x : 'c) : #('c * string) = magic_any x
+[%%expect{|
+|}]

--- a/typing/jkind.ml
+++ b/typing/jkind.ml
@@ -428,6 +428,7 @@ module Layout = struct
         | Var _ ->
           let sort_var_str = Fmt.asprintf "%a" Sort.format s in
           pp_string_list ppf (sort_var_str :: Scannable_axes.to_string_list sa)
+        | Product _ when nested -> Fmt.fprintf ppf "(%a)" Sort.format s
         (* definitely never scannable *)
         | Base _ | Product _ | Univar _ -> Fmt.fprintf ppf "%a" Sort.format s)
       | Product ts ->

--- a/typing/jkind_types.ml
+++ b/typing/jkind_types.ml
@@ -846,6 +846,13 @@ module Sort = struct
     | Equal_mutated_second -> Equal_mutated_first
     | (Unequal | Equal_no_mutation | Equal_mutated_both) as r -> r
 
+  let rec var_occurs v = function
+    | Var v' -> (
+      v == v'
+      || match v'.contents with None -> false | Some s -> var_occurs v s)
+    | Base _ | Univar _ -> false
+    | Product ts -> List.exists (var_occurs v) ts
+
   let[@inline] sorts_of_product s =
     (* In the equate functions, it's useful to pass around lists of sorts inside
        the product constructor they came from to avoid re-allocating it if we
@@ -920,8 +927,11 @@ module Sort = struct
     | Some s1 -> equate_sort_product s1 s2
     | None when is_rigidvar v1 -> Unequal
     | None ->
-      set v1 (Some s2);
-      Equal_mutated_first
+      if var_occurs v1 s2
+      then Unequal
+      else (
+        set v1 (Some s2);
+        Equal_mutated_first)
 
   and equate_sort_product s1 s2 =
     match s1 with


### PR DESCRIPTION
Currently, we do not perform an occurs check when unifying sort variables - possibly under the assumption that any problematic cases would be caught by the occurs check for type variables.

However, it is possible to have separate type variables which share a sort variable, as applications of `[@layout_poly]` externals instantiate a new variable shared among all variables annotated as `any`. This causes the compilation of following program to stack overflow:
```ocaml
(* All [any] type variables at applications of layout_poly externals must share sort variables *)
external magic_any : ('a : any) ('b : any). 'a -> 'b = "%identity"
[@@layout_poly]

(* The return type would need sort ['s1 = 's1 & value] *)
let bad (x : 'c) : #('c * string) = magic_any x
```

**Reviewing.** This also contains a drive-by printing fix.