### PR TITLE
Improve debuginfo attribution of spills, reloads and inserted blocks

### DIFF
--- a/backend/cfg/cfg.ml
+++ b/backend/cfg/cfg.ml
@@ -463,11 +463,11 @@ let make_instruction ~desc ?(arg = [||]) ?(res = [||]) ?(dbg = Debuginfo.none)
   }
 
 let make_instruction_from_copy (copy : _ instruction) ~desc ~id ?(arg = [||])
-    ?(res = [||]) () =
+    ?(res = [||]) ?dbg () =
   { desc;
     arg;
     res;
-    dbg = copy.dbg;
+    dbg = (match dbg with None -> copy.dbg | Some dbg -> dbg);
     fdo = copy.fdo;
     live = copy.live;
     stack_offset = copy.stack_offset;

--- a/backend/cfg/cfg.mli
+++ b/backend/cfg/cfg.mli
@@ -282,6 +282,7 @@ val make_instruction_from_copy :
   id:InstructionId.t ->
   ?arg:Reg.t array ->
   ?res:Reg.t array ->
+  ?dbg:Debuginfo.t ->
   unit ->
   'b instruction
 

--- a/backend/cfg/cfg_with_layout.ml
+++ b/backend/cfg/cfg_with_layout.ml
@@ -421,8 +421,16 @@ let insert_block :
         phantom_available_before ) =
     match DLL.last body with
     | None ->
-      ( Debuginfo.none,
-        Fdo_info.none,
+      (* The debuginfo (and FDO information) of the predecessor's terminator is
+         propagated to the new block's terminator, so that instructions
+         subsequently inserted into the new block whose debuginfo is derived
+         from that of the terminator (e.g. reloads inserted after a call, cf.
+         [Regalloc_split]) can be attributed to the relevant position in the
+         predecessor. The availability sets are placeholders: they are computed
+         later, by [Cfg_available_regs], which runs after register
+         allocation. *)
+      ( predecessor_block.terminator.dbg,
+        predecessor_block.terminator.fdo,
         Reg.Set.empty,
         predecessor_block.terminator.stack_offset,
         Reg_availability_set.Unreachable,

--- a/backend/cfg/sub_cfg.ml
+++ b/backend/cfg/sub_cfg.ml
@@ -134,12 +134,13 @@ let join_tail ~from ~to_ =
   List.iter (fun from -> transfer ~from ~to_) from;
   add_never_block to_ ~label:(Cmm.new_label ())
 
-let update_exit_terminator ?arg sub_cfg desc =
+let update_exit_terminator ?arg ?dbg sub_cfg desc =
   sub_cfg.exit.terminator
     <- { sub_cfg.exit.terminator with
          desc;
          id = next_instr_id ();
-         arg = Option.value arg ~default:sub_cfg.exit.terminator.arg
+         arg = Option.value arg ~default:sub_cfg.exit.terminator.arg;
+         dbg = Option.value dbg ~default:sub_cfg.exit.terminator.dbg
        }
 
 let mark_as_trap_handler sub_cfg = sub_cfg.entry.is_trap_handler <- true

--- a/backend/cfg/sub_cfg.mli
+++ b/backend/cfg/sub_cfg.mli
@@ -103,7 +103,8 @@ val join : from:t list -> to_:t -> unit
 
 val join_tail : from:t list -> to_:t -> unit
 
-val update_exit_terminator : ?arg:Reg.t array -> t -> Cfg.terminator -> unit
+val update_exit_terminator :
+  ?arg:Reg.t array -> ?dbg:Debuginfo.t -> t -> Cfg.terminator -> unit
 
 val start_label : t -> Label.t
 

--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1072,9 +1072,8 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           term)
 
   and emit_expr_ifthenelse env sub_cfg bound_name econd _ifso_dbg eif
-      (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t) :
+      (_ifnot_dbg : Debuginfo.t) eelse (dbg : Debuginfo.t) :
       _ Or_never_returns.t =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
     let cond, earg = select_condition econd in
     match emit_expr env sub_cfg earg ~bound_name:None with
     | Never_returns -> Never_returns
@@ -1088,13 +1087,12 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_true:(Sub_cfg.start_label sub_if)
           ~label_false:(Sub_cfg.start_label sub_else)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg ~dbg;
       Sub_cfg.join ~from:[sub_if; sub_else] ~to_:sub_cfg;
       r
 
   and emit_expr_switch env sub_cfg bound_name esel index ecases
-      (_dbg : Debuginfo.t) : _ Or_never_returns.t =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+      (dbg : Debuginfo.t) : _ Or_never_returns.t =
     match emit_expr env sub_cfg esel ~bound_name:None with
     | Never_returns -> Never_returns
     | Ok rsel ->
@@ -1109,7 +1107,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       let term_desc : Cfg.terminator =
         Switch (Array.map (fun idx -> Sub_cfg.start_label subs.(idx)) index)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel ~dbg;
       Sub_cfg.join ~from:(Array.to_list subs) ~to_:sub_cfg;
       r
 
@@ -1367,8 +1365,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
       | _ -> Misc.fatal_error "Cfg_selectgen.emit_tail")
 
   and emit_tail_ifthenelse env sub_cfg econd (_ifso_dbg : Debuginfo.t) eif
