### PR TITLE
Add `initial-exec` TLS model configuration option

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -633,6 +633,31 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
   fi
 ])
 
+# Detects whether the C compiler supports requesting the initial-exec TLS
+# model for a thread-local variable. The __has_attribute test mirrors the
+# one guarding CAMLthread_local_initial_exec in runtime/caml/misc.h, so that
+# a compiler accepted here is one that will honour the attribute.
+AC_DEFUN([OCAML_CC_SUPPORTS_INITIAL_EXEC_TLS], [
+  AC_CACHE_CHECK(m4_normalize([whether $CC supports
+    __attribute__((__tls_model__("initial-exec")))]),
+    [ocaml_cv_prog_cc_initial_exec_tls],
+    [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if !defined(__has_attribute) || !__has_attribute(__tls_model__)
+#error the __tls_model__ attribute is not supported
+#endif
+static __attribute__((__tls_model__("initial-exec")))
+  _Thread_local int tls_var = 0;
+      ]], [[
+  return tls_var;
+      ]])],
+       [ocaml_cv_prog_cc_initial_exec_tls=yes],
+       [ocaml_cv_prog_cc_initial_exec_tls=no])
+  ])
+  AS_IF([test x"$ocaml_cv_prog_cc_initial_exec_tls" = "xyes"],
+    [cc_supports_initial_exec_tls=true],
+    [cc_supports_initial_exec_tls=false])
+])
+
 AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
   AC_MSG_CHECKING([for a workable solution for ln -sf])
   AS_IF([m4_normalize(MSYS=winsymlinks:nativestrict

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -635,7 +635,7 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
 
 # Detects whether the C compiler supports requesting the initial-exec TLS
 # model for a thread-local variable. The __has_attribute test mirrors the
-# one guarding CAMLthread_local_initial_exec in runtime/caml/misc.h, so that
+# one guarding CAMLthread_local_hot in runtime/caml/misc.h, so that
 # a compiler accepted here is one that will honour the attribute.
 AC_DEFUN([OCAML_CC_SUPPORTS_INITIAL_EXEC_TLS], [
   AC_CACHE_CHECK(m4_normalize([whether $CC supports

--- a/configure.ac
+++ b/configure.ac
@@ -873,6 +873,15 @@ AC_ARG_ENABLE([multidomain],
   [AS_HELP_STRING([--enable-multidomain],
     [allow the creation of multiple domains])])
 
+AC_ARG_ENABLE([initial-exec-tls],
+  [AS_HELP_STRING([--enable-initial-exec-tls],
+    [use the initial-exec TLS model for the runtime's hot thread-local
+     variables. This avoids calls to __tls_get_addr in position-independent
+     builds of the runtime, but consumes static TLS space, which restricts
+     how late a shared object embedding the runtime can be dlopen'd.
+     Supported on GNU/Linux with glibc only, which is the only platform
+     reserving surplus static TLS space for dlopen'd modules])])
+
 AC_ARG_ENABLE([assembler-suitable-for-dissector],
   [AS_HELP_STRING([--enable-assembler-suitable-for-dissector@<:@=PATH@:>@],
     [Use LLVM assembler with large code mode for dissector. If PATH is not
@@ -1679,6 +1688,23 @@ AS_CASE([$target],
   [*-apple-darwin*|*-w64-mingw32*|*-pc-windows], [],
   [AC_DEFINE([HAS_FULL_THREAD_VARIABLES], [1])]
 )
+
+# Handle --enable-initial-exec-tls
+# Only the ELF/glibc combination guarantees that a module using the
+# initial-exec TLS model can still be loaded with dlopen, thanks to the
+# surplus static TLS area glibc reserves for that purpose.
+
+AS_IF([test x"$enable_initial_exec_tls" = "xyes"],
+  [AS_CASE([$target],
+    [*-*-linux-gnu*], [],
+    [AC_MSG_ERROR(m4_normalize([the initial-exec TLS model is only supported
+       on GNU/Linux with glibc]))])
+  OCAML_CC_SUPPORTS_INITIAL_EXEC_TLS
+  AS_IF([$cc_supports_initial_exec_tls],
+    [AC_DEFINE([CAML_INITIAL_EXEC_TLS], [1])
+    AC_MSG_NOTICE([using the initial-exec TLS model])],
+    [AC_MSG_ERROR(m4_normalize([$CC does not support
+       __attribute__((__tls_model__("initial-exec")))]))])])
 
 # Shared library support
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -173,7 +173,7 @@ struct caml_thread_struct {
 
 typedef struct caml_thread_struct* caml_thread_t;
 
-static CAMLthread_local_initial_exec caml_thread_t This_thread;
+static CAMLthread_local_hot caml_thread_t This_thread;
 
 /* overall table for threads across domains */
 struct caml_thread_table {

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -173,7 +173,7 @@ struct caml_thread_struct {
 
 typedef struct caml_thread_struct* caml_thread_t;
 
-static CAMLthread_local caml_thread_t This_thread;
+static CAMLthread_local_initial_exec caml_thread_t This_thread;
 
 /* overall table for threads across domains */
 struct caml_thread_table {

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -47,7 +47,7 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern CAMLthread_local caml_domain_state* caml_state;
+  CAMLextern CAMLthread_local_initial_exec caml_domain_state* caml_state;
   #define Caml_state_opt caml_state
 #else
 #if __has_attribute(pure) || defined(__GNUC__)

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -47,7 +47,7 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern CAMLthread_local_initial_exec caml_domain_state* caml_state;
+  CAMLextern CAMLthread_local_hot caml_domain_state* caml_state;
   #define Caml_state_opt caml_state
 #else
 #if __has_attribute(pure) || defined(__GNUC__)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -183,7 +183,7 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLthread_local _Thread_local
 #endif
 
-/* CAMLthread_local_initial_exec is used for the thread-local variables that
+/* CAMLthread_local_hot is used for the thread-local variables that
    sit on hot paths of the runtime. In position-independent code, the default
    (general-dynamic) TLS model makes every access to such a variable go
    through a call to __tls_get_addr, which is costly when the runtime ends up
@@ -199,10 +199,10 @@ CAMLdeprecated_typedef(addr, char *);
    under DEBUG should stay plain CAMLthread_local. */
 #if defined(CAML_INITIAL_EXEC_TLS) && defined(__PIC__) \
     && __has_attribute(__tls_model__)
-#define CAMLthread_local_initial_exec \
+#define CAMLthread_local_hot \
   CAMLthread_local __attribute__((__tls_model__("initial-exec")))
 #else
-#define CAMLthread_local_initial_exec CAMLthread_local
+#define CAMLthread_local_hot CAMLthread_local
 #endif
 
 /* Prefetching */

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -183,6 +183,28 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLthread_local _Thread_local
 #endif
 
+/* CAMLthread_local_initial_exec is used for the thread-local variables that
+   sit on hot paths of the runtime. In position-independent code, the default
+   (general-dynamic) TLS model makes every access to such a variable go
+   through a call to __tls_get_addr, which is costly when the runtime ends up
+   in a shared object. The initial-exec model gets rid of these calls, but
+   requires the variable to live in the static TLS block, which restricts how
+   late the module defining it can be dlopen'd. It is therefore opt-in, via
+   the --enable-initial-exec-tls configure option.
+
+   The static TLS block is a finite resource shared with every other module
+   the process may dlopen, so use this sparingly: it is meant for variables
+   read on essentially every allocation, OCaml/C transition or I/O
+   operation. Variables only touched at startup, at GC-scan granularity, or
+   under DEBUG should stay plain CAMLthread_local. */
+#if defined(CAML_INITIAL_EXEC_TLS) && defined(__PIC__) \
+    && __has_attribute(__tls_model__)
+#define CAMLthread_local_initial_exec \
+  CAMLthread_local __attribute__((__tls_model__("initial-exec")))
+#else
+#define CAMLthread_local_initial_exec CAMLthread_local
+#endif
+
 /* Prefetching */
 
 #ifdef CAML_INTERNALS

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -48,6 +48,12 @@
    including across DLLs. This is not the case with macOS and with Windows +
    MinGW-w64. */
 
+#undef CAML_INITIAL_EXEC_TLS
+
+/* Define CAML_INITIAL_EXEC_TLS to request the initial-exec TLS model for the
+   runtime's hot thread-local variables, see CAMLthread_local_initial_exec in
+   misc.h. Only supported on Linux. */
+
 #undef HAS_C99_FLOAT_OPS
 
 /* Define HAS_C99_FLOAT_OPS if <math.h> conforms to ISO C99.

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -51,7 +51,7 @@
 #undef CAML_INITIAL_EXEC_TLS
 
 /* Define CAML_INITIAL_EXEC_TLS to request the initial-exec TLS model for the
-   runtime's hot thread-local variables, see CAMLthread_local_initial_exec in
+   runtime's hot thread-local variables, see CAMLthread_local_hot in
    misc.h. Only supported on Linux. */
 
 #undef HAS_C99_FLOAT_OPS

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -300,7 +300,7 @@ uintnat caml_minor_heap_max_wsz;
 
 CAMLexport uintnat caml_minor_heaps_start;
 CAMLexport uintnat caml_minor_heaps_end;
-static CAMLthread_local_initial_exec dom_internal* domain_self;
+static CAMLthread_local_hot dom_internal* domain_self;
 
 /*
  * This structure is protected by all_domains_lock.
@@ -365,7 +365,7 @@ static dom_internal* next_free_domain(void) {
   return stw_domains.domains[stw_domains.participating_domains];
 }
 
-CAMLexport CAMLthread_local_initial_exec caml_domain_state* caml_state;
+CAMLexport CAMLthread_local_hot caml_domain_state* caml_state;
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -300,7 +300,7 @@ uintnat caml_minor_heap_max_wsz;
 
 CAMLexport uintnat caml_minor_heaps_start;
 CAMLexport uintnat caml_minor_heaps_end;
-static CAMLthread_local dom_internal* domain_self;
+static CAMLthread_local_initial_exec dom_internal* domain_self;
 
 /*
  * This structure is protected by all_domains_lock.
@@ -365,7 +365,7 @@ static dom_internal* next_free_domain(void) {
   return stw_domains.domains[stw_domains.participating_domains];
 }
 
-CAMLexport CAMLthread_local caml_domain_state* caml_state;
+CAMLexport CAMLthread_local_initial_exec caml_domain_state* caml_state;
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -34,7 +34,7 @@
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* Greater than zero when the current thread is scanning the roots */
-static CAMLthread_local int iterating_roots = 0;
+static CAMLthread_local_initial_exec int iterating_roots = 0;
 
 enum { ROOT_PRESENT = 0, ROOT_DELETED = 1 };
 

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -34,7 +34,7 @@
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* Greater than zero when the current thread is scanning the roots */
-static CAMLthread_local_initial_exec int iterating_roots = 0;
+static CAMLthread_local_hot int iterating_roots = 0;
 
 enum { ROOT_PRESENT = 0, ROOT_DELETED = 1 };
 

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -83,7 +83,7 @@ static char dummy_buff[1];
    currently locked channel (if any), which is then called by
    [caml_raise].
  */
-static CAMLthread_local_initial_exec
+static CAMLthread_local_hot
   struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -83,7 +83,8 @@ static char dummy_buff[1];
    currently locked channel (if any), which is then called by
    [caml_raise].
  */
-static CAMLthread_local struct channel* last_channel_locked = NULL;
+static CAMLthread_local_initial_exec
+  struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {


### PR DESCRIPTION
The runtime implementation makes use of several TLS variables. On GNU/Linux this is quite efficient when code is compiled in non-PIC mode (so the `local-exec` model can be used).

However, when building the PIC runtime and linking it into a dynamic shared object which gets loaded dynamically (not using `LD_PRELOAD` or as a `DT_NEEDED` dependency), `initial-exec` can't be used and instead the `{local,global}-dynamic` model is used, leading to runtime calls to `__tls_get_addr` on every access of the TLS value (e.g., when using `CAMLparam`, or `caml_callback*` functions).

One work-around on modern systems is to compile the runtime with `-mtls-dialect=gnu2`, opting into a more efficient model.

For older systems, and to decrease the performance impact more, glibc allows for a small amount of `initial-exec` TLS blocks to be claimed by `dlopen`ed DSOs (it reserves some space in per-thread allocations for this purpose).

This patch adds a new `configure` option, `--enable-initial-exec-tls`, which probes the compiler for support for the required attributes, and if available, emits code to use the `initial-exec` model for a couple of "hot" TLS variables in the runtime.

Note this may lead to DSOs which fail to load:

- The dynamic linker may not support `initial-exec` TLS blocks (`musl`, for example, doesn't), or
- The space reserved for `initial-exec` TLS blocks of `dlopen`ed DSOs may be exhausted, leading to `dlopen` failure.

However, most DSOs should *not* use this option, and the TLS values marked in the runtime to get this attribute only amount for tens of bytes.