### PR TITLE
Fix ocamloptcomp compile flags

### DIFF
--- a/dune
+++ b/dune
@@ -557,7 +557,12 @@
  ; We should change the code so this "-open" can be removed.
  ; Likewise fix occurrences of warnings 9, 27, 32, 33, 34, 37, 39, and 60.
  (flags
-  (:standard -w -27-32-33-34-37-39-60-69-70))
+  (:standard
+   -strict-sequence
+   -bin-annot
+   -safe-string
+   -strict-formats
+   -w -27-32-33-34-37-39-60-69-70))
  (ocamlopt_flags
   (:standard (:include %{project_root}/ocamlopt_flags.sexp)))
  (instrumentation


### PR DESCRIPTION
We're compiling `ocamloptcomp` with the wrong flags, and it looks like it's been this way more or less since flambda-backend branched from upstream ocaml.

(I only noticed because I wrote a bug that `-strict-sequence` would have caught and was surprised that it didn't)