-      (_ifnot_dbg : Debuginfo.t) eelse (_dbg : Debuginfo.t) =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+      (_ifnot_dbg : Debuginfo.t) eelse (dbg : Debuginfo.t) =
     let cond, earg = select_condition econd in
     match emit_expr env sub_cfg earg ~bound_name:None with
     | Never_returns -> ()
@@ -1381,11 +1378,10 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
           ~label_true:(Sub_cfg.start_label sub_if)
           ~label_false:(Sub_cfg.start_label sub_else)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rarg ~dbg;
       Sub_cfg.join_tail ~from:[sub_if; sub_else] ~to_:sub_cfg
 
-  and emit_tail_switch env sub_cfg esel index ecases (_dbg : Debuginfo.t) =
-    (* CR-someday xclerc for xclerc: use the `_dbg` parameter *)
+  and emit_tail_switch env sub_cfg esel index ecases (dbg : Debuginfo.t) =
     match emit_expr env sub_cfg esel ~bound_name:None with
     | Never_returns -> ()
     | Ok rsel ->
@@ -1397,7 +1393,7 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
         Switch
           (Array.map (fun idx -> Sub_cfg.start_label sub_cases.(idx)) index)
       in
-      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel;
+      Sub_cfg.update_exit_terminator sub_cfg term_desc ~arg:rsel ~dbg;
       Sub_cfg.join_tail ~from:(Array.to_list sub_cases) ~to_:sub_cfg
 
   and emit_tail_catch env sub_cfg (flag : Cmm.ccatch_flag) handlers e1 =

--- a/backend/regalloc/regalloc_split.ml
+++ b/backend/regalloc/regalloc_split.ml
@@ -254,9 +254,17 @@ let insert_spills_in_block :
       (* See comment before Insert_skipping_name_for_debugger *)
       Insert_skipping_name_for_debugger.insert_after cell instr ~reg)
     ~copy_default:
+      (* The terminator is the destruction point that has necessitated the
+         spill, making its debug and FDO information the natural choice for a
+         spill that is not associated with any instruction in the block's body.
+         Such a spill is inserted at the beginning of the block, however, so the
+         other fields (in particular the stack offset) must come from the first
+         instruction of the block, since they may differ from those of the
+         terminator. *)
       (match DLL.hd block.body with
       | None -> dummy_instr_of_terminator block.terminator
-      | Some hd -> hd)
+      | Some hd ->
+        { hd with dbg = block.terminator.dbg; fdo = block.terminator.fdo })
     ~add_default:(fun list instr reg ->
       (* See comment before Insert_skipping_name_for_debugger *)
       Insert_skipping_name_for_debugger.add_begin list instr ~reg)
@@ -309,10 +317,39 @@ let make_reload : type a. a make_operation =
     ~id:(InstructionId.get_and_incr instr_id)
     ~copy ~from:stack_reg ~to_:new_reg
 
+(* Computes the default copy instruction for reloads at the beginning of [block]
+   that are not associated with any instruction in the block's body. Such
+   reloads exist because of a destruction point at the end of a predecessor; the
+   debug and FDO information of that destruction point (e.g. a call) is the
+   natural choice. The relevant terminator is found by walking the
+   unique-predecessor chain while the terminators encountered have no debuginfo,
+   since the block may be separated from the destruction point by empty blocks
+   inserted on destruction (or critical) edges. Only the debug and FDO
+   information is taken from that terminator: the other fields (in particular
+   the stack offset) come from the block's own terminator, as they may differ
+   from those of the predecessors' terminators. *)
+let default_copy_for_reloads : Cfg.t -> Cfg.basic_block -> Instruction.t =
+ fun cfg block ->
+  let rec find_dbg_source (block : Cfg.basic_block) fuel =
+    if (not (Debuginfo.is_none block.terminator.dbg)) || fuel <= 0
+    then block.terminator
+    else
+      match Label.Set.elements block.predecessors with
+      | [predecessor_label] ->
+        find_dbg_source (Cfg.get_block_exn cfg predecessor_label) (pred fuel)
+      | [] | _ :: _ -> block.terminator
+  in
+  let dbg_source = find_dbg_source block 3 in
+  { (dummy_instr_of_terminator block.terminator) with
+    dbg = dbg_source.dbg;
+    fdo = dbg_source.fdo
+  }
+
 (* Inserts the reloads in a block, as late as possible (i.e. immediately before
    the register is first read), to reduce live ranges. *)
 let insert_reloads_in_block :
     State.t ->
+    cfg:Cfg.t ->
     instr_id:InstructionId.sequence ->
     block_subst:Substitution.t ->
     stack_subst:Substitution.t ->
@@ -320,7 +357,7 @@ let insert_reloads_in_block :
     Instruction.t DLL.cell option ->
     Reg.Set.t ->
     unit =
- fun state ~instr_id ~block_subst ~stack_subst block cell
+ fun state ~cfg ~instr_id ~block_subst ~stack_subst block cell
      live_at_definition_point ->
   insert_spills_or_reloads_in_block state ~instr_id
     ~make_spill_or_reload:make_reload ~occur_check
@@ -332,7 +369,7 @@ let insert_reloads_in_block :
          Reg_availability_set.canonicalise), so it's probably not necessary to
          add a Name_for_debugger on the reloaded one. *)
       DLL.insert_before cell instr)
