### PR TITLE
Allow Parsetree compiler hooks to edit the AST

### DIFF
--- a/driver/compile.ml
+++ b/driver/compile.ml
@@ -28,8 +28,8 @@ let interface ~source_file ~output_prefix =
   in
   with_info ~dump_ext:"cmi" unit_info @@ fun info ->
   Compile_common.interface
-    ~hook_parse_tree:(fun _ -> ())
-    ~hook_typed_tree:(fun _ -> ())
+    ~hook_parse_tree:Fun.id
+    ~hook_typed_tree:ignore
     info
 
 (** Bytecode compilation backend for .ml files. *)
@@ -134,8 +134,8 @@ let implementation_aux ~start_from ~source_file ~output_prefix
       emit_bytecode info bytecode
     in
     Compile_common.implementation
-      ~hook_parse_tree:(fun _ -> ())
-      ~hook_typed_tree:(fun _ -> ())
+      ~hook_parse_tree:Fun.id
+      ~hook_typed_tree:ignore
       info ~backend
   | Instantiation { runtime_args; main_module_block_repr; arg_descr } ->
     begin

--- a/driver/compile_common.ml
+++ b/driver/compile_common.ml
@@ -146,7 +146,7 @@ let interface ~hook_parse_tree ~hook_typed_tree info =
   Profile.(record_call (annotate_file_name (
     Unit_info.raw_source_file info.target))) @@ fun () ->
   let { ast; info } : _ Parse_result.t = parse_intf info in
-  hook_parse_tree ast;
+  let ast = hook_parse_tree ast in
   if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
     let alerts, tsg = typecheck_intf info ast in
     hook_typed_tree tsg;
@@ -189,7 +189,7 @@ let implementation ~hook_parse_tree ~hook_typed_tree info ~backend =
   let exceptionally = Misc.remove_successful_output_files in
   Misc.try_finally ?always:None ~exceptionally (fun () ->
     let { ast = parsed; info } : _ Parse_result.t = parse_impl info in
-    hook_parse_tree parsed;
+    let parsed = hook_parse_tree parsed in
     if Clflags.(should_stop_after Compiler_pass.Parsing) then () else begin
       let typed = typecheck_impl info parsed in
       hook_typed_tree typed;

--- a/driver/compile_common.mli
+++ b/driver/compile_common.mli
@@ -79,7 +79,7 @@ val emit_signature : info -> Misc.alerts -> Typedtree.signature -> unit
 *)
 
 val interface :
-  hook_parse_tree:(Parsetree.signature -> unit)
+  hook_parse_tree:(Parsetree.signature -> Parsetree.signature)
   -> hook_typed_tree:(Typedtree.signature -> unit)
   -> info -> unit
 (** The complete compilation pipeline for interfaces. *)
@@ -96,7 +96,7 @@ val typecheck_impl : info -> Parsetree.structure -> Typedtree.implementation
 *)
 
 val implementation :
-  hook_parse_tree:(Parsetree.structure -> unit)
+  hook_parse_tree:(Parsetree.structure -> Parsetree.structure)
   -> hook_typed_tree:(Typedtree.implementation -> unit)
   -> info ->
   backend:(info -> Typedtree.implementation -> unit) ->

--- a/driver/compiler_hooks.ml
+++ b/driver/compiler_hooks.ml
@@ -10,29 +10,30 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type _ pass =
-  | Parse_tree_intf : Parsetree.signature pass
-  | Parse_tree_impl : Parsetree.structure pass
-  | Typed_tree_intf : Typedtree.signature pass
-  | Typed_tree_impl : Typedtree.implementation pass
-  | Raw_lambda : Lambda.program pass
-  | Lambda : Lambda.program pass
-  | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass
-  | Flambda2 : Flambda2_terms.Flambda_unit.t pass
-  | Reaped_flambda2 : Flambda2_terms.Flambda_unit.t pass
+type (_,_) pass =
+  | Parse_tree_intf : (Parsetree.signature, Parsetree.signature) pass
+  | Parse_tree_impl : (Parsetree.structure, Parsetree.structure) pass
+  | Typed_tree_intf : (Typedtree.signature,unit) pass
+  | Typed_tree_impl : (Typedtree.implementation,unit) pass
+  | Raw_lambda : (Lambda.program,unit) pass
+  | Lambda : (Lambda.program,unit) pass
+  | Raw_flambda2 : (Flambda2_terms.Flambda_unit.t,unit) pass
+  | Flambda2 : (Flambda2_terms.Flambda_unit.t,unit) pass
+  | Reaped_flambda2 : (Flambda2_terms.Flambda_unit.t,unit) pass
 
