### PR TITLE
Fix principal checking in ocamltest

### DIFF
--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -328,29 +328,32 @@ let current_arch_filter () =
 (* For [%%expect]:
    - {|...|} alone: used for both principal and non-principal
    - {|...|}, Principal{|...|}: first for non-principal, second for principal
+*)
+let eval_toplevel_expectation expectation ~output =
+  let corrected s = { s with str = output } in
+  let combine if_not_principal if_principal =
+    if if_not_principal.str = if_principal.str
+    then [([], if_not_principal)]
+    else [([], if_not_principal); ([Principal], if_principal)]
+  in
+  let expected_output =
+    match expectation.expected_output, !Clflags.principal with
+    | [([], if_not_principal)], false -> [([], corrected if_not_principal)]
+    | [([], expected)], true -> combine expected (corrected expected)
+    | [([], if_not_principal); ([Principal], if_principal)], false ->
+      combine (corrected if_not_principal) if_principal
+    | [([], if_not_principal); ([Principal], if_principal)], true ->
+      combine if_not_principal (corrected if_principal)
+    | _ -> Misc.fatal_error "impossible: already validated"
+  in
+  if expected_output = expectation.expected_output
+  then None
+  else Some { expectation with expected_output }
 
-   For [%%expect_asm]:
+(* For [%%expect_asm]:
    - All entries must have architecture tags (X86_64)
 *)
-let eval_expectation expectation ~output =
-  let to_update = match expectation.kind with
-  | Expect_toplevel ->
-    (match expectation.expected_output with
-      | [([], expected)] -> [([], expected)]
-      | [([], if_not_principal); ([Principal], if_principal)] ->
-        if !Clflags.principal
-        then [([Principal], if_principal)]
-        else [([], if_not_principal)]
-      | _ -> Misc.fatal_error "impossible: already validated")
-  | Expect_asm _ ->
-    List.filter
-      ~f:(fun (f, _) ->
-          match current_arch_filter () with
-          | None -> false
-          | Some arch -> List.mem ~set:f arch)
-      expectation.expected_output
-  | Expect_fexpr -> expectation.expected_output
-  in
+let eval_filtered_expectation expectation ~output ~to_update =
   match to_update with
   | [(filters, s)] when s.str <> output ->
     let s = { s with str = output } in
@@ -364,6 +367,23 @@ let eval_expectation expectation ~output =
       ~loc:expectation.payload_loc
       "duplicate architectures in [%%%%expect_asm]"
   | _ -> None
+
+let eval_expectation expectation ~output =
+  match expectation.kind with
+  | Expect_toplevel -> eval_toplevel_expectation expectation ~output
+  | Expect_fexpr ->
+    eval_filtered_expectation expectation ~output
+      ~to_update:expectation.expected_output
+  | Expect_asm _ ->
+    let to_update =
+      List.filter
+        ~f:(fun (f, _) ->
+            match current_arch_filter () with
+            | None -> false
+            | Some arch -> List.mem ~set:f arch)
+        expectation.expected_output
+    in
+    eval_filtered_expectation expectation ~output ~to_update
 
 let shift_lines delta phrases =
   let position (pos : Lexing.position) =

--- a/oxcaml/testsuite/tools/expectcommon.ml
+++ b/oxcaml/testsuite/tools/expectcommon.ml
@@ -559,6 +559,8 @@ let eval_expect_file fname ~file_contents ~execute_phrase =
         ~f:(fun () -> let (_, r, _, _) = exec_phrases phrases in r)
   in
   let needs_principal =
