### PR TITLE
Insert parameter naming operations even when there is no provenance

### DIFF
--- a/backend/cfg_selectgen.ml
+++ b/backend/cfg_selectgen.ml
@@ -1567,19 +1567,24 @@ module Make (Target : Cfg_selectgen_target_intf.S) = struct
               loc_arg.(!loc_arg_index + index))
         in
         loc_arg_index := !loc_arg_index + num_regs_for_arg;
-        if Option.is_some provenance
-        then
-          let naming_op =
-            Operation.Name_for_debugger
-              { ident = var;
-                provenance;
-                which_parameter = Some param_index;
-                regs = hard_regs_for_arg
-              }
-          in
-          DLL.add_end block.Cfg.body
-            (Sub_cfg.make_instr (Cfg.Op naming_op) [||] [||] Debuginfo.none
-               ~phantom_available_before))
+        (* The naming operation is inserted even when [provenance] is [None], in
+           which case no named variable will be visible in the debugger (such
+           variables only receive hidden, artificial DIEs). The register
+           availability information arising from the naming operation is
+           nonetheless used when generating DWARF call site information -- in
+           particular entry values, including for compiler-generated functions
+           such as [caml_applyN], whose parameters have no provenance. *)
+        let naming_op =
+          Operation.Name_for_debugger
+            { ident = var;
+              provenance;
+              which_parameter = Some param_index;
+              regs = hard_regs_for_arg
+            }
+        in
+        DLL.add_end block.Cfg.body
+          (Sub_cfg.make_instr (Cfg.Op naming_op) [||] [||] Debuginfo.none
+             ~phantom_available_before))
       fun_args
 
   (* Sequentialization of a function definition *)


### PR DESCRIPTION
Part of the `dwarf202607` series; split out of #6517 so that that PR retains only basic phantom-let preservation. Stacked on #6822.

Parameters without provenance (e.g. those of compiler-generated functions such as `caml_applyN`) do not give rise to visible variables in the debugger — they only receive hidden, artificial DIEs — but the register availability information arising from their naming operations is used when generating DWARF call site information (later in the series), in particular entry values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)