-  | Linear : Linear.fundecl pass
-  | Cfg_combine : Cfg_with_layout.t pass
-  | Cfg_cse : Cfg_with_layout.t pass
-  | Cfg : Cfg_with_layout.t pass
-  | Cmm : Cmm.phrase list pass
+  | Linear : (Linear.fundecl,unit) pass
+  | Cfg_combine : (Cfg_with_layout.t,unit) pass
+  | Cfg_cse : (Cfg_with_layout.t,unit) pass
+  | Cfg : (Cfg_with_layout.t,unit) pass
+  | Cmm : (Cmm.phrase list,unit) pass
 
-  | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
-  | Check_allocations : Zero_alloc_checker.iter_witnesses pass
+  | Inlining_tree :
+      (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t,unit) pass
+  | Check_allocations : (Zero_alloc_checker.iter_witnesses,unit) pass
 
 type t = {
-  mutable parse_tree_intf : (Parsetree.signature -> unit) list;
-  mutable parse_tree_impl : (Parsetree.structure -> unit) list;
+  mutable parse_tree_intf : (Parsetree.signature -> Parsetree.signature) list;
+  mutable parse_tree_impl : (Parsetree.structure -> Parsetree.structure) list;
   mutable typed_tree_intf : (Typedtree.signature -> unit) list;
   mutable typed_tree_impl : (Typedtree.implementation -> unit) list;
   mutable raw_lambda : (Lambda.program -> unit) list;
@@ -45,7 +46,8 @@ type t = {
   mutable cfg_cse : (Cfg_with_layout.t -> unit) list;
   mutable cfg : (Cfg_with_layout.t -> unit) list;
   mutable cmm : (Cmm.phrase list -> unit) list;
-  mutable inlining_tree : (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t -> unit) list;
+  mutable inlining_tree :
+    (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t -> unit) list;
   mutable check_allocations : (Zero_alloc_checker.iter_witnesses -> unit) list
 }
 let hooks : t = {
@@ -70,7 +72,10 @@ let hooks : t = {
 let execute_hooks : type a. (a -> unit) list -> a -> unit = fun hooks arg ->
   List.iter (fun f -> f arg) hooks
 
-let register : type a. a pass -> (a -> unit) -> unit =
+let fold_hooks : type a. (a -> a) list -> a -> a = fun hooks arg ->
+  List.fold_left (|>) arg hooks
+
+let register : type a out. (a,out) pass -> (a -> out) -> unit =
   fun representation f ->
   match representation with
   | Parse_tree_intf -> hooks.parse_tree_intf <- f :: hooks.parse_tree_intf
@@ -92,11 +97,11 @@ let register : type a. a pass -> (a -> unit) -> unit =
   | Check_allocations ->
     hooks.check_allocations <- f :: hooks.check_allocations
 
-let execute : type a. a pass -> a -> unit =
+let execute : type a out. (a,out) pass -> a -> out =
   fun representation arg ->
   match representation with
-  | Parse_tree_intf -> execute_hooks hooks.parse_tree_intf arg
-  | Parse_tree_impl -> execute_hooks hooks.parse_tree_impl arg
+  | Parse_tree_intf -> fold_hooks hooks.parse_tree_intf arg
+  | Parse_tree_impl -> fold_hooks hooks.parse_tree_impl arg
   | Typed_tree_intf -> execute_hooks hooks.typed_tree_intf arg
   | Typed_tree_impl -> execute_hooks hooks.typed_tree_impl arg
   | Raw_lambda -> execute_hooks hooks.raw_lambda arg
@@ -114,7 +119,7 @@ let execute : type a. a pass -> a -> unit =
 
 let execute_and_pipe r a = execute r a; a
 
-let clear : type a. a pass -> unit =
+let clear : type a out. (a,out) pass -> unit =
   function
   | Parse_tree_intf -> hooks.parse_tree_intf <- []
   | Parse_tree_impl -> hooks.parse_tree_impl <- []

--- a/driver/compiler_hooks.mli
+++ b/driver/compiler_hooks.mli
@@ -16,6 +16,7 @@
    Hooks are allowed to inspect the data but are prohibited from
    altering it. If one hook were to mutate the data there's no guarantee
    of how the compiler would behave.
+   (The exception is the Parse_tree hooks, which can modify the AST like a ppx)
    Several hooks can be registered for the same pass. There's no guarantees
    on the order of execution of hooks.
    When one IR is the output of several passes, the hooks are usually called
@@ -23,33 +24,34 @@
    where corresponding hooks are called on the earliest version of the IR).
 *)
 
-type _ pass =
-  | Parse_tree_intf : Parsetree.signature pass
-  | Parse_tree_impl : Parsetree.structure pass
-  | Typed_tree_intf : Typedtree.signature pass
-  | Typed_tree_impl : Typedtree.implementation pass
-  | Raw_lambda : Lambda.program pass
-  | Lambda : Lambda.program pass
-  | Raw_flambda2 : Flambda2_terms.Flambda_unit.t pass
-  | Flambda2 : Flambda2_terms.Flambda_unit.t pass
-  | Reaped_flambda2 : Flambda2_terms.Flambda_unit.t pass
+type (_,_) pass =
+  | Parse_tree_intf : (Parsetree.signature, Parsetree.signature) pass
+  | Parse_tree_impl : (Parsetree.structure, Parsetree.structure) pass
+  | Typed_tree_intf : (Typedtree.signature,unit) pass
+  | Typed_tree_impl : (Typedtree.implementation,unit) pass
+  | Raw_lambda : (Lambda.program,unit) pass
+  | Lambda : (Lambda.program,unit) pass
+  | Raw_flambda2 : (Flambda2_terms.Flambda_unit.t,unit) pass
+  | Flambda2 : (Flambda2_terms.Flambda_unit.t,unit) pass
+  | Reaped_flambda2 : (Flambda2_terms.Flambda_unit.t,unit) pass
 
-  | Linear : Linear.fundecl pass
-  | Cfg_combine : Cfg_with_layout.t pass
-  | Cfg_cse : Cfg_with_layout.t pass
-  | Cfg : Cfg_with_layout.t pass
-  | Cmm : Cmm.phrase list pass
+  | Linear : (Linear.fundecl,unit) pass
+  | Cfg_combine : (Cfg_with_layout.t,unit) pass
+  | Cfg_cse : (Cfg_with_layout.t,unit) pass
+  | Cfg : (Cfg_with_layout.t,unit) pass
+  | Cmm : (Cmm.phrase list,unit) pass
 
-  | Inlining_tree : Flambda2_simplify_shared.Inlining_report.Inlining_tree.t pass
-  | Check_allocations : Zero_alloc_checker.iter_witnesses pass
+  | Inlining_tree :
+      (Flambda2_simplify_shared.Inlining_report.Inlining_tree.t,unit) pass
+  | Check_allocations : (Zero_alloc_checker.iter_witnesses,unit) pass
 
 (* Register a new hook for [pass]. *)
-val register : 'a pass -> ('a -> unit) -> unit
+val register : ('a,'out) pass -> ('a -> 'out) -> unit
 
 (* Execute the hooks registered for [pass]. *)