+    Option.is_some trailing_code
+    ||
     List.exists chunks ~f:(fun chunk ->
       List.exists chunk.expectations ~f:(fun expectation ->
         match expectation.kind with

--- a/testsuite/tests/comprehensions/array_comprehensions_pure.ml
+++ b/testsuite/tests/comprehensions/array_comprehensions_pure.ml
@@ -261,13 +261,6 @@ Line 1, characters 13-15:
 Error: The constructor "[]" has type "'a list"
        but an expression was expected of type "'b array"
        because it is in a for-in iterator in an array comprehension
-|}, Principal{|
-Line 1, characters 13-15:
-1 | [|x for x in []|];;
-                 ^^
-Error: The constructor "[]" has type "'a list"
-       but an expression was expected of type "'b array"
-       because it is in a for-in iterator in an array comprehension
 |}];;
 
 (* As above, but don't trigger type-based disambiguation; this affects the error

--- a/testsuite/tests/comprehensions/iarray_comprehensions_pure.ml
+++ b/testsuite/tests/comprehensions/iarray_comprehensions_pure.ml
@@ -267,13 +267,6 @@ Line 1, characters 13-15:
 Error: The constructor "[]" has type "'a list"
        but an expression was expected of type "'b iarray"
        because it is in a for-in iterator in an immutable array comprehension
-|}, Principal{|
-Line 1, characters 13-15:
-1 | [:x for x in []:];;
-                 ^^
-Error: The constructor "[]" has type "'a list"
-       but an expression was expected of type "'b iarray"
-       because it is in a for-in iterator in an immutable array comprehension
 |}];;
 
 (* As above, but don't trigger type-based disambiguation; this affects the error

--- a/testsuite/tests/effect-syntax/modes.ml
+++ b/testsuite/tests/effect-syntax/modes.ml
@@ -98,6 +98,7 @@ let () =
   | r -> ignore !r
   | effect Need_ref, k -> use_unique (continue k (ref 0))
 [%%expect {|
+|}, Principal{|
 Line 4, characters 37-57:
 4 |   | effect Need_ref, k -> use_unique (continue k (ref 0))
                                          ^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/tool-expect-test/principal.ml
+++ b/testsuite/tests/tool-expect-test/principal.ml
@@ -1,0 +1,39 @@
+(* TEST
+  setup-simple-build-env;
+  run-expect;
+  reference = "${test_source_directory}/principal.reference";
+  check-program-output;
+*)
+
+type t1 = A
+type t2 = A
+[%%expect{|
+type t1 = A
+type t2 = A
+|}]
+
+(* -principal output doesn't match expectation *)
+let x = [(A : t1); A]
+[%%expect{|
+val x : t1 list = [A; A]
+|}]
+
+(* -no-principal output doesn't match expectation *)
+let x = [(A : t1); A]
+[%%expect{|
+Line 1, characters 19-20:
+1 | let x = [(A : t1); A]
+                       ^
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
+
+val x : t1 list = [A; A]
+|}]
+
+(* -principal and -no-principal have the same output *)
+let x = [(A : t1); (A : t1)]
+[%%expect{|
+val x : t1 list = [A; A]
+|}, Principal{|
+val x : t1 list = [A; A]
+|}]

--- a/testsuite/tests/tool-expect-test/principal.reference
+++ b/testsuite/tests/tool-expect-test/principal.reference
@@ -1,0 +1,47 @@
+(* TEST
+  setup-simple-build-env;
+  run-expect;
+  reference = "${test_source_directory}/principal.reference";
+  check-program-output;
+*)
+
+type t1 = A
+type t2 = A
+[%%expect{|
+type t1 = A
+type t2 = A
+|}]
+
+(* -principal output doesn't match expectation *)
+let x = [(A : t1); A]
+[%%expect{|
+val x : t1 list = [A; A]
+|}, Principal{|
+Line 1, characters 19-20:
+1 | let x = [(A : t1); A]
+                       ^
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
+
+val x : t1 list = [A; A]
+|}]
+
+(* -no-principal output doesn't match expectation *)
+let x = [(A : t1); A]
+[%%expect{|
+val x : t1 list = [A; A]
+|}, Principal{|
+Line 1, characters 19-20:
+1 | let x = [(A : t1); A]
+                       ^
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
+
+val x : t1 list = [A; A]
+|}]
+
+(* -principal and -no-principal have the same output *)
+let x = [(A : t1); (A : t1)]
+[%%expect{|
+val x : t1 list = [A; A]
+|}]

--- a/testsuite/tests/tool-expect-test/principal_trailing_code.ml
+++ b/testsuite/tests/tool-expect-test/principal_trailing_code.ml
@@ -1,0 +1,11 @@
+(* TEST
+  setup-simple-build-env;
+  run-expect;
+  reference = "${test_source_directory}/principal_trailing_code.reference";
+  check-program-output;
+*)
+
+(* Trailing code with different -principal and -no-principal outputs *)
+type t1 = A
+type t2 = A
+let x = [(A : t1); A]

--- a/testsuite/tests/tool-expect-test/principal_trailing_code.reference
+++ b/testsuite/tests/tool-expect-test/principal_trailing_code.reference
@@ -1,0 +1,27 @@
+(* TEST
+  setup-simple-build-env;
+  run-expect;
+  reference = "${test_source_directory}/principal_trailing_code.reference";
+  check-program-output;
+*)
+
+(* Trailing code with different -principal and -no-principal outputs *)
+type t1 = A
+type t2 = A
+let x = [(A : t1); A]
+
+[%%expect{|
+type t1 = A
+type t2 = A
+val x : t1 list = [A; A]
+|}, Principal{|
+type t1 = A
+type t2 = A
+Line 3, characters 19-20:
+3 | let x = [(A : t1); A]
+                       ^
+Warning 18 [not-principal]: this type-based constructor disambiguation is not
+  principal.
+
+val x : t1 list = [A; A]
+|}]

--- a/testsuite/tests/typing-jkind-bounds/annots.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots.ml
@@ -256,19 +256,6 @@ Error: This alias is bound to type "int list"
        Note: The layout of immediate is value non_pointer.
        Note: The kinds mutable_data, immutable_data, and sync_data have
        the layout value non_float.
-|}, Principal{|
-Line 1, characters 21-23:
-1 | let x : int list as ('a : immediate) = [3;4;5]
-                         ^^
-Error: This alias is bound to type "int list"
-       but is used as an instance of type "('a : immediate)"
-       The layout of int list is value non_float
-         because it's a boxed variant type.
-       But the layout of int list must be a sublayout of value non_pointer
-         because of the annotation on the type variable 'a.
-       Note: The layout of immediate is value non_pointer.
-       Note: The kinds mutable_data, immutable_data, and sync_data have
-       the layout value non_float.
 |}]
 (* CR layouts: error message could be phrased better *)
 

--- a/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/annots_ikinds.ml
@@ -254,19 +254,6 @@ Error: This alias is bound to type "int list"
        Note: The layout of immediate is value non_pointer.
        Note: The kinds mutable_data, immutable_data, and sync_data have
        the layout value non_float.
-|}, Principal{|
-Line 1, characters 21-23:
-1 | let x : int list as ('a : immediate) = [3;4;5]
-                         ^^
-Error: This alias is bound to type "int list"
-       but is used as an instance of type "('a : immediate)"
-       The layout of int list is value non_float
-         because it's a boxed variant type.
-       But the layout of int list must be a sublayout of value non_pointer
-         because of the annotation on the type variable 'a.
-       Note: The layout of immediate is value non_pointer.
-       Note: The kinds mutable_data, immutable_data, and sync_data have
-       the layout value non_float.
 |}]
 (* CR layouts: error message could be phrased better *)
 

--- a/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/composite_ikinds.ml
@@ -162,8 +162,6 @@ type ('a : immutable_data) t = { x : 'a list; }
 let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
-|}, Principal{|
-val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}]
 
 let foo (t : int t @ contended) = use_uncontended t
@@ -371,8 +369,6 @@ val foo : int t @ contended -> unit = <fun>
 
 let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
-val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
-|}, Principal{|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/records_ikinds.ml
@@ -517,9 +517,6 @@ let foo (t : _ t @ nonportable contended once) =
 [%%expect {|
 type ('a : immutable_data) t = { x : 'a; }
 val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
-|}, Principal{|
-type ('a : immutable_data) t = { x : 'a; }
-val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
 |}]
 
 let foo (t : _ t @ local) = use_global t [@nontail]

--- a/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/row_ikinds.ml
@@ -326,6 +326,8 @@ type t3 : value non_float mod everything with [ `A of string] t1 = C of string  
    ikinds regression vs non-ikinds.
    Internal ticket 6481. *)
 [%%expect{|
+type t3 = C of string
+|}, Principal{|
 Line 1, characters 0-78:
 1 | type t3 : value non_float mod everything with [ `A of string] t1 = C of string  (* should be accepted *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -356,6 +358,8 @@ type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] 
    ikinds regression vs non-ikinds.
    Internal ticket 6481. *)
 [%%expect{|
+type t3 = C of string
+|}, Principal{|
 Line 1, characters 0-96:
 1 | type t3 : value non_float mod everything with [ `A of string | `B of int | `C ] t1 = C of string  (* should be accepted *)
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/testsuite/tests/typing-jkind-bounds/stall-once/test.ml
+++ b/testsuite/tests/typing-jkind-bounds/stall-once/test.ml
@@ -28,6 +28,8 @@ val require_portable : ('a : value mod portable). 'a -> unit = <fun>
    more than we use if we ran out previously. *)
 let f (t : int list list list t) = require_portable t
 [%%expect {|
+val f : int list list list t -> unit = <fun>
+|}, Principal{|
 Line 1, characters 52-53:
 1 | let f (t : int list list list t) = require_portable t
                                                         ^
@@ -62,6 +64,8 @@ val require_portable : ('a : value mod portable). 'a -> unit = <fun>
 |}]
 let f (t : int list list list Foo.t) = require_portable t
 [%%expect {|
+val f : int list list list Foo.t -> unit = <fun>
+|}, Principal{|
 Line 1, characters 56-57:
 1 | let f (t : int list list list Foo.t) = require_portable t
                                                             ^

--- a/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/variants_ikinds.ml
@@ -544,9 +544,6 @@ let foo (t : _ t @ nonportable contended once) =
 [%%expect {|
 type ('a : immutable_data) t = Foo of { x : 'a; } | Bar of 'a
 val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
-|}, Principal{|
-type ('a : immutable_data) t = Foo of { x : 'a; } | Bar of 'a
-val foo : ('a : immutable_data). 'a t @ once contended -> unit = <fun>
 |}]
 
 let foo (t : _ t @ local) = use_global t [@nontail]
@@ -1038,6 +1035,10 @@ module M : sig type t end = struct type t = int end
 type 'a many = Foo of ('a * 'a) many | Leaf
 let f (x : M.t many) = cross_contended x
 [%%expect {|
+module M : sig type t end
+type 'a many = Foo of ('a * 'a) many | Leaf
+val f : M.t many -> unit = <fun>
+|}, Principal{|
 module M : sig type t end
 type 'a many = Foo of ('a * 'a) many | Leaf
 Line 3, characters 39-40:

--- a/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
+++ b/testsuite/tests/typing-jkind-bounds/with_basics_ikinds.ml
@@ -901,8 +901,6 @@ val foo : int t @ contended -> unit = <fun>
 let foo (t : _ t @ contended) = use_uncontended t
 [%%expect {|
 val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
-|}, Principal{|
-val foo : ('a : immutable_data). 'a t @ contended -> unit = <fun>
 |}]
 
 let foo (t : int t @ nonportable) = use_portable t
@@ -1072,8 +1070,6 @@ val foo : int t -> unit = <fun>
 
 let foo (t : _ t @ nonportable) = use_portable t
 [%%expect {|
-val foo : ('a : immutable_data). 'a t -> unit = <fun>
-|}, Principal{|
 val foo : ('a : immutable_data). 'a t -> unit = <fun>
 |}]
 

--- a/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
+++ b/testsuite/tests/typing-layouts-arrays/basics_alpha.ml
@@ -395,18 +395,6 @@ type bad_5 = bad_3 with_i64s
 type bad_6 =
     #(float * #(float * float) * #(float * #(float * float * float)))
 type bad_7 = #{ i : int64#; bad_4 : bad_4; j : int64#; }
-|}, Principal{|
-type ('a : any separable) with_i64s = #(int64# * 'a * int64#)
-type ok_1 = #(int64# * int32#)
-type ok_2 = float# with_i64s
-type bad_1 = #(int * int32#)
-type bad_2 = int
-type bad_3 = A | B | C
-type bad_4 = #{ a : int64#; enum : bad_3; }
-type bad_5 = bad_3 with_i64s
-type bad_6 =
-    #(float * #(float * float) * #(float * #(float * float * float)))
-type bad_7 = #{ i : int64#; bad_4 : bad_4; j : int64#; }
 |}]
 
 (* Allowed usages *)

--- a/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_any.ml
+++ b/testsuite/tests/typing-layouts-gadt-sort-var/function_arg_gadt_any.ml
@@ -99,6 +99,15 @@ let g_opt : type (a : any). ?x:(a opt) -> a -> unit -> (int -> int) =
   fun ?x:(YesO = assert false) y () -> y
 [%%expect{|
 type ('a : any) opt = YesO : (int -> int) opt
+Line 4, characters 31-32:
+4 |   fun ?x:(YesO = assert false) y () -> y
+                                   ^
+Error: This function's argument has type a,
+       whose layout is known only from the GADT pattern match at line 4, characters 10-14.
+       That pattern matches an optional argument that a caller could omit, so a caller could reach this argument at a different layout.
+       Function arguments and results must be representable independently of the patterns of optional arguments.
+|}, Principal{|
+type ('a : any) opt = YesO : (int -> int) opt
 Line 4, characters 10-14:
 4 |   fun ?x:(YesO = assert false) y () -> y
               ^^^^
@@ -122,6 +131,9 @@ type _ w = AW : int w
 let opt_value : type a. ?x:(a w) -> a -> unit =
   fun ?x:(AW = assert false) _y -> ()
 [%%expect{|
+type _ w = AW : int w
+val opt_value : ?x:'a w -> 'a -> unit = <fun>
+|}, Principal{|
 type _ w = AW : int w
 Line 4, characters 10-12:
 4 |   fun ?x:(AW = assert false) _y -> ()

--- a/testsuite/tests/typing-layouts-products/basics.ml
+++ b/testsuite/tests/typing-layouts-products/basics.ml
@@ -2133,15 +2133,6 @@ Error: This type "string t" should be an instance of type "('a : any mod global)
          because of the definition of t at line 2, characters 0-47.
        But the kind of string t must be a subkind of any mod global
          because of the definition of needs_any_mod_global at line 4, characters 0-47.
-|}, Principal{|
-Line 1, characters 19-27:
-1 | type should_fail = string t needs_any_mod_global
-                       ^^^^^^^^
-Error: This type "string t" should be an instance of type "('a : any mod global)"
-       The kind of string t is immutable_data & immutable_data
-         because of the definition of t at line 2, characters 0-47.
-       But the kind of string t must be a subkind of any mod global
-         because of the definition of needs_any_mod_global at line 4, characters 0-47.
 |}]
 
 type ('a : any mod external_) t


### PR DESCRIPTION
Recent `expect_asm` work broke expect-tests for principal outputs, overriding the same expect block, if only one is present, with both non-principal and principal outputs. Properly split the output in those cases. Combine back principal and non-principal cases that are the same.

Promote existing tests.