-    ~copy_default:(dummy_instr_of_terminator block.terminator)
+    ~copy_default:(default_copy_for_reloads cfg block)
     ~add_default:(fun list instr _reg ->
       (* Same reasoning as for insert above *)
       DLL.add_end list instr)
@@ -350,11 +387,12 @@ let insert_reloads :
   Label.Map.iter
     (fun label live_at_definition_point ->
       if debug then log "block %a" Label.format label;
+      let cfg = Cfg_with_infos.cfg cfg_with_infos in
       let block = Cfg_with_infos.get_block_exn cfg_with_infos label in
-      let instr_id = (Cfg_with_infos.cfg cfg_with_infos).next_instruction_id in
+      let instr_id = cfg.next_instruction_id in
       let block_subst = Substitution.for_label substs label in
-      insert_reloads_in_block state ~instr_id ~block_subst ~stack_subst block
-        (DLL.hd_cell block.body) live_at_definition_point)
+      insert_reloads_in_block state ~cfg ~instr_id ~block_subst ~stack_subst
+        block (DLL.hd_cell block.body) live_at_definition_point)
     (State.definitions_at_beginning state);
   if debug then dedent ()
 

--- a/backend/regalloc/regalloc_utils.ml
+++ b/backend/regalloc/regalloc_utils.ml
@@ -260,6 +260,25 @@ module Move = struct
     | Load -> Operation.Reload
     | Store -> Operation.Spill
 
+  (* Spills and reloads are bookkeeping, not code lowered from the source of the
+     function identified by the debuginfo of [copy]. If such debuginfo were used
+     unaltered for spill and reload instructions, then in the case where such
+     debuginfo indicated the body of an inlined function, the instructions would
+     be attributed to that inlined function (e.g. by a profiler reading the
+     DWARF line table), which could be confusing: for example reloads, of a
+     caller's variables after a call, being attributed to an inlined callee.
+     Instead only the outermost frame of the debuginfo is kept, attributing such
+     instructions to the enclosing (non-inlined) function. This is consistent
+     with [Inlined_frame_ranges], which excludes spills and reloads from the
+     DWARF address ranges of all inlined frames. *)
+  let dbg_for_move (move : t) (copy : _ Cfg.instruction) : Debuginfo.t =
+    match move with
+    | Plain -> copy.dbg
+    | Load | Store -> (
+      match Debuginfo.to_items copy.dbg with
+      | [] | [_] -> copy.dbg
+      | outermost :: _ :: _ -> Debuginfo.of_items [outermost])
+
   let make_instr :
       t ->
       id:InstructionId.t ->
@@ -270,7 +289,7 @@ module Move = struct
    fun move ~id ~copy ~from ~to_ ->
     Cfg.make_instruction_from_copy copy
       ~desc:(Cfg.Op (op_of_move move))
-      ~arg:[| from |] ~res:[| to_ |] ~id ()
+      ~arg:[| from |] ~res:[| to_ |] ~id ~dbg:(dbg_for_move move copy) ()
 
   let to_string = function Plain -> "move" | Load -> "load" | Store -> "store"
 end


### PR DESCRIPTION
Part of the `dwarf202607` series; split out of #6517 so that that PR retains only basic phantom-let preservation.

- Spills and reloads keep only the outermost frame of the debuginfo of the instruction they were copied from, so that they are not attributed to inlined callees (`Regalloc_utils.Move.dbg_for_move`). This is consistent with `Inlined_frame_ranges` (later in the series), which excludes spills and reloads from the DWARF address ranges of all inlined frames.
- Spills and reloads not associated with any instruction in a block's body take their debug and FDO information from the relevant destruction point: the block's own terminator for spills, and for reloads the terminator found by walking the unique-predecessor chain (`Regalloc_split.default_copy_for_reloads`), since empty blocks inserted on destruction or critical edges can separate the block from the destruction point.
- Blocks inserted on edges propagate the predecessor terminator's debug and FDO information to their terminator.
- Branch and switch terminators now carry the debuginfo of the corresponding Cmm construct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)