-val execute : 'a pass -> 'a -> unit
+val execute : ('a,'out) pass -> 'a -> 'out
 
-val execute_and_pipe : 'a pass -> 'a -> 'a
+val execute_and_pipe : ('a,unit) pass -> 'a -> 'a
 
 (* Remove all hooks registered for [pass] *)
-val clear : 'a pass -> unit
+val clear : ('a,_) pass -> unit

--- a/driver/jscompile.ml
+++ b/driver/jscompile.ml
@@ -25,10 +25,7 @@ let interface ~source_file ~output_prefix =
       ~compilation_unit:Inferred_from_output_prefix
   in
   with_info ~dump_ext:"cmi" unit_info @@ fun info ->
-  Compile_common.interface
-    ~hook_parse_tree:(fun _ -> ())
-    ~hook_typed_tree:(fun _ -> ())
-    info
+  Compile_common.interface ~hook_parse_tree:Fun.id ~hook_typed_tree:ignore info
 
 (** Js_of_ocaml IR compilation backend for .ml files. *)
 
@@ -156,10 +153,8 @@ let implementation_aux ~start_from ~source_file ~output_prefix
         let jsir = to_jsir info typed ~as_arg_for in
         emit_jsir info jsir
       in
-      Compile_common.implementation
-        ~hook_parse_tree:(fun _ -> ())
-        ~hook_typed_tree:(fun _ -> ())
-        info ~backend
+      Compile_common.implementation ~hook_parse_tree:Fun.id
+        ~hook_typed_tree:ignore info ~backend
   | Instantiation { runtime_args; main_module_block_repr; arg_descr } ->
       (match !Clflags.as_argument_for with
       | Some _ ->


### PR DESCRIPTION
The Compiler_hooks module doesn't allow hooks to edit the IRs, because to do so will in general break internal invariants. It's fine for parsetree hooks, though, since that's how ppxs work.