### PR TITLE
Add skill for updating merlin

### DIFF
--- a/.claude/skills/update-merlin/SKILL.md
+++ b/.claude/skills/update-merlin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-merlin
 description: Update/merge the vendored Merlin after a compiler frontend change (parsing/, typing/, file_formats/, utils/), fix a failing Merlin-sync CI check, or teach Merlin about a new compiler flag.
-allowed-tools: Bash(external/merlin/scripts/import-ocaml-source.sh)
+allowed-tools: Bash(external/merlin/scripts/import-ocaml-source.sh), Bash(make merlin-build), Bash(external/merlin/scripts/assert-in-sync.sh), Bash(make merlin-test), Bash(make merlin-promote)
 ---
 
 # Updating Merlin After Compiler Frontend Changes

--- a/.claude/skills/update-merlin/SKILL.md
+++ b/.claude/skills/update-merlin/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: update-merlin
+description: Update/merge the vendored Merlin after a compiler frontend change (parsing/, typing/, file_formats/, utils/), fix a failing Merlin-sync CI check, or teach Merlin about a new compiler flag.
+allowed-tools: Bash(external/merlin/scripts/import-ocaml-source.sh)
+---
+
+# Updating Merlin After Compiler Frontend Changes
+
+Merlin (`external/merlin/`) vendors the compiler's frontend. Any frontend change — approximately `parsing/`, `typing/`, and the files in `file_formats/` and `utils/` they use — must be imported into Merlin; a CI check verifies this. Import by running `external/merlin/scripts/import-ocaml-source.sh` (never hand-merge compiler changes into `external/merlin`, and never manually modify `external/merlin/upstream/ocaml_flambda` except for `external/merlin/upstream/ocaml_flambda/.gitattributes`), then get `make merlin-test` passing. This is what the user is asking you to do if they say something like "Update Merlin", "Fix Merlin", or "Merge compiler/frontend/typing/type-checker changes into Merlin". New compiler flags (even backend-only ones) also require a Merlin update. Don't do anything before reading the full documentation: `external/merlin/HACKING.jst.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ If the execution of `autoconf` fails because the version is too old, try with `a
 
 Configuration is needed after changing `.in` files or the autoconf script.
 
+## Updating Merlin After Compiler Frontend Changes
+
+Merlin (`external/merlin/`) vendors the compiler's frontend. Any frontend change — approximately `parsing/`, `typing/`, and the files in `file_formats/` and `utils/` they use — must be imported into Merlin; a CI check verifies this. Import by running `external/merlin/scripts/import-ocaml-source.sh` (never hand-merge compiler changes into `external/merlin`, and never manually modify `external/merlin/upstream/ocaml_flambda` except for `external/merlin/upstream/ocaml_flambda/.gitattributes`), then get `make merlin-test` passing. This is what the user is asking you to do if they say something like "Update Merlin", "Fix Merlin", or "Merge compiler/frontend/typing/type-checker changes into Merlin". New compiler flags (even backend-only ones) also require a Merlin update. Don't do anything before reading the full documentation: `external/merlin/HACKING.jst.md`.
+
 ## Development Guidelines
 - Always verify changes build with `make -s boot-compiler`
 - Run `make -s fmt` to ensure code formatting


### PR DESCRIPTION
Title. The skill is intentionally kept short and points to `external/merlin/HACKING.jst.md` in an effort to prevent it from becoming stale.