### PR TITLE
Make Ldd rigid var ids word-size-independent and 32-bit-safe

### DIFF
--- a/external/merlin/src/ocaml/typing/ldd.ml
+++ b/external/merlin/src/ocaml/typing/ldd.ml
@@ -129,8 +129,9 @@ module Make (V : Ordered) = struct
     (* Keep rigid ids strictly above any non-rigid ids. We choose the top half
        of the *positive* int range, so rigid ids stay positive and satisfy the
        invariant used by [inline_solved_vars] to avoid descending under
-       rigids. *)
-    let rigid_var_start = 1 lsl (Sys.word_size - 3)
+       rigids. 
+       We use 29 here rather than 61 in order to support 32 bit platforms. *)
+    let rigid_var_start = 1 lsl 29
 
     let[@inline] rigid_id (name : V.t) : int =
       let h = stable_hash name land (rigid_var_start - 1) in

--- a/external/merlin/upstream/ocaml_flambda/typing/ldd.ml
+++ b/external/merlin/upstream/ocaml_flambda/typing/ldd.ml
@@ -129,8 +129,9 @@ module Make (V : Ordered) = struct
     (* Keep rigid ids strictly above any non-rigid ids. We choose the top half
        of the *positive* int range, so rigid ids stay positive and satisfy the
        invariant used by [inline_solved_vars] to avoid descending under
-       rigids. *)
-    let rigid_var_start = 1 lsl (Sys.word_size - 3)
+       rigids. 
+       We use 29 here rather than 61 in order to support 32 bit platforms. *)
+    let rigid_var_start = 1 lsl 29
 
     let[@inline] rigid_id (name : V.t) : int =
       let h = stable_hash name land (rigid_var_start - 1) in

--- a/typing/ldd.ml
+++ b/typing/ldd.ml
@@ -130,7 +130,7 @@ module Make (V : Ordered) = struct
        of the *positive* int range, so rigid ids stay positive and satisfy the
        invariant used by [inline_solved_vars] to avoid descending under
        rigids. *)
-    let rigid_var_start = 1 lsl (Sys.word_size - 3)
+    let rigid_var_start = 1 lsl 29
 
     let[@inline] rigid_id (name : V.t) : int =
       let h = stable_hash name land (rigid_var_start - 1) in

--- a/typing/ldd.ml
+++ b/typing/ldd.ml
@@ -129,7 +129,8 @@ module Make (V : Ordered) = struct
     (* Keep rigid ids strictly above any non-rigid ids. We choose the top half
        of the *positive* int range, so rigid ids stay positive and satisfy the
        invariant used by [inline_solved_vars] to avoid descending under
-       rigids. *)
+       rigids. 
+       We use 29 here rather than 61 in order to support 32 bit platforms. *)
     let rigid_var_start = 1 lsl 29
 
     let[@inline] rigid_id (name : V.t) : int =


### PR DESCRIPTION
Rigid variable ids were based at `1 lsl (Sys.word_size - 3)` = 2^61 on 64-bit hosts. These ids are marshaled into cmi files via solver state stored in kinds, and a 32-bit runtime such as js_of_ocaml (the browser playground toplevel) fails to unmarshal them (`input_value: integer too large`); the id scheme was also inconsistent between word sizes.

Base rigid ids at `1 lsl 29` on all platforms instead. Collisions are already handled by bucketing and comparing names, so the smaller hash space only affects collision frequency, not correctness.